### PR TITLE
feat(security): two-bucket findings with the impact-or-exploitability bar (#1839)

### DIFF
--- a/plugins/lisa-agy/agents/security-specialist.md
+++ b/plugins/lisa-agy/agents/security-specialist.md
@@ -35,12 +35,26 @@ Structure your findings as:
 - [ ] No XSS vectors in user-facing output
 - [ ] Dependencies free of known CVEs
 
-### Vulnerabilities Found
-- [vulnerability] -- where in the code, how to prevent
+### Security (proven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: [evidence ref]
+  - impact: [who can do what, to what data, under what preconditions]
+  - reason: reproducer + bounded impact
+
+### Security (unproven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: none
+  - impact: unproven
+  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)
 ```
+
+A finding is **proven** only with both a reproducer evidence ref and a bounded impact statement;
+missing either, it stays **unproven** inside the security section. The full bar, the per-finding
+fields, and the `security.review.unprovenBucket` policy point live in the `security-review` skill --
+follow it, do not restate it.
 
 ## Rules
 

--- a/plugins/lisa-agy/agents/security-specialist.md
+++ b/plugins/lisa-agy/agents/security-specialist.md
@@ -43,18 +43,21 @@ Structure your findings as:
 
 ### Security (unproven)
 - [finding] -- where in the code, how to prevent
-  - reproducer: none
-  - impact: unproven
-  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
+  - reproducer: [evidence ref if one exists, else `none`]
+  - impact: [bounded statement if one exists, else `unproven`]
+  - reason: [which half is missing -- e.g. "impact bounded, but never reproduced"]
+    -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)
 ```
 
 A finding is **proven** only with both a reproducer evidence ref and a bounded impact statement;
-missing either, it stays **unproven** inside the security section. The full bar, the per-finding
-fields, and the `security.review.unprovenBucket` policy point live in the `security-review` skill --
-follow it, do not restate it.
+missing either, it stays **unproven** inside the security section. Record the two halves
+independently -- keep whichever one you have and let the `reason` name the missing half; never
+overwrite a real value with a placeholder. The full bar, the per-finding fields, and the
+`security.review.unprovenBucket` policy point live in the `security-review` skill -- follow it, do
+not restate it.
 
 ## Rules
 

--- a/plugins/lisa-agy/skills/lisa-security-review/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-security-review/SKILL.md
@@ -16,6 +16,50 @@ Identify vulnerabilities, evaluate threats, and recommend mitigations for code c
 5. **Check auth/authz** -- are access controls properly enforced for new endpoints or features?
 6. **Review dependencies** -- do new dependencies introduce known vulnerabilities?
 
+## The impact-or-exploitability bar
+
+Severity is **earned, not pattern-matched**. Every security-shaped finding is classified
+mechanically, before it is written up:
+
+| Field | What it holds |
+|-------|---------------|
+| `reproducer` | an evidence ref of a kind that reaches the claim's boundary, or `none` |
+| `impact` | a bounded impact/exploitability statement (who can do what, to what data, under what preconditions), or `unproven` |
+| `reason` | one line saying why the finding landed in its bucket |
+
+**The bar:** a finding is **proven** only when it carries **both** a reproducer **and** a bounded
+impact statement. **Missing either ⇒ unproven.** No other input changes the bucket.
+
+What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract, not here:
+an injection claim at the `http-api` boundary needs an `http-transcript`; a UI claim needs a
+`screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and never
+discharges either.
+
+## The two buckets — conservative by default
+
+Findings render in two clearly-labeled buckets: **Security (proven)** and **Security (unproven)**.
+
+A reproducer-less finding **stays in the security section**, labeled `unproven` with its reason. It
+is **never auto-demoted** to a `maintenance` bucket and it is **not removed** from the report —
+under-reporting a real vulnerability is the worse failure, so the conservative default keeps it
+visible where a security reader looks.
+
+**Single policy point.** The unproven bucket's label is the only thing an owner may change:
+`security.review.unprovenBucket` in `.lisa.config.json`, default `security-unproven`. An owner who
+prefers true demotion sets it to a maintenance label; the finding then renders under that bucket and
+**no other classification logic changes** — the bar, the fields, and the reasons are identical.
+
+Write both buckets in operator voice (`factory-model` rule 5): a person who does not code reads this
+at the gate. "Anyone who can reach the search box can read other customers' orders — reproduced with
+the request transcript below" is usable; "possible SQLi in handler" is not.
+
+This bar governs *code-review* security findings. Dependency CVE remediation keeps its own decision
+ladder in the `security-audit-handling` rule — cite it, do not restate or fork it.
+
+Bucketing is **advisory** — it shapes the report, it does not block a merge — on the same terms as
+the boundary checks, which stay reporting-only until `verification.gate.enforceBoundaries` is `true`
+in `.lisa.config.json`.
+
 ## Output Format
 
 Structure findings as:
@@ -41,17 +85,32 @@ Structure findings as:
 - [ ] No XSS vectors in user-facing output
 - [ ] Dependencies free of known CVEs
 
-### Vulnerabilities Found
-- [vulnerability] -- where in the code, how to prevent
+### Security (proven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: [evidence ref, e.g. evidence/<ticket>/http-transcript-01.txt]
+  - impact: [who can do what, to what data, under what preconditions]
+  - reason: reproducer + bounded impact
+
+### Security (unproven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: none
+  - impact: unproven
+  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)
 ```
 
+Rename the unproven heading only when `security.review.unprovenBucket` is set to something other
+than `security-unproven`; everything else stays as written.
+
 ## Rules
 
 - Focus on the specific changes proposed, not a full security audit of the entire codebase
 - Flag only real risks -- do not invent hypothetical threats for internal tooling with no user input
+- Classify every finding against the bar before writing it up; never leave a finding unbucketed
+- Never silently drop or downgrade a finding out of the security section -- `unproven` is the
+  conservative landing spot, and the reason line says why
 - Prioritize OWASP Top 10 vulnerabilities
 - If the changes are purely internal (config, refactoring, docs), report "No security concerns" and explain why
 - Always check `.gitleaksignore` patterns to understand what secrets scanning is already in place

--- a/plugins/lisa-agy/skills/lisa-security-review/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-security-review/SKILL.md
@@ -30,10 +30,17 @@ mechanically, before it is written up:
 **The bar:** a finding is **proven** only when it carries **both** a reproducer **and** a bounded
 impact statement. **Missing either ⇒ unproven.** No other input changes the bucket.
 
-What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract, not here:
-an injection claim at the `http-api` boundary needs an `http-transcript`; a UI claim needs a
-`screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and never
-discharges either.
+What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract (**BCE-1**,
+#1835), not here: an injection claim at the `http-api` boundary needs an `http-transcript`; a UI
+claim needs a `screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and
+never discharges either.
+
+**Each field stands on its own.** The two halves are recorded independently: a finding with a bounded
+impact but no reproducer keeps its impact statement verbatim and only `reproducer` reads `none`; a
+finding with a reproducer but no bounded impact keeps the evidence ref and only `impact` reads
+`unproven`. **Never overwrite** a field you actually have with a missing-value placeholder — the
+`reason` line names which half is missing, and the surviving half is the head start the next reviewer
+needs.
 
 ## The two buckets — conservative by default
 
@@ -93,9 +100,10 @@ Structure findings as:
 
 ### Security (unproven)
 - [finding] -- where in the code, how to prevent
-  - reproducer: none
-  - impact: unproven
-  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
+  - reproducer: [evidence ref if one exists, else `none`]
+  - impact: [bounded statement if one exists, else `unproven`]
+  - reason: [which half is missing -- e.g. "impact bounded, but never reproduced"]
+    -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)

--- a/plugins/lisa-agy/skills/lisa-security-zap-scan/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-security-zap-scan/SKILL.md
@@ -25,7 +25,19 @@ Run a ZAP baseline security scan against the local application.
      - List each Medium+ finding with its rule ID, name, and recommended fix
      - Categorize findings as "infrastructure-level" (fix at CDN/proxy) vs "application-level" (fix in code)
 
-4. **Handle failures**:
+4. **Apply the impact-or-exploitability bar** -- the same bar the `lisa-security-review` skill
+   defines; follow that skill, do not restate it. A ZAP alert is not a reproducer by itself: the
+   alert names a pattern, not an exercised impact path.
+   - **Security (proven)** -- the alert carries a reproducer (the ZAP request/response transcript for
+     that alert, or a captured `http-transcript`) **and** a bounded impact statement.
+   - **Security (unproven)** -- everything else, each with a one-line `reason` (typically
+     "alert only, no reproducer / no bounded impact"). Unproven alerts are **not dropped** and not
+     demoted out of the security summary -- they render in the unproven bucket so a reader still sees
+     them.
+   - Rename the unproven heading only if `security.review.unprovenBucket` is set to something other
+     than `security-unproven`; no other classification changes.
+
+5. **Handle failures**:
    - If the scan failed, explain what failed and suggest concrete remediation steps
 
 ## Execution

--- a/plugins/lisa-agy/skills/lisa-security-zap-scan/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-security-zap-scan/SKILL.md
@@ -22,18 +22,26 @@ Run a ZAP baseline security scan against the local application.
    - After the scan completes, read `zap-report.html` (or `zap-report.md` for text)
    - Summarize findings:
      - Total number of alerts by risk level (High, Medium, Low, Informational)
-     - List each Medium+ finding with its rule ID, name, and recommended fix
+     - **Every alert reaches classification** -- High, Medium, Low, and Informational alike. Risk
+       level orders the summary; it never filters it. **Nothing is dropped before classification**,
+       so no alert can leave the report unclassified. Medium+ alerts are listed first, in full (rule
+       ID, name, recommended fix); Low/Informational alerts are still listed, bucketed, and given a
+       `reason`, even when compressed to one line each.
      - Categorize findings as "infrastructure-level" (fix at CDN/proxy) vs "application-level" (fix in code)
 
 4. **Apply the impact-or-exploitability bar** -- the same bar the `lisa-security-review` skill
    defines; follow that skill, do not restate it. A ZAP alert is not a reproducer by itself: the
    alert names a pattern, not an exercised impact path.
-   - **Security (proven)** -- the alert carries a reproducer (the ZAP request/response transcript for
-     that alert, or a captured `http-transcript`) **and** a bounded impact statement.
+   - **Security (proven)** -- the alert carries a reproducer **and** a bounded impact statement. The
+     reproducer counts only if its evidence kind **reaches the claim's boundary** under the
+     `claim-evidence-mapping` contract (BCE-1, #1835): a ZAP request/response transcript is an
+     `http-transcript` and reaches the `http-api` boundary only. An alert whose claim is about
+     rendered UI (`browser`) or persisted state (`data`) needs evidence at *that* boundary -- a
+     transcript never proves it.
    - **Security (unproven)** -- everything else, each with a one-line `reason` (typically
-     "alert only, no reproducer / no bounded impact"). Unproven alerts are **not dropped** and not
-     demoted out of the security summary -- they render in the unproven bucket so a reader still sees
-     them.
+     "alert only, no reproducer / no bounded impact", or "transcript does not reach the claim's
+     boundary"). Unproven alerts are **not dropped** and not demoted out of the security summary --
+     they render in the unproven bucket so a reader still sees them.
    - Rename the unproven heading only if `security.review.unprovenBucket` is set to something other
      than `security-unproven`; no other classification changes.
 

--- a/plugins/lisa-copilot/agents/security-specialist.agent.md
+++ b/plugins/lisa-copilot/agents/security-specialist.agent.md
@@ -35,12 +35,26 @@ Structure your findings as:
 - [ ] No XSS vectors in user-facing output
 - [ ] Dependencies free of known CVEs
 
-### Vulnerabilities Found
-- [vulnerability] -- where in the code, how to prevent
+### Security (proven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: [evidence ref]
+  - impact: [who can do what, to what data, under what preconditions]
+  - reason: reproducer + bounded impact
+
+### Security (unproven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: none
+  - impact: unproven
+  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)
 ```
+
+A finding is **proven** only with both a reproducer evidence ref and a bounded impact statement;
+missing either, it stays **unproven** inside the security section. The full bar, the per-finding
+fields, and the `security.review.unprovenBucket` policy point live in the `security-review` skill --
+follow it, do not restate it.
 
 ## Rules
 

--- a/plugins/lisa-copilot/agents/security-specialist.agent.md
+++ b/plugins/lisa-copilot/agents/security-specialist.agent.md
@@ -43,18 +43,21 @@ Structure your findings as:
 
 ### Security (unproven)
 - [finding] -- where in the code, how to prevent
-  - reproducer: none
-  - impact: unproven
-  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
+  - reproducer: [evidence ref if one exists, else `none`]
+  - impact: [bounded statement if one exists, else `unproven`]
+  - reason: [which half is missing -- e.g. "impact bounded, but never reproduced"]
+    -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)
 ```
 
 A finding is **proven** only with both a reproducer evidence ref and a bounded impact statement;
-missing either, it stays **unproven** inside the security section. The full bar, the per-finding
-fields, and the `security.review.unprovenBucket` policy point live in the `security-review` skill --
-follow it, do not restate it.
+missing either, it stays **unproven** inside the security section. Record the two halves
+independently -- keep whichever one you have and let the `reason` name the missing half; never
+overwrite a real value with a placeholder. The full bar, the per-finding fields, and the
+`security.review.unprovenBucket` policy point live in the `security-review` skill -- follow it, do
+not restate it.
 
 ## Rules
 

--- a/plugins/lisa-copilot/rules/eager/claim-evidence-mapping.md
+++ b/plugins/lisa-copilot/rules/eager/claim-evidence-mapping.md
@@ -37,8 +37,15 @@ rule 5).
 A claim carries three fields — `claim_id`, `boundary`, and `required_evidence_kinds` — named here so
 every downstream surface uses one spelling. This ticket only writes the contract down; the schema and
 gate that make these fields executable ship with **BCE-2 (#1836)** — do not assume that surface is
-present in this branch. The conservative security-bucket default is set in **BCE-5 (#1839)** — named
-here, defined there.
+present in this branch.
+
+## Security buckets (conservative by default)
+
+A security finding is **proven** only with both a reproducer of a reaching kind and a bounded
+impact/exploitability statement; missing either, it renders **unproven** with its reason and **stays
+in the security section** — never auto-demoted to maintenance. The label is one policy point,
+`security.review.unprovenBucket` (default `security-unproven`); the procedure lives in the
+`lisa-security-review` skill.
 
 ## Artifact identity (pinned, never assumed)
 

--- a/plugins/lisa-copilot/rules/reference/claim-evidence-mapping.md
+++ b/plugins/lisa-copilot/rules/reference/claim-evidence-mapping.md
@@ -82,10 +82,9 @@ defines the names; it stores nothing:
 A claim whose `required_evidence_kinds` has no captured, reaching artifact is **Not established** —
 defined in full, with its evidence templates, in the section below. Artifact identity — what makes
 two captured artifacts the same or different — is defined in the *Artifact identity* section below
-(shipped by BCE-4, #1838). The conservative default bucket for a security-sensitive claim is set in
-**BCE-5 (#1839)** — named here as a field BCE-2's schema carries, not defined by this contract, and
-it ships with that ticket. Where such a sibling surface is not installed in a given branch, name what
-you can and continue.
+(shipped by BCE-4, #1838). The bucket a security-sensitive claim lands in is defined in the *Security
+buckets* section below (shipped by BCE-5, #1839). Where such a sibling surface is not installed in a
+given branch, name what you can and continue.
 
 ### Worked example
 
@@ -178,6 +177,28 @@ second one. Identity reconciliation is the same definition read from the evidenc
   is what may declare completion.
 
 Two guards, one definition — so they cannot disagree about what shipped.
+
+## Security buckets — the impact-or-exploitability bar
+
+A security-shaped claim is a claim like any other: it reaches only as far as its evidence. Applied to
+security findings (shipped by BCE-5, #1839), that yields two buckets and one bar:
+
+- **Security (proven)** — the finding carries **both** a `reproducer` (an evidence ref of a kind that
+  reaches the claim's boundary, per the taxonomy above — e.g. an `http-transcript` for an injection
+  claim at `http-api`) **and** a bounded `impact`/exploitability statement.
+- **Security (unproven)** — **missing either**. It keeps a one-line `reason` and **stays in the
+  security section**: a reproducer-less finding is **never auto-demoted** to a `maintenance` bucket,
+  because under-reporting a real vulnerability is the worse failure.
+
+The unproven bucket's label is the single configurable policy point —
+`security.review.unprovenBucket` in `.lisa.config.json`, default `security-unproven`. An owner who
+prefers true demotion flips that one value; no other classification logic changes. Like the boundary
+checks, bucketing is **advisory** — it shapes the report, not the merge — until
+`verification.gate.enforceBoundaries` is `true`.
+
+The full procedure — per-finding fields, report shape, ZAP alignment — lives in the
+`lisa-security-review` skill (with `lisa-security-zap-scan` citing it); dependency-CVE remediation
+keeps its separate ladder in `security-audit-handling`. Cite those slugs; do not restate them here.
 
 ## The "Not established" section — required, never omitted
 

--- a/plugins/lisa-copilot/skills/lisa-security-review/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-security-review/SKILL.md
@@ -16,6 +16,50 @@ Identify vulnerabilities, evaluate threats, and recommend mitigations for code c
 5. **Check auth/authz** -- are access controls properly enforced for new endpoints or features?
 6. **Review dependencies** -- do new dependencies introduce known vulnerabilities?
 
+## The impact-or-exploitability bar
+
+Severity is **earned, not pattern-matched**. Every security-shaped finding is classified
+mechanically, before it is written up:
+
+| Field | What it holds |
+|-------|---------------|
+| `reproducer` | an evidence ref of a kind that reaches the claim's boundary, or `none` |
+| `impact` | a bounded impact/exploitability statement (who can do what, to what data, under what preconditions), or `unproven` |
+| `reason` | one line saying why the finding landed in its bucket |
+
+**The bar:** a finding is **proven** only when it carries **both** a reproducer **and** a bounded
+impact statement. **Missing either ⇒ unproven.** No other input changes the bucket.
+
+What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract, not here:
+an injection claim at the `http-api` boundary needs an `http-transcript`; a UI claim needs a
+`screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and never
+discharges either.
+
+## The two buckets — conservative by default
+
+Findings render in two clearly-labeled buckets: **Security (proven)** and **Security (unproven)**.
+
+A reproducer-less finding **stays in the security section**, labeled `unproven` with its reason. It
+is **never auto-demoted** to a `maintenance` bucket and it is **not removed** from the report —
+under-reporting a real vulnerability is the worse failure, so the conservative default keeps it
+visible where a security reader looks.
+
+**Single policy point.** The unproven bucket's label is the only thing an owner may change:
+`security.review.unprovenBucket` in `.lisa.config.json`, default `security-unproven`. An owner who
+prefers true demotion sets it to a maintenance label; the finding then renders under that bucket and
+**no other classification logic changes** — the bar, the fields, and the reasons are identical.
+
+Write both buckets in operator voice (`factory-model` rule 5): a person who does not code reads this
+at the gate. "Anyone who can reach the search box can read other customers' orders — reproduced with
+the request transcript below" is usable; "possible SQLi in handler" is not.
+
+This bar governs *code-review* security findings. Dependency CVE remediation keeps its own decision
+ladder in the `security-audit-handling` rule — cite it, do not restate or fork it.
+
+Bucketing is **advisory** — it shapes the report, it does not block a merge — on the same terms as
+the boundary checks, which stay reporting-only until `verification.gate.enforceBoundaries` is `true`
+in `.lisa.config.json`.
+
 ## Output Format
 
 Structure findings as:
@@ -41,17 +85,32 @@ Structure findings as:
 - [ ] No XSS vectors in user-facing output
 - [ ] Dependencies free of known CVEs
 
-### Vulnerabilities Found
-- [vulnerability] -- where in the code, how to prevent
+### Security (proven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: [evidence ref, e.g. evidence/<ticket>/http-transcript-01.txt]
+  - impact: [who can do what, to what data, under what preconditions]
+  - reason: reproducer + bounded impact
+
+### Security (unproven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: none
+  - impact: unproven
+  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)
 ```
 
+Rename the unproven heading only when `security.review.unprovenBucket` is set to something other
+than `security-unproven`; everything else stays as written.
+
 ## Rules
 
 - Focus on the specific changes proposed, not a full security audit of the entire codebase
 - Flag only real risks -- do not invent hypothetical threats for internal tooling with no user input
+- Classify every finding against the bar before writing it up; never leave a finding unbucketed
+- Never silently drop or downgrade a finding out of the security section -- `unproven` is the
+  conservative landing spot, and the reason line says why
 - Prioritize OWASP Top 10 vulnerabilities
 - If the changes are purely internal (config, refactoring, docs), report "No security concerns" and explain why
 - Always check `.gitleaksignore` patterns to understand what secrets scanning is already in place

--- a/plugins/lisa-copilot/skills/lisa-security-review/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-security-review/SKILL.md
@@ -30,10 +30,17 @@ mechanically, before it is written up:
 **The bar:** a finding is **proven** only when it carries **both** a reproducer **and** a bounded
 impact statement. **Missing either ⇒ unproven.** No other input changes the bucket.
 
-What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract, not here:
-an injection claim at the `http-api` boundary needs an `http-transcript`; a UI claim needs a
-`screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and never
-discharges either.
+What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract (**BCE-1**,
+#1835), not here: an injection claim at the `http-api` boundary needs an `http-transcript`; a UI
+claim needs a `screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and
+never discharges either.
+
+**Each field stands on its own.** The two halves are recorded independently: a finding with a bounded
+impact but no reproducer keeps its impact statement verbatim and only `reproducer` reads `none`; a
+finding with a reproducer but no bounded impact keeps the evidence ref and only `impact` reads
+`unproven`. **Never overwrite** a field you actually have with a missing-value placeholder — the
+`reason` line names which half is missing, and the surviving half is the head start the next reviewer
+needs.
 
 ## The two buckets — conservative by default
 
@@ -93,9 +100,10 @@ Structure findings as:
 
 ### Security (unproven)
 - [finding] -- where in the code, how to prevent
-  - reproducer: none
-  - impact: unproven
-  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
+  - reproducer: [evidence ref if one exists, else `none`]
+  - impact: [bounded statement if one exists, else `unproven`]
+  - reason: [which half is missing -- e.g. "impact bounded, but never reproduced"]
+    -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)

--- a/plugins/lisa-copilot/skills/lisa-security-zap-scan/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-security-zap-scan/SKILL.md
@@ -25,7 +25,19 @@ Run a ZAP baseline security scan against the local application.
      - List each Medium+ finding with its rule ID, name, and recommended fix
      - Categorize findings as "infrastructure-level" (fix at CDN/proxy) vs "application-level" (fix in code)
 
-4. **Handle failures**:
+4. **Apply the impact-or-exploitability bar** -- the same bar the `lisa-security-review` skill
+   defines; follow that skill, do not restate it. A ZAP alert is not a reproducer by itself: the
+   alert names a pattern, not an exercised impact path.
+   - **Security (proven)** -- the alert carries a reproducer (the ZAP request/response transcript for
+     that alert, or a captured `http-transcript`) **and** a bounded impact statement.
+   - **Security (unproven)** -- everything else, each with a one-line `reason` (typically
+     "alert only, no reproducer / no bounded impact"). Unproven alerts are **not dropped** and not
+     demoted out of the security summary -- they render in the unproven bucket so a reader still sees
+     them.
+   - Rename the unproven heading only if `security.review.unprovenBucket` is set to something other
+     than `security-unproven`; no other classification changes.
+
+5. **Handle failures**:
    - If the scan failed, explain what failed and suggest concrete remediation steps
 
 ## Execution

--- a/plugins/lisa-copilot/skills/lisa-security-zap-scan/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-security-zap-scan/SKILL.md
@@ -22,18 +22,26 @@ Run a ZAP baseline security scan against the local application.
    - After the scan completes, read `zap-report.html` (or `zap-report.md` for text)
    - Summarize findings:
      - Total number of alerts by risk level (High, Medium, Low, Informational)
-     - List each Medium+ finding with its rule ID, name, and recommended fix
+     - **Every alert reaches classification** -- High, Medium, Low, and Informational alike. Risk
+       level orders the summary; it never filters it. **Nothing is dropped before classification**,
+       so no alert can leave the report unclassified. Medium+ alerts are listed first, in full (rule
+       ID, name, recommended fix); Low/Informational alerts are still listed, bucketed, and given a
+       `reason`, even when compressed to one line each.
      - Categorize findings as "infrastructure-level" (fix at CDN/proxy) vs "application-level" (fix in code)
 
 4. **Apply the impact-or-exploitability bar** -- the same bar the `lisa-security-review` skill
    defines; follow that skill, do not restate it. A ZAP alert is not a reproducer by itself: the
    alert names a pattern, not an exercised impact path.
-   - **Security (proven)** -- the alert carries a reproducer (the ZAP request/response transcript for
-     that alert, or a captured `http-transcript`) **and** a bounded impact statement.
+   - **Security (proven)** -- the alert carries a reproducer **and** a bounded impact statement. The
+     reproducer counts only if its evidence kind **reaches the claim's boundary** under the
+     `claim-evidence-mapping` contract (BCE-1, #1835): a ZAP request/response transcript is an
+     `http-transcript` and reaches the `http-api` boundary only. An alert whose claim is about
+     rendered UI (`browser`) or persisted state (`data`) needs evidence at *that* boundary -- a
+     transcript never proves it.
    - **Security (unproven)** -- everything else, each with a one-line `reason` (typically
-     "alert only, no reproducer / no bounded impact"). Unproven alerts are **not dropped** and not
-     demoted out of the security summary -- they render in the unproven bucket so a reader still sees
-     them.
+     "alert only, no reproducer / no bounded impact", or "transcript does not reach the claim's
+     boundary"). Unproven alerts are **not dropped** and not demoted out of the security summary --
+     they render in the unproven bucket so a reader still sees them.
    - Rename the unproven heading only if `security.review.unprovenBucket` is set to something other
      than `security-unproven`; no other classification changes.
 

--- a/plugins/lisa-cursor/agents/security-specialist.md
+++ b/plugins/lisa-cursor/agents/security-specialist.md
@@ -35,12 +35,26 @@ Structure your findings as:
 - [ ] No XSS vectors in user-facing output
 - [ ] Dependencies free of known CVEs
 
-### Vulnerabilities Found
-- [vulnerability] -- where in the code, how to prevent
+### Security (proven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: [evidence ref]
+  - impact: [who can do what, to what data, under what preconditions]
+  - reason: reproducer + bounded impact
+
+### Security (unproven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: none
+  - impact: unproven
+  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)
 ```
+
+A finding is **proven** only with both a reproducer evidence ref and a bounded impact statement;
+missing either, it stays **unproven** inside the security section. The full bar, the per-finding
+fields, and the `security.review.unprovenBucket` policy point live in the `security-review` skill --
+follow it, do not restate it.
 
 ## Rules
 

--- a/plugins/lisa-cursor/agents/security-specialist.md
+++ b/plugins/lisa-cursor/agents/security-specialist.md
@@ -43,18 +43,21 @@ Structure your findings as:
 
 ### Security (unproven)
 - [finding] -- where in the code, how to prevent
-  - reproducer: none
-  - impact: unproven
-  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
+  - reproducer: [evidence ref if one exists, else `none`]
+  - impact: [bounded statement if one exists, else `unproven`]
+  - reason: [which half is missing -- e.g. "impact bounded, but never reproduced"]
+    -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)
 ```
 
 A finding is **proven** only with both a reproducer evidence ref and a bounded impact statement;
-missing either, it stays **unproven** inside the security section. The full bar, the per-finding
-fields, and the `security.review.unprovenBucket` policy point live in the `security-review` skill --
-follow it, do not restate it.
+missing either, it stays **unproven** inside the security section. Record the two halves
+independently -- keep whichever one you have and let the `reason` name the missing half; never
+overwrite a real value with a placeholder. The full bar, the per-finding fields, and the
+`security.review.unprovenBucket` policy point live in the `security-review` skill -- follow it, do
+not restate it.
 
 ## Rules
 

--- a/plugins/lisa-cursor/rules/claim-evidence-mapping-reference.mdc
+++ b/plugins/lisa-cursor/rules/claim-evidence-mapping-reference.mdc
@@ -87,10 +87,9 @@ defines the names; it stores nothing:
 A claim whose `required_evidence_kinds` has no captured, reaching artifact is **Not established** —
 defined in full, with its evidence templates, in the section below. Artifact identity — what makes
 two captured artifacts the same or different — is defined in the *Artifact identity* section below
-(shipped by BCE-4, #1838). The conservative default bucket for a security-sensitive claim is set in
-**BCE-5 (#1839)** — named here as a field BCE-2's schema carries, not defined by this contract, and
-it ships with that ticket. Where such a sibling surface is not installed in a given branch, name what
-you can and continue.
+(shipped by BCE-4, #1838). The bucket a security-sensitive claim lands in is defined in the *Security
+buckets* section below (shipped by BCE-5, #1839). Where such a sibling surface is not installed in a
+given branch, name what you can and continue.
 
 ### Worked example
 
@@ -183,6 +182,28 @@ second one. Identity reconciliation is the same definition read from the evidenc
   is what may declare completion.
 
 Two guards, one definition — so they cannot disagree about what shipped.
+
+## Security buckets — the impact-or-exploitability bar
+
+A security-shaped claim is a claim like any other: it reaches only as far as its evidence. Applied to
+security findings (shipped by BCE-5, #1839), that yields two buckets and one bar:
+
+- **Security (proven)** — the finding carries **both** a `reproducer` (an evidence ref of a kind that
+  reaches the claim's boundary, per the taxonomy above — e.g. an `http-transcript` for an injection
+  claim at `http-api`) **and** a bounded `impact`/exploitability statement.
+- **Security (unproven)** — **missing either**. It keeps a one-line `reason` and **stays in the
+  security section**: a reproducer-less finding is **never auto-demoted** to a `maintenance` bucket,
+  because under-reporting a real vulnerability is the worse failure.
+
+The unproven bucket's label is the single configurable policy point —
+`security.review.unprovenBucket` in `.lisa.config.json`, default `security-unproven`. An owner who
+prefers true demotion flips that one value; no other classification logic changes. Like the boundary
+checks, bucketing is **advisory** — it shapes the report, not the merge — until
+`verification.gate.enforceBoundaries` is `true`.
+
+The full procedure — per-finding fields, report shape, ZAP alignment — lives in the
+`lisa-security-review` skill (with `lisa-security-zap-scan` citing it); dependency-CVE remediation
+keeps its separate ladder in `security-audit-handling`. Cite those slugs; do not restate them here.
 
 ## The "Not established" section — required, never omitted
 

--- a/plugins/lisa-cursor/rules/claim-evidence-mapping.mdc
+++ b/plugins/lisa-cursor/rules/claim-evidence-mapping.mdc
@@ -42,8 +42,15 @@ rule 5).
 A claim carries three fields — `claim_id`, `boundary`, and `required_evidence_kinds` — named here so
 every downstream surface uses one spelling. This ticket only writes the contract down; the schema and
 gate that make these fields executable ship with **BCE-2 (#1836)** — do not assume that surface is
-present in this branch. The conservative security-bucket default is set in **BCE-5 (#1839)** — named
-here, defined there.
+present in this branch.
+
+## Security buckets (conservative by default)
+
+A security finding is **proven** only with both a reproducer of a reaching kind and a bounded
+impact/exploitability statement; missing either, it renders **unproven** with its reason and **stays
+in the security section** — never auto-demoted to maintenance. The label is one policy point,
+`security.review.unprovenBucket` (default `security-unproven`); the procedure lives in the
+`lisa-security-review` skill.
 
 ## Artifact identity (pinned, never assumed)
 

--- a/plugins/lisa-cursor/skills/lisa-security-review/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-security-review/SKILL.md
@@ -16,6 +16,50 @@ Identify vulnerabilities, evaluate threats, and recommend mitigations for code c
 5. **Check auth/authz** -- are access controls properly enforced for new endpoints or features?
 6. **Review dependencies** -- do new dependencies introduce known vulnerabilities?
 
+## The impact-or-exploitability bar
+
+Severity is **earned, not pattern-matched**. Every security-shaped finding is classified
+mechanically, before it is written up:
+
+| Field | What it holds |
+|-------|---------------|
+| `reproducer` | an evidence ref of a kind that reaches the claim's boundary, or `none` |
+| `impact` | a bounded impact/exploitability statement (who can do what, to what data, under what preconditions), or `unproven` |
+| `reason` | one line saying why the finding landed in its bucket |
+
+**The bar:** a finding is **proven** only when it carries **both** a reproducer **and** a bounded
+impact statement. **Missing either ⇒ unproven.** No other input changes the bucket.
+
+What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract, not here:
+an injection claim at the `http-api` boundary needs an `http-transcript`; a UI claim needs a
+`screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and never
+discharges either.
+
+## The two buckets — conservative by default
+
+Findings render in two clearly-labeled buckets: **Security (proven)** and **Security (unproven)**.
+
+A reproducer-less finding **stays in the security section**, labeled `unproven` with its reason. It
+is **never auto-demoted** to a `maintenance` bucket and it is **not removed** from the report —
+under-reporting a real vulnerability is the worse failure, so the conservative default keeps it
+visible where a security reader looks.
+
+**Single policy point.** The unproven bucket's label is the only thing an owner may change:
+`security.review.unprovenBucket` in `.lisa.config.json`, default `security-unproven`. An owner who
+prefers true demotion sets it to a maintenance label; the finding then renders under that bucket and
+**no other classification logic changes** — the bar, the fields, and the reasons are identical.
+
+Write both buckets in operator voice (`factory-model` rule 5): a person who does not code reads this
+at the gate. "Anyone who can reach the search box can read other customers' orders — reproduced with
+the request transcript below" is usable; "possible SQLi in handler" is not.
+
+This bar governs *code-review* security findings. Dependency CVE remediation keeps its own decision
+ladder in the `security-audit-handling` rule — cite it, do not restate or fork it.
+
+Bucketing is **advisory** — it shapes the report, it does not block a merge — on the same terms as
+the boundary checks, which stay reporting-only until `verification.gate.enforceBoundaries` is `true`
+in `.lisa.config.json`.
+
 ## Output Format
 
 Structure findings as:
@@ -41,17 +85,32 @@ Structure findings as:
 - [ ] No XSS vectors in user-facing output
 - [ ] Dependencies free of known CVEs
 
-### Vulnerabilities Found
-- [vulnerability] -- where in the code, how to prevent
+### Security (proven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: [evidence ref, e.g. evidence/<ticket>/http-transcript-01.txt]
+  - impact: [who can do what, to what data, under what preconditions]
+  - reason: reproducer + bounded impact
+
+### Security (unproven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: none
+  - impact: unproven
+  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)
 ```
 
+Rename the unproven heading only when `security.review.unprovenBucket` is set to something other
+than `security-unproven`; everything else stays as written.
+
 ## Rules
 
 - Focus on the specific changes proposed, not a full security audit of the entire codebase
 - Flag only real risks -- do not invent hypothetical threats for internal tooling with no user input
+- Classify every finding against the bar before writing it up; never leave a finding unbucketed
+- Never silently drop or downgrade a finding out of the security section -- `unproven` is the
+  conservative landing spot, and the reason line says why
 - Prioritize OWASP Top 10 vulnerabilities
 - If the changes are purely internal (config, refactoring, docs), report "No security concerns" and explain why
 - Always check `.gitleaksignore` patterns to understand what secrets scanning is already in place

--- a/plugins/lisa-cursor/skills/lisa-security-review/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-security-review/SKILL.md
@@ -30,10 +30,17 @@ mechanically, before it is written up:
 **The bar:** a finding is **proven** only when it carries **both** a reproducer **and** a bounded
 impact statement. **Missing either ⇒ unproven.** No other input changes the bucket.
 
-What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract, not here:
-an injection claim at the `http-api` boundary needs an `http-transcript`; a UI claim needs a
-`screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and never
-discharges either.
+What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract (**BCE-1**,
+#1835), not here: an injection claim at the `http-api` boundary needs an `http-transcript`; a UI
+claim needs a `screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and
+never discharges either.
+
+**Each field stands on its own.** The two halves are recorded independently: a finding with a bounded
+impact but no reproducer keeps its impact statement verbatim and only `reproducer` reads `none`; a
+finding with a reproducer but no bounded impact keeps the evidence ref and only `impact` reads
+`unproven`. **Never overwrite** a field you actually have with a missing-value placeholder — the
+`reason` line names which half is missing, and the surviving half is the head start the next reviewer
+needs.
 
 ## The two buckets — conservative by default
 
@@ -93,9 +100,10 @@ Structure findings as:
 
 ### Security (unproven)
 - [finding] -- where in the code, how to prevent
-  - reproducer: none
-  - impact: unproven
-  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
+  - reproducer: [evidence ref if one exists, else `none`]
+  - impact: [bounded statement if one exists, else `unproven`]
+  - reason: [which half is missing -- e.g. "impact bounded, but never reproduced"]
+    -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)

--- a/plugins/lisa-cursor/skills/lisa-security-zap-scan/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-security-zap-scan/SKILL.md
@@ -25,7 +25,19 @@ Run a ZAP baseline security scan against the local application.
      - List each Medium+ finding with its rule ID, name, and recommended fix
      - Categorize findings as "infrastructure-level" (fix at CDN/proxy) vs "application-level" (fix in code)
 
-4. **Handle failures**:
+4. **Apply the impact-or-exploitability bar** -- the same bar the `lisa-security-review` skill
+   defines; follow that skill, do not restate it. A ZAP alert is not a reproducer by itself: the
+   alert names a pattern, not an exercised impact path.
+   - **Security (proven)** -- the alert carries a reproducer (the ZAP request/response transcript for
+     that alert, or a captured `http-transcript`) **and** a bounded impact statement.
+   - **Security (unproven)** -- everything else, each with a one-line `reason` (typically
+     "alert only, no reproducer / no bounded impact"). Unproven alerts are **not dropped** and not
+     demoted out of the security summary -- they render in the unproven bucket so a reader still sees
+     them.
+   - Rename the unproven heading only if `security.review.unprovenBucket` is set to something other
+     than `security-unproven`; no other classification changes.
+
+5. **Handle failures**:
    - If the scan failed, explain what failed and suggest concrete remediation steps
 
 ## Execution

--- a/plugins/lisa-cursor/skills/lisa-security-zap-scan/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-security-zap-scan/SKILL.md
@@ -22,18 +22,26 @@ Run a ZAP baseline security scan against the local application.
    - After the scan completes, read `zap-report.html` (or `zap-report.md` for text)
    - Summarize findings:
      - Total number of alerts by risk level (High, Medium, Low, Informational)
-     - List each Medium+ finding with its rule ID, name, and recommended fix
+     - **Every alert reaches classification** -- High, Medium, Low, and Informational alike. Risk
+       level orders the summary; it never filters it. **Nothing is dropped before classification**,
+       so no alert can leave the report unclassified. Medium+ alerts are listed first, in full (rule
+       ID, name, recommended fix); Low/Informational alerts are still listed, bucketed, and given a
+       `reason`, even when compressed to one line each.
      - Categorize findings as "infrastructure-level" (fix at CDN/proxy) vs "application-level" (fix in code)
 
 4. **Apply the impact-or-exploitability bar** -- the same bar the `lisa-security-review` skill
    defines; follow that skill, do not restate it. A ZAP alert is not a reproducer by itself: the
    alert names a pattern, not an exercised impact path.
-   - **Security (proven)** -- the alert carries a reproducer (the ZAP request/response transcript for
-     that alert, or a captured `http-transcript`) **and** a bounded impact statement.
+   - **Security (proven)** -- the alert carries a reproducer **and** a bounded impact statement. The
+     reproducer counts only if its evidence kind **reaches the claim's boundary** under the
+     `claim-evidence-mapping` contract (BCE-1, #1835): a ZAP request/response transcript is an
+     `http-transcript` and reaches the `http-api` boundary only. An alert whose claim is about
+     rendered UI (`browser`) or persisted state (`data`) needs evidence at *that* boundary -- a
+     transcript never proves it.
    - **Security (unproven)** -- everything else, each with a one-line `reason` (typically
-     "alert only, no reproducer / no bounded impact"). Unproven alerts are **not dropped** and not
-     demoted out of the security summary -- they render in the unproven bucket so a reader still sees
-     them.
+     "alert only, no reproducer / no bounded impact", or "transcript does not reach the claim's
+     boundary"). Unproven alerts are **not dropped** and not demoted out of the security summary --
+     they render in the unproven bucket so a reader still sees them.
    - Rename the unproven heading only if `security.review.unprovenBucket` is set to something other
      than `security-unproven`; no other classification changes.
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-security-review/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-security-review/SKILL.md
@@ -16,6 +16,50 @@ Identify vulnerabilities, evaluate threats, and recommend mitigations for code c
 5. **Check auth/authz** -- are access controls properly enforced for new endpoints or features?
 6. **Review dependencies** -- do new dependencies introduce known vulnerabilities?
 
+## The impact-or-exploitability bar
+
+Severity is **earned, not pattern-matched**. Every security-shaped finding is classified
+mechanically, before it is written up:
+
+| Field | What it holds |
+|-------|---------------|
+| `reproducer` | an evidence ref of a kind that reaches the claim's boundary, or `none` |
+| `impact` | a bounded impact/exploitability statement (who can do what, to what data, under what preconditions), or `unproven` |
+| `reason` | one line saying why the finding landed in its bucket |
+
+**The bar:** a finding is **proven** only when it carries **both** a reproducer **and** a bounded
+impact statement. **Missing either ⇒ unproven.** No other input changes the bucket.
+
+What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract, not here:
+an injection claim at the `http-api` boundary needs an `http-transcript`; a UI claim needs a
+`screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and never
+discharges either.
+
+## The two buckets — conservative by default
+
+Findings render in two clearly-labeled buckets: **Security (proven)** and **Security (unproven)**.
+
+A reproducer-less finding **stays in the security section**, labeled `unproven` with its reason. It
+is **never auto-demoted** to a `maintenance` bucket and it is **not removed** from the report —
+under-reporting a real vulnerability is the worse failure, so the conservative default keeps it
+visible where a security reader looks.
+
+**Single policy point.** The unproven bucket's label is the only thing an owner may change:
+`security.review.unprovenBucket` in `.lisa.config.json`, default `security-unproven`. An owner who
+prefers true demotion sets it to a maintenance label; the finding then renders under that bucket and
+**no other classification logic changes** — the bar, the fields, and the reasons are identical.
+
+Write both buckets in operator voice (`factory-model` rule 5): a person who does not code reads this
+at the gate. "Anyone who can reach the search box can read other customers' orders — reproduced with
+the request transcript below" is usable; "possible SQLi in handler" is not.
+
+This bar governs *code-review* security findings. Dependency CVE remediation keeps its own decision
+ladder in the `security-audit-handling` rule — cite it, do not restate or fork it.
+
+Bucketing is **advisory** — it shapes the report, it does not block a merge — on the same terms as
+the boundary checks, which stay reporting-only until `verification.gate.enforceBoundaries` is `true`
+in `.lisa.config.json`.
+
 ## Output Format
 
 Structure findings as:
@@ -41,17 +85,32 @@ Structure findings as:
 - [ ] No XSS vectors in user-facing output
 - [ ] Dependencies free of known CVEs
 
-### Vulnerabilities Found
-- [vulnerability] -- where in the code, how to prevent
+### Security (proven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: [evidence ref, e.g. evidence/<ticket>/http-transcript-01.txt]
+  - impact: [who can do what, to what data, under what preconditions]
+  - reason: reproducer + bounded impact
+
+### Security (unproven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: none
+  - impact: unproven
+  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)
 ```
 
+Rename the unproven heading only when `security.review.unprovenBucket` is set to something other
+than `security-unproven`; everything else stays as written.
+
 ## Rules
 
 - Focus on the specific changes proposed, not a full security audit of the entire codebase
 - Flag only real risks -- do not invent hypothetical threats for internal tooling with no user input
+- Classify every finding against the bar before writing it up; never leave a finding unbucketed
+- Never silently drop or downgrade a finding out of the security section -- `unproven` is the
+  conservative landing spot, and the reason line says why
 - Prioritize OWASP Top 10 vulnerabilities
 - If the changes are purely internal (config, refactoring, docs), report "No security concerns" and explain why
 - Always check `.gitleaksignore` patterns to understand what secrets scanning is already in place

--- a/plugins/lisa/.codex-plugin/skills/lisa-security-review/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-security-review/SKILL.md
@@ -30,10 +30,17 @@ mechanically, before it is written up:
 **The bar:** a finding is **proven** only when it carries **both** a reproducer **and** a bounded
 impact statement. **Missing either ⇒ unproven.** No other input changes the bucket.
 
-What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract, not here:
-an injection claim at the `http-api` boundary needs an `http-transcript`; a UI claim needs a
-`screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and never
-discharges either.
+What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract (**BCE-1**,
+#1835), not here: an injection claim at the `http-api` boundary needs an `http-transcript`; a UI
+claim needs a `screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and
+never discharges either.
+
+**Each field stands on its own.** The two halves are recorded independently: a finding with a bounded
+impact but no reproducer keeps its impact statement verbatim and only `reproducer` reads `none`; a
+finding with a reproducer but no bounded impact keeps the evidence ref and only `impact` reads
+`unproven`. **Never overwrite** a field you actually have with a missing-value placeholder — the
+`reason` line names which half is missing, and the surviving half is the head start the next reviewer
+needs.
 
 ## The two buckets — conservative by default
 
@@ -93,9 +100,10 @@ Structure findings as:
 
 ### Security (unproven)
 - [finding] -- where in the code, how to prevent
-  - reproducer: none
-  - impact: unproven
-  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
+  - reproducer: [evidence ref if one exists, else `none`]
+  - impact: [bounded statement if one exists, else `unproven`]
+  - reason: [which half is missing -- e.g. "impact bounded, but never reproduced"]
+    -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)

--- a/plugins/lisa/.codex-plugin/skills/lisa-security-zap-scan/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-security-zap-scan/SKILL.md
@@ -25,7 +25,19 @@ Run a ZAP baseline security scan against the local application.
      - List each Medium+ finding with its rule ID, name, and recommended fix
      - Categorize findings as "infrastructure-level" (fix at CDN/proxy) vs "application-level" (fix in code)
 
-4. **Handle failures**:
+4. **Apply the impact-or-exploitability bar** -- the same bar the `lisa-security-review` skill
+   defines; follow that skill, do not restate it. A ZAP alert is not a reproducer by itself: the
+   alert names a pattern, not an exercised impact path.
+   - **Security (proven)** -- the alert carries a reproducer (the ZAP request/response transcript for
+     that alert, or a captured `http-transcript`) **and** a bounded impact statement.
+   - **Security (unproven)** -- everything else, each with a one-line `reason` (typically
+     "alert only, no reproducer / no bounded impact"). Unproven alerts are **not dropped** and not
+     demoted out of the security summary -- they render in the unproven bucket so a reader still sees
+     them.
+   - Rename the unproven heading only if `security.review.unprovenBucket` is set to something other
+     than `security-unproven`; no other classification changes.
+
+5. **Handle failures**:
    - If the scan failed, explain what failed and suggest concrete remediation steps
 
 ## Execution

--- a/plugins/lisa/.codex-plugin/skills/lisa-security-zap-scan/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-security-zap-scan/SKILL.md
@@ -22,18 +22,26 @@ Run a ZAP baseline security scan against the local application.
    - After the scan completes, read `zap-report.html` (or `zap-report.md` for text)
    - Summarize findings:
      - Total number of alerts by risk level (High, Medium, Low, Informational)
-     - List each Medium+ finding with its rule ID, name, and recommended fix
+     - **Every alert reaches classification** -- High, Medium, Low, and Informational alike. Risk
+       level orders the summary; it never filters it. **Nothing is dropped before classification**,
+       so no alert can leave the report unclassified. Medium+ alerts are listed first, in full (rule
+       ID, name, recommended fix); Low/Informational alerts are still listed, bucketed, and given a
+       `reason`, even when compressed to one line each.
      - Categorize findings as "infrastructure-level" (fix at CDN/proxy) vs "application-level" (fix in code)
 
 4. **Apply the impact-or-exploitability bar** -- the same bar the `lisa-security-review` skill
    defines; follow that skill, do not restate it. A ZAP alert is not a reproducer by itself: the
    alert names a pattern, not an exercised impact path.
-   - **Security (proven)** -- the alert carries a reproducer (the ZAP request/response transcript for
-     that alert, or a captured `http-transcript`) **and** a bounded impact statement.
+   - **Security (proven)** -- the alert carries a reproducer **and** a bounded impact statement. The
+     reproducer counts only if its evidence kind **reaches the claim's boundary** under the
+     `claim-evidence-mapping` contract (BCE-1, #1835): a ZAP request/response transcript is an
+     `http-transcript` and reaches the `http-api` boundary only. An alert whose claim is about
+     rendered UI (`browser`) or persisted state (`data`) needs evidence at *that* boundary -- a
+     transcript never proves it.
    - **Security (unproven)** -- everything else, each with a one-line `reason` (typically
-     "alert only, no reproducer / no bounded impact"). Unproven alerts are **not dropped** and not
-     demoted out of the security summary -- they render in the unproven bucket so a reader still sees
-     them.
+     "alert only, no reproducer / no bounded impact", or "transcript does not reach the claim's
+     boundary"). Unproven alerts are **not dropped** and not demoted out of the security summary --
+     they render in the unproven bucket so a reader still sees them.
    - Rename the unproven heading only if `security.review.unprovenBucket` is set to something other
      than `security-unproven`; no other classification changes.
 

--- a/plugins/lisa/agents/security-specialist.md
+++ b/plugins/lisa/agents/security-specialist.md
@@ -35,12 +35,26 @@ Structure your findings as:
 - [ ] No XSS vectors in user-facing output
 - [ ] Dependencies free of known CVEs
 
-### Vulnerabilities Found
-- [vulnerability] -- where in the code, how to prevent
+### Security (proven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: [evidence ref]
+  - impact: [who can do what, to what data, under what preconditions]
+  - reason: reproducer + bounded impact
+
+### Security (unproven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: none
+  - impact: unproven
+  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)
 ```
+
+A finding is **proven** only with both a reproducer evidence ref and a bounded impact statement;
+missing either, it stays **unproven** inside the security section. The full bar, the per-finding
+fields, and the `security.review.unprovenBucket` policy point live in the `security-review` skill --
+follow it, do not restate it.
 
 ## Rules
 

--- a/plugins/lisa/agents/security-specialist.md
+++ b/plugins/lisa/agents/security-specialist.md
@@ -43,18 +43,21 @@ Structure your findings as:
 
 ### Security (unproven)
 - [finding] -- where in the code, how to prevent
-  - reproducer: none
-  - impact: unproven
-  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
+  - reproducer: [evidence ref if one exists, else `none`]
+  - impact: [bounded statement if one exists, else `unproven`]
+  - reason: [which half is missing -- e.g. "impact bounded, but never reproduced"]
+    -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)
 ```
 
 A finding is **proven** only with both a reproducer evidence ref and a bounded impact statement;
-missing either, it stays **unproven** inside the security section. The full bar, the per-finding
-fields, and the `security.review.unprovenBucket` policy point live in the `security-review` skill --
-follow it, do not restate it.
+missing either, it stays **unproven** inside the security section. Record the two halves
+independently -- keep whichever one you have and let the `reason` name the missing half; never
+overwrite a real value with a placeholder. The full bar, the per-finding fields, and the
+`security.review.unprovenBucket` policy point live in the `security-review` skill -- follow it, do
+not restate it.
 
 ## Rules
 

--- a/plugins/lisa/rules/eager/claim-evidence-mapping.md
+++ b/plugins/lisa/rules/eager/claim-evidence-mapping.md
@@ -37,8 +37,15 @@ rule 5).
 A claim carries three fields — `claim_id`, `boundary`, and `required_evidence_kinds` — named here so
 every downstream surface uses one spelling. This ticket only writes the contract down; the schema and
 gate that make these fields executable ship with **BCE-2 (#1836)** — do not assume that surface is
-present in this branch. The conservative security-bucket default is set in **BCE-5 (#1839)** — named
-here, defined there.
+present in this branch.
+
+## Security buckets (conservative by default)
+
+A security finding is **proven** only with both a reproducer of a reaching kind and a bounded
+impact/exploitability statement; missing either, it renders **unproven** with its reason and **stays
+in the security section** — never auto-demoted to maintenance. The label is one policy point,
+`security.review.unprovenBucket` (default `security-unproven`); the procedure lives in the
+`lisa-security-review` skill.
 
 ## Artifact identity (pinned, never assumed)
 

--- a/plugins/lisa/rules/reference/claim-evidence-mapping.md
+++ b/plugins/lisa/rules/reference/claim-evidence-mapping.md
@@ -82,10 +82,9 @@ defines the names; it stores nothing:
 A claim whose `required_evidence_kinds` has no captured, reaching artifact is **Not established** —
 defined in full, with its evidence templates, in the section below. Artifact identity — what makes
 two captured artifacts the same or different — is defined in the *Artifact identity* section below
-(shipped by BCE-4, #1838). The conservative default bucket for a security-sensitive claim is set in
-**BCE-5 (#1839)** — named here as a field BCE-2's schema carries, not defined by this contract, and
-it ships with that ticket. Where such a sibling surface is not installed in a given branch, name what
-you can and continue.
+(shipped by BCE-4, #1838). The bucket a security-sensitive claim lands in is defined in the *Security
+buckets* section below (shipped by BCE-5, #1839). Where such a sibling surface is not installed in a
+given branch, name what you can and continue.
 
 ### Worked example
 
@@ -178,6 +177,28 @@ second one. Identity reconciliation is the same definition read from the evidenc
   is what may declare completion.
 
 Two guards, one definition — so they cannot disagree about what shipped.
+
+## Security buckets — the impact-or-exploitability bar
+
+A security-shaped claim is a claim like any other: it reaches only as far as its evidence. Applied to
+security findings (shipped by BCE-5, #1839), that yields two buckets and one bar:
+
+- **Security (proven)** — the finding carries **both** a `reproducer` (an evidence ref of a kind that
+  reaches the claim's boundary, per the taxonomy above — e.g. an `http-transcript` for an injection
+  claim at `http-api`) **and** a bounded `impact`/exploitability statement.
+- **Security (unproven)** — **missing either**. It keeps a one-line `reason` and **stays in the
+  security section**: a reproducer-less finding is **never auto-demoted** to a `maintenance` bucket,
+  because under-reporting a real vulnerability is the worse failure.
+
+The unproven bucket's label is the single configurable policy point —
+`security.review.unprovenBucket` in `.lisa.config.json`, default `security-unproven`. An owner who
+prefers true demotion flips that one value; no other classification logic changes. Like the boundary
+checks, bucketing is **advisory** — it shapes the report, not the merge — until
+`verification.gate.enforceBoundaries` is `true`.
+
+The full procedure — per-finding fields, report shape, ZAP alignment — lives in the
+`lisa-security-review` skill (with `lisa-security-zap-scan` citing it); dependency-CVE remediation
+keeps its separate ladder in `security-audit-handling`. Cite those slugs; do not restate them here.
 
 ## The "Not established" section — required, never omitted
 

--- a/plugins/lisa/skills/lisa-security-review/SKILL.md
+++ b/plugins/lisa/skills/lisa-security-review/SKILL.md
@@ -16,6 +16,50 @@ Identify vulnerabilities, evaluate threats, and recommend mitigations for code c
 5. **Check auth/authz** -- are access controls properly enforced for new endpoints or features?
 6. **Review dependencies** -- do new dependencies introduce known vulnerabilities?
 
+## The impact-or-exploitability bar
+
+Severity is **earned, not pattern-matched**. Every security-shaped finding is classified
+mechanically, before it is written up:
+
+| Field | What it holds |
+|-------|---------------|
+| `reproducer` | an evidence ref of a kind that reaches the claim's boundary, or `none` |
+| `impact` | a bounded impact/exploitability statement (who can do what, to what data, under what preconditions), or `unproven` |
+| `reason` | one line saying why the finding landed in its bucket |
+
+**The bar:** a finding is **proven** only when it carries **both** a reproducer **and** a bounded
+impact statement. **Missing either ⇒ unproven.** No other input changes the bucket.
+
+What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract, not here:
+an injection claim at the `http-api` boundary needs an `http-transcript`; a UI claim needs a
+`screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and never
+discharges either.
+
+## The two buckets — conservative by default
+
+Findings render in two clearly-labeled buckets: **Security (proven)** and **Security (unproven)**.
+
+A reproducer-less finding **stays in the security section**, labeled `unproven` with its reason. It
+is **never auto-demoted** to a `maintenance` bucket and it is **not removed** from the report —
+under-reporting a real vulnerability is the worse failure, so the conservative default keeps it
+visible where a security reader looks.
+
+**Single policy point.** The unproven bucket's label is the only thing an owner may change:
+`security.review.unprovenBucket` in `.lisa.config.json`, default `security-unproven`. An owner who
+prefers true demotion sets it to a maintenance label; the finding then renders under that bucket and
+**no other classification logic changes** — the bar, the fields, and the reasons are identical.
+
+Write both buckets in operator voice (`factory-model` rule 5): a person who does not code reads this
+at the gate. "Anyone who can reach the search box can read other customers' orders — reproduced with
+the request transcript below" is usable; "possible SQLi in handler" is not.
+
+This bar governs *code-review* security findings. Dependency CVE remediation keeps its own decision
+ladder in the `security-audit-handling` rule — cite it, do not restate or fork it.
+
+Bucketing is **advisory** — it shapes the report, it does not block a merge — on the same terms as
+the boundary checks, which stay reporting-only until `verification.gate.enforceBoundaries` is `true`
+in `.lisa.config.json`.
+
 ## Output Format
 
 Structure findings as:
@@ -41,17 +85,32 @@ Structure findings as:
 - [ ] No XSS vectors in user-facing output
 - [ ] Dependencies free of known CVEs
 
-### Vulnerabilities Found
-- [vulnerability] -- where in the code, how to prevent
+### Security (proven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: [evidence ref, e.g. evidence/<ticket>/http-transcript-01.txt]
+  - impact: [who can do what, to what data, under what preconditions]
+  - reason: reproducer + bounded impact
+
+### Security (unproven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: none
+  - impact: unproven
+  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)
 ```
 
+Rename the unproven heading only when `security.review.unprovenBucket` is set to something other
+than `security-unproven`; everything else stays as written.
+
 ## Rules
 
 - Focus on the specific changes proposed, not a full security audit of the entire codebase
 - Flag only real risks -- do not invent hypothetical threats for internal tooling with no user input
+- Classify every finding against the bar before writing it up; never leave a finding unbucketed
+- Never silently drop or downgrade a finding out of the security section -- `unproven` is the
+  conservative landing spot, and the reason line says why
 - Prioritize OWASP Top 10 vulnerabilities
 - If the changes are purely internal (config, refactoring, docs), report "No security concerns" and explain why
 - Always check `.gitleaksignore` patterns to understand what secrets scanning is already in place

--- a/plugins/lisa/skills/lisa-security-review/SKILL.md
+++ b/plugins/lisa/skills/lisa-security-review/SKILL.md
@@ -30,10 +30,17 @@ mechanically, before it is written up:
 **The bar:** a finding is **proven** only when it carries **both** a reproducer **and** a bounded
 impact statement. **Missing either ⇒ unproven.** No other input changes the bucket.
 
-What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract, not here:
-an injection claim at the `http-api` boundary needs an `http-transcript`; a UI claim needs a
-`screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and never
-discharges either.
+What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract (**BCE-1**,
+#1835), not here: an injection claim at the `http-api` boundary needs an `http-transcript`; a UI
+claim needs a `screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and
+never discharges either.
+
+**Each field stands on its own.** The two halves are recorded independently: a finding with a bounded
+impact but no reproducer keeps its impact statement verbatim and only `reproducer` reads `none`; a
+finding with a reproducer but no bounded impact keeps the evidence ref and only `impact` reads
+`unproven`. **Never overwrite** a field you actually have with a missing-value placeholder — the
+`reason` line names which half is missing, and the surviving half is the head start the next reviewer
+needs.
 
 ## The two buckets — conservative by default
 
@@ -93,9 +100,10 @@ Structure findings as:
 
 ### Security (unproven)
 - [finding] -- where in the code, how to prevent
-  - reproducer: none
-  - impact: unproven
-  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
+  - reproducer: [evidence ref if one exists, else `none`]
+  - impact: [bounded statement if one exists, else `unproven`]
+  - reason: [which half is missing -- e.g. "impact bounded, but never reproduced"]
+    -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)

--- a/plugins/lisa/skills/lisa-security-zap-scan/SKILL.md
+++ b/plugins/lisa/skills/lisa-security-zap-scan/SKILL.md
@@ -25,7 +25,19 @@ Run a ZAP baseline security scan against the local application.
      - List each Medium+ finding with its rule ID, name, and recommended fix
      - Categorize findings as "infrastructure-level" (fix at CDN/proxy) vs "application-level" (fix in code)
 
-4. **Handle failures**:
+4. **Apply the impact-or-exploitability bar** -- the same bar the `lisa-security-review` skill
+   defines; follow that skill, do not restate it. A ZAP alert is not a reproducer by itself: the
+   alert names a pattern, not an exercised impact path.
+   - **Security (proven)** -- the alert carries a reproducer (the ZAP request/response transcript for
+     that alert, or a captured `http-transcript`) **and** a bounded impact statement.
+   - **Security (unproven)** -- everything else, each with a one-line `reason` (typically
+     "alert only, no reproducer / no bounded impact"). Unproven alerts are **not dropped** and not
+     demoted out of the security summary -- they render in the unproven bucket so a reader still sees
+     them.
+   - Rename the unproven heading only if `security.review.unprovenBucket` is set to something other
+     than `security-unproven`; no other classification changes.
+
+5. **Handle failures**:
    - If the scan failed, explain what failed and suggest concrete remediation steps
 
 ## Execution

--- a/plugins/lisa/skills/lisa-security-zap-scan/SKILL.md
+++ b/plugins/lisa/skills/lisa-security-zap-scan/SKILL.md
@@ -22,18 +22,26 @@ Run a ZAP baseline security scan against the local application.
    - After the scan completes, read `zap-report.html` (or `zap-report.md` for text)
    - Summarize findings:
      - Total number of alerts by risk level (High, Medium, Low, Informational)
-     - List each Medium+ finding with its rule ID, name, and recommended fix
+     - **Every alert reaches classification** -- High, Medium, Low, and Informational alike. Risk
+       level orders the summary; it never filters it. **Nothing is dropped before classification**,
+       so no alert can leave the report unclassified. Medium+ alerts are listed first, in full (rule
+       ID, name, recommended fix); Low/Informational alerts are still listed, bucketed, and given a
+       `reason`, even when compressed to one line each.
      - Categorize findings as "infrastructure-level" (fix at CDN/proxy) vs "application-level" (fix in code)
 
 4. **Apply the impact-or-exploitability bar** -- the same bar the `lisa-security-review` skill
    defines; follow that skill, do not restate it. A ZAP alert is not a reproducer by itself: the
    alert names a pattern, not an exercised impact path.
-   - **Security (proven)** -- the alert carries a reproducer (the ZAP request/response transcript for
-     that alert, or a captured `http-transcript`) **and** a bounded impact statement.
+   - **Security (proven)** -- the alert carries a reproducer **and** a bounded impact statement. The
+     reproducer counts only if its evidence kind **reaches the claim's boundary** under the
+     `claim-evidence-mapping` contract (BCE-1, #1835): a ZAP request/response transcript is an
+     `http-transcript` and reaches the `http-api` boundary only. An alert whose claim is about
+     rendered UI (`browser`) or persisted state (`data`) needs evidence at *that* boundary -- a
+     transcript never proves it.
    - **Security (unproven)** -- everything else, each with a one-line `reason` (typically
-     "alert only, no reproducer / no bounded impact"). Unproven alerts are **not dropped** and not
-     demoted out of the security summary -- they render in the unproven bucket so a reader still sees
-     them.
+     "alert only, no reproducer / no bounded impact", or "transcript does not reach the claim's
+     boundary"). Unproven alerts are **not dropped** and not demoted out of the security summary --
+     they render in the unproven bucket so a reader still sees them.
    - Rename the unproven heading only if `security.review.unprovenBucket` is set to something other
      than `security-unproven`; no other classification changes.
 

--- a/plugins/src/base/agents/security-specialist.md
+++ b/plugins/src/base/agents/security-specialist.md
@@ -35,12 +35,26 @@ Structure your findings as:
 - [ ] No XSS vectors in user-facing output
 - [ ] Dependencies free of known CVEs
 
-### Vulnerabilities Found
-- [vulnerability] -- where in the code, how to prevent
+### Security (proven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: [evidence ref]
+  - impact: [who can do what, to what data, under what preconditions]
+  - reason: reproducer + bounded impact
+
+### Security (unproven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: none
+  - impact: unproven
+  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)
 ```
+
+A finding is **proven** only with both a reproducer evidence ref and a bounded impact statement;
+missing either, it stays **unproven** inside the security section. The full bar, the per-finding
+fields, and the `security.review.unprovenBucket` policy point live in the `security-review` skill --
+follow it, do not restate it.
 
 ## Rules
 

--- a/plugins/src/base/agents/security-specialist.md
+++ b/plugins/src/base/agents/security-specialist.md
@@ -43,18 +43,21 @@ Structure your findings as:
 
 ### Security (unproven)
 - [finding] -- where in the code, how to prevent
-  - reproducer: none
-  - impact: unproven
-  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
+  - reproducer: [evidence ref if one exists, else `none`]
+  - impact: [bounded statement if one exists, else `unproven`]
+  - reason: [which half is missing -- e.g. "impact bounded, but never reproduced"]
+    -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)
 ```
 
 A finding is **proven** only with both a reproducer evidence ref and a bounded impact statement;
-missing either, it stays **unproven** inside the security section. The full bar, the per-finding
-fields, and the `security.review.unprovenBucket` policy point live in the `security-review` skill --
-follow it, do not restate it.
+missing either, it stays **unproven** inside the security section. Record the two halves
+independently -- keep whichever one you have and let the `reason` name the missing half; never
+overwrite a real value with a placeholder. The full bar, the per-finding fields, and the
+`security.review.unprovenBucket` policy point live in the `security-review` skill -- follow it, do
+not restate it.
 
 ## Rules
 

--- a/plugins/src/base/rules/eager/claim-evidence-mapping.md
+++ b/plugins/src/base/rules/eager/claim-evidence-mapping.md
@@ -37,8 +37,15 @@ rule 5).
 A claim carries three fields — `claim_id`, `boundary`, and `required_evidence_kinds` — named here so
 every downstream surface uses one spelling. This ticket only writes the contract down; the schema and
 gate that make these fields executable ship with **BCE-2 (#1836)** — do not assume that surface is
-present in this branch. The conservative security-bucket default is set in **BCE-5 (#1839)** — named
-here, defined there.
+present in this branch.
+
+## Security buckets (conservative by default)
+
+A security finding is **proven** only with both a reproducer of a reaching kind and a bounded
+impact/exploitability statement; missing either, it renders **unproven** with its reason and **stays
+in the security section** — never auto-demoted to maintenance. The label is one policy point,
+`security.review.unprovenBucket` (default `security-unproven`); the procedure lives in the
+`lisa-security-review` skill.
 
 ## Artifact identity (pinned, never assumed)
 

--- a/plugins/src/base/rules/reference/claim-evidence-mapping.md
+++ b/plugins/src/base/rules/reference/claim-evidence-mapping.md
@@ -82,10 +82,9 @@ defines the names; it stores nothing:
 A claim whose `required_evidence_kinds` has no captured, reaching artifact is **Not established** —
 defined in full, with its evidence templates, in the section below. Artifact identity — what makes
 two captured artifacts the same or different — is defined in the *Artifact identity* section below
-(shipped by BCE-4, #1838). The conservative default bucket for a security-sensitive claim is set in
-**BCE-5 (#1839)** — named here as a field BCE-2's schema carries, not defined by this contract, and
-it ships with that ticket. Where such a sibling surface is not installed in a given branch, name what
-you can and continue.
+(shipped by BCE-4, #1838). The bucket a security-sensitive claim lands in is defined in the *Security
+buckets* section below (shipped by BCE-5, #1839). Where such a sibling surface is not installed in a
+given branch, name what you can and continue.
 
 ### Worked example
 
@@ -178,6 +177,28 @@ second one. Identity reconciliation is the same definition read from the evidenc
   is what may declare completion.
 
 Two guards, one definition — so they cannot disagree about what shipped.
+
+## Security buckets — the impact-or-exploitability bar
+
+A security-shaped claim is a claim like any other: it reaches only as far as its evidence. Applied to
+security findings (shipped by BCE-5, #1839), that yields two buckets and one bar:
+
+- **Security (proven)** — the finding carries **both** a `reproducer` (an evidence ref of a kind that
+  reaches the claim's boundary, per the taxonomy above — e.g. an `http-transcript` for an injection
+  claim at `http-api`) **and** a bounded `impact`/exploitability statement.
+- **Security (unproven)** — **missing either**. It keeps a one-line `reason` and **stays in the
+  security section**: a reproducer-less finding is **never auto-demoted** to a `maintenance` bucket,
+  because under-reporting a real vulnerability is the worse failure.
+
+The unproven bucket's label is the single configurable policy point —
+`security.review.unprovenBucket` in `.lisa.config.json`, default `security-unproven`. An owner who
+prefers true demotion flips that one value; no other classification logic changes. Like the boundary
+checks, bucketing is **advisory** — it shapes the report, not the merge — until
+`verification.gate.enforceBoundaries` is `true`.
+
+The full procedure — per-finding fields, report shape, ZAP alignment — lives in the
+`lisa-security-review` skill (with `lisa-security-zap-scan` citing it); dependency-CVE remediation
+keeps its separate ladder in `security-audit-handling`. Cite those slugs; do not restate them here.
 
 ## The "Not established" section — required, never omitted
 

--- a/plugins/src/base/skills/lisa-security-review/SKILL.md
+++ b/plugins/src/base/skills/lisa-security-review/SKILL.md
@@ -16,6 +16,50 @@ Identify vulnerabilities, evaluate threats, and recommend mitigations for code c
 5. **Check auth/authz** -- are access controls properly enforced for new endpoints or features?
 6. **Review dependencies** -- do new dependencies introduce known vulnerabilities?
 
+## The impact-or-exploitability bar
+
+Severity is **earned, not pattern-matched**. Every security-shaped finding is classified
+mechanically, before it is written up:
+
+| Field | What it holds |
+|-------|---------------|
+| `reproducer` | an evidence ref of a kind that reaches the claim's boundary, or `none` |
+| `impact` | a bounded impact/exploitability statement (who can do what, to what data, under what preconditions), or `unproven` |
+| `reason` | one line saying why the finding landed in its bucket |
+
+**The bar:** a finding is **proven** only when it carries **both** a reproducer **and** a bounded
+impact statement. **Missing either ⇒ unproven.** No other input changes the bucket.
+
+What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract, not here:
+an injection claim at the `http-api` boundary needs an `http-transcript`; a UI claim needs a
+`screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and never
+discharges either.
+
+## The two buckets — conservative by default
+
+Findings render in two clearly-labeled buckets: **Security (proven)** and **Security (unproven)**.
+
+A reproducer-less finding **stays in the security section**, labeled `unproven` with its reason. It
+is **never auto-demoted** to a `maintenance` bucket and it is **not removed** from the report —
+under-reporting a real vulnerability is the worse failure, so the conservative default keeps it
+visible where a security reader looks.
+
+**Single policy point.** The unproven bucket's label is the only thing an owner may change:
+`security.review.unprovenBucket` in `.lisa.config.json`, default `security-unproven`. An owner who
+prefers true demotion sets it to a maintenance label; the finding then renders under that bucket and
+**no other classification logic changes** — the bar, the fields, and the reasons are identical.
+
+Write both buckets in operator voice (`factory-model` rule 5): a person who does not code reads this
+at the gate. "Anyone who can reach the search box can read other customers' orders — reproduced with
+the request transcript below" is usable; "possible SQLi in handler" is not.
+
+This bar governs *code-review* security findings. Dependency CVE remediation keeps its own decision
+ladder in the `security-audit-handling` rule — cite it, do not restate or fork it.
+
+Bucketing is **advisory** — it shapes the report, it does not block a merge — on the same terms as
+the boundary checks, which stay reporting-only until `verification.gate.enforceBoundaries` is `true`
+in `.lisa.config.json`.
+
 ## Output Format
 
 Structure findings as:
@@ -41,17 +85,32 @@ Structure findings as:
 - [ ] No XSS vectors in user-facing output
 - [ ] Dependencies free of known CVEs
 
-### Vulnerabilities Found
-- [vulnerability] -- where in the code, how to prevent
+### Security (proven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: [evidence ref, e.g. evidence/<ticket>/http-transcript-01.txt]
+  - impact: [who can do what, to what data, under what preconditions]
+  - reason: reproducer + bounded impact
+
+### Security (unproven)
+- [finding] -- where in the code, how to prevent
+  - reproducer: none
+  - impact: unproven
+  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)
 ```
 
+Rename the unproven heading only when `security.review.unprovenBucket` is set to something other
+than `security-unproven`; everything else stays as written.
+
 ## Rules
 
 - Focus on the specific changes proposed, not a full security audit of the entire codebase
 - Flag only real risks -- do not invent hypothetical threats for internal tooling with no user input
+- Classify every finding against the bar before writing it up; never leave a finding unbucketed
+- Never silently drop or downgrade a finding out of the security section -- `unproven` is the
+  conservative landing spot, and the reason line says why
 - Prioritize OWASP Top 10 vulnerabilities
 - If the changes are purely internal (config, refactoring, docs), report "No security concerns" and explain why
 - Always check `.gitleaksignore` patterns to understand what secrets scanning is already in place

--- a/plugins/src/base/skills/lisa-security-review/SKILL.md
+++ b/plugins/src/base/skills/lisa-security-review/SKILL.md
@@ -30,10 +30,17 @@ mechanically, before it is written up:
 **The bar:** a finding is **proven** only when it carries **both** a reproducer **and** a bounded
 impact statement. **Missing either ⇒ unproven.** No other input changes the bucket.
 
-What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract, not here:
-an injection claim at the `http-api` boundary needs an `http-transcript`; a UI claim needs a
-`screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and never
-discharges either.
+What counts as a reaching reproducer is defined by the `claim-evidence-mapping` contract (**BCE-1**,
+#1835), not here: an injection claim at the `http-api` boundary needs an `http-transcript`; a UI
+claim needs a `screenshot` or `recording`. A passing unit `test-run-log` reaches `code-unit` only and
+never discharges either.
+
+**Each field stands on its own.** The two halves are recorded independently: a finding with a bounded
+impact but no reproducer keeps its impact statement verbatim and only `reproducer` reads `none`; a
+finding with a reproducer but no bounded impact keeps the evidence ref and only `impact` reads
+`unproven`. **Never overwrite** a field you actually have with a missing-value placeholder — the
+`reason` line names which half is missing, and the surviving half is the head start the next reviewer
+needs.
 
 ## The two buckets — conservative by default
 
@@ -93,9 +100,10 @@ Structure findings as:
 
 ### Security (unproven)
 - [finding] -- where in the code, how to prevent
-  - reproducer: none
-  - impact: unproven
-  - reason: no reproducer / no bounded impact -- kept in the security section, not demoted
+  - reproducer: [evidence ref if one exists, else `none`]
+  - impact: [bounded statement if one exists, else `unproven`]
+  - reason: [which half is missing -- e.g. "impact bounded, but never reproduced"]
+    -- kept in the security section, not demoted
 
 ### Recommendations
 - [recommendation] -- priority (critical/warning/suggestion)

--- a/plugins/src/base/skills/lisa-security-zap-scan/SKILL.md
+++ b/plugins/src/base/skills/lisa-security-zap-scan/SKILL.md
@@ -25,7 +25,19 @@ Run a ZAP baseline security scan against the local application.
      - List each Medium+ finding with its rule ID, name, and recommended fix
      - Categorize findings as "infrastructure-level" (fix at CDN/proxy) vs "application-level" (fix in code)
 
-4. **Handle failures**:
+4. **Apply the impact-or-exploitability bar** -- the same bar the `lisa-security-review` skill
+   defines; follow that skill, do not restate it. A ZAP alert is not a reproducer by itself: the
+   alert names a pattern, not an exercised impact path.
+   - **Security (proven)** -- the alert carries a reproducer (the ZAP request/response transcript for
+     that alert, or a captured `http-transcript`) **and** a bounded impact statement.
+   - **Security (unproven)** -- everything else, each with a one-line `reason` (typically
+     "alert only, no reproducer / no bounded impact"). Unproven alerts are **not dropped** and not
+     demoted out of the security summary -- they render in the unproven bucket so a reader still sees
+     them.
+   - Rename the unproven heading only if `security.review.unprovenBucket` is set to something other
+     than `security-unproven`; no other classification changes.
+
+5. **Handle failures**:
    - If the scan failed, explain what failed and suggest concrete remediation steps
 
 ## Execution

--- a/plugins/src/base/skills/lisa-security-zap-scan/SKILL.md
+++ b/plugins/src/base/skills/lisa-security-zap-scan/SKILL.md
@@ -22,18 +22,26 @@ Run a ZAP baseline security scan against the local application.
    - After the scan completes, read `zap-report.html` (or `zap-report.md` for text)
    - Summarize findings:
      - Total number of alerts by risk level (High, Medium, Low, Informational)
-     - List each Medium+ finding with its rule ID, name, and recommended fix
+     - **Every alert reaches classification** -- High, Medium, Low, and Informational alike. Risk
+       level orders the summary; it never filters it. **Nothing is dropped before classification**,
+       so no alert can leave the report unclassified. Medium+ alerts are listed first, in full (rule
+       ID, name, recommended fix); Low/Informational alerts are still listed, bucketed, and given a
+       `reason`, even when compressed to one line each.
      - Categorize findings as "infrastructure-level" (fix at CDN/proxy) vs "application-level" (fix in code)
 
 4. **Apply the impact-or-exploitability bar** -- the same bar the `lisa-security-review` skill
    defines; follow that skill, do not restate it. A ZAP alert is not a reproducer by itself: the
    alert names a pattern, not an exercised impact path.
-   - **Security (proven)** -- the alert carries a reproducer (the ZAP request/response transcript for
-     that alert, or a captured `http-transcript`) **and** a bounded impact statement.
+   - **Security (proven)** -- the alert carries a reproducer **and** a bounded impact statement. The
+     reproducer counts only if its evidence kind **reaches the claim's boundary** under the
+     `claim-evidence-mapping` contract (BCE-1, #1835): a ZAP request/response transcript is an
+     `http-transcript` and reaches the `http-api` boundary only. An alert whose claim is about
+     rendered UI (`browser`) or persisted state (`data`) needs evidence at *that* boundary -- a
+     transcript never proves it.
    - **Security (unproven)** -- everything else, each with a one-line `reason` (typically
-     "alert only, no reproducer / no bounded impact"). Unproven alerts are **not dropped** and not
-     demoted out of the security summary -- they render in the unproven bucket so a reader still sees
-     them.
+     "alert only, no reproducer / no bounded impact", or "transcript does not reach the claim's
+     boundary"). Unproven alerts are **not dropped** and not demoted out of the security summary --
+     they render in the unproven bucket so a reader still sees them.
    - Rename the unproven heading only if `security.review.unprovenBucket` is set to something other
      than `security-unproven`; no other classification changes.
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -417,7 +417,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/agents/quality-specialist.md":
       "2a1b433fa1be1c8b23c2c83e5f247b851c61e3c253a79caf8a3eb7f326744a22",
     "plugins/src/base/agents/security-specialist.md":
-      "de35dd064d4d0ab27c4185395fffbc2d00cc41c86ee78cc93f50d112fea3439c",
+      "2d592b4c2666082ef84cae8878be99b9ebd07f75ab77656409beff306f17a6b4",
     "plugins/src/base/agents/skill-evaluator.md":
       "83af6324ed0ee0cd5c4132429e137649c3fd616ef6fa5d4bd95579438d401894",
     "plugins/src/base/agents/spec-conformance-specialist.md":
@@ -1009,9 +1009,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-root-cause-analysis/SKILL.md":
       "2b1cb5bac2be7e8bb6b852efb0bd499cbcdca6299c342a54e0c8d872821c7364",
     "plugins/src/base/skills/lisa-security-review/SKILL.md":
-      "b2971c09ed469762df543b1490a7c07ff864b27daf22990c46bb40c10b296d35",
+      "5a980eaf5efc4fcce66e75521ec5b1eda143a5b0d36e7157234a705dac94e3f5",
     "plugins/src/base/skills/lisa-security-zap-scan/SKILL.md":
-      "da13f56e23290115ca722367504605114404ef27bac03cf93a48ee751fa7deed",
+      "a5189442dbf970cc49fd089ab03c386c8a205b856e09501f6ad1966321e7e4b5",
     "plugins/src/base/skills/lisa-sentry-access/SKILL.md":
       "ecaf49b42bbf399781a3ebd0b1595e5a8ac44422537832e0442b2f184da0c83c",
     "plugins/src/base/skills/lisa-setup-atlassian/SKILL.md":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -417,7 +417,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/agents/quality-specialist.md":
       "2a1b433fa1be1c8b23c2c83e5f247b851c61e3c253a79caf8a3eb7f326744a22",
     "plugins/src/base/agents/security-specialist.md":
-      "7aa6775e6e43a860338fe77e5378a61dcc34c7f76f7d3c840288ae882f6cfd38",
+      "de35dd064d4d0ab27c4185395fffbc2d00cc41c86ee78cc93f50d112fea3439c",
     "plugins/src/base/agents/skill-evaluator.md":
       "83af6324ed0ee0cd5c4132429e137649c3fd616ef6fa5d4bd95579438d401894",
     "plugins/src/base/agents/spec-conformance-specialist.md":
@@ -611,7 +611,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/eager/claim-archaeology.md":
       "96afa034075593dfb7433c5c990b472a6b6f7320332da42ef54b1f01fa45664b",
     "plugins/src/base/rules/eager/claim-evidence-mapping.md":
-      "d3428bb877c1a25639745d776e20b16c8ade7987e81c7c3bf3175fc0f12dbfb3",
+      "d12a6153b8c22db2826153c479d107c7a885e22cbcdd49e4fd8193e0cbbe8ae3",
     "plugins/src/base/rules/eager/coding-philosophy.md":
       "cf2c52032e0368d81f17f002fed5c957ab350d01fc4a43f66b5f366516bac54a",
     "plugins/src/base/rules/eager/config-resolution.md":
@@ -667,7 +667,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/reference/claim-archaeology.md":
       "fff025d47848c768d5b2c7047de744b7151eb2e44148d2df058c87310859457b",
     "plugins/src/base/rules/reference/claim-evidence-mapping.md":
-      "97a7cf623f6df51d57f6d649036c04067d4fe42d4ab66230ac51306f0104b4a1",
+      "49a3bbf4e8a9a8ca9e13eeafa672517d077060cfeb5d9710881ec9f5c3f3ec75",
     "plugins/src/base/rules/reference/coding-philosophy.md":
       "fed8381f16a5d6793a49d84d5813d62125808cb2f4981a558b119cf63e2586d9",
     "plugins/src/base/rules/reference/config-resolution.md":
@@ -1009,9 +1009,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-root-cause-analysis/SKILL.md":
       "2b1cb5bac2be7e8bb6b852efb0bd499cbcdca6299c342a54e0c8d872821c7364",
     "plugins/src/base/skills/lisa-security-review/SKILL.md":
-      "4d5c30c4d637e8438ae02f904e08eb81cde2b3c8384c55469e76ae1b91bb96bd",
+      "b2971c09ed469762df543b1490a7c07ff864b27daf22990c46bb40c10b296d35",
     "plugins/src/base/skills/lisa-security-zap-scan/SKILL.md":
-      "7abb4231389b54ffeff2dd081c9100500ee6803e1e034ac2a230b173a5d1537a",
+      "da13f56e23290115ca722367504605114404ef27bac03cf93a48ee751fa7deed",
     "plugins/src/base/skills/lisa-sentry-access/SKILL.md":
       "ecaf49b42bbf399781a3ebd0b1595e5a8ac44422537832e0442b2f184da0c83c",
     "plugins/src/base/skills/lisa-setup-atlassian/SKILL.md":
@@ -7792,6 +7792,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/repair-intake-contract.test.ts": true,
     "tests/unit/strategies/repo-scope-claim.test.ts": true,
     "tests/unit/strategies/rework-triage-skill.test.ts": true,
+    "tests/unit/strategies/security-two-bucket-contract.test.ts": true,
     "tests/unit/strategies/setup-confluence-verified-parent.test.ts": true,
     "tests/unit/strategies/setup-github-prd-verified-label.test.ts": true,
     "tests/unit/strategies/setup-github-project-verification.test.ts": true,

--- a/tests/unit/strategies/security-two-bucket-contract.test.ts
+++ b/tests/unit/strategies/security-two-bucket-contract.test.ts
@@ -77,6 +77,19 @@ describe("Security two-bucket contract (BCE-5)", () => {
         expect(review).toContain("http-transcript");
       });
 
+      it("names the BCE-1 evidence contract and its ticket at that citation", () => {
+        expect(review).toContain("BCE-1");
+        expect(review).toContain("#1835");
+      });
+
+      it("preserves each field independently when only one half is missing", () => {
+        // A bounded impact with no reproducer keeps its impact text — the
+        // placeholder belongs only to the half that is actually absent.
+        expect(review).toMatch(/each field stands on its own|independently/i);
+        expect(review).toMatch(/never overwrite|do not overwrite/i);
+        expect(review).toMatch(/which half|names? what is missing/i);
+      });
+
       it("keeps the unproven finding in the security section by default", () => {
         expect(review).toMatch(/not (auto-)?demote|never (auto-)?demote/i);
         expect(review).toMatch(/maintenance/i);
@@ -123,6 +136,18 @@ describe("Security two-bucket contract (BCE-5)", () => {
 
       it("honors the same policy point", () => {
         expect(zap).toContain(POLICY_POINT);
+      });
+
+      it("requires a proven alert's reproducer to reach the claim's boundary", () => {
+        expect(zap).toContain(MAPPING_SLUG);
+        expect(zap).toMatch(/boundary/i);
+      });
+
+      it("classifies every alert instead of summarizing Medium+ only", () => {
+        expect(zap).toMatch(/every alert|all alerts/i);
+        expect(zap).toMatch(
+          /before classification|unclassified|nothing is dropped/i
+        );
       });
     });
 

--- a/tests/unit/strategies/security-two-bucket-contract.test.ts
+++ b/tests/unit/strategies/security-two-bucket-contract.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Contract coverage for BCE-5 (#1839): security-review findings split into two
+ * buckets behind an impact-or-exploitability bar, with a conservative
+ * unproven default.
+ *
+ * A security-shaped pattern match with no reproducer inflates severity and
+ * buries the one finding that is real. This suite pins the prose layer that
+ * makes severity earned: a finding claims **Security (proven)** only with a
+ * reproducer evidence ref (of a kind that reaches the claim's boundary, per
+ * BCE-1) *and* a bounded impact/exploitability statement. Missing either, it
+ * stays in the security section labeled **unproven** with its reason — it is
+ * never auto-demoted to maintenance. The bucket label is a single configurable
+ * policy point (`security.review.unprovenBucket`) so an owner who prefers true
+ * demotion flips one value. Both plugin roots are checked so the generated
+ * copies cannot drift.
+ * @module tests/unit/strategies/security-two-bucket-contract
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+
+/** The single configurable policy point for the unproven bucket label. */
+const POLICY_POINT = "security.review.unprovenBucket";
+/** Its conservative default — still inside the security section. */
+const DEFAULT_BUCKET = "security-unproven";
+/** The contract that defines what counts as a reaching reproducer. */
+const MAPPING_SLUG = "claim-evidence-mapping";
+/** The dependency-CVE ladder this ticket cites but never forks. */
+const CVE_LADDER_SLUG = "security-audit-handling";
+
+/** The two bucket headings every finding surface renders. */
+const PROVEN = "Security (proven)";
+const UNPROVEN = "Security (unproven)";
+
+/** Every surface that renders a security finding must carry the same buckets. */
+const FINDING_SURFACES = [
+  "skills/lisa-security-review/SKILL.md",
+  "agents/security-specialist.md",
+] as const;
+
+const read = (root: string, rel: string): string =>
+  readFileSync(path.resolve(root, rel), "utf8");
+
+describe("Security two-bucket contract (BCE-5)", () => {
+  describe.each(ROOTS)("%s", root => {
+    const review = read(root, "skills/lisa-security-review/SKILL.md");
+    const zap = read(root, "skills/lisa-security-zap-scan/SKILL.md");
+    const reference = read(root, "rules/reference/claim-evidence-mapping.md");
+    const eager = read(root, "rules/eager/claim-evidence-mapping.md");
+
+    describe("the security-review skill owns the bar", () => {
+      it("renders two named buckets instead of a flat vulnerability list", () => {
+        expect(review).toContain(PROVEN);
+        expect(review).toContain(UNPROVEN);
+      });
+
+      it("states the bar as reproducer AND bounded impact", () => {
+        expect(review).toMatch(/reproducer/i);
+        expect(review).toMatch(/impact|exploitability/i);
+        expect(review).toMatch(/both|and a bounded|missing either/i);
+        expect(review).toMatch(/missing either/i);
+      });
+
+      it("carries the per-finding fields that make the classifier mechanical", () => {
+        for (const field of ["reproducer", "impact", "reason"]) {
+          expect(review).toContain(field);
+        }
+        expect(review).toMatch(/none/i);
+        expect(review).toMatch(/unproven/);
+      });
+
+      it("cites the mapping contract for what counts as a reaching reproducer", () => {
+        expect(review).toContain(MAPPING_SLUG);
+        expect(review).toContain("http-transcript");
+      });
+
+      it("keeps the unproven finding in the security section by default", () => {
+        expect(review).toMatch(/not (auto-)?demote|never (auto-)?demote/i);
+        expect(review).toMatch(/maintenance/i);
+        expect(review).toMatch(/stays? in the security section|not removed/i);
+      });
+
+      it("names the single configurable policy point and its default", () => {
+        expect(review).toContain(POLICY_POINT);
+        expect(review).toContain(DEFAULT_BUCKET);
+        expect(review).toMatch(
+          /no other classification|only the label|nothing else changes/i
+        );
+      });
+
+      it("requires operator-readable finding text", () => {
+        expect(review).toContain("factory-model");
+      });
+
+      it("cites the dependency-CVE ladder rather than forking it", () => {
+        expect(review).toContain(CVE_LADDER_SLUG);
+      });
+
+      it("stays advisory-consistent with the shipped ratchet flag", () => {
+        expect(review).toContain("verification.gate.enforceBoundaries");
+        expect(review).toMatch(/advisory/i);
+      });
+    });
+
+    describe("the ZAP scan applies the same bar", () => {
+      it("buckets alerts proven/unproven with a reason", () => {
+        expect(zap).toContain(PROVEN);
+        expect(zap).toContain(UNPROVEN);
+        expect(zap).toMatch(/reason/i);
+      });
+
+      it("treats a reproducer-less alert as unproven, not dropped", () => {
+        expect(zap).toMatch(/reproducer/i);
+        expect(zap).toMatch(/not (dropped|removed|demoted)/i);
+      });
+
+      it("cites the review skill for the bar instead of restating it", () => {
+        expect(zap).toContain("lisa-security-review");
+      });
+
+      it("honors the same policy point", () => {
+        expect(zap).toContain(POLICY_POINT);
+      });
+    });
+
+    describe.each(FINDING_SURFACES)("%s", rel => {
+      it("renders both buckets so the agent and skill cannot drift", () => {
+        const doc = read(root, rel);
+        expect(doc).toContain(PROVEN);
+        expect(doc).toContain(UNPROVEN);
+        expect(doc).toMatch(/reproducer/i);
+      });
+    });
+
+    describe("the mapping contract carries the definition, not a hedge", () => {
+      it("replaces the BCE-5 hedge with the two-bucket definition", () => {
+        expect(reference).toMatch(/^#+ .*security bucket/im);
+        expect(reference).not.toMatch(
+          /is set in \*\*BCE-5 \(#1839\)\*\*[\s\S]{0,120}ships with that ticket/
+        );
+        expect(reference).not.toMatch(
+          /conservative default bucket[\s\S]{0,200}not defined by this contract/i
+        );
+      });
+
+      it("states the bar and the conservative default compactly", () => {
+        expect(reference).toContain(DEFAULT_BUCKET);
+        expect(reference).toContain(POLICY_POINT);
+        expect(reference).toMatch(/reproducer/i);
+        expect(reference).toMatch(/never (auto-)?demote|not (auto-)?demoted/i);
+      });
+
+      it("defers the full procedure to the security skill by slug", () => {
+        expect(reference).toContain("lisa-security-review");
+      });
+
+      it("keeps the ticket provenance the sibling pins rely on", () => {
+        expect(reference).toContain("#1839");
+      });
+
+      it("names the buckets in the eager head so they load", () => {
+        expect(eager).toMatch(/unproven/i);
+        expect(eager).toContain(POLICY_POINT);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

BCE-5 of PRD #1738. Security-review findings now split into two buckets behind an
**impact-or-exploitability bar**, so severity is earned rather than pattern-matched.

- **The bar** — a finding is **Security (proven)** only with **both** a `reproducer` evidence ref of
  a kind that reaches its claim's boundary (per the `claim-evidence-mapping` contract shipped in
  #1835 — an `http-transcript` for an injection claim, not a unit `test-run-log`) **and** a bounded
  `impact`/exploitability statement. Missing either ⇒ **Security (unproven)**, with a one-line
  `reason`.
- **Conservative default (intake decision)** — a reproducer-less finding **stays in the security
  section** labeled `unproven`. It is **never auto-demoted** to a `maintenance` bucket: under-reporting
  a real vulnerability is the worse failure. This deliberately diverges from the PRD's original goal-3
  Gherkin (and from mheilimo gate #6); intake reconciled the PRD to this default, and the coverage
  comment on #1738 flagged it for owner ratification — flagging it again here for the record.
- **One flip point** — `security.review.unprovenBucket` in `.lisa.config.json`, default
  `security-unproven`. An owner who prefers true demotion sets it to a maintenance label; the finding
  renders under that bucket and **no other classification logic changes**.

## Provenance

- PRD: #1738 (Bounded-claim evidence discipline)
- Contract spine: #1835 (BCE-1 claim→evidence mapping), advisory posture from #1836's
  `verification.gate.enforceBoundaries` ratchet
- `security-audit-handling` (dependency-CVE ladder) is **cited, never forked** — a different surface

## Files changed

- `plugins/src/base/skills/lisa-security-review/SKILL.md` — the bar, the two buckets, per-finding
  fields, the policy point, operator-readable wording (`factory-model` rule 5), advisory posture
- `plugins/src/base/skills/lisa-security-zap-scan/SKILL.md` — the same bar applied to ZAP alerts
  (an alert is not a reproducer by itself), citing the review skill rather than restating it
- `plugins/src/base/agents/security-specialist.md` — mirrored bucket output so agent and skill
  cannot drift
- `plugins/src/base/rules/{reference,eager}/claim-evidence-mapping.md` — the BCE-5 hedge replaced
  with the compact *Security buckets* definition, deferring the procedure to the skill by slug
- Generated plugin variants (claude/codex/cursor/agy/copilot) + upstream evidence manifest

## TDD evidence

- **RED**: `tests/unit/strategies/security-two-bucket-contract.test.ts` — 38 failed / 2 passed (40)
- **GREEN**: 40/40 passed, both plugin roots (`plugins/src/base` and `plugins/lisa`)
- Prior pin families untouched-green: claim-evidence-mapping + not-established + artifact-identity
  → 110/110; full strategies + v2 hook suite → 3768/3768 across 146 files
- `bun run typecheck`, `bun run check:rules-pairing`, `bun run check:plugins`, and
  `generate-upstream-evidence-manifest.mjs --check` all green

## Out of scope

Verdict schema/gate changes (BCE-2), evidence templates (BCE-3), artifact identity (BCE-4), fixtures
and CI wiring (BCE-6), and any change to the dependency-CVE ladder.

Closes #1839

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Security findings are now reported in **Security (proven)** vs **Security (unproven)**.
  * A finding is **proven** only when both reaching reproducer evidence and bounded impact/exploitability are present; otherwise it’s **unproven** and stays visible with an explanation.
  * ZAP scan reports classify every alert using the same bar, and the **unproven** heading label can be customized via `security.review.unprovenBucket`.

* **Documentation**
  * Updated security review, agent templates, and claim-evidence mapping references to match the new two-bucket format and field expectations.

* **Tests**
  * Added contract tests to prevent security reporting/template drift across plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->