### PR TITLE
fix(skills): verify a deploy run exists for the merge SHA in drive-pr-to-merge (#1777)

### DIFF
--- a/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-drive-pr-to-merge
-description: This skill should be used to drive a pull request all the way to MERGED, handling ANYTHING that blocks the merge. It enables auto-merge when the repo supports it (direct-merge fallback otherwise), keeps the branch rebased/synced and resolves merge conflicts, fixes failing CI/deploy checks, addresses and resolves every human and bot review comment (CodeRabbit, etc.) — implementing valid feedback and replying-then-resolving invalid feedback — dismisses stale CHANGES_REQUESTED gates, and verifies the fix actually shipped (auto-merge race ancestry check). Composable and inline — invoked by other skills (e.g. git-submit-pr, implement, sync-down) via the Skill tool, never as a standalone user command.
+description: This skill should be used to drive a pull request all the way to MERGED, handling ANYTHING that blocks the merge. It enables auto-merge when the repo supports it (direct-merge fallback otherwise), keeps the branch rebased/synced and resolves merge conflicts, fixes failing CI/deploy checks, addresses and resolves every human and bot review comment (CodeRabbit, etc.) — implementing valid feedback and replying-then-resolving invalid feedback — dismisses stale CHANGES_REQUESTED gates, and verifies the fix actually shipped — both merge ancestry and that a deploy/release run fired for the merge SHA (auto-merge race + zero-deploy-run check). Composable and inline — invoked by other skills (e.g. git-submit-pr, implement, sync-down) via the Skill tool, never as a standalone user command.
 allowed-tools: ["Bash", "Read", "Edit", "Write", "Grep", "Glob", "Skill"]
 ---
 
@@ -246,11 +246,16 @@ head's checks to start, then re-enable auto-merge (section 1). In
 `on_blocker=report` mode this whole step is off-limits (diagnose-only): do not
 merge, close, or delete anything — return `blocked:pending-auto-fix`.
 
-## 3. Merge and verify it actually shipped (ancestry check)
+## 3. Merge and verify it actually shipped (ancestry + deploy run)
 
 Enabling auto-merge + green checks + resolved threads is **not** proof the merge
-included your fix. Auto-merge can land the PRIOR head the instant gates go green,
-before a late fix commit becomes the head. After the PR reports `MERGED`:
+included your fix, and a passing merge **not** proof anything deployed. Both must
+be verified after the PR reports `MERGED`.
+
+### a. Ancestry check — is my code in the merged branch
+
+Auto-merge can land the PRIOR head the instant gates go green, before a late fix
+commit becomes the head:
 
 ```bash
 git fetch origin
@@ -263,11 +268,78 @@ ship — fix forward with a new commit/PR and re-drive. Re-confirm after any com
 that lands while auto-merge is enabled; a successful merge of an older head is a
 failed drive-to-merge outcome, not a successful closeout.
 
+### b. Deploy-run check — did a deploy/release workflow run actually fire
+
+Ancestry proves your code is *in* the merged branch; it does **not** prove
+anything deployed. GitHub can **suppress the `on: push` event for a merge commit
+created by auto-merge or a bot token** (`GITHUB_TOKEN`), so the deploy workflow
+fires **zero** runs — no run, not even a `startup_failure` — while the ancestry
+check above stays green. Incident of record: TunnlAI/frontend **TUN-186** (PR #67)
+merged to `dev` via auto-merge; the merge commit `1b3f836` produced **no**
+`deploy.yml` run, and only the next human push `d1fe18c` (which carries `1b3f836`
+as an ancestor) actually shipped it. **Never report shipped on ancestry alone.**
+
+After ancestry passes, capture the merge SHA and poll for a **deploy/release
+workflow run** whose head SHA **is the merge SHA or an including descendant** (a
+run whose head has the merge SHA as an ancestor also shipped the merge, mirroring
+`d1fe18c` shipping `1b3f836`), keyed to the merged-into branch. The observing
+workflow name is **not fixed** — do **not** hardcode `deploy.yml`:
+
+- **Downstream projects:** the deploy/release workflow run keyed to the base
+  branch resolved via `.lisa.config.json` `deploy.branches` (the merged-into env
+  branch) — the same "deploy run keyed to the merged-into branch via
+  `deploy.branches`" observation `lisa-linear-build-intake` performs before
+  relabeling.
+- **lisa / other repos:** the repo's release or publish workflow for
+  `<baseRefName>`.
+
+Discover the run with the same `gh run list --json …headSha…` pattern
+`lisa-verify-workflow-change` uses:
+
+```bash
+merge_sha=$(gh pr view <pr> --json mergeCommit -q .mergeCommit.oid)
+gh run list --branch <baseRefName> --commit "$merge_sha" \
+  --json databaseId,workflowName,status,conclusion,headSha,headBranch,createdAt --limit 20
+```
+
+**Bounded wait:** a just-created run can take a few seconds to register — poll
+briefly (a small number of short intervals / a short ceiling, mirroring the "wait
+for that head's checks to start" bound used above) before concluding the run is
+absent, so a not-yet-registered run is not mis-read as zero. When no run matches
+the merge SHA directly, also accept a descendant run whose head has `$merge_sha`
+as an ancestor (`git merge-base --is-ancestor "$merge_sha" <run_head_sha>`).
+
+**Zero runs after the bounded wait — do NOT report shipped.** Recover in order:
+
+1. **Dispatch the deploy, then re-verify.** Trigger the env's `workflow_dispatch`
+   for the merged-into branch and re-poll for a run that now covers the merge SHA
+   (or an including descendant):
+   ```bash
+   gh workflow run <deploy-or-release-workflow> --ref <baseRefName>
+   ```
+   Once such a run appears, the merge is confirmed shipped.
+2. **Still zero, or dispatch not permitted → surface a blocker.** Emit a hard
+   block (`blocked:deploy`) reporting exactly what was observed — the merge SHA,
+   the base branch, and zero deploy runs. A failed/blocked path, **never** a
+   silent "done".
+
+In **`on_blocker=report`** mode this deploy-run step is diagnose-only: dispatching
+a workflow is an action, so do **not** run `gh workflow run` / `workflow_dispatch`
+— classify the absence as `blocked:deploy` (or `blocked:no-deploy-run`) and return
+it for the caller to act on, consistent with the report-mode contract (steps b–f
+of section 2 are diagnose-only).
+
 ## 4. Terminal states
 
 Loop until one of:
 
-- **`MERGED`** and the ancestry check passes → success.
+- **`MERGED`** and the ancestry check passes **and** a deploy/release run for the
+  merge SHA (or an including descendant) is confirmed — observed directly or after
+  a `workflow_dispatch` recovery → success. Ancestry alone is **not** success.
+- **`blocked:deploy`** — merged with ancestry green, but after the bounded wait no
+  deploy/release run fired for the merge SHA and dispatch recovery could not
+  confirm one (or was not permitted, e.g. `on_blocker=report`). Stop and report
+  the merge SHA, base branch, and zero observed runs — never a silent "done".
 - **`awaiting-human`** (`auto_merge=false` only) → success. The PR is `OPEN`,
   required checks are green, the review gate is clear, and
   `mergeable == MERGEABLE`, with auto-merge deliberately not enabled

--- a/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-drive-pr-to-merge
-description: This skill should be used to drive a pull request all the way to MERGED, handling ANYTHING that blocks the merge. It enables auto-merge when the repo supports it (direct-merge fallback otherwise), keeps the branch rebased/synced and resolves merge conflicts, fixes failing CI/deploy checks, addresses and resolves every human and bot review comment (CodeRabbit, etc.) — implementing valid feedback and replying-then-resolving invalid feedback — dismisses stale CHANGES_REQUESTED gates, and verifies the fix actually shipped (auto-merge race ancestry check). Composable and inline — invoked by other skills (e.g. git-submit-pr, implement, sync-down) via the Skill tool, never as a standalone user command.
+description: This skill should be used to drive a pull request all the way to MERGED, handling ANYTHING that blocks the merge. It enables auto-merge when the repo supports it (direct-merge fallback otherwise), keeps the branch rebased/synced and resolves merge conflicts, fixes failing CI/deploy checks, addresses and resolves every human and bot review comment (CodeRabbit, etc.) — implementing valid feedback and replying-then-resolving invalid feedback — dismisses stale CHANGES_REQUESTED gates, and verifies the fix actually shipped — both merge ancestry and that a deploy/release run fired for the merge SHA (auto-merge race + zero-deploy-run check). Composable and inline — invoked by other skills (e.g. git-submit-pr, implement, sync-down) via the Skill tool, never as a standalone user command.
 allowed-tools: ["Bash", "Read", "Edit", "Write", "Grep", "Glob", "Skill"]
 ---
 
@@ -246,11 +246,16 @@ head's checks to start, then re-enable auto-merge (section 1). In
 `on_blocker=report` mode this whole step is off-limits (diagnose-only): do not
 merge, close, or delete anything — return `blocked:pending-auto-fix`.
 
-## 3. Merge and verify it actually shipped (ancestry check)
+## 3. Merge and verify it actually shipped (ancestry + deploy run)
 
 Enabling auto-merge + green checks + resolved threads is **not** proof the merge
-included your fix. Auto-merge can land the PRIOR head the instant gates go green,
-before a late fix commit becomes the head. After the PR reports `MERGED`:
+included your fix, and a passing merge **not** proof anything deployed. Both must
+be verified after the PR reports `MERGED`.
+
+### a. Ancestry check — is my code in the merged branch
+
+Auto-merge can land the PRIOR head the instant gates go green, before a late fix
+commit becomes the head:
 
 ```bash
 git fetch origin
@@ -263,11 +268,78 @@ ship — fix forward with a new commit/PR and re-drive. Re-confirm after any com
 that lands while auto-merge is enabled; a successful merge of an older head is a
 failed drive-to-merge outcome, not a successful closeout.
 
+### b. Deploy-run check — did a deploy/release workflow run actually fire
+
+Ancestry proves your code is *in* the merged branch; it does **not** prove
+anything deployed. GitHub can **suppress the `on: push` event for a merge commit
+created by auto-merge or a bot token** (`GITHUB_TOKEN`), so the deploy workflow
+fires **zero** runs — no run, not even a `startup_failure` — while the ancestry
+check above stays green. Incident of record: TunnlAI/frontend **TUN-186** (PR #67)
+merged to `dev` via auto-merge; the merge commit `1b3f836` produced **no**
+`deploy.yml` run, and only the next human push `d1fe18c` (which carries `1b3f836`
+as an ancestor) actually shipped it. **Never report shipped on ancestry alone.**
+
+After ancestry passes, capture the merge SHA and poll for a **deploy/release
+workflow run** whose head SHA **is the merge SHA or an including descendant** (a
+run whose head has the merge SHA as an ancestor also shipped the merge, mirroring
+`d1fe18c` shipping `1b3f836`), keyed to the merged-into branch. The observing
+workflow name is **not fixed** — do **not** hardcode `deploy.yml`:
+
+- **Downstream projects:** the deploy/release workflow run keyed to the base
+  branch resolved via `.lisa.config.json` `deploy.branches` (the merged-into env
+  branch) — the same "deploy run keyed to the merged-into branch via
+  `deploy.branches`" observation `lisa-linear-build-intake` performs before
+  relabeling.
+- **lisa / other repos:** the repo's release or publish workflow for
+  `<baseRefName>`.
+
+Discover the run with the same `gh run list --json …headSha…` pattern
+`lisa-verify-workflow-change` uses:
+
+```bash
+merge_sha=$(gh pr view <pr> --json mergeCommit -q .mergeCommit.oid)
+gh run list --branch <baseRefName> --commit "$merge_sha" \
+  --json databaseId,workflowName,status,conclusion,headSha,headBranch,createdAt --limit 20
+```
+
+**Bounded wait:** a just-created run can take a few seconds to register — poll
+briefly (a small number of short intervals / a short ceiling, mirroring the "wait
+for that head's checks to start" bound used above) before concluding the run is
+absent, so a not-yet-registered run is not mis-read as zero. When no run matches
+the merge SHA directly, also accept a descendant run whose head has `$merge_sha`
+as an ancestor (`git merge-base --is-ancestor "$merge_sha" <run_head_sha>`).
+
+**Zero runs after the bounded wait — do NOT report shipped.** Recover in order:
+
+1. **Dispatch the deploy, then re-verify.** Trigger the env's `workflow_dispatch`
+   for the merged-into branch and re-poll for a run that now covers the merge SHA
+   (or an including descendant):
+   ```bash
+   gh workflow run <deploy-or-release-workflow> --ref <baseRefName>
+   ```
+   Once such a run appears, the merge is confirmed shipped.
+2. **Still zero, or dispatch not permitted → surface a blocker.** Emit a hard
+   block (`blocked:deploy`) reporting exactly what was observed — the merge SHA,
+   the base branch, and zero deploy runs. A failed/blocked path, **never** a
+   silent "done".
+
+In **`on_blocker=report`** mode this deploy-run step is diagnose-only: dispatching
+a workflow is an action, so do **not** run `gh workflow run` / `workflow_dispatch`
+— classify the absence as `blocked:deploy` (or `blocked:no-deploy-run`) and return
+it for the caller to act on, consistent with the report-mode contract (steps b–f
+of section 2 are diagnose-only).
+
 ## 4. Terminal states
 
 Loop until one of:
 
-- **`MERGED`** and the ancestry check passes → success.
+- **`MERGED`** and the ancestry check passes **and** a deploy/release run for the
+  merge SHA (or an including descendant) is confirmed — observed directly or after
+  a `workflow_dispatch` recovery → success. Ancestry alone is **not** success.
+- **`blocked:deploy`** — merged with ancestry green, but after the bounded wait no
+  deploy/release run fired for the merge SHA and dispatch recovery could not
+  confirm one (or was not permitted, e.g. `on_blocker=report`). Stop and report
+  the merge SHA, base branch, and zero observed runs — never a silent "done".
 - **`awaiting-human`** (`auto_merge=false` only) → success. The PR is `OPEN`,
   required checks are green, the review gate is clear, and
   `mergeable == MERGEABLE`, with auto-merge deliberately not enabled

--- a/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-drive-pr-to-merge
-description: This skill should be used to drive a pull request all the way to MERGED, handling ANYTHING that blocks the merge. It enables auto-merge when the repo supports it (direct-merge fallback otherwise), keeps the branch rebased/synced and resolves merge conflicts, fixes failing CI/deploy checks, addresses and resolves every human and bot review comment (CodeRabbit, etc.) — implementing valid feedback and replying-then-resolving invalid feedback — dismisses stale CHANGES_REQUESTED gates, and verifies the fix actually shipped (auto-merge race ancestry check). Composable and inline — invoked by other skills (e.g. git-submit-pr, implement, sync-down) via the Skill tool, never as a standalone user command.
+description: This skill should be used to drive a pull request all the way to MERGED, handling ANYTHING that blocks the merge. It enables auto-merge when the repo supports it (direct-merge fallback otherwise), keeps the branch rebased/synced and resolves merge conflicts, fixes failing CI/deploy checks, addresses and resolves every human and bot review comment (CodeRabbit, etc.) — implementing valid feedback and replying-then-resolving invalid feedback — dismisses stale CHANGES_REQUESTED gates, and verifies the fix actually shipped — both merge ancestry and that a deploy/release run fired for the merge SHA (auto-merge race + zero-deploy-run check). Composable and inline — invoked by other skills (e.g. git-submit-pr, implement, sync-down) via the Skill tool, never as a standalone user command.
 allowed-tools: ["Bash", "Read", "Edit", "Write", "Grep", "Glob", "Skill"]
 ---
 
@@ -246,11 +246,16 @@ head's checks to start, then re-enable auto-merge (section 1). In
 `on_blocker=report` mode this whole step is off-limits (diagnose-only): do not
 merge, close, or delete anything — return `blocked:pending-auto-fix`.
 
-## 3. Merge and verify it actually shipped (ancestry check)
+## 3. Merge and verify it actually shipped (ancestry + deploy run)
 
 Enabling auto-merge + green checks + resolved threads is **not** proof the merge
-included your fix. Auto-merge can land the PRIOR head the instant gates go green,
-before a late fix commit becomes the head. After the PR reports `MERGED`:
+included your fix, and a passing merge **not** proof anything deployed. Both must
+be verified after the PR reports `MERGED`.
+
+### a. Ancestry check — is my code in the merged branch
+
+Auto-merge can land the PRIOR head the instant gates go green, before a late fix
+commit becomes the head:
 
 ```bash
 git fetch origin
@@ -263,11 +268,78 @@ ship — fix forward with a new commit/PR and re-drive. Re-confirm after any com
 that lands while auto-merge is enabled; a successful merge of an older head is a
 failed drive-to-merge outcome, not a successful closeout.
 
+### b. Deploy-run check — did a deploy/release workflow run actually fire
+
+Ancestry proves your code is *in* the merged branch; it does **not** prove
+anything deployed. GitHub can **suppress the `on: push` event for a merge commit
+created by auto-merge or a bot token** (`GITHUB_TOKEN`), so the deploy workflow
+fires **zero** runs — no run, not even a `startup_failure` — while the ancestry
+check above stays green. Incident of record: TunnlAI/frontend **TUN-186** (PR #67)
+merged to `dev` via auto-merge; the merge commit `1b3f836` produced **no**
+`deploy.yml` run, and only the next human push `d1fe18c` (which carries `1b3f836`
+as an ancestor) actually shipped it. **Never report shipped on ancestry alone.**
+
+After ancestry passes, capture the merge SHA and poll for a **deploy/release
+workflow run** whose head SHA **is the merge SHA or an including descendant** (a
+run whose head has the merge SHA as an ancestor also shipped the merge, mirroring
+`d1fe18c` shipping `1b3f836`), keyed to the merged-into branch. The observing
+workflow name is **not fixed** — do **not** hardcode `deploy.yml`:
+
+- **Downstream projects:** the deploy/release workflow run keyed to the base
+  branch resolved via `.lisa.config.json` `deploy.branches` (the merged-into env
+  branch) — the same "deploy run keyed to the merged-into branch via
+  `deploy.branches`" observation `lisa-linear-build-intake` performs before
+  relabeling.
+- **lisa / other repos:** the repo's release or publish workflow for
+  `<baseRefName>`.
+
+Discover the run with the same `gh run list --json …headSha…` pattern
+`lisa-verify-workflow-change` uses:
+
+```bash
+merge_sha=$(gh pr view <pr> --json mergeCommit -q .mergeCommit.oid)
+gh run list --branch <baseRefName> --commit "$merge_sha" \
+  --json databaseId,workflowName,status,conclusion,headSha,headBranch,createdAt --limit 20
+```
+
+**Bounded wait:** a just-created run can take a few seconds to register — poll
+briefly (a small number of short intervals / a short ceiling, mirroring the "wait
+for that head's checks to start" bound used above) before concluding the run is
+absent, so a not-yet-registered run is not mis-read as zero. When no run matches
+the merge SHA directly, also accept a descendant run whose head has `$merge_sha`
+as an ancestor (`git merge-base --is-ancestor "$merge_sha" <run_head_sha>`).
+
+**Zero runs after the bounded wait — do NOT report shipped.** Recover in order:
+
+1. **Dispatch the deploy, then re-verify.** Trigger the env's `workflow_dispatch`
+   for the merged-into branch and re-poll for a run that now covers the merge SHA
+   (or an including descendant):
+   ```bash
+   gh workflow run <deploy-or-release-workflow> --ref <baseRefName>
+   ```
+   Once such a run appears, the merge is confirmed shipped.
+2. **Still zero, or dispatch not permitted → surface a blocker.** Emit a hard
+   block (`blocked:deploy`) reporting exactly what was observed — the merge SHA,
+   the base branch, and zero deploy runs. A failed/blocked path, **never** a
+   silent "done".
+
+In **`on_blocker=report`** mode this deploy-run step is diagnose-only: dispatching
+a workflow is an action, so do **not** run `gh workflow run` / `workflow_dispatch`
+— classify the absence as `blocked:deploy` (or `blocked:no-deploy-run`) and return
+it for the caller to act on, consistent with the report-mode contract (steps b–f
+of section 2 are diagnose-only).
+
 ## 4. Terminal states
 
 Loop until one of:
 
-- **`MERGED`** and the ancestry check passes → success.
+- **`MERGED`** and the ancestry check passes **and** a deploy/release run for the
+  merge SHA (or an including descendant) is confirmed — observed directly or after
+  a `workflow_dispatch` recovery → success. Ancestry alone is **not** success.
+- **`blocked:deploy`** — merged with ancestry green, but after the bounded wait no
+  deploy/release run fired for the merge SHA and dispatch recovery could not
+  confirm one (or was not permitted, e.g. `on_blocker=report`). Stop and report
+  the merge SHA, base branch, and zero observed runs — never a silent "done".
 - **`awaiting-human`** (`auto_merge=false` only) → success. The PR is `OPEN`,
   required checks are green, the review gate is clear, and
   `mergeable == MERGEABLE`, with auto-merge deliberately not enabled

--- a/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -246,11 +246,16 @@ head's checks to start, then re-enable auto-merge (section 1). In
 `on_blocker=report` mode this whole step is off-limits (diagnose-only): do not
 merge, close, or delete anything — return `blocked:pending-auto-fix`.
 
-## 3. Merge and verify it actually shipped (ancestry check)
+## 3. Merge and verify it actually shipped (ancestry + deploy run)
 
 Enabling auto-merge + green checks + resolved threads is **not** proof the merge
-included your fix. Auto-merge can land the PRIOR head the instant gates go green,
-before a late fix commit becomes the head. After the PR reports `MERGED`:
+included your fix, and a passing merge **not** proof anything deployed. Both must
+be verified after the PR reports `MERGED`.
+
+### a. Ancestry check — is my code in the merged branch
+
+Auto-merge can land the PRIOR head the instant gates go green, before a late fix
+commit becomes the head:
 
 ```bash
 git fetch origin
@@ -263,11 +268,78 @@ ship — fix forward with a new commit/PR and re-drive. Re-confirm after any com
 that lands while auto-merge is enabled; a successful merge of an older head is a
 failed drive-to-merge outcome, not a successful closeout.
 
+### b. Deploy-run check — did a deploy/release workflow run actually fire
+
+Ancestry proves your code is *in* the merged branch; it does **not** prove
+anything deployed. GitHub can **suppress the `on: push` event for a merge commit
+created by auto-merge or a bot token** (`GITHUB_TOKEN`), so the deploy workflow
+fires **zero** runs — no run, not even a `startup_failure` — while the ancestry
+check above stays green. Incident of record: TunnlAI/frontend **TUN-186** (PR #67)
+merged to `dev` via auto-merge; the merge commit `1b3f836` produced **no**
+`deploy.yml` run, and only the next human push `d1fe18c` (which carries `1b3f836`
+as an ancestor) actually shipped it. **Never report shipped on ancestry alone.**
+
+After ancestry passes, capture the merge SHA and poll for a **deploy/release
+workflow run** whose head SHA **is the merge SHA or an including descendant** (a
+run whose head has the merge SHA as an ancestor also shipped the merge, mirroring
+`d1fe18c` shipping `1b3f836`), keyed to the merged-into branch. The observing
+workflow name is **not fixed** — do **not** hardcode `deploy.yml`:
+
+- **Downstream projects:** the deploy/release workflow run keyed to the base
+  branch resolved via `.lisa.config.json` `deploy.branches` (the merged-into env
+  branch) — the same "deploy run keyed to the merged-into branch via
+  `deploy.branches`" observation `lisa-linear-build-intake` performs before
+  relabeling.
+- **lisa / other repos:** the repo's release or publish workflow for
+  `<baseRefName>`.
+
+Discover the run with the same `gh run list --json …headSha…` pattern
+`lisa-verify-workflow-change` uses:
+
+```bash
+merge_sha=$(gh pr view <pr> --json mergeCommit -q .mergeCommit.oid)
+gh run list --branch <baseRefName> --commit "$merge_sha" \
+  --json databaseId,workflowName,status,conclusion,headSha,headBranch,createdAt --limit 20
+```
+
+**Bounded wait:** a just-created run can take a few seconds to register — poll
+briefly (a small number of short intervals / a short ceiling, mirroring the "wait
+for that head's checks to start" bound used above) before concluding the run is
+absent, so a not-yet-registered run is not mis-read as zero. When no run matches
+the merge SHA directly, also accept a descendant run whose head has `$merge_sha`
+as an ancestor (`git merge-base --is-ancestor "$merge_sha" <run_head_sha>`).
+
+**Zero runs after the bounded wait — do NOT report shipped.** Recover in order:
+
+1. **Dispatch the deploy, then re-verify.** Trigger the env's `workflow_dispatch`
+   for the merged-into branch and re-poll for a run that now covers the merge SHA
+   (or an including descendant):
+   ```bash
+   gh workflow run <deploy-or-release-workflow> --ref <baseRefName>
+   ```
+   Once such a run appears, the merge is confirmed shipped.
+2. **Still zero, or dispatch not permitted → surface a blocker.** Emit a hard
+   block (`blocked:deploy`) reporting exactly what was observed — the merge SHA,
+   the base branch, and zero deploy runs. A failed/blocked path, **never** a
+   silent "done".
+
+In **`on_blocker=report`** mode this deploy-run step is diagnose-only: dispatching
+a workflow is an action, so do **not** run `gh workflow run` / `workflow_dispatch`
+— classify the absence as `blocked:deploy` (or `blocked:no-deploy-run`) and return
+it for the caller to act on, consistent with the report-mode contract (steps b–f
+of section 2 are diagnose-only).
+
 ## 4. Terminal states
 
 Loop until one of:
 
-- **`MERGED`** and the ancestry check passes → success.
+- **`MERGED`** and the ancestry check passes **and** a deploy/release run for the
+  merge SHA (or an including descendant) is confirmed — observed directly or after
+  a `workflow_dispatch` recovery → success. Ancestry alone is **not** success.
+- **`blocked:deploy`** — merged with ancestry green, but after the bounded wait no
+  deploy/release run fired for the merge SHA and dispatch recovery could not
+  confirm one (or was not permitted, e.g. `on_blocker=report`). Stop and report
+  the merge SHA, base branch, and zero observed runs — never a silent "done".
 - **`awaiting-human`** (`auto_merge=false` only) → success. The PR is `OPEN`,
   required checks are green, the review gate is clear, and
   `mergeable == MERGEABLE`, with auto-merge deliberately not enabled

--- a/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-drive-pr-to-merge
-description: This skill should be used to drive a pull request all the way to MERGED, handling ANYTHING that blocks the merge. It enables auto-merge when the repo supports it (direct-merge fallback otherwise), keeps the branch rebased/synced and resolves merge conflicts, fixes failing CI/deploy checks, addresses and resolves every human and bot review comment (CodeRabbit, etc.) — implementing valid feedback and replying-then-resolving invalid feedback — dismisses stale CHANGES_REQUESTED gates, and verifies the fix actually shipped (auto-merge race ancestry check). Composable and inline — invoked by other skills (e.g. git-submit-pr, implement, sync-down) via the Skill tool, never as a standalone user command.
+description: This skill should be used to drive a pull request all the way to MERGED, handling ANYTHING that blocks the merge. It enables auto-merge when the repo supports it (direct-merge fallback otherwise), keeps the branch rebased/synced and resolves merge conflicts, fixes failing CI/deploy checks, addresses and resolves every human and bot review comment (CodeRabbit, etc.) — implementing valid feedback and replying-then-resolving invalid feedback — dismisses stale CHANGES_REQUESTED gates, and verifies the fix actually shipped — both merge ancestry and that a deploy/release run fired for the merge SHA (auto-merge race + zero-deploy-run check). Composable and inline — invoked by other skills (e.g. git-submit-pr, implement, sync-down) via the Skill tool, never as a standalone user command.
 allowed-tools: ["Bash", "Read", "Edit", "Write", "Grep", "Glob", "Skill"]
 ---
 
@@ -246,11 +246,16 @@ head's checks to start, then re-enable auto-merge (section 1). In
 `on_blocker=report` mode this whole step is off-limits (diagnose-only): do not
 merge, close, or delete anything — return `blocked:pending-auto-fix`.
 
-## 3. Merge and verify it actually shipped (ancestry check)
+## 3. Merge and verify it actually shipped (ancestry + deploy run)
 
 Enabling auto-merge + green checks + resolved threads is **not** proof the merge
-included your fix. Auto-merge can land the PRIOR head the instant gates go green,
-before a late fix commit becomes the head. After the PR reports `MERGED`:
+included your fix, and a passing merge **not** proof anything deployed. Both must
+be verified after the PR reports `MERGED`.
+
+### a. Ancestry check — is my code in the merged branch
+
+Auto-merge can land the PRIOR head the instant gates go green, before a late fix
+commit becomes the head:
 
 ```bash
 git fetch origin
@@ -263,11 +268,78 @@ ship — fix forward with a new commit/PR and re-drive. Re-confirm after any com
 that lands while auto-merge is enabled; a successful merge of an older head is a
 failed drive-to-merge outcome, not a successful closeout.
 
+### b. Deploy-run check — did a deploy/release workflow run actually fire
+
+Ancestry proves your code is *in* the merged branch; it does **not** prove
+anything deployed. GitHub can **suppress the `on: push` event for a merge commit
+created by auto-merge or a bot token** (`GITHUB_TOKEN`), so the deploy workflow
+fires **zero** runs — no run, not even a `startup_failure` — while the ancestry
+check above stays green. Incident of record: TunnlAI/frontend **TUN-186** (PR #67)
+merged to `dev` via auto-merge; the merge commit `1b3f836` produced **no**
+`deploy.yml` run, and only the next human push `d1fe18c` (which carries `1b3f836`
+as an ancestor) actually shipped it. **Never report shipped on ancestry alone.**
+
+After ancestry passes, capture the merge SHA and poll for a **deploy/release
+workflow run** whose head SHA **is the merge SHA or an including descendant** (a
+run whose head has the merge SHA as an ancestor also shipped the merge, mirroring
+`d1fe18c` shipping `1b3f836`), keyed to the merged-into branch. The observing
+workflow name is **not fixed** — do **not** hardcode `deploy.yml`:
+
+- **Downstream projects:** the deploy/release workflow run keyed to the base
+  branch resolved via `.lisa.config.json` `deploy.branches` (the merged-into env
+  branch) — the same "deploy run keyed to the merged-into branch via
+  `deploy.branches`" observation `lisa-linear-build-intake` performs before
+  relabeling.
+- **lisa / other repos:** the repo's release or publish workflow for
+  `<baseRefName>`.
+
+Discover the run with the same `gh run list --json …headSha…` pattern
+`lisa-verify-workflow-change` uses:
+
+```bash
+merge_sha=$(gh pr view <pr> --json mergeCommit -q .mergeCommit.oid)
+gh run list --branch <baseRefName> --commit "$merge_sha" \
+  --json databaseId,workflowName,status,conclusion,headSha,headBranch,createdAt --limit 20
+```
+
+**Bounded wait:** a just-created run can take a few seconds to register — poll
+briefly (a small number of short intervals / a short ceiling, mirroring the "wait
+for that head's checks to start" bound used above) before concluding the run is
+absent, so a not-yet-registered run is not mis-read as zero. When no run matches
+the merge SHA directly, also accept a descendant run whose head has `$merge_sha`
+as an ancestor (`git merge-base --is-ancestor "$merge_sha" <run_head_sha>`).
+
+**Zero runs after the bounded wait — do NOT report shipped.** Recover in order:
+
+1. **Dispatch the deploy, then re-verify.** Trigger the env's `workflow_dispatch`
+   for the merged-into branch and re-poll for a run that now covers the merge SHA
+   (or an including descendant):
+   ```bash
+   gh workflow run <deploy-or-release-workflow> --ref <baseRefName>
+   ```
+   Once such a run appears, the merge is confirmed shipped.
+2. **Still zero, or dispatch not permitted → surface a blocker.** Emit a hard
+   block (`blocked:deploy`) reporting exactly what was observed — the merge SHA,
+   the base branch, and zero deploy runs. A failed/blocked path, **never** a
+   silent "done".
+
+In **`on_blocker=report`** mode this deploy-run step is diagnose-only: dispatching
+a workflow is an action, so do **not** run `gh workflow run` / `workflow_dispatch`
+— classify the absence as `blocked:deploy` (or `blocked:no-deploy-run`) and return
+it for the caller to act on, consistent with the report-mode contract (steps b–f
+of section 2 are diagnose-only).
+
 ## 4. Terminal states
 
 Loop until one of:
 
-- **`MERGED`** and the ancestry check passes → success.
+- **`MERGED`** and the ancestry check passes **and** a deploy/release run for the
+  merge SHA (or an including descendant) is confirmed — observed directly or after
+  a `workflow_dispatch` recovery → success. Ancestry alone is **not** success.
+- **`blocked:deploy`** — merged with ancestry green, but after the bounded wait no
+  deploy/release run fired for the merge SHA and dispatch recovery could not
+  confirm one (or was not permitted, e.g. `on_blocker=report`). Stop and report
+  the merge SHA, base branch, and zero observed runs — never a silent "done".
 - **`awaiting-human`** (`auto_merge=false` only) → success. The PR is `OPEN`,
   required checks are green, the review gate is clear, and
   `mergeable == MERGEABLE`, with auto-merge deliberately not enabled

--- a/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-drive-pr-to-merge
-description: This skill should be used to drive a pull request all the way to MERGED, handling ANYTHING that blocks the merge. It enables auto-merge when the repo supports it (direct-merge fallback otherwise), keeps the branch rebased/synced and resolves merge conflicts, fixes failing CI/deploy checks, addresses and resolves every human and bot review comment (CodeRabbit, etc.) — implementing valid feedback and replying-then-resolving invalid feedback — dismisses stale CHANGES_REQUESTED gates, and verifies the fix actually shipped (auto-merge race ancestry check). Composable and inline — invoked by other skills (e.g. git-submit-pr, implement, sync-down) via the Skill tool, never as a standalone user command.
+description: This skill should be used to drive a pull request all the way to MERGED, handling ANYTHING that blocks the merge. It enables auto-merge when the repo supports it (direct-merge fallback otherwise), keeps the branch rebased/synced and resolves merge conflicts, fixes failing CI/deploy checks, addresses and resolves every human and bot review comment (CodeRabbit, etc.) — implementing valid feedback and replying-then-resolving invalid feedback — dismisses stale CHANGES_REQUESTED gates, and verifies the fix actually shipped — both merge ancestry and that a deploy/release run fired for the merge SHA (auto-merge race + zero-deploy-run check). Composable and inline — invoked by other skills (e.g. git-submit-pr, implement, sync-down) via the Skill tool, never as a standalone user command.
 allowed-tools: ["Bash", "Read", "Edit", "Write", "Grep", "Glob", "Skill"]
 ---
 
@@ -246,11 +246,16 @@ head's checks to start, then re-enable auto-merge (section 1). In
 `on_blocker=report` mode this whole step is off-limits (diagnose-only): do not
 merge, close, or delete anything — return `blocked:pending-auto-fix`.
 
-## 3. Merge and verify it actually shipped (ancestry check)
+## 3. Merge and verify it actually shipped (ancestry + deploy run)
 
 Enabling auto-merge + green checks + resolved threads is **not** proof the merge
-included your fix. Auto-merge can land the PRIOR head the instant gates go green,
-before a late fix commit becomes the head. After the PR reports `MERGED`:
+included your fix, and a passing merge **not** proof anything deployed. Both must
+be verified after the PR reports `MERGED`.
+
+### a. Ancestry check — is my code in the merged branch
+
+Auto-merge can land the PRIOR head the instant gates go green, before a late fix
+commit becomes the head:
 
 ```bash
 git fetch origin
@@ -263,11 +268,78 @@ ship — fix forward with a new commit/PR and re-drive. Re-confirm after any com
 that lands while auto-merge is enabled; a successful merge of an older head is a
 failed drive-to-merge outcome, not a successful closeout.
 
+### b. Deploy-run check — did a deploy/release workflow run actually fire
+
+Ancestry proves your code is *in* the merged branch; it does **not** prove
+anything deployed. GitHub can **suppress the `on: push` event for a merge commit
+created by auto-merge or a bot token** (`GITHUB_TOKEN`), so the deploy workflow
+fires **zero** runs — no run, not even a `startup_failure` — while the ancestry
+check above stays green. Incident of record: TunnlAI/frontend **TUN-186** (PR #67)
+merged to `dev` via auto-merge; the merge commit `1b3f836` produced **no**
+`deploy.yml` run, and only the next human push `d1fe18c` (which carries `1b3f836`
+as an ancestor) actually shipped it. **Never report shipped on ancestry alone.**
+
+After ancestry passes, capture the merge SHA and poll for a **deploy/release
+workflow run** whose head SHA **is the merge SHA or an including descendant** (a
+run whose head has the merge SHA as an ancestor also shipped the merge, mirroring
+`d1fe18c` shipping `1b3f836`), keyed to the merged-into branch. The observing
+workflow name is **not fixed** — do **not** hardcode `deploy.yml`:
+
+- **Downstream projects:** the deploy/release workflow run keyed to the base
+  branch resolved via `.lisa.config.json` `deploy.branches` (the merged-into env
+  branch) — the same "deploy run keyed to the merged-into branch via
+  `deploy.branches`" observation `lisa-linear-build-intake` performs before
+  relabeling.
+- **lisa / other repos:** the repo's release or publish workflow for
+  `<baseRefName>`.
+
+Discover the run with the same `gh run list --json …headSha…` pattern
+`lisa-verify-workflow-change` uses:
+
+```bash
+merge_sha=$(gh pr view <pr> --json mergeCommit -q .mergeCommit.oid)
+gh run list --branch <baseRefName> --commit "$merge_sha" \
+  --json databaseId,workflowName,status,conclusion,headSha,headBranch,createdAt --limit 20
+```
+
+**Bounded wait:** a just-created run can take a few seconds to register — poll
+briefly (a small number of short intervals / a short ceiling, mirroring the "wait
+for that head's checks to start" bound used above) before concluding the run is
+absent, so a not-yet-registered run is not mis-read as zero. When no run matches
+the merge SHA directly, also accept a descendant run whose head has `$merge_sha`
+as an ancestor (`git merge-base --is-ancestor "$merge_sha" <run_head_sha>`).
+
+**Zero runs after the bounded wait — do NOT report shipped.** Recover in order:
+
+1. **Dispatch the deploy, then re-verify.** Trigger the env's `workflow_dispatch`
+   for the merged-into branch and re-poll for a run that now covers the merge SHA
+   (or an including descendant):
+   ```bash
+   gh workflow run <deploy-or-release-workflow> --ref <baseRefName>
+   ```
+   Once such a run appears, the merge is confirmed shipped.
+2. **Still zero, or dispatch not permitted → surface a blocker.** Emit a hard
+   block (`blocked:deploy`) reporting exactly what was observed — the merge SHA,
+   the base branch, and zero deploy runs. A failed/blocked path, **never** a
+   silent "done".
+
+In **`on_blocker=report`** mode this deploy-run step is diagnose-only: dispatching
+a workflow is an action, so do **not** run `gh workflow run` / `workflow_dispatch`
+— classify the absence as `blocked:deploy` (or `blocked:no-deploy-run`) and return
+it for the caller to act on, consistent with the report-mode contract (steps b–f
+of section 2 are diagnose-only).
+
 ## 4. Terminal states
 
 Loop until one of:
 
-- **`MERGED`** and the ancestry check passes → success.
+- **`MERGED`** and the ancestry check passes **and** a deploy/release run for the
+  merge SHA (or an including descendant) is confirmed — observed directly or after
+  a `workflow_dispatch` recovery → success. Ancestry alone is **not** success.
+- **`blocked:deploy`** — merged with ancestry green, but after the bounded wait no
+  deploy/release run fired for the merge SHA and dispatch recovery could not
+  confirm one (or was not permitted, e.g. `on_blocker=report`). Stop and report
+  the merge SHA, base branch, and zero observed runs — never a silent "done".
 - **`awaiting-human`** (`auto_merge=false` only) → success. The PR is `OPEN`,
   required checks are green, the review gate is clear, and
   `mergeable == MERGEABLE`, with auto-merge deliberately not enabled

--- a/tests/unit/strategies/drive-pr-auto-merge-race.test.ts
+++ b/tests/unit/strategies/drive-pr-auto-merge-race.test.ts
@@ -2,8 +2,13 @@
  * Regression tests for issue #1395: auto-merge must not stay armed while a
  * later fix commit is still being pushed or queued for checks.
  *
- * Both source and generated plugin roots are asserted so a missed
- * `bun run build:plugins` fails the suite.
+ * Extended for issue #1777: shipped-verification must also assert a deploy/
+ * release workflow run actually fired for the merge SHA (auto-merge can trigger
+ * zero deploy runs when GitHub suppresses the `on: push` event for a bot merge
+ * commit), not just merge ancestry.
+ *
+ * Both source and generated plugin roots — including the sixth Codex root — are
+ * asserted so a missed `bun run build:plugins` fails the suite.
  * @module tests/unit/strategies/drive-pr-auto-merge-race
  */
 import { readFileSync } from "node:fs";
@@ -17,6 +22,7 @@ const ROOTS = [
   "plugins/lisa-agy/skills",
   "plugins/lisa-copilot/skills",
   "plugins/lisa-cursor/skills",
+  "plugins/lisa/.codex-plugin/skills",
 ] as const;
 
 const readSkill = (root: string, slug: string): string =>
@@ -42,5 +48,44 @@ describe.each(ROOTS)("drive-pr-to-merge auto-merge race guard (%s)", root => {
     );
     expect(content).toMatch(/wait for that head's checks to start/i);
     expect(content).toMatch(/failed drive-to-merge outcome/i);
+  });
+
+  it("asserts a deploy/release workflow run fired for the merge SHA, keyed to the merged-into branch", () => {
+    expect(content).toMatch(/deploy\/release workflow run|deploy run/i);
+    expect(content).toMatch(/is the merge SHA or an including descendant/i);
+    expect(content).toMatch(/deploy\.branches/);
+    // Vendor-neutral on the workflow name — must not hardcode a single file.
+    expect(content).toMatch(/not\s+(?:fixed|hardcode)/i);
+  });
+
+  it("names the on:push-suppression root cause and the incident of record", () => {
+    expect(content).toMatch(/on: push/);
+    expect(content).toMatch(/suppress/i);
+    expect(content).toMatch(/1b3f836/);
+    expect(content).toMatch(/TUN-186/);
+  });
+
+  it("bounds the poll before concluding a deploy run is absent", () => {
+    expect(content).toMatch(/before concluding/i);
+    expect(content).toMatch(/bounded wait/i);
+  });
+
+  it("recovers zero deploy runs via workflow_dispatch then re-verify, else blocks", () => {
+    expect(content).toMatch(/gh workflow run/);
+    expect(content).toMatch(/workflow_dispatch/);
+    expect(content).toMatch(/blocked:deploy/);
+    expect(content).toMatch(/silent "done"/);
+    expect(content).toMatch(/[Nn]ever report shipped on ancestry alone/);
+  });
+
+  it("in report mode classifies the deploy-run absence without dispatching", () => {
+    expect(content).toMatch(/dispatching\s+a\s+workflow\s+is\s+an\s+action/i);
+    expect(content).toMatch(/diagnose-only/i);
+  });
+
+  it("makes a confirmed deploy run part of the MERGED success terminal", () => {
+    expect(content).toMatch(
+      /deploy(?:\/release)? run for the[\s\S]{0,10}merge SHA[\s\S]{0,160}success/i
+    );
   });
 });


### PR DESCRIPTION
## What & why

`lisa-drive-pr-to-merge`'s shipped-verification checked only that the fix commit was a git **ancestor** of the merged base — it never confirmed that a **deploy/release workflow run actually fired for the merge SHA**. So an auto-merge that triggers **zero** deploy runs was reported "shipped" when nothing deployed.

### Root cause

GitHub **suppresses the `on: push` event for a merge commit created by auto-merge or a bot token** (`GITHUB_TOKEN`), so the deploy workflow fires **zero** runs — not even a `startup_failure` — while the ancestry check stays green.

**Incident of record:** TunnlAI/frontend **TUN-186** (PR #67) merged to `dev` via auto-merge. Merge commit `1b3f836` produced **no** `deploy.yml` run; only the next human push `d1fe18c` (which carries `1b3f836` as an ancestor) actually shipped it.

## Change

Prose + tests only. Single source of truth is `plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md`, fanned out to all 6 generated roots via `bun run build:plugins`.

- **Section 3** keeps the ancestry check and adds a **vendor-neutral deploy-run assertion**: after ancestry passes, bounded-poll for a deploy/release run whose head SHA **is the merge SHA or an including descendant**, keyed to the merged-into branch — downstream via `.lisa.config.json` `deploy.branches` (aligned with `lisa-linear-build-intake`'s wording), lisa via its release/publish workflow. Reuses the `gh run list --json …headSha…` discovery pattern from `lisa-verify-workflow-change`. **Does not hardcode `deploy.yml`.**
- **Zero runs after the bounded wait → do NOT report shipped.** Recover via `gh workflow run` / `workflow_dispatch` for the base branch, then re-verify; if still absent or `on_blocker=report`, surface `blocked:deploy` — **never a silent "done"**. Report mode classifies without dispatching (diagnose-only contract).
- **Section 4** MERGED success terminal now requires ancestry **and** a confirmed deploy run; adds a `blocked:deploy` terminal. Frontmatter description updated to match behavior.
- **`lisa-implement` steps 10–11 stay thin** — the skill is the single source of truth for the merge loop, so no implement edits and no downstream template changes.

## Tests (TDD)

- **RED:** extended `tests/unit/strategies/drive-pr-auto-merge-race.test.ts` with deploy-run wording pins (deploy-run phrase, "merge SHA or an including descendant", `deploy.branches`, on:push-suppression + `1b3f836`/`TUN-186` incident, bounded wait, `gh workflow run`/`workflow_dispatch` recovery, `blocked:deploy`, "never report shipped on ancestry alone", report-mode no-dispatch, MERGED-success requires a deploy run) and **added the 6th (Codex) root** `plugins/lisa/.codex-plugin/skills` to `ROOTS`. → `36 failed | 18 passed`.
- **GREEN:** after editing base SKILL.md + `bun run build:plugins` → `54 passed`.

## Gates

- `tests/unit/strategies/drive-pr-auto-merge-race.test.ts`: **54 passed**
- Full strategies suite: **3560 passed (141 files)**
- `bun run typecheck`: clean
- `bun run check:plugins`: exit 0 — artifacts in sync, marketplace registers every plugin

Closes #1777

🤖 Generated with Claude Code
