### PR TITLE
feat(verification): spec-conformance consumption, parity backstop, and bounded-claims docs (#1841)

### DIFF
--- a/plugins/lisa-agy/agents/spec-conformance-specialist.md
+++ b/plugins/lisa-agy/agents/spec-conformance-specialist.md
@@ -30,8 +30,9 @@ Follow the `spec-conformance` skill end-to-end:
 
 1. Resolve the spec source (plan file, JIRA key, Linear, GitHub issue, PRD).
 2. Extract every requirement into a structured list — acceptance criteria, Out of Scope, technical commitments, Validation Journey assertions, deliverables.
-3. Inspect shipped work (diff, tests, PR body, verification-specialist evidence).
-4. Build the coverage matrix — every requirement gets a row with a status.
+3. Inspect shipped work (diff, tests, PR body, verification-specialist evidence) **and load the machine-readable verdict** at `.lisa/verification-status.json`.
+3b. Cross-check every claim against its **boundary** — the `claim-evidence-mapping` contract's taxonomy — plus artifact identity and the Not-established review.
+4. Build the coverage matrix — every requirement gets a row with a boundary, an evidence kind, and a status.
 5. Detect scope creep and untraceable changes separately.
 6. Produce the verdict.
 
@@ -42,6 +43,8 @@ Return the structured report defined in the skill. Never summarize or drop rows.
 ## Rules
 
 - **Require empirical evidence.** A requirement is not `MATCH` because code exists. It is `MATCH` only when there is a test AND runtime observation (captured by verification-specialist).
+- **A cited-evidence-boundary mismatch is a conformance finding.** The `claim-evidence-mapping` rule binds every claim to a boundary and every boundary to the evidence kinds that reach it. When a v2 verdict cites evidence whose `kind` does not reach the claim's `boundary` — a unit `test-run-log` for a `browser` claim — or whose `artifact_head_sha` does not match `artifact.head_sha`, or when the verdict omits the Not-established review, the row is `BOUNDARY_MISMATCH` and the verdict is `DIVERGES`. Name the boundary, the kind cited, and the kind(s) required. This is not the same failure as a miss: the work may be correct and the proof still not establish it.
+- **Degrade, never block, on an absent or v1 verdict.** If no v2 verdict exists, say so in the report, cap affected rows at `PARTIAL`, and do not invent a mismatch you could not check.
 - **Scope creep is a distinct failure.** Do not fold `SCOPE_CREEP_VIOLATION` into "missing" or "untraceable." Scope creep means Out of Scope was violated — it blocks shipping.
 - **Untraceable changes get surfaced, not judged.** Refactors and test helpers often land here. Surface them so the human can confirm intent; do not automatically fail.
 - **If the spec itself is inadequate** (no acceptance criteria, no Out of Scope, no Validation Journey for runtime changes), the verdict is `DIVERGES` until the spec is tightened. Do not paper over an ambiguous spec with a generous match.

--- a/plugins/lisa-agy/agents/verification-specialist.md
+++ b/plugins/lisa-agy/agents/verification-specialist.md
@@ -12,7 +12,7 @@ skills:
 
 You are a verification specialist. Your job is to **prove empirically** that work is done -- not by reading code, but by running the actual system and observing the results.
 
-Read `.claude/rules/verification.md` at the start of every investigation for the full verification framework, types, and lifecycle.
+Read `.claude/rules/verification.md` at the start of every investigation for the full verification framework, types, and lifecycle. Read `.claude/rules/claim-evidence-mapping.md` alongside it: it binds every claim to the **boundary** it asserts and every boundary to the evidence **kinds** that reach it. The verdict you write is what `spec-conformance-specialist` cross-checks — record each claim's `boundary`, its `required_evidence_kinds`, its `evidence_refs`, and its `not_established` list so a boundary mismatch is catchable rather than invisible.
 
 ## Core Philosophy
 

--- a/plugins/lisa-agy/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-implement/SKILL.md
@@ -278,7 +278,28 @@ Before shutting down the team, execute the Verify flow:
     - **Actionable blocker** — an unresolved dependency or fixable technical gap that some team or repository could build (a missing or changed schema field, an unbuilt sibling work item, a required upstream fix), **including cross-repo dependencies**. Before writing the blocked verdict you MUST (1) file a build-ready fix/dependency ticket capturing the diagnosis — in the dependency's own repository/tracker when it is cross-repo (e.g. a `[<repo>] …` ticket in the shared project, or the sibling tracker) — and (2) link the current work item to it as `is blocked by`. Only then write the verdict. This is the same discipline as the regression-spec blocker and the remote-verification-fail exits above, and it is what makes the block machine-recoverable: `repair-intake` re-dispatches a blocked item once its linked `is blocked by` dependency closes, but it cannot act on a prose-only comment. Recommending the ticket "as a human follow-up" without filing and linking it is **not** a permitted exit.
     - **Human-only blocker** — an input the agent genuinely cannot obtain or produce no matter what it does: credentials, secrets, or **tool access** it does not have (AWS/CloudWatch, Figma, Jam, Sentry, SonarCloud, a database, a protected deploy target, …), or a product/design decision only a human can make. For missing tool access, follow the `tool-access-gate` rule's break-out protocol: post the "Access Needed" comment naming the exact credential/role/env var to grant and the probe that must pass — never work around the gap by substituting weaker verification, mocking the inaccessible system, or narrowing scope. Record the blocked verdict, mark it `human_needed` (the marker `repair-intake` recognizes, so it won't churn re-dispatching it), and surface or reassign to a human; do **not** fabricate a build-ready ticket, because there is no build-ready work.
 
-    Other harnesses fall back to this prose obligation.
+    **Harnesses that do not fire a Stop hook enforce the same discipline by convention.** The
+    `enforce-verification-gate.sh` Stop hook is a **Claude-only** surface — Codex, Cursor, Antigravity,
+    Copilot, and OpenCode carry the skills, agents, and (where the runtime has a rules surface) the
+    `claim-evidence-mapping` rule, but nothing on those runtimes can refuse to stop. That is a known
+    **representation gap**, documented here rather than dropped: on those harnesses this prose gate
+    *is* the gate, and the flow may not declare completion until it has written the same v2 verdict
+    and self-checked it against the same expectations the hook would have applied:
+
+    - `schema_version: 2` is written, with `plan`, `status`, and `updated_at` terminal and fresh.
+    - Every claim carries a `claim_id`, a `boundary` from the closed set, and the
+      `required_evidence_kinds` that reach that boundary — and its `evidence_refs` resolve to evidence
+      whose `kind` is one of them. A unit `test-run-log` cited for a `browser`, `http-api`, or
+      `deploy-health` claim is the failure this check exists to catch.
+    - `artifact.head_sha` names what will ship, and every evidence entry's `artifact_head_sha` matches
+      it, with a `sha256` digest and `captured_at` recorded as values, never placeholders.
+    - The `not_established` list is present on every claim and `not_established_reviewed` is `true` —
+      an empty list is fine, an omitted flag is not.
+
+    Record the self-check in the completion summary the way the hook would have reported it: name the
+    boundary each claim reached, or name the violation. Where the runtime lacks the rules surface (the
+    agy artifacts carry no rules tree), the obligation still travels in this skill — cite the
+    `claim-evidence-mapping` contract by slug and continue; never block on the absent surface.
 3. Write the highest-practical-observation regression test encoding the verification. For user-visible bugs or user-visible Build changes with an available browser/device/e2e harness, this means a deterministic spec on the reported surface — and for frontend work, once the validation journey is verified, codification into **every supported UI runner**: a Playwright spec in the Playwright runner AND a Maestro flow when the project supports Maestro, per `codify-verification`. Prove the new spec actually executed and passed in PR CI by recording a named spec log/reporter line or equivalent execution record; green CI without that named evidence does not satisfy this step.
 4. Record Implement usage on the originating work artifact via `lisa-usage-accounting` so the work item (or other implementation-owned artifact) gains a direct `lisa-implement` usage entry in the canonical `## Lisa Usage` section. If the parent / child graph is already known, prefer `record_and_rollup` so ancestor totals refresh in the same write; otherwise still write the direct entry, and if runtime usage is unavailable, use `source: unavailable` with nullable token/cost fields instead of skipping the row.
 5. Commit ALL outstanding changes in logical batches on the branch (minus sensitive data/information) — not just changes made by the agent team. This includes pre-existing uncommitted changes that were on the branch before the plan started. Do NOT filter commits to only "task-related" files. If it shows up in git status, it gets committed (unless it contains secrets).

--- a/plugins/lisa-agy/skills/lisa-spec-conformance/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-spec-conformance/SKILL.md
@@ -67,10 +67,27 @@ Gather evidence of what was actually shipped:
    git diff "${BASE_BRANCH}"...HEAD -- '**/*.test.*' '**/*.spec.*'
    ```
 4. **Empirical evidence** — output of `verification-specialist` if available (proof artifacts, API captures, UI screenshots, DB queries). If that report isn't in context, ask the caller for it before proceeding — do not substitute reading code for running the system.
+4a. **The machine-readable verdict** — `Read` `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json`. Under **schema v2** it is the structured form of the evidence above, and it is what lets you check a claim's *reach* instead of taking "verified" at its word. Load `artifact` (`repository`, `head_sha`, `environment`), `claims[]` (`claim_id`, `statement`, `boundary`, `required_evidence_kinds`, `status`, `evidence_refs`, `not_established`), `evidence[]` (`evidence_id`, `kind`, `locator`, `sha256`, `captured_at`, `artifact_head_sha`), and the `not_established_reviewed` flag.
 5. **PR description** — `gh pr view --json title,body,files` if a PR exists.
 6. **Deployed state** — if the verification phase already hit a deployed environment, use those captures.
 
 Do NOT run the system yourself — that's the verification-specialist's job. Your job is to map their evidence to the spec.
+
+## Phase 3b — Cross-Check Claims Against Their Boundaries
+
+The `claim-evidence-mapping` rule is the contract: **every claim declares a boundary, and a claim is established only by evidence of a kind that reaches that boundary.** Conformance is not just "was it built" — it is also "does the proof offered actually reach the thing the requirement asserts." A unit `test-run-log` cited for a requirement about browser-visible behavior is a conformance defect even when the code is perfect.
+
+For every v2 claim loaded in Phase 3 step 4a, run three checks:
+
+| Check | Rule | Failure |
+|-------|------|---------|
+| **Boundary reach** | Each `evidence_refs` entry resolves to an `evidence[]` row whose `kind` appears in that claim's `required_evidence_kinds` — and those kinds are the ones the `claim-evidence-mapping` taxonomy binds to the claim's `boundary` | `BOUNDARY_MISMATCH` |
+| **Artifact identity** | Every cited evidence row's `artifact_head_sha` equals `artifact.head_sha` — the claim applies only to the artifact the evidence was collected against | `BOUNDARY_MISMATCH`, noting both SHAs |
+| **Not established** | `not_established_reviewed` is present and `true`, and every claim carries a `not_established` list (possibly empty) | `BOUNDARY_MISMATCH` on the verdict as a whole |
+
+Then bind the verdict back to the spec: map each `claim_id` to the requirement row it discharges. A requirement whose only supporting claim fails a check is **not** `MATCH`, no matter what the verification report's prose said. A requirement with no claim at all is `MISSING`, not `PARTIAL`.
+
+**Degrade, never block.** If `.lisa/verification-status.json` is absent, or carries **v1** (no `schema_version`, or `schema_version: 1` — only `plan` / `status` / `criteria[]` / `updated_at`), the boundary cross-check is not available. Say so explicitly in the report ("v2 verdict not present — boundary reach unverified"), fall back to the prose evidence from Phase 3, and cap the verdict at `PARTIAL` for any requirement whose boundary you cannot confirm. Do not invent a mismatch you could not check, and do not silently upgrade an unchecked claim to `MATCH`.
 
 ## Phase 4 — Build Coverage Matrix
 
@@ -81,8 +98,10 @@ For every requirement extracted in Phase 2, produce one row:
 | Requirement ID | Stable identifier (e.g. `AC-1`, `OOS-2`, `ASSERT-3`) |
 | Classification | `acceptance` / `excluded` / `technical` / `assertion` / `deliverable` / `task` / `blocker` |
 | Requirement Text | Verbatim from spec |
-| Evidence | Specific pointer — file:line, test name, verification report section, PR file, screenshot name |
-| Status | `MATCH` / `PARTIAL` / `MISSING` / `SCOPE_CREEP_VIOLATION` |
+| Evidence | Specific pointer — file:line, test name, verification report section, PR file, screenshot name. When a v2 verdict exists, also name the `claim_id` and `evidence_id` that discharge it |
+| Boundary | The claim's `boundary` from the v2 verdict (`code-unit` / `browser` / `http-api` / `cli` / `data` / `deploy-health` / `performance` / `standards-compat`), or `—` when no v2 claim maps to this row |
+| Evidence kind | The `kind` of each cited evidence row, so a reader sees the reach without opening the verdict |
+| Status | `MATCH` / `PARTIAL` / `MISSING` / `BOUNDARY_MISMATCH` / `SCOPE_CREEP_VIOLATION` |
 | Notes | One line — why partial, what's missing, or where evidence is thin |
 
 ### Status definitions
@@ -90,6 +109,7 @@ For every requirement extracted in Phase 2, produce one row:
 - **`MATCH`** — requirement is implemented AND there is empirical evidence it works (test + verification report).
 - **`PARTIAL`** — implementation exists but evidence is incomplete (e.g. code present, no test; or test present, no run-time verification).
 - **`MISSING`** — requirement has no corresponding implementation OR no evidence at all.
+- **`BOUNDARY_MISMATCH`** — the requirement was implemented and evidence was cited, but the evidence does not *reach* the claim's boundary (a unit `test-run-log` offered for a `browser` claim), or its `artifact_head_sha` does not match `artifact.head_sha`, or the verdict omits the required Not-established review. This is a distinct failure from a miss: the work may be right and the proof still does not establish it. A `BOUNDARY_MISMATCH` row forces the verdict to `DIVERGES` — it can never render as `CONFORMS` or `PARTIAL`. Name the boundary, the kind cited, and the kind(s) required, citing the `claim-evidence-mapping` taxonomy.
 - **`SCOPE_CREEP_VIOLATION`** — used for `excluded` classification only. An Out-of-Scope item appears to have been shipped anyway. This is a different failure than a miss — it means the agent exceeded the spec.
 
 ### Scope creep detection
@@ -106,9 +126,9 @@ Untraceable changes are not automatic failures. They become findings the human r
 
 Produce exactly one verdict:
 
-- **`CONFORMS`** — every requirement is `MATCH`. No `SCOPE_CREEP_VIOLATION`. Untraceable changes, if any, are clearly refactors or test support.
-- **`PARTIAL`** — some requirements are `PARTIAL` but none are `MISSING` or `SCOPE_CREEP_VIOLATION`. Work is mostly there but evidence is thin.
-- **`DIVERGES`** — at least one requirement is `MISSING`, OR at least one `SCOPE_CREEP_VIOLATION` exists, OR there are substantive untraceable changes that materially alter behavior.
+- **`CONFORMS`** — every requirement is `MATCH`. No `SCOPE_CREEP_VIOLATION`, no `BOUNDARY_MISMATCH`. Untraceable changes, if any, are clearly refactors or test support.
+- **`PARTIAL`** — some requirements are `PARTIAL` but none are `MISSING`, `BOUNDARY_MISMATCH`, or `SCOPE_CREEP_VIOLATION`. Work is mostly there but evidence is thin.
+- **`DIVERGES`** — at least one requirement is `MISSING`, OR at least one `BOUNDARY_MISMATCH` exists, OR at least one `SCOPE_CREEP_VIOLATION` exists, OR there are substantive untraceable changes that materially alter behavior.
 
 A verdict of `PARTIAL` or `DIVERGES` blocks task completion. The caller must resolve the gaps (implement the miss, remove the creep, add the missing evidence) before re-running.
 
@@ -121,15 +141,24 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 
 **Spec source:** <plan file / JIRA key / Linear / GitHub issue / PRD>
 **Shipped scope:** <N commits, M files, K tests on branch <branch> vs <default-branch>>
+**Verdict artifact:** <.lisa/verification-status.json schema v2, artifact.head_sha <sha> — or "v2 verdict not present — boundary reach unverified">
 
 ### Coverage Matrix
 
-| ID | Class | Requirement | Evidence | Status | Notes |
-|----|-------|-------------|----------|--------|-------|
-| AC-1 | acceptance | [text] | [pointer] | MATCH | |
-| AC-2 | acceptance | [text] | — | MISSING | No corresponding code or test |
-| OOS-1 | excluded | [text] | src/foo.ts:42 | SCOPE_CREEP_VIOLATION | Added anyway |
-| ASSERT-1 | assertion | [text] | verification-report §2 | PARTIAL | Asserted in code, not run in verification |
+| ID | Class | Requirement | Evidence | Boundary | Evidence kind | Status | Notes |
+|----|-------|-------------|----------|----------|---------------|--------|-------|
+| AC-1 | acceptance | [text] | [pointer] (AC-1 / EV-1) | browser | screenshot | MATCH | |
+| AC-2 | acceptance | [text] | — | — | — | MISSING | No corresponding code or test |
+| AC-3 | acceptance | [text] | EV-4 | browser | test-run-log | BOUNDARY_MISMATCH | Unit log cannot establish a browser claim — needs screenshot or recording |
+| OOS-1 | excluded | [text] | src/foo.ts:42 | — | — | SCOPE_CREEP_VIOLATION | Added anyway |
+| ASSERT-1 | assertion | [text] | verification-report §2 | http-api | — | PARTIAL | Asserted in code, not run in verification |
+
+### Not Established
+
+Reproduce the verdict's `not_established` entries verbatim, grouped by claim, plus anything the matrix could not confirm. This section is **never omitted and never blank**: with nothing outstanding it renders `None outstanding — reviewed`. State whether `not_established_reviewed` was `true`.
+
+- AC-1 — not exercised on mobile viewports; Safari not tested
+- AC-4 — offline behavior consciously out of scope for this ticket
 
 ### Untraceable Changes
 - src/utils/helpers.ts — extracted shared regex constant (refactor, no behavior change)
@@ -140,6 +169,7 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 **Matches:** N/Total
 **Partial:** N
 **Missing:** N
+**Boundary mismatches:** N
 **Scope creep violations:** N
 **Untraceable changes flagged for review:** N
 
@@ -152,6 +182,8 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 
 - Never substitute "I read the code and it looks right" for empirical evidence. If verification-specialist hasn't run yet, request its report before producing a verdict.
 - Never mark a requirement `MATCH` based on the presence of code alone — evidence means test + runtime observation.
+- Never mark a requirement `MATCH` on evidence that does not **reach** its claim's boundary. Per the `claim-evidence-mapping` contract, a unit `test-run-log` establishes only `code-unit` behavior; cited for a `browser`, `http-api`, `deploy-health`, or `standards-compat` claim it is a `BOUNDARY_MISMATCH`, not a match.
+- Always report the Not-established section, even when empty. A report that lists only what passed is unreadable at a gate.
 - Always surface scope creep separately from misses. They are distinct failures.
 - Always surface untraceable changes — even benign refactors — so the human can confirm intent.
 - The Out of Scope section is load-bearing. If the spec has one, every item must appear in the matrix as `excluded`.

--- a/plugins/lisa-copilot/agents/spec-conformance-specialist.agent.md
+++ b/plugins/lisa-copilot/agents/spec-conformance-specialist.agent.md
@@ -30,8 +30,9 @@ Follow the `spec-conformance` skill end-to-end:
 
 1. Resolve the spec source (plan file, JIRA key, Linear, GitHub issue, PRD).
 2. Extract every requirement into a structured list — acceptance criteria, Out of Scope, technical commitments, Validation Journey assertions, deliverables.
-3. Inspect shipped work (diff, tests, PR body, verification-specialist evidence).
-4. Build the coverage matrix — every requirement gets a row with a status.
+3. Inspect shipped work (diff, tests, PR body, verification-specialist evidence) **and load the machine-readable verdict** at `.lisa/verification-status.json`.
+3b. Cross-check every claim against its **boundary** — the `claim-evidence-mapping` contract's taxonomy — plus artifact identity and the Not-established review.
+4. Build the coverage matrix — every requirement gets a row with a boundary, an evidence kind, and a status.
 5. Detect scope creep and untraceable changes separately.
 6. Produce the verdict.
 
@@ -42,6 +43,8 @@ Return the structured report defined in the skill. Never summarize or drop rows.
 ## Rules
 
 - **Require empirical evidence.** A requirement is not `MATCH` because code exists. It is `MATCH` only when there is a test AND runtime observation (captured by verification-specialist).
+- **A cited-evidence-boundary mismatch is a conformance finding.** The `claim-evidence-mapping` rule binds every claim to a boundary and every boundary to the evidence kinds that reach it. When a v2 verdict cites evidence whose `kind` does not reach the claim's `boundary` — a unit `test-run-log` for a `browser` claim — or whose `artifact_head_sha` does not match `artifact.head_sha`, or when the verdict omits the Not-established review, the row is `BOUNDARY_MISMATCH` and the verdict is `DIVERGES`. Name the boundary, the kind cited, and the kind(s) required. This is not the same failure as a miss: the work may be correct and the proof still not establish it.
+- **Degrade, never block, on an absent or v1 verdict.** If no v2 verdict exists, say so in the report, cap affected rows at `PARTIAL`, and do not invent a mismatch you could not check.
 - **Scope creep is a distinct failure.** Do not fold `SCOPE_CREEP_VIOLATION` into "missing" or "untraceable." Scope creep means Out of Scope was violated — it blocks shipping.
 - **Untraceable changes get surfaced, not judged.** Refactors and test helpers often land here. Surface them so the human can confirm intent; do not automatically fail.
 - **If the spec itself is inadequate** (no acceptance criteria, no Out of Scope, no Validation Journey for runtime changes), the verdict is `DIVERGES` until the spec is tightened. Do not paper over an ambiguous spec with a generous match.

--- a/plugins/lisa-copilot/agents/verification-specialist.agent.md
+++ b/plugins/lisa-copilot/agents/verification-specialist.agent.md
@@ -12,7 +12,7 @@ skills:
 
 You are a verification specialist. Your job is to **prove empirically** that work is done -- not by reading code, but by running the actual system and observing the results.
 
-Read `.claude/rules/verification.md` at the start of every investigation for the full verification framework, types, and lifecycle.
+Read `.claude/rules/verification.md` at the start of every investigation for the full verification framework, types, and lifecycle. Read `.claude/rules/claim-evidence-mapping.md` alongside it: it binds every claim to the **boundary** it asserts and every boundary to the evidence **kinds** that reach it. The verdict you write is what `spec-conformance-specialist` cross-checks — record each claim's `boundary`, its `required_evidence_kinds`, its `evidence_refs`, and its `not_established` list so a boundary mismatch is catchable rather than invisible.
 
 ## Core Philosophy
 

--- a/plugins/lisa-copilot/rules/reference/verification.md
+++ b/plugins/lisa-copilot/rules/reference/verification.md
@@ -177,6 +177,8 @@ The list may be empty; the flag may not be missing. An absent `not_established_r
 
 The boundary each artifact type reaches — and therefore which claim a captured artifact can discharge — is the `claim-evidence-mapping` rule's taxonomy; the type table above is its evidence-kind source.
 
+The verdict is read twice. The Claude-only `enforce-verification-gate.sh` Stop hook reads it to decide whether the flow may stop; `lisa-spec-conformance` (run by `spec-conformance-specialist` in the verification phase) reads it to decide whether each shipped requirement's proof actually reaches its boundary — a cited-evidence-boundary mismatch is a `BOUNDARY_MISMATCH` conformance finding there, caught alongside empirical verification rather than after it. On harnesses without a Stop hook, `lisa-implement`'s prose gate carries the same v2 expectations by convention. The whole system, operator-readable end to end, is written up as the Lisa wiki's **Bounded-Claims Evidence System** concept page (`wiki/concepts/bounded-claims-evidence-system.md` upstream).
+
 ### Cross-work-item evidence references are non-claiming
 
 When prose needs to point at evidence declared by another work item, use the dedicated reference form:

--- a/plugins/lisa-copilot/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-implement/SKILL.md
@@ -278,7 +278,28 @@ Before shutting down the team, execute the Verify flow:
     - **Actionable blocker** — an unresolved dependency or fixable technical gap that some team or repository could build (a missing or changed schema field, an unbuilt sibling work item, a required upstream fix), **including cross-repo dependencies**. Before writing the blocked verdict you MUST (1) file a build-ready fix/dependency ticket capturing the diagnosis — in the dependency's own repository/tracker when it is cross-repo (e.g. a `[<repo>] …` ticket in the shared project, or the sibling tracker) — and (2) link the current work item to it as `is blocked by`. Only then write the verdict. This is the same discipline as the regression-spec blocker and the remote-verification-fail exits above, and it is what makes the block machine-recoverable: `repair-intake` re-dispatches a blocked item once its linked `is blocked by` dependency closes, but it cannot act on a prose-only comment. Recommending the ticket "as a human follow-up" without filing and linking it is **not** a permitted exit.
     - **Human-only blocker** — an input the agent genuinely cannot obtain or produce no matter what it does: credentials, secrets, or **tool access** it does not have (AWS/CloudWatch, Figma, Jam, Sentry, SonarCloud, a database, a protected deploy target, …), or a product/design decision only a human can make. For missing tool access, follow the `tool-access-gate` rule's break-out protocol: post the "Access Needed" comment naming the exact credential/role/env var to grant and the probe that must pass — never work around the gap by substituting weaker verification, mocking the inaccessible system, or narrowing scope. Record the blocked verdict, mark it `human_needed` (the marker `repair-intake` recognizes, so it won't churn re-dispatching it), and surface or reassign to a human; do **not** fabricate a build-ready ticket, because there is no build-ready work.
 
-    Other harnesses fall back to this prose obligation.
+    **Harnesses that do not fire a Stop hook enforce the same discipline by convention.** The
+    `enforce-verification-gate.sh` Stop hook is a **Claude-only** surface — Codex, Cursor, Antigravity,
+    Copilot, and OpenCode carry the skills, agents, and (where the runtime has a rules surface) the
+    `claim-evidence-mapping` rule, but nothing on those runtimes can refuse to stop. That is a known
+    **representation gap**, documented here rather than dropped: on those harnesses this prose gate
+    *is* the gate, and the flow may not declare completion until it has written the same v2 verdict
+    and self-checked it against the same expectations the hook would have applied:
+
+    - `schema_version: 2` is written, with `plan`, `status`, and `updated_at` terminal and fresh.
+    - Every claim carries a `claim_id`, a `boundary` from the closed set, and the
+      `required_evidence_kinds` that reach that boundary — and its `evidence_refs` resolve to evidence
+      whose `kind` is one of them. A unit `test-run-log` cited for a `browser`, `http-api`, or
+      `deploy-health` claim is the failure this check exists to catch.
+    - `artifact.head_sha` names what will ship, and every evidence entry's `artifact_head_sha` matches
+      it, with a `sha256` digest and `captured_at` recorded as values, never placeholders.
+    - The `not_established` list is present on every claim and `not_established_reviewed` is `true` —
+      an empty list is fine, an omitted flag is not.
+
+    Record the self-check in the completion summary the way the hook would have reported it: name the
+    boundary each claim reached, or name the violation. Where the runtime lacks the rules surface (the
+    agy artifacts carry no rules tree), the obligation still travels in this skill — cite the
+    `claim-evidence-mapping` contract by slug and continue; never block on the absent surface.
 3. Write the highest-practical-observation regression test encoding the verification. For user-visible bugs or user-visible Build changes with an available browser/device/e2e harness, this means a deterministic spec on the reported surface — and for frontend work, once the validation journey is verified, codification into **every supported UI runner**: a Playwright spec in the Playwright runner AND a Maestro flow when the project supports Maestro, per `codify-verification`. Prove the new spec actually executed and passed in PR CI by recording a named spec log/reporter line or equivalent execution record; green CI without that named evidence does not satisfy this step.
 4. Record Implement usage on the originating work artifact via `lisa-usage-accounting` so the work item (or other implementation-owned artifact) gains a direct `lisa-implement` usage entry in the canonical `## Lisa Usage` section. If the parent / child graph is already known, prefer `record_and_rollup` so ancestor totals refresh in the same write; otherwise still write the direct entry, and if runtime usage is unavailable, use `source: unavailable` with nullable token/cost fields instead of skipping the row.
 5. Commit ALL outstanding changes in logical batches on the branch (minus sensitive data/information) — not just changes made by the agent team. This includes pre-existing uncommitted changes that were on the branch before the plan started. Do NOT filter commits to only "task-related" files. If it shows up in git status, it gets committed (unless it contains secrets).

--- a/plugins/lisa-copilot/skills/lisa-spec-conformance/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-spec-conformance/SKILL.md
@@ -67,10 +67,27 @@ Gather evidence of what was actually shipped:
    git diff "${BASE_BRANCH}"...HEAD -- '**/*.test.*' '**/*.spec.*'
    ```
 4. **Empirical evidence** — output of `verification-specialist` if available (proof artifacts, API captures, UI screenshots, DB queries). If that report isn't in context, ask the caller for it before proceeding — do not substitute reading code for running the system.
+4a. **The machine-readable verdict** — `Read` `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json`. Under **schema v2** it is the structured form of the evidence above, and it is what lets you check a claim's *reach* instead of taking "verified" at its word. Load `artifact` (`repository`, `head_sha`, `environment`), `claims[]` (`claim_id`, `statement`, `boundary`, `required_evidence_kinds`, `status`, `evidence_refs`, `not_established`), `evidence[]` (`evidence_id`, `kind`, `locator`, `sha256`, `captured_at`, `artifact_head_sha`), and the `not_established_reviewed` flag.
 5. **PR description** — `gh pr view --json title,body,files` if a PR exists.
 6. **Deployed state** — if the verification phase already hit a deployed environment, use those captures.
 
 Do NOT run the system yourself — that's the verification-specialist's job. Your job is to map their evidence to the spec.
+
+## Phase 3b — Cross-Check Claims Against Their Boundaries
+
+The `claim-evidence-mapping` rule is the contract: **every claim declares a boundary, and a claim is established only by evidence of a kind that reaches that boundary.** Conformance is not just "was it built" — it is also "does the proof offered actually reach the thing the requirement asserts." A unit `test-run-log` cited for a requirement about browser-visible behavior is a conformance defect even when the code is perfect.
+
+For every v2 claim loaded in Phase 3 step 4a, run three checks:
+
+| Check | Rule | Failure |
+|-------|------|---------|
+| **Boundary reach** | Each `evidence_refs` entry resolves to an `evidence[]` row whose `kind` appears in that claim's `required_evidence_kinds` — and those kinds are the ones the `claim-evidence-mapping` taxonomy binds to the claim's `boundary` | `BOUNDARY_MISMATCH` |
+| **Artifact identity** | Every cited evidence row's `artifact_head_sha` equals `artifact.head_sha` — the claim applies only to the artifact the evidence was collected against | `BOUNDARY_MISMATCH`, noting both SHAs |
+| **Not established** | `not_established_reviewed` is present and `true`, and every claim carries a `not_established` list (possibly empty) | `BOUNDARY_MISMATCH` on the verdict as a whole |
+
+Then bind the verdict back to the spec: map each `claim_id` to the requirement row it discharges. A requirement whose only supporting claim fails a check is **not** `MATCH`, no matter what the verification report's prose said. A requirement with no claim at all is `MISSING`, not `PARTIAL`.
+
+**Degrade, never block.** If `.lisa/verification-status.json` is absent, or carries **v1** (no `schema_version`, or `schema_version: 1` — only `plan` / `status` / `criteria[]` / `updated_at`), the boundary cross-check is not available. Say so explicitly in the report ("v2 verdict not present — boundary reach unverified"), fall back to the prose evidence from Phase 3, and cap the verdict at `PARTIAL` for any requirement whose boundary you cannot confirm. Do not invent a mismatch you could not check, and do not silently upgrade an unchecked claim to `MATCH`.
 
 ## Phase 4 — Build Coverage Matrix
 
@@ -81,8 +98,10 @@ For every requirement extracted in Phase 2, produce one row:
 | Requirement ID | Stable identifier (e.g. `AC-1`, `OOS-2`, `ASSERT-3`) |
 | Classification | `acceptance` / `excluded` / `technical` / `assertion` / `deliverable` / `task` / `blocker` |
 | Requirement Text | Verbatim from spec |
-| Evidence | Specific pointer — file:line, test name, verification report section, PR file, screenshot name |
-| Status | `MATCH` / `PARTIAL` / `MISSING` / `SCOPE_CREEP_VIOLATION` |
+| Evidence | Specific pointer — file:line, test name, verification report section, PR file, screenshot name. When a v2 verdict exists, also name the `claim_id` and `evidence_id` that discharge it |
+| Boundary | The claim's `boundary` from the v2 verdict (`code-unit` / `browser` / `http-api` / `cli` / `data` / `deploy-health` / `performance` / `standards-compat`), or `—` when no v2 claim maps to this row |
+| Evidence kind | The `kind` of each cited evidence row, so a reader sees the reach without opening the verdict |
+| Status | `MATCH` / `PARTIAL` / `MISSING` / `BOUNDARY_MISMATCH` / `SCOPE_CREEP_VIOLATION` |
 | Notes | One line — why partial, what's missing, or where evidence is thin |
 
 ### Status definitions
@@ -90,6 +109,7 @@ For every requirement extracted in Phase 2, produce one row:
 - **`MATCH`** — requirement is implemented AND there is empirical evidence it works (test + verification report).
 - **`PARTIAL`** — implementation exists but evidence is incomplete (e.g. code present, no test; or test present, no run-time verification).
 - **`MISSING`** — requirement has no corresponding implementation OR no evidence at all.
+- **`BOUNDARY_MISMATCH`** — the requirement was implemented and evidence was cited, but the evidence does not *reach* the claim's boundary (a unit `test-run-log` offered for a `browser` claim), or its `artifact_head_sha` does not match `artifact.head_sha`, or the verdict omits the required Not-established review. This is a distinct failure from a miss: the work may be right and the proof still does not establish it. A `BOUNDARY_MISMATCH` row forces the verdict to `DIVERGES` — it can never render as `CONFORMS` or `PARTIAL`. Name the boundary, the kind cited, and the kind(s) required, citing the `claim-evidence-mapping` taxonomy.
 - **`SCOPE_CREEP_VIOLATION`** — used for `excluded` classification only. An Out-of-Scope item appears to have been shipped anyway. This is a different failure than a miss — it means the agent exceeded the spec.
 
 ### Scope creep detection
@@ -106,9 +126,9 @@ Untraceable changes are not automatic failures. They become findings the human r
 
 Produce exactly one verdict:
 
-- **`CONFORMS`** — every requirement is `MATCH`. No `SCOPE_CREEP_VIOLATION`. Untraceable changes, if any, are clearly refactors or test support.
-- **`PARTIAL`** — some requirements are `PARTIAL` but none are `MISSING` or `SCOPE_CREEP_VIOLATION`. Work is mostly there but evidence is thin.
-- **`DIVERGES`** — at least one requirement is `MISSING`, OR at least one `SCOPE_CREEP_VIOLATION` exists, OR there are substantive untraceable changes that materially alter behavior.
+- **`CONFORMS`** — every requirement is `MATCH`. No `SCOPE_CREEP_VIOLATION`, no `BOUNDARY_MISMATCH`. Untraceable changes, if any, are clearly refactors or test support.
+- **`PARTIAL`** — some requirements are `PARTIAL` but none are `MISSING`, `BOUNDARY_MISMATCH`, or `SCOPE_CREEP_VIOLATION`. Work is mostly there but evidence is thin.
+- **`DIVERGES`** — at least one requirement is `MISSING`, OR at least one `BOUNDARY_MISMATCH` exists, OR at least one `SCOPE_CREEP_VIOLATION` exists, OR there are substantive untraceable changes that materially alter behavior.
 
 A verdict of `PARTIAL` or `DIVERGES` blocks task completion. The caller must resolve the gaps (implement the miss, remove the creep, add the missing evidence) before re-running.
 
@@ -121,15 +141,24 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 
 **Spec source:** <plan file / JIRA key / Linear / GitHub issue / PRD>
 **Shipped scope:** <N commits, M files, K tests on branch <branch> vs <default-branch>>
+**Verdict artifact:** <.lisa/verification-status.json schema v2, artifact.head_sha <sha> — or "v2 verdict not present — boundary reach unverified">
 
 ### Coverage Matrix
 
-| ID | Class | Requirement | Evidence | Status | Notes |
-|----|-------|-------------|----------|--------|-------|
-| AC-1 | acceptance | [text] | [pointer] | MATCH | |
-| AC-2 | acceptance | [text] | — | MISSING | No corresponding code or test |
-| OOS-1 | excluded | [text] | src/foo.ts:42 | SCOPE_CREEP_VIOLATION | Added anyway |
-| ASSERT-1 | assertion | [text] | verification-report §2 | PARTIAL | Asserted in code, not run in verification |
+| ID | Class | Requirement | Evidence | Boundary | Evidence kind | Status | Notes |
+|----|-------|-------------|----------|----------|---------------|--------|-------|
+| AC-1 | acceptance | [text] | [pointer] (AC-1 / EV-1) | browser | screenshot | MATCH | |
+| AC-2 | acceptance | [text] | — | — | — | MISSING | No corresponding code or test |
+| AC-3 | acceptance | [text] | EV-4 | browser | test-run-log | BOUNDARY_MISMATCH | Unit log cannot establish a browser claim — needs screenshot or recording |
+| OOS-1 | excluded | [text] | src/foo.ts:42 | — | — | SCOPE_CREEP_VIOLATION | Added anyway |
+| ASSERT-1 | assertion | [text] | verification-report §2 | http-api | — | PARTIAL | Asserted in code, not run in verification |
+
+### Not Established
+
+Reproduce the verdict's `not_established` entries verbatim, grouped by claim, plus anything the matrix could not confirm. This section is **never omitted and never blank**: with nothing outstanding it renders `None outstanding — reviewed`. State whether `not_established_reviewed` was `true`.
+
+- AC-1 — not exercised on mobile viewports; Safari not tested
+- AC-4 — offline behavior consciously out of scope for this ticket
 
 ### Untraceable Changes
 - src/utils/helpers.ts — extracted shared regex constant (refactor, no behavior change)
@@ -140,6 +169,7 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 **Matches:** N/Total
 **Partial:** N
 **Missing:** N
+**Boundary mismatches:** N
 **Scope creep violations:** N
 **Untraceable changes flagged for review:** N
 
@@ -152,6 +182,8 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 
 - Never substitute "I read the code and it looks right" for empirical evidence. If verification-specialist hasn't run yet, request its report before producing a verdict.
 - Never mark a requirement `MATCH` based on the presence of code alone — evidence means test + runtime observation.
+- Never mark a requirement `MATCH` on evidence that does not **reach** its claim's boundary. Per the `claim-evidence-mapping` contract, a unit `test-run-log` establishes only `code-unit` behavior; cited for a `browser`, `http-api`, `deploy-health`, or `standards-compat` claim it is a `BOUNDARY_MISMATCH`, not a match.
+- Always report the Not-established section, even when empty. A report that lists only what passed is unreadable at a gate.
 - Always surface scope creep separately from misses. They are distinct failures.
 - Always surface untraceable changes — even benign refactors — so the human can confirm intent.
 - The Out of Scope section is load-bearing. If the spec has one, every item must appear in the matrix as `excluded`.

--- a/plugins/lisa-cursor/agents/spec-conformance-specialist.md
+++ b/plugins/lisa-cursor/agents/spec-conformance-specialist.md
@@ -30,8 +30,9 @@ Follow the `spec-conformance` skill end-to-end:
 
 1. Resolve the spec source (plan file, JIRA key, Linear, GitHub issue, PRD).
 2. Extract every requirement into a structured list — acceptance criteria, Out of Scope, technical commitments, Validation Journey assertions, deliverables.
-3. Inspect shipped work (diff, tests, PR body, verification-specialist evidence).
-4. Build the coverage matrix — every requirement gets a row with a status.
+3. Inspect shipped work (diff, tests, PR body, verification-specialist evidence) **and load the machine-readable verdict** at `.lisa/verification-status.json`.
+3b. Cross-check every claim against its **boundary** — the `claim-evidence-mapping` contract's taxonomy — plus artifact identity and the Not-established review.
+4. Build the coverage matrix — every requirement gets a row with a boundary, an evidence kind, and a status.
 5. Detect scope creep and untraceable changes separately.
 6. Produce the verdict.
 
@@ -42,6 +43,8 @@ Return the structured report defined in the skill. Never summarize or drop rows.
 ## Rules
 
 - **Require empirical evidence.** A requirement is not `MATCH` because code exists. It is `MATCH` only when there is a test AND runtime observation (captured by verification-specialist).
+- **A cited-evidence-boundary mismatch is a conformance finding.** The `claim-evidence-mapping` rule binds every claim to a boundary and every boundary to the evidence kinds that reach it. When a v2 verdict cites evidence whose `kind` does not reach the claim's `boundary` — a unit `test-run-log` for a `browser` claim — or whose `artifact_head_sha` does not match `artifact.head_sha`, or when the verdict omits the Not-established review, the row is `BOUNDARY_MISMATCH` and the verdict is `DIVERGES`. Name the boundary, the kind cited, and the kind(s) required. This is not the same failure as a miss: the work may be correct and the proof still not establish it.
+- **Degrade, never block, on an absent or v1 verdict.** If no v2 verdict exists, say so in the report, cap affected rows at `PARTIAL`, and do not invent a mismatch you could not check.
 - **Scope creep is a distinct failure.** Do not fold `SCOPE_CREEP_VIOLATION` into "missing" or "untraceable." Scope creep means Out of Scope was violated — it blocks shipping.
 - **Untraceable changes get surfaced, not judged.** Refactors and test helpers often land here. Surface them so the human can confirm intent; do not automatically fail.
 - **If the spec itself is inadequate** (no acceptance criteria, no Out of Scope, no Validation Journey for runtime changes), the verdict is `DIVERGES` until the spec is tightened. Do not paper over an ambiguous spec with a generous match.

--- a/plugins/lisa-cursor/agents/verification-specialist.md
+++ b/plugins/lisa-cursor/agents/verification-specialist.md
@@ -12,7 +12,7 @@ skills:
 
 You are a verification specialist. Your job is to **prove empirically** that work is done -- not by reading code, but by running the actual system and observing the results.
 
-Read `.claude/rules/verification.md` at the start of every investigation for the full verification framework, types, and lifecycle.
+Read `.claude/rules/verification.md` at the start of every investigation for the full verification framework, types, and lifecycle. Read `.claude/rules/claim-evidence-mapping.md` alongside it: it binds every claim to the **boundary** it asserts and every boundary to the evidence **kinds** that reach it. The verdict you write is what `spec-conformance-specialist` cross-checks — record each claim's `boundary`, its `required_evidence_kinds`, its `evidence_refs`, and its `not_established` list so a boundary mismatch is catchable rather than invisible.
 
 ## Core Philosophy
 

--- a/plugins/lisa-cursor/rules/verification-reference.mdc
+++ b/plugins/lisa-cursor/rules/verification-reference.mdc
@@ -182,6 +182,8 @@ The list may be empty; the flag may not be missing. An absent `not_established_r
 
 The boundary each artifact type reaches — and therefore which claim a captured artifact can discharge — is the `claim-evidence-mapping` rule's taxonomy; the type table above is its evidence-kind source.
 
+The verdict is read twice. The Claude-only `enforce-verification-gate.sh` Stop hook reads it to decide whether the flow may stop; `lisa-spec-conformance` (run by `spec-conformance-specialist` in the verification phase) reads it to decide whether each shipped requirement's proof actually reaches its boundary — a cited-evidence-boundary mismatch is a `BOUNDARY_MISMATCH` conformance finding there, caught alongside empirical verification rather than after it. On harnesses without a Stop hook, `lisa-implement`'s prose gate carries the same v2 expectations by convention. The whole system, operator-readable end to end, is written up as the Lisa wiki's **Bounded-Claims Evidence System** concept page (`wiki/concepts/bounded-claims-evidence-system.md` upstream).
+
 ### Cross-work-item evidence references are non-claiming
 
 When prose needs to point at evidence declared by another work item, use the dedicated reference form:

--- a/plugins/lisa-cursor/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-implement/SKILL.md
@@ -278,7 +278,28 @@ Before shutting down the team, execute the Verify flow:
     - **Actionable blocker** — an unresolved dependency or fixable technical gap that some team or repository could build (a missing or changed schema field, an unbuilt sibling work item, a required upstream fix), **including cross-repo dependencies**. Before writing the blocked verdict you MUST (1) file a build-ready fix/dependency ticket capturing the diagnosis — in the dependency's own repository/tracker when it is cross-repo (e.g. a `[<repo>] …` ticket in the shared project, or the sibling tracker) — and (2) link the current work item to it as `is blocked by`. Only then write the verdict. This is the same discipline as the regression-spec blocker and the remote-verification-fail exits above, and it is what makes the block machine-recoverable: `repair-intake` re-dispatches a blocked item once its linked `is blocked by` dependency closes, but it cannot act on a prose-only comment. Recommending the ticket "as a human follow-up" without filing and linking it is **not** a permitted exit.
     - **Human-only blocker** — an input the agent genuinely cannot obtain or produce no matter what it does: credentials, secrets, or **tool access** it does not have (AWS/CloudWatch, Figma, Jam, Sentry, SonarCloud, a database, a protected deploy target, …), or a product/design decision only a human can make. For missing tool access, follow the `tool-access-gate` rule's break-out protocol: post the "Access Needed" comment naming the exact credential/role/env var to grant and the probe that must pass — never work around the gap by substituting weaker verification, mocking the inaccessible system, or narrowing scope. Record the blocked verdict, mark it `human_needed` (the marker `repair-intake` recognizes, so it won't churn re-dispatching it), and surface or reassign to a human; do **not** fabricate a build-ready ticket, because there is no build-ready work.
 
-    Other harnesses fall back to this prose obligation.
+    **Harnesses that do not fire a Stop hook enforce the same discipline by convention.** The
+    `enforce-verification-gate.sh` Stop hook is a **Claude-only** surface — Codex, Cursor, Antigravity,
+    Copilot, and OpenCode carry the skills, agents, and (where the runtime has a rules surface) the
+    `claim-evidence-mapping` rule, but nothing on those runtimes can refuse to stop. That is a known
+    **representation gap**, documented here rather than dropped: on those harnesses this prose gate
+    *is* the gate, and the flow may not declare completion until it has written the same v2 verdict
+    and self-checked it against the same expectations the hook would have applied:
+
+    - `schema_version: 2` is written, with `plan`, `status`, and `updated_at` terminal and fresh.
+    - Every claim carries a `claim_id`, a `boundary` from the closed set, and the
+      `required_evidence_kinds` that reach that boundary — and its `evidence_refs` resolve to evidence
+      whose `kind` is one of them. A unit `test-run-log` cited for a `browser`, `http-api`, or
+      `deploy-health` claim is the failure this check exists to catch.
+    - `artifact.head_sha` names what will ship, and every evidence entry's `artifact_head_sha` matches
+      it, with a `sha256` digest and `captured_at` recorded as values, never placeholders.
+    - The `not_established` list is present on every claim and `not_established_reviewed` is `true` —
+      an empty list is fine, an omitted flag is not.
+
+    Record the self-check in the completion summary the way the hook would have reported it: name the
+    boundary each claim reached, or name the violation. Where the runtime lacks the rules surface (the
+    agy artifacts carry no rules tree), the obligation still travels in this skill — cite the
+    `claim-evidence-mapping` contract by slug and continue; never block on the absent surface.
 3. Write the highest-practical-observation regression test encoding the verification. For user-visible bugs or user-visible Build changes with an available browser/device/e2e harness, this means a deterministic spec on the reported surface — and for frontend work, once the validation journey is verified, codification into **every supported UI runner**: a Playwright spec in the Playwright runner AND a Maestro flow when the project supports Maestro, per `codify-verification`. Prove the new spec actually executed and passed in PR CI by recording a named spec log/reporter line or equivalent execution record; green CI without that named evidence does not satisfy this step.
 4. Record Implement usage on the originating work artifact via `lisa-usage-accounting` so the work item (or other implementation-owned artifact) gains a direct `lisa-implement` usage entry in the canonical `## Lisa Usage` section. If the parent / child graph is already known, prefer `record_and_rollup` so ancestor totals refresh in the same write; otherwise still write the direct entry, and if runtime usage is unavailable, use `source: unavailable` with nullable token/cost fields instead of skipping the row.
 5. Commit ALL outstanding changes in logical batches on the branch (minus sensitive data/information) — not just changes made by the agent team. This includes pre-existing uncommitted changes that were on the branch before the plan started. Do NOT filter commits to only "task-related" files. If it shows up in git status, it gets committed (unless it contains secrets).

--- a/plugins/lisa-cursor/skills/lisa-spec-conformance/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-spec-conformance/SKILL.md
@@ -67,10 +67,27 @@ Gather evidence of what was actually shipped:
    git diff "${BASE_BRANCH}"...HEAD -- '**/*.test.*' '**/*.spec.*'
    ```
 4. **Empirical evidence** — output of `verification-specialist` if available (proof artifacts, API captures, UI screenshots, DB queries). If that report isn't in context, ask the caller for it before proceeding — do not substitute reading code for running the system.
+4a. **The machine-readable verdict** — `Read` `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json`. Under **schema v2** it is the structured form of the evidence above, and it is what lets you check a claim's *reach* instead of taking "verified" at its word. Load `artifact` (`repository`, `head_sha`, `environment`), `claims[]` (`claim_id`, `statement`, `boundary`, `required_evidence_kinds`, `status`, `evidence_refs`, `not_established`), `evidence[]` (`evidence_id`, `kind`, `locator`, `sha256`, `captured_at`, `artifact_head_sha`), and the `not_established_reviewed` flag.
 5. **PR description** — `gh pr view --json title,body,files` if a PR exists.
 6. **Deployed state** — if the verification phase already hit a deployed environment, use those captures.
 
 Do NOT run the system yourself — that's the verification-specialist's job. Your job is to map their evidence to the spec.
+
+## Phase 3b — Cross-Check Claims Against Their Boundaries
+
+The `claim-evidence-mapping` rule is the contract: **every claim declares a boundary, and a claim is established only by evidence of a kind that reaches that boundary.** Conformance is not just "was it built" — it is also "does the proof offered actually reach the thing the requirement asserts." A unit `test-run-log` cited for a requirement about browser-visible behavior is a conformance defect even when the code is perfect.
+
+For every v2 claim loaded in Phase 3 step 4a, run three checks:
+
+| Check | Rule | Failure |
+|-------|------|---------|
+| **Boundary reach** | Each `evidence_refs` entry resolves to an `evidence[]` row whose `kind` appears in that claim's `required_evidence_kinds` — and those kinds are the ones the `claim-evidence-mapping` taxonomy binds to the claim's `boundary` | `BOUNDARY_MISMATCH` |
+| **Artifact identity** | Every cited evidence row's `artifact_head_sha` equals `artifact.head_sha` — the claim applies only to the artifact the evidence was collected against | `BOUNDARY_MISMATCH`, noting both SHAs |
+| **Not established** | `not_established_reviewed` is present and `true`, and every claim carries a `not_established` list (possibly empty) | `BOUNDARY_MISMATCH` on the verdict as a whole |
+
+Then bind the verdict back to the spec: map each `claim_id` to the requirement row it discharges. A requirement whose only supporting claim fails a check is **not** `MATCH`, no matter what the verification report's prose said. A requirement with no claim at all is `MISSING`, not `PARTIAL`.
+
+**Degrade, never block.** If `.lisa/verification-status.json` is absent, or carries **v1** (no `schema_version`, or `schema_version: 1` — only `plan` / `status` / `criteria[]` / `updated_at`), the boundary cross-check is not available. Say so explicitly in the report ("v2 verdict not present — boundary reach unverified"), fall back to the prose evidence from Phase 3, and cap the verdict at `PARTIAL` for any requirement whose boundary you cannot confirm. Do not invent a mismatch you could not check, and do not silently upgrade an unchecked claim to `MATCH`.
 
 ## Phase 4 — Build Coverage Matrix
 
@@ -81,8 +98,10 @@ For every requirement extracted in Phase 2, produce one row:
 | Requirement ID | Stable identifier (e.g. `AC-1`, `OOS-2`, `ASSERT-3`) |
 | Classification | `acceptance` / `excluded` / `technical` / `assertion` / `deliverable` / `task` / `blocker` |
 | Requirement Text | Verbatim from spec |
-| Evidence | Specific pointer — file:line, test name, verification report section, PR file, screenshot name |
-| Status | `MATCH` / `PARTIAL` / `MISSING` / `SCOPE_CREEP_VIOLATION` |
+| Evidence | Specific pointer — file:line, test name, verification report section, PR file, screenshot name. When a v2 verdict exists, also name the `claim_id` and `evidence_id` that discharge it |
+| Boundary | The claim's `boundary` from the v2 verdict (`code-unit` / `browser` / `http-api` / `cli` / `data` / `deploy-health` / `performance` / `standards-compat`), or `—` when no v2 claim maps to this row |
+| Evidence kind | The `kind` of each cited evidence row, so a reader sees the reach without opening the verdict |
+| Status | `MATCH` / `PARTIAL` / `MISSING` / `BOUNDARY_MISMATCH` / `SCOPE_CREEP_VIOLATION` |
 | Notes | One line — why partial, what's missing, or where evidence is thin |
 
 ### Status definitions
@@ -90,6 +109,7 @@ For every requirement extracted in Phase 2, produce one row:
 - **`MATCH`** — requirement is implemented AND there is empirical evidence it works (test + verification report).
 - **`PARTIAL`** — implementation exists but evidence is incomplete (e.g. code present, no test; or test present, no run-time verification).
 - **`MISSING`** — requirement has no corresponding implementation OR no evidence at all.
+- **`BOUNDARY_MISMATCH`** — the requirement was implemented and evidence was cited, but the evidence does not *reach* the claim's boundary (a unit `test-run-log` offered for a `browser` claim), or its `artifact_head_sha` does not match `artifact.head_sha`, or the verdict omits the required Not-established review. This is a distinct failure from a miss: the work may be right and the proof still does not establish it. A `BOUNDARY_MISMATCH` row forces the verdict to `DIVERGES` — it can never render as `CONFORMS` or `PARTIAL`. Name the boundary, the kind cited, and the kind(s) required, citing the `claim-evidence-mapping` taxonomy.
 - **`SCOPE_CREEP_VIOLATION`** — used for `excluded` classification only. An Out-of-Scope item appears to have been shipped anyway. This is a different failure than a miss — it means the agent exceeded the spec.
 
 ### Scope creep detection
@@ -106,9 +126,9 @@ Untraceable changes are not automatic failures. They become findings the human r
 
 Produce exactly one verdict:
 
-- **`CONFORMS`** — every requirement is `MATCH`. No `SCOPE_CREEP_VIOLATION`. Untraceable changes, if any, are clearly refactors or test support.
-- **`PARTIAL`** — some requirements are `PARTIAL` but none are `MISSING` or `SCOPE_CREEP_VIOLATION`. Work is mostly there but evidence is thin.
-- **`DIVERGES`** — at least one requirement is `MISSING`, OR at least one `SCOPE_CREEP_VIOLATION` exists, OR there are substantive untraceable changes that materially alter behavior.
+- **`CONFORMS`** — every requirement is `MATCH`. No `SCOPE_CREEP_VIOLATION`, no `BOUNDARY_MISMATCH`. Untraceable changes, if any, are clearly refactors or test support.
+- **`PARTIAL`** — some requirements are `PARTIAL` but none are `MISSING`, `BOUNDARY_MISMATCH`, or `SCOPE_CREEP_VIOLATION`. Work is mostly there but evidence is thin.
+- **`DIVERGES`** — at least one requirement is `MISSING`, OR at least one `BOUNDARY_MISMATCH` exists, OR at least one `SCOPE_CREEP_VIOLATION` exists, OR there are substantive untraceable changes that materially alter behavior.
 
 A verdict of `PARTIAL` or `DIVERGES` blocks task completion. The caller must resolve the gaps (implement the miss, remove the creep, add the missing evidence) before re-running.
 
@@ -121,15 +141,24 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 
 **Spec source:** <plan file / JIRA key / Linear / GitHub issue / PRD>
 **Shipped scope:** <N commits, M files, K tests on branch <branch> vs <default-branch>>
+**Verdict artifact:** <.lisa/verification-status.json schema v2, artifact.head_sha <sha> — or "v2 verdict not present — boundary reach unverified">
 
 ### Coverage Matrix
 
-| ID | Class | Requirement | Evidence | Status | Notes |
-|----|-------|-------------|----------|--------|-------|
-| AC-1 | acceptance | [text] | [pointer] | MATCH | |
-| AC-2 | acceptance | [text] | — | MISSING | No corresponding code or test |
-| OOS-1 | excluded | [text] | src/foo.ts:42 | SCOPE_CREEP_VIOLATION | Added anyway |
-| ASSERT-1 | assertion | [text] | verification-report §2 | PARTIAL | Asserted in code, not run in verification |
+| ID | Class | Requirement | Evidence | Boundary | Evidence kind | Status | Notes |
+|----|-------|-------------|----------|----------|---------------|--------|-------|
+| AC-1 | acceptance | [text] | [pointer] (AC-1 / EV-1) | browser | screenshot | MATCH | |
+| AC-2 | acceptance | [text] | — | — | — | MISSING | No corresponding code or test |
+| AC-3 | acceptance | [text] | EV-4 | browser | test-run-log | BOUNDARY_MISMATCH | Unit log cannot establish a browser claim — needs screenshot or recording |
+| OOS-1 | excluded | [text] | src/foo.ts:42 | — | — | SCOPE_CREEP_VIOLATION | Added anyway |
+| ASSERT-1 | assertion | [text] | verification-report §2 | http-api | — | PARTIAL | Asserted in code, not run in verification |
+
+### Not Established
+
+Reproduce the verdict's `not_established` entries verbatim, grouped by claim, plus anything the matrix could not confirm. This section is **never omitted and never blank**: with nothing outstanding it renders `None outstanding — reviewed`. State whether `not_established_reviewed` was `true`.
+
+- AC-1 — not exercised on mobile viewports; Safari not tested
+- AC-4 — offline behavior consciously out of scope for this ticket
 
 ### Untraceable Changes
 - src/utils/helpers.ts — extracted shared regex constant (refactor, no behavior change)
@@ -140,6 +169,7 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 **Matches:** N/Total
 **Partial:** N
 **Missing:** N
+**Boundary mismatches:** N
 **Scope creep violations:** N
 **Untraceable changes flagged for review:** N
 
@@ -152,6 +182,8 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 
 - Never substitute "I read the code and it looks right" for empirical evidence. If verification-specialist hasn't run yet, request its report before producing a verdict.
 - Never mark a requirement `MATCH` based on the presence of code alone — evidence means test + runtime observation.
+- Never mark a requirement `MATCH` on evidence that does not **reach** its claim's boundary. Per the `claim-evidence-mapping` contract, a unit `test-run-log` establishes only `code-unit` behavior; cited for a `browser`, `http-api`, `deploy-health`, or `standards-compat` claim it is a `BOUNDARY_MISMATCH`, not a match.
+- Always report the Not-established section, even when empty. A report that lists only what passed is unreadable at a gate.
 - Always surface scope creep separately from misses. They are distinct failures.
 - Always surface untraceable changes — even benign refactors — so the human can confirm intent.
 - The Out of Scope section is load-bearing. If the spec has one, every item must appear in the matrix as `excluded`.

--- a/plugins/lisa/.codex-plugin/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-implement/SKILL.md
@@ -278,7 +278,28 @@ Before shutting down the team, execute the Verify flow:
     - **Actionable blocker** — an unresolved dependency or fixable technical gap that some team or repository could build (a missing or changed schema field, an unbuilt sibling work item, a required upstream fix), **including cross-repo dependencies**. Before writing the blocked verdict you MUST (1) file a build-ready fix/dependency ticket capturing the diagnosis — in the dependency's own repository/tracker when it is cross-repo (e.g. a `[<repo>] …` ticket in the shared project, or the sibling tracker) — and (2) link the current work item to it as `is blocked by`. Only then write the verdict. This is the same discipline as the regression-spec blocker and the remote-verification-fail exits above, and it is what makes the block machine-recoverable: `repair-intake` re-dispatches a blocked item once its linked `is blocked by` dependency closes, but it cannot act on a prose-only comment. Recommending the ticket "as a human follow-up" without filing and linking it is **not** a permitted exit.
     - **Human-only blocker** — an input the agent genuinely cannot obtain or produce no matter what it does: credentials, secrets, or **tool access** it does not have (AWS/CloudWatch, Figma, Jam, Sentry, SonarCloud, a database, a protected deploy target, …), or a product/design decision only a human can make. For missing tool access, follow the `tool-access-gate` rule's break-out protocol: post the "Access Needed" comment naming the exact credential/role/env var to grant and the probe that must pass — never work around the gap by substituting weaker verification, mocking the inaccessible system, or narrowing scope. Record the blocked verdict, mark it `human_needed` (the marker `repair-intake` recognizes, so it won't churn re-dispatching it), and surface or reassign to a human; do **not** fabricate a build-ready ticket, because there is no build-ready work.
 
-    Other harnesses fall back to this prose obligation.
+    **Harnesses that do not fire a Stop hook enforce the same discipline by convention.** The
+    `enforce-verification-gate.sh` Stop hook is a **Claude-only** surface — Codex, Cursor, Antigravity,
+    Copilot, and OpenCode carry the skills, agents, and (where the runtime has a rules surface) the
+    `claim-evidence-mapping` rule, but nothing on those runtimes can refuse to stop. That is a known
+    **representation gap**, documented here rather than dropped: on those harnesses this prose gate
+    *is* the gate, and the flow may not declare completion until it has written the same v2 verdict
+    and self-checked it against the same expectations the hook would have applied:
+
+    - `schema_version: 2` is written, with `plan`, `status`, and `updated_at` terminal and fresh.
+    - Every claim carries a `claim_id`, a `boundary` from the closed set, and the
+      `required_evidence_kinds` that reach that boundary — and its `evidence_refs` resolve to evidence
+      whose `kind` is one of them. A unit `test-run-log` cited for a `browser`, `http-api`, or
+      `deploy-health` claim is the failure this check exists to catch.
+    - `artifact.head_sha` names what will ship, and every evidence entry's `artifact_head_sha` matches
+      it, with a `sha256` digest and `captured_at` recorded as values, never placeholders.
+    - The `not_established` list is present on every claim and `not_established_reviewed` is `true` —
+      an empty list is fine, an omitted flag is not.
+
+    Record the self-check in the completion summary the way the hook would have reported it: name the
+    boundary each claim reached, or name the violation. Where the runtime lacks the rules surface (the
+    agy artifacts carry no rules tree), the obligation still travels in this skill — cite the
+    `claim-evidence-mapping` contract by slug and continue; never block on the absent surface.
 3. Write the highest-practical-observation regression test encoding the verification. For user-visible bugs or user-visible Build changes with an available browser/device/e2e harness, this means a deterministic spec on the reported surface — and for frontend work, once the validation journey is verified, codification into **every supported UI runner**: a Playwright spec in the Playwright runner AND a Maestro flow when the project supports Maestro, per `codify-verification`. Prove the new spec actually executed and passed in PR CI by recording a named spec log/reporter line or equivalent execution record; green CI without that named evidence does not satisfy this step.
 4. Record Implement usage on the originating work artifact via `lisa-usage-accounting` so the work item (or other implementation-owned artifact) gains a direct `lisa-implement` usage entry in the canonical `## Lisa Usage` section. If the parent / child graph is already known, prefer `record_and_rollup` so ancestor totals refresh in the same write; otherwise still write the direct entry, and if runtime usage is unavailable, use `source: unavailable` with nullable token/cost fields instead of skipping the row.
 5. Commit ALL outstanding changes in logical batches on the branch (minus sensitive data/information) — not just changes made by the agent team. This includes pre-existing uncommitted changes that were on the branch before the plan started. Do NOT filter commits to only "task-related" files. If it shows up in git status, it gets committed (unless it contains secrets).

--- a/plugins/lisa/.codex-plugin/skills/lisa-spec-conformance/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-spec-conformance/SKILL.md
@@ -67,10 +67,27 @@ Gather evidence of what was actually shipped:
    git diff "${BASE_BRANCH}"...HEAD -- '**/*.test.*' '**/*.spec.*'
    ```
 4. **Empirical evidence** — output of `verification-specialist` if available (proof artifacts, API captures, UI screenshots, DB queries). If that report isn't in context, ask the caller for it before proceeding — do not substitute reading code for running the system.
+4a. **The machine-readable verdict** — `Read` `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json`. Under **schema v2** it is the structured form of the evidence above, and it is what lets you check a claim's *reach* instead of taking "verified" at its word. Load `artifact` (`repository`, `head_sha`, `environment`), `claims[]` (`claim_id`, `statement`, `boundary`, `required_evidence_kinds`, `status`, `evidence_refs`, `not_established`), `evidence[]` (`evidence_id`, `kind`, `locator`, `sha256`, `captured_at`, `artifact_head_sha`), and the `not_established_reviewed` flag.
 5. **PR description** — `gh pr view --json title,body,files` if a PR exists.
 6. **Deployed state** — if the verification phase already hit a deployed environment, use those captures.
 
 Do NOT run the system yourself — that's the verification-specialist's job. Your job is to map their evidence to the spec.
+
+## Phase 3b — Cross-Check Claims Against Their Boundaries
+
+The `claim-evidence-mapping` rule is the contract: **every claim declares a boundary, and a claim is established only by evidence of a kind that reaches that boundary.** Conformance is not just "was it built" — it is also "does the proof offered actually reach the thing the requirement asserts." A unit `test-run-log` cited for a requirement about browser-visible behavior is a conformance defect even when the code is perfect.
+
+For every v2 claim loaded in Phase 3 step 4a, run three checks:
+
+| Check | Rule | Failure |
+|-------|------|---------|
+| **Boundary reach** | Each `evidence_refs` entry resolves to an `evidence[]` row whose `kind` appears in that claim's `required_evidence_kinds` — and those kinds are the ones the `claim-evidence-mapping` taxonomy binds to the claim's `boundary` | `BOUNDARY_MISMATCH` |
+| **Artifact identity** | Every cited evidence row's `artifact_head_sha` equals `artifact.head_sha` — the claim applies only to the artifact the evidence was collected against | `BOUNDARY_MISMATCH`, noting both SHAs |
+| **Not established** | `not_established_reviewed` is present and `true`, and every claim carries a `not_established` list (possibly empty) | `BOUNDARY_MISMATCH` on the verdict as a whole |
+
+Then bind the verdict back to the spec: map each `claim_id` to the requirement row it discharges. A requirement whose only supporting claim fails a check is **not** `MATCH`, no matter what the verification report's prose said. A requirement with no claim at all is `MISSING`, not `PARTIAL`.
+
+**Degrade, never block.** If `.lisa/verification-status.json` is absent, or carries **v1** (no `schema_version`, or `schema_version: 1` — only `plan` / `status` / `criteria[]` / `updated_at`), the boundary cross-check is not available. Say so explicitly in the report ("v2 verdict not present — boundary reach unverified"), fall back to the prose evidence from Phase 3, and cap the verdict at `PARTIAL` for any requirement whose boundary you cannot confirm. Do not invent a mismatch you could not check, and do not silently upgrade an unchecked claim to `MATCH`.
 
 ## Phase 4 — Build Coverage Matrix
 
@@ -81,8 +98,10 @@ For every requirement extracted in Phase 2, produce one row:
 | Requirement ID | Stable identifier (e.g. `AC-1`, `OOS-2`, `ASSERT-3`) |
 | Classification | `acceptance` / `excluded` / `technical` / `assertion` / `deliverable` / `task` / `blocker` |
 | Requirement Text | Verbatim from spec |
-| Evidence | Specific pointer — file:line, test name, verification report section, PR file, screenshot name |
-| Status | `MATCH` / `PARTIAL` / `MISSING` / `SCOPE_CREEP_VIOLATION` |
+| Evidence | Specific pointer — file:line, test name, verification report section, PR file, screenshot name. When a v2 verdict exists, also name the `claim_id` and `evidence_id` that discharge it |
+| Boundary | The claim's `boundary` from the v2 verdict (`code-unit` / `browser` / `http-api` / `cli` / `data` / `deploy-health` / `performance` / `standards-compat`), or `—` when no v2 claim maps to this row |
+| Evidence kind | The `kind` of each cited evidence row, so a reader sees the reach without opening the verdict |
+| Status | `MATCH` / `PARTIAL` / `MISSING` / `BOUNDARY_MISMATCH` / `SCOPE_CREEP_VIOLATION` |
 | Notes | One line — why partial, what's missing, or where evidence is thin |
 
 ### Status definitions
@@ -90,6 +109,7 @@ For every requirement extracted in Phase 2, produce one row:
 - **`MATCH`** — requirement is implemented AND there is empirical evidence it works (test + verification report).
 - **`PARTIAL`** — implementation exists but evidence is incomplete (e.g. code present, no test; or test present, no run-time verification).
 - **`MISSING`** — requirement has no corresponding implementation OR no evidence at all.
+- **`BOUNDARY_MISMATCH`** — the requirement was implemented and evidence was cited, but the evidence does not *reach* the claim's boundary (a unit `test-run-log` offered for a `browser` claim), or its `artifact_head_sha` does not match `artifact.head_sha`, or the verdict omits the required Not-established review. This is a distinct failure from a miss: the work may be right and the proof still does not establish it. A `BOUNDARY_MISMATCH` row forces the verdict to `DIVERGES` — it can never render as `CONFORMS` or `PARTIAL`. Name the boundary, the kind cited, and the kind(s) required, citing the `claim-evidence-mapping` taxonomy.
 - **`SCOPE_CREEP_VIOLATION`** — used for `excluded` classification only. An Out-of-Scope item appears to have been shipped anyway. This is a different failure than a miss — it means the agent exceeded the spec.
 
 ### Scope creep detection
@@ -106,9 +126,9 @@ Untraceable changes are not automatic failures. They become findings the human r
 
 Produce exactly one verdict:
 
-- **`CONFORMS`** — every requirement is `MATCH`. No `SCOPE_CREEP_VIOLATION`. Untraceable changes, if any, are clearly refactors or test support.
-- **`PARTIAL`** — some requirements are `PARTIAL` but none are `MISSING` or `SCOPE_CREEP_VIOLATION`. Work is mostly there but evidence is thin.
-- **`DIVERGES`** — at least one requirement is `MISSING`, OR at least one `SCOPE_CREEP_VIOLATION` exists, OR there are substantive untraceable changes that materially alter behavior.
+- **`CONFORMS`** — every requirement is `MATCH`. No `SCOPE_CREEP_VIOLATION`, no `BOUNDARY_MISMATCH`. Untraceable changes, if any, are clearly refactors or test support.
+- **`PARTIAL`** — some requirements are `PARTIAL` but none are `MISSING`, `BOUNDARY_MISMATCH`, or `SCOPE_CREEP_VIOLATION`. Work is mostly there but evidence is thin.
+- **`DIVERGES`** — at least one requirement is `MISSING`, OR at least one `BOUNDARY_MISMATCH` exists, OR at least one `SCOPE_CREEP_VIOLATION` exists, OR there are substantive untraceable changes that materially alter behavior.
 
 A verdict of `PARTIAL` or `DIVERGES` blocks task completion. The caller must resolve the gaps (implement the miss, remove the creep, add the missing evidence) before re-running.
 
@@ -121,15 +141,24 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 
 **Spec source:** <plan file / JIRA key / Linear / GitHub issue / PRD>
 **Shipped scope:** <N commits, M files, K tests on branch <branch> vs <default-branch>>
+**Verdict artifact:** <.lisa/verification-status.json schema v2, artifact.head_sha <sha> — or "v2 verdict not present — boundary reach unverified">
 
 ### Coverage Matrix
 
-| ID | Class | Requirement | Evidence | Status | Notes |
-|----|-------|-------------|----------|--------|-------|
-| AC-1 | acceptance | [text] | [pointer] | MATCH | |
-| AC-2 | acceptance | [text] | — | MISSING | No corresponding code or test |
-| OOS-1 | excluded | [text] | src/foo.ts:42 | SCOPE_CREEP_VIOLATION | Added anyway |
-| ASSERT-1 | assertion | [text] | verification-report §2 | PARTIAL | Asserted in code, not run in verification |
+| ID | Class | Requirement | Evidence | Boundary | Evidence kind | Status | Notes |
+|----|-------|-------------|----------|----------|---------------|--------|-------|
+| AC-1 | acceptance | [text] | [pointer] (AC-1 / EV-1) | browser | screenshot | MATCH | |
+| AC-2 | acceptance | [text] | — | — | — | MISSING | No corresponding code or test |
+| AC-3 | acceptance | [text] | EV-4 | browser | test-run-log | BOUNDARY_MISMATCH | Unit log cannot establish a browser claim — needs screenshot or recording |
+| OOS-1 | excluded | [text] | src/foo.ts:42 | — | — | SCOPE_CREEP_VIOLATION | Added anyway |
+| ASSERT-1 | assertion | [text] | verification-report §2 | http-api | — | PARTIAL | Asserted in code, not run in verification |
+
+### Not Established
+
+Reproduce the verdict's `not_established` entries verbatim, grouped by claim, plus anything the matrix could not confirm. This section is **never omitted and never blank**: with nothing outstanding it renders `None outstanding — reviewed`. State whether `not_established_reviewed` was `true`.
+
+- AC-1 — not exercised on mobile viewports; Safari not tested
+- AC-4 — offline behavior consciously out of scope for this ticket
 
 ### Untraceable Changes
 - src/utils/helpers.ts — extracted shared regex constant (refactor, no behavior change)
@@ -140,6 +169,7 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 **Matches:** N/Total
 **Partial:** N
 **Missing:** N
+**Boundary mismatches:** N
 **Scope creep violations:** N
 **Untraceable changes flagged for review:** N
 
@@ -152,6 +182,8 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 
 - Never substitute "I read the code and it looks right" for empirical evidence. If verification-specialist hasn't run yet, request its report before producing a verdict.
 - Never mark a requirement `MATCH` based on the presence of code alone — evidence means test + runtime observation.
+- Never mark a requirement `MATCH` on evidence that does not **reach** its claim's boundary. Per the `claim-evidence-mapping` contract, a unit `test-run-log` establishes only `code-unit` behavior; cited for a `browser`, `http-api`, `deploy-health`, or `standards-compat` claim it is a `BOUNDARY_MISMATCH`, not a match.
+- Always report the Not-established section, even when empty. A report that lists only what passed is unreadable at a gate.
 - Always surface scope creep separately from misses. They are distinct failures.
 - Always surface untraceable changes — even benign refactors — so the human can confirm intent.
 - The Out of Scope section is load-bearing. If the spec has one, every item must appear in the matrix as `excluded`.

--- a/plugins/lisa/agents/spec-conformance-specialist.md
+++ b/plugins/lisa/agents/spec-conformance-specialist.md
@@ -30,8 +30,9 @@ Follow the `spec-conformance` skill end-to-end:
 
 1. Resolve the spec source (plan file, JIRA key, Linear, GitHub issue, PRD).
 2. Extract every requirement into a structured list — acceptance criteria, Out of Scope, technical commitments, Validation Journey assertions, deliverables.
-3. Inspect shipped work (diff, tests, PR body, verification-specialist evidence).
-4. Build the coverage matrix — every requirement gets a row with a status.
+3. Inspect shipped work (diff, tests, PR body, verification-specialist evidence) **and load the machine-readable verdict** at `.lisa/verification-status.json`.
+3b. Cross-check every claim against its **boundary** — the `claim-evidence-mapping` contract's taxonomy — plus artifact identity and the Not-established review.
+4. Build the coverage matrix — every requirement gets a row with a boundary, an evidence kind, and a status.
 5. Detect scope creep and untraceable changes separately.
 6. Produce the verdict.
 
@@ -42,6 +43,8 @@ Return the structured report defined in the skill. Never summarize or drop rows.
 ## Rules
 
 - **Require empirical evidence.** A requirement is not `MATCH` because code exists. It is `MATCH` only when there is a test AND runtime observation (captured by verification-specialist).
+- **A cited-evidence-boundary mismatch is a conformance finding.** The `claim-evidence-mapping` rule binds every claim to a boundary and every boundary to the evidence kinds that reach it. When a v2 verdict cites evidence whose `kind` does not reach the claim's `boundary` — a unit `test-run-log` for a `browser` claim — or whose `artifact_head_sha` does not match `artifact.head_sha`, or when the verdict omits the Not-established review, the row is `BOUNDARY_MISMATCH` and the verdict is `DIVERGES`. Name the boundary, the kind cited, and the kind(s) required. This is not the same failure as a miss: the work may be correct and the proof still not establish it.
+- **Degrade, never block, on an absent or v1 verdict.** If no v2 verdict exists, say so in the report, cap affected rows at `PARTIAL`, and do not invent a mismatch you could not check.
 - **Scope creep is a distinct failure.** Do not fold `SCOPE_CREEP_VIOLATION` into "missing" or "untraceable." Scope creep means Out of Scope was violated — it blocks shipping.
 - **Untraceable changes get surfaced, not judged.** Refactors and test helpers often land here. Surface them so the human can confirm intent; do not automatically fail.
 - **If the spec itself is inadequate** (no acceptance criteria, no Out of Scope, no Validation Journey for runtime changes), the verdict is `DIVERGES` until the spec is tightened. Do not paper over an ambiguous spec with a generous match.

--- a/plugins/lisa/agents/verification-specialist.md
+++ b/plugins/lisa/agents/verification-specialist.md
@@ -12,7 +12,7 @@ skills:
 
 You are a verification specialist. Your job is to **prove empirically** that work is done -- not by reading code, but by running the actual system and observing the results.
 
-Read `.claude/rules/verification.md` at the start of every investigation for the full verification framework, types, and lifecycle.
+Read `.claude/rules/verification.md` at the start of every investigation for the full verification framework, types, and lifecycle. Read `.claude/rules/claim-evidence-mapping.md` alongside it: it binds every claim to the **boundary** it asserts and every boundary to the evidence **kinds** that reach it. The verdict you write is what `spec-conformance-specialist` cross-checks — record each claim's `boundary`, its `required_evidence_kinds`, its `evidence_refs`, and its `not_established` list so a boundary mismatch is catchable rather than invisible.
 
 ## Core Philosophy
 

--- a/plugins/lisa/rules/reference/verification.md
+++ b/plugins/lisa/rules/reference/verification.md
@@ -177,6 +177,8 @@ The list may be empty; the flag may not be missing. An absent `not_established_r
 
 The boundary each artifact type reaches — and therefore which claim a captured artifact can discharge — is the `claim-evidence-mapping` rule's taxonomy; the type table above is its evidence-kind source.
 
+The verdict is read twice. The Claude-only `enforce-verification-gate.sh` Stop hook reads it to decide whether the flow may stop; `lisa-spec-conformance` (run by `spec-conformance-specialist` in the verification phase) reads it to decide whether each shipped requirement's proof actually reaches its boundary — a cited-evidence-boundary mismatch is a `BOUNDARY_MISMATCH` conformance finding there, caught alongside empirical verification rather than after it. On harnesses without a Stop hook, `lisa-implement`'s prose gate carries the same v2 expectations by convention. The whole system, operator-readable end to end, is written up as the Lisa wiki's **Bounded-Claims Evidence System** concept page (`wiki/concepts/bounded-claims-evidence-system.md` upstream).
+
 ### Cross-work-item evidence references are non-claiming
 
 When prose needs to point at evidence declared by another work item, use the dedicated reference form:

--- a/plugins/lisa/skills/lisa-implement/SKILL.md
+++ b/plugins/lisa/skills/lisa-implement/SKILL.md
@@ -278,7 +278,28 @@ Before shutting down the team, execute the Verify flow:
     - **Actionable blocker** — an unresolved dependency or fixable technical gap that some team or repository could build (a missing or changed schema field, an unbuilt sibling work item, a required upstream fix), **including cross-repo dependencies**. Before writing the blocked verdict you MUST (1) file a build-ready fix/dependency ticket capturing the diagnosis — in the dependency's own repository/tracker when it is cross-repo (e.g. a `[<repo>] …` ticket in the shared project, or the sibling tracker) — and (2) link the current work item to it as `is blocked by`. Only then write the verdict. This is the same discipline as the regression-spec blocker and the remote-verification-fail exits above, and it is what makes the block machine-recoverable: `repair-intake` re-dispatches a blocked item once its linked `is blocked by` dependency closes, but it cannot act on a prose-only comment. Recommending the ticket "as a human follow-up" without filing and linking it is **not** a permitted exit.
     - **Human-only blocker** — an input the agent genuinely cannot obtain or produce no matter what it does: credentials, secrets, or **tool access** it does not have (AWS/CloudWatch, Figma, Jam, Sentry, SonarCloud, a database, a protected deploy target, …), or a product/design decision only a human can make. For missing tool access, follow the `tool-access-gate` rule's break-out protocol: post the "Access Needed" comment naming the exact credential/role/env var to grant and the probe that must pass — never work around the gap by substituting weaker verification, mocking the inaccessible system, or narrowing scope. Record the blocked verdict, mark it `human_needed` (the marker `repair-intake` recognizes, so it won't churn re-dispatching it), and surface or reassign to a human; do **not** fabricate a build-ready ticket, because there is no build-ready work.
 
-    Other harnesses fall back to this prose obligation.
+    **Harnesses that do not fire a Stop hook enforce the same discipline by convention.** The
+    `enforce-verification-gate.sh` Stop hook is a **Claude-only** surface — Codex, Cursor, Antigravity,
+    Copilot, and OpenCode carry the skills, agents, and (where the runtime has a rules surface) the
+    `claim-evidence-mapping` rule, but nothing on those runtimes can refuse to stop. That is a known
+    **representation gap**, documented here rather than dropped: on those harnesses this prose gate
+    *is* the gate, and the flow may not declare completion until it has written the same v2 verdict
+    and self-checked it against the same expectations the hook would have applied:
+
+    - `schema_version: 2` is written, with `plan`, `status`, and `updated_at` terminal and fresh.
+    - Every claim carries a `claim_id`, a `boundary` from the closed set, and the
+      `required_evidence_kinds` that reach that boundary — and its `evidence_refs` resolve to evidence
+      whose `kind` is one of them. A unit `test-run-log` cited for a `browser`, `http-api`, or
+      `deploy-health` claim is the failure this check exists to catch.
+    - `artifact.head_sha` names what will ship, and every evidence entry's `artifact_head_sha` matches
+      it, with a `sha256` digest and `captured_at` recorded as values, never placeholders.
+    - The `not_established` list is present on every claim and `not_established_reviewed` is `true` —
+      an empty list is fine, an omitted flag is not.
+
+    Record the self-check in the completion summary the way the hook would have reported it: name the
+    boundary each claim reached, or name the violation. Where the runtime lacks the rules surface (the
+    agy artifacts carry no rules tree), the obligation still travels in this skill — cite the
+    `claim-evidence-mapping` contract by slug and continue; never block on the absent surface.
 3. Write the highest-practical-observation regression test encoding the verification. For user-visible bugs or user-visible Build changes with an available browser/device/e2e harness, this means a deterministic spec on the reported surface — and for frontend work, once the validation journey is verified, codification into **every supported UI runner**: a Playwright spec in the Playwright runner AND a Maestro flow when the project supports Maestro, per `codify-verification`. Prove the new spec actually executed and passed in PR CI by recording a named spec log/reporter line or equivalent execution record; green CI without that named evidence does not satisfy this step.
 4. Record Implement usage on the originating work artifact via `lisa-usage-accounting` so the work item (or other implementation-owned artifact) gains a direct `lisa-implement` usage entry in the canonical `## Lisa Usage` section. If the parent / child graph is already known, prefer `record_and_rollup` so ancestor totals refresh in the same write; otherwise still write the direct entry, and if runtime usage is unavailable, use `source: unavailable` with nullable token/cost fields instead of skipping the row.
 5. Commit ALL outstanding changes in logical batches on the branch (minus sensitive data/information) — not just changes made by the agent team. This includes pre-existing uncommitted changes that were on the branch before the plan started. Do NOT filter commits to only "task-related" files. If it shows up in git status, it gets committed (unless it contains secrets).

--- a/plugins/lisa/skills/lisa-spec-conformance/SKILL.md
+++ b/plugins/lisa/skills/lisa-spec-conformance/SKILL.md
@@ -67,10 +67,27 @@ Gather evidence of what was actually shipped:
    git diff "${BASE_BRANCH}"...HEAD -- '**/*.test.*' '**/*.spec.*'
    ```
 4. **Empirical evidence** — output of `verification-specialist` if available (proof artifacts, API captures, UI screenshots, DB queries). If that report isn't in context, ask the caller for it before proceeding — do not substitute reading code for running the system.
+4a. **The machine-readable verdict** — `Read` `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json`. Under **schema v2** it is the structured form of the evidence above, and it is what lets you check a claim's *reach* instead of taking "verified" at its word. Load `artifact` (`repository`, `head_sha`, `environment`), `claims[]` (`claim_id`, `statement`, `boundary`, `required_evidence_kinds`, `status`, `evidence_refs`, `not_established`), `evidence[]` (`evidence_id`, `kind`, `locator`, `sha256`, `captured_at`, `artifact_head_sha`), and the `not_established_reviewed` flag.
 5. **PR description** — `gh pr view --json title,body,files` if a PR exists.
 6. **Deployed state** — if the verification phase already hit a deployed environment, use those captures.
 
 Do NOT run the system yourself — that's the verification-specialist's job. Your job is to map their evidence to the spec.
+
+## Phase 3b — Cross-Check Claims Against Their Boundaries
+
+The `claim-evidence-mapping` rule is the contract: **every claim declares a boundary, and a claim is established only by evidence of a kind that reaches that boundary.** Conformance is not just "was it built" — it is also "does the proof offered actually reach the thing the requirement asserts." A unit `test-run-log` cited for a requirement about browser-visible behavior is a conformance defect even when the code is perfect.
+
+For every v2 claim loaded in Phase 3 step 4a, run three checks:
+
+| Check | Rule | Failure |
+|-------|------|---------|
+| **Boundary reach** | Each `evidence_refs` entry resolves to an `evidence[]` row whose `kind` appears in that claim's `required_evidence_kinds` — and those kinds are the ones the `claim-evidence-mapping` taxonomy binds to the claim's `boundary` | `BOUNDARY_MISMATCH` |
+| **Artifact identity** | Every cited evidence row's `artifact_head_sha` equals `artifact.head_sha` — the claim applies only to the artifact the evidence was collected against | `BOUNDARY_MISMATCH`, noting both SHAs |
+| **Not established** | `not_established_reviewed` is present and `true`, and every claim carries a `not_established` list (possibly empty) | `BOUNDARY_MISMATCH` on the verdict as a whole |
+
+Then bind the verdict back to the spec: map each `claim_id` to the requirement row it discharges. A requirement whose only supporting claim fails a check is **not** `MATCH`, no matter what the verification report's prose said. A requirement with no claim at all is `MISSING`, not `PARTIAL`.
+
+**Degrade, never block.** If `.lisa/verification-status.json` is absent, or carries **v1** (no `schema_version`, or `schema_version: 1` — only `plan` / `status` / `criteria[]` / `updated_at`), the boundary cross-check is not available. Say so explicitly in the report ("v2 verdict not present — boundary reach unverified"), fall back to the prose evidence from Phase 3, and cap the verdict at `PARTIAL` for any requirement whose boundary you cannot confirm. Do not invent a mismatch you could not check, and do not silently upgrade an unchecked claim to `MATCH`.
 
 ## Phase 4 — Build Coverage Matrix
 
@@ -81,8 +98,10 @@ For every requirement extracted in Phase 2, produce one row:
 | Requirement ID | Stable identifier (e.g. `AC-1`, `OOS-2`, `ASSERT-3`) |
 | Classification | `acceptance` / `excluded` / `technical` / `assertion` / `deliverable` / `task` / `blocker` |
 | Requirement Text | Verbatim from spec |
-| Evidence | Specific pointer — file:line, test name, verification report section, PR file, screenshot name |
-| Status | `MATCH` / `PARTIAL` / `MISSING` / `SCOPE_CREEP_VIOLATION` |
+| Evidence | Specific pointer — file:line, test name, verification report section, PR file, screenshot name. When a v2 verdict exists, also name the `claim_id` and `evidence_id` that discharge it |
+| Boundary | The claim's `boundary` from the v2 verdict (`code-unit` / `browser` / `http-api` / `cli` / `data` / `deploy-health` / `performance` / `standards-compat`), or `—` when no v2 claim maps to this row |
+| Evidence kind | The `kind` of each cited evidence row, so a reader sees the reach without opening the verdict |
+| Status | `MATCH` / `PARTIAL` / `MISSING` / `BOUNDARY_MISMATCH` / `SCOPE_CREEP_VIOLATION` |
 | Notes | One line — why partial, what's missing, or where evidence is thin |
 
 ### Status definitions
@@ -90,6 +109,7 @@ For every requirement extracted in Phase 2, produce one row:
 - **`MATCH`** — requirement is implemented AND there is empirical evidence it works (test + verification report).
 - **`PARTIAL`** — implementation exists but evidence is incomplete (e.g. code present, no test; or test present, no run-time verification).
 - **`MISSING`** — requirement has no corresponding implementation OR no evidence at all.
+- **`BOUNDARY_MISMATCH`** — the requirement was implemented and evidence was cited, but the evidence does not *reach* the claim's boundary (a unit `test-run-log` offered for a `browser` claim), or its `artifact_head_sha` does not match `artifact.head_sha`, or the verdict omits the required Not-established review. This is a distinct failure from a miss: the work may be right and the proof still does not establish it. A `BOUNDARY_MISMATCH` row forces the verdict to `DIVERGES` — it can never render as `CONFORMS` or `PARTIAL`. Name the boundary, the kind cited, and the kind(s) required, citing the `claim-evidence-mapping` taxonomy.
 - **`SCOPE_CREEP_VIOLATION`** — used for `excluded` classification only. An Out-of-Scope item appears to have been shipped anyway. This is a different failure than a miss — it means the agent exceeded the spec.
 
 ### Scope creep detection
@@ -106,9 +126,9 @@ Untraceable changes are not automatic failures. They become findings the human r
 
 Produce exactly one verdict:
 
-- **`CONFORMS`** — every requirement is `MATCH`. No `SCOPE_CREEP_VIOLATION`. Untraceable changes, if any, are clearly refactors or test support.
-- **`PARTIAL`** — some requirements are `PARTIAL` but none are `MISSING` or `SCOPE_CREEP_VIOLATION`. Work is mostly there but evidence is thin.
-- **`DIVERGES`** — at least one requirement is `MISSING`, OR at least one `SCOPE_CREEP_VIOLATION` exists, OR there are substantive untraceable changes that materially alter behavior.
+- **`CONFORMS`** — every requirement is `MATCH`. No `SCOPE_CREEP_VIOLATION`, no `BOUNDARY_MISMATCH`. Untraceable changes, if any, are clearly refactors or test support.
+- **`PARTIAL`** — some requirements are `PARTIAL` but none are `MISSING`, `BOUNDARY_MISMATCH`, or `SCOPE_CREEP_VIOLATION`. Work is mostly there but evidence is thin.
+- **`DIVERGES`** — at least one requirement is `MISSING`, OR at least one `BOUNDARY_MISMATCH` exists, OR at least one `SCOPE_CREEP_VIOLATION` exists, OR there are substantive untraceable changes that materially alter behavior.
 
 A verdict of `PARTIAL` or `DIVERGES` blocks task completion. The caller must resolve the gaps (implement the miss, remove the creep, add the missing evidence) before re-running.
 
@@ -121,15 +141,24 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 
 **Spec source:** <plan file / JIRA key / Linear / GitHub issue / PRD>
 **Shipped scope:** <N commits, M files, K tests on branch <branch> vs <default-branch>>
+**Verdict artifact:** <.lisa/verification-status.json schema v2, artifact.head_sha <sha> — or "v2 verdict not present — boundary reach unverified">
 
 ### Coverage Matrix
 
-| ID | Class | Requirement | Evidence | Status | Notes |
-|----|-------|-------------|----------|--------|-------|
-| AC-1 | acceptance | [text] | [pointer] | MATCH | |
-| AC-2 | acceptance | [text] | — | MISSING | No corresponding code or test |
-| OOS-1 | excluded | [text] | src/foo.ts:42 | SCOPE_CREEP_VIOLATION | Added anyway |
-| ASSERT-1 | assertion | [text] | verification-report §2 | PARTIAL | Asserted in code, not run in verification |
+| ID | Class | Requirement | Evidence | Boundary | Evidence kind | Status | Notes |
+|----|-------|-------------|----------|----------|---------------|--------|-------|
+| AC-1 | acceptance | [text] | [pointer] (AC-1 / EV-1) | browser | screenshot | MATCH | |
+| AC-2 | acceptance | [text] | — | — | — | MISSING | No corresponding code or test |
+| AC-3 | acceptance | [text] | EV-4 | browser | test-run-log | BOUNDARY_MISMATCH | Unit log cannot establish a browser claim — needs screenshot or recording |
+| OOS-1 | excluded | [text] | src/foo.ts:42 | — | — | SCOPE_CREEP_VIOLATION | Added anyway |
+| ASSERT-1 | assertion | [text] | verification-report §2 | http-api | — | PARTIAL | Asserted in code, not run in verification |
+
+### Not Established
+
+Reproduce the verdict's `not_established` entries verbatim, grouped by claim, plus anything the matrix could not confirm. This section is **never omitted and never blank**: with nothing outstanding it renders `None outstanding — reviewed`. State whether `not_established_reviewed` was `true`.
+
+- AC-1 — not exercised on mobile viewports; Safari not tested
+- AC-4 — offline behavior consciously out of scope for this ticket
 
 ### Untraceable Changes
 - src/utils/helpers.ts — extracted shared regex constant (refactor, no behavior change)
@@ -140,6 +169,7 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 **Matches:** N/Total
 **Partial:** N
 **Missing:** N
+**Boundary mismatches:** N
 **Scope creep violations:** N
 **Untraceable changes flagged for review:** N
 
@@ -152,6 +182,8 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 
 - Never substitute "I read the code and it looks right" for empirical evidence. If verification-specialist hasn't run yet, request its report before producing a verdict.
 - Never mark a requirement `MATCH` based on the presence of code alone — evidence means test + runtime observation.
+- Never mark a requirement `MATCH` on evidence that does not **reach** its claim's boundary. Per the `claim-evidence-mapping` contract, a unit `test-run-log` establishes only `code-unit` behavior; cited for a `browser`, `http-api`, `deploy-health`, or `standards-compat` claim it is a `BOUNDARY_MISMATCH`, not a match.
+- Always report the Not-established section, even when empty. A report that lists only what passed is unreadable at a gate.
 - Always surface scope creep separately from misses. They are distinct failures.
 - Always surface untraceable changes — even benign refactors — so the human can confirm intent.
 - The Out of Scope section is load-bearing. If the spec has one, every item must appear in the matrix as `excluded`.

--- a/plugins/src/base/agents/spec-conformance-specialist.md
+++ b/plugins/src/base/agents/spec-conformance-specialist.md
@@ -30,8 +30,9 @@ Follow the `spec-conformance` skill end-to-end:
 
 1. Resolve the spec source (plan file, JIRA key, Linear, GitHub issue, PRD).
 2. Extract every requirement into a structured list — acceptance criteria, Out of Scope, technical commitments, Validation Journey assertions, deliverables.
-3. Inspect shipped work (diff, tests, PR body, verification-specialist evidence).
-4. Build the coverage matrix — every requirement gets a row with a status.
+3. Inspect shipped work (diff, tests, PR body, verification-specialist evidence) **and load the machine-readable verdict** at `.lisa/verification-status.json`.
+3b. Cross-check every claim against its **boundary** — the `claim-evidence-mapping` contract's taxonomy — plus artifact identity and the Not-established review.
+4. Build the coverage matrix — every requirement gets a row with a boundary, an evidence kind, and a status.
 5. Detect scope creep and untraceable changes separately.
 6. Produce the verdict.
 
@@ -42,6 +43,8 @@ Return the structured report defined in the skill. Never summarize or drop rows.
 ## Rules
 
 - **Require empirical evidence.** A requirement is not `MATCH` because code exists. It is `MATCH` only when there is a test AND runtime observation (captured by verification-specialist).
+- **A cited-evidence-boundary mismatch is a conformance finding.** The `claim-evidence-mapping` rule binds every claim to a boundary and every boundary to the evidence kinds that reach it. When a v2 verdict cites evidence whose `kind` does not reach the claim's `boundary` — a unit `test-run-log` for a `browser` claim — or whose `artifact_head_sha` does not match `artifact.head_sha`, or when the verdict omits the Not-established review, the row is `BOUNDARY_MISMATCH` and the verdict is `DIVERGES`. Name the boundary, the kind cited, and the kind(s) required. This is not the same failure as a miss: the work may be correct and the proof still not establish it.
+- **Degrade, never block, on an absent or v1 verdict.** If no v2 verdict exists, say so in the report, cap affected rows at `PARTIAL`, and do not invent a mismatch you could not check.
 - **Scope creep is a distinct failure.** Do not fold `SCOPE_CREEP_VIOLATION` into "missing" or "untraceable." Scope creep means Out of Scope was violated — it blocks shipping.
 - **Untraceable changes get surfaced, not judged.** Refactors and test helpers often land here. Surface them so the human can confirm intent; do not automatically fail.
 - **If the spec itself is inadequate** (no acceptance criteria, no Out of Scope, no Validation Journey for runtime changes), the verdict is `DIVERGES` until the spec is tightened. Do not paper over an ambiguous spec with a generous match.

--- a/plugins/src/base/agents/verification-specialist.md
+++ b/plugins/src/base/agents/verification-specialist.md
@@ -12,7 +12,7 @@ skills:
 
 You are a verification specialist. Your job is to **prove empirically** that work is done -- not by reading code, but by running the actual system and observing the results.
 
-Read `.claude/rules/verification.md` at the start of every investigation for the full verification framework, types, and lifecycle.
+Read `.claude/rules/verification.md` at the start of every investigation for the full verification framework, types, and lifecycle. Read `.claude/rules/claim-evidence-mapping.md` alongside it: it binds every claim to the **boundary** it asserts and every boundary to the evidence **kinds** that reach it. The verdict you write is what `spec-conformance-specialist` cross-checks — record each claim's `boundary`, its `required_evidence_kinds`, its `evidence_refs`, and its `not_established` list so a boundary mismatch is catchable rather than invisible.
 
 ## Core Philosophy
 

--- a/plugins/src/base/rules/reference/verification.md
+++ b/plugins/src/base/rules/reference/verification.md
@@ -177,6 +177,8 @@ The list may be empty; the flag may not be missing. An absent `not_established_r
 
 The boundary each artifact type reaches — and therefore which claim a captured artifact can discharge — is the `claim-evidence-mapping` rule's taxonomy; the type table above is its evidence-kind source.
 
+The verdict is read twice. The Claude-only `enforce-verification-gate.sh` Stop hook reads it to decide whether the flow may stop; `lisa-spec-conformance` (run by `spec-conformance-specialist` in the verification phase) reads it to decide whether each shipped requirement's proof actually reaches its boundary — a cited-evidence-boundary mismatch is a `BOUNDARY_MISMATCH` conformance finding there, caught alongside empirical verification rather than after it. On harnesses without a Stop hook, `lisa-implement`'s prose gate carries the same v2 expectations by convention. The whole system, operator-readable end to end, is written up as the Lisa wiki's **Bounded-Claims Evidence System** concept page (`wiki/concepts/bounded-claims-evidence-system.md` upstream).
+
 ### Cross-work-item evidence references are non-claiming
 
 When prose needs to point at evidence declared by another work item, use the dedicated reference form:

--- a/plugins/src/base/skills/lisa-implement/SKILL.md
+++ b/plugins/src/base/skills/lisa-implement/SKILL.md
@@ -278,7 +278,28 @@ Before shutting down the team, execute the Verify flow:
     - **Actionable blocker** — an unresolved dependency or fixable technical gap that some team or repository could build (a missing or changed schema field, an unbuilt sibling work item, a required upstream fix), **including cross-repo dependencies**. Before writing the blocked verdict you MUST (1) file a build-ready fix/dependency ticket capturing the diagnosis — in the dependency's own repository/tracker when it is cross-repo (e.g. a `[<repo>] …` ticket in the shared project, or the sibling tracker) — and (2) link the current work item to it as `is blocked by`. Only then write the verdict. This is the same discipline as the regression-spec blocker and the remote-verification-fail exits above, and it is what makes the block machine-recoverable: `repair-intake` re-dispatches a blocked item once its linked `is blocked by` dependency closes, but it cannot act on a prose-only comment. Recommending the ticket "as a human follow-up" without filing and linking it is **not** a permitted exit.
     - **Human-only blocker** — an input the agent genuinely cannot obtain or produce no matter what it does: credentials, secrets, or **tool access** it does not have (AWS/CloudWatch, Figma, Jam, Sentry, SonarCloud, a database, a protected deploy target, …), or a product/design decision only a human can make. For missing tool access, follow the `tool-access-gate` rule's break-out protocol: post the "Access Needed" comment naming the exact credential/role/env var to grant and the probe that must pass — never work around the gap by substituting weaker verification, mocking the inaccessible system, or narrowing scope. Record the blocked verdict, mark it `human_needed` (the marker `repair-intake` recognizes, so it won't churn re-dispatching it), and surface or reassign to a human; do **not** fabricate a build-ready ticket, because there is no build-ready work.
 
-    Other harnesses fall back to this prose obligation.
+    **Harnesses that do not fire a Stop hook enforce the same discipline by convention.** The
+    `enforce-verification-gate.sh` Stop hook is a **Claude-only** surface — Codex, Cursor, Antigravity,
+    Copilot, and OpenCode carry the skills, agents, and (where the runtime has a rules surface) the
+    `claim-evidence-mapping` rule, but nothing on those runtimes can refuse to stop. That is a known
+    **representation gap**, documented here rather than dropped: on those harnesses this prose gate
+    *is* the gate, and the flow may not declare completion until it has written the same v2 verdict
+    and self-checked it against the same expectations the hook would have applied:
+
+    - `schema_version: 2` is written, with `plan`, `status`, and `updated_at` terminal and fresh.
+    - Every claim carries a `claim_id`, a `boundary` from the closed set, and the
+      `required_evidence_kinds` that reach that boundary — and its `evidence_refs` resolve to evidence
+      whose `kind` is one of them. A unit `test-run-log` cited for a `browser`, `http-api`, or
+      `deploy-health` claim is the failure this check exists to catch.
+    - `artifact.head_sha` names what will ship, and every evidence entry's `artifact_head_sha` matches
+      it, with a `sha256` digest and `captured_at` recorded as values, never placeholders.
+    - The `not_established` list is present on every claim and `not_established_reviewed` is `true` —
+      an empty list is fine, an omitted flag is not.
+
+    Record the self-check in the completion summary the way the hook would have reported it: name the
+    boundary each claim reached, or name the violation. Where the runtime lacks the rules surface (the
+    agy artifacts carry no rules tree), the obligation still travels in this skill — cite the
+    `claim-evidence-mapping` contract by slug and continue; never block on the absent surface.
 3. Write the highest-practical-observation regression test encoding the verification. For user-visible bugs or user-visible Build changes with an available browser/device/e2e harness, this means a deterministic spec on the reported surface — and for frontend work, once the validation journey is verified, codification into **every supported UI runner**: a Playwright spec in the Playwright runner AND a Maestro flow when the project supports Maestro, per `codify-verification`. Prove the new spec actually executed and passed in PR CI by recording a named spec log/reporter line or equivalent execution record; green CI without that named evidence does not satisfy this step.
 4. Record Implement usage on the originating work artifact via `lisa-usage-accounting` so the work item (or other implementation-owned artifact) gains a direct `lisa-implement` usage entry in the canonical `## Lisa Usage` section. If the parent / child graph is already known, prefer `record_and_rollup` so ancestor totals refresh in the same write; otherwise still write the direct entry, and if runtime usage is unavailable, use `source: unavailable` with nullable token/cost fields instead of skipping the row.
 5. Commit ALL outstanding changes in logical batches on the branch (minus sensitive data/information) — not just changes made by the agent team. This includes pre-existing uncommitted changes that were on the branch before the plan started. Do NOT filter commits to only "task-related" files. If it shows up in git status, it gets committed (unless it contains secrets).

--- a/plugins/src/base/skills/lisa-spec-conformance/SKILL.md
+++ b/plugins/src/base/skills/lisa-spec-conformance/SKILL.md
@@ -67,10 +67,27 @@ Gather evidence of what was actually shipped:
    git diff "${BASE_BRANCH}"...HEAD -- '**/*.test.*' '**/*.spec.*'
    ```
 4. **Empirical evidence** — output of `verification-specialist` if available (proof artifacts, API captures, UI screenshots, DB queries). If that report isn't in context, ask the caller for it before proceeding — do not substitute reading code for running the system.
+4a. **The machine-readable verdict** — `Read` `${CLAUDE_PROJECT_DIR:-.}/.lisa/verification-status.json`. Under **schema v2** it is the structured form of the evidence above, and it is what lets you check a claim's *reach* instead of taking "verified" at its word. Load `artifact` (`repository`, `head_sha`, `environment`), `claims[]` (`claim_id`, `statement`, `boundary`, `required_evidence_kinds`, `status`, `evidence_refs`, `not_established`), `evidence[]` (`evidence_id`, `kind`, `locator`, `sha256`, `captured_at`, `artifact_head_sha`), and the `not_established_reviewed` flag.
 5. **PR description** — `gh pr view --json title,body,files` if a PR exists.
 6. **Deployed state** — if the verification phase already hit a deployed environment, use those captures.
 
 Do NOT run the system yourself — that's the verification-specialist's job. Your job is to map their evidence to the spec.
+
+## Phase 3b — Cross-Check Claims Against Their Boundaries
+
+The `claim-evidence-mapping` rule is the contract: **every claim declares a boundary, and a claim is established only by evidence of a kind that reaches that boundary.** Conformance is not just "was it built" — it is also "does the proof offered actually reach the thing the requirement asserts." A unit `test-run-log` cited for a requirement about browser-visible behavior is a conformance defect even when the code is perfect.
+
+For every v2 claim loaded in Phase 3 step 4a, run three checks:
+
+| Check | Rule | Failure |
+|-------|------|---------|
+| **Boundary reach** | Each `evidence_refs` entry resolves to an `evidence[]` row whose `kind` appears in that claim's `required_evidence_kinds` — and those kinds are the ones the `claim-evidence-mapping` taxonomy binds to the claim's `boundary` | `BOUNDARY_MISMATCH` |
+| **Artifact identity** | Every cited evidence row's `artifact_head_sha` equals `artifact.head_sha` — the claim applies only to the artifact the evidence was collected against | `BOUNDARY_MISMATCH`, noting both SHAs |
+| **Not established** | `not_established_reviewed` is present and `true`, and every claim carries a `not_established` list (possibly empty) | `BOUNDARY_MISMATCH` on the verdict as a whole |
+
+Then bind the verdict back to the spec: map each `claim_id` to the requirement row it discharges. A requirement whose only supporting claim fails a check is **not** `MATCH`, no matter what the verification report's prose said. A requirement with no claim at all is `MISSING`, not `PARTIAL`.
+
+**Degrade, never block.** If `.lisa/verification-status.json` is absent, or carries **v1** (no `schema_version`, or `schema_version: 1` — only `plan` / `status` / `criteria[]` / `updated_at`), the boundary cross-check is not available. Say so explicitly in the report ("v2 verdict not present — boundary reach unverified"), fall back to the prose evidence from Phase 3, and cap the verdict at `PARTIAL` for any requirement whose boundary you cannot confirm. Do not invent a mismatch you could not check, and do not silently upgrade an unchecked claim to `MATCH`.
 
 ## Phase 4 — Build Coverage Matrix
 
@@ -81,8 +98,10 @@ For every requirement extracted in Phase 2, produce one row:
 | Requirement ID | Stable identifier (e.g. `AC-1`, `OOS-2`, `ASSERT-3`) |
 | Classification | `acceptance` / `excluded` / `technical` / `assertion` / `deliverable` / `task` / `blocker` |
 | Requirement Text | Verbatim from spec |
-| Evidence | Specific pointer — file:line, test name, verification report section, PR file, screenshot name |
-| Status | `MATCH` / `PARTIAL` / `MISSING` / `SCOPE_CREEP_VIOLATION` |
+| Evidence | Specific pointer — file:line, test name, verification report section, PR file, screenshot name. When a v2 verdict exists, also name the `claim_id` and `evidence_id` that discharge it |
+| Boundary | The claim's `boundary` from the v2 verdict (`code-unit` / `browser` / `http-api` / `cli` / `data` / `deploy-health` / `performance` / `standards-compat`), or `—` when no v2 claim maps to this row |
+| Evidence kind | The `kind` of each cited evidence row, so a reader sees the reach without opening the verdict |
+| Status | `MATCH` / `PARTIAL` / `MISSING` / `BOUNDARY_MISMATCH` / `SCOPE_CREEP_VIOLATION` |
 | Notes | One line — why partial, what's missing, or where evidence is thin |
 
 ### Status definitions
@@ -90,6 +109,7 @@ For every requirement extracted in Phase 2, produce one row:
 - **`MATCH`** — requirement is implemented AND there is empirical evidence it works (test + verification report).
 - **`PARTIAL`** — implementation exists but evidence is incomplete (e.g. code present, no test; or test present, no run-time verification).
 - **`MISSING`** — requirement has no corresponding implementation OR no evidence at all.
+- **`BOUNDARY_MISMATCH`** — the requirement was implemented and evidence was cited, but the evidence does not *reach* the claim's boundary (a unit `test-run-log` offered for a `browser` claim), or its `artifact_head_sha` does not match `artifact.head_sha`, or the verdict omits the required Not-established review. This is a distinct failure from a miss: the work may be right and the proof still does not establish it. A `BOUNDARY_MISMATCH` row forces the verdict to `DIVERGES` — it can never render as `CONFORMS` or `PARTIAL`. Name the boundary, the kind cited, and the kind(s) required, citing the `claim-evidence-mapping` taxonomy.
 - **`SCOPE_CREEP_VIOLATION`** — used for `excluded` classification only. An Out-of-Scope item appears to have been shipped anyway. This is a different failure than a miss — it means the agent exceeded the spec.
 
 ### Scope creep detection
@@ -106,9 +126,9 @@ Untraceable changes are not automatic failures. They become findings the human r
 
 Produce exactly one verdict:
 
-- **`CONFORMS`** — every requirement is `MATCH`. No `SCOPE_CREEP_VIOLATION`. Untraceable changes, if any, are clearly refactors or test support.
-- **`PARTIAL`** — some requirements are `PARTIAL` but none are `MISSING` or `SCOPE_CREEP_VIOLATION`. Work is mostly there but evidence is thin.
-- **`DIVERGES`** — at least one requirement is `MISSING`, OR at least one `SCOPE_CREEP_VIOLATION` exists, OR there are substantive untraceable changes that materially alter behavior.
+- **`CONFORMS`** — every requirement is `MATCH`. No `SCOPE_CREEP_VIOLATION`, no `BOUNDARY_MISMATCH`. Untraceable changes, if any, are clearly refactors or test support.
+- **`PARTIAL`** — some requirements are `PARTIAL` but none are `MISSING`, `BOUNDARY_MISMATCH`, or `SCOPE_CREEP_VIOLATION`. Work is mostly there but evidence is thin.
+- **`DIVERGES`** — at least one requirement is `MISSING`, OR at least one `BOUNDARY_MISMATCH` exists, OR at least one `SCOPE_CREEP_VIOLATION` exists, OR there are substantive untraceable changes that materially alter behavior.
 
 A verdict of `PARTIAL` or `DIVERGES` blocks task completion. The caller must resolve the gaps (implement the miss, remove the creep, add the missing evidence) before re-running.
 
@@ -121,15 +141,24 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 
 **Spec source:** <plan file / JIRA key / Linear / GitHub issue / PRD>
 **Shipped scope:** <N commits, M files, K tests on branch <branch> vs <default-branch>>
+**Verdict artifact:** <.lisa/verification-status.json schema v2, artifact.head_sha <sha> — or "v2 verdict not present — boundary reach unverified">
 
 ### Coverage Matrix
 
-| ID | Class | Requirement | Evidence | Status | Notes |
-|----|-------|-------------|----------|--------|-------|
-| AC-1 | acceptance | [text] | [pointer] | MATCH | |
-| AC-2 | acceptance | [text] | — | MISSING | No corresponding code or test |
-| OOS-1 | excluded | [text] | src/foo.ts:42 | SCOPE_CREEP_VIOLATION | Added anyway |
-| ASSERT-1 | assertion | [text] | verification-report §2 | PARTIAL | Asserted in code, not run in verification |
+| ID | Class | Requirement | Evidence | Boundary | Evidence kind | Status | Notes |
+|----|-------|-------------|----------|----------|---------------|--------|-------|
+| AC-1 | acceptance | [text] | [pointer] (AC-1 / EV-1) | browser | screenshot | MATCH | |
+| AC-2 | acceptance | [text] | — | — | — | MISSING | No corresponding code or test |
+| AC-3 | acceptance | [text] | EV-4 | browser | test-run-log | BOUNDARY_MISMATCH | Unit log cannot establish a browser claim — needs screenshot or recording |
+| OOS-1 | excluded | [text] | src/foo.ts:42 | — | — | SCOPE_CREEP_VIOLATION | Added anyway |
+| ASSERT-1 | assertion | [text] | verification-report §2 | http-api | — | PARTIAL | Asserted in code, not run in verification |
+
+### Not Established
+
+Reproduce the verdict's `not_established` entries verbatim, grouped by claim, plus anything the matrix could not confirm. This section is **never omitted and never blank**: with nothing outstanding it renders `None outstanding — reviewed`. State whether `not_established_reviewed` was `true`.
+
+- AC-1 — not exercised on mobile viewports; Safari not tested
+- AC-4 — offline behavior consciously out of scope for this ticket
 
 ### Untraceable Changes
 - src/utils/helpers.ts — extracted shared regex constant (refactor, no behavior change)
@@ -140,6 +169,7 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 **Matches:** N/Total
 **Partial:** N
 **Missing:** N
+**Boundary mismatches:** N
 **Scope creep violations:** N
 **Untraceable changes flagged for review:** N
 
@@ -152,6 +182,8 @@ Structure the report so it can be pasted into a PR comment or JIRA ticket:
 
 - Never substitute "I read the code and it looks right" for empirical evidence. If verification-specialist hasn't run yet, request its report before producing a verdict.
 - Never mark a requirement `MATCH` based on the presence of code alone — evidence means test + runtime observation.
+- Never mark a requirement `MATCH` on evidence that does not **reach** its claim's boundary. Per the `claim-evidence-mapping` contract, a unit `test-run-log` establishes only `code-unit` behavior; cited for a `browser`, `http-api`, `deploy-health`, or `standards-compat` claim it is a `BOUNDARY_MISMATCH`, not a match.
+- Always report the Not-established section, even when empty. A report that lists only what passed is unreadable at a gate.
 - Always surface scope creep separately from misses. They are distinct failures.
 - Always surface untraceable changes — even benign refactors — so the human can confirm intent.
 - The Out of Scope section is load-bearing. If the spec has one, every item must appear in the matrix as `excluded`.

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -421,13 +421,13 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/agents/skill-evaluator.md":
       "83af6324ed0ee0cd5c4132429e137649c3fd616ef6fa5d4bd95579438d401894",
     "plugins/src/base/agents/spec-conformance-specialist.md":
-      "b869bccbb1289db8ce05be6ea07827f8cdd336bb0e986167a5d08244c7936277",
+      "f589e4d543a617d3c421aa28d6583e1b25e0b18fc83412e6d544a389bdac225c",
     "plugins/src/base/agents/test-specialist.md":
       "0e6f7137b8338f76d0302cb7a930f50821b4d66dd197977012f32ab5a0c38061",
     "plugins/src/base/agents/tracker-mining-specialist.md":
       "fef49c3ca8622c83a54d34b3f960471e0f2ad50e6889f691585b0f208180f6bd",
     "plugins/src/base/agents/verification-specialist.md":
-      "5e016e5f03435a7a8dc75934173d962138868dc0c538630080468af527c60076",
+      "32d8a660ba486279fdbb6d0c6665bee36a9703e0cb05e1ab0629b82bc26ebd04",
     "plugins/src/base/commands/agent-ready.md":
       "b1bc19c90330b9885b44f733e83cc6b44afa9b5e9fd2e9aba99995480e0829e1",
     "plugins/src/base/commands/analyze-claude-remote.md":
@@ -713,7 +713,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/reference/usage-accounting.md":
       "d2a24f8f176dbd900beb6e396fc669008b0be0c9033fac5c1c1ecc19002bd7c2",
     "plugins/src/base/rules/reference/verification.md":
-      "aeb348f8bcf4cd3dc1e6c8e3984afd4461bb2f1283055b9298dab3979c53a115",
+      "9aa9ec95a739268181b74d6952fa7cda16c96d633ece6a3e889d3b28a8f8ffb7",
     "plugins/src/base/rules/reference/wiki-knowledge-source.md":
       "305d38e13984c2a64144f302336405d0ccbec493a6ed3ec67d210fed44940717",
     "plugins/src/base/scripts/automation-run-record.mjs":
@@ -833,7 +833,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-github-write-prd/SKILL.md":
       "bc919c52e2f42129d41a3f40279d2def99486ec58bed2dab51ca7166b427a947",
     "plugins/src/base/skills/lisa-implement/SKILL.md":
-      "046bc040b7a1182f71dd4be7a04e977a963a5ab707fad627d89ef0877d4a789b",
+      "634f09dbd2654af070be393f5fd41e8d7fedee7437be2890e54d47ec59258539",
     "plugins/src/base/skills/lisa-improve-code-complexity/SKILL.md":
       "24ab5b193b409db6ee6bee981a1c0a48d08991782d7846116ad01658c8bc1ae8",
     "plugins/src/base/skills/lisa-improve-harness/SKILL.md":
@@ -1037,7 +1037,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-sonarcloud-access/SKILL.md":
       "924b6f54e38bf000625fcbecef828e78f7b4a401c36a5353b7c22ff12d530d5c",
     "plugins/src/base/skills/lisa-spec-conformance/SKILL.md":
-      "0d0b5576e1c3a1cd3352d613851d399c825de6fa31c1c75a3c691171ce7817c3",
+      "3bcaf6d3b47917d00732542e30a8a302c3e293a9957faf79cac5b1d75cc538a2",
     "plugins/src/base/skills/lisa-sync-down/SKILL.md":
       "c32e6a4e3115ca32b7d335e90d0a73b243c6c631a2d192568423be0cb5944e84",
     "plugins/src/base/skills/lisa-task-decomposition/SKILL.md":
@@ -7727,6 +7727,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/automation-status-scaffold.test.ts": true,
     "tests/unit/strategies/automations-retirement.test.ts": true,
     "tests/unit/strategies/automations-skills.test.ts": true,
+    "tests/unit/strategies/bce-parity-and-consumption.test.ts": true,
     "tests/unit/strategies/browser-verification-controller-contract.test.ts": true,
     "tests/unit/strategies/build-intake-duplicate-closeout.test.ts": true,
     "tests/unit/strategies/build-ready-control.test.ts": true,
@@ -7955,6 +7956,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "wiki/architecture/pattern-b-fan-out-spec.md": true,
     "wiki/architecture/template-governance.md": true,
     "wiki/concepts/.gitkeep": true,
+    "wiki/concepts/bounded-claims-evidence-system.md": true,
     "wiki/concepts/coding-agent-feature-taxonomy.md": true,
     "wiki/concepts/lisa-vocabulary.md": true,
     "wiki/decisions/.gitkeep": true,

--- a/tests/unit/strategies/bce-parity-and-consumption.test.ts
+++ b/tests/unit/strategies/bce-parity-and-consumption.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Contract coverage for BCE-7 (#1841): the bounded-claims evidence disciplines
+ * reach every supported agent surface, spec-conformance consumes the v2 verdict,
+ * and the whole system is documented for an operator.
+ *
+ * BCE-1..BCE-6 shipped the disciplines into `plugins/src/base`. Claude is the
+ * reference implementation, so a discipline that never leaves the source tree is
+ * a discipline five of six agents never see. This suite is the parity backstop:
+ * every BCE-touched source file is pinned present and body-identical in each
+ * generated root that can represent it, and the one surface that genuinely
+ * cannot be represented (agy carries no rules tree; only Claude fires a Stop
+ * hook) is pinned as a DOCUMENTED gap with a prose fallback, never a silent drop.
+ *
+ * It also pins the two wiring obligations of the closeout ticket: the
+ * `lisa-spec-conformance` surface reads the v2 verdict's claim→evidence mapping
+ * (boundary, required evidence kinds, artifact identity, Not established) so a
+ * boundary mismatch is a conformance finding, and the operator-readable
+ * end-to-end write-up exists and names both config flip points.
+ * @module tests/unit/strategies/bce-parity-and-consumption
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/** Source of truth for every generated plugin root. */
+const SRC = "plugins/src/base";
+
+/** The Claude reference artifact plus the four derived agent roots. */
+const CLAUDE_ROOT = "plugins/lisa";
+const CODEX_ROOT = "plugins/lisa/.codex-plugin";
+const CURSOR_ROOT = "plugins/lisa-cursor";
+const AGY_ROOT = "plugins/lisa-agy";
+const COPILOT_ROOT = "plugins/lisa-copilot";
+
+/**
+ * Every `plugins/src` file touched by BCE-1..BCE-6, grouped by the surface kind
+ * that decides which roots can represent it.
+ */
+const BCE_SKILLS = [
+  "lisa-implement",
+  "lisa-security-review",
+  "lisa-security-zap-scan",
+  "lisa-tracker-evidence",
+  "lisa-github-evidence",
+  "lisa-jira-evidence",
+  "lisa-linear-evidence",
+] as const;
+
+const BCE_RULES = [
+  "rules/eager/claim-evidence-mapping.md",
+  "rules/reference/claim-evidence-mapping.md",
+  "rules/reference/verification.md",
+  "rules/reference/config-resolution.md",
+] as const;
+
+const BCE_AGENTS = ["security-specialist"] as const;
+
+const BCE_HOOKS = ["hooks/enforce-verification-gate.sh"] as const;
+
+/** Roots that carry skills verbatim (Codex transforms only the frontmatter). */
+const VERBATIM_SKILL_ROOTS = [
+  CLAUDE_ROOT,
+  CURSOR_ROOT,
+  AGY_ROOT,
+  COPILOT_ROOT,
+] as const;
+
+const read = (rel: string): string => readFileSync(path.resolve(rel), "utf8");
+
+/**
+ * Strip a leading YAML frontmatter block so per-agent frontmatter transforms
+ * (Codex description rewrites, Cursor `.mdc` headers) do not read as drift.
+ * @param text - the raw file contents
+ * @returns the trimmed body with any frontmatter removed
+ */
+const body = (text: string): string => {
+  if (!text.startsWith("---\n")) return text.trim();
+  const end = text.indexOf("\n---", 3);
+  return end === -1 ? text.trim() : text.slice(end + 4).trim();
+};
+
+/**
+ * Cursor rewrites sibling rule links to its flattened `.mdc` names, so compare
+ * prose with link *targets* normalized away — the words must still match.
+ * @param text - the raw file contents
+ * @returns the body with every markdown link target emptied
+ */
+const proseOnly = (text: string): string =>
+  body(text).replace(/\]\([^)]*\)/g, "]()");
+
+describe("BCE six-agent parity backstop (BCE-7)", () => {
+  describe.each(BCE_SKILLS)("skill %s", skill => {
+    const rel = `skills/${skill}/SKILL.md`;
+    const source = read(`${SRC}/${rel}`);
+
+    it.each(VERBATIM_SKILL_ROOTS)("ships byte-identical in %s", root => {
+      expect(existsSync(path.resolve(root, rel))).toBe(true);
+      expect(read(`${root}/${rel}`)).toBe(source);
+    });
+
+    it("ships in the Codex surface with only the frontmatter transformed", () => {
+      const codex = read(`${CODEX_ROOT}/${rel}`);
+      expect(body(codex)).toBe(body(source));
+    });
+  });
+
+  describe.each(BCE_RULES)("rule %s", rel => {
+    const source = read(`${SRC}/${rel}`);
+
+    it("ships byte-identical in the Claude and Copilot roots", () => {
+      expect(read(`${CLAUDE_ROOT}/${rel}`)).toBe(source);
+      expect(read(`${COPILOT_ROOT}/${rel}`)).toBe(source);
+    });
+
+    it("ships in the Cursor root as an .mdc rule with the same body", () => {
+      const slug = path.basename(rel, ".md");
+      const cursorName = rel.startsWith("rules/reference/")
+        ? `${slug}-reference.mdc`
+        : `${slug}.mdc`;
+      const cursor = read(`${CURSOR_ROOT}/rules/${cursorName}`);
+      expect(proseOnly(cursor)).toBe(proseOnly(source));
+    });
+  });
+
+  describe.each(BCE_AGENTS)("agent %s", agent => {
+    const rel = `agents/${agent}.md`;
+    const source = read(`${SRC}/${rel}`);
+
+    it("ships byte-identical in the Claude, Cursor, and agy roots", () => {
+      for (const root of [CLAUDE_ROOT, CURSOR_ROOT, AGY_ROOT]) {
+        expect(read(`${root}/${rel}`)).toBe(source);
+      }
+    });
+
+    it("ships in the Copilot root under the .agent.md adapter name", () => {
+      const copilot = read(`${COPILOT_ROOT}/agents/${agent}.agent.md`);
+      expect(body(copilot)).toBe(body(source));
+    });
+  });
+
+  describe.each(BCE_HOOKS)("hook %s", rel => {
+    const source = read(`${SRC}/${rel}`);
+
+    it("ships byte-identical everywhere a hook script can run", () => {
+      expect(read(`${CLAUDE_ROOT}/${rel}`)).toBe(source);
+      expect(read(`${CURSOR_ROOT}/${rel}`)).toBe(source);
+      expect(read(`${COPILOT_ROOT}/${rel}`)).toBe(source);
+    });
+  });
+
+  describe("representation gaps are documented, never silent", () => {
+    it("agy carries no rules tree, and the generator says why", () => {
+      expect(existsSync(path.resolve(AGY_ROOT, "rules"))).toBe(false);
+      const generator = read("scripts/generate-agy-plugin-artifacts.mjs");
+      expect(generator).toMatch(/rules/i);
+      expect(generator).toMatch(/no full rules tree in agy artifacts/i);
+    });
+
+    it("the Stop-hook gate is Claude-only, so the prose gate carries it", () => {
+      const implement = read(`${SRC}/skills/lisa-implement/SKILL.md`);
+      expect(implement).toMatch(/Claude-only/i);
+    });
+  });
+});
+
+describe("Non-Claude prose gate carries the v2 expectations (BCE-7)", () => {
+  const implement = read(`${SRC}/skills/lisa-implement/SKILL.md`);
+
+  it("names every v2 expectation a harness without a Stop hook must self-enforce", () => {
+    for (const expectation of [
+      "schema_version",
+      "boundary",
+      "required_evidence_kinds",
+      "artifact.head_sha",
+      "not_established",
+      "not_established_reviewed",
+    ]) {
+      expect(implement).toContain(expectation);
+    }
+  });
+
+  it("states the obligation is by convention where no Stop hook fires", () => {
+    expect(implement).toMatch(
+      /harness(es)? (that )?(do(es)? not|without)[^.]*Stop hook/i
+    );
+    expect(implement).toMatch(/claim-evidence-mapping/);
+  });
+
+  it("names the Claude-only gate as the known representation gap, not a drop", () => {
+    const claudeOnly = implement.indexOf("Claude-only");
+    expect(claudeOnly).toBeGreaterThan(-1);
+    // The gap must be named in the same passage, not somewhere else entirely.
+    expect(implement.slice(claudeOnly, claudeOnly + 800)).toMatch(
+      /representation\W{0,4}gap/i
+    );
+  });
+});
+
+describe("spec-conformance consumes the v2 claim→evidence mapping (BCE-7)", () => {
+  const ROOTS = [SRC, CLAUDE_ROOT] as const;
+  /** The contract slug every consuming surface must cite by name. */
+  const MAPPING_SLUG = "claim-evidence-mapping";
+
+  describe.each(ROOTS)("%s", root => {
+    const skill = read(`${root}/skills/lisa-spec-conformance/SKILL.md`);
+    const agent = read(`${root}/agents/spec-conformance-specialist.md`);
+
+    it("reads the v2 verdict file and cites the mapping contract by slug", () => {
+      expect(skill).toContain(".lisa/verification-status.json");
+      expect(skill).toContain(MAPPING_SLUG);
+      expect(skill).toMatch(/schema_version.*2|v2/);
+    });
+
+    it("cross-checks each cited claim against its boundary and evidence kinds", () => {
+      expect(skill).toContain("boundary");
+      expect(skill).toContain("required_evidence_kinds");
+      expect(skill).toContain("evidence_refs");
+    });
+
+    it("makes a boundary mismatch its own conformance finding status", () => {
+      expect(skill).toContain("BOUNDARY_MISMATCH");
+      // A mismatch must not be able to render as CONFORMS.
+      expect(skill).toMatch(/BOUNDARY_MISMATCH[\s\S]{0,600}DIVERGES/);
+    });
+
+    it("surfaces the Not-established section in the coverage matrix output", () => {
+      expect(skill).toMatch(/Not established/i);
+      expect(skill).toContain("not_established_reviewed");
+      // Never omitted: an empty list still renders.
+      expect(skill).toMatch(/None outstanding/i);
+    });
+
+    it("checks artifact identity so the verdict is bound to what shipped", () => {
+      expect(skill).toContain("artifact_head_sha");
+    });
+
+    it("degrades instead of blocking when no v2 verdict is present", () => {
+      expect(skill).toMatch(/v1|absent|not present|missing/i);
+    });
+
+    it("tells the specialist agent a boundary mismatch is a finding", () => {
+      expect(agent).toContain(MAPPING_SLUG);
+      expect(agent).toMatch(/boundary/i);
+      expect(agent).toContain("BOUNDARY_MISMATCH");
+    });
+
+    it("has verification-specialist cite the same contract", () => {
+      const verification = read(`${root}/agents/verification-specialist.md`);
+      expect(verification).toContain(MAPPING_SLUG);
+    });
+  });
+});
+
+/** One evidence row of a v2 verdict, as the skill instructs it be read. */
+type EvidenceRow = {
+  evidence_id: string;
+  kind: string;
+  artifact_head_sha?: string;
+};
+
+/** One claim of a v2 verdict, bound to its boundary and reaching kinds. */
+type ClaimRow = {
+  claim_id: string;
+  boundary: string;
+  required_evidence_kinds?: string[];
+  evidence_refs?: string[];
+  not_established?: string[];
+};
+
+/** The v2 verdict shape Phase 3b of `lisa-spec-conformance` consumes. */
+type Verdict = {
+  artifact?: { head_sha?: string };
+  claims?: ClaimRow[];
+  evidence?: EvidenceRow[];
+  not_established_reviewed?: boolean;
+};
+
+/**
+ * Findings for one cited evidence reference: does the kind reach the claim's
+ * boundary, and was it captured against the artifact that will ship?
+ * @param claim - the claim doing the citing
+ * @param ref - the `evidence_id` it cites
+ * @param byId - every evidence row of the verdict, keyed by id
+ * @param headSha - the verdict's `artifact.head_sha`
+ * @returns zero or more human-readable findings
+ */
+const referenceFindings = (
+  claim: ClaimRow,
+  ref: string,
+  byId: Map<string, EvidenceRow>,
+  headSha: string | undefined
+): string[] => {
+  const ev = byId.get(ref);
+  if (!ev) return [`${claim.claim_id}: dangling evidence ref ${ref}`];
+  const findings: string[] = [];
+  if (!(claim.required_evidence_kinds ?? []).includes(ev.kind)) {
+    findings.push(
+      `${claim.claim_id}: ${ev.kind} does not reach boundary ${claim.boundary}`
+    );
+  }
+  if (ev.artifact_head_sha !== headSha) {
+    findings.push(`${claim.claim_id}: artifact identity mismatch on ${ref}`);
+  }
+  return findings;
+};
+
+/**
+ * The three checks Phase 3b of `lisa-spec-conformance` instructs — boundary
+ * reach, artifact identity, and the Not-established review — implemented here
+ * against the SHIPPED BCE-6 fixtures. The skill is prose an agent follows; this
+ * pins that the procedure it describes is actually decidable, and that the
+ * fixtures still carry the fields the procedure reads.
+ * @param verdict - a parsed `.lisa/verification-status.json` in schema v2
+ * @returns every conformance finding, empty when the verdict is clean
+ */
+const conformanceFindings = (verdict: Verdict): string[] => {
+  const findings: string[] = [];
+  const byId = new Map((verdict.evidence ?? []).map(e => [e.evidence_id, e]));
+  const headSha = verdict.artifact?.head_sha;
+  for (const claim of verdict.claims ?? []) {
+    for (const ref of claim.evidence_refs ?? []) {
+      findings.push(...referenceFindings(claim, ref, byId, headSha));
+    }
+    if (claim.not_established === undefined) {
+      findings.push(`${claim.claim_id}: missing not_established list`);
+    }
+  }
+  if (verdict.not_established_reviewed !== true) {
+    findings.push("verdict: not_established_reviewed is not true");
+  }
+  return findings;
+};
+
+const fixture = (name: string): Record<string, unknown> =>
+  JSON.parse(read(`tests/fixtures/verification/${name}.json`));
+
+describe("The Phase 3b cross-check is decidable on the shipped fixtures (BCE-7)", () => {
+  it("raises a boundary finding for a unit log cited on a browser claim", () => {
+    const findings = conformanceFindings(fixture("evidence_kind_mismatch"));
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toContain(
+      "test-run-log does not reach boundary browser"
+    );
+  });
+
+  it("raises an identity finding when evidence names a different head", () => {
+    const findings = conformanceFindings(fixture("artifact_mismatch"));
+    expect(findings.some(f => f.includes("artifact identity mismatch"))).toBe(
+      true
+    );
+  });
+
+  it("raises a finding when the Not-established review is missing", () => {
+    const findings = conformanceFindings(fixture("not_established_unreviewed"));
+    expect(
+      findings.some(f => f.includes("not_established_reviewed is not true"))
+    ).toBe(true);
+  });
+
+  it("raises nothing on a clean v2 verdict", () => {
+    expect(conformanceFindings(fixture("v2_pass_clean"))).toEqual([]);
+  });
+});
+
+describe("The bounded-claims evidence system is documented end-to-end (BCE-7)", () => {
+  const DOC = "wiki/concepts/bounded-claims-evidence-system.md";
+  const doc = read(DOC);
+
+  it("is linked from the wiki index", () => {
+    expect(read("wiki/index.md")).toContain(
+      "concepts/bounded-claims-evidence-system.md"
+    );
+  });
+
+  it("names all four disciplines in operator-readable terms", () => {
+    for (const discipline of [
+      "boundary",
+      "Not established",
+      "artifact identity",
+      "security",
+    ]) {
+      expect(doc.toLowerCase()).toContain(discipline.toLowerCase());
+    }
+  });
+
+  it("names both config flip points and their defaults", () => {
+    expect(doc).toContain("verification.gate.enforceBoundaries");
+    expect(doc).toContain("security.review.unprovenBucket");
+    expect(doc).toContain("security-unproven");
+  });
+
+  it("describes the advisory→blocking ratchet path", () => {
+    expect(doc).toMatch(/advisory/i);
+    expect(doc).toMatch(/ratchet/i);
+  });
+
+  it("names the six agent surfaces and the documented gaps", () => {
+    for (const agent of [
+      "Claude",
+      "Codex",
+      "Cursor",
+      "Antigravity",
+      "Copilot",
+      "OpenCode",
+    ]) {
+      expect(doc).toContain(agent);
+    }
+  });
+
+  it("is cross-linked from the verification reference rule", () => {
+    expect(read(`${SRC}/rules/reference/verification.md`)).toContain(
+      "spec-conformance"
+    );
+  });
+});

--- a/wiki/concepts/bounded-claims-evidence-system.md
+++ b/wiki/concepts/bounded-claims-evidence-system.md
@@ -1,0 +1,101 @@
+# Bounded-Claims Evidence System
+
+When a report says a piece of software is "verified," that word has to mean something specific, or it means nothing. Before this system, a claim that a button worked in the browser could be backed by nothing more than a passing unit test — and the report read exactly the same as one backed by a screenshot of the button actually working.
+
+The bounded-claims evidence system fixes that. **Every claim names the boundary it reaches, and a claim counts as established only when the evidence behind it is of a kind that reaches that boundary.** A report you read at the gate now states its own limits.
+
+This page is the end-to-end map: what the four disciplines are, where each one is enforced, which two configuration switches control how strict it is, and how strictness gets turned up over time.
+
+Shipped by PRD [#1738](https://github.com/CodySwannGT/lisa/issues/1738), tickets #1835–#1841.
+
+## The core idea, in one line
+
+**Unit tests ≠ browser behavior ≠ a healthy deployment ≠ standards compatibility.**
+
+Each of those is a different *boundary*. Evidence collected at one boundary never proves a claim at another. A passing unit test is a quality prerequisite — it proves the code unit behaves in isolation, and nothing more.
+
+## The claim-boundary taxonomy
+
+Every claim binds to exactly one boundary from a closed set, and each boundary is discharged only by evidence of the kinds that reach it:
+
+| Boundary | What it asserts | Established by | Cannot be established by |
+|---|---|---|---|
+| `code-unit` | pure-logic behavior in isolation | unit `test-run-log` | — (and it satisfies no other boundary) |
+| `browser` | user-visible UI behavior | `screenshot`, `recording` | a unit `test-run-log` |
+| `http-api` | request/response contract | `http-transcript` | a unit `test-run-log` |
+| `cli` | command behavior | `cli-output` | prose |
+| `data` | persisted state | `db-query-output`, `state-dump` | a unit `test-run-log` |
+| `deploy-health` | a healthy running deployment | `deploy-log` | any pre-deploy artifact |
+| `performance` | latency / throughput / frame timing | `perf-trace` with methodology | a screenshot |
+| `standards-compat` | conformance to an external standard | `cli-output` / `test-run-log` from the compat runner | assertion prose |
+
+The contract lives in the `claim-evidence-mapping` rule pair — a short load-bearing `rules/eager` head and the full `rules/reference` body. Every other surface cites it; none restates it.
+
+## The four disciplines
+
+### 1. Bounded claims
+
+The verdict file every flow writes — `.lisa/verification-status.json`, schema **v2** — records, for each claim, a `claim_id`, the plain-language `statement`, its `boundary`, the `required_evidence_kinds` that reach that boundary, and the `evidence_refs` that were actually cited. Citing evidence whose kind does not reach the boundary is a defect, not a matter of taste.
+
+### 2. Not established
+
+Every verdict and every evidence comment carries a **Not established** section: what was *not* proved — boundaries not exercised, environments not tested, behavior consciously left out of scope. It is never omitted and never blank; with nothing outstanding it renders `None outstanding — reviewed`, and a `not_established_reviewed` flag attests that somebody asked the question even when the answer was "nothing." A report that lists only what passed is unreadable at a gate: a journey that skipped an edge state looks identical to one that covered it.
+
+### 3. Artifact identity
+
+A claim applies only to the artifact its evidence was collected against. The verdict pins `artifact.head_sha` — the commit the run observed — and every evidence entry pins the `artifact_head_sha` in force when it was captured, a `sha256` content digest, and `captured_at`. Pre-merge evidence counts for a merge commit only when that head is a parent of the merge, using the one ancestry-plus-deploy-run definition of "what shipped" that `lisa-drive-pr-to-merge` already owns. A mismatched SHA or a digest that no longer recomputes fails loudly, naming both values.
+
+### 4. Two-bucket security findings
+
+A security finding is **proven** only when it has both a reproducer of a reaching kind and a bounded impact or exploitability statement. Missing either, it renders **unproven**, with its reason stated — and it stays in the security section. It is never quietly demoted to maintenance work because nobody could prove it yet.
+
+## Where each discipline is enforced
+
+| Surface | What it does | Runtime |
+|---|---|---|
+| `claim-evidence-mapping` rule pair | states the contract | every agent with a rules surface |
+| `lisa-implement` step 2a | tells the flow to write the v2 verdict, and carries the prose gate | all six agents |
+| `enforce-verification-gate.sh` Stop hook | refuses to let the flow stop on a non-terminal or contract-violating verdict | **Claude only** |
+| `lisa-spec-conformance` / `spec-conformance-specialist` | cross-checks each shipped requirement's proof against its claim's boundary, artifact identity, and Not-established review; a mismatch is a `BOUNDARY_MISMATCH` finding forcing a `DIVERGES` verdict | all six agents |
+| `lisa-tracker-evidence` and the vendor evidence skills | refuse to post an evidence comment missing the required sections or identity values | all six agents |
+| `lisa-security-review` / `lisa-security-zap-scan` | split findings into the proven and unproven buckets | all six agents |
+| `tests/fixtures/verification/` fixture suite | drives five named failure modes through the real hook, twice — enforcement off and on | CI |
+
+## The two configuration flip points
+
+Both live in `.lisa.config.json`, and both are deliberately conservative out of the box:
+
+| Setting | Default | Effect |
+|---|---|---|
+| `verification.gate.enforceBoundaries` | `false` | While `false`, the Stop hook's v2 claim, identity, and Not-established checks are **advisory** — a violation is reported to stderr but does not block. Set to `true` and the same violations block completion. |
+| `security.review.unprovenBucket` | `security-unproven` | The label an unproven security finding renders under. It stays inside the security section under whatever name you give it. |
+
+An advisory warning is a defect to fix now, not a warning to live with — it becomes blocking on the ratchet.
+
+## The advisory → blocking ratchet
+
+New enforcement lands **advisory-first** so an existing project is never red on day one. Turning it up is a deliberate, reviewed act, governed by the same threshold-ratchet discipline as every other Lisa gate: thresholds may only tighten, and loosening one requires an explicit allow entry merged in its own PR first.
+
+The path for a project is:
+
+1. Adopt the disciplines. Verdicts are written in v2; violations are reported but do not block.
+2. Read the advisories. Each one is a real gap between what a report claimed and what its evidence reached.
+3. Fix them, then flip `verification.gate.enforceBoundaries` to `true` in its own PR. From then on the gate blocks.
+4. The flag never goes back down without a ratchet allow entry.
+
+## Six-agent parity, and the one honest gap
+
+Claude Code is the reference implementation; a discipline that only Claude sees is a discipline five of six agents ignore. The source of truth is `plugins/src/base/`, and `bun run build:plugins` fans it to Claude, **Codex** (via the `.codex-plugin` pointer inside the Claude artifact), **Cursor**, **Antigravity** (agy), and **Copilot**. **OpenCode** reads the same `.claude/skills` and `AGENTS.md` surfaces directly. `bun run check:plugins` fails if any generated artifact drifts from source.
+
+Two representation gaps are documented rather than dropped:
+
+- **The Stop hook is Claude-only.** No other runtime can refuse to stop. On those harnesses the prose gate in `lisa-implement` carries the same v2 expectations by convention, and the flow records its own self-check in the completion summary.
+- **Antigravity artifacts carry no rules tree.** The obligation travels in the skills instead, which every runtime does carry.
+
+Where a surface cannot be represented, the rule is always the same: cite the contract, continue, and write the gap down. Never block on an absent surface, and never let a discipline silently disappear.
+
+## Related
+
+- `plugins/src/base/rules/reference/claim-evidence-mapping.md` — the full contract
+- `plugins/src/base/rules/reference/verification.md` — the verification framework and artifact-type taxonomy
+- [Pattern B Per-Agent Plugin Variants](../architecture/pattern-b-fan-out-spec.md) — how the fan-out works

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -55,6 +55,8 @@ Last updated by connector ingest on 2026-06-14 for Lisa `2.165.6` and current mo
 
 - [Lisa Vocabulary](concepts/lisa-vocabulary.md)
 - [Coding-Agent Feature Taxonomy](concepts/coding-agent-feature-taxonomy.md)
+- [Bounded-Claims Evidence System](concepts/bounded-claims-evidence-system.md)
+  - What "verified" means: the claim-boundary taxonomy, the four evidence disciplines, the `verification.gate.enforceBoundaries` / `security.review.unprovenBucket` flip points, and the advisory→blocking ratchet.
 
 ## Entities
 


### PR DESCRIPTION
## Summary

The closeout ticket for PRD #1738's bounded-claims evidence decomposition (BCE-1 … BCE-7). BCE-1..6 shipped the disciplines into `plugins/src/base`; this PR proves they reached all six agent surfaces, wires the last consumer, and documents the system for an operator.

Closes #1841. This completes PRD #1738's BCE decomposition — #1835, #1836, #1837, #1838, #1839, #1840, #1841 all shipped.

## Parity audit result: zero drift

Every `plugins/src` file touched by BCE-1..6 was diffed against each generated root. Nothing needed a rebuild fix — `check:plugins` was green before and after.

| Surface | lisa (Claude) | Codex (`.codex-plugin`) | lisa-cursor | lisa-agy | lisa-copilot |
|---|---|---|---|---|---|
| 7 skills (`lisa-implement`, `lisa-security-review`, `lisa-security-zap-scan`, `lisa-tracker-evidence`, + 3 vendor evidence skills) | byte-identical | body-identical (frontmatter description transform only) | byte-identical | byte-identical | byte-identical |
| 4 rules (`claim-evidence-mapping` eager + reference, `verification`, `config-resolution`) | byte-identical | n/a | prose-identical as flattened `.mdc` | **documented gap** | byte-identical |
| `security-specialist` agent | byte-identical | n/a | byte-identical | byte-identical | body-identical as `.agent.md` |
| `enforce-verification-gate.sh` | byte-identical | n/a | byte-identical | **Claude-only gate** | byte-identical |

Two representation gaps are pinned as **documented, never silent**:

- **The Stop-hook gate is Claude-only.** No other runtime can refuse to stop, so `lisa-implement` step 2a now carries an explicit prose gate for harnesses that fire no Stop hook — write `schema_version: 2`, bind every claim to a `boundary` and the `required_evidence_kinds` that reach it, match every evidence entry's `artifact_head_sha` to `artifact.head_sha` with a real `sha256`/`captured_at`, and keep `not_established` present with `not_established_reviewed: true`. The passage names the Claude-only gate as the known representation gap rather than dropping the obligation.
- **The agy artifacts carry no rules tree** (the generator says so, and the test asserts it). The obligation travels in the skills instead.

The audit is now a test, not a one-time inspection — it fails the build if a future source edit stops regenerating cleanly.

## spec-conformance consumption

`lisa-spec-conformance` gains **Phase 3b — Cross-Check Claims Against Their Boundaries**. It loads `.lisa/verification-status.json` (v2) and runs three checks per claim:

| Check | Rule |
|---|---|
| Boundary reach | each `evidence_refs` entry resolves to evidence whose `kind` is in the claim's `required_evidence_kinds` for its `boundary` |
| Artifact identity | every cited evidence row's `artifact_head_sha` equals `artifact.head_sha` |
| Not established | `not_established_reviewed` is `true` and every claim carries a `not_established` list |

A failure is **`BOUNDARY_MISMATCH`** — a new coverage-matrix status that forces the verdict to `DIVERGES`. It is deliberately a distinct failure from a miss: the work may be right and the proof still not establish it. A unit `test-run-log` cited on a `browser` claim is exactly the case it catches, per the `claim-evidence-mapping` contract.

The matrix gains `Boundary` and `Evidence kind` columns, the report gains a never-omitted **Not Established** section (renders `None outstanding — reviewed` when empty), and an absent or v1 verdict **degrades rather than blocks**: the report says "v2 verdict not present — boundary reach unverified" and caps affected rows at `PARTIAL`. `spec-conformance-specialist` and `verification-specialist` both cite the contract by slug.

## Docs

`wiki/concepts/bounded-claims-evidence-system.md` — operator-readable, end to end:

- the core inequality (unit tests ≠ browser behavior ≠ healthy deployment ≠ standards compatibility) and the full boundary taxonomy table
- the four disciplines (bounded claims, Not established, artifact identity, two-bucket security)
- where each is enforced and on which runtime
- the two config flip points: `verification.gate.enforceBoundaries` (default `false`) and `security.review.unprovenBucket` (default `security-unproven`)
- the four-step advisory→blocking ratchet path
- the six-agent parity model and its two honest gaps

Linked from `wiki/index.md`; cross-linked from `rules/reference/verification.md`.

## Tests

`tests/unit/strategies/bce-parity-and-consumption.test.ts` — 77 pins:

- the parity matrix, per file per root
- the prose-gate v2 expectations and the named Claude-only gap
- the consumption wiring, asserted on both `plugins/src/base` and `plugins/lisa`
- a **decidability** pin that runs the exact Phase 3b procedure against the shipped BCE-6 fixtures: `evidence_kind_mismatch` → boundary finding, `artifact_mismatch` → identity finding, `not_established_unreviewed` → review finding, `v2_pass_clean` → nothing

## Gate results

| Gate | Result |
|---|---|
| `vitest tests/unit/strategies tests/unit/hooks` | 167 files, **4087 passed** |
| prior BCE pin families (5 suites) | **207 passed** |
| `bun run typecheck` | ✅ |
| `bun run lint` | ✅ 0 errors |
| `bun run format:check` | ✅ |
| `bun run check:rules-pairing` | ✅ |
| `bun run check:plugins` (post-commit) | ✅ in sync — the parity proof |
| upstream evidence manifest `--check` | ✅ not stale |

🤖 Generated with Claude Code
