### PR TITLE
feat(automations): add durable run outcome records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,6 +217,10 @@ expo-env.d.ts
 # flow and read by the enforce-verification-gate Stop hook. Never committed.
 .lisa/verification-status.json
 
+# Automation run outcomes — local scheduler observations read by
+# /lisa:automation-status. Runbooks are project knowledge; run records are not.
+.lisa/automations/runs/
+
 # Built Claude Code plugins are committed so the GitHub marketplace works.
 # Regenerate with: bun run build:plugins
 

--- a/plugins/lisa-agy/scripts/automation-run-record.mjs
+++ b/plugins/lisa-agy/scripts/automation-run-record.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * Dependency-free run outcome recorder for registered Lisa automation loops.
+ *
+ * The file is local scheduler state, not project knowledge: one bounded JSONL
+ * file per loop under `.lisa/automations/runs/`.
+ */
+
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export const AUTOMATION_RUN_OUTCOMES = [
+  "nothing-needed",
+  "candidate-proposed",
+  "change-proved",
+  "approval-requested",
+  "recovery-required",
+  "policy-obsolete",
+];
+
+export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
+
+/**
+ * @typedef {{
+ *   readonly ts: string
+ *   readonly loop_id: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ *   readonly runbook: string
+ *   readonly refs: readonly string[]
+ *   readonly run_id: string
+ * }} AutomationRunRecord
+ *
+ * @typedef {{
+ *   readonly projectRoot?: string
+ *   readonly loopId: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ *   readonly runbook: string
+ *   readonly refs?: readonly string[]
+ *   readonly runId?: string
+ *   readonly ts?: string | Date
+ *   readonly maxEntries?: number
+ * }} RecordAutomationRunInput
+ */
+
+/**
+ * Record one automation-loop outcome, suppressing duplicate re-appends for the
+ * same `run_id` and trimming the file to the configured history bound.
+ *
+ * @param {RecordAutomationRunInput} input
+ * @returns {Promise<{ readonly path: string, readonly record: AutomationRunRecord, readonly records: readonly AutomationRunRecord[], readonly appended: boolean, readonly skippedCorruptLines: number, readonly maxEntries: number }>}
+ */
+export async function recordAutomationRun(input) {
+  const projectRoot = path.resolve(input.projectRoot ?? process.cwd());
+  const maxEntries =
+    input.maxEntries ??
+    (await resolveAutomationRunHistoryMaxEntries(projectRoot));
+  const record = buildAutomationRunRecord(input);
+  const filePath = automationRunRecordPath(projectRoot, record.loop_id);
+  const readResult = await readAutomationRunRecords(filePath);
+
+  if (readResult.records.some(existing => existing.run_id === record.run_id)) {
+    return {
+      path: filePath,
+      record,
+      records: readResult.records,
+      appended: false,
+      skippedCorruptLines: readResult.skippedCorruptLines,
+      maxEntries,
+    };
+  }
+
+  const nextRecords = [...readResult.records, record].slice(-maxEntries);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeJsonlAtomically(filePath, nextRecords);
+
+  return {
+    path: filePath,
+    record,
+    records: nextRecords,
+    appended: true,
+    skippedCorruptLines: readResult.skippedCorruptLines,
+    maxEntries,
+  };
+}
+
+/**
+ * @param {string} projectRoot
+ * @returns {Promise<number>}
+ */
+export async function resolveAutomationRunHistoryMaxEntries(projectRoot) {
+  const globalConfig = await readJsonIfPresent(
+    path.join(projectRoot, ".lisa.config.json")
+  );
+  const localConfig = await readJsonIfPresent(
+    path.join(projectRoot, ".lisa.config.local.json")
+  );
+  const configured =
+    localConfig?.automations?.runHistory?.maxEntries ??
+    globalConfig?.automations?.runHistory?.maxEntries;
+
+  if (Number.isInteger(configured) && configured > 0) {
+    return configured;
+  }
+
+  return DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES;
+}
+
+/**
+ * @param {string} projectRoot
+ * @param {string} loopId
+ * @returns {string}
+ */
+export function automationRunRecordPath(projectRoot, loopId) {
+  return path.join(
+    path.resolve(projectRoot),
+    ".lisa",
+    "automations",
+    "runs",
+    `${normalizeLoopId(loopId)}.jsonl`
+  );
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<{ readonly records: readonly AutomationRunRecord[], readonly skippedCorruptLines: number }>}
+ */
+export async function readAutomationRunRecords(filePath) {
+  let content = "";
+  try {
+    content = await readFile(filePath, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return { records: [], skippedCorruptLines: 0 };
+    }
+    throw error;
+  }
+
+  const records = [];
+  let skippedCorruptLines = 0;
+  for (const line of content.split(/\n/)) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(line);
+      records.push(validateStoredRecord(parsed));
+    } catch {
+      skippedCorruptLines += 1;
+    }
+  }
+
+  return { records, skippedCorruptLines };
+}
+
+/**
+ * @param {RecordAutomationRunInput} input
+ * @returns {AutomationRunRecord}
+ */
+function buildAutomationRunRecord(input) {
+  const loopId = normalizeLoopId(input.loopId);
+  const summary = String(input.summary ?? "").trim();
+  const runbook = String(input.runbook ?? "").trim();
+  const refs = Array.isArray(input.refs)
+    ? input.refs.map(ref => String(ref))
+    : [];
+  const ts =
+    input.ts instanceof Date
+      ? input.ts.toISOString()
+      : input.ts
+        ? new Date(input.ts).toISOString()
+        : new Date().toISOString();
+  const runId = String(input.runId ?? `${loopId}:${ts}`).trim();
+
+  if (!AUTOMATION_RUN_OUTCOMES.includes(input.outcome)) {
+    throw new Error(
+      `Invalid automation run outcome "${input.outcome}". Valid outcomes: ${AUTOMATION_RUN_OUTCOMES.join(", ")}.`
+    );
+  }
+  if (!summary) {
+    throw new Error("Automation run summary is required.");
+  }
+  if (!runbook) {
+    throw new Error("Automation runbook path is required.");
+  }
+  if (!runId) {
+    throw new Error("Automation run_id is required.");
+  }
+
+  return {
+    ts,
+    loop_id: loopId,
+    outcome: input.outcome,
+    summary,
+    runbook,
+    refs,
+    run_id: runId,
+  };
+}
+
+/**
+ * @param {unknown} value
+ * @returns {AutomationRunRecord}
+ */
+function validateStoredRecord(value) {
+  if (!value || typeof value !== "object") {
+    throw new Error("Automation run record must be an object.");
+  }
+  return buildAutomationRunRecord({
+    ts: String(value.ts ?? ""),
+    loopId: String(value.loop_id ?? ""),
+    outcome: String(value.outcome ?? ""),
+    summary: String(value.summary ?? ""),
+    runbook: String(value.runbook ?? ""),
+    refs: Array.isArray(value.refs) ? value.refs.map(ref => String(ref)) : [],
+    runId: String(value.run_id ?? ""),
+  });
+}
+
+/**
+ * @param {string} loopId
+ * @returns {string}
+ */
+function normalizeLoopId(loopId) {
+  const normalized = String(loopId ?? "").trim();
+  if (!/^[a-z0-9][a-z0-9._-]*$/i.test(normalized)) {
+    throw new Error(
+      "Automation loop_id must be a non-empty slug containing only letters, numbers, dots, underscores, and hyphens."
+    );
+  }
+  return normalized;
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<unknown | undefined>}
+ */
+async function readJsonIfPresent(filePath) {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return undefined;
+    }
+    if (error instanceof SyntaxError) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+/**
+ * @param {string} filePath
+ * @param {readonly AutomationRunRecord[]} records
+ */
+async function writeJsonlAtomically(filePath, records) {
+  const content = `${records.map(record => JSON.stringify(record)).join("\n")}\n`;
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tempPath, content, "utf8");
+  await rename(tempPath, filePath);
+}

--- a/plugins/lisa-copilot/rules/eager/automation-runbook-contract.md
+++ b/plugins/lisa-copilot/rules/eager/automation-runbook-contract.md
@@ -50,7 +50,10 @@ loop itself is broken, not that a work item was blocked.
 
 Every run — including a trivial early termination — ends by naming exactly one run outcome plus a
 one-line operator summary of what happened, recorded where the status surface can read it —
-there is no silent exit. Silence and health must never look identical to an operator.
+there is no silent exit. The shared local substrate is
+`plugins/src/base/scripts/automation-run-record.mjs`, which writes bounded JSONL records under
+`.lisa/automations/runs/<loop-id>.jsonl`. Silence and health must never look identical to an
+operator.
 
 ## Never block, always degrade
 

--- a/plugins/lisa-copilot/rules/reference/automation-runbook-contract.md
+++ b/plugins/lisa-copilot/rules/reference/automation-runbook-contract.md
@@ -121,8 +121,17 @@ there is no silent exit for an operator to misread as health. A run that ends wi
 recorded outcome is indistinguishable from a crashed scheduler, which is exactly the ambiguity this
 contract removes. This generalizes `lisa-improve-harness`'s result-record discipline — every
 terminal step posts its result record before stopping, so there is no silent exit — from one flow to
-every registered loop. (The run-record substrate that stores outcomes and summaries is named here
-only; it ships with that ticket (#1797), do not assume its file is present in this branch.)
+every registered loop.
+
+The local storage substrate is `plugins/src/base/scripts/automation-run-record.mjs`. It writes one
+bounded JSONL file per loop at `.lisa/automations/runs/<loop-id>.jsonl`, with one object per line:
+`{ ts, loop_id, outcome, summary, runbook, refs[], run_id }`. The helper rejects any outcome outside
+the closed six-value vocabulary, requires a non-empty operator-readable summary, suppresses duplicate
+re-appends for the same `run_id`, skips corrupt/truncated lines on read, and trims to the newest
+configured records on write. The default bound is 50 records per loop, overridable via
+`.lisa.config.json` / `.lisa.config.local.json` `automations.runHistory.maxEntries`. These records
+are local scheduler observations, not project knowledge, so `.lisa/automations/runs/` is ignored;
+the runbooks under `.lisa/automations/*.runbook.md` remain checked-in knowledge.
 
 ## A run outcome is not a work-item lifecycle terminal state
 
@@ -209,8 +218,8 @@ packet above. A degraded run never blocks other work and never leaves the run un
 
 ## Citing adjacent work
 
-Cite these by name; each ships with its own ticket, do not assume its file is present in this
-branch: the runbook scaffolding that instantiates this template (#1796), the run-record substrate
-that stores outcomes and summaries (#1797), and the evidence packet defined by the evidence PRD
-(#1738) — named here, with no evidence format defined by this contract. Rejection memory
-extends `rejection-detection`; this contract neither restates nor overrides it.
+Cite these by name. The run-record substrate ships with that ticket (#1797), do not assume its file
+is present in older branches. The evidence packet ships with that ticket, do not assume its file is present in this branch. Other adjacent artifacts keep their own lifecycle: the runbook scaffolding
+that instantiates this template (#1796), and the evidence packet defined by the evidence PRD (#1738)
+— named here, with no evidence format defined by this contract. Rejection memory extends
+`rejection-detection`; this contract neither restates nor overrides it.

--- a/plugins/lisa-copilot/scripts/automation-run-record.mjs
+++ b/plugins/lisa-copilot/scripts/automation-run-record.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * Dependency-free run outcome recorder for registered Lisa automation loops.
+ *
+ * The file is local scheduler state, not project knowledge: one bounded JSONL
+ * file per loop under `.lisa/automations/runs/`.
+ */
+
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export const AUTOMATION_RUN_OUTCOMES = [
+  "nothing-needed",
+  "candidate-proposed",
+  "change-proved",
+  "approval-requested",
+  "recovery-required",
+  "policy-obsolete",
+];
+
+export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
+
+/**
+ * @typedef {{
+ *   readonly ts: string
+ *   readonly loop_id: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ *   readonly runbook: string
+ *   readonly refs: readonly string[]
+ *   readonly run_id: string
+ * }} AutomationRunRecord
+ *
+ * @typedef {{
+ *   readonly projectRoot?: string
+ *   readonly loopId: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ *   readonly runbook: string
+ *   readonly refs?: readonly string[]
+ *   readonly runId?: string
+ *   readonly ts?: string | Date
+ *   readonly maxEntries?: number
+ * }} RecordAutomationRunInput
+ */
+
+/**
+ * Record one automation-loop outcome, suppressing duplicate re-appends for the
+ * same `run_id` and trimming the file to the configured history bound.
+ *
+ * @param {RecordAutomationRunInput} input
+ * @returns {Promise<{ readonly path: string, readonly record: AutomationRunRecord, readonly records: readonly AutomationRunRecord[], readonly appended: boolean, readonly skippedCorruptLines: number, readonly maxEntries: number }>}
+ */
+export async function recordAutomationRun(input) {
+  const projectRoot = path.resolve(input.projectRoot ?? process.cwd());
+  const maxEntries =
+    input.maxEntries ??
+    (await resolveAutomationRunHistoryMaxEntries(projectRoot));
+  const record = buildAutomationRunRecord(input);
+  const filePath = automationRunRecordPath(projectRoot, record.loop_id);
+  const readResult = await readAutomationRunRecords(filePath);
+
+  if (readResult.records.some(existing => existing.run_id === record.run_id)) {
+    return {
+      path: filePath,
+      record,
+      records: readResult.records,
+      appended: false,
+      skippedCorruptLines: readResult.skippedCorruptLines,
+      maxEntries,
+    };
+  }
+
+  const nextRecords = [...readResult.records, record].slice(-maxEntries);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeJsonlAtomically(filePath, nextRecords);
+
+  return {
+    path: filePath,
+    record,
+    records: nextRecords,
+    appended: true,
+    skippedCorruptLines: readResult.skippedCorruptLines,
+    maxEntries,
+  };
+}
+
+/**
+ * @param {string} projectRoot
+ * @returns {Promise<number>}
+ */
+export async function resolveAutomationRunHistoryMaxEntries(projectRoot) {
+  const globalConfig = await readJsonIfPresent(
+    path.join(projectRoot, ".lisa.config.json")
+  );
+  const localConfig = await readJsonIfPresent(
+    path.join(projectRoot, ".lisa.config.local.json")
+  );
+  const configured =
+    localConfig?.automations?.runHistory?.maxEntries ??
+    globalConfig?.automations?.runHistory?.maxEntries;
+
+  if (Number.isInteger(configured) && configured > 0) {
+    return configured;
+  }
+
+  return DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES;
+}
+
+/**
+ * @param {string} projectRoot
+ * @param {string} loopId
+ * @returns {string}
+ */
+export function automationRunRecordPath(projectRoot, loopId) {
+  return path.join(
+    path.resolve(projectRoot),
+    ".lisa",
+    "automations",
+    "runs",
+    `${normalizeLoopId(loopId)}.jsonl`
+  );
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<{ readonly records: readonly AutomationRunRecord[], readonly skippedCorruptLines: number }>}
+ */
+export async function readAutomationRunRecords(filePath) {
+  let content = "";
+  try {
+    content = await readFile(filePath, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return { records: [], skippedCorruptLines: 0 };
+    }
+    throw error;
+  }
+
+  const records = [];
+  let skippedCorruptLines = 0;
+  for (const line of content.split(/\n/)) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(line);
+      records.push(validateStoredRecord(parsed));
+    } catch {
+      skippedCorruptLines += 1;
+    }
+  }
+
+  return { records, skippedCorruptLines };
+}
+
+/**
+ * @param {RecordAutomationRunInput} input
+ * @returns {AutomationRunRecord}
+ */
+function buildAutomationRunRecord(input) {
+  const loopId = normalizeLoopId(input.loopId);
+  const summary = String(input.summary ?? "").trim();
+  const runbook = String(input.runbook ?? "").trim();
+  const refs = Array.isArray(input.refs)
+    ? input.refs.map(ref => String(ref))
+    : [];
+  const ts =
+    input.ts instanceof Date
+      ? input.ts.toISOString()
+      : input.ts
+        ? new Date(input.ts).toISOString()
+        : new Date().toISOString();
+  const runId = String(input.runId ?? `${loopId}:${ts}`).trim();
+
+  if (!AUTOMATION_RUN_OUTCOMES.includes(input.outcome)) {
+    throw new Error(
+      `Invalid automation run outcome "${input.outcome}". Valid outcomes: ${AUTOMATION_RUN_OUTCOMES.join(", ")}.`
+    );
+  }
+  if (!summary) {
+    throw new Error("Automation run summary is required.");
+  }
+  if (!runbook) {
+    throw new Error("Automation runbook path is required.");
+  }
+  if (!runId) {
+    throw new Error("Automation run_id is required.");
+  }
+
+  return {
+    ts,
+    loop_id: loopId,
+    outcome: input.outcome,
+    summary,
+    runbook,
+    refs,
+    run_id: runId,
+  };
+}
+
+/**
+ * @param {unknown} value
+ * @returns {AutomationRunRecord}
+ */
+function validateStoredRecord(value) {
+  if (!value || typeof value !== "object") {
+    throw new Error("Automation run record must be an object.");
+  }
+  return buildAutomationRunRecord({
+    ts: String(value.ts ?? ""),
+    loopId: String(value.loop_id ?? ""),
+    outcome: String(value.outcome ?? ""),
+    summary: String(value.summary ?? ""),
+    runbook: String(value.runbook ?? ""),
+    refs: Array.isArray(value.refs) ? value.refs.map(ref => String(ref)) : [],
+    runId: String(value.run_id ?? ""),
+  });
+}
+
+/**
+ * @param {string} loopId
+ * @returns {string}
+ */
+function normalizeLoopId(loopId) {
+  const normalized = String(loopId ?? "").trim();
+  if (!/^[a-z0-9][a-z0-9._-]*$/i.test(normalized)) {
+    throw new Error(
+      "Automation loop_id must be a non-empty slug containing only letters, numbers, dots, underscores, and hyphens."
+    );
+  }
+  return normalized;
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<unknown | undefined>}
+ */
+async function readJsonIfPresent(filePath) {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return undefined;
+    }
+    if (error instanceof SyntaxError) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+/**
+ * @param {string} filePath
+ * @param {readonly AutomationRunRecord[]} records
+ */
+async function writeJsonlAtomically(filePath, records) {
+  const content = `${records.map(record => JSON.stringify(record)).join("\n")}\n`;
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tempPath, content, "utf8");
+  await rename(tempPath, filePath);
+}

--- a/plugins/lisa-cursor/rules/automation-runbook-contract-reference.mdc
+++ b/plugins/lisa-cursor/rules/automation-runbook-contract-reference.mdc
@@ -126,8 +126,17 @@ there is no silent exit for an operator to misread as health. A run that ends wi
 recorded outcome is indistinguishable from a crashed scheduler, which is exactly the ambiguity this
 contract removes. This generalizes `lisa-improve-harness`'s result-record discipline — every
 terminal step posts its result record before stopping, so there is no silent exit — from one flow to
-every registered loop. (The run-record substrate that stores outcomes and summaries is named here
-only; it ships with that ticket (#1797), do not assume its file is present in this branch.)
+every registered loop.
+
+The local storage substrate is `plugins/src/base/scripts/automation-run-record.mjs`. It writes one
+bounded JSONL file per loop at `.lisa/automations/runs/<loop-id>.jsonl`, with one object per line:
+`{ ts, loop_id, outcome, summary, runbook, refs[], run_id }`. The helper rejects any outcome outside
+the closed six-value vocabulary, requires a non-empty operator-readable summary, suppresses duplicate
+re-appends for the same `run_id`, skips corrupt/truncated lines on read, and trims to the newest
+configured records on write. The default bound is 50 records per loop, overridable via
+`.lisa.config.json` / `.lisa.config.local.json` `automations.runHistory.maxEntries`. These records
+are local scheduler observations, not project knowledge, so `.lisa/automations/runs/` is ignored;
+the runbooks under `.lisa/automations/*.runbook.md` remain checked-in knowledge.
 
 ## A run outcome is not a work-item lifecycle terminal state
 
@@ -214,8 +223,8 @@ packet above. A degraded run never blocks other work and never leaves the run un
 
 ## Citing adjacent work
 
-Cite these by name; each ships with its own ticket, do not assume its file is present in this
-branch: the runbook scaffolding that instantiates this template (#1796), the run-record substrate
-that stores outcomes and summaries (#1797), and the evidence packet defined by the evidence PRD
-(#1738) — named here, with no evidence format defined by this contract. Rejection memory
-extends `rejection-detection`; this contract neither restates nor overrides it.
+Cite these by name. The run-record substrate ships with that ticket (#1797), do not assume its file
+is present in older branches. The evidence packet ships with that ticket, do not assume its file is present in this branch. Other adjacent artifacts keep their own lifecycle: the runbook scaffolding
+that instantiates this template (#1796), and the evidence packet defined by the evidence PRD (#1738)
+— named here, with no evidence format defined by this contract. Rejection memory extends
+`rejection-detection`; this contract neither restates nor overrides it.

--- a/plugins/lisa-cursor/rules/automation-runbook-contract.mdc
+++ b/plugins/lisa-cursor/rules/automation-runbook-contract.mdc
@@ -55,7 +55,10 @@ loop itself is broken, not that a work item was blocked.
 
 Every run — including a trivial early termination — ends by naming exactly one run outcome plus a
 one-line operator summary of what happened, recorded where the status surface can read it —
-there is no silent exit. Silence and health must never look identical to an operator.
+there is no silent exit. The shared local substrate is
+`plugins/src/base/scripts/automation-run-record.mjs`, which writes bounded JSONL records under
+`.lisa/automations/runs/<loop-id>.jsonl`. Silence and health must never look identical to an
+operator.
 
 ## Never block, always degrade
 

--- a/plugins/lisa-cursor/scripts/automation-run-record.mjs
+++ b/plugins/lisa-cursor/scripts/automation-run-record.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * Dependency-free run outcome recorder for registered Lisa automation loops.
+ *
+ * The file is local scheduler state, not project knowledge: one bounded JSONL
+ * file per loop under `.lisa/automations/runs/`.
+ */
+
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export const AUTOMATION_RUN_OUTCOMES = [
+  "nothing-needed",
+  "candidate-proposed",
+  "change-proved",
+  "approval-requested",
+  "recovery-required",
+  "policy-obsolete",
+];
+
+export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
+
+/**
+ * @typedef {{
+ *   readonly ts: string
+ *   readonly loop_id: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ *   readonly runbook: string
+ *   readonly refs: readonly string[]
+ *   readonly run_id: string
+ * }} AutomationRunRecord
+ *
+ * @typedef {{
+ *   readonly projectRoot?: string
+ *   readonly loopId: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ *   readonly runbook: string
+ *   readonly refs?: readonly string[]
+ *   readonly runId?: string
+ *   readonly ts?: string | Date
+ *   readonly maxEntries?: number
+ * }} RecordAutomationRunInput
+ */
+
+/**
+ * Record one automation-loop outcome, suppressing duplicate re-appends for the
+ * same `run_id` and trimming the file to the configured history bound.
+ *
+ * @param {RecordAutomationRunInput} input
+ * @returns {Promise<{ readonly path: string, readonly record: AutomationRunRecord, readonly records: readonly AutomationRunRecord[], readonly appended: boolean, readonly skippedCorruptLines: number, readonly maxEntries: number }>}
+ */
+export async function recordAutomationRun(input) {
+  const projectRoot = path.resolve(input.projectRoot ?? process.cwd());
+  const maxEntries =
+    input.maxEntries ??
+    (await resolveAutomationRunHistoryMaxEntries(projectRoot));
+  const record = buildAutomationRunRecord(input);
+  const filePath = automationRunRecordPath(projectRoot, record.loop_id);
+  const readResult = await readAutomationRunRecords(filePath);
+
+  if (readResult.records.some(existing => existing.run_id === record.run_id)) {
+    return {
+      path: filePath,
+      record,
+      records: readResult.records,
+      appended: false,
+      skippedCorruptLines: readResult.skippedCorruptLines,
+      maxEntries,
+    };
+  }
+
+  const nextRecords = [...readResult.records, record].slice(-maxEntries);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeJsonlAtomically(filePath, nextRecords);
+
+  return {
+    path: filePath,
+    record,
+    records: nextRecords,
+    appended: true,
+    skippedCorruptLines: readResult.skippedCorruptLines,
+    maxEntries,
+  };
+}
+
+/**
+ * @param {string} projectRoot
+ * @returns {Promise<number>}
+ */
+export async function resolveAutomationRunHistoryMaxEntries(projectRoot) {
+  const globalConfig = await readJsonIfPresent(
+    path.join(projectRoot, ".lisa.config.json")
+  );
+  const localConfig = await readJsonIfPresent(
+    path.join(projectRoot, ".lisa.config.local.json")
+  );
+  const configured =
+    localConfig?.automations?.runHistory?.maxEntries ??
+    globalConfig?.automations?.runHistory?.maxEntries;
+
+  if (Number.isInteger(configured) && configured > 0) {
+    return configured;
+  }
+
+  return DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES;
+}
+
+/**
+ * @param {string} projectRoot
+ * @param {string} loopId
+ * @returns {string}
+ */
+export function automationRunRecordPath(projectRoot, loopId) {
+  return path.join(
+    path.resolve(projectRoot),
+    ".lisa",
+    "automations",
+    "runs",
+    `${normalizeLoopId(loopId)}.jsonl`
+  );
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<{ readonly records: readonly AutomationRunRecord[], readonly skippedCorruptLines: number }>}
+ */
+export async function readAutomationRunRecords(filePath) {
+  let content = "";
+  try {
+    content = await readFile(filePath, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return { records: [], skippedCorruptLines: 0 };
+    }
+    throw error;
+  }
+
+  const records = [];
+  let skippedCorruptLines = 0;
+  for (const line of content.split(/\n/)) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(line);
+      records.push(validateStoredRecord(parsed));
+    } catch {
+      skippedCorruptLines += 1;
+    }
+  }
+
+  return { records, skippedCorruptLines };
+}
+
+/**
+ * @param {RecordAutomationRunInput} input
+ * @returns {AutomationRunRecord}
+ */
+function buildAutomationRunRecord(input) {
+  const loopId = normalizeLoopId(input.loopId);
+  const summary = String(input.summary ?? "").trim();
+  const runbook = String(input.runbook ?? "").trim();
+  const refs = Array.isArray(input.refs)
+    ? input.refs.map(ref => String(ref))
+    : [];
+  const ts =
+    input.ts instanceof Date
+      ? input.ts.toISOString()
+      : input.ts
+        ? new Date(input.ts).toISOString()
+        : new Date().toISOString();
+  const runId = String(input.runId ?? `${loopId}:${ts}`).trim();
+
+  if (!AUTOMATION_RUN_OUTCOMES.includes(input.outcome)) {
+    throw new Error(
+      `Invalid automation run outcome "${input.outcome}". Valid outcomes: ${AUTOMATION_RUN_OUTCOMES.join(", ")}.`
+    );
+  }
+  if (!summary) {
+    throw new Error("Automation run summary is required.");
+  }
+  if (!runbook) {
+    throw new Error("Automation runbook path is required.");
+  }
+  if (!runId) {
+    throw new Error("Automation run_id is required.");
+  }
+
+  return {
+    ts,
+    loop_id: loopId,
+    outcome: input.outcome,
+    summary,
+    runbook,
+    refs,
+    run_id: runId,
+  };
+}
+
+/**
+ * @param {unknown} value
+ * @returns {AutomationRunRecord}
+ */
+function validateStoredRecord(value) {
+  if (!value || typeof value !== "object") {
+    throw new Error("Automation run record must be an object.");
+  }
+  return buildAutomationRunRecord({
+    ts: String(value.ts ?? ""),
+    loopId: String(value.loop_id ?? ""),
+    outcome: String(value.outcome ?? ""),
+    summary: String(value.summary ?? ""),
+    runbook: String(value.runbook ?? ""),
+    refs: Array.isArray(value.refs) ? value.refs.map(ref => String(ref)) : [],
+    runId: String(value.run_id ?? ""),
+  });
+}
+
+/**
+ * @param {string} loopId
+ * @returns {string}
+ */
+function normalizeLoopId(loopId) {
+  const normalized = String(loopId ?? "").trim();
+  if (!/^[a-z0-9][a-z0-9._-]*$/i.test(normalized)) {
+    throw new Error(
+      "Automation loop_id must be a non-empty slug containing only letters, numbers, dots, underscores, and hyphens."
+    );
+  }
+  return normalized;
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<unknown | undefined>}
+ */
+async function readJsonIfPresent(filePath) {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return undefined;
+    }
+    if (error instanceof SyntaxError) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+/**
+ * @param {string} filePath
+ * @param {readonly AutomationRunRecord[]} records
+ */
+async function writeJsonlAtomically(filePath, records) {
+  const content = `${records.map(record => JSON.stringify(record)).join("\n")}\n`;
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tempPath, content, "utf8");
+  await rename(tempPath, filePath);
+}

--- a/plugins/lisa/rules/eager/automation-runbook-contract.md
+++ b/plugins/lisa/rules/eager/automation-runbook-contract.md
@@ -50,7 +50,10 @@ loop itself is broken, not that a work item was blocked.
 
 Every run — including a trivial early termination — ends by naming exactly one run outcome plus a
 one-line operator summary of what happened, recorded where the status surface can read it —
-there is no silent exit. Silence and health must never look identical to an operator.
+there is no silent exit. The shared local substrate is
+`plugins/src/base/scripts/automation-run-record.mjs`, which writes bounded JSONL records under
+`.lisa/automations/runs/<loop-id>.jsonl`. Silence and health must never look identical to an
+operator.
 
 ## Never block, always degrade
 

--- a/plugins/lisa/rules/reference/automation-runbook-contract.md
+++ b/plugins/lisa/rules/reference/automation-runbook-contract.md
@@ -121,8 +121,17 @@ there is no silent exit for an operator to misread as health. A run that ends wi
 recorded outcome is indistinguishable from a crashed scheduler, which is exactly the ambiguity this
 contract removes. This generalizes `lisa-improve-harness`'s result-record discipline — every
 terminal step posts its result record before stopping, so there is no silent exit — from one flow to
-every registered loop. (The run-record substrate that stores outcomes and summaries is named here
-only; it ships with that ticket (#1797), do not assume its file is present in this branch.)
+every registered loop.
+
+The local storage substrate is `plugins/src/base/scripts/automation-run-record.mjs`. It writes one
+bounded JSONL file per loop at `.lisa/automations/runs/<loop-id>.jsonl`, with one object per line:
+`{ ts, loop_id, outcome, summary, runbook, refs[], run_id }`. The helper rejects any outcome outside
+the closed six-value vocabulary, requires a non-empty operator-readable summary, suppresses duplicate
+re-appends for the same `run_id`, skips corrupt/truncated lines on read, and trims to the newest
+configured records on write. The default bound is 50 records per loop, overridable via
+`.lisa.config.json` / `.lisa.config.local.json` `automations.runHistory.maxEntries`. These records
+are local scheduler observations, not project knowledge, so `.lisa/automations/runs/` is ignored;
+the runbooks under `.lisa/automations/*.runbook.md` remain checked-in knowledge.
 
 ## A run outcome is not a work-item lifecycle terminal state
 
@@ -209,8 +218,8 @@ packet above. A degraded run never blocks other work and never leaves the run un
 
 ## Citing adjacent work
 
-Cite these by name; each ships with its own ticket, do not assume its file is present in this
-branch: the runbook scaffolding that instantiates this template (#1796), the run-record substrate
-that stores outcomes and summaries (#1797), and the evidence packet defined by the evidence PRD
-(#1738) — named here, with no evidence format defined by this contract. Rejection memory
-extends `rejection-detection`; this contract neither restates nor overrides it.
+Cite these by name. The run-record substrate ships with that ticket (#1797), do not assume its file
+is present in older branches. The evidence packet ships with that ticket, do not assume its file is present in this branch. Other adjacent artifacts keep their own lifecycle: the runbook scaffolding
+that instantiates this template (#1796), and the evidence packet defined by the evidence PRD (#1738)
+— named here, with no evidence format defined by this contract. Rejection memory extends
+`rejection-detection`; this contract neither restates nor overrides it.

--- a/plugins/lisa/scripts/automation-run-record.mjs
+++ b/plugins/lisa/scripts/automation-run-record.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * Dependency-free run outcome recorder for registered Lisa automation loops.
+ *
+ * The file is local scheduler state, not project knowledge: one bounded JSONL
+ * file per loop under `.lisa/automations/runs/`.
+ */
+
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export const AUTOMATION_RUN_OUTCOMES = [
+  "nothing-needed",
+  "candidate-proposed",
+  "change-proved",
+  "approval-requested",
+  "recovery-required",
+  "policy-obsolete",
+];
+
+export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
+
+/**
+ * @typedef {{
+ *   readonly ts: string
+ *   readonly loop_id: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ *   readonly runbook: string
+ *   readonly refs: readonly string[]
+ *   readonly run_id: string
+ * }} AutomationRunRecord
+ *
+ * @typedef {{
+ *   readonly projectRoot?: string
+ *   readonly loopId: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ *   readonly runbook: string
+ *   readonly refs?: readonly string[]
+ *   readonly runId?: string
+ *   readonly ts?: string | Date
+ *   readonly maxEntries?: number
+ * }} RecordAutomationRunInput
+ */
+
+/**
+ * Record one automation-loop outcome, suppressing duplicate re-appends for the
+ * same `run_id` and trimming the file to the configured history bound.
+ *
+ * @param {RecordAutomationRunInput} input
+ * @returns {Promise<{ readonly path: string, readonly record: AutomationRunRecord, readonly records: readonly AutomationRunRecord[], readonly appended: boolean, readonly skippedCorruptLines: number, readonly maxEntries: number }>}
+ */
+export async function recordAutomationRun(input) {
+  const projectRoot = path.resolve(input.projectRoot ?? process.cwd());
+  const maxEntries =
+    input.maxEntries ??
+    (await resolveAutomationRunHistoryMaxEntries(projectRoot));
+  const record = buildAutomationRunRecord(input);
+  const filePath = automationRunRecordPath(projectRoot, record.loop_id);
+  const readResult = await readAutomationRunRecords(filePath);
+
+  if (readResult.records.some(existing => existing.run_id === record.run_id)) {
+    return {
+      path: filePath,
+      record,
+      records: readResult.records,
+      appended: false,
+      skippedCorruptLines: readResult.skippedCorruptLines,
+      maxEntries,
+    };
+  }
+
+  const nextRecords = [...readResult.records, record].slice(-maxEntries);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeJsonlAtomically(filePath, nextRecords);
+
+  return {
+    path: filePath,
+    record,
+    records: nextRecords,
+    appended: true,
+    skippedCorruptLines: readResult.skippedCorruptLines,
+    maxEntries,
+  };
+}
+
+/**
+ * @param {string} projectRoot
+ * @returns {Promise<number>}
+ */
+export async function resolveAutomationRunHistoryMaxEntries(projectRoot) {
+  const globalConfig = await readJsonIfPresent(
+    path.join(projectRoot, ".lisa.config.json")
+  );
+  const localConfig = await readJsonIfPresent(
+    path.join(projectRoot, ".lisa.config.local.json")
+  );
+  const configured =
+    localConfig?.automations?.runHistory?.maxEntries ??
+    globalConfig?.automations?.runHistory?.maxEntries;
+
+  if (Number.isInteger(configured) && configured > 0) {
+    return configured;
+  }
+
+  return DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES;
+}
+
+/**
+ * @param {string} projectRoot
+ * @param {string} loopId
+ * @returns {string}
+ */
+export function automationRunRecordPath(projectRoot, loopId) {
+  return path.join(
+    path.resolve(projectRoot),
+    ".lisa",
+    "automations",
+    "runs",
+    `${normalizeLoopId(loopId)}.jsonl`
+  );
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<{ readonly records: readonly AutomationRunRecord[], readonly skippedCorruptLines: number }>}
+ */
+export async function readAutomationRunRecords(filePath) {
+  let content = "";
+  try {
+    content = await readFile(filePath, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return { records: [], skippedCorruptLines: 0 };
+    }
+    throw error;
+  }
+
+  const records = [];
+  let skippedCorruptLines = 0;
+  for (const line of content.split(/\n/)) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(line);
+      records.push(validateStoredRecord(parsed));
+    } catch {
+      skippedCorruptLines += 1;
+    }
+  }
+
+  return { records, skippedCorruptLines };
+}
+
+/**
+ * @param {RecordAutomationRunInput} input
+ * @returns {AutomationRunRecord}
+ */
+function buildAutomationRunRecord(input) {
+  const loopId = normalizeLoopId(input.loopId);
+  const summary = String(input.summary ?? "").trim();
+  const runbook = String(input.runbook ?? "").trim();
+  const refs = Array.isArray(input.refs)
+    ? input.refs.map(ref => String(ref))
+    : [];
+  const ts =
+    input.ts instanceof Date
+      ? input.ts.toISOString()
+      : input.ts
+        ? new Date(input.ts).toISOString()
+        : new Date().toISOString();
+  const runId = String(input.runId ?? `${loopId}:${ts}`).trim();
+
+  if (!AUTOMATION_RUN_OUTCOMES.includes(input.outcome)) {
+    throw new Error(
+      `Invalid automation run outcome "${input.outcome}". Valid outcomes: ${AUTOMATION_RUN_OUTCOMES.join(", ")}.`
+    );
+  }
+  if (!summary) {
+    throw new Error("Automation run summary is required.");
+  }
+  if (!runbook) {
+    throw new Error("Automation runbook path is required.");
+  }
+  if (!runId) {
+    throw new Error("Automation run_id is required.");
+  }
+
+  return {
+    ts,
+    loop_id: loopId,
+    outcome: input.outcome,
+    summary,
+    runbook,
+    refs,
+    run_id: runId,
+  };
+}
+
+/**
+ * @param {unknown} value
+ * @returns {AutomationRunRecord}
+ */
+function validateStoredRecord(value) {
+  if (!value || typeof value !== "object") {
+    throw new Error("Automation run record must be an object.");
+  }
+  return buildAutomationRunRecord({
+    ts: String(value.ts ?? ""),
+    loopId: String(value.loop_id ?? ""),
+    outcome: String(value.outcome ?? ""),
+    summary: String(value.summary ?? ""),
+    runbook: String(value.runbook ?? ""),
+    refs: Array.isArray(value.refs) ? value.refs.map(ref => String(ref)) : [],
+    runId: String(value.run_id ?? ""),
+  });
+}
+
+/**
+ * @param {string} loopId
+ * @returns {string}
+ */
+function normalizeLoopId(loopId) {
+  const normalized = String(loopId ?? "").trim();
+  if (!/^[a-z0-9][a-z0-9._-]*$/i.test(normalized)) {
+    throw new Error(
+      "Automation loop_id must be a non-empty slug containing only letters, numbers, dots, underscores, and hyphens."
+    );
+  }
+  return normalized;
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<unknown | undefined>}
+ */
+async function readJsonIfPresent(filePath) {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return undefined;
+    }
+    if (error instanceof SyntaxError) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+/**
+ * @param {string} filePath
+ * @param {readonly AutomationRunRecord[]} records
+ */
+async function writeJsonlAtomically(filePath, records) {
+  const content = `${records.map(record => JSON.stringify(record)).join("\n")}\n`;
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tempPath, content, "utf8");
+  await rename(tempPath, filePath);
+}

--- a/plugins/src/base/rules/eager/automation-runbook-contract.md
+++ b/plugins/src/base/rules/eager/automation-runbook-contract.md
@@ -50,7 +50,10 @@ loop itself is broken, not that a work item was blocked.
 
 Every run — including a trivial early termination — ends by naming exactly one run outcome plus a
 one-line operator summary of what happened, recorded where the status surface can read it —
-there is no silent exit. Silence and health must never look identical to an operator.
+there is no silent exit. The shared local substrate is
+`plugins/src/base/scripts/automation-run-record.mjs`, which writes bounded JSONL records under
+`.lisa/automations/runs/<loop-id>.jsonl`. Silence and health must never look identical to an
+operator.
 
 ## Never block, always degrade
 

--- a/plugins/src/base/rules/reference/automation-runbook-contract.md
+++ b/plugins/src/base/rules/reference/automation-runbook-contract.md
@@ -121,8 +121,17 @@ there is no silent exit for an operator to misread as health. A run that ends wi
 recorded outcome is indistinguishable from a crashed scheduler, which is exactly the ambiguity this
 contract removes. This generalizes `lisa-improve-harness`'s result-record discipline — every
 terminal step posts its result record before stopping, so there is no silent exit — from one flow to
-every registered loop. (The run-record substrate that stores outcomes and summaries is named here
-only; it ships with that ticket (#1797), do not assume its file is present in this branch.)
+every registered loop.
+
+The local storage substrate is `plugins/src/base/scripts/automation-run-record.mjs`. It writes one
+bounded JSONL file per loop at `.lisa/automations/runs/<loop-id>.jsonl`, with one object per line:
+`{ ts, loop_id, outcome, summary, runbook, refs[], run_id }`. The helper rejects any outcome outside
+the closed six-value vocabulary, requires a non-empty operator-readable summary, suppresses duplicate
+re-appends for the same `run_id`, skips corrupt/truncated lines on read, and trims to the newest
+configured records on write. The default bound is 50 records per loop, overridable via
+`.lisa.config.json` / `.lisa.config.local.json` `automations.runHistory.maxEntries`. These records
+are local scheduler observations, not project knowledge, so `.lisa/automations/runs/` is ignored;
+the runbooks under `.lisa/automations/*.runbook.md` remain checked-in knowledge.
 
 ## A run outcome is not a work-item lifecycle terminal state
 
@@ -209,8 +218,8 @@ packet above. A degraded run never blocks other work and never leaves the run un
 
 ## Citing adjacent work
 
-Cite these by name; each ships with its own ticket, do not assume its file is present in this
-branch: the runbook scaffolding that instantiates this template (#1796), the run-record substrate
-that stores outcomes and summaries (#1797), and the evidence packet defined by the evidence PRD
-(#1738) — named here, with no evidence format defined by this contract. Rejection memory
-extends `rejection-detection`; this contract neither restates nor overrides it.
+Cite these by name. The run-record substrate ships with that ticket (#1797), do not assume its file
+is present in older branches. The evidence packet ships with that ticket, do not assume its file is present in this branch. Other adjacent artifacts keep their own lifecycle: the runbook scaffolding
+that instantiates this template (#1796), and the evidence packet defined by the evidence PRD (#1738)
+— named here, with no evidence format defined by this contract. Rejection memory extends
+`rejection-detection`; this contract neither restates nor overrides it.

--- a/plugins/src/base/scripts/automation-run-record.mjs
+++ b/plugins/src/base/scripts/automation-run-record.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * Dependency-free run outcome recorder for registered Lisa automation loops.
+ *
+ * The file is local scheduler state, not project knowledge: one bounded JSONL
+ * file per loop under `.lisa/automations/runs/`.
+ */
+
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export const AUTOMATION_RUN_OUTCOMES = [
+  "nothing-needed",
+  "candidate-proposed",
+  "change-proved",
+  "approval-requested",
+  "recovery-required",
+  "policy-obsolete",
+];
+
+export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
+
+/**
+ * @typedef {{
+ *   readonly ts: string
+ *   readonly loop_id: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ *   readonly runbook: string
+ *   readonly refs: readonly string[]
+ *   readonly run_id: string
+ * }} AutomationRunRecord
+ *
+ * @typedef {{
+ *   readonly projectRoot?: string
+ *   readonly loopId: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ *   readonly runbook: string
+ *   readonly refs?: readonly string[]
+ *   readonly runId?: string
+ *   readonly ts?: string | Date
+ *   readonly maxEntries?: number
+ * }} RecordAutomationRunInput
+ */
+
+/**
+ * Record one automation-loop outcome, suppressing duplicate re-appends for the
+ * same `run_id` and trimming the file to the configured history bound.
+ *
+ * @param {RecordAutomationRunInput} input
+ * @returns {Promise<{ readonly path: string, readonly record: AutomationRunRecord, readonly records: readonly AutomationRunRecord[], readonly appended: boolean, readonly skippedCorruptLines: number, readonly maxEntries: number }>}
+ */
+export async function recordAutomationRun(input) {
+  const projectRoot = path.resolve(input.projectRoot ?? process.cwd());
+  const maxEntries =
+    input.maxEntries ??
+    (await resolveAutomationRunHistoryMaxEntries(projectRoot));
+  const record = buildAutomationRunRecord(input);
+  const filePath = automationRunRecordPath(projectRoot, record.loop_id);
+  const readResult = await readAutomationRunRecords(filePath);
+
+  if (readResult.records.some(existing => existing.run_id === record.run_id)) {
+    return {
+      path: filePath,
+      record,
+      records: readResult.records,
+      appended: false,
+      skippedCorruptLines: readResult.skippedCorruptLines,
+      maxEntries,
+    };
+  }
+
+  const nextRecords = [...readResult.records, record].slice(-maxEntries);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeJsonlAtomically(filePath, nextRecords);
+
+  return {
+    path: filePath,
+    record,
+    records: nextRecords,
+    appended: true,
+    skippedCorruptLines: readResult.skippedCorruptLines,
+    maxEntries,
+  };
+}
+
+/**
+ * @param {string} projectRoot
+ * @returns {Promise<number>}
+ */
+export async function resolveAutomationRunHistoryMaxEntries(projectRoot) {
+  const globalConfig = await readJsonIfPresent(
+    path.join(projectRoot, ".lisa.config.json")
+  );
+  const localConfig = await readJsonIfPresent(
+    path.join(projectRoot, ".lisa.config.local.json")
+  );
+  const configured =
+    localConfig?.automations?.runHistory?.maxEntries ??
+    globalConfig?.automations?.runHistory?.maxEntries;
+
+  if (Number.isInteger(configured) && configured > 0) {
+    return configured;
+  }
+
+  return DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES;
+}
+
+/**
+ * @param {string} projectRoot
+ * @param {string} loopId
+ * @returns {string}
+ */
+export function automationRunRecordPath(projectRoot, loopId) {
+  return path.join(
+    path.resolve(projectRoot),
+    ".lisa",
+    "automations",
+    "runs",
+    `${normalizeLoopId(loopId)}.jsonl`
+  );
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<{ readonly records: readonly AutomationRunRecord[], readonly skippedCorruptLines: number }>}
+ */
+export async function readAutomationRunRecords(filePath) {
+  let content = "";
+  try {
+    content = await readFile(filePath, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return { records: [], skippedCorruptLines: 0 };
+    }
+    throw error;
+  }
+
+  const records = [];
+  let skippedCorruptLines = 0;
+  for (const line of content.split(/\n/)) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(line);
+      records.push(validateStoredRecord(parsed));
+    } catch {
+      skippedCorruptLines += 1;
+    }
+  }
+
+  return { records, skippedCorruptLines };
+}
+
+/**
+ * @param {RecordAutomationRunInput} input
+ * @returns {AutomationRunRecord}
+ */
+function buildAutomationRunRecord(input) {
+  const loopId = normalizeLoopId(input.loopId);
+  const summary = String(input.summary ?? "").trim();
+  const runbook = String(input.runbook ?? "").trim();
+  const refs = Array.isArray(input.refs)
+    ? input.refs.map(ref => String(ref))
+    : [];
+  const ts =
+    input.ts instanceof Date
+      ? input.ts.toISOString()
+      : input.ts
+        ? new Date(input.ts).toISOString()
+        : new Date().toISOString();
+  const runId = String(input.runId ?? `${loopId}:${ts}`).trim();
+
+  if (!AUTOMATION_RUN_OUTCOMES.includes(input.outcome)) {
+    throw new Error(
+      `Invalid automation run outcome "${input.outcome}". Valid outcomes: ${AUTOMATION_RUN_OUTCOMES.join(", ")}.`
+    );
+  }
+  if (!summary) {
+    throw new Error("Automation run summary is required.");
+  }
+  if (!runbook) {
+    throw new Error("Automation runbook path is required.");
+  }
+  if (!runId) {
+    throw new Error("Automation run_id is required.");
+  }
+
+  return {
+    ts,
+    loop_id: loopId,
+    outcome: input.outcome,
+    summary,
+    runbook,
+    refs,
+    run_id: runId,
+  };
+}
+
+/**
+ * @param {unknown} value
+ * @returns {AutomationRunRecord}
+ */
+function validateStoredRecord(value) {
+  if (!value || typeof value !== "object") {
+    throw new Error("Automation run record must be an object.");
+  }
+  return buildAutomationRunRecord({
+    ts: String(value.ts ?? ""),
+    loopId: String(value.loop_id ?? ""),
+    outcome: String(value.outcome ?? ""),
+    summary: String(value.summary ?? ""),
+    runbook: String(value.runbook ?? ""),
+    refs: Array.isArray(value.refs) ? value.refs.map(ref => String(ref)) : [],
+    runId: String(value.run_id ?? ""),
+  });
+}
+
+/**
+ * @param {string} loopId
+ * @returns {string}
+ */
+function normalizeLoopId(loopId) {
+  const normalized = String(loopId ?? "").trim();
+  if (!/^[a-z0-9][a-z0-9._-]*$/i.test(normalized)) {
+    throw new Error(
+      "Automation loop_id must be a non-empty slug containing only letters, numbers, dots, underscores, and hyphens."
+    );
+  }
+  return normalized;
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<unknown | undefined>}
+ */
+async function readJsonIfPresent(filePath) {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return undefined;
+    }
+    if (error instanceof SyntaxError) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+/**
+ * @param {string} filePath
+ * @param {readonly AutomationRunRecord[]} records
+ */
+async function writeJsonlAtomically(filePath, records) {
+  const content = `${records.map(record => JSON.stringify(record)).join("\n")}\n`;
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tempPath, content, "utf8");
+  await rename(tempPath, filePath);
+}

--- a/tests/unit/strategies/automation-run-record.test.ts
+++ b/tests/unit/strategies/automation-run-record.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the durable per-run automation outcome substrate (#1797).
+ *
+ * The helper is dependency-free and shared by every registered Lisa automation
+ * loop: one bounded JSONL file per loop, with closed outcome vocabulary and
+ * idempotent per-invocation writes.
+ * @module tests/unit/strategies/automation-run-record
+ */
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  AUTOMATION_RUN_OUTCOMES,
+  automationRunRecordPath,
+  readAutomationRunRecords,
+  recordAutomationRun,
+  resolveAutomationRunHistoryMaxEntries,
+} from "../../../plugins/src/base/scripts/automation-run-record.mjs";
+
+const LOOP_ID = "intake-build";
+const RUNBOOK_PATH = ".lisa/automations/intake-build.runbook.md";
+const RECORDS_PATH = ".lisa/automations/runs/intake-build.jsonl";
+const NOTHING_NEEDED = "nothing-needed";
+const BASE_TS = "2026-07-20T07:00:00.000Z";
+
+let root: string;
+
+const put = (rel: string, contents: string): void => {
+  const abs = path.join(root, rel);
+  mkdirSync(path.dirname(abs), { recursive: true });
+  writeFileSync(abs, contents);
+};
+
+const readLines = (rel: string): string[] =>
+  readFileSync(path.join(root, rel), "utf8").trim().split(/\n/);
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "lisa-run-record-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("automation run records (#1797)", () => {
+  it("appends exactly one operator-readable record for a run", async () => {
+    const result = await recordAutomationRun({
+      projectRoot: root,
+      loopId: LOOP_ID,
+      outcome: NOTHING_NEEDED,
+      summary: "Scanned 0 ready issues; nothing to propose.",
+      runbook: RUNBOOK_PATH,
+      refs: ["https://github.com/CodySwannGT/lisa/issues/1797"],
+      runId: "run-1",
+      ts: BASE_TS,
+    });
+
+    expect(result.appended).toBe(true);
+    expect(result.record).toMatchObject({
+      loop_id: LOOP_ID,
+      outcome: NOTHING_NEEDED,
+      summary: "Scanned 0 ready issues; nothing to propose.",
+      runbook: RUNBOOK_PATH,
+      refs: ["https://github.com/CodySwannGT/lisa/issues/1797"],
+      run_id: "run-1",
+    });
+    expect(readLines(RECORDS_PATH)).toHaveLength(1);
+  });
+
+  it("trims history at the configured bound", async () => {
+    put(
+      ".lisa.config.json",
+      JSON.stringify({ automations: { runHistory: { maxEntries: 2 } } })
+    );
+
+    for (const runId of ["run-1", "run-2", "run-3"]) {
+      await recordAutomationRun({
+        projectRoot: root,
+        loopId: LOOP_ID,
+        outcome: "candidate-proposed",
+        summary: `Recorded ${runId}.`,
+        runbook: RUNBOOK_PATH,
+        runId,
+        ts: `2026-07-20T07:00:0${runId.at(-1)}.000Z`,
+      });
+    }
+
+    const records = readLines(RECORDS_PATH).map(line => JSON.parse(line));
+    expect(records.map(record => record.run_id)).toEqual(["run-2", "run-3"]);
+  });
+
+  it("lets local config override the shared history bound", async () => {
+    put(
+      ".lisa.config.json",
+      JSON.stringify({ automations: { runHistory: { maxEntries: 4 } } })
+    );
+    put(
+      ".lisa.config.local.json",
+      JSON.stringify({ automations: { runHistory: { maxEntries: 3 } } })
+    );
+
+    await expect(resolveAutomationRunHistoryMaxEntries(root)).resolves.toBe(3);
+  });
+
+  it("skips corrupt lines instead of breaking the next append", async () => {
+    put(
+      ".lisa/automations/runs/intake-build.jsonl",
+      [
+        JSON.stringify({
+          ts: BASE_TS,
+          loop_id: LOOP_ID,
+          outcome: NOTHING_NEEDED,
+          summary: "Previous valid record.",
+          runbook: RUNBOOK_PATH,
+          refs: [],
+          run_id: "run-1",
+        }),
+        '{"truncated"',
+        "",
+      ].join("\n")
+    );
+
+    const result = await recordAutomationRun({
+      projectRoot: root,
+      loopId: LOOP_ID,
+      outcome: "change-proved",
+      summary: "Wrote the run substrate and verified append behavior.",
+      runbook: RUNBOOK_PATH,
+      runId: "run-2",
+      ts: "2026-07-20T07:01:00.000Z",
+    });
+
+    expect(result.skippedCorruptLines).toBe(1);
+    expect(result.records.map(record => record.run_id)).toEqual([
+      "run-1",
+      "run-2",
+    ]);
+  });
+
+  it("rejects outcomes outside the closed six-value vocabulary", async () => {
+    await expect(
+      recordAutomationRun({
+        projectRoot: root,
+        loopId: LOOP_ID,
+        outcome: "blocked",
+        summary: "This should not be recorded.",
+        runbook: RUNBOOK_PATH,
+        runId: "run-1",
+      })
+    ).rejects.toThrow(AUTOMATION_RUN_OUTCOMES.join(", "));
+  });
+
+  it("suppresses duplicate re-appends for the same run_id", async () => {
+    const input = {
+      projectRoot: root,
+      loopId: LOOP_ID,
+      outcome: "approval-requested",
+      summary: "Deploy approval is waiting.",
+      runbook: RUNBOOK_PATH,
+      runId: "same-run",
+      ts: BASE_TS,
+    } as const;
+
+    await recordAutomationRun(input);
+    const second = await recordAutomationRun(input);
+
+    expect(second.appended).toBe(false);
+    expect(readLines(RECORDS_PATH)).toHaveLength(1);
+  });
+
+  it("stores each loop under its bounded local runs directory", () => {
+    expect(automationRunRecordPath(root, "monitor")).toBe(
+      path.join(root, ".lisa/automations/runs/monitor.jsonl")
+    );
+  });
+
+  it("documents the local runs directory as ignored project state", () => {
+    const gitignore = readFileSync(path.resolve(".gitignore"), "utf8");
+    expect(gitignore).toContain(".lisa/automations/runs/");
+  });
+
+  it("keeps the distributed script artifact in lockstep with the source script", () => {
+    const sourcePath = path.resolve(
+      "plugins/src/base/scripts/automation-run-record.mjs"
+    );
+    const generatedPath = path.resolve(
+      "plugins/lisa/scripts/automation-run-record.mjs"
+    );
+
+    expect(existsSync(generatedPath)).toBe(true);
+    expect(readFileSync(generatedPath, "utf8")).toBe(
+      readFileSync(sourcePath, "utf8")
+    );
+  });
+
+  it("reads a missing records file as empty history", async () => {
+    await expect(
+      readAutomationRunRecords(path.join(root, ".lisa/missing.jsonl"))
+    ).resolves.toMatchObject({ records: [], skippedCorruptLines: 0 });
+  });
+});


### PR DESCRIPTION
## What this does

Adds the durable per-run automation outcome substrate for #1797:

- `automation-run-record.mjs` records one bounded JSONL file per registered loop under `.lisa/automations/runs/<loop-id>.jsonl`.
- Records carry `{ ts, loop_id, outcome, summary, runbook, refs[], run_id }`, enforce the closed six-outcome vocabulary, require a non-empty operator summary, skip corrupt lines, suppress duplicate `run_id` appends, and trim to `automations.runHistory.maxEntries` with a default of 50.
- `.lisa/automations/runs/` is gitignored as local scheduler state while runbooks remain tracked project knowledge.
- The automation-runbook contract now points at the real helper, and generated Lisa plugin variants are in sync.

## Verification

- `bunx vitest run tests/unit/strategies/automation-run-record.test.ts tests/unit/strategies/automation-runbook-contract-rule.test.ts`
- `bun run typecheck`
- Scratch helper check: four appends with `maxEntries=2` kept run IDs `c,d`; Git reported `.lisa/automations/runs/` ignored.
- `bun run check:plugins`
- Pre-push hook: slow lint passed, knip passed, `vitest run --coverage` passed (`343` files / `5757` tests), and `vitest run tests/integration` passed (`9` files / `133` tests).

Closes #1797
