### PR TITLE
fix(ci): deliberate least-privilege permissions for quality.yml and caller templates (#1769)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -180,6 +180,33 @@ concurrency:
   group: ${{ inputs.concurrency_group != '' && inputs.concurrency_group || format('lisa-quality-no-serialize-{0}', github.run_id) }}
   cancel-in-progress: false
 
+# -----------------------------------------------------------------------------
+# Least-privilege token scope (deliberate, audited — see #1769)
+# -----------------------------------------------------------------------------
+# `contents: read` is the FLOOR for every job in this workflow. An audit of all
+# 32 jobs found ZERO uses of `gh`, `github.rest.*`, `github.request`,
+# `GITHUB_TOKEN`, or `github.token` anywhere in the file, so no job needs a
+# write scope:
+#   - SonarCloud PR decoration is performed server-side by the GitHub App, not
+#     by the workflow token (the scan action receives SONAR_TOKEN only).
+#   - Snyk / GitGuardian / FOSSA / Maestro authenticate with their own secrets.
+#   - `zaproxy/action-baseline` runs with `allow_issue_writing: false`; if that
+#     flag is ever flipped to true, that job — and only that job — needs
+#     `issues: write` added at the job level.
+#   - `actions/github-script` in audit_logger only writes a local file and the
+#     step summary; artifact upload/download and cache use the run-scoped
+#     runtime token, not GITHUB_TOKEN.
+#   - verification_coverage deliberately reads PR labels from the event payload
+#     instead of the API, so it must NEVER gain a `pull-requests` scope.
+# This workflow is `workflow_call`-only and consumed fleet-wide via @main.
+# Reusable-workflow tokens can only be DOWNGRADED relative to the caller's
+# grant, never escalated, so this floor is safe for every consumer: callers
+# granting >= read keep working, and no job relies on a write scope.
+# Jobs that touch neither the repository nor the API declare `permissions: {}`.
+# Never widen this floor — grant a job its minimal scope at the job level.
+permissions:
+  contents: read
+
 jobs:
   # Central dependency installation job to optimize performance
   install_dependencies:
@@ -191,6 +218,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
@@ -295,6 +324,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
@@ -349,6 +380,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
@@ -388,6 +421,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
@@ -427,6 +462,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
@@ -579,6 +616,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
@@ -645,6 +684,7 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           # Full history so the gate can diff changed files against the PR base.
           fetch-depth: 0
 
@@ -711,6 +751,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
@@ -776,6 +818,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
@@ -860,6 +904,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔍 Check for Maestro API key
         id: check_maestro
@@ -938,6 +984,8 @@ jobs:
   playwright_e2e_setup:
     name: 🎭 Playwright Shard Setup
     runs-on: ubuntu-latest
+    # Pure shell arithmetic — no checkout, no API. Needs no token at all.
+    permissions: {}
     if: ${{ !contains(inputs.skip_jobs, 'playwright_e2e') }}
     outputs:
       shards: ${{ steps.matrix.outputs.shards }}
@@ -976,6 +1024,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
@@ -1121,6 +1171,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔍 Check for Playwright config
         id: check_playwright
@@ -1222,6 +1274,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
@@ -1261,6 +1315,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
@@ -1383,6 +1439,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
@@ -1428,6 +1486,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
@@ -1505,6 +1565,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
@@ -1691,6 +1753,7 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0 # Full depth for proper analysis
 
       - name: 🔍 Check for SonarCloud token
@@ -1779,6 +1842,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔍 Check for Snyk token
         id: check_snyk
@@ -1849,6 +1914,7 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0 # Full depth for scanning history
 
       - name: 🔍 Check for GitGuardian API key
@@ -1904,6 +1970,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔍 Check for FOSSA API key
         id: check_fossa
@@ -1940,6 +2008,8 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
@@ -1998,6 +2068,8 @@ jobs:
   security_tools_summary:
     name: 🔒 Security Tools Summary
     runs-on: ubuntu-latest
+    # Step-summary echoes off needs.*.result only — no checkout, no API.
+    permissions: {}
     if: always() && (needs.sonarcloud.result != 'skipped' || needs.snyk.result != 'skipped' || needs.secret_scanning.result != 'skipped' || needs.license_compliance.result != 'skipped' || needs.zap_baseline.result != 'skipped')
     needs: [sonarcloud, snyk, secret_scanning, license_compliance, zap_baseline]
     steps:
@@ -2130,6 +2202,8 @@ jobs:
   compliance_validation:
     name: ✅ Compliance Validation
     runs-on: ubuntu-latest
+    # Step-summary echoes off needs.*.result only — no checkout, no API.
+    permissions: {}
     if: ${{ inputs.compliance_framework != 'none' }}
     needs:
       [
@@ -2549,6 +2623,8 @@ jobs:
   performance_summary:
     name: ⚡ Performance Summary
     runs-on: ubuntu-latest
+    # Step-summary echoes off needs.*.result only — no checkout, no API.
+    permissions: {}
     if: always()
     needs:
       [

--- a/cdk/create-only/.github/workflows/ci.yml
+++ b/cdk/create-only/.github/workflows/ci.yml
@@ -133,7 +133,6 @@ jobs:
     # Reference to the quality checks workflow
     permissions:
       contents: read
-      pull-requests: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'

--- a/cdk/create-only/.github/workflows/ci.yml
+++ b/cdk/create-only/.github/workflows/ci.yml
@@ -131,6 +131,9 @@ jobs:
     name: 🔍 Quality Checks
     needs: [determine_environment, cdk-checks] # Ensure CDK checks pass first
     # Reference to the quality checks workflow
+    permissions:
+      contents: read
+      pull-requests: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'

--- a/expo/create-only/.github/workflows/ci.yml
+++ b/expo/create-only/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
     # Reference to the quality checks workflow
     permissions:
       contents: read
-      pull-requests: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'

--- a/expo/create-only/.github/workflows/ci.yml
+++ b/expo/create-only/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
   quality:
     name: 🔍 Quality Checks
     # Reference to the quality checks workflow
+    permissions:
+      contents: read
+      pull-requests: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'

--- a/harper-fabric/copy-overwrite/.github/workflows/ci.yml
+++ b/harper-fabric/copy-overwrite/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
     name: 🔍 Quality Checks
     permissions:
       contents: read
-      pull-requests: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'

--- a/harper-fabric/copy-overwrite/.github/workflows/ci.yml
+++ b/harper-fabric/copy-overwrite/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   quality:
     name: 🔍 Quality Checks
+    permissions:
+      contents: read
+      pull-requests: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'

--- a/nestjs/create-only/.github/workflows/ci.yml
+++ b/nestjs/create-only/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
   quality:
     name: 🔍 Quality Checks
     # Reference to the quality checks workflow
+    permissions:
+      contents: read
+      pull-requests: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'

--- a/nestjs/create-only/.github/workflows/ci.yml
+++ b/nestjs/create-only/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     # Reference to the quality checks workflow
     permissions:
       contents: read
-      pull-requests: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'

--- a/phaser/copy-overwrite/.github/workflows/ci.yml
+++ b/phaser/copy-overwrite/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   quality:
     name: 🔍 Quality Checks
+    permissions:
+      contents: read
+      pull-requests: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'

--- a/phaser/copy-overwrite/.github/workflows/ci.yml
+++ b/phaser/copy-overwrite/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
     name: 🔍 Quality Checks
     permissions:
       contents: read
-      pull-requests: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -81,6 +81,7 @@ interface QualityWorkflow {
     };
   };
   concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+  permissions?: Record<string, unknown>;
   jobs: Record<string, WorkflowJob>;
 }
 
@@ -282,7 +283,12 @@ describe("quality.yml reusable workflow", () => {
   describe("verification coverage labels", () => {
     it("passes event labels to the coverage script without live GitHub context", () => {
       const job = workflow.jobs.verification_coverage;
-      expect(job.permissions).toBeUndefined();
+      // The job declares no permissions of its own, so it resolves to the
+      // workflow-level least-privilege floor (#1769). What must never change
+      // is that it gains no `pull-requests` scope — the gate reads PR labels
+      // from the event payload, not the API.
+      expect(workflow.permissions).toEqual({ contents: "read" });
+      expect(job.permissions?.["pull-requests"]).toBeUndefined();
 
       const steps = job.steps ?? [];
       const check = steps.find(s =>
@@ -295,6 +301,60 @@ describe("quality.yml reusable workflow", () => {
       expect(check?.env?.VERIFY_LABELS).toContain(
         "github.event.pull_request.labels"
       );
+    });
+  });
+
+  describe("least-privilege permissions floor", () => {
+    it("declares a workflow-level contents:read floor", () => {
+      // #1769: quality.yml is consumed fleet-wide via @main. Reusable-workflow
+      // tokens can only be downgraded relative to the caller's grant, so a
+      // read-only floor is safe for every consumer while capping consumers
+      // whose caller job declares no `permissions:` block of its own.
+      expect(workflow.permissions).toEqual({ contents: "read" });
+    });
+
+    it("gives summary-only jobs an empty permissions block", () => {
+      // These jobs neither check out the repository nor call the API.
+      for (const jobName of [
+        "playwright_e2e_setup",
+        "security_tools_summary",
+        "compliance_validation",
+        "performance_summary",
+      ]) {
+        expect(workflow.jobs[jobName]?.permissions, jobName).toEqual({});
+      }
+    });
+
+    it("resolves every job to a scope with no write access", () => {
+      // Effective scope = job-level block when present, otherwise the
+      // workflow-level floor. An audit of all jobs found zero uses of `gh`,
+      // `github.rest.*`, `GITHUB_TOKEN`, or `github.token`, so no job needs a
+      // write scope. This assertion catches a future job silently regressing
+      // the floor by declaring one.
+      for (const [jobName, job] of Object.entries(workflow.jobs)) {
+        const effective = job.permissions ?? workflow.permissions ?? {};
+        const writeScopes = Object.entries(effective)
+          .filter(([, value]) => value === "write")
+          .map(([scope]) => scope);
+        expect(writeScopes, `${jobName} must not hold a write scope`).toEqual(
+          []
+        );
+      }
+    });
+
+    it("checks out without persisting the git credential", () => {
+      // A persisted credential outlives the checkout step and is readable by
+      // every later step (and any compromised third-party action) in the job.
+      // No job in this workflow reuses the checkout credential.
+      for (const [jobName, job] of Object.entries(workflow.jobs)) {
+        for (const step of job.steps ?? []) {
+          if (!step.uses?.startsWith("actions/checkout@")) {
+            continue;
+          }
+
+          expect(step.with?.["persist-credentials"], jobName).toBe(false);
+        }
+      }
     });
   });
 


### PR DESCRIPTION
## What

`.github/workflows/quality.yml` declared **no `permissions:` block anywhere** — every one of its jobs ran with whatever token scope the caller granted. This PR gives it a deliberate, audited least-privilege posture, and closes the same gap on the caller templates that lacked a cap.

## The audit (evidence)

All **32 jobs** enumerated (the ticket's "~25" is an undercount). Grep across the whole file for `gh `, `gh api`, `gh pr`, `github.rest.*`, `github.request`, `GITHUB_TOKEN`, `github.token` → **zero hits**. Therefore **no job in this workflow needs a write scope**:

| Job class | Jobs | Effective scope |
|---|---|---|
| Checkout + run (lint, lint_slow, typecheck, format, dead_code, sg_scan, build, install_dependencies, npm_security_scan, threshold_ratchet, e2e_coverage, learnings_budget) | 12 | `contents: read` (floor) |
| Test jobs (test, test_unit, test_mutation, test_integration, test_e2e, maestro_e2e, playwright_e2e, playwright_e2e_aggregate) | 8 | `contents: read` (floor) |
| External-secret scanners (sonarcloud, snyk, secret_scanning, license_compliance, zap_baseline) | 5 | `contents: read` (floor) |
| `verification_coverage` | 1 | `contents: read` — must **never** gain `pull-requests` |
| `audit_logger`, `approval_gate` | 2 | `contents: read` (floor) |
| Summary-only, no checkout, no API (playwright_e2e_setup, security_tools_summary, compliance_validation, performance_summary) | 4 | **`permissions: {}`** |

Why the ticket's prediction ("sonarcloud/snyk/zap and the summary jobs need checks/PR writes") does **not** hold:
- SonarCloud PR decoration is performed **server-side by the GitHub App**; the scan action receives `SONAR_TOKEN` only, no `GITHUB_TOKEN`.
- Snyk / GitGuardian / FOSSA / Maestro authenticate with their own secrets.
- `zaproxy/action-baseline` runs with `allow_issue_writing: false` — the one setting that would otherwise require `issues: write` (noted in a comment so a future flip grants that job, and only that job, the scope).
- The lone `actions/github-script` (audit_logger) only does `fs.writeFileSync` + `core.summary` + `core.setOutput`.
- Artifact upload/download and cache use the **run-scoped runtime token**, not `GITHUB_TOKEN`; all downloads are same-run.

## Premise corrections vs. the ticket

1. **"Every job inherits the repository default token scope" is false for lisa itself.** This repo's `ci.yml` and `release.yml` already cap the calling job at `contents: read` + `pull-requests: read`, and reusable-workflow tokens can only be **downgraded**, never escalated.
2. **The real exposure is uncapped downstream callers** — the expo/cdk/nestjs/phaser/harper-fabric `ci.yml` templates had no `permissions:` block, so consumers inherited their repo default (often read/write). Fixed here.
3. **32 jobs, not ~25.**

## Changes

- `quality.yml`: workflow-level `permissions: {contents: read}` floor + a header comment recording the audit, the per-job exceptions, and the never-widen rule.
- `quality.yml`: `permissions: {}` on the four pure-summary jobs.
- `quality.yml`: `persist-credentials: false` added to the **22 checkouts that lacked it** (all 26 now hardened). Same hardening family — no job reuses the checkout credential; the `fetch-depth: 0` jobs already fetch every ref up front, so no credentialed fetch happens later.
- Caller templates (`expo`, `cdk`, `nestjs`, `phaser`, `harper-fabric`): added `permissions: {contents: read, pull-requests: read}` matching the **existing typescript template's exact style/scopes**, so all callers are uniform.
- `learnings_budget` untouched (already hardened; Out of Scope) — it inherits the floor.
- `quality-rails.yml`'s over-broad block left alone (explicitly Out of Scope).

## Tests

- Updated the blocker-class assertion at `tests/integration/quality-workflow.test.ts` (`verification coverage labels`): `expect(job.permissions).toBeUndefined()` → assert the workflow floor is `{contents: read}` **and** the job holds no `pull-requests` scope. The surrounding no-`VERIFY_GITHUB_TOKEN` / no-`VERIFY_PR_NUMBER` / event-payload-labels assertions are preserved **verbatim** — they encode the `0b3f1fc61` incident fix.
- New `least-privilege permissions floor` describe block with four invariants:
  - workflow-level floor is exactly `{contents: read}`
  - the four summary jobs declare `{}`
  - **every job's effective scope** (job-level override else workflow-level) contains **no `*: write`** — this is what stops a future job from silently regressing the floor
  - every `actions/checkout` sets `persist-credentials: false`

RED verified: with `quality.yml` reverted to `origin/main`, 4 of these tests fail; with the change, `tests/integration/quality-workflow.test.ts` is 39/39 green.

## Fleet propagation

`quality.yml` has no template copy — downstream repos pin `@main`, so this is live fleet-wide at merge. Blast radius is bounded by downgrade-only semantics: any consumer whose caller grants ≥ read keeps working, and per the audit no job relies on a write scope. The caller-template change is **create-only** — existing hosts do **not** retro-receive it (new projects only; fleet migration of existing `ci.yml` files is out of scope for this ticket).

## Verification

This PR's own CI run is the primary evidence: lisa's `ci.yml` → `quality.yml` exercises ~26 of the 32 jobs (install_dependencies, lint, lint_slow, typecheck, test, e2e_coverage, learnings_budget, test_unit, test_mutation, test_integration, test_e2e, playwright_e2e_setup/+matrix/+aggregate, format, build, threshold_ratchet, dead_code, sg_scan, npm_security_scan, sonarcloud, snyk, secret_scanning, license_compliance, audit_logger, performance_summary, security_tools_summary). Every one must stay green under the new scopes.

The 6 not exercised on a lisa PR — `verification_coverage` (needs `verify_enforced: true`), `maestro_e2e` (needs `MAESTRO_API_KEY`), `zap_baseline` (needs `zap_target_url`), `compliance_validation` and `approval_gate` (need `compliance_framework != none`), and the real Playwright body (no `playwright.config` here) — are echo/artifact-only or externally-authenticated paths that were read line-by-line in the audit, and `verification_coverage` is additionally locked by the integration test above.

Local gates: `tests/integration/` + the quality.yml-adjacent unit tests 201/201 green, `typecheck` clean, `lint` 0 errors/0 warnings, prettier clean.

Closes #1769

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Enhancements**
  - Tightened CI workflow token permissions to a least-privilege model (read-only `contents` and restricted pull-request access where applicable).
  - Updated quality-related jobs to explicitly declare read-only permissions, and summary-only jobs to declare no token permissions.
  - Disabled credential persistence for `checkout` steps to prevent lingering Git credentials on runners.

- **Tests**
  - Added/expanded assertions to enforce workflow permission contracts (including empty permissions for summary-only jobs) and credential-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->