### PR TITLE
feat(automations): show runbook, last outcome, and bounded run history in automation-status (#1799)

### DIFF
--- a/plugins/lisa-agy/scripts/automation-status-claude-adapter.mjs
+++ b/plugins/lisa-agy/scripts/automation-status-claude-adapter.mjs
@@ -15,6 +15,10 @@ import {
   createAutomationGroupBins,
   renderAutomationGroups,
 } from "./automation-status-expected-fleet.mjs";
+import {
+  resolveAutomationRunDisplay,
+  resolveRecoveryEscalation,
+} from "./automation-status-run-history.mjs";
 
 const CLAUDE_RUNTIME_LABEL = "Claude /schedule";
 const CLAUDE_ACTIVE_STATUSES = new Set([
@@ -51,9 +55,10 @@ const NEGATED_FAILURE_PATTERN =
  * @param {{
  *   readonly expectedFleet: ExpectedFleet
  *   readonly scheduleListing?: string | readonly unknown[] | Record<string, unknown> | null
+ *   readonly projectRoot?: string
  *   readonly now?: string | Date
  * }} input
- * @returns {{
+ * @returns {Promise<{
  *   readonly runtime: string
  *   readonly generatedAt: string
  *   readonly groups: readonly {
@@ -66,19 +71,26 @@ const NEGATED_FAILURE_PATTERN =
  *       readonly expectedCadence?: string
  *       readonly expectedCommand?: string
  *       readonly observed?: string
+ *       readonly runbook?: string
+ *       readonly lastOutcome?: { readonly ts: string, readonly outcome: string, readonly summary: string }
+ *       readonly outcomeHistory?: readonly string[]
+ *       readonly olderRecordCount?: number
  *       readonly remediation?: string
  *     }[]
  *   }[]
  *   readonly observedAutomations: readonly ObservedClaudeAutomation[]
- * }}}
+ * }>}
  */
-export function inspectClaudeAutomationFleet(input) {
+export async function inspectClaudeAutomationFleet(input) {
   const expectedFleet = input.expectedFleet;
   const now = normalizeDate(input.now);
+  const projectRoot = input.projectRoot ?? process.cwd();
   const observedAutomations = listClaudeAutomations({
     scheduleListing: input.scheduleListing,
     automationPrefix: expectedFleet.automationPrefix,
   });
+
+  const runDisplays = await resolveFleetRunDisplays(projectRoot, expectedFleet);
 
   const expectedGroups = createAutomationGroupBins();
 
@@ -96,17 +108,23 @@ export function inspectClaudeAutomationFleet(input) {
         expected,
         comparison,
         now,
+        runDisplay: runDisplays.get(expected.id),
       })
     );
   }
 
   for (const unsupported of expectedFleet.unsupported) {
+    const runDisplay = runDisplays.get(unsupported.id);
     assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
       expectedCadence: unsupported.expectedCadence,
       observed: "No automation is expected for this repo/runtime combination.",
+      runbook: runDisplay?.runbook,
+      lastOutcome: runDisplay?.lastOutcome,
+      outcomeHistory: runDisplay?.outcomeHistory,
+      olderRecordCount: runDisplay?.olderRecordCount,
     });
   }
 
@@ -195,15 +213,43 @@ function extractClaudeScheduleCadence(command) {
   );
 }
 
+/**
+ * Read the read-only run-history display for every expected and unsupported
+ * loop up front, keyed by the loop's short id, so the per-entry item builder
+ * stays synchronous.
+ *
+ * @param {string} projectRoot
+ * @param {ExpectedFleet} expectedFleet
+ * @returns {Promise<Map<string, import("./automation-status-run-history.mjs").AutomationRunDisplay>>}
+ */
+async function resolveFleetRunDisplays(projectRoot, expectedFleet) {
+  const entries = [...expectedFleet.expected, ...expectedFleet.unsupported];
+  const displays = await Promise.all(
+    entries.map(entry =>
+      resolveAutomationRunDisplay({
+        projectRoot,
+        loopId: entry.id,
+        runbookPath: entry.runbookPath,
+      })
+    )
+  );
+  return new Map(entries.map((entry, index) => [entry.id, displays[index]]));
+}
+
 function createObservedStatusItem(input) {
   const expected = input.expected;
   const comparison = input.comparison;
   const observed = comparison.observedAutomation;
+  const runDisplay = input.runDisplay;
   const runSignal = classifyAutomationRunSignal({
     expected,
     observedAutomation: observed,
     now: input.now,
   });
+  // Three or more consecutive recorded recovery-required runs flip the loop to
+  // FAILING even when the /schedule entry looks fine — the fleet-health signal
+  // the scheduler surface cannot see. It wins over the scheduler run-signal.
+  const escalation = resolveRecoveryEscalation(runDisplay);
 
   const observedDetails = [comparison.observed];
   if (observed?.status) {
@@ -223,20 +269,30 @@ function createObservedStatusItem(input) {
   }
 
   const status =
+    escalation?.status ??
     runSignal?.status ??
     /** @type {"HEALTHY" | "MISSING" | "DRIFTED"} */ (comparison.status);
 
   return {
     id: expected.automationId,
     status,
-    summary: composeAutomationSummary({
-      comparison,
-      runSignal,
-    }),
+    summary: escalation
+      ? escalation.summary
+      : composeAutomationSummary({
+          comparison,
+          runSignal,
+        }),
     expectedCadence: expected.expectedCadence,
     expectedCommand: expected.expectedCommand,
     observed: observedDetails.join(" "),
-    remediation: runSignal?.remediation ?? comparison.remediation,
+    runbook: runDisplay?.runbook,
+    lastOutcome: runDisplay?.lastOutcome,
+    outcomeHistory: runDisplay?.outcomeHistory,
+    olderRecordCount: runDisplay?.olderRecordCount,
+    remediation:
+      escalation?.remediation ??
+      runSignal?.remediation ??
+      comparison.remediation,
   };
 }
 

--- a/plugins/lisa-agy/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa-agy/scripts/automation-status-codex-adapter.mjs
@@ -22,6 +22,10 @@ import {
   createAutomationGroupBins,
   renderAutomationGroups,
 } from "./automation-status-expected-fleet.mjs";
+import {
+  resolveAutomationRunDisplay,
+  resolveRecoveryEscalation,
+} from "./automation-status-run-history.mjs";
 
 const CODEx_RUNTIME_LABEL = "Codex automations";
 const RUN_TIMESTAMP_PATTERN = /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/;
@@ -132,6 +136,7 @@ async function execGitWithRetry(args, options, attempts = 4) {
  * @param {{
  *   readonly expectedFleet: ExpectedFleet
  *   readonly automationsDir?: string
+ *   readonly projectRoot?: string
  *   readonly now?: string | Date
  * }} input
  * @returns {Promise<{
@@ -147,6 +152,10 @@ async function execGitWithRetry(args, options, attempts = 4) {
  *       readonly expectedCadence?: string
  *       readonly expectedCommand?: string
  *       readonly observed?: string
+ *       readonly runbook?: string
+ *       readonly lastOutcome?: { readonly ts: string, readonly outcome: string, readonly summary: string }
+ *       readonly outcomeHistory?: readonly string[]
+ *       readonly olderRecordCount?: number
  *       readonly remediation?: string
  *     }[]
  *   }[]
@@ -156,10 +165,13 @@ async function execGitWithRetry(args, options, attempts = 4) {
 export async function inspectCodexAutomationFleet(input) {
   const expectedFleet = input.expectedFleet;
   const now = normalizeDate(input.now);
+  const projectRoot = input.projectRoot ?? process.cwd();
   const observedAutomations = await listCodexAutomations({
     automationsDir: input.automationsDir,
     automationPrefix: expectedFleet.automationPrefix,
   });
+
+  const runDisplays = await resolveFleetRunDisplays(projectRoot, expectedFleet);
 
   const expectedGroups = createAutomationGroupBins();
 
@@ -177,17 +189,23 @@ export async function inspectCodexAutomationFleet(input) {
         expected,
         comparison,
         now,
+        runDisplay: runDisplays.get(expected.id),
       })
     );
   }
 
   for (const unsupported of expectedFleet.unsupported) {
+    const runDisplay = runDisplays.get(unsupported.id);
     assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
       expectedCadence: unsupported.expectedCadence,
       observed: "No automation is expected for this repo/runtime combination.",
+      runbook: runDisplay?.runbook,
+      lastOutcome: runDisplay?.lastOutcome,
+      outcomeHistory: runDisplay?.outcomeHistory,
+      olderRecordCount: runDisplay?.olderRecordCount,
     });
   }
 
@@ -374,15 +392,43 @@ async function readCodexAutomation(automationDir) {
   };
 }
 
+/**
+ * Read the read-only run-history display for every expected and unsupported
+ * loop up front, keyed by the loop's short id, so the per-entry item builder
+ * stays synchronous.
+ *
+ * @param {string} projectRoot
+ * @param {ExpectedFleet} expectedFleet
+ * @returns {Promise<Map<string, import("./automation-status-run-history.mjs").AutomationRunDisplay>>}
+ */
+async function resolveFleetRunDisplays(projectRoot, expectedFleet) {
+  const entries = [...expectedFleet.expected, ...expectedFleet.unsupported];
+  const displays = await Promise.all(
+    entries.map(entry =>
+      resolveAutomationRunDisplay({
+        projectRoot,
+        loopId: entry.id,
+        runbookPath: entry.runbookPath,
+      })
+    )
+  );
+  return new Map(entries.map((entry, index) => [entry.id, displays[index]]));
+}
+
 function createObservedStatusItem(input) {
   const expected = input.expected;
   const comparison = input.comparison;
   const observed = comparison.observedAutomation;
+  const runDisplay = input.runDisplay;
   const runSignal = classifyAutomationRunSignal({
     expected,
     observedAutomation: observed,
     now: input.now,
   });
+  // Three or more consecutive recorded recovery-required runs flip the loop to
+  // FAILING even when the scheduler entry looks fine — the fleet-health signal
+  // the raw backing store cannot see. It wins over the scheduler run-signal.
+  const escalation = resolveRecoveryEscalation(runDisplay);
 
   const observedDetails = [comparison.observed];
   if (observed?.status) {
@@ -401,20 +447,30 @@ function createObservedStatusItem(input) {
   }
 
   const status =
+    escalation?.status ??
     runSignal?.status ??
     /** @type {"HEALTHY" | "MISSING" | "DRIFTED"} */ (comparison.status);
 
   return {
     id: expected.automationId,
     status,
-    summary: composeAutomationSummary({
-      comparison,
-      runSignal,
-    }),
+    summary: escalation
+      ? escalation.summary
+      : composeAutomationSummary({
+          comparison,
+          runSignal,
+        }),
     expectedCadence: expected.expectedCadence,
     expectedCommand: expected.expectedCommand,
     observed: observedDetails.join(" "),
-    remediation: runSignal?.remediation ?? comparison.remediation,
+    runbook: runDisplay?.runbook,
+    lastOutcome: runDisplay?.lastOutcome,
+    outcomeHistory: runDisplay?.outcomeHistory,
+    olderRecordCount: runDisplay?.olderRecordCount,
+    remediation:
+      escalation?.remediation ??
+      runSignal?.remediation ??
+      comparison.remediation,
   };
 }
 

--- a/plugins/lisa-agy/scripts/automation-status-report.mjs
+++ b/plugins/lisa-agy/scripts/automation-status-report.mjs
@@ -26,12 +26,22 @@ export const AUTOMATION_FLEET_VERDICTS = [
  * @typedef {"HEALTHY" | "PARTIAL_SUPPORT" | "ATTENTION_NEEDED"} AutomationFleetVerdict
  *
  * @typedef {{
+ *   readonly ts: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ * }} AutomationLastOutcome
+ *
+ * @typedef {{
  *   readonly id: string
  *   readonly status: AutomationHealthStatus
  *   readonly summary: string
  *   readonly expectedCadence?: string
  *   readonly expectedCommand?: string
  *   readonly observed?: string
+ *   readonly runbook?: string
+ *   readonly lastOutcome?: AutomationLastOutcome
+ *   readonly outcomeHistory?: readonly string[]
+ *   readonly olderRecordCount?: number
  *   readonly remediation?: string
  * }} AutomationStatusItem
  *
@@ -129,6 +139,26 @@ export function renderAutomationStatusReport(input) {
       }
       if (item.observed) {
         lines.push(`  Observed: ${item.observed}`);
+      }
+      // Contract + run-history block: observable facts about where the runbook
+      // lives and how recent runs ended, kept between Observed and Remediation
+      // so operators read the state before the fix. Every line degrades
+      // explicitly — an absent runbook or empty history is stated, never blank.
+      if (item.runbook !== undefined) {
+        lines.push(`  Runbook: ${item.runbook}`);
+        lines.push(
+          item.lastOutcome
+            ? `  Last run: ${item.lastOutcome.outcome} — ${item.lastOutcome.summary} (${item.lastOutcome.ts})`
+            : "  Last run: no recorded runs yet"
+        );
+        if (item.outcomeHistory && item.outcomeHistory.length > 0) {
+          const historyLine = `  History: ${item.outcomeHistory.join(", ")} (newest first)`;
+          lines.push(
+            item.olderRecordCount && item.olderRecordCount > 0
+              ? `${historyLine}; … and ${item.olderRecordCount} older records`
+              : historyLine
+          );
+        }
       }
       if (item.remediation) {
         lines.push(`  Remediation: ${item.remediation}`);

--- a/plugins/lisa-agy/scripts/automation-status-run-history.mjs
+++ b/plugins/lisa-agy/scripts/automation-status-run-history.mjs
@@ -121,11 +121,16 @@ export function resolveRecoveryEscalation(runDisplay) {
     return null;
   }
 
-  const summaries = runDisplay.recoverySummaries.join("; ");
+  // Number the citations rather than joining on a delimiter: recorded summaries
+  // carry their own `;` and `.`, so a `; `-separated list is ambiguous. `(1) …
+  // (2) …` stays legible no matter what punctuation a summary contains.
+  const citations = runDisplay.recoverySummaries
+    .map((summary, index) => `(${index + 1}) ${summary}`)
+    .join(" ");
   return {
     status: "FAILING",
     summary: `the last ${runDisplay.recoveryRequiredStreak} recorded runs all required recovery`,
-    remediation: `Repeated recovery-required runs (${summaries}). Inspect the loop's runbook and the cited runs, fix the recurring failure, then let the next scheduled run confirm recovery.`,
+    remediation: `Repeated recovery-required runs — ${citations} Inspect the loop's runbook and the cited runs, fix the recurring failure, then let the next scheduled run confirm recovery.`,
   };
 }
 

--- a/plugins/lisa-agy/scripts/automation-status-run-history.mjs
+++ b/plugins/lisa-agy/scripts/automation-status-run-history.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Shared read-only run-history projection for `/lisa:automation-status`.
+ *
+ * The durable run-outcome substrate (RBC-3, `automation-run-record.mjs`) stores
+ * one bounded JSONL file per registered loop under `.lisa/automations/runs/`.
+ * This module turns that substrate — plus the checked-in per-loop runbook
+ * (`automation-runbook-contract`) — into the per-item display fields both
+ * runtime adapters attach to their status rows, so the Codex and Claude
+ * adapters never diverge on how the contract, last outcome, and bounded history
+ * are rendered.
+ *
+ * STRICTLY READ-ONLY: it stats the runbook and reads the run-record file. It
+ * never creates the runs directory, a runbook, or a run record — a status read
+ * must leave the fleet byte-identical.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  automationRunRecordPath,
+  readAutomationRunRecords,
+} from "./automation-run-record.mjs";
+
+/**
+ * Inline history cap: the newest N outcomes are listed, the remainder is only
+ * counted. A bounded view of an already-bounded file, with the trim stated in
+ * the output rather than applied silently.
+ */
+export const AUTOMATION_RUN_HISTORY_DISPLAY_LIMIT = 5;
+
+/** The recorded outcome that signals a loop could not finish its own work. */
+export const RECOVERY_REQUIRED_OUTCOME = "recovery-required";
+
+/**
+ * How many trailing `recovery-required` runs in a row flip a loop to `FAILING`.
+ * The RBC-5 acceptance criteria pin "last three runs" as the escalation
+ * trigger; that wins over the ticket prose's looser "five in a row" pattern.
+ */
+export const RECOVERY_REQUIRED_ESCALATION_THRESHOLD = 3;
+
+const RUNBOOK_NOT_SCAFFOLDED_LINE =
+  "not scaffolded — run /lisa:setup-automations";
+const NO_RECORDED_RUNS_LINE = "no recorded runs yet";
+
+/**
+ * @typedef {{
+ *   readonly ts: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ * }} AutomationLastOutcome
+ *
+ * @typedef {{
+ *   readonly runbook: string
+ *   readonly lastOutcome?: AutomationLastOutcome
+ *   readonly outcomeHistory: readonly string[]
+ *   readonly olderRecordCount: number
+ *   readonly recoveryRequiredStreak: number
+ *   readonly recoverySummaries: readonly string[]
+ *   readonly skippedCorruptLines: number
+ * }} AutomationRunDisplay
+ */
+
+/**
+ * Resolve the read-only run-history display fields for one registered loop.
+ *
+ * @param {{
+ *   readonly projectRoot?: string
+ *   readonly loopId: string
+ *   readonly runbookPath?: string
+ * }} input
+ * @returns {Promise<AutomationRunDisplay>}
+ */
+export async function resolveAutomationRunDisplay(input) {
+  const projectRoot = path.resolve(input.projectRoot ?? process.cwd());
+  const runbook = await resolveRunbookLine(projectRoot, input.runbookPath);
+  const { records, skippedCorruptLines } = await readAutomationRunRecords(
+    automationRunRecordPath(projectRoot, input.loopId)
+  );
+
+  const newestFirst = records.toReversed();
+  const latest = records.at(-1);
+  const lastOutcome = latest
+    ? { ts: latest.ts, outcome: latest.outcome, summary: latest.summary }
+    : undefined;
+  const outcomeHistory = newestFirst
+    .slice(0, AUTOMATION_RUN_HISTORY_DISPLAY_LIMIT)
+    .map(record => record.outcome);
+  const olderRecordCount = Math.max(
+    0,
+    records.length - AUTOMATION_RUN_HISTORY_DISPLAY_LIMIT
+  );
+  const trailingRecovery = collectTrailingRecoveryRuns(records);
+
+  return {
+    runbook,
+    lastOutcome,
+    outcomeHistory,
+    olderRecordCount,
+    recoveryRequiredStreak: trailingRecovery.length,
+    recoverySummaries: trailingRecovery.map(record => record.summary),
+    skippedCorruptLines,
+  };
+}
+
+/**
+ * Force a `FAILING` verdict when a loop has recorded three or more consecutive
+ * `recovery-required` runs — the fleet-health signal the scheduler surface
+ * cannot see on its own. Returns a run-signal-shaped escalation, or null when
+ * the streak is below the threshold.
+ *
+ * @param {AutomationRunDisplay | undefined} runDisplay
+ * @returns {{ readonly status: "FAILING", readonly summary: string, readonly remediation: string } | null}
+ */
+export function resolveRecoveryEscalation(runDisplay) {
+  if (
+    !runDisplay ||
+    runDisplay.recoveryRequiredStreak < RECOVERY_REQUIRED_ESCALATION_THRESHOLD
+  ) {
+    return null;
+  }
+
+  const summaries = runDisplay.recoverySummaries.join("; ");
+  return {
+    status: "FAILING",
+    summary: `the last ${runDisplay.recoveryRequiredStreak} recorded runs all required recovery`,
+    remediation: `Repeated recovery-required runs (${summaries}). Inspect the loop's runbook and the cited runs, fix the recurring failure, then let the next scheduled run confirm recovery.`,
+  };
+}
+
+/**
+ * @param {string} projectRoot
+ * @param {string | undefined} runbookPath
+ * @returns {Promise<string>}
+ */
+async function resolveRunbookLine(projectRoot, runbookPath) {
+  if (!runbookPath) {
+    return RUNBOOK_NOT_SCAFFOLDED_LINE;
+  }
+  const scaffolded = await runbookIsScaffolded(
+    path.join(projectRoot, runbookPath)
+  );
+  return scaffolded ? runbookPath : RUNBOOK_NOT_SCAFFOLDED_LINE;
+}
+
+/**
+ * Read-only existence check for a checked-in runbook. Any stat failure — the
+ * file is absent, unreadable, or not a regular file — degrades to "not
+ * scaffolded" so the status read never implies health it could not confirm and
+ * never throws mid-report.
+ *
+ * @param {string} runbookAbsolutePath
+ * @returns {Promise<boolean>}
+ */
+async function runbookIsScaffolded(runbookAbsolutePath) {
+  try {
+    const stat = await fs.stat(runbookAbsolutePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {readonly import("./automation-run-record.mjs").AutomationRunRecord[]} records
+ * @returns {readonly import("./automation-run-record.mjs").AutomationRunRecord[]} trailing recovery-required runs, newest first
+ */
+function collectTrailingRecoveryRuns(records) {
+  const trailing = [];
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    if (records[index].outcome !== RECOVERY_REQUIRED_OUTCOME) {
+      break;
+    }
+    trailing.push(records[index]);
+  }
+  return trailing;
+}
+
+export { RUNBOOK_NOT_SCAFFOLDED_LINE, NO_RECORDED_RUNS_LINE };

--- a/plugins/lisa-agy/skills/lisa-automation-status/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-automation-status/SKILL.md
@@ -53,8 +53,13 @@ For each expected automation, report:
 4. Any detected drift in name, cadence, command shape, or queue arguments.
 5. Any available recent-run health signal such as stale last-run timing or repeated failure status.
 6. A concise remediation hint when attention is needed.
+7. Where the loop's checked-in runbook lives (`automation-runbook-contract`), or `not scaffolded — run /lisa:setup-automations` when it is absent.
+8. How the last recorded run ended — its outcome, one-line summary, and timestamp — or `no recorded runs yet` when the loop has never recorded one.
+9. A bounded run history: the five most recent outcomes newest first, plus a count of how many older records exist when the file holds more.
 
-Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected.
+The last-run and history facts come from the durable run-outcome substrate recorded by each loop (the RBC-3 records under `.lisa/automations/runs/<loop-id>.jsonl`, read through `readAutomationRunRecords`). That directory is local scheduler state, not project knowledge — read it, never write it.
+
+Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected. **Repeated recovery is a fleet-health signal the scheduler cannot see**: when a loop's last three or more consecutive recorded runs are all `recovery-required`, report that loop `FAILING` — and therefore the overall verdict `ATTENTION_NEEDED` — even when its scheduler entry itself looks healthy, and point the remediation at the recorded run summaries.
 
 ## Operator usage
 
@@ -89,7 +94,7 @@ Status-specific remediation guidance:
 - `MISSING`: tell the operator which job is absent and recommend rerunning `/lisa:setup-automations` or recreating the missing job with the expected cadence and command.
 - `DRIFTED`: show the expected versus observed cadence/command mismatch and recommend aligning the scheduler entry with Lisa's current setup contract, usually by rerunning `/lisa:setup-automations`.
 - `STALE`: explain that the job exists but has not run recently enough for its cadence. Recommend inspecting the runtime's recent-run history or failure logs before changing queue state.
-- `FAILING`: surface the failure signal directly and recommend checking the latest runtime error plus the affected queue command (`/lisa:intake`, `/lisa:repair-intake`, or exploratory job) after the scheduler issue is resolved.
+- `FAILING`: surface the failure signal directly and recommend checking the latest runtime error plus the affected queue command (`/lisa:intake`, `/lisa:repair-intake`, or exploratory job) after the scheduler issue is resolved. A loop also reports `FAILING` when its last three or more consecutive recorded runs are all `recovery-required` — even with a healthy scheduler entry — in which case cite the recorded run summaries and point the operator at the loop's runbook.
 - `UNSUPPORTED`: explain why the job is intentionally absent and say that no remediation is required unless the project stack or runtime support changed.
 
 Render the report in grouped sections using the shared `scripts/automation-status-report.mjs` contract:
@@ -104,10 +109,13 @@ Generated at: <ISO timestamp>
 - <STATUS> <automation-id>: <summary>
   Expected: <cadence> -> <command>
   Observed: <what the runtime exposed>
+  Runbook: <.lisa/automations/<loop-id>.runbook.md, or "not scaffolded — run /lisa:setup-automations">
+  Last run: <outcome> — <summary> (<ts>), or "no recorded runs yet"
+  History: <outcome>, <outcome>, … (newest first); … and <N> older records
   Remediation: <next step when attention is needed>
 ```
 
-Keep observable runtime facts separate from remediation guidance so operators can distinguish drift, unsupported jobs, and actual failures quickly.
+The Runbook, Last run, and History lines are observable facts and sit between Observed and Remediation. Keep observable runtime facts separate from remediation guidance so operators can distinguish drift, unsupported jobs, and actual failures quickly.
 
 ## Rules
 

--- a/plugins/lisa-copilot/scripts/automation-status-claude-adapter.mjs
+++ b/plugins/lisa-copilot/scripts/automation-status-claude-adapter.mjs
@@ -15,6 +15,10 @@ import {
   createAutomationGroupBins,
   renderAutomationGroups,
 } from "./automation-status-expected-fleet.mjs";
+import {
+  resolveAutomationRunDisplay,
+  resolveRecoveryEscalation,
+} from "./automation-status-run-history.mjs";
 
 const CLAUDE_RUNTIME_LABEL = "Claude /schedule";
 const CLAUDE_ACTIVE_STATUSES = new Set([
@@ -51,9 +55,10 @@ const NEGATED_FAILURE_PATTERN =
  * @param {{
  *   readonly expectedFleet: ExpectedFleet
  *   readonly scheduleListing?: string | readonly unknown[] | Record<string, unknown> | null
+ *   readonly projectRoot?: string
  *   readonly now?: string | Date
  * }} input
- * @returns {{
+ * @returns {Promise<{
  *   readonly runtime: string
  *   readonly generatedAt: string
  *   readonly groups: readonly {
@@ -66,19 +71,26 @@ const NEGATED_FAILURE_PATTERN =
  *       readonly expectedCadence?: string
  *       readonly expectedCommand?: string
  *       readonly observed?: string
+ *       readonly runbook?: string
+ *       readonly lastOutcome?: { readonly ts: string, readonly outcome: string, readonly summary: string }
+ *       readonly outcomeHistory?: readonly string[]
+ *       readonly olderRecordCount?: number
  *       readonly remediation?: string
  *     }[]
  *   }[]
  *   readonly observedAutomations: readonly ObservedClaudeAutomation[]
- * }}}
+ * }>}
  */
-export function inspectClaudeAutomationFleet(input) {
+export async function inspectClaudeAutomationFleet(input) {
   const expectedFleet = input.expectedFleet;
   const now = normalizeDate(input.now);
+  const projectRoot = input.projectRoot ?? process.cwd();
   const observedAutomations = listClaudeAutomations({
     scheduleListing: input.scheduleListing,
     automationPrefix: expectedFleet.automationPrefix,
   });
+
+  const runDisplays = await resolveFleetRunDisplays(projectRoot, expectedFleet);
 
   const expectedGroups = createAutomationGroupBins();
 
@@ -96,17 +108,23 @@ export function inspectClaudeAutomationFleet(input) {
         expected,
         comparison,
         now,
+        runDisplay: runDisplays.get(expected.id),
       })
     );
   }
 
   for (const unsupported of expectedFleet.unsupported) {
+    const runDisplay = runDisplays.get(unsupported.id);
     assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
       expectedCadence: unsupported.expectedCadence,
       observed: "No automation is expected for this repo/runtime combination.",
+      runbook: runDisplay?.runbook,
+      lastOutcome: runDisplay?.lastOutcome,
+      outcomeHistory: runDisplay?.outcomeHistory,
+      olderRecordCount: runDisplay?.olderRecordCount,
     });
   }
 
@@ -195,15 +213,43 @@ function extractClaudeScheduleCadence(command) {
   );
 }
 
+/**
+ * Read the read-only run-history display for every expected and unsupported
+ * loop up front, keyed by the loop's short id, so the per-entry item builder
+ * stays synchronous.
+ *
+ * @param {string} projectRoot
+ * @param {ExpectedFleet} expectedFleet
+ * @returns {Promise<Map<string, import("./automation-status-run-history.mjs").AutomationRunDisplay>>}
+ */
+async function resolveFleetRunDisplays(projectRoot, expectedFleet) {
+  const entries = [...expectedFleet.expected, ...expectedFleet.unsupported];
+  const displays = await Promise.all(
+    entries.map(entry =>
+      resolveAutomationRunDisplay({
+        projectRoot,
+        loopId: entry.id,
+        runbookPath: entry.runbookPath,
+      })
+    )
+  );
+  return new Map(entries.map((entry, index) => [entry.id, displays[index]]));
+}
+
 function createObservedStatusItem(input) {
   const expected = input.expected;
   const comparison = input.comparison;
   const observed = comparison.observedAutomation;
+  const runDisplay = input.runDisplay;
   const runSignal = classifyAutomationRunSignal({
     expected,
     observedAutomation: observed,
     now: input.now,
   });
+  // Three or more consecutive recorded recovery-required runs flip the loop to
+  // FAILING even when the /schedule entry looks fine — the fleet-health signal
+  // the scheduler surface cannot see. It wins over the scheduler run-signal.
+  const escalation = resolveRecoveryEscalation(runDisplay);
 
   const observedDetails = [comparison.observed];
   if (observed?.status) {
@@ -223,20 +269,30 @@ function createObservedStatusItem(input) {
   }
 
   const status =
+    escalation?.status ??
     runSignal?.status ??
     /** @type {"HEALTHY" | "MISSING" | "DRIFTED"} */ (comparison.status);
 
   return {
     id: expected.automationId,
     status,
-    summary: composeAutomationSummary({
-      comparison,
-      runSignal,
-    }),
+    summary: escalation
+      ? escalation.summary
+      : composeAutomationSummary({
+          comparison,
+          runSignal,
+        }),
     expectedCadence: expected.expectedCadence,
     expectedCommand: expected.expectedCommand,
     observed: observedDetails.join(" "),
-    remediation: runSignal?.remediation ?? comparison.remediation,
+    runbook: runDisplay?.runbook,
+    lastOutcome: runDisplay?.lastOutcome,
+    outcomeHistory: runDisplay?.outcomeHistory,
+    olderRecordCount: runDisplay?.olderRecordCount,
+    remediation:
+      escalation?.remediation ??
+      runSignal?.remediation ??
+      comparison.remediation,
   };
 }
 

--- a/plugins/lisa-copilot/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa-copilot/scripts/automation-status-codex-adapter.mjs
@@ -22,6 +22,10 @@ import {
   createAutomationGroupBins,
   renderAutomationGroups,
 } from "./automation-status-expected-fleet.mjs";
+import {
+  resolveAutomationRunDisplay,
+  resolveRecoveryEscalation,
+} from "./automation-status-run-history.mjs";
 
 const CODEx_RUNTIME_LABEL = "Codex automations";
 const RUN_TIMESTAMP_PATTERN = /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/;
@@ -132,6 +136,7 @@ async function execGitWithRetry(args, options, attempts = 4) {
  * @param {{
  *   readonly expectedFleet: ExpectedFleet
  *   readonly automationsDir?: string
+ *   readonly projectRoot?: string
  *   readonly now?: string | Date
  * }} input
  * @returns {Promise<{
@@ -147,6 +152,10 @@ async function execGitWithRetry(args, options, attempts = 4) {
  *       readonly expectedCadence?: string
  *       readonly expectedCommand?: string
  *       readonly observed?: string
+ *       readonly runbook?: string
+ *       readonly lastOutcome?: { readonly ts: string, readonly outcome: string, readonly summary: string }
+ *       readonly outcomeHistory?: readonly string[]
+ *       readonly olderRecordCount?: number
  *       readonly remediation?: string
  *     }[]
  *   }[]
@@ -156,10 +165,13 @@ async function execGitWithRetry(args, options, attempts = 4) {
 export async function inspectCodexAutomationFleet(input) {
   const expectedFleet = input.expectedFleet;
   const now = normalizeDate(input.now);
+  const projectRoot = input.projectRoot ?? process.cwd();
   const observedAutomations = await listCodexAutomations({
     automationsDir: input.automationsDir,
     automationPrefix: expectedFleet.automationPrefix,
   });
+
+  const runDisplays = await resolveFleetRunDisplays(projectRoot, expectedFleet);
 
   const expectedGroups = createAutomationGroupBins();
 
@@ -177,17 +189,23 @@ export async function inspectCodexAutomationFleet(input) {
         expected,
         comparison,
         now,
+        runDisplay: runDisplays.get(expected.id),
       })
     );
   }
 
   for (const unsupported of expectedFleet.unsupported) {
+    const runDisplay = runDisplays.get(unsupported.id);
     assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
       expectedCadence: unsupported.expectedCadence,
       observed: "No automation is expected for this repo/runtime combination.",
+      runbook: runDisplay?.runbook,
+      lastOutcome: runDisplay?.lastOutcome,
+      outcomeHistory: runDisplay?.outcomeHistory,
+      olderRecordCount: runDisplay?.olderRecordCount,
     });
   }
 
@@ -374,15 +392,43 @@ async function readCodexAutomation(automationDir) {
   };
 }
 
+/**
+ * Read the read-only run-history display for every expected and unsupported
+ * loop up front, keyed by the loop's short id, so the per-entry item builder
+ * stays synchronous.
+ *
+ * @param {string} projectRoot
+ * @param {ExpectedFleet} expectedFleet
+ * @returns {Promise<Map<string, import("./automation-status-run-history.mjs").AutomationRunDisplay>>}
+ */
+async function resolveFleetRunDisplays(projectRoot, expectedFleet) {
+  const entries = [...expectedFleet.expected, ...expectedFleet.unsupported];
+  const displays = await Promise.all(
+    entries.map(entry =>
+      resolveAutomationRunDisplay({
+        projectRoot,
+        loopId: entry.id,
+        runbookPath: entry.runbookPath,
+      })
+    )
+  );
+  return new Map(entries.map((entry, index) => [entry.id, displays[index]]));
+}
+
 function createObservedStatusItem(input) {
   const expected = input.expected;
   const comparison = input.comparison;
   const observed = comparison.observedAutomation;
+  const runDisplay = input.runDisplay;
   const runSignal = classifyAutomationRunSignal({
     expected,
     observedAutomation: observed,
     now: input.now,
   });
+  // Three or more consecutive recorded recovery-required runs flip the loop to
+  // FAILING even when the scheduler entry looks fine — the fleet-health signal
+  // the raw backing store cannot see. It wins over the scheduler run-signal.
+  const escalation = resolveRecoveryEscalation(runDisplay);
 
   const observedDetails = [comparison.observed];
   if (observed?.status) {
@@ -401,20 +447,30 @@ function createObservedStatusItem(input) {
   }
 
   const status =
+    escalation?.status ??
     runSignal?.status ??
     /** @type {"HEALTHY" | "MISSING" | "DRIFTED"} */ (comparison.status);
 
   return {
     id: expected.automationId,
     status,
-    summary: composeAutomationSummary({
-      comparison,
-      runSignal,
-    }),
+    summary: escalation
+      ? escalation.summary
+      : composeAutomationSummary({
+          comparison,
+          runSignal,
+        }),
     expectedCadence: expected.expectedCadence,
     expectedCommand: expected.expectedCommand,
     observed: observedDetails.join(" "),
-    remediation: runSignal?.remediation ?? comparison.remediation,
+    runbook: runDisplay?.runbook,
+    lastOutcome: runDisplay?.lastOutcome,
+    outcomeHistory: runDisplay?.outcomeHistory,
+    olderRecordCount: runDisplay?.olderRecordCount,
+    remediation:
+      escalation?.remediation ??
+      runSignal?.remediation ??
+      comparison.remediation,
   };
 }
 

--- a/plugins/lisa-copilot/scripts/automation-status-report.mjs
+++ b/plugins/lisa-copilot/scripts/automation-status-report.mjs
@@ -26,12 +26,22 @@ export const AUTOMATION_FLEET_VERDICTS = [
  * @typedef {"HEALTHY" | "PARTIAL_SUPPORT" | "ATTENTION_NEEDED"} AutomationFleetVerdict
  *
  * @typedef {{
+ *   readonly ts: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ * }} AutomationLastOutcome
+ *
+ * @typedef {{
  *   readonly id: string
  *   readonly status: AutomationHealthStatus
  *   readonly summary: string
  *   readonly expectedCadence?: string
  *   readonly expectedCommand?: string
  *   readonly observed?: string
+ *   readonly runbook?: string
+ *   readonly lastOutcome?: AutomationLastOutcome
+ *   readonly outcomeHistory?: readonly string[]
+ *   readonly olderRecordCount?: number
  *   readonly remediation?: string
  * }} AutomationStatusItem
  *
@@ -129,6 +139,26 @@ export function renderAutomationStatusReport(input) {
       }
       if (item.observed) {
         lines.push(`  Observed: ${item.observed}`);
+      }
+      // Contract + run-history block: observable facts about where the runbook
+      // lives and how recent runs ended, kept between Observed and Remediation
+      // so operators read the state before the fix. Every line degrades
+      // explicitly — an absent runbook or empty history is stated, never blank.
+      if (item.runbook !== undefined) {
+        lines.push(`  Runbook: ${item.runbook}`);
+        lines.push(
+          item.lastOutcome
+            ? `  Last run: ${item.lastOutcome.outcome} — ${item.lastOutcome.summary} (${item.lastOutcome.ts})`
+            : "  Last run: no recorded runs yet"
+        );
+        if (item.outcomeHistory && item.outcomeHistory.length > 0) {
+          const historyLine = `  History: ${item.outcomeHistory.join(", ")} (newest first)`;
+          lines.push(
+            item.olderRecordCount && item.olderRecordCount > 0
+              ? `${historyLine}; … and ${item.olderRecordCount} older records`
+              : historyLine
+          );
+        }
       }
       if (item.remediation) {
         lines.push(`  Remediation: ${item.remediation}`);

--- a/plugins/lisa-copilot/scripts/automation-status-run-history.mjs
+++ b/plugins/lisa-copilot/scripts/automation-status-run-history.mjs
@@ -121,11 +121,16 @@ export function resolveRecoveryEscalation(runDisplay) {
     return null;
   }
 
-  const summaries = runDisplay.recoverySummaries.join("; ");
+  // Number the citations rather than joining on a delimiter: recorded summaries
+  // carry their own `;` and `.`, so a `; `-separated list is ambiguous. `(1) …
+  // (2) …` stays legible no matter what punctuation a summary contains.
+  const citations = runDisplay.recoverySummaries
+    .map((summary, index) => `(${index + 1}) ${summary}`)
+    .join(" ");
   return {
     status: "FAILING",
     summary: `the last ${runDisplay.recoveryRequiredStreak} recorded runs all required recovery`,
-    remediation: `Repeated recovery-required runs (${summaries}). Inspect the loop's runbook and the cited runs, fix the recurring failure, then let the next scheduled run confirm recovery.`,
+    remediation: `Repeated recovery-required runs — ${citations} Inspect the loop's runbook and the cited runs, fix the recurring failure, then let the next scheduled run confirm recovery.`,
   };
 }
 

--- a/plugins/lisa-copilot/scripts/automation-status-run-history.mjs
+++ b/plugins/lisa-copilot/scripts/automation-status-run-history.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Shared read-only run-history projection for `/lisa:automation-status`.
+ *
+ * The durable run-outcome substrate (RBC-3, `automation-run-record.mjs`) stores
+ * one bounded JSONL file per registered loop under `.lisa/automations/runs/`.
+ * This module turns that substrate — plus the checked-in per-loop runbook
+ * (`automation-runbook-contract`) — into the per-item display fields both
+ * runtime adapters attach to their status rows, so the Codex and Claude
+ * adapters never diverge on how the contract, last outcome, and bounded history
+ * are rendered.
+ *
+ * STRICTLY READ-ONLY: it stats the runbook and reads the run-record file. It
+ * never creates the runs directory, a runbook, or a run record — a status read
+ * must leave the fleet byte-identical.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  automationRunRecordPath,
+  readAutomationRunRecords,
+} from "./automation-run-record.mjs";
+
+/**
+ * Inline history cap: the newest N outcomes are listed, the remainder is only
+ * counted. A bounded view of an already-bounded file, with the trim stated in
+ * the output rather than applied silently.
+ */
+export const AUTOMATION_RUN_HISTORY_DISPLAY_LIMIT = 5;
+
+/** The recorded outcome that signals a loop could not finish its own work. */
+export const RECOVERY_REQUIRED_OUTCOME = "recovery-required";
+
+/**
+ * How many trailing `recovery-required` runs in a row flip a loop to `FAILING`.
+ * The RBC-5 acceptance criteria pin "last three runs" as the escalation
+ * trigger; that wins over the ticket prose's looser "five in a row" pattern.
+ */
+export const RECOVERY_REQUIRED_ESCALATION_THRESHOLD = 3;
+
+const RUNBOOK_NOT_SCAFFOLDED_LINE =
+  "not scaffolded — run /lisa:setup-automations";
+const NO_RECORDED_RUNS_LINE = "no recorded runs yet";
+
+/**
+ * @typedef {{
+ *   readonly ts: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ * }} AutomationLastOutcome
+ *
+ * @typedef {{
+ *   readonly runbook: string
+ *   readonly lastOutcome?: AutomationLastOutcome
+ *   readonly outcomeHistory: readonly string[]
+ *   readonly olderRecordCount: number
+ *   readonly recoveryRequiredStreak: number
+ *   readonly recoverySummaries: readonly string[]
+ *   readonly skippedCorruptLines: number
+ * }} AutomationRunDisplay
+ */
+
+/**
+ * Resolve the read-only run-history display fields for one registered loop.
+ *
+ * @param {{
+ *   readonly projectRoot?: string
+ *   readonly loopId: string
+ *   readonly runbookPath?: string
+ * }} input
+ * @returns {Promise<AutomationRunDisplay>}
+ */
+export async function resolveAutomationRunDisplay(input) {
+  const projectRoot = path.resolve(input.projectRoot ?? process.cwd());
+  const runbook = await resolveRunbookLine(projectRoot, input.runbookPath);
+  const { records, skippedCorruptLines } = await readAutomationRunRecords(
+    automationRunRecordPath(projectRoot, input.loopId)
+  );
+
+  const newestFirst = records.toReversed();
+  const latest = records.at(-1);
+  const lastOutcome = latest
+    ? { ts: latest.ts, outcome: latest.outcome, summary: latest.summary }
+    : undefined;
+  const outcomeHistory = newestFirst
+    .slice(0, AUTOMATION_RUN_HISTORY_DISPLAY_LIMIT)
+    .map(record => record.outcome);
+  const olderRecordCount = Math.max(
+    0,
+    records.length - AUTOMATION_RUN_HISTORY_DISPLAY_LIMIT
+  );
+  const trailingRecovery = collectTrailingRecoveryRuns(records);
+
+  return {
+    runbook,
+    lastOutcome,
+    outcomeHistory,
+    olderRecordCount,
+    recoveryRequiredStreak: trailingRecovery.length,
+    recoverySummaries: trailingRecovery.map(record => record.summary),
+    skippedCorruptLines,
+  };
+}
+
+/**
+ * Force a `FAILING` verdict when a loop has recorded three or more consecutive
+ * `recovery-required` runs — the fleet-health signal the scheduler surface
+ * cannot see on its own. Returns a run-signal-shaped escalation, or null when
+ * the streak is below the threshold.
+ *
+ * @param {AutomationRunDisplay | undefined} runDisplay
+ * @returns {{ readonly status: "FAILING", readonly summary: string, readonly remediation: string } | null}
+ */
+export function resolveRecoveryEscalation(runDisplay) {
+  if (
+    !runDisplay ||
+    runDisplay.recoveryRequiredStreak < RECOVERY_REQUIRED_ESCALATION_THRESHOLD
+  ) {
+    return null;
+  }
+
+  const summaries = runDisplay.recoverySummaries.join("; ");
+  return {
+    status: "FAILING",
+    summary: `the last ${runDisplay.recoveryRequiredStreak} recorded runs all required recovery`,
+    remediation: `Repeated recovery-required runs (${summaries}). Inspect the loop's runbook and the cited runs, fix the recurring failure, then let the next scheduled run confirm recovery.`,
+  };
+}
+
+/**
+ * @param {string} projectRoot
+ * @param {string | undefined} runbookPath
+ * @returns {Promise<string>}
+ */
+async function resolveRunbookLine(projectRoot, runbookPath) {
+  if (!runbookPath) {
+    return RUNBOOK_NOT_SCAFFOLDED_LINE;
+  }
+  const scaffolded = await runbookIsScaffolded(
+    path.join(projectRoot, runbookPath)
+  );
+  return scaffolded ? runbookPath : RUNBOOK_NOT_SCAFFOLDED_LINE;
+}
+
+/**
+ * Read-only existence check for a checked-in runbook. Any stat failure — the
+ * file is absent, unreadable, or not a regular file — degrades to "not
+ * scaffolded" so the status read never implies health it could not confirm and
+ * never throws mid-report.
+ *
+ * @param {string} runbookAbsolutePath
+ * @returns {Promise<boolean>}
+ */
+async function runbookIsScaffolded(runbookAbsolutePath) {
+  try {
+    const stat = await fs.stat(runbookAbsolutePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {readonly import("./automation-run-record.mjs").AutomationRunRecord[]} records
+ * @returns {readonly import("./automation-run-record.mjs").AutomationRunRecord[]} trailing recovery-required runs, newest first
+ */
+function collectTrailingRecoveryRuns(records) {
+  const trailing = [];
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    if (records[index].outcome !== RECOVERY_REQUIRED_OUTCOME) {
+      break;
+    }
+    trailing.push(records[index]);
+  }
+  return trailing;
+}
+
+export { RUNBOOK_NOT_SCAFFOLDED_LINE, NO_RECORDED_RUNS_LINE };

--- a/plugins/lisa-copilot/skills/lisa-automation-status/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-automation-status/SKILL.md
@@ -53,8 +53,13 @@ For each expected automation, report:
 4. Any detected drift in name, cadence, command shape, or queue arguments.
 5. Any available recent-run health signal such as stale last-run timing or repeated failure status.
 6. A concise remediation hint when attention is needed.
+7. Where the loop's checked-in runbook lives (`automation-runbook-contract`), or `not scaffolded — run /lisa:setup-automations` when it is absent.
+8. How the last recorded run ended — its outcome, one-line summary, and timestamp — or `no recorded runs yet` when the loop has never recorded one.
+9. A bounded run history: the five most recent outcomes newest first, plus a count of how many older records exist when the file holds more.
 
-Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected.
+The last-run and history facts come from the durable run-outcome substrate recorded by each loop (the RBC-3 records under `.lisa/automations/runs/<loop-id>.jsonl`, read through `readAutomationRunRecords`). That directory is local scheduler state, not project knowledge — read it, never write it.
+
+Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected. **Repeated recovery is a fleet-health signal the scheduler cannot see**: when a loop's last three or more consecutive recorded runs are all `recovery-required`, report that loop `FAILING` — and therefore the overall verdict `ATTENTION_NEEDED` — even when its scheduler entry itself looks healthy, and point the remediation at the recorded run summaries.
 
 ## Operator usage
 
@@ -89,7 +94,7 @@ Status-specific remediation guidance:
 - `MISSING`: tell the operator which job is absent and recommend rerunning `/lisa:setup-automations` or recreating the missing job with the expected cadence and command.
 - `DRIFTED`: show the expected versus observed cadence/command mismatch and recommend aligning the scheduler entry with Lisa's current setup contract, usually by rerunning `/lisa:setup-automations`.
 - `STALE`: explain that the job exists but has not run recently enough for its cadence. Recommend inspecting the runtime's recent-run history or failure logs before changing queue state.
-- `FAILING`: surface the failure signal directly and recommend checking the latest runtime error plus the affected queue command (`/lisa:intake`, `/lisa:repair-intake`, or exploratory job) after the scheduler issue is resolved.
+- `FAILING`: surface the failure signal directly and recommend checking the latest runtime error plus the affected queue command (`/lisa:intake`, `/lisa:repair-intake`, or exploratory job) after the scheduler issue is resolved. A loop also reports `FAILING` when its last three or more consecutive recorded runs are all `recovery-required` — even with a healthy scheduler entry — in which case cite the recorded run summaries and point the operator at the loop's runbook.
 - `UNSUPPORTED`: explain why the job is intentionally absent and say that no remediation is required unless the project stack or runtime support changed.
 
 Render the report in grouped sections using the shared `scripts/automation-status-report.mjs` contract:
@@ -104,10 +109,13 @@ Generated at: <ISO timestamp>
 - <STATUS> <automation-id>: <summary>
   Expected: <cadence> -> <command>
   Observed: <what the runtime exposed>
+  Runbook: <.lisa/automations/<loop-id>.runbook.md, or "not scaffolded — run /lisa:setup-automations">
+  Last run: <outcome> — <summary> (<ts>), or "no recorded runs yet"
+  History: <outcome>, <outcome>, … (newest first); … and <N> older records
   Remediation: <next step when attention is needed>
 ```
 
-Keep observable runtime facts separate from remediation guidance so operators can distinguish drift, unsupported jobs, and actual failures quickly.
+The Runbook, Last run, and History lines are observable facts and sit between Observed and Remediation. Keep observable runtime facts separate from remediation guidance so operators can distinguish drift, unsupported jobs, and actual failures quickly.
 
 ## Rules
 

--- a/plugins/lisa-cursor/scripts/automation-status-claude-adapter.mjs
+++ b/plugins/lisa-cursor/scripts/automation-status-claude-adapter.mjs
@@ -15,6 +15,10 @@ import {
   createAutomationGroupBins,
   renderAutomationGroups,
 } from "./automation-status-expected-fleet.mjs";
+import {
+  resolveAutomationRunDisplay,
+  resolveRecoveryEscalation,
+} from "./automation-status-run-history.mjs";
 
 const CLAUDE_RUNTIME_LABEL = "Claude /schedule";
 const CLAUDE_ACTIVE_STATUSES = new Set([
@@ -51,9 +55,10 @@ const NEGATED_FAILURE_PATTERN =
  * @param {{
  *   readonly expectedFleet: ExpectedFleet
  *   readonly scheduleListing?: string | readonly unknown[] | Record<string, unknown> | null
+ *   readonly projectRoot?: string
  *   readonly now?: string | Date
  * }} input
- * @returns {{
+ * @returns {Promise<{
  *   readonly runtime: string
  *   readonly generatedAt: string
  *   readonly groups: readonly {
@@ -66,19 +71,26 @@ const NEGATED_FAILURE_PATTERN =
  *       readonly expectedCadence?: string
  *       readonly expectedCommand?: string
  *       readonly observed?: string
+ *       readonly runbook?: string
+ *       readonly lastOutcome?: { readonly ts: string, readonly outcome: string, readonly summary: string }
+ *       readonly outcomeHistory?: readonly string[]
+ *       readonly olderRecordCount?: number
  *       readonly remediation?: string
  *     }[]
  *   }[]
  *   readonly observedAutomations: readonly ObservedClaudeAutomation[]
- * }}}
+ * }>}
  */
-export function inspectClaudeAutomationFleet(input) {
+export async function inspectClaudeAutomationFleet(input) {
   const expectedFleet = input.expectedFleet;
   const now = normalizeDate(input.now);
+  const projectRoot = input.projectRoot ?? process.cwd();
   const observedAutomations = listClaudeAutomations({
     scheduleListing: input.scheduleListing,
     automationPrefix: expectedFleet.automationPrefix,
   });
+
+  const runDisplays = await resolveFleetRunDisplays(projectRoot, expectedFleet);
 
   const expectedGroups = createAutomationGroupBins();
 
@@ -96,17 +108,23 @@ export function inspectClaudeAutomationFleet(input) {
         expected,
         comparison,
         now,
+        runDisplay: runDisplays.get(expected.id),
       })
     );
   }
 
   for (const unsupported of expectedFleet.unsupported) {
+    const runDisplay = runDisplays.get(unsupported.id);
     assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
       expectedCadence: unsupported.expectedCadence,
       observed: "No automation is expected for this repo/runtime combination.",
+      runbook: runDisplay?.runbook,
+      lastOutcome: runDisplay?.lastOutcome,
+      outcomeHistory: runDisplay?.outcomeHistory,
+      olderRecordCount: runDisplay?.olderRecordCount,
     });
   }
 
@@ -195,15 +213,43 @@ function extractClaudeScheduleCadence(command) {
   );
 }
 
+/**
+ * Read the read-only run-history display for every expected and unsupported
+ * loop up front, keyed by the loop's short id, so the per-entry item builder
+ * stays synchronous.
+ *
+ * @param {string} projectRoot
+ * @param {ExpectedFleet} expectedFleet
+ * @returns {Promise<Map<string, import("./automation-status-run-history.mjs").AutomationRunDisplay>>}
+ */
+async function resolveFleetRunDisplays(projectRoot, expectedFleet) {
+  const entries = [...expectedFleet.expected, ...expectedFleet.unsupported];
+  const displays = await Promise.all(
+    entries.map(entry =>
+      resolveAutomationRunDisplay({
+        projectRoot,
+        loopId: entry.id,
+        runbookPath: entry.runbookPath,
+      })
+    )
+  );
+  return new Map(entries.map((entry, index) => [entry.id, displays[index]]));
+}
+
 function createObservedStatusItem(input) {
   const expected = input.expected;
   const comparison = input.comparison;
   const observed = comparison.observedAutomation;
+  const runDisplay = input.runDisplay;
   const runSignal = classifyAutomationRunSignal({
     expected,
     observedAutomation: observed,
     now: input.now,
   });
+  // Three or more consecutive recorded recovery-required runs flip the loop to
+  // FAILING even when the /schedule entry looks fine — the fleet-health signal
+  // the scheduler surface cannot see. It wins over the scheduler run-signal.
+  const escalation = resolveRecoveryEscalation(runDisplay);
 
   const observedDetails = [comparison.observed];
   if (observed?.status) {
@@ -223,20 +269,30 @@ function createObservedStatusItem(input) {
   }
 
   const status =
+    escalation?.status ??
     runSignal?.status ??
     /** @type {"HEALTHY" | "MISSING" | "DRIFTED"} */ (comparison.status);
 
   return {
     id: expected.automationId,
     status,
-    summary: composeAutomationSummary({
-      comparison,
-      runSignal,
-    }),
+    summary: escalation
+      ? escalation.summary
+      : composeAutomationSummary({
+          comparison,
+          runSignal,
+        }),
     expectedCadence: expected.expectedCadence,
     expectedCommand: expected.expectedCommand,
     observed: observedDetails.join(" "),
-    remediation: runSignal?.remediation ?? comparison.remediation,
+    runbook: runDisplay?.runbook,
+    lastOutcome: runDisplay?.lastOutcome,
+    outcomeHistory: runDisplay?.outcomeHistory,
+    olderRecordCount: runDisplay?.olderRecordCount,
+    remediation:
+      escalation?.remediation ??
+      runSignal?.remediation ??
+      comparison.remediation,
   };
 }
 

--- a/plugins/lisa-cursor/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa-cursor/scripts/automation-status-codex-adapter.mjs
@@ -22,6 +22,10 @@ import {
   createAutomationGroupBins,
   renderAutomationGroups,
 } from "./automation-status-expected-fleet.mjs";
+import {
+  resolveAutomationRunDisplay,
+  resolveRecoveryEscalation,
+} from "./automation-status-run-history.mjs";
 
 const CODEx_RUNTIME_LABEL = "Codex automations";
 const RUN_TIMESTAMP_PATTERN = /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/;
@@ -132,6 +136,7 @@ async function execGitWithRetry(args, options, attempts = 4) {
  * @param {{
  *   readonly expectedFleet: ExpectedFleet
  *   readonly automationsDir?: string
+ *   readonly projectRoot?: string
  *   readonly now?: string | Date
  * }} input
  * @returns {Promise<{
@@ -147,6 +152,10 @@ async function execGitWithRetry(args, options, attempts = 4) {
  *       readonly expectedCadence?: string
  *       readonly expectedCommand?: string
  *       readonly observed?: string
+ *       readonly runbook?: string
+ *       readonly lastOutcome?: { readonly ts: string, readonly outcome: string, readonly summary: string }
+ *       readonly outcomeHistory?: readonly string[]
+ *       readonly olderRecordCount?: number
  *       readonly remediation?: string
  *     }[]
  *   }[]
@@ -156,10 +165,13 @@ async function execGitWithRetry(args, options, attempts = 4) {
 export async function inspectCodexAutomationFleet(input) {
   const expectedFleet = input.expectedFleet;
   const now = normalizeDate(input.now);
+  const projectRoot = input.projectRoot ?? process.cwd();
   const observedAutomations = await listCodexAutomations({
     automationsDir: input.automationsDir,
     automationPrefix: expectedFleet.automationPrefix,
   });
+
+  const runDisplays = await resolveFleetRunDisplays(projectRoot, expectedFleet);
 
   const expectedGroups = createAutomationGroupBins();
 
@@ -177,17 +189,23 @@ export async function inspectCodexAutomationFleet(input) {
         expected,
         comparison,
         now,
+        runDisplay: runDisplays.get(expected.id),
       })
     );
   }
 
   for (const unsupported of expectedFleet.unsupported) {
+    const runDisplay = runDisplays.get(unsupported.id);
     assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
       expectedCadence: unsupported.expectedCadence,
       observed: "No automation is expected for this repo/runtime combination.",
+      runbook: runDisplay?.runbook,
+      lastOutcome: runDisplay?.lastOutcome,
+      outcomeHistory: runDisplay?.outcomeHistory,
+      olderRecordCount: runDisplay?.olderRecordCount,
     });
   }
 
@@ -374,15 +392,43 @@ async function readCodexAutomation(automationDir) {
   };
 }
 
+/**
+ * Read the read-only run-history display for every expected and unsupported
+ * loop up front, keyed by the loop's short id, so the per-entry item builder
+ * stays synchronous.
+ *
+ * @param {string} projectRoot
+ * @param {ExpectedFleet} expectedFleet
+ * @returns {Promise<Map<string, import("./automation-status-run-history.mjs").AutomationRunDisplay>>}
+ */
+async function resolveFleetRunDisplays(projectRoot, expectedFleet) {
+  const entries = [...expectedFleet.expected, ...expectedFleet.unsupported];
+  const displays = await Promise.all(
+    entries.map(entry =>
+      resolveAutomationRunDisplay({
+        projectRoot,
+        loopId: entry.id,
+        runbookPath: entry.runbookPath,
+      })
+    )
+  );
+  return new Map(entries.map((entry, index) => [entry.id, displays[index]]));
+}
+
 function createObservedStatusItem(input) {
   const expected = input.expected;
   const comparison = input.comparison;
   const observed = comparison.observedAutomation;
+  const runDisplay = input.runDisplay;
   const runSignal = classifyAutomationRunSignal({
     expected,
     observedAutomation: observed,
     now: input.now,
   });
+  // Three or more consecutive recorded recovery-required runs flip the loop to
+  // FAILING even when the scheduler entry looks fine — the fleet-health signal
+  // the raw backing store cannot see. It wins over the scheduler run-signal.
+  const escalation = resolveRecoveryEscalation(runDisplay);
 
   const observedDetails = [comparison.observed];
   if (observed?.status) {
@@ -401,20 +447,30 @@ function createObservedStatusItem(input) {
   }
 
   const status =
+    escalation?.status ??
     runSignal?.status ??
     /** @type {"HEALTHY" | "MISSING" | "DRIFTED"} */ (comparison.status);
 
   return {
     id: expected.automationId,
     status,
-    summary: composeAutomationSummary({
-      comparison,
-      runSignal,
-    }),
+    summary: escalation
+      ? escalation.summary
+      : composeAutomationSummary({
+          comparison,
+          runSignal,
+        }),
     expectedCadence: expected.expectedCadence,
     expectedCommand: expected.expectedCommand,
     observed: observedDetails.join(" "),
-    remediation: runSignal?.remediation ?? comparison.remediation,
+    runbook: runDisplay?.runbook,
+    lastOutcome: runDisplay?.lastOutcome,
+    outcomeHistory: runDisplay?.outcomeHistory,
+    olderRecordCount: runDisplay?.olderRecordCount,
+    remediation:
+      escalation?.remediation ??
+      runSignal?.remediation ??
+      comparison.remediation,
   };
 }
 

--- a/plugins/lisa-cursor/scripts/automation-status-report.mjs
+++ b/plugins/lisa-cursor/scripts/automation-status-report.mjs
@@ -26,12 +26,22 @@ export const AUTOMATION_FLEET_VERDICTS = [
  * @typedef {"HEALTHY" | "PARTIAL_SUPPORT" | "ATTENTION_NEEDED"} AutomationFleetVerdict
  *
  * @typedef {{
+ *   readonly ts: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ * }} AutomationLastOutcome
+ *
+ * @typedef {{
  *   readonly id: string
  *   readonly status: AutomationHealthStatus
  *   readonly summary: string
  *   readonly expectedCadence?: string
  *   readonly expectedCommand?: string
  *   readonly observed?: string
+ *   readonly runbook?: string
+ *   readonly lastOutcome?: AutomationLastOutcome
+ *   readonly outcomeHistory?: readonly string[]
+ *   readonly olderRecordCount?: number
  *   readonly remediation?: string
  * }} AutomationStatusItem
  *
@@ -129,6 +139,26 @@ export function renderAutomationStatusReport(input) {
       }
       if (item.observed) {
         lines.push(`  Observed: ${item.observed}`);
+      }
+      // Contract + run-history block: observable facts about where the runbook
+      // lives and how recent runs ended, kept between Observed and Remediation
+      // so operators read the state before the fix. Every line degrades
+      // explicitly — an absent runbook or empty history is stated, never blank.
+      if (item.runbook !== undefined) {
+        lines.push(`  Runbook: ${item.runbook}`);
+        lines.push(
+          item.lastOutcome
+            ? `  Last run: ${item.lastOutcome.outcome} — ${item.lastOutcome.summary} (${item.lastOutcome.ts})`
+            : "  Last run: no recorded runs yet"
+        );
+        if (item.outcomeHistory && item.outcomeHistory.length > 0) {
+          const historyLine = `  History: ${item.outcomeHistory.join(", ")} (newest first)`;
+          lines.push(
+            item.olderRecordCount && item.olderRecordCount > 0
+              ? `${historyLine}; … and ${item.olderRecordCount} older records`
+              : historyLine
+          );
+        }
       }
       if (item.remediation) {
         lines.push(`  Remediation: ${item.remediation}`);

--- a/plugins/lisa-cursor/scripts/automation-status-run-history.mjs
+++ b/plugins/lisa-cursor/scripts/automation-status-run-history.mjs
@@ -121,11 +121,16 @@ export function resolveRecoveryEscalation(runDisplay) {
     return null;
   }
 
-  const summaries = runDisplay.recoverySummaries.join("; ");
+  // Number the citations rather than joining on a delimiter: recorded summaries
+  // carry their own `;` and `.`, so a `; `-separated list is ambiguous. `(1) …
+  // (2) …` stays legible no matter what punctuation a summary contains.
+  const citations = runDisplay.recoverySummaries
+    .map((summary, index) => `(${index + 1}) ${summary}`)
+    .join(" ");
   return {
     status: "FAILING",
     summary: `the last ${runDisplay.recoveryRequiredStreak} recorded runs all required recovery`,
-    remediation: `Repeated recovery-required runs (${summaries}). Inspect the loop's runbook and the cited runs, fix the recurring failure, then let the next scheduled run confirm recovery.`,
+    remediation: `Repeated recovery-required runs — ${citations} Inspect the loop's runbook and the cited runs, fix the recurring failure, then let the next scheduled run confirm recovery.`,
   };
 }
 

--- a/plugins/lisa-cursor/scripts/automation-status-run-history.mjs
+++ b/plugins/lisa-cursor/scripts/automation-status-run-history.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Shared read-only run-history projection for `/lisa:automation-status`.
+ *
+ * The durable run-outcome substrate (RBC-3, `automation-run-record.mjs`) stores
+ * one bounded JSONL file per registered loop under `.lisa/automations/runs/`.
+ * This module turns that substrate — plus the checked-in per-loop runbook
+ * (`automation-runbook-contract`) — into the per-item display fields both
+ * runtime adapters attach to their status rows, so the Codex and Claude
+ * adapters never diverge on how the contract, last outcome, and bounded history
+ * are rendered.
+ *
+ * STRICTLY READ-ONLY: it stats the runbook and reads the run-record file. It
+ * never creates the runs directory, a runbook, or a run record — a status read
+ * must leave the fleet byte-identical.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  automationRunRecordPath,
+  readAutomationRunRecords,
+} from "./automation-run-record.mjs";
+
+/**
+ * Inline history cap: the newest N outcomes are listed, the remainder is only
+ * counted. A bounded view of an already-bounded file, with the trim stated in
+ * the output rather than applied silently.
+ */
+export const AUTOMATION_RUN_HISTORY_DISPLAY_LIMIT = 5;
+
+/** The recorded outcome that signals a loop could not finish its own work. */
+export const RECOVERY_REQUIRED_OUTCOME = "recovery-required";
+
+/**
+ * How many trailing `recovery-required` runs in a row flip a loop to `FAILING`.
+ * The RBC-5 acceptance criteria pin "last three runs" as the escalation
+ * trigger; that wins over the ticket prose's looser "five in a row" pattern.
+ */
+export const RECOVERY_REQUIRED_ESCALATION_THRESHOLD = 3;
+
+const RUNBOOK_NOT_SCAFFOLDED_LINE =
+  "not scaffolded — run /lisa:setup-automations";
+const NO_RECORDED_RUNS_LINE = "no recorded runs yet";
+
+/**
+ * @typedef {{
+ *   readonly ts: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ * }} AutomationLastOutcome
+ *
+ * @typedef {{
+ *   readonly runbook: string
+ *   readonly lastOutcome?: AutomationLastOutcome
+ *   readonly outcomeHistory: readonly string[]
+ *   readonly olderRecordCount: number
+ *   readonly recoveryRequiredStreak: number
+ *   readonly recoverySummaries: readonly string[]
+ *   readonly skippedCorruptLines: number
+ * }} AutomationRunDisplay
+ */
+
+/**
+ * Resolve the read-only run-history display fields for one registered loop.
+ *
+ * @param {{
+ *   readonly projectRoot?: string
+ *   readonly loopId: string
+ *   readonly runbookPath?: string
+ * }} input
+ * @returns {Promise<AutomationRunDisplay>}
+ */
+export async function resolveAutomationRunDisplay(input) {
+  const projectRoot = path.resolve(input.projectRoot ?? process.cwd());
+  const runbook = await resolveRunbookLine(projectRoot, input.runbookPath);
+  const { records, skippedCorruptLines } = await readAutomationRunRecords(
+    automationRunRecordPath(projectRoot, input.loopId)
+  );
+
+  const newestFirst = records.toReversed();
+  const latest = records.at(-1);
+  const lastOutcome = latest
+    ? { ts: latest.ts, outcome: latest.outcome, summary: latest.summary }
+    : undefined;
+  const outcomeHistory = newestFirst
+    .slice(0, AUTOMATION_RUN_HISTORY_DISPLAY_LIMIT)
+    .map(record => record.outcome);
+  const olderRecordCount = Math.max(
+    0,
+    records.length - AUTOMATION_RUN_HISTORY_DISPLAY_LIMIT
+  );
+  const trailingRecovery = collectTrailingRecoveryRuns(records);
+
+  return {
+    runbook,
+    lastOutcome,
+    outcomeHistory,
+    olderRecordCount,
+    recoveryRequiredStreak: trailingRecovery.length,
+    recoverySummaries: trailingRecovery.map(record => record.summary),
+    skippedCorruptLines,
+  };
+}
+
+/**
+ * Force a `FAILING` verdict when a loop has recorded three or more consecutive
+ * `recovery-required` runs — the fleet-health signal the scheduler surface
+ * cannot see on its own. Returns a run-signal-shaped escalation, or null when
+ * the streak is below the threshold.
+ *
+ * @param {AutomationRunDisplay | undefined} runDisplay
+ * @returns {{ readonly status: "FAILING", readonly summary: string, readonly remediation: string } | null}
+ */
+export function resolveRecoveryEscalation(runDisplay) {
+  if (
+    !runDisplay ||
+    runDisplay.recoveryRequiredStreak < RECOVERY_REQUIRED_ESCALATION_THRESHOLD
+  ) {
+    return null;
+  }
+
+  const summaries = runDisplay.recoverySummaries.join("; ");
+  return {
+    status: "FAILING",
+    summary: `the last ${runDisplay.recoveryRequiredStreak} recorded runs all required recovery`,
+    remediation: `Repeated recovery-required runs (${summaries}). Inspect the loop's runbook and the cited runs, fix the recurring failure, then let the next scheduled run confirm recovery.`,
+  };
+}
+
+/**
+ * @param {string} projectRoot
+ * @param {string | undefined} runbookPath
+ * @returns {Promise<string>}
+ */
+async function resolveRunbookLine(projectRoot, runbookPath) {
+  if (!runbookPath) {
+    return RUNBOOK_NOT_SCAFFOLDED_LINE;
+  }
+  const scaffolded = await runbookIsScaffolded(
+    path.join(projectRoot, runbookPath)
+  );
+  return scaffolded ? runbookPath : RUNBOOK_NOT_SCAFFOLDED_LINE;
+}
+
+/**
+ * Read-only existence check for a checked-in runbook. Any stat failure — the
+ * file is absent, unreadable, or not a regular file — degrades to "not
+ * scaffolded" so the status read never implies health it could not confirm and
+ * never throws mid-report.
+ *
+ * @param {string} runbookAbsolutePath
+ * @returns {Promise<boolean>}
+ */
+async function runbookIsScaffolded(runbookAbsolutePath) {
+  try {
+    const stat = await fs.stat(runbookAbsolutePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {readonly import("./automation-run-record.mjs").AutomationRunRecord[]} records
+ * @returns {readonly import("./automation-run-record.mjs").AutomationRunRecord[]} trailing recovery-required runs, newest first
+ */
+function collectTrailingRecoveryRuns(records) {
+  const trailing = [];
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    if (records[index].outcome !== RECOVERY_REQUIRED_OUTCOME) {
+      break;
+    }
+    trailing.push(records[index]);
+  }
+  return trailing;
+}
+
+export { RUNBOOK_NOT_SCAFFOLDED_LINE, NO_RECORDED_RUNS_LINE };

--- a/plugins/lisa-cursor/skills/lisa-automation-status/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-automation-status/SKILL.md
@@ -53,8 +53,13 @@ For each expected automation, report:
 4. Any detected drift in name, cadence, command shape, or queue arguments.
 5. Any available recent-run health signal such as stale last-run timing or repeated failure status.
 6. A concise remediation hint when attention is needed.
+7. Where the loop's checked-in runbook lives (`automation-runbook-contract`), or `not scaffolded — run /lisa:setup-automations` when it is absent.
+8. How the last recorded run ended — its outcome, one-line summary, and timestamp — or `no recorded runs yet` when the loop has never recorded one.
+9. A bounded run history: the five most recent outcomes newest first, plus a count of how many older records exist when the file holds more.
 
-Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected.
+The last-run and history facts come from the durable run-outcome substrate recorded by each loop (the RBC-3 records under `.lisa/automations/runs/<loop-id>.jsonl`, read through `readAutomationRunRecords`). That directory is local scheduler state, not project knowledge — read it, never write it.
+
+Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected. **Repeated recovery is a fleet-health signal the scheduler cannot see**: when a loop's last three or more consecutive recorded runs are all `recovery-required`, report that loop `FAILING` — and therefore the overall verdict `ATTENTION_NEEDED` — even when its scheduler entry itself looks healthy, and point the remediation at the recorded run summaries.
 
 ## Operator usage
 
@@ -89,7 +94,7 @@ Status-specific remediation guidance:
 - `MISSING`: tell the operator which job is absent and recommend rerunning `/lisa:setup-automations` or recreating the missing job with the expected cadence and command.
 - `DRIFTED`: show the expected versus observed cadence/command mismatch and recommend aligning the scheduler entry with Lisa's current setup contract, usually by rerunning `/lisa:setup-automations`.
 - `STALE`: explain that the job exists but has not run recently enough for its cadence. Recommend inspecting the runtime's recent-run history or failure logs before changing queue state.
-- `FAILING`: surface the failure signal directly and recommend checking the latest runtime error plus the affected queue command (`/lisa:intake`, `/lisa:repair-intake`, or exploratory job) after the scheduler issue is resolved.
+- `FAILING`: surface the failure signal directly and recommend checking the latest runtime error plus the affected queue command (`/lisa:intake`, `/lisa:repair-intake`, or exploratory job) after the scheduler issue is resolved. A loop also reports `FAILING` when its last three or more consecutive recorded runs are all `recovery-required` — even with a healthy scheduler entry — in which case cite the recorded run summaries and point the operator at the loop's runbook.
 - `UNSUPPORTED`: explain why the job is intentionally absent and say that no remediation is required unless the project stack or runtime support changed.
 
 Render the report in grouped sections using the shared `scripts/automation-status-report.mjs` contract:
@@ -104,10 +109,13 @@ Generated at: <ISO timestamp>
 - <STATUS> <automation-id>: <summary>
   Expected: <cadence> -> <command>
   Observed: <what the runtime exposed>
+  Runbook: <.lisa/automations/<loop-id>.runbook.md, or "not scaffolded — run /lisa:setup-automations">
+  Last run: <outcome> — <summary> (<ts>), or "no recorded runs yet"
+  History: <outcome>, <outcome>, … (newest first); … and <N> older records
   Remediation: <next step when attention is needed>
 ```
 
-Keep observable runtime facts separate from remediation guidance so operators can distinguish drift, unsupported jobs, and actual failures quickly.
+The Runbook, Last run, and History lines are observable facts and sit between Observed and Remediation. Keep observable runtime facts separate from remediation guidance so operators can distinguish drift, unsupported jobs, and actual failures quickly.
 
 ## Rules
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-automation-status/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-automation-status/SKILL.md
@@ -53,8 +53,13 @@ For each expected automation, report:
 4. Any detected drift in name, cadence, command shape, or queue arguments.
 5. Any available recent-run health signal such as stale last-run timing or repeated failure status.
 6. A concise remediation hint when attention is needed.
+7. Where the loop's checked-in runbook lives (`automation-runbook-contract`), or `not scaffolded — run /lisa:setup-automations` when it is absent.
+8. How the last recorded run ended — its outcome, one-line summary, and timestamp — or `no recorded runs yet` when the loop has never recorded one.
+9. A bounded run history: the five most recent outcomes newest first, plus a count of how many older records exist when the file holds more.
 
-Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected.
+The last-run and history facts come from the durable run-outcome substrate recorded by each loop (the RBC-3 records under `.lisa/automations/runs/<loop-id>.jsonl`, read through `readAutomationRunRecords`). That directory is local scheduler state, not project knowledge — read it, never write it.
+
+Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected. **Repeated recovery is a fleet-health signal the scheduler cannot see**: when a loop's last three or more consecutive recorded runs are all `recovery-required`, report that loop `FAILING` — and therefore the overall verdict `ATTENTION_NEEDED` — even when its scheduler entry itself looks healthy, and point the remediation at the recorded run summaries.
 
 ## Operator usage
 
@@ -89,7 +94,7 @@ Status-specific remediation guidance:
 - `MISSING`: tell the operator which job is absent and recommend rerunning `/lisa:setup-automations` or recreating the missing job with the expected cadence and command.
 - `DRIFTED`: show the expected versus observed cadence/command mismatch and recommend aligning the scheduler entry with Lisa's current setup contract, usually by rerunning `/lisa:setup-automations`.
 - `STALE`: explain that the job exists but has not run recently enough for its cadence. Recommend inspecting the runtime's recent-run history or failure logs before changing queue state.
-- `FAILING`: surface the failure signal directly and recommend checking the latest runtime error plus the affected queue command (`/lisa:intake`, `/lisa:repair-intake`, or exploratory job) after the scheduler issue is resolved.
+- `FAILING`: surface the failure signal directly and recommend checking the latest runtime error plus the affected queue command (`/lisa:intake`, `/lisa:repair-intake`, or exploratory job) after the scheduler issue is resolved. A loop also reports `FAILING` when its last three or more consecutive recorded runs are all `recovery-required` — even with a healthy scheduler entry — in which case cite the recorded run summaries and point the operator at the loop's runbook.
 - `UNSUPPORTED`: explain why the job is intentionally absent and say that no remediation is required unless the project stack or runtime support changed.
 
 Render the report in grouped sections using the shared `scripts/automation-status-report.mjs` contract:
@@ -104,10 +109,13 @@ Generated at: <ISO timestamp>
 - <STATUS> <automation-id>: <summary>
   Expected: <cadence> -> <command>
   Observed: <what the runtime exposed>
+  Runbook: <.lisa/automations/<loop-id>.runbook.md, or "not scaffolded — run /lisa:setup-automations">
+  Last run: <outcome> — <summary> (<ts>), or "no recorded runs yet"
+  History: <outcome>, <outcome>, … (newest first); … and <N> older records
   Remediation: <next step when attention is needed>
 ```
 
-Keep observable runtime facts separate from remediation guidance so operators can distinguish drift, unsupported jobs, and actual failures quickly.
+The Runbook, Last run, and History lines are observable facts and sit between Observed and Remediation. Keep observable runtime facts separate from remediation guidance so operators can distinguish drift, unsupported jobs, and actual failures quickly.
 
 ## Rules
 

--- a/plugins/lisa/scripts/automation-status-claude-adapter.mjs
+++ b/plugins/lisa/scripts/automation-status-claude-adapter.mjs
@@ -15,6 +15,10 @@ import {
   createAutomationGroupBins,
   renderAutomationGroups,
 } from "./automation-status-expected-fleet.mjs";
+import {
+  resolveAutomationRunDisplay,
+  resolveRecoveryEscalation,
+} from "./automation-status-run-history.mjs";
 
 const CLAUDE_RUNTIME_LABEL = "Claude /schedule";
 const CLAUDE_ACTIVE_STATUSES = new Set([
@@ -51,9 +55,10 @@ const NEGATED_FAILURE_PATTERN =
  * @param {{
  *   readonly expectedFleet: ExpectedFleet
  *   readonly scheduleListing?: string | readonly unknown[] | Record<string, unknown> | null
+ *   readonly projectRoot?: string
  *   readonly now?: string | Date
  * }} input
- * @returns {{
+ * @returns {Promise<{
  *   readonly runtime: string
  *   readonly generatedAt: string
  *   readonly groups: readonly {
@@ -66,19 +71,26 @@ const NEGATED_FAILURE_PATTERN =
  *       readonly expectedCadence?: string
  *       readonly expectedCommand?: string
  *       readonly observed?: string
+ *       readonly runbook?: string
+ *       readonly lastOutcome?: { readonly ts: string, readonly outcome: string, readonly summary: string }
+ *       readonly outcomeHistory?: readonly string[]
+ *       readonly olderRecordCount?: number
  *       readonly remediation?: string
  *     }[]
  *   }[]
  *   readonly observedAutomations: readonly ObservedClaudeAutomation[]
- * }}}
+ * }>}
  */
-export function inspectClaudeAutomationFleet(input) {
+export async function inspectClaudeAutomationFleet(input) {
   const expectedFleet = input.expectedFleet;
   const now = normalizeDate(input.now);
+  const projectRoot = input.projectRoot ?? process.cwd();
   const observedAutomations = listClaudeAutomations({
     scheduleListing: input.scheduleListing,
     automationPrefix: expectedFleet.automationPrefix,
   });
+
+  const runDisplays = await resolveFleetRunDisplays(projectRoot, expectedFleet);
 
   const expectedGroups = createAutomationGroupBins();
 
@@ -96,17 +108,23 @@ export function inspectClaudeAutomationFleet(input) {
         expected,
         comparison,
         now,
+        runDisplay: runDisplays.get(expected.id),
       })
     );
   }
 
   for (const unsupported of expectedFleet.unsupported) {
+    const runDisplay = runDisplays.get(unsupported.id);
     assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
       expectedCadence: unsupported.expectedCadence,
       observed: "No automation is expected for this repo/runtime combination.",
+      runbook: runDisplay?.runbook,
+      lastOutcome: runDisplay?.lastOutcome,
+      outcomeHistory: runDisplay?.outcomeHistory,
+      olderRecordCount: runDisplay?.olderRecordCount,
     });
   }
 
@@ -195,15 +213,43 @@ function extractClaudeScheduleCadence(command) {
   );
 }
 
+/**
+ * Read the read-only run-history display for every expected and unsupported
+ * loop up front, keyed by the loop's short id, so the per-entry item builder
+ * stays synchronous.
+ *
+ * @param {string} projectRoot
+ * @param {ExpectedFleet} expectedFleet
+ * @returns {Promise<Map<string, import("./automation-status-run-history.mjs").AutomationRunDisplay>>}
+ */
+async function resolveFleetRunDisplays(projectRoot, expectedFleet) {
+  const entries = [...expectedFleet.expected, ...expectedFleet.unsupported];
+  const displays = await Promise.all(
+    entries.map(entry =>
+      resolveAutomationRunDisplay({
+        projectRoot,
+        loopId: entry.id,
+        runbookPath: entry.runbookPath,
+      })
+    )
+  );
+  return new Map(entries.map((entry, index) => [entry.id, displays[index]]));
+}
+
 function createObservedStatusItem(input) {
   const expected = input.expected;
   const comparison = input.comparison;
   const observed = comparison.observedAutomation;
+  const runDisplay = input.runDisplay;
   const runSignal = classifyAutomationRunSignal({
     expected,
     observedAutomation: observed,
     now: input.now,
   });
+  // Three or more consecutive recorded recovery-required runs flip the loop to
+  // FAILING even when the /schedule entry looks fine — the fleet-health signal
+  // the scheduler surface cannot see. It wins over the scheduler run-signal.
+  const escalation = resolveRecoveryEscalation(runDisplay);
 
   const observedDetails = [comparison.observed];
   if (observed?.status) {
@@ -223,20 +269,30 @@ function createObservedStatusItem(input) {
   }
 
   const status =
+    escalation?.status ??
     runSignal?.status ??
     /** @type {"HEALTHY" | "MISSING" | "DRIFTED"} */ (comparison.status);
 
   return {
     id: expected.automationId,
     status,
-    summary: composeAutomationSummary({
-      comparison,
-      runSignal,
-    }),
+    summary: escalation
+      ? escalation.summary
+      : composeAutomationSummary({
+          comparison,
+          runSignal,
+        }),
     expectedCadence: expected.expectedCadence,
     expectedCommand: expected.expectedCommand,
     observed: observedDetails.join(" "),
-    remediation: runSignal?.remediation ?? comparison.remediation,
+    runbook: runDisplay?.runbook,
+    lastOutcome: runDisplay?.lastOutcome,
+    outcomeHistory: runDisplay?.outcomeHistory,
+    olderRecordCount: runDisplay?.olderRecordCount,
+    remediation:
+      escalation?.remediation ??
+      runSignal?.remediation ??
+      comparison.remediation,
   };
 }
 

--- a/plugins/lisa/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa/scripts/automation-status-codex-adapter.mjs
@@ -22,6 +22,10 @@ import {
   createAutomationGroupBins,
   renderAutomationGroups,
 } from "./automation-status-expected-fleet.mjs";
+import {
+  resolveAutomationRunDisplay,
+  resolveRecoveryEscalation,
+} from "./automation-status-run-history.mjs";
 
 const CODEx_RUNTIME_LABEL = "Codex automations";
 const RUN_TIMESTAMP_PATTERN = /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/;
@@ -132,6 +136,7 @@ async function execGitWithRetry(args, options, attempts = 4) {
  * @param {{
  *   readonly expectedFleet: ExpectedFleet
  *   readonly automationsDir?: string
+ *   readonly projectRoot?: string
  *   readonly now?: string | Date
  * }} input
  * @returns {Promise<{
@@ -147,6 +152,10 @@ async function execGitWithRetry(args, options, attempts = 4) {
  *       readonly expectedCadence?: string
  *       readonly expectedCommand?: string
  *       readonly observed?: string
+ *       readonly runbook?: string
+ *       readonly lastOutcome?: { readonly ts: string, readonly outcome: string, readonly summary: string }
+ *       readonly outcomeHistory?: readonly string[]
+ *       readonly olderRecordCount?: number
  *       readonly remediation?: string
  *     }[]
  *   }[]
@@ -156,10 +165,13 @@ async function execGitWithRetry(args, options, attempts = 4) {
 export async function inspectCodexAutomationFleet(input) {
   const expectedFleet = input.expectedFleet;
   const now = normalizeDate(input.now);
+  const projectRoot = input.projectRoot ?? process.cwd();
   const observedAutomations = await listCodexAutomations({
     automationsDir: input.automationsDir,
     automationPrefix: expectedFleet.automationPrefix,
   });
+
+  const runDisplays = await resolveFleetRunDisplays(projectRoot, expectedFleet);
 
   const expectedGroups = createAutomationGroupBins();
 
@@ -177,17 +189,23 @@ export async function inspectCodexAutomationFleet(input) {
         expected,
         comparison,
         now,
+        runDisplay: runDisplays.get(expected.id),
       })
     );
   }
 
   for (const unsupported of expectedFleet.unsupported) {
+    const runDisplay = runDisplays.get(unsupported.id);
     assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
       expectedCadence: unsupported.expectedCadence,
       observed: "No automation is expected for this repo/runtime combination.",
+      runbook: runDisplay?.runbook,
+      lastOutcome: runDisplay?.lastOutcome,
+      outcomeHistory: runDisplay?.outcomeHistory,
+      olderRecordCount: runDisplay?.olderRecordCount,
     });
   }
 
@@ -374,15 +392,43 @@ async function readCodexAutomation(automationDir) {
   };
 }
 
+/**
+ * Read the read-only run-history display for every expected and unsupported
+ * loop up front, keyed by the loop's short id, so the per-entry item builder
+ * stays synchronous.
+ *
+ * @param {string} projectRoot
+ * @param {ExpectedFleet} expectedFleet
+ * @returns {Promise<Map<string, import("./automation-status-run-history.mjs").AutomationRunDisplay>>}
+ */
+async function resolveFleetRunDisplays(projectRoot, expectedFleet) {
+  const entries = [...expectedFleet.expected, ...expectedFleet.unsupported];
+  const displays = await Promise.all(
+    entries.map(entry =>
+      resolveAutomationRunDisplay({
+        projectRoot,
+        loopId: entry.id,
+        runbookPath: entry.runbookPath,
+      })
+    )
+  );
+  return new Map(entries.map((entry, index) => [entry.id, displays[index]]));
+}
+
 function createObservedStatusItem(input) {
   const expected = input.expected;
   const comparison = input.comparison;
   const observed = comparison.observedAutomation;
+  const runDisplay = input.runDisplay;
   const runSignal = classifyAutomationRunSignal({
     expected,
     observedAutomation: observed,
     now: input.now,
   });
+  // Three or more consecutive recorded recovery-required runs flip the loop to
+  // FAILING even when the scheduler entry looks fine — the fleet-health signal
+  // the raw backing store cannot see. It wins over the scheduler run-signal.
+  const escalation = resolveRecoveryEscalation(runDisplay);
 
   const observedDetails = [comparison.observed];
   if (observed?.status) {
@@ -401,20 +447,30 @@ function createObservedStatusItem(input) {
   }
 
   const status =
+    escalation?.status ??
     runSignal?.status ??
     /** @type {"HEALTHY" | "MISSING" | "DRIFTED"} */ (comparison.status);
 
   return {
     id: expected.automationId,
     status,
-    summary: composeAutomationSummary({
-      comparison,
-      runSignal,
-    }),
+    summary: escalation
+      ? escalation.summary
+      : composeAutomationSummary({
+          comparison,
+          runSignal,
+        }),
     expectedCadence: expected.expectedCadence,
     expectedCommand: expected.expectedCommand,
     observed: observedDetails.join(" "),
-    remediation: runSignal?.remediation ?? comparison.remediation,
+    runbook: runDisplay?.runbook,
+    lastOutcome: runDisplay?.lastOutcome,
+    outcomeHistory: runDisplay?.outcomeHistory,
+    olderRecordCount: runDisplay?.olderRecordCount,
+    remediation:
+      escalation?.remediation ??
+      runSignal?.remediation ??
+      comparison.remediation,
   };
 }
 

--- a/plugins/lisa/scripts/automation-status-report.mjs
+++ b/plugins/lisa/scripts/automation-status-report.mjs
@@ -26,12 +26,22 @@ export const AUTOMATION_FLEET_VERDICTS = [
  * @typedef {"HEALTHY" | "PARTIAL_SUPPORT" | "ATTENTION_NEEDED"} AutomationFleetVerdict
  *
  * @typedef {{
+ *   readonly ts: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ * }} AutomationLastOutcome
+ *
+ * @typedef {{
  *   readonly id: string
  *   readonly status: AutomationHealthStatus
  *   readonly summary: string
  *   readonly expectedCadence?: string
  *   readonly expectedCommand?: string
  *   readonly observed?: string
+ *   readonly runbook?: string
+ *   readonly lastOutcome?: AutomationLastOutcome
+ *   readonly outcomeHistory?: readonly string[]
+ *   readonly olderRecordCount?: number
  *   readonly remediation?: string
  * }} AutomationStatusItem
  *
@@ -129,6 +139,26 @@ export function renderAutomationStatusReport(input) {
       }
       if (item.observed) {
         lines.push(`  Observed: ${item.observed}`);
+      }
+      // Contract + run-history block: observable facts about where the runbook
+      // lives and how recent runs ended, kept between Observed and Remediation
+      // so operators read the state before the fix. Every line degrades
+      // explicitly — an absent runbook or empty history is stated, never blank.
+      if (item.runbook !== undefined) {
+        lines.push(`  Runbook: ${item.runbook}`);
+        lines.push(
+          item.lastOutcome
+            ? `  Last run: ${item.lastOutcome.outcome} — ${item.lastOutcome.summary} (${item.lastOutcome.ts})`
+            : "  Last run: no recorded runs yet"
+        );
+        if (item.outcomeHistory && item.outcomeHistory.length > 0) {
+          const historyLine = `  History: ${item.outcomeHistory.join(", ")} (newest first)`;
+          lines.push(
+            item.olderRecordCount && item.olderRecordCount > 0
+              ? `${historyLine}; … and ${item.olderRecordCount} older records`
+              : historyLine
+          );
+        }
       }
       if (item.remediation) {
         lines.push(`  Remediation: ${item.remediation}`);

--- a/plugins/lisa/scripts/automation-status-run-history.mjs
+++ b/plugins/lisa/scripts/automation-status-run-history.mjs
@@ -121,11 +121,16 @@ export function resolveRecoveryEscalation(runDisplay) {
     return null;
   }
 
-  const summaries = runDisplay.recoverySummaries.join("; ");
+  // Number the citations rather than joining on a delimiter: recorded summaries
+  // carry their own `;` and `.`, so a `; `-separated list is ambiguous. `(1) …
+  // (2) …` stays legible no matter what punctuation a summary contains.
+  const citations = runDisplay.recoverySummaries
+    .map((summary, index) => `(${index + 1}) ${summary}`)
+    .join(" ");
   return {
     status: "FAILING",
     summary: `the last ${runDisplay.recoveryRequiredStreak} recorded runs all required recovery`,
-    remediation: `Repeated recovery-required runs (${summaries}). Inspect the loop's runbook and the cited runs, fix the recurring failure, then let the next scheduled run confirm recovery.`,
+    remediation: `Repeated recovery-required runs — ${citations} Inspect the loop's runbook and the cited runs, fix the recurring failure, then let the next scheduled run confirm recovery.`,
   };
 }
 

--- a/plugins/lisa/scripts/automation-status-run-history.mjs
+++ b/plugins/lisa/scripts/automation-status-run-history.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Shared read-only run-history projection for `/lisa:automation-status`.
+ *
+ * The durable run-outcome substrate (RBC-3, `automation-run-record.mjs`) stores
+ * one bounded JSONL file per registered loop under `.lisa/automations/runs/`.
+ * This module turns that substrate — plus the checked-in per-loop runbook
+ * (`automation-runbook-contract`) — into the per-item display fields both
+ * runtime adapters attach to their status rows, so the Codex and Claude
+ * adapters never diverge on how the contract, last outcome, and bounded history
+ * are rendered.
+ *
+ * STRICTLY READ-ONLY: it stats the runbook and reads the run-record file. It
+ * never creates the runs directory, a runbook, or a run record — a status read
+ * must leave the fleet byte-identical.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  automationRunRecordPath,
+  readAutomationRunRecords,
+} from "./automation-run-record.mjs";
+
+/**
+ * Inline history cap: the newest N outcomes are listed, the remainder is only
+ * counted. A bounded view of an already-bounded file, with the trim stated in
+ * the output rather than applied silently.
+ */
+export const AUTOMATION_RUN_HISTORY_DISPLAY_LIMIT = 5;
+
+/** The recorded outcome that signals a loop could not finish its own work. */
+export const RECOVERY_REQUIRED_OUTCOME = "recovery-required";
+
+/**
+ * How many trailing `recovery-required` runs in a row flip a loop to `FAILING`.
+ * The RBC-5 acceptance criteria pin "last three runs" as the escalation
+ * trigger; that wins over the ticket prose's looser "five in a row" pattern.
+ */
+export const RECOVERY_REQUIRED_ESCALATION_THRESHOLD = 3;
+
+const RUNBOOK_NOT_SCAFFOLDED_LINE =
+  "not scaffolded — run /lisa:setup-automations";
+const NO_RECORDED_RUNS_LINE = "no recorded runs yet";
+
+/**
+ * @typedef {{
+ *   readonly ts: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ * }} AutomationLastOutcome
+ *
+ * @typedef {{
+ *   readonly runbook: string
+ *   readonly lastOutcome?: AutomationLastOutcome
+ *   readonly outcomeHistory: readonly string[]
+ *   readonly olderRecordCount: number
+ *   readonly recoveryRequiredStreak: number
+ *   readonly recoverySummaries: readonly string[]
+ *   readonly skippedCorruptLines: number
+ * }} AutomationRunDisplay
+ */
+
+/**
+ * Resolve the read-only run-history display fields for one registered loop.
+ *
+ * @param {{
+ *   readonly projectRoot?: string
+ *   readonly loopId: string
+ *   readonly runbookPath?: string
+ * }} input
+ * @returns {Promise<AutomationRunDisplay>}
+ */
+export async function resolveAutomationRunDisplay(input) {
+  const projectRoot = path.resolve(input.projectRoot ?? process.cwd());
+  const runbook = await resolveRunbookLine(projectRoot, input.runbookPath);
+  const { records, skippedCorruptLines } = await readAutomationRunRecords(
+    automationRunRecordPath(projectRoot, input.loopId)
+  );
+
+  const newestFirst = records.toReversed();
+  const latest = records.at(-1);
+  const lastOutcome = latest
+    ? { ts: latest.ts, outcome: latest.outcome, summary: latest.summary }
+    : undefined;
+  const outcomeHistory = newestFirst
+    .slice(0, AUTOMATION_RUN_HISTORY_DISPLAY_LIMIT)
+    .map(record => record.outcome);
+  const olderRecordCount = Math.max(
+    0,
+    records.length - AUTOMATION_RUN_HISTORY_DISPLAY_LIMIT
+  );
+  const trailingRecovery = collectTrailingRecoveryRuns(records);
+
+  return {
+    runbook,
+    lastOutcome,
+    outcomeHistory,
+    olderRecordCount,
+    recoveryRequiredStreak: trailingRecovery.length,
+    recoverySummaries: trailingRecovery.map(record => record.summary),
+    skippedCorruptLines,
+  };
+}
+
+/**
+ * Force a `FAILING` verdict when a loop has recorded three or more consecutive
+ * `recovery-required` runs — the fleet-health signal the scheduler surface
+ * cannot see on its own. Returns a run-signal-shaped escalation, or null when
+ * the streak is below the threshold.
+ *
+ * @param {AutomationRunDisplay | undefined} runDisplay
+ * @returns {{ readonly status: "FAILING", readonly summary: string, readonly remediation: string } | null}
+ */
+export function resolveRecoveryEscalation(runDisplay) {
+  if (
+    !runDisplay ||
+    runDisplay.recoveryRequiredStreak < RECOVERY_REQUIRED_ESCALATION_THRESHOLD
+  ) {
+    return null;
+  }
+
+  const summaries = runDisplay.recoverySummaries.join("; ");
+  return {
+    status: "FAILING",
+    summary: `the last ${runDisplay.recoveryRequiredStreak} recorded runs all required recovery`,
+    remediation: `Repeated recovery-required runs (${summaries}). Inspect the loop's runbook and the cited runs, fix the recurring failure, then let the next scheduled run confirm recovery.`,
+  };
+}
+
+/**
+ * @param {string} projectRoot
+ * @param {string | undefined} runbookPath
+ * @returns {Promise<string>}
+ */
+async function resolveRunbookLine(projectRoot, runbookPath) {
+  if (!runbookPath) {
+    return RUNBOOK_NOT_SCAFFOLDED_LINE;
+  }
+  const scaffolded = await runbookIsScaffolded(
+    path.join(projectRoot, runbookPath)
+  );
+  return scaffolded ? runbookPath : RUNBOOK_NOT_SCAFFOLDED_LINE;
+}
+
+/**
+ * Read-only existence check for a checked-in runbook. Any stat failure — the
+ * file is absent, unreadable, or not a regular file — degrades to "not
+ * scaffolded" so the status read never implies health it could not confirm and
+ * never throws mid-report.
+ *
+ * @param {string} runbookAbsolutePath
+ * @returns {Promise<boolean>}
+ */
+async function runbookIsScaffolded(runbookAbsolutePath) {
+  try {
+    const stat = await fs.stat(runbookAbsolutePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {readonly import("./automation-run-record.mjs").AutomationRunRecord[]} records
+ * @returns {readonly import("./automation-run-record.mjs").AutomationRunRecord[]} trailing recovery-required runs, newest first
+ */
+function collectTrailingRecoveryRuns(records) {
+  const trailing = [];
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    if (records[index].outcome !== RECOVERY_REQUIRED_OUTCOME) {
+      break;
+    }
+    trailing.push(records[index]);
+  }
+  return trailing;
+}
+
+export { RUNBOOK_NOT_SCAFFOLDED_LINE, NO_RECORDED_RUNS_LINE };

--- a/plugins/lisa/skills/lisa-automation-status/SKILL.md
+++ b/plugins/lisa/skills/lisa-automation-status/SKILL.md
@@ -53,8 +53,13 @@ For each expected automation, report:
 4. Any detected drift in name, cadence, command shape, or queue arguments.
 5. Any available recent-run health signal such as stale last-run timing or repeated failure status.
 6. A concise remediation hint when attention is needed.
+7. Where the loop's checked-in runbook lives (`automation-runbook-contract`), or `not scaffolded — run /lisa:setup-automations` when it is absent.
+8. How the last recorded run ended — its outcome, one-line summary, and timestamp — or `no recorded runs yet` when the loop has never recorded one.
+9. A bounded run history: the five most recent outcomes newest first, plus a count of how many older records exist when the file holds more.
 
-Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected.
+The last-run and history facts come from the durable run-outcome substrate recorded by each loop (the RBC-3 records under `.lisa/automations/runs/<loop-id>.jsonl`, read through `readAutomationRunRecords`). That directory is local scheduler state, not project knowledge — read it, never write it.
+
+Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected. **Repeated recovery is a fleet-health signal the scheduler cannot see**: when a loop's last three or more consecutive recorded runs are all `recovery-required`, report that loop `FAILING` — and therefore the overall verdict `ATTENTION_NEEDED` — even when its scheduler entry itself looks healthy, and point the remediation at the recorded run summaries.
 
 ## Operator usage
 
@@ -89,7 +94,7 @@ Status-specific remediation guidance:
 - `MISSING`: tell the operator which job is absent and recommend rerunning `/lisa:setup-automations` or recreating the missing job with the expected cadence and command.
 - `DRIFTED`: show the expected versus observed cadence/command mismatch and recommend aligning the scheduler entry with Lisa's current setup contract, usually by rerunning `/lisa:setup-automations`.
 - `STALE`: explain that the job exists but has not run recently enough for its cadence. Recommend inspecting the runtime's recent-run history or failure logs before changing queue state.
-- `FAILING`: surface the failure signal directly and recommend checking the latest runtime error plus the affected queue command (`/lisa:intake`, `/lisa:repair-intake`, or exploratory job) after the scheduler issue is resolved.
+- `FAILING`: surface the failure signal directly and recommend checking the latest runtime error plus the affected queue command (`/lisa:intake`, `/lisa:repair-intake`, or exploratory job) after the scheduler issue is resolved. A loop also reports `FAILING` when its last three or more consecutive recorded runs are all `recovery-required` — even with a healthy scheduler entry — in which case cite the recorded run summaries and point the operator at the loop's runbook.
 - `UNSUPPORTED`: explain why the job is intentionally absent and say that no remediation is required unless the project stack or runtime support changed.
 
 Render the report in grouped sections using the shared `scripts/automation-status-report.mjs` contract:
@@ -104,10 +109,13 @@ Generated at: <ISO timestamp>
 - <STATUS> <automation-id>: <summary>
   Expected: <cadence> -> <command>
   Observed: <what the runtime exposed>
+  Runbook: <.lisa/automations/<loop-id>.runbook.md, or "not scaffolded — run /lisa:setup-automations">
+  Last run: <outcome> — <summary> (<ts>), or "no recorded runs yet"
+  History: <outcome>, <outcome>, … (newest first); … and <N> older records
   Remediation: <next step when attention is needed>
 ```
 
-Keep observable runtime facts separate from remediation guidance so operators can distinguish drift, unsupported jobs, and actual failures quickly.
+The Runbook, Last run, and History lines are observable facts and sit between Observed and Remediation. Keep observable runtime facts separate from remediation guidance so operators can distinguish drift, unsupported jobs, and actual failures quickly.
 
 ## Rules
 

--- a/plugins/src/base/scripts/automation-status-claude-adapter.mjs
+++ b/plugins/src/base/scripts/automation-status-claude-adapter.mjs
@@ -15,6 +15,10 @@ import {
   createAutomationGroupBins,
   renderAutomationGroups,
 } from "./automation-status-expected-fleet.mjs";
+import {
+  resolveAutomationRunDisplay,
+  resolveRecoveryEscalation,
+} from "./automation-status-run-history.mjs";
 
 const CLAUDE_RUNTIME_LABEL = "Claude /schedule";
 const CLAUDE_ACTIVE_STATUSES = new Set([
@@ -51,9 +55,10 @@ const NEGATED_FAILURE_PATTERN =
  * @param {{
  *   readonly expectedFleet: ExpectedFleet
  *   readonly scheduleListing?: string | readonly unknown[] | Record<string, unknown> | null
+ *   readonly projectRoot?: string
  *   readonly now?: string | Date
  * }} input
- * @returns {{
+ * @returns {Promise<{
  *   readonly runtime: string
  *   readonly generatedAt: string
  *   readonly groups: readonly {
@@ -66,19 +71,26 @@ const NEGATED_FAILURE_PATTERN =
  *       readonly expectedCadence?: string
  *       readonly expectedCommand?: string
  *       readonly observed?: string
+ *       readonly runbook?: string
+ *       readonly lastOutcome?: { readonly ts: string, readonly outcome: string, readonly summary: string }
+ *       readonly outcomeHistory?: readonly string[]
+ *       readonly olderRecordCount?: number
  *       readonly remediation?: string
  *     }[]
  *   }[]
  *   readonly observedAutomations: readonly ObservedClaudeAutomation[]
- * }}}
+ * }>}
  */
-export function inspectClaudeAutomationFleet(input) {
+export async function inspectClaudeAutomationFleet(input) {
   const expectedFleet = input.expectedFleet;
   const now = normalizeDate(input.now);
+  const projectRoot = input.projectRoot ?? process.cwd();
   const observedAutomations = listClaudeAutomations({
     scheduleListing: input.scheduleListing,
     automationPrefix: expectedFleet.automationPrefix,
   });
+
+  const runDisplays = await resolveFleetRunDisplays(projectRoot, expectedFleet);
 
   const expectedGroups = createAutomationGroupBins();
 
@@ -96,17 +108,23 @@ export function inspectClaudeAutomationFleet(input) {
         expected,
         comparison,
         now,
+        runDisplay: runDisplays.get(expected.id),
       })
     );
   }
 
   for (const unsupported of expectedFleet.unsupported) {
+    const runDisplay = runDisplays.get(unsupported.id);
     assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
       expectedCadence: unsupported.expectedCadence,
       observed: "No automation is expected for this repo/runtime combination.",
+      runbook: runDisplay?.runbook,
+      lastOutcome: runDisplay?.lastOutcome,
+      outcomeHistory: runDisplay?.outcomeHistory,
+      olderRecordCount: runDisplay?.olderRecordCount,
     });
   }
 
@@ -195,15 +213,43 @@ function extractClaudeScheduleCadence(command) {
   );
 }
 
+/**
+ * Read the read-only run-history display for every expected and unsupported
+ * loop up front, keyed by the loop's short id, so the per-entry item builder
+ * stays synchronous.
+ *
+ * @param {string} projectRoot
+ * @param {ExpectedFleet} expectedFleet
+ * @returns {Promise<Map<string, import("./automation-status-run-history.mjs").AutomationRunDisplay>>}
+ */
+async function resolveFleetRunDisplays(projectRoot, expectedFleet) {
+  const entries = [...expectedFleet.expected, ...expectedFleet.unsupported];
+  const displays = await Promise.all(
+    entries.map(entry =>
+      resolveAutomationRunDisplay({
+        projectRoot,
+        loopId: entry.id,
+        runbookPath: entry.runbookPath,
+      })
+    )
+  );
+  return new Map(entries.map((entry, index) => [entry.id, displays[index]]));
+}
+
 function createObservedStatusItem(input) {
   const expected = input.expected;
   const comparison = input.comparison;
   const observed = comparison.observedAutomation;
+  const runDisplay = input.runDisplay;
   const runSignal = classifyAutomationRunSignal({
     expected,
     observedAutomation: observed,
     now: input.now,
   });
+  // Three or more consecutive recorded recovery-required runs flip the loop to
+  // FAILING even when the /schedule entry looks fine — the fleet-health signal
+  // the scheduler surface cannot see. It wins over the scheduler run-signal.
+  const escalation = resolveRecoveryEscalation(runDisplay);
 
   const observedDetails = [comparison.observed];
   if (observed?.status) {
@@ -223,20 +269,30 @@ function createObservedStatusItem(input) {
   }
 
   const status =
+    escalation?.status ??
     runSignal?.status ??
     /** @type {"HEALTHY" | "MISSING" | "DRIFTED"} */ (comparison.status);
 
   return {
     id: expected.automationId,
     status,
-    summary: composeAutomationSummary({
-      comparison,
-      runSignal,
-    }),
+    summary: escalation
+      ? escalation.summary
+      : composeAutomationSummary({
+          comparison,
+          runSignal,
+        }),
     expectedCadence: expected.expectedCadence,
     expectedCommand: expected.expectedCommand,
     observed: observedDetails.join(" "),
-    remediation: runSignal?.remediation ?? comparison.remediation,
+    runbook: runDisplay?.runbook,
+    lastOutcome: runDisplay?.lastOutcome,
+    outcomeHistory: runDisplay?.outcomeHistory,
+    olderRecordCount: runDisplay?.olderRecordCount,
+    remediation:
+      escalation?.remediation ??
+      runSignal?.remediation ??
+      comparison.remediation,
   };
 }
 

--- a/plugins/src/base/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/src/base/scripts/automation-status-codex-adapter.mjs
@@ -22,6 +22,10 @@ import {
   createAutomationGroupBins,
   renderAutomationGroups,
 } from "./automation-status-expected-fleet.mjs";
+import {
+  resolveAutomationRunDisplay,
+  resolveRecoveryEscalation,
+} from "./automation-status-run-history.mjs";
 
 const CODEx_RUNTIME_LABEL = "Codex automations";
 const RUN_TIMESTAMP_PATTERN = /20\d{2}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z/;
@@ -132,6 +136,7 @@ async function execGitWithRetry(args, options, attempts = 4) {
  * @param {{
  *   readonly expectedFleet: ExpectedFleet
  *   readonly automationsDir?: string
+ *   readonly projectRoot?: string
  *   readonly now?: string | Date
  * }} input
  * @returns {Promise<{
@@ -147,6 +152,10 @@ async function execGitWithRetry(args, options, attempts = 4) {
  *       readonly expectedCadence?: string
  *       readonly expectedCommand?: string
  *       readonly observed?: string
+ *       readonly runbook?: string
+ *       readonly lastOutcome?: { readonly ts: string, readonly outcome: string, readonly summary: string }
+ *       readonly outcomeHistory?: readonly string[]
+ *       readonly olderRecordCount?: number
  *       readonly remediation?: string
  *     }[]
  *   }[]
@@ -156,10 +165,13 @@ async function execGitWithRetry(args, options, attempts = 4) {
 export async function inspectCodexAutomationFleet(input) {
   const expectedFleet = input.expectedFleet;
   const now = normalizeDate(input.now);
+  const projectRoot = input.projectRoot ?? process.cwd();
   const observedAutomations = await listCodexAutomations({
     automationsDir: input.automationsDir,
     automationPrefix: expectedFleet.automationPrefix,
   });
+
+  const runDisplays = await resolveFleetRunDisplays(projectRoot, expectedFleet);
 
   const expectedGroups = createAutomationGroupBins();
 
@@ -177,17 +189,23 @@ export async function inspectCodexAutomationFleet(input) {
         expected,
         comparison,
         now,
+        runDisplay: runDisplays.get(expected.id),
       })
     );
   }
 
   for (const unsupported of expectedFleet.unsupported) {
+    const runDisplay = runDisplays.get(unsupported.id);
     assignToAutomationGroup(expectedGroups, unsupported.group, {
       id: unsupported.automationId,
       status: "UNSUPPORTED",
       summary: unsupported.reason,
       expectedCadence: unsupported.expectedCadence,
       observed: "No automation is expected for this repo/runtime combination.",
+      runbook: runDisplay?.runbook,
+      lastOutcome: runDisplay?.lastOutcome,
+      outcomeHistory: runDisplay?.outcomeHistory,
+      olderRecordCount: runDisplay?.olderRecordCount,
     });
   }
 
@@ -374,15 +392,43 @@ async function readCodexAutomation(automationDir) {
   };
 }
 
+/**
+ * Read the read-only run-history display for every expected and unsupported
+ * loop up front, keyed by the loop's short id, so the per-entry item builder
+ * stays synchronous.
+ *
+ * @param {string} projectRoot
+ * @param {ExpectedFleet} expectedFleet
+ * @returns {Promise<Map<string, import("./automation-status-run-history.mjs").AutomationRunDisplay>>}
+ */
+async function resolveFleetRunDisplays(projectRoot, expectedFleet) {
+  const entries = [...expectedFleet.expected, ...expectedFleet.unsupported];
+  const displays = await Promise.all(
+    entries.map(entry =>
+      resolveAutomationRunDisplay({
+        projectRoot,
+        loopId: entry.id,
+        runbookPath: entry.runbookPath,
+      })
+    )
+  );
+  return new Map(entries.map((entry, index) => [entry.id, displays[index]]));
+}
+
 function createObservedStatusItem(input) {
   const expected = input.expected;
   const comparison = input.comparison;
   const observed = comparison.observedAutomation;
+  const runDisplay = input.runDisplay;
   const runSignal = classifyAutomationRunSignal({
     expected,
     observedAutomation: observed,
     now: input.now,
   });
+  // Three or more consecutive recorded recovery-required runs flip the loop to
+  // FAILING even when the scheduler entry looks fine — the fleet-health signal
+  // the raw backing store cannot see. It wins over the scheduler run-signal.
+  const escalation = resolveRecoveryEscalation(runDisplay);
 
   const observedDetails = [comparison.observed];
   if (observed?.status) {
@@ -401,20 +447,30 @@ function createObservedStatusItem(input) {
   }
 
   const status =
+    escalation?.status ??
     runSignal?.status ??
     /** @type {"HEALTHY" | "MISSING" | "DRIFTED"} */ (comparison.status);
 
   return {
     id: expected.automationId,
     status,
-    summary: composeAutomationSummary({
-      comparison,
-      runSignal,
-    }),
+    summary: escalation
+      ? escalation.summary
+      : composeAutomationSummary({
+          comparison,
+          runSignal,
+        }),
     expectedCadence: expected.expectedCadence,
     expectedCommand: expected.expectedCommand,
     observed: observedDetails.join(" "),
-    remediation: runSignal?.remediation ?? comparison.remediation,
+    runbook: runDisplay?.runbook,
+    lastOutcome: runDisplay?.lastOutcome,
+    outcomeHistory: runDisplay?.outcomeHistory,
+    olderRecordCount: runDisplay?.olderRecordCount,
+    remediation:
+      escalation?.remediation ??
+      runSignal?.remediation ??
+      comparison.remediation,
   };
 }
 

--- a/plugins/src/base/scripts/automation-status-report.mjs
+++ b/plugins/src/base/scripts/automation-status-report.mjs
@@ -26,12 +26,22 @@ export const AUTOMATION_FLEET_VERDICTS = [
  * @typedef {"HEALTHY" | "PARTIAL_SUPPORT" | "ATTENTION_NEEDED"} AutomationFleetVerdict
  *
  * @typedef {{
+ *   readonly ts: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ * }} AutomationLastOutcome
+ *
+ * @typedef {{
  *   readonly id: string
  *   readonly status: AutomationHealthStatus
  *   readonly summary: string
  *   readonly expectedCadence?: string
  *   readonly expectedCommand?: string
  *   readonly observed?: string
+ *   readonly runbook?: string
+ *   readonly lastOutcome?: AutomationLastOutcome
+ *   readonly outcomeHistory?: readonly string[]
+ *   readonly olderRecordCount?: number
  *   readonly remediation?: string
  * }} AutomationStatusItem
  *
@@ -129,6 +139,26 @@ export function renderAutomationStatusReport(input) {
       }
       if (item.observed) {
         lines.push(`  Observed: ${item.observed}`);
+      }
+      // Contract + run-history block: observable facts about where the runbook
+      // lives and how recent runs ended, kept between Observed and Remediation
+      // so operators read the state before the fix. Every line degrades
+      // explicitly — an absent runbook or empty history is stated, never blank.
+      if (item.runbook !== undefined) {
+        lines.push(`  Runbook: ${item.runbook}`);
+        lines.push(
+          item.lastOutcome
+            ? `  Last run: ${item.lastOutcome.outcome} — ${item.lastOutcome.summary} (${item.lastOutcome.ts})`
+            : "  Last run: no recorded runs yet"
+        );
+        if (item.outcomeHistory && item.outcomeHistory.length > 0) {
+          const historyLine = `  History: ${item.outcomeHistory.join(", ")} (newest first)`;
+          lines.push(
+            item.olderRecordCount && item.olderRecordCount > 0
+              ? `${historyLine}; … and ${item.olderRecordCount} older records`
+              : historyLine
+          );
+        }
       }
       if (item.remediation) {
         lines.push(`  Remediation: ${item.remediation}`);

--- a/plugins/src/base/scripts/automation-status-run-history.mjs
+++ b/plugins/src/base/scripts/automation-status-run-history.mjs
@@ -121,11 +121,16 @@ export function resolveRecoveryEscalation(runDisplay) {
     return null;
   }
 
-  const summaries = runDisplay.recoverySummaries.join("; ");
+  // Number the citations rather than joining on a delimiter: recorded summaries
+  // carry their own `;` and `.`, so a `; `-separated list is ambiguous. `(1) …
+  // (2) …` stays legible no matter what punctuation a summary contains.
+  const citations = runDisplay.recoverySummaries
+    .map((summary, index) => `(${index + 1}) ${summary}`)
+    .join(" ");
   return {
     status: "FAILING",
     summary: `the last ${runDisplay.recoveryRequiredStreak} recorded runs all required recovery`,
-    remediation: `Repeated recovery-required runs (${summaries}). Inspect the loop's runbook and the cited runs, fix the recurring failure, then let the next scheduled run confirm recovery.`,
+    remediation: `Repeated recovery-required runs — ${citations} Inspect the loop's runbook and the cited runs, fix the recurring failure, then let the next scheduled run confirm recovery.`,
   };
 }
 

--- a/plugins/src/base/scripts/automation-status-run-history.mjs
+++ b/plugins/src/base/scripts/automation-status-run-history.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Shared read-only run-history projection for `/lisa:automation-status`.
+ *
+ * The durable run-outcome substrate (RBC-3, `automation-run-record.mjs`) stores
+ * one bounded JSONL file per registered loop under `.lisa/automations/runs/`.
+ * This module turns that substrate — plus the checked-in per-loop runbook
+ * (`automation-runbook-contract`) — into the per-item display fields both
+ * runtime adapters attach to their status rows, so the Codex and Claude
+ * adapters never diverge on how the contract, last outcome, and bounded history
+ * are rendered.
+ *
+ * STRICTLY READ-ONLY: it stats the runbook and reads the run-record file. It
+ * never creates the runs directory, a runbook, or a run record — a status read
+ * must leave the fleet byte-identical.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  automationRunRecordPath,
+  readAutomationRunRecords,
+} from "./automation-run-record.mjs";
+
+/**
+ * Inline history cap: the newest N outcomes are listed, the remainder is only
+ * counted. A bounded view of an already-bounded file, with the trim stated in
+ * the output rather than applied silently.
+ */
+export const AUTOMATION_RUN_HISTORY_DISPLAY_LIMIT = 5;
+
+/** The recorded outcome that signals a loop could not finish its own work. */
+export const RECOVERY_REQUIRED_OUTCOME = "recovery-required";
+
+/**
+ * How many trailing `recovery-required` runs in a row flip a loop to `FAILING`.
+ * The RBC-5 acceptance criteria pin "last three runs" as the escalation
+ * trigger; that wins over the ticket prose's looser "five in a row" pattern.
+ */
+export const RECOVERY_REQUIRED_ESCALATION_THRESHOLD = 3;
+
+const RUNBOOK_NOT_SCAFFOLDED_LINE =
+  "not scaffolded — run /lisa:setup-automations";
+const NO_RECORDED_RUNS_LINE = "no recorded runs yet";
+
+/**
+ * @typedef {{
+ *   readonly ts: string
+ *   readonly outcome: string
+ *   readonly summary: string
+ * }} AutomationLastOutcome
+ *
+ * @typedef {{
+ *   readonly runbook: string
+ *   readonly lastOutcome?: AutomationLastOutcome
+ *   readonly outcomeHistory: readonly string[]
+ *   readonly olderRecordCount: number
+ *   readonly recoveryRequiredStreak: number
+ *   readonly recoverySummaries: readonly string[]
+ *   readonly skippedCorruptLines: number
+ * }} AutomationRunDisplay
+ */
+
+/**
+ * Resolve the read-only run-history display fields for one registered loop.
+ *
+ * @param {{
+ *   readonly projectRoot?: string
+ *   readonly loopId: string
+ *   readonly runbookPath?: string
+ * }} input
+ * @returns {Promise<AutomationRunDisplay>}
+ */
+export async function resolveAutomationRunDisplay(input) {
+  const projectRoot = path.resolve(input.projectRoot ?? process.cwd());
+  const runbook = await resolveRunbookLine(projectRoot, input.runbookPath);
+  const { records, skippedCorruptLines } = await readAutomationRunRecords(
+    automationRunRecordPath(projectRoot, input.loopId)
+  );
+
+  const newestFirst = records.toReversed();
+  const latest = records.at(-1);
+  const lastOutcome = latest
+    ? { ts: latest.ts, outcome: latest.outcome, summary: latest.summary }
+    : undefined;
+  const outcomeHistory = newestFirst
+    .slice(0, AUTOMATION_RUN_HISTORY_DISPLAY_LIMIT)
+    .map(record => record.outcome);
+  const olderRecordCount = Math.max(
+    0,
+    records.length - AUTOMATION_RUN_HISTORY_DISPLAY_LIMIT
+  );
+  const trailingRecovery = collectTrailingRecoveryRuns(records);
+
+  return {
+    runbook,
+    lastOutcome,
+    outcomeHistory,
+    olderRecordCount,
+    recoveryRequiredStreak: trailingRecovery.length,
+    recoverySummaries: trailingRecovery.map(record => record.summary),
+    skippedCorruptLines,
+  };
+}
+
+/**
+ * Force a `FAILING` verdict when a loop has recorded three or more consecutive
+ * `recovery-required` runs — the fleet-health signal the scheduler surface
+ * cannot see on its own. Returns a run-signal-shaped escalation, or null when
+ * the streak is below the threshold.
+ *
+ * @param {AutomationRunDisplay | undefined} runDisplay
+ * @returns {{ readonly status: "FAILING", readonly summary: string, readonly remediation: string } | null}
+ */
+export function resolveRecoveryEscalation(runDisplay) {
+  if (
+    !runDisplay ||
+    runDisplay.recoveryRequiredStreak < RECOVERY_REQUIRED_ESCALATION_THRESHOLD
+  ) {
+    return null;
+  }
+
+  const summaries = runDisplay.recoverySummaries.join("; ");
+  return {
+    status: "FAILING",
+    summary: `the last ${runDisplay.recoveryRequiredStreak} recorded runs all required recovery`,
+    remediation: `Repeated recovery-required runs (${summaries}). Inspect the loop's runbook and the cited runs, fix the recurring failure, then let the next scheduled run confirm recovery.`,
+  };
+}
+
+/**
+ * @param {string} projectRoot
+ * @param {string | undefined} runbookPath
+ * @returns {Promise<string>}
+ */
+async function resolveRunbookLine(projectRoot, runbookPath) {
+  if (!runbookPath) {
+    return RUNBOOK_NOT_SCAFFOLDED_LINE;
+  }
+  const scaffolded = await runbookIsScaffolded(
+    path.join(projectRoot, runbookPath)
+  );
+  return scaffolded ? runbookPath : RUNBOOK_NOT_SCAFFOLDED_LINE;
+}
+
+/**
+ * Read-only existence check for a checked-in runbook. Any stat failure — the
+ * file is absent, unreadable, or not a regular file — degrades to "not
+ * scaffolded" so the status read never implies health it could not confirm and
+ * never throws mid-report.
+ *
+ * @param {string} runbookAbsolutePath
+ * @returns {Promise<boolean>}
+ */
+async function runbookIsScaffolded(runbookAbsolutePath) {
+  try {
+    const stat = await fs.stat(runbookAbsolutePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {readonly import("./automation-run-record.mjs").AutomationRunRecord[]} records
+ * @returns {readonly import("./automation-run-record.mjs").AutomationRunRecord[]} trailing recovery-required runs, newest first
+ */
+function collectTrailingRecoveryRuns(records) {
+  const trailing = [];
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    if (records[index].outcome !== RECOVERY_REQUIRED_OUTCOME) {
+      break;
+    }
+    trailing.push(records[index]);
+  }
+  return trailing;
+}
+
+export { RUNBOOK_NOT_SCAFFOLDED_LINE, NO_RECORDED_RUNS_LINE };

--- a/plugins/src/base/skills/lisa-automation-status/SKILL.md
+++ b/plugins/src/base/skills/lisa-automation-status/SKILL.md
@@ -53,8 +53,13 @@ For each expected automation, report:
 4. Any detected drift in name, cadence, command shape, or queue arguments.
 5. Any available recent-run health signal such as stale last-run timing or repeated failure status.
 6. A concise remediation hint when attention is needed.
+7. Where the loop's checked-in runbook lives (`automation-runbook-contract`), or `not scaffolded — run /lisa:setup-automations` when it is absent.
+8. How the last recorded run ended — its outcome, one-line summary, and timestamp — or `no recorded runs yet` when the loop has never recorded one.
+9. A bounded run history: the five most recent outcomes newest first, plus a count of how many older records exist when the file holds more.
 
-Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected.
+The last-run and history facts come from the durable run-outcome substrate recorded by each loop (the RBC-3 records under `.lisa/automations/runs/<loop-id>.jsonl`, read through `readAutomationRunRecords`). That directory is local scheduler state, not project knowledge — read it, never write it.
+
+Emit an overall grouped fleet verdict such as `HEALTHY`, `ATTENTION_NEEDED`, or `PARTIAL_SUPPORT`, plus the runtime surface inspected. **Repeated recovery is a fleet-health signal the scheduler cannot see**: when a loop's last three or more consecutive recorded runs are all `recovery-required`, report that loop `FAILING` — and therefore the overall verdict `ATTENTION_NEEDED` — even when its scheduler entry itself looks healthy, and point the remediation at the recorded run summaries.
 
 ## Operator usage
 
@@ -89,7 +94,7 @@ Status-specific remediation guidance:
 - `MISSING`: tell the operator which job is absent and recommend rerunning `/lisa:setup-automations` or recreating the missing job with the expected cadence and command.
 - `DRIFTED`: show the expected versus observed cadence/command mismatch and recommend aligning the scheduler entry with Lisa's current setup contract, usually by rerunning `/lisa:setup-automations`.
 - `STALE`: explain that the job exists but has not run recently enough for its cadence. Recommend inspecting the runtime's recent-run history or failure logs before changing queue state.
-- `FAILING`: surface the failure signal directly and recommend checking the latest runtime error plus the affected queue command (`/lisa:intake`, `/lisa:repair-intake`, or exploratory job) after the scheduler issue is resolved.
+- `FAILING`: surface the failure signal directly and recommend checking the latest runtime error plus the affected queue command (`/lisa:intake`, `/lisa:repair-intake`, or exploratory job) after the scheduler issue is resolved. A loop also reports `FAILING` when its last three or more consecutive recorded runs are all `recovery-required` — even with a healthy scheduler entry — in which case cite the recorded run summaries and point the operator at the loop's runbook.
 - `UNSUPPORTED`: explain why the job is intentionally absent and say that no remediation is required unless the project stack or runtime support changed.
 
 Render the report in grouped sections using the shared `scripts/automation-status-report.mjs` contract:
@@ -104,10 +109,13 @@ Generated at: <ISO timestamp>
 - <STATUS> <automation-id>: <summary>
   Expected: <cadence> -> <command>
   Observed: <what the runtime exposed>
+  Runbook: <.lisa/automations/<loop-id>.runbook.md, or "not scaffolded — run /lisa:setup-automations">
+  Last run: <outcome> — <summary> (<ts>), or "no recorded runs yet"
+  History: <outcome>, <outcome>, … (newest first); … and <N> older records
   Remediation: <next step when attention is needed>
 ```
 
-Keep observable runtime facts separate from remediation guidance so operators can distinguish drift, unsupported jobs, and actual failures quickly.
+The Runbook, Last run, and History lines are observable facts and sit between Observed and Remediation. Keep observable runtime facts separate from remediation guidance so operators can distinguish drift, unsupported jobs, and actual failures quickly.
 
 ## Rules
 

--- a/tests/unit/strategies/automation-run-history-helpers.ts
+++ b/tests/unit/strategies/automation-run-history-helpers.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared read-only fixtures for the automation-status run-history adapter tests.
+ *
+ * These seed the RBC-3 run-record substrate (`.lisa/automations/runs/<id>.jsonl`)
+ * and the checked-in per-loop runbook under a temporary project root so both
+ * runtime adapters can be exercised against real files.
+ * @module tests/unit/strategies/automation-run-history-helpers
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+
+/** One synthetic run-record's fields. */
+export type RunRecordInput = {
+  /** Short loop id, e.g. `intake-prd`. */
+  readonly loopId: string;
+  /** Recorded outcome, e.g. `recovery-required`. */
+  readonly outcome: string;
+  /** Ordinal that makes the synthetic timestamp deterministic (1-9). */
+  readonly n: number;
+  /** Optional operator-readable summary; defaulted when omitted. */
+  readonly summary?: string;
+};
+
+/**
+ * Write a checked-in runbook so the adapter reports its path, not "not scaffolded".
+ * @param projectRoot - Fixture project root.
+ * @param loopId - Short loop id, e.g. `intake-prd`.
+ * @returns Nothing.
+ */
+export async function scaffoldRunbook(
+  projectRoot: string,
+  loopId: string
+): Promise<void> {
+  const runbookDir = path.join(projectRoot, ".lisa", "automations");
+  await fs.mkdir(runbookDir, { recursive: true });
+  await fs.writeFile(
+    path.join(runbookDir, `${loopId}.runbook.md`),
+    `# ${loopId} runbook\n`
+  );
+}
+
+/**
+ * Write a per-loop JSONL run-record file where the RBC-3 substrate stores it.
+ * @param projectRoot - Fixture project root.
+ * @param loopId - Short loop id.
+ * @param lines - Raw JSONL lines (a corrupt line may be included on purpose).
+ * @returns Nothing.
+ */
+export async function writeRunRecordsFile(
+  projectRoot: string,
+  loopId: string,
+  lines: readonly string[]
+): Promise<void> {
+  const runsDir = path.join(projectRoot, ".lisa", "automations", "runs");
+  await fs.mkdir(runsDir, { recursive: true });
+  await fs.writeFile(
+    path.join(runsDir, `${loopId}.jsonl`),
+    `${lines.join("\n")}\n`
+  );
+}
+
+/**
+ * Build one valid JSONL run-record line; `n` orders the synthetic timestamps so
+ * append order (oldest first) is deterministic.
+ * @param input - The record fields.
+ * @returns The serialized JSONL line.
+ */
+export function runRecordLine(input: RunRecordInput): string {
+  const ts = `2026-05-26T10:0${input.n}:00.000Z`;
+  return JSON.stringify({
+    ts,
+    loop_id: input.loopId,
+    outcome: input.outcome,
+    summary: input.summary ?? `Run ${input.n} recorded ${input.outcome}.`,
+    runbook: `.lisa/automations/${input.loopId}.runbook.md`,
+    refs: [],
+    run_id: `${input.loopId}:${input.n}`,
+  });
+}

--- a/tests/unit/strategies/automation-status-claude-adapter.test.ts
+++ b/tests/unit/strategies/automation-status-claude-adapter.test.ts
@@ -39,14 +39,14 @@ const HOURLY_SCHEDULE = "hourly";
 const TEN_MINUTE_SCHEDULE = "every 10 minutes";
 
 describe("automation-status Claude adapter (#802)", () => {
-  it("maps structured Claude schedule metadata into shared health states", () => {
+  it("maps structured Claude schedule metadata into shared health states", async () => {
     const expectedFleet = resolveExpectedAutomationFleet({
       config: REPO_CONFIG,
       detectedTypes: DETECTED_TYPES,
       autoStartPrds: true,
     });
 
-    const report = inspectClaudeAutomationFleet({
+    const report = await inspectClaudeAutomationFleet({
       expectedFleet,
       scheduleListing: {
         routines: [
@@ -125,13 +125,13 @@ describe("automation-status Claude adapter (#802)", () => {
     );
   });
 
-  it("parses human-readable /schedule listings and marks unavailable run fields explicitly", () => {
+  it("parses human-readable /schedule listings and marks unavailable run fields explicitly", async () => {
     const expectedFleet = resolveExpectedAutomationFleet({
       config: REPO_CONFIG,
       detectedTypes: DETECTED_TYPES,
     });
 
-    const report = inspectClaudeAutomationFleet({
+    const report = await inspectClaudeAutomationFleet({
       expectedFleet,
       scheduleListing: `
 Name: ${REPAIR_AUTOMATION_ID}
@@ -161,14 +161,14 @@ Last result: No recent failures reported.
     );
   });
 
-  it("normalizes quoted /schedule cadences when text listings omit cadence fields", () => {
+  it("normalizes quoted /schedule cadences when text listings omit cadence fields", async () => {
     const expectedFleet = resolveExpectedAutomationFleet({
       config: REPO_CONFIG,
       detectedTypes: DETECTED_TYPES,
       autoStartPrds: true,
     });
 
-    const report = inspectClaudeAutomationFleet({
+    const report = await inspectClaudeAutomationFleet({
       expectedFleet,
       scheduleListing: `
 ID: lisa-auto-codyswanngt-lisa-exploratory-prds
@@ -198,13 +198,13 @@ Status: ACTIVE
     );
   });
 
-  it("does not classify negated error or exception summaries as failures (#885)", () => {
+  it("does not classify negated error or exception summaries as failures (#885)", async () => {
     const expectedFleet = resolveExpectedAutomationFleet({
       config: REPO_CONFIG,
       detectedTypes: DETECTED_TYPES,
     });
 
-    const report = inspectClaudeAutomationFleet({
+    const report = await inspectClaudeAutomationFleet({
       expectedFleet,
       scheduleListing: {
         routines: [
@@ -264,7 +264,7 @@ Status: ACTIVE
     ).toBe("/lisa:project-ideation prd_ready=true");
   });
 
-  it("inspects structured schedule metadata read-only", () => {
+  it("inspects structured schedule metadata read-only", async () => {
     const scheduleListing = Object.freeze({
       routines: Object.freeze([
         Object.freeze({
@@ -276,7 +276,7 @@ Status: ACTIVE
       ]),
     });
 
-    expect(() =>
+    await expect(
       inspectClaudeAutomationFleet({
         expectedFleet: resolveExpectedAutomationFleet({
           config: REPO_CONFIG,
@@ -285,7 +285,7 @@ Status: ACTIVE
         scheduleListing,
         now: FIXTURE_NOW,
       })
-    ).not.toThrow();
+    ).resolves.toBeDefined();
 
     expect(scheduleListing.routines[0].status).toBe("ACTIVE");
     expect(scheduleListing.routines).toHaveLength(1);

--- a/tests/unit/strategies/automation-status-opt-in-group.test.ts
+++ b/tests/unit/strategies/automation-status-opt-in-group.test.ts
@@ -73,8 +73,8 @@ const optInGroup = (report: AdapterReport): AdapterReport["groups"][number] => {
 };
 
 describe("opt-in fleet group is rendered, never dropped (#1796)", () => {
-  it("Claude: an opted-in, registered gardener is compared like any other loop", () => {
-    const report = inspectClaudeAutomationFleet({
+  it("Claude: an opted-in, registered gardener is compared like any other loop", async () => {
+    const report = await inspectClaudeAutomationFleet({
       expectedFleet: fleetFor(true),
       scheduleListing: {
         routines: [
@@ -101,8 +101,8 @@ describe("opt-in fleet group is rendered, never dropped (#1796)", () => {
     );
   });
 
-  it("Claude: an opted-in gardener missing from the scheduler reports MISSING", () => {
-    const report = inspectClaudeAutomationFleet({
+  it("Claude: an opted-in gardener missing from the scheduler reports MISSING", async () => {
+    const report = await inspectClaudeAutomationFleet({
       expectedFleet: fleetFor(true),
       scheduleListing: { routines: [] },
       now: NOW,
@@ -113,8 +113,8 @@ describe("opt-in fleet group is rendered, never dropped (#1796)", () => {
     );
   });
 
-  it("Claude: an un-opted-in gardener reports UNSUPPORTED with the enabling command", () => {
-    const report = inspectClaudeAutomationFleet({
+  it("Claude: an un-opted-in gardener reports UNSUPPORTED with the enabling command", async () => {
+    const report = await inspectClaudeAutomationFleet({
       expectedFleet: fleetFor(false),
       scheduleListing: { routines: [] },
       now: NOW,

--- a/tests/unit/strategies/automation-status-report-rendering.test.ts
+++ b/tests/unit/strategies/automation-status-report-rendering.test.ts
@@ -18,6 +18,11 @@ import {
 const EXPLORATORY_QA_UNSUPPORTED =
   "The current repo does not expose the exploratory-qa skill surface.";
 const EXPLORATORY_AUTOMATIONS_GROUP = "Exploratory automations";
+const CORE_GROUP_TITLE = "Core automations";
+const PRD_ITEM_ID = "intake-prd";
+const PRESENT_AND_CURRENT = "present and current";
+const OUTCOME_CHANGE_PROVED = "change-proved";
+const OUTCOME_NOTHING_NEEDED = "nothing-needed";
 
 describe("automation-status report rendering (#798)", () => {
   it("renders grouped fleet sections with expected contract and remediation lines", () => {
@@ -30,7 +35,7 @@ describe("automation-status report rendering (#798)", () => {
           title: "Core queue automations",
           items: [
             {
-              id: "intake-prd",
+              id: PRD_ITEM_ID,
               status: "HEALTHY",
               summary: "expected automation exists and matches the contract",
               expectedCadence: "every 60 minutes",
@@ -107,7 +112,7 @@ describe("automation-status report rendering (#798)", () => {
             {
               id: "intake-repair",
               status: "HEALTHY",
-              summary: "present and current",
+              summary: PRESENT_AND_CURRENT,
             },
           ],
         },
@@ -161,6 +166,113 @@ describe("automation-status report rendering (#798)", () => {
       STALE: 1,
       FAILING: 1,
     });
+  });
+
+  it("renders the runbook, last outcome, and bounded history between Observed and Remediation (#1799)", () => {
+    const report = renderAutomationStatusReport({
+      runtime: "Codex automations",
+      groups: [
+        {
+          id: "1",
+          title: CORE_GROUP_TITLE,
+          items: [
+            {
+              id: PRD_ITEM_ID,
+              status: "HEALTHY",
+              summary: "latest recorded run is within cadence",
+              observed: "Scheduler status: ACTIVE",
+              runbook: ".lisa/automations/intake-prd.runbook.md",
+              lastOutcome: {
+                ts: "2026-05-26T11:55:00Z",
+                outcome: OUTCOME_CHANGE_PROVED,
+                summary: "Shipped one build ticket.",
+              },
+              outcomeHistory: [
+                OUTCOME_CHANGE_PROVED,
+                "candidate-proposed",
+                OUTCOME_NOTHING_NEEDED,
+                OUTCOME_CHANGE_PROVED,
+                OUTCOME_NOTHING_NEEDED,
+              ],
+              olderRecordCount: 7,
+              remediation: "None needed.",
+            },
+          ],
+        },
+      ],
+    });
+
+    const lines = report.text.split("\n");
+    const observedIndex = lines.findIndex(line =>
+      line.includes("Observed: Scheduler status: ACTIVE")
+    );
+    const runbookIndex = lines.findIndex(line =>
+      line.includes("Runbook: .lisa/automations/intake-prd.runbook.md")
+    );
+    const remediationIndex = lines.findIndex(line =>
+      line.includes("Remediation: None needed.")
+    );
+
+    expect(observedIndex).toBeLessThan(runbookIndex);
+    expect(runbookIndex).toBeLessThan(remediationIndex);
+    expect(report.text).toContain(
+      "  Last run: change-proved — Shipped one build ticket. (2026-05-26T11:55:00Z)"
+    );
+    expect(report.text).toContain(
+      "  History: change-proved, candidate-proposed, nothing-needed, change-proved, nothing-needed (newest first); … and 7 older records"
+    );
+  });
+
+  it("states absent runbook and empty history explicitly, never blank (#1799)", () => {
+    const report = renderAutomationStatusReport({
+      groups: [
+        {
+          id: "1",
+          title: CORE_GROUP_TITLE,
+          items: [
+            {
+              id: PRD_ITEM_ID,
+              status: "HEALTHY",
+              summary: PRESENT_AND_CURRENT,
+              runbook: "not scaffolded — run /lisa:setup-automations",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(report.text).toContain(
+      "  Runbook: not scaffolded — run /lisa:setup-automations"
+    );
+    expect(report.text).toContain("  Last run: no recorded runs yet");
+    // With no outcomeHistory the History line is omitted rather than blank.
+    expect(report.text).not.toContain("  History:");
+  });
+
+  it("omits the older-records clause when history is not trimmed (#1799)", () => {
+    const report = renderAutomationStatusReport({
+      groups: [
+        {
+          id: "1",
+          title: CORE_GROUP_TITLE,
+          items: [
+            {
+              id: "monitor",
+              status: "HEALTHY",
+              summary: PRESENT_AND_CURRENT,
+              runbook: ".lisa/automations/monitor.runbook.md",
+              outcomeHistory: [OUTCOME_NOTHING_NEEDED, OUTCOME_NOTHING_NEEDED],
+              olderRecordCount: 0,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(report.text).toContain(
+      "  History: nothing-needed, nothing-needed (newest first)"
+    );
+    expect(report.text).not.toContain("older records");
   });
 
   it("renders empty groups as intentional unsupported buckets", () => {

--- a/tests/unit/strategies/automation-status-run-history.test.ts
+++ b/tests/unit/strategies/automation-status-run-history.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Regression coverage for the run-history overlay both automation-status
+ * adapters attach (#1799).
+ *
+ * Each registered loop's row now carries its checked-in runbook line, its last
+ * recorded run outcome, and a bounded newest-first history read from the RBC-3
+ * substrate. Three or more trailing `recovery-required` runs flip the loop to
+ * FAILING even when the scheduler entry looks healthy, and the whole surface
+ * stays strictly read-only.
+ * @module tests/unit/strategies/automation-status-run-history
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveExpectedAutomationFleet } from "../../../plugins/src/base/scripts/automation-status-expected-fleet.mjs";
+import { inspectClaudeAutomationFleet } from "../../../plugins/src/base/scripts/automation-status-claude-adapter.mjs";
+import { inspectCodexAutomationFleet } from "../../../plugins/src/base/scripts/automation-status-codex-adapter.mjs";
+import { computeAutomationFleetVerdict } from "../../../plugins/src/base/scripts/automation-status-report.mjs";
+import {
+  runRecordLine,
+  scaffoldRunbook,
+  writeRunRecordsFile,
+} from "./automation-run-history-helpers.js";
+
+const REPO_CONFIG = {
+  tracker: "github",
+  github: { org: "CodySwannGT", repo: "lisa" },
+};
+const DETECTED_TYPES = ["typescript"];
+const NOW = "2026-05-26T12:00:00Z";
+const PRD_LOOP = "intake-prd";
+const TICKETS_LOOP = "intake-tickets";
+const PRD_ID = "lisa-auto-codyswanngt-lisa-intake-prd";
+const TICKETS_ID = "lisa-auto-codyswanngt-lisa-intake-tickets";
+const PRD_RUNBOOK = ".lisa/automations/intake-prd.runbook.md";
+const NOT_SCAFFOLDED = "not scaffolded — run /lisa:setup-automations";
+const NOTHING = "nothing-needed";
+const CANDIDATE = "candidate-proposed";
+const CHANGE = "change-proved";
+const APPROVAL = "approval-requested";
+const RECOVERY = "recovery-required";
+const POLICY = "policy-obsolete";
+const CRASH_SUMMARY = "Build agent crashed on startup.";
+const RUNS_DIR_PARTS = [".lisa", "automations", "runs"] as const;
+
+/** The slice of an adapter report these assertions read. */
+type ReportItem = {
+  readonly id: string;
+  readonly status:
+    | "HEALTHY"
+    | "MISSING"
+    | "UNSUPPORTED"
+    | "DRIFTED"
+    | "STALE"
+    | "FAILING";
+  readonly summary: string;
+  readonly runbook?: string;
+  readonly lastOutcome?: {
+    readonly ts: string;
+    readonly outcome: string;
+    readonly summary: string;
+  };
+  readonly outcomeHistory?: readonly string[];
+  readonly olderRecordCount?: number;
+  readonly remediation?: string;
+};
+/** The slice of an adapter report carrying grouped items. */
+type Report = {
+  readonly groups: readonly {
+    readonly id: string;
+    readonly title: string;
+    readonly items: readonly ReportItem[];
+  }[];
+};
+
+/**
+ * Flatten every rendered item across a report's groups.
+ * @param report - An adapter report.
+ * @returns Every item, group order preserved.
+ */
+const allItems = (report: Report): readonly ReportItem[] =>
+  report.groups.flatMap(group => group.items);
+
+/**
+ * Seed one loop with seven valid records plus a corrupt line, and another with a
+ * clean run followed by three trailing recovery-required runs.
+ * @param projectRoot - Fixture project root.
+ * @returns Nothing.
+ */
+const seedRunRecords = async (projectRoot: string): Promise<void> => {
+  await scaffoldRunbook(projectRoot, PRD_LOOP);
+  await writeRunRecordsFile(projectRoot, PRD_LOOP, [
+    runRecordLine({ loopId: PRD_LOOP, outcome: NOTHING, n: 1 }),
+    runRecordLine({ loopId: PRD_LOOP, outcome: NOTHING, n: 2 }),
+    runRecordLine({ loopId: PRD_LOOP, outcome: CANDIDATE, n: 3 }),
+    runRecordLine({ loopId: PRD_LOOP, outcome: CHANGE, n: 4 }),
+    "{ corrupt json line",
+    runRecordLine({ loopId: PRD_LOOP, outcome: POLICY, n: 5 }),
+    runRecordLine({ loopId: PRD_LOOP, outcome: APPROVAL, n: 6 }),
+    runRecordLine({ loopId: PRD_LOOP, outcome: CHANGE, n: 7 }),
+  ]);
+  await writeRunRecordsFile(projectRoot, TICKETS_LOOP, [
+    runRecordLine({ loopId: TICKETS_LOOP, outcome: CHANGE, n: 1 }),
+    runRecordLine({
+      loopId: TICKETS_LOOP,
+      outcome: RECOVERY,
+      n: 2,
+      summary: "GitHub auth expired mid-run.",
+    }),
+    runRecordLine({
+      loopId: TICKETS_LOOP,
+      outcome: RECOVERY,
+      n: 3,
+      summary: "Queue lock could not be acquired.",
+    }),
+    runRecordLine({
+      loopId: TICKETS_LOOP,
+      outcome: RECOVERY,
+      n: 4,
+      summary: CRASH_SUMMARY,
+    }),
+  ]);
+};
+
+/**
+ * Assert the shared overlay/escalation expectations against a resolved report.
+ * @param report - The adapter report to inspect.
+ */
+const expectOverlayAndEscalation = (report: Report): void => {
+  const prd = allItems(report).find(item => item.id === PRD_ID);
+  const tickets = allItems(report).find(item => item.id === TICKETS_ID);
+
+  // Bounded history: newest five outcomes, two older stated, corrupt line skipped.
+  expect(prd?.runbook).toBe(PRD_RUNBOOK);
+  expect(prd?.outcomeHistory).toEqual([
+    CHANGE,
+    APPROVAL,
+    POLICY,
+    CHANGE,
+    CANDIDATE,
+  ]);
+  expect(prd?.olderRecordCount).toBe(2);
+  expect(prd?.lastOutcome).toEqual(
+    expect.objectContaining({ outcome: CHANGE })
+  );
+
+  // Three trailing recoveries flip the loop and the fleet verdict, citing summaries.
+  expect(tickets?.runbook).toBe(NOT_SCAFFOLDED);
+  expect(tickets?.status).toBe("FAILING");
+  expect(tickets?.summary).toContain("required recovery");
+  expect(tickets?.remediation).toContain(CRASH_SUMMARY);
+  expect(computeAutomationFleetVerdict(report.groups)).toBe("ATTENTION_NEEDED");
+};
+
+describe("automation-status run-history overlay (#1799)", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map(dir => fs.rm(dir, { recursive: true, force: true }))
+    );
+    tempDirs.length = 0;
+  });
+
+  /**
+   * Create a fresh temp project root registered for cleanup.
+   * @returns The project root path.
+   */
+  const makeProjectRoot = async (): Promise<string> => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "lisa-run-history-"));
+    tempDirs.push(dir);
+    return dir;
+  };
+
+  it("Codex: overlays runbook, bounded history, and recovery escalation", async () => {
+    const projectRoot = await makeProjectRoot();
+    const automationsDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "lisa-run-history-codex-")
+    );
+    tempDirs.push(automationsDir);
+    await seedRunRecords(projectRoot);
+
+    const report = await inspectCodexAutomationFleet({
+      expectedFleet: resolveExpectedAutomationFleet({
+        config: REPO_CONFIG,
+        detectedTypes: DETECTED_TYPES,
+        autoStartPrds: true,
+      }),
+      automationsDir,
+      projectRoot,
+      now: NOW,
+    });
+
+    expectOverlayAndEscalation(report);
+  });
+
+  it("Claude: overlays runbook, bounded history, and recovery escalation over a healthy schedule", async () => {
+    const projectRoot = await makeProjectRoot();
+    await seedRunRecords(projectRoot);
+
+    const report = await inspectClaudeAutomationFleet({
+      expectedFleet: resolveExpectedAutomationFleet({
+        config: REPO_CONFIG,
+        detectedTypes: DETECTED_TYPES,
+        autoStartPrds: true,
+      }),
+      // The tickets entry looks healthy on the scheduler; the run records win.
+      scheduleListing: {
+        routines: [
+          {
+            name: TICKETS_ID,
+            cadence: "every 10 minutes",
+            command:
+              '/schedule "every 10 minutes" /lisa:intake CodySwannGT/lisa intake_mode=build',
+            status: "ACTIVE",
+            lastRunAt: "2026-05-26T11:55:00Z",
+            lastResult: "Completed successfully.",
+          },
+        ],
+      },
+      projectRoot,
+      now: NOW,
+    });
+
+    expectOverlayAndEscalation(report);
+  });
+
+  it("Codex: states absent records and never creates the runs directory (read-only)", async () => {
+    const projectRoot = await makeProjectRoot();
+    const automationsDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "lisa-run-history-empty-")
+    );
+    tempDirs.push(automationsDir);
+
+    const report = await inspectCodexAutomationFleet({
+      expectedFleet: resolveExpectedAutomationFleet({
+        config: REPO_CONFIG,
+        detectedTypes: DETECTED_TYPES,
+      }),
+      automationsDir,
+      projectRoot,
+      now: NOW,
+    });
+
+    const runsDirExists = await fs
+      .stat(path.join(projectRoot, ...RUNS_DIR_PARTS))
+      .then(() => true)
+      .catch(() => false);
+    expect(runsDirExists).toBe(false);
+
+    const prd = allItems(report).find(item => item.id === PRD_ID);
+    expect(prd?.lastOutcome).toBeUndefined();
+    expect(prd?.outcomeHistory).toEqual([]);
+    expect(prd?.runbook).toBe(NOT_SCAFFOLDED);
+  });
+
+  it("Claude: states absent records and never creates the runs directory (read-only)", async () => {
+    const projectRoot = await makeProjectRoot();
+
+    const report = await inspectClaudeAutomationFleet({
+      expectedFleet: resolveExpectedAutomationFleet({
+        config: REPO_CONFIG,
+        detectedTypes: DETECTED_TYPES,
+      }),
+      scheduleListing: { routines: [] },
+      projectRoot,
+      now: NOW,
+    });
+
+    const runsDirExists = await fs
+      .stat(path.join(projectRoot, ...RUNS_DIR_PARTS))
+      .then(() => true)
+      .catch(() => false);
+    expect(runsDirExists).toBe(false);
+
+    const prd = allItems(report).find(item => item.id === PRD_ID);
+    expect(prd?.lastOutcome).toBeUndefined();
+    expect(prd?.runbook).toBe(NOT_SCAFFOLDED);
+  });
+});

--- a/tests/unit/strategies/automation-status-run-history.test.ts
+++ b/tests/unit/strategies/automation-status-run-history.test.ts
@@ -20,6 +20,10 @@ import { inspectClaudeAutomationFleet } from "../../../plugins/src/base/scripts/
 import { inspectCodexAutomationFleet } from "../../../plugins/src/base/scripts/automation-status-codex-adapter.mjs";
 import { computeAutomationFleetVerdict } from "../../../plugins/src/base/scripts/automation-status-report.mjs";
 import {
+  resolveAutomationRunDisplay,
+  resolveRecoveryEscalation,
+} from "../../../plugins/src/base/scripts/automation-status-run-history.mjs";
+import {
   runRecordLine,
   scaffoldRunbook,
   writeRunRecordsFile,
@@ -147,11 +151,19 @@ const expectOverlayAndEscalation = (report: Report): void => {
     expect.objectContaining({ outcome: CHANGE })
   );
 
-  // Three trailing recoveries flip the loop and the fleet verdict, citing summaries.
+  // Three trailing recoveries flip the loop and the fleet verdict; the citations
+  // are numbered (newest first) so summaries carrying their own punctuation stay
+  // legible.
   expect(tickets?.runbook).toBe(NOT_SCAFFOLDED);
   expect(tickets?.status).toBe("FAILING");
   expect(tickets?.summary).toContain("required recovery");
-  expect(tickets?.remediation).toContain(CRASH_SUMMARY);
+  expect(tickets?.remediation).toContain(
+    `Repeated recovery-required runs — (1) ${CRASH_SUMMARY}`
+  );
+  expect(tickets?.remediation).toContain(
+    "(2) Queue lock could not be acquired."
+  );
+  expect(tickets?.remediation).toContain("(3) GitHub auth expired mid-run.");
   expect(computeAutomationFleetVerdict(report.groups)).toBe("ATTENTION_NEEDED");
 };
 
@@ -279,5 +291,54 @@ describe("automation-status run-history overlay (#1799)", () => {
     const prd = allItems(report).find(item => item.id === PRD_ID);
     expect(prd?.lastOutcome).toBeUndefined();
     expect(prd?.runbook).toBe(NOT_SCAFFOLDED);
+  });
+
+  it("does not escalate a recovery burst that is not all trailing (#1799)", async () => {
+    const projectRoot = await makeProjectRoot();
+    // Write order (oldest → newest): three recovery-required runs, but a later
+    // NOTHING run breaks the streak, so only one recovery is trailing.
+    await writeRunRecordsFile(projectRoot, TICKETS_LOOP, [
+      runRecordLine({ loopId: TICKETS_LOOP, outcome: RECOVERY, n: 1 }),
+      runRecordLine({ loopId: TICKETS_LOOP, outcome: RECOVERY, n: 2 }),
+      runRecordLine({ loopId: TICKETS_LOOP, outcome: NOTHING, n: 3 }),
+      runRecordLine({ loopId: TICKETS_LOOP, outcome: RECOVERY, n: 4 }),
+    ]);
+
+    // Only the trailing streak counts, so there is no escalation to drive FAILING.
+    const display = await resolveAutomationRunDisplay({
+      projectRoot,
+      loopId: TICKETS_LOOP,
+    });
+    expect(display.recoveryRequiredStreak).toBe(1);
+    expect(resolveRecoveryEscalation(display)).toBeNull();
+
+    const report = await inspectClaudeAutomationFleet({
+      expectedFleet: resolveExpectedAutomationFleet({
+        config: REPO_CONFIG,
+        detectedTypes: DETECTED_TYPES,
+        autoStartPrds: true,
+      }),
+      scheduleListing: {
+        routines: [
+          {
+            name: TICKETS_ID,
+            cadence: "every 10 minutes",
+            command:
+              '/schedule "every 10 minutes" /lisa:intake CodySwannGT/lisa intake_mode=build',
+            status: "ACTIVE",
+            lastRunAt: "2026-05-26T11:55:00Z",
+            lastResult: "Completed successfully.",
+          },
+        ],
+      },
+      projectRoot,
+      now: NOW,
+    });
+
+    // Healthy scheduler entry + non-trailing recoveries ⇒ the loop stays HEALTHY;
+    // the fleet verdict is not driven to ATTENTION_NEEDED by this loop.
+    const tickets = allItems(report).find(item => item.id === TICKETS_ID);
+    expect(tickets?.status).toBe("HEALTHY");
+    expect(tickets?.lastOutcome?.outcome).toBe(RECOVERY);
   });
 });


### PR DESCRIPTION
## Summary

Makes `/lisa:automation-status` the single screen that tells a quiet fleet apart from a broken one. Each registered loop's row now shows, as observable facts between Observed and Remediation:

- **Runbook** — the checked-in `.lisa/automations/<id>.runbook.md`, or `not scaffolded — run /lisa:setup-automations` when absent.
- **Last run** — the last recorded outcome, one-line summary, and timestamp, or `no recorded runs yet`.
- **History** — the five most recent outcomes newest-first, plus `… and N older records` when the file holds more.

A loop whose **last three or more consecutive** recorded runs are all `recovery-required` is reported `FAILING` (driving the fleet verdict to `ATTENTION_NEEDED`) **even when its scheduler entry looks healthy** — the fleet-health signal today's surface cannot see — with remediation citing the recorded summaries. The whole surface stays strictly read-only: it reads the RBC-3 run-record substrate and stats the runbook, and never creates the runs directory, a runbook, or a record.

Closes #1799

## Review story

Three verification lanes ran and all passed:

- **Product (PASS)** — walked the real rendered output as an operator: for each loop the runbook location, a plain-English last outcome, and the recent pattern are legible; deleting a loop's records file renders `no recorded runs yet` rather than going blank or implying health; three consecutive `recovery-required` runs flip the verdict to `ATTENTION_NEEDED` with the summaries cited.
- **Quality (PASS)** — recovery citations are now numbered (`(1) … (2) … (3) …`) so summaries carrying their own `;`/`.` stay legible, and a negative trailing-streak test pins "escalate only on trailing runs".
- **Spec conformance (CONFORMS)** — every acceptance criterion is covered; read-only is proven by tests asserting the runs directory is never created when absent (both adapters).

## Gate results

- `tsc --noEmit`: exit 0
- `tests/unit/strategies/`: 139 files, 3340 tests passed
- `bun run check:plugins` (post-commit): exit 0 — artifacts in sync, marketplace registers every built plugin
- Byte-parity (#803 family): green

## Deferred (not in this PR)

Humanized timestamps, an outcome-token glossary, and a HEALTHY-beside-not-scaffolded signal — operator-polish candidates for a later ticket if wanted.

🤖 Generated with Claude Code
