### PR TITLE
fix(tests): eliminate module-resolution race in expo-eslint-local-config temp project (#1824)

### DIFF
--- a/tests/unit/config/expo-eslint-local-config.test.ts
+++ b/tests/unit/config/expo-eslint-local-config.test.ts
@@ -9,14 +9,7 @@
  * @module tests/unit/config/expo-eslint-local-config
  */
 import { spawnSync } from "node:child_process";
-import {
-  copyFileSync,
-  mkdirSync,
-  mkdtempSync,
-  rmSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -31,6 +24,25 @@ const EXPO_ESLINT_TEMPLATE = path.join(
   MANAGED_CONFIG_FILENAME
 );
 const TSC = path.join(REPO_ROOT, "node_modules", "typescript", "bin", "tsc");
+
+/**
+ * The managed template imports `@codyswann/lisa/eslint/expo`, which the package
+ * `exports` map points at the built `dist/configs/eslint/expo.js`. Resolving
+ * through that live artifact raced sibling suites that rebuild `dist/` mid-run:
+ * `cli-smoke.test.ts` runs `build:dist`, whose `clean-dist` step deletes `dist/`
+ * before `tsc` regenerates it, so under full-suite parallelism this temp project
+ * intermittently failed with TS2307 (#1824). The factory source is the very file
+ * that `dist/configs/eslint/expo.d.ts` is emitted from — identical public types,
+ * but never deleted by a build — so the fixture resolves the subpath straight to
+ * source via a tsconfig `paths` mapping, decoupling it from the mutable `dist/`.
+ */
+const EXPO_ESLINT_FACTORY_SOURCE = path.join(
+  REPO_ROOT,
+  "src",
+  "configs",
+  "eslint",
+  "expo.ts"
+);
 
 const MINIMAL_CUSTOM_PLUGIN = `
 const customPlugin = {
@@ -107,14 +119,13 @@ function compileHostFixture(name: string, localConfig: string): string {
           target: "ES2022",
           typeRoots: [path.join(REPO_ROOT, "node_modules", "@types")],
           types: ["node"],
+          paths: {
+            "@codyswann/lisa/eslint/expo": [EXPO_ESLINT_FACTORY_SOURCE],
+          },
         },
         include: [MANAGED_CONFIG_FILENAME, LOCAL_CONFIG_FILENAME],
       })
     );
-
-    const packageScope = path.join(fixture, "node_modules", "@codyswann");
-    mkdirSync(packageScope, { recursive: true });
-    symlinkSync(REPO_ROOT, path.join(packageScope, "lisa"), "dir");
 
     const result = spawnSync(
       process.execPath,


### PR DESCRIPTION
## What & why

`tests/unit/config/expo-eslint-local-config.test.ts` scaffolds a temp project that
imports `@codyswann/lisa/eslint/expo`. The package `exports` map resolves that
subpath to the built `dist/configs/eslint/expo.js`, and the fixture symlinked the
repo root into `node_modules/@codyswann/lisa` so `tsc` read the **live** `dist/`
tree.

Under the pre-push gate (`vitest run --coverage`, all suites in parallel) this
raced `tests/integration/cli-smoke.test.ts`, which runs `build:dist`. Its first
step — `scripts/clean-dist.mjs` — deletes `dist/` before `tsc` regenerates it.
Whenever that delete/rebuild window overlapped the fixture's `tsc` read, module
resolution missed and the run failed with:

```
error TS2307: Cannot find module '@codyswann/lisa/eslint/expo' or its corresponding type declarations.
```

…then passed 2/2 in isolation. Observed twice in the wild on 2026-07-20 (during
#1713's first push; the identical push succeeded on retry).

## Root cause

Shared-mutable-resource contention on the single `REPO_ROOT/dist` tree: one suite
reads it for module resolution while another deletes-then-rebuilds it mid-run. The
temp-dir naming was already unique (`mkdtempSync`) — the race was the `dist/`
dependency, not the fixture directory.

## Reproduction (deterministic)

Running the two contending suites together reproduced the exact ticket error every
time:

```
$ for i in 1..8; bunx vitest run \
    tests/unit/config/expo-eslint-local-config.test.ts \
    tests/integration/cli-smoke.test.ts
→ TS2307 failures: 8 / 8
```

## Fix

Resolve the factory subpath straight to its **stable source**
(`src/configs/eslint/expo.ts`) via a tsconfig `paths` mapping, instead of through
the mutable `dist/` artifact. The source is the exact file `expo.d.ts` is emitted
from, so the public types the test validates are identical — but source is never
deleted by a build. The fixture no longer touches `dist/` at all, and the now-unused
package-symlink scaffolding is dropped. No test skipped; no retries added.

## Proof

- Reproduction harness (expo + cli-smoke together), post-fix: **0 / 10** TS2307
  failures (was 8/8).
- Isolated run: 2/2 pass.
- Full `bun run test:cov` (the pre-push gate): **355 files, 6144/6144 tests pass**,
  zero TS2307.
- `bun run typecheck`: clean. `oxlint` + `eslint` on the file: 0 warnings, 0 errors.

Closes #1824

🤖 Generated with Claude Code
