### PR TITLE
feat(health): add deterministic project probes

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "refresh:upstream-public-commits": "node scripts/generate-upstream-evidence-manifest.mjs --refresh-public-commits",
     "check:rules-pairing": "bash scripts/check-rules-pairing.sh",
     "check:workflow-inputs": "node scripts/detect-stale-workflow-inputs.mjs --project . --project typescript/create-only --project rails/create-only --json",
-    "verify:health-contract": "bun run build:dist && node scripts/verify-health-contract-built.mjs"
+    "verify:health-contract": "bun run build:dist && node scripts/verify-health-contract-built.mjs",
+    "verify:health-deterministic": "bun run build:dist && node scripts/verify-health-deterministic-built.mjs"
   },
   "engines": {
     "npm": "please-use-bun",

--- a/package.lisa.json
+++ b/package.lisa.json
@@ -12,6 +12,7 @@
       "sg:scan": "ast-grep scan",
       "build": "tsc",
       "verify:health-contract": "bun run build:dist && node scripts/verify-health-contract-built.mjs",
+      "verify:health-deterministic": "bun run build:dist && node scripts/verify-health-deterministic-built.mjs",
       "prepare": "$npm_execpath run build && husky install || true",
       "lisa:update": "npx @codyswann/lisa@latest ."
     },

--- a/scripts/detect-stale-workflow-inputs.mjs
+++ b/scripts/detect-stale-workflow-inputs.mjs
@@ -42,11 +42,26 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  diffStaleKeys,
+  extractCallerJobs,
+  extractDeclaredInputs,
+  parseReusableReference,
+} from "./lib/reusable-workflow-contract.mjs";
+
+export {
+  diffStaleKeys,
+  extractCallerJobs,
+  extractDeclaredInputs,
+  parseReusableReference,
+};
 
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   ".."
 );
+const LISA_OWNER = "codyswanngt";
+const LISA_REPO = "lisa";
 
 /**
  * Usage error — thrown by `parseArgs` for an invalid invocation so `main` can
@@ -66,153 +81,6 @@ function isDirectory(target) {
   } catch {
     return false;
   }
-}
-
-/**
- * Leading-whitespace width of a line (its indentation level).
- *
- * @param {string} line - a single source line.
- * @returns {number} number of leading whitespace characters.
- */
-function indentOf(line) {
-  return line.length - line.trimStart().length;
-}
-
-/**
- * Collect the immediate child `key:` names nested directly under a block
- * opener line, given the opener's own indentation. Stops at the first line
- * whose indentation is `<= parentIndent` (blank lines are skipped).
- *
- * @param {readonly string[]} lines - full file, split into lines.
- * @param {number} openerIndex - index of the block-opener line (e.g. `with:`).
- * @param {number} parentIndent - indentation width of the opener line itself.
- * @returns {string[]} the immediate child key names, in file order.
- */
-function collectImmediateChildKeys(lines, openerIndex, parentIndent) {
-  const keys = [];
-  for (let k = openerIndex + 1; k < lines.length; k++) {
-    const line = lines[k];
-    if (line.trim() === "") {
-      continue;
-    }
-    const lineIndent = indentOf(line);
-    if (lineIndent <= parentIndent) {
-      break;
-    }
-    const match = /^\s*([A-Za-z0-9_-]+):/.exec(line);
-    if (match && lineIndent === parentIndent + 2) {
-      keys.push(match[1]);
-    }
-  }
-  return keys;
-}
-
-/**
- * Parse a `uses:` value referencing a reusable workflow into its basename and
- * ref, or `null` if it doesn't match the `.../.github/workflows/<file>@<ref>`
- * shape (e.g. a plain action reference like `actions/checkout@v6`).
- *
- * @param {string} usesValue - the raw value after `uses:`.
- * @returns {{ file: string, ref: string } | null} the parsed reference.
- */
-export function parseReusableReference(usesValue) {
-  const match = /\.github\/workflows\/([\w.-]+\.ya?ml)@(\S+)$/.exec(
-    usesValue.trim()
-  );
-  if (!match) {
-    return null;
-  }
-  return { file: match[1], ref: match[2] };
-}
-
-/**
- * Scan a caller workflow file's contents for every job that invokes a
- * reusable workflow, returning the `with:` keys each job passes.
- *
- * @param {string} content - full caller workflow file contents.
- * @returns {{ reusableFile: string, ref: string, withKeys: string[] }[]}
- *   one entry per job that calls a reusable workflow (in file order).
- */
-export function extractCallerJobs(content) {
-  const lines = content.split(/\r?\n/);
-  const jobs = [];
-  for (let i = 0; i < lines.length; i++) {
-    const usesMatch = /^(\s*)uses:\s*(\S+)\s*$/.exec(lines[i]);
-    if (!usesMatch) {
-      continue;
-    }
-    const [, indentStr, usesValue] = usesMatch;
-    const ref = parseReusableReference(usesValue);
-    if (!ref) {
-      continue;
-    }
-    const indent = indentStr.length;
-    let withKeys = [];
-    for (let j = i + 1; j < lines.length; j++) {
-      const line = lines[j];
-      if (line.trim() === "") {
-        continue;
-      }
-      const lineIndent = indentOf(line);
-      if (lineIndent < indent) {
-        break;
-      }
-      if (lineIndent === indent && /^\s*with:\s*$/.test(line)) {
-        withKeys = collectImmediateChildKeys(lines, j, indent).sort();
-        break;
-      }
-    }
-    jobs.push({ reusableFile: ref.file, ref: ref.ref, withKeys });
-  }
-  return jobs;
-}
-
-/**
- * Extract the declared `on.workflow_call.inputs` key names from a reusable
- * workflow's contents.
- *
- * @param {string} content - full reusable workflow file contents.
- * @returns {string[] | null} declared input names (sorted), an empty array when
- *   the reusable workflow declares no inputs, or `null` if the file has no
- *   `workflow_call:` block.
- */
-export function extractDeclaredInputs(content) {
-  const lines = content.split(/\r?\n/);
-  for (let i = 0; i < lines.length; i++) {
-    if (!/^\s*workflow_call:\s*$/.test(lines[i])) {
-      continue;
-    }
-    const wcIndent = indentOf(lines[i]);
-    for (let j = i + 1; j < lines.length; j++) {
-      const line = lines[j];
-      if (line.trim() === "") {
-        continue;
-      }
-      const lineIndent = indentOf(line);
-      if (lineIndent <= wcIndent) {
-        break;
-      }
-      if (lineIndent === wcIndent + 2 && /^\s*inputs:\s*$/.test(line)) {
-        return collectImmediateChildKeys(lines, j, lineIndent).sort();
-      }
-    }
-    return [];
-  }
-  return null;
-}
-
-/**
- * Keys present in `used` but absent from `declared` — i.e. inputs a caller
- * passes that the reusable workflow's contract no longer accepts.
- *
- * @param {readonly string[]} used - `with:` keys a caller passes.
- * @param {readonly string[]} declared - `workflow_call.inputs` keys the
- *   reusable workflow declares.
- * @returns {string[]} the stale keys, sorted.
- */
-export function diffStaleKeys(used, declared) {
-  const declaredSet = new Set(declared);
-  return used.filter(key => !declaredSet.has(key)).sort();
 }
 
 /**
@@ -245,7 +113,12 @@ function resolveContractInputs(contractsRoot, reusableFile) {
 function scanCallerFile(filePath, contractsRoot) {
   const jobs = extractCallerJobs(fs.readFileSync(filePath, "utf8"));
   return jobs.map(job => {
-    const declared = resolveContractInputs(contractsRoot, job.reusableFile);
+    const isLisaContract =
+      job.owner?.toLowerCase() === LISA_OWNER &&
+      job.repo?.toLowerCase() === LISA_REPO;
+    const declared = isLisaContract
+      ? resolveContractInputs(contractsRoot, job.reusableFile)
+      : null;
     if (declared === null) {
       return { ...job, staleInputs: [], status: "unknown-contract" };
     }

--- a/scripts/lib/reusable-workflow-contract.d.mts
+++ b/scripts/lib/reusable-workflow-contract.d.mts
@@ -1,0 +1,24 @@
+export interface ReusableCallerJob {
+  readonly reusableFile: string;
+  readonly ref: string;
+  readonly owner: string | null;
+  readonly repo: string | null;
+  readonly withKeys: readonly string[];
+}
+
+export function parseReusableReference(usesValue: string): {
+  readonly file: string;
+  readonly ref: string;
+  readonly owner: string | null;
+  readonly repo: string | null;
+} | null;
+export function extractCallerJobs(
+  content: string
+): readonly ReusableCallerJob[];
+export function extractDeclaredInputs(
+  content: string
+): readonly string[] | null;
+export function diffStaleKeys(
+  used: readonly string[],
+  declared: readonly string[]
+): readonly string[];

--- a/scripts/lib/reusable-workflow-contract.mjs
+++ b/scripts/lib/reusable-workflow-contract.mjs
@@ -1,0 +1,123 @@
+/** Pure reusable-workflow caller/contract comparison shared by health and CLI. */
+
+/** @param {string} line @returns {number} */
+function indentOf(line) {
+  return line.length - line.trimStart().length;
+}
+
+/**
+ * @param {readonly string[]} lines
+ * @param {number} openerIndex
+ * @param {number} parentIndent
+ * @returns {string[]}
+ */
+function collectImmediateChildKeys(lines, openerIndex, parentIndent) {
+  const keys = [];
+  for (let index = openerIndex + 1; index < lines.length; index++) {
+    const line = lines[index];
+    if (line.trim() === "") continue;
+    const indentation = indentOf(line);
+    if (indentation <= parentIndent) break;
+    const match = /^\s*([A-Za-z0-9_-]+):/.exec(line);
+    if (match && indentation === parentIndent + 2) keys.push(match[1]);
+  }
+  return keys;
+}
+
+/**
+ * @param {string} usesValue
+ * @returns {{ file: string, ref: string, owner: string | null, repo: string | null } | null}
+ */
+export function parseReusableReference(usesValue) {
+  const value = usesValue.trim();
+  const local = /^\.\/\.github\/workflows\/([\w.-]+\.ya?ml)$/.exec(value);
+  if (local) {
+    return { file: local[1], ref: "local", owner: null, repo: null };
+  }
+  const remote =
+    /^([^/\s]+)\/([^/\s]+)\/\.github\/workflows\/([\w.-]+\.ya?ml)@(\S+)$/.exec(
+      value
+    );
+  return remote
+    ? {
+        file: remote[3],
+        ref: remote[4],
+        owner: remote[1],
+        repo: remote[2],
+      }
+    : null;
+}
+
+/**
+ * @param {string} content
+ * @returns {{ reusableFile: string, ref: string, owner: string | null, repo: string | null, withKeys: string[] }[]}
+ */
+export function extractCallerJobs(content) {
+  const lines = content.split(/\r?\n/);
+  const jobs = [];
+  for (let index = 0; index < lines.length; index++) {
+    const usesMatch = /^(\s*)uses:\s*(\S+)\s*$/.exec(lines[index]);
+    if (!usesMatch) continue;
+    const reference = parseReusableReference(usesMatch[2]);
+    if (!reference) continue;
+    const indentation = usesMatch[1].length;
+    let withKeys = [];
+    for (let child = index + 1; child < lines.length; child++) {
+      const line = lines[child];
+      if (line.trim() === "") continue;
+      const childIndentation = indentOf(line);
+      if (childIndentation < indentation) break;
+      if (childIndentation === indentation && /^\s*with:\s*$/.test(line)) {
+        withKeys = collectImmediateChildKeys(lines, child, indentation).sort(
+          (left, right) => left.localeCompare(right)
+        );
+        break;
+      }
+    }
+    jobs.push({
+      reusableFile: reference.file,
+      ref: reference.ref,
+      owner: reference.owner,
+      repo: reference.repo,
+      withKeys,
+    });
+  }
+  return jobs;
+}
+
+/** @param {string} content @returns {string[] | null} */
+export function extractDeclaredInputs(content) {
+  const lines = content.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index++) {
+    if (!/^\s*workflow_call:\s*$/.test(lines[index])) continue;
+    const indentation = indentOf(lines[index]);
+    for (let child = index + 1; child < lines.length; child++) {
+      const line = lines[child];
+      if (line.trim() === "") continue;
+      const childIndentation = indentOf(line);
+      if (childIndentation <= indentation) break;
+      if (
+        childIndentation === indentation + 2 &&
+        /^\s*inputs:\s*$/.test(line)
+      ) {
+        return collectImmediateChildKeys(lines, child, childIndentation).sort(
+          (left, right) => left.localeCompare(right)
+        );
+      }
+    }
+    return [];
+  }
+  return null;
+}
+
+/**
+ * @param {readonly string[]} used
+ * @param {readonly string[]} declared
+ * @returns {string[]}
+ */
+export function diffStaleKeys(used, declared) {
+  const declaredSet = new Set(declared);
+  return used
+    .filter(key => !declaredSet.has(key))
+    .sort((left, right) => left.localeCompare(right));
+}

--- a/scripts/verify-health-deterministic-built.mjs
+++ b/scripts/verify-health-deterministic-built.mjs
@@ -1,0 +1,499 @@
+#!/usr/bin/env node
+/** Empirical proof for the shipped deterministic Health fast path. */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  readlink,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+let assertions = 0;
+const check = (condition, message) => {
+  assertions += 1;
+  assert.ok(condition, message);
+};
+const equal = (actual, expected, message) => {
+  assertions += 1;
+  assert.deepEqual(actual, expected, message);
+};
+
+const root = process.cwd();
+const workspace = await mkdtemp(path.join(tmpdir(), "lisa-health-fast-path-"));
+const project = path.join(workspace, "host");
+const isolatedBin = path.join(workspace, "bin");
+const gitExecutable = execFileSync("which", ["git"], {
+  encoding: "utf8",
+}).trim();
+const healthFile = path.join(project, ".lisa", "health", "latest.json");
+const startedAt = Date.now();
+
+const run = (executable, argv, options = {}) =>
+  execFileSync(executable, argv, {
+    cwd: project,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+
+const git = (...argv) => run(gitExecutable, argv);
+
+async function snapshotTree(directory) {
+  const records = [];
+  const visit = async (absolute, relative) => {
+    const entries = await readdir(absolute, { withFileTypes: true });
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      if (relative.length === 0 && entry.name === ".git") continue;
+      const childRelative =
+        relative.length === 0 ? entry.name : `${relative}/${entry.name}`;
+      const childAbsolute = path.join(absolute, entry.name);
+      const stat = await lstat(childAbsolute);
+      const mode = stat.mode & 0o7777;
+      if (stat.isSymbolicLink()) {
+        records.push([
+          childRelative,
+          "symlink",
+          mode,
+          await readlink(childAbsolute),
+        ]);
+      } else if (stat.isDirectory()) {
+        records.push([childRelative, "directory", mode]);
+        await visit(childAbsolute, childRelative);
+      } else if (stat.isFile()) {
+        const digest = createHash("sha256")
+          .update(await readFile(childAbsolute))
+          .digest("hex");
+        records.push([childRelative, "file", mode, digest]);
+      } else {
+        records.push([childRelative, "special", mode]);
+      }
+    }
+  };
+  await visit(directory, "");
+  return records;
+}
+
+async function rulesetDocuments() {
+  const groups = await Promise.all(
+    ["all", "typescript"].map(async type => {
+      const directory = path.join(root, type, "github-rulesets");
+      return Promise.all(
+        (await readdir(directory, { withFileTypes: true }))
+          .filter(entry => entry.isFile())
+          .map(async entry => {
+            const parsed = JSON.parse(
+              await readFile(path.join(directory, entry.name), "utf8")
+            );
+            return {
+              name: parsed.name,
+              target: parsed.target,
+              enforcement: parsed.enforcement,
+              conditions: parsed.conditions,
+              rules: parsed.rules,
+            };
+          })
+      );
+    })
+  );
+  return Object.values(
+    Object.fromEntries(groups.flat().map(document => [document.name, document]))
+  );
+}
+
+async function assertPureCollection(health, options) {
+  const beforeTree = await snapshotTree(project);
+  const beforeStatus = git("status", "--porcelain=v1", "--untracked-files=all");
+  const beforeExitCode = process.exitCode;
+  const beforeHealthFile = await lstat(healthFile)
+    .then(() => true)
+    .catch(() => false);
+  const result = await health.runDeterministicHealth(project, options);
+  equal(
+    await snapshotTree(project),
+    beforeTree,
+    "health collection preserves every working-tree inode and byte"
+  );
+  equal(
+    git("status", "--porcelain=v1", "--untracked-files=all"),
+    beforeStatus,
+    "health collection preserves git status"
+  );
+  equal(
+    process.exitCode,
+    beforeExitCode,
+    "health collection preserves process exit state"
+  );
+  equal(
+    await lstat(healthFile)
+      .then(() => true)
+      .catch(() => false),
+    beforeHealthFile,
+    "health collection never persists latest.json"
+  );
+  return result;
+}
+
+try {
+  await mkdir(project, { recursive: true });
+  await mkdir(isolatedBin, { recursive: true });
+  await symlink(gitExecutable, path.join(isolatedBin, "git"));
+  await writeFile(
+    path.join(project, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "deterministic-health-fixture",
+        private: true,
+        devDependencies: { harperdb: "4.6.3", typescript: "5.9.3" },
+      },
+      null,
+      2
+    )}\n`
+  );
+  await writeFile(
+    path.join(project, ".lisa.config.json"),
+    `${JSON.stringify(
+      {
+        tracker: "github",
+        github: { org: "example", repo: "health-fixture" },
+        harness: "claude",
+      },
+      null,
+      2
+    )}\n`
+  );
+  await mkdir(path.join(project, "harper-app"), { recursive: true });
+  await writeFile(
+    path.join(project, "harper-app", "config.yaml"),
+    "graphqlSchema: ./schema.graphql\njsResource: true\nstatic: ./web\n"
+  );
+  await writeFile(
+    path.join(project, "harper-app", "schema.graphql"),
+    "type Query { health: Boolean! }\n"
+  );
+  git("init", "--initial-branch=main");
+  git("config", "user.name", "Lisa Health Verifier");
+  git("config", "user.email", "health-verifier@example.invalid");
+  git("add", ".");
+  git("commit", "-m", "fixture bootstrap");
+
+  run(
+    process.execPath,
+    [
+      path.join(root, "dist/index.js"),
+      "--no-update-check",
+      "apply",
+      "--yes",
+      "--harness=claude",
+      project,
+    ],
+    {
+      cwd: root,
+      env: {
+        ...process.env,
+        LISA_BOOTSTRAP: "1",
+        LISA_SKIP_UPDATE_CHECK: "1",
+        PATH: isolatedBin,
+      },
+    }
+  );
+  run(
+    process.execPath,
+    [path.join(root, "dist/index.js"), "sync", project, "--json"],
+    {
+      cwd: root,
+      env: {
+        ...process.env,
+        LISA_SKIP_UPDATE_CHECK: "1",
+        PATH: isolatedBin,
+      },
+    }
+  );
+  const version = JSON.parse(
+    await readFile(path.join(root, "package.json"), "utf8")
+  ).version;
+  await writeFile(
+    path.join(project, ".claude", ".lisa-plugins-synced"),
+    `${version}\n`
+  );
+  git("add", ".");
+  git("commit", "-m", "apply Lisa fixture");
+
+  const health = await import("@codyswann/lisa/health");
+  check(
+    typeof health.runDeterministicHealth === "function",
+    "compiled health export resolves runner"
+  );
+  const expectedRulesets = await rulesetDocuments();
+  const settings = JSON.parse(
+    await readFile(path.join(project, ".claude", "settings.json"), "utf8")
+  );
+  const installedPlugins = Object.entries(settings.enabledPlugins)
+    .filter(([, enabled]) => enabled === true)
+    .map(([plugin]) => plugin);
+  const options = {
+    readRulesets: async () => expectedRulesets,
+    readHooksPath: async () => ".husky",
+    readInstalledPlugins: async () => installedPlugins,
+  };
+
+  const clean = await assertPureCollection(health, options);
+  equal(clean.mode, "deterministic", "runner returns deterministic mode");
+  check(
+    clean.findings.every(finding => finding.layer === "deterministic"),
+    "only deterministic findings are emitted"
+  );
+  equal(clean.summary.counts.fail, 0, "clean fixture has zero failures");
+  equal(clean.summary.verdict, "in band", "clean fixture is in band");
+  equal(
+    clean.findings.find(finding => finding.check === "templates.managed")
+      .status,
+    "pass",
+    "the real TypeScript plus Harper child template stack composes cleanly"
+  );
+  check(
+    (await readFile(path.join(project, ".prettierignore"), "utf8")).includes(
+      "AI GUARDRAILS HARPER-FABRIC"
+    ),
+    "the real child copy-contents block survives its parent overwrite"
+  );
+  equal(
+    clean.findings.find(finding => finding.check === "project.wiki").status,
+    "pass",
+    "the applied fixture has a healthy project wiki"
+  );
+  equal(
+    clean.findings.find(finding => finding.check === "starters.remote").status,
+    "warn",
+    "offline starter inspection remains an explicit warning"
+  );
+
+  const callerPath = path.join(project, ".github", "workflows", "claude.yml");
+  const callerOriginal = await readFile(callerPath, "utf8");
+  await writeFile(
+    callerPath,
+    callerOriginal.replace(
+      "    with:\n",
+      "    with:\n      obsolete_health_input: true\n"
+    )
+  );
+  const staleCaller = await assertPureCollection(health, options);
+  const workflowFinding = staleCaller.findings.find(
+    finding => finding.check === "ci.workflows"
+  );
+  equal(workflowFinding.status, "fail", "stale create-only input is a failure");
+  check(
+    workflowFinding.reason.includes("obsolete_health_input"),
+    "stale create-only input is named"
+  );
+  await writeFile(callerPath, callerOriginal);
+
+  const prettierPath = path.join(project, ".prettierignore");
+  const prettierOriginal = await readFile(prettierPath);
+  await writeFile(path.join(project, ".lisaignore"), ".prettierignore\n");
+  await writeFile(prettierPath, "project-owned while ignored\n");
+  const ignoredTemplate = await assertPureCollection(health, options);
+  equal(
+    ignoredTemplate.findings.find(
+      finding => finding.check === "templates.managed"
+    ).status,
+    "pass",
+    "ignored templates are outside Lisa ownership"
+  );
+  await rm(path.join(project, ".lisaignore"));
+  await writeFile(prettierPath, prettierOriginal);
+
+  const deletedWorkflow = path.join(
+    project,
+    ".github",
+    "workflows",
+    "quality.yml"
+  );
+  await writeFile(deletedWorkflow, "name: project-owned deletion fixture\n");
+  const deletionOwned = await assertPureCollection(health, options);
+  check(
+    deletionOwned.findings.every(
+      finding => !finding.reason.includes("quality.yml")
+    ),
+    "pending deletions are excluded from managed ownership"
+  );
+  await rm(deletedWorkflow);
+
+  const learningsPath = path.join(project, ".lisa", "PROJECT_LEARNINGS.md");
+  const learningsOriginal = await readFile(learningsPath);
+  const customLearnings = Buffer.from(
+    "# Project learnings\n\nHost-owned evidence.\n"
+  );
+  await writeFile(learningsPath, customLearnings);
+  const learningsOwned = await assertPureCollection(health, options);
+  equal(
+    learningsOwned.findings.find(
+      finding => finding.check === "templates.managed"
+    ).status,
+    "pass",
+    "project learnings remain host-owned after their initial seed"
+  );
+  equal(
+    await readFile(learningsPath),
+    customLearnings,
+    "health preserves project-owned learning bytes"
+  );
+  await writeFile(learningsPath, learningsOriginal);
+
+  const missingPlugin = await assertPureCollection(health, {
+    ...options,
+    readInstalledPlugins: async () => [],
+  });
+  equal(
+    missingPlugin.findings.find(finding => finding.check === "plugins.current")
+      .status,
+    "fail",
+    "a current marker cannot hide a missing actual plugin installation"
+  );
+
+  const disabledRuleset = await assertPureCollection(health, {
+    ...options,
+    readRulesets: async () => [
+      { ...expectedRulesets[0], enforcement: "disabled" },
+      ...expectedRulesets.slice(1),
+    ],
+  });
+  equal(
+    disabledRuleset.findings.find(
+      finding => finding.check === "github.rulesets"
+    ).status,
+    "fail",
+    "a present but disabled ruleset is material drift"
+  );
+
+  const prePushPath = path.join(project, ".husky", "pre-push");
+  await chmod(prePushPath, 0o644);
+  const nonExecutableHook = await assertPureCollection(health, options);
+  equal(
+    nonExecutableHook.findings.find(
+      finding => finding.check === "hooks.managed"
+    ).status,
+    "fail",
+    "a non-executable managed hook is drift"
+  );
+  await chmod(prePushPath, 0o755);
+
+  const eslintPath = path.join(project, "eslint.config.ts");
+  const eslintOriginal = await readFile(eslintPath);
+  await writeFile(
+    eslintPath,
+    Buffer.concat([eslintOriginal, Buffer.from("\n// health drift\n")])
+  );
+  const drift = await assertPureCollection(health, options);
+  const managedDrift = drift.findings.filter(
+    finding =>
+      finding.check === "templates.managed" && finding.status === "fail"
+  );
+  equal(
+    managedDrift.length,
+    1,
+    "managed drift yields exactly one managed-file failure"
+  );
+  check(
+    managedDrift[0].reason.includes("eslint.config.ts"),
+    "managed failure names the relative file"
+  );
+  equal(
+    await readFile(eslintPath),
+    Buffer.concat([eslintOriginal, Buffer.from("\n// health drift\n")]),
+    "drifted bytes remain unchanged"
+  );
+  console.log("[EVIDENCE: managed-file-drift-fail]");
+
+  await writeFile(eslintPath, eslintOriginal);
+  const restored = await assertPureCollection(health, options);
+  equal(restored.summary.counts.fail, 0, "restored fixture has zero failures");
+  equal(restored.summary.verdict, "in band", "restored fixture is in band");
+  console.log("[EVIDENCE: clean-project-in-band]");
+  console.log("[EVIDENCE: managed-file-restoration-in-band]");
+
+  const configPath = path.join(project, ".lisa.config.json");
+  const config = JSON.parse(await readFile(configPath, "utf8"));
+  delete config.github.repo;
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  const missing = await assertPureCollection(health, options);
+  const missingConfig = missing.findings.find(
+    finding => finding.check === "config.required"
+  );
+  equal(missingConfig.status, "fail", "missing required config is a failure");
+  check(
+    missingConfig.reason.includes("github.repo"),
+    "missing finding names the required key"
+  );
+  check(
+    !missingConfig.reason.includes("health-fixture"),
+    "missing finding never exposes the removed value"
+  );
+  console.log("[EVIDENCE: missing-config-key-named]");
+
+  for (const result of [clean, drift, restored, missing]) {
+    equal(
+      result.mode,
+      "deterministic",
+      "all proof runs use deterministic mode"
+    );
+    check(
+      result.findings.every(finding => finding.layer === "deterministic"),
+      "all proof findings are deterministic"
+    );
+  }
+  console.log("[EVIDENCE: deterministic-only-findings]");
+
+  if (process.platform !== "win32") {
+    const unsafeProject = path.join(workspace, "unsafe-host");
+    await mkdir(unsafeProject, { recursive: true });
+    await writeFile(
+      path.join(unsafeProject, ".lisa.config.json"),
+      '{"tracker":"github","harness":"codex"}\n'
+    );
+    execFileSync("mkfifo", [path.join(unsafeProject, "package.json")]);
+    const unsafeStarted = Date.now();
+    const unsafe = await health.runDeterministicHealth(unsafeProject, {
+      lisaRoot: root,
+      deadlineMs: 25,
+      readRulesets: async () => new Promise(() => undefined),
+      readHooksPath: async () => new Promise(() => undefined),
+      readInstalledPlugins: async () => new Promise(() => undefined),
+    });
+    check(
+      Date.now() - unsafeStarted < 1_000,
+      "FIFO and never-settling injected readers stay under the public deadline"
+    );
+    equal(
+      unsafe.findings.length,
+      12,
+      "deadline fallback preserves the fixed finding cardinality"
+    );
+    equal(
+      unsafe.findings.find(finding => finding.check === "project.state").status,
+      "fail",
+      "unsafe FIFO state is surfaced without opening it"
+    );
+  }
+
+  const elapsedMs = Date.now() - startedAt;
+  check(elapsedMs < 120_000, "built proof completes under two minutes");
+  console.log("[EVIDENCE: under-two-minute-budget]");
+  console.log("[EVIDENCE: no-surprise-side-effects]");
+  check(assertions > 0, "proof must execute assertions");
+  console.log(
+    `health-deterministic assertions=${assertions} elapsedMs=${elapsedMs}`
+  );
+} finally {
+  await rm(workspace, { recursive: true, force: true });
+}

--- a/src/core/lisa-plugin-selection.ts
+++ b/src/core/lisa-plugin-selection.ts
@@ -47,15 +47,29 @@ export async function selectProjectLisaPlugins(
   detectedTypes: readonly ProjectType[]
 ): Promise<ReadonlySet<string>> {
   const config = await readProjectConfig(destDir);
+  const hasLocalWiki = await fse.pathExists(
+    path.join(destDir, "wiki", "lisa-wiki.config.json")
+  );
+  return selectProjectLisaPluginsFromState(config, detectedTypes, hasLocalWiki);
+}
+
+/**
+ * Select plugins from already-safe project state without filesystem access.
+ * @param config - Parsed project config
+ * @param detectedTypes - Expanded, ordered project types
+ * @param hasLocalWiki - Whether the local wiki contract marker exists
+ * @returns Stable selected plugin set
+ */
+export function selectProjectLisaPluginsFromState(
+  config: LisaProjectConfig,
+  detectedTypes: readonly ProjectType[],
+  hasLocalWiki: boolean
+): ReadonlySet<string> {
   const configuredStandalonePlugins = Object.entries(
     STANDALONE_PLUGIN_CONFIG_KEYS
   )
     .filter(([configKey]) => config[configKey] !== undefined)
     .map(([, pluginName]) => pluginName);
-  const hasLocalWiki = await fse.pathExists(
-    path.join(destDir, "wiki", "lisa-wiki.config.json")
-  );
-
   return new Set([
     "lisa",
     ...detectedTypes.map(type => `lisa-${type}`),

--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -86,6 +86,10 @@ import {
   resolveLegacyProjectLearningsFile,
   resolveProjectLearningsFile,
 } from "./project-config.js";
+import {
+  decideTemplateOwnership,
+  templateSkipDescription,
+} from "./template-ownership.js";
 
 /**
  * Log fragment used when a create-only instruction file already exists and is
@@ -1662,58 +1666,6 @@ export class Lisa {
   }
 
   /**
-   * Identify the single machine-managed file that remains host-owned after
-   * creation, regardless of later stack templates or deletion manifests.
-   * @param relativePath - Candidate destination path
-   * @returns Whether the path is the registered project learnings destination
-   */
-  private isProjectLearningsPath(relativePath: string): boolean {
-    return (
-      this.projectLearningsTemplateRegistered &&
-      relativePath === this.projectLearningsFile
-    );
-  }
-
-  /**
-   * Whether the create-only strategy must skip seeding the empty ledger because
-   * a populated legacy ledger is pending relocation into this destination.
-   * @param isProjectLearnings - Whether the candidate is the ledger destination
-   * @param strategyName - Strategy that would apply the file
-   * @returns True when the empty seed must be suppressed
-   */
-  private isSuppressedLearningsSeed(
-    isProjectLearnings: boolean,
-    strategyName: CopyStrategy
-  ): boolean {
-    return (
-      isProjectLearnings &&
-      strategyName === CREATE_ONLY_STRATEGY &&
-      this.suppressLearningsSeedForRelocation
-    );
-  }
-
-  /**
-   * The other-type owner of a create-only path, when a more-specific stack owns
-   * it and would otherwise be overwritten by this pass — else undefined. Flat
-   * predicate so the file router stays under its complexity budget.
-   * @param relativePath - Path relative to the strategy source directory
-   * @param strategyName - Strategy that would apply the file
-   * @param currentType - Project type currently being processed
-   * @returns The owning type to defer to, or undefined when none applies
-   */
-  private createOnlyOverrideOwner(
-    relativePath: string,
-    strategyName: CopyStrategy,
-    currentType: string
-  ): string | undefined {
-    if (strategyName !== CREATE_ONLY_STRATEGY) {
-      return undefined;
-    }
-    const owner = this.createOnlyOwnership.get(relativePath);
-    return owner !== undefined && owner !== currentType ? owner : undefined;
-  }
-
-  /**
    * Decide whether a candidate source file should be passed to its strategy.
    * Centralizes three independent skip rules that all need to short-circuit
    * before a strategy ever sees the file:
@@ -1739,98 +1691,30 @@ export class Lisa {
     strategyName: CopyStrategy,
     currentType: string
   ): boolean {
-    if (this.ignorePatterns.shouldIgnore(relativePath)) {
-      this.counters.ignored++;
-      this.logSkip(`ignored`, relativePath, "Ignored");
-      return false;
-    }
-    const isProjectLearnings = this.isProjectLearningsPath(relativePath);
-    if (this.isSuppressedLearningsSeed(isProjectLearnings, strategyName)) {
-      this.counters.skipped++;
-      this.logSkip(
-        "legacy learnings ledger pending relocation",
-        relativePath,
-        "Skipped (legacy learnings ledger pending relocation)"
-      );
-      return false;
-    }
-    if (this.pendingDeletions.has(relativePath) && !isProjectLearnings) {
-      this.counters.skipped++;
-      this.logSkip(
-        "pending deletion by detected type",
-        relativePath,
-        "Skipped (pending deletion)"
-      );
-      return false;
-    }
-    if (isProjectLearnings && strategyName !== CREATE_ONLY_STRATEGY) {
-      this.counters.skipped++;
-      this.logSkip(
-        "owned by all/create-only",
-        relativePath,
-        "Skipped (host-owned project learnings)"
-      );
-      return false;
-    }
-    const overridingOwner = this.createOnlyOverrideOwner(
+    const decision = decideTemplateOwnership({
       relativePath,
-      strategyName,
-      currentType
-    );
-    if (overridingOwner !== undefined) {
-      this.counters.skipped++;
-      const reason = `overridden by ${overridingOwner}/create-only`;
-      this.logSkip(reason, relativePath, `Skipped (${reason})`);
+      strategy: strategyName,
+      currentType,
+      orderedTypes: ["all", ...this.detectedTypes],
+      ignored: this.ignorePatterns.shouldIgnore(relativePath),
+      pendingDeletion: this.pendingDeletions.has(relativePath),
+      projectLearningsPath: this.projectLearningsTemplateRegistered
+        ? this.projectLearningsFile
+        : undefined,
+      suppressLearningsSeed: this.suppressLearningsSeedForRelocation,
+      createOnlyOwner: this.createOnlyOwnership.get(relativePath),
+      copyOverwriteOwner: this.copyOverwriteOwnership.get(relativePath),
+    });
+    if (decision.process) return true;
+    if (decision.reason === "ignored") {
+      this.counters.ignored++;
+      this.logSkip("ignored", relativePath, "Ignored");
       return false;
     }
-    if (strategyName === "copy-overwrite") {
-      return this.shouldProcessCopyOverwrite(relativePath, currentType);
-    }
-    return true;
-  }
-
-  /**
-   * Apply copy-overwrite-specific ownership rules.
-   * @param relativePath - Path relative to the strategy source directory
-   * @param currentType - Project type currently being processed
-   * @returns True if copy-overwrite should apply the file, false to skip
-   */
-  private shouldProcessCopyOverwrite(
-    relativePath: string,
-    currentType: string
-  ): boolean {
-    const createOnlyOwner = this.createOnlyOwnership.get(relativePath);
-    if (
-      createOnlyOwner !== undefined &&
-      createOnlyOwner !== currentType &&
-      this.isMoreSpecificType(createOnlyOwner, currentType)
-    ) {
-      this.counters.skipped++;
-      const reason = `owned by ${createOnlyOwner}/create-only`;
-      this.logSkip(reason, relativePath, `Skipped (${reason})`);
-      return false;
-    }
-    const owner = this.copyOverwriteOwnership.get(relativePath);
-    if (owner !== undefined && owner !== currentType) {
-      this.counters.skipped++;
-      const reason = `overridden by ${owner}/copy-overwrite`;
-      this.logSkip(reason, relativePath, `Skipped (${reason})`);
-      return false;
-    }
-    return true;
-  }
-
-  /**
-   * Determine whether one detected stack is more specific than another.
-   * `expandAndOrderTypes` orders parents before children, matching the strategy
-   * processing order, so a higher index means a more-specific owner.
-   * @param candidate - Potential child stack
-   * @param currentType - Current stack being processed
-   * @returns True when candidate is ordered after currentType
-   */
-  private isMoreSpecificType(candidate: string, currentType: string): boolean {
-    const orderedTypes = ["all", ...this.detectedTypes];
-    return orderedTypes.indexOf(candidate) > orderedTypes.indexOf(currentType);
+    this.counters.skipped++;
+    const reason = templateSkipDescription(decision);
+    this.logSkip(reason, relativePath, `Skipped (${reason})`);
+    return false;
   }
 
   /**

--- a/src/core/template-ownership.ts
+++ b/src/core/template-ownership.ts
@@ -1,0 +1,182 @@
+/** Pure ownership decision shared by Lisa apply and deterministic health. */
+/* eslint-disable jsdoc/require-param-description, jsdoc/require-returns -- typed private helpers are self-describing */
+import type { CopyStrategy } from "./config.js";
+
+const CREATE_ONLY = "create-only";
+const COPY_OVERWRITE = "copy-overwrite";
+
+/** Inputs required to route one template candidate. */
+export interface TemplateOwnershipInput {
+  readonly relativePath: string;
+  readonly strategy: CopyStrategy;
+  readonly currentType: string;
+  readonly orderedTypes: readonly string[];
+  readonly ignored: boolean;
+  readonly pendingDeletion: boolean;
+  readonly projectLearningsPath: string | undefined;
+  readonly suppressLearningsSeed: boolean;
+  readonly createOnlyOwner: string | undefined;
+  readonly copyOverwriteOwner: string | undefined;
+}
+
+/** Stable reason why apply and health omit a template candidate. */
+export type TemplateSkipReason =
+  | "ignored"
+  | "suppressed-learnings-seed"
+  | "pending-deletion"
+  | "project-learnings-owned"
+  | "create-only-override"
+  | "create-only-cross-owner"
+  | "copy-overwrite-override";
+
+/** Pure routing decision for one template candidate. */
+export type TemplateOwnershipDecision =
+  | { readonly process: true }
+  | {
+      readonly process: false;
+      readonly reason: TemplateSkipReason;
+      readonly owner?: string;
+    };
+
+/**
+ * Apply Lisa's exact ignore, deletion, learnings, and ownership precedence.
+ * @param input - Candidate plus precomputed project ownership state
+ * @returns Whether the candidate is applicable and, when omitted, why
+ */
+export function decideTemplateOwnership(
+  input: TemplateOwnershipInput
+): TemplateOwnershipDecision {
+  if (input.ignored) return { process: false, reason: "ignored" };
+  const isLearnings =
+    input.projectLearningsPath !== undefined &&
+    input.relativePath === input.projectLearningsPath;
+  if (
+    isLearnings &&
+    input.strategy === CREATE_ONLY &&
+    input.suppressLearningsSeed
+  ) {
+    return { process: false, reason: "suppressed-learnings-seed" };
+  }
+  if (input.pendingDeletion && !isLearnings) {
+    return { process: false, reason: "pending-deletion" };
+  }
+  if (isLearnings && input.strategy !== CREATE_ONLY) {
+    return { process: false, reason: "project-learnings-owned" };
+  }
+  const createOnlyDecision = createOnlyOwnership(input);
+  if (createOnlyDecision !== undefined) return createOnlyDecision;
+  if (input.strategy !== COPY_OVERWRITE) return { process: true };
+  return copyOverwriteOwnership(input);
+}
+
+/**
+ * Resolve same-strategy create-only ownership.
+ * @param input - Ownership inputs
+ * @returns Skip decision when another stack owns the path
+ */
+function createOnlyOwnership(
+  input: TemplateOwnershipInput
+): TemplateOwnershipDecision | undefined {
+  return input.strategy === CREATE_ONLY &&
+    input.createOnlyOwner !== undefined &&
+    input.createOnlyOwner !== input.currentType
+    ? {
+        process: false,
+        reason: "create-only-override",
+        owner: input.createOnlyOwner,
+      }
+    : undefined;
+}
+
+/**
+ * Resolve cross-strategy and same-strategy overwrite ownership.
+ * @param input - Ownership inputs
+ * @returns Process or skip decision
+ */
+function copyOverwriteOwnership(
+  input: TemplateOwnershipInput
+): TemplateOwnershipDecision {
+  if (
+    input.createOnlyOwner !== undefined &&
+    input.createOnlyOwner !== input.currentType &&
+    isMoreSpecific(input.createOnlyOwner, input.currentType, input.orderedTypes)
+  ) {
+    return {
+      process: false,
+      reason: "create-only-cross-owner",
+      owner: input.createOnlyOwner,
+    };
+  }
+  if (
+    input.copyOverwriteOwner !== undefined &&
+    input.copyOverwriteOwner !== input.currentType
+  ) {
+    return {
+      process: false,
+      reason: "copy-overwrite-override",
+      owner: input.copyOverwriteOwner,
+    };
+  }
+  return { process: true };
+}
+
+/**
+ * Render one stable human-readable skip reason.
+ * @param decision - Skip decision
+ * @returns Stable operator-facing reason
+ */
+export function templateSkipDescription(
+  decision: Exclude<TemplateOwnershipDecision, { readonly process: true }>
+): string {
+  const owner = decision.owner;
+  switch (decision.reason) {
+    case "suppressed-learnings-seed":
+      return "legacy learnings ledger pending relocation";
+    case "pending-deletion":
+      return "pending deletion by detected type";
+    case "project-learnings-owned":
+      return "owned by all/create-only";
+    case "create-only-override":
+      return `overridden by ${owner}/create-only`;
+    case "create-only-cross-owner":
+      return `owned by ${owner}/create-only`;
+    case "copy-overwrite-override":
+      return `overridden by ${owner}/copy-overwrite`;
+    case "ignored":
+      return "ignored";
+  }
+}
+
+/**
+ * Parse one trusted deletions manifest using Lisa's paths-minus-keep contract.
+ * @param candidate - Parsed deletions.json value
+ * @returns Paths that remain pending deletion
+ */
+export function pendingDeletionPaths(candidate: unknown): readonly string[] {
+  if (candidate === null || typeof candidate !== "object") return [];
+  const paths = Reflect.get(candidate, "paths");
+  const keep = Reflect.get(candidate, "keep");
+  if (!Array.isArray(paths) || !paths.every(path => typeof path === "string")) {
+    return [];
+  }
+  const kept = new Set(
+    Array.isArray(keep) ? keep.filter(item => typeof item === "string") : []
+  );
+  return paths.filter(path => !kept.has(path));
+}
+
+/**
+ * Compare canonical stack specificity.
+ * @param candidate - Candidate stack type
+ * @param current - Current stack type
+ * @param orderedTypes - Canonical stack order
+ * @returns Whether the candidate is more specific
+ */
+function isMoreSpecific(
+  candidate: string,
+  current: string,
+  orderedTypes: readonly string[]
+): boolean {
+  return orderedTypes.indexOf(candidate) > orderedTypes.indexOf(current);
+}
+/* eslint-enable jsdoc/require-param-description, jsdoc/require-returns -- restore repository documentation defaults */

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1817,7 +1817,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/copy-opencode-plugin-templates.mjs":
       "bef79103c293b73d7c37e8a8c9fa1b4f1f2e53367898a6326b12f8a0ba8ddc43",
     "scripts/detect-stale-workflow-inputs.mjs":
-      "6ae55754a69157bd79e1fe2b5f5b5e6c6e0fbf966a03b9ce643ea8c5248f50b1",
+      "204e64ccbd87de0edde0045668814638181dec2fa439fa4d8f06a0aaf5082af4",
     "scripts/fix-namespace-test-assertions.mjs":
       "bfed6f27753660b38457c3f0a032a6c866691666d2d5d61fc10c3fb2f4f4f412",
     "scripts/fix-test-assertions-pass2.mjs":
@@ -1854,6 +1854,10 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "c52b2f48edbc17edcc60ae33536549829cbc279c60c5d85d912ac6609cae9bea",
     "scripts/lib/per-agent-hook-filter.mjs":
       "2565e2cb414f253fa7fd014021120ec9760f4e716bf0ae69e5f7de09a5b966c1",
+    "scripts/lib/reusable-workflow-contract.d.mts":
+      "791f01b55dd7a6b5d9a5f4cb9c44167caa146c2fc3c31a2ae4c2d8a350adc2f1",
+    "scripts/lib/reusable-workflow-contract.mjs":
+      "134ee2a327290f066f1eb318b5ed53c711557c3e10ed462c00ff5c97cfb20863",
     "scripts/lisa-commit-and-pr-local.sh":
       "605409c3ce6ec38ad3275604291a1ceae98f7807a605654263bc14f811c03903",
     "scripts/lisa-github-environments.sh":
@@ -1888,6 +1892,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "e26a3ac716c33013e22bf5223a58457452f5af2038218a0e3a51c244eab5ddc9",
     "scripts/verify-health-contract-built.mjs":
       "9e090e3378325c4193e96ba03acff17fb63e40c9e7f2dd89296f72353ab6ba88",
+    "scripts/verify-health-deterministic-built.mjs":
+      "ab19427ec4b1dfaa06037cc23b7fc06319b4c12d8c6b67808dddd77e5367fd12",
     "tsconfig/base.json":
       "d04a105ec81aa9dc69d230d4a83406d920c305b6fc13c641ebafde0c41fc658f",
     "tsconfig/build.json":
@@ -7195,6 +7201,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "scripts/internal-opencode-skill-policy.json": true,
     "scripts/lib/nest-plugin-commands.mjs": true,
     "scripts/lib/per-agent-hook-filter.mjs": true,
+    "scripts/lib/reusable-workflow-contract.d.mts": true,
+    "scripts/lib/reusable-workflow-contract.mjs": true,
     "scripts/lisa-commit-and-pr-local.sh": true,
     "scripts/lisa-github-environments.sh": true,
     "scripts/lisa-github-repo-settings.sh": true,
@@ -7212,6 +7220,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "scripts/update-node-version.ts": true,
     "scripts/update-test-skill-paths.mjs": true,
     "scripts/verify-health-contract-built.mjs": true,
+    "scripts/verify-health-deterministic-built.mjs": true,
     "sgconfig.yml": true,
     "specs/.keep": true,
     "src/agy/mcp-installer.ts": true,
@@ -7341,6 +7350,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/core/project-config-kane.ts": true,
     "src/core/project-config.ts": true,
     "src/core/self-apply.ts": true,
+    "src/core/template-ownership.ts": true,
     "src/core/upstream-attribution-body.ts": true,
     "src/detection/detector.interface.ts": true,
     "src/detection/detectors/cdk.ts": true,
@@ -7354,10 +7364,20 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/detection/index.ts": true,
     "src/errors/index.ts": true,
     "src/health/contract.ts": true,
+    "src/health/deadline.ts": true,
+    "src/health/deterministic.ts": true,
     "src/health/directory-sync.ts": true,
+    "src/health/finding-utils.ts": true,
+    "src/health/governance-probes.ts": true,
+    "src/health/hook-inspection.ts": true,
     "src/health/index.ts": true,
+    "src/health/plugin-inspection.ts": true,
+    "src/health/project-probes.ts": true,
+    "src/health/read-only-fs.ts": true,
+    "src/health/ruleset-inspection.ts": true,
     "src/health/storage.ts": true,
     "src/health/strict-validation.ts": true,
+    "src/health/template-inspection.ts": true,
     "src/index.ts": true,
     "src/logging/console-logger.ts": true,
     "src/logging/index.ts": true,
@@ -7595,6 +7615,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/detection/detectors.test.ts": true,
     "tests/unit/governance-contracts.test.ts": true,
     "tests/unit/health/contract.test.ts": true,
+    "tests/unit/health/deterministic-regressions.test.ts": true,
+    "tests/unit/health/deterministic.test.ts": true,
     "tests/unit/health/directory-sync.test.ts": true,
     "tests/unit/health/gitignore.test.ts": true,
     "tests/unit/health/package-surfaces.test.ts": true,

--- a/src/health/deadline.ts
+++ b/src/health/deadline.ts
@@ -1,0 +1,54 @@
+/** One absolute wall-clock deadline shared by every health collaborator. */
+/* eslint-disable jsdoc/require-returns -- typed deadline helpers are self-describing */
+import { performance } from "node:perf_hooks";
+
+const MAX_DEADLINE_MS = 119_000;
+
+/** Absolute monotonic deadline and cancellation signal. */
+export class HealthDeadline {
+  readonly signal: AbortSignal;
+  private readonly controller = new AbortController();
+  private readonly expired: Promise<void>;
+  private readonly expiresAt: number;
+  private readonly timer: NodeJS.Timeout;
+
+  /**
+   * Start a deadline immediately, before any project setup or detection.
+   * @param requestedMs - Requested total budget
+   */
+  constructor(requestedMs: number) {
+    const duration = Math.max(1, Math.min(requestedMs, MAX_DEADLINE_MS));
+    this.signal = this.controller.signal;
+    this.expiresAt = performance.now() + duration;
+    this.expired = new Promise(resolve => {
+      this.signal.addEventListener("abort", () => resolve(), { once: true });
+    });
+    this.timer = setTimeout(() => this.controller.abort(), duration);
+    this.timer.unref();
+  }
+
+  /** Remaining whole milliseconds available to a bounded command. */
+  remainingMs(): number {
+    return Math.max(0, Math.floor(this.expiresAt - performance.now()));
+  }
+
+  /**
+   * Race one collaborator against the shared absolute deadline.
+   * @param work - Lazy collaborator so expired work never starts
+   * @param fallback - Value returned on timeout or collaborator failure
+   * @returns Work result or fallback
+   */
+  async run<T>(work: () => Promise<T>, fallback: T): Promise<T> {
+    if (this.signal.aborted || this.remainingMs() === 0) return fallback;
+    return Promise.race([
+      work().catch(() => fallback),
+      this.expired.then(() => fallback),
+    ]);
+  }
+
+  /** Release the deadline timer after collection finishes. */
+  close(): void {
+    clearTimeout(this.timer);
+  }
+}
+/* eslint-enable jsdoc/require-returns -- restore repository documentation defaults */

--- a/src/health/deterministic.ts
+++ b/src/health/deterministic.ts
@@ -1,0 +1,362 @@
+/** Side-effect-free deterministic Health v1 collection. */
+/* eslint-disable jsdoc/require-param-description, jsdoc/require-returns -- typed probe assembly helpers are self-describing */
+import { lstat, realpath } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  runConfigSync,
+  type SyncReadDependencies,
+} from "../sync/config-sync.js";
+import {
+  summarizeHealthFindings,
+  type HealthFinding,
+  type HealthResult,
+  type HealthStatus,
+  validateHealthResult,
+} from "./contract.js";
+import { HealthDeadline } from "./deadline.js";
+import { deterministicFinding } from "./finding-utils.js";
+import {
+  hookFinding,
+  managedTemplateFinding,
+  packageFinding,
+  pluginFinding,
+  workflowFinding,
+} from "./governance-probes.js";
+import { readCoreHooksPath, type HooksPathReader } from "./hook-inspection.js";
+import {
+  readInstalledClaudePlugins,
+  type InstalledPluginReader,
+} from "./plugin-inspection.js";
+import {
+  configFindings,
+  instructionFinding,
+  projectStateFinding,
+  starterFinding,
+  wikiFinding,
+  type HealthConfigState,
+} from "./project-probes.js";
+import {
+  projectPathKind,
+  readProjectJsonObject,
+  readProjectText,
+} from "./read-only-fs.js";
+import {
+  readGithubRulesets,
+  rulesetFinding,
+  type RulesetReader,
+} from "./ruleset-inspection.js";
+import {
+  detectHealthProjectShape,
+  type HealthProjectShape,
+} from "./template-inspection.js";
+
+const DEFAULT_DEADLINE_MS = 110_000;
+
+/**
+ * Injectable deterministic-health collaborators. Reader overrides must honor
+ * their AbortSignal and release owned handles; the runner bounds its own return
+ * but cannot reclaim arbitrary handles created by caller-supplied JavaScript.
+ */
+export interface DeterministicHealthOptions {
+  /** Lisa package root containing stack templates. */
+  readonly lisaRoot?: string;
+  /** Total wall-clock deadline, including root/config/type setup. */
+  readonly deadlineMs?: number;
+  /** Injectable timestamp clock for contract tests. */
+  readonly now?: () => Date;
+  /** Injectable bounded detailed ruleset reader. */
+  readonly readRulesets?: RulesetReader;
+  /** Injectable bounded actual installed-plugin reader. */
+  readonly readInstalledPlugins?: InstalledPluginReader;
+  /** Injectable bounded repository hooks-path reader. */
+  readonly readHooksPath?: HooksPathReader;
+}
+
+/** One fixed-order check and its unavailable fallback status. */
+interface Probe {
+  readonly check: string;
+  readonly unavailable: HealthStatus;
+  readonly run: () => Promise<HealthFinding>;
+}
+
+const CHECKS: readonly Pick<Probe, "check" | "unavailable">[] = [
+  { check: "project.state", unavailable: "fail" },
+  { check: "project.wiki", unavailable: "fail" },
+  { check: "starters.remote", unavailable: "warn" },
+  { check: "config.required", unavailable: "fail" },
+  { check: "config.sync", unavailable: "fail" },
+  { check: "templates.managed", unavailable: "fail" },
+  { check: "package.conformance", unavailable: "fail" },
+  { check: "instructions.canonical", unavailable: "fail" },
+  { check: "hooks.managed", unavailable: "fail" },
+  { check: "plugins.current", unavailable: "warn" },
+  { check: "ci.workflows", unavailable: "fail" },
+  { check: "github.rulesets", unavailable: "warn" },
+];
+
+/**
+ * Stable fallback when a check cannot complete inside the shared deadline.
+ * @param check
+ * @param status
+ */
+function unavailableFinding(
+  check: string,
+  status: HealthStatus
+): HealthFinding {
+  return deterministicFinding(
+    check,
+    status,
+    `${check} could not be safely observed within the deterministic deadline.`
+  );
+}
+
+/**
+ * Read config while preserving missing vs malformed state.
+ * @param projectRoot
+ */
+async function loadConfigState(
+  projectRoot: string
+): Promise<HealthConfigState> {
+  const kind = await projectPathKind(projectRoot, ".lisa.config.json");
+  if (kind === "missing") {
+    return { config: {}, present: false, readable: false };
+  }
+  if (kind !== "file") {
+    return { config: {}, present: true, readable: false };
+  }
+  try {
+    const config = await readProjectJsonObject(
+      projectRoot,
+      ".lisa.config.json"
+    );
+    return { config: config ?? {}, present: true, readable: true };
+  } catch {
+    return { config: {}, present: true, readable: false };
+  }
+}
+
+/**
+ * Confined JSON/path readers for the shared sync planner.
+ * @param projectRoot
+ */
+function safeSyncReads(projectRoot: string): SyncReadDependencies {
+  return {
+    readJson: async relativePath => {
+      const text = await readProjectText(projectRoot, relativePath);
+      if (text === undefined) return null;
+      try {
+        return JSON.parse(text) as unknown;
+      } catch (error) {
+        if (error instanceof SyntaxError) return null;
+        throw error;
+      }
+    },
+    pathExists: async relativePath =>
+      (await projectPathKind(projectRoot, relativePath)) !== "missing",
+  };
+}
+
+/**
+ * Build a validated immutable HealthResult from ordered findings.
+ * @param started
+ * @param completed
+ * @param findings
+ */
+function result(
+  started: Date,
+  completed: Date,
+  findings: readonly HealthFinding[]
+): HealthResult {
+  const safeCompleted = completed < started ? started : completed;
+  return validateHealthResult({
+    schemaVersion: 1,
+    runId: `health-${crypto.randomUUID()}`,
+    mode: "deterministic",
+    startedAt: started.toISOString(),
+    completedAt: safeCompleted.toISOString(),
+    findings,
+    summary: summarizeHealthFindings(findings),
+  });
+}
+
+/**
+ * Resolve canonical project and Lisa roots inside the shared deadline.
+ * @param projectPath
+ * @param lisaPath
+ */
+async function resolveRoots(
+  projectPath: string,
+  lisaPath: string
+): Promise<{ readonly projectRoot: string; readonly lisaRoot: string }> {
+  const [projectRoot, lisaRoot] = await Promise.all([
+    realpath(path.resolve(projectPath)),
+    realpath(lisaPath),
+  ]);
+  if (!(await lstat(projectRoot)).isDirectory()) {
+    throw new Error("Health project root is not a directory");
+  }
+  return { projectRoot, lisaRoot };
+}
+
+/**
+ * Create the fixed-order probe registry from safely captured setup state.
+ * @param roots
+ * @param roots.projectRoot
+ * @param roots.lisaRoot
+ * @param configState
+ * @param shape
+ * @param deadline
+ * @param options
+ */
+// eslint-disable-next-line max-lines-per-function -- fixed-order registry keeps the complete contract auditable
+function probes(
+  roots: { readonly projectRoot: string; readonly lisaRoot: string },
+  configState: HealthConfigState,
+  shape: HealthProjectShape | undefined,
+  deadline: HealthDeadline,
+  options: DeterministicHealthOptions
+): readonly Probe[] {
+  const safeShape: HealthProjectShape = shape ?? {
+    types: [],
+    packageJson: undefined,
+  };
+  const sync = runConfigSync(roots.projectRoot, {
+    dryRun: true,
+    reads: safeSyncReads(roots.projectRoot),
+  });
+  return [
+    {
+      ...CHECKS[0]!,
+      run: () => projectStateFinding(roots.projectRoot, configState, shape),
+    },
+    { ...CHECKS[1]!, run: () => wikiFinding(roots.projectRoot) },
+    { ...CHECKS[2]!, run: async () => starterFinding() },
+    { ...CHECKS[3]!, run: async () => (await configFindings(await sync))[0] },
+    { ...CHECKS[4]!, run: async () => (await configFindings(await sync))[1] },
+    {
+      ...CHECKS[5]!,
+      run: () =>
+        managedTemplateFinding(
+          roots.lisaRoot,
+          roots.projectRoot,
+          safeShape,
+          configState.config
+        ),
+    },
+    {
+      ...CHECKS[6]!,
+      run: () => packageFinding(roots.lisaRoot, roots.projectRoot, safeShape),
+    },
+    { ...CHECKS[7]!, run: () => instructionFinding(roots.projectRoot) },
+    {
+      ...CHECKS[8]!,
+      run: () =>
+        hookFinding(
+          roots.lisaRoot,
+          roots.projectRoot,
+          safeShape.types,
+          configState.config,
+          options.readHooksPath ?? readCoreHooksPath,
+          deadline.remainingMs(),
+          deadline.signal
+        ),
+    },
+    {
+      ...CHECKS[9]!,
+      run: () =>
+        pluginFinding(
+          roots.projectRoot,
+          configState.config,
+          safeShape.types,
+          options.readInstalledPlugins ?? readInstalledClaudePlugins,
+          deadline.remainingMs(),
+          deadline.signal
+        ),
+    },
+    {
+      ...CHECKS[10]!,
+      run: () =>
+        workflowFinding(
+          roots.lisaRoot,
+          roots.projectRoot,
+          safeShape.types,
+          configState.config
+        ),
+    },
+    {
+      ...CHECKS[11]!,
+      run: () =>
+        rulesetFinding(
+          roots.lisaRoot,
+          roots.projectRoot,
+          safeShape.types,
+          configState.config,
+          options.readRulesets ?? readGithubRulesets,
+          deadline.remainingMs(),
+          deadline.signal
+        ),
+    },
+  ];
+}
+
+/**
+ * Collect deterministic Health v1 without persistence, repair, installation,
+ * update checks, process-exit mutation, or model calls.
+ * @param projectPath - Host project root
+ * @param options - Injectable roots, deadline, clock, and bounded readers
+ * @returns Validated immutable deterministic HealthResult
+ */
+export async function runDeterministicHealth(
+  projectPath: string,
+  options: DeterministicHealthOptions = {}
+): Promise<HealthResult> {
+  const now = options.now ?? (() => new Date());
+  const started = now();
+  const deadline = new HealthDeadline(
+    options.deadlineMs ?? DEFAULT_DEADLINE_MS
+  );
+  try {
+    const lisaPath =
+      options.lisaRoot ??
+      path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+    const roots = await deadline.run(
+      () => resolveRoots(projectPath, lisaPath),
+      undefined
+    );
+    if (roots === undefined) {
+      return result(
+        started,
+        now(),
+        CHECKS.map(spec => unavailableFinding(spec.check, spec.unavailable))
+      );
+    }
+    const [configState, shape] = await Promise.all([
+      deadline.run(() => loadConfigState(roots.projectRoot), {
+        config: {},
+        present: false,
+        readable: false,
+      }),
+      deadline.run(
+        () => detectHealthProjectShape(roots.projectRoot),
+        undefined
+      ),
+    ]);
+    const findings = await Promise.all(
+      probes(roots, configState, shape, deadline, options).map(probe =>
+        deadline.run(
+          probe.run,
+          unavailableFinding(probe.check, probe.unavailable)
+        )
+      )
+    );
+    return result(started, now(), findings);
+  } finally {
+    deadline.close();
+  }
+}
+
+export { readGithubRulesets };
+export type { RulesetReader };
+/* eslint-enable jsdoc/require-param-description, jsdoc/require-returns -- restore repository documentation defaults */

--- a/src/health/finding-utils.ts
+++ b/src/health/finding-utils.ts
@@ -1,0 +1,36 @@
+/** Stable, bounded deterministic health finding helpers. */
+/* eslint-disable jsdoc/require-param-description, jsdoc/require-returns -- typed formatting helpers are self-describing */
+import type { HealthFinding, HealthStatus } from "./contract.js";
+
+/**
+ * Create one deterministic finding.
+ * @param check
+ * @param status
+ * @param reason
+ */
+export function deterministicFinding(
+  check: string,
+  status: HealthStatus,
+  reason: string
+): HealthFinding {
+  return { check, layer: "deterministic", status, reason };
+}
+/* eslint-enable jsdoc/require-param-description, jsdoc/require-returns -- restore repository documentation defaults */
+
+/**
+ * Format a bounded sorted identifier list without exposing values.
+ * @param label - Stable human prefix
+ * @param names - Safe relative paths, keys, or public contract names
+ * @returns Bounded reason
+ */
+export function namedReason(label: string, names: readonly string[]): string {
+  const sorted = [...new Set(names)].sort((left, right) =>
+    left.localeCompare(right)
+  );
+  const shown = sorted.slice(0, 12);
+  const suffix =
+    sorted.length > shown.length
+      ? ` (+${sorted.length - shown.length} more)`
+      : "";
+  return `${label}: ${shown.join(", ")}${suffix}`;
+}

--- a/src/health/governance-probes.ts
+++ b/src/health/governance-probes.ts
@@ -1,0 +1,211 @@
+/** Template, package, hook, plugin, and CI deterministic health probes. */
+/* eslint-disable jsdoc/require-param-description, jsdoc/require-returns -- typed probe adapters are self-describing */
+import type { ProjectType } from "../core/config.js";
+import type { HealthFinding } from "./contract.js";
+import { deterministicFinding, namedReason } from "./finding-utils.js";
+import {
+  inspectHookInstallation,
+  type HooksPathReader,
+} from "./hook-inspection.js";
+import {
+  inspectPlugins,
+  type InstalledPluginReader,
+} from "./plugin-inspection.js";
+import {
+  inspectCreateOnlyWorkflows,
+  inspectManagedTemplates,
+  inspectWorkflowInputs,
+  packageJsonConforms,
+  type HealthProjectShape,
+} from "./template-inspection.js";
+
+const HOOK_CHECK = "hooks.managed";
+const PLUGIN_CHECK = "plugins.current";
+const WORKFLOW_CHECK = "ci.workflows";
+
+/**
+ * Managed template finding.
+ * @param lisaRoot
+ * @param projectRoot
+ * @param shape
+ * @param config
+ */
+export async function managedTemplateFinding(
+  lisaRoot: string,
+  projectRoot: string,
+  shape: HealthProjectShape,
+  config: Readonly<Record<string, unknown>>
+): Promise<HealthFinding> {
+  const drift = await inspectManagedTemplates(
+    lisaRoot,
+    projectRoot,
+    shape.types,
+    "managed",
+    config
+  );
+  return drift.length === 0
+    ? deterministicFinding(
+        "templates.managed",
+        "pass",
+        "Managed files match their ownership-aware templates."
+      )
+    : deterministicFinding(
+        "templates.managed",
+        "fail",
+        namedReason("Managed files do not match templates", drift)
+      );
+}
+
+/**
+ * Package governance finding.
+ * @param lisaRoot
+ * @param projectRoot
+ * @param shape
+ */
+export async function packageFinding(
+  lisaRoot: string,
+  projectRoot: string,
+  shape: HealthProjectShape
+): Promise<HealthFinding> {
+  const conforms = await packageJsonConforms(
+    lisaRoot,
+    projectRoot,
+    shape.types,
+    shape.packageJson
+  );
+  return conforms
+    ? deterministicFinding(
+        "package.conformance",
+        "pass",
+        "package.json conforms to Lisa governance."
+      )
+    : deterministicFinding(
+        "package.conformance",
+        "fail",
+        "Package drift: package.json"
+      );
+}
+/**
+ * Hook bytes, mode, and installed-state finding.
+ * @param lisaRoot
+ * @param projectRoot
+ * @param types
+ * @param config
+ * @param reader
+ * @param timeoutMs
+ * @param signal
+ */
+export async function hookFinding(
+  lisaRoot: string,
+  projectRoot: string,
+  types: readonly ProjectType[],
+  config: Readonly<Record<string, unknown>>,
+  reader: HooksPathReader,
+  timeoutMs: number,
+  signal: AbortSignal
+): Promise<HealthFinding> {
+  const [templateDrift, installed] = await Promise.all([
+    inspectManagedTemplates(lisaRoot, projectRoot, types, "hooks", config),
+    inspectHookInstallation(projectRoot, types, reader, timeoutMs, signal),
+  ]);
+  const drift = [...templateDrift, ...installed.drift];
+  if (templateDrift.length > 0 || installed.status === "fail") {
+    return deterministicFinding(
+      HOOK_CHECK,
+      "fail",
+      namedReason("Git hook drift", drift)
+    );
+  }
+  return installed.status === "warn"
+    ? deterministicFinding(
+        HOOK_CHECK,
+        "warn",
+        namedReason("Git hook state unavailable", installed.drift)
+      )
+    : deterministicFinding(
+        HOOK_CHECK,
+        "pass",
+        "Git hook bytes, modes, and installation are current."
+      );
+}
+/**
+ * Actual enabled and installed plugin finding.
+ * @param projectRoot
+ * @param config
+ * @param types
+ * @param reader
+ * @param timeoutMs
+ * @param signal
+ */
+export async function pluginFinding(
+  projectRoot: string,
+  config: Readonly<Record<string, unknown>>,
+  types: readonly ProjectType[],
+  reader: InstalledPluginReader,
+  timeoutMs: number,
+  signal: AbortSignal
+): Promise<HealthFinding> {
+  const inspected = await inspectPlugins(
+    projectRoot,
+    config,
+    types,
+    reader,
+    timeoutMs,
+    signal
+  );
+  if (inspected.status === "pass") {
+    return deterministicFinding(
+      PLUGIN_CHECK,
+      "pass",
+      "Lisa plugins are enabled, installed, and version-current."
+    );
+  }
+  return deterministicFinding(
+    PLUGIN_CHECK,
+    inspected.status,
+    namedReason(
+      inspected.status === "warn" ? "Plugin state unavailable" : "Plugin drift",
+      inspected.drift
+    )
+  );
+}
+
+/**
+ * Workflow presence, managed bytes, and reusable-input contract finding.
+ * @param lisaRoot
+ * @param projectRoot
+ * @param types
+ * @param config
+ */
+export async function workflowFinding(
+  lisaRoot: string,
+  projectRoot: string,
+  types: readonly ProjectType[],
+  config: Readonly<Record<string, unknown>>
+): Promise<HealthFinding> {
+  const [managed, missing, inputs] = await Promise.all([
+    inspectManagedTemplates(lisaRoot, projectRoot, types, "workflows", config),
+    inspectCreateOnlyWorkflows(lisaRoot, projectRoot, types, config),
+    inspectWorkflowInputs(lisaRoot, projectRoot, types, config),
+  ]);
+  const drift = [...managed, ...missing, ...inputs.stale];
+  if (drift.length > 0) {
+    return deterministicFinding(
+      WORKFLOW_CHECK,
+      "fail",
+      namedReason("CI workflow drift", drift)
+    );
+  }
+  return inputs.unknown.length > 0
+    ? deterministicFinding(
+        WORKFLOW_CHECK,
+        "warn",
+        namedReason("Reusable workflow contracts unavailable", inputs.unknown)
+      )
+    : deterministicFinding(
+        WORKFLOW_CHECK,
+        "pass",
+        "CI workflows are present and caller inputs match shipped contracts."
+      );
+}
+/* eslint-enable jsdoc/require-param-description, jsdoc/require-returns -- restore repository documentation defaults */

--- a/src/health/hook-inspection.ts
+++ b/src/health/hook-inspection.ts
@@ -1,0 +1,182 @@
+/** Installed and executable Git-hook inspection without running hooks. */
+/* eslint-disable jsdoc/require-param-description, jsdoc/require-returns -- typed hook readers are self-describing */
+import { execFile } from "node:child_process";
+import path from "node:path";
+
+import type { ProjectType } from "../core/config.js";
+import {
+  projectPathKind,
+  readProjectFile,
+  readProjectText,
+} from "./read-only-fs.js";
+
+const GIT_TIMEOUT_MS = 10_000;
+const MAX_GIT_OUTPUT_BYTES = 16 * 1024;
+const HUSKY_HOOKS = [
+  "commit-msg",
+  "post-checkout",
+  "pre-commit",
+  "pre-push",
+  "prepare-commit-msg",
+] as const;
+const LEFTHOOK_HOOKS = [
+  "commit-msg",
+  "pre-commit",
+  "pre-push",
+  "prepare-commit-msg",
+] as const;
+
+/**
+ * Injectable reader for repository-local core.hooksPath. Implementations must
+ * honor `signal` and release any owned handles before settling.
+ */
+export type HooksPathReader = (
+  projectRoot: string,
+  timeoutMs: number,
+  signal: AbortSignal
+) => Promise<string | undefined>;
+
+/** Hook installation outcome. */
+export type HookInstallationInspection =
+  | { readonly status: "pass"; readonly drift: readonly string[] }
+  | { readonly status: "warn"; readonly drift: readonly string[] }
+  | { readonly status: "fail"; readonly drift: readonly string[] };
+
+/**
+ * Default fixed-argv local git-config reader.
+ * @param projectRoot
+ * @param timeoutMs
+ * @param signal
+ */
+export const readCoreHooksPath: HooksPathReader = async (
+  projectRoot,
+  timeoutMs,
+  signal
+) =>
+  new Promise((resolve, reject) => {
+    execFile(
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- fixed user-installed git executable
+      "git",
+      ["config", "--local", "--get", "core.hooksPath"],
+      {
+        cwd: projectRoot,
+        encoding: "utf8",
+        maxBuffer: MAX_GIT_OUTPUT_BYTES,
+        signal,
+        killSignal: "SIGKILL",
+        timeout: Math.max(1, Math.min(timeoutMs, GIT_TIMEOUT_MS)),
+      },
+      (error, stdout) => {
+        if (error === null) {
+          resolve(stdout.trim() || undefined);
+          return;
+        }
+        if ((error as unknown as { code?: string | number }).code === 1) {
+          resolve(undefined);
+          return;
+        }
+        reject(error);
+      }
+    );
+  });
+
+/**
+ * Check executable regular files under one project-relative prefix.
+ * @param projectRoot
+ * @param prefix
+ * @param names
+ */
+async function executableDrift(
+  projectRoot: string,
+  prefix: string,
+  names: readonly string[]
+): Promise<readonly string[]> {
+  const checks = await Promise.all(
+    names.map(async name => {
+      const relative = path.join(prefix, name);
+      const file = await readProjectFile(projectRoot, relative);
+      return file !== undefined && (file.mode & 0o100) !== 0
+        ? undefined
+        : relative.split(path.sep).join("/");
+    })
+  );
+  return checks.filter((item): item is string => item !== undefined);
+}
+
+/**
+ * Inspect Lefthook wrappers when the git directory is locally readable.
+ * @param projectRoot
+ */
+async function inspectLefthook(
+  projectRoot: string
+): Promise<HookInstallationInspection> {
+  const gitKind = await projectPathKind(projectRoot, ".git");
+  if (gitKind !== "directory") {
+    return { status: "warn", drift: ["lefthook installation unavailable"] };
+  }
+  const modeDrift = await executableDrift(
+    projectRoot,
+    path.join(".git", "hooks"),
+    LEFTHOOK_HOOKS
+  );
+  const contentDrift = (
+    await Promise.all(
+      LEFTHOOK_HOOKS.map(async name => {
+        const relative = path.join(".git", "hooks", name);
+        const content = await readProjectText(projectRoot, relative);
+        return content !== undefined &&
+          !content.toLowerCase().includes("lefthook")
+          ? relative.split(path.sep).join("/")
+          : undefined;
+      })
+    )
+  ).filter((item): item is string => item !== undefined);
+  const drift = [...new Set([...modeDrift, ...contentDrift])].sort(
+    (left, right) => left.localeCompare(right)
+  );
+  return drift.length === 0
+    ? { status: "pass", drift: [] }
+    : { status: "fail", drift };
+}
+/**
+ * Inspect actual installed hook state for applicable stacks.
+ * @param projectRoot - Canonical host root
+ * @param types - Safely detected project types
+ * @param reader - core.hooksPath reader
+ * @param timeoutMs - Remaining shared deadline
+ * @param signal - Shared cancellation signal
+ * @returns Hook installation status
+ */
+export async function inspectHookInstallation(
+  projectRoot: string,
+  types: readonly ProjectType[],
+  reader: HooksPathReader,
+  timeoutMs: number,
+  signal: AbortSignal
+): Promise<HookInstallationInspection> {
+  if (types.includes("rails")) return inspectLefthook(projectRoot);
+  if (!types.includes("typescript")) {
+    return { status: "warn", drift: ["unsupported hook stack"] };
+  }
+  const modeDrift = [
+    ...(await executableDrift(projectRoot, ".husky", HUSKY_HOOKS)),
+  ];
+  const hooksPath = await reader(projectRoot, timeoutMs, signal).catch(
+    () => null
+  );
+  if (hooksPath === null) {
+    return modeDrift.length === 0
+      ? { status: "warn", drift: ["core.hooksPath unavailable"] }
+      : { status: "fail", drift: modeDrift };
+  }
+  const drift = [
+    ...modeDrift,
+    ...(hooksPath === ".husky" || hooksPath === ".husky/_"
+      ? []
+      : ["core.hooksPath"]),
+  ];
+  return drift.length === 0
+    ? { status: "pass", drift: [] }
+    : { status: "fail", drift };
+}
+/* eslint-enable jsdoc/require-param-description, jsdoc/require-returns -- restore repository documentation defaults */

--- a/src/health/index.ts
+++ b/src/health/index.ts
@@ -1,2 +1,3 @@
 export * from "./contract.js";
+export * from "./deterministic.js";
 export * from "./storage.js";

--- a/src/health/plugin-inspection.ts
+++ b/src/health/plugin-inspection.ts
@@ -1,0 +1,191 @@
+/** Bounded actual plugin-installation inspection for deterministic health. */
+/* eslint-disable jsdoc/require-param-description, jsdoc/require-returns -- typed plugin readers are self-describing */
+import { execFile } from "node:child_process";
+import path from "node:path";
+
+import {
+  DEFAULT_HARNESS,
+  harnessIncludesAgent,
+  type Harness,
+  type ProjectType,
+} from "../core/config.js";
+import { selectProjectLisaPluginsFromState } from "../core/lisa-plugin-selection.js";
+import { getPackageVersion } from "../cli/version.js";
+import {
+  projectPathKind,
+  readProjectJsonObject,
+  readProjectText,
+} from "./read-only-fs.js";
+
+const MAX_PLUGIN_OUTPUT_BYTES = 256 * 1024;
+const MAX_INSTALLED_PLUGINS = 512;
+const PLUGIN_TIMEOUT_MS = 15_000;
+
+/**
+ * Injectable fixed-argv reader for actual project plugin installation.
+ * Implementations must honor `signal` and release any owned handles before
+ * settling.
+ */
+export type InstalledPluginReader = (
+  projectRoot: string,
+  timeoutMs: number,
+  signal: AbortSignal
+) => Promise<readonly string[]>;
+
+/** Structured plugin inspection outcome. */
+export type PluginInspection =
+  | { readonly status: "pass"; readonly drift: readonly string[] }
+  | { readonly status: "warn"; readonly drift: readonly string[] }
+  | { readonly status: "fail"; readonly drift: readonly string[] };
+
+/**
+ * Default fixed-argv Claude installed-plugin reader.
+ * @param projectRoot
+ * @param timeoutMs
+ * @param signal
+ */
+export const readInstalledClaudePlugins: InstalledPluginReader = async (
+  projectRoot,
+  timeoutMs,
+  signal
+) =>
+  new Promise((resolve, reject) => {
+    execFile(
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- fixed user-installed Claude executable
+      "claude",
+      ["plugin", "list", "--json"],
+      {
+        cwd: projectRoot,
+        encoding: "utf8",
+        maxBuffer: MAX_PLUGIN_OUTPUT_BYTES,
+        signal,
+        killSignal: "SIGKILL",
+        timeout: Math.max(1, Math.min(timeoutMs, PLUGIN_TIMEOUT_MS)),
+      },
+      (error, stdout) => {
+        if (error !== null) {
+          reject(error);
+          return;
+        }
+        try {
+          const parsed = JSON.parse(stdout) as unknown;
+          if (!Array.isArray(parsed) || parsed.length > MAX_INSTALLED_PLUGINS) {
+            throw new Error("Installed plugin response exceeded its contract");
+          }
+          const ids = parsed.flatMap(entry => {
+            if (entry === null || typeof entry !== "object") return [];
+            const id = Reflect.get(entry, "id");
+            const projectPath = Reflect.get(entry, "projectPath");
+            return typeof id === "string" && projectPath === projectRoot
+              ? [id]
+              : [];
+          });
+          resolve(
+            [...new Set(ids)].sort((left, right) => left.localeCompare(right))
+          );
+        } catch (parseError) {
+          reject(parseError);
+        }
+      }
+    );
+  });
+
+/**
+ * Resolve configured harness without accepting invalid strings.
+ * @param config
+ */
+function configuredHarness(
+  config: Readonly<Record<string, unknown>>
+): Harness | undefined {
+  const harness = config.harness ?? DEFAULT_HARNESS;
+  return typeof harness === "string" &&
+    [
+      "claude",
+      "codex",
+      "cursor",
+      "agy",
+      "copilot",
+      "opencode",
+      "fleet",
+    ].includes(harness)
+    ? (harness as Harness)
+    : undefined;
+}
+
+/**
+ * Inspect settings, marker, and actual installed plugin state.
+ * @param projectRoot - Canonical host root
+ * @param config - Safe project config
+ * @param types - Safely detected project types
+ * @param reader - Actual installed-plugin reader
+ * @param timeoutMs - Remaining shared deadline
+ * @param signal - Shared cancellation signal
+ * @returns Pass, fail, or optional-harness warning
+ */
+export async function inspectPlugins(
+  projectRoot: string,
+  config: Readonly<Record<string, unknown>>,
+  types: readonly ProjectType[],
+  reader: InstalledPluginReader,
+  timeoutMs: number,
+  signal: AbortSignal
+): Promise<PluginInspection> {
+  const harness = configuredHarness(config);
+  if (harness === undefined || !harnessIncludesAgent(harness, "claude")) {
+    return { status: "warn", drift: ["unsupported harness"] };
+  }
+  const settings = await readProjectJsonObject(
+    projectRoot,
+    path.join(".claude", "settings.json")
+  );
+  if (settings === undefined) {
+    return { status: "fail", drift: [".claude/settings.json"] };
+  }
+  const enabled = settings.enabledPlugins;
+  if (
+    enabled === null ||
+    typeof enabled !== "object" ||
+    Array.isArray(enabled)
+  ) {
+    return { status: "fail", drift: ["plugin settings"] };
+  }
+  const hasWiki =
+    (await projectPathKind(
+      projectRoot,
+      path.join("wiki", "lisa-wiki.config.json")
+    )) === "file";
+  const expected = [
+    ...selectProjectLisaPluginsFromState(config, types, hasWiki),
+  ]
+    .map(plugin => `${plugin}@lisa`)
+    .sort((left, right) => left.localeCompare(right));
+  const settingsDrift = expected.filter(
+    plugin => Reflect.get(enabled, plugin) !== true
+  );
+  const marker = await readProjectText(
+    projectRoot,
+    path.join(".claude", ".lisa-plugins-synced")
+  );
+  const drift = [
+    ...settingsDrift,
+    ...(marker?.trim() === getPackageVersion()
+      ? []
+      : ["plugin version marker"]),
+  ];
+  if (drift.length > 0) return { status: "fail", drift };
+  const installed = await reader(projectRoot, timeoutMs, signal).catch(
+    () => undefined
+  );
+  if (installed === undefined) {
+    return {
+      status: "warn",
+      drift: ["actual plugin installation unavailable"],
+    };
+  }
+  const installedSet = new Set(installed);
+  const missing = expected.filter(plugin => !installedSet.has(plugin));
+  return missing.length === 0
+    ? { status: "pass", drift: [] }
+    : { status: "fail", drift: missing };
+}
+/* eslint-enable jsdoc/require-param-description, jsdoc/require-returns -- restore repository documentation defaults */

--- a/src/health/project-probes.ts
+++ b/src/health/project-probes.ts
@@ -1,0 +1,204 @@
+/** Safe local project/doctor-derived deterministic health probes. */
+/* eslint-disable jsdoc/require-param-description, jsdoc/require-returns -- typed doctor projections are self-describing */
+import path from "node:path";
+
+import { CLAUDE_MD_AGENTS_IMPORT } from "../claude/claude-md-installer.js";
+import {
+  LISA_HOOKS_SUBDIR,
+  LISA_RULES_SUBDIR,
+} from "../codex/hooks-installer.js";
+import { LISA_SKILLS_SUBDIR } from "../codex/skills-installer.js";
+import {
+  LISA_RULES_END_MARKER,
+  LISA_RULES_START_MARKER,
+} from "../core/instruction-files-migration.js";
+import type { SyncReport } from "../sync/config-sync.js";
+import type { HealthFinding } from "./contract.js";
+import { deterministicFinding, namedReason } from "./finding-utils.js";
+import { projectPathKind, readProjectText } from "./read-only-fs.js";
+import type { HealthProjectShape } from "./template-inspection.js";
+
+const PROJECT_STATE_CHECK = "project.state";
+const PROJECT_WIKI_CHECK = "project.wiki";
+
+/** Result of safely loading committed project configuration. */
+export interface HealthConfigState {
+  readonly config: Readonly<Record<string, unknown>>;
+  readonly present: boolean;
+  readonly readable: boolean;
+}
+
+/**
+ * Project and legacy overlay check derived from doctor without mutation.
+ * @param projectRoot
+ * @param configState
+ * @param shape
+ */
+export async function projectStateFinding(
+  projectRoot: string,
+  configState: HealthConfigState,
+  shape: HealthProjectShape | undefined
+): Promise<HealthFinding> {
+  if (!configState.present || !configState.readable || shape === undefined) {
+    return deterministicFinding(
+      PROJECT_STATE_CHECK,
+      "fail",
+      "Project config or project shape is missing, malformed, or unsafe."
+    );
+  }
+  if (shape.types.length === 0) {
+    return deterministicFinding(
+      PROJECT_STATE_CHECK,
+      "warn",
+      "No supported Lisa project type was safely detected."
+    );
+  }
+  const legacy = await Promise.all(
+    [LISA_HOOKS_SUBDIR, LISA_RULES_SUBDIR, LISA_SKILLS_SUBDIR].map(
+      async subdir => {
+        const relative = path.join(".codex", subdir);
+        return (await projectPathKind(projectRoot, relative)) === "directory"
+          ? relative.split(path.sep).join("/")
+          : undefined;
+      }
+    )
+  );
+  const present = legacy.filter((item): item is string => item !== undefined);
+  return present.length === 0
+    ? deterministicFinding(
+        PROJECT_STATE_CHECK,
+        "pass",
+        "Project config, type, and local doctor state are readable."
+      )
+    : deterministicFinding(
+        PROJECT_STATE_CHECK,
+        "warn",
+        namedReason("Legacy Codex overlay paths", present)
+      );
+}
+
+/**
+ * Local wiki contract check derived from doctor without network or writes.
+ * @param projectRoot
+ */
+export async function wikiFinding(projectRoot: string): Promise<HealthFinding> {
+  const wiki = await projectPathKind(projectRoot, "wiki");
+  if (wiki === "missing") {
+    return deterministicFinding(
+      PROJECT_WIKI_CHECK,
+      "pass",
+      "No local wiki contract is present."
+    );
+  }
+  if (wiki !== "directory") {
+    return deterministicFinding(
+      PROJECT_WIKI_CHECK,
+      "fail",
+      "The local wiki path is unsafe or not a directory."
+    );
+  }
+  const required = [
+    "wiki/lisa-wiki.config.json",
+    "wiki/schema/llm-wiki-contract.md",
+    "wiki/index.md",
+  ];
+  const missing = (
+    await Promise.all(
+      required.map(async relative =>
+        (await projectPathKind(projectRoot, relative)) === "file"
+          ? undefined
+          : relative
+      )
+    )
+  ).filter((item): item is string => item !== undefined);
+  return missing.length === 0
+    ? deterministicFinding(
+        PROJECT_WIKI_CHECK,
+        "pass",
+        "Local wiki contract files are present."
+      )
+    : deterministicFinding(
+        PROJECT_WIKI_CHECK,
+        "fail",
+        namedReason("Missing wiki contract files", missing)
+      );
+}
+
+/** Offline representation of doctor's network-only starter check. */
+export function starterFinding(): HealthFinding {
+  return deterministicFinding(
+    "starters.remote",
+    "warn",
+    "Starter repository reachability is unavailable in the offline deterministic path."
+  );
+}
+
+/**
+ * Read-only canonical instruction check.
+ * @param projectRoot
+ */
+export async function instructionFinding(
+  projectRoot: string
+): Promise<HealthFinding> {
+  const [agents, claude] = await Promise.all([
+    readProjectText(projectRoot, "AGENTS.md"),
+    readProjectText(projectRoot, "CLAUDE.md"),
+  ]);
+  const drift = [
+    ...(agents === undefined ? ["AGENTS.md"] : []),
+    ...(agents?.includes(LISA_RULES_START_MARKER) === true ||
+    agents?.includes(LISA_RULES_END_MARKER) === true
+      ? ["AGENTS.md legacy managed block"]
+      : []),
+    ...(claude === undefined || !claude.includes(CLAUDE_MD_AGENTS_IMPORT)
+      ? ["CLAUDE.md"]
+      : []),
+  ];
+  return drift.length === 0
+    ? deterministicFinding(
+        "instructions.canonical",
+        "pass",
+        "Instruction files are canonical."
+      )
+    : deterministicFinding(
+        "instructions.canonical",
+        "fail",
+        namedReason("Instruction file drift", drift)
+      );
+}
+
+/**
+ * Convert one dry-run sync report into required-key and sync findings.
+ * @param report
+ */
+export function configFindings(
+  report: SyncReport
+): readonly [HealthFinding, HealthFinding] {
+  const keys = report.missingRequired.map(item => item.key);
+  const actions = report.actions.map(action => action.key);
+  return [
+    keys.length === 0
+      ? deterministicFinding(
+          "config.required",
+          "pass",
+          "Required config keys are populated."
+        )
+      : deterministicFinding(
+          "config.required",
+          "fail",
+          namedReason("Missing required config keys", keys)
+        ),
+    actions.length === 0
+      ? deterministicFinding(
+          "config.sync",
+          "pass",
+          "Config and mirrored artifacts are synchronized."
+        )
+      : deterministicFinding(
+          "config.sync",
+          "fail",
+          namedReason("Config sync drift", actions)
+        ),
+  ];
+}
+/* eslint-enable jsdoc/require-param-description, jsdoc/require-returns -- restore repository documentation defaults */

--- a/src/health/read-only-fs.ts
+++ b/src/health/read-only-fs.ts
@@ -1,0 +1,198 @@
+/** Confined, bounded filesystem reads for deterministic health probes. */
+import { constants, type Stats } from "node:fs";
+import { lstat, open, realpath, type FileHandle } from "node:fs/promises";
+import path from "node:path";
+
+const DEFAULT_MAX_BYTES = 512 * 1024;
+const READ_CHUNK_BYTES = 64 * 1024;
+
+/** Stable metadata and bytes captured from one confined regular file. */
+export interface ProjectFileSnapshot {
+  readonly bytes: Buffer;
+  readonly mode: number;
+}
+
+/** Safe path kinds understood by deterministic health. */
+export type ProjectPathKind = "missing" | "file" | "directory";
+
+/**
+ * Resolve a project-relative path without permitting traversal.
+ * @param root - Canonical project root
+ * @param relativePath - Project-relative path
+ * @returns Confined absolute path
+ */
+export function resolveProjectPath(root: string, relativePath: string): string {
+  if (path.isAbsolute(relativePath)) {
+    throw new Error("Health path must be project-relative");
+  }
+  const target = path.resolve(root, relativePath);
+  if (target !== root && !target.startsWith(`${root}${path.sep}`)) {
+    throw new Error("Health path escapes project root");
+  }
+  return target;
+}
+
+/**
+ * Assert that one lstat result is a bounded regular file.
+ * @param stat - File metadata
+ * @param maximumBytes - Maximum allowed size
+ */
+function assertBoundedFile(stat: Stats, maximumBytes: number): void {
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error("Unsafe health project file");
+  }
+  if (stat.size > maximumBytes) {
+    throw new Error("Health project file exceeds size limit");
+  }
+}
+
+/**
+ * Read at most maximum plus one bytes without unbounded stream behavior.
+ * @param handle - Open nonblocking regular-file handle
+ * @param maximumBytes - Maximum allowed payload size
+ * @param offset - Current read offset
+ * @returns Bounded bytes
+ */
+async function readBounded(
+  handle: FileHandle,
+  maximumBytes: number,
+  offset = 0
+): Promise<Buffer> {
+  const remaining = maximumBytes + 1 - offset;
+  if (remaining <= 0) return Buffer.alloc(0);
+  const chunk = Buffer.allocUnsafe(Math.min(READ_CHUNK_BYTES, remaining));
+  const { bytesRead } = await handle.read(chunk, 0, chunk.length, offset);
+  if (bytesRead === 0) return Buffer.alloc(0);
+  const current = chunk.subarray(0, bytesRead);
+  const tail = await readBounded(handle, maximumBytes, offset + bytesRead);
+  return Buffer.concat([current, tail], bytesRead + tail.length);
+}
+
+/**
+ * Read one stable regular file without following a target outside the project.
+ * @param root - Canonical project root
+ * @param relativePath - Project-relative path
+ * @param maximumBytes - Maximum permitted file size
+ * @returns File bytes, or undefined when absent
+ */
+export async function readProjectFile(
+  root: string,
+  relativePath: string,
+  maximumBytes = DEFAULT_MAX_BYTES
+): Promise<ProjectFileSnapshot | undefined> {
+  const target = resolveProjectPath(root, relativePath);
+  try {
+    const before = await lstat(target);
+    assertBoundedFile(before, maximumBytes);
+    const actual = await realpath(target);
+    if (!actual.startsWith(`${root}${path.sep}`)) {
+      throw new Error("Unsafe health project file escapes project root");
+    }
+    const handle = await open(
+      target,
+      constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK
+    );
+    try {
+      const opened = await handle.stat();
+      assertBoundedFile(opened, maximumBytes);
+      if (opened.dev !== before.dev || opened.ino !== before.ino) {
+        throw new Error("Health project file changed during read");
+      }
+      const bytes = await readBounded(handle, maximumBytes);
+      if (bytes.length > maximumBytes) {
+        throw new Error("Health project file exceeds size limit");
+      }
+      const after = await handle.stat();
+      if (after.size !== opened.size || bytes.length !== after.size) {
+        throw new Error("Health project file changed during read");
+      }
+      return { bytes, mode: opened.mode };
+    } finally {
+      await handle.close();
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+/**
+ * Read just the bytes from one confined stable regular file.
+ * @param root - Canonical project root
+ * @param relativePath - Project-relative path
+ * @param maximumBytes - Maximum permitted file size
+ * @returns File bytes, or undefined when absent
+ */
+export async function readProjectBytes(
+  root: string,
+  relativePath: string,
+  maximumBytes = DEFAULT_MAX_BYTES
+): Promise<Buffer | undefined> {
+  return (await readProjectFile(root, relativePath, maximumBytes))?.bytes;
+}
+
+/**
+ * Classify a confined path without following symbolic links or accepting
+ * special files such as FIFOs and devices.
+ * @param root - Canonical project root
+ * @param relativePath - Project-relative path
+ * @returns Safe path kind
+ */
+export async function projectPathKind(
+  root: string,
+  relativePath: string
+): Promise<ProjectPathKind> {
+  const target = resolveProjectPath(root, relativePath);
+  try {
+    const stat = await lstat(target);
+    if (stat.isSymbolicLink()) throw new Error("Unsafe health project path");
+    if (!stat.isFile() && !stat.isDirectory()) {
+      throw new Error("Unsafe health project path");
+    }
+    const actual = await realpath(target);
+    if (actual !== root && !actual.startsWith(`${root}${path.sep}`)) {
+      throw new Error("Unsafe health project path escapes project root");
+    }
+    return stat.isDirectory() ? "directory" : "file";
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing";
+    throw error;
+  }
+}
+
+/**
+ * Read strict UTF-8 text from a confined project file.
+ * @param root - Canonical project root
+ * @param relativePath - Project-relative path
+ * @param maximumBytes - Maximum permitted file size
+ * @returns Text, or undefined when absent
+ */
+export async function readProjectText(
+  root: string,
+  relativePath: string,
+  maximumBytes = DEFAULT_MAX_BYTES
+): Promise<string | undefined> {
+  const bytes = await readProjectBytes(root, relativePath, maximumBytes);
+  return bytes === undefined
+    ? undefined
+    : new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+}
+
+/**
+ * Read a JSON object without exposing its values in failures.
+ * @param root - Canonical project root
+ * @param relativePath - Project-relative JSON path
+ * @returns Parsed object, or undefined when absent
+ */
+export async function readProjectJsonObject(
+  root: string,
+  relativePath: string
+): Promise<Readonly<Record<string, unknown>> | undefined> {
+  const text = await readProjectText(root, relativePath);
+  if (text === undefined) return undefined;
+  const parsed = JSON.parse(text) as unknown;
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Health project JSON must be an object");
+  }
+  return parsed as Readonly<Record<string, unknown>>;
+}

--- a/src/health/ruleset-inspection.ts
+++ b/src/health/ruleset-inspection.ts
@@ -1,0 +1,450 @@
+/** Structured, bounded GitHub ruleset collection and canonical comparison. */
+/* eslint-disable jsdoc/require-param-description, jsdoc/require-returns, max-lines -- structured collection and normalization stay colocated */
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { ProjectType } from "../core/config.js";
+import { listFilesRecursive } from "../utils/file-operations.js";
+import type { HealthFinding } from "./contract.js";
+import { deterministicFinding, namedReason } from "./finding-utils.js";
+import { projectPathKind } from "./read-only-fs.js";
+
+const GH_TIMEOUT_MS = 15_000;
+const MAX_GH_OUTPUT_BYTES = 256 * 1024;
+const MAX_RULESETS = 32;
+const ACTIONS_INTEGRATION_ID = 15_368;
+const REPOSITORY_PART = /^[A-Za-z0-9_.-]{1,100}$/u;
+const RULESET_CHECK = "github.rulesets";
+const WARN = "warn";
+
+/**
+ * Return a sorted copy without mutating caller-owned input.
+ * @param items - Caller-owned items
+ * @param compare - Stable comparator
+ */
+function sortedCopy<T>(
+  items: readonly T[],
+  compare: (left: T, right: T) => number
+): readonly T[] {
+  const copy = [...items];
+  // eslint-disable-next-line functional/immutable-data -- only the detached copy is sorted
+  return copy.sort(compare);
+}
+
+/** Material ruleset fields health compares. */
+export interface HealthRuleset {
+  readonly name: string;
+  readonly target: unknown;
+  readonly enforcement: unknown;
+  readonly conditions: unknown;
+  readonly rules: unknown;
+}
+
+/**
+ * Injectable structured ruleset reader. Implementations must honor `signal`
+ * and release any owned handles before settling.
+ */
+export type RulesetReader = (
+  owner: string,
+  repo: string,
+  projectRoot: string,
+  timeoutMs: number,
+  signal: AbortSignal
+) => Promise<readonly HealthRuleset[]>;
+
+/** Ruleset comparison result containing names only. */
+export interface RulesetDrift {
+  readonly missing: readonly string[];
+  readonly drifted: readonly string[];
+}
+
+/**
+ * Run one fixed-argv bounded gh JSON read.
+ * @param argv
+ * @param cwd
+ * @param timeoutMs
+ * @param signal
+ */
+function readGhJson(
+  argv: readonly string[],
+  cwd: string,
+  timeoutMs: number,
+  signal: AbortSignal
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- fixed user-installed gh executable
+      "gh",
+      [...argv],
+      {
+        cwd,
+        encoding: "utf8",
+        maxBuffer: MAX_GH_OUTPUT_BYTES,
+        signal,
+        killSignal: "SIGKILL",
+        timeout: Math.max(1, Math.min(timeoutMs, GH_TIMEOUT_MS)),
+      },
+      (error, stdout) => {
+        if (error !== null) {
+          reject(error);
+          return;
+        }
+        try {
+          resolve(JSON.parse(stdout) as unknown);
+        } catch (parseError) {
+          reject(parseError);
+        }
+      }
+    );
+  });
+}
+
+/**
+ * Validate and project one detailed GitHub ruleset response.
+ * @param candidate
+ */
+function projectRuleset(candidate: unknown): HealthRuleset {
+  if (candidate === null || typeof candidate !== "object") {
+    throw new Error("Ruleset detail was not an object");
+  }
+  const name = Reflect.get(candidate, "name");
+  if (typeof name !== "string" || name.trim().length === 0) {
+    throw new Error("Ruleset detail omitted its name");
+  }
+  return {
+    name,
+    target: Reflect.get(candidate, "target"),
+    enforcement: Reflect.get(candidate, "enforcement"),
+    conditions: Reflect.get(candidate, "conditions"),
+    rules: Reflect.get(candidate, "rules"),
+  };
+}
+
+/**
+ * Default fixed-argv detailed GitHub ruleset reader.
+ * @param owner
+ * @param repo
+ * @param projectRoot
+ * @param timeoutMs
+ * @param signal
+ */
+export const readGithubRulesets: RulesetReader = async (
+  owner,
+  repo,
+  projectRoot,
+  timeoutMs,
+  signal
+) => {
+  const listed = await readGhJson(
+    ["api", "-X", "GET", `repos/${owner}/${repo}/rulesets`],
+    projectRoot,
+    timeoutMs,
+    signal
+  );
+  if (!Array.isArray(listed) || listed.length > MAX_RULESETS) {
+    throw new Error("Ruleset list exceeded its bounded contract");
+  }
+  const details = await Promise.all(
+    listed.map(async entry => {
+      if (entry === null || typeof entry !== "object") {
+        throw new Error("Ruleset list entry was not an object");
+      }
+      const id = Reflect.get(entry, "id");
+      if (!Number.isSafeInteger(id)) {
+        throw new Error("Ruleset list entry omitted its id");
+      }
+      return projectRuleset(
+        await readGhJson(
+          ["api", "-X", "GET", `repos/${owner}/${repo}/rulesets/${String(id)}`],
+          projectRoot,
+          timeoutMs,
+          signal
+        )
+      );
+    })
+  );
+  return sortedCopy(details, (left, right) =>
+    left.name.localeCompare(right.name)
+  );
+};
+
+/**
+ * Read configured required-check opt-outs without exposing their values.
+ * @param config
+ */
+function droppedChecks(
+  config: Readonly<Record<string, unknown>>
+): ReadonlySet<string> {
+  const github = config.github;
+  const rulesets =
+    github !== null && typeof github === "object" && !Array.isArray(github)
+      ? Reflect.get(github, "rulesets")
+      : undefined;
+  const dropped =
+    rulesets !== null &&
+    typeof rulesets === "object" &&
+    !Array.isArray(rulesets)
+      ? Reflect.get(rulesets, "dropRequiredChecks")
+      : undefined;
+  return new Set(
+    Array.isArray(dropped)
+      ? dropped.filter(item => typeof item === "string")
+      : []
+  );
+}
+
+/**
+ * Apply workflow and configured required-check normalization used by apply.
+ * @param rules
+ * @param hasWorkflows
+ * @param dropped
+ */
+function normalizeExpectedRules(
+  rules: unknown,
+  hasWorkflows: boolean,
+  dropped: ReadonlySet<string>
+): unknown {
+  if (!Array.isArray(rules)) return rules;
+  return rules.flatMap(rule => {
+    if (
+      rule === null ||
+      typeof rule !== "object" ||
+      Reflect.get(rule, "type") !== "required_status_checks"
+    ) {
+      return [rule];
+    }
+    const parameters = Reflect.get(rule, "parameters");
+    if (parameters === null || typeof parameters !== "object") return [rule];
+    const checks = Reflect.get(parameters, "required_status_checks");
+    if (!Array.isArray(checks)) return [rule];
+    const retained = checks.filter(check => {
+      if (check === null || typeof check !== "object") return true;
+      const integration = Reflect.get(check, "integration_id");
+      const context = Reflect.get(check, "context");
+      return (
+        (hasWorkflows || integration !== ACTIONS_INTEGRATION_ID) &&
+        (typeof context !== "string" || !dropped.has(context))
+      );
+    });
+    if (retained.length === 0) return [];
+    return [
+      {
+        ...rule,
+        parameters: { ...parameters, required_status_checks: retained },
+      },
+    ];
+  });
+}
+
+/**
+ * Read expected material rulesets after the same per-project normalization as apply.
+ * @param lisaRoot - Lisa package root
+ * @param projectRoot - Canonical host root
+ * @param types - Canonically ordered project types
+ * @param config - Safe project config
+ * @returns Expected rulesets sorted by name
+ */
+// eslint-disable-next-line sonarjs/cognitive-complexity -- normalization mirrors the apply contract explicitly
+export async function expectedRulesets(
+  lisaRoot: string,
+  projectRoot: string,
+  types: readonly ProjectType[],
+  config: Readonly<Record<string, unknown>>
+): Promise<readonly HealthRuleset[]> {
+  const hasWorkflows =
+    (await projectPathKind(projectRoot, path.join(".github", "workflows"))) ===
+    "directory";
+  const dropped = droppedChecks(config);
+  const byName = new Map<string, HealthRuleset>();
+  for (const type of ["all", ...types]) {
+    const directory = path.join(lisaRoot, type, "github-rulesets");
+    try {
+      for (const file of await listFilesRecursive(directory)) {
+        const parsed = JSON.parse(await readFile(file, "utf8")) as unknown;
+        const projected = projectRuleset(parsed);
+        const normalized = {
+          ...projected,
+          rules: normalizeExpectedRules(projected.rules, hasWorkflows, dropped),
+        };
+        if (!Array.isArray(normalized.rules) || normalized.rules.length > 0) {
+          // eslint-disable-next-line functional/immutable-data -- most-specific stack wins in the bounded plan
+          byName.set(normalized.name, normalized);
+        }
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+  return [...byName.values()].sort((left, right) =>
+    left.name.localeCompare(right.name)
+  );
+}
+
+/**
+ * Canonicalize semantically unordered JSON objects and arrays.
+ * @param value
+ */
+function canonical(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value
+      .map(canonical)
+      .sort((left, right) =>
+        JSON.stringify(left).localeCompare(JSON.stringify(right))
+      );
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, canonical(item)])
+    );
+  }
+  return value;
+}
+
+/**
+ * Remove read-only defaults GitHub may add to otherwise equivalent rules.
+ * This projection is applied symmetrically so authored non-default values
+ * remain material.
+ * @param value
+ */
+function withoutGithubDefaults(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(withoutGithubDefaults);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).flatMap(([key, item]) =>
+        key === "required_reviewers" && Array.isArray(item) && item.length === 0
+          ? []
+          : [[key, withoutGithubDefaults(item)]]
+      )
+    );
+  }
+  return value;
+}
+
+/**
+ * Compare expected and observed material ruleset documents.
+ * @param expected
+ * @param actual
+ */
+export function compareRulesets(
+  expected: readonly HealthRuleset[],
+  actual: readonly HealthRuleset[]
+): RulesetDrift {
+  const observed = new Map(actual.map(item => [item.name, item]));
+  const missing = expected
+    .filter(item => !observed.has(item.name))
+    .map(item => item.name);
+  const drifted = expected.flatMap(item => {
+    const present = observed.get(item.name);
+    if (present === undefined) return [];
+    const expectedMaterial = canonical(
+      withoutGithubDefaults({
+        target: item.target,
+        enforcement: item.enforcement,
+        conditions: item.conditions,
+        rules: item.rules,
+      })
+    );
+    const actualMaterial = canonical(
+      withoutGithubDefaults({
+        target: present.target,
+        enforcement: present.enforcement,
+        conditions: present.conditions,
+        rules: present.rules,
+      })
+    );
+    if (JSON.stringify(expectedMaterial) !== JSON.stringify(actualMaterial)) {
+      return [item.name];
+    }
+    return [];
+  });
+  return {
+    missing: sortedCopy(missing, (left, right) => left.localeCompare(right)),
+    drifted: sortedCopy(drifted, (left, right) => left.localeCompare(right)),
+  };
+}
+
+/**
+ * Extract a safe GitHub target without reporting configured values.
+ * @param config
+ */
+function githubTarget(
+  config: Readonly<Record<string, unknown>>
+): { readonly owner: string; readonly repo: string } | undefined {
+  const github = config.github;
+  if (github === null || typeof github !== "object" || Array.isArray(github)) {
+    return undefined;
+  }
+  const owner = Reflect.get(github, "org");
+  const repo = Reflect.get(github, "repo");
+  return typeof owner === "string" &&
+    typeof repo === "string" &&
+    REPOSITORY_PART.test(owner) &&
+    REPOSITORY_PART.test(repo)
+    ? { owner, repo }
+    : undefined;
+}
+
+/**
+ * Collect and compare detailed material GitHub ruleset state.
+ * @param lisaRoot - Lisa package root
+ * @param projectRoot - Canonical host root
+ * @param types - Safely detected project types
+ * @param config - Safe project config
+ * @param reader - Structured remote ruleset reader
+ * @param timeoutMs - Remaining shared deadline
+ * @param signal - Shared cancellation signal
+ * @returns GitHub ruleset finding
+ */
+export async function rulesetFinding(
+  lisaRoot: string,
+  projectRoot: string,
+  types: readonly ProjectType[],
+  config: Readonly<Record<string, unknown>>,
+  reader: RulesetReader,
+  timeoutMs: number,
+  signal: AbortSignal
+): Promise<HealthFinding> {
+  const target = githubTarget(config);
+  if (target === undefined) {
+    return deterministicFinding(
+      "github.rulesets",
+      "warn",
+      "GitHub rulesets are unavailable without a configured repository."
+    );
+  }
+  const actual = await reader(
+    target.owner,
+    target.repo,
+    projectRoot,
+    timeoutMs,
+    signal
+  ).catch(() => undefined);
+  if (actual === undefined) {
+    return deterministicFinding(
+      RULESET_CHECK,
+      WARN,
+      "GitHub rulesets could not be observed within the deterministic deadline."
+    );
+  }
+  const expected = await expectedRulesets(lisaRoot, projectRoot, types, config);
+  const drift = compareRulesets(expected, actual);
+  const names = [
+    ...drift.missing.map(name => `${name} missing`),
+    ...drift.drifted.map(name => `${name} drifted`),
+  ];
+  return names.length === 0
+    ? deterministicFinding(
+        RULESET_CHECK,
+        "pass",
+        "Required GitHub rulesets are active and materially current."
+      )
+    : deterministicFinding(
+        RULESET_CHECK,
+        "fail",
+        namedReason("GitHub ruleset drift", names)
+      );
+}
+/* eslint-enable jsdoc/require-param-description, jsdoc/require-returns, max-lines -- restore repository defaults */

--- a/src/health/template-inspection.ts
+++ b/src/health/template-inspection.ts
@@ -1,0 +1,707 @@
+/** Safe read-only template ownership and conformance inspection. */
+/* eslint-disable jsdoc/require-param-description, jsdoc/require-returns, max-lines -- ownership planning and exact comparators stay colocated */
+import { lstat, readFile } from "node:fs/promises";
+import * as fse from "fs-extra";
+import path from "node:path";
+
+import {
+  PROJECT_TYPE_HIERARCHY,
+  PROJECT_TYPE_ORDER,
+  type CopyStrategy,
+  type ProjectType,
+} from "../core/config.js";
+import {
+  decideTemplateOwnership,
+  pendingDeletionPaths,
+} from "../core/template-ownership.js";
+import {
+  DEFAULT_PROJECT_LEARNINGS_FILE,
+  resolveLegacyProjectLearningsFile,
+  resolveProjectLearningsFile,
+  type ProjectConfig,
+} from "../core/project-config.js";
+import { mergeCopyContents } from "../strategies/copy-contents.js";
+import { mergeTemplateJson } from "../strategies/merge.js";
+import { PackageLisaStrategy } from "../strategies/package-lisa.js";
+import { TaggedMergeStrategy } from "../strategies/tagged-merge.js";
+import { listFilesRecursive } from "../utils/file-operations.js";
+import {
+  matchesAnyPattern,
+  parseIgnorePatterns,
+} from "../utils/ignore-patterns.js";
+import {
+  diffStaleKeys,
+  extractCallerJobs,
+  extractDeclaredInputs,
+} from "../../scripts/lib/reusable-workflow-contract.mjs";
+import {
+  projectPathKind,
+  readProjectFile,
+  readProjectJsonObject,
+  readProjectText,
+} from "./read-only-fs.js";
+
+const COPY_OVERWRITE = "copy-overwrite";
+const COPY_CONTENTS = "copy-contents";
+const CREATE_ONLY = "create-only";
+const MANAGED = "managed";
+const HOOKS = "hooks";
+const WORKFLOWS = "workflows";
+const HARPER_APP = "harper-app";
+const LISA_WORKFLOW_OWNER = "codyswanngt";
+const LISA_WORKFLOW_REPO = "lisa";
+const STRATEGIES: readonly CopyStrategy[] = [
+  COPY_OVERWRITE,
+  COPY_CONTENTS,
+  CREATE_ONLY,
+  "merge",
+  "tagged-merge",
+];
+const MAX_TEMPLATE_BYTES = 1024 * 1024;
+const PROJECT_LEARNINGS_SOURCE = path.join(".lisa", "PROJECT_LEARNINGS.md");
+
+/** Template categories reported by separate deterministic findings. */
+export type ManagedTemplateCategory =
+  | typeof MANAGED
+  | typeof HOOKS
+  | typeof WORKFLOWS;
+
+/** One applicable template after Lisa ownership filters. */
+interface TemplateCandidate {
+  readonly type: string;
+  readonly strategy: CopyStrategy;
+  readonly source: string;
+  readonly destination: string;
+}
+
+/** In-memory destination after one or more factory strategy applications. */
+interface ComposedDestination {
+  readonly bytes: Buffer;
+  readonly comparison: "bytes" | "json";
+  readonly requiresExecutable: boolean;
+}
+
+/** Stale or unresolvable reusable-workflow inputs. */
+export interface WorkflowInputInspection {
+  readonly stale: readonly string[];
+  readonly unknown: readonly string[];
+}
+
+/** Safely-detected project shape reused by health probes. */
+export interface HealthProjectShape {
+  readonly types: readonly ProjectType[];
+  readonly packageJson: Readonly<Record<string, unknown>> | undefined;
+}
+
+/**
+ * Resolve whether a caller contract is shipped by Lisa, local, or external.
+ * @param owner
+ * @param repo
+ * @param config
+ */
+function workflowContractOwner(
+  owner: string | null,
+  repo: string | null,
+  config: Readonly<Record<string, unknown>>
+): "lisa" | "project" | undefined {
+  if (owner === null && repo === null) return "project";
+  const normalizedOwner = owner?.toLowerCase();
+  const normalizedRepo = repo?.toLowerCase();
+  if (
+    normalizedOwner === LISA_WORKFLOW_OWNER &&
+    normalizedRepo === LISA_WORKFLOW_REPO
+  ) {
+    return "lisa";
+  }
+  const github = config.github;
+  if (github === null || typeof github !== "object" || Array.isArray(github)) {
+    return undefined;
+  }
+  const configuredOwner = Reflect.get(github, "org");
+  const configuredRepo = Reflect.get(github, "repo");
+  return typeof configuredOwner === "string" &&
+    typeof configuredRepo === "string" &&
+    normalizedOwner === configuredOwner.toLowerCase() &&
+    normalizedRepo === configuredRepo.toLowerCase()
+    ? "project"
+    : undefined;
+}
+
+/**
+ * Read a safe file signal, rejecting unsafe path types.
+ * @param root
+ * @param relativePath
+ */
+async function fileSignal(
+  root: string,
+  relativePath: string
+): Promise<boolean> {
+  const kind = await projectPathKind(root, relativePath);
+  if (kind === "directory") throw new Error("Project signal is not a file");
+  return kind === "file";
+}
+
+/**
+ * Return dependency maps from a safe package document.
+ * @param packageJson
+ */
+function dependencyNames(
+  packageJson: Readonly<Record<string, unknown>> | undefined
+): readonly string[] {
+  if (packageJson === undefined) return [];
+  return ["dependencies", "devDependencies"].flatMap(field => {
+    const value = packageJson[field];
+    return value !== null && typeof value === "object" && !Array.isArray(value)
+      ? Object.keys(value)
+      : [];
+  });
+}
+
+/**
+ * Expand detected types using Lisa's canonical hierarchy and ordering.
+ * @param types
+ */
+function expandTypes(types: ReadonlySet<ProjectType>): readonly ProjectType[] {
+  const expanded = new Set([
+    ...types,
+    ...[...types].flatMap(type => {
+      const parent = PROJECT_TYPE_HIERARCHY[type];
+      return parent === undefined ? [] : [parent];
+    }),
+  ]);
+  return PROJECT_TYPE_ORDER.filter(type => expanded.has(type));
+}
+
+/**
+ * Detect project types using only confined, bounded project reads.
+ * @param projectRoot - Canonical host project root
+ * @returns Safe project shape
+ */
+// eslint-disable-next-line sonarjs/cognitive-complexity -- explicit signals keep stack detection auditable
+export async function detectHealthProjectShape(
+  projectRoot: string
+): Promise<HealthProjectShape> {
+  const packageJson = await readProjectJsonObject(projectRoot, "package.json");
+  const dependencies = dependencyNames(packageJson);
+  const hasDependency = (name: string): boolean => dependencies.includes(name);
+  const hasPrefix = (prefix: string): boolean =>
+    dependencies.some(name => name.startsWith(prefix));
+  const [
+    tsconfig,
+    app,
+    eas,
+    nest,
+    cdk,
+    railsBin,
+    railsApp,
+    harperConfig,
+    harperSchema,
+  ] = await Promise.all([
+    fileSignal(projectRoot, "tsconfig.json"),
+    fileSignal(projectRoot, "app.json"),
+    fileSignal(projectRoot, "eas.json"),
+    fileSignal(projectRoot, "nest-cli.json"),
+    fileSignal(projectRoot, "cdk.json"),
+    fileSignal(projectRoot, path.join("bin", "rails")),
+    fileSignal(projectRoot, path.join("config", "application.rb")),
+    fileSignal(projectRoot, path.join(HARPER_APP, "config.yaml")),
+    fileSignal(projectRoot, path.join(HARPER_APP, "schema.graphql")),
+  ]);
+  const harperText = harperConfig
+    ? await readProjectText(projectRoot, path.join(HARPER_APP, "config.yaml"))
+    : undefined;
+  const harperSignals =
+    harperText?.includes("graphqlSchema:") === true &&
+    harperText.includes("jsResource:") &&
+    harperText.includes("static:");
+  const harper =
+    harperConfig &&
+    harperSchema &&
+    (harperSignals || hasDependency("harperdb"));
+  const publishable =
+    packageJson !== undefined &&
+    packageJson.private !== true &&
+    ["main", "bin", "exports", "files"].some(field =>
+      Object.hasOwn(packageJson, field)
+    );
+  const detected = new Set<ProjectType>([
+    ...(tsconfig || hasDependency("typescript") ? ["typescript" as const] : []),
+    ...(app || eas || hasDependency("expo") ? ["expo" as const] : []),
+    ...(nest || hasPrefix("@nestjs") ? ["nestjs" as const] : []),
+    ...(cdk || hasPrefix("aws-cdk") ? ["cdk" as const] : []),
+    ...(harper ? ["harper-fabric" as const] : []),
+    ...(hasDependency("phaser") ? ["phaser" as const] : []),
+    ...(publishable ? ["npm-package" as const] : []),
+    ...(railsBin || railsApp ? ["rails" as const] : []),
+  ]);
+  return { types: expandTypes(detected), packageJson };
+}
+
+/**
+ * Backward-compatible type-only detector surface.
+ * @param projectRoot
+ */
+export async function detectHealthProjectTypes(
+  projectRoot: string
+): Promise<readonly ProjectType[]> {
+  return (await detectHealthProjectShape(projectRoot)).types;
+}
+
+/**
+ * Normalize a template destination exactly as apply does.
+ * @param relativePath
+ * @param strategy
+ * @param type
+ * @param learningsFile
+ */
+function destinationFor(
+  relativePath: string,
+  strategy: CopyStrategy,
+  type: string,
+  learningsFile: string
+): string {
+  if (
+    type === "all" &&
+    strategy === CREATE_ONLY &&
+    relativePath === PROJECT_LEARNINGS_SOURCE
+  ) {
+    return learningsFile;
+  }
+  if (
+    strategy === COPY_CONTENTS &&
+    path.basename(relativePath) === "gitignore"
+  ) {
+    return path.join(path.dirname(relativePath), ".gitignore");
+  }
+  return relativePath;
+}
+
+/**
+ * Collect all trusted template candidates.
+ * @param lisaRoot
+ * @param types
+ * @param learningsFile
+ */
+async function collectCandidates(
+  lisaRoot: string,
+  types: readonly ProjectType[],
+  learningsFile: string
+): Promise<readonly TemplateCandidate[]> {
+  const groups = await Promise.all(
+    ["all", ...types].flatMap(type =>
+      STRATEGIES.map(async strategy => {
+        const directory = path.join(lisaRoot, type, strategy);
+        if (!(await fse.pathExists(directory))) return [];
+        return (await listFilesRecursive(directory)).map(source => {
+          const relativePath = path.relative(directory, source);
+          return {
+            type,
+            strategy,
+            source,
+            destination: destinationFor(
+              relativePath,
+              strategy,
+              type,
+              learningsFile
+            ),
+          } satisfies TemplateCandidate;
+        });
+      })
+    )
+  );
+  return groups.flat();
+}
+
+/**
+ * Resolve most-specific path ownership for one strategy.
+ * @param candidates
+ * @param strategy
+ */
+function owners(
+  candidates: readonly TemplateCandidate[],
+  strategy: CopyStrategy
+): ReadonlyMap<string, string> {
+  return new Map(
+    candidates
+      .filter(candidate => candidate.strategy === strategy)
+      .map(candidate => [candidate.destination, candidate.type] as const)
+  );
+}
+
+/**
+ * Read pending deletion paths from trusted Lisa manifests.
+ * @param lisaRoot
+ * @param types
+ */
+async function pendingDeletions(
+  lisaRoot: string,
+  types: readonly ProjectType[]
+): Promise<ReadonlySet<string>> {
+  const all = await Promise.all(
+    ["all", ...types].map(async type => {
+      try {
+        const parsed = JSON.parse(
+          await readFile(path.join(lisaRoot, type, "deletions.json"), "utf8")
+        ) as unknown;
+        return pendingDeletionPaths(parsed).map(item => path.normalize(item));
+      } catch {
+        return [];
+      }
+    })
+  );
+  return new Set(all.flat());
+}
+
+/**
+ * Build the exact applicable template plan without touching the host.
+ * @param lisaRoot
+ * @param projectRoot
+ * @param types
+ * @param config
+ */
+async function applicableCandidates(
+  lisaRoot: string,
+  projectRoot: string,
+  types: readonly ProjectType[],
+  config: Readonly<Record<string, unknown>>
+): Promise<readonly TemplateCandidate[]> {
+  const projectConfig = config as ProjectConfig;
+  const learningsFile = path.normalize(
+    resolveProjectLearningsFile(projectConfig)
+  );
+  const candidates = await collectCandidates(lisaRoot, types, learningsFile);
+  const createOwners = owners(candidates, CREATE_ONLY);
+  const overwriteOwners = owners(candidates, COPY_OVERWRITE);
+  const deletions = await pendingDeletions(lisaRoot, types);
+  const ignoreText = await readProjectText(projectRoot, ".lisaignore");
+  const ignorePatterns = parseIgnorePatterns(ignoreText ?? "");
+  const canonicalLearning = candidates.some(
+    candidate =>
+      candidate.type === "all" &&
+      candidate.strategy === CREATE_ONLY &&
+      candidate.destination === learningsFile
+  );
+  const legacyFile = path.normalize(
+    resolveLegacyProjectLearningsFile(projectConfig)
+  );
+  const suppressLearning =
+    canonicalLearning &&
+    legacyFile !== learningsFile &&
+    (await projectPathKind(projectRoot, legacyFile)) === "file" &&
+    (await projectPathKind(projectRoot, learningsFile)) === "missing";
+  const orderedTypes = ["all", ...types];
+  return candidates.filter(
+    candidate =>
+      decideTemplateOwnership({
+        relativePath: candidate.destination,
+        strategy: candidate.strategy,
+        currentType: candidate.type,
+        orderedTypes,
+        ignored: matchesAnyPattern(candidate.destination, ignorePatterns),
+        pendingDeletion: deletions.has(path.normalize(candidate.destination)),
+        projectLearningsPath: canonicalLearning ? learningsFile : undefined,
+        suppressLearningsSeed: suppressLearning,
+        createOnlyOwner: createOwners.get(candidate.destination),
+        copyOverwriteOwner: overwriteOwners.get(candidate.destination),
+      }).process
+  );
+}
+
+/**
+ * Classify a template destination into its health finding.
+ * @param relativePath
+ */
+function categoryFor(relativePath: string): ManagedTemplateCategory {
+  const normalized = relativePath.split(path.sep).join("/");
+  if (normalized === "lefthook.yml" || normalized.startsWith(".husky/")) {
+    return HOOKS;
+  }
+  if (normalized.startsWith(".github/workflows/")) return WORKFLOWS;
+  return MANAGED;
+}
+
+/**
+ * Decode trusted or safely captured bytes as strict UTF-8.
+ * @param bytes
+ */
+function decode(bytes: Uint8Array): string {
+  return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+}
+
+/**
+ * Canonicalize JSON object key order while preserving array order.
+ * @param value
+ */
+function canonicalJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalJson);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, canonicalJson(item)])
+    );
+  }
+  return value;
+}
+
+/**
+ * Apply one candidate to an in-memory destination in factory order.
+ * @param current
+ * @param candidate
+ */
+async function composeCandidate(
+  current: ComposedDestination,
+  candidate: TemplateCandidate
+): Promise<ComposedDestination> {
+  const sourceStat = await lstat(candidate.source);
+  if (!sourceStat.isFile() || sourceStat.size > MAX_TEMPLATE_BYTES) {
+    throw new Error("Unsafe health template source");
+  }
+  const source = await readFile(candidate.source);
+  const executable =
+    current.requiresExecutable || (sourceStat.mode & 0o100) !== 0;
+  if (candidate.strategy === COPY_OVERWRITE) {
+    return {
+      bytes: source,
+      comparison: "bytes",
+      requiresExecutable: executable,
+    };
+  }
+  if (candidate.strategy === COPY_CONTENTS) {
+    return {
+      bytes: Buffer.from(
+        mergeCopyContents(decode(source), decode(current.bytes))
+      ),
+      comparison: "bytes",
+      requiresExecutable: executable,
+    };
+  }
+  const sourceJson = JSON.parse(decode(source)) as Record<string, unknown>;
+  const targetJson = JSON.parse(decode(current.bytes)) as Record<
+    string,
+    unknown
+  >;
+  const merged =
+    candidate.strategy === "merge"
+      ? mergeTemplateJson(sourceJson, targetJson)
+      : new TaggedMergeStrategy().mergeJson(sourceJson, targetJson);
+  return {
+    bytes: Buffer.from(JSON.stringify(merged, null, 2)),
+    comparison: "json",
+    requiresExecutable: executable,
+  };
+}
+
+/**
+ * Compare one final composed destination against its captured host state.
+ * @param projectRoot
+ * @param candidates
+ */
+async function destinationConforms(
+  projectRoot: string,
+  candidates: readonly TemplateCandidate[]
+): Promise<boolean> {
+  const first = candidates[0];
+  if (first === undefined) return true;
+  const target = await readProjectFile(projectRoot, first.destination);
+  if (target === undefined) return false;
+  const initial: ComposedDestination = {
+    bytes: target.bytes,
+    comparison: "bytes",
+    requiresExecutable: false,
+  };
+  const planned = await candidates.reduce<Promise<ComposedDestination>>(
+    async (state, candidate) => composeCandidate(await state, candidate),
+    Promise.resolve(initial)
+  );
+  const normalizedDestination = first.destination.split(path.sep).join("/");
+  if (
+    normalizedDestination.startsWith(".husky/") &&
+    planned.requiresExecutable &&
+    (target.mode & 0o100) === 0
+  ) {
+    return false;
+  }
+  if (planned.comparison === "bytes") return planned.bytes.equals(target.bytes);
+  return (
+    JSON.stringify(canonicalJson(JSON.parse(decode(planned.bytes)))) ===
+    JSON.stringify(canonicalJson(JSON.parse(decode(target.bytes))))
+  );
+}
+
+/**
+ * Inspect one category using Lisa's shared ownership and pure comparators.
+ * @param lisaRoot - Lisa package root
+ * @param projectRoot - Canonical host root
+ * @param types - Canonically ordered types
+ * @param category - Health category
+ * @param config - Safe project config
+ * @returns Sorted project-relative drift paths
+ */
+export async function inspectManagedTemplates(
+  lisaRoot: string,
+  projectRoot: string,
+  types: readonly ProjectType[],
+  category: ManagedTemplateCategory,
+  config: Readonly<Record<string, unknown>> = {}
+): Promise<readonly string[]> {
+  const candidates = (
+    await applicableCandidates(lisaRoot, projectRoot, types, config)
+  ).filter(
+    candidate =>
+      candidate.strategy !== CREATE_ONLY &&
+      categoryFor(candidate.destination) === category
+  );
+  const destinations = [...new Set(candidates.map(item => item.destination))];
+  const checks = await Promise.all(
+    destinations.map(async destination => ({
+      destination,
+      conforms: await destinationConforms(
+        projectRoot,
+        candidates.filter(candidate => candidate.destination === destination)
+      ).catch(() => false),
+    }))
+  );
+  return [
+    ...new Set(
+      checks
+        .filter(check => !check.conforms)
+        .map(check => check.destination.split(path.sep).join("/"))
+    ),
+  ].sort((left, right) => left.localeCompare(right));
+}
+
+/**
+ * Require applicable create-only workflow presence while preserving bytes.
+ * @param lisaRoot - Lisa package root
+ * @param projectRoot - Canonical host root
+ * @param types - Canonically ordered types
+ * @param config - Safe project config
+ * @returns Missing workflow paths
+ */
+export async function inspectCreateOnlyWorkflows(
+  lisaRoot: string,
+  projectRoot: string,
+  types: readonly ProjectType[],
+  config: Readonly<Record<string, unknown>> = {}
+): Promise<readonly string[]> {
+  const candidates = (
+    await applicableCandidates(lisaRoot, projectRoot, types, config)
+  ).filter(
+    candidate =>
+      candidate.strategy === CREATE_ONLY &&
+      categoryFor(candidate.destination) === WORKFLOWS
+  );
+  const missing = await Promise.all(
+    candidates.map(async candidate =>
+      (await projectPathKind(projectRoot, candidate.destination)) === "file"
+        ? undefined
+        : candidate.destination.split(path.sep).join("/")
+    )
+  );
+  return missing
+    .filter((item): item is string => item !== undefined)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+/**
+ * Inspect applicable create-only workflow caller inputs against shipped contracts.
+ * @param lisaRoot - Lisa package root
+ * @param projectRoot - Canonical host root
+ * @param types - Canonically ordered types
+ * @param config - Safe project config
+ * @returns Stale and unknown caller descriptions
+ */
+// eslint-disable-next-line sonarjs/cognitive-complexity -- parser outcomes remain explicit and bounded
+export async function inspectWorkflowInputs(
+  lisaRoot: string,
+  projectRoot: string,
+  types: readonly ProjectType[],
+  config: Readonly<Record<string, unknown>> = {}
+): Promise<WorkflowInputInspection> {
+  const candidates = (
+    await applicableCandidates(lisaRoot, projectRoot, types, config)
+  ).filter(candidate => categoryFor(candidate.destination) === WORKFLOWS);
+  const stale: string[] = [];
+  const unknown: string[] = [];
+  for (const candidate of candidates) {
+    const caller = await readProjectText(projectRoot, candidate.destination);
+    if (caller === undefined) continue;
+    for (const job of extractCallerJobs(caller)) {
+      const label = `${candidate.destination.split(path.sep).join("/")}#${job.reusableFile}`;
+      const contractOwner = workflowContractOwner(job.owner, job.repo, config);
+      if (contractOwner === undefined) {
+        // eslint-disable-next-line functional/immutable-data -- bounded local result collector
+        unknown.push(label);
+        continue;
+      }
+      const declared =
+        contractOwner === "lisa"
+          ? await readFile(
+              path.join(
+                lisaRoot,
+                ".github",
+                WORKFLOWS,
+                path.basename(job.reusableFile)
+              ),
+              "utf8"
+            )
+              .then(content => extractDeclaredInputs(content))
+              .catch(() => null)
+          : await readProjectText(
+              projectRoot,
+              path.join(".github", WORKFLOWS, job.reusableFile)
+            )
+              .then(content =>
+                content === undefined ? null : extractDeclaredInputs(content)
+              )
+              .catch(() => null);
+      if (declared === null) {
+        // eslint-disable-next-line functional/immutable-data -- bounded local result collector
+        unknown.push(label);
+        continue;
+      }
+      for (const key of diffStaleKeys(job.withKeys, declared)) {
+        // eslint-disable-next-line functional/immutable-data -- bounded local result collector
+        stale.push(`${label}:${key}`);
+      }
+    }
+  }
+  return {
+    stale: [...new Set(stale)].sort((left, right) => left.localeCompare(right)),
+    unknown: [...new Set(unknown)].sort((left, right) =>
+      left.localeCompare(right)
+    ),
+  };
+}
+
+/**
+ * Inspect package.json through the exact pure package-lisa planner.
+ * @param lisaRoot - Lisa package root
+ * @param projectRoot - Canonical host root
+ * @param types - Safely detected project types
+ * @param packageJson - Safely captured package document
+ * @returns Whether package.json conforms
+ */
+export async function packageJsonConforms(
+  lisaRoot: string,
+  projectRoot: string,
+  types?: readonly ProjectType[],
+  packageJson?: Readonly<Record<string, unknown>>
+): Promise<boolean> {
+  const safePackage =
+    packageJson ?? (await readProjectJsonObject(projectRoot, "package.json"));
+  if (safePackage === undefined) return false;
+  const safeTypes = types ?? (await detectHealthProjectTypes(projectRoot));
+  const planned = await new PackageLisaStrategy().planPackageJson(
+    { ...safePackage },
+    safeTypes,
+    lisaRoot
+  );
+  return (
+    JSON.stringify(planned, null, 2) === JSON.stringify(safePackage, null, 2)
+  );
+}
+
+export { DEFAULT_PROJECT_LEARNINGS_FILE };
+/* eslint-enable jsdoc/require-param-description, jsdoc/require-returns, max-lines -- restore repository defaults */

--- a/src/strategies/copy-contents.ts
+++ b/src/strategies/copy-contents.ts
@@ -5,6 +5,43 @@ import type { FileOperationResult } from "../core/config.js";
 import type { ICopyStrategy, StrategyContext } from "./strategy.interface.js";
 import { filesIdentical, ensureParentDir } from "../utils/file-operations.js";
 
+const BEGIN_MARKER_PREFIX = "# BEGIN: AI GUARDRAILS";
+const END_MARKER_PREFIX = "# END: AI GUARDRAILS";
+
+/**
+ * Produce the exact copy-contents result without reading or writing files.
+ * @param sourceContent - Lisa-managed source block
+ * @param destinationContent - Existing host content
+ * @returns Content that apply would persist
+ */
+export function mergeCopyContents(
+  sourceContent: string,
+  destinationContent: string
+): string {
+  if (!sourceContent.includes(BEGIN_MARKER_PREFIX)) return sourceContent;
+  const lines = sourceContent.split(/\r?\n/);
+  const begin =
+    lines.find(line => line.startsWith(BEGIN_MARKER_PREFIX)) ??
+    BEGIN_MARKER_PREFIX;
+  const suffix = begin.slice(BEGIN_MARKER_PREFIX.length);
+  const matchingEnd = `${END_MARKER_PREFIX}${suffix}`;
+  const end = lines.includes(matchingEnd) ? matchingEnd : END_MARKER_PREFIX;
+  const startIndex = destinationContent.indexOf(begin);
+  const endIndex = destinationContent.indexOf(end, startIndex + begin.length);
+  if (startIndex !== -1 && endIndex !== -1) {
+    const trimmedSource = sourceContent.endsWith("\n")
+      ? sourceContent.slice(0, -1)
+      : sourceContent;
+    return (
+      destinationContent.slice(0, startIndex) +
+      trimmedSource +
+      destinationContent.slice(endIndex + end.length)
+    );
+  }
+  const prefix = destinationContent.endsWith("\n") ? "\n" : "\n\n";
+  return destinationContent + prefix + sourceContent;
+}
+
 /**
  * Copy-contents strategy: Block-based merge for .gitignore-style files
  * - Create new files silently
@@ -14,93 +51,6 @@ import { filesIdentical, ensureParentDir } from "../utils/file-operations.js";
  */
 export class CopyContentsStrategy implements ICopyStrategy {
   readonly name = "copy-contents" as const;
-
-  private readonly BEGIN_MARKER_PREFIX = "# BEGIN: AI GUARDRAILS";
-  private readonly END_MARKER_PREFIX = "# END: AI GUARDRAILS";
-
-  /**
-   * Find the guardrails block in content
-   * @param content File content to search
-   * @param beginMarker Opening marker for this managed block
-   * @param endMarker Closing marker for this managed block
-   * @returns Object with start/end indices or null if not found
-   */
-  private findGuardrailsBlock(
-    content: string,
-    beginMarker: string,
-    endMarker: string
-  ): { start: number; end: number } | null {
-    const startIndex = content.indexOf(beginMarker);
-    if (startIndex === -1) {
-      return null;
-    }
-
-    const endIndex = content.indexOf(
-      endMarker,
-      startIndex + beginMarker.length
-    );
-    if (endIndex === -1) {
-      return null;
-    }
-
-    return { start: startIndex, end: endIndex + endMarker.length };
-  }
-
-  /**
-   * Read the guardrail marker pair from the source block. This supports
-   * stack-specific blocks such as `# BEGIN: AI GUARDRAILS HARPER-FABRIC`
-   * without replacing the universal guardrails block.
-   * @param sourceContent Source file content
-   * @returns Marker pair to use while merging
-   */
-  private getSourceMarkers(sourceContent: string): {
-    readonly begin: string;
-    readonly end: string;
-  } {
-    const lines = sourceContent.split(/\r?\n/);
-    const begin =
-      lines.find(line => line.startsWith(this.BEGIN_MARKER_PREFIX)) ??
-      this.BEGIN_MARKER_PREFIX;
-    const suffix = begin.slice(this.BEGIN_MARKER_PREFIX.length);
-    const matchingEnd = `${this.END_MARKER_PREFIX}${suffix}`;
-    const end = lines.includes(matchingEnd)
-      ? matchingEnd
-      : this.END_MARKER_PREFIX;
-
-    return { begin, end };
-  }
-
-  /**
-   * Merge source content with destination, replacing or appending guardrails block
-   * @param sourceContent Source file content
-   * @param destContent Destination file content
-   * @returns Merged content
-   */
-  private mergeContent(sourceContent: string, destContent: string): string {
-    const markers = this.getSourceMarkers(sourceContent);
-    const block = this.findGuardrailsBlock(
-      destContent,
-      markers.begin,
-      markers.end
-    );
-
-    if (block) {
-      // Replace existing block, trimming source trailing newline
-      // to prevent doubling with destination's post-marker newline
-      const trimmedSource = sourceContent.endsWith("\n")
-        ? sourceContent.slice(0, -1)
-        : sourceContent;
-      return (
-        destContent.slice(0, block.start) +
-        trimmedSource +
-        destContent.slice(block.end)
-      );
-    }
-
-    // Append if no block exists
-    const prefix = destContent.endsWith("\n") ? "\n" : "\n\n";
-    return destContent + prefix + sourceContent;
-  }
 
   /**
    * Handle the case where destination doesn't exist
@@ -242,7 +192,7 @@ export class CopyContentsStrategy implements ICopyStrategy {
     // bug that shipped lisa-mutation.mjs twice). Such a file is fully
     // Lisa-managed and belongs in copy-overwrite — treat it as an overwrite
     // here so a miscategorized file can never silently self-duplicate.
-    if (!sourceContent.includes(this.BEGIN_MARKER_PREFIX)) {
+    if (!sourceContent.includes(BEGIN_MARKER_PREFIX)) {
       return this.handleOverwrite(
         realDestPath,
         realRelativePath,
@@ -251,7 +201,7 @@ export class CopyContentsStrategy implements ICopyStrategy {
       );
     }
 
-    const mergedContent = this.mergeContent(sourceContent, destContent);
+    const mergedContent = mergeCopyContents(sourceContent, destContent);
 
     if (mergedContent === destContent) {
       return {

--- a/src/strategies/merge.ts
+++ b/src/strategies/merge.ts
@@ -11,6 +11,19 @@ import {
 import { JsonMergeError } from "../errors/index.js";
 
 /**
+ * Produce the exact JSON merge result without filesystem access.
+ * @param source - Lisa template object
+ * @param destination - Existing host object
+ * @returns Merged object with Lisa values taking precedence
+ */
+export function mergeTemplateJson(
+  source: Record<string, unknown>,
+  destination: Record<string, unknown>
+): Record<string, unknown> {
+  return deepMergeWithArrayUnion(destination, source);
+}
+
+/**
  * Merge strategy: Deep merge JSON files (Lisa values take precedence)
  * - Project values serve as defaults
  * - Lisa values take precedence on conflicts
@@ -64,7 +77,10 @@ export class MergeStrategy implements ICopyStrategy {
 
     // Deep merge: Lisa (source) takes precedence, project (dest) provides defaults.
     // Arrays are unioned so Lisa templates add guardrails without removing host ones.
-    const merged = deepMergeWithArrayUnion(destJson, sourceJson);
+    const merged = mergeTemplateJson(
+      sourceJson as Record<string, unknown>,
+      destJson as Record<string, unknown>
+    );
 
     // Normalize for comparison (parse and re-stringify both)
     const normalizedDest = JSON.stringify(destJson, null, 2);

--- a/src/strategies/package-lisa.ts
+++ b/src/strategies/package-lisa.ts
@@ -60,6 +60,30 @@ export class PackageLisaStrategy implements ICopyStrategy {
   );
 
   /**
+   * Produce the exact package.json result from already-safe project inputs.
+   * @param projectJson - Parsed host package.json
+   * @param detectedTypes - Canonically detected project types
+   * @param lisaDir - Lisa package root
+   * @param securityPinsOnly - Restrict to postinstall-safe security pins
+   * @returns Package document that apply would persist
+   */
+  async planPackageJson(
+    projectJson: Record<string, unknown>,
+    detectedTypes: readonly ProjectType[],
+    lisaDir: string,
+    securityPinsOnly = false
+  ): Promise<Record<string, unknown>> {
+    const merged = await this.loadAndMergeTemplates(lisaDir, detectedTypes);
+    const effective =
+      securityPinsOnly || projectJson.name === LISA_PACKAGE_NAME
+        ? this.restrictToSecurityPins(merged)
+        : merged;
+    const result = this.applyTemplate(projectJson, effective);
+    assertNoDanglingDollarRefs(result, this.PACKAGE_JSON);
+    return result;
+  }
+
+  /**
    * Apply package-lisa strategy: Load templates from inheritance chain, apply to package.json
    * @remarks
    * This strategy is unique because:
@@ -218,32 +242,12 @@ export class PackageLisaStrategy implements ICopyStrategy {
     // Get detected project types by analyzing the project structure
     const detectedTypes = await this.detectProjectTypes(projectDir);
 
-    // Load and merge all package.lisa.json templates from type hierarchy
-    const merged = await this.loadAndMergeTemplates(lisaDir, detectedTypes);
-
-    // A self-apply against the Lisa source repo must apply only dependency
-    // governance (security floors), never Lisa's own scripts/defaults — those
-    // are hand-authored, not template-derived. Same restriction as a
-    // skip-git-check apply, regardless of the git-check flag.
-    const isLisaSelfApply = projectJson.name === LISA_PACKAGE_NAME;
-
-    // During a skip-git-check apply on an existing package.json, restrict to the
-    // security-critical force.resolutions/force.overrides sections so host
-    // scripts/deps/defaults are preserved while dependency pins still land.
-    const effective =
-      securityPinsOnly || isLisaSelfApply
-        ? this.restrictToSecurityPins(merged)
-        : merged;
-
-    // Apply force/defaults/merge logic to project's package.json
-    const result = this.applyTemplate(projectJson, effective);
-
-    // Never emit a package.json whose overrides/resolutions carry a `$name`
-    // self-reference without the backing direct dependency — npm ci fails in
-    // CI with a dangling $ref. Fail the apply loudly instead.
-    assertNoDanglingDollarRefs(result, path.basename(packageJsonPath));
-
-    return result;
+    return this.planPackageJson(
+      projectJson,
+      detectedTypes,
+      lisaDir,
+      securityPinsOnly
+    );
   }
 
   /**
@@ -487,7 +491,7 @@ export class PackageLisaStrategy implements ICopyStrategy {
    */
   private async loadAndMergeTemplates(
     lisaDir: string,
-    detectedTypes: ProjectType[]
+    detectedTypes: readonly ProjectType[]
   ): Promise<ResolvedPackageLisaTemplate> {
     const initial: ResolvedPackageLisaTemplate = {
       force: {},
@@ -537,7 +541,7 @@ export class PackageLisaStrategy implements ICopyStrategy {
    * @returns Expanded types including parents, sorted parents-first
    * @private
    */
-  private expandTypeHierarchy(types: ProjectType[]): ProjectType[] {
+  private expandTypeHierarchy(types: readonly ProjectType[]): ProjectType[] {
     const allTypes = new Set<ProjectType>(types);
 
     for (const type of types) {

--- a/src/strategies/tagged-merge.ts
+++ b/src/strategies/tagged-merge.ts
@@ -35,6 +35,19 @@ export class TaggedMergeStrategy implements ICopyStrategy {
   readonly name = "tagged-merge" as const;
 
   /**
+   * Produce the exact tagged-merge result without filesystem access.
+   * @param source - Lisa tagged template object
+   * @param destination - Existing host object
+   * @returns Merged object preserving host-owned sections
+   */
+  mergeJson(
+    source: Record<string, unknown>,
+    destination: Record<string, unknown>
+  ): Record<string, unknown> {
+    return this.mergeWithTags(source, destination);
+  }
+
+  /**
    * Regex pattern for parsing opening tags
    * @remarks Captures behavior (force|defaults|merge) and category name for routing to appropriate merge logic
    */
@@ -87,7 +100,7 @@ export class TaggedMergeStrategy implements ICopyStrategy {
       }
     );
 
-    const merged = this.mergeWithTags(sourceJson, destJson);
+    const merged = this.mergeJson(sourceJson, destJson);
     const normalizedDest = JSON.stringify(destJson, null, 2);
     const normalizedMerged = JSON.stringify(merged, null, 2);
 

--- a/src/sync/config-sync.ts
+++ b/src/sync/config-sync.ts
@@ -67,6 +67,14 @@ export interface SyncReport {
 export interface SyncOptions {
   /** Report without writing anything */
   readonly dryRun?: boolean;
+  /** Optional confined readers used by side-effect-free callers. */
+  readonly reads?: SyncReadDependencies;
+}
+
+/** Read-only project inputs consumed by the sync planner. */
+export interface SyncReadDependencies {
+  readonly readJson: (relativePath: string) => Promise<unknown | null>;
+  readonly pathExists: (relativePath: string) => Promise<boolean>;
 }
 
 /** Accumulated state threaded through the sync pass. */
@@ -107,22 +115,22 @@ function isRelevant(
 
 /**
  * Read the first existing artifact's value for a setting.
- * @param destDir - Project root
  * @param entry - Registry entry
+ * @param reads - Project input readers
  * @returns The artifact value, or undefined when no artifact holds one
  */
 async function readArtifactValue(
-  destDir: string,
-  entry: SyncedSetting
+  entry: SyncedSetting,
+  reads: SyncReadDependencies
 ): Promise<JsonValue | undefined> {
   const bindings = entry.artifacts ?? [];
-  const reads = await Promise.all(
+  const values = await Promise.all(
     bindings.map(async binding => {
-      const parsed = await readJsonOrNull(path.join(destDir, binding.file));
+      const parsed = await reads.readJson(binding.file);
       return parsed === null ? undefined : getAtPath(parsed, binding.pointer);
     })
   );
-  return reads.find(value => value !== undefined);
+  return values.find(value => value !== undefined);
 }
 
 /**
@@ -263,15 +271,15 @@ function populateEntry(
  * artifacts into stacks that do not use them.
  * @param state - Current sync state
  * @param entry - Registry entry
- * @param destDir - Project root
  * @param local - Local config overlay
+ * @param reads - Project input readers
  * @returns Updated state
  */
 async function syncArtifacts(
   state: SyncState,
   entry: SyncedSetting,
-  destDir: string,
-  local: JsonObject
+  local: JsonObject,
+  reads: SyncReadDependencies
 ): Promise<SyncState> {
   const bindings = entry.artifacts ?? [];
   if (bindings.length === 0) {
@@ -284,11 +292,9 @@ async function syncArtifacts(
   const validatedEffective = validateEntryValue(entry, effective);
   return bindings.reduce<Promise<SyncState>>(async (statePromise, binding) => {
     const current = await statePromise;
-    const filePath = path.join(destDir, binding.file);
     const pending = current.artifactWrites.get(binding.file);
-    const parsed =
-      pending ?? (await readJsonOrNull<unknown>(filePath)) ?? undefined;
-    if (parsed === undefined && !(await fse.pathExists(filePath))) {
+    const parsed = pending ?? (await reads.readJson(binding.file)) ?? undefined;
+    if (parsed === undefined && !(await reads.pathExists(binding.file))) {
       return current;
     }
     const fileObject = isJsonObject(parsed) ? parsed : {};
@@ -356,10 +362,9 @@ export async function runConfigSync(
   destDir: string,
   options: SyncOptions = {}
 ): Promise<SyncReport> {
-  const committedPath = path.join(destDir, ".lisa.config.json");
-  const localPath = path.join(destDir, ".lisa.config.local.json");
-  const committedRaw = await readJsonOrNull<unknown>(committedPath);
-  const localRaw = await readJsonOrNull<unknown>(localPath);
+  const reads = options.reads ?? defaultSyncReads(destDir);
+  const committedRaw = await reads.readJson(".lisa.config.json");
+  const localRaw = await reads.readJson(".lisa.config.local.json");
   const committed = isJsonObject(committedRaw) ? committedRaw : {};
   const local = isJsonObject(localRaw) ? localRaw : {};
 
@@ -375,7 +380,7 @@ export async function runConfigSync(
       if (!isRelevant(merged, entry.relevantWhen)) {
         return state;
       }
-      const artifactValue = await readArtifactValue(destDir, entry);
+      const artifactValue = await readArtifactValue(entry, reads);
       const populated = populateEntry(
         state,
         entry,
@@ -383,7 +388,7 @@ export async function runConfigSync(
         local,
         artifactValue
       );
-      return syncArtifacts(populated, entry, destDir, local);
+      return syncArtifacts(populated, entry, local, reads);
     },
     Promise.resolve(initial)
   );
@@ -398,6 +403,16 @@ export async function runConfigSync(
     dryRun: options.dryRun === true,
   };
 }
+
+/**
+ * Build the normal filesystem-backed readers used by mutating and CLI sync.
+ * @param destDir - Project root
+ * @returns Default sync input readers
+ */
+const defaultSyncReads = (destDir: string): SyncReadDependencies => ({
+  readJson: relativePath => readJsonOrNull(path.join(destDir, relativePath)),
+  pathExists: relativePath => fse.pathExists(path.join(destDir, relativePath)),
+});
 
 /**
  * Write the updated committed config and every queued artifact file.

--- a/src/utils/ignore-patterns.ts
+++ b/src/utils/ignore-patterns.ts
@@ -64,7 +64,7 @@ export interface IgnorePatterns {
  * @param content - Raw content of the .lisaignore file
  * @returns Array of parsed patterns
  */
-function parseIgnorePatterns(content: string): readonly string[] {
+export function parseIgnorePatterns(content: string): readonly string[] {
   return content
     .split("\n")
     .map(line => line.trim())
@@ -77,7 +77,7 @@ function parseIgnorePatterns(content: string): readonly string[] {
  * @param patterns - Array of gitignore-style patterns
  * @returns True if the path should be ignored
  */
-function matchesAnyPattern(
+export function matchesAnyPattern(
   relativePath: string,
   patterns: readonly string[]
 ): boolean {

--- a/tests/unit/health/deterministic-regressions.test.ts
+++ b/tests/unit/health/deterministic-regressions.test.ts
@@ -1,0 +1,428 @@
+/* eslint-disable jsdoc/require-jsdoc, sonarjs/no-duplicate-string, max-lines -- security and parity fixtures stay colocated */
+import { execFileSync } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getPackageVersion } from "../../../src/cli/version.js";
+import { runDeterministicHealth } from "../../../src/health/deterministic.js";
+import { inspectHookInstallation } from "../../../src/health/hook-inspection.js";
+import {
+  inspectPlugins,
+  readInstalledClaudePlugins,
+} from "../../../src/health/plugin-inspection.js";
+import { readProjectFile } from "../../../src/health/read-only-fs.js";
+import {
+  compareRulesets,
+  expectedRulesets,
+  type HealthRuleset,
+} from "../../../src/health/ruleset-inspection.js";
+import {
+  inspectManagedTemplates,
+  inspectWorkflowInputs,
+} from "../../../src/health/template-inspection.js";
+import { mergeTemplateJson } from "../../../src/strategies/merge.js";
+import { TaggedMergeStrategy } from "../../../src/strategies/tagged-merge.js";
+
+const temporaryRoots: string[] = [];
+const HUSKY_HOOKS = [
+  "commit-msg",
+  "post-checkout",
+  "pre-commit",
+  "pre-push",
+  "prepare-commit-msg",
+] as const;
+
+async function temporaryRoot(prefix: string): Promise<string> {
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), prefix)));
+  temporaryRoots.push(root);
+  return root;
+}
+
+async function write(
+  relativeRoot: string,
+  relativePath: string,
+  content: string
+) {
+  const destination = path.join(relativeRoot, relativePath);
+  await mkdir(path.dirname(destination), { recursive: true });
+  await writeFile(destination, content);
+}
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map(root => rm(root, { recursive: true, force: true }))
+  );
+});
+
+describe("deterministic health safety regressions", () => {
+  const fifoIt = process.platform === "win32" ? it.skip : it;
+
+  fifoIt("hard-kills a default subprocess that ignores SIGTERM", async () => {
+    const root = await temporaryRoot("lisa-health-subprocess-");
+    const bin = path.join(root, "bin");
+    await write(
+      bin,
+      "claude",
+      "#!/bin/sh\ntrap '' TERM\nwhile :; do :; done\n"
+    );
+    await chmod(path.join(bin, "claude"), 0o755);
+    vi.stubEnv("PATH", `${bin}${path.delimiter}${process.env.PATH ?? ""}`);
+
+    const started = Date.now();
+    await expect(
+      readInstalledClaudePlugins(root, 25, new AbortController().signal)
+    ).rejects.toBeDefined();
+    expect(Date.now() - started).toBeLessThan(1_000);
+  });
+
+  fifoIt(
+    "rejects project FIFOs and external FIFO symlinks without blocking",
+    async () => {
+      const root = await temporaryRoot("lisa-health-fifo-");
+      const external = await temporaryRoot("lisa-health-external-fifo-");
+      const internalFifo = path.join(root, "package.json");
+      const externalFifo = path.join(external, "outside.json");
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- fixed POSIX fixture command
+      execFileSync("mkfifo", [internalFifo]);
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- fixed POSIX fixture command
+      execFileSync("mkfifo", [externalFifo]);
+
+      const started = Date.now();
+      await expect(readProjectFile(root, "package.json")).rejects.toThrow(
+        "Unsafe health project file"
+      );
+      await rm(internalFifo);
+      await symlink(externalFifo, internalFifo);
+      await expect(readProjectFile(root, "package.json")).rejects.toThrow(
+        "Unsafe health project file"
+      );
+      expect(Date.now() - started).toBeLessThan(1_000);
+    }
+  );
+
+  fifoIt(
+    "includes setup and unsafe package detection in one absolute deadline",
+    async () => {
+      const root = await temporaryRoot("lisa-health-deadline-");
+      await write(
+        root,
+        ".lisa.config.json",
+        '{"tracker":"github","harness":"codex"}\n'
+      );
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- fixed POSIX fixture command
+      execFileSync("mkfifo", [path.join(root, "package.json")]);
+      const started = Date.now();
+      const result = await runDeterministicHealth(root, {
+        lisaRoot: process.cwd(),
+        deadlineMs: 25,
+        readRulesets: async () => new Promise(() => undefined),
+        readHooksPath: async () => new Promise(() => undefined),
+        readInstalledPlugins: async () => new Promise(() => undefined),
+      });
+
+      expect(Date.now() - started).toBeLessThan(1_000);
+      expect(result.findings).toHaveLength(12);
+      expect(
+        result.findings.find(finding => finding.check === "project.state")
+      ).toMatchObject({ status: "fail" });
+    }
+  );
+});
+describe("deterministic health governance regressions", () => {
+  it("finds stale with keys in create-only workflow callers", async () => {
+    const lisaRoot = await temporaryRoot("lisa-health-workflow-source-");
+    const projectRoot = await temporaryRoot("lisa-health-workflow-host-");
+    const caller = `jobs:\n  verify:\n    uses: CodySwannGT/lisa/.github/workflows/reusable.yml@main\n    with:\n      stale_input: true\n`;
+    await write(
+      lisaRoot,
+      "typescript/create-only/.github/workflows/caller.yml",
+      caller
+    );
+    await write(
+      lisaRoot,
+      ".github/workflows/reusable.yml",
+      "on:\n  workflow_call:\n    inputs:\n      current_input:\n        type: boolean\n"
+    );
+    await write(projectRoot, ".github/workflows/caller.yml", caller);
+
+    await expect(
+      inspectWorkflowInputs(lisaRoot, projectRoot, ["typescript"])
+    ).resolves.toEqual({
+      stale: [".github/workflows/caller.yml#reusable.yml:stale_input"],
+      unknown: [],
+    });
+  });
+
+  it("does not resolve third-party contracts by a Lisa workflow basename", async () => {
+    const lisaRoot = await temporaryRoot("lisa-health-third-party-source-");
+    const projectRoot = await temporaryRoot("lisa-health-third-party-host-");
+    const caller = `jobs:\n  verify:\n    uses: vendor/other/.github/workflows/reusable.yml@v1\n    with:\n      stale_input: true\n`;
+    await write(
+      lisaRoot,
+      "typescript/create-only/.github/workflows/caller.yml",
+      caller
+    );
+    await write(
+      lisaRoot,
+      ".github/workflows/reusable.yml",
+      "on:\n  workflow_call:\n    inputs:\n      current_input:\n        type: boolean\n"
+    );
+    await write(projectRoot, ".github/workflows/caller.yml", caller);
+
+    await expect(
+      inspectWorkflowInputs(lisaRoot, projectRoot, ["typescript"])
+    ).resolves.toEqual({
+      stale: [],
+      unknown: [".github/workflows/caller.yml#reusable.yml"],
+    });
+  });
+
+  it("honors ignore and deletion ownership before reporting managed drift", async () => {
+    const lisaRoot = await temporaryRoot("lisa-health-ownership-source-");
+    const projectRoot = await temporaryRoot("lisa-health-ownership-host-");
+    await write(lisaRoot, "all/copy-overwrite/managed.txt", "expected\n");
+    await write(projectRoot, "managed.txt", "custom\n");
+    await write(projectRoot, ".lisaignore", "managed.txt\n");
+    await expect(
+      inspectManagedTemplates(lisaRoot, projectRoot, [], "managed")
+    ).resolves.toEqual([]);
+
+    await write(projectRoot, ".lisaignore", "");
+    await write(
+      lisaRoot,
+      "all/deletions.json",
+      '{"paths":["managed.txt"],"keep":[]}\n'
+    );
+    await expect(
+      inspectManagedTemplates(lisaRoot, projectRoot, [], "managed")
+    ).resolves.toEqual([]);
+  });
+
+  it("uses exact managed-block semantics for copy-contents", async () => {
+    const lisaRoot = await temporaryRoot("lisa-health-block-source-");
+    const projectRoot = await temporaryRoot("lisa-health-block-host-");
+    const block = "# BEGIN: AI GUARDRAILS\nbuild/\n# END: AI GUARDRAILS\n";
+    await write(lisaRoot, "all/copy-contents/gitignore", block);
+    await write(projectRoot, ".gitignore", `custom/\n${block}`);
+    await expect(
+      inspectManagedTemplates(lisaRoot, projectRoot, [], "managed")
+    ).resolves.toEqual([]);
+
+    await write(
+      projectRoot,
+      ".gitignore",
+      "custom/\n# BEGIN: AI GUARDRAILS\nstale/\n# END: AI GUARDRAILS\n"
+    );
+    await expect(
+      inspectManagedTemplates(lisaRoot, projectRoot, [], "managed")
+    ).resolves.toEqual([".gitignore"]);
+  });
+
+  it("composes parent overwrite and child content management before comparing", async () => {
+    const lisaRoot = await temporaryRoot("lisa-health-composed-source-");
+    const projectRoot = await temporaryRoot("lisa-health-composed-host-");
+    await write(lisaRoot, "all/copy-overwrite/.prettierignore", "dist/\n");
+    await write(
+      lisaRoot,
+      "harper-fabric/copy-contents/.prettierignore",
+      "# BEGIN: AI GUARDRAILS\nharper-app/.cache/\n# END: AI GUARDRAILS\n"
+    );
+    await write(
+      projectRoot,
+      ".prettierignore",
+      "dist/\n\n# BEGIN: AI GUARDRAILS\nharper-app/.cache/\n# END: AI GUARDRAILS\n"
+    );
+
+    await expect(
+      inspectManagedTemplates(
+        lisaRoot,
+        projectRoot,
+        ["typescript", "harper-fabric"],
+        "managed"
+      )
+    ).resolves.toEqual([]);
+  });
+
+  it("composes overlapping merge and tagged-merge destinations once", async () => {
+    const lisaRoot = await temporaryRoot("lisa-health-json-stack-source-");
+    const projectRoot = await temporaryRoot("lisa-health-json-stack-host-");
+    const parent = { base: true, shared: "parent" };
+    const child = {
+      "//lisa-force-governed": "required",
+      governed: { enabled: true },
+      "//end-lisa-force-governed": "",
+    };
+    const host = { custom: true };
+    const expected = new TaggedMergeStrategy().mergeJson(
+      child,
+      mergeTemplateJson(parent, host)
+    );
+    await write(lisaRoot, "all/merge/settings.json", JSON.stringify(parent));
+    await write(
+      lisaRoot,
+      "typescript/tagged-merge/settings.json",
+      JSON.stringify(child)
+    );
+    await write(projectRoot, "settings.json", JSON.stringify(expected));
+
+    await expect(
+      inspectManagedTemplates(lisaRoot, projectRoot, ["typescript"], "managed")
+    ).resolves.toEqual([]);
+
+    await write(
+      projectRoot,
+      "settings.json",
+      JSON.stringify({ ...expected, governed: { enabled: false } })
+    );
+    await expect(
+      inspectManagedTemplates(lisaRoot, projectRoot, ["typescript"], "managed")
+    ).resolves.toEqual(["settings.json"]);
+  });
+
+  it("requires executable Husky hooks and installed plugin state", async () => {
+    const root = await temporaryRoot("lisa-health-installed-state-");
+    for (const hook of HUSKY_HOOKS) {
+      await write(root, path.join(".husky", hook), "#!/bin/sh\n");
+      await chmod(path.join(root, ".husky", hook), 0o755);
+    }
+    await chmod(path.join(root, ".husky", "pre-push"), 0o644);
+    await expect(
+      inspectHookInstallation(
+        root,
+        ["typescript"],
+        async () => ".husky",
+        1_000,
+        new AbortController().signal
+      )
+    ).resolves.toEqual({ status: "fail", drift: [".husky/pre-push"] });
+
+    await write(
+      root,
+      ".claude/settings.json",
+      '{"enabledPlugins":{"lisa@lisa":true}}\n'
+    );
+    await write(
+      root,
+      ".claude/.lisa-plugins-synced",
+      `${getPackageVersion()}\n`
+    );
+    await expect(
+      inspectPlugins(
+        root,
+        { harness: "claude" },
+        [],
+        async () => [],
+        1_000,
+        new AbortController().signal
+      )
+    ).resolves.toEqual({ status: "fail", drift: ["lisa@lisa"] });
+  });
+
+  it("compares material ruleset state and normalizes dropped checks", async () => {
+    const base: HealthRuleset = {
+      name: "base",
+      target: "branch",
+      enforcement: "active",
+      conditions: { ref_name: { include: ["~DEFAULT_BRANCH"], exclude: [] } },
+      rules: [{ type: "deletion" }],
+    };
+    expect(
+      compareRulesets([base], [{ ...base, enforcement: "disabled" }])
+    ).toEqual({ missing: [], drifted: ["base"] });
+    expect(
+      compareRulesets(
+        [base],
+        [{ ...base, conditions: { ref_name: { include: ["main"] } } }]
+      )
+    ).toEqual({ missing: [], drifted: ["base"] });
+
+    const reviewRule: HealthRuleset = {
+      ...base,
+      rules: [
+        {
+          type: "pull_request",
+          parameters: { required_approving_review_count: 1 },
+        },
+      ],
+    };
+    expect(
+      compareRulesets(
+        [reviewRule],
+        [
+          {
+            ...reviewRule,
+            rules: [
+              {
+                type: "pull_request",
+                parameters: {
+                  required_approving_review_count: 1,
+                  required_reviewers: [],
+                },
+              },
+            ],
+          },
+        ]
+      )
+    ).toEqual({ missing: [], drifted: [] });
+    expect(
+      compareRulesets(
+        [reviewRule],
+        [
+          {
+            ...reviewRule,
+            rules: [
+              {
+                type: "pull_request",
+                parameters: {
+                  required_approving_review_count: 1,
+                  required_reviewers: [{ type: "Team", id: 7 }],
+                },
+              },
+            ],
+          },
+        ]
+      )
+    ).toEqual({ missing: [], drifted: ["base"] });
+
+    const lisaRoot = await temporaryRoot("lisa-health-ruleset-source-");
+    const projectRoot = await temporaryRoot("lisa-health-ruleset-host-");
+    await write(
+      lisaRoot,
+      "all/github-rulesets/base.json",
+      `${JSON.stringify({
+        ...base,
+        rules: [
+          { type: "deletion" },
+          {
+            type: "required_status_checks",
+            parameters: {
+              required_status_checks: [
+                { context: "CI", integration_id: 15_368 },
+                { context: "Optional", integration_id: 1 },
+              ],
+            },
+          },
+        ],
+      })}\n`
+    );
+    const [normalized] = await expectedRulesets(lisaRoot, projectRoot, [], {
+      github: { rulesets: { dropRequiredChecks: ["Optional"] } },
+    });
+    expect(normalized?.rules).toEqual([{ type: "deletion" }]);
+  });
+});
+/* eslint-enable jsdoc/require-jsdoc, sonarjs/no-duplicate-string, max-lines -- restore repository test defaults */

--- a/tests/unit/health/deterministic.test.ts
+++ b/tests/unit/health/deterministic.test.ts
@@ -1,0 +1,356 @@
+/* eslint-disable sonarjs/no-duplicate-string, jsdoc/require-jsdoc, max-lines, @eslint-community/eslint-comments/disable-enable-pair -- repeated fixture identifiers make the finding matrix explicit */
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  config: {} as Record<string, unknown>,
+  configPresent: true,
+  settings: {} as Record<string, unknown> | undefined,
+  texts: new Map<string, string | undefined>(),
+  sync: {
+    actions: [] as { key: string; kind: string; detail: string }[],
+    missingRequired: [] as { key: string; setupHint: string }[],
+    dryRun: true,
+  },
+  drift: {
+    managed: [] as string[],
+    hooks: [] as string[],
+    workflows: [] as string[],
+  },
+  missingWorkflows: [] as string[],
+  staleWorkflowInputs: [] as string[],
+  packageConforms: true,
+  rulesetsPresent: true,
+  runConfigSync: vi.fn(),
+}));
+
+vi.mock("../../../src/sync/config-sync.js", () => ({
+  runConfigSync: mocks.runConfigSync,
+}));
+
+vi.mock("../../../src/core/lisa-plugin-selection.js", () => ({
+  selectProjectLisaPlugins: vi.fn(async () => ["lisa"]),
+}));
+
+vi.mock("../../../src/cli/version.js", () => ({
+  getPackageVersion: vi.fn(() => "2.999.0"),
+}));
+
+vi.mock("../../../src/health/read-only-fs.js", () => ({
+  projectPathKind: vi.fn(async (_root: string, relativePath: string) =>
+    relativePath === ".lisa.config.json" && mocks.configPresent
+      ? "file"
+      : "missing"
+  ),
+  readProjectJsonObject: vi.fn(async (_root: string, relativePath: string) =>
+    relativePath === ".lisa.config.json" ? mocks.config : mocks.settings
+  ),
+  readProjectText: vi.fn(async (_root: string, relativePath: string) =>
+    mocks.texts.get(relativePath)
+  ),
+}));
+
+vi.mock("../../../src/health/template-inspection.js", () => ({
+  detectHealthProjectShape: vi.fn(async () => ({
+    types: ["typescript"],
+    packageJson: { name: "fixture", devDependencies: { typescript: "5.9.3" } },
+  })),
+  detectHealthProjectTypes: vi.fn(async () => []),
+  inspectCreateOnlyWorkflows: vi.fn(async () => mocks.missingWorkflows),
+  inspectWorkflowInputs: vi.fn(async () => ({
+    stale: mocks.staleWorkflowInputs,
+    unknown: [],
+  })),
+  inspectManagedTemplates: vi.fn(
+    async (
+      _lisaRoot: string,
+      _projectRoot: string,
+      _types: readonly string[],
+      category: "managed" | "hooks" | "workflows"
+    ) => mocks.drift[category]
+  ),
+  packageJsonConforms: vi.fn(async () => mocks.packageConforms),
+}));
+
+vi.mock("../../../src/health/hook-inspection.js", () => ({
+  readCoreHooksPath: vi.fn(async () => ".husky"),
+  inspectHookInstallation: vi.fn(async () => ({ status: "pass", drift: [] })),
+}));
+
+vi.mock("../../../src/health/plugin-inspection.js", () => ({
+  readInstalledClaudePlugins: vi.fn(async () => ["lisa@lisa"]),
+  inspectPlugins: vi.fn(async () => {
+    const marker = mocks.texts.get(
+      path.join(".claude", ".lisa-plugins-synced")
+    );
+    if (mocks.settings === undefined) {
+      return { status: "warn", drift: ["unsupported harness"] };
+    }
+    return marker === "2.999.0\n"
+      ? { status: "pass", drift: [] }
+      : { status: "fail", drift: ["plugin version marker"] };
+  }),
+}));
+
+vi.mock("../../../src/health/ruleset-inspection.js", () => ({
+  readGithubRulesets: vi.fn(async () => []),
+  rulesetFinding: vi.fn(
+    async (
+      _lisaRoot: string,
+      _projectRoot: string,
+      _types: readonly string[],
+      _config: Record<string, unknown>,
+      reader: () => Promise<unknown>
+    ) => {
+      try {
+        await reader();
+      } catch {
+        return {
+          check: "github.rulesets",
+          layer: "deterministic",
+          status: "warn",
+          reason:
+            "GitHub rulesets could not be observed within the deterministic deadline.",
+        };
+      }
+      return mocks.rulesetsPresent
+        ? {
+            check: "github.rulesets",
+            layer: "deterministic",
+            status: "pass",
+            reason:
+              "Required GitHub rulesets are active and materially current.",
+          }
+        : {
+            check: "github.rulesets",
+            layer: "deterministic",
+            status: "fail",
+            reason: "GitHub ruleset drift: Base missing",
+          };
+    }
+  ),
+}));
+
+import { runDeterministicHealth } from "../../../src/health/deterministic.js";
+
+const CHECK_ORDER = [
+  "project.state",
+  "project.wiki",
+  "starters.remote",
+  "config.required",
+  "config.sync",
+  "templates.managed",
+  "package.conformance",
+  "instructions.canonical",
+  "hooks.managed",
+  "plugins.current",
+  "ci.workflows",
+  "github.rulesets",
+] as const;
+
+let projectRoot: string;
+
+function resetMocks(): void {
+  mocks.config = {
+    tracker: "github",
+    github: { org: "example", repo: "project" },
+  };
+  mocks.configPresent = true;
+  mocks.settings = { enabledPlugins: { "lisa@lisa": true } };
+  mocks.texts = new Map([
+    ["AGENTS.md", "Canonical project instructions."],
+    ["CLAUDE.md", "@AGENTS.md"],
+    [path.join(".claude", ".lisa-plugins-synced"), "2.999.0\n"],
+  ]);
+  mocks.sync = { actions: [], missingRequired: [], dryRun: true };
+  mocks.drift = { managed: [], hooks: [], workflows: [] };
+  mocks.missingWorkflows = [];
+  mocks.staleWorkflowInputs = [];
+  mocks.packageConforms = true;
+  mocks.rulesetsPresent = true;
+  mocks.runConfigSync.mockReset();
+  mocks.runConfigSync.mockImplementation(async () => mocks.sync);
+}
+
+async function collect(
+  overrides: Parameters<typeof runDeterministicHealth>[1] = {}
+) {
+  return runDeterministicHealth(projectRoot, {
+    lisaRoot: projectRoot,
+    now: () => new Date("2026-07-20T12:00:00.000Z"),
+    ...overrides,
+  });
+}
+
+beforeAll(async () => {
+  projectRoot = await realpath(
+    await mkdtemp(path.join(tmpdir(), "lisa-health-unit-"))
+  );
+});
+
+beforeEach(() => {
+  resetMocks();
+});
+
+afterAll(async () => {
+  await rm(projectRoot, { recursive: true, force: true });
+});
+
+describe("runDeterministicHealth", () => {
+  it("returns a strict frozen result with every check in deterministic order", async () => {
+    const exitCode = process.exitCode;
+    const result = await collect();
+
+    expect(result.findings.map(finding => finding.check)).toEqual(CHECK_ORDER);
+    expect(result.mode).toBe("deterministic");
+    expect(
+      result.findings.every(finding => finding.layer === "deterministic")
+    ).toBe(true);
+    expect(result.summary).toEqual({
+      verdict: "in band",
+      counts: { pass: 11, warn: 1, fail: 0 },
+    });
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.findings)).toBe(true);
+    expect(process.exitCode).toBe(exitCode);
+    expect(mocks.runConfigSync).toHaveBeenCalledTimes(1);
+    expect(mocks.runConfigSync).toHaveBeenCalledWith(projectRoot, {
+      dryRun: true,
+      reads: expect.objectContaining({
+        readJson: expect.any(Function),
+        pathExists: expect.any(Function),
+      }),
+    });
+  });
+
+  it.each([
+    ["project.state", () => (mocks.configPresent = false), "Project config"],
+    [
+      "config.required",
+      () =>
+        (mocks.sync.missingRequired = [
+          { key: "github.repo", setupHint: "do not disclose this hint" },
+        ]),
+      "github.repo",
+    ],
+    [
+      "config.sync",
+      () =>
+        (mocks.sync.actions = [
+          {
+            key: "quality.lintBudgets",
+            kind: "artifact-synced",
+            detail: "secret",
+          },
+        ]),
+      "quality.lintBudgets",
+    ],
+    [
+      "templates.managed",
+      () => mocks.drift.managed.push("eslint.config.ts"),
+      "eslint.config.ts",
+    ],
+    [
+      "package.conformance",
+      () => (mocks.packageConforms = false),
+      "package.json",
+    ],
+    [
+      "instructions.canonical",
+      () => mocks.texts.delete("AGENTS.md"),
+      "AGENTS.md",
+    ],
+    [
+      "hooks.managed",
+      () => mocks.drift.hooks.push(".husky/pre-push"),
+      ".husky/pre-push",
+    ],
+    [
+      "plugins.current",
+      () =>
+        mocks.texts.set(path.join(".claude", ".lisa-plugins-synced"), "old"),
+      "plugin version marker",
+    ],
+    [
+      "ci.workflows",
+      () => mocks.missingWorkflows.push(".github/workflows/ci.yml"),
+      "ci.yml",
+    ],
+    ["github.rulesets", () => (mocks.rulesetsPresent = false), "Base"],
+  ])(
+    "reports observed %s drift as a named failure",
+    async (check, arrange, name) => {
+      arrange();
+      const result = await collect();
+      const observed = result.findings.find(finding => finding.check === check);
+
+      expect(observed).toMatchObject({
+        status: "fail",
+        layer: "deterministic",
+      });
+      expect(observed?.reason).toContain(name);
+      expect(observed?.reason).not.toContain("do not disclose this hint");
+      expect(observed?.reason).not.toContain("secret");
+    }
+  );
+
+  it("maps unavailable optional capabilities to bounded warnings without raw errors", async () => {
+    mocks.settings = undefined;
+    const result = await collect({
+      readRulesets: async () => {
+        throw new Error("token=never-print-this /absolute/private/path");
+      },
+    });
+
+    expect(
+      result.findings.find(finding => finding.check === "plugins.current")
+    ).toMatchObject({
+      status: "warn",
+      reason: "Plugin state unavailable: unsupported harness",
+    });
+    const rulesets = result.findings.find(
+      finding => finding.check === "github.rulesets"
+    );
+    expect(rulesets?.status).toBe("warn");
+    expect(rulesets?.reason).not.toContain("never-print-this");
+    expect(rulesets?.reason).not.toContain("/absolute/private/path");
+  });
+
+  it("maps deterministic exceptions to failures and respects the shared timeout", async () => {
+    mocks.runConfigSync.mockRejectedValue(new Error("config-secret"));
+    const started = Date.now();
+    const result = await collect({
+      deadlineMs: 10,
+      readRulesets: async () => new Promise(() => undefined),
+    });
+
+    expect(Date.now() - started).toBeLessThan(1_000);
+    expect(
+      result.findings.find(finding => finding.check === "config.required")
+    ).toMatchObject({
+      status: "fail",
+    });
+    expect(
+      result.findings.find(finding => finding.check === "config.sync")
+    ).toMatchObject({
+      status: "fail",
+    });
+    expect(
+      result.findings.find(finding => finding.check === "github.rulesets")
+    ).toMatchObject({
+      status: "warn",
+    });
+    expect(JSON.stringify(result)).not.toContain("config-secret");
+  });
+});

--- a/tests/unit/health/package-surfaces.test.ts
+++ b/tests/unit/health/package-surfaces.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest";
 const VERIFY_SCRIPT =
   "bun run build:dist && node scripts/verify-health-contract-built.mjs";
 const HEALTH_EXPORT = "./dist/health/index.js";
+const DETERMINISTIC_VERIFY_SCRIPT =
+  "bun run build:dist && node scripts/verify-health-deterministic-built.mjs";
 
 describe("Health v1 package surfaces", () => {
   it("keeps the source package and forced package template synchronized", async () => {
@@ -26,5 +28,11 @@ describe("Health v1 package surfaces", () => {
     );
     expect(source.exports["./health"]).toBe(HEALTH_EXPORT);
     expect(template.force.exports["./health"]).toBe(HEALTH_EXPORT);
+    expect(source.scripts["verify:health-deterministic"]).toBe(
+      DETERMINISTIC_VERIFY_SCRIPT
+    );
+    expect(template.force.scripts["verify:health-deterministic"]).toBe(
+      DETERMINISTIC_VERIFY_SCRIPT
+    );
   });
 });

--- a/tests/unit/scripts/detect-stale-workflow-inputs.test.ts
+++ b/tests/unit/scripts/detect-stale-workflow-inputs.test.ts
@@ -169,7 +169,12 @@ describe("parseReusableReference", () => {
       parseReusableReference(
         "CodySwannGT/lisa/.github/workflows/reusable-claude.yml@main"
       )
-    ).toEqual({ file: REUSABLE_CLAUDE_YML, ref: "main" });
+    ).toEqual({
+      file: REUSABLE_CLAUDE_YML,
+      owner: "CodySwannGT",
+      repo: "lisa",
+      ref: "main",
+    });
   });
 
   it("returns null for a plain action reference", () => {
@@ -191,6 +196,8 @@ describe("extractCallerJobs", () => {
     ].join("\n");
     expect(extractCallerJobs(content)).toEqual([
       {
+        owner: "CodySwannGT",
+        repo: "lisa",
         reusableFile: REUSABLE_CLAUDE_YML,
         ref: "main",
         withKeys: ["event_name", "package_manager"],
@@ -207,7 +214,13 @@ describe("extractCallerJobs", () => {
       "",
     ].join("\n");
     expect(extractCallerJobs(content)).toEqual([
-      { reusableFile: REUSABLE_CLAUDE_YML, ref: "main", withKeys: [] },
+      {
+        owner: "CodySwannGT",
+        repo: "lisa",
+        reusableFile: REUSABLE_CLAUDE_YML,
+        ref: "main",
+        withKeys: [],
+      },
     ]);
   });
 


### PR DESCRIPTION
## Summary

- add a standalone, read-only deterministic health layer covering project state, managed templates, packages, config sync, hooks, installed plugins, reusable workflows, and material GitHub rulesets
- centralize template ownership and workflow-contract planning so health compares the same composed artifacts Lisa installs across supported project stacks
- enforce one bounded deadline, safe filesystem reads, bounded subprocesses, deterministic findings, and a built real-host acceptance verifier

Closes #1517

## Test plan

- `bun run verify:health-deterministic` — 83 assertions, all seven required evidence markers, approximately 0.8–1.1 seconds
- `bun run test` — 370 files, 6,431 tests passed
- `bun run typecheck`
- `bun run lint` — 0 warnings/errors across 829 files
- `bun run check:plugins`
- `bun run check:workflow-inputs`
- `bun run check:upstream-evidence-manifest`
- full pre-push gate, including production dependency audit, slow lint, dead-code analysis, coverage, and 137 integration tests

## Verification

Independent verification approved exact commit `f3b229128283aa26a8e5d632891836fbdbade22d`. The built verifier proved managed-file drift detection and restoration, clean-project in-band state, named missing configuration, deterministic-only output, the sub-two-minute budget, and no filesystem/process side effects.
