### PR TITLE
test(ci): raise the npm-pack budget test timeout to 60s (#1871)

### DIFF
--- a/tests/unit/scripts/check-learnings-budget.test.ts
+++ b/tests/unit/scripts/check-learnings-budget.test.ts
@@ -251,7 +251,12 @@ describe("check:learnings-budget", () => {
       "learnings budget passed"
     );
     expect(result.status).toBe(0);
-  });
+    // This test compiles dist, `bun pm pack`s, and tar-extracts the full
+    // published surface — its cost grows with the packaged content, and it
+    // already grants its own subprocesses 30s. Match that budget at the it()
+    // level so a normal content addition can't tip it over the 10s default.
+    // Durable decoupling from surface growth is tracked as a follow-up.
+  }, 60_000);
 });
 
 /**


### PR DESCRIPTION
## Summary

The `check-learnings-budget` test "runs against the canonical default from an extracted npm pack" compiles dist, `bun pm pack`s, and tar-extracts the **full published surface**, then runs the budget check. Its wall-clock cost grows monotonically with packaged content. It sat ~0.7s under the vitest 10s default (9.2–9.4s on recent PRs) and the growing RRR rule content was tipping it over the cliff — while the test already grants its own `bun pm pack`/`tar` subprocesses 30s.

This raises the `it()` timeout to **60s** (matching its subprocess budgets) as the immediate stopgap so a normal content addition can't flake the gate.

Refs #1871 (durable decoupling of the test from packaged-surface growth remains tracked there).

## Scope

One line + explanatory comment; `tests/unit/scripts/check-learnings-budget.test.ts` only. No production change.

## Verification

- Target test passes at 2.5s locally (13/13).
- Net diff vs main is exactly this one file.

🤖 Generated with Claude Code