### PR TITLE
feat(verification): verdict schema v2 with claim-boundary mapping and compat-windowed gate (#1836)

### DIFF
--- a/plugins/lisa-agy/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-implement/SKILL.md
@@ -228,22 +228,52 @@ Before shutting down the team, execute the Verify flow:
 
 1. Run quality gates: lint, typecheck, tests — all must pass. These are prerequisites, NOT verification.
 2. `verification-specialist`: verify locally by running the actual system and observing results (empirical proof that the change works). This is the real verification step. For UI-surface bugs, the proof must observe the UI surface with browser/device automation against the target environment whenever such a harness exists; unit-level or API-only proof cannot satisfy the empirical verification contract for a UI-surface defect.
-2a. **Record the verification verdict** — the independent, machine-readable proof that gates completion. The `verification-specialist` writes `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json` with one entry per acceptance criterion, each carrying the proof command's observed evidence:
+2a. **Record the verification verdict** — the independent, machine-readable proof that gates completion. The `verification-specialist` writes `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json` in **schema v2**, which binds every claim to the *boundary* it asserts and to the evidence *kinds* that reach that boundary, per the `claim-evidence-mapping` rule:
 
     ```json
     {
+      "schema_version": 2,
       "plan": "<plan-name>",
-      "status": "pass | fail | blocked | in_progress",
+      "artifact": {
+        "repository": "<owner/repo>", "base_sha": "<sha>", "head_sha": "<sha of what will ship>",
+        "build_id": "<build/run id>", "environment": "<where it was observed>", "observed_at": "<ISO8601 UTC>"
+      },
+      "claims": [
+        {
+          "claim_id": "AC-1",
+          "statement": "<the claim, in the operator's language>",
+          "boundary": "code-unit | browser | http-api | cli | data | deploy-health | performance | standards-compat",
+          "required_for_gate": true,
+          "required_evidence_kinds": ["<kinds that reach this boundary, e.g. screenshot, recording>"],
+          "status": "established | not-established",
+          "evidence_refs": ["EV-1"],
+          "not_established": ["<what this claim does NOT cover>"]
+        }
+      ],
+      "evidence": [
+        {
+          "evidence_id": "EV-1",
+          "kind": "screenshot | recording | http-transcript | cli-output | log-snippet | db-query-output | perf-trace | test-run-log | deploy-log | state-dump",
+          "locator": "evidence/<ticket>/<file>", "sha256": "<hash>",
+          "captured_at": "<ISO8601 UTC>", "artifact_head_sha": "<sha the artifact was captured at>"
+        }
+      ],
+      "not_established_reviewed": true,
       "criteria": [
         { "task": "<task id or title>", "criterion": "<the completion condition>", "status": "pass | fail | blocked", "evidence": "<the proof command run and the observed result; for a blocked criterion, the blocker diagnosis (e.g. the missing access and the probe that must pass)>" }
       ],
+      "status": "pass | fail | blocked | in_progress",
       "updated_at": "<ISO8601 UTC>"
     }
     ```
 
+    Rules for v2: a claim is established **only** by evidence whose `kind` reaches its `boundary` — a unit `test-run-log` reaches only `code-unit` and can never establish a `browser`, `http-api`, or `deploy-health` claim. `not_established_reviewed` must always be present (the `not_established` list may be empty, but the flag may never be omitted). `artifact.head_sha` names what will ship, and each evidence entry's `artifact_head_sha` must match it. The legacy `criteria[]` array is retained and still read, but under v2 it is **display-only** — it can never establish a v2 claim.
+
+    **v1 is still accepted during the compatibility window.** A verdict that omits `schema_version` (or sets it to `1`) carries only `plan` / `status` / `criteria[]` / `updated_at` and is judged exactly as before: terminal `status` plus no failing criterion plus freshness. Write v2 for new work; nothing in flight breaks.
+
     Set `status: "pass"` only when every criterion is `pass` with real evidence (output from running the system, not a claim). The verdict must be judged by an agent that did NOT implement the change (the `verification-specialist`), never self-certified by the implementer. This is runtime scratch — it is gitignored and MUST NOT be committed (treat it like the secrets exclusion in the commit step).
 
-    On Claude, the `enforce-verification-gate.sh` Stop hook reads this file and **will not let the flow stop** until it shows a terminal, all-`pass` verdict — carrying over the non-bypassable completion gate of the `/goal` primitive, but checked deterministically against real evidence rather than by a transcript-only evaluator model. If you must stop before completion, write the verdict with `status: "blocked"` and the reason — marking each criterion whose proof is blocked as `status: "blocked"` with the blocker diagnosis as its `evidence`, while unaffected criteria keep their real `pass`/`fail` result — that records the outcome and releases the gate instead of leaving it to spin. But a `blocked` verdict is a last resort, not a shortcut around fillable work: **first resolve every gap you can resolve yourself.** If the work item is thin — missing its Validation Journey, acceptance criteria, or other derivable detail — enrich it: derive the missing detail from the ticket context and the codebase, write it back, and proceed. Do **not** block on a gap you could have filled. Only a blocker that survives that attempt is real, and it is one of two kinds:
+    On Claude, the `enforce-verification-gate.sh` Stop hook reads this file — both v1 and v2 — and **will not let the flow stop** until it shows a terminal, all-`pass` verdict. The v2 claim/evidence checks are **advisory-first**: a boundary or identity violation is reported to stderr but does not block until `verification.gate.enforceBoundaries` is set to `true` in `.lisa.config.json` (default `false`, promoted via the threshold ratchet). Treat an advisory warning as a defect to fix now, not a warning to ignore — it becomes blocking on the ratchet. The gate — carrying over the non-bypassable completion gate of the `/goal` primitive, but checked deterministically against real evidence rather than by a transcript-only evaluator model. If you must stop before completion, write the verdict with `status: "blocked"` and the reason — marking each criterion whose proof is blocked as `status: "blocked"` with the blocker diagnosis as its `evidence`, while unaffected criteria keep their real `pass`/`fail` result — that records the outcome and releases the gate instead of leaving it to spin. But a `blocked` verdict is a last resort, not a shortcut around fillable work: **first resolve every gap you can resolve yourself.** If the work item is thin — missing its Validation Journey, acceptance criteria, or other derivable detail — enrich it: derive the missing detail from the ticket context and the codebase, write it back, and proceed. Do **not** block on a gap you could have filled. Only a blocker that survives that attempt is real, and it is one of two kinds:
 
     - **Actionable blocker** — an unresolved dependency or fixable technical gap that some team or repository could build (a missing or changed schema field, an unbuilt sibling work item, a required upstream fix), **including cross-repo dependencies**. Before writing the blocked verdict you MUST (1) file a build-ready fix/dependency ticket capturing the diagnosis — in the dependency's own repository/tracker when it is cross-repo (e.g. a `[<repo>] …` ticket in the shared project, or the sibling tracker) — and (2) link the current work item to it as `is blocked by`. Only then write the verdict. This is the same discipline as the regression-spec blocker and the remote-verification-fail exits above, and it is what makes the block machine-recoverable: `repair-intake` re-dispatches a blocked item once its linked `is blocked by` dependency closes, but it cannot act on a prose-only comment. Recommending the ticket "as a human follow-up" without filing and linking it is **not** a permitted exit.
     - **Human-only blocker** — an input the agent genuinely cannot obtain or produce no matter what it does: credentials, secrets, or **tool access** it does not have (AWS/CloudWatch, Figma, Jam, Sentry, SonarCloud, a database, a protected deploy target, …), or a product/design decision only a human can make. For missing tool access, follow the `tool-access-gate` rule's break-out protocol: post the "Access Needed" comment naming the exact credential/role/env var to grant and the probe that must pass — never work around the gap by substituting weaker verification, mocking the inaccessible system, or narrowing scope. Record the blocked verdict, mark it `human_needed` (the marker `repair-intake` recognizes, so it won't churn re-dispatching it), and surface or reassign to a human; do **not** fabricate a build-ready ticket, because there is no build-ready work.

--- a/plugins/lisa-copilot/hooks/enforce-verification-gate.sh
+++ b/plugins/lisa-copilot/hooks/enforce-verification-gate.sh
@@ -27,7 +27,33 @@
 #                        by a per-session block counter so a genuinely-stuck flow
 #                        ESCALATES instead of looping forever.
 #
-# The verdict artifact lives at "$CLAUDE_PROJECT_DIR/.lisa/verification-status.json":
+# The verdict artifact lives at "$CLAUDE_PROJECT_DIR/.lisa/verification-status.json".
+#
+# SCHEMA v2 (current) binds every claim to a boundary and to the evidence kinds
+# that reach it, per the claim-evidence-mapping contract:
+#   {
+#     "schema_version": 2,
+#     "plan": "<plan-name>",
+#     "artifact": { "repository": "owner/repo", "base_sha": "...", "head_sha": "...",
+#                   "build_id": "...", "environment": "...", "observed_at": "<ISO8601 UTC>" },
+#     "claims": [
+#       { "claim_id": "AC-1", "statement": "...", "boundary": "browser",
+#         "required_for_gate": true, "required_evidence_kinds": ["screenshot","recording"],
+#         "status": "established" | "not-established", "evidence_refs": ["EV-1"],
+#         "not_established": ["<what this claim does NOT cover>"] }
+#     ],
+#     "evidence": [
+#       { "evidence_id": "EV-1", "kind": "screenshot", "locator": "evidence/1836/x.png",
+#         "sha256": "...", "captured_at": "<ISO8601 UTC>", "artifact_head_sha": "..." }
+#     ],
+#     "not_established_reviewed": true,
+#     "criteria": [ ... legacy, display-only ... ],
+#     "status": "pass" | "fail" | "blocked" | "in_progress",
+#     "updated_at": "<ISO8601 UTC>"
+#   }
+#
+# SCHEMA v1 (legacy, still accepted during the compatibility window) omits
+# "schema_version" or sets it to 1, and carries only:
 #   {
 #     "plan": "<plan-name>",
 #     "status": "pass" | "fail" | "blocked" | "in_progress",
@@ -36,15 +62,39 @@
 #     ],
 #     "updated_at": "<ISO8601 UTC>"
 #   }
-# status "pass" (all criteria pass) or "blocked" (flow recorded a blocker and is
-# stopping deliberately) are terminal and release the gate. "fail"/"in_progress"
-# or a missing/stale file keep it closed.
+#
+# In BOTH schemas, status "pass" (all criteria pass) or "blocked" (flow recorded
+# a blocker and is stopping deliberately) are terminal and release the gate.
+# "fail"/"in_progress" or a missing/stale file keep it closed.
+#
+# Compatibility window: the gate branches on "schema_version". Absent or 1 takes
+# the v1 path unchanged — byte-for-byte the pre-v2 decision. 2 takes the v1 path
+# PLUS the claim->evidence checks below. Legacy "criteria" is display-only under
+# v2 and can never establish a v2 claim.
+#
+# v2 claim checks (only ever applied to an overall "pass"; a deliberate
+# "blocked" stop is terminal on the v1 conditions alone):
+#   - every claim with "required_for_gate": true is "status": "established"
+#   - each such claim's "evidence_refs" resolve to "evidence[]" entries, at
+#     least one of whose "kind" is in the claim's "required_evidence_kinds"
+#   - "not_established_reviewed": true is present (the list may be empty, but
+#     the flag may never be omitted)
+#   - "artifact.head_sha" exists and no evidence entry declares a different
+#     "artifact_head_sha" (reconciliation with the MERGED head is BCE-4)
+#
+# ADVISORY-FIRST: those v2 checks report to stderr but do NOT block unless
+# "verification.gate.enforceBoundaries" is true in .lisa.config.json (default
+# false at ship, promoted via the threshold ratchet). While it is false, a v2
+# verdict releases on exactly the v1-equivalent conditions.
 #
 # Per-session state lives under "$STATE_DIR" as flag files keyed by session_id.
 # Stale state (>24h) is cleaned on each invocation.
 #
-# Fail-open: any unexpected jq parse failure or missing field exits 0 rather
-# than blocking. A broken gate must never brick a session.
+# Fail-open: any unexpected jq parse failure or missing field degrades to the
+# LESS strict outcome rather than inventing a new hard failure, and the
+# MAX_BLOCKS escalation below guarantees the gate always releases eventually. A
+# broken gate must never brick a session. In particular, a v2 verdict whose
+# claim structure cannot be evaluated is judged on the v1 conditions alone.
 
 set -uo pipefail
 
@@ -137,9 +187,14 @@ fi
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 VERDICT_FILE="${PROJECT_DIR}/.lisa/verification-status.json"
 
+# Set by the v2 path when a claim/evidence violation is what closed the gate,
+# so the block message can state the real reason instead of the v1 fallback.
+V2_BLOCK_REASON=""
+
 # A terminal verdict (pass or blocked) with no failing criterion, written AFTER
-# the flow was armed, releases the gate.
-verdict_is_terminal() {
+# the flow was armed, releases the gate. This is the v1 decision, unchanged, and
+# it remains the floor for v2 as well.
+verdict_is_terminal_v1() {
   [ -f "$VERDICT_FILE" ] || return 1
 
   local status fails
@@ -158,6 +213,101 @@ verdict_is_terminal() {
   fi
 
   return 0
+}
+
+# True when the project has ratcheted the v2 claim checks from advisory to
+# blocking. Default false: a missing/unreadable config is advisory-only.
+boundary_enforcement_enabled() {
+  local config_file value
+  config_file="${PROJECT_DIR}/.lisa.config.json"
+  [ -f "$config_file" ] || return 1
+  value=$(jq -r '.verification.gate.enforceBoundaries // false' "$config_file" 2>/dev/null || printf 'false')
+  [ "$value" = "true" ]
+}
+
+# Emits one line per v2 claim->evidence contract violation. Empty output means
+# the verdict satisfies the contract (or could not be evaluated, which degrades
+# to the v1 decision rather than to a new hard failure).
+v2_contract_violations() {
+  jq -r '
+    . as $v
+    | ($v.evidence // []) as $ev
+    | (($v.artifact // {}).head_sha // "") as $head
+    | [
+        (if ($v.not_established_reviewed == true) then empty
+         else "not_established_reviewed is absent or not true - the flag may never be omitted" end),
+        (if ($head | length) > 0 then empty
+         else "artifact.head_sha is missing - required for a v2 pass" end),
+        ( $ev[]
+          | select(($head | length) > 0)
+          | select(((.artifact_head_sha // "") | length) > 0)
+          | select(.artifact_head_sha != $head)
+          | "evidence \(.evidence_id // "?") was captured at \(.artifact_head_sha) but artifact.head_sha is \($head)" ),
+        ( ($v.claims // [])[]
+          | select((.required_for_gate // false) == true)
+          | . as $c
+          | ($c.claim_id // "?") as $cid
+          | ($c.boundary // "?") as $bnd
+          | ($c.required_evidence_kinds // []) as $req
+          | ($req | join(", ")) as $reqs
+          | ([ ($c.evidence_refs // [])[] as $r | $ev[] | select((.evidence_id // "") == $r) ]) as $res
+          | (
+              (if (($c.status // "") == "established") then empty
+               else "claim \($cid) [boundary \($bnd)] is not established (status: \($c.status // "missing"); required kinds: \($reqs))" end),
+              (if ($res | length) == 0
+               then "claim \($cid) [boundary \($bnd)] cites no resolvable evidence (required kinds: \($reqs))"
+               elif ([ $res[].kind // "" ] | map(select(. as $k | $req | index($k))) | length) == 0
+               then "claim \($cid) [boundary \($bnd)] cited evidence kinds [\([$res[].kind // "?"] | join(", "))] do not reach the boundary (required kinds: \($reqs))"
+               else empty end)
+            )
+        )
+      ]
+    | .[]
+  ' "$VERDICT_FILE" 2>/dev/null || true
+}
+
+# v2 = the v1 decision PLUS the claim->evidence contract, the latter advisory
+# until verification.gate.enforceBoundaries is ratcheted on.
+verdict_is_terminal_v2() {
+  verdict_is_terminal_v1 || return 1
+
+  # Only a "pass" asserts that claims are established. A deliberate "blocked"
+  # stop records an outcome and is terminal on the v1 conditions alone.
+  local status violations
+  status=$(jq -r '.status // empty' "$VERDICT_FILE" 2>/dev/null || true)
+  [ "$status" = "pass" ] || return 0
+
+  violations=$(v2_contract_violations)
+  [ -n "$violations" ] || return 0
+
+  if boundary_enforcement_enabled; then
+    # Hand the diagnosis to the block message below so the operator reads one
+    # coherent reason instead of this plus a generic v1-shaped fallback.
+    V2_BLOCK_REASON=$(printf '%s\n' "$violations" | sed 's/^/  - /')
+    return 1
+  fi
+
+  {
+    echo "Verification gate (advisory): the v2 claim/evidence contract is not"
+    echo "satisfied. Releasing anyway because verification.gate.enforceBoundaries"
+    echo "is false. These become blocking when the flag is ratcheted on:"
+    printf '%s\n' "$violations" | sed 's/^/  - /'
+  } >&2
+  return 0
+}
+
+# Compatibility window: branch on schema_version. Absent or 1 -> the v1 decision
+# unchanged; 2 -> v1 plus the claim->evidence contract. An unrecognized or
+# unparseable value degrades to v1 rather than to a new failure mode.
+verdict_is_terminal() {
+  [ -f "$VERDICT_FILE" ] || return 1
+
+  local schema_version
+  schema_version=$(jq -r '.schema_version // empty' "$VERDICT_FILE" 2>/dev/null || true)
+  case "$schema_version" in
+    2) verdict_is_terminal_v2 ;;
+    *) verdict_is_terminal_v1 ;;
+  esac
 }
 
 if verdict_is_terminal; then
@@ -205,6 +355,16 @@ fi
     echo "failed, base branch missing, unresolved dependency), write the verdict"
     echo "with status \"blocked\" and the reason instead. That records the"
     echo "outcome and releases this gate."
+  elif [ -n "$V2_BLOCK_REASON" ]; then
+    echo "The verdict claims to pass, but its evidence does not establish every"
+    echo "claim the gate requires:"
+    printf '%s\n' "$V2_BLOCK_REASON"
+    echo
+    echo "A claim counts only when the evidence cited for it is of a kind that"
+    echo "reaches that claim's boundary — a unit test log does not prove a"
+    echo "button works in a browser. Capture the reaching evidence and"
+    echo "re-verify, or — if genuinely blocked — set status \"blocked\" with the"
+    echo "reason."
   else
     echo "The verification verdict is not terminal-and-passing. Outstanding:"
     if [ -n "$REASON_DETAIL" ]; then

--- a/plugins/lisa-copilot/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-implement/SKILL.md
@@ -228,22 +228,52 @@ Before shutting down the team, execute the Verify flow:
 
 1. Run quality gates: lint, typecheck, tests — all must pass. These are prerequisites, NOT verification.
 2. `verification-specialist`: verify locally by running the actual system and observing results (empirical proof that the change works). This is the real verification step. For UI-surface bugs, the proof must observe the UI surface with browser/device automation against the target environment whenever such a harness exists; unit-level or API-only proof cannot satisfy the empirical verification contract for a UI-surface defect.
-2a. **Record the verification verdict** — the independent, machine-readable proof that gates completion. The `verification-specialist` writes `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json` with one entry per acceptance criterion, each carrying the proof command's observed evidence:
+2a. **Record the verification verdict** — the independent, machine-readable proof that gates completion. The `verification-specialist` writes `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json` in **schema v2**, which binds every claim to the *boundary* it asserts and to the evidence *kinds* that reach that boundary, per the `claim-evidence-mapping` rule:
 
     ```json
     {
+      "schema_version": 2,
       "plan": "<plan-name>",
-      "status": "pass | fail | blocked | in_progress",
+      "artifact": {
+        "repository": "<owner/repo>", "base_sha": "<sha>", "head_sha": "<sha of what will ship>",
+        "build_id": "<build/run id>", "environment": "<where it was observed>", "observed_at": "<ISO8601 UTC>"
+      },
+      "claims": [
+        {
+          "claim_id": "AC-1",
+          "statement": "<the claim, in the operator's language>",
+          "boundary": "code-unit | browser | http-api | cli | data | deploy-health | performance | standards-compat",
+          "required_for_gate": true,
+          "required_evidence_kinds": ["<kinds that reach this boundary, e.g. screenshot, recording>"],
+          "status": "established | not-established",
+          "evidence_refs": ["EV-1"],
+          "not_established": ["<what this claim does NOT cover>"]
+        }
+      ],
+      "evidence": [
+        {
+          "evidence_id": "EV-1",
+          "kind": "screenshot | recording | http-transcript | cli-output | log-snippet | db-query-output | perf-trace | test-run-log | deploy-log | state-dump",
+          "locator": "evidence/<ticket>/<file>", "sha256": "<hash>",
+          "captured_at": "<ISO8601 UTC>", "artifact_head_sha": "<sha the artifact was captured at>"
+        }
+      ],
+      "not_established_reviewed": true,
       "criteria": [
         { "task": "<task id or title>", "criterion": "<the completion condition>", "status": "pass | fail | blocked", "evidence": "<the proof command run and the observed result; for a blocked criterion, the blocker diagnosis (e.g. the missing access and the probe that must pass)>" }
       ],
+      "status": "pass | fail | blocked | in_progress",
       "updated_at": "<ISO8601 UTC>"
     }
     ```
 
+    Rules for v2: a claim is established **only** by evidence whose `kind` reaches its `boundary` — a unit `test-run-log` reaches only `code-unit` and can never establish a `browser`, `http-api`, or `deploy-health` claim. `not_established_reviewed` must always be present (the `not_established` list may be empty, but the flag may never be omitted). `artifact.head_sha` names what will ship, and each evidence entry's `artifact_head_sha` must match it. The legacy `criteria[]` array is retained and still read, but under v2 it is **display-only** — it can never establish a v2 claim.
+
+    **v1 is still accepted during the compatibility window.** A verdict that omits `schema_version` (or sets it to `1`) carries only `plan` / `status` / `criteria[]` / `updated_at` and is judged exactly as before: terminal `status` plus no failing criterion plus freshness. Write v2 for new work; nothing in flight breaks.
+
     Set `status: "pass"` only when every criterion is `pass` with real evidence (output from running the system, not a claim). The verdict must be judged by an agent that did NOT implement the change (the `verification-specialist`), never self-certified by the implementer. This is runtime scratch — it is gitignored and MUST NOT be committed (treat it like the secrets exclusion in the commit step).
 
-    On Claude, the `enforce-verification-gate.sh` Stop hook reads this file and **will not let the flow stop** until it shows a terminal, all-`pass` verdict — carrying over the non-bypassable completion gate of the `/goal` primitive, but checked deterministically against real evidence rather than by a transcript-only evaluator model. If you must stop before completion, write the verdict with `status: "blocked"` and the reason — marking each criterion whose proof is blocked as `status: "blocked"` with the blocker diagnosis as its `evidence`, while unaffected criteria keep their real `pass`/`fail` result — that records the outcome and releases the gate instead of leaving it to spin. But a `blocked` verdict is a last resort, not a shortcut around fillable work: **first resolve every gap you can resolve yourself.** If the work item is thin — missing its Validation Journey, acceptance criteria, or other derivable detail — enrich it: derive the missing detail from the ticket context and the codebase, write it back, and proceed. Do **not** block on a gap you could have filled. Only a blocker that survives that attempt is real, and it is one of two kinds:
+    On Claude, the `enforce-verification-gate.sh` Stop hook reads this file — both v1 and v2 — and **will not let the flow stop** until it shows a terminal, all-`pass` verdict. The v2 claim/evidence checks are **advisory-first**: a boundary or identity violation is reported to stderr but does not block until `verification.gate.enforceBoundaries` is set to `true` in `.lisa.config.json` (default `false`, promoted via the threshold ratchet). Treat an advisory warning as a defect to fix now, not a warning to ignore — it becomes blocking on the ratchet. The gate — carrying over the non-bypassable completion gate of the `/goal` primitive, but checked deterministically against real evidence rather than by a transcript-only evaluator model. If you must stop before completion, write the verdict with `status: "blocked"` and the reason — marking each criterion whose proof is blocked as `status: "blocked"` with the blocker diagnosis as its `evidence`, while unaffected criteria keep their real `pass`/`fail` result — that records the outcome and releases the gate instead of leaving it to spin. But a `blocked` verdict is a last resort, not a shortcut around fillable work: **first resolve every gap you can resolve yourself.** If the work item is thin — missing its Validation Journey, acceptance criteria, or other derivable detail — enrich it: derive the missing detail from the ticket context and the codebase, write it back, and proceed. Do **not** block on a gap you could have filled. Only a blocker that survives that attempt is real, and it is one of two kinds:
 
     - **Actionable blocker** — an unresolved dependency or fixable technical gap that some team or repository could build (a missing or changed schema field, an unbuilt sibling work item, a required upstream fix), **including cross-repo dependencies**. Before writing the blocked verdict you MUST (1) file a build-ready fix/dependency ticket capturing the diagnosis — in the dependency's own repository/tracker when it is cross-repo (e.g. a `[<repo>] …` ticket in the shared project, or the sibling tracker) — and (2) link the current work item to it as `is blocked by`. Only then write the verdict. This is the same discipline as the regression-spec blocker and the remote-verification-fail exits above, and it is what makes the block machine-recoverable: `repair-intake` re-dispatches a blocked item once its linked `is blocked by` dependency closes, but it cannot act on a prose-only comment. Recommending the ticket "as a human follow-up" without filing and linking it is **not** a permitted exit.
     - **Human-only blocker** — an input the agent genuinely cannot obtain or produce no matter what it does: credentials, secrets, or **tool access** it does not have (AWS/CloudWatch, Figma, Jam, Sentry, SonarCloud, a database, a protected deploy target, …), or a product/design decision only a human can make. For missing tool access, follow the `tool-access-gate` rule's break-out protocol: post the "Access Needed" comment naming the exact credential/role/env var to grant and the probe that must pass — never work around the gap by substituting weaker verification, mocking the inaccessible system, or narrowing scope. Record the blocked verdict, mark it `human_needed` (the marker `repair-intake` recognizes, so it won't churn re-dispatching it), and surface or reassign to a human; do **not** fabricate a build-ready ticket, because there is no build-ready work.

--- a/plugins/lisa-cursor/hooks/enforce-verification-gate.sh
+++ b/plugins/lisa-cursor/hooks/enforce-verification-gate.sh
@@ -27,7 +27,33 @@
 #                        by a per-session block counter so a genuinely-stuck flow
 #                        ESCALATES instead of looping forever.
 #
-# The verdict artifact lives at "$CLAUDE_PROJECT_DIR/.lisa/verification-status.json":
+# The verdict artifact lives at "$CLAUDE_PROJECT_DIR/.lisa/verification-status.json".
+#
+# SCHEMA v2 (current) binds every claim to a boundary and to the evidence kinds
+# that reach it, per the claim-evidence-mapping contract:
+#   {
+#     "schema_version": 2,
+#     "plan": "<plan-name>",
+#     "artifact": { "repository": "owner/repo", "base_sha": "...", "head_sha": "...",
+#                   "build_id": "...", "environment": "...", "observed_at": "<ISO8601 UTC>" },
+#     "claims": [
+#       { "claim_id": "AC-1", "statement": "...", "boundary": "browser",
+#         "required_for_gate": true, "required_evidence_kinds": ["screenshot","recording"],
+#         "status": "established" | "not-established", "evidence_refs": ["EV-1"],
+#         "not_established": ["<what this claim does NOT cover>"] }
+#     ],
+#     "evidence": [
+#       { "evidence_id": "EV-1", "kind": "screenshot", "locator": "evidence/1836/x.png",
+#         "sha256": "...", "captured_at": "<ISO8601 UTC>", "artifact_head_sha": "..." }
+#     ],
+#     "not_established_reviewed": true,
+#     "criteria": [ ... legacy, display-only ... ],
+#     "status": "pass" | "fail" | "blocked" | "in_progress",
+#     "updated_at": "<ISO8601 UTC>"
+#   }
+#
+# SCHEMA v1 (legacy, still accepted during the compatibility window) omits
+# "schema_version" or sets it to 1, and carries only:
 #   {
 #     "plan": "<plan-name>",
 #     "status": "pass" | "fail" | "blocked" | "in_progress",
@@ -36,15 +62,39 @@
 #     ],
 #     "updated_at": "<ISO8601 UTC>"
 #   }
-# status "pass" (all criteria pass) or "blocked" (flow recorded a blocker and is
-# stopping deliberately) are terminal and release the gate. "fail"/"in_progress"
-# or a missing/stale file keep it closed.
+#
+# In BOTH schemas, status "pass" (all criteria pass) or "blocked" (flow recorded
+# a blocker and is stopping deliberately) are terminal and release the gate.
+# "fail"/"in_progress" or a missing/stale file keep it closed.
+#
+# Compatibility window: the gate branches on "schema_version". Absent or 1 takes
+# the v1 path unchanged — byte-for-byte the pre-v2 decision. 2 takes the v1 path
+# PLUS the claim->evidence checks below. Legacy "criteria" is display-only under
+# v2 and can never establish a v2 claim.
+#
+# v2 claim checks (only ever applied to an overall "pass"; a deliberate
+# "blocked" stop is terminal on the v1 conditions alone):
+#   - every claim with "required_for_gate": true is "status": "established"
+#   - each such claim's "evidence_refs" resolve to "evidence[]" entries, at
+#     least one of whose "kind" is in the claim's "required_evidence_kinds"
+#   - "not_established_reviewed": true is present (the list may be empty, but
+#     the flag may never be omitted)
+#   - "artifact.head_sha" exists and no evidence entry declares a different
+#     "artifact_head_sha" (reconciliation with the MERGED head is BCE-4)
+#
+# ADVISORY-FIRST: those v2 checks report to stderr but do NOT block unless
+# "verification.gate.enforceBoundaries" is true in .lisa.config.json (default
+# false at ship, promoted via the threshold ratchet). While it is false, a v2
+# verdict releases on exactly the v1-equivalent conditions.
 #
 # Per-session state lives under "$STATE_DIR" as flag files keyed by session_id.
 # Stale state (>24h) is cleaned on each invocation.
 #
-# Fail-open: any unexpected jq parse failure or missing field exits 0 rather
-# than blocking. A broken gate must never brick a session.
+# Fail-open: any unexpected jq parse failure or missing field degrades to the
+# LESS strict outcome rather than inventing a new hard failure, and the
+# MAX_BLOCKS escalation below guarantees the gate always releases eventually. A
+# broken gate must never brick a session. In particular, a v2 verdict whose
+# claim structure cannot be evaluated is judged on the v1 conditions alone.
 
 set -uo pipefail
 
@@ -137,9 +187,14 @@ fi
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 VERDICT_FILE="${PROJECT_DIR}/.lisa/verification-status.json"
 
+# Set by the v2 path when a claim/evidence violation is what closed the gate,
+# so the block message can state the real reason instead of the v1 fallback.
+V2_BLOCK_REASON=""
+
 # A terminal verdict (pass or blocked) with no failing criterion, written AFTER
-# the flow was armed, releases the gate.
-verdict_is_terminal() {
+# the flow was armed, releases the gate. This is the v1 decision, unchanged, and
+# it remains the floor for v2 as well.
+verdict_is_terminal_v1() {
   [ -f "$VERDICT_FILE" ] || return 1
 
   local status fails
@@ -158,6 +213,101 @@ verdict_is_terminal() {
   fi
 
   return 0
+}
+
+# True when the project has ratcheted the v2 claim checks from advisory to
+# blocking. Default false: a missing/unreadable config is advisory-only.
+boundary_enforcement_enabled() {
+  local config_file value
+  config_file="${PROJECT_DIR}/.lisa.config.json"
+  [ -f "$config_file" ] || return 1
+  value=$(jq -r '.verification.gate.enforceBoundaries // false' "$config_file" 2>/dev/null || printf 'false')
+  [ "$value" = "true" ]
+}
+
+# Emits one line per v2 claim->evidence contract violation. Empty output means
+# the verdict satisfies the contract (or could not be evaluated, which degrades
+# to the v1 decision rather than to a new hard failure).
+v2_contract_violations() {
+  jq -r '
+    . as $v
+    | ($v.evidence // []) as $ev
+    | (($v.artifact // {}).head_sha // "") as $head
+    | [
+        (if ($v.not_established_reviewed == true) then empty
+         else "not_established_reviewed is absent or not true - the flag may never be omitted" end),
+        (if ($head | length) > 0 then empty
+         else "artifact.head_sha is missing - required for a v2 pass" end),
+        ( $ev[]
+          | select(($head | length) > 0)
+          | select(((.artifact_head_sha // "") | length) > 0)
+          | select(.artifact_head_sha != $head)
+          | "evidence \(.evidence_id // "?") was captured at \(.artifact_head_sha) but artifact.head_sha is \($head)" ),
+        ( ($v.claims // [])[]
+          | select((.required_for_gate // false) == true)
+          | . as $c
+          | ($c.claim_id // "?") as $cid
+          | ($c.boundary // "?") as $bnd
+          | ($c.required_evidence_kinds // []) as $req
+          | ($req | join(", ")) as $reqs
+          | ([ ($c.evidence_refs // [])[] as $r | $ev[] | select((.evidence_id // "") == $r) ]) as $res
+          | (
+              (if (($c.status // "") == "established") then empty
+               else "claim \($cid) [boundary \($bnd)] is not established (status: \($c.status // "missing"); required kinds: \($reqs))" end),
+              (if ($res | length) == 0
+               then "claim \($cid) [boundary \($bnd)] cites no resolvable evidence (required kinds: \($reqs))"
+               elif ([ $res[].kind // "" ] | map(select(. as $k | $req | index($k))) | length) == 0
+               then "claim \($cid) [boundary \($bnd)] cited evidence kinds [\([$res[].kind // "?"] | join(", "))] do not reach the boundary (required kinds: \($reqs))"
+               else empty end)
+            )
+        )
+      ]
+    | .[]
+  ' "$VERDICT_FILE" 2>/dev/null || true
+}
+
+# v2 = the v1 decision PLUS the claim->evidence contract, the latter advisory
+# until verification.gate.enforceBoundaries is ratcheted on.
+verdict_is_terminal_v2() {
+  verdict_is_terminal_v1 || return 1
+
+  # Only a "pass" asserts that claims are established. A deliberate "blocked"
+  # stop records an outcome and is terminal on the v1 conditions alone.
+  local status violations
+  status=$(jq -r '.status // empty' "$VERDICT_FILE" 2>/dev/null || true)
+  [ "$status" = "pass" ] || return 0
+
+  violations=$(v2_contract_violations)
+  [ -n "$violations" ] || return 0
+
+  if boundary_enforcement_enabled; then
+    # Hand the diagnosis to the block message below so the operator reads one
+    # coherent reason instead of this plus a generic v1-shaped fallback.
+    V2_BLOCK_REASON=$(printf '%s\n' "$violations" | sed 's/^/  - /')
+    return 1
+  fi
+
+  {
+    echo "Verification gate (advisory): the v2 claim/evidence contract is not"
+    echo "satisfied. Releasing anyway because verification.gate.enforceBoundaries"
+    echo "is false. These become blocking when the flag is ratcheted on:"
+    printf '%s\n' "$violations" | sed 's/^/  - /'
+  } >&2
+  return 0
+}
+
+# Compatibility window: branch on schema_version. Absent or 1 -> the v1 decision
+# unchanged; 2 -> v1 plus the claim->evidence contract. An unrecognized or
+# unparseable value degrades to v1 rather than to a new failure mode.
+verdict_is_terminal() {
+  [ -f "$VERDICT_FILE" ] || return 1
+
+  local schema_version
+  schema_version=$(jq -r '.schema_version // empty' "$VERDICT_FILE" 2>/dev/null || true)
+  case "$schema_version" in
+    2) verdict_is_terminal_v2 ;;
+    *) verdict_is_terminal_v1 ;;
+  esac
 }
 
 if verdict_is_terminal; then
@@ -205,6 +355,16 @@ fi
     echo "failed, base branch missing, unresolved dependency), write the verdict"
     echo "with status \"blocked\" and the reason instead. That records the"
     echo "outcome and releases this gate."
+  elif [ -n "$V2_BLOCK_REASON" ]; then
+    echo "The verdict claims to pass, but its evidence does not establish every"
+    echo "claim the gate requires:"
+    printf '%s\n' "$V2_BLOCK_REASON"
+    echo
+    echo "A claim counts only when the evidence cited for it is of a kind that"
+    echo "reaches that claim's boundary — a unit test log does not prove a"
+    echo "button works in a browser. Capture the reaching evidence and"
+    echo "re-verify, or — if genuinely blocked — set status \"blocked\" with the"
+    echo "reason."
   else
     echo "The verification verdict is not terminal-and-passing. Outstanding:"
     if [ -n "$REASON_DETAIL" ]; then

--- a/plugins/lisa-cursor/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-implement/SKILL.md
@@ -228,22 +228,52 @@ Before shutting down the team, execute the Verify flow:
 
 1. Run quality gates: lint, typecheck, tests — all must pass. These are prerequisites, NOT verification.
 2. `verification-specialist`: verify locally by running the actual system and observing results (empirical proof that the change works). This is the real verification step. For UI-surface bugs, the proof must observe the UI surface with browser/device automation against the target environment whenever such a harness exists; unit-level or API-only proof cannot satisfy the empirical verification contract for a UI-surface defect.
-2a. **Record the verification verdict** — the independent, machine-readable proof that gates completion. The `verification-specialist` writes `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json` with one entry per acceptance criterion, each carrying the proof command's observed evidence:
+2a. **Record the verification verdict** — the independent, machine-readable proof that gates completion. The `verification-specialist` writes `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json` in **schema v2**, which binds every claim to the *boundary* it asserts and to the evidence *kinds* that reach that boundary, per the `claim-evidence-mapping` rule:
 
     ```json
     {
+      "schema_version": 2,
       "plan": "<plan-name>",
-      "status": "pass | fail | blocked | in_progress",
+      "artifact": {
+        "repository": "<owner/repo>", "base_sha": "<sha>", "head_sha": "<sha of what will ship>",
+        "build_id": "<build/run id>", "environment": "<where it was observed>", "observed_at": "<ISO8601 UTC>"
+      },
+      "claims": [
+        {
+          "claim_id": "AC-1",
+          "statement": "<the claim, in the operator's language>",
+          "boundary": "code-unit | browser | http-api | cli | data | deploy-health | performance | standards-compat",
+          "required_for_gate": true,
+          "required_evidence_kinds": ["<kinds that reach this boundary, e.g. screenshot, recording>"],
+          "status": "established | not-established",
+          "evidence_refs": ["EV-1"],
+          "not_established": ["<what this claim does NOT cover>"]
+        }
+      ],
+      "evidence": [
+        {
+          "evidence_id": "EV-1",
+          "kind": "screenshot | recording | http-transcript | cli-output | log-snippet | db-query-output | perf-trace | test-run-log | deploy-log | state-dump",
+          "locator": "evidence/<ticket>/<file>", "sha256": "<hash>",
+          "captured_at": "<ISO8601 UTC>", "artifact_head_sha": "<sha the artifact was captured at>"
+        }
+      ],
+      "not_established_reviewed": true,
       "criteria": [
         { "task": "<task id or title>", "criterion": "<the completion condition>", "status": "pass | fail | blocked", "evidence": "<the proof command run and the observed result; for a blocked criterion, the blocker diagnosis (e.g. the missing access and the probe that must pass)>" }
       ],
+      "status": "pass | fail | blocked | in_progress",
       "updated_at": "<ISO8601 UTC>"
     }
     ```
 
+    Rules for v2: a claim is established **only** by evidence whose `kind` reaches its `boundary` — a unit `test-run-log` reaches only `code-unit` and can never establish a `browser`, `http-api`, or `deploy-health` claim. `not_established_reviewed` must always be present (the `not_established` list may be empty, but the flag may never be omitted). `artifact.head_sha` names what will ship, and each evidence entry's `artifact_head_sha` must match it. The legacy `criteria[]` array is retained and still read, but under v2 it is **display-only** — it can never establish a v2 claim.
+
+    **v1 is still accepted during the compatibility window.** A verdict that omits `schema_version` (or sets it to `1`) carries only `plan` / `status` / `criteria[]` / `updated_at` and is judged exactly as before: terminal `status` plus no failing criterion plus freshness. Write v2 for new work; nothing in flight breaks.
+
     Set `status: "pass"` only when every criterion is `pass` with real evidence (output from running the system, not a claim). The verdict must be judged by an agent that did NOT implement the change (the `verification-specialist`), never self-certified by the implementer. This is runtime scratch — it is gitignored and MUST NOT be committed (treat it like the secrets exclusion in the commit step).
 
-    On Claude, the `enforce-verification-gate.sh` Stop hook reads this file and **will not let the flow stop** until it shows a terminal, all-`pass` verdict — carrying over the non-bypassable completion gate of the `/goal` primitive, but checked deterministically against real evidence rather than by a transcript-only evaluator model. If you must stop before completion, write the verdict with `status: "blocked"` and the reason — marking each criterion whose proof is blocked as `status: "blocked"` with the blocker diagnosis as its `evidence`, while unaffected criteria keep their real `pass`/`fail` result — that records the outcome and releases the gate instead of leaving it to spin. But a `blocked` verdict is a last resort, not a shortcut around fillable work: **first resolve every gap you can resolve yourself.** If the work item is thin — missing its Validation Journey, acceptance criteria, or other derivable detail — enrich it: derive the missing detail from the ticket context and the codebase, write it back, and proceed. Do **not** block on a gap you could have filled. Only a blocker that survives that attempt is real, and it is one of two kinds:
+    On Claude, the `enforce-verification-gate.sh` Stop hook reads this file — both v1 and v2 — and **will not let the flow stop** until it shows a terminal, all-`pass` verdict. The v2 claim/evidence checks are **advisory-first**: a boundary or identity violation is reported to stderr but does not block until `verification.gate.enforceBoundaries` is set to `true` in `.lisa.config.json` (default `false`, promoted via the threshold ratchet). Treat an advisory warning as a defect to fix now, not a warning to ignore — it becomes blocking on the ratchet. The gate — carrying over the non-bypassable completion gate of the `/goal` primitive, but checked deterministically against real evidence rather than by a transcript-only evaluator model. If you must stop before completion, write the verdict with `status: "blocked"` and the reason — marking each criterion whose proof is blocked as `status: "blocked"` with the blocker diagnosis as its `evidence`, while unaffected criteria keep their real `pass`/`fail` result — that records the outcome and releases the gate instead of leaving it to spin. But a `blocked` verdict is a last resort, not a shortcut around fillable work: **first resolve every gap you can resolve yourself.** If the work item is thin — missing its Validation Journey, acceptance criteria, or other derivable detail — enrich it: derive the missing detail from the ticket context and the codebase, write it back, and proceed. Do **not** block on a gap you could have filled. Only a blocker that survives that attempt is real, and it is one of two kinds:
 
     - **Actionable blocker** — an unresolved dependency or fixable technical gap that some team or repository could build (a missing or changed schema field, an unbuilt sibling work item, a required upstream fix), **including cross-repo dependencies**. Before writing the blocked verdict you MUST (1) file a build-ready fix/dependency ticket capturing the diagnosis — in the dependency's own repository/tracker when it is cross-repo (e.g. a `[<repo>] …` ticket in the shared project, or the sibling tracker) — and (2) link the current work item to it as `is blocked by`. Only then write the verdict. This is the same discipline as the regression-spec blocker and the remote-verification-fail exits above, and it is what makes the block machine-recoverable: `repair-intake` re-dispatches a blocked item once its linked `is blocked by` dependency closes, but it cannot act on a prose-only comment. Recommending the ticket "as a human follow-up" without filing and linking it is **not** a permitted exit.
     - **Human-only blocker** — an input the agent genuinely cannot obtain or produce no matter what it does: credentials, secrets, or **tool access** it does not have (AWS/CloudWatch, Figma, Jam, Sentry, SonarCloud, a database, a protected deploy target, …), or a product/design decision only a human can make. For missing tool access, follow the `tool-access-gate` rule's break-out protocol: post the "Access Needed" comment naming the exact credential/role/env var to grant and the probe that must pass — never work around the gap by substituting weaker verification, mocking the inaccessible system, or narrowing scope. Record the blocked verdict, mark it `human_needed` (the marker `repair-intake` recognizes, so it won't churn re-dispatching it), and surface or reassign to a human; do **not** fabricate a build-ready ticket, because there is no build-ready work.

--- a/plugins/lisa/.codex-plugin/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-implement/SKILL.md
@@ -228,22 +228,52 @@ Before shutting down the team, execute the Verify flow:
 
 1. Run quality gates: lint, typecheck, tests — all must pass. These are prerequisites, NOT verification.
 2. `verification-specialist`: verify locally by running the actual system and observing results (empirical proof that the change works). This is the real verification step. For UI-surface bugs, the proof must observe the UI surface with browser/device automation against the target environment whenever such a harness exists; unit-level or API-only proof cannot satisfy the empirical verification contract for a UI-surface defect.
-2a. **Record the verification verdict** — the independent, machine-readable proof that gates completion. The `verification-specialist` writes `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json` with one entry per acceptance criterion, each carrying the proof command's observed evidence:
+2a. **Record the verification verdict** — the independent, machine-readable proof that gates completion. The `verification-specialist` writes `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json` in **schema v2**, which binds every claim to the *boundary* it asserts and to the evidence *kinds* that reach that boundary, per the `claim-evidence-mapping` rule:
 
     ```json
     {
+      "schema_version": 2,
       "plan": "<plan-name>",
-      "status": "pass | fail | blocked | in_progress",
+      "artifact": {
+        "repository": "<owner/repo>", "base_sha": "<sha>", "head_sha": "<sha of what will ship>",
+        "build_id": "<build/run id>", "environment": "<where it was observed>", "observed_at": "<ISO8601 UTC>"
+      },
+      "claims": [
+        {
+          "claim_id": "AC-1",
+          "statement": "<the claim, in the operator's language>",
+          "boundary": "code-unit | browser | http-api | cli | data | deploy-health | performance | standards-compat",
+          "required_for_gate": true,
+          "required_evidence_kinds": ["<kinds that reach this boundary, e.g. screenshot, recording>"],
+          "status": "established | not-established",
+          "evidence_refs": ["EV-1"],
+          "not_established": ["<what this claim does NOT cover>"]
+        }
+      ],
+      "evidence": [
+        {
+          "evidence_id": "EV-1",
+          "kind": "screenshot | recording | http-transcript | cli-output | log-snippet | db-query-output | perf-trace | test-run-log | deploy-log | state-dump",
+          "locator": "evidence/<ticket>/<file>", "sha256": "<hash>",
+          "captured_at": "<ISO8601 UTC>", "artifact_head_sha": "<sha the artifact was captured at>"
+        }
+      ],
+      "not_established_reviewed": true,
       "criteria": [
         { "task": "<task id or title>", "criterion": "<the completion condition>", "status": "pass | fail | blocked", "evidence": "<the proof command run and the observed result; for a blocked criterion, the blocker diagnosis (e.g. the missing access and the probe that must pass)>" }
       ],
+      "status": "pass | fail | blocked | in_progress",
       "updated_at": "<ISO8601 UTC>"
     }
     ```
 
+    Rules for v2: a claim is established **only** by evidence whose `kind` reaches its `boundary` — a unit `test-run-log` reaches only `code-unit` and can never establish a `browser`, `http-api`, or `deploy-health` claim. `not_established_reviewed` must always be present (the `not_established` list may be empty, but the flag may never be omitted). `artifact.head_sha` names what will ship, and each evidence entry's `artifact_head_sha` must match it. The legacy `criteria[]` array is retained and still read, but under v2 it is **display-only** — it can never establish a v2 claim.
+
+    **v1 is still accepted during the compatibility window.** A verdict that omits `schema_version` (or sets it to `1`) carries only `plan` / `status` / `criteria[]` / `updated_at` and is judged exactly as before: terminal `status` plus no failing criterion plus freshness. Write v2 for new work; nothing in flight breaks.
+
     Set `status: "pass"` only when every criterion is `pass` with real evidence (output from running the system, not a claim). The verdict must be judged by an agent that did NOT implement the change (the `verification-specialist`), never self-certified by the implementer. This is runtime scratch — it is gitignored and MUST NOT be committed (treat it like the secrets exclusion in the commit step).
 
-    On Claude, the `enforce-verification-gate.sh` Stop hook reads this file and **will not let the flow stop** until it shows a terminal, all-`pass` verdict — carrying over the non-bypassable completion gate of the `/goal` primitive, but checked deterministically against real evidence rather than by a transcript-only evaluator model. If you must stop before completion, write the verdict with `status: "blocked"` and the reason — marking each criterion whose proof is blocked as `status: "blocked"` with the blocker diagnosis as its `evidence`, while unaffected criteria keep their real `pass`/`fail` result — that records the outcome and releases the gate instead of leaving it to spin. But a `blocked` verdict is a last resort, not a shortcut around fillable work: **first resolve every gap you can resolve yourself.** If the work item is thin — missing its Validation Journey, acceptance criteria, or other derivable detail — enrich it: derive the missing detail from the ticket context and the codebase, write it back, and proceed. Do **not** block on a gap you could have filled. Only a blocker that survives that attempt is real, and it is one of two kinds:
+    On Claude, the `enforce-verification-gate.sh` Stop hook reads this file — both v1 and v2 — and **will not let the flow stop** until it shows a terminal, all-`pass` verdict. The v2 claim/evidence checks are **advisory-first**: a boundary or identity violation is reported to stderr but does not block until `verification.gate.enforceBoundaries` is set to `true` in `.lisa.config.json` (default `false`, promoted via the threshold ratchet). Treat an advisory warning as a defect to fix now, not a warning to ignore — it becomes blocking on the ratchet. The gate — carrying over the non-bypassable completion gate of the `/goal` primitive, but checked deterministically against real evidence rather than by a transcript-only evaluator model. If you must stop before completion, write the verdict with `status: "blocked"` and the reason — marking each criterion whose proof is blocked as `status: "blocked"` with the blocker diagnosis as its `evidence`, while unaffected criteria keep their real `pass`/`fail` result — that records the outcome and releases the gate instead of leaving it to spin. But a `blocked` verdict is a last resort, not a shortcut around fillable work: **first resolve every gap you can resolve yourself.** If the work item is thin — missing its Validation Journey, acceptance criteria, or other derivable detail — enrich it: derive the missing detail from the ticket context and the codebase, write it back, and proceed. Do **not** block on a gap you could have filled. Only a blocker that survives that attempt is real, and it is one of two kinds:
 
     - **Actionable blocker** — an unresolved dependency or fixable technical gap that some team or repository could build (a missing or changed schema field, an unbuilt sibling work item, a required upstream fix), **including cross-repo dependencies**. Before writing the blocked verdict you MUST (1) file a build-ready fix/dependency ticket capturing the diagnosis — in the dependency's own repository/tracker when it is cross-repo (e.g. a `[<repo>] …` ticket in the shared project, or the sibling tracker) — and (2) link the current work item to it as `is blocked by`. Only then write the verdict. This is the same discipline as the regression-spec blocker and the remote-verification-fail exits above, and it is what makes the block machine-recoverable: `repair-intake` re-dispatches a blocked item once its linked `is blocked by` dependency closes, but it cannot act on a prose-only comment. Recommending the ticket "as a human follow-up" without filing and linking it is **not** a permitted exit.
     - **Human-only blocker** — an input the agent genuinely cannot obtain or produce no matter what it does: credentials, secrets, or **tool access** it does not have (AWS/CloudWatch, Figma, Jam, Sentry, SonarCloud, a database, a protected deploy target, …), or a product/design decision only a human can make. For missing tool access, follow the `tool-access-gate` rule's break-out protocol: post the "Access Needed" comment naming the exact credential/role/env var to grant and the probe that must pass — never work around the gap by substituting weaker verification, mocking the inaccessible system, or narrowing scope. Record the blocked verdict, mark it `human_needed` (the marker `repair-intake` recognizes, so it won't churn re-dispatching it), and surface or reassign to a human; do **not** fabricate a build-ready ticket, because there is no build-ready work.

--- a/plugins/lisa/hooks/enforce-verification-gate.sh
+++ b/plugins/lisa/hooks/enforce-verification-gate.sh
@@ -27,7 +27,33 @@
 #                        by a per-session block counter so a genuinely-stuck flow
 #                        ESCALATES instead of looping forever.
 #
-# The verdict artifact lives at "$CLAUDE_PROJECT_DIR/.lisa/verification-status.json":
+# The verdict artifact lives at "$CLAUDE_PROJECT_DIR/.lisa/verification-status.json".
+#
+# SCHEMA v2 (current) binds every claim to a boundary and to the evidence kinds
+# that reach it, per the claim-evidence-mapping contract:
+#   {
+#     "schema_version": 2,
+#     "plan": "<plan-name>",
+#     "artifact": { "repository": "owner/repo", "base_sha": "...", "head_sha": "...",
+#                   "build_id": "...", "environment": "...", "observed_at": "<ISO8601 UTC>" },
+#     "claims": [
+#       { "claim_id": "AC-1", "statement": "...", "boundary": "browser",
+#         "required_for_gate": true, "required_evidence_kinds": ["screenshot","recording"],
+#         "status": "established" | "not-established", "evidence_refs": ["EV-1"],
+#         "not_established": ["<what this claim does NOT cover>"] }
+#     ],
+#     "evidence": [
+#       { "evidence_id": "EV-1", "kind": "screenshot", "locator": "evidence/1836/x.png",
+#         "sha256": "...", "captured_at": "<ISO8601 UTC>", "artifact_head_sha": "..." }
+#     ],
+#     "not_established_reviewed": true,
+#     "criteria": [ ... legacy, display-only ... ],
+#     "status": "pass" | "fail" | "blocked" | "in_progress",
+#     "updated_at": "<ISO8601 UTC>"
+#   }
+#
+# SCHEMA v1 (legacy, still accepted during the compatibility window) omits
+# "schema_version" or sets it to 1, and carries only:
 #   {
 #     "plan": "<plan-name>",
 #     "status": "pass" | "fail" | "blocked" | "in_progress",
@@ -36,15 +62,39 @@
 #     ],
 #     "updated_at": "<ISO8601 UTC>"
 #   }
-# status "pass" (all criteria pass) or "blocked" (flow recorded a blocker and is
-# stopping deliberately) are terminal and release the gate. "fail"/"in_progress"
-# or a missing/stale file keep it closed.
+#
+# In BOTH schemas, status "pass" (all criteria pass) or "blocked" (flow recorded
+# a blocker and is stopping deliberately) are terminal and release the gate.
+# "fail"/"in_progress" or a missing/stale file keep it closed.
+#
+# Compatibility window: the gate branches on "schema_version". Absent or 1 takes
+# the v1 path unchanged — byte-for-byte the pre-v2 decision. 2 takes the v1 path
+# PLUS the claim->evidence checks below. Legacy "criteria" is display-only under
+# v2 and can never establish a v2 claim.
+#
+# v2 claim checks (only ever applied to an overall "pass"; a deliberate
+# "blocked" stop is terminal on the v1 conditions alone):
+#   - every claim with "required_for_gate": true is "status": "established"
+#   - each such claim's "evidence_refs" resolve to "evidence[]" entries, at
+#     least one of whose "kind" is in the claim's "required_evidence_kinds"
+#   - "not_established_reviewed": true is present (the list may be empty, but
+#     the flag may never be omitted)
+#   - "artifact.head_sha" exists and no evidence entry declares a different
+#     "artifact_head_sha" (reconciliation with the MERGED head is BCE-4)
+#
+# ADVISORY-FIRST: those v2 checks report to stderr but do NOT block unless
+# "verification.gate.enforceBoundaries" is true in .lisa.config.json (default
+# false at ship, promoted via the threshold ratchet). While it is false, a v2
+# verdict releases on exactly the v1-equivalent conditions.
 #
 # Per-session state lives under "$STATE_DIR" as flag files keyed by session_id.
 # Stale state (>24h) is cleaned on each invocation.
 #
-# Fail-open: any unexpected jq parse failure or missing field exits 0 rather
-# than blocking. A broken gate must never brick a session.
+# Fail-open: any unexpected jq parse failure or missing field degrades to the
+# LESS strict outcome rather than inventing a new hard failure, and the
+# MAX_BLOCKS escalation below guarantees the gate always releases eventually. A
+# broken gate must never brick a session. In particular, a v2 verdict whose
+# claim structure cannot be evaluated is judged on the v1 conditions alone.
 
 set -uo pipefail
 
@@ -137,9 +187,14 @@ fi
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 VERDICT_FILE="${PROJECT_DIR}/.lisa/verification-status.json"
 
+# Set by the v2 path when a claim/evidence violation is what closed the gate,
+# so the block message can state the real reason instead of the v1 fallback.
+V2_BLOCK_REASON=""
+
 # A terminal verdict (pass or blocked) with no failing criterion, written AFTER
-# the flow was armed, releases the gate.
-verdict_is_terminal() {
+# the flow was armed, releases the gate. This is the v1 decision, unchanged, and
+# it remains the floor for v2 as well.
+verdict_is_terminal_v1() {
   [ -f "$VERDICT_FILE" ] || return 1
 
   local status fails
@@ -158,6 +213,101 @@ verdict_is_terminal() {
   fi
 
   return 0
+}
+
+# True when the project has ratcheted the v2 claim checks from advisory to
+# blocking. Default false: a missing/unreadable config is advisory-only.
+boundary_enforcement_enabled() {
+  local config_file value
+  config_file="${PROJECT_DIR}/.lisa.config.json"
+  [ -f "$config_file" ] || return 1
+  value=$(jq -r '.verification.gate.enforceBoundaries // false' "$config_file" 2>/dev/null || printf 'false')
+  [ "$value" = "true" ]
+}
+
+# Emits one line per v2 claim->evidence contract violation. Empty output means
+# the verdict satisfies the contract (or could not be evaluated, which degrades
+# to the v1 decision rather than to a new hard failure).
+v2_contract_violations() {
+  jq -r '
+    . as $v
+    | ($v.evidence // []) as $ev
+    | (($v.artifact // {}).head_sha // "") as $head
+    | [
+        (if ($v.not_established_reviewed == true) then empty
+         else "not_established_reviewed is absent or not true - the flag may never be omitted" end),
+        (if ($head | length) > 0 then empty
+         else "artifact.head_sha is missing - required for a v2 pass" end),
+        ( $ev[]
+          | select(($head | length) > 0)
+          | select(((.artifact_head_sha // "") | length) > 0)
+          | select(.artifact_head_sha != $head)
+          | "evidence \(.evidence_id // "?") was captured at \(.artifact_head_sha) but artifact.head_sha is \($head)" ),
+        ( ($v.claims // [])[]
+          | select((.required_for_gate // false) == true)
+          | . as $c
+          | ($c.claim_id // "?") as $cid
+          | ($c.boundary // "?") as $bnd
+          | ($c.required_evidence_kinds // []) as $req
+          | ($req | join(", ")) as $reqs
+          | ([ ($c.evidence_refs // [])[] as $r | $ev[] | select((.evidence_id // "") == $r) ]) as $res
+          | (
+              (if (($c.status // "") == "established") then empty
+               else "claim \($cid) [boundary \($bnd)] is not established (status: \($c.status // "missing"); required kinds: \($reqs))" end),
+              (if ($res | length) == 0
+               then "claim \($cid) [boundary \($bnd)] cites no resolvable evidence (required kinds: \($reqs))"
+               elif ([ $res[].kind // "" ] | map(select(. as $k | $req | index($k))) | length) == 0
+               then "claim \($cid) [boundary \($bnd)] cited evidence kinds [\([$res[].kind // "?"] | join(", "))] do not reach the boundary (required kinds: \($reqs))"
+               else empty end)
+            )
+        )
+      ]
+    | .[]
+  ' "$VERDICT_FILE" 2>/dev/null || true
+}
+
+# v2 = the v1 decision PLUS the claim->evidence contract, the latter advisory
+# until verification.gate.enforceBoundaries is ratcheted on.
+verdict_is_terminal_v2() {
+  verdict_is_terminal_v1 || return 1
+
+  # Only a "pass" asserts that claims are established. A deliberate "blocked"
+  # stop records an outcome and is terminal on the v1 conditions alone.
+  local status violations
+  status=$(jq -r '.status // empty' "$VERDICT_FILE" 2>/dev/null || true)
+  [ "$status" = "pass" ] || return 0
+
+  violations=$(v2_contract_violations)
+  [ -n "$violations" ] || return 0
+
+  if boundary_enforcement_enabled; then
+    # Hand the diagnosis to the block message below so the operator reads one
+    # coherent reason instead of this plus a generic v1-shaped fallback.
+    V2_BLOCK_REASON=$(printf '%s\n' "$violations" | sed 's/^/  - /')
+    return 1
+  fi
+
+  {
+    echo "Verification gate (advisory): the v2 claim/evidence contract is not"
+    echo "satisfied. Releasing anyway because verification.gate.enforceBoundaries"
+    echo "is false. These become blocking when the flag is ratcheted on:"
+    printf '%s\n' "$violations" | sed 's/^/  - /'
+  } >&2
+  return 0
+}
+
+# Compatibility window: branch on schema_version. Absent or 1 -> the v1 decision
+# unchanged; 2 -> v1 plus the claim->evidence contract. An unrecognized or
+# unparseable value degrades to v1 rather than to a new failure mode.
+verdict_is_terminal() {
+  [ -f "$VERDICT_FILE" ] || return 1
+
+  local schema_version
+  schema_version=$(jq -r '.schema_version // empty' "$VERDICT_FILE" 2>/dev/null || true)
+  case "$schema_version" in
+    2) verdict_is_terminal_v2 ;;
+    *) verdict_is_terminal_v1 ;;
+  esac
 }
 
 if verdict_is_terminal; then
@@ -205,6 +355,16 @@ fi
     echo "failed, base branch missing, unresolved dependency), write the verdict"
     echo "with status \"blocked\" and the reason instead. That records the"
     echo "outcome and releases this gate."
+  elif [ -n "$V2_BLOCK_REASON" ]; then
+    echo "The verdict claims to pass, but its evidence does not establish every"
+    echo "claim the gate requires:"
+    printf '%s\n' "$V2_BLOCK_REASON"
+    echo
+    echo "A claim counts only when the evidence cited for it is of a kind that"
+    echo "reaches that claim's boundary — a unit test log does not prove a"
+    echo "button works in a browser. Capture the reaching evidence and"
+    echo "re-verify, or — if genuinely blocked — set status \"blocked\" with the"
+    echo "reason."
   else
     echo "The verification verdict is not terminal-and-passing. Outstanding:"
     if [ -n "$REASON_DETAIL" ]; then

--- a/plugins/lisa/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa/skills/lisa-implement/SKILL.md
@@ -228,22 +228,52 @@ Before shutting down the team, execute the Verify flow:
 
 1. Run quality gates: lint, typecheck, tests — all must pass. These are prerequisites, NOT verification.
 2. `verification-specialist`: verify locally by running the actual system and observing results (empirical proof that the change works). This is the real verification step. For UI-surface bugs, the proof must observe the UI surface with browser/device automation against the target environment whenever such a harness exists; unit-level or API-only proof cannot satisfy the empirical verification contract for a UI-surface defect.
-2a. **Record the verification verdict** — the independent, machine-readable proof that gates completion. The `verification-specialist` writes `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json` with one entry per acceptance criterion, each carrying the proof command's observed evidence:
+2a. **Record the verification verdict** — the independent, machine-readable proof that gates completion. The `verification-specialist` writes `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json` in **schema v2**, which binds every claim to the *boundary* it asserts and to the evidence *kinds* that reach that boundary, per the `claim-evidence-mapping` rule:
 
     ```json
     {
+      "schema_version": 2,
       "plan": "<plan-name>",
-      "status": "pass | fail | blocked | in_progress",
+      "artifact": {
+        "repository": "<owner/repo>", "base_sha": "<sha>", "head_sha": "<sha of what will ship>",
+        "build_id": "<build/run id>", "environment": "<where it was observed>", "observed_at": "<ISO8601 UTC>"
+      },
+      "claims": [
+        {
+          "claim_id": "AC-1",
+          "statement": "<the claim, in the operator's language>",
+          "boundary": "code-unit | browser | http-api | cli | data | deploy-health | performance | standards-compat",
+          "required_for_gate": true,
+          "required_evidence_kinds": ["<kinds that reach this boundary, e.g. screenshot, recording>"],
+          "status": "established | not-established",
+          "evidence_refs": ["EV-1"],
+          "not_established": ["<what this claim does NOT cover>"]
+        }
+      ],
+      "evidence": [
+        {
+          "evidence_id": "EV-1",
+          "kind": "screenshot | recording | http-transcript | cli-output | log-snippet | db-query-output | perf-trace | test-run-log | deploy-log | state-dump",
+          "locator": "evidence/<ticket>/<file>", "sha256": "<hash>",
+          "captured_at": "<ISO8601 UTC>", "artifact_head_sha": "<sha the artifact was captured at>"
+        }
+      ],
+      "not_established_reviewed": true,
       "criteria": [
         { "task": "<task id or title>", "criterion": "<the completion condition>", "status": "pass | fail | blocked", "evidence": "<the proof command run and the observed result; for a blocked criterion, the blocker diagnosis (e.g. the missing access and the probe that must pass)>" }
       ],
+      "status": "pass | fail | blocked | in_progress",
       "updated_at": "<ISO8601 UTC>"
     }
     ```
 
+    Rules for v2: a claim is established **only** by evidence whose `kind` reaches its `boundary` — a unit `test-run-log` reaches only `code-unit` and can never establish a `browser`, `http-api`, or `deploy-health` claim. `not_established_reviewed` must always be present (the `not_established` list may be empty, but the flag may never be omitted). `artifact.head_sha` names what will ship, and each evidence entry's `artifact_head_sha` must match it. The legacy `criteria[]` array is retained and still read, but under v2 it is **display-only** — it can never establish a v2 claim.
+
+    **v1 is still accepted during the compatibility window.** A verdict that omits `schema_version` (or sets it to `1`) carries only `plan` / `status` / `criteria[]` / `updated_at` and is judged exactly as before: terminal `status` plus no failing criterion plus freshness. Write v2 for new work; nothing in flight breaks.
+
     Set `status: "pass"` only when every criterion is `pass` with real evidence (output from running the system, not a claim). The verdict must be judged by an agent that did NOT implement the change (the `verification-specialist`), never self-certified by the implementer. This is runtime scratch — it is gitignored and MUST NOT be committed (treat it like the secrets exclusion in the commit step).
 
-    On Claude, the `enforce-verification-gate.sh` Stop hook reads this file and **will not let the flow stop** until it shows a terminal, all-`pass` verdict — carrying over the non-bypassable completion gate of the `/goal` primitive, but checked deterministically against real evidence rather than by a transcript-only evaluator model. If you must stop before completion, write the verdict with `status: "blocked"` and the reason — marking each criterion whose proof is blocked as `status: "blocked"` with the blocker diagnosis as its `evidence`, while unaffected criteria keep their real `pass`/`fail` result — that records the outcome and releases the gate instead of leaving it to spin. But a `blocked` verdict is a last resort, not a shortcut around fillable work: **first resolve every gap you can resolve yourself.** If the work item is thin — missing its Validation Journey, acceptance criteria, or other derivable detail — enrich it: derive the missing detail from the ticket context and the codebase, write it back, and proceed. Do **not** block on a gap you could have filled. Only a blocker that survives that attempt is real, and it is one of two kinds:
+    On Claude, the `enforce-verification-gate.sh` Stop hook reads this file — both v1 and v2 — and **will not let the flow stop** until it shows a terminal, all-`pass` verdict. The v2 claim/evidence checks are **advisory-first**: a boundary or identity violation is reported to stderr but does not block until `verification.gate.enforceBoundaries` is set to `true` in `.lisa.config.json` (default `false`, promoted via the threshold ratchet). Treat an advisory warning as a defect to fix now, not a warning to ignore — it becomes blocking on the ratchet. The gate — carrying over the non-bypassable completion gate of the `/goal` primitive, but checked deterministically against real evidence rather than by a transcript-only evaluator model. If you must stop before completion, write the verdict with `status: "blocked"` and the reason — marking each criterion whose proof is blocked as `status: "blocked"` with the blocker diagnosis as its `evidence`, while unaffected criteria keep their real `pass`/`fail` result — that records the outcome and releases the gate instead of leaving it to spin. But a `blocked` verdict is a last resort, not a shortcut around fillable work: **first resolve every gap you can resolve yourself.** If the work item is thin — missing its Validation Journey, acceptance criteria, or other derivable detail — enrich it: derive the missing detail from the ticket context and the codebase, write it back, and proceed. Do **not** block on a gap you could have filled. Only a blocker that survives that attempt is real, and it is one of two kinds:
 
     - **Actionable blocker** — an unresolved dependency or fixable technical gap that some team or repository could build (a missing or changed schema field, an unbuilt sibling work item, a required upstream fix), **including cross-repo dependencies**. Before writing the blocked verdict you MUST (1) file a build-ready fix/dependency ticket capturing the diagnosis — in the dependency's own repository/tracker when it is cross-repo (e.g. a `[<repo>] …` ticket in the shared project, or the sibling tracker) — and (2) link the current work item to it as `is blocked by`. Only then write the verdict. This is the same discipline as the regression-spec blocker and the remote-verification-fail exits above, and it is what makes the block machine-recoverable: `repair-intake` re-dispatches a blocked item once its linked `is blocked by` dependency closes, but it cannot act on a prose-only comment. Recommending the ticket "as a human follow-up" without filing and linking it is **not** a permitted exit.
     - **Human-only blocker** — an input the agent genuinely cannot obtain or produce no matter what it does: credentials, secrets, or **tool access** it does not have (AWS/CloudWatch, Figma, Jam, Sentry, SonarCloud, a database, a protected deploy target, …), or a product/design decision only a human can make. For missing tool access, follow the `tool-access-gate` rule's break-out protocol: post the "Access Needed" comment naming the exact credential/role/env var to grant and the probe that must pass — never work around the gap by substituting weaker verification, mocking the inaccessible system, or narrowing scope. Record the blocked verdict, mark it `human_needed` (the marker `repair-intake` recognizes, so it won't churn re-dispatching it), and surface or reassign to a human; do **not** fabricate a build-ready ticket, because there is no build-ready work.

--- a/plugins/src/base/hooks/enforce-verification-gate.sh
+++ b/plugins/src/base/hooks/enforce-verification-gate.sh
@@ -27,7 +27,33 @@
 #                        by a per-session block counter so a genuinely-stuck flow
 #                        ESCALATES instead of looping forever.
 #
-# The verdict artifact lives at "$CLAUDE_PROJECT_DIR/.lisa/verification-status.json":
+# The verdict artifact lives at "$CLAUDE_PROJECT_DIR/.lisa/verification-status.json".
+#
+# SCHEMA v2 (current) binds every claim to a boundary and to the evidence kinds
+# that reach it, per the claim-evidence-mapping contract:
+#   {
+#     "schema_version": 2,
+#     "plan": "<plan-name>",
+#     "artifact": { "repository": "owner/repo", "base_sha": "...", "head_sha": "...",
+#                   "build_id": "...", "environment": "...", "observed_at": "<ISO8601 UTC>" },
+#     "claims": [
+#       { "claim_id": "AC-1", "statement": "...", "boundary": "browser",
+#         "required_for_gate": true, "required_evidence_kinds": ["screenshot","recording"],
+#         "status": "established" | "not-established", "evidence_refs": ["EV-1"],
+#         "not_established": ["<what this claim does NOT cover>"] }
+#     ],
+#     "evidence": [
+#       { "evidence_id": "EV-1", "kind": "screenshot", "locator": "evidence/1836/x.png",
+#         "sha256": "...", "captured_at": "<ISO8601 UTC>", "artifact_head_sha": "..." }
+#     ],
+#     "not_established_reviewed": true,
+#     "criteria": [ ... legacy, display-only ... ],
+#     "status": "pass" | "fail" | "blocked" | "in_progress",
+#     "updated_at": "<ISO8601 UTC>"
+#   }
+#
+# SCHEMA v1 (legacy, still accepted during the compatibility window) omits
+# "schema_version" or sets it to 1, and carries only:
 #   {
 #     "plan": "<plan-name>",
 #     "status": "pass" | "fail" | "blocked" | "in_progress",
@@ -36,15 +62,39 @@
 #     ],
 #     "updated_at": "<ISO8601 UTC>"
 #   }
-# status "pass" (all criteria pass) or "blocked" (flow recorded a blocker and is
-# stopping deliberately) are terminal and release the gate. "fail"/"in_progress"
-# or a missing/stale file keep it closed.
+#
+# In BOTH schemas, status "pass" (all criteria pass) or "blocked" (flow recorded
+# a blocker and is stopping deliberately) are terminal and release the gate.
+# "fail"/"in_progress" or a missing/stale file keep it closed.
+#
+# Compatibility window: the gate branches on "schema_version". Absent or 1 takes
+# the v1 path unchanged — byte-for-byte the pre-v2 decision. 2 takes the v1 path
+# PLUS the claim->evidence checks below. Legacy "criteria" is display-only under
+# v2 and can never establish a v2 claim.
+#
+# v2 claim checks (only ever applied to an overall "pass"; a deliberate
+# "blocked" stop is terminal on the v1 conditions alone):
+#   - every claim with "required_for_gate": true is "status": "established"
+#   - each such claim's "evidence_refs" resolve to "evidence[]" entries, at
+#     least one of whose "kind" is in the claim's "required_evidence_kinds"
+#   - "not_established_reviewed": true is present (the list may be empty, but
+#     the flag may never be omitted)
+#   - "artifact.head_sha" exists and no evidence entry declares a different
+#     "artifact_head_sha" (reconciliation with the MERGED head is BCE-4)
+#
+# ADVISORY-FIRST: those v2 checks report to stderr but do NOT block unless
+# "verification.gate.enforceBoundaries" is true in .lisa.config.json (default
+# false at ship, promoted via the threshold ratchet). While it is false, a v2
+# verdict releases on exactly the v1-equivalent conditions.
 #
 # Per-session state lives under "$STATE_DIR" as flag files keyed by session_id.
 # Stale state (>24h) is cleaned on each invocation.
 #
-# Fail-open: any unexpected jq parse failure or missing field exits 0 rather
-# than blocking. A broken gate must never brick a session.
+# Fail-open: any unexpected jq parse failure or missing field degrades to the
+# LESS strict outcome rather than inventing a new hard failure, and the
+# MAX_BLOCKS escalation below guarantees the gate always releases eventually. A
+# broken gate must never brick a session. In particular, a v2 verdict whose
+# claim structure cannot be evaluated is judged on the v1 conditions alone.
 
 set -uo pipefail
 
@@ -137,9 +187,14 @@ fi
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 VERDICT_FILE="${PROJECT_DIR}/.lisa/verification-status.json"
 
+# Set by the v2 path when a claim/evidence violation is what closed the gate,
+# so the block message can state the real reason instead of the v1 fallback.
+V2_BLOCK_REASON=""
+
 # A terminal verdict (pass or blocked) with no failing criterion, written AFTER
-# the flow was armed, releases the gate.
-verdict_is_terminal() {
+# the flow was armed, releases the gate. This is the v1 decision, unchanged, and
+# it remains the floor for v2 as well.
+verdict_is_terminal_v1() {
   [ -f "$VERDICT_FILE" ] || return 1
 
   local status fails
@@ -158,6 +213,101 @@ verdict_is_terminal() {
   fi
 
   return 0
+}
+
+# True when the project has ratcheted the v2 claim checks from advisory to
+# blocking. Default false: a missing/unreadable config is advisory-only.
+boundary_enforcement_enabled() {
+  local config_file value
+  config_file="${PROJECT_DIR}/.lisa.config.json"
+  [ -f "$config_file" ] || return 1
+  value=$(jq -r '.verification.gate.enforceBoundaries // false' "$config_file" 2>/dev/null || printf 'false')
+  [ "$value" = "true" ]
+}
+
+# Emits one line per v2 claim->evidence contract violation. Empty output means
+# the verdict satisfies the contract (or could not be evaluated, which degrades
+# to the v1 decision rather than to a new hard failure).
+v2_contract_violations() {
+  jq -r '
+    . as $v
+    | ($v.evidence // []) as $ev
+    | (($v.artifact // {}).head_sha // "") as $head
+    | [
+        (if ($v.not_established_reviewed == true) then empty
+         else "not_established_reviewed is absent or not true - the flag may never be omitted" end),
+        (if ($head | length) > 0 then empty
+         else "artifact.head_sha is missing - required for a v2 pass" end),
+        ( $ev[]
+          | select(($head | length) > 0)
+          | select(((.artifact_head_sha // "") | length) > 0)
+          | select(.artifact_head_sha != $head)
+          | "evidence \(.evidence_id // "?") was captured at \(.artifact_head_sha) but artifact.head_sha is \($head)" ),
+        ( ($v.claims // [])[]
+          | select((.required_for_gate // false) == true)
+          | . as $c
+          | ($c.claim_id // "?") as $cid
+          | ($c.boundary // "?") as $bnd
+          | ($c.required_evidence_kinds // []) as $req
+          | ($req | join(", ")) as $reqs
+          | ([ ($c.evidence_refs // [])[] as $r | $ev[] | select((.evidence_id // "") == $r) ]) as $res
+          | (
+              (if (($c.status // "") == "established") then empty
+               else "claim \($cid) [boundary \($bnd)] is not established (status: \($c.status // "missing"); required kinds: \($reqs))" end),
+              (if ($res | length) == 0
+               then "claim \($cid) [boundary \($bnd)] cites no resolvable evidence (required kinds: \($reqs))"
+               elif ([ $res[].kind // "" ] | map(select(. as $k | $req | index($k))) | length) == 0
+               then "claim \($cid) [boundary \($bnd)] cited evidence kinds [\([$res[].kind // "?"] | join(", "))] do not reach the boundary (required kinds: \($reqs))"
+               else empty end)
+            )
+        )
+      ]
+    | .[]
+  ' "$VERDICT_FILE" 2>/dev/null || true
+}
+
+# v2 = the v1 decision PLUS the claim->evidence contract, the latter advisory
+# until verification.gate.enforceBoundaries is ratcheted on.
+verdict_is_terminal_v2() {
+  verdict_is_terminal_v1 || return 1
+
+  # Only a "pass" asserts that claims are established. A deliberate "blocked"
+  # stop records an outcome and is terminal on the v1 conditions alone.
+  local status violations
+  status=$(jq -r '.status // empty' "$VERDICT_FILE" 2>/dev/null || true)
+  [ "$status" = "pass" ] || return 0
+
+  violations=$(v2_contract_violations)
+  [ -n "$violations" ] || return 0
+
+  if boundary_enforcement_enabled; then
+    # Hand the diagnosis to the block message below so the operator reads one
+    # coherent reason instead of this plus a generic v1-shaped fallback.
+    V2_BLOCK_REASON=$(printf '%s\n' "$violations" | sed 's/^/  - /')
+    return 1
+  fi
+
+  {
+    echo "Verification gate (advisory): the v2 claim/evidence contract is not"
+    echo "satisfied. Releasing anyway because verification.gate.enforceBoundaries"
+    echo "is false. These become blocking when the flag is ratcheted on:"
+    printf '%s\n' "$violations" | sed 's/^/  - /'
+  } >&2
+  return 0
+}
+
+# Compatibility window: branch on schema_version. Absent or 1 -> the v1 decision
+# unchanged; 2 -> v1 plus the claim->evidence contract. An unrecognized or
+# unparseable value degrades to v1 rather than to a new failure mode.
+verdict_is_terminal() {
+  [ -f "$VERDICT_FILE" ] || return 1
+
+  local schema_version
+  schema_version=$(jq -r '.schema_version // empty' "$VERDICT_FILE" 2>/dev/null || true)
+  case "$schema_version" in
+    2) verdict_is_terminal_v2 ;;
+    *) verdict_is_terminal_v1 ;;
+  esac
 }
 
 if verdict_is_terminal; then
@@ -205,6 +355,16 @@ fi
     echo "failed, base branch missing, unresolved dependency), write the verdict"
     echo "with status \"blocked\" and the reason instead. That records the"
     echo "outcome and releases this gate."
+  elif [ -n "$V2_BLOCK_REASON" ]; then
+    echo "The verdict claims to pass, but its evidence does not establish every"
+    echo "claim the gate requires:"
+    printf '%s\n' "$V2_BLOCK_REASON"
+    echo
+    echo "A claim counts only when the evidence cited for it is of a kind that"
+    echo "reaches that claim's boundary — a unit test log does not prove a"
+    echo "button works in a browser. Capture the reaching evidence and"
+    echo "re-verify, or — if genuinely blocked — set status \"blocked\" with the"
+    echo "reason."
   else
     echo "The verification verdict is not terminal-and-passing. Outstanding:"
     if [ -n "$REASON_DETAIL" ]; then

--- a/plugins/src/base/skills/lisa-implement/SKILL.md
+++ b/plugins/src/base/skills/lisa-implement/SKILL.md
@@ -228,22 +228,52 @@ Before shutting down the team, execute the Verify flow:
 
 1. Run quality gates: lint, typecheck, tests — all must pass. These are prerequisites, NOT verification.
 2. `verification-specialist`: verify locally by running the actual system and observing results (empirical proof that the change works). This is the real verification step. For UI-surface bugs, the proof must observe the UI surface with browser/device automation against the target environment whenever such a harness exists; unit-level or API-only proof cannot satisfy the empirical verification contract for a UI-surface defect.
-2a. **Record the verification verdict** — the independent, machine-readable proof that gates completion. The `verification-specialist` writes `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json` with one entry per acceptance criterion, each carrying the proof command's observed evidence:
+2a. **Record the verification verdict** — the independent, machine-readable proof that gates completion. The `verification-specialist` writes `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json` in **schema v2**, which binds every claim to the *boundary* it asserts and to the evidence *kinds* that reach that boundary, per the `claim-evidence-mapping` rule:
 
     ```json
     {
+      "schema_version": 2,
       "plan": "<plan-name>",
-      "status": "pass | fail | blocked | in_progress",
+      "artifact": {
+        "repository": "<owner/repo>", "base_sha": "<sha>", "head_sha": "<sha of what will ship>",
+        "build_id": "<build/run id>", "environment": "<where it was observed>", "observed_at": "<ISO8601 UTC>"
+      },
+      "claims": [
+        {
+          "claim_id": "AC-1",
+          "statement": "<the claim, in the operator's language>",
+          "boundary": "code-unit | browser | http-api | cli | data | deploy-health | performance | standards-compat",
+          "required_for_gate": true,
+          "required_evidence_kinds": ["<kinds that reach this boundary, e.g. screenshot, recording>"],
+          "status": "established | not-established",
+          "evidence_refs": ["EV-1"],
+          "not_established": ["<what this claim does NOT cover>"]
+        }
+      ],
+      "evidence": [
+        {
+          "evidence_id": "EV-1",
+          "kind": "screenshot | recording | http-transcript | cli-output | log-snippet | db-query-output | perf-trace | test-run-log | deploy-log | state-dump",
+          "locator": "evidence/<ticket>/<file>", "sha256": "<hash>",
+          "captured_at": "<ISO8601 UTC>", "artifact_head_sha": "<sha the artifact was captured at>"
+        }
+      ],
+      "not_established_reviewed": true,
       "criteria": [
         { "task": "<task id or title>", "criterion": "<the completion condition>", "status": "pass | fail | blocked", "evidence": "<the proof command run and the observed result; for a blocked criterion, the blocker diagnosis (e.g. the missing access and the probe that must pass)>" }
       ],
+      "status": "pass | fail | blocked | in_progress",
       "updated_at": "<ISO8601 UTC>"
     }
     ```
 
+    Rules for v2: a claim is established **only** by evidence whose `kind` reaches its `boundary` — a unit `test-run-log` reaches only `code-unit` and can never establish a `browser`, `http-api`, or `deploy-health` claim. `not_established_reviewed` must always be present (the `not_established` list may be empty, but the flag may never be omitted). `artifact.head_sha` names what will ship, and each evidence entry's `artifact_head_sha` must match it. The legacy `criteria[]` array is retained and still read, but under v2 it is **display-only** — it can never establish a v2 claim.
+
+    **v1 is still accepted during the compatibility window.** A verdict that omits `schema_version` (or sets it to `1`) carries only `plan` / `status` / `criteria[]` / `updated_at` and is judged exactly as before: terminal `status` plus no failing criterion plus freshness. Write v2 for new work; nothing in flight breaks.
+
     Set `status: "pass"` only when every criterion is `pass` with real evidence (output from running the system, not a claim). The verdict must be judged by an agent that did NOT implement the change (the `verification-specialist`), never self-certified by the implementer. This is runtime scratch — it is gitignored and MUST NOT be committed (treat it like the secrets exclusion in the commit step).
 
-    On Claude, the `enforce-verification-gate.sh` Stop hook reads this file and **will not let the flow stop** until it shows a terminal, all-`pass` verdict — carrying over the non-bypassable completion gate of the `/goal` primitive, but checked deterministically against real evidence rather than by a transcript-only evaluator model. If you must stop before completion, write the verdict with `status: "blocked"` and the reason — marking each criterion whose proof is blocked as `status: "blocked"` with the blocker diagnosis as its `evidence`, while unaffected criteria keep their real `pass`/`fail` result — that records the outcome and releases the gate instead of leaving it to spin. But a `blocked` verdict is a last resort, not a shortcut around fillable work: **first resolve every gap you can resolve yourself.** If the work item is thin — missing its Validation Journey, acceptance criteria, or other derivable detail — enrich it: derive the missing detail from the ticket context and the codebase, write it back, and proceed. Do **not** block on a gap you could have filled. Only a blocker that survives that attempt is real, and it is one of two kinds:
+    On Claude, the `enforce-verification-gate.sh` Stop hook reads this file — both v1 and v2 — and **will not let the flow stop** until it shows a terminal, all-`pass` verdict. The v2 claim/evidence checks are **advisory-first**: a boundary or identity violation is reported to stderr but does not block until `verification.gate.enforceBoundaries` is set to `true` in `.lisa.config.json` (default `false`, promoted via the threshold ratchet). Treat an advisory warning as a defect to fix now, not a warning to ignore — it becomes blocking on the ratchet. The gate — carrying over the non-bypassable completion gate of the `/goal` primitive, but checked deterministically against real evidence rather than by a transcript-only evaluator model. If you must stop before completion, write the verdict with `status: "blocked"` and the reason — marking each criterion whose proof is blocked as `status: "blocked"` with the blocker diagnosis as its `evidence`, while unaffected criteria keep their real `pass`/`fail` result — that records the outcome and releases the gate instead of leaving it to spin. But a `blocked` verdict is a last resort, not a shortcut around fillable work: **first resolve every gap you can resolve yourself.** If the work item is thin — missing its Validation Journey, acceptance criteria, or other derivable detail — enrich it: derive the missing detail from the ticket context and the codebase, write it back, and proceed. Do **not** block on a gap you could have filled. Only a blocker that survives that attempt is real, and it is one of two kinds:
 
     - **Actionable blocker** — an unresolved dependency or fixable technical gap that some team or repository could build (a missing or changed schema field, an unbuilt sibling work item, a required upstream fix), **including cross-repo dependencies**. Before writing the blocked verdict you MUST (1) file a build-ready fix/dependency ticket capturing the diagnosis — in the dependency's own repository/tracker when it is cross-repo (e.g. a `[<repo>] …` ticket in the shared project, or the sibling tracker) — and (2) link the current work item to it as `is blocked by`. Only then write the verdict. This is the same discipline as the regression-spec blocker and the remote-verification-fail exits above, and it is what makes the block machine-recoverable: `repair-intake` re-dispatches a blocked item once its linked `is blocked by` dependency closes, but it cannot act on a prose-only comment. Recommending the ticket "as a human follow-up" without filing and linking it is **not** a permitted exit.
     - **Human-only blocker** — an input the agent genuinely cannot obtain or produce no matter what it does: credentials, secrets, or **tool access** it does not have (AWS/CloudWatch, Figma, Jam, Sentry, SonarCloud, a database, a protected deploy target, …), or a product/design decision only a human can make. For missing tool access, follow the `tool-access-gate` rule's break-out protocol: post the "Access Needed" comment naming the exact credential/role/env var to grant and the probe that must pass — never work around the gap by substituting weaker verification, mocking the inaccessible system, or narrowing scope. Record the blocked verdict, mark it `human_needed` (the marker `repair-intake` recognizes, so it won't churn re-dispatching it), and surface or reassign to a human; do **not** fabricate a build-ready ticket, because there is no build-ready work.

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -575,7 +575,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/enforce-team-first.sh":
       "51d2e929ea6c04e7c7851be7849dd7d3e7cd0c211b4c8fb856e858a51ddeeb58",
     "plugins/src/base/hooks/enforce-verification-gate.sh":
-      "108b471e810687d9942bc6c3db120399dd644e67e1f4ae9beea2596646bd8172",
+      "827b1a48622ad6b5715d924d555fa19715e84f787cf45de30f5fb389c2281b7a",
     "plugins/src/base/hooks/inject-flow-context.sh":
       "f4ab07065762d592c0fc36be2e4918e767b293aaa4094b9d85d69010576c6dbf",
     "plugins/src/base/hooks/inject-rules.sh":
@@ -833,7 +833,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-github-write-prd/SKILL.md":
       "bc919c52e2f42129d41a3f40279d2def99486ec58bed2dab51ca7166b427a947",
     "plugins/src/base/skills/lisa-implement/SKILL.md":
-      "74910bffb2dbfce03a57aa9b1314a01ab1898c755bc9ce8701e70d30e16f73c4",
+      "046bc040b7a1182f71dd4be7a04e977a963a5ab707fad627d89ef0877d4a789b",
     "plugins/src/base/skills/lisa-improve-code-complexity/SKILL.md":
       "24ab5b193b409db6ee6bee981a1c0a48d08991782d7846116ad01658c8bc1ae8",
     "plugins/src/base/skills/lisa-improve-harness/SKILL.md":
@@ -7449,6 +7449,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/fixtures/wiki-safety/redaction-source.md": true,
     "tests/helpers/__fixtures__/wiki-status-fixture.ts": true,
     "tests/helpers/test-utils.ts": true,
+    "tests/helpers/verification-gate-fixtures.ts": true,
+    "tests/helpers/verification-gate-harness.ts": true,
     "tests/helpers/workflow-test-utils.ts": true,
     "tests/integration/autofix-ownership-guards.test.ts": true,
     "tests/integration/cli-smoke.test.ts": true,
@@ -7591,6 +7593,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/hooks/commit-msg.test.ts": true,
     "tests/unit/hooks/enforce-config-extensions.test.ts": true,
     "tests/unit/hooks/enforce-team-first.test.ts": true,
+    "tests/unit/hooks/enforce-verification-gate-v1.test.ts": true,
+    "tests/unit/hooks/enforce-verification-gate-v2.test.ts": true,
     "tests/unit/hooks/enforcement-gates-e2e.test.ts": true,
     "tests/unit/hooks/inject-rules.test.ts": true,
     "tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts": true,

--- a/tests/helpers/verification-gate-fixtures.ts
+++ b/tests/helpers/verification-gate-fixtures.ts
@@ -1,0 +1,129 @@
+/**
+ * Verdict fixtures for the enforce-verification-gate.sh tests.
+ *
+ * Kept beside the harness so the v1 and v2 suites build their verdicts from
+ * one definition of each schema — a v1 fixture that drifted from the real v1
+ * shape would silently weaken the compatibility proof.
+ * @module tests/helpers/verification-gate-fixtures
+ */
+import {
+  FIXTURE_HEAD_SHA,
+  FIXTURE_TIMESTAMP,
+} from "./verification-gate-harness";
+
+/** Boundary asserted by the default v2 fixture claim. */
+export const BROWSER_BOUNDARY = "browser";
+
+/** Evidence kind that reaches the browser boundary. */
+export const SCREENSHOT_KIND = "screenshot";
+
+/** Evidence kind that reaches only the code-unit boundary. */
+export const UNIT_LOG_KIND = "test-run-log";
+
+/** Claim id used by the default v2 fixture. */
+export const GATED_CLAIM_ID = "AC-1";
+
+/** Evidence id used by the default v2 fixture. */
+const EVIDENCE_ID = "EV-1";
+
+/** A criterion in the legacy criteria[] array that passed. */
+export const PASSING_CRITERION = {
+  task: "T1",
+  criterion: "the gate releases",
+  status: "pass",
+  evidence: "ran the hook, observed exit 0",
+};
+
+/** A criterion in the legacy criteria[] array that failed. */
+export const FAILING_CRITERION = {
+  task: "T2",
+  criterion: "the gate blocks",
+  status: "fail",
+  evidence: "observed exit 0, expected 2",
+};
+
+/**
+ * Builds a legacy v1 verdict.
+ * @param status - Overall verdict status.
+ * @param criteria - The legacy criteria entries.
+ * @param extra - Extra top-level fields (e.g. an explicit schema_version).
+ * @returns Serialized verdict JSON.
+ */
+export const v1Verdict = (
+  status: string,
+  criteria: Array<Record<string, unknown>>,
+  extra: Record<string, unknown> = {}
+): string =>
+  JSON.stringify({
+    plan: "bce-2",
+    status,
+    criteria,
+    updated_at: FIXTURE_TIMESTAMP,
+    ...extra,
+  });
+
+/**
+ * Builds a v2 verdict. Defaults describe a clean, all-established browser
+ * claim proven by a screenshot captured at the verdict's own head_sha.
+ * @param overrides - Top-level fields to replace on the default verdict.
+ * @returns Serialized verdict JSON.
+ */
+export const v2Verdict = (overrides: Record<string, unknown> = {}): string =>
+  JSON.stringify({
+    schema_version: 2,
+    plan: "bce-2",
+    artifact: {
+      repository: "CodySwannGT/lisa",
+      base_sha: "aaaa111",
+      head_sha: FIXTURE_HEAD_SHA,
+      build_id: "build-1",
+      environment: "local",
+      observed_at: FIXTURE_TIMESTAMP,
+    },
+    claims: [
+      {
+        claim_id: GATED_CLAIM_ID,
+        statement: "the button works in the browser",
+        boundary: BROWSER_BOUNDARY,
+        required_for_gate: true,
+        required_evidence_kinds: [SCREENSHOT_KIND, "recording"],
+        status: "established",
+        evidence_refs: [EVIDENCE_ID],
+        not_established: [],
+      },
+    ],
+    evidence: [
+      {
+        evidence_id: EVIDENCE_ID,
+        kind: SCREENSHOT_KIND,
+        locator: "evidence/1836/button.png",
+        sha256: "deadbeef",
+        captured_at: FIXTURE_TIMESTAMP,
+        artifact_head_sha: FIXTURE_HEAD_SHA,
+      },
+    ],
+    not_established_reviewed: true,
+    criteria: [PASSING_CRITERION],
+    status: "pass",
+    updated_at: FIXTURE_TIMESTAMP,
+    ...overrides,
+  });
+
+/**
+ * A v2 verdict whose gated browser claim cites only a unit test-run-log —
+ * the canonical claim/evidence boundary violation.
+ * @returns Serialized verdict JSON.
+ */
+export const v2BoundaryMismatch = (): string =>
+  v2Verdict({
+    evidence: [
+      {
+        evidence_id: EVIDENCE_ID,
+        kind: UNIT_LOG_KIND,
+        locator: "evidence/1836/unit.txt",
+        sha256: "deadbeef",
+        captured_at: FIXTURE_TIMESTAMP,
+        artifact_head_sha: FIXTURE_HEAD_SHA,
+      },
+    ],
+  });

--- a/tests/helpers/verification-gate-harness.ts
+++ b/tests/helpers/verification-gate-harness.ts
@@ -1,0 +1,137 @@
+/**
+ * Shared harness for the enforce-verification-gate.sh Stop hook tests.
+ *
+ * The gate is exercised as a real process — the tests spawn the actual shipped
+ * hook against a throwaway project directory and state directory, so what is
+ * pinned is the hook's observable contract (exit code + stderr), not a
+ * reimplementation of its logic.
+ *
+ * The v1 and v2 suites share this harness so the compatibility window is
+ * proven against one identical driver: the same arming, freshness, and config
+ * mechanics judge both schema versions.
+ * @module tests/helpers/verification-gate-harness
+ */
+import { spawnSync } from "child_process";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+
+const BASH_PATH = "/bin/bash";
+
+/** Exit code the hook uses to block a stop. */
+export const EXIT_BLOCKED = 2;
+
+/** Exit code the hook uses to allow a stop. */
+export const EXIT_ALLOWED = 0;
+
+/** Matches the hook's own MAX_BLOCKS escalation bound. */
+export const MAX_BLOCKS = 8;
+
+/** Seconds the verdict mtime is pushed past the arm flag to be "fresh". */
+const FRESH_SKEW_SECONDS = 30;
+
+const IMPLEMENT_PROMPT = "/lisa:implement BCE-2";
+
+const HOOK_PATH = path.resolve(
+  "plugins/lisa/hooks/enforce-verification-gate.sh"
+);
+
+/** Timestamp reused across fixtures so no literal is duplicated. */
+export const FIXTURE_TIMESTAMP = "2026-07-20T00:00:00Z";
+
+/** The head_sha a clean v2 fixture claims to have been captured at. */
+export const FIXTURE_HEAD_SHA = "bbbb222";
+
+/** Result of one hook invocation. */
+export type HookResult = { status: number | null; stderr: string };
+
+/** Options controlling how a verdict file is written. */
+export type WriteVerdictOptions = { stale?: boolean };
+
+/** One isolated gate scenario, bound to its own temp directories. */
+export type GateScenario = {
+  cleanup: () => void;
+  runHook: (payload: Record<string, unknown>) => HookResult;
+  armSession: (sessionId: string) => void;
+  stop: (sessionId: string) => HookResult;
+  writeVerdict: (contents: string, options?: WriteVerdictOptions) => void;
+  writeConfig: (enforceBoundaries: boolean) => void;
+};
+
+/**
+ * Creates an isolated scenario around the real hook, with a fresh session
+ * state directory and project directory. Call once per test and cleanup after.
+ * @param baseEnv - Environment to inherit (callers pass process.env).
+ * @returns The scenario driver.
+ */
+export const createGateScenario = (
+  baseEnv: Record<string, string | undefined>
+): GateScenario => {
+  const stateRoot = mkdtempSync(path.join(tmpdir(), "lisa-verify-hook-"));
+  const projectDir = mkdtempSync(path.join(tmpdir(), "lisa-verify-proj-"));
+  const verdictFile = path.join(
+    projectDir,
+    ".lisa",
+    "verification-status.json"
+  );
+  const runHook = (payload: Record<string, unknown>): HookResult => {
+    const result = spawnSync(BASH_PATH, [HOOK_PATH], {
+      input: JSON.stringify(payload),
+      encoding: "utf-8",
+      env: { ...baseEnv, TMPDIR: stateRoot, CLAUDE_PROJECT_DIR: projectDir },
+    });
+    return { status: result.status, stderr: result.stderr };
+  };
+
+  mkdirSync(path.join(projectDir, ".lisa"), { recursive: true });
+
+  return {
+    cleanup: (): void => {
+      rmSync(stateRoot, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
+    },
+
+    runHook,
+
+    armSession: (sessionId: string): void => {
+      runHook({
+        hook_event_name: "UserPromptSubmit",
+        session_id: sessionId,
+        prompt: IMPLEMENT_PROMPT,
+      });
+    },
+
+    stop: (sessionId: string): HookResult =>
+      runHook({ hook_event_name: "Stop", session_id: sessionId }),
+
+    /**
+     * Writes the verdict file and forces its mtime relative to the arm flag so
+     * the hook's freshness check is exercised deterministically.
+     * @param contents - Raw contents, so malformed JSON is testable.
+     * @param options - Options bag.
+     * @param options.stale - Backdate the verdict behind the arm flag.
+     */
+    writeVerdict: (
+      contents: string,
+      options: WriteVerdictOptions = {}
+    ): void => {
+      const now = Date.now() / 1000;
+      const when = options.stale
+        ? now - FRESH_SKEW_SECONDS * 2
+        : now + FRESH_SKEW_SECONDS;
+      writeFileSync(verdictFile, contents);
+      utimesSync(verdictFile, when, when);
+    },
+
+    /**
+     * Writes .lisa.config.json setting the boundary-enforcement posture.
+     * @param enforceBoundaries - Value for verification.gate.enforceBoundaries.
+     */
+    writeConfig: (enforceBoundaries: boolean): void => {
+      writeFileSync(
+        path.join(projectDir, ".lisa.config.json"),
+        JSON.stringify({ verification: { gate: { enforceBoundaries } } })
+      );
+    },
+  };
+};

--- a/tests/unit/hooks/enforce-verification-gate-v1.test.ts
+++ b/tests/unit/hooks/enforce-verification-gate-v1.test.ts
@@ -1,0 +1,162 @@
+/**
+ * v1 compatibility pins for the enforce-verification-gate.sh Stop hook.
+ *
+ * This hook is the non-bypassable completion gate for /lisa:implement, so its
+ * pre-schema-v2 decision table is pinned here verbatim. These tests are the
+ * compatibility proof for the v1/v2 window: they passed before the v2 upgrade
+ * and must pass identically after it, because a verdict with no
+ * `schema_version` (or `1`) has to be judged exactly as it was before v2
+ * existed. A change that reddens this file is a break in the compat window,
+ * not a test that needs updating.
+ *
+ * Fail-open and MAX_BLOCKS escalation are pinned here too — a malformed or
+ * missing verdict must block (a green gate is never free) while the block
+ * counter guarantees the session is never hard-wedged.
+ * @module tests/unit/hooks/enforce-verification-gate-v1
+ */
+import {
+  FAILING_CRITERION,
+  PASSING_CRITERION,
+  v1Verdict,
+} from "../../helpers/verification-gate-fixtures";
+import type { GateScenario } from "../../helpers/verification-gate-harness";
+import {
+  createGateScenario,
+  EXIT_ALLOWED,
+  EXIT_BLOCKED,
+  MAX_BLOCKS,
+} from "../../helpers/verification-gate-harness";
+
+let harness: GateScenario;
+
+beforeEach(() => {
+  harness = createGateScenario(process.env);
+});
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+describe("enforce-verification-gate.sh (v1 compatibility)", () => {
+  describe("arming and exemptions", () => {
+    it("allows a stop when no implement flow was ever armed", () => {
+      expect(harness.stop("idle-session").status).toBe(EXIT_ALLOWED);
+    });
+
+    it("arms on a /lisa:implement prompt", () => {
+      harness.armSession("s1");
+      expect(harness.stop("s1").status).toBe(EXIT_BLOCKED);
+    });
+
+    it("arms when the Skill tool loads lisa-implement", () => {
+      harness.runHook({
+        hook_event_name: "PreToolUse",
+        session_id: "s2",
+        tool_name: "Skill",
+        tool_input: { skill: "lisa-implement" },
+      });
+      expect(harness.stop("s2").status).toBe(EXIT_BLOCKED);
+    });
+
+    it("never gates a teammate (subagent) stop", () => {
+      harness.armSession("s3");
+      harness.runHook({
+        hook_event_name: "SubagentStart",
+        session_id: "s3",
+      });
+      expect(harness.stop("s3").status).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("decision table", () => {
+    it("blocks when no verdict file exists", () => {
+      harness.armSession("v1-missing");
+      const { status, stderr } = harness.stop("v1-missing");
+      expect(status).toBe(EXIT_BLOCKED);
+      expect(stderr).toContain("No verification verdict found");
+    });
+
+    it("releases on a schema-less pass verdict with all criteria passing", () => {
+      harness.armSession("v1-pass");
+      harness.writeVerdict(v1Verdict("pass", [PASSING_CRITERION]));
+      expect(harness.stop("v1-pass").status).toBe(EXIT_ALLOWED);
+    });
+
+    it("releases on an explicit schema_version 1 pass verdict", () => {
+      harness.armSession("v1-explicit");
+      harness.writeVerdict(
+        v1Verdict("pass", [PASSING_CRITERION], { schema_version: 1 })
+      );
+      expect(harness.stop("v1-explicit").status).toBe(EXIT_ALLOWED);
+    });
+
+    it("releases on a blocked verdict (deliberate stop)", () => {
+      harness.armSession("v1-blocked");
+      harness.writeVerdict(
+        v1Verdict("blocked", [
+          {
+            ...PASSING_CRITERION,
+            status: "blocked",
+            evidence: "no AWS access",
+          },
+        ])
+      );
+      expect(harness.stop("v1-blocked").status).toBe(EXIT_ALLOWED);
+    });
+
+    it("disarms after releasing so a follow-up stop is not re-gated", () => {
+      harness.armSession("v1-disarm");
+      harness.writeVerdict(v1Verdict("pass", [PASSING_CRITERION]));
+      harness.stop("v1-disarm");
+      harness.writeVerdict(v1Verdict("in_progress", []));
+      expect(harness.stop("v1-disarm").status).toBe(EXIT_ALLOWED);
+    });
+
+    it("blocks a pass verdict that still carries a failing criterion", () => {
+      harness.armSession("v1-failcrit");
+      harness.writeVerdict(
+        v1Verdict("pass", [PASSING_CRITERION, FAILING_CRITERION])
+      );
+      const { status, stderr } = harness.stop("v1-failcrit");
+      expect(status).toBe(EXIT_BLOCKED);
+      expect(stderr).toContain("T2");
+    });
+
+    it("blocks an in_progress verdict", () => {
+      harness.armSession("v1-inprogress");
+      harness.writeVerdict(v1Verdict("in_progress", [PASSING_CRITERION]));
+      expect(harness.stop("v1-inprogress").status).toBe(EXIT_BLOCKED);
+    });
+
+    it("blocks a fail verdict", () => {
+      harness.armSession("v1-fail");
+      harness.writeVerdict(v1Verdict("fail", [FAILING_CRITERION]));
+      expect(harness.stop("v1-fail").status).toBe(EXIT_BLOCKED);
+    });
+
+    it("blocks a stale verdict left over from a previous plan", () => {
+      harness.armSession("v1-stale");
+      harness.writeVerdict(v1Verdict("pass", [PASSING_CRITERION]), {
+        stale: true,
+      });
+      expect(harness.stop("v1-stale").status).toBe(EXIT_BLOCKED);
+    });
+
+    it("does not crash on a malformed verdict", () => {
+      harness.armSession("v1-malformed");
+      harness.writeVerdict("{ this is not json");
+      expect(harness.stop("v1-malformed").status).toBe(EXIT_BLOCKED);
+    });
+
+    it("escalates and releases after MAX_BLOCKS consecutive blocks", () => {
+      const session = "v1-escalate";
+      harness.armSession(session);
+      for (let i = 0; i < MAX_BLOCKS; i += 1) {
+        expect(harness.stop(session).status).toBe(EXIT_BLOCKED);
+      }
+      const { status, stderr } = harness.stop(session);
+      expect(status).toBe(EXIT_ALLOWED);
+      expect(stderr).toContain("Do NOT claim this work is verified");
+    });
+  });
+});

--- a/tests/unit/hooks/enforce-verification-gate-v2.test.ts
+++ b/tests/unit/hooks/enforce-verification-gate-v2.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Schema-v2 behavior for the enforce-verification-gate.sh Stop hook.
+ *
+ * v2 binds every claim to a boundary and to the evidence kinds that reach it
+ * (the claim-evidence-mapping contract). The gate applies those checks ON TOP
+ * of the unchanged v1 conditions, and they are advisory-first: a violation is
+ * reported to stderr but only blocks once
+ * `verification.gate.enforceBoundaries` is ratcheted to true.
+ *
+ * The v1 conditions that still govern v2 (freshness, terminal status,
+ * MAX_BLOCKS, fail-open) are re-pinned here against v2 verdicts, because
+ * "v2 = v1 + claim checks" is the safety property the compat window rests on.
+ * @module tests/unit/hooks/enforce-verification-gate-v2
+ */
+import {
+  BROWSER_BOUNDARY,
+  GATED_CLAIM_ID,
+  SCREENSHOT_KIND,
+  v2BoundaryMismatch,
+  v2Verdict,
+} from "../../helpers/verification-gate-fixtures";
+import type { GateScenario } from "../../helpers/verification-gate-harness";
+import {
+  createGateScenario,
+  EXIT_ALLOWED,
+  EXIT_BLOCKED,
+  FIXTURE_HEAD_SHA,
+  MAX_BLOCKS,
+} from "../../helpers/verification-gate-harness";
+
+let harness: GateScenario;
+
+const DRIFTED_SHA = "cccc333";
+
+beforeEach(() => {
+  harness = createGateScenario(process.env);
+});
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+describe("enforce-verification-gate.sh (schema v2)", () => {
+  describe("v1 invariants still govern a v2 verdict", () => {
+    it("releases a clean v2 verdict whose claims are all established", () => {
+      harness.armSession("v2-clean");
+      harness.writeVerdict(v2Verdict());
+      expect(harness.stop("v2-clean").status).toBe(EXIT_ALLOWED);
+    });
+
+    it("releases a clean v2 verdict under enforcement", () => {
+      harness.armSession("v2-clean-enforced");
+      harness.writeConfig(true);
+      harness.writeVerdict(v2Verdict());
+      expect(harness.stop("v2-clean-enforced").status).toBe(EXIT_ALLOWED);
+    });
+
+    it("still applies the freshness check to a v2 verdict", () => {
+      harness.armSession("v2-stale");
+      harness.writeVerdict(v2Verdict(), { stale: true });
+      expect(harness.stop("v2-stale").status).toBe(EXIT_BLOCKED);
+    });
+
+    it("releases a v2 blocked verdict without applying claim checks", () => {
+      harness.armSession("v2-blocked");
+      harness.writeConfig(true);
+      harness.writeVerdict(
+        v2Verdict({
+          status: "blocked",
+          claims: [],
+          not_established_reviewed: true,
+        })
+      );
+      expect(harness.stop("v2-blocked").status).toBe(EXIT_ALLOWED);
+    });
+
+    it("does not crash on a malformed v2 verdict", () => {
+      harness.armSession("v2-malformed");
+      harness.writeConfig(true);
+      harness.writeVerdict('{ "schema_version": 2, "claims": [ }');
+      expect(harness.stop("v2-malformed").status).toBe(EXIT_BLOCKED);
+    });
+
+    it("escalates after MAX_BLOCKS on a v2 verdict too", () => {
+      const session = "v2-escalate";
+      harness.armSession(session);
+      harness.writeConfig(true);
+      harness.writeVerdict(v2BoundaryMismatch());
+      for (let i = 0; i < MAX_BLOCKS; i += 1) {
+        expect(harness.stop(session).status).toBe(EXIT_BLOCKED);
+      }
+      expect(harness.stop(session).status).toBe(EXIT_ALLOWED);
+    });
+
+    it("falls back to the v1 decision for an unrecognized schema_version", () => {
+      harness.armSession("v2-unknown");
+      harness.writeConfig(true);
+      harness.writeVerdict(
+        JSON.stringify({
+          ...(JSON.parse(v2BoundaryMismatch()) as Record<string, unknown>),
+          schema_version: 99,
+        })
+      );
+      expect(harness.stop("v2-unknown").status).toBe(EXIT_ALLOWED);
+    });
+
+    it("accepts and ignores a top-level not_established list", () => {
+      harness.armSession("v2-notest");
+      harness.writeConfig(true);
+      harness.writeVerdict(v2Verdict({ not_established: ["mobile viewport"] }));
+      expect(harness.stop("v2-notest").status).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("boundary enforcement is advisory-first", () => {
+    it("reports a boundary mismatch but still releases when enforcement is off", () => {
+      harness.armSession("v2-advisory");
+      harness.writeConfig(false);
+      harness.writeVerdict(v2BoundaryMismatch());
+      const { status, stderr } = harness.stop("v2-advisory");
+      expect(status).toBe(EXIT_ALLOWED);
+      expect(stderr).toContain(GATED_CLAIM_ID);
+      expect(stderr).toContain(BROWSER_BOUNDARY);
+      expect(stderr).toContain(SCREENSHOT_KIND);
+    });
+
+    it("treats a missing config as enforcement off", () => {
+      harness.armSession("v2-noconfig");
+      harness.writeVerdict(v2BoundaryMismatch());
+      const { status, stderr } = harness.stop("v2-noconfig");
+      expect(status).toBe(EXIT_ALLOWED);
+      expect(stderr).toContain(GATED_CLAIM_ID);
+    });
+
+    it("blocks a boundary mismatch when enforcement is on, naming the claim", () => {
+      harness.armSession("v2-enforced");
+      harness.writeConfig(true);
+      harness.writeVerdict(v2BoundaryMismatch());
+      const { status, stderr } = harness.stop("v2-enforced");
+      expect(status).toBe(EXIT_BLOCKED);
+      expect(stderr).toContain(GATED_CLAIM_ID);
+      expect(stderr).toContain(BROWSER_BOUNDARY);
+      expect(stderr).toContain(SCREENSHOT_KIND);
+    });
+
+    it("states the boundary violation as the block reason, not the v1 fallback", () => {
+      harness.armSession("v2-reason");
+      harness.writeConfig(true);
+      harness.writeVerdict(v2BoundaryMismatch());
+      const { stderr } = harness.stop("v2-reason");
+      expect(stderr).toContain("reaches that claim's boundary");
+      expect(stderr).not.toContain("status is not pass/blocked");
+    });
+
+    it("blocks a gated claim that is not established", () => {
+      harness.armSession("v2-notestablished");
+      harness.writeConfig(true);
+      harness.writeVerdict(
+        v2Verdict({
+          claims: [
+            {
+              claim_id: "AC-9",
+              statement: "the API returns 200",
+              boundary: "http-api",
+              required_for_gate: true,
+              required_evidence_kinds: ["http-transcript"],
+              status: "not-established",
+              evidence_refs: [],
+            },
+          ],
+        })
+      );
+      const { status, stderr } = harness.stop("v2-notestablished");
+      expect(status).toBe(EXIT_BLOCKED);
+      expect(stderr).toContain("AC-9");
+    });
+
+    it("blocks a claim whose evidence_refs resolve to nothing", () => {
+      harness.armSession("v2-dangling");
+      harness.writeConfig(true);
+      harness.writeVerdict(v2Verdict({ evidence: [] }));
+      const { status, stderr } = harness.stop("v2-dangling");
+      expect(status).toBe(EXIT_BLOCKED);
+      expect(stderr).toContain(GATED_CLAIM_ID);
+    });
+
+    it("ignores claims that are not required_for_gate", () => {
+      harness.armSession("v2-optional");
+      harness.writeConfig(true);
+      harness.writeVerdict(
+        v2Verdict({
+          claims: [
+            {
+              claim_id: GATED_CLAIM_ID,
+              boundary: BROWSER_BOUNDARY,
+              required_for_gate: true,
+              required_evidence_kinds: [SCREENSHOT_KIND],
+              status: "established",
+              evidence_refs: ["EV-1"],
+            },
+            {
+              claim_id: "AC-2",
+              boundary: BROWSER_BOUNDARY,
+              required_for_gate: false,
+              required_evidence_kinds: [SCREENSHOT_KIND],
+              status: "not-established",
+              evidence_refs: [],
+            },
+          ],
+        })
+      );
+      expect(harness.stop("v2-optional").status).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("not_established_reviewed may never be omitted", () => {
+    const withoutReviewFlag = (): string => {
+      const verdict = JSON.parse(v2Verdict()) as Record<string, unknown>;
+      delete verdict.not_established_reviewed;
+      return JSON.stringify(verdict);
+    };
+
+    it("blocks when the flag is omitted under enforcement", () => {
+      harness.armSession("v2-noreview");
+      harness.writeConfig(true);
+      harness.writeVerdict(withoutReviewFlag());
+      const { status, stderr } = harness.stop("v2-noreview");
+      expect(status).toBe(EXIT_BLOCKED);
+      expect(stderr).toContain("not_established_reviewed");
+    });
+
+    it("only warns when the flag is omitted and enforcement is off", () => {
+      harness.armSession("v2-noreview-advisory");
+      harness.writeConfig(false);
+      harness.writeVerdict(withoutReviewFlag());
+      const { status, stderr } = harness.stop("v2-noreview-advisory");
+      expect(status).toBe(EXIT_ALLOWED);
+      expect(stderr).toContain("not_established_reviewed");
+    });
+  });
+
+  describe("artifact identity", () => {
+    it("blocks a v2 pass verdict missing artifact.head_sha under enforcement", () => {
+      harness.armSession("v2-nohead");
+      harness.writeConfig(true);
+      harness.writeVerdict(
+        v2Verdict({ artifact: { repository: "CodySwannGT/lisa" } })
+      );
+      const { status, stderr } = harness.stop("v2-nohead");
+      expect(status).toBe(EXIT_BLOCKED);
+      expect(stderr).toContain("head_sha");
+    });
+
+    it("blocks evidence captured at a different artifact head_sha", () => {
+      harness.armSession("v2-shadrift");
+      harness.writeConfig(true);
+      harness.writeVerdict(
+        v2Verdict({
+          evidence: [
+            {
+              evidence_id: "EV-1",
+              kind: SCREENSHOT_KIND,
+              locator: "evidence/1836/button.png",
+              captured_at: "2026-07-20T00:00:00Z",
+              artifact_head_sha: DRIFTED_SHA,
+            },
+          ],
+        })
+      );
+      const { status, stderr } = harness.stop("v2-shadrift");
+      expect(status).toBe(EXIT_BLOCKED);
+      expect(stderr).toContain(DRIFTED_SHA);
+      expect(stderr).toContain(FIXTURE_HEAD_SHA);
+    });
+  });
+});


### PR DESCRIPTION
## What this changes

The Stop-hook gate now judges whether the evidence a verdict cites actually **reaches the claim it is offered for**. Today a claim about browser-visible behavior backed only by a unit test log reads as "verified"; after this, it does not.

`verification-status.json` gains **schema v2**: `schema_version: 2`, an `artifact` identity block, `claims[]` carrying the BCE-1 contract field names (`claim_id` / `boundary` / `required_evidence_kinds`), a resolvable `evidence[]` table, and the never-omitted `not_established_reviewed` flag. A top-level `not_established` list is accepted and ignored as the BCE-3 hedge. Legacy `criteria[]` is retained but **display-only** under v2 — it can never establish a v2 claim.

## Risk framing

`enforce-verification-gate.sh` is the **non-bypassable Claude Stop hook**. A schema bug here strands every implement flow on every project, so this ships behind three safety properties, in priority order:

1. **Compat window.** `verdict_is_terminal` branches on `schema_version`. Absent or `1` → the v1 path, unchanged. `2` → v1 **plus** the claim checks. An unrecognized value (e.g. `99`) degrades to v1 rather than to a new failure mode.
2. **Advisory-first.** The v2 claim/evidence checks report to stderr but **do not block** until `verification.gate.enforceBoundaries` is `true` in `.lisa.config.json` (default `false`; promoted via the threshold ratchet). While it is false, a v2 verdict releases on exactly the v1-equivalent conditions. **No blocking behavior changes for anyone on merge.**
3. **Fail-open + MAX_BLOCKS preserved.** An unevaluable v2 claim structure degrades to the v1 decision instead of inventing a hard failure, and the 8-block escalation is untouched, so a schema bug can never wedge a session.

## Compat proof

The 15 v1 decision-table pins were written **first**, then run against the **pre-change hook restored from HEAD** and against the new hook:

| Hook under test | v1 pins |
|---|---|
| `HEAD` (pre-change) | **15/15 pass** |
| this branch (v2) | **15/15 pass** |

A change that reddens `enforce-verification-gate-v1.test.ts` is a break in the compat window, not a test to update — the file says so in its module docblock.

## Empirical hook legs

The real hook was executed under `sh` against 24 fixture verdicts (`bash` produces byte-identical output — verified by checksum):

| case | exit | stderr |
|---|---|---|
| not armed (no implement flow) | 0 | — |
| armed, no verdict file | 2 | No verification verdict found |
| v1 pass, all criteria pass | 0 | — |
| v1 explicit `schema_version: 1`, pass | 0 | — |
| v1 blocked (deliberate stop) | 0 | — |
| v1 pass with a failing criterion | 2 | Blocked … |
| v1 in_progress | 2 | Blocked … |
| v1 pass but stale | 2 | Blocked … |
| malformed JSON | 2 | Blocked … (bounded by MAX_BLOCKS) |
| v2 clean, enforcement off | 0 | — |
| v2 clean, enforcement ON | 0 | — |
| v2 clean but stale | 2 | Blocked … |
| v2 boundary mismatch, enforcement OFF | **0** | advisory naming AC-1 |
| v2 boundary mismatch, **no config at all** | **0** | advisory naming AC-1 |
| v2 boundary mismatch, enforcement ON | 2 | names AC-1, boundary, required kinds |
| v2 claim not established, ON | 2 | names AC-9 |
| v2 dangling `evidence_refs`, ON | 2 | cites no resolvable evidence |
| v2 `not_established_reviewed` absent, ON | 2 | flag may never be omitted |
| v2 `not_established_reviewed` absent, OFF | 0 | advisory |
| v2 `artifact.head_sha` missing, ON | 2 | required for a v2 pass |
| v2 evidence `head_sha` drift, ON | 2 | names both SHAs |
| v2 `blocked` status (claims skipped), ON | 0 | — |
| malformed v2, ON | 2 | Blocked … (falls back to v1) |
| v2 unknown `schema_version: 99` | 0 | — (v1 path) |

The operator-facing message under enforcement reads, in full:

```
The verdict claims to pass, but its evidence does not establish every
claim the gate requires:
  - claim AC-1 [boundary browser] cited evidence kinds [test-run-log] do not
    reach the boundary (required kinds: screenshot, recording)

A claim counts only when the evidence cited for it is of a kind that
reaches that claim's boundary — a unit test log does not prove a
button works in a browser.
```

## Gates

- `enforce-verification-gate-v1/-v2` suites: **34/34**
- Full suite: **6208/6208** across 358 files
- `typecheck`, `lint`: clean
- `sh -n` + `bash -n` on the hook: clean
- `check:plugins`: artifacts in sync (fanned to `lisa`, `lisa-cursor`, `lisa-copilot`, `lisa-agy`, `.codex-plugin`)
- upstream evidence manifest `--check`: clean

## Reviewer replay

1. `npx vitest run tests/unit/hooks/enforce-verification-gate-v1.test.ts` → 15 pass.
2. `git stash` the hook, `git show origin/main:plugins/lisa/hooks/enforce-verification-gate.sh > plugins/lisa/hooks/enforce-verification-gate.sh`, re-run step 1 → still 15 pass. That is the compat window.
3. Restore the hook, then flip `verification.gate.enforceBoundaries` to `true` in a scratch project and feed it a v2 verdict whose browser claim cites a `test-run-log` → gate blocks and names the claim. Flip to `false` → gate releases with the advisory.

## Notes for the follow-on tickets

- `artifact.head_sha` is only checked for presence and internal consistency with each evidence entry's `artifact_head_sha`. Reconciliation with the **merged** head is BCE-4 (#1838).
- Non-Claude harnesses still fall back to the prose gate; `lisa-implement/SKILL.md` now documents v2 for that parity, and BCE-7 (#1841) fans it out.
- One deliberate reading, flagged for reviewer confirmation: the ticket's "schema error never bricks the session" Gherkin says *exit 0*, but a malformed verdict blocks today (bounded by MAX_BLOCKS). Making it exit 0 would let any garbage file bypass the gate, so "fail-open" is implemented as **"never hard-wedges"** (MAX_BLOCKS guarantees release) rather than "never blocks". v1 behavior is preserved verbatim.

Closes #1836

🤖 Generated with Claude Code
