### PR TITLE
fix(husky): fail closed when mktemp cannot create the gitleaks ignore file (#1709)

### DIFF
--- a/tests/unit/config/gitleaks-template.test.ts
+++ b/tests/unit/config/gitleaks-template.test.ts
@@ -1,7 +1,76 @@
+import { execFileSync } from "node:child_process";
 import * as fs from "fs-extra";
+import * as os from "node:os";
 import * as path from "node:path";
 
 const repoRoot = process.cwd();
+
+const hookPath = path.join(
+  repoRoot,
+  "typescript",
+  "copy-contents",
+  ".husky",
+  "pre-commit"
+);
+
+/**
+ * Extracts the `mktemp` fail-closed guard block from the pre-commit template so
+ * the test can execute it under a real POSIX shell. Behavioral coverage matters
+ * here because the hook runs without `set -e`: a content pin alone cannot prove
+ * the hook actually aborts when the temp file cannot be created.
+ *
+ * @param hook - Full text of the pre-commit template.
+ * @returns The guard block, verbatim, ready to execute under `sh`.
+ */
+const extractMktempGuard = (hook: string): string => {
+  const match = /^[ \t]*if ! GITLEAKS_COMBINED_IGNORE=[\s\S]*?^[ \t]*fi$/m.exec(
+    hook
+  );
+
+  if (match === null) {
+    throw new Error("pre-commit template has no mktemp guard block");
+  }
+
+  return match[0];
+};
+
+/**
+ * Runs a shell snippet under `sh` with an explicit TMPDIR, returning the exit
+ * status alongside stdout/stderr so assertions can inspect both the failure
+ * mode and the operator-facing message.
+ *
+ * @param snippet - Shell source to execute.
+ * @param tmpdir - Value to expose as TMPDIR to the snippet.
+ * @returns Exit status plus captured stdout and stderr.
+ */
+const runUnderSh = (
+  snippet: string,
+  tmpdir: string
+): { status: number; stdout: string; stderr: string } => {
+  try {
+    // Absolute path: husky hooks are invoked as `/bin/sh` and pinning it here
+    // keeps the test independent of whatever PATH the runner inherits.
+    const stdout = execFileSync("/bin/sh", ["-c", snippet], {
+      encoding: "utf8",
+      env: { ...process.env, TMPDIR: tmpdir },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    return { status: 0, stdout, stderr: "" };
+  } catch (error) {
+    const failure = error as {
+      status: number | null;
+      stdout: string;
+      stderr: string;
+    };
+
+    return {
+      status: failure.status ?? -1,
+      stdout: failure.stdout ?? "",
+      stderr: failure.stderr ?? "",
+    };
+  }
+};
 
 describe("gitleaks allowlist templates", () => {
   it("keeps host-owned .gitleaksignore under create-only", async () => {
@@ -34,36 +103,71 @@ describe("gitleaks allowlist templates", () => {
   });
 
   it("combines host and Lisa gitleaks ignore files in the pre-commit hook", async () => {
-    const hook = await fs.readFile(
-      path.join(
-        repoRoot,
-        "typescript",
-        "copy-contents",
-        ".husky",
-        "pre-commit"
-      ),
-      "utf8"
-    );
+    const hook = await fs.readFile(hookPath, "utf8");
 
     expect(hook).toContain(".gitleaksignore.local");
     expect(hook).toContain("--gitleaks-ignore-path=$GITLEAKS_COMBINED_IGNORE");
   });
 
   it("uses a portable mktemp template (bare mktemp errors on BSD/macOS)", async () => {
-    const hook = await fs.readFile(
-      path.join(
-        repoRoot,
-        "typescript",
-        "copy-contents",
-        ".husky",
-        "pre-commit"
-      ),
-      "utf8"
-    );
+    const hook = await fs.readFile(hookPath, "utf8");
 
     // BSD/macOS `mktemp` requires an explicit template argument with a trailing
     // X run; bare `$(mktemp)` errors there. GNU mktemp accepts the template too.
     expect(hook).toContain('mktemp "${TMPDIR:-/tmp}/gitleaks-ignore.XXXXXXXX"');
     expect(hook).not.toContain('"$(mktemp)"');
+  });
+
+  it("fails closed when mktemp fails", async () => {
+    const hook = await fs.readFile(hookPath, "utf8");
+
+    // The hook runs without `set -e`, so an unguarded `mktemp` failure would
+    // leave GITLEAKS_COMBINED_IGNORE empty and hand gitleaks a malformed
+    // `--gitleaks-ignore-path=`. The guard must abort instead.
+    expect(hook).toContain("if ! GITLEAKS_COMBINED_IGNORE=");
+    expect(hook).toContain('[ -z "$GITLEAKS_COMBINED_IGNORE" ]');
+    expect(hook).toContain(
+      "Failed to create the temporary Gitleaks ignore file"
+    );
+    expect(hook).toContain("TMPDIR");
+
+    const guard = extractMktempGuard(hook);
+
+    expect(guard).toContain("exit 1");
+  });
+
+  it("aborts with an operator-facing error when TMPDIR is unusable", async () => {
+    const hook = await fs.readFile(hookPath, "utf8");
+    const guard = extractMktempGuard(hook);
+
+    const result = runUnderSh(
+      guard,
+      path.join(os.tmpdir(), "lisa-gitleaks-guard-does-not-exist")
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Failed to create the temporary Gitleaks ignore file"
+    );
+  });
+
+  it("creates the temporary ignore file when TMPDIR is usable", async () => {
+    const hook = await fs.readFile(hookPath, "utf8");
+    const guard = extractMktempGuard(hook);
+
+    const workdir = await fs.mkdtemp(path.join(os.tmpdir(), "lisa-gitleaks-"));
+
+    try {
+      const result = runUnderSh(
+        `${guard}\nprintf '%s' "$GITLEAKS_COMBINED_IGNORE"`,
+        workdir
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(path.join(workdir, "gitleaks-ignore."));
+      await expect(fs.pathExists(result.stdout)).resolves.toBe(true);
+    } finally {
+      await fs.remove(workdir);
+    }
   });
 });

--- a/typescript/copy-contents/.husky/pre-commit
+++ b/typescript/copy-contents/.husky/pre-commit
@@ -54,7 +54,14 @@ if command -v gitleaks >/dev/null 2>&1; then
     # Explicit template with a trailing X run keeps this portable: BSD/macOS
     # `mktemp` requires a template argument (bare `mktemp` errors), while GNU
     # `mktemp` accepts it too.
-    GITLEAKS_COMBINED_IGNORE="$(mktemp "${TMPDIR:-/tmp}/gitleaks-ignore.XXXXXXXX")"
+    # This hook does not run under `set -e`, so an unguarded failure would leave
+    # the path empty and hand gitleaks a malformed --gitleaks-ignore-path=.
+    # Fail closed instead: a degraded secret scan is worse than a blocked commit.
+    if ! GITLEAKS_COMBINED_IGNORE="$(mktemp "${TMPDIR:-/tmp}/gitleaks-ignore.XXXXXXXX")" || [ -z "$GITLEAKS_COMBINED_IGNORE" ]; then
+      echo "❌ Failed to create the temporary Gitleaks ignore file." >&2
+      echo "   Check that TMPDIR (${TMPDIR:-/tmp}) exists and is writable." >&2
+      exit 1
+    fi
     if [ -f ".gitleaksignore" ]; then
       cat .gitleaksignore > "$GITLEAKS_COMBINED_IGNORE"
       printf '\n' >> "$GITLEAKS_COMBINED_IGNORE"


### PR DESCRIPTION
## Summary

The Lisa-owned `typescript/copy-contents/.husky/pre-commit` template built its combined Gitleaks ignore file with an unguarded `mktemp`. The hook does not run under `set -e`, so a failed `mktemp` (full `/tmp`, restrictive or missing `TMPDIR`) left `GITLEAKS_COMBINED_IGNORE` empty, the follow-on `cat` redirections failed silently, and `gitleaks protect` was still invoked with a malformed `--gitleaks-ignore-path=` — a degraded secret scan that looked like a passing one. This wraps the assignment in a fail-closed guard that also rejects a successful-but-empty result, prints an operator-facing message naming `TMPDIR`, and exits 1.

## Provenance

CodeRabbit raised this as a Minor stability advisory on the inline `.husky/pre-commit` L57 thread of `geminisportsai/ask-gemini#724` during the 2.232.0 rollout. Because the file is a Lisa `copy-contents` template, a downstream edit would be reverted on the next `lisa apply`, so the downstream thread was resolved with a fix-belongs-upstream reply (per PROJECT_RULES: fix the template, not the rendered copy) and routed here as #1709.

## Empirical guard observations

Extracted the guard block from the patched template and executed it under a real `/bin/sh`:

1. **Unusable `TMPDIR` → fails closed.** With `TMPDIR=/tmp/lisa-no-such-dir-1709` (nonexistent) and again with a `chmod 500` directory (unwritable):
   ```
   mktemp: mkstemp failed on /tmp/lisa-no-such-dir-1709/gitleaks-ignore.Y6XO9IWw: No such file or directory
   ❌ Failed to create the temporary Gitleaks ignore file.
      Check that TMPDIR (/tmp/lisa-no-such-dir-1709) exists and is writable.
   exit=1
   ```
2. **Valid `TMPDIR` → succeeds and creates the file.**
   ```
   created=/tmp/lisa-1709-ok/gitleaks-ignore.zUgZoY7s
   -rw------- 1 cody wheel 0 /tmp/lisa-1709-ok/gitleaks-ignore.zUgZoY7s
   exit=0
   ```

Both observations are pinned as executing regression tests in `tests/unit/config/gitleaks-template.test.ts` (not content-pins alone), alongside a content pin for the guard form. TDD RED was confirmed against `main` before the fix (3 failures); GREEN is 7/7 in that file, 312/312 across `tests/unit/config/`. `sh -n` on the patched template passes; typecheck and lint are clean.

## Notes

- The `mktemp` call stays on one line so the existing portable-template test (`mktemp "${TMPDIR:-/tmp}/gitleaks-ignore.XXXXXXXX"`) keeps passing.
- POSIX-`sh` compatible (`if ! VAR="$(...)" || [ -z "$VAR" ]`); husky hooks run under `sh`.
- Failure is confined to the existing `[ -f ".gitleaksignore.local" ]` branch, so hosts without the Lisa companion file are unaffected.
- Every TypeScript-derived stack (expo, nestjs, cdk, harper-fabric, phaser, npm-package) inherits this template and self-heals on the next `lisa apply` via the AI GUARDRAILS region rewrite — no downstream edits required.
- Lisa's own root `.husky/pre-commit` is the pre-guardrails variant by design (Lisa self-skips its own apply) and has no `mktemp` block, so there is no rendered copy to sync here.

Closes #1709

🤖 Generated with Claude Code
