### PR TITLE
fix(expo): isolate local eslint config typing

### DIFF
--- a/expo/copy-overwrite/eslint.config.ts
+++ b/expo/copy-overwrite/eslint.config.ts
@@ -47,21 +47,22 @@ const localIgnores: string[] = existsSync(
   ? (require("./eslint.ignore.config.local.json").ignores ?? [])
   : [];
 
-// Annotate with the factory's return type so `tsc --noEmit` under
-// `declaration: true` does not surface @eslint/core's `RulesConfig` in the
-// emitted declaration (TS2883). Do NOT import `Linter` from "eslint" directly —
-// that trips knip's unlisted-dependency check.
-const config: ReturnType<typeof getExpoConfig> = [
-  ...getExpoConfig({
-    tsconfigRootDir: __dirname,
-    ignorePatterns: [
-      ...(ignoreConfig.ignores || defaultIgnores),
-      ...localIgnores,
-    ],
-    thresholds: { ...defaultThresholds, ...thresholdsConfig },
-    sourceRoot,
-  }),
-  ...localConfig,
-];
+// Type only the managed factory result, then trust project-owned additions at
+// their spread boundary. The double assertion is intentional: one custom-plugin
+// entry can be structurally different enough for a direct cast to raise TS2352.
+// Annotating an assembled array force-conforms the host's local config. Do not
+// import `Linter` from "eslint" directly either; that trips knip's
+// unlisted-dependency check.
+const config: ReturnType<typeof getExpoConfig> = getExpoConfig({
+  tsconfigRootDir: __dirname,
+  ignorePatterns: [
+    ...(ignoreConfig.ignores || defaultIgnores),
+    ...localIgnores,
+  ],
+  thresholds: { ...defaultThresholds, ...thresholdsConfig },
+  sourceRoot,
+});
+
+config.push(...(localConfig as unknown as ReturnType<typeof getExpoConfig>));
 
 export default config;

--- a/tests/unit/config/eslint-ignore-wiki.test.ts
+++ b/tests/unit/config/eslint-ignore-wiki.test.ts
@@ -82,22 +82,23 @@ describe(".lisa.config.json ESLint ignore", () => {
 });
 
 /**
- * The managed eslint.config.ts / eslint.slow.config.ts wrappers must (a) annotate
- * their default export with the factory's ReturnType so `tsc --noEmit` under
- * `declaration: true` does not surface @eslint/core's `RulesConfig` (TS2883), and
- * (b) merge an optional, project-owned eslint.ignore.config.local.json so the
- * copy-overwrite of eslint.ignore.config.json stops wiping host ignore
- * customizations. Neither may import `Linter` from "eslint" directly (knip
- * unlisted-dependency). Kept in lock-step across every stack copy + Lisa's own root.
+ * The managed eslint.config.ts / eslint.slow.config.ts wrappers must (a) retain
+ * the factory's ReturnType so `tsc --noEmit` under `declaration: true` does not
+ * surface @eslint/core's `RulesConfig` (TS2883), and (b) merge an optional,
+ * project-owned eslint.ignore.config.local.json so the copy-overwrite of
+ * eslint.ignore.config.json stops wiping host ignore customizations. Neither may
+ * import `Linter` from "eslint" directly (knip unlisted-dependency). Kept in
+ * lock-step across every stack copy + Lisa's own root.
  */
 describe("managed eslint config wrappers", () => {
   const readText = (relativePath: string): string =>
     fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8");
+  const EXPO_CONFIG = "expo/copy-overwrite/eslint.config.ts";
 
   const CONFIGS = [
     ["eslint.config.ts", "getTypescriptConfig"],
     ["typescript/copy-overwrite/eslint.config.ts", "getTypescriptConfig"],
-    ["expo/copy-overwrite/eslint.config.ts", "getExpoConfig"],
+    [EXPO_CONFIG, "getExpoConfig"],
     ["nestjs/copy-overwrite/eslint.config.ts", "getNestjsConfig"],
     ["cdk/copy-overwrite/eslint.config.ts", "getCdkConfig"],
     ["harper-fabric/copy-overwrite/eslint.config.ts", "getHarperFabricConfig"],
@@ -112,7 +113,12 @@ describe("managed eslint config wrappers", () => {
     "cdk/copy-overwrite/eslint.slow.config.ts",
   ] as const;
 
-  it.each(CONFIGS.map(c => [c[0], c[1]]))(
+  it.each(
+    CONFIGS.filter(([relPath]) => relPath !== EXPO_CONFIG).map(c => [
+      c[0],
+      c[1],
+    ])
+  )(
     "%s annotates the default export with ReturnType<typeof %s> and never imports Linter",
     (relPath, factory) => {
       const src = readText(relPath);
@@ -150,4 +156,15 @@ describe("managed eslint config wrappers", () => {
       expect(importsEslint).toBe(false);
     }
   );
+
+  it("trusts Expo host config only at the localConfig spread boundary", () => {
+    const src = readText(EXPO_CONFIG);
+
+    expect(src).not.toMatch(
+      /const\s+config\s*:\s*ReturnType<typeof\s+getExpoConfig>\s*=\s*\[/
+    );
+    expect(src).toContain(
+      "...(localConfig as unknown as ReturnType<typeof getExpoConfig>)"
+    );
+  });
 });

--- a/tests/unit/config/expo-eslint-local-config.test.ts
+++ b/tests/unit/config/expo-eslint-local-config.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Host-boundary regression coverage for the managed Expo ESLint wrapper.
+ *
+ * The real copy-overwrite template is compiled from an isolated package-shaped
+ * fixture. Its project-owned local config deliberately carries custom-plugin
+ * metadata whose inferred `meta.type` is the broader `string` type. Runtime
+ * ESLint accepts that host extension, so Lisa must not force it through the
+ * factory return type while preserving the managed factory's own typing.
+ * @module tests/unit/config/expo-eslint-local-config
+ */
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const MANAGED_CONFIG_FILENAME = "eslint.config.ts";
+const LOCAL_CONFIG_FILENAME = "eslint.config.local.ts";
+const EXPO_ESLINT_TEMPLATE = path.join(
+  REPO_ROOT,
+  "expo",
+  "copy-overwrite",
+  MANAGED_CONFIG_FILENAME
+);
+const TSC = path.join(REPO_ROOT, "node_modules", "typescript", "bin", "tsc");
+
+const MINIMAL_CUSTOM_PLUGIN = `
+const customPlugin = {
+  rules: {
+    local: {
+      meta: { type: "problem" as string },
+      create: () => ({}),
+    },
+  },
+};
+
+export default [{ plugins: { custom: customPlugin } }];
+`;
+
+const REALISTIC_CUSTOM_PLUGIN = `
+const customPlugin = {
+  meta: { name: "custom-project-plugin", version: "1.0.0" },
+  rules: {
+    "prefer-project-api": {
+      meta: {
+        type: "suggestion" as string,
+        docs: { description: "Prefer the project API" },
+        schema: [],
+      },
+      create: () => ({}),
+    },
+  },
+};
+
+export default [
+  { ignores: ["generated/**"] },
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    plugins: { project: customPlugin },
+    rules: { "project/prefer-project-api": "warn" },
+  },
+];
+`;
+
+/**
+ * Compile the real managed template against one host-owned local config.
+ * @param name - Stable fixture name surfaced by the test runner
+ * @param localConfig - Project-owned TypeScript config source
+ * @returns TypeScript's list of files compiled for non-vacuous proof
+ */
+function compileHostFixture(name: string, localConfig: string): string {
+  const fixture = mkdtempSync(path.join(tmpdir(), `lisa-expo-${name}-`));
+  try {
+    copyFileSync(
+      EXPO_ESLINT_TEMPLATE,
+      path.join(fixture, MANAGED_CONFIG_FILENAME)
+    );
+    writeFileSync(path.join(fixture, LOCAL_CONFIG_FILENAME), localConfig);
+    writeFileSync(
+      path.join(fixture, "eslint.ignore.config.json"),
+      JSON.stringify({ ignores: [] })
+    );
+    writeFileSync(
+      path.join(fixture, "eslint.thresholds.json"),
+      JSON.stringify({})
+    );
+    writeFileSync(
+      path.join(fixture, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          allowImportingTsExtensions: true,
+          declaration: true,
+          module: "preserve",
+          moduleResolution: "bundler",
+          noEmit: true,
+          resolveJsonModule: true,
+          skipLibCheck: true,
+          strict: true,
+          target: "ES2022",
+          typeRoots: [path.join(REPO_ROOT, "node_modules", "@types")],
+          types: ["node"],
+        },
+        include: [MANAGED_CONFIG_FILENAME, LOCAL_CONFIG_FILENAME],
+      })
+    );
+
+    const packageScope = path.join(fixture, "node_modules", "@codyswann");
+    mkdirSync(packageScope, { recursive: true });
+    symlinkSync(REPO_ROOT, path.join(packageScope, "lisa"), "dir");
+
+    const result = spawnSync(
+      process.execPath,
+      [TSC, "--project", path.join(fixture, "tsconfig.json"), "--listFiles"],
+      { encoding: "utf8" }
+    );
+    const output = `${result.stdout}${result.stderr}`;
+
+    expect(result.status, output).toBe(0);
+    expect(output).toContain(path.join(fixture, MANAGED_CONFIG_FILENAME));
+    expect(output).toContain(path.join(fixture, LOCAL_CONFIG_FILENAME));
+    return output;
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+}
+
+describe("Expo local ESLint config host boundary", () => {
+  it("typechecks a single custom-plugin entry with widened metadata", () => {
+    const compiledFiles = compileHostFixture(
+      "single-custom-plugin",
+      MINIMAL_CUSTOM_PLUGIN
+    );
+
+    expect(compiledFiles).toContain(LOCAL_CONFIG_FILENAME);
+  });
+
+  it("typechecks realistic multi-entry custom-plugin configuration", () => {
+    const compiledFiles = compileHostFixture(
+      "multi-custom-plugin",
+      REALISTIC_CUSTOM_PLUGIN
+    );
+
+    expect(compiledFiles).toContain(LOCAL_CONFIG_FILENAME);
+  });
+});


### PR DESCRIPTION
## Summary

- keep the managed Expo ESLint factory result explicitly typed for declaration portability
- confine trust for broader project-owned custom plugin config to its spread boundary, including the single-entry TS2352 edge
- compile the real packaged template against minimal and realistic host configurations in regression tests

Closes #1707

## Test plan

- `bunx vitest run tests/unit/config/expo-eslint-local-config.test.ts tests/unit/config/eslint-ignore-wiki.test.ts --reporter=verbose` (2 files, 32 tests)
- `bun run lint` (780 files, 0 warnings/errors)
- `bun run typecheck`
- `bun run test` (348 files, 5,999 tests)
- `bun run build`
- `bun run check:plugins`
- `bun pm pack --dry-run --ignore-scripts` and confirm `expo/copy-overwrite/eslint.config.ts` is included
- `git diff --check`