### PR TITLE
fix(automations): restore the RBC-3 run-history substrate as a valid retirement-condition source (#1819)

### DIFF
--- a/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
@@ -198,11 +198,16 @@ One line each; expand them into the operator's voice, keep the meaning.
 **Retirement condition is mandatory and non-empty.** Every seeded runbook states one, and a loop
 that is structurally permanent says exactly that instead of leaving the section blank — an operator
 reading it aloud must be able to say when this loop should stop existing, or that it never should.
-A valid condition is **stateless**: derived from the tracker, and **never an ad-hoc counter**, a new
-state file, or bounded run-history record. The mechanism itself — the two-part test, the single
-marker-deduped teardown proposal, and the
-three operator responses — is defined once in the `automation-runbook-contract` rule; these seeds
-only fill in each loop's specifics. A seed may add a **domain conjunct** on top of the contract's
+A valid condition is **stateless**: derived from the tracker, or from the loop's own bounded run
+history at `.lisa/automations/runs/<loop-id>.jsonl` — written by the contract's own recorder, not
+private per-loop state — and **never an ad-hoc counter** or a new state file. Those two sources are
+the same discipline, not a loosening of the contract's "never from a counter or a state file": the
+run history is written and bounded by `automation-run-record.mjs`, is readable by any run on any
+machine, and is never invented per loop. What the contract forbids is a loop minting private state
+to remember itself by. Prefer the tracker; reach for the run history only when the tracker cannot
+answer the question. The mechanism itself — the two-part test, the single marker-deduped teardown
+proposal, and the three operator responses — is defined once in the `automation-runbook-contract`
+rule; these seeds only fill in each loop's specifics. A seed may add a **domain conjunct** on top of the contract's
 two-part test — an extra AND that must also hold — because an additional conjunct is strictly
 tighter and never divergent. It may never drop or weaken either of the contract's two conditions.
 Silence alone means obsolescence only for the gardener; for a monitoring or exploratory loop a quiet

--- a/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
@@ -198,11 +198,16 @@ One line each; expand them into the operator's voice, keep the meaning.
 **Retirement condition is mandatory and non-empty.** Every seeded runbook states one, and a loop
 that is structurally permanent says exactly that instead of leaving the section blank — an operator
 reading it aloud must be able to say when this loop should stop existing, or that it never should.
-A valid condition is **stateless**: derived from the tracker, and **never an ad-hoc counter**, a new
-state file, or bounded run-history record. The mechanism itself — the two-part test, the single
-marker-deduped teardown proposal, and the
-three operator responses — is defined once in the `automation-runbook-contract` rule; these seeds
-only fill in each loop's specifics. A seed may add a **domain conjunct** on top of the contract's
+A valid condition is **stateless**: derived from the tracker, or from the loop's own bounded run
+history at `.lisa/automations/runs/<loop-id>.jsonl` — written by the contract's own recorder, not
+private per-loop state — and **never an ad-hoc counter** or a new state file. Those two sources are
+the same discipline, not a loosening of the contract's "never from a counter or a state file": the
+run history is written and bounded by `automation-run-record.mjs`, is readable by any run on any
+machine, and is never invented per loop. What the contract forbids is a loop minting private state
+to remember itself by. Prefer the tracker; reach for the run history only when the tracker cannot
+answer the question. The mechanism itself — the two-part test, the single marker-deduped teardown
+proposal, and the three operator responses — is defined once in the `automation-runbook-contract`
+rule; these seeds only fill in each loop's specifics. A seed may add a **domain conjunct** on top of the contract's
 two-part test — an extra AND that must also hold — because an additional conjunct is strictly
 tighter and never divergent. It may never drop or weaken either of the contract's two conditions.
 Silence alone means obsolescence only for the gardener; for a monitoring or exploratory loop a quiet

--- a/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
@@ -198,11 +198,16 @@ One line each; expand them into the operator's voice, keep the meaning.
 **Retirement condition is mandatory and non-empty.** Every seeded runbook states one, and a loop
 that is structurally permanent says exactly that instead of leaving the section blank — an operator
 reading it aloud must be able to say when this loop should stop existing, or that it never should.
-A valid condition is **stateless**: derived from the tracker, and **never an ad-hoc counter**, a new
-state file, or bounded run-history record. The mechanism itself — the two-part test, the single
-marker-deduped teardown proposal, and the
-three operator responses — is defined once in the `automation-runbook-contract` rule; these seeds
-only fill in each loop's specifics. A seed may add a **domain conjunct** on top of the contract's
+A valid condition is **stateless**: derived from the tracker, or from the loop's own bounded run
+history at `.lisa/automations/runs/<loop-id>.jsonl` — written by the contract's own recorder, not
+private per-loop state — and **never an ad-hoc counter** or a new state file. Those two sources are
+the same discipline, not a loosening of the contract's "never from a counter or a state file": the
+run history is written and bounded by `automation-run-record.mjs`, is readable by any run on any
+machine, and is never invented per loop. What the contract forbids is a loop minting private state
+to remember itself by. Prefer the tracker; reach for the run history only when the tracker cannot
+answer the question. The mechanism itself — the two-part test, the single marker-deduped teardown
+proposal, and the three operator responses — is defined once in the `automation-runbook-contract`
+rule; these seeds only fill in each loop's specifics. A seed may add a **domain conjunct** on top of the contract's
 two-part test — an extra AND that must also hold — because an additional conjunct is strictly
 tighter and never divergent. It may never drop or weaken either of the contract's two conditions.
 Silence alone means obsolescence only for the gardener; for a monitoring or exploratory loop a quiet

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
@@ -198,11 +198,16 @@ One line each; expand them into the operator's voice, keep the meaning.
 **Retirement condition is mandatory and non-empty.** Every seeded runbook states one, and a loop
 that is structurally permanent says exactly that instead of leaving the section blank — an operator
 reading it aloud must be able to say when this loop should stop existing, or that it never should.
-A valid condition is **stateless**: derived from the tracker, and **never an ad-hoc counter**, a new
-state file, or bounded run-history record. The mechanism itself — the two-part test, the single
-marker-deduped teardown proposal, and the
-three operator responses — is defined once in the `automation-runbook-contract` rule; these seeds
-only fill in each loop's specifics. A seed may add a **domain conjunct** on top of the contract's
+A valid condition is **stateless**: derived from the tracker, or from the loop's own bounded run
+history at `.lisa/automations/runs/<loop-id>.jsonl` — written by the contract's own recorder, not
+private per-loop state — and **never an ad-hoc counter** or a new state file. Those two sources are
+the same discipline, not a loosening of the contract's "never from a counter or a state file": the
+run history is written and bounded by `automation-run-record.mjs`, is readable by any run on any
+machine, and is never invented per loop. What the contract forbids is a loop minting private state
+to remember itself by. Prefer the tracker; reach for the run history only when the tracker cannot
+answer the question. The mechanism itself — the two-part test, the single marker-deduped teardown
+proposal, and the three operator responses — is defined once in the `automation-runbook-contract`
+rule; these seeds only fill in each loop's specifics. A seed may add a **domain conjunct** on top of the contract's
 two-part test — an extra AND that must also hold — because an additional conjunct is strictly
 tighter and never divergent. It may never drop or weaken either of the contract's two conditions.
 Silence alone means obsolescence only for the gardener; for a monitoring or exploratory loop a quiet

--- a/plugins/lisa/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-automations/SKILL.md
@@ -198,11 +198,16 @@ One line each; expand them into the operator's voice, keep the meaning.
 **Retirement condition is mandatory and non-empty.** Every seeded runbook states one, and a loop
 that is structurally permanent says exactly that instead of leaving the section blank — an operator
 reading it aloud must be able to say when this loop should stop existing, or that it never should.
-A valid condition is **stateless**: derived from the tracker, and **never an ad-hoc counter**, a new
-state file, or bounded run-history record. The mechanism itself — the two-part test, the single
-marker-deduped teardown proposal, and the
-three operator responses — is defined once in the `automation-runbook-contract` rule; these seeds
-only fill in each loop's specifics. A seed may add a **domain conjunct** on top of the contract's
+A valid condition is **stateless**: derived from the tracker, or from the loop's own bounded run
+history at `.lisa/automations/runs/<loop-id>.jsonl` — written by the contract's own recorder, not
+private per-loop state — and **never an ad-hoc counter** or a new state file. Those two sources are
+the same discipline, not a loosening of the contract's "never from a counter or a state file": the
+run history is written and bounded by `automation-run-record.mjs`, is readable by any run on any
+machine, and is never invented per loop. What the contract forbids is a loop minting private state
+to remember itself by. Prefer the tracker; reach for the run history only when the tracker cannot
+answer the question. The mechanism itself — the two-part test, the single marker-deduped teardown
+proposal, and the three operator responses — is defined once in the `automation-runbook-contract`
+rule; these seeds only fill in each loop's specifics. A seed may add a **domain conjunct** on top of the contract's
 two-part test — an extra AND that must also hold — because an additional conjunct is strictly
 tighter and never divergent. It may never drop or weaken either of the contract's two conditions.
 Silence alone means obsolescence only for the gardener; for a monitoring or exploratory loop a quiet

--- a/plugins/src/base/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-automations/SKILL.md
@@ -198,11 +198,16 @@ One line each; expand them into the operator's voice, keep the meaning.
 **Retirement condition is mandatory and non-empty.** Every seeded runbook states one, and a loop
 that is structurally permanent says exactly that instead of leaving the section blank — an operator
 reading it aloud must be able to say when this loop should stop existing, or that it never should.
-A valid condition is **stateless**: derived from the tracker, and **never an ad-hoc counter**, a new
-state file, or bounded run-history record. The mechanism itself — the two-part test, the single
-marker-deduped teardown proposal, and the
-three operator responses — is defined once in the `automation-runbook-contract` rule; these seeds
-only fill in each loop's specifics. A seed may add a **domain conjunct** on top of the contract's
+A valid condition is **stateless**: derived from the tracker, or from the loop's own bounded run
+history at `.lisa/automations/runs/<loop-id>.jsonl` — written by the contract's own recorder, not
+private per-loop state — and **never an ad-hoc counter** or a new state file. Those two sources are
+the same discipline, not a loosening of the contract's "never from a counter or a state file": the
+run history is written and bounded by `automation-run-record.mjs`, is readable by any run on any
+machine, and is never invented per loop. What the contract forbids is a loop minting private state
+to remember itself by. Prefer the tracker; reach for the run history only when the tracker cannot
+answer the question. The mechanism itself — the two-part test, the single marker-deduped teardown
+proposal, and the three operator responses — is defined once in the `automation-runbook-contract`
+rule; these seeds only fill in each loop's specifics. A seed may add a **domain conjunct** on top of the contract's
 two-part test — an extra AND that must also hold — because an additional conjunct is strictly
 tighter and never divergent. It may never drop or weaken either of the contract's two conditions.
 Silence alone means obsolescence only for the gardener; for a monitoring or exploratory loop a quiet

--- a/tests/unit/strategies/automations-retirement.test.ts
+++ b/tests/unit/strategies/automations-retirement.test.ts
@@ -120,9 +120,13 @@ describe("the runbook seed states a retirement condition per loop (#1801)", () =
       expect(content).toMatch(/never an ad-hoc counter/i);
       expect(content).toMatch(/stateless/i);
       expect(content).toMatch(/derived from the tracker/i);
-      expect(content).toMatch(/never an ad-hoc counter/i);
-      expect(content).toMatch(/bounded run-history record/i);
-      expect(content).not.toContain(".lisa/automations/runs/<loop-id>.jsonl");
+      // Both valid substrates, per the ticket: the tracker OR RBC-3's bounded
+      // run history. The run record is the contract's own recorder-written
+      // substrate, so it is not the "counter or state file" the contract bans.
+      expect(content).toContain(".lisa/automations/runs/<loop-id>.jsonl");
+      expect(content).toMatch(/same discipline, not a loosening/);
+      expect(content).toContain("automation-run-record.mjs");
+      expect(content).toMatch(/Prefer the tracker/);
       expect(content).toContain(CONTRACT);
     });
 


### PR DESCRIPTION
## Summary

RBC-7 (#1801) required every runbook's Retirement condition to be **stateless**, and named two valid sources: the tracker, **or** the loop's own bounded run history at `.lisa/automations/runs/<loop-id>.jsonl` (the RBC-3 substrate). During review of #1818, CodeRabbit correctly flagged an apparent tension with the frozen `automation-runbook-contract`, which says a condition is "derived from the tracker, **never** from a counter or a state file". That tension was resolved on `main` by **deleting the run-history option** — the seed became "derived from the tracker, and never an ad-hoc counter, a new state file, or bounded run-history record", and the test was inverted to assert the path's absence. The contradiction was closed by dropping a ticket requirement rather than by reconciling it, and the inverted assertion then pinned the regression in place where nothing but a human reading the spec would catch it. This PR restores the substrate and reconciles it explicitly: the run history is written and bounded by the contract's **own** recorder (`automation-run-record.mjs`), is readable by any run on any host, and is never invented per loop — so it is not the private per-loop state the contract bans, which is a loop minting bespoke state to remember itself by. The tracker stays preferred; the run history is the fallback for questions the tracker cannot answer.

The frozen normative paragraphs of `automation-runbook-contract` are **not** touched.

Closes #1819
Follow-up to #1801, shipped in #1818.

## Changes

- `plugins/src/base/skills/lisa-setup-automations/SKILL.md` — restores the run-history source alongside the tracker and adds the reconciliation (same discipline, not a loosening; names the recorder; tracker preferred).
- `tests/unit/strategies/automations-retirement.test.ts` — flips the assertion back to positive and additionally pins the reconciliation wording, so the substrate cannot be silently dropped again.
- Regenerated artifacts for all five plugin roots.

## Gate results

| Gate | Result |
|---|---|
| `bunx vitest run tests/unit/strategies/` | **141 files / 3,515 tests passed** |
| `bun run typecheck` | exit 0 |
| `bun run check:plugins` | exit 0 |
| `scripts/check-rules-pairing.sh` | exit 0 |

## Note on the commit subject

The commit subject references `#1819` rather than `#1801` because `#1801` auto-closed when #1818 merged, and the work-item hook requires an open, claimed item. `#1819` was opened for this regression and carries the full spec; `#1801` and `#1818` are referenced in the body for traceability.

🤖 Generated with Claude Code
