### PR TITLE
fix(expo): pin e2e-coverage route sort to code-unit order (#1713)

### DIFF
--- a/expo/copy-overwrite/scripts/check-e2e-coverage.mjs
+++ b/expo/copy-overwrite/scripts/check-e2e-coverage.mjs
@@ -98,7 +98,10 @@ export function enumerateRoutes(files) {
   const routes = files
     .map(file => routeFromFile(file))
     .filter(route => route !== null);
-  return [...new Set(routes)].sort((a, b) => a.localeCompare(b));
+  // Code-unit comparator (not `localeCompare()`): route order must be
+  // reproducible across environments regardless of the runtime's default
+  // ICU locale, since localeCompare()'s collation is locale-sensitive.
+  return [...new Set(routes)].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
 }
 
 /**

--- a/tests/unit/scripts/e2e-coverage.test.ts
+++ b/tests/unit/scripts/e2e-coverage.test.ts
@@ -137,9 +137,10 @@ describe("check-e2e-coverage", () => {
     });
 
     it("sorts by code-unit order, not locale-aware collation", () => {
-      // localeCompare() collates case-insensitively → ["/apple", "/Zebra"].
-      // Code-unit order puts uppercase (< 0x5B) before lowercase (>= 0x61),
-      // keeping report ordering reproducible across ICU locales.
+      // Code-unit order is deterministic: uppercase code units (< 0x5B) sort
+      // before lowercase (>= 0x61), so ["/Zebra", "/apple"] — reproducible
+      // regardless of the runtime's ICU locale, unlike locale-sensitive
+      // collation.
       expect(enumerateRoutes(["apple.tsx", "Zebra.tsx"])).toEqual([
         "/Zebra",
         "/apple",

--- a/tests/unit/scripts/e2e-coverage.test.ts
+++ b/tests/unit/scripts/e2e-coverage.test.ts
@@ -135,6 +135,16 @@ describe("check-e2e-coverage", () => {
         enumerateRoutes(["(a)/home.tsx", "(b)/home.tsx", "_layout.tsx"])
       ).toEqual(["/home"]);
     });
+
+    it("sorts by code-unit order, not locale-aware collation", () => {
+      // localeCompare() collates case-insensitively → ["/apple", "/Zebra"].
+      // Code-unit order puts uppercase (< 0x5B) before lowercase (>= 0x61),
+      // keeping report ordering reproducible across ICU locales.
+      expect(enumerateRoutes(["apple.tsx", "Zebra.tsx"])).toEqual([
+        "/Zebra",
+        "/apple",
+      ]);
+    });
   });
 
   describe("visited path normalization", () => {


### PR DESCRIPTION
## Summary

`enumerateRoutes()` in the managed Expo template `scripts/check-e2e-coverage.mjs` sorted routes with `localeCompare()`, whose collation is locale-sensitive — route ordering (and therefore coverage-diff output) could differ across machines and CI locales. This pins the sort to a code-unit comparator so report ordering is reproducible everywhere.

Coverage math (`covered/total`, thresholds, pass/fail) is order-independent, so this changes report ordering only — zero risk to the gate verdict.

## Provenance — upstreaming a downstream fix

- geminisportsai/frontend-v2 already made this exact fix downstream in commit `9ec5276dc` ("pin route sort to code-unit order"), prompted by a CodeRabbit review comment on their PR #6189.
- But `scripts/check-e2e-coverage.mjs` is a Lisa **copy-overwrite** template, so every `lisa apply` silently reverted it — observed on frontend-v2#6190 during the 2.233.0 rollout, where the update agent had to restore it by hand.
- The hunk here is ported **byte-identically** from the downstream file, so `filesIdentical()` short-circuits on the next apply: the clobber/restore cycle ends, and **every Lisa-managed Expo host self-heals on next apply with no downstream PR required.** (Verified: `diff` of the full template against frontend-v2's `scripts/check-e2e-coverage.mjs` is now empty.)

The sort ladder for this file is now complete: bare `.sort()` (Sonar S2871 violation) → `localeCompare()` (`158225776`, Sonar-clean but locale-dependent) → code-unit comparator (Sonar-clean **and** deterministic). An explicit comparator argument is retained, so S2871 stays satisfied.

## Changes

- `expo/copy-overwrite/scripts/check-e2e-coverage.mjs` — code-unit comparator + explanatory comment (verbatim downstream hunk).
- `tests/unit/scripts/e2e-coverage.test.ts` — new behavioral pin: `enumerateRoutes(["apple.tsx", "Zebra.tsx"])` → `["/Zebra", "/apple"]`.

## RED / GREEN evidence

**RED** (new test against the pre-fix template):

```
 [
-   "/Zebra",
     "/apple",
+   "/Zebra",
 ]
 ❯ tests/unit/scripts/e2e-coverage.test.ts:143:59
 Tests  1 failed | 30 passed (31)
```

**GREEN** (after the comparator change):

```
node --check expo/copy-overwrite/scripts/check-e2e-coverage.mjs  → SYNTAX_OK
bunx vitest run tests/unit/scripts/   → Test Files 26 passed (26) | Tests 336 passed (336)
bun run typecheck                     → clean
bun run lint                          → 0 warnings, 0 errors
diff template vs frontend-v2 file     → identical (byte-for-byte)
```

## Out of scope

Downstream `9ec5276dc` also added `scripts/__tests__/check-e2e-coverage.test.mjs` (a host-owned `node:test` suite). Shipping a test file into every Expo host needs its own runner wiring (jest ignores `scripts/`) and is a separate design decision — the behavior is pinned in Lisa's own vitest suite instead.

Closes #1713

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route ordering consistency across different environments, ensuring predictable results during end-to-end coverage checks.

* **Tests**
  * Added coverage to verify routes are sorted consistently regardless of locale settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->