### PR TITLE
feat(rules): add the readiness-rubric rule pair with eight dimensions and seven blockers (#1853)

### DIFF
--- a/plugins/lisa-copilot/rules/eager/readiness-rubric.md
+++ b/plugins/lisa-copilot/rules/eager/readiness-rubric.md
@@ -1,0 +1,58 @@
+# Repository Readiness Rubric (load-bearing)
+
+**"Lisa is installed correctly" and "an agent fleet may run here unattended" are two different
+questions.** Doctor's shipped grouped checks answer the first — *installation readiness*. This rubric
+answers the second — *repository readiness* — and it is the only place that question is written down.
+A green test suite is not an answer to it.
+
+## Eight ownership dimensions
+
+Repository readiness is assessed across exactly eight dimensions, never fewer, and a dimension with
+no applicable evidence renders `SKIP` **with a reason** rather than a blank:
+
+1. **context/routing** — can an agent recover the real job from what is written down?
+2. **capabilities/tools** — is every tool the work needs *provably* reachable, not merely installed?
+3. **domain ownership** — are the business rules, glossary, and danger zones owned and written down?
+4. **execution/proof** — can the claimed user-visible outcome be proved by running the system?
+5. **feedback/guardrails** — does a failing loop produce a named outcome and a runbook?
+6. **dependencies/supply chain** — is there a confidence model for what the repo depends on?
+7. **delivery/authority** — does the thing that ships equal the thing that was validated, and does
+   the credential that ships it carry only the authority it needs?
+8. **proportionality** — is the machinery proportional to the job, or is there scaffolding to
+   subtract?
+
+## Seven ship blockers (closed set, v1)
+
+A **ship blocker** is a condition that, standing alone, means the answer to "may an unattended fleet
+run here?" is no. The set is closed in v1 — seven, no more — and extended only by editing this rule:
+
+- **B1** a realistic path causes **silent data loss**
+- **B2** a **release path bypasses the validated artifact**
+- **B3** **credentials carry material unintended authority**
+- **B4** a **consequential operation has no gate and no recovery**
+- **B5** an **owned compatibility or security surface has no confidence model**
+- **B6** **documentation overstates enforced guarantees**
+- **B7** there is **no way to prove the claimed user-visible outcome**
+
+## Verdict and narrowed claim
+
+The verdict reuses the shipped `READY` / `READY_WITH_WARNINGS` / `NOT_READY` ladder — cite doctor's
+ladder, never fork a parallel enum. **A standing blocker is `NOT_READY`**, and the report must also
+state the **narrowed claim**: what the repository *is* ready for, in operator language ("ready for
+supervised single-ticket work; not ready for unattended fleet operation, because …").
+
+## Ordering
+
+**Report section order stays stable and never silently omits a section; findings are ordered by
+consequence** — highest-consequence first — within and across sections. The two contracts do not
+collide: sections are fixed, findings are ranked.
+
+## Warn-only
+
+This rubric **gates a claim, not a process**. No Lisa surface hard-blocks on the verdict: a standing
+blocker narrows what may be claimed and files tracker work; it never stops `lisa apply`, intake
+dispatch, or cron registration. Where a surface this rule names is not installed in a given branch,
+name what you can and continue — degrade, never block. Written to be read by someone who does not
+code (`factory-model` rule 5).
+
+Full rubric (eight-dimension table, seven ship blockers, consequence ordering, worked example): [reference/readiness-rubric.md](../reference/readiness-rubric.md).

--- a/plugins/lisa-copilot/rules/reference/readiness-rubric.md
+++ b/plugins/lisa-copilot/rules/reference/readiness-rubric.md
@@ -1,0 +1,179 @@
+# Repository Readiness Rubric
+
+Lisa can already tell you whether it is *installed* correctly. It cannot tell you whether a
+repository is somewhere an agent fleet can safely operate **unattended**. Those are two different
+questions, and conflating them is how a brownfield onboarding ends in "we built a wiki, looks good"
+instead of a verdict someone can act on.
+
+This document writes the second question down once: **eight ownership dimensions** with concrete
+warning signs, and **seven ship blockers** that, if any one of them stands, mean the answer is no.
+It is documentation. Nothing here executes — the later tickets of PRD #1739 instantiate this rubric
+rather than redefine it.
+
+## Two readinesses, one report
+
+| | Installation readiness | Repository readiness |
+|---|---|---|
+| Question | is Lisa installed and wired correctly here? | may an agent fleet operate here unattended? |
+| Owner | `lisa doctor`'s shipped grouped checks (project detection, config, distribution, tracker preflight, automation prerequisites, …) | this rubric's eight dimensions |
+| Answer shape | the shipped verdict ladder | the same shipped verdict ladder, plus a narrowed claim |
+
+They are **orthogonal** — a repository can be perfectly installed and completely unready, or ready in
+substance while Lisa's own wiring is incomplete. Both render in the same report, under separately
+titled sections, so a reader is never left guessing which question a verdict answered. The doctor
+mode that renders the repository-readiness group ships with **RRR-3 (#1855)**; do not assume that
+surface is present in this branch.
+
+## The eight ownership dimensions
+
+Exactly eight, always reported, never silently omitted. Each row names what the dimension asks,
+concrete warning signs an assessor can look for, and the **existing** Lisa rule or wiki page that
+supplies its evidence. Cite those slugs; do not restate them, and do not invent a parallel vocabulary
+for a concept another rule already owns.
+
+| # | Dimension | The question | Warning signs | Evidence source (existing) |
+|---|---|---|---|---|
+| 1 | context/routing | Can an agent recover the real job from what is written down? | no canonical entry document; routing decided by tribal knowledge; ambiguous config resolution; a README that describes a system that no longer exists | `integration-access-layer`, `wiki-knowledge-source`, `config-resolution` |
+| 2 | capabilities/tools | Is every tool the work needs *provably* reachable, not merely installed? | presence-on-PATH treated as access; no read-only probe before the work starts; agents inventing workarounds instead of breaking out | `tool-access-gate` |
+| 3 | domain ownership | Are the business rules, glossary, and danger zones owned and written down? | undocumented money paths; migrations with no owner; irreversible jobs nobody has described | the wiki pages agent-ready's domain phase already produces |
+| 4 | execution/proof | Can the claimed user-visible outcome be proved by running the system? | claims backed only by unit tests; no representative end-to-end journey; "verified" that names no boundary | `verification`, `empirical-inquiry`, `claim-evidence-mapping` |
+| 5 | feedback/guardrails | Does a failing loop produce a named outcome and a runbook? | silent failures; no run-outcome vocabulary; no observability on the loops that run unattended | `automation-runbook-contract`, `observability-audit` |
+| 6 | dependencies/supply chain | Is there a confidence model for what the repo depends on? | unpinned or unowned dependencies; no trust class; no decision record for why a risky dependency stays | `security-audit-handling` |
+| 7 | delivery/authority | Does the thing that ships equal the thing that was validated, and does the credential that ships it carry only the authority it needs? | a release path that bypasses the validated artifact; broad-scope tokens; deploy credentials shared across environments | `claim-archaeology`, `security-audit-handling` |
+| 8 | proportionality | Is the machinery proportional to the job, or is there scaffolding to subtract? | redundant checks that assert the same thing twice; abandoned harnesses still running in CI | `repo-scope-split`, and the scaffolding-subtraction candidates the journey work of **#1742** already surfaces |
+
+**`SKIP` carries a reason and is never blank.** A dimension with no applicable evidence renders
+`SKIP with a reason` — "no deployment target configured, so delivery/authority was not assessed" —
+never an empty cell and never a silent omission. An unassessed dimension is a known unknown, and the
+report says so.
+
+## The seven ship blockers
+
+A **ship blocker** is a condition that, standing alone, makes the claim "an unattended fleet may run
+here" false. Each has a one-line test an assessor can apply and the dimension that owns it.
+
+| # | Blocker | The test an assessor applies | Owning dimension |
+|---|---|---|---|
+| B1 | A realistic path causes **silent data loss** | can you name a plausible sequence that destroys or corrupts data with no error surfaced and no recovery path? | 3 |
+| B2 | A **release path bypasses the validated artifact** | can something reach production that is not the artifact CI actually validated? | 7 |
+| B3 | **Credentials carry material unintended authority** | does any credential used by automation grant authority materially beyond the job it does? | 7 |
+| B4 | A **consequential operation has no gate and no recovery** | is there an irreversible or expensive operation reachable without a gate, with no way back? | 3, 5 |
+| B5 | An **owned compatibility or security surface has no confidence model** | for a surface this repo owns, is there any basis beyond hope for believing it still works? | 6 |
+| B6 | **Documentation overstates enforced guarantees** | does the written word claim something is enforced that nothing actually enforces? | 1 |
+| B7 | There is **no way to prove the claimed user-visible outcome** | can the headline user-visible claim be demonstrated by running the system, at the boundary it claims? | 4 |
+
+### The set is a closed set in v1
+
+Seven, and only seven, in v1. The set is **not configurable** — there is no config key, no
+host-defined blockers, no severity dial. Extending it is a deliberate **rule edit** here plus a
+version bump, not a configuration surface to design, migrate, and support. Host-specific concerns
+surface as *findings within a dimension*, which is enough to make them visible without fragmenting
+the vocabulary.
+
+### "Ship blocker" is net-new vocabulary
+
+It is deliberately distinct from three terms other rules already own, and it never replaces them:
+
+- `convergent-review`'s **blocking finding** — a review-level judgment about one change.
+- `tool-access-gate`'s **break-out** — the escalation when a required tool is not provably reachable.
+- `leaf-only-lifecycle`'s **safe-block** — a lifecycle-state repair on a work item.
+
+A ship blocker is none of these: it is a property of the *repository*, asserted about *unattended
+operation*, and it gates a claim rather than a change, a tool call, or a ticket.
+
+## Verdict: the shipped ladder, plus a narrowed claim
+
+The rubric reuses the shipped `READY` / `READY_WITH_WARNINGS` / `NOT_READY` verdict ladder that
+`lisa doctor` already emits. There is **no new verdict** value and no new severity level — inventing
+a parallel enum would make two reports disagree about what "ready" means.
+
+- **`READY`** — eight dimensions assessed, no blocker stands, no warnings material to unattended
+  operation.
+- **`READY_WITH_WARNINGS`** — no blocker stands, but findings exist that a human should see.
+- **`NOT_READY`** — **at least one ship blocker stands.**
+
+**The narrowed claim is the net-new field.** When the verdict is `NOT_READY`, the report must also
+state, in operator language, **what the repository IS ready for** — never just what it is not. A
+verdict that only says no is unactionable at the gate; a narrowed claim tells the operator exactly
+which mode of operation remains available and what would widen it.
+
+## Consequence ordering
+
+Two ordering contracts meet here, and they do not collide:
+
+- **Section order stays stable.** The report renders its sections in a fixed order and **never
+  silently omits** one — the discipline `lisa doctor`'s grouped output already guarantees.
+- **Findings are ordered by consequence.** Within and across sections, the finding with the largest
+  consequence if left standing comes first. Alphabetical, chronological, and discovery order are all
+  wrong: the reader at the gate has limited attention, and it belongs on the worst thing first.
+
+### The five fields a readiness finding carries
+
+On top of the severity / blocking / failure-scenario / evidence / smallest-fix fields
+`convergent-review` already requires, a readiness finding names:
+
+| Field | What it states |
+|---|---|
+| `invariant_violated` | the invariant actually at risk, stated as a property of the system |
+| `evidence` | what was observed that establishes the finding, at a boundary that reaches the claim (`claim-evidence-mapping`) |
+| `why_proof_missed` | why the existing proof machinery did not catch this |
+| `root_correction` | the correction at the **owning boundary**, not a patch at the symptom |
+| `machinery_to_remove` | redundant machinery the correction makes unnecessary, if any |
+
+Two of these — `invariant_violated` and `machinery_to_remove` — are folded into the shared
+`convergent-review` finding shape by **RRR-2 (#1854)**; that extension ships with that ticket, so do
+not assume the shared shape carries them in this branch.
+
+### Worked example
+
+```text
+Repository: acme/checkout-service
+
+  Verdict          NOT_READY
+  Standing blocker B2 — a release path bypasses the validated artifact
+  Owning dimension 7 (delivery/authority)
+
+  invariant_violated   What ships to production is the artifact CI validated.
+  evidence             The deploy job rebuilds from source at deploy time rather than
+                       promoting the CI-built image; the deployed digest never matches
+                       the one the test job signed off on.
+  why_proof_missed     Every check is green — they all ran against a different artifact
+                       than the one that shipped. Nothing compared the two.
+  root_correction      Promote the validated image by digest at the delivery boundary.
+  machinery_to_remove  The duplicate deploy-time build step.
+
+  Narrowed claim   This repository IS ready for supervised, single-ticket agent work with a
+                   human approving each release. It is NOT ready for unattended fleet
+                   operation, because a release can ship code no check ever ran against.
+```
+
+## Where the evidence comes from
+
+The rubric consumes evidence that already exists; it commissions no second harness.
+
+- **execution/proof** consumes the existing qualification evidence recorded by the worker-epoch
+  requalification path and, when that evidence is absent or stale, triggers a journey run through the
+  shipped `lisa-use-the-product` skill — the machinery **#1742** already ships. There is no second
+  journey harness, and the evidence is recorded in the shape `claim-evidence-mapping` defines. That
+  wiring ships with **RRR-6 (#1858)**.
+- **domain ownership** sources its findings from the danger-zone wiki pages agent-ready's domain
+  phase already produces; the readiness assessment that reads them, and files standing blockers as
+  tracker work rather than in-session questions, ships with **RRR-4 (#1856)**.
+- The persisted report at `.lisa/readiness.json` (schema-versioned, read through a single resolver)
+  and the doctor render group ship with **RRR-3 (#1855)**; the blocker gate that emits the narrowed
+  claim ships with **RRR-5 (#1857)**; the `setup-automations` warning, six-agent parity fan-out, and
+  vocabulary documentation ship with **RRR-7 (#1859)**. Each of those surfaces may not yet be present
+  in a given branch — name what you can and continue.
+
+## Warn-only, always
+
+This rubric **gates a claim, not a process**. It is **warn-only** everywhere: no Lisa surface
+hard-blocks on the readiness verdict. `lisa apply`, intake dispatch, and cron registration are
+unaffected; the automation setup flow warns with the standing blocker count and the narrowed claim
+and still completes, consistent with the shipped never-block-always-degrade posture. Where a surface
+named here is not installed, **degrade, never block**: state what was assessed, state what was not,
+and continue.
+
+Read the eight dimension titles and the seven blockers to someone who has never seen Lisa. They
+should be able to say, unprompted, why "the tests pass" is not the same as "an agent fleet can run
+here unattended" — that is the bar this document is written to (`factory-model` rule 5).

--- a/plugins/lisa-cursor/rules/readiness-rubric-reference.mdc
+++ b/plugins/lisa-cursor/rules/readiness-rubric-reference.mdc
@@ -1,0 +1,184 @@
+---
+description: "Repository Readiness Rubric"
+alwaysApply: false
+---
+
+# Repository Readiness Rubric
+
+Lisa can already tell you whether it is *installed* correctly. It cannot tell you whether a
+repository is somewhere an agent fleet can safely operate **unattended**. Those are two different
+questions, and conflating them is how a brownfield onboarding ends in "we built a wiki, looks good"
+instead of a verdict someone can act on.
+
+This document writes the second question down once: **eight ownership dimensions** with concrete
+warning signs, and **seven ship blockers** that, if any one of them stands, mean the answer is no.
+It is documentation. Nothing here executes — the later tickets of PRD #1739 instantiate this rubric
+rather than redefine it.
+
+## Two readinesses, one report
+
+| | Installation readiness | Repository readiness |
+|---|---|---|
+| Question | is Lisa installed and wired correctly here? | may an agent fleet operate here unattended? |
+| Owner | `lisa doctor`'s shipped grouped checks (project detection, config, distribution, tracker preflight, automation prerequisites, …) | this rubric's eight dimensions |
+| Answer shape | the shipped verdict ladder | the same shipped verdict ladder, plus a narrowed claim |
+
+They are **orthogonal** — a repository can be perfectly installed and completely unready, or ready in
+substance while Lisa's own wiring is incomplete. Both render in the same report, under separately
+titled sections, so a reader is never left guessing which question a verdict answered. The doctor
+mode that renders the repository-readiness group ships with **RRR-3 (#1855)**; do not assume that
+surface is present in this branch.
+
+## The eight ownership dimensions
+
+Exactly eight, always reported, never silently omitted. Each row names what the dimension asks,
+concrete warning signs an assessor can look for, and the **existing** Lisa rule or wiki page that
+supplies its evidence. Cite those slugs; do not restate them, and do not invent a parallel vocabulary
+for a concept another rule already owns.
+
+| # | Dimension | The question | Warning signs | Evidence source (existing) |
+|---|---|---|---|---|
+| 1 | context/routing | Can an agent recover the real job from what is written down? | no canonical entry document; routing decided by tribal knowledge; ambiguous config resolution; a README that describes a system that no longer exists | `integration-access-layer`, `wiki-knowledge-source`, `config-resolution` |
+| 2 | capabilities/tools | Is every tool the work needs *provably* reachable, not merely installed? | presence-on-PATH treated as access; no read-only probe before the work starts; agents inventing workarounds instead of breaking out | `tool-access-gate` |
+| 3 | domain ownership | Are the business rules, glossary, and danger zones owned and written down? | undocumented money paths; migrations with no owner; irreversible jobs nobody has described | the wiki pages agent-ready's domain phase already produces |
+| 4 | execution/proof | Can the claimed user-visible outcome be proved by running the system? | claims backed only by unit tests; no representative end-to-end journey; "verified" that names no boundary | `verification`, `empirical-inquiry`, `claim-evidence-mapping` |
+| 5 | feedback/guardrails | Does a failing loop produce a named outcome and a runbook? | silent failures; no run-outcome vocabulary; no observability on the loops that run unattended | `automation-runbook-contract`, `observability-audit` |
+| 6 | dependencies/supply chain | Is there a confidence model for what the repo depends on? | unpinned or unowned dependencies; no trust class; no decision record for why a risky dependency stays | `security-audit-handling` |
+| 7 | delivery/authority | Does the thing that ships equal the thing that was validated, and does the credential that ships it carry only the authority it needs? | a release path that bypasses the validated artifact; broad-scope tokens; deploy credentials shared across environments | `claim-archaeology`, `security-audit-handling` |
+| 8 | proportionality | Is the machinery proportional to the job, or is there scaffolding to subtract? | redundant checks that assert the same thing twice; abandoned harnesses still running in CI | `repo-scope-split`, and the scaffolding-subtraction candidates the journey work of **#1742** already surfaces |
+
+**`SKIP` carries a reason and is never blank.** A dimension with no applicable evidence renders
+`SKIP with a reason` — "no deployment target configured, so delivery/authority was not assessed" —
+never an empty cell and never a silent omission. An unassessed dimension is a known unknown, and the
+report says so.
+
+## The seven ship blockers
+
+A **ship blocker** is a condition that, standing alone, makes the claim "an unattended fleet may run
+here" false. Each has a one-line test an assessor can apply and the dimension that owns it.
+
+| # | Blocker | The test an assessor applies | Owning dimension |
+|---|---|---|---|
+| B1 | A realistic path causes **silent data loss** | can you name a plausible sequence that destroys or corrupts data with no error surfaced and no recovery path? | 3 |
+| B2 | A **release path bypasses the validated artifact** | can something reach production that is not the artifact CI actually validated? | 7 |
+| B3 | **Credentials carry material unintended authority** | does any credential used by automation grant authority materially beyond the job it does? | 7 |
+| B4 | A **consequential operation has no gate and no recovery** | is there an irreversible or expensive operation reachable without a gate, with no way back? | 3, 5 |
+| B5 | An **owned compatibility or security surface has no confidence model** | for a surface this repo owns, is there any basis beyond hope for believing it still works? | 6 |
+| B6 | **Documentation overstates enforced guarantees** | does the written word claim something is enforced that nothing actually enforces? | 1 |
+| B7 | There is **no way to prove the claimed user-visible outcome** | can the headline user-visible claim be demonstrated by running the system, at the boundary it claims? | 4 |
+
+### The set is a closed set in v1
+
+Seven, and only seven, in v1. The set is **not configurable** — there is no config key, no
+host-defined blockers, no severity dial. Extending it is a deliberate **rule edit** here plus a
+version bump, not a configuration surface to design, migrate, and support. Host-specific concerns
+surface as *findings within a dimension*, which is enough to make them visible without fragmenting
+the vocabulary.
+
+### "Ship blocker" is net-new vocabulary
+
+It is deliberately distinct from three terms other rules already own, and it never replaces them:
+
+- `convergent-review`'s **blocking finding** — a review-level judgment about one change.
+- `tool-access-gate`'s **break-out** — the escalation when a required tool is not provably reachable.
+- `leaf-only-lifecycle`'s **safe-block** — a lifecycle-state repair on a work item.
+
+A ship blocker is none of these: it is a property of the *repository*, asserted about *unattended
+operation*, and it gates a claim rather than a change, a tool call, or a ticket.
+
+## Verdict: the shipped ladder, plus a narrowed claim
+
+The rubric reuses the shipped `READY` / `READY_WITH_WARNINGS` / `NOT_READY` verdict ladder that
+`lisa doctor` already emits. There is **no new verdict** value and no new severity level — inventing
+a parallel enum would make two reports disagree about what "ready" means.
+
+- **`READY`** — eight dimensions assessed, no blocker stands, no warnings material to unattended
+  operation.
+- **`READY_WITH_WARNINGS`** — no blocker stands, but findings exist that a human should see.
+- **`NOT_READY`** — **at least one ship blocker stands.**
+
+**The narrowed claim is the net-new field.** When the verdict is `NOT_READY`, the report must also
+state, in operator language, **what the repository IS ready for** — never just what it is not. A
+verdict that only says no is unactionable at the gate; a narrowed claim tells the operator exactly
+which mode of operation remains available and what would widen it.
+
+## Consequence ordering
+
+Two ordering contracts meet here, and they do not collide:
+
+- **Section order stays stable.** The report renders its sections in a fixed order and **never
+  silently omits** one — the discipline `lisa doctor`'s grouped output already guarantees.
+- **Findings are ordered by consequence.** Within and across sections, the finding with the largest
+  consequence if left standing comes first. Alphabetical, chronological, and discovery order are all
+  wrong: the reader at the gate has limited attention, and it belongs on the worst thing first.
+
+### The five fields a readiness finding carries
+
+On top of the severity / blocking / failure-scenario / evidence / smallest-fix fields
+`convergent-review` already requires, a readiness finding names:
+
+| Field | What it states |
+|---|---|
+| `invariant_violated` | the invariant actually at risk, stated as a property of the system |
+| `evidence` | what was observed that establishes the finding, at a boundary that reaches the claim (`claim-evidence-mapping`) |
+| `why_proof_missed` | why the existing proof machinery did not catch this |
+| `root_correction` | the correction at the **owning boundary**, not a patch at the symptom |
+| `machinery_to_remove` | redundant machinery the correction makes unnecessary, if any |
+
+Two of these — `invariant_violated` and `machinery_to_remove` — are folded into the shared
+`convergent-review` finding shape by **RRR-2 (#1854)**; that extension ships with that ticket, so do
+not assume the shared shape carries them in this branch.
+
+### Worked example
+
+```text
+Repository: acme/checkout-service
+
+  Verdict          NOT_READY
+  Standing blocker B2 — a release path bypasses the validated artifact
+  Owning dimension 7 (delivery/authority)
+
+  invariant_violated   What ships to production is the artifact CI validated.
+  evidence             The deploy job rebuilds from source at deploy time rather than
+                       promoting the CI-built image; the deployed digest never matches
+                       the one the test job signed off on.
+  why_proof_missed     Every check is green — they all ran against a different artifact
+                       than the one that shipped. Nothing compared the two.
+  root_correction      Promote the validated image by digest at the delivery boundary.
+  machinery_to_remove  The duplicate deploy-time build step.
+
+  Narrowed claim   This repository IS ready for supervised, single-ticket agent work with a
+                   human approving each release. It is NOT ready for unattended fleet
+                   operation, because a release can ship code no check ever ran against.
+```
+
+## Where the evidence comes from
+
+The rubric consumes evidence that already exists; it commissions no second harness.
+
+- **execution/proof** consumes the existing qualification evidence recorded by the worker-epoch
+  requalification path and, when that evidence is absent or stale, triggers a journey run through the
+  shipped `lisa-use-the-product` skill — the machinery **#1742** already ships. There is no second
+  journey harness, and the evidence is recorded in the shape `claim-evidence-mapping` defines. That
+  wiring ships with **RRR-6 (#1858)**.
+- **domain ownership** sources its findings from the danger-zone wiki pages agent-ready's domain
+  phase already produces; the readiness assessment that reads them, and files standing blockers as
+  tracker work rather than in-session questions, ships with **RRR-4 (#1856)**.
+- The persisted report at `.lisa/readiness.json` (schema-versioned, read through a single resolver)
+  and the doctor render group ship with **RRR-3 (#1855)**; the blocker gate that emits the narrowed
+  claim ships with **RRR-5 (#1857)**; the `setup-automations` warning, six-agent parity fan-out, and
+  vocabulary documentation ship with **RRR-7 (#1859)**. Each of those surfaces may not yet be present
+  in a given branch — name what you can and continue.
+
+## Warn-only, always
+
+This rubric **gates a claim, not a process**. It is **warn-only** everywhere: no Lisa surface
+hard-blocks on the readiness verdict. `lisa apply`, intake dispatch, and cron registration are
+unaffected; the automation setup flow warns with the standing blocker count and the narrowed claim
+and still completes, consistent with the shipped never-block-always-degrade posture. Where a surface
+named here is not installed, **degrade, never block**: state what was assessed, state what was not,
+and continue.
+
+Read the eight dimension titles and the seven blockers to someone who has never seen Lisa. They
+should be able to say, unprompted, why "the tests pass" is not the same as "an agent fleet can run
+here unattended" — that is the bar this document is written to (`factory-model` rule 5).

--- a/plugins/lisa-cursor/rules/readiness-rubric.mdc
+++ b/plugins/lisa-cursor/rules/readiness-rubric.mdc
@@ -1,0 +1,63 @@
+---
+description: "Repository Readiness Rubric (load-bearing)"
+alwaysApply: true
+---
+
+# Repository Readiness Rubric (load-bearing)
+
+**"Lisa is installed correctly" and "an agent fleet may run here unattended" are two different
+questions.** Doctor's shipped grouped checks answer the first — *installation readiness*. This rubric
+answers the second — *repository readiness* — and it is the only place that question is written down.
+A green test suite is not an answer to it.
+
+## Eight ownership dimensions
+
+Repository readiness is assessed across exactly eight dimensions, never fewer, and a dimension with
+no applicable evidence renders `SKIP` **with a reason** rather than a blank:
+
+1. **context/routing** — can an agent recover the real job from what is written down?
+2. **capabilities/tools** — is every tool the work needs *provably* reachable, not merely installed?
+3. **domain ownership** — are the business rules, glossary, and danger zones owned and written down?
+4. **execution/proof** — can the claimed user-visible outcome be proved by running the system?
+5. **feedback/guardrails** — does a failing loop produce a named outcome and a runbook?
+6. **dependencies/supply chain** — is there a confidence model for what the repo depends on?
+7. **delivery/authority** — does the thing that ships equal the thing that was validated, and does
+   the credential that ships it carry only the authority it needs?
+8. **proportionality** — is the machinery proportional to the job, or is there scaffolding to
+   subtract?
+
+## Seven ship blockers (closed set, v1)
+
+A **ship blocker** is a condition that, standing alone, means the answer to "may an unattended fleet
+run here?" is no. The set is closed in v1 — seven, no more — and extended only by editing this rule:
+
+- **B1** a realistic path causes **silent data loss**
+- **B2** a **release path bypasses the validated artifact**
+- **B3** **credentials carry material unintended authority**
+- **B4** a **consequential operation has no gate and no recovery**
+- **B5** an **owned compatibility or security surface has no confidence model**
+- **B6** **documentation overstates enforced guarantees**
+- **B7** there is **no way to prove the claimed user-visible outcome**
+
+## Verdict and narrowed claim
+
+The verdict reuses the shipped `READY` / `READY_WITH_WARNINGS` / `NOT_READY` ladder — cite doctor's
+ladder, never fork a parallel enum. **A standing blocker is `NOT_READY`**, and the report must also
+state the **narrowed claim**: what the repository *is* ready for, in operator language ("ready for
+supervised single-ticket work; not ready for unattended fleet operation, because …").
+
+## Ordering
+
+**Report section order stays stable and never silently omits a section; findings are ordered by
+consequence** — highest-consequence first — within and across sections. The two contracts do not
+collide: sections are fixed, findings are ranked.
+
+## Warn-only
+
+This rubric **gates a claim, not a process**. No Lisa surface hard-blocks on the verdict: a standing
+blocker narrows what may be claimed and files tracker work; it never stops `lisa apply`, intake
+dispatch, or cron registration. Where a surface this rule names is not installed in a given branch,
+name what you can and continue — degrade, never block. Written to be read by someone who does not
+code (`factory-model` rule 5).
+
+Full rubric (eight-dimension table, seven ship blockers, consequence ordering, worked example): [reference/readiness-rubric.md](readiness-rubric-reference.mdc).

--- a/plugins/lisa/rules/eager/readiness-rubric.md
+++ b/plugins/lisa/rules/eager/readiness-rubric.md
@@ -1,0 +1,58 @@
+# Repository Readiness Rubric (load-bearing)
+
+**"Lisa is installed correctly" and "an agent fleet may run here unattended" are two different
+questions.** Doctor's shipped grouped checks answer the first — *installation readiness*. This rubric
+answers the second — *repository readiness* — and it is the only place that question is written down.
+A green test suite is not an answer to it.
+
+## Eight ownership dimensions
+
+Repository readiness is assessed across exactly eight dimensions, never fewer, and a dimension with
+no applicable evidence renders `SKIP` **with a reason** rather than a blank:
+
+1. **context/routing** — can an agent recover the real job from what is written down?
+2. **capabilities/tools** — is every tool the work needs *provably* reachable, not merely installed?
+3. **domain ownership** — are the business rules, glossary, and danger zones owned and written down?
+4. **execution/proof** — can the claimed user-visible outcome be proved by running the system?
+5. **feedback/guardrails** — does a failing loop produce a named outcome and a runbook?
+6. **dependencies/supply chain** — is there a confidence model for what the repo depends on?
+7. **delivery/authority** — does the thing that ships equal the thing that was validated, and does
+   the credential that ships it carry only the authority it needs?
+8. **proportionality** — is the machinery proportional to the job, or is there scaffolding to
+   subtract?
+
+## Seven ship blockers (closed set, v1)
+
+A **ship blocker** is a condition that, standing alone, means the answer to "may an unattended fleet
+run here?" is no. The set is closed in v1 — seven, no more — and extended only by editing this rule:
+
+- **B1** a realistic path causes **silent data loss**
+- **B2** a **release path bypasses the validated artifact**
+- **B3** **credentials carry material unintended authority**
+- **B4** a **consequential operation has no gate and no recovery**
+- **B5** an **owned compatibility or security surface has no confidence model**
+- **B6** **documentation overstates enforced guarantees**
+- **B7** there is **no way to prove the claimed user-visible outcome**
+
+## Verdict and narrowed claim
+
+The verdict reuses the shipped `READY` / `READY_WITH_WARNINGS` / `NOT_READY` ladder — cite doctor's
+ladder, never fork a parallel enum. **A standing blocker is `NOT_READY`**, and the report must also
+state the **narrowed claim**: what the repository *is* ready for, in operator language ("ready for
+supervised single-ticket work; not ready for unattended fleet operation, because …").
+
+## Ordering
+
+**Report section order stays stable and never silently omits a section; findings are ordered by
+consequence** — highest-consequence first — within and across sections. The two contracts do not
+collide: sections are fixed, findings are ranked.
+
+## Warn-only
+
+This rubric **gates a claim, not a process**. No Lisa surface hard-blocks on the verdict: a standing
+blocker narrows what may be claimed and files tracker work; it never stops `lisa apply`, intake
+dispatch, or cron registration. Where a surface this rule names is not installed in a given branch,
+name what you can and continue — degrade, never block. Written to be read by someone who does not
+code (`factory-model` rule 5).
+
+Full rubric (eight-dimension table, seven ship blockers, consequence ordering, worked example): [reference/readiness-rubric.md](../reference/readiness-rubric.md).

--- a/plugins/lisa/rules/reference/readiness-rubric.md
+++ b/plugins/lisa/rules/reference/readiness-rubric.md
@@ -1,0 +1,179 @@
+# Repository Readiness Rubric
+
+Lisa can already tell you whether it is *installed* correctly. It cannot tell you whether a
+repository is somewhere an agent fleet can safely operate **unattended**. Those are two different
+questions, and conflating them is how a brownfield onboarding ends in "we built a wiki, looks good"
+instead of a verdict someone can act on.
+
+This document writes the second question down once: **eight ownership dimensions** with concrete
+warning signs, and **seven ship blockers** that, if any one of them stands, mean the answer is no.
+It is documentation. Nothing here executes — the later tickets of PRD #1739 instantiate this rubric
+rather than redefine it.
+
+## Two readinesses, one report
+
+| | Installation readiness | Repository readiness |
+|---|---|---|
+| Question | is Lisa installed and wired correctly here? | may an agent fleet operate here unattended? |
+| Owner | `lisa doctor`'s shipped grouped checks (project detection, config, distribution, tracker preflight, automation prerequisites, …) | this rubric's eight dimensions |
+| Answer shape | the shipped verdict ladder | the same shipped verdict ladder, plus a narrowed claim |
+
+They are **orthogonal** — a repository can be perfectly installed and completely unready, or ready in
+substance while Lisa's own wiring is incomplete. Both render in the same report, under separately
+titled sections, so a reader is never left guessing which question a verdict answered. The doctor
+mode that renders the repository-readiness group ships with **RRR-3 (#1855)**; do not assume that
+surface is present in this branch.
+
+## The eight ownership dimensions
+
+Exactly eight, always reported, never silently omitted. Each row names what the dimension asks,
+concrete warning signs an assessor can look for, and the **existing** Lisa rule or wiki page that
+supplies its evidence. Cite those slugs; do not restate them, and do not invent a parallel vocabulary
+for a concept another rule already owns.
+
+| # | Dimension | The question | Warning signs | Evidence source (existing) |
+|---|---|---|---|---|
+| 1 | context/routing | Can an agent recover the real job from what is written down? | no canonical entry document; routing decided by tribal knowledge; ambiguous config resolution; a README that describes a system that no longer exists | `integration-access-layer`, `wiki-knowledge-source`, `config-resolution` |
+| 2 | capabilities/tools | Is every tool the work needs *provably* reachable, not merely installed? | presence-on-PATH treated as access; no read-only probe before the work starts; agents inventing workarounds instead of breaking out | `tool-access-gate` |
+| 3 | domain ownership | Are the business rules, glossary, and danger zones owned and written down? | undocumented money paths; migrations with no owner; irreversible jobs nobody has described | the wiki pages agent-ready's domain phase already produces |
+| 4 | execution/proof | Can the claimed user-visible outcome be proved by running the system? | claims backed only by unit tests; no representative end-to-end journey; "verified" that names no boundary | `verification`, `empirical-inquiry`, `claim-evidence-mapping` |
+| 5 | feedback/guardrails | Does a failing loop produce a named outcome and a runbook? | silent failures; no run-outcome vocabulary; no observability on the loops that run unattended | `automation-runbook-contract`, `observability-audit` |
+| 6 | dependencies/supply chain | Is there a confidence model for what the repo depends on? | unpinned or unowned dependencies; no trust class; no decision record for why a risky dependency stays | `security-audit-handling` |
+| 7 | delivery/authority | Does the thing that ships equal the thing that was validated, and does the credential that ships it carry only the authority it needs? | a release path that bypasses the validated artifact; broad-scope tokens; deploy credentials shared across environments | `claim-archaeology`, `security-audit-handling` |
+| 8 | proportionality | Is the machinery proportional to the job, or is there scaffolding to subtract? | redundant checks that assert the same thing twice; abandoned harnesses still running in CI | `repo-scope-split`, and the scaffolding-subtraction candidates the journey work of **#1742** already surfaces |
+
+**`SKIP` carries a reason and is never blank.** A dimension with no applicable evidence renders
+`SKIP with a reason` — "no deployment target configured, so delivery/authority was not assessed" —
+never an empty cell and never a silent omission. An unassessed dimension is a known unknown, and the
+report says so.
+
+## The seven ship blockers
+
+A **ship blocker** is a condition that, standing alone, makes the claim "an unattended fleet may run
+here" false. Each has a one-line test an assessor can apply and the dimension that owns it.
+
+| # | Blocker | The test an assessor applies | Owning dimension |
+|---|---|---|---|
+| B1 | A realistic path causes **silent data loss** | can you name a plausible sequence that destroys or corrupts data with no error surfaced and no recovery path? | 3 |
+| B2 | A **release path bypasses the validated artifact** | can something reach production that is not the artifact CI actually validated? | 7 |
+| B3 | **Credentials carry material unintended authority** | does any credential used by automation grant authority materially beyond the job it does? | 7 |
+| B4 | A **consequential operation has no gate and no recovery** | is there an irreversible or expensive operation reachable without a gate, with no way back? | 3, 5 |
+| B5 | An **owned compatibility or security surface has no confidence model** | for a surface this repo owns, is there any basis beyond hope for believing it still works? | 6 |
+| B6 | **Documentation overstates enforced guarantees** | does the written word claim something is enforced that nothing actually enforces? | 1 |
+| B7 | There is **no way to prove the claimed user-visible outcome** | can the headline user-visible claim be demonstrated by running the system, at the boundary it claims? | 4 |
+
+### The set is a closed set in v1
+
+Seven, and only seven, in v1. The set is **not configurable** — there is no config key, no
+host-defined blockers, no severity dial. Extending it is a deliberate **rule edit** here plus a
+version bump, not a configuration surface to design, migrate, and support. Host-specific concerns
+surface as *findings within a dimension*, which is enough to make them visible without fragmenting
+the vocabulary.
+
+### "Ship blocker" is net-new vocabulary
+
+It is deliberately distinct from three terms other rules already own, and it never replaces them:
+
+- `convergent-review`'s **blocking finding** — a review-level judgment about one change.
+- `tool-access-gate`'s **break-out** — the escalation when a required tool is not provably reachable.
+- `leaf-only-lifecycle`'s **safe-block** — a lifecycle-state repair on a work item.
+
+A ship blocker is none of these: it is a property of the *repository*, asserted about *unattended
+operation*, and it gates a claim rather than a change, a tool call, or a ticket.
+
+## Verdict: the shipped ladder, plus a narrowed claim
+
+The rubric reuses the shipped `READY` / `READY_WITH_WARNINGS` / `NOT_READY` verdict ladder that
+`lisa doctor` already emits. There is **no new verdict** value and no new severity level — inventing
+a parallel enum would make two reports disagree about what "ready" means.
+
+- **`READY`** — eight dimensions assessed, no blocker stands, no warnings material to unattended
+  operation.
+- **`READY_WITH_WARNINGS`** — no blocker stands, but findings exist that a human should see.
+- **`NOT_READY`** — **at least one ship blocker stands.**
+
+**The narrowed claim is the net-new field.** When the verdict is `NOT_READY`, the report must also
+state, in operator language, **what the repository IS ready for** — never just what it is not. A
+verdict that only says no is unactionable at the gate; a narrowed claim tells the operator exactly
+which mode of operation remains available and what would widen it.
+
+## Consequence ordering
+
+Two ordering contracts meet here, and they do not collide:
+
+- **Section order stays stable.** The report renders its sections in a fixed order and **never
+  silently omits** one — the discipline `lisa doctor`'s grouped output already guarantees.
+- **Findings are ordered by consequence.** Within and across sections, the finding with the largest
+  consequence if left standing comes first. Alphabetical, chronological, and discovery order are all
+  wrong: the reader at the gate has limited attention, and it belongs on the worst thing first.
+
+### The five fields a readiness finding carries
+
+On top of the severity / blocking / failure-scenario / evidence / smallest-fix fields
+`convergent-review` already requires, a readiness finding names:
+
+| Field | What it states |
+|---|---|
+| `invariant_violated` | the invariant actually at risk, stated as a property of the system |
+| `evidence` | what was observed that establishes the finding, at a boundary that reaches the claim (`claim-evidence-mapping`) |
+| `why_proof_missed` | why the existing proof machinery did not catch this |
+| `root_correction` | the correction at the **owning boundary**, not a patch at the symptom |
+| `machinery_to_remove` | redundant machinery the correction makes unnecessary, if any |
+
+Two of these — `invariant_violated` and `machinery_to_remove` — are folded into the shared
+`convergent-review` finding shape by **RRR-2 (#1854)**; that extension ships with that ticket, so do
+not assume the shared shape carries them in this branch.
+
+### Worked example
+
+```text
+Repository: acme/checkout-service
+
+  Verdict          NOT_READY
+  Standing blocker B2 — a release path bypasses the validated artifact
+  Owning dimension 7 (delivery/authority)
+
+  invariant_violated   What ships to production is the artifact CI validated.
+  evidence             The deploy job rebuilds from source at deploy time rather than
+                       promoting the CI-built image; the deployed digest never matches
+                       the one the test job signed off on.
+  why_proof_missed     Every check is green — they all ran against a different artifact
+                       than the one that shipped. Nothing compared the two.
+  root_correction      Promote the validated image by digest at the delivery boundary.
+  machinery_to_remove  The duplicate deploy-time build step.
+
+  Narrowed claim   This repository IS ready for supervised, single-ticket agent work with a
+                   human approving each release. It is NOT ready for unattended fleet
+                   operation, because a release can ship code no check ever ran against.
+```
+
+## Where the evidence comes from
+
+The rubric consumes evidence that already exists; it commissions no second harness.
+
+- **execution/proof** consumes the existing qualification evidence recorded by the worker-epoch
+  requalification path and, when that evidence is absent or stale, triggers a journey run through the
+  shipped `lisa-use-the-product` skill — the machinery **#1742** already ships. There is no second
+  journey harness, and the evidence is recorded in the shape `claim-evidence-mapping` defines. That
+  wiring ships with **RRR-6 (#1858)**.
+- **domain ownership** sources its findings from the danger-zone wiki pages agent-ready's domain
+  phase already produces; the readiness assessment that reads them, and files standing blockers as
+  tracker work rather than in-session questions, ships with **RRR-4 (#1856)**.
+- The persisted report at `.lisa/readiness.json` (schema-versioned, read through a single resolver)
+  and the doctor render group ship with **RRR-3 (#1855)**; the blocker gate that emits the narrowed
+  claim ships with **RRR-5 (#1857)**; the `setup-automations` warning, six-agent parity fan-out, and
+  vocabulary documentation ship with **RRR-7 (#1859)**. Each of those surfaces may not yet be present
+  in a given branch — name what you can and continue.
+
+## Warn-only, always
+
+This rubric **gates a claim, not a process**. It is **warn-only** everywhere: no Lisa surface
+hard-blocks on the readiness verdict. `lisa apply`, intake dispatch, and cron registration are
+unaffected; the automation setup flow warns with the standing blocker count and the narrowed claim
+and still completes, consistent with the shipped never-block-always-degrade posture. Where a surface
+named here is not installed, **degrade, never block**: state what was assessed, state what was not,
+and continue.
+
+Read the eight dimension titles and the seven blockers to someone who has never seen Lisa. They
+should be able to say, unprompted, why "the tests pass" is not the same as "an agent fleet can run
+here unattended" — that is the bar this document is written to (`factory-model` rule 5).

--- a/plugins/src/base/rules/eager/readiness-rubric.md
+++ b/plugins/src/base/rules/eager/readiness-rubric.md
@@ -1,0 +1,58 @@
+# Repository Readiness Rubric (load-bearing)
+
+**"Lisa is installed correctly" and "an agent fleet may run here unattended" are two different
+questions.** Doctor's shipped grouped checks answer the first — *installation readiness*. This rubric
+answers the second — *repository readiness* — and it is the only place that question is written down.
+A green test suite is not an answer to it.
+
+## Eight ownership dimensions
+
+Repository readiness is assessed across exactly eight dimensions, never fewer, and a dimension with
+no applicable evidence renders `SKIP` **with a reason** rather than a blank:
+
+1. **context/routing** — can an agent recover the real job from what is written down?
+2. **capabilities/tools** — is every tool the work needs *provably* reachable, not merely installed?
+3. **domain ownership** — are the business rules, glossary, and danger zones owned and written down?
+4. **execution/proof** — can the claimed user-visible outcome be proved by running the system?
+5. **feedback/guardrails** — does a failing loop produce a named outcome and a runbook?
+6. **dependencies/supply chain** — is there a confidence model for what the repo depends on?
+7. **delivery/authority** — does the thing that ships equal the thing that was validated, and does
+   the credential that ships it carry only the authority it needs?
+8. **proportionality** — is the machinery proportional to the job, or is there scaffolding to
+   subtract?
+
+## Seven ship blockers (closed set, v1)
+
+A **ship blocker** is a condition that, standing alone, means the answer to "may an unattended fleet
+run here?" is no. The set is closed in v1 — seven, no more — and extended only by editing this rule:
+
+- **B1** a realistic path causes **silent data loss**
+- **B2** a **release path bypasses the validated artifact**
+- **B3** **credentials carry material unintended authority**
+- **B4** a **consequential operation has no gate and no recovery**
+- **B5** an **owned compatibility or security surface has no confidence model**
+- **B6** **documentation overstates enforced guarantees**
+- **B7** there is **no way to prove the claimed user-visible outcome**
+
+## Verdict and narrowed claim
+
+The verdict reuses the shipped `READY` / `READY_WITH_WARNINGS` / `NOT_READY` ladder — cite doctor's
+ladder, never fork a parallel enum. **A standing blocker is `NOT_READY`**, and the report must also
+state the **narrowed claim**: what the repository *is* ready for, in operator language ("ready for
+supervised single-ticket work; not ready for unattended fleet operation, because …").
+
+## Ordering
+
+**Report section order stays stable and never silently omits a section; findings are ordered by
+consequence** — highest-consequence first — within and across sections. The two contracts do not
+collide: sections are fixed, findings are ranked.
+
+## Warn-only
+
+This rubric **gates a claim, not a process**. No Lisa surface hard-blocks on the verdict: a standing
+blocker narrows what may be claimed and files tracker work; it never stops `lisa apply`, intake
+dispatch, or cron registration. Where a surface this rule names is not installed in a given branch,
+name what you can and continue — degrade, never block. Written to be read by someone who does not
+code (`factory-model` rule 5).
+
+Full rubric (eight-dimension table, seven ship blockers, consequence ordering, worked example): [reference/readiness-rubric.md](../reference/readiness-rubric.md).

--- a/plugins/src/base/rules/reference/readiness-rubric.md
+++ b/plugins/src/base/rules/reference/readiness-rubric.md
@@ -1,0 +1,179 @@
+# Repository Readiness Rubric
+
+Lisa can already tell you whether it is *installed* correctly. It cannot tell you whether a
+repository is somewhere an agent fleet can safely operate **unattended**. Those are two different
+questions, and conflating them is how a brownfield onboarding ends in "we built a wiki, looks good"
+instead of a verdict someone can act on.
+
+This document writes the second question down once: **eight ownership dimensions** with concrete
+warning signs, and **seven ship blockers** that, if any one of them stands, mean the answer is no.
+It is documentation. Nothing here executes — the later tickets of PRD #1739 instantiate this rubric
+rather than redefine it.
+
+## Two readinesses, one report
+
+| | Installation readiness | Repository readiness |
+|---|---|---|
+| Question | is Lisa installed and wired correctly here? | may an agent fleet operate here unattended? |
+| Owner | `lisa doctor`'s shipped grouped checks (project detection, config, distribution, tracker preflight, automation prerequisites, …) | this rubric's eight dimensions |
+| Answer shape | the shipped verdict ladder | the same shipped verdict ladder, plus a narrowed claim |
+
+They are **orthogonal** — a repository can be perfectly installed and completely unready, or ready in
+substance while Lisa's own wiring is incomplete. Both render in the same report, under separately
+titled sections, so a reader is never left guessing which question a verdict answered. The doctor
+mode that renders the repository-readiness group ships with **RRR-3 (#1855)**; do not assume that
+surface is present in this branch.
+
+## The eight ownership dimensions
+
+Exactly eight, always reported, never silently omitted. Each row names what the dimension asks,
+concrete warning signs an assessor can look for, and the **existing** Lisa rule or wiki page that
+supplies its evidence. Cite those slugs; do not restate them, and do not invent a parallel vocabulary
+for a concept another rule already owns.
+
+| # | Dimension | The question | Warning signs | Evidence source (existing) |
+|---|---|---|---|---|
+| 1 | context/routing | Can an agent recover the real job from what is written down? | no canonical entry document; routing decided by tribal knowledge; ambiguous config resolution; a README that describes a system that no longer exists | `integration-access-layer`, `wiki-knowledge-source`, `config-resolution` |
+| 2 | capabilities/tools | Is every tool the work needs *provably* reachable, not merely installed? | presence-on-PATH treated as access; no read-only probe before the work starts; agents inventing workarounds instead of breaking out | `tool-access-gate` |
+| 3 | domain ownership | Are the business rules, glossary, and danger zones owned and written down? | undocumented money paths; migrations with no owner; irreversible jobs nobody has described | the wiki pages agent-ready's domain phase already produces |
+| 4 | execution/proof | Can the claimed user-visible outcome be proved by running the system? | claims backed only by unit tests; no representative end-to-end journey; "verified" that names no boundary | `verification`, `empirical-inquiry`, `claim-evidence-mapping` |
+| 5 | feedback/guardrails | Does a failing loop produce a named outcome and a runbook? | silent failures; no run-outcome vocabulary; no observability on the loops that run unattended | `automation-runbook-contract`, `observability-audit` |
+| 6 | dependencies/supply chain | Is there a confidence model for what the repo depends on? | unpinned or unowned dependencies; no trust class; no decision record for why a risky dependency stays | `security-audit-handling` |
+| 7 | delivery/authority | Does the thing that ships equal the thing that was validated, and does the credential that ships it carry only the authority it needs? | a release path that bypasses the validated artifact; broad-scope tokens; deploy credentials shared across environments | `claim-archaeology`, `security-audit-handling` |
+| 8 | proportionality | Is the machinery proportional to the job, or is there scaffolding to subtract? | redundant checks that assert the same thing twice; abandoned harnesses still running in CI | `repo-scope-split`, and the scaffolding-subtraction candidates the journey work of **#1742** already surfaces |
+
+**`SKIP` carries a reason and is never blank.** A dimension with no applicable evidence renders
+`SKIP with a reason` — "no deployment target configured, so delivery/authority was not assessed" —
+never an empty cell and never a silent omission. An unassessed dimension is a known unknown, and the
+report says so.
+
+## The seven ship blockers
+
+A **ship blocker** is a condition that, standing alone, makes the claim "an unattended fleet may run
+here" false. Each has a one-line test an assessor can apply and the dimension that owns it.
+
+| # | Blocker | The test an assessor applies | Owning dimension |
+|---|---|---|---|
+| B1 | A realistic path causes **silent data loss** | can you name a plausible sequence that destroys or corrupts data with no error surfaced and no recovery path? | 3 |
+| B2 | A **release path bypasses the validated artifact** | can something reach production that is not the artifact CI actually validated? | 7 |
+| B3 | **Credentials carry material unintended authority** | does any credential used by automation grant authority materially beyond the job it does? | 7 |
+| B4 | A **consequential operation has no gate and no recovery** | is there an irreversible or expensive operation reachable without a gate, with no way back? | 3, 5 |
+| B5 | An **owned compatibility or security surface has no confidence model** | for a surface this repo owns, is there any basis beyond hope for believing it still works? | 6 |
+| B6 | **Documentation overstates enforced guarantees** | does the written word claim something is enforced that nothing actually enforces? | 1 |
+| B7 | There is **no way to prove the claimed user-visible outcome** | can the headline user-visible claim be demonstrated by running the system, at the boundary it claims? | 4 |
+
+### The set is a closed set in v1
+
+Seven, and only seven, in v1. The set is **not configurable** — there is no config key, no
+host-defined blockers, no severity dial. Extending it is a deliberate **rule edit** here plus a
+version bump, not a configuration surface to design, migrate, and support. Host-specific concerns
+surface as *findings within a dimension*, which is enough to make them visible without fragmenting
+the vocabulary.
+
+### "Ship blocker" is net-new vocabulary
+
+It is deliberately distinct from three terms other rules already own, and it never replaces them:
+
+- `convergent-review`'s **blocking finding** — a review-level judgment about one change.
+- `tool-access-gate`'s **break-out** — the escalation when a required tool is not provably reachable.
+- `leaf-only-lifecycle`'s **safe-block** — a lifecycle-state repair on a work item.
+
+A ship blocker is none of these: it is a property of the *repository*, asserted about *unattended
+operation*, and it gates a claim rather than a change, a tool call, or a ticket.
+
+## Verdict: the shipped ladder, plus a narrowed claim
+
+The rubric reuses the shipped `READY` / `READY_WITH_WARNINGS` / `NOT_READY` verdict ladder that
+`lisa doctor` already emits. There is **no new verdict** value and no new severity level — inventing
+a parallel enum would make two reports disagree about what "ready" means.
+
+- **`READY`** — eight dimensions assessed, no blocker stands, no warnings material to unattended
+  operation.
+- **`READY_WITH_WARNINGS`** — no blocker stands, but findings exist that a human should see.
+- **`NOT_READY`** — **at least one ship blocker stands.**
+
+**The narrowed claim is the net-new field.** When the verdict is `NOT_READY`, the report must also
+state, in operator language, **what the repository IS ready for** — never just what it is not. A
+verdict that only says no is unactionable at the gate; a narrowed claim tells the operator exactly
+which mode of operation remains available and what would widen it.
+
+## Consequence ordering
+
+Two ordering contracts meet here, and they do not collide:
+
+- **Section order stays stable.** The report renders its sections in a fixed order and **never
+  silently omits** one — the discipline `lisa doctor`'s grouped output already guarantees.
+- **Findings are ordered by consequence.** Within and across sections, the finding with the largest
+  consequence if left standing comes first. Alphabetical, chronological, and discovery order are all
+  wrong: the reader at the gate has limited attention, and it belongs on the worst thing first.
+
+### The five fields a readiness finding carries
+
+On top of the severity / blocking / failure-scenario / evidence / smallest-fix fields
+`convergent-review` already requires, a readiness finding names:
+
+| Field | What it states |
+|---|---|
+| `invariant_violated` | the invariant actually at risk, stated as a property of the system |
+| `evidence` | what was observed that establishes the finding, at a boundary that reaches the claim (`claim-evidence-mapping`) |
+| `why_proof_missed` | why the existing proof machinery did not catch this |
+| `root_correction` | the correction at the **owning boundary**, not a patch at the symptom |
+| `machinery_to_remove` | redundant machinery the correction makes unnecessary, if any |
+
+Two of these — `invariant_violated` and `machinery_to_remove` — are folded into the shared
+`convergent-review` finding shape by **RRR-2 (#1854)**; that extension ships with that ticket, so do
+not assume the shared shape carries them in this branch.
+
+### Worked example
+
+```text
+Repository: acme/checkout-service
+
+  Verdict          NOT_READY
+  Standing blocker B2 — a release path bypasses the validated artifact
+  Owning dimension 7 (delivery/authority)
+
+  invariant_violated   What ships to production is the artifact CI validated.
+  evidence             The deploy job rebuilds from source at deploy time rather than
+                       promoting the CI-built image; the deployed digest never matches
+                       the one the test job signed off on.
+  why_proof_missed     Every check is green — they all ran against a different artifact
+                       than the one that shipped. Nothing compared the two.
+  root_correction      Promote the validated image by digest at the delivery boundary.
+  machinery_to_remove  The duplicate deploy-time build step.
+
+  Narrowed claim   This repository IS ready for supervised, single-ticket agent work with a
+                   human approving each release. It is NOT ready for unattended fleet
+                   operation, because a release can ship code no check ever ran against.
+```
+
+## Where the evidence comes from
+
+The rubric consumes evidence that already exists; it commissions no second harness.
+
+- **execution/proof** consumes the existing qualification evidence recorded by the worker-epoch
+  requalification path and, when that evidence is absent or stale, triggers a journey run through the
+  shipped `lisa-use-the-product` skill — the machinery **#1742** already ships. There is no second
+  journey harness, and the evidence is recorded in the shape `claim-evidence-mapping` defines. That
+  wiring ships with **RRR-6 (#1858)**.
+- **domain ownership** sources its findings from the danger-zone wiki pages agent-ready's domain
+  phase already produces; the readiness assessment that reads them, and files standing blockers as
+  tracker work rather than in-session questions, ships with **RRR-4 (#1856)**.
+- The persisted report at `.lisa/readiness.json` (schema-versioned, read through a single resolver)
+  and the doctor render group ship with **RRR-3 (#1855)**; the blocker gate that emits the narrowed
+  claim ships with **RRR-5 (#1857)**; the `setup-automations` warning, six-agent parity fan-out, and
+  vocabulary documentation ship with **RRR-7 (#1859)**. Each of those surfaces may not yet be present
+  in a given branch — name what you can and continue.
+
+## Warn-only, always
+
+This rubric **gates a claim, not a process**. It is **warn-only** everywhere: no Lisa surface
+hard-blocks on the readiness verdict. `lisa apply`, intake dispatch, and cron registration are
+unaffected; the automation setup flow warns with the standing blocker count and the narrowed claim
+and still completes, consistent with the shipped never-block-always-degrade posture. Where a surface
+named here is not installed, **degrade, never block**: state what was assessed, state what was not,
+and continue.
+
+Read the eight dimension titles and the seven blockers to someone who has never seen Lisa. They
+should be able to say, unprompted, why "the tests pass" is not the same as "an agent fleet can run
+here unattended" — that is the bar this document is written to (`factory-model` rule 5).

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -642,6 +642,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "de0983a45b05f8509f7cc54e8f553f571f932c347b46778e1675b71233e87513",
     "plugins/src/base/rules/eager/promotion-contract.md":
       "e10dc13b99c5c7621309d5764635d2465ab72e603c3c8a925c4eb27878256e8a",
+    "plugins/src/base/rules/eager/readiness-rubric.md":
+      "5fee9f6ce3855b147d2f03b3e82a5dc6acb60d5c99cb3d328a71d74986f8fad9",
     "plugins/src/base/rules/eager/rejection-detection.md":
       "c80771ce3b59230734e66e582b11b548b6da2498a2f822eca5db70379150ea66",
     "plugins/src/base/rules/eager/repo-scope-split.md":
@@ -698,6 +700,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "0326d553d6cb9b997c6cb865635f72ec8b7d5026565f788f46bff0e912748e85",
     "plugins/src/base/rules/reference/promotion-contract.md":
       "472416b82eda5431c8e5467d6093fe9da79efa7eb836e79c77b75ef77ee194a4",
+    "plugins/src/base/rules/reference/readiness-rubric.md":
+      "6b09f171166a7fc8e85f6e2deea68f42d89a554767bc91e8eed08d1e08501672",
     "plugins/src/base/rules/reference/rejection-detection.md":
       "9088ce1560c13a8753b44bab80d9f9101e8a59404a2df3fd80ff2ab539ae0aef",
     "plugins/src/base/rules/reference/repo-scope-split.md":
@@ -3277,6 +3281,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/rules/eager/pre-flight-autofill.md": true,
     "plugins/lisa-copilot/rules/eager/project-learnings.md": true,
     "plugins/lisa-copilot/rules/eager/promotion-contract.md": true,
+    "plugins/lisa-copilot/rules/eager/readiness-rubric.md": true,
     "plugins/lisa-copilot/rules/eager/rejection-detection.md": true,
     "plugins/lisa-copilot/rules/eager/repo-scope-split.md": true,
     "plugins/lisa-copilot/rules/eager/security-audit-handling.md": true,
@@ -3305,6 +3310,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/rules/reference/pre-flight-autofill.md": true,
     "plugins/lisa-copilot/rules/reference/project-learnings.md": true,
     "plugins/lisa-copilot/rules/reference/promotion-contract.md": true,
+    "plugins/lisa-copilot/rules/reference/readiness-rubric.md": true,
     "plugins/lisa-copilot/rules/reference/rejection-detection.md": true,
     "plugins/lisa-copilot/rules/reference/repo-scope-split.md": true,
     "plugins/lisa-copilot/rules/reference/security-audit-handling.md": true,
@@ -3649,6 +3655,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/rules/project-learnings.mdc": true,
     "plugins/lisa-cursor/rules/promotion-contract-reference.mdc": true,
     "plugins/lisa-cursor/rules/promotion-contract.mdc": true,
+    "plugins/lisa-cursor/rules/readiness-rubric-reference.mdc": true,
+    "plugins/lisa-cursor/rules/readiness-rubric.mdc": true,
     "plugins/lisa-cursor/rules/rejection-detection-reference.mdc": true,
     "plugins/lisa-cursor/rules/rejection-detection.mdc": true,
     "plugins/lisa-cursor/rules/repo-scope-split-reference.mdc": true,
@@ -6004,6 +6012,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/rules/eager/pre-flight-autofill.md": true,
     "plugins/lisa/rules/eager/project-learnings.md": true,
     "plugins/lisa/rules/eager/promotion-contract.md": true,
+    "plugins/lisa/rules/eager/readiness-rubric.md": true,
     "plugins/lisa/rules/eager/rejection-detection.md": true,
     "plugins/lisa/rules/eager/repo-scope-split.md": true,
     "plugins/lisa/rules/eager/security-audit-handling.md": true,
@@ -6032,6 +6041,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/rules/reference/pre-flight-autofill.md": true,
     "plugins/lisa/rules/reference/project-learnings.md": true,
     "plugins/lisa/rules/reference/promotion-contract.md": true,
+    "plugins/lisa/rules/reference/readiness-rubric.md": true,
     "plugins/lisa/rules/reference/rejection-detection.md": true,
     "plugins/lisa/rules/reference/repo-scope-split.md": true,
     "plugins/lisa/rules/reference/security-audit-handling.md": true,
@@ -6525,6 +6535,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/rules/eager/pre-flight-autofill.md": true,
     "plugins/src/base/rules/eager/project-learnings.md": true,
     "plugins/src/base/rules/eager/promotion-contract.md": true,
+    "plugins/src/base/rules/eager/readiness-rubric.md": true,
     "plugins/src/base/rules/eager/rejection-detection.md": true,
     "plugins/src/base/rules/eager/repo-scope-split.md": true,
     "plugins/src/base/rules/eager/security-audit-handling.md": true,
@@ -6553,6 +6564,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/rules/reference/pre-flight-autofill.md": true,
     "plugins/src/base/rules/reference/project-learnings.md": true,
     "plugins/src/base/rules/reference/promotion-contract.md": true,
+    "plugins/src/base/rules/reference/readiness-rubric.md": true,
     "plugins/src/base/rules/reference/rejection-detection.md": true,
     "plugins/src/base/rules/reference/repo-scope-split.md": true,
     "plugins/src/base/rules/reference/security-audit-handling.md": true,
@@ -7819,6 +7831,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/queue-status-fixture-smoke-and-read-only.test.ts": true,
     "tests/unit/strategies/queue-status-prd-readers.test.ts": true,
     "tests/unit/strategies/queue-status-scaffold.test.ts": true,
+    "tests/unit/strategies/readiness-rubric-contract.test.ts": true,
     "tests/unit/strategies/rejection-detection-rule.test.ts": true,
     "tests/unit/strategies/remote-agent-aws-setup-wrapper.test.ts": true,
     "tests/unit/strategies/remote-agent-aws-setup.test.ts": true,

--- a/tests/unit/strategies/readiness-rubric-contract.test.ts
+++ b/tests/unit/strategies/readiness-rubric-contract.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Contract coverage for the vendor-neutral readiness-rubric rule pair.
+ *
+ * The eager head + reference body are the spine every later ticket of PRD #1739
+ * instantiates (RRR-2..RRR-7): repository readiness — "may an agent fleet run
+ * here unattended?" — is a different question from installation readiness, and
+ * it is answered by eight ownership dimensions plus a closed set of seven ship
+ * blockers. These assertions pin the eight dimension names, the seven blockers
+ * and their owning dimensions, the closed-set statement, the shipped
+ * READY / READY_WITH_WARNINGS / NOT_READY ladder (cited from doctor, never
+ * forked), the narrowed-claim field, the consequence-ordering split against
+ * doctor's stable section order, the five consequence-ordered finding fields,
+ * the never-blank SKIP-with-reason rule, the warn-only posture, the breadcrumb
+ * the cursor generator rewrites, the cite-don't-restate discipline, and the
+ * sibling-ticket hedges. Both plugin roots are checked so the generated copy can
+ * never drift from the source.
+ * @module tests/unit/strategies/readiness-rubric-contract
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+
+/** The eight ownership dimensions, in the order the rubric reports them. */
+const DIMENSIONS = [
+  "context/routing",
+  "capabilities/tools",
+  "domain ownership",
+  "execution/proof",
+  "feedback/guardrails",
+  "dependencies/supply chain",
+  "delivery/authority",
+  "proportionality",
+] as const;
+
+/** The closed v1 set of ship blockers. */
+const BLOCKERS = ["B1", "B2", "B3", "B4", "B5", "B6", "B7"] as const;
+
+/** The five fields a consequence-ordered readiness finding carries. */
+const FINDING_FIELDS = [
+  "invariant_violated",
+  "evidence",
+  "why_proof_missed",
+  "root_correction",
+  "machinery_to_remove",
+] as const;
+
+/** Sibling tickets whose surfaces must be hedged, never assumed present. */
+const SIBLING_TICKETS = [
+  "#1854",
+  "#1855",
+  "#1856",
+  "#1857",
+  "#1858",
+  "#1859",
+] as const;
+
+const read = (root: string, rel: string): string =>
+  readFileSync(path.resolve(root, rel), "utf8");
+
+/**
+ * Collapse all whitespace so assertions survive reflowed markdown prose.
+ * @param text - the raw markdown document to normalize
+ * @returns the same text with every whitespace run collapsed to one space
+ */
+const squash = (text: string): string => text.replace(/\s+/g, " ");
+
+describe("readiness-rubric rule contract", () => {
+  describe.each(ROOTS)("%s", root => {
+    const eager = read(root, "rules/eager/readiness-rubric.md");
+    const reference = read(root, "rules/reference/readiness-rubric.md");
+    const eagerFlat = squash(eager);
+    const referenceFlat = squash(reference);
+
+    it("ships as a paired rule with a non-trivial body on both sides", () => {
+      expect(eager.length).toBeGreaterThan(500);
+      expect(reference.length).toBeGreaterThan(2000);
+    });
+
+    it("eager head breadcrumbs to the reference body verbatim", () => {
+      expect(eager).toContain(
+        "Full rubric (eight-dimension table, seven ship blockers, consequence ordering, worked example): [reference/readiness-rubric.md](../reference/readiness-rubric.md)."
+      );
+    });
+
+    it("distinguishes repository readiness from installation readiness", () => {
+      for (const flat of [eagerFlat, referenceFlat]) {
+        expect(flat).toMatch(/installation readiness/i);
+        expect(flat).toMatch(/repository readiness/i);
+      }
+      // Doctor's shipped grouped sections are the installation-readiness side.
+      expect(referenceFlat).toMatch(/doctor/i);
+      expect(referenceFlat).toMatch(
+        /different question|orthogonal|not the same question/i
+      );
+    });
+
+    it("names all eight ownership dimensions in both halves", () => {
+      for (const flat of [eagerFlat, referenceFlat]) {
+        for (const dimension of DIMENSIONS) {
+          expect(flat).toContain(dimension);
+        }
+      }
+      expect(eagerFlat).toMatch(/eight (ownership )?dimensions/i);
+    });
+
+    it("gives every dimension a question, a warning sign, and an existing evidence source", () => {
+      expect(reference).toMatch(/\| # \| Dimension \|/);
+      expect(referenceFlat).toMatch(/Warning signs/i);
+      expect(referenceFlat).toMatch(/Evidence source/i);
+      // Each row cites an already-shipped rule slug rather than inventing a
+      // parallel vocabulary for a concept another rule already owns.
+      for (const slug of [
+        "integration-access-layer",
+        "wiki-knowledge-source",
+        "config-resolution",
+        "tool-access-gate",
+        "verification",
+        "empirical-inquiry",
+        "claim-evidence-mapping",
+        "automation-runbook-contract",
+        "observability-audit",
+        "security-audit-handling",
+        "claim-archaeology",
+        "repo-scope-split",
+      ]) {
+        expect(reference).toContain(slug);
+      }
+      // Cite by slug, never by reference path.
+      expect(reference).not.toContain("rules/reference/tool-access-gate.md");
+    });
+
+    it("lists exactly seven ship blockers, each mapped to an owning dimension", () => {
+      for (const blocker of BLOCKERS) {
+        expect(reference).toContain(`| ${blocker} |`);
+      }
+      expect(reference).not.toContain("| B8 |");
+      expect(reference).toMatch(/\| Owning dimension/);
+      for (const flat of [eagerFlat, referenceFlat]) {
+        expect(flat).toMatch(/seven ship blockers|seven blockers/i);
+      }
+      // The seven conditions themselves, in operator language.
+      for (const condition of [
+        /silent data loss/i,
+        /release path (that )?bypass/i,
+        /unintended authority/i,
+        /no gate and no recovery/i,
+        /no confidence model/i,
+        /overstates?.*enforced guarantees/i,
+        /no way to prove/i,
+      ]) {
+        expect(referenceFlat).toMatch(condition);
+      }
+    });
+
+    it("states the blocker set is closed in v1 and extended only by editing this rule", () => {
+      expect(referenceFlat).toMatch(/closed (set )?in v1|closed set/i);
+      expect(referenceFlat).toMatch(
+        /editing this rule|edit(ing)? the rule|rule edit/i
+      );
+      // No configuration surface — intake decision O4.
+      expect(referenceFlat).toMatch(
+        /not configurable|no config|never configurable/i
+      );
+    });
+
+    it("reuses the shipped verdict ladder instead of forking a new enum", () => {
+      for (const verdict of ["READY_WITH_WARNINGS", "NOT_READY", "READY"]) {
+        expect(reference).toContain(verdict);
+      }
+      expect(eager).toContain("NOT_READY");
+      expect(referenceFlat).toMatch(
+        /no new verdict|never a new verdict|no new enum/i
+      );
+    });
+
+    it("defines the narrowed claim as the net-new field a standing blocker requires", () => {
+      for (const flat of [eagerFlat, referenceFlat]) {
+        expect(flat).toMatch(/narrowed claim/i);
+      }
+      expect(referenceFlat).toMatch(/what the repo(sitory)? IS ready for/i);
+    });
+
+    it("states the consequence-ordering split against doctor's stable section order", () => {
+      for (const flat of [eagerFlat, referenceFlat]) {
+        expect(flat).toMatch(/section order (stays|is) stable/i);
+        expect(flat).toMatch(/ordered by consequence|order.*by consequence/i);
+      }
+      expect(referenceFlat).toMatch(/never silently omit/i);
+    });
+
+    it("names the five fields a consequence-ordered finding carries", () => {
+      for (const field of FINDING_FIELDS) {
+        expect(reference).toContain(field);
+      }
+      // RRR-2 (#1854) extends convergent-review with two of them.
+      expect(reference).toContain("convergent-review");
+      expect(referenceFlat).toMatch(/invariant.violated/i);
+      expect(referenceFlat).toMatch(/machinery.to.remove/i);
+    });
+
+    it("requires SKIP to carry a reason and never render blank", () => {
+      expect(reference).toContain("SKIP");
+      expect(referenceFlat).toMatch(
+        /SKIP with a reason|SKIP.*never (a )?blank|never blank/i
+      );
+    });
+
+    it("keeps ship-blocker vocabulary distinct from the terms other rules own", () => {
+      for (const owned of [
+        "convergent-review",
+        "tool-access-gate",
+        "leaf-only-lifecycle",
+      ]) {
+        expect(reference).toContain(owned);
+      }
+      expect(referenceFlat).toMatch(/blocking finding/i);
+      expect(referenceFlat).toMatch(/break.out/i);
+      expect(referenceFlat).toMatch(/safe.block/i);
+    });
+
+    it("carries a worked example fence in operator language", () => {
+      const fence = /```text\n([\s\S]*?)```/.exec(reference)?.[1] ?? "";
+      expect(fence.length).toBeGreaterThan(0);
+      expect(squash(fence)).toMatch(/NOT_READY/);
+      expect(squash(fence)).toMatch(/narrowed claim/i);
+    });
+
+    it("is warn-only: it gates a claim, not a process", () => {
+      for (const flat of [eagerFlat, referenceFlat]) {
+        expect(flat).toMatch(/warn.only/i);
+        expect(flat).toMatch(/gates? a claim, not a process/i);
+      }
+      expect(referenceFlat).toMatch(/hard.block/i);
+    });
+
+    it("reuses the shipped journey machinery rather than adding a second harness", () => {
+      expect(reference).toContain("lisa-use-the-product");
+      expect(referenceFlat).toMatch(
+        /qualification evidence|qualificationEvidence/
+      );
+      expect(reference).toContain("#1742");
+    });
+
+    it("hedges every surface that ships with a sibling ticket", () => {
+      for (const ticket of SIBLING_TICKETS) {
+        expect(reference).toContain(ticket);
+      }
+      expect(reference).toContain(".lisa/readiness.json");
+      expect(referenceFlat).toMatch(
+        /ships with that ticket|not (yet )?(be )?present|do not assume/i
+      );
+    });
+
+    it("is operator-readable and degrades rather than blocking", () => {
+      for (const doc of [eager, reference]) {
+        expect(doc).toContain("factory-model");
+      }
+      expect(referenceFlat).toMatch(/degrade|never block/i);
+    });
+  });
+});


### PR DESCRIPTION
## What & Why

Lisa could already tell you whether it was *installed* correctly. It could not tell you whether a
repository is somewhere an agent fleet may operate **unattended**. This PR writes that second
question down once, as a rule pair: **eight ownership dimensions** with concrete warning signs, and
**seven ship blockers** that, if any one stands, mean the answer is no.

So onboarding a brownfield project stops ending in "we built a wiki, looks good" and ends in a
verdict an operator can act on — *"not ready for unattended operation, because the release path can
ship an artifact nobody validated; here is the smallest fix."*

Provenance: **PRD #1739** (readiness rubric for agent-ready and doctor). This is **RRR-1, the spine
ticket** — the other six RRR tickets (#1854–#1859) instantiate this document rather than redefine it,
exactly as RBC-1 (#1737) preceded RBC-2/3 and BCE-1 (#1835) preceded BCE-2.

Closes #1853

## What ships

Following the shipped `automation-runbook-contract` / `claim-evidence-mapping` rule-pair anatomy
(eager head + reference body, gated by `scripts/check-rules-pairing.sh`):

- **`rules/eager/readiness-rubric.md`** — load-bearing head: repository readiness vs installation
  readiness, the eight dimensions, the seven blockers, the shipped verdict ladder plus narrowed
  claim, the ordering split, warn-only, breadcrumb to the reference body.
- **`rules/reference/readiness-rubric.md`** — the full rubric: the eight-dimension table (question,
  warning signs, and the **existing** Lisa rule each dimension draws its evidence from — cite, don't
  restate), the seven-blocker table with a one-line assessor test and owning dimension, the
  closed-set statement, the five consequence-ordered finding fields, a worked example in operator
  language, and the vocabulary discipline keeping "ship blocker" distinct from `convergent-review`'s
  *blocking finding*, `tool-access-gate`'s *break-out*, and `leaf-only-lifecycle`'s *safe-block*.
- Regenerated `plugins/lisa*` mirrors (Claude, Cursor, Copilot) + upstream evidence manifest, in the
  same commit.

Key discipline calls, carried from PRD #1739's intake decisions:

- **F1** — installation readiness (doctor's shipped groups) and repository readiness (this rubric)
  are orthogonal questions rendered in the same report.
- **F2** — reuses the shipped `READY` / `READY_WITH_WARNINGS` / `NOT_READY` ladder. No new enum. A
  standing blocker is `NOT_READY` **plus a narrowed claim** naming what the repo *is* ready for.
- **F7** — section order stays stable and never silently omits; findings order by consequence.
- **O1** — warn-only: this gates a *claim*, not a *process*.
- **O4** — the blocker set is closed in v1, extended only by editing this rule; no config surface.

## TDD evidence

- **RED** — companion contract test written first;
  `npx vitest run tests/unit/strategies/readiness-rubric-contract.test.ts` failed with
  `ENOENT … plugins/src/base/rules/eager/readiness-rubric.md` (module-absent RED: the rule pair did
  not exist).
- **GREEN** — after authoring both halves and `bun run build:plugins`: **36/36 passed**, across both
  plugin roots (`plugins/src/base` and `plugins/lisa`) so the generated copy cannot drift.

## Gates

| Gate | Result |
|---|---|
| `scripts/check-rules-pairing.sh` | ✅ exit 0 |
| `readiness-rubric-contract.test.ts` | ✅ 36/36, both roots |
| Full `tests/unit/strategies` suite | ✅ 3870/3870 across 147 files |
| `bun run typecheck` | ✅ clean |
| `bun run check:plugins` (post-commit) | ✅ artifacts in sync, marketplace registers every plugin |
| `generate-upstream-evidence-manifest.mjs --check` | ✅ not stale |

## Out of scope (sibling tickets, hedged in the body — never assumed present)

Findings-shape extension (RRR-2 #1854), doctor `--readiness` mode + `.lisa/readiness.json`
(RRR-3 #1855), agent-ready consumption and blocker filing (RRR-4 #1856), the blocker gate
(RRR-5 #1857), journey evidence reuse (RRR-6 #1858), `setup-automations` warn + parity + docs
(RRR-7 #1859).

**No behavior change**: no CLI, no schema, no skill edits. The only non-markdown files touched are
the generated upstream-evidence manifest and the new companion test.

🤖 Generated with Claude Code
