### PR TITLE
feat(verification): executable failure-mode fixtures and the could-not-evaluate guard (#1840)

### DIFF
--- a/plugins/lisa-copilot/hooks/enforce-verification-gate.sh
+++ b/plugins/lisa-copilot/hooks/enforce-verification-gate.sh
@@ -81,6 +81,20 @@
 #     the flag may never be omitted)
 #   - "artifact.head_sha" exists and no evidence entry declares a different
 #     "artifact_head_sha" (reconciliation with the MERGED head is BCE-4)
+#   - every evidence entry that records BOTH a "sha256" and a "locator"
+#     resolving to a file on disk still hashes to that digest
+#     ("evidence_digest_mismatch"). A locator that is not on disk at stop time
+#     is NOT judged here: the Stop hook sees only the working tree, and evidence
+#     may legitimately live outside it. The absent-artifact arm of that check
+#     belongs to the read-side review surfaces, which see the committed
+#     evidence directory.
+#   - the claim/evidence structure is EVALUABLE at all: a v2 verdict whose
+#     "claims"/"evidence"/"artifact" are not the shapes the schema defines
+#     (claims as a string, evidence as a scalar) is reported as
+#     could-not-evaluate. Could-not-evaluate is NOT the same as no-violations:
+#     a verdict the gate cannot read may never be treated as a clean one, or a
+#     structurally-wrong verdict would sail past the gate the moment
+#     enforcement is ratcheted on.
 #
 # ADVISORY-FIRST: those v2 checks report to stderr but do NOT block unless
 # "verification.gate.enforceBoundaries" is true in .lisa.config.json (default
@@ -90,11 +104,15 @@
 # Per-session state lives under "$STATE_DIR" as flag files keyed by session_id.
 # Stale state (>24h) is cleaned on each invocation.
 #
-# Fail-open: any unexpected jq parse failure or missing field degrades to the
-# LESS strict outcome rather than inventing a new hard failure, and the
-# MAX_BLOCKS escalation below guarantees the gate always releases eventually. A
-# broken gate must never brick a session. In particular, a v2 verdict whose
-# claim structure cannot be evaluated is judged on the v1 conditions alone.
+# Fail-open: a missing field degrades to the LESS strict outcome rather than
+# inventing a new hard failure, and the MAX_BLOCKS escalation below guarantees
+# the gate always releases eventually. A broken gate must never brick a session.
+#
+# That fail-open posture bounds the BLAST RADIUS of a gate failure; it is not a
+# licence to read an unreadable verdict as a clean one. So a v2 verdict whose
+# claim structure cannot be evaluated is reported like any other violation —
+# advisory while the ratchet is off, blocking (still MAX_BLOCKS-bounded, so it
+# can never hard-wedge a session) once it is on.
 
 set -uo pipefail
 
@@ -225,9 +243,39 @@ boundary_enforcement_enabled() {
   [ "$value" = "true" ]
 }
 
+# Prints the sha256 of a file using whichever tool this machine has. Prints
+# nothing when neither exists — an unrecomputable digest is not a violation.
+sha256_of() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" 2>/dev/null | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" 2>/dev/null | awk '{print $1}'
+  fi
+}
+
+# Emits one line per evidence entry whose bytes no longer hash to the digest the
+# verdict recorded. Only entries recording BOTH a sha256 and a locator that
+# resolves to a file on disk are judged; see the header for why an absent
+# locator is out of this hook's scope.
+v2_digest_violations() {
+  jq -r '
+    (.evidence // [])[]
+    | select(((.sha256 // "") | length) > 0)
+    | select(((.locator // "") | length) > 0)
+    | "\(.evidence_id // "?")\t\(.locator)\t\(.sha256)"
+  ' "$VERDICT_FILE" 2>/dev/null | while IFS=$'\t' read -r eid locator recorded; do
+    evidence_path="${PROJECT_DIR}/${locator}"
+    [ -f "$evidence_path" ] || continue
+    actual=$(sha256_of "$evidence_path")
+    [ -n "$actual" ] || continue
+    [ "$actual" = "$recorded" ] && continue
+    echo "evidence ${eid} (${locator}) no longer matches its recorded digest: recorded ${recorded}, bytes now hash to ${actual}"
+  done
+}
+
 # Emits one line per v2 claim->evidence contract violation. Empty output means
-# the verdict satisfies the contract (or could not be evaluated, which degrades
-# to the v1 decision rather than to a new hard failure).
+# the verdict satisfies the contract. A jq evaluation failure is NOT empty
+# output — see v2_evaluate_contract, which turns it into its own violation.
 v2_contract_violations() {
   jq -r '
     . as $v
@@ -263,7 +311,32 @@ v2_contract_violations() {
         )
       ]
     | .[]
-  ' "$VERDICT_FILE" 2>/dev/null || true
+  ' "$VERDICT_FILE" 2>/dev/null
+}
+
+# Set by v2_evaluate_contract: every violation line, or empty when the verdict
+# satisfies the contract. A global rather than a return value because a command
+# substitution would swallow the could-not-evaluate signal along with it.
+V2_VIOLATIONS=""
+
+# Evaluates the full v2 contract into V2_VIOLATIONS.
+#
+# The load-bearing distinction: jq returns NOTHING on an evaluation error, which
+# is byte-identical to "this verdict is clean". A parseable v2 verdict whose
+# claims/evidence are the wrong SHAPE (claims as a string, evidence as a scalar)
+# therefore used to read as violation-free — harmless while advisory, a genuine
+# bypass of the gate the moment enforcement is ratcheted on. So a non-zero jq
+# exit becomes its own, named violation.
+v2_evaluate_contract() {
+  local structural digests
+  structural=$(v2_contract_violations)
+  if [ "$?" -ne 0 ]; then
+    V2_VIOLATIONS="the v2 claim/evidence structure could not be evaluated - \"claims\" and \"evidence\" must be arrays of objects and \"artifact\" an object. A verdict the gate cannot read is not a verdict with no violations"
+    return 0
+  fi
+
+  digests=$(v2_digest_violations)
+  V2_VIOLATIONS=$(printf '%s\n%s' "$structural" "$digests" | sed '/^[[:space:]]*$/d')
 }
 
 # v2 = the v1 decision PLUS the claim->evidence contract, the latter advisory
@@ -277,7 +350,8 @@ verdict_is_terminal_v2() {
   status=$(jq -r '.status // empty' "$VERDICT_FILE" 2>/dev/null || true)
   [ "$status" = "pass" ] || return 0
 
-  violations=$(v2_contract_violations)
+  v2_evaluate_contract
+  violations="$V2_VIOLATIONS"
   [ -n "$violations" ] || return 0
 
   if boundary_enforcement_enabled; then

--- a/plugins/lisa-cursor/hooks/enforce-verification-gate.sh
+++ b/plugins/lisa-cursor/hooks/enforce-verification-gate.sh
@@ -81,6 +81,20 @@
 #     the flag may never be omitted)
 #   - "artifact.head_sha" exists and no evidence entry declares a different
 #     "artifact_head_sha" (reconciliation with the MERGED head is BCE-4)
+#   - every evidence entry that records BOTH a "sha256" and a "locator"
+#     resolving to a file on disk still hashes to that digest
+#     ("evidence_digest_mismatch"). A locator that is not on disk at stop time
+#     is NOT judged here: the Stop hook sees only the working tree, and evidence
+#     may legitimately live outside it. The absent-artifact arm of that check
+#     belongs to the read-side review surfaces, which see the committed
+#     evidence directory.
+#   - the claim/evidence structure is EVALUABLE at all: a v2 verdict whose
+#     "claims"/"evidence"/"artifact" are not the shapes the schema defines
+#     (claims as a string, evidence as a scalar) is reported as
+#     could-not-evaluate. Could-not-evaluate is NOT the same as no-violations:
+#     a verdict the gate cannot read may never be treated as a clean one, or a
+#     structurally-wrong verdict would sail past the gate the moment
+#     enforcement is ratcheted on.
 #
 # ADVISORY-FIRST: those v2 checks report to stderr but do NOT block unless
 # "verification.gate.enforceBoundaries" is true in .lisa.config.json (default
@@ -90,11 +104,15 @@
 # Per-session state lives under "$STATE_DIR" as flag files keyed by session_id.
 # Stale state (>24h) is cleaned on each invocation.
 #
-# Fail-open: any unexpected jq parse failure or missing field degrades to the
-# LESS strict outcome rather than inventing a new hard failure, and the
-# MAX_BLOCKS escalation below guarantees the gate always releases eventually. A
-# broken gate must never brick a session. In particular, a v2 verdict whose
-# claim structure cannot be evaluated is judged on the v1 conditions alone.
+# Fail-open: a missing field degrades to the LESS strict outcome rather than
+# inventing a new hard failure, and the MAX_BLOCKS escalation below guarantees
+# the gate always releases eventually. A broken gate must never brick a session.
+#
+# That fail-open posture bounds the BLAST RADIUS of a gate failure; it is not a
+# licence to read an unreadable verdict as a clean one. So a v2 verdict whose
+# claim structure cannot be evaluated is reported like any other violation —
+# advisory while the ratchet is off, blocking (still MAX_BLOCKS-bounded, so it
+# can never hard-wedge a session) once it is on.
 
 set -uo pipefail
 
@@ -225,9 +243,39 @@ boundary_enforcement_enabled() {
   [ "$value" = "true" ]
 }
 
+# Prints the sha256 of a file using whichever tool this machine has. Prints
+# nothing when neither exists — an unrecomputable digest is not a violation.
+sha256_of() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" 2>/dev/null | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" 2>/dev/null | awk '{print $1}'
+  fi
+}
+
+# Emits one line per evidence entry whose bytes no longer hash to the digest the
+# verdict recorded. Only entries recording BOTH a sha256 and a locator that
+# resolves to a file on disk are judged; see the header for why an absent
+# locator is out of this hook's scope.
+v2_digest_violations() {
+  jq -r '
+    (.evidence // [])[]
+    | select(((.sha256 // "") | length) > 0)
+    | select(((.locator // "") | length) > 0)
+    | "\(.evidence_id // "?")\t\(.locator)\t\(.sha256)"
+  ' "$VERDICT_FILE" 2>/dev/null | while IFS=$'\t' read -r eid locator recorded; do
+    evidence_path="${PROJECT_DIR}/${locator}"
+    [ -f "$evidence_path" ] || continue
+    actual=$(sha256_of "$evidence_path")
+    [ -n "$actual" ] || continue
+    [ "$actual" = "$recorded" ] && continue
+    echo "evidence ${eid} (${locator}) no longer matches its recorded digest: recorded ${recorded}, bytes now hash to ${actual}"
+  done
+}
+
 # Emits one line per v2 claim->evidence contract violation. Empty output means
-# the verdict satisfies the contract (or could not be evaluated, which degrades
-# to the v1 decision rather than to a new hard failure).
+# the verdict satisfies the contract. A jq evaluation failure is NOT empty
+# output — see v2_evaluate_contract, which turns it into its own violation.
 v2_contract_violations() {
   jq -r '
     . as $v
@@ -263,7 +311,32 @@ v2_contract_violations() {
         )
       ]
     | .[]
-  ' "$VERDICT_FILE" 2>/dev/null || true
+  ' "$VERDICT_FILE" 2>/dev/null
+}
+
+# Set by v2_evaluate_contract: every violation line, or empty when the verdict
+# satisfies the contract. A global rather than a return value because a command
+# substitution would swallow the could-not-evaluate signal along with it.
+V2_VIOLATIONS=""
+
+# Evaluates the full v2 contract into V2_VIOLATIONS.
+#
+# The load-bearing distinction: jq returns NOTHING on an evaluation error, which
+# is byte-identical to "this verdict is clean". A parseable v2 verdict whose
+# claims/evidence are the wrong SHAPE (claims as a string, evidence as a scalar)
+# therefore used to read as violation-free — harmless while advisory, a genuine
+# bypass of the gate the moment enforcement is ratcheted on. So a non-zero jq
+# exit becomes its own, named violation.
+v2_evaluate_contract() {
+  local structural digests
+  structural=$(v2_contract_violations)
+  if [ "$?" -ne 0 ]; then
+    V2_VIOLATIONS="the v2 claim/evidence structure could not be evaluated - \"claims\" and \"evidence\" must be arrays of objects and \"artifact\" an object. A verdict the gate cannot read is not a verdict with no violations"
+    return 0
+  fi
+
+  digests=$(v2_digest_violations)
+  V2_VIOLATIONS=$(printf '%s\n%s' "$structural" "$digests" | sed '/^[[:space:]]*$/d')
 }
 
 # v2 = the v1 decision PLUS the claim->evidence contract, the latter advisory
@@ -277,7 +350,8 @@ verdict_is_terminal_v2() {
   status=$(jq -r '.status // empty' "$VERDICT_FILE" 2>/dev/null || true)
   [ "$status" = "pass" ] || return 0
 
-  violations=$(v2_contract_violations)
+  v2_evaluate_contract
+  violations="$V2_VIOLATIONS"
   [ -n "$violations" ] || return 0
 
   if boundary_enforcement_enabled; then

--- a/plugins/lisa/hooks/enforce-verification-gate.sh
+++ b/plugins/lisa/hooks/enforce-verification-gate.sh
@@ -81,6 +81,20 @@
 #     the flag may never be omitted)
 #   - "artifact.head_sha" exists and no evidence entry declares a different
 #     "artifact_head_sha" (reconciliation with the MERGED head is BCE-4)
+#   - every evidence entry that records BOTH a "sha256" and a "locator"
+#     resolving to a file on disk still hashes to that digest
+#     ("evidence_digest_mismatch"). A locator that is not on disk at stop time
+#     is NOT judged here: the Stop hook sees only the working tree, and evidence
+#     may legitimately live outside it. The absent-artifact arm of that check
+#     belongs to the read-side review surfaces, which see the committed
+#     evidence directory.
+#   - the claim/evidence structure is EVALUABLE at all: a v2 verdict whose
+#     "claims"/"evidence"/"artifact" are not the shapes the schema defines
+#     (claims as a string, evidence as a scalar) is reported as
+#     could-not-evaluate. Could-not-evaluate is NOT the same as no-violations:
+#     a verdict the gate cannot read may never be treated as a clean one, or a
+#     structurally-wrong verdict would sail past the gate the moment
+#     enforcement is ratcheted on.
 #
 # ADVISORY-FIRST: those v2 checks report to stderr but do NOT block unless
 # "verification.gate.enforceBoundaries" is true in .lisa.config.json (default
@@ -90,11 +104,15 @@
 # Per-session state lives under "$STATE_DIR" as flag files keyed by session_id.
 # Stale state (>24h) is cleaned on each invocation.
 #
-# Fail-open: any unexpected jq parse failure or missing field degrades to the
-# LESS strict outcome rather than inventing a new hard failure, and the
-# MAX_BLOCKS escalation below guarantees the gate always releases eventually. A
-# broken gate must never brick a session. In particular, a v2 verdict whose
-# claim structure cannot be evaluated is judged on the v1 conditions alone.
+# Fail-open: a missing field degrades to the LESS strict outcome rather than
+# inventing a new hard failure, and the MAX_BLOCKS escalation below guarantees
+# the gate always releases eventually. A broken gate must never brick a session.
+#
+# That fail-open posture bounds the BLAST RADIUS of a gate failure; it is not a
+# licence to read an unreadable verdict as a clean one. So a v2 verdict whose
+# claim structure cannot be evaluated is reported like any other violation —
+# advisory while the ratchet is off, blocking (still MAX_BLOCKS-bounded, so it
+# can never hard-wedge a session) once it is on.
 
 set -uo pipefail
 
@@ -225,9 +243,39 @@ boundary_enforcement_enabled() {
   [ "$value" = "true" ]
 }
 
+# Prints the sha256 of a file using whichever tool this machine has. Prints
+# nothing when neither exists — an unrecomputable digest is not a violation.
+sha256_of() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" 2>/dev/null | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" 2>/dev/null | awk '{print $1}'
+  fi
+}
+
+# Emits one line per evidence entry whose bytes no longer hash to the digest the
+# verdict recorded. Only entries recording BOTH a sha256 and a locator that
+# resolves to a file on disk are judged; see the header for why an absent
+# locator is out of this hook's scope.
+v2_digest_violations() {
+  jq -r '
+    (.evidence // [])[]
+    | select(((.sha256 // "") | length) > 0)
+    | select(((.locator // "") | length) > 0)
+    | "\(.evidence_id // "?")\t\(.locator)\t\(.sha256)"
+  ' "$VERDICT_FILE" 2>/dev/null | while IFS=$'\t' read -r eid locator recorded; do
+    evidence_path="${PROJECT_DIR}/${locator}"
+    [ -f "$evidence_path" ] || continue
+    actual=$(sha256_of "$evidence_path")
+    [ -n "$actual" ] || continue
+    [ "$actual" = "$recorded" ] && continue
+    echo "evidence ${eid} (${locator}) no longer matches its recorded digest: recorded ${recorded}, bytes now hash to ${actual}"
+  done
+}
+
 # Emits one line per v2 claim->evidence contract violation. Empty output means
-# the verdict satisfies the contract (or could not be evaluated, which degrades
-# to the v1 decision rather than to a new hard failure).
+# the verdict satisfies the contract. A jq evaluation failure is NOT empty
+# output — see v2_evaluate_contract, which turns it into its own violation.
 v2_contract_violations() {
   jq -r '
     . as $v
@@ -263,7 +311,32 @@ v2_contract_violations() {
         )
       ]
     | .[]
-  ' "$VERDICT_FILE" 2>/dev/null || true
+  ' "$VERDICT_FILE" 2>/dev/null
+}
+
+# Set by v2_evaluate_contract: every violation line, or empty when the verdict
+# satisfies the contract. A global rather than a return value because a command
+# substitution would swallow the could-not-evaluate signal along with it.
+V2_VIOLATIONS=""
+
+# Evaluates the full v2 contract into V2_VIOLATIONS.
+#
+# The load-bearing distinction: jq returns NOTHING on an evaluation error, which
+# is byte-identical to "this verdict is clean". A parseable v2 verdict whose
+# claims/evidence are the wrong SHAPE (claims as a string, evidence as a scalar)
+# therefore used to read as violation-free — harmless while advisory, a genuine
+# bypass of the gate the moment enforcement is ratcheted on. So a non-zero jq
+# exit becomes its own, named violation.
+v2_evaluate_contract() {
+  local structural digests
+  structural=$(v2_contract_violations)
+  if [ "$?" -ne 0 ]; then
+    V2_VIOLATIONS="the v2 claim/evidence structure could not be evaluated - \"claims\" and \"evidence\" must be arrays of objects and \"artifact\" an object. A verdict the gate cannot read is not a verdict with no violations"
+    return 0
+  fi
+
+  digests=$(v2_digest_violations)
+  V2_VIOLATIONS=$(printf '%s\n%s' "$structural" "$digests" | sed '/^[[:space:]]*$/d')
 }
 
 # v2 = the v1 decision PLUS the claim->evidence contract, the latter advisory
@@ -277,7 +350,8 @@ verdict_is_terminal_v2() {
   status=$(jq -r '.status // empty' "$VERDICT_FILE" 2>/dev/null || true)
   [ "$status" = "pass" ] || return 0
 
-  violations=$(v2_contract_violations)
+  v2_evaluate_contract
+  violations="$V2_VIOLATIONS"
   [ -n "$violations" ] || return 0
 
   if boundary_enforcement_enabled; then

--- a/plugins/src/base/hooks/enforce-verification-gate.sh
+++ b/plugins/src/base/hooks/enforce-verification-gate.sh
@@ -81,6 +81,20 @@
 #     the flag may never be omitted)
 #   - "artifact.head_sha" exists and no evidence entry declares a different
 #     "artifact_head_sha" (reconciliation with the MERGED head is BCE-4)
+#   - every evidence entry that records BOTH a "sha256" and a "locator"
+#     resolving to a file on disk still hashes to that digest
+#     ("evidence_digest_mismatch"). A locator that is not on disk at stop time
+#     is NOT judged here: the Stop hook sees only the working tree, and evidence
+#     may legitimately live outside it. The absent-artifact arm of that check
+#     belongs to the read-side review surfaces, which see the committed
+#     evidence directory.
+#   - the claim/evidence structure is EVALUABLE at all: a v2 verdict whose
+#     "claims"/"evidence"/"artifact" are not the shapes the schema defines
+#     (claims as a string, evidence as a scalar) is reported as
+#     could-not-evaluate. Could-not-evaluate is NOT the same as no-violations:
+#     a verdict the gate cannot read may never be treated as a clean one, or a
+#     structurally-wrong verdict would sail past the gate the moment
+#     enforcement is ratcheted on.
 #
 # ADVISORY-FIRST: those v2 checks report to stderr but do NOT block unless
 # "verification.gate.enforceBoundaries" is true in .lisa.config.json (default
@@ -90,11 +104,15 @@
 # Per-session state lives under "$STATE_DIR" as flag files keyed by session_id.
 # Stale state (>24h) is cleaned on each invocation.
 #
-# Fail-open: any unexpected jq parse failure or missing field degrades to the
-# LESS strict outcome rather than inventing a new hard failure, and the
-# MAX_BLOCKS escalation below guarantees the gate always releases eventually. A
-# broken gate must never brick a session. In particular, a v2 verdict whose
-# claim structure cannot be evaluated is judged on the v1 conditions alone.
+# Fail-open: a missing field degrades to the LESS strict outcome rather than
+# inventing a new hard failure, and the MAX_BLOCKS escalation below guarantees
+# the gate always releases eventually. A broken gate must never brick a session.
+#
+# That fail-open posture bounds the BLAST RADIUS of a gate failure; it is not a
+# licence to read an unreadable verdict as a clean one. So a v2 verdict whose
+# claim structure cannot be evaluated is reported like any other violation —
+# advisory while the ratchet is off, blocking (still MAX_BLOCKS-bounded, so it
+# can never hard-wedge a session) once it is on.
 
 set -uo pipefail
 
@@ -225,9 +243,39 @@ boundary_enforcement_enabled() {
   [ "$value" = "true" ]
 }
 
+# Prints the sha256 of a file using whichever tool this machine has. Prints
+# nothing when neither exists — an unrecomputable digest is not a violation.
+sha256_of() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" 2>/dev/null | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" 2>/dev/null | awk '{print $1}'
+  fi
+}
+
+# Emits one line per evidence entry whose bytes no longer hash to the digest the
+# verdict recorded. Only entries recording BOTH a sha256 and a locator that
+# resolves to a file on disk are judged; see the header for why an absent
+# locator is out of this hook's scope.
+v2_digest_violations() {
+  jq -r '
+    (.evidence // [])[]
+    | select(((.sha256 // "") | length) > 0)
+    | select(((.locator // "") | length) > 0)
+    | "\(.evidence_id // "?")\t\(.locator)\t\(.sha256)"
+  ' "$VERDICT_FILE" 2>/dev/null | while IFS=$'\t' read -r eid locator recorded; do
+    evidence_path="${PROJECT_DIR}/${locator}"
+    [ -f "$evidence_path" ] || continue
+    actual=$(sha256_of "$evidence_path")
+    [ -n "$actual" ] || continue
+    [ "$actual" = "$recorded" ] && continue
+    echo "evidence ${eid} (${locator}) no longer matches its recorded digest: recorded ${recorded}, bytes now hash to ${actual}"
+  done
+}
+
 # Emits one line per v2 claim->evidence contract violation. Empty output means
-# the verdict satisfies the contract (or could not be evaluated, which degrades
-# to the v1 decision rather than to a new hard failure).
+# the verdict satisfies the contract. A jq evaluation failure is NOT empty
+# output — see v2_evaluate_contract, which turns it into its own violation.
 v2_contract_violations() {
   jq -r '
     . as $v
@@ -263,7 +311,32 @@ v2_contract_violations() {
         )
       ]
     | .[]
-  ' "$VERDICT_FILE" 2>/dev/null || true
+  ' "$VERDICT_FILE" 2>/dev/null
+}
+
+# Set by v2_evaluate_contract: every violation line, or empty when the verdict
+# satisfies the contract. A global rather than a return value because a command
+# substitution would swallow the could-not-evaluate signal along with it.
+V2_VIOLATIONS=""
+
+# Evaluates the full v2 contract into V2_VIOLATIONS.
+#
+# The load-bearing distinction: jq returns NOTHING on an evaluation error, which
+# is byte-identical to "this verdict is clean". A parseable v2 verdict whose
+# claims/evidence are the wrong SHAPE (claims as a string, evidence as a scalar)
+# therefore used to read as violation-free — harmless while advisory, a genuine
+# bypass of the gate the moment enforcement is ratcheted on. So a non-zero jq
+# exit becomes its own, named violation.
+v2_evaluate_contract() {
+  local structural digests
+  structural=$(v2_contract_violations)
+  if [ "$?" -ne 0 ]; then
+    V2_VIOLATIONS="the v2 claim/evidence structure could not be evaluated - \"claims\" and \"evidence\" must be arrays of objects and \"artifact\" an object. A verdict the gate cannot read is not a verdict with no violations"
+    return 0
+  fi
+
+  digests=$(v2_digest_violations)
+  V2_VIOLATIONS=$(printf '%s\n%s' "$structural" "$digests" | sed '/^[[:space:]]*$/d')
 }
 
 # v2 = the v1 decision PLUS the claim->evidence contract, the latter advisory
@@ -277,7 +350,8 @@ verdict_is_terminal_v2() {
   status=$(jq -r '.status // empty' "$VERDICT_FILE" 2>/dev/null || true)
   [ "$status" = "pass" ] || return 0
 
-  violations=$(v2_contract_violations)
+  v2_evaluate_contract
+  violations="$V2_VIOLATIONS"
   [ -n "$violations" ] || return 0
 
   if boundary_enforcement_enabled; then

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -575,7 +575,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/enforce-team-first.sh":
       "51d2e929ea6c04e7c7851be7849dd7d3e7cd0c211b4c8fb856e858a51ddeeb58",
     "plugins/src/base/hooks/enforce-verification-gate.sh":
-      "827b1a48622ad6b5715d924d555fa19715e84f787cf45de30f5fb389c2281b7a",
+      "120cec1795ad4cb49ab67a54fb0c3552185338bb0b8dda0f19f70dc1dac288f9",
     "plugins/src/base/hooks/inject-flow-context.sh":
       "f4ab07065762d592c0fc36be2e4918e767b293aaa4094b9d85d69010576c6dbf",
     "plugins/src/base/hooks/inject-rules.sh":
@@ -7453,6 +7453,15 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/fixtures/queue-status-prd-readers/github.json": true,
     "tests/fixtures/queue-status-prd-readers/linear.json": true,
     "tests/fixtures/queue-status-prd-readers/notion.json": true,
+    "tests/fixtures/verification/artifact_mismatch.json": true,
+    "tests/fixtures/verification/evidence_digest_mismatch.json": true,
+    "tests/fixtures/verification/evidence_kind_mismatch.json": true,
+    "tests/fixtures/verification/not_established_unreviewed.json": true,
+    "tests/fixtures/verification/pass_with_named_unproved_edge.json": true,
+    "tests/fixtures/verification/security_shaped_without_reproducer.json": true,
+    "tests/fixtures/verification/v1_back_compat.json": true,
+    "tests/fixtures/verification/v2_pass_clean.json": true,
+    "tests/fixtures/verification/v2_structurally_invalid_claims.json": true,
     "tests/fixtures/wiki-safety/allowed-contacts.md": true,
     "tests/fixtures/wiki-safety/redaction-source.md": true,
     "tests/helpers/__fixtures__/wiki-status-fixture.ts": true,
@@ -7617,6 +7626,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/hooks/parity-safety-net.test.ts": true,
     "tests/unit/hooks/post-checkout.test.ts": true,
     "tests/unit/hooks/track-plan-sessions.test.ts": true,
+    "tests/unit/hooks/verification-failure-mode-fixtures.test.ts": true,
     "tests/unit/hooks/work-item-wiring.test.ts": true,
     "tests/unit/hooks/worktree-create.test.ts": true,
     "tests/unit/migrations/ensure-audit-ignore-local-exclusions.test.ts": true,

--- a/tests/fixtures/verification/artifact_mismatch.json
+++ b/tests/fixtures/verification/artifact_mismatch.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 2,
+  "plan": "bce-6",
+  "artifact": {
+    "repository": "CodySwannGT/lisa",
+    "base_sha": "aaaa111",
+    "head_sha": "bbbb222",
+    "build_id": "build-1840",
+    "environment": "local",
+    "observed_at": "2026-07-20T00:00:00Z"
+  },
+  "claims": [
+    {
+      "claim_id": "AC-1",
+      "statement": "the checkout button submits the order and shows a confirmation",
+      "boundary": "browser",
+      "required_for_gate": true,
+      "required_evidence_kinds": ["screenshot", "recording"],
+      "status": "established",
+      "evidence_refs": ["EV-1"],
+      "not_established": []
+    }
+  ],
+  "evidence": [
+    {
+      "evidence_id": "EV-1",
+      "kind": "screenshot",
+      "locator": "evidence/1840/confirmation.png",
+      "sha256": "990a93ea77cc735408f25a80e9b4dd048a771c0c27f4c106a8404632dd86a1ce",
+      "captured_at": "2026-07-19T00:00:00Z",
+      "artifact_head_sha": "9999aaa"
+    }
+  ],
+  "not_established": [],
+  "not_established_reviewed": true,
+  "criteria": [
+    {
+      "task": "T1",
+      "criterion": "the confirmation renders after a real click",
+      "status": "pass",
+      "evidence": "screenshot captured on the previous head, before the last commit"
+    }
+  ],
+  "status": "pass",
+  "updated_at": "2026-07-20T00:00:00Z"
+}

--- a/tests/fixtures/verification/evidence_digest_mismatch.json
+++ b/tests/fixtures/verification/evidence_digest_mismatch.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 2,
+  "plan": "bce-6",
+  "artifact": {
+    "repository": "CodySwannGT/lisa",
+    "base_sha": "aaaa111",
+    "head_sha": "bbbb222",
+    "build_id": "build-1840",
+    "environment": "local",
+    "observed_at": "2026-07-20T00:00:00Z"
+  },
+  "claims": [
+    {
+      "claim_id": "AC-1",
+      "statement": "the checkout button submits the order and shows a confirmation",
+      "boundary": "browser",
+      "required_for_gate": true,
+      "required_evidence_kinds": ["screenshot", "recording"],
+      "status": "established",
+      "evidence_refs": ["EV-1"],
+      "not_established": []
+    }
+  ],
+  "evidence": [
+    {
+      "evidence_id": "EV-1",
+      "kind": "screenshot",
+      "locator": "evidence/1840/confirmation.png",
+      "sha256": "990a93ea77cc735408f25a80e9b4dd048a771c0c27f4c106a8404632dd86a1ce",
+      "captured_at": "2026-07-20T00:00:00Z",
+      "artifact_head_sha": "bbbb222"
+    }
+  ],
+  "not_established": [],
+  "not_established_reviewed": true,
+  "criteria": [
+    {
+      "task": "T1",
+      "criterion": "the confirmation renders after a real click",
+      "status": "pass",
+      "evidence": "clicked the button in Chrome, captured the confirmation screenshot"
+    }
+  ],
+  "status": "pass",
+  "updated_at": "2026-07-20T00:00:00Z"
+}

--- a/tests/fixtures/verification/evidence_kind_mismatch.json
+++ b/tests/fixtures/verification/evidence_kind_mismatch.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 2,
+  "plan": "bce-6",
+  "artifact": {
+    "repository": "CodySwannGT/lisa",
+    "base_sha": "aaaa111",
+    "head_sha": "bbbb222",
+    "build_id": "build-1840",
+    "environment": "local",
+    "observed_at": "2026-07-20T00:00:00Z"
+  },
+  "claims": [
+    {
+      "claim_id": "AC-1",
+      "statement": "the checkout button submits the order and shows a confirmation",
+      "boundary": "browser",
+      "required_for_gate": true,
+      "required_evidence_kinds": ["screenshot", "recording"],
+      "status": "established",
+      "evidence_refs": ["EV-1"],
+      "not_established": []
+    }
+  ],
+  "evidence": [
+    {
+      "evidence_id": "EV-1",
+      "kind": "test-run-log",
+      "locator": "evidence/1840/submit-handler.txt",
+      "sha256": "990a93ea77cc735408f25a80e9b4dd048a771c0c27f4c106a8404632dd86a1ce",
+      "captured_at": "2026-07-20T00:00:00Z",
+      "artifact_head_sha": "bbbb222"
+    }
+  ],
+  "not_established": [],
+  "not_established_reviewed": true,
+  "criteria": [
+    {
+      "task": "T1",
+      "criterion": "the confirmation renders after a real click",
+      "status": "pass",
+      "evidence": "unit tests for the submit handler passed"
+    }
+  ],
+  "status": "pass",
+  "updated_at": "2026-07-20T00:00:00Z"
+}

--- a/tests/fixtures/verification/not_established_unreviewed.json
+++ b/tests/fixtures/verification/not_established_unreviewed.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": 2,
+  "plan": "bce-6",
+  "artifact": {
+    "repository": "CodySwannGT/lisa",
+    "base_sha": "aaaa111",
+    "head_sha": "bbbb222",
+    "build_id": "build-1840",
+    "environment": "local",
+    "observed_at": "2026-07-20T00:00:00Z"
+  },
+  "claims": [
+    {
+      "claim_id": "AC-1",
+      "statement": "the checkout button submits the order and shows a confirmation",
+      "boundary": "browser",
+      "required_for_gate": true,
+      "required_evidence_kinds": ["screenshot", "recording"],
+      "status": "established",
+      "evidence_refs": ["EV-1"],
+      "not_established": []
+    }
+  ],
+  "evidence": [
+    {
+      "evidence_id": "EV-1",
+      "kind": "screenshot",
+      "locator": "evidence/1840/confirmation.png",
+      "sha256": "990a93ea77cc735408f25a80e9b4dd048a771c0c27f4c106a8404632dd86a1ce",
+      "captured_at": "2026-07-20T00:00:00Z",
+      "artifact_head_sha": "bbbb222"
+    }
+  ],
+  "criteria": [
+    {
+      "task": "T1",
+      "criterion": "the confirmation renders after a real click",
+      "status": "pass",
+      "evidence": "clicked the button in Chrome, captured the confirmation screenshot"
+    }
+  ],
+  "status": "pass",
+  "updated_at": "2026-07-20T00:00:00Z"
+}

--- a/tests/fixtures/verification/pass_with_named_unproved_edge.json
+++ b/tests/fixtures/verification/pass_with_named_unproved_edge.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 2,
+  "plan": "bce-6",
+  "artifact": {
+    "repository": "CodySwannGT/lisa",
+    "base_sha": "aaaa111",
+    "head_sha": "bbbb222",
+    "build_id": "build-1840",
+    "environment": "local",
+    "observed_at": "2026-07-20T00:00:00Z"
+  },
+  "claims": [
+    {
+      "claim_id": "AC-1",
+      "statement": "the checkout button submits the order and shows a confirmation",
+      "boundary": "browser",
+      "required_for_gate": true,
+      "required_evidence_kinds": ["screenshot", "recording"],
+      "status": "established",
+      "evidence_refs": ["EV-1"],
+      "not_established": [
+        "Checked on production Chrome at 1440x900 only. Not checked on mobile Safari."
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "evidence_id": "EV-1",
+      "kind": "screenshot",
+      "locator": "evidence/1840/confirmation.png",
+      "sha256": "990a93ea77cc735408f25a80e9b4dd048a771c0c27f4c106a8404632dd86a1ce",
+      "captured_at": "2026-07-20T00:00:00Z",
+      "artifact_head_sha": "bbbb222"
+    }
+  ],
+  "not_established": [
+    "Checked on production Chrome at 1440x900 only. Not checked on mobile Safari.",
+    "The order's persisted row was never queried, so the data boundary is not established."
+  ],
+  "not_established_reviewed": true,
+  "criteria": [
+    {
+      "task": "T1",
+      "criterion": "the confirmation renders after a real click",
+      "status": "pass",
+      "evidence": "clicked the button in Chrome, captured the confirmation screenshot"
+    }
+  ],
+  "status": "pass",
+  "updated_at": "2026-07-20T00:00:00Z"
+}

--- a/tests/fixtures/verification/security_shaped_without_reproducer.json
+++ b/tests/fixtures/verification/security_shaped_without_reproducer.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 2,
+  "plan": "bce-6",
+  "artifact": {
+    "repository": "CodySwannGT/lisa",
+    "base_sha": "aaaa111",
+    "head_sha": "bbbb222",
+    "build_id": "build-1840",
+    "environment": "local",
+    "observed_at": "2026-07-20T00:00:00Z"
+  },
+  "claims": [
+    {
+      "claim_id": "AC-1",
+      "statement": "the checkout button submits the order and shows a confirmation",
+      "boundary": "browser",
+      "required_for_gate": true,
+      "required_evidence_kinds": ["screenshot", "recording"],
+      "status": "established",
+      "evidence_refs": ["EV-1"],
+      "not_established": []
+    },
+    {
+      "claim_id": "SEC-1",
+      "statement": "the search box lets a signed-in customer read another customer's orders",
+      "boundary": "http-api",
+      "required_for_gate": false,
+      "required_evidence_kinds": ["http-transcript"],
+      "status": "not-established",
+      "evidence_refs": [],
+      "not_established": [
+        "Never reproduced against a running API, so this finding is reported unproven rather than dropped."
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "evidence_id": "EV-1",
+      "kind": "screenshot",
+      "locator": "evidence/1840/confirmation.png",
+      "sha256": "990a93ea77cc735408f25a80e9b4dd048a771c0c27f4c106a8404632dd86a1ce",
+      "captured_at": "2026-07-20T00:00:00Z",
+      "artifact_head_sha": "bbbb222"
+    }
+  ],
+  "security_findings": [
+    {
+      "finding_id": "SEC-1",
+      "bucket": "security-unproven",
+      "summary": "The order search box may accept an unvalidated customer id.",
+      "reproducer": "none",
+      "impact": "unproven",
+      "reason": "no reproducer was captured; the finding stays in the security section and is not demoted"
+    }
+  ],
+  "not_established": [
+    "Never reproduced against a running API, so this finding is reported unproven rather than dropped."
+  ],
+  "not_established_reviewed": true,
+  "criteria": [
+    {
+      "task": "T1",
+      "criterion": "the confirmation renders after a real click",
+      "status": "pass",
+      "evidence": "clicked the button in Chrome, captured the confirmation screenshot"
+    }
+  ],
+  "status": "pass",
+  "updated_at": "2026-07-20T00:00:00Z"
+}

--- a/tests/fixtures/verification/v1_back_compat.json
+++ b/tests/fixtures/verification/v1_back_compat.json
@@ -1,0 +1,13 @@
+{
+  "plan": "bce-6",
+  "status": "pass",
+  "criteria": [
+    {
+      "task": "T1",
+      "criterion": "the confirmation renders after a real click",
+      "status": "pass",
+      "evidence": "clicked the button in Chrome, observed the confirmation"
+    }
+  ],
+  "updated_at": "2026-07-20T00:00:00Z"
+}

--- a/tests/fixtures/verification/v2_pass_clean.json
+++ b/tests/fixtures/verification/v2_pass_clean.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 2,
+  "plan": "bce-6",
+  "artifact": {
+    "repository": "CodySwannGT/lisa",
+    "base_sha": "aaaa111",
+    "head_sha": "bbbb222",
+    "build_id": "build-1840",
+    "environment": "local",
+    "observed_at": "2026-07-20T00:00:00Z"
+  },
+  "claims": [
+    {
+      "claim_id": "AC-1",
+      "statement": "the checkout button submits the order and shows a confirmation",
+      "boundary": "browser",
+      "required_for_gate": true,
+      "required_evidence_kinds": ["screenshot", "recording"],
+      "status": "established",
+      "evidence_refs": ["EV-1"],
+      "not_established": []
+    }
+  ],
+  "evidence": [
+    {
+      "evidence_id": "EV-1",
+      "kind": "screenshot",
+      "locator": "evidence/1840/confirmation.png",
+      "sha256": "990a93ea77cc735408f25a80e9b4dd048a771c0c27f4c106a8404632dd86a1ce",
+      "captured_at": "2026-07-20T00:00:00Z",
+      "artifact_head_sha": "bbbb222"
+    }
+  ],
+  "not_established": [],
+  "not_established_reviewed": true,
+  "criteria": [
+    {
+      "task": "T1",
+      "criterion": "the confirmation renders after a real click",
+      "status": "pass",
+      "evidence": "clicked the button in Chrome, captured the confirmation screenshot"
+    }
+  ],
+  "status": "pass",
+  "updated_at": "2026-07-20T00:00:00Z"
+}

--- a/tests/fixtures/verification/v2_structurally_invalid_claims.json
+++ b/tests/fixtures/verification/v2_structurally_invalid_claims.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 2,
+  "plan": "bce-6",
+  "artifact": {
+    "repository": "CodySwannGT/lisa",
+    "base_sha": "aaaa111",
+    "head_sha": "bbbb222",
+    "build_id": "build-1840",
+    "environment": "local",
+    "observed_at": "2026-07-20T00:00:00Z"
+  },
+  "claims": "AC-1 established in the browser",
+  "evidence": 3,
+  "not_established_reviewed": true,
+  "criteria": [
+    {
+      "task": "T1",
+      "criterion": "the confirmation renders after a real click",
+      "status": "pass",
+      "evidence": "asserted in prose"
+    }
+  ],
+  "status": "pass",
+  "updated_at": "2026-07-20T00:00:00Z"
+}

--- a/tests/helpers/verification-gate-fixtures.ts
+++ b/tests/helpers/verification-gate-fixtures.ts
@@ -6,10 +6,28 @@
  * shape would silently weaken the compatibility proof.
  * @module tests/helpers/verification-gate-fixtures
  */
+import { readFileSync } from "fs";
+import path from "path";
+
 import {
   FIXTURE_HEAD_SHA,
   FIXTURE_TIMESTAMP,
 } from "./verification-gate-harness";
+
+/** Directory holding the committed failure-mode verdict fixtures (BCE-6). */
+const FAILURE_MODE_DIR = path.resolve("tests/fixtures/verification");
+
+/**
+ * Reads one committed failure-mode fixture verbatim.
+ *
+ * The fixtures are files rather than builders on purpose: each is the artifact
+ * a reviewer opens to see what the failure mode looks like, and the suite
+ * drives the same bytes through the real hook.
+ * @param name - Fixture basename without the .json extension.
+ * @returns The fixture's raw JSON text.
+ */
+export const loadFailureModeFixture = (name: string): string =>
+  readFileSync(path.join(FAILURE_MODE_DIR, `${name}.json`), "utf-8");
 
 /** Boundary asserted by the default v2 fixture claim. */
 export const BROWSER_BOUNDARY = "browser";

--- a/tests/helpers/verification-gate-harness.ts
+++ b/tests/helpers/verification-gate-harness.ts
@@ -56,6 +56,7 @@ export type GateScenario = {
   stop: (sessionId: string) => HookResult;
   writeVerdict: (contents: string, options?: WriteVerdictOptions) => void;
   writeConfig: (enforceBoundaries: boolean) => void;
+  writeEvidenceFile: (relativePath: string, contents: string) => void;
 };
 
 /**
@@ -132,6 +133,19 @@ export const createGateScenario = (
         path.join(projectDir, ".lisa.config.json"),
         JSON.stringify({ verification: { gate: { enforceBoundaries } } })
       );
+    },
+
+    /**
+     * Materializes an evidence artifact inside the scenario's project directory
+     * so the gate's digest check has real bytes to recompute. Evidence
+     * `locator` values are project-relative, exactly as a verdict records them.
+     * @param relativePath - Locator relative to the project directory.
+     * @param contents - Bytes to write at that locator.
+     */
+    writeEvidenceFile: (relativePath: string, contents: string): void => {
+      const target = path.join(projectDir, relativePath);
+      mkdirSync(path.dirname(target), { recursive: true });
+      writeFileSync(target, contents);
     },
   };
 };

--- a/tests/unit/hooks/verification-failure-mode-fixtures.test.ts
+++ b/tests/unit/hooks/verification-failure-mode-fixtures.test.ts
@@ -1,0 +1,336 @@
+/**
+ * BCE-6 (#1840): the five failure-mode verdict fixtures, executable.
+ *
+ * Each named failure mode from the bounded-claims PRD becomes a committed
+ * verdict under `tests/fixtures/verification/` that this suite drives through
+ * the REAL Stop hook — the same harness the v1/v2 suites use. A fixture is not
+ * a description of a failure mode; it is the failure mode, run.
+ *
+ * The suite is advisory-first by construction: every detector fixture is run
+ * twice, once with `verification.gate.enforceBoundaries` false and once true,
+ * and BOTH legs are asserted. Advisory mode must still *report* — a detector
+ * that silently degrades to "clean" while advisory would be indistinguishable
+ * from a working one right up until the ratchet flips it to blocking, which is
+ * exactly the bypass this ticket exists to close. The enforcement-ON legs set
+ * the flag in the scenario's own throwaway config; no repo default is flipped.
+ *
+ * CI: these are plain vitest tests under `tests/unit`, so they run in the
+ * existing required `🧪 Run Unit Tests` job (`bun run test:unit`) — the check
+ * that already gates every PR. No separate job, and nothing here is skipped or
+ * capped: what is advisory versus blocking is asserted per fixture below and
+ * named in the hook's own stderr, never silently dropped.
+ * @module tests/unit/hooks/verification-failure-mode-fixtures
+ */
+import { existsSync } from "fs";
+import path from "path";
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+import { loadFailureModeFixture } from "../../helpers/verification-gate-fixtures";
+import type { GateScenario } from "../../helpers/verification-gate-harness";
+import {
+  createGateScenario,
+  EXIT_ALLOWED,
+  EXIT_BLOCKED,
+  MAX_BLOCKS,
+} from "../../helpers/verification-gate-harness";
+
+/** The ratchet flag every v2 check rides. Named in the advisory output. */
+const RATCHET_FLAG = "verification.gate.enforceBoundaries";
+
+/** head_sha the fixtures' verdicts claim to have observed. */
+const VERDICT_HEAD_SHA = "bbbb222";
+
+/** head_sha the artifact_mismatch fixture's evidence was captured at. */
+const STALE_EVIDENCE_HEAD_SHA = "9999aaa";
+
+/** Locator every screenshot-bearing fixture records for its evidence. */
+const EVIDENCE_LOCATOR = "evidence/1840/confirmation.png";
+
+/** The bytes whose digest the fixtures record. */
+const EVIDENCE_BYTES = "captured screenshot bytes v1\n";
+
+/** The digest recorded in the fixtures for EVIDENCE_BYTES. */
+const RECORDED_DIGEST =
+  "990a93ea77cc735408f25a80e9b4dd048a771c0c27f4c106a8404632dd86a1ce";
+
+/** Bytes that replace the evidence after it was recorded. */
+const TAMPERED_BYTES = "captured screenshot bytes v2 (tampered)\n";
+
+/** The five failure modes the PRD names, plus the compatibility fixture. */
+const NAMED_FAILURE_MODES = [
+  "evidence_kind_mismatch",
+  "artifact_mismatch",
+  "evidence_digest_mismatch",
+  "pass_with_named_unproved_edge",
+  "security_shaped_without_reproducer",
+] as const;
+
+let harness: GateScenario;
+
+beforeEach(() => {
+  harness = createGateScenario(process.env);
+});
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+/**
+ * Runs one fixture through the real hook at a given enforcement posture.
+ * @param fixture - Fixture basename under tests/fixtures/verification.
+ * @param enforce - Value written to verification.gate.enforceBoundaries.
+ * @returns The hook's exit status and stderr.
+ */
+const runFixture = (
+  fixture: string,
+  enforce: boolean
+): { status: number | null; stderr: string } => {
+  const session = `${fixture}-${enforce ? "on" : "off"}`;
+  harness.armSession(session);
+  harness.writeConfig(enforce);
+  harness.writeVerdict(loadFailureModeFixture(fixture));
+  return harness.stop(session);
+};
+
+describe("verification failure-mode fixtures (BCE-6)", () => {
+  describe("every named failure mode is a committed, executable fixture", () => {
+    it.each(NAMED_FAILURE_MODES)("ships a %s fixture", name => {
+      expect(
+        existsSync(path.resolve("tests/fixtures/verification", `${name}.json`))
+      ).toBe(true);
+      expect(JSON.parse(loadFailureModeFixture(name))).toBeTypeOf("object");
+    });
+  });
+
+  describe("v2_pass_clean: a claim-mapped verdict passes end to end", () => {
+    it("releases the gate when enforcement is off", () => {
+      expect(runFixture("v2_pass_clean", false).status).toBe(EXIT_ALLOWED);
+    });
+
+    it("releases the gate when enforcement is on", () => {
+      expect(runFixture("v2_pass_clean", true).status).toBe(EXIT_ALLOWED);
+    });
+
+    it("reports nothing — a clean verdict raises no advisory", () => {
+      expect(runFixture("v2_pass_clean", false).stderr).not.toContain(
+        "advisory"
+      );
+    });
+  });
+
+  describe("evidence_kind_mismatch: a unit log cited for a browser claim", () => {
+    it("reports the mismatch and still releases while advisory", () => {
+      const { status, stderr } = runFixture("evidence_kind_mismatch", false);
+      expect(status).toBe(EXIT_ALLOWED);
+      expect(stderr).toContain("AC-1");
+      expect(stderr).toContain("browser");
+      expect(stderr).toContain("test-run-log");
+      expect(stderr).toContain("screenshot");
+    });
+
+    it("blocks the stop once enforcement is on", () => {
+      const { status, stderr } = runFixture("evidence_kind_mismatch", true);
+      expect(status).toBe(EXIT_BLOCKED);
+      expect(stderr).toContain("AC-1");
+      expect(stderr).toContain("reaches that claim's boundary");
+    });
+  });
+
+  describe("artifact_mismatch: evidence captured on a previous head", () => {
+    it("names both SHAs while advisory and releases", () => {
+      const { status, stderr } = runFixture("artifact_mismatch", false);
+      expect(status).toBe(EXIT_ALLOWED);
+      expect(stderr).toContain(STALE_EVIDENCE_HEAD_SHA);
+      expect(stderr).toContain(VERDICT_HEAD_SHA);
+    });
+
+    it("fails loudly naming both SHAs once enforcement is on", () => {
+      const { status, stderr } = runFixture("artifact_mismatch", true);
+      expect(status).toBe(EXIT_BLOCKED);
+      expect(stderr).toContain(STALE_EVIDENCE_HEAD_SHA);
+      expect(stderr).toContain(VERDICT_HEAD_SHA);
+      expect(stderr).toContain("EV-1");
+    });
+  });
+
+  describe("evidence_digest_mismatch: the bytes changed after recording", () => {
+    /**
+     * Runs the digest fixture with the evidence file materialized.
+     * @param bytes - Bytes written at the recorded locator.
+     * @param enforce - Enforcement posture.
+     * @returns The hook's exit status and stderr.
+     */
+    const runWithEvidence = (
+      bytes: string,
+      enforce: boolean
+    ): { status: number | null; stderr: string } => {
+      const session = `digest-${enforce ? "on" : "off"}`;
+      harness.armSession(session);
+      harness.writeConfig(enforce);
+      harness.writeEvidenceFile(EVIDENCE_LOCATOR, bytes);
+      harness.writeVerdict(loadFailureModeFixture("evidence_digest_mismatch"));
+      return harness.stop(session);
+    };
+
+    it("reports the tampered digest while advisory and releases", () => {
+      const { status, stderr } = runWithEvidence(TAMPERED_BYTES, false);
+      expect(status).toBe(EXIT_ALLOWED);
+      expect(stderr).toContain("EV-1");
+      expect(stderr).toContain(RECORDED_DIGEST);
+    });
+
+    it("blocks once enforcement is on, naming the evidence id", () => {
+      const { status, stderr } = runWithEvidence(TAMPERED_BYTES, true);
+      expect(status).toBe(EXIT_BLOCKED);
+      expect(stderr).toContain("EV-1");
+      expect(stderr).toContain(EVIDENCE_LOCATOR);
+    });
+
+    it("releases when the bytes still match the recorded digest", () => {
+      const { status, stderr } = runWithEvidence(EVIDENCE_BYTES, true);
+      expect(status).toBe(EXIT_ALLOWED);
+      expect(stderr).not.toContain("digest");
+    });
+
+    it("does not invent a digest failure when the artifact is not on disk", () => {
+      expect(runFixture("evidence_digest_mismatch", true).status).toBe(
+        EXIT_ALLOWED
+      );
+    });
+  });
+
+  describe("pass_with_named_unproved_edge: a pass that names its edges", () => {
+    it("stays a pass under enforcement", () => {
+      expect(runFixture("pass_with_named_unproved_edge", true).status).toBe(
+        EXIT_ALLOWED
+      );
+    });
+
+    it("keeps the unproved edge states visible in the verdict", () => {
+      const verdict = JSON.parse(
+        loadFailureModeFixture("pass_with_named_unproved_edge")
+      ) as {
+        not_established: string[];
+        not_established_reviewed: boolean;
+      };
+      expect(verdict.not_established_reviewed).toBe(true);
+      expect(verdict.not_established.length).toBeGreaterThan(0);
+      expect(verdict.not_established.join(" ")).toContain("mobile Safari");
+    });
+  });
+
+  describe("not_established_unreviewed: the flag may never be omitted", () => {
+    it("reports the missing flag while advisory and releases", () => {
+      const { status, stderr } = runFixture(
+        "not_established_unreviewed",
+        false
+      );
+      expect(status).toBe(EXIT_ALLOWED);
+      expect(stderr).toContain("not_established_reviewed");
+    });
+
+    it("blocks once enforcement is on", () => {
+      const { status, stderr } = runFixture("not_established_unreviewed", true);
+      expect(status).toBe(EXIT_BLOCKED);
+      expect(stderr).toContain("not_established_reviewed");
+    });
+  });
+
+  describe("security_shaped_without_reproducer: unproven, never dropped", () => {
+    it("shapes the report, not the merge — the gate still releases", () => {
+      expect(
+        runFixture("security_shaped_without_reproducer", true).status
+      ).toBe(EXIT_ALLOWED);
+    });
+
+    it("keeps the finding in the security bucket labeled unproven", () => {
+      const verdict = JSON.parse(
+        loadFailureModeFixture("security_shaped_without_reproducer")
+      ) as {
+        security_findings: Array<Record<string, string>>;
+      };
+      const [finding] = verdict.security_findings;
+      expect(finding?.bucket).toBe("security-unproven");
+      expect(finding?.reproducer).toBe("none");
+      expect(finding?.impact).toBe("unproven");
+      expect(finding?.reason).toContain("reproducer");
+    });
+
+    it("never demotes the finding to a maintenance bucket", () => {
+      expect(
+        loadFailureModeFixture("security_shaped_without_reproducer")
+      ).not.toContain("maintenance");
+    });
+  });
+
+  describe("v2_structurally_invalid_claims: could-not-evaluate is not clean", () => {
+    it("does NOT silently release under enforcement", () => {
+      const { status } = runFixture("v2_structurally_invalid_claims", true);
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("names the structural problem instead of a generic failure", () => {
+      const { stderr } = runFixture("v2_structurally_invalid_claims", true);
+      expect(stderr).toContain("could not be evaluated");
+      expect(stderr).toContain("claims");
+      expect(stderr).toContain("evidence");
+    });
+
+    it("surfaces the same structural problem as an advisory when off", () => {
+      const { status, stderr } = runFixture(
+        "v2_structurally_invalid_claims",
+        false
+      );
+      expect(status).toBe(EXIT_ALLOWED);
+      expect(stderr).toContain("could not be evaluated");
+    });
+
+    it("never hard-wedges — it releases after MAX_BLOCKS with escalation", () => {
+      const session = "structural-wedge";
+      harness.armSession(session);
+      harness.writeConfig(true);
+      harness.writeVerdict(
+        loadFailureModeFixture("v2_structurally_invalid_claims")
+      );
+      for (let i = 0; i < MAX_BLOCKS; i += 1) {
+        expect(harness.stop(session).status).toBe(EXIT_BLOCKED);
+      }
+      const escalated = harness.stop(session);
+      expect(escalated.status).toBe(EXIT_ALLOWED);
+      expect(escalated.stderr).toContain("Do NOT claim this work is verified");
+    });
+  });
+
+  describe("v1_back_compat: the compatibility window is regression-guarded", () => {
+    it("releases a v1 verdict exactly as the pre-v2 gate did", () => {
+      expect(runFixture("v1_back_compat", true).status).toBe(EXIT_ALLOWED);
+    });
+
+    it("applies no v2 claim check to a v1 verdict, even a structurally odd one", () => {
+      const session = "v1-odd";
+      harness.armSession(session);
+      harness.writeConfig(true);
+      harness.writeVerdict(
+        JSON.stringify({
+          ...(JSON.parse(loadFailureModeFixture("v1_back_compat")) as Record<
+            string,
+            unknown
+          >),
+          claims: "not a v2 verdict",
+        })
+      );
+      const { status, stderr } = harness.stop(session);
+      expect(status).toBe(EXIT_ALLOWED);
+      expect(stderr).toBe("");
+    });
+  });
+
+  describe("advisory versus blocking is logged, never silent", () => {
+    it("names the ratchet flag that would make the report blocking", () => {
+      const { stderr } = runFixture("evidence_kind_mismatch", false);
+      expect(stderr).toContain(RATCHET_FLAG);
+      expect(stderr).toContain("advisory");
+    });
+  });
+});


### PR DESCRIPTION
## What

The bounded-claims PRD (#1738) names five failure modes the evidence disciplines are supposed to
catch. Until now they were prose in a comment. This ships them as **committed verdict fixtures**
under `tests/fixtures/verification/` and drives every one through the **real Stop hook** — the same
harness the shipped v1/v2 gate suites use.

Every detector fixture runs **twice**: once with `verification.gate.enforceBoundaries` off and once
on, and both legs are asserted. Advisory mode that silently degrades to "clean" is indistinguishable
from a working detector right up until the ratchet flips it to blocking — which is precisely the
class of bug this ticket exists to close.

### The fixture table

| Fixture | Enforcement OFF | Enforcement ON |
|---|---|---|
| `v2_pass_clean` | releases, raises no advisory | releases |
| `evidence_kind_mismatch` (unit log cited for a `browser` claim) | releases + reports claim, boundary, cited and required kinds | **blocks**, naming the claim and "reaches that claim's boundary" |
| `artifact_mismatch` (evidence captured on a previous head) | releases + names **both SHAs** | **blocks**, naming both SHAs and the evidence id |
| `evidence_digest_mismatch` (bytes changed after recording) | releases + names the evidence id and recorded digest | **blocks**, naming the evidence id and locator |
| `pass_with_named_unproved_edge` | releases; the named edge stays visible | releases |
| `security_shaped_without_reproducer` | releases (shapes the report, not the merge) | releases; finding stays `security-unproven`, never demoted |
| `not_established_unreviewed` | releases + names `not_established_reviewed` | **blocks** |
| `v2_structurally_invalid_claims` | releases + names the structural problem | **blocks** — does **not** silently release |
| `v1_back_compat` | releases | releases (no v2 check applied, stderr empty) |

## The carry-in guard: could-not-evaluate ≠ no-violations

The binding carry-in from BCE-2 (#1836 / PR #1844):

> the hook's jq contract-checker returns empty output on ANY evaluation error, which reads as
> 'clean' — a parseable v2 verdict with structurally wrong claims/evidence shapes (e.g. claims as a
> string) silently no-ops. Safe while advisory, **a genuine bypass under enforcement**.

`jq` prints nothing when it errors, and "nothing" is byte-identical to "this verdict satisfies the
contract". A verdict with `"claims": "AC-1 established"` and `"evidence": 3` parses as JSON, reaches
the v2 path, produces zero violation lines, and releases the gate. Today that is harmless because the
checks are advisory. The moment the threshold ratchet promotes `enforceBoundaries` to `true`, it
becomes the one shape of verdict that walks straight through the gate the ratchet was supposed to
close.

Fixed by capturing jq's exit status instead of discarding it (`|| true` removed) and turning a
non-zero exit into its own named violation: *"the v2 claim/evidence structure could not be evaluated
… A verdict the gate cannot read is not a verdict with no violations."* Advisory while the flag is
off; blocking once it is on.

## Gherkin reconciliation

BCE-2's ticket said a schema error exits 0. The implementation deliberately kept MAX_BLOCKS-bounded
blocking ("never hard-wedges") because literal exit-0 lets any garbage verdict bypass the Stop gate.
The fixtures here are written against **the shipped semantics, not the original Gherkin**: a
structurally-unevaluable verdict under enforcement **blocks**, and a dedicated pin proves that
blocking stays MAX_BLOCKS-bounded and escalates rather than hard-wedging the session.

## Two detectors that had no implementation

`evidence_kind_mismatch`, `artifact_mismatch`, `not_established_unreviewed` and the pass fixtures all
went green on the first run against the shipped hook — the shipped detectors fire. Two did not, and
are added here, both advisory-first on the same ratchet flag:

- **`evidence_digest_mismatch`** — BCE-4 defined it in the `claim-evidence-mapping` rule; nothing
  implemented it. The hook now recomputes the `sha256` of each evidence artifact whose `locator`
  resolves on disk and names the recorded and actual digests when they disagree. A locator **not** on
  disk at stop time is explicitly out of scope for the Stop hook — it sees only the working tree, and
  evidence may legitimately live elsewhere; the absent-artifact arm belongs to the read-side review
  surfaces. That boundary is documented in the hook header and pinned by its own test, so it is a
  stated limit rather than a silent cap. This also keeps the existing pins byte-identical.
- **could-not-evaluate** — above.

## CI wiring

The suite is plain vitest under `tests/unit`, so it runs in the existing **required** `🧪 Run Unit
Tests` job (`bun run test:unit`) that already gates every PR. No new workflow job, and no repo
default flipped: the enforcement-ON legs write the flag into each scenario's own throwaway
`.lisa.config.json`.

## Evidence

- **RED**: 6 failed / 24 passed — exactly the digest and could-not-evaluate legs; every other
  detector already green.
- **GREEN**: 30/30 in the new suite.
- **Deliberate regression** (Validation Journey): patched the boundary check to accept any cited
  evidence kind → `evidence_kind_mismatch` went red (3 failed / 27 passed). Reverted → 30/30.
- Prior families unchanged: 253 hook tests (21 files) green, including the 34 gate pins; 3757
  strategies tests (145 files) green.
- `typecheck`, `lint`, `check:plugins`, `check-rules-pairing.sh`, `shellcheck`, `bash -n`/`sh -n`,
  upstream-evidence manifest `--check` — all green.

Closes #1840

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * v2 verification gates now validate evidence integrity by checking recorded SHA-256 digests against on-disk bytes.
  * Structurally invalid or unevaluable v2 verdicts are now treated as violations (advisory when boundary enforcement is off; blocking when on), with escalation behavior preserved.
  * Version 1 verification behavior remains unchanged.

* **Tests**
  * Added new failure-mode fixtures and a unit test suite covering evidence digest mismatches, invalid shapes, advisory vs blocking ratchet behavior, escalation limits, and v1 compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->