### PR TITLE
test(learnings): isolate packed checker closure

### DIFF
--- a/tests/unit/scripts/check-learnings-budget-helpers.ts
+++ b/tests/unit/scripts/check-learnings-budget-helpers.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { cpSync, mkdirSync, realpathSync } from "node:fs";
+import { cpSync, mkdirSync, realpathSync, writeFileSync } from "node:fs";
 import * as path from "node:path";
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
@@ -90,19 +90,52 @@ export function stagePackageWithFreshDist(
   const compiler = realpathSync(
     path.join(REPO_ROOT, "node_modules", "typescript", "bin", "tsc")
   );
+  const compilerConfig = path.join(
+    stagingRoot,
+    "tsconfig.check-learnings-budget.json"
+  );
+  writeFileSync(
+    compilerConfig,
+    `${JSON.stringify(
+      {
+        extends: path.join(REPO_ROOT, "tsconfig.json"),
+        compilerOptions: {
+          declaration: false,
+          declarationMap: false,
+          outDir: path.join(stagingRoot, "dist"),
+          rootDir: path.join(REPO_ROOT, "src"),
+          sourceMap: false,
+          typeRoots: [path.join(REPO_ROOT, "node_modules", "@types")],
+          types: ["node"],
+        },
+        files: [
+          path.join(REPO_ROOT, "src", "core", "learnings-budget-check.ts"),
+        ],
+        include: [],
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  return runCompiler(bunExecutable, compiler, compilerConfig);
+}
+
+/**
+ * Compile the staged checker's static dependency closure.
+ * @param bunExecutable - Validated absolute Bun executable path
+ * @param compiler - Real repository TypeScript compiler path
+ * @param compilerConfig - Temporary closure-only TypeScript configuration
+ * @returns Compiler exit status and combined output
+ */
+function runCompiler(
+  bunExecutable: string,
+  compiler: string,
+  compilerConfig: string
+): CommandResult {
   const result = spawnSync(
     bunExecutable,
-    [
-      compiler,
-      "--project",
-      path.join(REPO_ROOT, "tsconfig.json"),
-      "--outDir",
-      path.join(stagingRoot, "dist"),
-      "--declarationMap",
-      "false",
-      "--sourceMap",
-      "false",
-    ],
+    [compiler, "--project", compilerConfig],
     { cwd: REPO_ROOT, encoding: "utf8", timeout: 30_000 }
   );
   return {

--- a/tests/unit/scripts/check-learnings-budget.test.ts
+++ b/tests/unit/scripts/check-learnings-budget.test.ts
@@ -235,9 +235,20 @@ describe("check:learnings-budget", () => {
 
     const packageRoot = path.join(extracted, "package");
     expect(existsSync(path.join(packageRoot, "src"))).toBe(false);
-    expect(
-      existsSync(path.join(packageRoot, "dist", "core", "learnings.js"))
-    ).toBe(true);
+    const closureModules = [
+      "learnings-budget-check.js",
+      "learnings-contract.js",
+      "learnings-document.js",
+      "learnings-entry.js",
+    ] as const;
+    for (const moduleName of closureModules) {
+      expect(
+        existsSync(path.join(packageRoot, "dist", "core", moduleName))
+      ).toBe(true);
+    }
+    expect(existsSync(path.join(packageRoot, "dist", "core", "lisa.js"))).toBe(
+      false
+    );
     const result = spawnSync(
       BUN_EXECUTABLE,
       [
@@ -251,12 +262,7 @@ describe("check:learnings-budget", () => {
       "learnings budget passed"
     );
     expect(result.status).toBe(0);
-    // This test compiles dist, `bun pm pack`s, and tar-extracts the full
-    // published surface — its cost grows with the packaged content, and it
-    // already grants its own subprocesses 30s. Match that budget at the it()
-    // level so a normal content addition can't tip it over the 10s default.
-    // Durable decoupling from surface growth is tracked as a follow-up.
-  }, 60_000);
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary

- compile the packaged learnings-budget checker from its exact TypeScript entrypoint
- let TypeScript derive the static runtime dependency closure instead of compiling all `src/**`
- prove the real packed artifact contains the required closure and excludes unrelated `dist/core/lisa.js`
- remove PR #1873's temporary 60-second timeout now that the structural coupling is gone

## Verification

- focused spec: 13/13 pass, repeated
- full suite: 376 files, 6,601 tests pass
- coverage: 376 files, 6,601 tests pass
- typecheck and lint pass
- upstream evidence manifest and `git diff --check` pass
- rebased focused spec: 13/13 pass in 1.32 seconds under Vitest's normal timeout
- rebased pre-push: slow lint, knip, coverage (6,601 tests), and 137 integration tests pass

Work-Item: CodySwannGT/lisa#1871

Closes #1871


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded the `check:learnings-budget` npm-pack validation to confirm all expected `dist/core` modules are present.
  * Added negative assertions to ensure unintended core modules are not included in the packaged output.
  * Improved test isolation by compiling only the required learnings-budget sources using a dedicated temporary TypeScript configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->