### PR TITLE
feat(rules): add invariant-violated and machinery-to-remove to convergent-review (#1854)

### DIFF
--- a/plugins/lisa-copilot/rules/eager/convergent-review.md
+++ b/plugins/lisa-copilot/rules/eager/convergent-review.md
@@ -7,7 +7,12 @@ Review exists to get correct work merged, not to keep a PR in review orbit.
   are non-blocking unless the work item or repository rules make them release
   criteria.
 - Every finding must state severity, blocking yes/no, a concrete failure
-  scenario, evidence, and the smallest actionable fix.
+  scenario, evidence, and the smallest actionable fix — plus
+  `invariant_violated` (the property at risk) and `machinery_to_remove` (what
+  becomes deletable, or `none`), required for `readiness-rubric` findings and
+  recommended elsewhere.
+- Present findings highest-consequence first, by severity and blast radius, not
+  by discovery order. Report section order stays stable.
 - A blocking finding without a concrete failure scenario is malformed by
   contract; downgrade it to non-blocking and ask for evidence.
 - Resolve each finding as `fixed`, `deferred`, or `pushed-back`. If the reviewer

--- a/plugins/lisa-copilot/rules/reference/convergent-review.md
+++ b/plugins/lisa-copilot/rules/reference/convergent-review.md
@@ -33,11 +33,56 @@ Every finding must state:
 - Evidence: the file, command output, observed behavior, ticket text, or
   external constraint proving the scenario is reachable.
 - Fix: the smallest actionable correction, or the reason no code change is
-  needed.
+  needed. The correction belongs at the **owning boundary** that permitted the
+  failure, not at the symptom site.
+- `invariant_violated`: the named property the system is supposed to hold that
+  this finding puts at risk — for example "the artifact that ships is the
+  artifact CI validated". The invariant is the property; the failure scenario is
+  the outcome when it breaks. State both; they are not interchangeable.
+- `machinery_to_remove`: the redundant checks, workarounds, or scaffolding that
+  become deletable once the correction lands, or explicitly `none`. This is a
+  **scaffolding-subtraction candidate** — it is surfaced for a human or the
+  implementer to act on and is never auto-deleted by any review pass.
 
 A finding marked blocking without a concrete failure scenario is malformed by
 contract. Downgrade it to non-blocking and ask for evidence instead of treating
 it as a merge blocker.
+
+### Compatibility
+
+`invariant_violated` and `machinery_to_remove` are **required for findings
+emitted under the `readiness-rubric`** and **recommended everywhere else**. A
+finding from an existing product, quality, local, bot-parity, or suggestion
+implementation pass that omits them is still well-formed by contract — this
+extension is additive and never retroactively malforms a shipped review surface.
+
+### Readiness findings map onto this shape
+
+A readiness finding names five fields. All five bind to this contract, so there
+is no second findings format anywhere in the repository:
+
+| Readiness field | Contract field |
+|---|---|
+| the at-risk invariant | `invariant_violated` (above) |
+| `evidence` | `Evidence` |
+| `why_proof_missed` | `Evidence`, extended with a required proof-gap clause: why the existing proof machinery did not catch this |
+| `root_correction` | `Fix`, qualified: the correction goes at the owning boundary, not the symptom site |
+| redundant machinery | `machinery_to_remove` (above) |
+
+Anything that needs a sixth field extends this section rather than starting a
+parallel format.
+
+### Consequence Ordering
+
+Findings are presented **highest-consequence first**. Consequence is determined
+by severity and blast radius — how much of the system, how many users, and how
+irreversible the outcome — not by discovery order, file order, or the order a
+tool happened to emit them in. Two reviewers ordering the same finding set
+differently is a defect, not a preference.
+
+This governs the order of findings **within** a section only. Report section
+order stays stable and is unaffected: never reorder, merge, or silently omit a
+section to surface a finding earlier.
 
 ## Dispositions
 

--- a/plugins/lisa-cursor/rules/convergent-review-reference.mdc
+++ b/plugins/lisa-cursor/rules/convergent-review-reference.mdc
@@ -38,11 +38,56 @@ Every finding must state:
 - Evidence: the file, command output, observed behavior, ticket text, or
   external constraint proving the scenario is reachable.
 - Fix: the smallest actionable correction, or the reason no code change is
-  needed.
+  needed. The correction belongs at the **owning boundary** that permitted the
+  failure, not at the symptom site.
+- `invariant_violated`: the named property the system is supposed to hold that
+  this finding puts at risk — for example "the artifact that ships is the
+  artifact CI validated". The invariant is the property; the failure scenario is
+  the outcome when it breaks. State both; they are not interchangeable.
+- `machinery_to_remove`: the redundant checks, workarounds, or scaffolding that
+  become deletable once the correction lands, or explicitly `none`. This is a
+  **scaffolding-subtraction candidate** — it is surfaced for a human or the
+  implementer to act on and is never auto-deleted by any review pass.
 
 A finding marked blocking without a concrete failure scenario is malformed by
 contract. Downgrade it to non-blocking and ask for evidence instead of treating
 it as a merge blocker.
+
+### Compatibility
+
+`invariant_violated` and `machinery_to_remove` are **required for findings
+emitted under the `readiness-rubric`** and **recommended everywhere else**. A
+finding from an existing product, quality, local, bot-parity, or suggestion
+implementation pass that omits them is still well-formed by contract — this
+extension is additive and never retroactively malforms a shipped review surface.
+
+### Readiness findings map onto this shape
+
+A readiness finding names five fields. All five bind to this contract, so there
+is no second findings format anywhere in the repository:
+
+| Readiness field | Contract field |
+|---|---|
+| the at-risk invariant | `invariant_violated` (above) |
+| `evidence` | `Evidence` |
+| `why_proof_missed` | `Evidence`, extended with a required proof-gap clause: why the existing proof machinery did not catch this |
+| `root_correction` | `Fix`, qualified: the correction goes at the owning boundary, not the symptom site |
+| redundant machinery | `machinery_to_remove` (above) |
+
+Anything that needs a sixth field extends this section rather than starting a
+parallel format.
+
+### Consequence Ordering
+
+Findings are presented **highest-consequence first**. Consequence is determined
+by severity and blast radius — how much of the system, how many users, and how
+irreversible the outcome — not by discovery order, file order, or the order a
+tool happened to emit them in. Two reviewers ordering the same finding set
+differently is a defect, not a preference.
+
+This governs the order of findings **within** a section only. Report section
+order stays stable and is unaffected: never reorder, merge, or silently omit a
+section to surface a finding earlier.
 
 ## Dispositions
 

--- a/plugins/lisa-cursor/rules/convergent-review.mdc
+++ b/plugins/lisa-cursor/rules/convergent-review.mdc
@@ -12,7 +12,12 @@ Review exists to get correct work merged, not to keep a PR in review orbit.
   are non-blocking unless the work item or repository rules make them release
   criteria.
 - Every finding must state severity, blocking yes/no, a concrete failure
-  scenario, evidence, and the smallest actionable fix.
+  scenario, evidence, and the smallest actionable fix — plus
+  `invariant_violated` (the property at risk) and `machinery_to_remove` (what
+  becomes deletable, or `none`), required for `readiness-rubric` findings and
+  recommended elsewhere.
+- Present findings highest-consequence first, by severity and blast radius, not
+  by discovery order. Report section order stays stable.
 - A blocking finding without a concrete failure scenario is malformed by
   contract; downgrade it to non-blocking and ask for evidence.
 - Resolve each finding as `fixed`, `deferred`, or `pushed-back`. If the reviewer

--- a/plugins/lisa/rules/eager/convergent-review.md
+++ b/plugins/lisa/rules/eager/convergent-review.md
@@ -7,7 +7,12 @@ Review exists to get correct work merged, not to keep a PR in review orbit.
   are non-blocking unless the work item or repository rules make them release
   criteria.
 - Every finding must state severity, blocking yes/no, a concrete failure
-  scenario, evidence, and the smallest actionable fix.
+  scenario, evidence, and the smallest actionable fix — plus
+  `invariant_violated` (the property at risk) and `machinery_to_remove` (what
+  becomes deletable, or `none`), required for `readiness-rubric` findings and
+  recommended elsewhere.
+- Present findings highest-consequence first, by severity and blast radius, not
+  by discovery order. Report section order stays stable.
 - A blocking finding without a concrete failure scenario is malformed by
   contract; downgrade it to non-blocking and ask for evidence.
 - Resolve each finding as `fixed`, `deferred`, or `pushed-back`. If the reviewer

--- a/plugins/lisa/rules/reference/convergent-review.md
+++ b/plugins/lisa/rules/reference/convergent-review.md
@@ -33,11 +33,56 @@ Every finding must state:
 - Evidence: the file, command output, observed behavior, ticket text, or
   external constraint proving the scenario is reachable.
 - Fix: the smallest actionable correction, or the reason no code change is
-  needed.
+  needed. The correction belongs at the **owning boundary** that permitted the
+  failure, not at the symptom site.
+- `invariant_violated`: the named property the system is supposed to hold that
+  this finding puts at risk — for example "the artifact that ships is the
+  artifact CI validated". The invariant is the property; the failure scenario is
+  the outcome when it breaks. State both; they are not interchangeable.
+- `machinery_to_remove`: the redundant checks, workarounds, or scaffolding that
+  become deletable once the correction lands, or explicitly `none`. This is a
+  **scaffolding-subtraction candidate** — it is surfaced for a human or the
+  implementer to act on and is never auto-deleted by any review pass.
 
 A finding marked blocking without a concrete failure scenario is malformed by
 contract. Downgrade it to non-blocking and ask for evidence instead of treating
 it as a merge blocker.
+
+### Compatibility
+
+`invariant_violated` and `machinery_to_remove` are **required for findings
+emitted under the `readiness-rubric`** and **recommended everywhere else**. A
+finding from an existing product, quality, local, bot-parity, or suggestion
+implementation pass that omits them is still well-formed by contract — this
+extension is additive and never retroactively malforms a shipped review surface.
+
+### Readiness findings map onto this shape
+
+A readiness finding names five fields. All five bind to this contract, so there
+is no second findings format anywhere in the repository:
+
+| Readiness field | Contract field |
+|---|---|
+| the at-risk invariant | `invariant_violated` (above) |
+| `evidence` | `Evidence` |
+| `why_proof_missed` | `Evidence`, extended with a required proof-gap clause: why the existing proof machinery did not catch this |
+| `root_correction` | `Fix`, qualified: the correction goes at the owning boundary, not the symptom site |
+| redundant machinery | `machinery_to_remove` (above) |
+
+Anything that needs a sixth field extends this section rather than starting a
+parallel format.
+
+### Consequence Ordering
+
+Findings are presented **highest-consequence first**. Consequence is determined
+by severity and blast radius — how much of the system, how many users, and how
+irreversible the outcome — not by discovery order, file order, or the order a
+tool happened to emit them in. Two reviewers ordering the same finding set
+differently is a defect, not a preference.
+
+This governs the order of findings **within** a section only. Report section
+order stays stable and is unaffected: never reorder, merge, or silently omit a
+section to surface a finding earlier.
 
 ## Dispositions
 

--- a/plugins/src/base/rules/eager/convergent-review.md
+++ b/plugins/src/base/rules/eager/convergent-review.md
@@ -7,7 +7,12 @@ Review exists to get correct work merged, not to keep a PR in review orbit.
   are non-blocking unless the work item or repository rules make them release
   criteria.
 - Every finding must state severity, blocking yes/no, a concrete failure
-  scenario, evidence, and the smallest actionable fix.
+  scenario, evidence, and the smallest actionable fix — plus
+  `invariant_violated` (the property at risk) and `machinery_to_remove` (what
+  becomes deletable, or `none`), required for `readiness-rubric` findings and
+  recommended elsewhere.
+- Present findings highest-consequence first, by severity and blast radius, not
+  by discovery order. Report section order stays stable.
 - A blocking finding without a concrete failure scenario is malformed by
   contract; downgrade it to non-blocking and ask for evidence.
 - Resolve each finding as `fixed`, `deferred`, or `pushed-back`. If the reviewer

--- a/plugins/src/base/rules/reference/convergent-review.md
+++ b/plugins/src/base/rules/reference/convergent-review.md
@@ -33,11 +33,56 @@ Every finding must state:
 - Evidence: the file, command output, observed behavior, ticket text, or
   external constraint proving the scenario is reachable.
 - Fix: the smallest actionable correction, or the reason no code change is
-  needed.
+  needed. The correction belongs at the **owning boundary** that permitted the
+  failure, not at the symptom site.
+- `invariant_violated`: the named property the system is supposed to hold that
+  this finding puts at risk — for example "the artifact that ships is the
+  artifact CI validated". The invariant is the property; the failure scenario is
+  the outcome when it breaks. State both; they are not interchangeable.
+- `machinery_to_remove`: the redundant checks, workarounds, or scaffolding that
+  become deletable once the correction lands, or explicitly `none`. This is a
+  **scaffolding-subtraction candidate** — it is surfaced for a human or the
+  implementer to act on and is never auto-deleted by any review pass.
 
 A finding marked blocking without a concrete failure scenario is malformed by
 contract. Downgrade it to non-blocking and ask for evidence instead of treating
 it as a merge blocker.
+
+### Compatibility
+
+`invariant_violated` and `machinery_to_remove` are **required for findings
+emitted under the `readiness-rubric`** and **recommended everywhere else**. A
+finding from an existing product, quality, local, bot-parity, or suggestion
+implementation pass that omits them is still well-formed by contract — this
+extension is additive and never retroactively malforms a shipped review surface.
+
+### Readiness findings map onto this shape
+
+A readiness finding names five fields. All five bind to this contract, so there
+is no second findings format anywhere in the repository:
+
+| Readiness field | Contract field |
+|---|---|
+| the at-risk invariant | `invariant_violated` (above) |
+| `evidence` | `Evidence` |
+| `why_proof_missed` | `Evidence`, extended with a required proof-gap clause: why the existing proof machinery did not catch this |
+| `root_correction` | `Fix`, qualified: the correction goes at the owning boundary, not the symptom site |
+| redundant machinery | `machinery_to_remove` (above) |
+
+Anything that needs a sixth field extends this section rather than starting a
+parallel format.
+
+### Consequence Ordering
+
+Findings are presented **highest-consequence first**. Consequence is determined
+by severity and blast radius — how much of the system, how many users, and how
+irreversible the outcome — not by discovery order, file order, or the order a
+tool happened to emit them in. Two reviewers ordering the same finding set
+differently is a defect, not a preference.
+
+This governs the order of findings **within** a section only. Report section
+order stays stable and is unaffected: never reorder, merge, or silently omit a
+section to surface a finding earlier.
 
 ## Dispositions
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -617,7 +617,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/eager/config-resolution.md":
       "2689c1f47903a5f6c84677fbfd2f1f148096faf122b7498b21d3b0f2345c6c87",
     "plugins/src/base/rules/eager/convergent-review.md":
-      "700e0ac9c9812316930134c92f0b2d65cee90e70cb45a27b7966edfbe6962bc3",
+      "ba4ba53863ef99be353c07c01195fa4ae2923ef2b2a5ad4427072802c260d208",
     "plugins/src/base/rules/eager/documentation-source-paths.md":
       "3a7c2a6264654a3cc44dd326441ba211a39c1c267033cc189c1c635adb84b52b",
     "plugins/src/base/rules/eager/empirical-inquiry.md":
@@ -675,7 +675,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/reference/config-resolution.md":
       "071b2c91f3b661ee493ea6f37d78f0fdea8004b4e4e7b5e94dcf232df7eceda7",
     "plugins/src/base/rules/reference/convergent-review.md":
-      "65f309c04095179eac28f8572da3c49c0e02741c4c594fe992ff643b341a4139",
+      "788a9d4dc2af7a928c3ccbb4d53a92856bb3544941ce512cfe38068d6b35850d",
     "plugins/src/base/rules/reference/documentation-source-paths.md":
       "555155889c9cf279865b9d8fc554bdd461c96a3ec76a5001dfeb361a71056999",
     "plugins/src/base/rules/reference/empirical-inquiry.md":
@@ -7747,6 +7747,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/claim-archaeology-rule.test.ts": true,
     "tests/unit/strategies/claim-evidence-mapping-contract.test.ts": true,
     "tests/unit/strategies/claude-remote-substrates.test.ts": true,
+    "tests/unit/strategies/convergent-review-contract.test.ts": true,
     "tests/unit/strategies/copy-contents-gitignore.test.ts": true,
     "tests/unit/strategies/copy-contents.test.ts": true,
     "tests/unit/strategies/copy-overwrite.test.ts": true,

--- a/tests/unit/strategies/convergent-review-contract.test.ts
+++ b/tests/unit/strategies/convergent-review-contract.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Contract coverage for the vendor-neutral convergent-review rule pair.
+ *
+ * `convergent-review` is the single findings format every review surface across
+ * every supported agent already cites. RRR-2 (#1854) extends it additively with
+ * the two fields the readiness rubric needs that no existing field covers —
+ * `invariant_violated` (the property at risk) and `machinery_to_remove` (the
+ * scaffolding the correction makes deletable) — plus consequence ordering, so
+ * the repo never grows a second findings format. These assertions pin the five
+ * fields the contract already shipped (they must not regress), the two new
+ * fields in both halves, the PRD-field mapping table, the required-for-readiness
+ * / recommended-elsewhere compatibility statement, and the consequence-ordering
+ * rule together with its explicit carve-out that report *section* order stays
+ * stable. Both plugin roots are checked so the generated copy can never drift
+ * from the source.
+ * @module tests/unit/strategies/convergent-review-contract
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+
+/** The finding fields the contract shipped before #1854 — never regress these. */
+const EXISTING_FIELDS = [
+  "Severity",
+  "Blocking",
+  "Failure scenario",
+  "Evidence",
+  "Fix",
+] as const;
+
+/** The two net-new fields RRR-2 folds into the shared finding shape. */
+const NEW_FIELDS = ["invariant_violated", "machinery_to_remove"] as const;
+
+const read = (root: string, rel: string): string =>
+  readFileSync(path.resolve(root, rel), "utf8");
+
+/**
+ * Collapse all whitespace so assertions survive reflowed markdown prose.
+ * @param text - the raw markdown document to normalize
+ * @returns the same text with every whitespace run collapsed to one space
+ */
+const squash = (text: string): string => text.replace(/\s+/g, " ");
+
+describe("convergent-review rule contract", () => {
+  describe.each(ROOTS)("%s", root => {
+    const eager = read(root, "rules/eager/convergent-review.md");
+    const reference = read(root, "rules/reference/convergent-review.md");
+    const eagerFlat = squash(eager);
+    const referenceFlat = squash(reference);
+
+    it("ships as a paired rule with a non-trivial body on both sides", () => {
+      expect(eager.length).toBeGreaterThan(500);
+      expect(reference.length).toBeGreaterThan(2000);
+    });
+
+    it("keeps the four shipped sections of the contract intact", () => {
+      for (const heading of [
+        "## Severity Bar",
+        "## Required Finding Shape",
+        "## Dispositions",
+        "## Stopping Rule",
+      ]) {
+        expect(reference).toContain(heading);
+      }
+      for (const disposition of ["`fixed`", "`deferred`", "`pushed-back`"]) {
+        expect(reference).toContain(disposition);
+      }
+    });
+
+    it("still requires the five finding fields it shipped with", () => {
+      for (const field of EXISTING_FIELDS) {
+        expect(reference).toContain(`- ${field}:`);
+      }
+      expect(eagerFlat).toMatch(
+        /severity, blocking yes\/no, a concrete failure scenario, evidence/i
+      );
+      expect(eagerFlat).toMatch(/smallest actionable fix/i);
+      // The malformed-blocking-finding rule is unchanged.
+      expect(referenceFlat).toMatch(/malformed by contract/i);
+    });
+
+    it("carries the two net-new fields in both halves", () => {
+      for (const field of NEW_FIELDS) {
+        expect(reference).toContain(field);
+        expect(eager).toContain(field);
+      }
+      // The invariant is the property at risk, distinct from the outcome the
+      // existing failure-scenario field already states.
+      expect(referenceFlat).toMatch(/property.*system/i);
+      expect(referenceFlat).toMatch(/failure scenario is the outcome/i);
+      // machinery-to-remove is surfaced, never auto-deleted, and may be "none".
+      expect(referenceFlat).toMatch(/`none`/);
+      expect(referenceFlat).toMatch(/never auto.deleted|surfaced.*never/i);
+      expect(reference).toContain("scaffolding-subtraction");
+    });
+
+    it("maps the readiness finding fields onto this contract instead of forking a second format", () => {
+      expect(reference).toContain("readiness-rubric");
+      expect(referenceFlat).toMatch(/no second findings format|second format/i);
+      // The mapping table binds each readiness field to a contract field.
+      for (const field of [
+        "invariant_violated",
+        "evidence",
+        "why_proof_missed",
+        "root_correction",
+        "machinery_to_remove",
+      ]) {
+        expect(reference).toContain(field);
+      }
+      // "why existing proof missed it" is served by evidence + a proof-gap
+      // clause; the root correction is the existing fix, at the owning boundary.
+      expect(referenceFlat).toMatch(/proof.gap/i);
+      expect(referenceFlat).toMatch(/owning boundary/i);
+    });
+
+    it("orders findings by consequence without licensing section reordering", () => {
+      for (const flat of [eagerFlat, referenceFlat]) {
+        expect(flat).toMatch(/highest.consequence first/i);
+      }
+      expect(referenceFlat).toMatch(/severity and blast radius/i);
+      expect(referenceFlat).toMatch(/not.*(discovery|file) order/i);
+      expect(referenceFlat).toMatch(/section order (stays|is) stable/i);
+    });
+
+    it("stays backwards compatible for existing review surfaces", () => {
+      expect(referenceFlat).toMatch(
+        /required for.*readiness|readiness.*required/i
+      );
+      expect(referenceFlat).toMatch(/recommended/i);
+      expect(referenceFlat).toMatch(
+        /well.formed|not.*malformed|never retroactively/i
+      );
+      // The passes that must not become malformed overnight.
+      for (const pass of ["product", "quality", "local", "bot-parity"]) {
+        expect(reference).toContain(pass);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

RRR-2 of PRD #1739. Extends the shared `convergent-review` finding contract — the one findings format every review surface across all six agents already cites — with the two fields the readiness rubric needs that no existing field covers, instead of introducing a second findings format.

Provenance: RRR-1 (#1853, merged) shipped the `readiness-rubric` rule pair and pinned the five consequence-ordered finding fields, hedging that two of them — `invariant_violated` and `machinery_to_remove` — are folded into `convergent-review` by "#1854". This PR makes `convergent-review` carry them, resolving that hedge. The readiness-rubric rule itself is untouched (its hedge is forward-looking prose and stays accurate).

**Intake correction honored (F4):** the PRD named `lisa-review-project` as the findings home; that skill is Lisa-repo-only and deliberately not distributed, so the distributed home is the `convergent-review` rule pair. This PR targets `convergent-review` only.

## What changed

- **`invariant_violated`** — the named property the system is supposed to hold that the finding puts at risk (e.g. "the artifact that ships is the artifact CI validated"). Explicitly distinguished from the existing *failure scenario*, which is the outcome when the property breaks.
- **`machinery_to_remove`** — redundant checks, workarounds, or scaffolding that become deletable once the correction lands, or explicitly `none`. Uses #1742's existing **scaffolding-subtraction candidate** vocabulary rather than a new term; surfaced only, never auto-deleted.
- **Mapping table** binding all five readiness finding fields onto this contract, so nobody adds a sixth format later: `why_proof_missed` → `Evidence` extended with a required proof-gap clause; `root_correction` → the existing `Fix`, qualified to the **owning boundary** rather than the symptom site.
- **Consequence ordering** — findings are presented highest-consequence first, by severity and blast radius, not by discovery or file order. Explicitly carved out: this governs order *within* a section; report **section order stays stable and is unaffected**, so this can never be read as licensing section reordering (F7).

## Additive, not breaking

The two new fields are **required only for findings emitted under `readiness-rubric`** and **recommended everywhere else**. Existing product, quality, local, bot-parity, and suggestion-implementation findings that omit them remain well-formed by contract — no shipped review surface becomes retroactively malformed. The four sections `convergent-review` shipped with (severity bar, dispositions, stopping rule, blocking bar) are unchanged.

## TDD

- **RED** — new companion contract test `tests/unit/strategies/convergent-review-contract.test.ts` pinning, across both plugin roots: the two new fields in both halves, the readiness mapping table, the consequence-ordering split, and the compatibility statement. Result: **8 failed | 6 passed** — the 6 passing are the pre-existing five-field / four-section pins, which is the additive proof that nothing regressed.
- **GREEN** — after editing the eager head and reference body: **14/14 green** on both roots.

## Gates

- `convergent-review-contract` + `readiness-rubric-contract`: 50 passed
- Full strategies suite: **148 files / 3884 tests passed**
- `check-rules-pairing.sh`: ✓ every eager rule has its paired reference body
- `tsc --noEmit`: clean
- `bun run check:plugins` (post-commit): ✓ artifacts in sync, marketplace complete
- `generate-upstream-evidence-manifest.mjs --check`: OK (regenerated after the formatter pass)

Closes #1854

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Strengthened Convergent Review guidance with structured finding requirements, including failure scenarios, evidence, actionable fixes, and readiness-specific details.
  * Clarified readiness finding compatibility, proof-gap requirements, and correction boundaries.
  * Added rules to present findings by severity and blast radius while preserving section order.

* **Tests**
  * Added contract coverage to verify required fields, readiness mappings, ordering rules, and backward compatibility across supported review guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->