### PR TITLE
feat(automations): scaffold per-loop runbooks and unify the fleet roster (#1796)

### DIFF
--- a/plugins/lisa-agy/scripts/automation-status-claude-adapter.mjs
+++ b/plugins/lisa-agy/scripts/automation-status-claude-adapter.mjs
@@ -10,6 +10,11 @@
  */
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
+import {
+  assignToAutomationGroup,
+  createAutomationGroupBins,
+  renderAutomationGroups,
+} from "./automation-status-expected-fleet.mjs";
 
 const CLAUDE_RUNTIME_LABEL = "Claude /schedule";
 const CLAUDE_ACTIVE_STATUSES = new Set([
@@ -75,10 +80,7 @@ export function inspectClaudeAutomationFleet(input) {
     automationPrefix: expectedFleet.automationPrefix,
   });
 
-  const expectedGroups = new Map([
-    ["core", []],
-    ["exploratory", []],
-  ]);
+  const expectedGroups = createAutomationGroupBins();
 
   const comparisons = compareAutomationFleet({
     expectedAutomations: expectedFleet.expected,
@@ -87,7 +89,9 @@ export function inspectClaudeAutomationFleet(input) {
 
   for (const [index, expected] of expectedFleet.expected.entries()) {
     const comparison = comparisons[index];
-    expectedGroups.get(expected.group)?.push(
+    assignToAutomationGroup(
+      expectedGroups,
+      expected.group,
       createObservedStatusItem({
         expected,
         comparison,
@@ -97,7 +101,7 @@ export function inspectClaudeAutomationFleet(input) {
   }
 
   for (const unsupported of expectedFleet.unsupported) {
-    expectedGroups.get(unsupported.group)?.push({
+    assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
@@ -109,18 +113,7 @@ export function inspectClaudeAutomationFleet(input) {
   return {
     runtime: `${CLAUDE_RUNTIME_LABEL} listing`,
     generatedAt: now.toISOString(),
-    groups: [
-      {
-        id: "1",
-        title: "Core automations",
-        items: expectedGroups.get("core") ?? [],
-      },
-      {
-        id: "2",
-        title: "Exploratory automations",
-        items: expectedGroups.get("exploratory") ?? [],
-      },
-    ],
+    groups: renderAutomationGroups(expectedGroups),
     observedAutomations,
   };
 }
@@ -487,6 +480,13 @@ function normalizeClaudeRRule(value) {
   ) {
     return "FREQ=DAILY;INTERVAL=1";
   }
+  if (
+    cadence === "once a week" ||
+    cadence === "every week" ||
+    cadence === "weekly"
+  ) {
+    return "FREQ=WEEKLY;INTERVAL=1";
+  }
 
   const everyMinutes = cadence.match(/every (\d+) minutes?/);
   if (everyMinutes?.[1]) {
@@ -501,6 +501,11 @@ function normalizeClaudeRRule(value) {
   const everyDays = cadence.match(/every (\d+) days?/);
   if (everyDays?.[1]) {
     return `FREQ=DAILY;INTERVAL=${everyDays[1]}`;
+  }
+
+  const everyWeeks = cadence.match(/every (\d+) weeks?/);
+  if (everyWeeks?.[1]) {
+    return `FREQ=WEEKLY;INTERVAL=${everyWeeks[1]}`;
   }
 
   return undefined;
@@ -526,6 +531,9 @@ function humanizeClaudeCadence(value) {
   }
   if (normalized === "every day") {
     return "once a day";
+  }
+  if (normalized === "weekly" || normalized === "every week") {
+    return "once a week";
   }
   return normalized;
 }
@@ -556,6 +564,11 @@ function humanizeRRule(rrule) {
     return Number(daily[1]) === 1 ? "once a day" : `every ${daily[1]} days`;
   }
 
+  const weekly = rrule.match(/^FREQ=WEEKLY;INTERVAL=(\d+)$/);
+  if (weekly?.[1]) {
+    return Number(weekly[1]) === 1 ? "once a week" : `every ${weekly[1]} weeks`;
+  }
+
   return rrule;
 }
 
@@ -572,6 +585,11 @@ function cadenceLabelToIntervalMs(label) {
   const oncePerDay = new Set(["once a day", "daily"]);
   if (oncePerDay.has(label)) {
     return 24 * 60 * 60_000;
+  }
+
+  const oncePerWeek = new Set(["once a week", "weekly"]);
+  if (oncePerWeek.has(label)) {
+    return 7 * 24 * 60 * 60_000;
   }
 
   return null;

--- a/plugins/lisa-agy/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa-agy/scripts/automation-status-codex-adapter.mjs
@@ -17,6 +17,11 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
+import {
+  assignToAutomationGroup,
+  createAutomationGroupBins,
+  renderAutomationGroups,
+} from "./automation-status-expected-fleet.mjs";
 
 const CODEx_RUNTIME_LABEL = "Codex automations";
 const RUN_TIMESTAMP_PATTERN = /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/;
@@ -156,10 +161,7 @@ export async function inspectCodexAutomationFleet(input) {
     automationPrefix: expectedFleet.automationPrefix,
   });
 
-  const expectedGroups = new Map([
-    ["core", []],
-    ["exploratory", []],
-  ]);
+  const expectedGroups = createAutomationGroupBins();
 
   const comparisons = compareAutomationFleet({
     expectedAutomations: expectedFleet.expected,
@@ -168,7 +170,9 @@ export async function inspectCodexAutomationFleet(input) {
 
   for (const [index, expected] of expectedFleet.expected.entries()) {
     const comparison = comparisons[index];
-    expectedGroups.get(expected.group)?.push(
+    assignToAutomationGroup(
+      expectedGroups,
+      expected.group,
       createObservedStatusItem({
         expected,
         comparison,
@@ -178,7 +182,7 @@ export async function inspectCodexAutomationFleet(input) {
   }
 
   for (const unsupported of expectedFleet.unsupported) {
-    expectedGroups.get(unsupported.group)?.push({
+    assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
@@ -190,18 +194,7 @@ export async function inspectCodexAutomationFleet(input) {
   return {
     runtime: `${CODEx_RUNTIME_LABEL} (backing-store metadata)`,
     generatedAt: now.toISOString(),
-    groups: [
-      {
-        id: "1",
-        title: "Core automations",
-        items: expectedGroups.get("core") ?? [],
-      },
-      {
-        id: "2",
-        title: "Exploratory automations",
-        items: expectedGroups.get("exploratory") ?? [],
-      },
-    ],
+    groups: renderAutomationGroups(expectedGroups),
     observedAutomations,
   };
 }
@@ -583,6 +576,13 @@ function humanizeAutomationCadence(rrule) {
       : `every ${everyDays[1]} days`;
   }
 
+  const everyWeeks = rrule.match(/^FREQ=WEEKLY;INTERVAL=(\d+)$/);
+  if (everyWeeks?.[1]) {
+    return Number(everyWeeks[1]) === 1
+      ? "once a week"
+      : `every ${everyWeeks[1]} weeks`;
+  }
+
   return rrule;
 }
 
@@ -606,6 +606,11 @@ function rruleToIntervalMs(rrule) {
     return Number(daily[1]) * 24 * 60 * 60_000;
   }
 
+  const weekly = rrule.match(/^FREQ=WEEKLY;INTERVAL=(\d+)$/);
+  if (weekly?.[1]) {
+    return Number(weekly[1]) * 7 * 24 * 60 * 60_000;
+  }
+
   return null;
 }
 
@@ -621,6 +626,10 @@ function cadenceLabelToIntervalMs(label) {
 
   if (label === "once a day") {
     return 24 * 60 * 60_000;
+  }
+
+  if (label === "once a week") {
+    return 7 * 24 * 60 * 60_000;
   }
 
   return null;

--- a/plugins/lisa-agy/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa-agy/scripts/automation-status-codex-adapter.mjs
@@ -242,21 +242,35 @@ export function deriveCodexObservedCommand(prompt) {
     return undefined;
   }
 
+  // The "with arguments" clause is optional: no-argument loops (monitor, the
+  // gardener) register without one. Requiring it made every such loop derive an
+  // undefined command and report DRIFTED forever, un-fixable by re-running setup.
   const lisaSkillMatch = prompt.match(
-    /Use the Lisa ([a-z0-9:-]+) skill with arguments `([^`]+)`/i
+    /Use the Lisa ([a-z0-9:-]+) skill(?: with arguments `([^`]*)`)?/i
   );
-  if (lisaSkillMatch?.[1] && lisaSkillMatch[2]) {
-    return `/lisa:${lisaSkillMatch[1]} ${lisaSkillMatch[2]}`.trim();
+  if (lisaSkillMatch?.[1]) {
+    return `/lisa:${lisaSkillMatch[1]} ${lisaSkillMatch[2] ?? ""}`.trim();
   }
 
   const aliasSkillMatch = prompt.match(
-    /Use the `\$([a-z0-9:-]+)` skill with arguments `([^`]+)`/i
+    /Use the `\$([a-z0-9:-]+)` skill(?: with arguments `([^`]*)`)?/i
   );
-  if (aliasSkillMatch?.[1] && aliasSkillMatch[2]) {
-    return `${canonicalizeCodexSkillAlias(aliasSkillMatch[1])} ${aliasSkillMatch[2]}`.trim();
+  if (aliasSkillMatch?.[1]) {
+    return `${canonicalizeCodexSkillAlias(aliasSkillMatch[1])} ${aliasSkillMatch[2] ?? ""}`.trim();
   }
 
-  return undefined;
+  // A registration whose prompt carries the literal Lisa command on its own
+  // line — the shape `/lisa:setup-automations` bakes so a command that is not a
+  // plain skill name (`/lisa:learnings:audit`) round-trips exactly. Mirrors the
+  // Claude adapter, which has always accepted a bare `/lisa:` command. Codex
+  // stores prompts as single-line TOML, so a line break arrives either real or
+  // as the two-character escape `\n`; both delimit a line here.
+  const literalCommand = prompt
+    .split(/\r?\n|\\n/)
+    .map(segment => segment.trim())
+    .find(segment => /^\/lisa[:-]\S/.test(segment));
+
+  return literalCommand;
 }
 
 function canonicalizeCodexSkillAlias(alias) {

--- a/plugins/lisa-agy/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa-agy/scripts/automation-status-expected-fleet.mjs
@@ -56,6 +56,68 @@ export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
 export const AUTOMATION_RUNBOOK_DIRECTORY = ".lisa/automations";
 
 /**
+ * Every fleet group, in render order, with the operator-facing title each one
+ * carries in the status report. This is the single source of truth for group
+ * membership: adapters bin entries with {@link createAutomationGroupBins} and
+ * render with {@link renderAutomationGroups}, so adding a group here surfaces it
+ * everywhere instead of silently dropping its entries.
+ */
+export const AUTOMATION_FLEET_GROUP_TITLES = {
+  core: "Core automations",
+  exploratory: "Exploratory automations",
+  "opt-in": "Opt-in automations",
+};
+
+/**
+ * Create one empty bin per known fleet group.
+ *
+ * @returns {Map<string, object[]>}
+ */
+export function createAutomationGroupBins() {
+  return new Map(
+    Object.keys(AUTOMATION_FLEET_GROUP_TITLES).map(group => [group, []])
+  );
+}
+
+/**
+ * Add a rendered status item to its group bin.
+ *
+ * Throws on an unknown group rather than dropping the item: a silently skipped
+ * entry is indistinguishable from a healthy fleet, which is exactly how the
+ * opt-in gardener went missing from both runtime adapters.
+ *
+ * @param {Map<string, object[]>} bins
+ * @param {string} group
+ * @param {object} item
+ * @returns {void}
+ */
+export function assignToAutomationGroup(bins, group, item) {
+  const bin = bins.get(group);
+  if (!bin) {
+    throw new Error(
+      `Unknown automation fleet group "${group}" for ${item?.id ?? "an automation"}. Add it to AUTOMATION_FLEET_GROUP_TITLES so the status report can render it.`
+    );
+  }
+  bin.push(item);
+}
+
+/**
+ * Render the group bins as the numbered report groups, in declaration order.
+ *
+ * @param {Map<string, object[]>} bins
+ * @returns {readonly { readonly id: string, readonly title: string, readonly items: readonly object[] }[]}
+ */
+export function renderAutomationGroups(bins) {
+  return Object.entries(AUTOMATION_FLEET_GROUP_TITLES).map(
+    ([group, title], index) => ({
+      id: String(index + 1),
+      title,
+      items: bins.get(group) ?? [],
+    })
+  );
+}
+
+/**
  * @typedef {{
  *   readonly id: string
  *   readonly automationId: string
@@ -76,6 +138,27 @@ export const AUTOMATION_RUNBOOK_DIRECTORY = ".lisa/automations";
  *   readonly runbookPath: string
  * }} UnsupportedAutomationEntry
  */
+
+/**
+ * Infer whether this project opted into the weekly gardener, from what is
+ * actually registered on the scheduler.
+ *
+ * Membership is registration, not configuration: there is no config key to
+ * read, so a read-only caller decides by looking for the registration itself.
+ * Pass the result as `learningsAudit` to {@link resolveExpectedAutomationFleet}
+ * so an opted-in project compares its gardener like any other loop instead of
+ * reporting it `UNSUPPORTED` forever.
+ *
+ * @param {{
+ *   readonly automationPrefix: string
+ *   readonly observedAutomationIds?: readonly string[]
+ * }} input
+ * @returns {boolean}
+ */
+export function inferLearningsAuditRegistration(input) {
+  const target = `${input.automationPrefix}learnings-audit`;
+  return (input.observedAutomationIds ?? []).includes(target);
+}
 
 /**
  * Resolve the repo-relative runbook path for a loop id.
@@ -129,6 +212,13 @@ export function resolveAutomationProjectIdentity(input = {}) {
  *   readonly autoStartTickets?: boolean | string
  *   readonly learningsAudit?: boolean | string
  * }} input
+ *
+ * `learningsAudit` has no config home by design — the gardener is opted into at
+ * registration time, and membership is registration, not configuration. A
+ * read-only caller (the status surface) therefore INFERS it: pass `true` when a
+ * `<automationPrefix>learnings-audit` entry is observed on the runtime
+ * scheduler. Without that inference an opted-in project would report the
+ * gardener `UNSUPPORTED` forever instead of comparing it like any other loop.
  * @returns {{
  *   readonly owner: string
  *   readonly repo: string
@@ -220,7 +310,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
       createUnsupportedEntry(
         identity,
         "exploratory-bugs",
-        "This repository does not ship an exploratory-qa command surface.",
+        "This project ships no exploratory-qa command, so there is nothing for this loop to run. No action needed unless the project adds one.",
         "exploratory"
       )
     );
@@ -240,7 +330,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
       createUnsupportedEntry(
         identity,
         "learnings-audit",
-        "The weekly gardener loop is opt-in and this project has not opted in (learnings-audit=false).",
+        "The weekly gardener loop is opt-in and this project has not opted in, so nobody is auditing its knowledge surfaces. Run /lisa:setup-automations learnings-audit=true to enable it.",
         "opt-in"
       )
     );

--- a/plugins/lisa-agy/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa-agy/scripts/automation-status-expected-fleet.mjs
@@ -37,9 +37,23 @@ export const AUTOMATION_EXPECTED_CADENCES = {
     human: "once a day",
     rrule: "FREQ=DAILY;INTERVAL=1",
   },
+  monitor: {
+    human: "once a day",
+    rrule: "FREQ=DAILY;INTERVAL=1",
+  },
+  "learnings-audit": {
+    human: "once a week",
+    rrule: "FREQ=WEEKLY;INTERVAL=1",
+  },
 };
 
 export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
+
+/**
+ * Directory (repo-relative) holding the checked-in per-loop runbooks scaffolded
+ * by `/lisa:setup-automations` per the `automation-runbook-contract` rule.
+ */
+export const AUTOMATION_RUNBOOK_DIRECTORY = ".lisa/automations";
 
 /**
  * @typedef {{
@@ -48,18 +62,30 @@ export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
  *   readonly expectedCadence: string
  *   readonly expectedRRule: string
  *   readonly expectedCommand: string
- *   readonly group: "core" | "exploratory"
+ *   readonly group: "core" | "exploratory" | "opt-in"
+ *   readonly runbookPath: string
  * }} ExpectedAutomationEntry
  *
  * @typedef {{
  *   readonly id: string
  *   readonly automationId: string
- *   readonly group: "core" | "exploratory"
+ *   readonly group: "core" | "exploratory" | "opt-in"
  *   readonly reason: string
  *   readonly expectedCadence: string
  *   readonly expectedRRule: string
+ *   readonly runbookPath: string
  * }} UnsupportedAutomationEntry
  */
+
+/**
+ * Resolve the repo-relative runbook path for a loop id.
+ *
+ * @param {string} id
+ * @returns {string}
+ */
+export function resolveAutomationRunbookPath(id) {
+  return `${AUTOMATION_RUNBOOK_DIRECTORY}/${id}.runbook.md`;
+}
 
 /**
  * Resolve the stable project identifier and automation prefix used by
@@ -101,6 +127,7 @@ export function resolveAutomationProjectIdentity(input = {}) {
  *   readonly detectedTypes?: readonly string[]
  *   readonly autoStartPrds?: boolean | string
  *   readonly autoStartTickets?: boolean | string
+ *   readonly learningsAudit?: boolean | string
  * }} input
  * @returns {{
  *   readonly owner: string
@@ -116,6 +143,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
   const identity = resolveAutomationProjectIdentity(input);
   const autoStartPrds = normalizeBooleanFlag(input.autoStartPrds);
   const autoStartTickets = normalizeBooleanFlag(input.autoStartTickets);
+  const learningsAudit = normalizeBooleanFlag(input.learningsAudit);
   const detectedTypes = input.detectedTypes ?? [];
 
   const tracker = config.tracker;
@@ -166,6 +194,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
       `/lisa:intake ${buildQueue}`,
       "core"
     ),
+    createExpectedEntry(identity, "monitor", "/lisa:monitor", "core"),
     createExpectedEntry(
       identity,
       "exploratory-prds",
@@ -191,7 +220,28 @@ export function resolveExpectedAutomationFleet(input = {}) {
       createUnsupportedEntry(
         identity,
         "exploratory-bugs",
-        "This repository does not ship an exploratory-qa command surface."
+        "This repository does not ship an exploratory-qa command surface.",
+        "exploratory"
+      )
+    );
+  }
+
+  if (learningsAudit) {
+    expected.push(
+      createExpectedEntry(
+        identity,
+        "learnings-audit",
+        "/lisa:learnings:audit",
+        "opt-in"
+      )
+    );
+  } else {
+    unsupported.push(
+      createUnsupportedEntry(
+        identity,
+        "learnings-audit",
+        "The weekly gardener loop is opt-in and this project has not opted in (learnings-audit=false).",
+        "opt-in"
       )
     );
   }
@@ -222,7 +272,7 @@ export function resolveExploratoryQaStack(detectedTypes = []) {
  * @param {{ readonly automationPrefix: string }} identity
  * @param {string} id
  * @param {string} expectedCommand
- * @param {"core" | "exploratory"} group
+ * @param {"core" | "exploratory" | "opt-in"} group
  * @returns {ExpectedAutomationEntry}
  */
 function createExpectedEntry(identity, id, expectedCommand, group) {
@@ -234,6 +284,7 @@ function createExpectedEntry(identity, id, expectedCommand, group) {
     expectedRRule: cadence.rrule,
     expectedCommand,
     group,
+    runbookPath: resolveAutomationRunbookPath(id),
   };
 }
 
@@ -241,17 +292,19 @@ function createExpectedEntry(identity, id, expectedCommand, group) {
  * @param {{ readonly automationPrefix: string }} identity
  * @param {string} id
  * @param {string} reason
+ * @param {"core" | "exploratory" | "opt-in"} group
  * @returns {UnsupportedAutomationEntry}
  */
-function createUnsupportedEntry(identity, id, reason) {
+function createUnsupportedEntry(identity, id, reason, group) {
   const cadence = AUTOMATION_EXPECTED_CADENCES[id];
   return {
     id,
     automationId: `${identity.automationPrefix}${id}`,
     expectedCadence: cadence.human,
     expectedRRule: cadence.rrule,
-    group: "exploratory",
+    group,
     reason,
+    runbookPath: resolveAutomationRunbookPath(id),
   };
 }
 

--- a/plugins/lisa-agy/skills/lisa-automation-status/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-automation-status/SKILL.md
@@ -23,6 +23,14 @@ exactly what `setup-automations` registers for this repo — including the stack
 roster** (`automation-runbook-contract`): carry no fixed list of loop names here, so a loop added to
 or removed from the registration set flows through without editing this skill.
 
+The gardener is opted into at registration time and has no config key, so **infer it from the
+scheduler**: list the project's automations first, then call
+`inferLearningsAuditRegistration({ automationPrefix, observedAutomationIds })` and pass the result
+as `learningsAudit` when resolving the fleet. A `lisa-auto-<project>-learnings-audit` entry on the
+scheduler means the project opted in, so the gardener is compared like any other loop; no such entry
+means it is reported `UNSUPPORTED` (opted out), never `MISSING`. This skill stays read-only — it
+infers, it never writes the flag anywhere.
+
 Resolve the expected project identifier, fleet naming prefix, queue arguments, cadence, and stack-support rules from the same contract used by `setup-automations` and `tear-down-automations`. Do **not** invent a second source of truth for fleet naming or queue resolution.
 
 ## Runtime inspection

--- a/plugins/lisa-agy/skills/lisa-automation-status/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-automation-status/SKILL.md
@@ -16,14 +16,12 @@ Do **not** ask for confirmation once invoked. This skill inspects scheduler stat
 
 ## Scope
 
-Inspect only the Lisa automation fleet for the current project:
-
-- `intake-repair`
-- `intake-prd`
-- `intake-tickets`
-- `exploratory-bugs` when the current stack supports `exploratory-qa`
-- `exploratory-prds`
-- `monitor`
+Inspect only the Lisa automation fleet for the current project. Derive that fleet from
+`scripts/automation-status-expected-fleet.mjs` (`resolveExpectedAutomationFleet`), which resolves
+exactly what `setup-automations` registers for this repo — including the stack-guarded
+`exploratory-bugs` and the opt-in `learnings-audit` gardener. **Membership is registration, not a
+roster** (`automation-runbook-contract`): carry no fixed list of loop names here, so a loop added to
+or removed from the registration set flows through without editing this skill.
 
 Resolve the expected project identifier, fleet naming prefix, queue arguments, cadence, and stack-support rules from the same contract used by `setup-automations` and `tear-down-automations`. Do **not** invent a second source of truth for fleet naming or queue resolution.
 

--- a/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
@@ -146,19 +146,53 @@ packet here** — cite the rule and instantiate it.
    id, the full automation name, the exact scheduled command with every `owner/repo` already baked
    in (never a placeholder), the human cadence and its `rrule`, the resolved queue arguments, and
    the resolved flag values that shaped the command (`auto-start-prds` / `auto-start-tickets` /
-   `learnings-audit`).
-2. The **ten contract sections** below it. Lisa owns them **only on first write**: seed each one
-   from this skill's per-loop defaults — what that loop maintains, what it reads, how it picks
-   candidates, its bounds, its proof, its approval boundary, its escalation, its recovery, its
-   next-run state, its retirement condition — written for a non-technical operator. After that they
-   belong to the operator.
+   `learnings-audit`). Its **first line inside the delimiters is a visible sentence**, so the
+   ownership boundary survives rendering to markdown where HTML comments disappear:
 
-**Re-run rule (idempotent, append-or-leave).** When the file already exists: rewrite the
+   ```text
+   Lisa rewrites this section on every /lisa:setup-automations run — edits here are lost. Your prose
+   belongs in the sections below.
+   ```
+
+   Immediately **below** the closing delimiter, write one more visible line — `Everything below is
+   yours.` — so an operator reading the rendered page knows where their half starts.
+2. The **ten contract sections** below it. Lisa owns them **only on first write**, then they belong
+   to the operator. Seed them deterministically, never improvised:
+   - **Intent, Sources of truth, Candidate selection, Scope/bounds, Retirement condition** come
+     from the per-loop seed table below.
+   - **Proof, Autonomous-vs-approval boundary, Escalation, Recovery, Next-run state** are derived
+     from **that loop's own SKILL.md** — named per loop in the table's last column — so the runbook
+     describes what the loop actually does rather than a generic paraphrase. Quote its behavior in
+     the operator's voice; if the skill file is unreadable, write one sentence saying the section
+     was not derivable and which file to read, and continue.
+
+   Every seeded sentence is written for a non-technical operator (`factory-model` rule 5).
+
+### Per-loop seed defaults
+
+One line each; expand them into the operator's voice, keep the meaning.
+
+| Loop | Intent | Sources of truth | Candidate selection | Scope/bounds | Retirement condition | Derive the other five from |
+|---|---|---|---|---|---|---|
+| **intake-repair** | Keeps the queues unstuck: work that stalled mid-flight gets diagnosed and moved again. | The PRD and build queues for this project, read through the tracker access layer. | Stuck or half-closed items — stalled in an in-progress role, terminal-labeled but still open, rollups whose children are all done — up to the `max_candidates` cap. | Only this project's configured queues; it repairs lifecycle state, never invents or closes real work. | Propose teardown when nothing has needed repair for a long quiet window AND this run found nothing. | `lisa-repair-intake/SKILL.md` |
+| **intake-prd** | Keeps PRDs moving: a PRD a human marked ready gets validated and decomposed into work items. | The configured PRD queue and its lifecycle roles, read through the source access layer. | The oldest PRD in the ready role, one per run. | Only this project's PRD queue; it never authors product intent, only validates and decomposes it. | Propose teardown when no PRD has entered the queue for a long quiet window AND this run proposed nothing. | `lisa-intake/SKILL.md` |
+| **intake-tickets** | Keeps the build queue moving: work items a human marked ready get built, reviewed, and shipped. | The configured tracker's build queue lanes plus each item's comments and linked PRs. | The oldest eligible leaf work item in the ready lane, one per run. | Only this repo's configured queue; containers with open children are repaired out, never built. | Propose teardown when no work item has entered this queue for a long quiet window AND this run proposed nothing. | `lisa-intake/SKILL.md` |
+| **monitor** | Keeps production honest: observability regressions become tracked work instead of silent decay. | The connected observability providers, each through its access layer, plus this project's `monitor.gapTiers` config. | The regressions and coverage gaps this cycle surfaced, capped per run. | Only this project's own services and dashboards; it files findings, it never changes production. | Propose teardown when the project has no connected observability surfaces AND this run found nothing. | `lisa-monitor/SKILL.md` |
+| **exploratory-prds** | Keeps the idea pipeline fed: the product's own gaps become PRDs when the PRD queue has room. | The PRD queue's pressure roles (the same ones `/lisa:queue-status` reports) and the project's own product surfaces. | One ideated PRD per run, and only when the pressure gate says the queue has capacity. | Never more than one PRD per run, and nothing at all while unresolved PRD pressure exists. | Propose teardown when the queue has been at pressure — or the project has shipped no new surface — across a long quiet window AND this run proposed nothing. | `lisa-project-ideation/SKILL.md` |
+| **exploratory-bugs** | Keeps quality visible: bugs and usability problems get found by using the product, before a customer does. | The running application through its exploratory-qa surface, plus this project's existing bug queue for dedupe. | The findings of one exploratory session, capped per run and deduped against already-filed items. | Only this project's own app; it files tickets, it never changes product code. | Propose teardown when no session has produced a finding across a long quiet window AND this run found nothing. | `lisa-exploratory-qa/SKILL.md` (the stack's own copy) |
+| **learnings-audit** | Keeps the project's knowledge true: stale, duplicated, or contradicted knowledge gets proposed for promotion, demotion, or retirement. | The learnings ledger, the rules trees, the skills, and the wiki — the project's knowledge surfaces. | The knowledge entries this audit judged stale, duplicated, or contradicted, capped per run. | It only proposes; every promote/demote/retire decision is a human-gated tracker ticket. | Propose teardown when the audit has proposed nothing across a long quiet window AND this run proposed nothing. | `lisa-learnings-audit/SKILL.md` |
+
+A loop not in this table — one registered later — seeds all ten sections from its own SKILL.md the
+same way. The table is seed prose for first write only; it is **not** a roster and never decides
+which automations exist.
+
+**Re-run rule (idempotent, never clobber).** When the file already exists: rewrite the
 machine-resolved block in place and **leave every one of the ten sections exactly as found** — an
-operator's edited Intent paragraph survives verbatim. If a section from the contract is **missing**
-from an existing file, append it with its seeded default; never overwrite, reorder, reword, or
-delete prose already on disk. If the machine-resolved delimiters are absent (a hand-written file),
-insert the block at the top and touch nothing else.
+operator's edited Intent paragraph survives verbatim. If a contract section is **missing** from an
+existing file, insert it **at its position in the contract's ten-section order** (never merely
+appended at the end, which would leave the file permanently out of order) with its seeded default.
+Never overwrite, reorder, reword, or delete prose already on disk. If the machine-resolved
+delimiters are absent (a hand-written file), insert the block at the top and touch nothing else.
 
 **Never a precondition.** A runbook that cannot be written is a **degradation, not a blocker**:
 report the failure and continue registering automations. A loop with a missing runbook still runs —
@@ -190,6 +224,15 @@ Then list each runbook written, by path (`.lisa/automations/<loop-id>.runbook.md
 whether it was **created** (seeded fresh) or **refreshed** (machine-resolved block rewritten,
 operator prose left untouched). Name every skipped loop again here and state plainly that it has no
 runbook because it was not registered, and why — for example, "exploratory-bugs was skipped because
-this project ships no exploratory-qa command, so no runbook was written for it." If a runbook could
-not be written, say which one and what failed; the automation itself is still registered. Write all
-of this so a non-technical operator can act on it without reading code.
+this project ships no exploratory-qa command, so no runbook was written for it."
+
+Close with the two lines that tell the operator what to do next:
+
+- When any runbook was newly created: "N new files were written under `.lisa/automations/` — commit
+  them so the whole team sees them."
+- When a runbook could not be written: name which one and what failed, then the consequence and the
+  fix — "that loop runs on defaults and its summaries will lead with 'Runbook missing' — re-run
+  `/lisa:setup-automations` to fix." The automation itself is still registered and still runs.
+
+Every line states the consequence and the action, in words a non-technical operator can act on
+without reading code.

--- a/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
@@ -105,6 +105,19 @@ the scheduled commands (for example `/lisa:intake acme/frontend intake_mode=prd`
 config/read-context failure cannot silently redirect the cron. A short queueRepo is normalized to
 `github.org` before writing the automation.
 
+**Registration prompt shape (so status can read the command back).** Whatever prose the prompt
+carries, it must contain the **literal Lisa command on a line of its own**, exactly as scheduled and
+with every `owner/repo` already baked in:
+
+```text
+/lisa:intake acme/planning intake_mode=build
+```
+
+This holds for loops that take **no arguments** too — `/lisa:monitor` and `/lisa:learnings:audit`
+are written the same way, on their own line, with nothing after them. `/lisa:automation-status`
+reads that line back to compare the live registration against this contract; a loop whose command
+cannot be read back reports as drifted even though it is registered correctly.
+
 **Naming + scope (so teardown is precise).** Name each automation with the stable prefix
 `lisa-auto-<project>-` (e.g. `lisa-auto-<project>-intake-tickets`), where `<project>` identifies this
 repo, and scope each Codex automation to the durable project automation checkout described above.

--- a/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lisa-setup-automations
 description: "Set up the recurring Lisa automations on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automations to create, how often, and with which parameters; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates six default automations: intake-repair (every 60 min), intake PRD (every 60 min), intake tickets (every 10 min), exploratory-bugs (once a day), exploratory-prds (once a day), monitor (once a day) — plus opt-in learnings-audit (once a week, the gardener). Three flags: auto-start-prds and auto-start-tickets control whether ideated PRDs / filed bug tickets are created auto-pickup-ready (prd_ready / ready, default true) or left for human review; learnings-audit (default false) opts into the weekly gardener loop. Tear down with /tear-down-automations."
-allowed-tools: ["Skill", "Bash", "Read"]
+allowed-tools: ["Skill", "Bash", "Read", "Write", "Edit"]
 ---
 
 # Set up Lisa automations: $ARGUMENTS
@@ -115,6 +115,57 @@ repos (don't rely on a bare repo basename when it could collide; qualify it, e.g
 **Idempotent.** Re-running this skill updates the existing `lisa-auto-<project>-*` automations in
 place (same names) rather than creating duplicates.
 
+## Runbook scaffolding
+
+Registration is what pulls a loop under the `automation-runbook-contract` rule, so registration is
+what must produce its runbook. For **every automation actually registered above** — including the
+conditionally-guarded `exploratory-bugs` and the opt-in `learnings-audit` — write a checked-in
+runbook at:
+
+```text
+.lisa/automations/<loop-id>.runbook.md
+```
+
+`<loop-id>` is the automation's suffix, not its full name: `intake-tickets`, not
+`lisa-auto-<project>-intake-tickets`. These files are **project knowledge and belong in git**, like
+`.lisa/PROJECT_LEARNINGS.md` — commit them; they are not scratch output. Derive the set of runbooks
+from what was registered on this run: a loop that was **skipped gets no runbook**, and a loop
+registered later gets one when this skill next runs. Never write a runbook from a fixed list of
+loop names.
+
+Follow the `automation-runbook-contract` rule for the runbook's shape: its ten sections, in its
+order, in its prose register. **Do not restate the template, the run outcomes, or the escalation
+packet here** — cite the rule and instantiate it.
+
+**File shape — two halves with different owners.**
+
+1. A **machine-resolved header block**, delimited exactly by
+   `<!-- lisa:machine-resolved:start -->` and `<!-- lisa:machine-resolved:end -->`, written first
+   in the file. Lisa owns it: on every run it is **rewritten wholesale** from the values resolved
+   above. It carries the project identity (`<owner>/<repo>` and the `<project>` token), the loop
+   id, the full automation name, the exact scheduled command with every `owner/repo` already baked
+   in (never a placeholder), the human cadence and its `rrule`, the resolved queue arguments, and
+   the resolved flag values that shaped the command (`auto-start-prds` / `auto-start-tickets` /
+   `learnings-audit`).
+2. The **ten contract sections** below it. Lisa owns them **only on first write**: seed each one
+   from this skill's per-loop defaults — what that loop maintains, what it reads, how it picks
+   candidates, its bounds, its proof, its approval boundary, its escalation, its recovery, its
+   next-run state, its retirement condition — written for a non-technical operator. After that they
+   belong to the operator.
+
+**Re-run rule (idempotent, append-or-leave).** When the file already exists: rewrite the
+machine-resolved block in place and **leave every one of the ten sections exactly as found** — an
+operator's edited Intent paragraph survives verbatim. If a section from the contract is **missing**
+from an existing file, append it with its seeded default; never overwrite, reorder, reword, or
+delete prose already on disk. If the machine-resolved delimiters are absent (a hand-written file),
+insert the block at the top and touch nothing else.
+
+**Never a precondition.** A runbook that cannot be written is a **degradation, not a blocker**:
+report the failure and continue registering automations. A loop with a missing runbook still runs —
+on the contract's defaults, saying so in its one-line summary — per the contract's
+never-block-always-degrade rule. Scaffolding failure never aborts setup and never leaves an
+automation unregistered.
+
 ## Conditions / guards
 
 - **exploratory-bugs** is created only when the project ships an `exploratory-qa` command (the
@@ -134,3 +185,11 @@ place (same names) rather than creating duplicates.
 
 List each automation created or updated (name, the command it runs, cadence, and the resolved
 `auto-start-prds` / `auto-start-tickets` values), plus any automation skipped and why.
+
+Then list each runbook written, by path (`.lisa/automations/<loop-id>.runbook.md`), saying for each
+whether it was **created** (seeded fresh) or **refreshed** (machine-resolved block rewritten,
+operator prose left untouched). Name every skipped loop again here and state plainly that it has no
+runbook because it was not registered, and why — for example, "exploratory-bugs was skipped because
+this project ships no exploratory-qa command, so no runbook was written for it." If a runbook could
+not be written, say which one and what failed; the automation itself is still registered. Write all
+of this so a non-technical operator can act on it without reading code.

--- a/plugins/lisa-agy/skills/lisa-tear-down-automations/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-tear-down-automations/SKILL.md
@@ -42,7 +42,13 @@ removes them with its **native** scheduling mechanism.
 
 ## Report
 
-List each automation removed by name, and any that the prefix sweep expected to find but that were
-already absent. State explicitly that the runbook files under `.lisa/automations/` were left on
-disk, and that nothing outside this project's `lisa-auto-<project>-` prefix was touched. Write it so
-a non-technical operator can confirm what happened without reading code.
+List each automation removed by name. For "already absent", compare against the one source of truth
+— the fleet `scripts/automation-status-expected-fleet.mjs` (`resolveExpectedAutomationFleet`)
+resolves for this project — and name anything it expects that the sweep did not find; that is a
+no-op, not an error. Do not invent an expected set of your own.
+
+Then state, in the operator's words, that the runbook files under `.lisa/automations/` were left on
+disk **and why**: they are the written record of what those jobs did, kept on purpose, and if you
+do not want them you delete them yourself in git. Finally, confirm that nothing outside this
+project's `lisa-auto-<project>-` prefix was touched. Write it so a non-technical operator can
+confirm what happened without reading code.

--- a/plugins/lisa-agy/skills/lisa-tear-down-automations/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-tear-down-automations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-tear-down-automations
-description: "Remove every recurring Lisa automation that /setup-automations created for this project (the lisa-auto-<project>-* set: intake-repair, intake-prd, intake-tickets, exploratory-bugs, exploratory-prds, monitor) using the CURRENT runtime's native scheduler — Codex automations or, on Claude, /schedule. This skill is a declarative specification: it identifies WHICH automations to remove; it does not run teardown scripts. Removes only this project's Lisa automations — never other projects' automations or non-Lisa ones. The inverse of /setup-automations."
+description: "Remove every recurring Lisa automation that /setup-automations registered for this project — whatever is actually registered under the lisa-auto-<project>-* prefix, including the opt-in learnings-audit gardener — using the CURRENT runtime's native scheduler — Codex automations or, on Claude, /schedule. This skill is a declarative specification: it identifies WHICH automations to remove; it does not run teardown scripts. Carries no fixed list of loops: the registration set is the roster. Removes only this project's Lisa automations — never other projects' automations or non-Lisa ones. Leaves checked-in runbook files on disk. The inverse of /setup-automations."
 allowed-tools: ["Skill", "Bash", "Read"]
 ---
 
@@ -21,14 +21,28 @@ removes them with its **native** scheduling mechanism.
 
 ## Scope (remove only what setup created)
 
-- Remove the six automations `/setup-automations` creates for the current project, matched by the
-  stable `lisa-auto-<project>-` name prefix: `intake-repair`, `intake-prd`, `intake-tickets`,
-  `exploratory-bugs`, `exploratory-prds`, `monitor`.
+- Remove **every** automation `/setup-automations` registered for the current project — the whole
+  set found under the stable `lisa-auto-<project>-` name prefix, whatever it currently contains.
+  **Membership is registration, not a roster** (`automation-runbook-contract`): sweep the prefix and
+  remove what is there. Do **not** work from a fixed list of loop names — a list drifts the moment a
+  loop is added, which is exactly how the opt-in gardener came to be orphaned.
+- This explicitly includes the opt-in **`learnings-audit`** gardener when it is registered:
+  `/setup-automations learnings-audit=true` registers it under the same prefix, so teardown removes
+  it with the rest. A conditionally-skipped loop (e.g. `exploratory-bugs` on a stack without
+  `exploratory-qa`) simply is not in the sweep.
 - **Never** remove automations for a different project, or any non-Lisa automation (e.g. unrelated
   crawlers/ingestors). Match strictly on the `lisa-auto-<project>-` prefix for THIS project; when in
   doubt about an automation's ownership, leave it and report it rather than deleting it.
-- **Idempotent** — an automation that is already absent is a no-op, not an error.
+- **Idempotent** — an automation that is already absent is a no-op, not an error. Re-running when
+  the prefix sweep finds nothing is a clean, successful no-op.
+- **Leave the runbooks alone.** The checked-in `.lisa/automations/<loop-id>.runbook.md` files that
+  `/setup-automations` scaffolded are project knowledge and the historical record of what these
+  loops did. Teardown removes scheduler registrations only; it never deletes, edits, or moves a
+  runbook file. An operator who wants them gone removes them deliberately, in git.
 
 ## Report
 
-List each automation removed, and any in the expected set that were already absent.
+List each automation removed by name, and any that the prefix sweep expected to find but that were
+already absent. State explicitly that the runbook files under `.lisa/automations/` were left on
+disk, and that nothing outside this project's `lisa-auto-<project>-` prefix was touched. Write it so
+a non-technical operator can confirm what happened without reading code.

--- a/plugins/lisa-copilot/scripts/automation-status-claude-adapter.mjs
+++ b/plugins/lisa-copilot/scripts/automation-status-claude-adapter.mjs
@@ -10,6 +10,11 @@
  */
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
+import {
+  assignToAutomationGroup,
+  createAutomationGroupBins,
+  renderAutomationGroups,
+} from "./automation-status-expected-fleet.mjs";
 
 const CLAUDE_RUNTIME_LABEL = "Claude /schedule";
 const CLAUDE_ACTIVE_STATUSES = new Set([
@@ -75,10 +80,7 @@ export function inspectClaudeAutomationFleet(input) {
     automationPrefix: expectedFleet.automationPrefix,
   });
 
-  const expectedGroups = new Map([
-    ["core", []],
-    ["exploratory", []],
-  ]);
+  const expectedGroups = createAutomationGroupBins();
 
   const comparisons = compareAutomationFleet({
     expectedAutomations: expectedFleet.expected,
@@ -87,7 +89,9 @@ export function inspectClaudeAutomationFleet(input) {
 
   for (const [index, expected] of expectedFleet.expected.entries()) {
     const comparison = comparisons[index];
-    expectedGroups.get(expected.group)?.push(
+    assignToAutomationGroup(
+      expectedGroups,
+      expected.group,
       createObservedStatusItem({
         expected,
         comparison,
@@ -97,7 +101,7 @@ export function inspectClaudeAutomationFleet(input) {
   }
 
   for (const unsupported of expectedFleet.unsupported) {
-    expectedGroups.get(unsupported.group)?.push({
+    assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
@@ -109,18 +113,7 @@ export function inspectClaudeAutomationFleet(input) {
   return {
     runtime: `${CLAUDE_RUNTIME_LABEL} listing`,
     generatedAt: now.toISOString(),
-    groups: [
-      {
-        id: "1",
-        title: "Core automations",
-        items: expectedGroups.get("core") ?? [],
-      },
-      {
-        id: "2",
-        title: "Exploratory automations",
-        items: expectedGroups.get("exploratory") ?? [],
-      },
-    ],
+    groups: renderAutomationGroups(expectedGroups),
     observedAutomations,
   };
 }
@@ -487,6 +480,13 @@ function normalizeClaudeRRule(value) {
   ) {
     return "FREQ=DAILY;INTERVAL=1";
   }
+  if (
+    cadence === "once a week" ||
+    cadence === "every week" ||
+    cadence === "weekly"
+  ) {
+    return "FREQ=WEEKLY;INTERVAL=1";
+  }
 
   const everyMinutes = cadence.match(/every (\d+) minutes?/);
   if (everyMinutes?.[1]) {
@@ -501,6 +501,11 @@ function normalizeClaudeRRule(value) {
   const everyDays = cadence.match(/every (\d+) days?/);
   if (everyDays?.[1]) {
     return `FREQ=DAILY;INTERVAL=${everyDays[1]}`;
+  }
+
+  const everyWeeks = cadence.match(/every (\d+) weeks?/);
+  if (everyWeeks?.[1]) {
+    return `FREQ=WEEKLY;INTERVAL=${everyWeeks[1]}`;
   }
 
   return undefined;
@@ -526,6 +531,9 @@ function humanizeClaudeCadence(value) {
   }
   if (normalized === "every day") {
     return "once a day";
+  }
+  if (normalized === "weekly" || normalized === "every week") {
+    return "once a week";
   }
   return normalized;
 }
@@ -556,6 +564,11 @@ function humanizeRRule(rrule) {
     return Number(daily[1]) === 1 ? "once a day" : `every ${daily[1]} days`;
   }
 
+  const weekly = rrule.match(/^FREQ=WEEKLY;INTERVAL=(\d+)$/);
+  if (weekly?.[1]) {
+    return Number(weekly[1]) === 1 ? "once a week" : `every ${weekly[1]} weeks`;
+  }
+
   return rrule;
 }
 
@@ -572,6 +585,11 @@ function cadenceLabelToIntervalMs(label) {
   const oncePerDay = new Set(["once a day", "daily"]);
   if (oncePerDay.has(label)) {
     return 24 * 60 * 60_000;
+  }
+
+  const oncePerWeek = new Set(["once a week", "weekly"]);
+  if (oncePerWeek.has(label)) {
+    return 7 * 24 * 60 * 60_000;
   }
 
   return null;

--- a/plugins/lisa-copilot/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa-copilot/scripts/automation-status-codex-adapter.mjs
@@ -17,6 +17,11 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
+import {
+  assignToAutomationGroup,
+  createAutomationGroupBins,
+  renderAutomationGroups,
+} from "./automation-status-expected-fleet.mjs";
 
 const CODEx_RUNTIME_LABEL = "Codex automations";
 const RUN_TIMESTAMP_PATTERN = /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/;
@@ -156,10 +161,7 @@ export async function inspectCodexAutomationFleet(input) {
     automationPrefix: expectedFleet.automationPrefix,
   });
 
-  const expectedGroups = new Map([
-    ["core", []],
-    ["exploratory", []],
-  ]);
+  const expectedGroups = createAutomationGroupBins();
 
   const comparisons = compareAutomationFleet({
     expectedAutomations: expectedFleet.expected,
@@ -168,7 +170,9 @@ export async function inspectCodexAutomationFleet(input) {
 
   for (const [index, expected] of expectedFleet.expected.entries()) {
     const comparison = comparisons[index];
-    expectedGroups.get(expected.group)?.push(
+    assignToAutomationGroup(
+      expectedGroups,
+      expected.group,
       createObservedStatusItem({
         expected,
         comparison,
@@ -178,7 +182,7 @@ export async function inspectCodexAutomationFleet(input) {
   }
 
   for (const unsupported of expectedFleet.unsupported) {
-    expectedGroups.get(unsupported.group)?.push({
+    assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
@@ -190,18 +194,7 @@ export async function inspectCodexAutomationFleet(input) {
   return {
     runtime: `${CODEx_RUNTIME_LABEL} (backing-store metadata)`,
     generatedAt: now.toISOString(),
-    groups: [
-      {
-        id: "1",
-        title: "Core automations",
-        items: expectedGroups.get("core") ?? [],
-      },
-      {
-        id: "2",
-        title: "Exploratory automations",
-        items: expectedGroups.get("exploratory") ?? [],
-      },
-    ],
+    groups: renderAutomationGroups(expectedGroups),
     observedAutomations,
   };
 }
@@ -583,6 +576,13 @@ function humanizeAutomationCadence(rrule) {
       : `every ${everyDays[1]} days`;
   }
 
+  const everyWeeks = rrule.match(/^FREQ=WEEKLY;INTERVAL=(\d+)$/);
+  if (everyWeeks?.[1]) {
+    return Number(everyWeeks[1]) === 1
+      ? "once a week"
+      : `every ${everyWeeks[1]} weeks`;
+  }
+
   return rrule;
 }
 
@@ -606,6 +606,11 @@ function rruleToIntervalMs(rrule) {
     return Number(daily[1]) * 24 * 60 * 60_000;
   }
 
+  const weekly = rrule.match(/^FREQ=WEEKLY;INTERVAL=(\d+)$/);
+  if (weekly?.[1]) {
+    return Number(weekly[1]) * 7 * 24 * 60 * 60_000;
+  }
+
   return null;
 }
 
@@ -621,6 +626,10 @@ function cadenceLabelToIntervalMs(label) {
 
   if (label === "once a day") {
     return 24 * 60 * 60_000;
+  }
+
+  if (label === "once a week") {
+    return 7 * 24 * 60 * 60_000;
   }
 
   return null;

--- a/plugins/lisa-copilot/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa-copilot/scripts/automation-status-codex-adapter.mjs
@@ -242,21 +242,35 @@ export function deriveCodexObservedCommand(prompt) {
     return undefined;
   }
 
+  // The "with arguments" clause is optional: no-argument loops (monitor, the
+  // gardener) register without one. Requiring it made every such loop derive an
+  // undefined command and report DRIFTED forever, un-fixable by re-running setup.
   const lisaSkillMatch = prompt.match(
-    /Use the Lisa ([a-z0-9:-]+) skill with arguments `([^`]+)`/i
+    /Use the Lisa ([a-z0-9:-]+) skill(?: with arguments `([^`]*)`)?/i
   );
-  if (lisaSkillMatch?.[1] && lisaSkillMatch[2]) {
-    return `/lisa:${lisaSkillMatch[1]} ${lisaSkillMatch[2]}`.trim();
+  if (lisaSkillMatch?.[1]) {
+    return `/lisa:${lisaSkillMatch[1]} ${lisaSkillMatch[2] ?? ""}`.trim();
   }
 
   const aliasSkillMatch = prompt.match(
-    /Use the `\$([a-z0-9:-]+)` skill with arguments `([^`]+)`/i
+    /Use the `\$([a-z0-9:-]+)` skill(?: with arguments `([^`]*)`)?/i
   );
-  if (aliasSkillMatch?.[1] && aliasSkillMatch[2]) {
-    return `${canonicalizeCodexSkillAlias(aliasSkillMatch[1])} ${aliasSkillMatch[2]}`.trim();
+  if (aliasSkillMatch?.[1]) {
+    return `${canonicalizeCodexSkillAlias(aliasSkillMatch[1])} ${aliasSkillMatch[2] ?? ""}`.trim();
   }
 
-  return undefined;
+  // A registration whose prompt carries the literal Lisa command on its own
+  // line — the shape `/lisa:setup-automations` bakes so a command that is not a
+  // plain skill name (`/lisa:learnings:audit`) round-trips exactly. Mirrors the
+  // Claude adapter, which has always accepted a bare `/lisa:` command. Codex
+  // stores prompts as single-line TOML, so a line break arrives either real or
+  // as the two-character escape `\n`; both delimit a line here.
+  const literalCommand = prompt
+    .split(/\r?\n|\\n/)
+    .map(segment => segment.trim())
+    .find(segment => /^\/lisa[:-]\S/.test(segment));
+
+  return literalCommand;
 }
 
 function canonicalizeCodexSkillAlias(alias) {

--- a/plugins/lisa-copilot/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa-copilot/scripts/automation-status-expected-fleet.mjs
@@ -56,6 +56,68 @@ export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
 export const AUTOMATION_RUNBOOK_DIRECTORY = ".lisa/automations";
 
 /**
+ * Every fleet group, in render order, with the operator-facing title each one
+ * carries in the status report. This is the single source of truth for group
+ * membership: adapters bin entries with {@link createAutomationGroupBins} and
+ * render with {@link renderAutomationGroups}, so adding a group here surfaces it
+ * everywhere instead of silently dropping its entries.
+ */
+export const AUTOMATION_FLEET_GROUP_TITLES = {
+  core: "Core automations",
+  exploratory: "Exploratory automations",
+  "opt-in": "Opt-in automations",
+};
+
+/**
+ * Create one empty bin per known fleet group.
+ *
+ * @returns {Map<string, object[]>}
+ */
+export function createAutomationGroupBins() {
+  return new Map(
+    Object.keys(AUTOMATION_FLEET_GROUP_TITLES).map(group => [group, []])
+  );
+}
+
+/**
+ * Add a rendered status item to its group bin.
+ *
+ * Throws on an unknown group rather than dropping the item: a silently skipped
+ * entry is indistinguishable from a healthy fleet, which is exactly how the
+ * opt-in gardener went missing from both runtime adapters.
+ *
+ * @param {Map<string, object[]>} bins
+ * @param {string} group
+ * @param {object} item
+ * @returns {void}
+ */
+export function assignToAutomationGroup(bins, group, item) {
+  const bin = bins.get(group);
+  if (!bin) {
+    throw new Error(
+      `Unknown automation fleet group "${group}" for ${item?.id ?? "an automation"}. Add it to AUTOMATION_FLEET_GROUP_TITLES so the status report can render it.`
+    );
+  }
+  bin.push(item);
+}
+
+/**
+ * Render the group bins as the numbered report groups, in declaration order.
+ *
+ * @param {Map<string, object[]>} bins
+ * @returns {readonly { readonly id: string, readonly title: string, readonly items: readonly object[] }[]}
+ */
+export function renderAutomationGroups(bins) {
+  return Object.entries(AUTOMATION_FLEET_GROUP_TITLES).map(
+    ([group, title], index) => ({
+      id: String(index + 1),
+      title,
+      items: bins.get(group) ?? [],
+    })
+  );
+}
+
+/**
  * @typedef {{
  *   readonly id: string
  *   readonly automationId: string
@@ -76,6 +138,27 @@ export const AUTOMATION_RUNBOOK_DIRECTORY = ".lisa/automations";
  *   readonly runbookPath: string
  * }} UnsupportedAutomationEntry
  */
+
+/**
+ * Infer whether this project opted into the weekly gardener, from what is
+ * actually registered on the scheduler.
+ *
+ * Membership is registration, not configuration: there is no config key to
+ * read, so a read-only caller decides by looking for the registration itself.
+ * Pass the result as `learningsAudit` to {@link resolveExpectedAutomationFleet}
+ * so an opted-in project compares its gardener like any other loop instead of
+ * reporting it `UNSUPPORTED` forever.
+ *
+ * @param {{
+ *   readonly automationPrefix: string
+ *   readonly observedAutomationIds?: readonly string[]
+ * }} input
+ * @returns {boolean}
+ */
+export function inferLearningsAuditRegistration(input) {
+  const target = `${input.automationPrefix}learnings-audit`;
+  return (input.observedAutomationIds ?? []).includes(target);
+}
 
 /**
  * Resolve the repo-relative runbook path for a loop id.
@@ -129,6 +212,13 @@ export function resolveAutomationProjectIdentity(input = {}) {
  *   readonly autoStartTickets?: boolean | string
  *   readonly learningsAudit?: boolean | string
  * }} input
+ *
+ * `learningsAudit` has no config home by design — the gardener is opted into at
+ * registration time, and membership is registration, not configuration. A
+ * read-only caller (the status surface) therefore INFERS it: pass `true` when a
+ * `<automationPrefix>learnings-audit` entry is observed on the runtime
+ * scheduler. Without that inference an opted-in project would report the
+ * gardener `UNSUPPORTED` forever instead of comparing it like any other loop.
  * @returns {{
  *   readonly owner: string
  *   readonly repo: string
@@ -220,7 +310,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
       createUnsupportedEntry(
         identity,
         "exploratory-bugs",
-        "This repository does not ship an exploratory-qa command surface.",
+        "This project ships no exploratory-qa command, so there is nothing for this loop to run. No action needed unless the project adds one.",
         "exploratory"
       )
     );
@@ -240,7 +330,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
       createUnsupportedEntry(
         identity,
         "learnings-audit",
-        "The weekly gardener loop is opt-in and this project has not opted in (learnings-audit=false).",
+        "The weekly gardener loop is opt-in and this project has not opted in, so nobody is auditing its knowledge surfaces. Run /lisa:setup-automations learnings-audit=true to enable it.",
         "opt-in"
       )
     );

--- a/plugins/lisa-copilot/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa-copilot/scripts/automation-status-expected-fleet.mjs
@@ -37,9 +37,23 @@ export const AUTOMATION_EXPECTED_CADENCES = {
     human: "once a day",
     rrule: "FREQ=DAILY;INTERVAL=1",
   },
+  monitor: {
+    human: "once a day",
+    rrule: "FREQ=DAILY;INTERVAL=1",
+  },
+  "learnings-audit": {
+    human: "once a week",
+    rrule: "FREQ=WEEKLY;INTERVAL=1",
+  },
 };
 
 export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
+
+/**
+ * Directory (repo-relative) holding the checked-in per-loop runbooks scaffolded
+ * by `/lisa:setup-automations` per the `automation-runbook-contract` rule.
+ */
+export const AUTOMATION_RUNBOOK_DIRECTORY = ".lisa/automations";
 
 /**
  * @typedef {{
@@ -48,18 +62,30 @@ export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
  *   readonly expectedCadence: string
  *   readonly expectedRRule: string
  *   readonly expectedCommand: string
- *   readonly group: "core" | "exploratory"
+ *   readonly group: "core" | "exploratory" | "opt-in"
+ *   readonly runbookPath: string
  * }} ExpectedAutomationEntry
  *
  * @typedef {{
  *   readonly id: string
  *   readonly automationId: string
- *   readonly group: "core" | "exploratory"
+ *   readonly group: "core" | "exploratory" | "opt-in"
  *   readonly reason: string
  *   readonly expectedCadence: string
  *   readonly expectedRRule: string
+ *   readonly runbookPath: string
  * }} UnsupportedAutomationEntry
  */
+
+/**
+ * Resolve the repo-relative runbook path for a loop id.
+ *
+ * @param {string} id
+ * @returns {string}
+ */
+export function resolveAutomationRunbookPath(id) {
+  return `${AUTOMATION_RUNBOOK_DIRECTORY}/${id}.runbook.md`;
+}
 
 /**
  * Resolve the stable project identifier and automation prefix used by
@@ -101,6 +127,7 @@ export function resolveAutomationProjectIdentity(input = {}) {
  *   readonly detectedTypes?: readonly string[]
  *   readonly autoStartPrds?: boolean | string
  *   readonly autoStartTickets?: boolean | string
+ *   readonly learningsAudit?: boolean | string
  * }} input
  * @returns {{
  *   readonly owner: string
@@ -116,6 +143,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
   const identity = resolveAutomationProjectIdentity(input);
   const autoStartPrds = normalizeBooleanFlag(input.autoStartPrds);
   const autoStartTickets = normalizeBooleanFlag(input.autoStartTickets);
+  const learningsAudit = normalizeBooleanFlag(input.learningsAudit);
   const detectedTypes = input.detectedTypes ?? [];
 
   const tracker = config.tracker;
@@ -166,6 +194,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
       `/lisa:intake ${buildQueue}`,
       "core"
     ),
+    createExpectedEntry(identity, "monitor", "/lisa:monitor", "core"),
     createExpectedEntry(
       identity,
       "exploratory-prds",
@@ -191,7 +220,28 @@ export function resolveExpectedAutomationFleet(input = {}) {
       createUnsupportedEntry(
         identity,
         "exploratory-bugs",
-        "This repository does not ship an exploratory-qa command surface."
+        "This repository does not ship an exploratory-qa command surface.",
+        "exploratory"
+      )
+    );
+  }
+
+  if (learningsAudit) {
+    expected.push(
+      createExpectedEntry(
+        identity,
+        "learnings-audit",
+        "/lisa:learnings:audit",
+        "opt-in"
+      )
+    );
+  } else {
+    unsupported.push(
+      createUnsupportedEntry(
+        identity,
+        "learnings-audit",
+        "The weekly gardener loop is opt-in and this project has not opted in (learnings-audit=false).",
+        "opt-in"
       )
     );
   }
@@ -222,7 +272,7 @@ export function resolveExploratoryQaStack(detectedTypes = []) {
  * @param {{ readonly automationPrefix: string }} identity
  * @param {string} id
  * @param {string} expectedCommand
- * @param {"core" | "exploratory"} group
+ * @param {"core" | "exploratory" | "opt-in"} group
  * @returns {ExpectedAutomationEntry}
  */
 function createExpectedEntry(identity, id, expectedCommand, group) {
@@ -234,6 +284,7 @@ function createExpectedEntry(identity, id, expectedCommand, group) {
     expectedRRule: cadence.rrule,
     expectedCommand,
     group,
+    runbookPath: resolveAutomationRunbookPath(id),
   };
 }
 
@@ -241,17 +292,19 @@ function createExpectedEntry(identity, id, expectedCommand, group) {
  * @param {{ readonly automationPrefix: string }} identity
  * @param {string} id
  * @param {string} reason
+ * @param {"core" | "exploratory" | "opt-in"} group
  * @returns {UnsupportedAutomationEntry}
  */
-function createUnsupportedEntry(identity, id, reason) {
+function createUnsupportedEntry(identity, id, reason, group) {
   const cadence = AUTOMATION_EXPECTED_CADENCES[id];
   return {
     id,
     automationId: `${identity.automationPrefix}${id}`,
     expectedCadence: cadence.human,
     expectedRRule: cadence.rrule,
-    group: "exploratory",
+    group,
     reason,
+    runbookPath: resolveAutomationRunbookPath(id),
   };
 }
 

--- a/plugins/lisa-copilot/skills/lisa-automation-status/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-automation-status/SKILL.md
@@ -23,6 +23,14 @@ exactly what `setup-automations` registers for this repo — including the stack
 roster** (`automation-runbook-contract`): carry no fixed list of loop names here, so a loop added to
 or removed from the registration set flows through without editing this skill.
 
+The gardener is opted into at registration time and has no config key, so **infer it from the
+scheduler**: list the project's automations first, then call
+`inferLearningsAuditRegistration({ automationPrefix, observedAutomationIds })` and pass the result
+as `learningsAudit` when resolving the fleet. A `lisa-auto-<project>-learnings-audit` entry on the
+scheduler means the project opted in, so the gardener is compared like any other loop; no such entry
+means it is reported `UNSUPPORTED` (opted out), never `MISSING`. This skill stays read-only — it
+infers, it never writes the flag anywhere.
+
 Resolve the expected project identifier, fleet naming prefix, queue arguments, cadence, and stack-support rules from the same contract used by `setup-automations` and `tear-down-automations`. Do **not** invent a second source of truth for fleet naming or queue resolution.
 
 ## Runtime inspection

--- a/plugins/lisa-copilot/skills/lisa-automation-status/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-automation-status/SKILL.md
@@ -16,14 +16,12 @@ Do **not** ask for confirmation once invoked. This skill inspects scheduler stat
 
 ## Scope
 
-Inspect only the Lisa automation fleet for the current project:
-
-- `intake-repair`
-- `intake-prd`
-- `intake-tickets`
-- `exploratory-bugs` when the current stack supports `exploratory-qa`
-- `exploratory-prds`
-- `monitor`
+Inspect only the Lisa automation fleet for the current project. Derive that fleet from
+`scripts/automation-status-expected-fleet.mjs` (`resolveExpectedAutomationFleet`), which resolves
+exactly what `setup-automations` registers for this repo — including the stack-guarded
+`exploratory-bugs` and the opt-in `learnings-audit` gardener. **Membership is registration, not a
+roster** (`automation-runbook-contract`): carry no fixed list of loop names here, so a loop added to
+or removed from the registration set flows through without editing this skill.
 
 Resolve the expected project identifier, fleet naming prefix, queue arguments, cadence, and stack-support rules from the same contract used by `setup-automations` and `tear-down-automations`. Do **not** invent a second source of truth for fleet naming or queue resolution.
 

--- a/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
@@ -146,19 +146,53 @@ packet here** — cite the rule and instantiate it.
    id, the full automation name, the exact scheduled command with every `owner/repo` already baked
    in (never a placeholder), the human cadence and its `rrule`, the resolved queue arguments, and
    the resolved flag values that shaped the command (`auto-start-prds` / `auto-start-tickets` /
-   `learnings-audit`).
-2. The **ten contract sections** below it. Lisa owns them **only on first write**: seed each one
-   from this skill's per-loop defaults — what that loop maintains, what it reads, how it picks
-   candidates, its bounds, its proof, its approval boundary, its escalation, its recovery, its
-   next-run state, its retirement condition — written for a non-technical operator. After that they
-   belong to the operator.
+   `learnings-audit`). Its **first line inside the delimiters is a visible sentence**, so the
+   ownership boundary survives rendering to markdown where HTML comments disappear:
 
-**Re-run rule (idempotent, append-or-leave).** When the file already exists: rewrite the
+   ```text
+   Lisa rewrites this section on every /lisa:setup-automations run — edits here are lost. Your prose
+   belongs in the sections below.
+   ```
+
+   Immediately **below** the closing delimiter, write one more visible line — `Everything below is
+   yours.` — so an operator reading the rendered page knows where their half starts.
+2. The **ten contract sections** below it. Lisa owns them **only on first write**, then they belong
+   to the operator. Seed them deterministically, never improvised:
+   - **Intent, Sources of truth, Candidate selection, Scope/bounds, Retirement condition** come
+     from the per-loop seed table below.
+   - **Proof, Autonomous-vs-approval boundary, Escalation, Recovery, Next-run state** are derived
+     from **that loop's own SKILL.md** — named per loop in the table's last column — so the runbook
+     describes what the loop actually does rather than a generic paraphrase. Quote its behavior in
+     the operator's voice; if the skill file is unreadable, write one sentence saying the section
+     was not derivable and which file to read, and continue.
+
+   Every seeded sentence is written for a non-technical operator (`factory-model` rule 5).
+
+### Per-loop seed defaults
+
+One line each; expand them into the operator's voice, keep the meaning.
+
+| Loop | Intent | Sources of truth | Candidate selection | Scope/bounds | Retirement condition | Derive the other five from |
+|---|---|---|---|---|---|---|
+| **intake-repair** | Keeps the queues unstuck: work that stalled mid-flight gets diagnosed and moved again. | The PRD and build queues for this project, read through the tracker access layer. | Stuck or half-closed items — stalled in an in-progress role, terminal-labeled but still open, rollups whose children are all done — up to the `max_candidates` cap. | Only this project's configured queues; it repairs lifecycle state, never invents or closes real work. | Propose teardown when nothing has needed repair for a long quiet window AND this run found nothing. | `lisa-repair-intake/SKILL.md` |
+| **intake-prd** | Keeps PRDs moving: a PRD a human marked ready gets validated and decomposed into work items. | The configured PRD queue and its lifecycle roles, read through the source access layer. | The oldest PRD in the ready role, one per run. | Only this project's PRD queue; it never authors product intent, only validates and decomposes it. | Propose teardown when no PRD has entered the queue for a long quiet window AND this run proposed nothing. | `lisa-intake/SKILL.md` |
+| **intake-tickets** | Keeps the build queue moving: work items a human marked ready get built, reviewed, and shipped. | The configured tracker's build queue lanes plus each item's comments and linked PRs. | The oldest eligible leaf work item in the ready lane, one per run. | Only this repo's configured queue; containers with open children are repaired out, never built. | Propose teardown when no work item has entered this queue for a long quiet window AND this run proposed nothing. | `lisa-intake/SKILL.md` |
+| **monitor** | Keeps production honest: observability regressions become tracked work instead of silent decay. | The connected observability providers, each through its access layer, plus this project's `monitor.gapTiers` config. | The regressions and coverage gaps this cycle surfaced, capped per run. | Only this project's own services and dashboards; it files findings, it never changes production. | Propose teardown when the project has no connected observability surfaces AND this run found nothing. | `lisa-monitor/SKILL.md` |
+| **exploratory-prds** | Keeps the idea pipeline fed: the product's own gaps become PRDs when the PRD queue has room. | The PRD queue's pressure roles (the same ones `/lisa:queue-status` reports) and the project's own product surfaces. | One ideated PRD per run, and only when the pressure gate says the queue has capacity. | Never more than one PRD per run, and nothing at all while unresolved PRD pressure exists. | Propose teardown when the queue has been at pressure — or the project has shipped no new surface — across a long quiet window AND this run proposed nothing. | `lisa-project-ideation/SKILL.md` |
+| **exploratory-bugs** | Keeps quality visible: bugs and usability problems get found by using the product, before a customer does. | The running application through its exploratory-qa surface, plus this project's existing bug queue for dedupe. | The findings of one exploratory session, capped per run and deduped against already-filed items. | Only this project's own app; it files tickets, it never changes product code. | Propose teardown when no session has produced a finding across a long quiet window AND this run found nothing. | `lisa-exploratory-qa/SKILL.md` (the stack's own copy) |
+| **learnings-audit** | Keeps the project's knowledge true: stale, duplicated, or contradicted knowledge gets proposed for promotion, demotion, or retirement. | The learnings ledger, the rules trees, the skills, and the wiki — the project's knowledge surfaces. | The knowledge entries this audit judged stale, duplicated, or contradicted, capped per run. | It only proposes; every promote/demote/retire decision is a human-gated tracker ticket. | Propose teardown when the audit has proposed nothing across a long quiet window AND this run proposed nothing. | `lisa-learnings-audit/SKILL.md` |
+
+A loop not in this table — one registered later — seeds all ten sections from its own SKILL.md the
+same way. The table is seed prose for first write only; it is **not** a roster and never decides
+which automations exist.
+
+**Re-run rule (idempotent, never clobber).** When the file already exists: rewrite the
 machine-resolved block in place and **leave every one of the ten sections exactly as found** — an
-operator's edited Intent paragraph survives verbatim. If a section from the contract is **missing**
-from an existing file, append it with its seeded default; never overwrite, reorder, reword, or
-delete prose already on disk. If the machine-resolved delimiters are absent (a hand-written file),
-insert the block at the top and touch nothing else.
+operator's edited Intent paragraph survives verbatim. If a contract section is **missing** from an
+existing file, insert it **at its position in the contract's ten-section order** (never merely
+appended at the end, which would leave the file permanently out of order) with its seeded default.
+Never overwrite, reorder, reword, or delete prose already on disk. If the machine-resolved
+delimiters are absent (a hand-written file), insert the block at the top and touch nothing else.
 
 **Never a precondition.** A runbook that cannot be written is a **degradation, not a blocker**:
 report the failure and continue registering automations. A loop with a missing runbook still runs —
@@ -190,6 +224,15 @@ Then list each runbook written, by path (`.lisa/automations/<loop-id>.runbook.md
 whether it was **created** (seeded fresh) or **refreshed** (machine-resolved block rewritten,
 operator prose left untouched). Name every skipped loop again here and state plainly that it has no
 runbook because it was not registered, and why — for example, "exploratory-bugs was skipped because
-this project ships no exploratory-qa command, so no runbook was written for it." If a runbook could
-not be written, say which one and what failed; the automation itself is still registered. Write all
-of this so a non-technical operator can act on it without reading code.
+this project ships no exploratory-qa command, so no runbook was written for it."
+
+Close with the two lines that tell the operator what to do next:
+
+- When any runbook was newly created: "N new files were written under `.lisa/automations/` — commit
+  them so the whole team sees them."
+- When a runbook could not be written: name which one and what failed, then the consequence and the
+  fix — "that loop runs on defaults and its summaries will lead with 'Runbook missing' — re-run
+  `/lisa:setup-automations` to fix." The automation itself is still registered and still runs.
+
+Every line states the consequence and the action, in words a non-technical operator can act on
+without reading code.

--- a/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
@@ -105,6 +105,19 @@ the scheduled commands (for example `/lisa:intake acme/frontend intake_mode=prd`
 config/read-context failure cannot silently redirect the cron. A short queueRepo is normalized to
 `github.org` before writing the automation.
 
+**Registration prompt shape (so status can read the command back).** Whatever prose the prompt
+carries, it must contain the **literal Lisa command on a line of its own**, exactly as scheduled and
+with every `owner/repo` already baked in:
+
+```text
+/lisa:intake acme/planning intake_mode=build
+```
+
+This holds for loops that take **no arguments** too — `/lisa:monitor` and `/lisa:learnings:audit`
+are written the same way, on their own line, with nothing after them. `/lisa:automation-status`
+reads that line back to compare the live registration against this contract; a loop whose command
+cannot be read back reports as drifted even though it is registered correctly.
+
 **Naming + scope (so teardown is precise).** Name each automation with the stable prefix
 `lisa-auto-<project>-` (e.g. `lisa-auto-<project>-intake-tickets`), where `<project>` identifies this
 repo, and scope each Codex automation to the durable project automation checkout described above.

--- a/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lisa-setup-automations
 description: "Set up the recurring Lisa automations on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automations to create, how often, and with which parameters; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates six default automations: intake-repair (every 60 min), intake PRD (every 60 min), intake tickets (every 10 min), exploratory-bugs (once a day), exploratory-prds (once a day), monitor (once a day) — plus opt-in learnings-audit (once a week, the gardener). Three flags: auto-start-prds and auto-start-tickets control whether ideated PRDs / filed bug tickets are created auto-pickup-ready (prd_ready / ready, default true) or left for human review; learnings-audit (default false) opts into the weekly gardener loop. Tear down with /tear-down-automations."
-allowed-tools: ["Skill", "Bash", "Read"]
+allowed-tools: ["Skill", "Bash", "Read", "Write", "Edit"]
 ---
 
 # Set up Lisa automations: $ARGUMENTS
@@ -115,6 +115,57 @@ repos (don't rely on a bare repo basename when it could collide; qualify it, e.g
 **Idempotent.** Re-running this skill updates the existing `lisa-auto-<project>-*` automations in
 place (same names) rather than creating duplicates.
 
+## Runbook scaffolding
+
+Registration is what pulls a loop under the `automation-runbook-contract` rule, so registration is
+what must produce its runbook. For **every automation actually registered above** — including the
+conditionally-guarded `exploratory-bugs` and the opt-in `learnings-audit` — write a checked-in
+runbook at:
+
+```text
+.lisa/automations/<loop-id>.runbook.md
+```
+
+`<loop-id>` is the automation's suffix, not its full name: `intake-tickets`, not
+`lisa-auto-<project>-intake-tickets`. These files are **project knowledge and belong in git**, like
+`.lisa/PROJECT_LEARNINGS.md` — commit them; they are not scratch output. Derive the set of runbooks
+from what was registered on this run: a loop that was **skipped gets no runbook**, and a loop
+registered later gets one when this skill next runs. Never write a runbook from a fixed list of
+loop names.
+
+Follow the `automation-runbook-contract` rule for the runbook's shape: its ten sections, in its
+order, in its prose register. **Do not restate the template, the run outcomes, or the escalation
+packet here** — cite the rule and instantiate it.
+
+**File shape — two halves with different owners.**
+
+1. A **machine-resolved header block**, delimited exactly by
+   `<!-- lisa:machine-resolved:start -->` and `<!-- lisa:machine-resolved:end -->`, written first
+   in the file. Lisa owns it: on every run it is **rewritten wholesale** from the values resolved
+   above. It carries the project identity (`<owner>/<repo>` and the `<project>` token), the loop
+   id, the full automation name, the exact scheduled command with every `owner/repo` already baked
+   in (never a placeholder), the human cadence and its `rrule`, the resolved queue arguments, and
+   the resolved flag values that shaped the command (`auto-start-prds` / `auto-start-tickets` /
+   `learnings-audit`).
+2. The **ten contract sections** below it. Lisa owns them **only on first write**: seed each one
+   from this skill's per-loop defaults — what that loop maintains, what it reads, how it picks
+   candidates, its bounds, its proof, its approval boundary, its escalation, its recovery, its
+   next-run state, its retirement condition — written for a non-technical operator. After that they
+   belong to the operator.
+
+**Re-run rule (idempotent, append-or-leave).** When the file already exists: rewrite the
+machine-resolved block in place and **leave every one of the ten sections exactly as found** — an
+operator's edited Intent paragraph survives verbatim. If a section from the contract is **missing**
+from an existing file, append it with its seeded default; never overwrite, reorder, reword, or
+delete prose already on disk. If the machine-resolved delimiters are absent (a hand-written file),
+insert the block at the top and touch nothing else.
+
+**Never a precondition.** A runbook that cannot be written is a **degradation, not a blocker**:
+report the failure and continue registering automations. A loop with a missing runbook still runs —
+on the contract's defaults, saying so in its one-line summary — per the contract's
+never-block-always-degrade rule. Scaffolding failure never aborts setup and never leaves an
+automation unregistered.
+
 ## Conditions / guards
 
 - **exploratory-bugs** is created only when the project ships an `exploratory-qa` command (the
@@ -134,3 +185,11 @@ place (same names) rather than creating duplicates.
 
 List each automation created or updated (name, the command it runs, cadence, and the resolved
 `auto-start-prds` / `auto-start-tickets` values), plus any automation skipped and why.
+
+Then list each runbook written, by path (`.lisa/automations/<loop-id>.runbook.md`), saying for each
+whether it was **created** (seeded fresh) or **refreshed** (machine-resolved block rewritten,
+operator prose left untouched). Name every skipped loop again here and state plainly that it has no
+runbook because it was not registered, and why — for example, "exploratory-bugs was skipped because
+this project ships no exploratory-qa command, so no runbook was written for it." If a runbook could
+not be written, say which one and what failed; the automation itself is still registered. Write all
+of this so a non-technical operator can act on it without reading code.

--- a/plugins/lisa-copilot/skills/lisa-tear-down-automations/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-tear-down-automations/SKILL.md
@@ -42,7 +42,13 @@ removes them with its **native** scheduling mechanism.
 
 ## Report
 
-List each automation removed by name, and any that the prefix sweep expected to find but that were
-already absent. State explicitly that the runbook files under `.lisa/automations/` were left on
-disk, and that nothing outside this project's `lisa-auto-<project>-` prefix was touched. Write it so
-a non-technical operator can confirm what happened without reading code.
+List each automation removed by name. For "already absent", compare against the one source of truth
+— the fleet `scripts/automation-status-expected-fleet.mjs` (`resolveExpectedAutomationFleet`)
+resolves for this project — and name anything it expects that the sweep did not find; that is a
+no-op, not an error. Do not invent an expected set of your own.
+
+Then state, in the operator's words, that the runbook files under `.lisa/automations/` were left on
+disk **and why**: they are the written record of what those jobs did, kept on purpose, and if you
+do not want them you delete them yourself in git. Finally, confirm that nothing outside this
+project's `lisa-auto-<project>-` prefix was touched. Write it so a non-technical operator can
+confirm what happened without reading code.

--- a/plugins/lisa-copilot/skills/lisa-tear-down-automations/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-tear-down-automations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-tear-down-automations
-description: "Remove every recurring Lisa automation that /setup-automations created for this project (the lisa-auto-<project>-* set: intake-repair, intake-prd, intake-tickets, exploratory-bugs, exploratory-prds, monitor) using the CURRENT runtime's native scheduler — Codex automations or, on Claude, /schedule. This skill is a declarative specification: it identifies WHICH automations to remove; it does not run teardown scripts. Removes only this project's Lisa automations — never other projects' automations or non-Lisa ones. The inverse of /setup-automations."
+description: "Remove every recurring Lisa automation that /setup-automations registered for this project — whatever is actually registered under the lisa-auto-<project>-* prefix, including the opt-in learnings-audit gardener — using the CURRENT runtime's native scheduler — Codex automations or, on Claude, /schedule. This skill is a declarative specification: it identifies WHICH automations to remove; it does not run teardown scripts. Carries no fixed list of loops: the registration set is the roster. Removes only this project's Lisa automations — never other projects' automations or non-Lisa ones. Leaves checked-in runbook files on disk. The inverse of /setup-automations."
 allowed-tools: ["Skill", "Bash", "Read"]
 ---
 
@@ -21,14 +21,28 @@ removes them with its **native** scheduling mechanism.
 
 ## Scope (remove only what setup created)
 
-- Remove the six automations `/setup-automations` creates for the current project, matched by the
-  stable `lisa-auto-<project>-` name prefix: `intake-repair`, `intake-prd`, `intake-tickets`,
-  `exploratory-bugs`, `exploratory-prds`, `monitor`.
+- Remove **every** automation `/setup-automations` registered for the current project — the whole
+  set found under the stable `lisa-auto-<project>-` name prefix, whatever it currently contains.
+  **Membership is registration, not a roster** (`automation-runbook-contract`): sweep the prefix and
+  remove what is there. Do **not** work from a fixed list of loop names — a list drifts the moment a
+  loop is added, which is exactly how the opt-in gardener came to be orphaned.
+- This explicitly includes the opt-in **`learnings-audit`** gardener when it is registered:
+  `/setup-automations learnings-audit=true` registers it under the same prefix, so teardown removes
+  it with the rest. A conditionally-skipped loop (e.g. `exploratory-bugs` on a stack without
+  `exploratory-qa`) simply is not in the sweep.
 - **Never** remove automations for a different project, or any non-Lisa automation (e.g. unrelated
   crawlers/ingestors). Match strictly on the `lisa-auto-<project>-` prefix for THIS project; when in
   doubt about an automation's ownership, leave it and report it rather than deleting it.
-- **Idempotent** — an automation that is already absent is a no-op, not an error.
+- **Idempotent** — an automation that is already absent is a no-op, not an error. Re-running when
+  the prefix sweep finds nothing is a clean, successful no-op.
+- **Leave the runbooks alone.** The checked-in `.lisa/automations/<loop-id>.runbook.md` files that
+  `/setup-automations` scaffolded are project knowledge and the historical record of what these
+  loops did. Teardown removes scheduler registrations only; it never deletes, edits, or moves a
+  runbook file. An operator who wants them gone removes them deliberately, in git.
 
 ## Report
 
-List each automation removed, and any in the expected set that were already absent.
+List each automation removed by name, and any that the prefix sweep expected to find but that were
+already absent. State explicitly that the runbook files under `.lisa/automations/` were left on
+disk, and that nothing outside this project's `lisa-auto-<project>-` prefix was touched. Write it so
+a non-technical operator can confirm what happened without reading code.

--- a/plugins/lisa-cursor/scripts/automation-status-claude-adapter.mjs
+++ b/plugins/lisa-cursor/scripts/automation-status-claude-adapter.mjs
@@ -10,6 +10,11 @@
  */
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
+import {
+  assignToAutomationGroup,
+  createAutomationGroupBins,
+  renderAutomationGroups,
+} from "./automation-status-expected-fleet.mjs";
 
 const CLAUDE_RUNTIME_LABEL = "Claude /schedule";
 const CLAUDE_ACTIVE_STATUSES = new Set([
@@ -75,10 +80,7 @@ export function inspectClaudeAutomationFleet(input) {
     automationPrefix: expectedFleet.automationPrefix,
   });
 
-  const expectedGroups = new Map([
-    ["core", []],
-    ["exploratory", []],
-  ]);
+  const expectedGroups = createAutomationGroupBins();
 
   const comparisons = compareAutomationFleet({
     expectedAutomations: expectedFleet.expected,
@@ -87,7 +89,9 @@ export function inspectClaudeAutomationFleet(input) {
 
   for (const [index, expected] of expectedFleet.expected.entries()) {
     const comparison = comparisons[index];
-    expectedGroups.get(expected.group)?.push(
+    assignToAutomationGroup(
+      expectedGroups,
+      expected.group,
       createObservedStatusItem({
         expected,
         comparison,
@@ -97,7 +101,7 @@ export function inspectClaudeAutomationFleet(input) {
   }
 
   for (const unsupported of expectedFleet.unsupported) {
-    expectedGroups.get(unsupported.group)?.push({
+    assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
@@ -109,18 +113,7 @@ export function inspectClaudeAutomationFleet(input) {
   return {
     runtime: `${CLAUDE_RUNTIME_LABEL} listing`,
     generatedAt: now.toISOString(),
-    groups: [
-      {
-        id: "1",
-        title: "Core automations",
-        items: expectedGroups.get("core") ?? [],
-      },
-      {
-        id: "2",
-        title: "Exploratory automations",
-        items: expectedGroups.get("exploratory") ?? [],
-      },
-    ],
+    groups: renderAutomationGroups(expectedGroups),
     observedAutomations,
   };
 }
@@ -487,6 +480,13 @@ function normalizeClaudeRRule(value) {
   ) {
     return "FREQ=DAILY;INTERVAL=1";
   }
+  if (
+    cadence === "once a week" ||
+    cadence === "every week" ||
+    cadence === "weekly"
+  ) {
+    return "FREQ=WEEKLY;INTERVAL=1";
+  }
 
   const everyMinutes = cadence.match(/every (\d+) minutes?/);
   if (everyMinutes?.[1]) {
@@ -501,6 +501,11 @@ function normalizeClaudeRRule(value) {
   const everyDays = cadence.match(/every (\d+) days?/);
   if (everyDays?.[1]) {
     return `FREQ=DAILY;INTERVAL=${everyDays[1]}`;
+  }
+
+  const everyWeeks = cadence.match(/every (\d+) weeks?/);
+  if (everyWeeks?.[1]) {
+    return `FREQ=WEEKLY;INTERVAL=${everyWeeks[1]}`;
   }
 
   return undefined;
@@ -526,6 +531,9 @@ function humanizeClaudeCadence(value) {
   }
   if (normalized === "every day") {
     return "once a day";
+  }
+  if (normalized === "weekly" || normalized === "every week") {
+    return "once a week";
   }
   return normalized;
 }
@@ -556,6 +564,11 @@ function humanizeRRule(rrule) {
     return Number(daily[1]) === 1 ? "once a day" : `every ${daily[1]} days`;
   }
 
+  const weekly = rrule.match(/^FREQ=WEEKLY;INTERVAL=(\d+)$/);
+  if (weekly?.[1]) {
+    return Number(weekly[1]) === 1 ? "once a week" : `every ${weekly[1]} weeks`;
+  }
+
   return rrule;
 }
 
@@ -572,6 +585,11 @@ function cadenceLabelToIntervalMs(label) {
   const oncePerDay = new Set(["once a day", "daily"]);
   if (oncePerDay.has(label)) {
     return 24 * 60 * 60_000;
+  }
+
+  const oncePerWeek = new Set(["once a week", "weekly"]);
+  if (oncePerWeek.has(label)) {
+    return 7 * 24 * 60 * 60_000;
   }
 
   return null;

--- a/plugins/lisa-cursor/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa-cursor/scripts/automation-status-codex-adapter.mjs
@@ -17,6 +17,11 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
+import {
+  assignToAutomationGroup,
+  createAutomationGroupBins,
+  renderAutomationGroups,
+} from "./automation-status-expected-fleet.mjs";
 
 const CODEx_RUNTIME_LABEL = "Codex automations";
 const RUN_TIMESTAMP_PATTERN = /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/;
@@ -156,10 +161,7 @@ export async function inspectCodexAutomationFleet(input) {
     automationPrefix: expectedFleet.automationPrefix,
   });
 
-  const expectedGroups = new Map([
-    ["core", []],
-    ["exploratory", []],
-  ]);
+  const expectedGroups = createAutomationGroupBins();
 
   const comparisons = compareAutomationFleet({
     expectedAutomations: expectedFleet.expected,
@@ -168,7 +170,9 @@ export async function inspectCodexAutomationFleet(input) {
 
   for (const [index, expected] of expectedFleet.expected.entries()) {
     const comparison = comparisons[index];
-    expectedGroups.get(expected.group)?.push(
+    assignToAutomationGroup(
+      expectedGroups,
+      expected.group,
       createObservedStatusItem({
         expected,
         comparison,
@@ -178,7 +182,7 @@ export async function inspectCodexAutomationFleet(input) {
   }
 
   for (const unsupported of expectedFleet.unsupported) {
-    expectedGroups.get(unsupported.group)?.push({
+    assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
@@ -190,18 +194,7 @@ export async function inspectCodexAutomationFleet(input) {
   return {
     runtime: `${CODEx_RUNTIME_LABEL} (backing-store metadata)`,
     generatedAt: now.toISOString(),
-    groups: [
-      {
-        id: "1",
-        title: "Core automations",
-        items: expectedGroups.get("core") ?? [],
-      },
-      {
-        id: "2",
-        title: "Exploratory automations",
-        items: expectedGroups.get("exploratory") ?? [],
-      },
-    ],
+    groups: renderAutomationGroups(expectedGroups),
     observedAutomations,
   };
 }
@@ -583,6 +576,13 @@ function humanizeAutomationCadence(rrule) {
       : `every ${everyDays[1]} days`;
   }
 
+  const everyWeeks = rrule.match(/^FREQ=WEEKLY;INTERVAL=(\d+)$/);
+  if (everyWeeks?.[1]) {
+    return Number(everyWeeks[1]) === 1
+      ? "once a week"
+      : `every ${everyWeeks[1]} weeks`;
+  }
+
   return rrule;
 }
 
@@ -606,6 +606,11 @@ function rruleToIntervalMs(rrule) {
     return Number(daily[1]) * 24 * 60 * 60_000;
   }
 
+  const weekly = rrule.match(/^FREQ=WEEKLY;INTERVAL=(\d+)$/);
+  if (weekly?.[1]) {
+    return Number(weekly[1]) * 7 * 24 * 60 * 60_000;
+  }
+
   return null;
 }
 
@@ -621,6 +626,10 @@ function cadenceLabelToIntervalMs(label) {
 
   if (label === "once a day") {
     return 24 * 60 * 60_000;
+  }
+
+  if (label === "once a week") {
+    return 7 * 24 * 60 * 60_000;
   }
 
   return null;

--- a/plugins/lisa-cursor/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa-cursor/scripts/automation-status-codex-adapter.mjs
@@ -242,21 +242,35 @@ export function deriveCodexObservedCommand(prompt) {
     return undefined;
   }
 
+  // The "with arguments" clause is optional: no-argument loops (monitor, the
+  // gardener) register without one. Requiring it made every such loop derive an
+  // undefined command and report DRIFTED forever, un-fixable by re-running setup.
   const lisaSkillMatch = prompt.match(
-    /Use the Lisa ([a-z0-9:-]+) skill with arguments `([^`]+)`/i
+    /Use the Lisa ([a-z0-9:-]+) skill(?: with arguments `([^`]*)`)?/i
   );
-  if (lisaSkillMatch?.[1] && lisaSkillMatch[2]) {
-    return `/lisa:${lisaSkillMatch[1]} ${lisaSkillMatch[2]}`.trim();
+  if (lisaSkillMatch?.[1]) {
+    return `/lisa:${lisaSkillMatch[1]} ${lisaSkillMatch[2] ?? ""}`.trim();
   }
 
   const aliasSkillMatch = prompt.match(
-    /Use the `\$([a-z0-9:-]+)` skill with arguments `([^`]+)`/i
+    /Use the `\$([a-z0-9:-]+)` skill(?: with arguments `([^`]*)`)?/i
   );
-  if (aliasSkillMatch?.[1] && aliasSkillMatch[2]) {
-    return `${canonicalizeCodexSkillAlias(aliasSkillMatch[1])} ${aliasSkillMatch[2]}`.trim();
+  if (aliasSkillMatch?.[1]) {
+    return `${canonicalizeCodexSkillAlias(aliasSkillMatch[1])} ${aliasSkillMatch[2] ?? ""}`.trim();
   }
 
-  return undefined;
+  // A registration whose prompt carries the literal Lisa command on its own
+  // line — the shape `/lisa:setup-automations` bakes so a command that is not a
+  // plain skill name (`/lisa:learnings:audit`) round-trips exactly. Mirrors the
+  // Claude adapter, which has always accepted a bare `/lisa:` command. Codex
+  // stores prompts as single-line TOML, so a line break arrives either real or
+  // as the two-character escape `\n`; both delimit a line here.
+  const literalCommand = prompt
+    .split(/\r?\n|\\n/)
+    .map(segment => segment.trim())
+    .find(segment => /^\/lisa[:-]\S/.test(segment));
+
+  return literalCommand;
 }
 
 function canonicalizeCodexSkillAlias(alias) {

--- a/plugins/lisa-cursor/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa-cursor/scripts/automation-status-expected-fleet.mjs
@@ -56,6 +56,68 @@ export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
 export const AUTOMATION_RUNBOOK_DIRECTORY = ".lisa/automations";
 
 /**
+ * Every fleet group, in render order, with the operator-facing title each one
+ * carries in the status report. This is the single source of truth for group
+ * membership: adapters bin entries with {@link createAutomationGroupBins} and
+ * render with {@link renderAutomationGroups}, so adding a group here surfaces it
+ * everywhere instead of silently dropping its entries.
+ */
+export const AUTOMATION_FLEET_GROUP_TITLES = {
+  core: "Core automations",
+  exploratory: "Exploratory automations",
+  "opt-in": "Opt-in automations",
+};
+
+/**
+ * Create one empty bin per known fleet group.
+ *
+ * @returns {Map<string, object[]>}
+ */
+export function createAutomationGroupBins() {
+  return new Map(
+    Object.keys(AUTOMATION_FLEET_GROUP_TITLES).map(group => [group, []])
+  );
+}
+
+/**
+ * Add a rendered status item to its group bin.
+ *
+ * Throws on an unknown group rather than dropping the item: a silently skipped
+ * entry is indistinguishable from a healthy fleet, which is exactly how the
+ * opt-in gardener went missing from both runtime adapters.
+ *
+ * @param {Map<string, object[]>} bins
+ * @param {string} group
+ * @param {object} item
+ * @returns {void}
+ */
+export function assignToAutomationGroup(bins, group, item) {
+  const bin = bins.get(group);
+  if (!bin) {
+    throw new Error(
+      `Unknown automation fleet group "${group}" for ${item?.id ?? "an automation"}. Add it to AUTOMATION_FLEET_GROUP_TITLES so the status report can render it.`
+    );
+  }
+  bin.push(item);
+}
+
+/**
+ * Render the group bins as the numbered report groups, in declaration order.
+ *
+ * @param {Map<string, object[]>} bins
+ * @returns {readonly { readonly id: string, readonly title: string, readonly items: readonly object[] }[]}
+ */
+export function renderAutomationGroups(bins) {
+  return Object.entries(AUTOMATION_FLEET_GROUP_TITLES).map(
+    ([group, title], index) => ({
+      id: String(index + 1),
+      title,
+      items: bins.get(group) ?? [],
+    })
+  );
+}
+
+/**
  * @typedef {{
  *   readonly id: string
  *   readonly automationId: string
@@ -76,6 +138,27 @@ export const AUTOMATION_RUNBOOK_DIRECTORY = ".lisa/automations";
  *   readonly runbookPath: string
  * }} UnsupportedAutomationEntry
  */
+
+/**
+ * Infer whether this project opted into the weekly gardener, from what is
+ * actually registered on the scheduler.
+ *
+ * Membership is registration, not configuration: there is no config key to
+ * read, so a read-only caller decides by looking for the registration itself.
+ * Pass the result as `learningsAudit` to {@link resolveExpectedAutomationFleet}
+ * so an opted-in project compares its gardener like any other loop instead of
+ * reporting it `UNSUPPORTED` forever.
+ *
+ * @param {{
+ *   readonly automationPrefix: string
+ *   readonly observedAutomationIds?: readonly string[]
+ * }} input
+ * @returns {boolean}
+ */
+export function inferLearningsAuditRegistration(input) {
+  const target = `${input.automationPrefix}learnings-audit`;
+  return (input.observedAutomationIds ?? []).includes(target);
+}
 
 /**
  * Resolve the repo-relative runbook path for a loop id.
@@ -129,6 +212,13 @@ export function resolveAutomationProjectIdentity(input = {}) {
  *   readonly autoStartTickets?: boolean | string
  *   readonly learningsAudit?: boolean | string
  * }} input
+ *
+ * `learningsAudit` has no config home by design — the gardener is opted into at
+ * registration time, and membership is registration, not configuration. A
+ * read-only caller (the status surface) therefore INFERS it: pass `true` when a
+ * `<automationPrefix>learnings-audit` entry is observed on the runtime
+ * scheduler. Without that inference an opted-in project would report the
+ * gardener `UNSUPPORTED` forever instead of comparing it like any other loop.
  * @returns {{
  *   readonly owner: string
  *   readonly repo: string
@@ -220,7 +310,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
       createUnsupportedEntry(
         identity,
         "exploratory-bugs",
-        "This repository does not ship an exploratory-qa command surface.",
+        "This project ships no exploratory-qa command, so there is nothing for this loop to run. No action needed unless the project adds one.",
         "exploratory"
       )
     );
@@ -240,7 +330,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
       createUnsupportedEntry(
         identity,
         "learnings-audit",
-        "The weekly gardener loop is opt-in and this project has not opted in (learnings-audit=false).",
+        "The weekly gardener loop is opt-in and this project has not opted in, so nobody is auditing its knowledge surfaces. Run /lisa:setup-automations learnings-audit=true to enable it.",
         "opt-in"
       )
     );

--- a/plugins/lisa-cursor/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa-cursor/scripts/automation-status-expected-fleet.mjs
@@ -37,9 +37,23 @@ export const AUTOMATION_EXPECTED_CADENCES = {
     human: "once a day",
     rrule: "FREQ=DAILY;INTERVAL=1",
   },
+  monitor: {
+    human: "once a day",
+    rrule: "FREQ=DAILY;INTERVAL=1",
+  },
+  "learnings-audit": {
+    human: "once a week",
+    rrule: "FREQ=WEEKLY;INTERVAL=1",
+  },
 };
 
 export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
+
+/**
+ * Directory (repo-relative) holding the checked-in per-loop runbooks scaffolded
+ * by `/lisa:setup-automations` per the `automation-runbook-contract` rule.
+ */
+export const AUTOMATION_RUNBOOK_DIRECTORY = ".lisa/automations";
 
 /**
  * @typedef {{
@@ -48,18 +62,30 @@ export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
  *   readonly expectedCadence: string
  *   readonly expectedRRule: string
  *   readonly expectedCommand: string
- *   readonly group: "core" | "exploratory"
+ *   readonly group: "core" | "exploratory" | "opt-in"
+ *   readonly runbookPath: string
  * }} ExpectedAutomationEntry
  *
  * @typedef {{
  *   readonly id: string
  *   readonly automationId: string
- *   readonly group: "core" | "exploratory"
+ *   readonly group: "core" | "exploratory" | "opt-in"
  *   readonly reason: string
  *   readonly expectedCadence: string
  *   readonly expectedRRule: string
+ *   readonly runbookPath: string
  * }} UnsupportedAutomationEntry
  */
+
+/**
+ * Resolve the repo-relative runbook path for a loop id.
+ *
+ * @param {string} id
+ * @returns {string}
+ */
+export function resolveAutomationRunbookPath(id) {
+  return `${AUTOMATION_RUNBOOK_DIRECTORY}/${id}.runbook.md`;
+}
 
 /**
  * Resolve the stable project identifier and automation prefix used by
@@ -101,6 +127,7 @@ export function resolveAutomationProjectIdentity(input = {}) {
  *   readonly detectedTypes?: readonly string[]
  *   readonly autoStartPrds?: boolean | string
  *   readonly autoStartTickets?: boolean | string
+ *   readonly learningsAudit?: boolean | string
  * }} input
  * @returns {{
  *   readonly owner: string
@@ -116,6 +143,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
   const identity = resolveAutomationProjectIdentity(input);
   const autoStartPrds = normalizeBooleanFlag(input.autoStartPrds);
   const autoStartTickets = normalizeBooleanFlag(input.autoStartTickets);
+  const learningsAudit = normalizeBooleanFlag(input.learningsAudit);
   const detectedTypes = input.detectedTypes ?? [];
 
   const tracker = config.tracker;
@@ -166,6 +194,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
       `/lisa:intake ${buildQueue}`,
       "core"
     ),
+    createExpectedEntry(identity, "monitor", "/lisa:monitor", "core"),
     createExpectedEntry(
       identity,
       "exploratory-prds",
@@ -191,7 +220,28 @@ export function resolveExpectedAutomationFleet(input = {}) {
       createUnsupportedEntry(
         identity,
         "exploratory-bugs",
-        "This repository does not ship an exploratory-qa command surface."
+        "This repository does not ship an exploratory-qa command surface.",
+        "exploratory"
+      )
+    );
+  }
+
+  if (learningsAudit) {
+    expected.push(
+      createExpectedEntry(
+        identity,
+        "learnings-audit",
+        "/lisa:learnings:audit",
+        "opt-in"
+      )
+    );
+  } else {
+    unsupported.push(
+      createUnsupportedEntry(
+        identity,
+        "learnings-audit",
+        "The weekly gardener loop is opt-in and this project has not opted in (learnings-audit=false).",
+        "opt-in"
       )
     );
   }
@@ -222,7 +272,7 @@ export function resolveExploratoryQaStack(detectedTypes = []) {
  * @param {{ readonly automationPrefix: string }} identity
  * @param {string} id
  * @param {string} expectedCommand
- * @param {"core" | "exploratory"} group
+ * @param {"core" | "exploratory" | "opt-in"} group
  * @returns {ExpectedAutomationEntry}
  */
 function createExpectedEntry(identity, id, expectedCommand, group) {
@@ -234,6 +284,7 @@ function createExpectedEntry(identity, id, expectedCommand, group) {
     expectedRRule: cadence.rrule,
     expectedCommand,
     group,
+    runbookPath: resolveAutomationRunbookPath(id),
   };
 }
 
@@ -241,17 +292,19 @@ function createExpectedEntry(identity, id, expectedCommand, group) {
  * @param {{ readonly automationPrefix: string }} identity
  * @param {string} id
  * @param {string} reason
+ * @param {"core" | "exploratory" | "opt-in"} group
  * @returns {UnsupportedAutomationEntry}
  */
-function createUnsupportedEntry(identity, id, reason) {
+function createUnsupportedEntry(identity, id, reason, group) {
   const cadence = AUTOMATION_EXPECTED_CADENCES[id];
   return {
     id,
     automationId: `${identity.automationPrefix}${id}`,
     expectedCadence: cadence.human,
     expectedRRule: cadence.rrule,
-    group: "exploratory",
+    group,
     reason,
+    runbookPath: resolveAutomationRunbookPath(id),
   };
 }
 

--- a/plugins/lisa-cursor/skills/lisa-automation-status/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-automation-status/SKILL.md
@@ -23,6 +23,14 @@ exactly what `setup-automations` registers for this repo — including the stack
 roster** (`automation-runbook-contract`): carry no fixed list of loop names here, so a loop added to
 or removed from the registration set flows through without editing this skill.
 
+The gardener is opted into at registration time and has no config key, so **infer it from the
+scheduler**: list the project's automations first, then call
+`inferLearningsAuditRegistration({ automationPrefix, observedAutomationIds })` and pass the result
+as `learningsAudit` when resolving the fleet. A `lisa-auto-<project>-learnings-audit` entry on the
+scheduler means the project opted in, so the gardener is compared like any other loop; no such entry
+means it is reported `UNSUPPORTED` (opted out), never `MISSING`. This skill stays read-only — it
+infers, it never writes the flag anywhere.
+
 Resolve the expected project identifier, fleet naming prefix, queue arguments, cadence, and stack-support rules from the same contract used by `setup-automations` and `tear-down-automations`. Do **not** invent a second source of truth for fleet naming or queue resolution.
 
 ## Runtime inspection

--- a/plugins/lisa-cursor/skills/lisa-automation-status/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-automation-status/SKILL.md
@@ -16,14 +16,12 @@ Do **not** ask for confirmation once invoked. This skill inspects scheduler stat
 
 ## Scope
 
-Inspect only the Lisa automation fleet for the current project:
-
-- `intake-repair`
-- `intake-prd`
-- `intake-tickets`
-- `exploratory-bugs` when the current stack supports `exploratory-qa`
-- `exploratory-prds`
-- `monitor`
+Inspect only the Lisa automation fleet for the current project. Derive that fleet from
+`scripts/automation-status-expected-fleet.mjs` (`resolveExpectedAutomationFleet`), which resolves
+exactly what `setup-automations` registers for this repo — including the stack-guarded
+`exploratory-bugs` and the opt-in `learnings-audit` gardener. **Membership is registration, not a
+roster** (`automation-runbook-contract`): carry no fixed list of loop names here, so a loop added to
+or removed from the registration set flows through without editing this skill.
 
 Resolve the expected project identifier, fleet naming prefix, queue arguments, cadence, and stack-support rules from the same contract used by `setup-automations` and `tear-down-automations`. Do **not** invent a second source of truth for fleet naming or queue resolution.
 

--- a/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
@@ -146,19 +146,53 @@ packet here** — cite the rule and instantiate it.
    id, the full automation name, the exact scheduled command with every `owner/repo` already baked
    in (never a placeholder), the human cadence and its `rrule`, the resolved queue arguments, and
    the resolved flag values that shaped the command (`auto-start-prds` / `auto-start-tickets` /
-   `learnings-audit`).
-2. The **ten contract sections** below it. Lisa owns them **only on first write**: seed each one
-   from this skill's per-loop defaults — what that loop maintains, what it reads, how it picks
-   candidates, its bounds, its proof, its approval boundary, its escalation, its recovery, its
-   next-run state, its retirement condition — written for a non-technical operator. After that they
-   belong to the operator.
+   `learnings-audit`). Its **first line inside the delimiters is a visible sentence**, so the
+   ownership boundary survives rendering to markdown where HTML comments disappear:
 
-**Re-run rule (idempotent, append-or-leave).** When the file already exists: rewrite the
+   ```text
+   Lisa rewrites this section on every /lisa:setup-automations run — edits here are lost. Your prose
+   belongs in the sections below.
+   ```
+
+   Immediately **below** the closing delimiter, write one more visible line — `Everything below is
+   yours.` — so an operator reading the rendered page knows where their half starts.
+2. The **ten contract sections** below it. Lisa owns them **only on first write**, then they belong
+   to the operator. Seed them deterministically, never improvised:
+   - **Intent, Sources of truth, Candidate selection, Scope/bounds, Retirement condition** come
+     from the per-loop seed table below.
+   - **Proof, Autonomous-vs-approval boundary, Escalation, Recovery, Next-run state** are derived
+     from **that loop's own SKILL.md** — named per loop in the table's last column — so the runbook
+     describes what the loop actually does rather than a generic paraphrase. Quote its behavior in
+     the operator's voice; if the skill file is unreadable, write one sentence saying the section
+     was not derivable and which file to read, and continue.
+
+   Every seeded sentence is written for a non-technical operator (`factory-model` rule 5).
+
+### Per-loop seed defaults
+
+One line each; expand them into the operator's voice, keep the meaning.
+
+| Loop | Intent | Sources of truth | Candidate selection | Scope/bounds | Retirement condition | Derive the other five from |
+|---|---|---|---|---|---|---|
+| **intake-repair** | Keeps the queues unstuck: work that stalled mid-flight gets diagnosed and moved again. | The PRD and build queues for this project, read through the tracker access layer. | Stuck or half-closed items — stalled in an in-progress role, terminal-labeled but still open, rollups whose children are all done — up to the `max_candidates` cap. | Only this project's configured queues; it repairs lifecycle state, never invents or closes real work. | Propose teardown when nothing has needed repair for a long quiet window AND this run found nothing. | `lisa-repair-intake/SKILL.md` |
+| **intake-prd** | Keeps PRDs moving: a PRD a human marked ready gets validated and decomposed into work items. | The configured PRD queue and its lifecycle roles, read through the source access layer. | The oldest PRD in the ready role, one per run. | Only this project's PRD queue; it never authors product intent, only validates and decomposes it. | Propose teardown when no PRD has entered the queue for a long quiet window AND this run proposed nothing. | `lisa-intake/SKILL.md` |
+| **intake-tickets** | Keeps the build queue moving: work items a human marked ready get built, reviewed, and shipped. | The configured tracker's build queue lanes plus each item's comments and linked PRs. | The oldest eligible leaf work item in the ready lane, one per run. | Only this repo's configured queue; containers with open children are repaired out, never built. | Propose teardown when no work item has entered this queue for a long quiet window AND this run proposed nothing. | `lisa-intake/SKILL.md` |
+| **monitor** | Keeps production honest: observability regressions become tracked work instead of silent decay. | The connected observability providers, each through its access layer, plus this project's `monitor.gapTiers` config. | The regressions and coverage gaps this cycle surfaced, capped per run. | Only this project's own services and dashboards; it files findings, it never changes production. | Propose teardown when the project has no connected observability surfaces AND this run found nothing. | `lisa-monitor/SKILL.md` |
+| **exploratory-prds** | Keeps the idea pipeline fed: the product's own gaps become PRDs when the PRD queue has room. | The PRD queue's pressure roles (the same ones `/lisa:queue-status` reports) and the project's own product surfaces. | One ideated PRD per run, and only when the pressure gate says the queue has capacity. | Never more than one PRD per run, and nothing at all while unresolved PRD pressure exists. | Propose teardown when the queue has been at pressure — or the project has shipped no new surface — across a long quiet window AND this run proposed nothing. | `lisa-project-ideation/SKILL.md` |
+| **exploratory-bugs** | Keeps quality visible: bugs and usability problems get found by using the product, before a customer does. | The running application through its exploratory-qa surface, plus this project's existing bug queue for dedupe. | The findings of one exploratory session, capped per run and deduped against already-filed items. | Only this project's own app; it files tickets, it never changes product code. | Propose teardown when no session has produced a finding across a long quiet window AND this run found nothing. | `lisa-exploratory-qa/SKILL.md` (the stack's own copy) |
+| **learnings-audit** | Keeps the project's knowledge true: stale, duplicated, or contradicted knowledge gets proposed for promotion, demotion, or retirement. | The learnings ledger, the rules trees, the skills, and the wiki — the project's knowledge surfaces. | The knowledge entries this audit judged stale, duplicated, or contradicted, capped per run. | It only proposes; every promote/demote/retire decision is a human-gated tracker ticket. | Propose teardown when the audit has proposed nothing across a long quiet window AND this run proposed nothing. | `lisa-learnings-audit/SKILL.md` |
+
+A loop not in this table — one registered later — seeds all ten sections from its own SKILL.md the
+same way. The table is seed prose for first write only; it is **not** a roster and never decides
+which automations exist.
+
+**Re-run rule (idempotent, never clobber).** When the file already exists: rewrite the
 machine-resolved block in place and **leave every one of the ten sections exactly as found** — an
-operator's edited Intent paragraph survives verbatim. If a section from the contract is **missing**
-from an existing file, append it with its seeded default; never overwrite, reorder, reword, or
-delete prose already on disk. If the machine-resolved delimiters are absent (a hand-written file),
-insert the block at the top and touch nothing else.
+operator's edited Intent paragraph survives verbatim. If a contract section is **missing** from an
+existing file, insert it **at its position in the contract's ten-section order** (never merely
+appended at the end, which would leave the file permanently out of order) with its seeded default.
+Never overwrite, reorder, reword, or delete prose already on disk. If the machine-resolved
+delimiters are absent (a hand-written file), insert the block at the top and touch nothing else.
 
 **Never a precondition.** A runbook that cannot be written is a **degradation, not a blocker**:
 report the failure and continue registering automations. A loop with a missing runbook still runs —
@@ -190,6 +224,15 @@ Then list each runbook written, by path (`.lisa/automations/<loop-id>.runbook.md
 whether it was **created** (seeded fresh) or **refreshed** (machine-resolved block rewritten,
 operator prose left untouched). Name every skipped loop again here and state plainly that it has no
 runbook because it was not registered, and why — for example, "exploratory-bugs was skipped because
-this project ships no exploratory-qa command, so no runbook was written for it." If a runbook could
-not be written, say which one and what failed; the automation itself is still registered. Write all
-of this so a non-technical operator can act on it without reading code.
+this project ships no exploratory-qa command, so no runbook was written for it."
+
+Close with the two lines that tell the operator what to do next:
+
+- When any runbook was newly created: "N new files were written under `.lisa/automations/` — commit
+  them so the whole team sees them."
+- When a runbook could not be written: name which one and what failed, then the consequence and the
+  fix — "that loop runs on defaults and its summaries will lead with 'Runbook missing' — re-run
+  `/lisa:setup-automations` to fix." The automation itself is still registered and still runs.
+
+Every line states the consequence and the action, in words a non-technical operator can act on
+without reading code.

--- a/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
@@ -105,6 +105,19 @@ the scheduled commands (for example `/lisa:intake acme/frontend intake_mode=prd`
 config/read-context failure cannot silently redirect the cron. A short queueRepo is normalized to
 `github.org` before writing the automation.
 
+**Registration prompt shape (so status can read the command back).** Whatever prose the prompt
+carries, it must contain the **literal Lisa command on a line of its own**, exactly as scheduled and
+with every `owner/repo` already baked in:
+
+```text
+/lisa:intake acme/planning intake_mode=build
+```
+
+This holds for loops that take **no arguments** too — `/lisa:monitor` and `/lisa:learnings:audit`
+are written the same way, on their own line, with nothing after them. `/lisa:automation-status`
+reads that line back to compare the live registration against this contract; a loop whose command
+cannot be read back reports as drifted even though it is registered correctly.
+
 **Naming + scope (so teardown is precise).** Name each automation with the stable prefix
 `lisa-auto-<project>-` (e.g. `lisa-auto-<project>-intake-tickets`), where `<project>` identifies this
 repo, and scope each Codex automation to the durable project automation checkout described above.

--- a/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lisa-setup-automations
 description: "Set up the recurring Lisa automations on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automations to create, how often, and with which parameters; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates six default automations: intake-repair (every 60 min), intake PRD (every 60 min), intake tickets (every 10 min), exploratory-bugs (once a day), exploratory-prds (once a day), monitor (once a day) — plus opt-in learnings-audit (once a week, the gardener). Three flags: auto-start-prds and auto-start-tickets control whether ideated PRDs / filed bug tickets are created auto-pickup-ready (prd_ready / ready, default true) or left for human review; learnings-audit (default false) opts into the weekly gardener loop. Tear down with /tear-down-automations."
-allowed-tools: ["Skill", "Bash", "Read"]
+allowed-tools: ["Skill", "Bash", "Read", "Write", "Edit"]
 ---
 
 # Set up Lisa automations: $ARGUMENTS
@@ -115,6 +115,57 @@ repos (don't rely on a bare repo basename when it could collide; qualify it, e.g
 **Idempotent.** Re-running this skill updates the existing `lisa-auto-<project>-*` automations in
 place (same names) rather than creating duplicates.
 
+## Runbook scaffolding
+
+Registration is what pulls a loop under the `automation-runbook-contract` rule, so registration is
+what must produce its runbook. For **every automation actually registered above** — including the
+conditionally-guarded `exploratory-bugs` and the opt-in `learnings-audit` — write a checked-in
+runbook at:
+
+```text
+.lisa/automations/<loop-id>.runbook.md
+```
+
+`<loop-id>` is the automation's suffix, not its full name: `intake-tickets`, not
+`lisa-auto-<project>-intake-tickets`. These files are **project knowledge and belong in git**, like
+`.lisa/PROJECT_LEARNINGS.md` — commit them; they are not scratch output. Derive the set of runbooks
+from what was registered on this run: a loop that was **skipped gets no runbook**, and a loop
+registered later gets one when this skill next runs. Never write a runbook from a fixed list of
+loop names.
+
+Follow the `automation-runbook-contract` rule for the runbook's shape: its ten sections, in its
+order, in its prose register. **Do not restate the template, the run outcomes, or the escalation
+packet here** — cite the rule and instantiate it.
+
+**File shape — two halves with different owners.**
+
+1. A **machine-resolved header block**, delimited exactly by
+   `<!-- lisa:machine-resolved:start -->` and `<!-- lisa:machine-resolved:end -->`, written first
+   in the file. Lisa owns it: on every run it is **rewritten wholesale** from the values resolved
+   above. It carries the project identity (`<owner>/<repo>` and the `<project>` token), the loop
+   id, the full automation name, the exact scheduled command with every `owner/repo` already baked
+   in (never a placeholder), the human cadence and its `rrule`, the resolved queue arguments, and
+   the resolved flag values that shaped the command (`auto-start-prds` / `auto-start-tickets` /
+   `learnings-audit`).
+2. The **ten contract sections** below it. Lisa owns them **only on first write**: seed each one
+   from this skill's per-loop defaults — what that loop maintains, what it reads, how it picks
+   candidates, its bounds, its proof, its approval boundary, its escalation, its recovery, its
+   next-run state, its retirement condition — written for a non-technical operator. After that they
+   belong to the operator.
+
+**Re-run rule (idempotent, append-or-leave).** When the file already exists: rewrite the
+machine-resolved block in place and **leave every one of the ten sections exactly as found** — an
+operator's edited Intent paragraph survives verbatim. If a section from the contract is **missing**
+from an existing file, append it with its seeded default; never overwrite, reorder, reword, or
+delete prose already on disk. If the machine-resolved delimiters are absent (a hand-written file),
+insert the block at the top and touch nothing else.
+
+**Never a precondition.** A runbook that cannot be written is a **degradation, not a blocker**:
+report the failure and continue registering automations. A loop with a missing runbook still runs —
+on the contract's defaults, saying so in its one-line summary — per the contract's
+never-block-always-degrade rule. Scaffolding failure never aborts setup and never leaves an
+automation unregistered.
+
 ## Conditions / guards
 
 - **exploratory-bugs** is created only when the project ships an `exploratory-qa` command (the
@@ -134,3 +185,11 @@ place (same names) rather than creating duplicates.
 
 List each automation created or updated (name, the command it runs, cadence, and the resolved
 `auto-start-prds` / `auto-start-tickets` values), plus any automation skipped and why.
+
+Then list each runbook written, by path (`.lisa/automations/<loop-id>.runbook.md`), saying for each
+whether it was **created** (seeded fresh) or **refreshed** (machine-resolved block rewritten,
+operator prose left untouched). Name every skipped loop again here and state plainly that it has no
+runbook because it was not registered, and why — for example, "exploratory-bugs was skipped because
+this project ships no exploratory-qa command, so no runbook was written for it." If a runbook could
+not be written, say which one and what failed; the automation itself is still registered. Write all
+of this so a non-technical operator can act on it without reading code.

--- a/plugins/lisa-cursor/skills/lisa-tear-down-automations/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-tear-down-automations/SKILL.md
@@ -42,7 +42,13 @@ removes them with its **native** scheduling mechanism.
 
 ## Report
 
-List each automation removed by name, and any that the prefix sweep expected to find but that were
-already absent. State explicitly that the runbook files under `.lisa/automations/` were left on
-disk, and that nothing outside this project's `lisa-auto-<project>-` prefix was touched. Write it so
-a non-technical operator can confirm what happened without reading code.
+List each automation removed by name. For "already absent", compare against the one source of truth
+— the fleet `scripts/automation-status-expected-fleet.mjs` (`resolveExpectedAutomationFleet`)
+resolves for this project — and name anything it expects that the sweep did not find; that is a
+no-op, not an error. Do not invent an expected set of your own.
+
+Then state, in the operator's words, that the runbook files under `.lisa/automations/` were left on
+disk **and why**: they are the written record of what those jobs did, kept on purpose, and if you
+do not want them you delete them yourself in git. Finally, confirm that nothing outside this
+project's `lisa-auto-<project>-` prefix was touched. Write it so a non-technical operator can
+confirm what happened without reading code.

--- a/plugins/lisa-cursor/skills/lisa-tear-down-automations/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-tear-down-automations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-tear-down-automations
-description: "Remove every recurring Lisa automation that /setup-automations created for this project (the lisa-auto-<project>-* set: intake-repair, intake-prd, intake-tickets, exploratory-bugs, exploratory-prds, monitor) using the CURRENT runtime's native scheduler — Codex automations or, on Claude, /schedule. This skill is a declarative specification: it identifies WHICH automations to remove; it does not run teardown scripts. Removes only this project's Lisa automations — never other projects' automations or non-Lisa ones. The inverse of /setup-automations."
+description: "Remove every recurring Lisa automation that /setup-automations registered for this project — whatever is actually registered under the lisa-auto-<project>-* prefix, including the opt-in learnings-audit gardener — using the CURRENT runtime's native scheduler — Codex automations or, on Claude, /schedule. This skill is a declarative specification: it identifies WHICH automations to remove; it does not run teardown scripts. Carries no fixed list of loops: the registration set is the roster. Removes only this project's Lisa automations — never other projects' automations or non-Lisa ones. Leaves checked-in runbook files on disk. The inverse of /setup-automations."
 allowed-tools: ["Skill", "Bash", "Read"]
 ---
 
@@ -21,14 +21,28 @@ removes them with its **native** scheduling mechanism.
 
 ## Scope (remove only what setup created)
 
-- Remove the six automations `/setup-automations` creates for the current project, matched by the
-  stable `lisa-auto-<project>-` name prefix: `intake-repair`, `intake-prd`, `intake-tickets`,
-  `exploratory-bugs`, `exploratory-prds`, `monitor`.
+- Remove **every** automation `/setup-automations` registered for the current project — the whole
+  set found under the stable `lisa-auto-<project>-` name prefix, whatever it currently contains.
+  **Membership is registration, not a roster** (`automation-runbook-contract`): sweep the prefix and
+  remove what is there. Do **not** work from a fixed list of loop names — a list drifts the moment a
+  loop is added, which is exactly how the opt-in gardener came to be orphaned.
+- This explicitly includes the opt-in **`learnings-audit`** gardener when it is registered:
+  `/setup-automations learnings-audit=true` registers it under the same prefix, so teardown removes
+  it with the rest. A conditionally-skipped loop (e.g. `exploratory-bugs` on a stack without
+  `exploratory-qa`) simply is not in the sweep.
 - **Never** remove automations for a different project, or any non-Lisa automation (e.g. unrelated
   crawlers/ingestors). Match strictly on the `lisa-auto-<project>-` prefix for THIS project; when in
   doubt about an automation's ownership, leave it and report it rather than deleting it.
-- **Idempotent** — an automation that is already absent is a no-op, not an error.
+- **Idempotent** — an automation that is already absent is a no-op, not an error. Re-running when
+  the prefix sweep finds nothing is a clean, successful no-op.
+- **Leave the runbooks alone.** The checked-in `.lisa/automations/<loop-id>.runbook.md` files that
+  `/setup-automations` scaffolded are project knowledge and the historical record of what these
+  loops did. Teardown removes scheduler registrations only; it never deletes, edits, or moves a
+  runbook file. An operator who wants them gone removes them deliberately, in git.
 
 ## Report
 
-List each automation removed, and any in the expected set that were already absent.
+List each automation removed by name, and any that the prefix sweep expected to find but that were
+already absent. State explicitly that the runbook files under `.lisa/automations/` were left on
+disk, and that nothing outside this project's `lisa-auto-<project>-` prefix was touched. Write it so
+a non-technical operator can confirm what happened without reading code.

--- a/plugins/lisa/.codex-plugin/skills/lisa-automation-status/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-automation-status/SKILL.md
@@ -23,6 +23,14 @@ exactly what `setup-automations` registers for this repo — including the stack
 roster** (`automation-runbook-contract`): carry no fixed list of loop names here, so a loop added to
 or removed from the registration set flows through without editing this skill.
 
+The gardener is opted into at registration time and has no config key, so **infer it from the
+scheduler**: list the project's automations first, then call
+`inferLearningsAuditRegistration({ automationPrefix, observedAutomationIds })` and pass the result
+as `learningsAudit` when resolving the fleet. A `lisa-auto-<project>-learnings-audit` entry on the
+scheduler means the project opted in, so the gardener is compared like any other loop; no such entry
+means it is reported `UNSUPPORTED` (opted out), never `MISSING`. This skill stays read-only — it
+infers, it never writes the flag anywhere.
+
 Resolve the expected project identifier, fleet naming prefix, queue arguments, cadence, and stack-support rules from the same contract used by `setup-automations` and `tear-down-automations`. Do **not** invent a second source of truth for fleet naming or queue resolution.
 
 ## Runtime inspection

--- a/plugins/lisa/.codex-plugin/skills/lisa-automation-status/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-automation-status/SKILL.md
@@ -16,14 +16,12 @@ Do **not** ask for confirmation once invoked. This skill inspects scheduler stat
 
 ## Scope
 
-Inspect only the Lisa automation fleet for the current project:
-
-- `intake-repair`
-- `intake-prd`
-- `intake-tickets`
-- `exploratory-bugs` when the current stack supports `exploratory-qa`
-- `exploratory-prds`
-- `monitor`
+Inspect only the Lisa automation fleet for the current project. Derive that fleet from
+`scripts/automation-status-expected-fleet.mjs` (`resolveExpectedAutomationFleet`), which resolves
+exactly what `setup-automations` registers for this repo — including the stack-guarded
+`exploratory-bugs` and the opt-in `learnings-audit` gardener. **Membership is registration, not a
+roster** (`automation-runbook-contract`): carry no fixed list of loop names here, so a loop added to
+or removed from the registration set flows through without editing this skill.
 
 Resolve the expected project identifier, fleet naming prefix, queue arguments, cadence, and stack-support rules from the same contract used by `setup-automations` and `tear-down-automations`. Do **not** invent a second source of truth for fleet naming or queue resolution.
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
@@ -146,19 +146,53 @@ packet here** — cite the rule and instantiate it.
    id, the full automation name, the exact scheduled command with every `owner/repo` already baked
    in (never a placeholder), the human cadence and its `rrule`, the resolved queue arguments, and
    the resolved flag values that shaped the command (`auto-start-prds` / `auto-start-tickets` /
-   `learnings-audit`).
-2. The **ten contract sections** below it. Lisa owns them **only on first write**: seed each one
-   from this skill's per-loop defaults — what that loop maintains, what it reads, how it picks
-   candidates, its bounds, its proof, its approval boundary, its escalation, its recovery, its
-   next-run state, its retirement condition — written for a non-technical operator. After that they
-   belong to the operator.
+   `learnings-audit`). Its **first line inside the delimiters is a visible sentence**, so the
+   ownership boundary survives rendering to markdown where HTML comments disappear:
 
-**Re-run rule (idempotent, append-or-leave).** When the file already exists: rewrite the
+   ```text
+   Lisa rewrites this section on every /lisa:setup-automations run — edits here are lost. Your prose
+   belongs in the sections below.
+   ```
+
+   Immediately **below** the closing delimiter, write one more visible line — `Everything below is
+   yours.` — so an operator reading the rendered page knows where their half starts.
+2. The **ten contract sections** below it. Lisa owns them **only on first write**, then they belong
+   to the operator. Seed them deterministically, never improvised:
+   - **Intent, Sources of truth, Candidate selection, Scope/bounds, Retirement condition** come
+     from the per-loop seed table below.
+   - **Proof, Autonomous-vs-approval boundary, Escalation, Recovery, Next-run state** are derived
+     from **that loop's own SKILL.md** — named per loop in the table's last column — so the runbook
+     describes what the loop actually does rather than a generic paraphrase. Quote its behavior in
+     the operator's voice; if the skill file is unreadable, write one sentence saying the section
+     was not derivable and which file to read, and continue.
+
+   Every seeded sentence is written for a non-technical operator (`factory-model` rule 5).
+
+### Per-loop seed defaults
+
+One line each; expand them into the operator's voice, keep the meaning.
+
+| Loop | Intent | Sources of truth | Candidate selection | Scope/bounds | Retirement condition | Derive the other five from |
+|---|---|---|---|---|---|---|
+| **intake-repair** | Keeps the queues unstuck: work that stalled mid-flight gets diagnosed and moved again. | The PRD and build queues for this project, read through the tracker access layer. | Stuck or half-closed items — stalled in an in-progress role, terminal-labeled but still open, rollups whose children are all done — up to the `max_candidates` cap. | Only this project's configured queues; it repairs lifecycle state, never invents or closes real work. | Propose teardown when nothing has needed repair for a long quiet window AND this run found nothing. | `lisa-repair-intake/SKILL.md` |
+| **intake-prd** | Keeps PRDs moving: a PRD a human marked ready gets validated and decomposed into work items. | The configured PRD queue and its lifecycle roles, read through the source access layer. | The oldest PRD in the ready role, one per run. | Only this project's PRD queue; it never authors product intent, only validates and decomposes it. | Propose teardown when no PRD has entered the queue for a long quiet window AND this run proposed nothing. | `lisa-intake/SKILL.md` |
+| **intake-tickets** | Keeps the build queue moving: work items a human marked ready get built, reviewed, and shipped. | The configured tracker's build queue lanes plus each item's comments and linked PRs. | The oldest eligible leaf work item in the ready lane, one per run. | Only this repo's configured queue; containers with open children are repaired out, never built. | Propose teardown when no work item has entered this queue for a long quiet window AND this run proposed nothing. | `lisa-intake/SKILL.md` |
+| **monitor** | Keeps production honest: observability regressions become tracked work instead of silent decay. | The connected observability providers, each through its access layer, plus this project's `monitor.gapTiers` config. | The regressions and coverage gaps this cycle surfaced, capped per run. | Only this project's own services and dashboards; it files findings, it never changes production. | Propose teardown when the project has no connected observability surfaces AND this run found nothing. | `lisa-monitor/SKILL.md` |
+| **exploratory-prds** | Keeps the idea pipeline fed: the product's own gaps become PRDs when the PRD queue has room. | The PRD queue's pressure roles (the same ones `/lisa:queue-status` reports) and the project's own product surfaces. | One ideated PRD per run, and only when the pressure gate says the queue has capacity. | Never more than one PRD per run, and nothing at all while unresolved PRD pressure exists. | Propose teardown when the queue has been at pressure — or the project has shipped no new surface — across a long quiet window AND this run proposed nothing. | `lisa-project-ideation/SKILL.md` |
+| **exploratory-bugs** | Keeps quality visible: bugs and usability problems get found by using the product, before a customer does. | The running application through its exploratory-qa surface, plus this project's existing bug queue for dedupe. | The findings of one exploratory session, capped per run and deduped against already-filed items. | Only this project's own app; it files tickets, it never changes product code. | Propose teardown when no session has produced a finding across a long quiet window AND this run found nothing. | `lisa-exploratory-qa/SKILL.md` (the stack's own copy) |
+| **learnings-audit** | Keeps the project's knowledge true: stale, duplicated, or contradicted knowledge gets proposed for promotion, demotion, or retirement. | The learnings ledger, the rules trees, the skills, and the wiki — the project's knowledge surfaces. | The knowledge entries this audit judged stale, duplicated, or contradicted, capped per run. | It only proposes; every promote/demote/retire decision is a human-gated tracker ticket. | Propose teardown when the audit has proposed nothing across a long quiet window AND this run proposed nothing. | `lisa-learnings-audit/SKILL.md` |
+
+A loop not in this table — one registered later — seeds all ten sections from its own SKILL.md the
+same way. The table is seed prose for first write only; it is **not** a roster and never decides
+which automations exist.
+
+**Re-run rule (idempotent, never clobber).** When the file already exists: rewrite the
 machine-resolved block in place and **leave every one of the ten sections exactly as found** — an
-operator's edited Intent paragraph survives verbatim. If a section from the contract is **missing**
-from an existing file, append it with its seeded default; never overwrite, reorder, reword, or
-delete prose already on disk. If the machine-resolved delimiters are absent (a hand-written file),
-insert the block at the top and touch nothing else.
+operator's edited Intent paragraph survives verbatim. If a contract section is **missing** from an
+existing file, insert it **at its position in the contract's ten-section order** (never merely
+appended at the end, which would leave the file permanently out of order) with its seeded default.
+Never overwrite, reorder, reword, or delete prose already on disk. If the machine-resolved
+delimiters are absent (a hand-written file), insert the block at the top and touch nothing else.
 
 **Never a precondition.** A runbook that cannot be written is a **degradation, not a blocker**:
 report the failure and continue registering automations. A loop with a missing runbook still runs —
@@ -190,6 +224,15 @@ Then list each runbook written, by path (`.lisa/automations/<loop-id>.runbook.md
 whether it was **created** (seeded fresh) or **refreshed** (machine-resolved block rewritten,
 operator prose left untouched). Name every skipped loop again here and state plainly that it has no
 runbook because it was not registered, and why — for example, "exploratory-bugs was skipped because
-this project ships no exploratory-qa command, so no runbook was written for it." If a runbook could
-not be written, say which one and what failed; the automation itself is still registered. Write all
-of this so a non-technical operator can act on it without reading code.
+this project ships no exploratory-qa command, so no runbook was written for it."
+
+Close with the two lines that tell the operator what to do next:
+
+- When any runbook was newly created: "N new files were written under `.lisa/automations/` — commit
+  them so the whole team sees them."
+- When a runbook could not be written: name which one and what failed, then the consequence and the
+  fix — "that loop runs on defaults and its summaries will lead with 'Runbook missing' — re-run
+  `/lisa:setup-automations` to fix." The automation itself is still registered and still runs.
+
+Every line states the consequence and the action, in words a non-technical operator can act on
+without reading code.

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
@@ -105,6 +105,19 @@ the scheduled commands (for example `/lisa:intake acme/frontend intake_mode=prd`
 config/read-context failure cannot silently redirect the cron. A short queueRepo is normalized to
 `github.org` before writing the automation.
 
+**Registration prompt shape (so status can read the command back).** Whatever prose the prompt
+carries, it must contain the **literal Lisa command on a line of its own**, exactly as scheduled and
+with every `owner/repo` already baked in:
+
+```text
+/lisa:intake acme/planning intake_mode=build
+```
+
+This holds for loops that take **no arguments** too — `/lisa:monitor` and `/lisa:learnings:audit`
+are written the same way, on their own line, with nothing after them. `/lisa:automation-status`
+reads that line back to compare the live registration against this contract; a loop whose command
+cannot be read back reports as drifted even though it is registered correctly.
+
 **Naming + scope (so teardown is precise).** Name each automation with the stable prefix
 `lisa-auto-<project>-` (e.g. `lisa-auto-<project>-intake-tickets`), where `<project>` identifies this
 repo, and scope each Codex automation to the durable project automation checkout described above.

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lisa-setup-automations
 description: "Set up the recurring Lisa…"
-allowed-tools: ["Skill", "Bash", "Read"]
+allowed-tools: ["Skill", "Bash", "Read", "Write", "Edit"]
 ---
 
 # Set up Lisa automations: $ARGUMENTS
@@ -115,6 +115,57 @@ repos (don't rely on a bare repo basename when it could collide; qualify it, e.g
 **Idempotent.** Re-running this skill updates the existing `lisa-auto-<project>-*` automations in
 place (same names) rather than creating duplicates.
 
+## Runbook scaffolding
+
+Registration is what pulls a loop under the `automation-runbook-contract` rule, so registration is
+what must produce its runbook. For **every automation actually registered above** — including the
+conditionally-guarded `exploratory-bugs` and the opt-in `learnings-audit` — write a checked-in
+runbook at:
+
+```text
+.lisa/automations/<loop-id>.runbook.md
+```
+
+`<loop-id>` is the automation's suffix, not its full name: `intake-tickets`, not
+`lisa-auto-<project>-intake-tickets`. These files are **project knowledge and belong in git**, like
+`.lisa/PROJECT_LEARNINGS.md` — commit them; they are not scratch output. Derive the set of runbooks
+from what was registered on this run: a loop that was **skipped gets no runbook**, and a loop
+registered later gets one when this skill next runs. Never write a runbook from a fixed list of
+loop names.
+
+Follow the `automation-runbook-contract` rule for the runbook's shape: its ten sections, in its
+order, in its prose register. **Do not restate the template, the run outcomes, or the escalation
+packet here** — cite the rule and instantiate it.
+
+**File shape — two halves with different owners.**
+
+1. A **machine-resolved header block**, delimited exactly by
+   `<!-- lisa:machine-resolved:start -->` and `<!-- lisa:machine-resolved:end -->`, written first
+   in the file. Lisa owns it: on every run it is **rewritten wholesale** from the values resolved
+   above. It carries the project identity (`<owner>/<repo>` and the `<project>` token), the loop
+   id, the full automation name, the exact scheduled command with every `owner/repo` already baked
+   in (never a placeholder), the human cadence and its `rrule`, the resolved queue arguments, and
+   the resolved flag values that shaped the command (`auto-start-prds` / `auto-start-tickets` /
+   `learnings-audit`).
+2. The **ten contract sections** below it. Lisa owns them **only on first write**: seed each one
+   from this skill's per-loop defaults — what that loop maintains, what it reads, how it picks
+   candidates, its bounds, its proof, its approval boundary, its escalation, its recovery, its
+   next-run state, its retirement condition — written for a non-technical operator. After that they
+   belong to the operator.
+
+**Re-run rule (idempotent, append-or-leave).** When the file already exists: rewrite the
+machine-resolved block in place and **leave every one of the ten sections exactly as found** — an
+operator's edited Intent paragraph survives verbatim. If a section from the contract is **missing**
+from an existing file, append it with its seeded default; never overwrite, reorder, reword, or
+delete prose already on disk. If the machine-resolved delimiters are absent (a hand-written file),
+insert the block at the top and touch nothing else.
+
+**Never a precondition.** A runbook that cannot be written is a **degradation, not a blocker**:
+report the failure and continue registering automations. A loop with a missing runbook still runs —
+on the contract's defaults, saying so in its one-line summary — per the contract's
+never-block-always-degrade rule. Scaffolding failure never aborts setup and never leaves an
+automation unregistered.
+
 ## Conditions / guards
 
 - **exploratory-bugs** is created only when the project ships an `exploratory-qa` command (the
@@ -134,3 +185,11 @@ place (same names) rather than creating duplicates.
 
 List each automation created or updated (name, the command it runs, cadence, and the resolved
 `auto-start-prds` / `auto-start-tickets` values), plus any automation skipped and why.
+
+Then list each runbook written, by path (`.lisa/automations/<loop-id>.runbook.md`), saying for each
+whether it was **created** (seeded fresh) or **refreshed** (machine-resolved block rewritten,
+operator prose left untouched). Name every skipped loop again here and state plainly that it has no
+runbook because it was not registered, and why — for example, "exploratory-bugs was skipped because
+this project ships no exploratory-qa command, so no runbook was written for it." If a runbook could
+not be written, say which one and what failed; the automation itself is still registered. Write all
+of this so a non-technical operator can act on it without reading code.

--- a/plugins/lisa/.codex-plugin/skills/lisa-tear-down-automations/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-tear-down-automations/SKILL.md
@@ -42,7 +42,13 @@ removes them with its **native** scheduling mechanism.
 
 ## Report
 
-List each automation removed by name, and any that the prefix sweep expected to find but that were
-already absent. State explicitly that the runbook files under `.lisa/automations/` were left on
-disk, and that nothing outside this project's `lisa-auto-<project>-` prefix was touched. Write it so
-a non-technical operator can confirm what happened without reading code.
+List each automation removed by name. For "already absent", compare against the one source of truth
+— the fleet `scripts/automation-status-expected-fleet.mjs` (`resolveExpectedAutomationFleet`)
+resolves for this project — and name anything it expects that the sweep did not find; that is a
+no-op, not an error. Do not invent an expected set of your own.
+
+Then state, in the operator's words, that the runbook files under `.lisa/automations/` were left on
+disk **and why**: they are the written record of what those jobs did, kept on purpose, and if you
+do not want them you delete them yourself in git. Finally, confirm that nothing outside this
+project's `lisa-auto-<project>-` prefix was touched. Write it so a non-technical operator can
+confirm what happened without reading code.

--- a/plugins/lisa/.codex-plugin/skills/lisa-tear-down-automations/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-tear-down-automations/SKILL.md
@@ -21,14 +21,28 @@ removes them with its **native** scheduling mechanism.
 
 ## Scope (remove only what setup created)
 
-- Remove the six automations `/setup-automations` creates for the current project, matched by the
-  stable `lisa-auto-<project>-` name prefix: `intake-repair`, `intake-prd`, `intake-tickets`,
-  `exploratory-bugs`, `exploratory-prds`, `monitor`.
+- Remove **every** automation `/setup-automations` registered for the current project — the whole
+  set found under the stable `lisa-auto-<project>-` name prefix, whatever it currently contains.
+  **Membership is registration, not a roster** (`automation-runbook-contract`): sweep the prefix and
+  remove what is there. Do **not** work from a fixed list of loop names — a list drifts the moment a
+  loop is added, which is exactly how the opt-in gardener came to be orphaned.
+- This explicitly includes the opt-in **`learnings-audit`** gardener when it is registered:
+  `/setup-automations learnings-audit=true` registers it under the same prefix, so teardown removes
+  it with the rest. A conditionally-skipped loop (e.g. `exploratory-bugs` on a stack without
+  `exploratory-qa`) simply is not in the sweep.
 - **Never** remove automations for a different project, or any non-Lisa automation (e.g. unrelated
   crawlers/ingestors). Match strictly on the `lisa-auto-<project>-` prefix for THIS project; when in
   doubt about an automation's ownership, leave it and report it rather than deleting it.
-- **Idempotent** — an automation that is already absent is a no-op, not an error.
+- **Idempotent** — an automation that is already absent is a no-op, not an error. Re-running when
+  the prefix sweep finds nothing is a clean, successful no-op.
+- **Leave the runbooks alone.** The checked-in `.lisa/automations/<loop-id>.runbook.md` files that
+  `/setup-automations` scaffolded are project knowledge and the historical record of what these
+  loops did. Teardown removes scheduler registrations only; it never deletes, edits, or moves a
+  runbook file. An operator who wants them gone removes them deliberately, in git.
 
 ## Report
 
-List each automation removed, and any in the expected set that were already absent.
+List each automation removed by name, and any that the prefix sweep expected to find but that were
+already absent. State explicitly that the runbook files under `.lisa/automations/` were left on
+disk, and that nothing outside this project's `lisa-auto-<project>-` prefix was touched. Write it so
+a non-technical operator can confirm what happened without reading code.

--- a/plugins/lisa/scripts/automation-status-claude-adapter.mjs
+++ b/plugins/lisa/scripts/automation-status-claude-adapter.mjs
@@ -10,6 +10,11 @@
  */
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
+import {
+  assignToAutomationGroup,
+  createAutomationGroupBins,
+  renderAutomationGroups,
+} from "./automation-status-expected-fleet.mjs";
 
 const CLAUDE_RUNTIME_LABEL = "Claude /schedule";
 const CLAUDE_ACTIVE_STATUSES = new Set([
@@ -75,10 +80,7 @@ export function inspectClaudeAutomationFleet(input) {
     automationPrefix: expectedFleet.automationPrefix,
   });
 
-  const expectedGroups = new Map([
-    ["core", []],
-    ["exploratory", []],
-  ]);
+  const expectedGroups = createAutomationGroupBins();
 
   const comparisons = compareAutomationFleet({
     expectedAutomations: expectedFleet.expected,
@@ -87,7 +89,9 @@ export function inspectClaudeAutomationFleet(input) {
 
   for (const [index, expected] of expectedFleet.expected.entries()) {
     const comparison = comparisons[index];
-    expectedGroups.get(expected.group)?.push(
+    assignToAutomationGroup(
+      expectedGroups,
+      expected.group,
       createObservedStatusItem({
         expected,
         comparison,
@@ -97,7 +101,7 @@ export function inspectClaudeAutomationFleet(input) {
   }
 
   for (const unsupported of expectedFleet.unsupported) {
-    expectedGroups.get(unsupported.group)?.push({
+    assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
@@ -109,18 +113,7 @@ export function inspectClaudeAutomationFleet(input) {
   return {
     runtime: `${CLAUDE_RUNTIME_LABEL} listing`,
     generatedAt: now.toISOString(),
-    groups: [
-      {
-        id: "1",
-        title: "Core automations",
-        items: expectedGroups.get("core") ?? [],
-      },
-      {
-        id: "2",
-        title: "Exploratory automations",
-        items: expectedGroups.get("exploratory") ?? [],
-      },
-    ],
+    groups: renderAutomationGroups(expectedGroups),
     observedAutomations,
   };
 }
@@ -487,6 +480,13 @@ function normalizeClaudeRRule(value) {
   ) {
     return "FREQ=DAILY;INTERVAL=1";
   }
+  if (
+    cadence === "once a week" ||
+    cadence === "every week" ||
+    cadence === "weekly"
+  ) {
+    return "FREQ=WEEKLY;INTERVAL=1";
+  }
 
   const everyMinutes = cadence.match(/every (\d+) minutes?/);
   if (everyMinutes?.[1]) {
@@ -501,6 +501,11 @@ function normalizeClaudeRRule(value) {
   const everyDays = cadence.match(/every (\d+) days?/);
   if (everyDays?.[1]) {
     return `FREQ=DAILY;INTERVAL=${everyDays[1]}`;
+  }
+
+  const everyWeeks = cadence.match(/every (\d+) weeks?/);
+  if (everyWeeks?.[1]) {
+    return `FREQ=WEEKLY;INTERVAL=${everyWeeks[1]}`;
   }
 
   return undefined;
@@ -526,6 +531,9 @@ function humanizeClaudeCadence(value) {
   }
   if (normalized === "every day") {
     return "once a day";
+  }
+  if (normalized === "weekly" || normalized === "every week") {
+    return "once a week";
   }
   return normalized;
 }
@@ -556,6 +564,11 @@ function humanizeRRule(rrule) {
     return Number(daily[1]) === 1 ? "once a day" : `every ${daily[1]} days`;
   }
 
+  const weekly = rrule.match(/^FREQ=WEEKLY;INTERVAL=(\d+)$/);
+  if (weekly?.[1]) {
+    return Number(weekly[1]) === 1 ? "once a week" : `every ${weekly[1]} weeks`;
+  }
+
   return rrule;
 }
 
@@ -572,6 +585,11 @@ function cadenceLabelToIntervalMs(label) {
   const oncePerDay = new Set(["once a day", "daily"]);
   if (oncePerDay.has(label)) {
     return 24 * 60 * 60_000;
+  }
+
+  const oncePerWeek = new Set(["once a week", "weekly"]);
+  if (oncePerWeek.has(label)) {
+    return 7 * 24 * 60 * 60_000;
   }
 
   return null;

--- a/plugins/lisa/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa/scripts/automation-status-codex-adapter.mjs
@@ -17,6 +17,11 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
+import {
+  assignToAutomationGroup,
+  createAutomationGroupBins,
+  renderAutomationGroups,
+} from "./automation-status-expected-fleet.mjs";
 
 const CODEx_RUNTIME_LABEL = "Codex automations";
 const RUN_TIMESTAMP_PATTERN = /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/;
@@ -156,10 +161,7 @@ export async function inspectCodexAutomationFleet(input) {
     automationPrefix: expectedFleet.automationPrefix,
   });
 
-  const expectedGroups = new Map([
-    ["core", []],
-    ["exploratory", []],
-  ]);
+  const expectedGroups = createAutomationGroupBins();
 
   const comparisons = compareAutomationFleet({
     expectedAutomations: expectedFleet.expected,
@@ -168,7 +170,9 @@ export async function inspectCodexAutomationFleet(input) {
 
   for (const [index, expected] of expectedFleet.expected.entries()) {
     const comparison = comparisons[index];
-    expectedGroups.get(expected.group)?.push(
+    assignToAutomationGroup(
+      expectedGroups,
+      expected.group,
       createObservedStatusItem({
         expected,
         comparison,
@@ -178,7 +182,7 @@ export async function inspectCodexAutomationFleet(input) {
   }
 
   for (const unsupported of expectedFleet.unsupported) {
-    expectedGroups.get(unsupported.group)?.push({
+    assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
@@ -190,18 +194,7 @@ export async function inspectCodexAutomationFleet(input) {
   return {
     runtime: `${CODEx_RUNTIME_LABEL} (backing-store metadata)`,
     generatedAt: now.toISOString(),
-    groups: [
-      {
-        id: "1",
-        title: "Core automations",
-        items: expectedGroups.get("core") ?? [],
-      },
-      {
-        id: "2",
-        title: "Exploratory automations",
-        items: expectedGroups.get("exploratory") ?? [],
-      },
-    ],
+    groups: renderAutomationGroups(expectedGroups),
     observedAutomations,
   };
 }
@@ -583,6 +576,13 @@ function humanizeAutomationCadence(rrule) {
       : `every ${everyDays[1]} days`;
   }
 
+  const everyWeeks = rrule.match(/^FREQ=WEEKLY;INTERVAL=(\d+)$/);
+  if (everyWeeks?.[1]) {
+    return Number(everyWeeks[1]) === 1
+      ? "once a week"
+      : `every ${everyWeeks[1]} weeks`;
+  }
+
   return rrule;
 }
 
@@ -606,6 +606,11 @@ function rruleToIntervalMs(rrule) {
     return Number(daily[1]) * 24 * 60 * 60_000;
   }
 
+  const weekly = rrule.match(/^FREQ=WEEKLY;INTERVAL=(\d+)$/);
+  if (weekly?.[1]) {
+    return Number(weekly[1]) * 7 * 24 * 60 * 60_000;
+  }
+
   return null;
 }
 
@@ -621,6 +626,10 @@ function cadenceLabelToIntervalMs(label) {
 
   if (label === "once a day") {
     return 24 * 60 * 60_000;
+  }
+
+  if (label === "once a week") {
+    return 7 * 24 * 60 * 60_000;
   }
 
   return null;

--- a/plugins/lisa/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa/scripts/automation-status-codex-adapter.mjs
@@ -242,21 +242,35 @@ export function deriveCodexObservedCommand(prompt) {
     return undefined;
   }
 
+  // The "with arguments" clause is optional: no-argument loops (monitor, the
+  // gardener) register without one. Requiring it made every such loop derive an
+  // undefined command and report DRIFTED forever, un-fixable by re-running setup.
   const lisaSkillMatch = prompt.match(
-    /Use the Lisa ([a-z0-9:-]+) skill with arguments `([^`]+)`/i
+    /Use the Lisa ([a-z0-9:-]+) skill(?: with arguments `([^`]*)`)?/i
   );
-  if (lisaSkillMatch?.[1] && lisaSkillMatch[2]) {
-    return `/lisa:${lisaSkillMatch[1]} ${lisaSkillMatch[2]}`.trim();
+  if (lisaSkillMatch?.[1]) {
+    return `/lisa:${lisaSkillMatch[1]} ${lisaSkillMatch[2] ?? ""}`.trim();
   }
 
   const aliasSkillMatch = prompt.match(
-    /Use the `\$([a-z0-9:-]+)` skill with arguments `([^`]+)`/i
+    /Use the `\$([a-z0-9:-]+)` skill(?: with arguments `([^`]*)`)?/i
   );
-  if (aliasSkillMatch?.[1] && aliasSkillMatch[2]) {
-    return `${canonicalizeCodexSkillAlias(aliasSkillMatch[1])} ${aliasSkillMatch[2]}`.trim();
+  if (aliasSkillMatch?.[1]) {
+    return `${canonicalizeCodexSkillAlias(aliasSkillMatch[1])} ${aliasSkillMatch[2] ?? ""}`.trim();
   }
 
-  return undefined;
+  // A registration whose prompt carries the literal Lisa command on its own
+  // line — the shape `/lisa:setup-automations` bakes so a command that is not a
+  // plain skill name (`/lisa:learnings:audit`) round-trips exactly. Mirrors the
+  // Claude adapter, which has always accepted a bare `/lisa:` command. Codex
+  // stores prompts as single-line TOML, so a line break arrives either real or
+  // as the two-character escape `\n`; both delimit a line here.
+  const literalCommand = prompt
+    .split(/\r?\n|\\n/)
+    .map(segment => segment.trim())
+    .find(segment => /^\/lisa[:-]\S/.test(segment));
+
+  return literalCommand;
 }
 
 function canonicalizeCodexSkillAlias(alias) {

--- a/plugins/lisa/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa/scripts/automation-status-expected-fleet.mjs
@@ -56,6 +56,68 @@ export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
 export const AUTOMATION_RUNBOOK_DIRECTORY = ".lisa/automations";
 
 /**
+ * Every fleet group, in render order, with the operator-facing title each one
+ * carries in the status report. This is the single source of truth for group
+ * membership: adapters bin entries with {@link createAutomationGroupBins} and
+ * render with {@link renderAutomationGroups}, so adding a group here surfaces it
+ * everywhere instead of silently dropping its entries.
+ */
+export const AUTOMATION_FLEET_GROUP_TITLES = {
+  core: "Core automations",
+  exploratory: "Exploratory automations",
+  "opt-in": "Opt-in automations",
+};
+
+/**
+ * Create one empty bin per known fleet group.
+ *
+ * @returns {Map<string, object[]>}
+ */
+export function createAutomationGroupBins() {
+  return new Map(
+    Object.keys(AUTOMATION_FLEET_GROUP_TITLES).map(group => [group, []])
+  );
+}
+
+/**
+ * Add a rendered status item to its group bin.
+ *
+ * Throws on an unknown group rather than dropping the item: a silently skipped
+ * entry is indistinguishable from a healthy fleet, which is exactly how the
+ * opt-in gardener went missing from both runtime adapters.
+ *
+ * @param {Map<string, object[]>} bins
+ * @param {string} group
+ * @param {object} item
+ * @returns {void}
+ */
+export function assignToAutomationGroup(bins, group, item) {
+  const bin = bins.get(group);
+  if (!bin) {
+    throw new Error(
+      `Unknown automation fleet group "${group}" for ${item?.id ?? "an automation"}. Add it to AUTOMATION_FLEET_GROUP_TITLES so the status report can render it.`
+    );
+  }
+  bin.push(item);
+}
+
+/**
+ * Render the group bins as the numbered report groups, in declaration order.
+ *
+ * @param {Map<string, object[]>} bins
+ * @returns {readonly { readonly id: string, readonly title: string, readonly items: readonly object[] }[]}
+ */
+export function renderAutomationGroups(bins) {
+  return Object.entries(AUTOMATION_FLEET_GROUP_TITLES).map(
+    ([group, title], index) => ({
+      id: String(index + 1),
+      title,
+      items: bins.get(group) ?? [],
+    })
+  );
+}
+
+/**
  * @typedef {{
  *   readonly id: string
  *   readonly automationId: string
@@ -76,6 +138,27 @@ export const AUTOMATION_RUNBOOK_DIRECTORY = ".lisa/automations";
  *   readonly runbookPath: string
  * }} UnsupportedAutomationEntry
  */
+
+/**
+ * Infer whether this project opted into the weekly gardener, from what is
+ * actually registered on the scheduler.
+ *
+ * Membership is registration, not configuration: there is no config key to
+ * read, so a read-only caller decides by looking for the registration itself.
+ * Pass the result as `learningsAudit` to {@link resolveExpectedAutomationFleet}
+ * so an opted-in project compares its gardener like any other loop instead of
+ * reporting it `UNSUPPORTED` forever.
+ *
+ * @param {{
+ *   readonly automationPrefix: string
+ *   readonly observedAutomationIds?: readonly string[]
+ * }} input
+ * @returns {boolean}
+ */
+export function inferLearningsAuditRegistration(input) {
+  const target = `${input.automationPrefix}learnings-audit`;
+  return (input.observedAutomationIds ?? []).includes(target);
+}
 
 /**
  * Resolve the repo-relative runbook path for a loop id.
@@ -129,6 +212,13 @@ export function resolveAutomationProjectIdentity(input = {}) {
  *   readonly autoStartTickets?: boolean | string
  *   readonly learningsAudit?: boolean | string
  * }} input
+ *
+ * `learningsAudit` has no config home by design — the gardener is opted into at
+ * registration time, and membership is registration, not configuration. A
+ * read-only caller (the status surface) therefore INFERS it: pass `true` when a
+ * `<automationPrefix>learnings-audit` entry is observed on the runtime
+ * scheduler. Without that inference an opted-in project would report the
+ * gardener `UNSUPPORTED` forever instead of comparing it like any other loop.
  * @returns {{
  *   readonly owner: string
  *   readonly repo: string
@@ -220,7 +310,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
       createUnsupportedEntry(
         identity,
         "exploratory-bugs",
-        "This repository does not ship an exploratory-qa command surface.",
+        "This project ships no exploratory-qa command, so there is nothing for this loop to run. No action needed unless the project adds one.",
         "exploratory"
       )
     );
@@ -240,7 +330,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
       createUnsupportedEntry(
         identity,
         "learnings-audit",
-        "The weekly gardener loop is opt-in and this project has not opted in (learnings-audit=false).",
+        "The weekly gardener loop is opt-in and this project has not opted in, so nobody is auditing its knowledge surfaces. Run /lisa:setup-automations learnings-audit=true to enable it.",
         "opt-in"
       )
     );

--- a/plugins/lisa/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/lisa/scripts/automation-status-expected-fleet.mjs
@@ -37,9 +37,23 @@ export const AUTOMATION_EXPECTED_CADENCES = {
     human: "once a day",
     rrule: "FREQ=DAILY;INTERVAL=1",
   },
+  monitor: {
+    human: "once a day",
+    rrule: "FREQ=DAILY;INTERVAL=1",
+  },
+  "learnings-audit": {
+    human: "once a week",
+    rrule: "FREQ=WEEKLY;INTERVAL=1",
+  },
 };
 
 export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
+
+/**
+ * Directory (repo-relative) holding the checked-in per-loop runbooks scaffolded
+ * by `/lisa:setup-automations` per the `automation-runbook-contract` rule.
+ */
+export const AUTOMATION_RUNBOOK_DIRECTORY = ".lisa/automations";
 
 /**
  * @typedef {{
@@ -48,18 +62,30 @@ export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
  *   readonly expectedCadence: string
  *   readonly expectedRRule: string
  *   readonly expectedCommand: string
- *   readonly group: "core" | "exploratory"
+ *   readonly group: "core" | "exploratory" | "opt-in"
+ *   readonly runbookPath: string
  * }} ExpectedAutomationEntry
  *
  * @typedef {{
  *   readonly id: string
  *   readonly automationId: string
- *   readonly group: "core" | "exploratory"
+ *   readonly group: "core" | "exploratory" | "opt-in"
  *   readonly reason: string
  *   readonly expectedCadence: string
  *   readonly expectedRRule: string
+ *   readonly runbookPath: string
  * }} UnsupportedAutomationEntry
  */
+
+/**
+ * Resolve the repo-relative runbook path for a loop id.
+ *
+ * @param {string} id
+ * @returns {string}
+ */
+export function resolveAutomationRunbookPath(id) {
+  return `${AUTOMATION_RUNBOOK_DIRECTORY}/${id}.runbook.md`;
+}
 
 /**
  * Resolve the stable project identifier and automation prefix used by
@@ -101,6 +127,7 @@ export function resolveAutomationProjectIdentity(input = {}) {
  *   readonly detectedTypes?: readonly string[]
  *   readonly autoStartPrds?: boolean | string
  *   readonly autoStartTickets?: boolean | string
+ *   readonly learningsAudit?: boolean | string
  * }} input
  * @returns {{
  *   readonly owner: string
@@ -116,6 +143,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
   const identity = resolveAutomationProjectIdentity(input);
   const autoStartPrds = normalizeBooleanFlag(input.autoStartPrds);
   const autoStartTickets = normalizeBooleanFlag(input.autoStartTickets);
+  const learningsAudit = normalizeBooleanFlag(input.learningsAudit);
   const detectedTypes = input.detectedTypes ?? [];
 
   const tracker = config.tracker;
@@ -166,6 +194,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
       `/lisa:intake ${buildQueue}`,
       "core"
     ),
+    createExpectedEntry(identity, "monitor", "/lisa:monitor", "core"),
     createExpectedEntry(
       identity,
       "exploratory-prds",
@@ -191,7 +220,28 @@ export function resolveExpectedAutomationFleet(input = {}) {
       createUnsupportedEntry(
         identity,
         "exploratory-bugs",
-        "This repository does not ship an exploratory-qa command surface."
+        "This repository does not ship an exploratory-qa command surface.",
+        "exploratory"
+      )
+    );
+  }
+
+  if (learningsAudit) {
+    expected.push(
+      createExpectedEntry(
+        identity,
+        "learnings-audit",
+        "/lisa:learnings:audit",
+        "opt-in"
+      )
+    );
+  } else {
+    unsupported.push(
+      createUnsupportedEntry(
+        identity,
+        "learnings-audit",
+        "The weekly gardener loop is opt-in and this project has not opted in (learnings-audit=false).",
+        "opt-in"
       )
     );
   }
@@ -222,7 +272,7 @@ export function resolveExploratoryQaStack(detectedTypes = []) {
  * @param {{ readonly automationPrefix: string }} identity
  * @param {string} id
  * @param {string} expectedCommand
- * @param {"core" | "exploratory"} group
+ * @param {"core" | "exploratory" | "opt-in"} group
  * @returns {ExpectedAutomationEntry}
  */
 function createExpectedEntry(identity, id, expectedCommand, group) {
@@ -234,6 +284,7 @@ function createExpectedEntry(identity, id, expectedCommand, group) {
     expectedRRule: cadence.rrule,
     expectedCommand,
     group,
+    runbookPath: resolveAutomationRunbookPath(id),
   };
 }
 
@@ -241,17 +292,19 @@ function createExpectedEntry(identity, id, expectedCommand, group) {
  * @param {{ readonly automationPrefix: string }} identity
  * @param {string} id
  * @param {string} reason
+ * @param {"core" | "exploratory" | "opt-in"} group
  * @returns {UnsupportedAutomationEntry}
  */
-function createUnsupportedEntry(identity, id, reason) {
+function createUnsupportedEntry(identity, id, reason, group) {
   const cadence = AUTOMATION_EXPECTED_CADENCES[id];
   return {
     id,
     automationId: `${identity.automationPrefix}${id}`,
     expectedCadence: cadence.human,
     expectedRRule: cadence.rrule,
-    group: "exploratory",
+    group,
     reason,
+    runbookPath: resolveAutomationRunbookPath(id),
   };
 }
 

--- a/plugins/lisa/skills/lisa-automation-status/SKILL.md
+++ b/plugins/lisa/skills/lisa-automation-status/SKILL.md
@@ -23,6 +23,14 @@ exactly what `setup-automations` registers for this repo — including the stack
 roster** (`automation-runbook-contract`): carry no fixed list of loop names here, so a loop added to
 or removed from the registration set flows through without editing this skill.
 
+The gardener is opted into at registration time and has no config key, so **infer it from the
+scheduler**: list the project's automations first, then call
+`inferLearningsAuditRegistration({ automationPrefix, observedAutomationIds })` and pass the result
+as `learningsAudit` when resolving the fleet. A `lisa-auto-<project>-learnings-audit` entry on the
+scheduler means the project opted in, so the gardener is compared like any other loop; no such entry
+means it is reported `UNSUPPORTED` (opted out), never `MISSING`. This skill stays read-only — it
+infers, it never writes the flag anywhere.
+
 Resolve the expected project identifier, fleet naming prefix, queue arguments, cadence, and stack-support rules from the same contract used by `setup-automations` and `tear-down-automations`. Do **not** invent a second source of truth for fleet naming or queue resolution.
 
 ## Runtime inspection

--- a/plugins/lisa/skills/lisa-automation-status/SKILL.md
+++ b/plugins/lisa/skills/lisa-automation-status/SKILL.md
@@ -16,14 +16,12 @@ Do **not** ask for confirmation once invoked. This skill inspects scheduler stat
 
 ## Scope
 
-Inspect only the Lisa automation fleet for the current project:
-
-- `intake-repair`
-- `intake-prd`
-- `intake-tickets`
-- `exploratory-bugs` when the current stack supports `exploratory-qa`
-- `exploratory-prds`
-- `monitor`
+Inspect only the Lisa automation fleet for the current project. Derive that fleet from
+`scripts/automation-status-expected-fleet.mjs` (`resolveExpectedAutomationFleet`), which resolves
+exactly what `setup-automations` registers for this repo — including the stack-guarded
+`exploratory-bugs` and the opt-in `learnings-audit` gardener. **Membership is registration, not a
+roster** (`automation-runbook-contract`): carry no fixed list of loop names here, so a loop added to
+or removed from the registration set flows through without editing this skill.
 
 Resolve the expected project identifier, fleet naming prefix, queue arguments, cadence, and stack-support rules from the same contract used by `setup-automations` and `tear-down-automations`. Do **not** invent a second source of truth for fleet naming or queue resolution.
 

--- a/plugins/lisa/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-automations/SKILL.md
@@ -146,19 +146,53 @@ packet here** — cite the rule and instantiate it.
    id, the full automation name, the exact scheduled command with every `owner/repo` already baked
    in (never a placeholder), the human cadence and its `rrule`, the resolved queue arguments, and
    the resolved flag values that shaped the command (`auto-start-prds` / `auto-start-tickets` /
-   `learnings-audit`).
-2. The **ten contract sections** below it. Lisa owns them **only on first write**: seed each one
-   from this skill's per-loop defaults — what that loop maintains, what it reads, how it picks
-   candidates, its bounds, its proof, its approval boundary, its escalation, its recovery, its
-   next-run state, its retirement condition — written for a non-technical operator. After that they
-   belong to the operator.
+   `learnings-audit`). Its **first line inside the delimiters is a visible sentence**, so the
+   ownership boundary survives rendering to markdown where HTML comments disappear:
 
-**Re-run rule (idempotent, append-or-leave).** When the file already exists: rewrite the
+   ```text
+   Lisa rewrites this section on every /lisa:setup-automations run — edits here are lost. Your prose
+   belongs in the sections below.
+   ```
+
+   Immediately **below** the closing delimiter, write one more visible line — `Everything below is
+   yours.` — so an operator reading the rendered page knows where their half starts.
+2. The **ten contract sections** below it. Lisa owns them **only on first write**, then they belong
+   to the operator. Seed them deterministically, never improvised:
+   - **Intent, Sources of truth, Candidate selection, Scope/bounds, Retirement condition** come
+     from the per-loop seed table below.
+   - **Proof, Autonomous-vs-approval boundary, Escalation, Recovery, Next-run state** are derived
+     from **that loop's own SKILL.md** — named per loop in the table's last column — so the runbook
+     describes what the loop actually does rather than a generic paraphrase. Quote its behavior in
+     the operator's voice; if the skill file is unreadable, write one sentence saying the section
+     was not derivable and which file to read, and continue.
+
+   Every seeded sentence is written for a non-technical operator (`factory-model` rule 5).
+
+### Per-loop seed defaults
+
+One line each; expand them into the operator's voice, keep the meaning.
+
+| Loop | Intent | Sources of truth | Candidate selection | Scope/bounds | Retirement condition | Derive the other five from |
+|---|---|---|---|---|---|---|
+| **intake-repair** | Keeps the queues unstuck: work that stalled mid-flight gets diagnosed and moved again. | The PRD and build queues for this project, read through the tracker access layer. | Stuck or half-closed items — stalled in an in-progress role, terminal-labeled but still open, rollups whose children are all done — up to the `max_candidates` cap. | Only this project's configured queues; it repairs lifecycle state, never invents or closes real work. | Propose teardown when nothing has needed repair for a long quiet window AND this run found nothing. | `lisa-repair-intake/SKILL.md` |
+| **intake-prd** | Keeps PRDs moving: a PRD a human marked ready gets validated and decomposed into work items. | The configured PRD queue and its lifecycle roles, read through the source access layer. | The oldest PRD in the ready role, one per run. | Only this project's PRD queue; it never authors product intent, only validates and decomposes it. | Propose teardown when no PRD has entered the queue for a long quiet window AND this run proposed nothing. | `lisa-intake/SKILL.md` |
+| **intake-tickets** | Keeps the build queue moving: work items a human marked ready get built, reviewed, and shipped. | The configured tracker's build queue lanes plus each item's comments and linked PRs. | The oldest eligible leaf work item in the ready lane, one per run. | Only this repo's configured queue; containers with open children are repaired out, never built. | Propose teardown when no work item has entered this queue for a long quiet window AND this run proposed nothing. | `lisa-intake/SKILL.md` |
+| **monitor** | Keeps production honest: observability regressions become tracked work instead of silent decay. | The connected observability providers, each through its access layer, plus this project's `monitor.gapTiers` config. | The regressions and coverage gaps this cycle surfaced, capped per run. | Only this project's own services and dashboards; it files findings, it never changes production. | Propose teardown when the project has no connected observability surfaces AND this run found nothing. | `lisa-monitor/SKILL.md` |
+| **exploratory-prds** | Keeps the idea pipeline fed: the product's own gaps become PRDs when the PRD queue has room. | The PRD queue's pressure roles (the same ones `/lisa:queue-status` reports) and the project's own product surfaces. | One ideated PRD per run, and only when the pressure gate says the queue has capacity. | Never more than one PRD per run, and nothing at all while unresolved PRD pressure exists. | Propose teardown when the queue has been at pressure — or the project has shipped no new surface — across a long quiet window AND this run proposed nothing. | `lisa-project-ideation/SKILL.md` |
+| **exploratory-bugs** | Keeps quality visible: bugs and usability problems get found by using the product, before a customer does. | The running application through its exploratory-qa surface, plus this project's existing bug queue for dedupe. | The findings of one exploratory session, capped per run and deduped against already-filed items. | Only this project's own app; it files tickets, it never changes product code. | Propose teardown when no session has produced a finding across a long quiet window AND this run found nothing. | `lisa-exploratory-qa/SKILL.md` (the stack's own copy) |
+| **learnings-audit** | Keeps the project's knowledge true: stale, duplicated, or contradicted knowledge gets proposed for promotion, demotion, or retirement. | The learnings ledger, the rules trees, the skills, and the wiki — the project's knowledge surfaces. | The knowledge entries this audit judged stale, duplicated, or contradicted, capped per run. | It only proposes; every promote/demote/retire decision is a human-gated tracker ticket. | Propose teardown when the audit has proposed nothing across a long quiet window AND this run proposed nothing. | `lisa-learnings-audit/SKILL.md` |
+
+A loop not in this table — one registered later — seeds all ten sections from its own SKILL.md the
+same way. The table is seed prose for first write only; it is **not** a roster and never decides
+which automations exist.
+
+**Re-run rule (idempotent, never clobber).** When the file already exists: rewrite the
 machine-resolved block in place and **leave every one of the ten sections exactly as found** — an
-operator's edited Intent paragraph survives verbatim. If a section from the contract is **missing**
-from an existing file, append it with its seeded default; never overwrite, reorder, reword, or
-delete prose already on disk. If the machine-resolved delimiters are absent (a hand-written file),
-insert the block at the top and touch nothing else.
+operator's edited Intent paragraph survives verbatim. If a contract section is **missing** from an
+existing file, insert it **at its position in the contract's ten-section order** (never merely
+appended at the end, which would leave the file permanently out of order) with its seeded default.
+Never overwrite, reorder, reword, or delete prose already on disk. If the machine-resolved
+delimiters are absent (a hand-written file), insert the block at the top and touch nothing else.
 
 **Never a precondition.** A runbook that cannot be written is a **degradation, not a blocker**:
 report the failure and continue registering automations. A loop with a missing runbook still runs —
@@ -190,6 +224,15 @@ Then list each runbook written, by path (`.lisa/automations/<loop-id>.runbook.md
 whether it was **created** (seeded fresh) or **refreshed** (machine-resolved block rewritten,
 operator prose left untouched). Name every skipped loop again here and state plainly that it has no
 runbook because it was not registered, and why — for example, "exploratory-bugs was skipped because
-this project ships no exploratory-qa command, so no runbook was written for it." If a runbook could
-not be written, say which one and what failed; the automation itself is still registered. Write all
-of this so a non-technical operator can act on it without reading code.
+this project ships no exploratory-qa command, so no runbook was written for it."
+
+Close with the two lines that tell the operator what to do next:
+
+- When any runbook was newly created: "N new files were written under `.lisa/automations/` — commit
+  them so the whole team sees them."
+- When a runbook could not be written: name which one and what failed, then the consequence and the
+  fix — "that loop runs on defaults and its summaries will lead with 'Runbook missing' — re-run
+  `/lisa:setup-automations` to fix." The automation itself is still registered and still runs.
+
+Every line states the consequence and the action, in words a non-technical operator can act on
+without reading code.

--- a/plugins/lisa/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-automations/SKILL.md
@@ -105,6 +105,19 @@ the scheduled commands (for example `/lisa:intake acme/frontend intake_mode=prd`
 config/read-context failure cannot silently redirect the cron. A short queueRepo is normalized to
 `github.org` before writing the automation.
 
+**Registration prompt shape (so status can read the command back).** Whatever prose the prompt
+carries, it must contain the **literal Lisa command on a line of its own**, exactly as scheduled and
+with every `owner/repo` already baked in:
+
+```text
+/lisa:intake acme/planning intake_mode=build
+```
+
+This holds for loops that take **no arguments** too — `/lisa:monitor` and `/lisa:learnings:audit`
+are written the same way, on their own line, with nothing after them. `/lisa:automation-status`
+reads that line back to compare the live registration against this contract; a loop whose command
+cannot be read back reports as drifted even though it is registered correctly.
+
 **Naming + scope (so teardown is precise).** Name each automation with the stable prefix
 `lisa-auto-<project>-` (e.g. `lisa-auto-<project>-intake-tickets`), where `<project>` identifies this
 repo, and scope each Codex automation to the durable project automation checkout described above.

--- a/plugins/lisa/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-automations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lisa-setup-automations
 description: "Set up the recurring Lisa automations on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automations to create, how often, and with which parameters; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates six default automations: intake-repair (every 60 min), intake PRD (every 60 min), intake tickets (every 10 min), exploratory-bugs (once a day), exploratory-prds (once a day), monitor (once a day) — plus opt-in learnings-audit (once a week, the gardener). Three flags: auto-start-prds and auto-start-tickets control whether ideated PRDs / filed bug tickets are created auto-pickup-ready (prd_ready / ready, default true) or left for human review; learnings-audit (default false) opts into the weekly gardener loop. Tear down with /tear-down-automations."
-allowed-tools: ["Skill", "Bash", "Read"]
+allowed-tools: ["Skill", "Bash", "Read", "Write", "Edit"]
 ---
 
 # Set up Lisa automations: $ARGUMENTS
@@ -115,6 +115,57 @@ repos (don't rely on a bare repo basename when it could collide; qualify it, e.g
 **Idempotent.** Re-running this skill updates the existing `lisa-auto-<project>-*` automations in
 place (same names) rather than creating duplicates.
 
+## Runbook scaffolding
+
+Registration is what pulls a loop under the `automation-runbook-contract` rule, so registration is
+what must produce its runbook. For **every automation actually registered above** — including the
+conditionally-guarded `exploratory-bugs` and the opt-in `learnings-audit` — write a checked-in
+runbook at:
+
+```text
+.lisa/automations/<loop-id>.runbook.md
+```
+
+`<loop-id>` is the automation's suffix, not its full name: `intake-tickets`, not
+`lisa-auto-<project>-intake-tickets`. These files are **project knowledge and belong in git**, like
+`.lisa/PROJECT_LEARNINGS.md` — commit them; they are not scratch output. Derive the set of runbooks
+from what was registered on this run: a loop that was **skipped gets no runbook**, and a loop
+registered later gets one when this skill next runs. Never write a runbook from a fixed list of
+loop names.
+
+Follow the `automation-runbook-contract` rule for the runbook's shape: its ten sections, in its
+order, in its prose register. **Do not restate the template, the run outcomes, or the escalation
+packet here** — cite the rule and instantiate it.
+
+**File shape — two halves with different owners.**
+
+1. A **machine-resolved header block**, delimited exactly by
+   `<!-- lisa:machine-resolved:start -->` and `<!-- lisa:machine-resolved:end -->`, written first
+   in the file. Lisa owns it: on every run it is **rewritten wholesale** from the values resolved
+   above. It carries the project identity (`<owner>/<repo>` and the `<project>` token), the loop
+   id, the full automation name, the exact scheduled command with every `owner/repo` already baked
+   in (never a placeholder), the human cadence and its `rrule`, the resolved queue arguments, and
+   the resolved flag values that shaped the command (`auto-start-prds` / `auto-start-tickets` /
+   `learnings-audit`).
+2. The **ten contract sections** below it. Lisa owns them **only on first write**: seed each one
+   from this skill's per-loop defaults — what that loop maintains, what it reads, how it picks
+   candidates, its bounds, its proof, its approval boundary, its escalation, its recovery, its
+   next-run state, its retirement condition — written for a non-technical operator. After that they
+   belong to the operator.
+
+**Re-run rule (idempotent, append-or-leave).** When the file already exists: rewrite the
+machine-resolved block in place and **leave every one of the ten sections exactly as found** — an
+operator's edited Intent paragraph survives verbatim. If a section from the contract is **missing**
+from an existing file, append it with its seeded default; never overwrite, reorder, reword, or
+delete prose already on disk. If the machine-resolved delimiters are absent (a hand-written file),
+insert the block at the top and touch nothing else.
+
+**Never a precondition.** A runbook that cannot be written is a **degradation, not a blocker**:
+report the failure and continue registering automations. A loop with a missing runbook still runs —
+on the contract's defaults, saying so in its one-line summary — per the contract's
+never-block-always-degrade rule. Scaffolding failure never aborts setup and never leaves an
+automation unregistered.
+
 ## Conditions / guards
 
 - **exploratory-bugs** is created only when the project ships an `exploratory-qa` command (the
@@ -134,3 +185,11 @@ place (same names) rather than creating duplicates.
 
 List each automation created or updated (name, the command it runs, cadence, and the resolved
 `auto-start-prds` / `auto-start-tickets` values), plus any automation skipped and why.
+
+Then list each runbook written, by path (`.lisa/automations/<loop-id>.runbook.md`), saying for each
+whether it was **created** (seeded fresh) or **refreshed** (machine-resolved block rewritten,
+operator prose left untouched). Name every skipped loop again here and state plainly that it has no
+runbook because it was not registered, and why — for example, "exploratory-bugs was skipped because
+this project ships no exploratory-qa command, so no runbook was written for it." If a runbook could
+not be written, say which one and what failed; the automation itself is still registered. Write all
+of this so a non-technical operator can act on it without reading code.

--- a/plugins/lisa/skills/lisa-tear-down-automations/SKILL.md
+++ b/plugins/lisa/skills/lisa-tear-down-automations/SKILL.md
@@ -42,7 +42,13 @@ removes them with its **native** scheduling mechanism.
 
 ## Report
 
-List each automation removed by name, and any that the prefix sweep expected to find but that were
-already absent. State explicitly that the runbook files under `.lisa/automations/` were left on
-disk, and that nothing outside this project's `lisa-auto-<project>-` prefix was touched. Write it so
-a non-technical operator can confirm what happened without reading code.
+List each automation removed by name. For "already absent", compare against the one source of truth
+— the fleet `scripts/automation-status-expected-fleet.mjs` (`resolveExpectedAutomationFleet`)
+resolves for this project — and name anything it expects that the sweep did not find; that is a
+no-op, not an error. Do not invent an expected set of your own.
+
+Then state, in the operator's words, that the runbook files under `.lisa/automations/` were left on
+disk **and why**: they are the written record of what those jobs did, kept on purpose, and if you
+do not want them you delete them yourself in git. Finally, confirm that nothing outside this
+project's `lisa-auto-<project>-` prefix was touched. Write it so a non-technical operator can
+confirm what happened without reading code.

--- a/plugins/lisa/skills/lisa-tear-down-automations/SKILL.md
+++ b/plugins/lisa/skills/lisa-tear-down-automations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-tear-down-automations
-description: "Remove every recurring Lisa automation that /setup-automations created for this project (the lisa-auto-<project>-* set: intake-repair, intake-prd, intake-tickets, exploratory-bugs, exploratory-prds, monitor) using the CURRENT runtime's native scheduler — Codex automations or, on Claude, /schedule. This skill is a declarative specification: it identifies WHICH automations to remove; it does not run teardown scripts. Removes only this project's Lisa automations — never other projects' automations or non-Lisa ones. The inverse of /setup-automations."
+description: "Remove every recurring Lisa automation that /setup-automations registered for this project — whatever is actually registered under the lisa-auto-<project>-* prefix, including the opt-in learnings-audit gardener — using the CURRENT runtime's native scheduler — Codex automations or, on Claude, /schedule. This skill is a declarative specification: it identifies WHICH automations to remove; it does not run teardown scripts. Carries no fixed list of loops: the registration set is the roster. Removes only this project's Lisa automations — never other projects' automations or non-Lisa ones. Leaves checked-in runbook files on disk. The inverse of /setup-automations."
 allowed-tools: ["Skill", "Bash", "Read"]
 ---
 
@@ -21,14 +21,28 @@ removes them with its **native** scheduling mechanism.
 
 ## Scope (remove only what setup created)
 
-- Remove the six automations `/setup-automations` creates for the current project, matched by the
-  stable `lisa-auto-<project>-` name prefix: `intake-repair`, `intake-prd`, `intake-tickets`,
-  `exploratory-bugs`, `exploratory-prds`, `monitor`.
+- Remove **every** automation `/setup-automations` registered for the current project — the whole
+  set found under the stable `lisa-auto-<project>-` name prefix, whatever it currently contains.
+  **Membership is registration, not a roster** (`automation-runbook-contract`): sweep the prefix and
+  remove what is there. Do **not** work from a fixed list of loop names — a list drifts the moment a
+  loop is added, which is exactly how the opt-in gardener came to be orphaned.
+- This explicitly includes the opt-in **`learnings-audit`** gardener when it is registered:
+  `/setup-automations learnings-audit=true` registers it under the same prefix, so teardown removes
+  it with the rest. A conditionally-skipped loop (e.g. `exploratory-bugs` on a stack without
+  `exploratory-qa`) simply is not in the sweep.
 - **Never** remove automations for a different project, or any non-Lisa automation (e.g. unrelated
   crawlers/ingestors). Match strictly on the `lisa-auto-<project>-` prefix for THIS project; when in
   doubt about an automation's ownership, leave it and report it rather than deleting it.
-- **Idempotent** — an automation that is already absent is a no-op, not an error.
+- **Idempotent** — an automation that is already absent is a no-op, not an error. Re-running when
+  the prefix sweep finds nothing is a clean, successful no-op.
+- **Leave the runbooks alone.** The checked-in `.lisa/automations/<loop-id>.runbook.md` files that
+  `/setup-automations` scaffolded are project knowledge and the historical record of what these
+  loops did. Teardown removes scheduler registrations only; it never deletes, edits, or moves a
+  runbook file. An operator who wants them gone removes them deliberately, in git.
 
 ## Report
 
-List each automation removed, and any in the expected set that were already absent.
+List each automation removed by name, and any that the prefix sweep expected to find but that were
+already absent. State explicitly that the runbook files under `.lisa/automations/` were left on
+disk, and that nothing outside this project's `lisa-auto-<project>-` prefix was touched. Write it so
+a non-technical operator can confirm what happened without reading code.

--- a/plugins/lisa/skills/lisa-tear-down-automations/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-tear-down-automations/agents/openai.yaml
@@ -1,4 +1,4 @@
 display_name: "Tear Down Automations"
-short_description: "Remove every recurring Lisa automation that /setup-automations created for this project (the lisa-auto-<project>-* set: intake-repair…"
+short_description: "Remove every recurring Lisa automation that /setup-automations registered for this project — whatever is actually registered under the…"
 default_prompt:
-  - "Use $lisa-tear-down-automations: Remove every recurring Lisa automation that /setup-automations created for this project (the lisa-auto-<project>-* set: intake-repair…."
+  - "Use $lisa-tear-down-automations: Remove every recurring Lisa automation that /setup-automations registered for this project — whatever is actually registered under the…."

--- a/plugins/src/base/scripts/automation-status-claude-adapter.mjs
+++ b/plugins/src/base/scripts/automation-status-claude-adapter.mjs
@@ -10,6 +10,11 @@
  */
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
+import {
+  assignToAutomationGroup,
+  createAutomationGroupBins,
+  renderAutomationGroups,
+} from "./automation-status-expected-fleet.mjs";
 
 const CLAUDE_RUNTIME_LABEL = "Claude /schedule";
 const CLAUDE_ACTIVE_STATUSES = new Set([
@@ -75,10 +80,7 @@ export function inspectClaudeAutomationFleet(input) {
     automationPrefix: expectedFleet.automationPrefix,
   });
 
-  const expectedGroups = new Map([
-    ["core", []],
-    ["exploratory", []],
-  ]);
+  const expectedGroups = createAutomationGroupBins();
 
   const comparisons = compareAutomationFleet({
     expectedAutomations: expectedFleet.expected,
@@ -87,7 +89,9 @@ export function inspectClaudeAutomationFleet(input) {
 
   for (const [index, expected] of expectedFleet.expected.entries()) {
     const comparison = comparisons[index];
-    expectedGroups.get(expected.group)?.push(
+    assignToAutomationGroup(
+      expectedGroups,
+      expected.group,
       createObservedStatusItem({
         expected,
         comparison,
@@ -97,7 +101,7 @@ export function inspectClaudeAutomationFleet(input) {
   }
 
   for (const unsupported of expectedFleet.unsupported) {
-    expectedGroups.get(unsupported.group)?.push({
+    assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
@@ -109,18 +113,7 @@ export function inspectClaudeAutomationFleet(input) {
   return {
     runtime: `${CLAUDE_RUNTIME_LABEL} listing`,
     generatedAt: now.toISOString(),
-    groups: [
-      {
-        id: "1",
-        title: "Core automations",
-        items: expectedGroups.get("core") ?? [],
-      },
-      {
-        id: "2",
-        title: "Exploratory automations",
-        items: expectedGroups.get("exploratory") ?? [],
-      },
-    ],
+    groups: renderAutomationGroups(expectedGroups),
     observedAutomations,
   };
 }
@@ -487,6 +480,13 @@ function normalizeClaudeRRule(value) {
   ) {
     return "FREQ=DAILY;INTERVAL=1";
   }
+  if (
+    cadence === "once a week" ||
+    cadence === "every week" ||
+    cadence === "weekly"
+  ) {
+    return "FREQ=WEEKLY;INTERVAL=1";
+  }
 
   const everyMinutes = cadence.match(/every (\d+) minutes?/);
   if (everyMinutes?.[1]) {
@@ -501,6 +501,11 @@ function normalizeClaudeRRule(value) {
   const everyDays = cadence.match(/every (\d+) days?/);
   if (everyDays?.[1]) {
     return `FREQ=DAILY;INTERVAL=${everyDays[1]}`;
+  }
+
+  const everyWeeks = cadence.match(/every (\d+) weeks?/);
+  if (everyWeeks?.[1]) {
+    return `FREQ=WEEKLY;INTERVAL=${everyWeeks[1]}`;
   }
 
   return undefined;
@@ -526,6 +531,9 @@ function humanizeClaudeCadence(value) {
   }
   if (normalized === "every day") {
     return "once a day";
+  }
+  if (normalized === "weekly" || normalized === "every week") {
+    return "once a week";
   }
   return normalized;
 }
@@ -556,6 +564,11 @@ function humanizeRRule(rrule) {
     return Number(daily[1]) === 1 ? "once a day" : `every ${daily[1]} days`;
   }
 
+  const weekly = rrule.match(/^FREQ=WEEKLY;INTERVAL=(\d+)$/);
+  if (weekly?.[1]) {
+    return Number(weekly[1]) === 1 ? "once a week" : `every ${weekly[1]} weeks`;
+  }
+
   return rrule;
 }
 
@@ -572,6 +585,11 @@ function cadenceLabelToIntervalMs(label) {
   const oncePerDay = new Set(["once a day", "daily"]);
   if (oncePerDay.has(label)) {
     return 24 * 60 * 60_000;
+  }
+
+  const oncePerWeek = new Set(["once a week", "weekly"]);
+  if (oncePerWeek.has(label)) {
+    return 7 * 24 * 60 * 60_000;
   }
 
   return null;

--- a/plugins/src/base/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/src/base/scripts/automation-status-codex-adapter.mjs
@@ -17,6 +17,11 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
+import {
+  assignToAutomationGroup,
+  createAutomationGroupBins,
+  renderAutomationGroups,
+} from "./automation-status-expected-fleet.mjs";
 
 const CODEx_RUNTIME_LABEL = "Codex automations";
 const RUN_TIMESTAMP_PATTERN = /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/;
@@ -156,10 +161,7 @@ export async function inspectCodexAutomationFleet(input) {
     automationPrefix: expectedFleet.automationPrefix,
   });
 
-  const expectedGroups = new Map([
-    ["core", []],
-    ["exploratory", []],
-  ]);
+  const expectedGroups = createAutomationGroupBins();
 
   const comparisons = compareAutomationFleet({
     expectedAutomations: expectedFleet.expected,
@@ -168,7 +170,9 @@ export async function inspectCodexAutomationFleet(input) {
 
   for (const [index, expected] of expectedFleet.expected.entries()) {
     const comparison = comparisons[index];
-    expectedGroups.get(expected.group)?.push(
+    assignToAutomationGroup(
+      expectedGroups,
+      expected.group,
       createObservedStatusItem({
         expected,
         comparison,
@@ -178,7 +182,7 @@ export async function inspectCodexAutomationFleet(input) {
   }
 
   for (const unsupported of expectedFleet.unsupported) {
-    expectedGroups.get(unsupported.group)?.push({
+    assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
@@ -190,18 +194,7 @@ export async function inspectCodexAutomationFleet(input) {
   return {
     runtime: `${CODEx_RUNTIME_LABEL} (backing-store metadata)`,
     generatedAt: now.toISOString(),
-    groups: [
-      {
-        id: "1",
-        title: "Core automations",
-        items: expectedGroups.get("core") ?? [],
-      },
-      {
-        id: "2",
-        title: "Exploratory automations",
-        items: expectedGroups.get("exploratory") ?? [],
-      },
-    ],
+    groups: renderAutomationGroups(expectedGroups),
     observedAutomations,
   };
 }
@@ -583,6 +576,13 @@ function humanizeAutomationCadence(rrule) {
       : `every ${everyDays[1]} days`;
   }
 
+  const everyWeeks = rrule.match(/^FREQ=WEEKLY;INTERVAL=(\d+)$/);
+  if (everyWeeks?.[1]) {
+    return Number(everyWeeks[1]) === 1
+      ? "once a week"
+      : `every ${everyWeeks[1]} weeks`;
+  }
+
   return rrule;
 }
 
@@ -606,6 +606,11 @@ function rruleToIntervalMs(rrule) {
     return Number(daily[1]) * 24 * 60 * 60_000;
   }
 
+  const weekly = rrule.match(/^FREQ=WEEKLY;INTERVAL=(\d+)$/);
+  if (weekly?.[1]) {
+    return Number(weekly[1]) * 7 * 24 * 60 * 60_000;
+  }
+
   return null;
 }
 
@@ -621,6 +626,10 @@ function cadenceLabelToIntervalMs(label) {
 
   if (label === "once a day") {
     return 24 * 60 * 60_000;
+  }
+
+  if (label === "once a week") {
+    return 7 * 24 * 60 * 60_000;
   }
 
   return null;

--- a/plugins/src/base/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/src/base/scripts/automation-status-codex-adapter.mjs
@@ -242,21 +242,35 @@ export function deriveCodexObservedCommand(prompt) {
     return undefined;
   }
 
+  // The "with arguments" clause is optional: no-argument loops (monitor, the
+  // gardener) register without one. Requiring it made every such loop derive an
+  // undefined command and report DRIFTED forever, un-fixable by re-running setup.
   const lisaSkillMatch = prompt.match(
-    /Use the Lisa ([a-z0-9:-]+) skill with arguments `([^`]+)`/i
+    /Use the Lisa ([a-z0-9:-]+) skill(?: with arguments `([^`]*)`)?/i
   );
-  if (lisaSkillMatch?.[1] && lisaSkillMatch[2]) {
-    return `/lisa:${lisaSkillMatch[1]} ${lisaSkillMatch[2]}`.trim();
+  if (lisaSkillMatch?.[1]) {
+    return `/lisa:${lisaSkillMatch[1]} ${lisaSkillMatch[2] ?? ""}`.trim();
   }
 
   const aliasSkillMatch = prompt.match(
-    /Use the `\$([a-z0-9:-]+)` skill with arguments `([^`]+)`/i
+    /Use the `\$([a-z0-9:-]+)` skill(?: with arguments `([^`]*)`)?/i
   );
-  if (aliasSkillMatch?.[1] && aliasSkillMatch[2]) {
-    return `${canonicalizeCodexSkillAlias(aliasSkillMatch[1])} ${aliasSkillMatch[2]}`.trim();
+  if (aliasSkillMatch?.[1]) {
+    return `${canonicalizeCodexSkillAlias(aliasSkillMatch[1])} ${aliasSkillMatch[2] ?? ""}`.trim();
   }
 
-  return undefined;
+  // A registration whose prompt carries the literal Lisa command on its own
+  // line — the shape `/lisa:setup-automations` bakes so a command that is not a
+  // plain skill name (`/lisa:learnings:audit`) round-trips exactly. Mirrors the
+  // Claude adapter, which has always accepted a bare `/lisa:` command. Codex
+  // stores prompts as single-line TOML, so a line break arrives either real or
+  // as the two-character escape `\n`; both delimit a line here.
+  const literalCommand = prompt
+    .split(/\r?\n|\\n/)
+    .map(segment => segment.trim())
+    .find(segment => /^\/lisa[:-]\S/.test(segment));
+
+  return literalCommand;
 }
 
 function canonicalizeCodexSkillAlias(alias) {

--- a/plugins/src/base/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/src/base/scripts/automation-status-expected-fleet.mjs
@@ -56,6 +56,68 @@ export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
 export const AUTOMATION_RUNBOOK_DIRECTORY = ".lisa/automations";
 
 /**
+ * Every fleet group, in render order, with the operator-facing title each one
+ * carries in the status report. This is the single source of truth for group
+ * membership: adapters bin entries with {@link createAutomationGroupBins} and
+ * render with {@link renderAutomationGroups}, so adding a group here surfaces it
+ * everywhere instead of silently dropping its entries.
+ */
+export const AUTOMATION_FLEET_GROUP_TITLES = {
+  core: "Core automations",
+  exploratory: "Exploratory automations",
+  "opt-in": "Opt-in automations",
+};
+
+/**
+ * Create one empty bin per known fleet group.
+ *
+ * @returns {Map<string, object[]>}
+ */
+export function createAutomationGroupBins() {
+  return new Map(
+    Object.keys(AUTOMATION_FLEET_GROUP_TITLES).map(group => [group, []])
+  );
+}
+
+/**
+ * Add a rendered status item to its group bin.
+ *
+ * Throws on an unknown group rather than dropping the item: a silently skipped
+ * entry is indistinguishable from a healthy fleet, which is exactly how the
+ * opt-in gardener went missing from both runtime adapters.
+ *
+ * @param {Map<string, object[]>} bins
+ * @param {string} group
+ * @param {object} item
+ * @returns {void}
+ */
+export function assignToAutomationGroup(bins, group, item) {
+  const bin = bins.get(group);
+  if (!bin) {
+    throw new Error(
+      `Unknown automation fleet group "${group}" for ${item?.id ?? "an automation"}. Add it to AUTOMATION_FLEET_GROUP_TITLES so the status report can render it.`
+    );
+  }
+  bin.push(item);
+}
+
+/**
+ * Render the group bins as the numbered report groups, in declaration order.
+ *
+ * @param {Map<string, object[]>} bins
+ * @returns {readonly { readonly id: string, readonly title: string, readonly items: readonly object[] }[]}
+ */
+export function renderAutomationGroups(bins) {
+  return Object.entries(AUTOMATION_FLEET_GROUP_TITLES).map(
+    ([group, title], index) => ({
+      id: String(index + 1),
+      title,
+      items: bins.get(group) ?? [],
+    })
+  );
+}
+
+/**
  * @typedef {{
  *   readonly id: string
  *   readonly automationId: string
@@ -76,6 +138,27 @@ export const AUTOMATION_RUNBOOK_DIRECTORY = ".lisa/automations";
  *   readonly runbookPath: string
  * }} UnsupportedAutomationEntry
  */
+
+/**
+ * Infer whether this project opted into the weekly gardener, from what is
+ * actually registered on the scheduler.
+ *
+ * Membership is registration, not configuration: there is no config key to
+ * read, so a read-only caller decides by looking for the registration itself.
+ * Pass the result as `learningsAudit` to {@link resolveExpectedAutomationFleet}
+ * so an opted-in project compares its gardener like any other loop instead of
+ * reporting it `UNSUPPORTED` forever.
+ *
+ * @param {{
+ *   readonly automationPrefix: string
+ *   readonly observedAutomationIds?: readonly string[]
+ * }} input
+ * @returns {boolean}
+ */
+export function inferLearningsAuditRegistration(input) {
+  const target = `${input.automationPrefix}learnings-audit`;
+  return (input.observedAutomationIds ?? []).includes(target);
+}
 
 /**
  * Resolve the repo-relative runbook path for a loop id.
@@ -129,6 +212,13 @@ export function resolveAutomationProjectIdentity(input = {}) {
  *   readonly autoStartTickets?: boolean | string
  *   readonly learningsAudit?: boolean | string
  * }} input
+ *
+ * `learningsAudit` has no config home by design — the gardener is opted into at
+ * registration time, and membership is registration, not configuration. A
+ * read-only caller (the status surface) therefore INFERS it: pass `true` when a
+ * `<automationPrefix>learnings-audit` entry is observed on the runtime
+ * scheduler. Without that inference an opted-in project would report the
+ * gardener `UNSUPPORTED` forever instead of comparing it like any other loop.
  * @returns {{
  *   readonly owner: string
  *   readonly repo: string
@@ -220,7 +310,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
       createUnsupportedEntry(
         identity,
         "exploratory-bugs",
-        "This repository does not ship an exploratory-qa command surface.",
+        "This project ships no exploratory-qa command, so there is nothing for this loop to run. No action needed unless the project adds one.",
         "exploratory"
       )
     );
@@ -240,7 +330,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
       createUnsupportedEntry(
         identity,
         "learnings-audit",
-        "The weekly gardener loop is opt-in and this project has not opted in (learnings-audit=false).",
+        "The weekly gardener loop is opt-in and this project has not opted in, so nobody is auditing its knowledge surfaces. Run /lisa:setup-automations learnings-audit=true to enable it.",
         "opt-in"
       )
     );

--- a/plugins/src/base/scripts/automation-status-expected-fleet.mjs
+++ b/plugins/src/base/scripts/automation-status-expected-fleet.mjs
@@ -37,9 +37,23 @@ export const AUTOMATION_EXPECTED_CADENCES = {
     human: "once a day",
     rrule: "FREQ=DAILY;INTERVAL=1",
   },
+  monitor: {
+    human: "once a day",
+    rrule: "FREQ=DAILY;INTERVAL=1",
+  },
+  "learnings-audit": {
+    human: "once a week",
+    rrule: "FREQ=WEEKLY;INTERVAL=1",
+  },
 };
 
 export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
+
+/**
+ * Directory (repo-relative) holding the checked-in per-loop runbooks scaffolded
+ * by `/lisa:setup-automations` per the `automation-runbook-contract` rule.
+ */
+export const AUTOMATION_RUNBOOK_DIRECTORY = ".lisa/automations";
 
 /**
  * @typedef {{
@@ -48,18 +62,30 @@ export const EXPLORATORY_QA_STACK_PRIORITY = ["expo", "rails", "harper-fabric"];
  *   readonly expectedCadence: string
  *   readonly expectedRRule: string
  *   readonly expectedCommand: string
- *   readonly group: "core" | "exploratory"
+ *   readonly group: "core" | "exploratory" | "opt-in"
+ *   readonly runbookPath: string
  * }} ExpectedAutomationEntry
  *
  * @typedef {{
  *   readonly id: string
  *   readonly automationId: string
- *   readonly group: "core" | "exploratory"
+ *   readonly group: "core" | "exploratory" | "opt-in"
  *   readonly reason: string
  *   readonly expectedCadence: string
  *   readonly expectedRRule: string
+ *   readonly runbookPath: string
  * }} UnsupportedAutomationEntry
  */
+
+/**
+ * Resolve the repo-relative runbook path for a loop id.
+ *
+ * @param {string} id
+ * @returns {string}
+ */
+export function resolveAutomationRunbookPath(id) {
+  return `${AUTOMATION_RUNBOOK_DIRECTORY}/${id}.runbook.md`;
+}
 
 /**
  * Resolve the stable project identifier and automation prefix used by
@@ -101,6 +127,7 @@ export function resolveAutomationProjectIdentity(input = {}) {
  *   readonly detectedTypes?: readonly string[]
  *   readonly autoStartPrds?: boolean | string
  *   readonly autoStartTickets?: boolean | string
+ *   readonly learningsAudit?: boolean | string
  * }} input
  * @returns {{
  *   readonly owner: string
@@ -116,6 +143,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
   const identity = resolveAutomationProjectIdentity(input);
   const autoStartPrds = normalizeBooleanFlag(input.autoStartPrds);
   const autoStartTickets = normalizeBooleanFlag(input.autoStartTickets);
+  const learningsAudit = normalizeBooleanFlag(input.learningsAudit);
   const detectedTypes = input.detectedTypes ?? [];
 
   const tracker = config.tracker;
@@ -166,6 +194,7 @@ export function resolveExpectedAutomationFleet(input = {}) {
       `/lisa:intake ${buildQueue}`,
       "core"
     ),
+    createExpectedEntry(identity, "monitor", "/lisa:monitor", "core"),
     createExpectedEntry(
       identity,
       "exploratory-prds",
@@ -191,7 +220,28 @@ export function resolveExpectedAutomationFleet(input = {}) {
       createUnsupportedEntry(
         identity,
         "exploratory-bugs",
-        "This repository does not ship an exploratory-qa command surface."
+        "This repository does not ship an exploratory-qa command surface.",
+        "exploratory"
+      )
+    );
+  }
+
+  if (learningsAudit) {
+    expected.push(
+      createExpectedEntry(
+        identity,
+        "learnings-audit",
+        "/lisa:learnings:audit",
+        "opt-in"
+      )
+    );
+  } else {
+    unsupported.push(
+      createUnsupportedEntry(
+        identity,
+        "learnings-audit",
+        "The weekly gardener loop is opt-in and this project has not opted in (learnings-audit=false).",
+        "opt-in"
       )
     );
   }
@@ -222,7 +272,7 @@ export function resolveExploratoryQaStack(detectedTypes = []) {
  * @param {{ readonly automationPrefix: string }} identity
  * @param {string} id
  * @param {string} expectedCommand
- * @param {"core" | "exploratory"} group
+ * @param {"core" | "exploratory" | "opt-in"} group
  * @returns {ExpectedAutomationEntry}
  */
 function createExpectedEntry(identity, id, expectedCommand, group) {
@@ -234,6 +284,7 @@ function createExpectedEntry(identity, id, expectedCommand, group) {
     expectedRRule: cadence.rrule,
     expectedCommand,
     group,
+    runbookPath: resolveAutomationRunbookPath(id),
   };
 }
 
@@ -241,17 +292,19 @@ function createExpectedEntry(identity, id, expectedCommand, group) {
  * @param {{ readonly automationPrefix: string }} identity
  * @param {string} id
  * @param {string} reason
+ * @param {"core" | "exploratory" | "opt-in"} group
  * @returns {UnsupportedAutomationEntry}
  */
-function createUnsupportedEntry(identity, id, reason) {
+function createUnsupportedEntry(identity, id, reason, group) {
   const cadence = AUTOMATION_EXPECTED_CADENCES[id];
   return {
     id,
     automationId: `${identity.automationPrefix}${id}`,
     expectedCadence: cadence.human,
     expectedRRule: cadence.rrule,
-    group: "exploratory",
+    group,
     reason,
+    runbookPath: resolveAutomationRunbookPath(id),
   };
 }
 

--- a/plugins/src/base/skills/lisa-automation-status/SKILL.md
+++ b/plugins/src/base/skills/lisa-automation-status/SKILL.md
@@ -23,6 +23,14 @@ exactly what `setup-automations` registers for this repo — including the stack
 roster** (`automation-runbook-contract`): carry no fixed list of loop names here, so a loop added to
 or removed from the registration set flows through without editing this skill.
 
+The gardener is opted into at registration time and has no config key, so **infer it from the
+scheduler**: list the project's automations first, then call
+`inferLearningsAuditRegistration({ automationPrefix, observedAutomationIds })` and pass the result
+as `learningsAudit` when resolving the fleet. A `lisa-auto-<project>-learnings-audit` entry on the
+scheduler means the project opted in, so the gardener is compared like any other loop; no such entry
+means it is reported `UNSUPPORTED` (opted out), never `MISSING`. This skill stays read-only — it
+infers, it never writes the flag anywhere.
+
 Resolve the expected project identifier, fleet naming prefix, queue arguments, cadence, and stack-support rules from the same contract used by `setup-automations` and `tear-down-automations`. Do **not** invent a second source of truth for fleet naming or queue resolution.
 
 ## Runtime inspection

--- a/plugins/src/base/skills/lisa-automation-status/SKILL.md
+++ b/plugins/src/base/skills/lisa-automation-status/SKILL.md
@@ -16,14 +16,12 @@ Do **not** ask for confirmation once invoked. This skill inspects scheduler stat
 
 ## Scope
 
-Inspect only the Lisa automation fleet for the current project:
-
-- `intake-repair`
-- `intake-prd`
-- `intake-tickets`
-- `exploratory-bugs` when the current stack supports `exploratory-qa`
-- `exploratory-prds`
-- `monitor`
+Inspect only the Lisa automation fleet for the current project. Derive that fleet from
+`scripts/automation-status-expected-fleet.mjs` (`resolveExpectedAutomationFleet`), which resolves
+exactly what `setup-automations` registers for this repo — including the stack-guarded
+`exploratory-bugs` and the opt-in `learnings-audit` gardener. **Membership is registration, not a
+roster** (`automation-runbook-contract`): carry no fixed list of loop names here, so a loop added to
+or removed from the registration set flows through without editing this skill.
 
 Resolve the expected project identifier, fleet naming prefix, queue arguments, cadence, and stack-support rules from the same contract used by `setup-automations` and `tear-down-automations`. Do **not** invent a second source of truth for fleet naming or queue resolution.
 

--- a/plugins/src/base/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-automations/SKILL.md
@@ -146,19 +146,53 @@ packet here** — cite the rule and instantiate it.
    id, the full automation name, the exact scheduled command with every `owner/repo` already baked
    in (never a placeholder), the human cadence and its `rrule`, the resolved queue arguments, and
    the resolved flag values that shaped the command (`auto-start-prds` / `auto-start-tickets` /
-   `learnings-audit`).
-2. The **ten contract sections** below it. Lisa owns them **only on first write**: seed each one
-   from this skill's per-loop defaults — what that loop maintains, what it reads, how it picks
-   candidates, its bounds, its proof, its approval boundary, its escalation, its recovery, its
-   next-run state, its retirement condition — written for a non-technical operator. After that they
-   belong to the operator.
+   `learnings-audit`). Its **first line inside the delimiters is a visible sentence**, so the
+   ownership boundary survives rendering to markdown where HTML comments disappear:
 
-**Re-run rule (idempotent, append-or-leave).** When the file already exists: rewrite the
+   ```text
+   Lisa rewrites this section on every /lisa:setup-automations run — edits here are lost. Your prose
+   belongs in the sections below.
+   ```
+
+   Immediately **below** the closing delimiter, write one more visible line — `Everything below is
+   yours.` — so an operator reading the rendered page knows where their half starts.
+2. The **ten contract sections** below it. Lisa owns them **only on first write**, then they belong
+   to the operator. Seed them deterministically, never improvised:
+   - **Intent, Sources of truth, Candidate selection, Scope/bounds, Retirement condition** come
+     from the per-loop seed table below.
+   - **Proof, Autonomous-vs-approval boundary, Escalation, Recovery, Next-run state** are derived
+     from **that loop's own SKILL.md** — named per loop in the table's last column — so the runbook
+     describes what the loop actually does rather than a generic paraphrase. Quote its behavior in
+     the operator's voice; if the skill file is unreadable, write one sentence saying the section
+     was not derivable and which file to read, and continue.
+
+   Every seeded sentence is written for a non-technical operator (`factory-model` rule 5).
+
+### Per-loop seed defaults
+
+One line each; expand them into the operator's voice, keep the meaning.
+
+| Loop | Intent | Sources of truth | Candidate selection | Scope/bounds | Retirement condition | Derive the other five from |
+|---|---|---|---|---|---|---|
+| **intake-repair** | Keeps the queues unstuck: work that stalled mid-flight gets diagnosed and moved again. | The PRD and build queues for this project, read through the tracker access layer. | Stuck or half-closed items — stalled in an in-progress role, terminal-labeled but still open, rollups whose children are all done — up to the `max_candidates` cap. | Only this project's configured queues; it repairs lifecycle state, never invents or closes real work. | Propose teardown when nothing has needed repair for a long quiet window AND this run found nothing. | `lisa-repair-intake/SKILL.md` |
+| **intake-prd** | Keeps PRDs moving: a PRD a human marked ready gets validated and decomposed into work items. | The configured PRD queue and its lifecycle roles, read through the source access layer. | The oldest PRD in the ready role, one per run. | Only this project's PRD queue; it never authors product intent, only validates and decomposes it. | Propose teardown when no PRD has entered the queue for a long quiet window AND this run proposed nothing. | `lisa-intake/SKILL.md` |
+| **intake-tickets** | Keeps the build queue moving: work items a human marked ready get built, reviewed, and shipped. | The configured tracker's build queue lanes plus each item's comments and linked PRs. | The oldest eligible leaf work item in the ready lane, one per run. | Only this repo's configured queue; containers with open children are repaired out, never built. | Propose teardown when no work item has entered this queue for a long quiet window AND this run proposed nothing. | `lisa-intake/SKILL.md` |
+| **monitor** | Keeps production honest: observability regressions become tracked work instead of silent decay. | The connected observability providers, each through its access layer, plus this project's `monitor.gapTiers` config. | The regressions and coverage gaps this cycle surfaced, capped per run. | Only this project's own services and dashboards; it files findings, it never changes production. | Propose teardown when the project has no connected observability surfaces AND this run found nothing. | `lisa-monitor/SKILL.md` |
+| **exploratory-prds** | Keeps the idea pipeline fed: the product's own gaps become PRDs when the PRD queue has room. | The PRD queue's pressure roles (the same ones `/lisa:queue-status` reports) and the project's own product surfaces. | One ideated PRD per run, and only when the pressure gate says the queue has capacity. | Never more than one PRD per run, and nothing at all while unresolved PRD pressure exists. | Propose teardown when the queue has been at pressure — or the project has shipped no new surface — across a long quiet window AND this run proposed nothing. | `lisa-project-ideation/SKILL.md` |
+| **exploratory-bugs** | Keeps quality visible: bugs and usability problems get found by using the product, before a customer does. | The running application through its exploratory-qa surface, plus this project's existing bug queue for dedupe. | The findings of one exploratory session, capped per run and deduped against already-filed items. | Only this project's own app; it files tickets, it never changes product code. | Propose teardown when no session has produced a finding across a long quiet window AND this run found nothing. | `lisa-exploratory-qa/SKILL.md` (the stack's own copy) |
+| **learnings-audit** | Keeps the project's knowledge true: stale, duplicated, or contradicted knowledge gets proposed for promotion, demotion, or retirement. | The learnings ledger, the rules trees, the skills, and the wiki — the project's knowledge surfaces. | The knowledge entries this audit judged stale, duplicated, or contradicted, capped per run. | It only proposes; every promote/demote/retire decision is a human-gated tracker ticket. | Propose teardown when the audit has proposed nothing across a long quiet window AND this run proposed nothing. | `lisa-learnings-audit/SKILL.md` |
+
+A loop not in this table — one registered later — seeds all ten sections from its own SKILL.md the
+same way. The table is seed prose for first write only; it is **not** a roster and never decides
+which automations exist.
+
+**Re-run rule (idempotent, never clobber).** When the file already exists: rewrite the
 machine-resolved block in place and **leave every one of the ten sections exactly as found** — an
-operator's edited Intent paragraph survives verbatim. If a section from the contract is **missing**
-from an existing file, append it with its seeded default; never overwrite, reorder, reword, or
-delete prose already on disk. If the machine-resolved delimiters are absent (a hand-written file),
-insert the block at the top and touch nothing else.
+operator's edited Intent paragraph survives verbatim. If a contract section is **missing** from an
+existing file, insert it **at its position in the contract's ten-section order** (never merely
+appended at the end, which would leave the file permanently out of order) with its seeded default.
+Never overwrite, reorder, reword, or delete prose already on disk. If the machine-resolved
+delimiters are absent (a hand-written file), insert the block at the top and touch nothing else.
 
 **Never a precondition.** A runbook that cannot be written is a **degradation, not a blocker**:
 report the failure and continue registering automations. A loop with a missing runbook still runs —
@@ -190,6 +224,15 @@ Then list each runbook written, by path (`.lisa/automations/<loop-id>.runbook.md
 whether it was **created** (seeded fresh) or **refreshed** (machine-resolved block rewritten,
 operator prose left untouched). Name every skipped loop again here and state plainly that it has no
 runbook because it was not registered, and why — for example, "exploratory-bugs was skipped because
-this project ships no exploratory-qa command, so no runbook was written for it." If a runbook could
-not be written, say which one and what failed; the automation itself is still registered. Write all
-of this so a non-technical operator can act on it without reading code.
+this project ships no exploratory-qa command, so no runbook was written for it."
+
+Close with the two lines that tell the operator what to do next:
+
+- When any runbook was newly created: "N new files were written under `.lisa/automations/` — commit
+  them so the whole team sees them."
+- When a runbook could not be written: name which one and what failed, then the consequence and the
+  fix — "that loop runs on defaults and its summaries will lead with 'Runbook missing' — re-run
+  `/lisa:setup-automations` to fix." The automation itself is still registered and still runs.
+
+Every line states the consequence and the action, in words a non-technical operator can act on
+without reading code.

--- a/plugins/src/base/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-automations/SKILL.md
@@ -105,6 +105,19 @@ the scheduled commands (for example `/lisa:intake acme/frontend intake_mode=prd`
 config/read-context failure cannot silently redirect the cron. A short queueRepo is normalized to
 `github.org` before writing the automation.
 
+**Registration prompt shape (so status can read the command back).** Whatever prose the prompt
+carries, it must contain the **literal Lisa command on a line of its own**, exactly as scheduled and
+with every `owner/repo` already baked in:
+
+```text
+/lisa:intake acme/planning intake_mode=build
+```
+
+This holds for loops that take **no arguments** too — `/lisa:monitor` and `/lisa:learnings:audit`
+are written the same way, on their own line, with nothing after them. `/lisa:automation-status`
+reads that line back to compare the live registration against this contract; a loop whose command
+cannot be read back reports as drifted even though it is registered correctly.
+
 **Naming + scope (so teardown is precise).** Name each automation with the stable prefix
 `lisa-auto-<project>-` (e.g. `lisa-auto-<project>-intake-tickets`), where `<project>` identifies this
 repo, and scope each Codex automation to the durable project automation checkout described above.

--- a/plugins/src/base/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-automations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lisa-setup-automations
 description: "Set up the recurring Lisa automations on the local workstation using the CURRENT runtime's native scheduler — Codex automations (the native automations / automation_update mechanism) or, on Claude, /schedule. This skill is a declarative specification: it states WHICH automations to create, how often, and with which parameters; it does not template schedule files or run scheduling code itself — the runtime's native automation mechanism does the creating. Creates six default automations: intake-repair (every 60 min), intake PRD (every 60 min), intake tickets (every 10 min), exploratory-bugs (once a day), exploratory-prds (once a day), monitor (once a day) — plus opt-in learnings-audit (once a week, the gardener). Three flags: auto-start-prds and auto-start-tickets control whether ideated PRDs / filed bug tickets are created auto-pickup-ready (prd_ready / ready, default true) or left for human review; learnings-audit (default false) opts into the weekly gardener loop. Tear down with /tear-down-automations."
-allowed-tools: ["Skill", "Bash", "Read"]
+allowed-tools: ["Skill", "Bash", "Read", "Write", "Edit"]
 ---
 
 # Set up Lisa automations: $ARGUMENTS
@@ -115,6 +115,57 @@ repos (don't rely on a bare repo basename when it could collide; qualify it, e.g
 **Idempotent.** Re-running this skill updates the existing `lisa-auto-<project>-*` automations in
 place (same names) rather than creating duplicates.
 
+## Runbook scaffolding
+
+Registration is what pulls a loop under the `automation-runbook-contract` rule, so registration is
+what must produce its runbook. For **every automation actually registered above** — including the
+conditionally-guarded `exploratory-bugs` and the opt-in `learnings-audit` — write a checked-in
+runbook at:
+
+```text
+.lisa/automations/<loop-id>.runbook.md
+```
+
+`<loop-id>` is the automation's suffix, not its full name: `intake-tickets`, not
+`lisa-auto-<project>-intake-tickets`. These files are **project knowledge and belong in git**, like
+`.lisa/PROJECT_LEARNINGS.md` — commit them; they are not scratch output. Derive the set of runbooks
+from what was registered on this run: a loop that was **skipped gets no runbook**, and a loop
+registered later gets one when this skill next runs. Never write a runbook from a fixed list of
+loop names.
+
+Follow the `automation-runbook-contract` rule for the runbook's shape: its ten sections, in its
+order, in its prose register. **Do not restate the template, the run outcomes, or the escalation
+packet here** — cite the rule and instantiate it.
+
+**File shape — two halves with different owners.**
+
+1. A **machine-resolved header block**, delimited exactly by
+   `<!-- lisa:machine-resolved:start -->` and `<!-- lisa:machine-resolved:end -->`, written first
+   in the file. Lisa owns it: on every run it is **rewritten wholesale** from the values resolved
+   above. It carries the project identity (`<owner>/<repo>` and the `<project>` token), the loop
+   id, the full automation name, the exact scheduled command with every `owner/repo` already baked
+   in (never a placeholder), the human cadence and its `rrule`, the resolved queue arguments, and
+   the resolved flag values that shaped the command (`auto-start-prds` / `auto-start-tickets` /
+   `learnings-audit`).
+2. The **ten contract sections** below it. Lisa owns them **only on first write**: seed each one
+   from this skill's per-loop defaults — what that loop maintains, what it reads, how it picks
+   candidates, its bounds, its proof, its approval boundary, its escalation, its recovery, its
+   next-run state, its retirement condition — written for a non-technical operator. After that they
+   belong to the operator.
+
+**Re-run rule (idempotent, append-or-leave).** When the file already exists: rewrite the
+machine-resolved block in place and **leave every one of the ten sections exactly as found** — an
+operator's edited Intent paragraph survives verbatim. If a section from the contract is **missing**
+from an existing file, append it with its seeded default; never overwrite, reorder, reword, or
+delete prose already on disk. If the machine-resolved delimiters are absent (a hand-written file),
+insert the block at the top and touch nothing else.
+
+**Never a precondition.** A runbook that cannot be written is a **degradation, not a blocker**:
+report the failure and continue registering automations. A loop with a missing runbook still runs —
+on the contract's defaults, saying so in its one-line summary — per the contract's
+never-block-always-degrade rule. Scaffolding failure never aborts setup and never leaves an
+automation unregistered.
+
 ## Conditions / guards
 
 - **exploratory-bugs** is created only when the project ships an `exploratory-qa` command (the
@@ -134,3 +185,11 @@ place (same names) rather than creating duplicates.
 
 List each automation created or updated (name, the command it runs, cadence, and the resolved
 `auto-start-prds` / `auto-start-tickets` values), plus any automation skipped and why.
+
+Then list each runbook written, by path (`.lisa/automations/<loop-id>.runbook.md`), saying for each
+whether it was **created** (seeded fresh) or **refreshed** (machine-resolved block rewritten,
+operator prose left untouched). Name every skipped loop again here and state plainly that it has no
+runbook because it was not registered, and why — for example, "exploratory-bugs was skipped because
+this project ships no exploratory-qa command, so no runbook was written for it." If a runbook could
+not be written, say which one and what failed; the automation itself is still registered. Write all
+of this so a non-technical operator can act on it without reading code.

--- a/plugins/src/base/skills/lisa-tear-down-automations/SKILL.md
+++ b/plugins/src/base/skills/lisa-tear-down-automations/SKILL.md
@@ -42,7 +42,13 @@ removes them with its **native** scheduling mechanism.
 
 ## Report
 
-List each automation removed by name, and any that the prefix sweep expected to find but that were
-already absent. State explicitly that the runbook files under `.lisa/automations/` were left on
-disk, and that nothing outside this project's `lisa-auto-<project>-` prefix was touched. Write it so
-a non-technical operator can confirm what happened without reading code.
+List each automation removed by name. For "already absent", compare against the one source of truth
+— the fleet `scripts/automation-status-expected-fleet.mjs` (`resolveExpectedAutomationFleet`)
+resolves for this project — and name anything it expects that the sweep did not find; that is a
+no-op, not an error. Do not invent an expected set of your own.
+
+Then state, in the operator's words, that the runbook files under `.lisa/automations/` were left on
+disk **and why**: they are the written record of what those jobs did, kept on purpose, and if you
+do not want them you delete them yourself in git. Finally, confirm that nothing outside this
+project's `lisa-auto-<project>-` prefix was touched. Write it so a non-technical operator can
+confirm what happened without reading code.

--- a/plugins/src/base/skills/lisa-tear-down-automations/SKILL.md
+++ b/plugins/src/base/skills/lisa-tear-down-automations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-tear-down-automations
-description: "Remove every recurring Lisa automation that /setup-automations created for this project (the lisa-auto-<project>-* set: intake-repair, intake-prd, intake-tickets, exploratory-bugs, exploratory-prds, monitor) using the CURRENT runtime's native scheduler — Codex automations or, on Claude, /schedule. This skill is a declarative specification: it identifies WHICH automations to remove; it does not run teardown scripts. Removes only this project's Lisa automations — never other projects' automations or non-Lisa ones. The inverse of /setup-automations."
+description: "Remove every recurring Lisa automation that /setup-automations registered for this project — whatever is actually registered under the lisa-auto-<project>-* prefix, including the opt-in learnings-audit gardener — using the CURRENT runtime's native scheduler — Codex automations or, on Claude, /schedule. This skill is a declarative specification: it identifies WHICH automations to remove; it does not run teardown scripts. Carries no fixed list of loops: the registration set is the roster. Removes only this project's Lisa automations — never other projects' automations or non-Lisa ones. Leaves checked-in runbook files on disk. The inverse of /setup-automations."
 allowed-tools: ["Skill", "Bash", "Read"]
 ---
 
@@ -21,14 +21,28 @@ removes them with its **native** scheduling mechanism.
 
 ## Scope (remove only what setup created)
 
-- Remove the six automations `/setup-automations` creates for the current project, matched by the
-  stable `lisa-auto-<project>-` name prefix: `intake-repair`, `intake-prd`, `intake-tickets`,
-  `exploratory-bugs`, `exploratory-prds`, `monitor`.
+- Remove **every** automation `/setup-automations` registered for the current project — the whole
+  set found under the stable `lisa-auto-<project>-` name prefix, whatever it currently contains.
+  **Membership is registration, not a roster** (`automation-runbook-contract`): sweep the prefix and
+  remove what is there. Do **not** work from a fixed list of loop names — a list drifts the moment a
+  loop is added, which is exactly how the opt-in gardener came to be orphaned.
+- This explicitly includes the opt-in **`learnings-audit`** gardener when it is registered:
+  `/setup-automations learnings-audit=true` registers it under the same prefix, so teardown removes
+  it with the rest. A conditionally-skipped loop (e.g. `exploratory-bugs` on a stack without
+  `exploratory-qa`) simply is not in the sweep.
 - **Never** remove automations for a different project, or any non-Lisa automation (e.g. unrelated
   crawlers/ingestors). Match strictly on the `lisa-auto-<project>-` prefix for THIS project; when in
   doubt about an automation's ownership, leave it and report it rather than deleting it.
-- **Idempotent** — an automation that is already absent is a no-op, not an error.
+- **Idempotent** — an automation that is already absent is a no-op, not an error. Re-running when
+  the prefix sweep finds nothing is a clean, successful no-op.
+- **Leave the runbooks alone.** The checked-in `.lisa/automations/<loop-id>.runbook.md` files that
+  `/setup-automations` scaffolded are project knowledge and the historical record of what these
+  loops did. Teardown removes scheduler registrations only; it never deletes, edits, or moves a
+  runbook file. An operator who wants them gone removes them deliberately, in git.
 
 ## Report
 
-List each automation removed, and any in the expected set that were already absent.
+List each automation removed by name, and any that the prefix sweep expected to find but that were
+already absent. State explicitly that the runbook files under `.lisa/automations/` were left on
+disk, and that nothing outside this project's `lisa-auto-<project>-` prefix was touched. Write it so
+a non-technical operator can confirm what happened without reading code.

--- a/tests/unit/strategies/automation-status-expected-fleet.test.ts
+++ b/tests/unit/strategies/automation-status-expected-fleet.test.ts
@@ -18,6 +18,20 @@ const INTAKE_PRD_COMMAND = "/lisa:intake CodySwannGT/lisa intake_mode=prd";
 const INTAKE_PRD_ID = "intake-prd";
 const INTAKE_REPAIR_ID = "intake-repair";
 const INTAKE_TICKETS_ID = "intake-tickets";
+const MONITOR_ID = "monitor";
+const EXPLORATORY_BUGS_ID = "exploratory-bugs";
+const EXPLORATORY_PRDS_ID = "exploratory-prds";
+const LEARNINGS_AUDIT_ID = "learnings-audit";
+const WEEKLY_CADENCE = "once a week";
+const WEEKLY_RRULE = "FREQ=WEEKLY;INTERVAL=1";
+const OPT_IN_GROUP = "opt-in";
+
+/**
+ * Expected repo-relative runbook path for a loop id.
+ * @param id - Loop id (the automation-name suffix)
+ * @returns The repo-relative runbook path
+ */
+const runbook = (id: string): string => `.lisa/automations/${id}.runbook.md`;
 
 describe("automation-status expected fleet (#799)", () => {
   it("resolves the self-host GitHub Lisa fleet and flags unsupported exploratory-bugs", () => {
@@ -54,16 +68,34 @@ describe("automation-status expected fleet (#799)", () => {
         expectedCommand: "/lisa:intake CodySwannGT/lisa intake_mode=build",
       }),
       expect.objectContaining({
-        id: "exploratory-prds",
+        id: MONITOR_ID,
+        automationId: "lisa-auto-codyswanngt-lisa-monitor",
+        expectedCadence: "once a day",
+        expectedRRule: "FREQ=DAILY;INTERVAL=1",
+        expectedCommand: "/lisa:monitor",
+        group: "core",
+        runbookPath: runbook(MONITOR_ID),
+      }),
+      expect.objectContaining({
+        id: EXPLORATORY_PRDS_ID,
         expectedCommand: "/lisa:project-ideation prd_ready=false",
       }),
     ]);
     expect(fleet.unsupported).toEqual([
       expect.objectContaining({
-        id: "exploratory-bugs",
-        automationId: "lisa-auto-codyswanngt-lisa-exploratory-bugs",
+        id: EXPLORATORY_BUGS_ID,
+        group: "exploratory",
         reason:
           "This repository does not ship an exploratory-qa command surface.",
+        runbookPath: runbook(EXPLORATORY_BUGS_ID),
+      }),
+      expect.objectContaining({
+        id: LEARNINGS_AUDIT_ID,
+        automationId: "lisa-auto-codyswanngt-lisa-learnings-audit",
+        expectedCadence: WEEKLY_CADENCE,
+        expectedRRule: WEEKLY_RRULE,
+        group: OPT_IN_GROUP,
+        runbookPath: runbook(LEARNINGS_AUDIT_ID),
       }),
     ]);
   });
@@ -182,7 +214,9 @@ describe("automation-status expected fleet (#799)", () => {
         expectedCommand: "/lisa:project-ideation prd_ready=true",
       })
     );
-    expect(fleet.unsupported).toEqual([]);
+    expect(fleet.unsupported.map(entry => entry.id)).toEqual([
+      LEARNINGS_AUDIT_ID,
+    ]);
   });
 
   it("covers the build repair queue for mixed PRD source and JIRA tracker repos", () => {

--- a/tests/unit/strategies/automation-status-expected-fleet.test.ts
+++ b/tests/unit/strategies/automation-status-expected-fleet.test.ts
@@ -85,8 +85,9 @@ describe("automation-status expected fleet (#799)", () => {
       expect.objectContaining({
         id: EXPLORATORY_BUGS_ID,
         group: "exploratory",
-        reason:
-          "This repository does not ship an exploratory-qa command surface.",
+        reason: expect.stringContaining(
+          "This project ships no exploratory-qa command"
+        ),
         runbookPath: runbook(EXPLORATORY_BUGS_ID),
       }),
       expect.objectContaining({

--- a/tests/unit/strategies/automation-status-fleet-runbooks.test.ts
+++ b/tests/unit/strategies/automation-status-fleet-runbooks.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression coverage for the #1796 additions to expected-fleet resolution.
+ *
+ * RBC-2 collapses three drifting fleet lists onto the shared resolver: `monitor`
+ * joins the core group unconditionally, the opt-in `learnings-audit` gardener is
+ * resolved from a flag (UNSUPPORTED, not MISSING, when a project has not opted
+ * in), and every entry — expected or unsupported — carries the repo-relative
+ * `runbookPath` that `/lisa:setup-automations` scaffolds and the status surface
+ * later renders.
+ * @module tests/unit/strategies/automation-status-fleet-runbooks
+ */
+import { describe, expect, it } from "vitest";
+
+import { resolveExpectedAutomationFleet } from "../../../plugins/src/base/scripts/automation-status-expected-fleet.mjs";
+
+const GITHUB = "github";
+const LEARNINGS_AUDIT_ID = "learnings-audit";
+const EXPLORATORY_BUGS_ID = "exploratory-bugs";
+const WEEKLY_CADENCE = "once a week";
+const WEEKLY_RRULE = "FREQ=WEEKLY;INTERVAL=1";
+const OPT_IN_GROUP = "opt-in";
+
+/**
+ * Expected repo-relative runbook path for a loop id.
+ * @param id - Loop id (the automation-name suffix)
+ * @returns The repo-relative runbook path
+ */
+const runbook = (id: string): string => `.lisa/automations/${id}.runbook.md`;
+
+describe("expected fleet runbook paths and opt-in gardener (#1796)", () => {
+  it("exposes a repo-relative runbook path for every registered loop", () => {
+    const fleet = resolveExpectedAutomationFleet({
+      config: {
+        tracker: GITHUB,
+        source: GITHUB,
+        github: { org: "Acme", repo: "mobile-app" },
+      },
+      detectedTypes: ["expo"],
+      learningsAudit: true,
+    });
+
+    expect(fleet.expected.map(entry => [entry.id, entry.runbookPath])).toEqual(
+      [
+        "intake-repair",
+        "intake-prd",
+        "intake-tickets",
+        "monitor",
+        "exploratory-prds",
+        EXPLORATORY_BUGS_ID,
+        LEARNINGS_AUDIT_ID,
+      ].map(id => [id, runbook(id)])
+    );
+  });
+
+  it("resolves monitor unconditionally into the core group", () => {
+    const fleet = resolveExpectedAutomationFleet({
+      config: { tracker: GITHUB, github: { org: "Acme", repo: "frontend" } },
+    });
+
+    expect(fleet.expected).toContainEqual(
+      expect.objectContaining({
+        id: "monitor",
+        automationId: "lisa-auto-acme-frontend-monitor",
+        expectedCadence: "once a day",
+        expectedRRule: "FREQ=DAILY;INTERVAL=1",
+        expectedCommand: "/lisa:monitor",
+        group: "core",
+      })
+    );
+  });
+
+  it("registers the weekly gardener only when learnings-audit is requested", () => {
+    const fleet = resolveExpectedAutomationFleet({
+      config: {
+        tracker: GITHUB,
+        source: GITHUB,
+        github: { org: "Acme", repo: "frontend" },
+      },
+      learningsAudit: "true",
+    });
+
+    expect(fleet.expected).toContainEqual(
+      expect.objectContaining({
+        id: LEARNINGS_AUDIT_ID,
+        automationId: "lisa-auto-acme-frontend-learnings-audit",
+        expectedCadence: WEEKLY_CADENCE,
+        expectedRRule: WEEKLY_RRULE,
+        expectedCommand: "/lisa:learnings:audit",
+        group: OPT_IN_GROUP,
+        runbookPath: runbook(LEARNINGS_AUDIT_ID),
+      })
+    );
+    expect(fleet.unsupported.map(entry => entry.id)).toEqual([
+      EXPLORATORY_BUGS_ID,
+    ]);
+  });
+
+  it("reports an un-opted-in gardener as unsupported, never missing", () => {
+    const fleet = resolveExpectedAutomationFleet({
+      config: {
+        tracker: GITHUB,
+        source: GITHUB,
+        github: { org: "Acme", repo: "mobile-app" },
+      },
+      detectedTypes: ["expo"],
+    });
+
+    expect(fleet.expected.map(entry => entry.id)).not.toContain(
+      LEARNINGS_AUDIT_ID
+    );
+    expect(fleet.unsupported).toEqual([
+      expect.objectContaining({
+        id: LEARNINGS_AUDIT_ID,
+        group: OPT_IN_GROUP,
+        expectedCadence: WEEKLY_CADENCE,
+        expectedRRule: WEEKLY_RRULE,
+        reason: expect.stringMatching(/opt-in/i),
+        runbookPath: runbook(LEARNINGS_AUDIT_ID),
+      }),
+    ]);
+  });
+});

--- a/tests/unit/strategies/automation-status-opt-in-group.test.ts
+++ b/tests/unit/strategies/automation-status-opt-in-group.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Regression coverage for the `opt-in` fleet group in both runtime adapters.
+ *
+ * Both adapters used to bin expected entries into a hardcoded
+ * `Map([["core"],["exploratory"]])` and push with `?.`, so any entry in a group
+ * the map did not know about was silently dropped — the opt-in `learnings-audit`
+ * gardener vanished from the report whether or not the project had opted in.
+ * These tests pin the rendered opt-in group per runtime and the loud failure
+ * that now replaces the silent drop.
+ * @module tests/unit/strategies/automation-status-opt-in-group
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  assignToAutomationGroup,
+  createAutomationGroupBins,
+  inferLearningsAuditRegistration,
+  resolveExpectedAutomationFleet,
+} from "../../../plugins/src/base/scripts/automation-status-expected-fleet.mjs";
+import { inspectClaudeAutomationFleet } from "../../../plugins/src/base/scripts/automation-status-claude-adapter.mjs";
+import { inspectCodexAutomationFleet } from "../../../plugins/src/base/scripts/automation-status-codex-adapter.mjs";
+
+const GARDENER_ID = "lisa-auto-codyswanngt-lisa-learnings-audit";
+const GARDENER_COMMAND = "/lisa:learnings:audit";
+const WEEKLY_RRULE = "FREQ=WEEKLY;INTERVAL=1";
+const OPT_IN_TITLE = "Opt-in automations";
+const LAST_RUN_AT = "2026-05-25T09:00:00Z";
+const NOW = "2026-05-26T12:00:00Z";
+const REPO_CONFIG = {
+  tracker: "github",
+  github: { org: "CodySwannGT", repo: "lisa" },
+};
+
+/**
+ * Resolve a fleet for the shared test repo.
+ * @param learningsAudit - Whether the project opted into the gardener
+ * @returns The resolved expected fleet
+ */
+const fleetFor = (
+  learningsAudit: boolean
+): ReturnType<typeof resolveExpectedAutomationFleet> =>
+  resolveExpectedAutomationFleet({
+    config: REPO_CONFIG,
+    detectedTypes: ["typescript"],
+    learningsAudit,
+  });
+
+/** The slice of an adapter report these tests read. */
+type AdapterReport = {
+  readonly groups: readonly {
+    readonly title: string;
+    readonly items: readonly { readonly id: string }[];
+  }[];
+};
+
+/**
+ * The single rendered group carrying opt-in loops.
+ * @param report - An adapter report
+ * @returns The opt-in group
+ */
+const optInGroup = (report: AdapterReport): AdapterReport["groups"][number] => {
+  const group = report.groups.find(entry => entry.title === OPT_IN_TITLE);
+  if (!group) {
+    throw new Error(
+      `No "${OPT_IN_TITLE}" group in report: ${report.groups.map(g => g.title).join(", ")}`
+    );
+  }
+  return group;
+};
+
+describe("opt-in fleet group is rendered, never dropped (#1796)", () => {
+  it("Claude: an opted-in, registered gardener is compared like any other loop", () => {
+    const report = inspectClaudeAutomationFleet({
+      expectedFleet: fleetFor(true),
+      scheduleListing: {
+        routines: [
+          {
+            name: GARDENER_ID,
+            schedule: WEEKLY_RRULE,
+            command: `/schedule "once a week" ${GARDENER_COMMAND}`,
+            status: "ACTIVE",
+            lastRunAt: LAST_RUN_AT,
+            lastResult: "Proposed nothing this week.",
+          },
+        ],
+      },
+      now: NOW,
+    });
+
+    expect(optInGroup(report).items).toContainEqual(
+      expect.objectContaining({
+        id: GARDENER_ID,
+        status: "HEALTHY",
+        expectedCadence: "once a week",
+        expectedCommand: GARDENER_COMMAND,
+      })
+    );
+  });
+
+  it("Claude: an opted-in gardener missing from the scheduler reports MISSING", () => {
+    const report = inspectClaudeAutomationFleet({
+      expectedFleet: fleetFor(true),
+      scheduleListing: { routines: [] },
+      now: NOW,
+    });
+
+    expect(optInGroup(report).items).toContainEqual(
+      expect.objectContaining({ id: GARDENER_ID, status: "MISSING" })
+    );
+  });
+
+  it("Claude: an un-opted-in gardener reports UNSUPPORTED with the enabling command", () => {
+    const report = inspectClaudeAutomationFleet({
+      expectedFleet: fleetFor(false),
+      scheduleListing: { routines: [] },
+      now: NOW,
+    });
+
+    expect(optInGroup(report).items).toContainEqual(
+      expect.objectContaining({
+        id: GARDENER_ID,
+        status: "UNSUPPORTED",
+        summary: expect.stringContaining(
+          "/lisa:setup-automations learnings-audit=true"
+        ),
+      })
+    );
+  });
+
+  it("infers opt-in from the observed registration, not from config", () => {
+    expect(
+      inferLearningsAuditRegistration({
+        automationPrefix: "lisa-auto-codyswanngt-lisa-",
+        observedAutomationIds: [GARDENER_ID],
+      })
+    ).toBe(true);
+    expect(
+      inferLearningsAuditRegistration({
+        automationPrefix: "lisa-auto-codyswanngt-lisa-",
+        observedAutomationIds: ["lisa-auto-codyswanngt-lisa-monitor"],
+      })
+    ).toBe(false);
+  });
+
+  it("fails loudly on an unknown group instead of dropping the entry", () => {
+    expect(() =>
+      assignToAutomationGroup(createAutomationGroupBins(), "brand-new-group", {
+        id: "lisa-auto-acme-app-something",
+      })
+    ).toThrow(/brand-new-group/);
+  });
+});
+
+describe("Codex adapter renders the opt-in group (#1796)", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map(dir => fs.rm(dir, { recursive: true, force: true }))
+    );
+    tempDirs.length = 0;
+  });
+
+  it("shows a registered gardener and an un-opted-in one in the same group", async () => {
+    const automationsDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "lisa-codex-opt-in-")
+    );
+    tempDirs.push(automationsDir);
+
+    const automationDir = path.join(automationsDir, GARDENER_ID);
+    await fs.mkdir(automationDir, { recursive: true });
+    await fs.writeFile(
+      path.join(automationDir, "automation.toml"),
+      [
+        "version = 1",
+        `id = "${GARDENER_ID}"`,
+        'kind = "cron"',
+        `name = "${GARDENER_ID}"`,
+        `prompt = "Run one Lisa learnings-audit cycle. Use the Lisa learnings-audit skill."`,
+        'status = "ACTIVE"',
+        `rrule = "${WEEKLY_RRULE}"`,
+        'execution_environment = "local"',
+        "",
+      ].join("\n")
+    );
+    await fs.writeFile(
+      path.join(automationDir, "memory.md"),
+      `${LAST_RUN_AT}\n\n- Proposed nothing this week.\n`
+    );
+
+    const optedIn = await inspectCodexAutomationFleet({
+      expectedFleet: fleetFor(true),
+      automationsDir,
+      now: NOW,
+    });
+
+    expect(optInGroup(optedIn).items.map(item => item.id)).toEqual([
+      GARDENER_ID,
+    ]);
+
+    const optedOut = await inspectCodexAutomationFleet({
+      expectedFleet: fleetFor(false),
+      automationsDir,
+      now: NOW,
+    });
+
+    expect(optInGroup(optedOut).items).toContainEqual(
+      expect.objectContaining({
+        id: GARDENER_ID,
+        status: "UNSUPPORTED",
+        summary: expect.stringContaining(
+          "/lisa:setup-automations learnings-audit=true"
+        ),
+      })
+    );
+  });
+});

--- a/tests/unit/strategies/automation-status-opt-in-group.test.ts
+++ b/tests/unit/strategies/automation-status-opt-in-group.test.ts
@@ -165,32 +165,83 @@ describe("Codex adapter renders the opt-in group (#1796)", () => {
     tempDirs.length = 0;
   });
 
+  it("reads no-argument registrations back as HEALTHY, not DRIFTED", async () => {
+    const fleet = fleetFor(true);
+    const automationsDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "lisa-codex-no-arg-")
+    );
+    tempDirs.push(automationsDir);
+
+    // monitor and the gardener are the two no-argument loops: their prompts
+    // carry the literal command with no "with arguments" clause at all.
+    for (const entry of fleet.expected) {
+      await writeCodexAutomation(automationsDir, {
+        automationId: entry.automationId,
+        rrule: entry.expectedRRule,
+        prompt: `Run one cycle for this project.\n${entry.expectedCommand}`,
+        lastRunAt: LAST_RUN_AT,
+      });
+    }
+
+    const report = await inspectCodexAutomationFleet({
+      expectedFleet: fleet,
+      automationsDir,
+      now: NOW,
+    });
+
+    const items = report.groups.flatMap(group => group.items);
+    for (const id of ["monitor", "learnings-audit"]) {
+      const entry = fleet.expected.find(candidate => candidate.id === id);
+      expect(items).toContainEqual(
+        expect.objectContaining({
+          id: entry?.automationId,
+          status: "HEALTHY",
+        })
+      );
+    }
+  });
+
+  it("still reports DRIFTED when a no-argument loop runs the wrong command", async () => {
+    const fleet = fleetFor(true);
+    const monitor = fleet.expected.find(entry => entry.id === "monitor");
+    const automationsDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "lisa-codex-drift-")
+    );
+    tempDirs.push(automationsDir);
+
+    await writeCodexAutomation(automationsDir, {
+      automationId: monitor?.automationId ?? "",
+      rrule: monitor?.expectedRRule ?? "",
+      prompt: "Run one cycle for this project.\n/lisa:queue-status",
+      lastRunAt: LAST_RUN_AT,
+    });
+
+    const report = await inspectCodexAutomationFleet({
+      expectedFleet: fleet,
+      automationsDir,
+      now: NOW,
+    });
+
+    expect(report.groups.flatMap(group => group.items)).toContainEqual(
+      expect.objectContaining({
+        id: monitor?.automationId,
+        status: "DRIFTED",
+      })
+    );
+  });
+
   it("shows a registered gardener and an un-opted-in one in the same group", async () => {
     const automationsDir = await fs.mkdtemp(
       path.join(os.tmpdir(), "lisa-codex-opt-in-")
     );
     tempDirs.push(automationsDir);
 
-    const automationDir = path.join(automationsDir, GARDENER_ID);
-    await fs.mkdir(automationDir, { recursive: true });
-    await fs.writeFile(
-      path.join(automationDir, "automation.toml"),
-      [
-        "version = 1",
-        `id = "${GARDENER_ID}"`,
-        'kind = "cron"',
-        `name = "${GARDENER_ID}"`,
-        `prompt = "Run one Lisa learnings-audit cycle. Use the Lisa learnings-audit skill."`,
-        'status = "ACTIVE"',
-        `rrule = "${WEEKLY_RRULE}"`,
-        'execution_environment = "local"',
-        "",
-      ].join("\n")
-    );
-    await fs.writeFile(
-      path.join(automationDir, "memory.md"),
-      `${LAST_RUN_AT}\n\n- Proposed nothing this week.\n`
-    );
+    await writeCodexAutomation(automationsDir, {
+      automationId: GARDENER_ID,
+      rrule: WEEKLY_RRULE,
+      prompt: `Run one Lisa learnings-audit cycle.\n${GARDENER_COMMAND}`,
+      lastRunAt: LAST_RUN_AT,
+    });
 
     const optedIn = await inspectCodexAutomationFleet({
       expectedFleet: fleetFor(true),
@@ -219,3 +270,50 @@ describe("Codex adapter renders the opt-in group (#1796)", () => {
     );
   });
 });
+
+/** One Codex automation fixture's backing-store fields. */
+type CodexAutomationFixture = {
+  /** Full automation name, e.g. `lisa-auto-acme-app-monitor`. */
+  readonly automationId: string;
+  /** Recurrence rule as Codex stores it. */
+  readonly rrule: string;
+  /** Registration prompt; newlines are escaped into the single-line TOML. */
+  readonly prompt: string;
+  /** Timestamp of the latest recorded run. */
+  readonly lastRunAt: string;
+};
+
+/**
+ * Write one Codex automation fixture (backing-store TOML + memory file).
+ * @param automationsDir - Fixture root standing in for `~/.codex/automations`
+ * @param input - The automation's backing-store fields
+ * @returns Nothing
+ */
+async function writeCodexAutomation(
+  automationsDir: string,
+  input: CodexAutomationFixture
+): Promise<void> {
+  const automationDir = path.join(automationsDir, input.automationId);
+  await fs.mkdir(automationDir, { recursive: true });
+  await fs.writeFile(
+    path.join(automationDir, "automation.toml"),
+    [
+      "version = 1",
+      `id = "${input.automationId}"`,
+      'kind = "cron"',
+      `name = "${input.automationId}"`,
+      // Codex stores prompts as single-line TOML: line breaks are escaped.
+      `prompt = "${input.prompt.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n")}"`,
+      'status = "ACTIVE"',
+      `rrule = "${input.rrule}"`,
+      'execution_environment = "local"',
+      // A real, non-bare Git work tree — an invalid cwd alone reports FAILING.
+      `cwds = ["${process.cwd()}"]`,
+      "",
+    ].join("\n")
+  );
+  await fs.writeFile(
+    path.join(automationDir, "memory.md"),
+    `${input.lastRunAt}\n\n- Completed the cycle cleanly.\n`
+  );
+}

--- a/tests/unit/strategies/automation-status-scaffold.test.ts
+++ b/tests/unit/strategies/automation-status-scaffold.test.ts
@@ -81,6 +81,18 @@ describe("automation-status scaffold (#797)", () => {
       expect(skill).toMatch(/stack-support/i);
     });
 
+    it("derives the fleet from the resolver, not a hardcoded roster (#1796)", () => {
+      const skill = read(root, SKILL_REL);
+
+      expect(skill).toContain("resolveExpectedAutomationFleet");
+      expect(skill).toContain("scripts/automation-status-expected-fleet.mjs");
+      expect(skill).toContain("automation-runbook-contract");
+      expect(skill).toMatch(/membership is registration, not a\s+roster/i);
+      expect(skill).toMatch(/carry no fixed list of loop names/i);
+      // The pre-#1796 roster bullet list must be gone.
+      expect(skill).not.toMatch(/^- `intake-repair`$/m);
+    });
+
     it("names the expected runtime branches and fleet outcomes", () => {
       const skill = read(root, SKILL_REL);
 

--- a/tests/unit/strategies/automations-skills.test.ts
+++ b/tests/unit/strategies/automations-skills.test.ts
@@ -120,7 +120,55 @@ describe("setup-automations is a runtime-branched declarative spec", () => {
 
     it("reports each runbook written and each skipped loop", () => {
       expect(content).toMatch(/list each runbook written/i);
-      expect(content).toMatch(/created.*refreshed|refreshed.*created/is);
+      // Anchored to the report sentence, not a wildcard span across the file.
+      expect(content).toMatch(
+        /whether it was \*\*created\*\* \(seeded fresh\) or \*\*refreshed\*\*/
+      );
+      expect(content).toMatch(/runbook because it was not registered/i);
+    });
+
+    it("states the consequence and the action on every report line", () => {
+      expect(content).toMatch(
+        /new files were written under `\.lisa\/automations\/` — commit\s+them/i
+      );
+      expect(content).toMatch(/runs on defaults and its summaries will lead/i);
+      expect(content).toMatch(/re-run\s+`\/lisa:setup-automations` to fix/i);
+    });
+
+    it("makes the ownership boundary visible in rendered markdown", () => {
+      expect(content).toMatch(
+        /Lisa rewrites this section on every \/lisa:setup-automations run — edits here are lost/
+      );
+      expect(content).toMatch(/Everything below is\s+yours\./);
+    });
+
+    it("seeds the ten sections deterministically, per loop", () => {
+      expect(content).toMatch(/### Per-loop seed defaults/);
+      for (const loop of [
+        "intake-repair",
+        "intake-prd",
+        "intake-tickets",
+        "monitor",
+        "exploratory-prds",
+        "exploratory-bugs",
+        "learnings-audit",
+      ]) {
+        expect(content).toContain(`| **${loop}** |`);
+      }
+      // The remaining five sections are derived from the loop's own skill file.
+      expect(content).toMatch(
+        /derived\s+from \*\*that loop's own SKILL\.md\*\*/i
+      );
+      expect(content).toContain("lisa-learnings-audit/SKILL.md");
+      // The seed table must not be mistaken for a roster.
+      expect(content).toMatch(/is \*\*not\*\* a roster/i);
+    });
+
+    it("inserts a missing section in contract order, never merely appended", () => {
+      expect(content).toMatch(
+        /insert it \*\*at its position in the contract's ten-section order\*\*/i
+      );
+      expect(content).toMatch(/never merely\s+appended at the end/i);
     });
   });
 });
@@ -161,9 +209,17 @@ describe("tear-down-automations removes only this project's lisa-auto set", () =
       expect(content).toMatch(/gardener/i);
     });
 
-    it("leaves scaffolded runbook files on disk", () => {
+    it("leaves scaffolded runbook files on disk, and says why", () => {
       expect(content).toContain(".lisa/automations/");
       expect(content).toMatch(/leave the runbooks alone|never deletes/i);
+      expect(content).toMatch(/written record of what those jobs did/i);
+      expect(content).toMatch(/kept on purpose/i);
+      expect(content).toMatch(/delete them yourself in git/i);
+    });
+
+    it("derives 'already absent' from the expected-fleet resolver", () => {
+      expect(content).toContain("resolveExpectedAutomationFleet");
+      expect(content).toMatch(/do not invent an expected set of your own/i);
     });
   });
 });

--- a/tests/unit/strategies/automations-skills.test.ts
+++ b/tests/unit/strategies/automations-skills.test.ts
@@ -4,11 +4,14 @@
  * These skills are declarative specifications, not scripts: they tell the
  * current runtime which recurring Lisa automations to create/remove, how often,
  * and with which parameters, and the runtime's NATIVE scheduler does the work
- * (Codex automations / Claude /schedule). setup creates five automations
+ * (Codex automations / Claude /schedule). setup registers the default loops
  * (intake-repair 60m, intake-prd 60m, intake-tickets 10m, exploratory-bugs
- * daily, exploratory-prds daily); auto-start-prds/auto-start-tickets map to
+ * daily, exploratory-prds daily, monitor daily) plus the opt-in weekly
+ * learnings-audit gardener; auto-start-prds/auto-start-tickets map to
  * project-ideation `prd_ready` / exploratory-qa `ready` (default true — autonomous).
- * teardown removes only the project's `lisa-auto-<project>-*` set.
+ * Registration also scaffolds one checked-in runbook per registered loop
+ * (#1796). teardown sweeps the project's `lisa-auto-<project>-*` registration
+ * set — no hardcoded roster — and leaves runbook files on disk.
  *
  * Both source and generated plugin roots are asserted.
  * @module tests/unit/strategies/automations-skills
@@ -44,7 +47,7 @@ describe("setup-automations is a runtime-branched declarative spec", () => {
       expect(content).toMatch(/local/);
     });
 
-    it("specifies all five automations with their commands", () => {
+    it("specifies every registered automation with its command", () => {
       expect(content).toContain("/lisa:repair-intake");
       expect(content).toContain("/lisa:intake");
       expect(content).toContain("lisa-exploratory-qa");
@@ -84,6 +87,41 @@ describe("setup-automations is a runtime-branched declarative spec", () => {
       expect(content).toMatch(/expo[^]{0,12}rails[^]{0,16}harper-fabric/);
       expect(content).toMatch(/skip that automation|do not invent/i);
     });
+
+    it("can author files (Write/Edit) so it can scaffold runbooks", () => {
+      expect(content).toMatch(/allowed-tools:.*"Write"/);
+      expect(content).toMatch(/allowed-tools:.*"Edit"/);
+    });
+
+    it("scaffolds one runbook per registered loop, citing the contract", () => {
+      expect(content).toContain(".lisa/automations/<loop-id>.runbook.md");
+      expect(content).toContain("automation-runbook-contract");
+      // Registration-derived, never a fixed list of loop names.
+      expect(content).toMatch(/never write a runbook from a fixed list/i);
+      // Skipped loops get no runbook.
+      expect(content).toMatch(/skipped gets no runbook/i);
+    });
+
+    it("refreshes only the machine block and never overwrites operator prose", () => {
+      expect(content).toContain("<!-- lisa:machine-resolved:start -->");
+      expect(content).toContain("<!-- lisa:machine-resolved:end -->");
+      expect(content).toMatch(
+        /rewritten wholesale|rewrite the\s+machine-resolved block/i
+      );
+      expect(content).toMatch(
+        /never overwrite, reorder, reword, or\s+delete prose/i
+      );
+    });
+
+    it("treats a missing runbook as a degradation, never a precondition", () => {
+      expect(content).toMatch(/degradation, not a blocker/i);
+      expect(content).toMatch(/never a precondition/i);
+    });
+
+    it("reports each runbook written and each skipped loop", () => {
+      expect(content).toMatch(/list each runbook written/i);
+      expect(content).toMatch(/created.*refreshed|refreshed.*created/is);
+    });
   });
 });
 
@@ -109,6 +147,23 @@ describe("tear-down-automations removes only this project's lisa-auto set", () =
     it("is idempotent (already-absent is a no-op)", () => {
       expect(content).toMatch(/idempotent/i);
       expect(content).toMatch(/already absent|no-op/i);
+    });
+
+    it("carries no hardcoded loop roster — the registration set is the roster", () => {
+      expect(content).toMatch(/membership is registration, not a roster/i);
+      expect(content).toMatch(/do \*\*not\*\* work from a fixed list/i);
+      // The old defective wording enumerated exactly six loops.
+      expect(content).not.toMatch(/the six automations/i);
+    });
+
+    it("explicitly covers the opt-in learnings-audit gardener", () => {
+      expect(content).toContain("learnings-audit");
+      expect(content).toMatch(/gardener/i);
+    });
+
+    it("leaves scaffolded runbook files on disk", () => {
+      expect(content).toContain(".lisa/automations/");
+      expect(content).toMatch(/leave the runbooks alone|never deletes/i);
     });
   });
 });


### PR DESCRIPTION
## What this does

Registration now **produces** the automation runbook contract instead of merely citing it, and the three drifting fleet lists collapse onto one registration-derived source.

### Runbook scaffolding (RBC-2)

`/lisa:setup-automations` writes a checked-in `.lisa/automations/<loop-id>.runbook.md` for **every loop it actually registers** — including the stack-guarded `exploratory-bugs` and the opt-in `learnings-audit` gardener. Skipped loops get no runbook, and the report says which and why.

The file has two halves with different owners:

- A **machine-resolved header block** (delimited, and carrying a visible "edits here are lost" sentence so the boundary survives rendering) that Lisa rewrites wholesale on every run: project identity, loop id, the exact scheduled command with every `owner/repo` baked in, cadence + rrule, queue arguments, resolved flags.
- The **ten contract sections**, seeded once and then owned by the operator. Seeds are deterministic, not improvised: a per-loop table supplies Intent / Sources of truth / Candidate selection / Scope/bounds / Retirement condition for all seven loops, and the remaining five are derived from that loop's own `SKILL.md`, named per loop.

Re-running refreshes only the machine block; operator prose survives verbatim, and a section missing from an existing file is inserted at its position in the contract's ten-section order. A runbook that cannot be written is a **degradation, never a precondition** — the automation is still registered and still runs.

### Fleet-roster unification

`lisa-tear-down-automations` carried a hardcoded six-loop roster that omitted `learnings-audit`, so an opted-in gardener could be **orphaned** by teardown even though `setup-automations` promised otherwise. It now sweeps the `lisa-auto-<project>-` registration set — membership is registration, not a roster — and leaves runbook files on disk as project knowledge, saying why.

`automation-status-expected-fleet.mjs` gains `monitor` (was missing from the resolved fleet entirely) and the opt-in `learnings-audit` (UNSUPPORTED, not MISSING, when a project has not opted in), plus a `runbookPath` on every entry. `lisa-automation-status`'s own hardcoded roster line now derives from the resolver.

## Review and verification story

Three review lanes and an independent verification pass ran against this branch. Both defects they found were real, and both were fixed before merge:

1. **Both runtime adapters silently dropped the new group.** They binned entries into a hardcoded `core`/`exploratory` map and pushed with `?.`, so the gardener vanished from every report whether or not the project had opted in. Fixed at the root: group membership lives once in `AUTOMATION_FLEET_GROUP_TITLES`, adapters bin and render through shared helpers, and an unknown group now **throws** instead of disappearing. Weekly cadence handling was added to both adapters so the gardener can be compared and aged like any other loop.
2. **Codex reported the two no-argument loops as permanently drifted.** `deriveCodexObservedCommand` only matched prompts carrying a non-empty argument capture, so `monitor` and `learnings-audit` derived no observed command and the drift classifier flagged them `DRIFTED` forever — un-fixable by re-running setup, since setup produced the same prompt shape. The argument clause is now optional, a literal command line is accepted (needed for `/lisa:learnings:audit`, which is not a plain skill name), and `setup-automations` specifies that prompt shape explicitly so the writer and the reader agree.

Also addressed from review: registration-inferred gardener opt-in (no config key to write), operator-readable report lines that state consequence **and** action, teardown's "already absent" set derived from the resolver, and a wildcard test regex replaced with an anchored one.

## Verification

- `bunx vitest run tests/unit/strategies/` — **136 files / 3265 tests passed**
- `tests/unit/cli/ui-automations-*` — 3 files / 9 passed
- `bun run typecheck` — exit 0
- `bun run check:plugins` — exit 0 (artifacts in sync, marketplace complete)
- Independent runtime harness exercising both adapters end-to-end through the rendered report — **20/20 checks pass, 0 failures**

New regression coverage pins: the opt-in group rendering per runtime, the unknown-group throw, no-argument Codex registrations reading back HEALTHY (with a genuine-drift case kept), `runbookPath` per loop, monitor-unconditional, gardener-only-when-opted-in, and the scaffolding/teardown skill contracts.

Out of scope, as specified: run-outcome records (#1797), loop-skill conformance (#1798), the status display of runbooks (#1799), retirement logic (#1801).

Closes #1796

🤖 Generated with Claude Code
