### PR TITLE
fix(plugins): harden learner frontmatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "check:rules-pairing": "bash scripts/check-rules-pairing.sh",
     "check:workflow-inputs": "node scripts/detect-stale-workflow-inputs.mjs --project . --project typescript/create-only --project rails/create-only --json",
     "verify:health-contract": "bun run build:dist && node scripts/verify-health-contract-built.mjs",
-    "verify:health-deterministic": "bun run build:dist && node scripts/verify-health-deterministic-built.mjs"
+    "verify:health-deterministic": "bun run build:dist && node scripts/verify-health-deterministic-built.mjs",
+    "verify:learner-frontmatter-built": "bun run build:dist && node scripts/verify-learner-frontmatter-built.mjs"
   },
   "engines": {
     "npm": "please-use-bun",

--- a/package.lisa.json
+++ b/package.lisa.json
@@ -13,6 +13,7 @@
       "build": "tsc",
       "verify:health-contract": "bun run build:dist && node scripts/verify-health-contract-built.mjs",
       "verify:health-deterministic": "bun run build:dist && node scripts/verify-health-deterministic-built.mjs",
+      "verify:learner-frontmatter-built": "bun run build:dist && node scripts/verify-learner-frontmatter-built.mjs",
       "prepare": "$npm_execpath run build && husky install || true",
       "lisa:update": "npx @codyswann/lisa@latest ."
     },

--- a/plugins/lisa-agy/agents/learner.md
+++ b/plugins/lisa-agy/agents/learner.md
@@ -1,6 +1,6 @@
 ---
 name: learner
-description: Post-implementation learning agent. Capture-only — collects task learnings, builds seven-field entries, and persists them to the machine-managed ledger through the executable contract with provenance. Never promotes: it creates no skills, appends no rules, files no upstream issues; promotion is exclusively the gardener's ticket-gated job.
+description: "Post-implementation learning agent. Capture-only — collects task learnings, builds seven-field entries, and persists them to the machine-managed ledger through the executable contract with provenance. Never promotes: it creates no skills, appends no rules, files no upstream issues; promotion is exclusively the gardener's ticket-gated job."
 ---
 
 # Learner Agent

--- a/plugins/lisa-copilot/agents/learner.agent.md
+++ b/plugins/lisa-copilot/agents/learner.agent.md
@@ -1,6 +1,6 @@
 ---
 name: learner
-description: Post-implementation learning agent. Capture-only — collects task learnings, builds seven-field entries, and persists them to the machine-managed ledger through the executable contract with provenance. Never promotes: it creates no skills, appends no rules, files no upstream issues; promotion is exclusively the gardener's ticket-gated job.
+description: "Post-implementation learning agent. Capture-only — collects task learnings, builds seven-field entries, and persists them to the machine-managed ledger through the executable contract with provenance. Never promotes: it creates no skills, appends no rules, files no upstream issues; promotion is exclusively the gardener's ticket-gated job."
 ---
 
 # Learner Agent

--- a/plugins/lisa-cursor/agents/learner.md
+++ b/plugins/lisa-cursor/agents/learner.md
@@ -1,6 +1,6 @@
 ---
 name: learner
-description: Post-implementation learning agent. Capture-only — collects task learnings, builds seven-field entries, and persists them to the machine-managed ledger through the executable contract with provenance. Never promotes: it creates no skills, appends no rules, files no upstream issues; promotion is exclusively the gardener's ticket-gated job.
+description: "Post-implementation learning agent. Capture-only — collects task learnings, builds seven-field entries, and persists them to the machine-managed ledger through the executable contract with provenance. Never promotes: it creates no skills, appends no rules, files no upstream issues; promotion is exclusively the gardener's ticket-gated job."
 ---
 
 # Learner Agent

--- a/plugins/lisa-wiki-agy/skills/lisa-wiki-add-role/SKILL.md
+++ b/plugins/lisa-wiki-agy/skills/lisa-wiki-add-role/SKILL.md
@@ -21,6 +21,11 @@ agent-team routing, private notebooks) is out of scope** — this skill only cre
 4. **Brain-pointed, not baked:** the subagent's instructions say *"your domain is `wiki/<owned>/`;
    `/query` it first, contribute via `/ingest`; stay in your lane."* It points at the live wiki so it
    never goes stale. Only its one-line `description` is synthesized from the wiki at generation time.
+5. **Serialize the description before rendering:** derive `roleDescriptionSerialized` with
+   `JSON.stringify(roleDescription)` or an exact equivalent that emits one JSON string literal on one
+   physical line. Substitute that serialized literal, including its surrounding quotes, directly for
+   `{{roleDescriptionSerialized}}` in both templates. Do not add another layer of quotes. This keeps
+   colon-space sequences, quotes, backslashes, and runtime newlines exact in both YAML and TOML.
 
 ## Rules
 - v1 instructs lane-keeping but does not *enforce* per-role write isolation (deferred).

--- a/plugins/lisa-wiki-agy/templates/agents/role-agent.claude.md
+++ b/plugins/lisa-wiki-agy/templates/agents/role-agent.claude.md
@@ -1,6 +1,6 @@
 ---
 name: {{id}}
-description: {{roleDescription}}
+description: {{roleDescriptionSerialized}}
 ---
 
 You are **{{role}}** for {{org}} — the domain expert for {{expertise}}.

--- a/plugins/lisa-wiki-agy/templates/agents/role-agent.codex.toml
+++ b/plugins/lisa-wiki-agy/templates/agents/role-agent.codex.toml
@@ -1,5 +1,5 @@
 name = "{{id}}"
-description = "{{roleDescription}}"
+description = {{roleDescriptionSerialized}}
 developer_instructions = """
 You are {{role}} for {{org}} — the domain expert for {{expertise}}.
 

--- a/plugins/lisa-wiki-copilot/skills/lisa-wiki-add-role/SKILL.md
+++ b/plugins/lisa-wiki-copilot/skills/lisa-wiki-add-role/SKILL.md
@@ -21,6 +21,11 @@ agent-team routing, private notebooks) is out of scope** — this skill only cre
 4. **Brain-pointed, not baked:** the subagent's instructions say *"your domain is `wiki/<owned>/`;
    `/query` it first, contribute via `/ingest`; stay in your lane."* It points at the live wiki so it
    never goes stale. Only its one-line `description` is synthesized from the wiki at generation time.
+5. **Serialize the description before rendering:** derive `roleDescriptionSerialized` with
+   `JSON.stringify(roleDescription)` or an exact equivalent that emits one JSON string literal on one
+   physical line. Substitute that serialized literal, including its surrounding quotes, directly for
+   `{{roleDescriptionSerialized}}` in both templates. Do not add another layer of quotes. This keeps
+   colon-space sequences, quotes, backslashes, and runtime newlines exact in both YAML and TOML.
 
 ## Rules
 - v1 instructs lane-keeping but does not *enforce* per-role write isolation (deferred).

--- a/plugins/lisa-wiki-copilot/templates/agents/role-agent.claude.md
+++ b/plugins/lisa-wiki-copilot/templates/agents/role-agent.claude.md
@@ -1,6 +1,6 @@
 ---
 name: {{id}}
-description: {{roleDescription}}
+description: {{roleDescriptionSerialized}}
 ---
 
 You are **{{role}}** for {{org}} — the domain expert for {{expertise}}.

--- a/plugins/lisa-wiki-copilot/templates/agents/role-agent.codex.toml
+++ b/plugins/lisa-wiki-copilot/templates/agents/role-agent.codex.toml
@@ -1,5 +1,5 @@
 name = "{{id}}"
-description = "{{roleDescription}}"
+description = {{roleDescriptionSerialized}}
 developer_instructions = """
 You are {{role}} for {{org}} — the domain expert for {{expertise}}.
 

--- a/plugins/lisa-wiki-cursor/skills/lisa-wiki-add-role/SKILL.md
+++ b/plugins/lisa-wiki-cursor/skills/lisa-wiki-add-role/SKILL.md
@@ -21,6 +21,11 @@ agent-team routing, private notebooks) is out of scope** — this skill only cre
 4. **Brain-pointed, not baked:** the subagent's instructions say *"your domain is `wiki/<owned>/`;
    `/query` it first, contribute via `/ingest`; stay in your lane."* It points at the live wiki so it
    never goes stale. Only its one-line `description` is synthesized from the wiki at generation time.
+5. **Serialize the description before rendering:** derive `roleDescriptionSerialized` with
+   `JSON.stringify(roleDescription)` or an exact equivalent that emits one JSON string literal on one
+   physical line. Substitute that serialized literal, including its surrounding quotes, directly for
+   `{{roleDescriptionSerialized}}` in both templates. Do not add another layer of quotes. This keeps
+   colon-space sequences, quotes, backslashes, and runtime newlines exact in both YAML and TOML.
 
 ## Rules
 - v1 instructs lane-keeping but does not *enforce* per-role write isolation (deferred).

--- a/plugins/lisa-wiki-cursor/templates/agents/role-agent.claude.md
+++ b/plugins/lisa-wiki-cursor/templates/agents/role-agent.claude.md
@@ -1,6 +1,6 @@
 ---
 name: {{id}}
-description: {{roleDescription}}
+description: {{roleDescriptionSerialized}}
 ---
 
 You are **{{role}}** for {{org}} — the domain expert for {{expertise}}.

--- a/plugins/lisa-wiki-cursor/templates/agents/role-agent.codex.toml
+++ b/plugins/lisa-wiki-cursor/templates/agents/role-agent.codex.toml
@@ -1,5 +1,5 @@
 name = "{{id}}"
-description = "{{roleDescription}}"
+description = {{roleDescriptionSerialized}}
 developer_instructions = """
 You are {{role}} for {{org}} — the domain expert for {{expertise}}.
 

--- a/plugins/lisa-wiki/.codex-plugin/skills/lisa-wiki-add-role/SKILL.md
+++ b/plugins/lisa-wiki/.codex-plugin/skills/lisa-wiki-add-role/SKILL.md
@@ -21,6 +21,11 @@ agent-team routing, private notebooks) is out of scope** — this skill only cre
 4. **Brain-pointed, not baked:** the subagent's instructions say *"your domain is `wiki/<owned>/`;
    `/query` it first, contribute via `/ingest`; stay in your lane."* It points at the live wiki so it
    never goes stale. Only its one-line `description` is synthesized from the wiki at generation time.
+5. **Serialize the description before rendering:** derive `roleDescriptionSerialized` with
+   `JSON.stringify(roleDescription)` or an exact equivalent that emits one JSON string literal on one
+   physical line. Substitute that serialized literal, including its surrounding quotes, directly for
+   `{{roleDescriptionSerialized}}` in both templates. Do not add another layer of quotes. This keeps
+   colon-space sequences, quotes, backslashes, and runtime newlines exact in both YAML and TOML.
 
 ## Rules
 - v1 instructs lane-keeping but does not *enforce* per-role write isolation (deferred).

--- a/plugins/lisa-wiki/skills/lisa-wiki-add-role/SKILL.md
+++ b/plugins/lisa-wiki/skills/lisa-wiki-add-role/SKILL.md
@@ -21,6 +21,11 @@ agent-team routing, private notebooks) is out of scope** — this skill only cre
 4. **Brain-pointed, not baked:** the subagent's instructions say *"your domain is `wiki/<owned>/`;
    `/query` it first, contribute via `/ingest`; stay in your lane."* It points at the live wiki so it
    never goes stale. Only its one-line `description` is synthesized from the wiki at generation time.
+5. **Serialize the description before rendering:** derive `roleDescriptionSerialized` with
+   `JSON.stringify(roleDescription)` or an exact equivalent that emits one JSON string literal on one
+   physical line. Substitute that serialized literal, including its surrounding quotes, directly for
+   `{{roleDescriptionSerialized}}` in both templates. Do not add another layer of quotes. This keeps
+   colon-space sequences, quotes, backslashes, and runtime newlines exact in both YAML and TOML.
 
 ## Rules
 - v1 instructs lane-keeping but does not *enforce* per-role write isolation (deferred).

--- a/plugins/lisa-wiki/templates/agents/role-agent.claude.md
+++ b/plugins/lisa-wiki/templates/agents/role-agent.claude.md
@@ -1,6 +1,6 @@
 ---
 name: {{id}}
-description: {{roleDescription}}
+description: {{roleDescriptionSerialized}}
 ---
 
 You are **{{role}}** for {{org}} — the domain expert for {{expertise}}.

--- a/plugins/lisa-wiki/templates/agents/role-agent.codex.toml
+++ b/plugins/lisa-wiki/templates/agents/role-agent.codex.toml
@@ -1,5 +1,5 @@
 name = "{{id}}"
-description = "{{roleDescription}}"
+description = {{roleDescriptionSerialized}}
 developer_instructions = """
 You are {{role}} for {{org}} — the domain expert for {{expertise}}.
 

--- a/plugins/lisa/agents/learner.md
+++ b/plugins/lisa/agents/learner.md
@@ -1,6 +1,6 @@
 ---
 name: learner
-description: Post-implementation learning agent. Capture-only — collects task learnings, builds seven-field entries, and persists them to the machine-managed ledger through the executable contract with provenance. Never promotes: it creates no skills, appends no rules, files no upstream issues; promotion is exclusively the gardener's ticket-gated job.
+description: "Post-implementation learning agent. Capture-only — collects task learnings, builds seven-field entries, and persists them to the machine-managed ledger through the executable contract with provenance. Never promotes: it creates no skills, appends no rules, files no upstream issues; promotion is exclusively the gardener's ticket-gated job."
 ---
 
 # Learner Agent

--- a/plugins/src/base/agents/learner.md
+++ b/plugins/src/base/agents/learner.md
@@ -1,6 +1,6 @@
 ---
 name: learner
-description: Post-implementation learning agent. Capture-only — collects task learnings, builds seven-field entries, and persists them to the machine-managed ledger through the executable contract with provenance. Never promotes: it creates no skills, appends no rules, files no upstream issues; promotion is exclusively the gardener's ticket-gated job.
+description: "Post-implementation learning agent. Capture-only — collects task learnings, builds seven-field entries, and persists them to the machine-managed ledger through the executable contract with provenance. Never promotes: it creates no skills, appends no rules, files no upstream issues; promotion is exclusively the gardener's ticket-gated job."
 ---
 
 # Learner Agent

--- a/plugins/src/wiki/skills/lisa-wiki-add-role/SKILL.md
+++ b/plugins/src/wiki/skills/lisa-wiki-add-role/SKILL.md
@@ -21,6 +21,11 @@ agent-team routing, private notebooks) is out of scope** — this skill only cre
 4. **Brain-pointed, not baked:** the subagent's instructions say *"your domain is `wiki/<owned>/`;
    `/query` it first, contribute via `/ingest`; stay in your lane."* It points at the live wiki so it
    never goes stale. Only its one-line `description` is synthesized from the wiki at generation time.
+5. **Serialize the description before rendering:** derive `roleDescriptionSerialized` with
+   `JSON.stringify(roleDescription)` or an exact equivalent that emits one JSON string literal on one
+   physical line. Substitute that serialized literal, including its surrounding quotes, directly for
+   `{{roleDescriptionSerialized}}` in both templates. Do not add another layer of quotes. This keeps
+   colon-space sequences, quotes, backslashes, and runtime newlines exact in both YAML and TOML.
 
 ## Rules
 - v1 instructs lane-keeping but does not *enforce* per-role write isolation (deferred).

--- a/plugins/src/wiki/templates/agents/role-agent.claude.md
+++ b/plugins/src/wiki/templates/agents/role-agent.claude.md
@@ -1,6 +1,6 @@
 ---
 name: {{id}}
-description: {{roleDescription}}
+description: {{roleDescriptionSerialized}}
 ---
 
 You are **{{role}}** for {{org}} — the domain expert for {{expertise}}.

--- a/plugins/src/wiki/templates/agents/role-agent.codex.toml
+++ b/plugins/src/wiki/templates/agents/role-agent.codex.toml
@@ -1,5 +1,5 @@
 name = "{{id}}"
-description = "{{roleDescription}}"
+description = {{roleDescriptionSerialized}}
 developer_instructions = """
 You are {{role}} for {{org}} — the domain expert for {{expertise}}.
 

--- a/scripts/verify-learner-frontmatter-built.mjs
+++ b/scripts/verify-learner-frontmatter-built.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/** Empirical proof that built Codex and OpenCode installers preserve learner metadata. */
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { load as loadYaml } from "js-yaml";
+import { parse as parseToml } from "smol-toml";
+import { discoverAndInstallAgents as installOpencodeAgents } from "../dist/opencode/agent-installer.js";
+
+const EXPECTED_DESCRIPTION =
+  "Post-implementation learning agent. Capture-only — collects task learnings, builds seven-field entries, and persists them to the machine-managed ledger through the executable contract with provenance. Never promotes: it creates no skills, appends no rules, files no upstream issues; promotion is exclusively the gardener's ticket-gated job.";
+const executeFile = promisify(execFile);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const destination = await mkdtemp(
+  path.join(tmpdir(), "lisa-learner-frontmatter-built-")
+);
+
+try {
+  const codexOverlay = await executeFile(
+    process.execPath,
+    [path.join(root, "dist", "codex", "project-overlay.js"), destination],
+    { cwd: root }
+  );
+  const opencodeResult = await installOpencodeAgents(root, destination, []);
+
+  assert.match(
+    codexOverlay.stderr,
+    /Lisa Codex overlay: \d+ native skills from \d+ project plugins\./
+  );
+  assert.equal(
+    opencodeResult.installed.some(agent => agent.id === "learner"),
+    true
+  );
+
+  const codexAgent = parseToml(
+    await readFile(
+      path.join(destination, ".codex", "agents", "lisa", "learner.toml"),
+      "utf8"
+    )
+  );
+  assert.equal(codexAgent.name, "lisa-learner");
+  assert.equal(codexAgent.description, EXPECTED_DESCRIPTION);
+
+  const opencodeMarkdown = await readFile(
+    path.join(destination, ".opencode", "agents", "lisa-learner.md"),
+    "utf8"
+  );
+  const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(opencodeMarkdown);
+  assert.notEqual(frontmatter, null);
+  const opencodeAgent = loadYaml(frontmatter?.[1] ?? "");
+  assert.equal(typeof opencodeAgent, "object");
+  assert.notEqual(opencodeAgent, null);
+  assert.equal(opencodeAgent.description, EXPECTED_DESCRIPTION);
+  assert.equal(opencodeAgent.mode, "subagent");
+
+  console.log(
+    "[EVIDENCE: learner-frontmatter-built] codex=preserved opencode=preserved"
+  );
+} finally {
+  await rm(destination, { recursive: true, force: true });
+}

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -395,7 +395,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/agents/jira-build-intake.md":
       "51397c08fe09380f53bd630fb81ff28905a532ea71336a424e944c28a0c2db55",
     "plugins/src/base/agents/learner.md":
-      "cd1a0ba1560f6d17d0c851b5d70167468c0a2953c77b6eb87d7782c48db8906d",
+      "50582e72b11eeb6b085845f2e32c31a6dcedd0439ca566bb1cca228dd1a45fee",
     "plugins/src/base/agents/learning-judge.md":
       "28618c3e20a0f790e4d254a9c8118645774233f19e3042b3cfeddf4ffbaf783a",
     "plugins/src/base/agents/learnings-synthesizer.md":
@@ -1635,7 +1635,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/wiki/skills/lisa-wiki-add-ingest/SKILL.md":
       "d7334ca07bc9bcd7d51865b77a377d772c20dc546c9a63b22dabe7624586e0fb",
     "plugins/src/wiki/skills/lisa-wiki-add-role/SKILL.md":
-      "bb84917eb0b0837d16c2545b79b346023cdf042ece94b6794ee8e91f65379cf2",
+      "72d3fe746d484a8e3bce34f3147ad384549229a24b5cc33d1867a0351cfc57b3",
     "plugins/src/wiki/skills/lisa-wiki-connector-confluence/SKILL.md":
       "ee3a98bb83b1efab6e7cc7604b15e0daa3f4288aed3d8dc6de30aa4ffc06a709",
     "plugins/src/wiki/skills/lisa-wiki-connector-docs/SKILL.md":
@@ -1677,9 +1677,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/wiki/skills/lisa-wiki-usage/SKILL.md":
       "1f2747204722a9f0b0000188770bb70ca71a550d9b4a607b1e02587156d48f71",
     "plugins/src/wiki/templates/agents/role-agent.claude.md":
-      "5ab447762a7b5a9493f1aa43a0a23101e0f55c64f41e20b1fd2e043bf04c5442",
+      "e66982fa5b343d9f0e2dff23442c40fc157c729f756133d98fc43ebd15ccf81b",
     "plugins/src/wiki/templates/agents/role-agent.codex.toml":
-      "67ed38aa69d10faec1636c7dd9139a5eeb479a8fa4450396e2a5668c57de3b02",
+      "98d7a64a5fe80fa8c7ac4d94aea05e35361730edc9bf3699536de867d4e3c3fa",
     "plugins/src/wiki/templates/index.md":
       "88b45130a0149d98895e132182aeaa7b7e6d6174545fbb6e9245170863edce42",
     "plugins/src/wiki/templates/llm-wiki-contract.md":
@@ -1898,6 +1898,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "9e090e3378325c4193e96ba03acff17fb63e40c9e7f2dd89296f72353ab6ba88",
     "scripts/verify-health-deterministic-built.mjs":
       "ab19427ec4b1dfaa06037cc23b7fc06319b4c12d8c6b67808dddd77e5367fd12",
+    "scripts/verify-learner-frontmatter-built.mjs":
+      "182e5e99f52257d3079ee1bc42b45c3dcca8b93a968205ddb3f3af26f2558b47",
     "tsconfig/base.json":
       "d04a105ec81aa9dc69d230d4a83406d920c305b6fc13c641ebafde0c41fc658f",
     "tsconfig/build.json":
@@ -7233,6 +7235,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "scripts/update-test-skill-paths.mjs": true,
     "scripts/verify-health-contract-built.mjs": true,
     "scripts/verify-health-deterministic-built.mjs": true,
+    "scripts/verify-learner-frontmatter-built.mjs": true,
     "sgconfig.yml": true,
     "specs/.keep": true,
     "src/agy/mcp-installer.ts": true,
@@ -7628,6 +7631,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/core/project-config-harness-migration.test.ts": true,
     "tests/unit/core/project-config-kane.test.ts": true,
     "tests/unit/core/project-config.test.ts": true,
+    "tests/unit/core/role-agent-template-contract.test.ts": true,
     "tests/unit/core/self-apply.test.ts": true,
     "tests/unit/core/skill-frontmatter-contract.test.ts": true,
     "tests/unit/core/upstream-attribution-body-hardening.test.ts": true,

--- a/tests/unit/codex/agent-transformer.test.ts
+++ b/tests/unit/codex/agent-transformer.test.ts
@@ -51,6 +51,16 @@ model: sonnet
 Body.
 `;
 
+const COLON_SPACE_DESCRIPTION =
+  "Capture-only. Never promotes: it creates no skills or rules.";
+const WITH_QUOTED_COLON_SPACE = `---
+name: learner
+description: ${JSON.stringify(COLON_SPACE_DESCRIPTION)}
+---
+
+Body.
+`;
+
 describe("agent-transformer", () => {
   describe("parseAgentMarkdown", () => {
     it("parses minimal frontmatter and body", () => {
@@ -73,6 +83,11 @@ describe("agent-transformer", () => {
       const result = parseAgentMarkdown(WITH_TOOLS_AND_MODEL);
       expect(result.frontmatter.tools).toBe("Read, Bash, Grep");
       expect(result.frontmatter.model).toBe("sonnet");
+    });
+
+    it("preserves a quoted colon-space sequence in description", () => {
+      const result = parseAgentMarkdown(WITH_QUOTED_COLON_SPACE);
+      expect(result.frontmatter.description).toBe(COLON_SPACE_DESCRIPTION);
     });
 
     it("trims leading whitespace from body", () => {

--- a/tests/unit/core/role-agent-template-contract.test.ts
+++ b/tests/unit/core/role-agent-template-contract.test.ts
@@ -1,0 +1,82 @@
+/** Contract for rendering canonical and generated wiki role-agent templates. */
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { load as loadYaml } from "js-yaml";
+import { parse as parseToml } from "smol-toml";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(fileURLToPath(import.meta.url), "../../../..");
+const TEMPLATE_ROOTS = [
+  "plugins/src/wiki",
+  "plugins/lisa-wiki",
+  "plugins/lisa-wiki-cursor",
+  "plugins/lisa-wiki-agy",
+  "plugins/lisa-wiki-copilot",
+] as const;
+const ADVERSARIAL_DESCRIPTION =
+  'Owns finance: says "quarterly"; reads C:\\wiki\\roles\nEscalates exceptions.';
+const TEMPLATE_VALUES = Object.freeze({
+  id: "finance",
+  role: "Finance lead",
+  roleDescriptionSerialized: JSON.stringify(ADVERSARIAL_DESCRIPTION),
+  org: "Example Org",
+  expertise: "financial operations",
+  ownedPaths: "wiki/finance/",
+  sensitivity: "confidential",
+});
+
+/**
+ * Render one role template using the same literal placeholder contract as the skill.
+ * @param template Raw role-agent template.
+ * @returns Fully rendered agent text.
+ */
+function renderTemplate(template: string): string {
+  return Object.entries(TEMPLATE_VALUES).reduce(
+    (rendered, [key, value]) => rendered.replaceAll(`{{${key}}}`, value),
+    template
+  );
+}
+
+/**
+ * Parse the leading YAML mapping from one rendered Claude agent.
+ * @param markdown Rendered Claude agent Markdown.
+ * @returns Parsed frontmatter mapping.
+ */
+function parseYamlFrontmatter(markdown: string): Record<string, unknown> {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(markdown);
+  if (match === null) {
+    throw new Error("rendered Claude agent has no YAML frontmatter");
+  }
+  const parsed = loadYaml(match[1]);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("rendered Claude agent frontmatter is not a mapping");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+describe("wiki role-agent template render contract", () => {
+  for (const templateRoot of TEMPLATE_ROOTS) {
+    it(`${templateRoot} preserves adversarial descriptions in YAML and TOML`, () => {
+      const claudeTemplate = readFileSync(
+        join(REPO_ROOT, templateRoot, "templates/agents/role-agent.claude.md"),
+        "utf8"
+      );
+      const codexTemplate = readFileSync(
+        join(REPO_ROOT, templateRoot, "templates/agents/role-agent.codex.toml"),
+        "utf8"
+      );
+
+      expect(claudeTemplate).toContain("{{roleDescriptionSerialized}}");
+      expect(codexTemplate).toContain("{{roleDescriptionSerialized}}");
+
+      const claudeAgent = parseYamlFrontmatter(renderTemplate(claudeTemplate));
+      const codexAgent = parseToml(renderTemplate(codexTemplate));
+
+      expect(claudeAgent["name"]).toBe(TEMPLATE_VALUES.id);
+      expect(claudeAgent["description"]).toBe(ADVERSARIAL_DESCRIPTION);
+      expect(codexAgent.name).toBe(TEMPLATE_VALUES.id);
+      expect(codexAgent.description).toBe(ADVERSARIAL_DESCRIPTION);
+    });
+  }
+});

--- a/tests/unit/core/skill-frontmatter-contract.test.ts
+++ b/tests/unit/core/skill-frontmatter-contract.test.ts
@@ -1,5 +1,5 @@
 /**
- * Cross-agent skill/command frontmatter contract.
+ * Cross-agent skill, command, and agent frontmatter contract.
  *
  * Every coding agent Lisa distributes to must be able to load every skill and
  * command. The strictest loader in the fleet (GitHub Copilot CLI) enforces:
@@ -11,9 +11,10 @@
  * lenient loaders accept it, so parseability is asserted with a real YAML
  * parser rather than a regex.
  *
- * Scans the source trees (`plugins/src`, root `.claude`, `.agents`) and the
- * generated plugin artifacts (`plugins/lisa*`) so both hand-edited sources and
- * generator output are covered.
+ * Agent Markdown includes both ordinary `*.md` and Copilot `*.agent.md`
+ * projections. Scans the source trees (`plugins/src`, root `.claude`,
+ * `.agents`) and generated plugin artifacts (`plugins/lisa*`) so both
+ * hand-edited sources and generator output are covered.
  */
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
@@ -28,15 +29,47 @@ const MAX_DESCRIPTION_LENGTH = 1024;
 const SCAN_ROOTS = [".agents", ".claude", "plugins"] as const;
 
 const SKIPPED_DIRECTORY_NAMES = new Set([".git", "node_modules", "worktrees"]);
+const AGENT_TEMPLATE_KIND = "agent-template" as const;
 
-/** A skill or command markdown file discovered during the repository scan. */
+/** Kind of frontmatter-bearing Markdown surface discovered by this contract. */
+type ScannedFileKind =
+  | "agent"
+  | typeof AGENT_TEMPLATE_KIND
+  | "command"
+  | "skill";
+
+/** A frontmatter-bearing Markdown file discovered during the repository scan. */
 interface ScannedFile {
-  readonly isSkill: boolean;
+  readonly kind: ScannedFileKind;
   readonly relativePath: string;
 }
 
 /**
- * Recursively collects SKILL.md and command markdown files under a directory.
+ * Classifies a frontmatter-bearing Markdown file by its repository path.
+ * @param absolutePath Absolute path of the candidate file.
+ * @param entry Basename of the candidate file.
+ * @returns The surface kind, or undefined when the file is outside the contract.
+ */
+function classifyMarkdownFile(
+  absolutePath: string,
+  entry: string
+): ScannedFileKind | undefined {
+  if (absolutePath.includes("/agents/") && entry.endsWith(".md")) {
+    return absolutePath.includes("/templates/agents/")
+      ? AGENT_TEMPLATE_KIND
+      : "agent";
+  }
+  if (entry === "SKILL.md") {
+    return "skill";
+  }
+  if (absolutePath.includes("/commands/") && entry.endsWith(".md")) {
+    return "command";
+  }
+  return undefined;
+}
+
+/**
+ * Recursively collects skill, command, and agent Markdown under a directory.
  * @param directory Absolute path of the directory to walk.
  * @param collected Accumulator the discovered files are pushed onto.
  */
@@ -54,12 +87,10 @@ function collectMarkdownFiles(
       collectMarkdownFiles(absolutePath, collected);
       continue;
     }
-    const isSkill = entry === "SKILL.md";
-    const isCommand =
-      absolutePath.includes("/commands/") && entry.endsWith(".md");
-    if (isSkill || isCommand) {
+    const kind = classifyMarkdownFile(absolutePath, entry);
+    if (kind !== undefined) {
       collected.push({
-        isSkill,
+        kind,
         relativePath: absolutePath.slice(REPO_ROOT.length + 1),
       });
     }
@@ -67,7 +98,7 @@ function collectMarkdownFiles(
 }
 
 /**
- * Scans every configured root for skill and command markdown files.
+ * Scans every configured root for frontmatter-bearing Markdown files.
  * @returns The discovered files, with repo-relative paths.
  */
 function scanRepository(): readonly ScannedFile[] {
@@ -122,55 +153,84 @@ function parseFrontmatter(text: string): {
 
 /**
  * Applies the loader contract to each file and reports every violation.
- * @param files Scanned skill and command files to validate.
+ * @param files Scanned skill, command, and agent files to validate.
  * @returns One entry per violated rule, empty when everything loads.
  */
 function findViolations(files: readonly ScannedFile[]): readonly Violation[] {
-  return files.flatMap(file => {
-    const text = readFileSync(join(REPO_ROOT, file.relativePath), "utf8");
-    const { error, frontmatter } = parseFrontmatter(text);
-    if (error !== undefined) {
-      return [{ detail: error, relativePath: file.relativePath }];
-    }
-    if (frontmatter === undefined) {
-      return file.isSkill
-        ? [
-            {
-              detail: "missing YAML frontmatter",
-              relativePath: file.relativePath,
-            },
-          ]
-        : [];
-    }
-    const violations: Violation[] = [];
-    const description = frontmatter["description"];
-    if (file.isSkill && typeof description !== "string") {
-      violations.push({
-        detail: "frontmatter is missing a string `description`",
-        relativePath: file.relativePath,
-      });
-    }
-    if (
-      typeof description === "string" &&
-      description.length > MAX_DESCRIPTION_LENGTH
-    ) {
-      violations.push({
-        detail: `description is ${String(description.length)} characters (max ${String(MAX_DESCRIPTION_LENGTH)})`,
-        relativePath: file.relativePath,
-      });
-    }
-    return violations;
-  });
+  return files
+    .filter(file => file.kind !== AGENT_TEMPLATE_KIND)
+    .flatMap(file => {
+      const text = readFileSync(join(REPO_ROOT, file.relativePath), "utf8");
+      const { error, frontmatter } = parseFrontmatter(text);
+      if (error !== undefined) {
+        return [{ detail: error, relativePath: file.relativePath }];
+      }
+      if (frontmatter === undefined) {
+        return file.kind !== "command"
+          ? [
+              {
+                detail: "missing YAML frontmatter",
+                relativePath: file.relativePath,
+              },
+            ]
+          : [];
+      }
+      const violations: Violation[] = [];
+      const name = frontmatter["name"];
+      const description = frontmatter["description"];
+      if (
+        file.kind === "agent" &&
+        (typeof name !== "string" || name.trim().length === 0)
+      ) {
+        violations.push({
+          detail: "frontmatter is missing a non-empty string `name`",
+          relativePath: file.relativePath,
+        });
+      }
+      if (
+        file.kind !== "command" &&
+        (typeof description !== "string" || description.trim().length === 0)
+      ) {
+        violations.push({
+          detail: "frontmatter is missing a non-empty string `description`",
+          relativePath: file.relativePath,
+        });
+      }
+      if (
+        typeof description === "string" &&
+        description.length > MAX_DESCRIPTION_LENGTH
+      ) {
+        violations.push({
+          detail: `description is ${String(description.length)} characters (max ${String(MAX_DESCRIPTION_LENGTH)})`,
+          relativePath: file.relativePath,
+        });
+      }
+      return violations;
+    });
 }
 
-describe("skill and command frontmatter contract", () => {
+describe("skill, command, and agent frontmatter contract", () => {
   const files = scanRepository();
 
-  it("finds skill and command files to validate", () => {
+  it("finds every frontmatter surface family to validate", () => {
     expect(files.length).toBeGreaterThan(300);
+    const agents = files.filter(file => file.kind === "agent");
+    const agentTemplates = files.filter(
+      file => file.kind === AGENT_TEMPLATE_KIND
+    );
+    expect(agents).toHaveLength(250);
+    expect(agentTemplates).toHaveLength(5);
+    expect(
+      agentTemplates.every(file =>
+        file.relativePath.endsWith("/templates/agents/role-agent.claude.md")
+      )
+    ).toBe(true);
+    expect(agents.some(file => file.relativePath.endsWith(".agent.md"))).toBe(
+      true
+    );
   });
 
-  it("every skill and command loads under the strictest agent loader", () => {
+  it("every rendered surface loads under the active YAML parser", () => {
     const violations = findViolations(files);
     const report = violations
       .map(violation => `${violation.relativePath}: ${violation.detail}`)

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -79,6 +79,24 @@ describe("PackageLisaStrategy", () => {
     });
   });
 
+  describe("root package template verifier scripts", () => {
+    it("preserves the learner frontmatter built verifier", () => {
+      const repoRoot = process.cwd();
+      const packageJson = fs.readJsonSync(path.join(repoRoot, "package.json"));
+      const packageTemplate = fs.readJsonSync(
+        path.join(repoRoot, "package.lisa.json")
+      );
+      const scriptName = "verify:learner-frontmatter-built";
+
+      expect(packageTemplate.force.scripts[scriptName]).toBe(
+        packageJson.scripts[scriptName]
+      );
+      expect(packageTemplate.force.scripts[scriptName]).toBe(
+        "bun run build:dist && node scripts/verify-learner-frontmatter-built.mjs"
+      );
+    });
+  });
+
   describe("when source does not exist", () => {
     it("skips when package.lisa.json not found", async () => {
       const sourcePath = path.join(


### PR DESCRIPTION
## Summary

- quote and regenerate the learner agent frontmatter for every supported agent
- parse every rendered agent surface under the active js-yaml runtime
- serialize role-agent descriptions once for safe YAML and TOML template rendering
- exercise the real compiled Codex and OpenCode install paths

## Verification

- 376 test files and 6,600 tests passed
- 9 integration files and 137 integration tests passed
- typecheck, lint, slow lint, security audit, knip, plugin parity, and manifest freshness passed
- `bun run verify:learner-frontmatter-built`
- disposable exact-commit frozen install preserved the learner description through the real project overlay

Work-Item: CodySwannGT/lisa#1869

Closes #1869

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable serialization for role descriptions in generated agent templates, preserving punctuation, quotes, escapes, and newlines across formats.
  * Added validation for learner metadata after build and installation.

* **Bug Fixes**
  * Improved frontmatter handling for agent descriptions containing quoted colon-space sequences.
  * Strengthened validation of agent names and descriptions.

* **Tests**
  * Added coverage for role-template rendering, frontmatter contracts, and built learner metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->