### PR TITLE
feat(doctor): add repository-readiness mode and .lisa/readiness.json (#1855)

### DIFF
--- a/plugins/lisa-agy/scripts/doctor-report.mjs
+++ b/plugins/lisa-agy/scripts/doctor-report.mjs
@@ -119,6 +119,98 @@ export function createPluginSyncDoctorGroup(root = process.cwd()) {
 }
 
 /**
+ * The eight repository-readiness ownership dimensions, in fixed render order,
+ * defined once by the `readiness-rubric` rule. This group consumes that rubric;
+ * it does not redefine the vocabulary. Evidence gathering for each dimension is
+ * wired by later PRD #1739 tickets, so every dimension renders `SKIP` with a
+ * reason here — reported, never silently omitted, per the shipped contract.
+ * @type {readonly { id: string, question: string, skipReason: string }[]}
+ */
+const REPOSITORY_READINESS_DIMENSIONS = [
+  {
+    id: "context-routing",
+    question:
+      "Can an agent recover the real job from what is written down (integration-access-layer, wiki-knowledge-source, config-resolution)?",
+    skipReason:
+      "Context/routing evidence is assessed by the agent-ready wiring (RRR-4, #1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "capabilities-tools",
+    question:
+      "Is every tool the work needs provably reachable, not merely installed (tool-access-gate)?",
+    skipReason:
+      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "domain-ownership",
+    question:
+      "Are the business rules, glossary, and danger zones owned and written down (agent-ready domain phase wiki pages)?",
+    skipReason:
+      "Domain-ownership evidence sources from agent-ready's danger-zone wiki pages, read by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "execution-proof",
+    question:
+      "Can the claimed user-visible outcome be proved by running the system (verification, empirical-inquiry, claim-evidence-mapping)?",
+    skipReason:
+      "Execution/proof consumes qualification evidence and representative journeys wired by RRR-6 (#1858); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "feedback-guardrails",
+    question:
+      "Does a failing loop produce a named outcome and a runbook (automation-runbook-contract, observability-audit)?",
+    skipReason:
+      "Feedback/guardrails evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "dependencies-supply-chain",
+    question:
+      "Is there a confidence model for what the repo depends on (security-audit-handling)?",
+    skipReason:
+      "Dependencies/supply-chain evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "delivery-authority",
+    question:
+      "Does the thing that ships equal the thing that was validated, and does the shipping credential carry only the authority it needs (claim-archaeology, security-audit-handling)?",
+    skipReason:
+      "Delivery/authority blockers are populated by the blocker gate in RRR-5 (#1857); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "proportionality",
+    question:
+      "Is the machinery proportional to the job, or is there scaffolding to subtract (repo-scope-split, #1742 subtraction candidates)?",
+    skipReason:
+      "Proportionality reuses the scaffolding-subtraction candidates surfaced by the journey work (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+  },
+];
+
+/**
+ * Build the orthogonal "Repository readiness" doctor group ("may an agent fleet
+ * operate here unattended?"), scored against the eight `readiness-rubric`
+ * ownership dimensions. It is separate from the installation-readiness groups
+ * and is appended in a fixed position by the readiness-mode caller; the eight
+ * dimension checks render in fixed order. In this Lisa version every dimension
+ * is `SKIP` with a stated reason because the evidence-gathering surfaces ship
+ * with later PRD #1739 tickets — reported, never silently omitted.
+ * @param {string} root
+ * @returns {DoctorGroup}
+ */
+export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
+  void path.resolve(root);
+  return {
+    id: "repository-readiness",
+    title: "Repository readiness",
+    checks: REPOSITORY_READINESS_DIMENSIONS.map(dimension => ({
+      id: dimension.id,
+      status: "SKIP",
+      summary: dimension.question,
+      observed: dimension.skipReason,
+    })),
+  };
+}
+
+/**
  * @param {readonly DoctorGroup[]} groups
  * @returns {DoctorVerdict}
  */

--- a/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
@@ -298,6 +298,41 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
    - Never require a wiki plugin surface when `wiki/` is absent.
    - Never let wiki-specific checks downgrade unrelated non-wiki repositories.
 
+### Minimum repository-readiness checks
+
+The eight groups above answer one question: **is Lisa installed correctly here?** There is a second,
+orthogonal question — **may an agent fleet operate here unattended?** — and conflating them is how a
+brownfield onboarding ends in "we built a wiki, looks good" instead of a verdict someone can act on.
+`Repository readiness` is that second question, and it is opt-in behind the `--readiness` flag; the
+default doctor path never renders it and stays byte-identical.
+
+1. **Render one separately-titled group.** When readiness mode is requested, append a single
+   `Repository readiness` group (id `repository-readiness`) in a fixed position after the eight
+   installation groups, using the shared `createRepositoryReadinessDoctorGroup` helper from
+   `scripts/doctor-report.mjs`. It is distinct from the installation groups so a reader is never left
+   guessing which question a verdict answered.
+2. **Score exactly the eight ownership dimensions from `readiness-rubric`.** Report **eight** checks,
+   in fixed order, **never fewer** and never silently omit one: `context-routing`,
+   `capabilities-tools`, `domain-ownership`, `execution-proof`, `feedback-guardrails`,
+   `dependencies-supply-chain`, `delivery-authority`, `proportionality`. Cite the `readiness-rubric`
+   slug for the dimension definitions, the seven ship blockers, and the consequence-ordering
+   contract; do not restate or fork that vocabulary here.
+3. **`SKIP` carries a reason and is never blank.** A dimension with no applicable evidence renders
+   `SKIP` with a stated reason ("no deployment target configured, so delivery/authority was not
+   assessed"). An unassessed dimension is a known unknown, and the report says so. In Lisa versions
+   where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
+   with that reason.
+4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
+   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. Section order stays stable; the
+   findings **within** each dimension check order highest-consequence-first.
+5. **Persist to a versioned, relocatable artifact.** Writing the report to `.lisa/readiness.json`
+   (`schema_version: 1`, with `verdict`, `blocker_count`, and per-dimension findings) is resolved
+   through a single resolver so the location is one line to change. The write is atomic and must
+   never fail the run: a write error degrades to a `WARN` check rather than throwing.
+6. **Warn-only, always.** This gates a claim, not a process: readiness never hard-blocks and never
+   changes doctor's exit-code semantics (exit 1 iff some check is `FAIL`). Where a surface named here
+   is not installed, degrade — state what was assessed, state what was not, and continue.
+
 ### Upstream Lisa change-history diagnosis
 
 A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed

--- a/plugins/lisa-copilot/scripts/doctor-report.mjs
+++ b/plugins/lisa-copilot/scripts/doctor-report.mjs
@@ -119,6 +119,98 @@ export function createPluginSyncDoctorGroup(root = process.cwd()) {
 }
 
 /**
+ * The eight repository-readiness ownership dimensions, in fixed render order,
+ * defined once by the `readiness-rubric` rule. This group consumes that rubric;
+ * it does not redefine the vocabulary. Evidence gathering for each dimension is
+ * wired by later PRD #1739 tickets, so every dimension renders `SKIP` with a
+ * reason here — reported, never silently omitted, per the shipped contract.
+ * @type {readonly { id: string, question: string, skipReason: string }[]}
+ */
+const REPOSITORY_READINESS_DIMENSIONS = [
+  {
+    id: "context-routing",
+    question:
+      "Can an agent recover the real job from what is written down (integration-access-layer, wiki-knowledge-source, config-resolution)?",
+    skipReason:
+      "Context/routing evidence is assessed by the agent-ready wiring (RRR-4, #1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "capabilities-tools",
+    question:
+      "Is every tool the work needs provably reachable, not merely installed (tool-access-gate)?",
+    skipReason:
+      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "domain-ownership",
+    question:
+      "Are the business rules, glossary, and danger zones owned and written down (agent-ready domain phase wiki pages)?",
+    skipReason:
+      "Domain-ownership evidence sources from agent-ready's danger-zone wiki pages, read by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "execution-proof",
+    question:
+      "Can the claimed user-visible outcome be proved by running the system (verification, empirical-inquiry, claim-evidence-mapping)?",
+    skipReason:
+      "Execution/proof consumes qualification evidence and representative journeys wired by RRR-6 (#1858); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "feedback-guardrails",
+    question:
+      "Does a failing loop produce a named outcome and a runbook (automation-runbook-contract, observability-audit)?",
+    skipReason:
+      "Feedback/guardrails evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "dependencies-supply-chain",
+    question:
+      "Is there a confidence model for what the repo depends on (security-audit-handling)?",
+    skipReason:
+      "Dependencies/supply-chain evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "delivery-authority",
+    question:
+      "Does the thing that ships equal the thing that was validated, and does the shipping credential carry only the authority it needs (claim-archaeology, security-audit-handling)?",
+    skipReason:
+      "Delivery/authority blockers are populated by the blocker gate in RRR-5 (#1857); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "proportionality",
+    question:
+      "Is the machinery proportional to the job, or is there scaffolding to subtract (repo-scope-split, #1742 subtraction candidates)?",
+    skipReason:
+      "Proportionality reuses the scaffolding-subtraction candidates surfaced by the journey work (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+  },
+];
+
+/**
+ * Build the orthogonal "Repository readiness" doctor group ("may an agent fleet
+ * operate here unattended?"), scored against the eight `readiness-rubric`
+ * ownership dimensions. It is separate from the installation-readiness groups
+ * and is appended in a fixed position by the readiness-mode caller; the eight
+ * dimension checks render in fixed order. In this Lisa version every dimension
+ * is `SKIP` with a stated reason because the evidence-gathering surfaces ship
+ * with later PRD #1739 tickets — reported, never silently omitted.
+ * @param {string} root
+ * @returns {DoctorGroup}
+ */
+export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
+  void path.resolve(root);
+  return {
+    id: "repository-readiness",
+    title: "Repository readiness",
+    checks: REPOSITORY_READINESS_DIMENSIONS.map(dimension => ({
+      id: dimension.id,
+      status: "SKIP",
+      summary: dimension.question,
+      observed: dimension.skipReason,
+    })),
+  };
+}
+
+/**
  * @param {readonly DoctorGroup[]} groups
  * @returns {DoctorVerdict}
  */

--- a/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
@@ -298,6 +298,41 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
    - Never require a wiki plugin surface when `wiki/` is absent.
    - Never let wiki-specific checks downgrade unrelated non-wiki repositories.
 
+### Minimum repository-readiness checks
+
+The eight groups above answer one question: **is Lisa installed correctly here?** There is a second,
+orthogonal question — **may an agent fleet operate here unattended?** — and conflating them is how a
+brownfield onboarding ends in "we built a wiki, looks good" instead of a verdict someone can act on.
+`Repository readiness` is that second question, and it is opt-in behind the `--readiness` flag; the
+default doctor path never renders it and stays byte-identical.
+
+1. **Render one separately-titled group.** When readiness mode is requested, append a single
+   `Repository readiness` group (id `repository-readiness`) in a fixed position after the eight
+   installation groups, using the shared `createRepositoryReadinessDoctorGroup` helper from
+   `scripts/doctor-report.mjs`. It is distinct from the installation groups so a reader is never left
+   guessing which question a verdict answered.
+2. **Score exactly the eight ownership dimensions from `readiness-rubric`.** Report **eight** checks,
+   in fixed order, **never fewer** and never silently omit one: `context-routing`,
+   `capabilities-tools`, `domain-ownership`, `execution-proof`, `feedback-guardrails`,
+   `dependencies-supply-chain`, `delivery-authority`, `proportionality`. Cite the `readiness-rubric`
+   slug for the dimension definitions, the seven ship blockers, and the consequence-ordering
+   contract; do not restate or fork that vocabulary here.
+3. **`SKIP` carries a reason and is never blank.** A dimension with no applicable evidence renders
+   `SKIP` with a stated reason ("no deployment target configured, so delivery/authority was not
+   assessed"). An unassessed dimension is a known unknown, and the report says so. In Lisa versions
+   where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
+   with that reason.
+4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
+   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. Section order stays stable; the
+   findings **within** each dimension check order highest-consequence-first.
+5. **Persist to a versioned, relocatable artifact.** Writing the report to `.lisa/readiness.json`
+   (`schema_version: 1`, with `verdict`, `blocker_count`, and per-dimension findings) is resolved
+   through a single resolver so the location is one line to change. The write is atomic and must
+   never fail the run: a write error degrades to a `WARN` check rather than throwing.
+6. **Warn-only, always.** This gates a claim, not a process: readiness never hard-blocks and never
+   changes doctor's exit-code semantics (exit 1 iff some check is `FAIL`). Where a surface named here
+   is not installed, degrade — state what was assessed, state what was not, and continue.
+
 ### Upstream Lisa change-history diagnosis
 
 A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed

--- a/plugins/lisa-cursor/scripts/doctor-report.mjs
+++ b/plugins/lisa-cursor/scripts/doctor-report.mjs
@@ -119,6 +119,98 @@ export function createPluginSyncDoctorGroup(root = process.cwd()) {
 }
 
 /**
+ * The eight repository-readiness ownership dimensions, in fixed render order,
+ * defined once by the `readiness-rubric` rule. This group consumes that rubric;
+ * it does not redefine the vocabulary. Evidence gathering for each dimension is
+ * wired by later PRD #1739 tickets, so every dimension renders `SKIP` with a
+ * reason here — reported, never silently omitted, per the shipped contract.
+ * @type {readonly { id: string, question: string, skipReason: string }[]}
+ */
+const REPOSITORY_READINESS_DIMENSIONS = [
+  {
+    id: "context-routing",
+    question:
+      "Can an agent recover the real job from what is written down (integration-access-layer, wiki-knowledge-source, config-resolution)?",
+    skipReason:
+      "Context/routing evidence is assessed by the agent-ready wiring (RRR-4, #1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "capabilities-tools",
+    question:
+      "Is every tool the work needs provably reachable, not merely installed (tool-access-gate)?",
+    skipReason:
+      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "domain-ownership",
+    question:
+      "Are the business rules, glossary, and danger zones owned and written down (agent-ready domain phase wiki pages)?",
+    skipReason:
+      "Domain-ownership evidence sources from agent-ready's danger-zone wiki pages, read by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "execution-proof",
+    question:
+      "Can the claimed user-visible outcome be proved by running the system (verification, empirical-inquiry, claim-evidence-mapping)?",
+    skipReason:
+      "Execution/proof consumes qualification evidence and representative journeys wired by RRR-6 (#1858); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "feedback-guardrails",
+    question:
+      "Does a failing loop produce a named outcome and a runbook (automation-runbook-contract, observability-audit)?",
+    skipReason:
+      "Feedback/guardrails evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "dependencies-supply-chain",
+    question:
+      "Is there a confidence model for what the repo depends on (security-audit-handling)?",
+    skipReason:
+      "Dependencies/supply-chain evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "delivery-authority",
+    question:
+      "Does the thing that ships equal the thing that was validated, and does the shipping credential carry only the authority it needs (claim-archaeology, security-audit-handling)?",
+    skipReason:
+      "Delivery/authority blockers are populated by the blocker gate in RRR-5 (#1857); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "proportionality",
+    question:
+      "Is the machinery proportional to the job, or is there scaffolding to subtract (repo-scope-split, #1742 subtraction candidates)?",
+    skipReason:
+      "Proportionality reuses the scaffolding-subtraction candidates surfaced by the journey work (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+  },
+];
+
+/**
+ * Build the orthogonal "Repository readiness" doctor group ("may an agent fleet
+ * operate here unattended?"), scored against the eight `readiness-rubric`
+ * ownership dimensions. It is separate from the installation-readiness groups
+ * and is appended in a fixed position by the readiness-mode caller; the eight
+ * dimension checks render in fixed order. In this Lisa version every dimension
+ * is `SKIP` with a stated reason because the evidence-gathering surfaces ship
+ * with later PRD #1739 tickets — reported, never silently omitted.
+ * @param {string} root
+ * @returns {DoctorGroup}
+ */
+export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
+  void path.resolve(root);
+  return {
+    id: "repository-readiness",
+    title: "Repository readiness",
+    checks: REPOSITORY_READINESS_DIMENSIONS.map(dimension => ({
+      id: dimension.id,
+      status: "SKIP",
+      summary: dimension.question,
+      observed: dimension.skipReason,
+    })),
+  };
+}
+
+/**
  * @param {readonly DoctorGroup[]} groups
  * @returns {DoctorVerdict}
  */

--- a/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
@@ -298,6 +298,41 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
    - Never require a wiki plugin surface when `wiki/` is absent.
    - Never let wiki-specific checks downgrade unrelated non-wiki repositories.
 
+### Minimum repository-readiness checks
+
+The eight groups above answer one question: **is Lisa installed correctly here?** There is a second,
+orthogonal question — **may an agent fleet operate here unattended?** — and conflating them is how a
+brownfield onboarding ends in "we built a wiki, looks good" instead of a verdict someone can act on.
+`Repository readiness` is that second question, and it is opt-in behind the `--readiness` flag; the
+default doctor path never renders it and stays byte-identical.
+
+1. **Render one separately-titled group.** When readiness mode is requested, append a single
+   `Repository readiness` group (id `repository-readiness`) in a fixed position after the eight
+   installation groups, using the shared `createRepositoryReadinessDoctorGroup` helper from
+   `scripts/doctor-report.mjs`. It is distinct from the installation groups so a reader is never left
+   guessing which question a verdict answered.
+2. **Score exactly the eight ownership dimensions from `readiness-rubric`.** Report **eight** checks,
+   in fixed order, **never fewer** and never silently omit one: `context-routing`,
+   `capabilities-tools`, `domain-ownership`, `execution-proof`, `feedback-guardrails`,
+   `dependencies-supply-chain`, `delivery-authority`, `proportionality`. Cite the `readiness-rubric`
+   slug for the dimension definitions, the seven ship blockers, and the consequence-ordering
+   contract; do not restate or fork that vocabulary here.
+3. **`SKIP` carries a reason and is never blank.** A dimension with no applicable evidence renders
+   `SKIP` with a stated reason ("no deployment target configured, so delivery/authority was not
+   assessed"). An unassessed dimension is a known unknown, and the report says so. In Lisa versions
+   where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
+   with that reason.
+4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
+   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. Section order stays stable; the
+   findings **within** each dimension check order highest-consequence-first.
+5. **Persist to a versioned, relocatable artifact.** Writing the report to `.lisa/readiness.json`
+   (`schema_version: 1`, with `verdict`, `blocker_count`, and per-dimension findings) is resolved
+   through a single resolver so the location is one line to change. The write is atomic and must
+   never fail the run: a write error degrades to a `WARN` check rather than throwing.
+6. **Warn-only, always.** This gates a claim, not a process: readiness never hard-blocks and never
+   changes doctor's exit-code semantics (exit 1 iff some check is `FAIL`). Where a surface named here
+   is not installed, degrade — state what was assessed, state what was not, and continue.
+
 ### Upstream Lisa change-history diagnosis
 
 A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed

--- a/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
@@ -298,6 +298,41 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
    - Never require a wiki plugin surface when `wiki/` is absent.
    - Never let wiki-specific checks downgrade unrelated non-wiki repositories.
 
+### Minimum repository-readiness checks
+
+The eight groups above answer one question: **is Lisa installed correctly here?** There is a second,
+orthogonal question — **may an agent fleet operate here unattended?** — and conflating them is how a
+brownfield onboarding ends in "we built a wiki, looks good" instead of a verdict someone can act on.
+`Repository readiness` is that second question, and it is opt-in behind the `--readiness` flag; the
+default doctor path never renders it and stays byte-identical.
+
+1. **Render one separately-titled group.** When readiness mode is requested, append a single
+   `Repository readiness` group (id `repository-readiness`) in a fixed position after the eight
+   installation groups, using the shared `createRepositoryReadinessDoctorGroup` helper from
+   `scripts/doctor-report.mjs`. It is distinct from the installation groups so a reader is never left
+   guessing which question a verdict answered.
+2. **Score exactly the eight ownership dimensions from `readiness-rubric`.** Report **eight** checks,
+   in fixed order, **never fewer** and never silently omit one: `context-routing`,
+   `capabilities-tools`, `domain-ownership`, `execution-proof`, `feedback-guardrails`,
+   `dependencies-supply-chain`, `delivery-authority`, `proportionality`. Cite the `readiness-rubric`
+   slug for the dimension definitions, the seven ship blockers, and the consequence-ordering
+   contract; do not restate or fork that vocabulary here.
+3. **`SKIP` carries a reason and is never blank.** A dimension with no applicable evidence renders
+   `SKIP` with a stated reason ("no deployment target configured, so delivery/authority was not
+   assessed"). An unassessed dimension is a known unknown, and the report says so. In Lisa versions
+   where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
+   with that reason.
+4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
+   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. Section order stays stable; the
+   findings **within** each dimension check order highest-consequence-first.
+5. **Persist to a versioned, relocatable artifact.** Writing the report to `.lisa/readiness.json`
+   (`schema_version: 1`, with `verdict`, `blocker_count`, and per-dimension findings) is resolved
+   through a single resolver so the location is one line to change. The write is atomic and must
+   never fail the run: a write error degrades to a `WARN` check rather than throwing.
+6. **Warn-only, always.** This gates a claim, not a process: readiness never hard-blocks and never
+   changes doctor's exit-code semantics (exit 1 iff some check is `FAIL`). Where a surface named here
+   is not installed, degrade — state what was assessed, state what was not, and continue.
+
 ### Upstream Lisa change-history diagnosis
 
 A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed

--- a/plugins/lisa/scripts/doctor-report.mjs
+++ b/plugins/lisa/scripts/doctor-report.mjs
@@ -119,6 +119,98 @@ export function createPluginSyncDoctorGroup(root = process.cwd()) {
 }
 
 /**
+ * The eight repository-readiness ownership dimensions, in fixed render order,
+ * defined once by the `readiness-rubric` rule. This group consumes that rubric;
+ * it does not redefine the vocabulary. Evidence gathering for each dimension is
+ * wired by later PRD #1739 tickets, so every dimension renders `SKIP` with a
+ * reason here — reported, never silently omitted, per the shipped contract.
+ * @type {readonly { id: string, question: string, skipReason: string }[]}
+ */
+const REPOSITORY_READINESS_DIMENSIONS = [
+  {
+    id: "context-routing",
+    question:
+      "Can an agent recover the real job from what is written down (integration-access-layer, wiki-knowledge-source, config-resolution)?",
+    skipReason:
+      "Context/routing evidence is assessed by the agent-ready wiring (RRR-4, #1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "capabilities-tools",
+    question:
+      "Is every tool the work needs provably reachable, not merely installed (tool-access-gate)?",
+    skipReason:
+      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "domain-ownership",
+    question:
+      "Are the business rules, glossary, and danger zones owned and written down (agent-ready domain phase wiki pages)?",
+    skipReason:
+      "Domain-ownership evidence sources from agent-ready's danger-zone wiki pages, read by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "execution-proof",
+    question:
+      "Can the claimed user-visible outcome be proved by running the system (verification, empirical-inquiry, claim-evidence-mapping)?",
+    skipReason:
+      "Execution/proof consumes qualification evidence and representative journeys wired by RRR-6 (#1858); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "feedback-guardrails",
+    question:
+      "Does a failing loop produce a named outcome and a runbook (automation-runbook-contract, observability-audit)?",
+    skipReason:
+      "Feedback/guardrails evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "dependencies-supply-chain",
+    question:
+      "Is there a confidence model for what the repo depends on (security-audit-handling)?",
+    skipReason:
+      "Dependencies/supply-chain evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "delivery-authority",
+    question:
+      "Does the thing that ships equal the thing that was validated, and does the shipping credential carry only the authority it needs (claim-archaeology, security-audit-handling)?",
+    skipReason:
+      "Delivery/authority blockers are populated by the blocker gate in RRR-5 (#1857); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "proportionality",
+    question:
+      "Is the machinery proportional to the job, or is there scaffolding to subtract (repo-scope-split, #1742 subtraction candidates)?",
+    skipReason:
+      "Proportionality reuses the scaffolding-subtraction candidates surfaced by the journey work (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+  },
+];
+
+/**
+ * Build the orthogonal "Repository readiness" doctor group ("may an agent fleet
+ * operate here unattended?"), scored against the eight `readiness-rubric`
+ * ownership dimensions. It is separate from the installation-readiness groups
+ * and is appended in a fixed position by the readiness-mode caller; the eight
+ * dimension checks render in fixed order. In this Lisa version every dimension
+ * is `SKIP` with a stated reason because the evidence-gathering surfaces ship
+ * with later PRD #1739 tickets — reported, never silently omitted.
+ * @param {string} root
+ * @returns {DoctorGroup}
+ */
+export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
+  void path.resolve(root);
+  return {
+    id: "repository-readiness",
+    title: "Repository readiness",
+    checks: REPOSITORY_READINESS_DIMENSIONS.map(dimension => ({
+      id: dimension.id,
+      status: "SKIP",
+      summary: dimension.question,
+      observed: dimension.skipReason,
+    })),
+  };
+}
+
+/**
  * @param {readonly DoctorGroup[]} groups
  * @returns {DoctorVerdict}
  */

--- a/plugins/lisa/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/skills/lisa-doctor/SKILL.md
@@ -298,6 +298,41 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
    - Never require a wiki plugin surface when `wiki/` is absent.
    - Never let wiki-specific checks downgrade unrelated non-wiki repositories.
 
+### Minimum repository-readiness checks
+
+The eight groups above answer one question: **is Lisa installed correctly here?** There is a second,
+orthogonal question — **may an agent fleet operate here unattended?** — and conflating them is how a
+brownfield onboarding ends in "we built a wiki, looks good" instead of a verdict someone can act on.
+`Repository readiness` is that second question, and it is opt-in behind the `--readiness` flag; the
+default doctor path never renders it and stays byte-identical.
+
+1. **Render one separately-titled group.** When readiness mode is requested, append a single
+   `Repository readiness` group (id `repository-readiness`) in a fixed position after the eight
+   installation groups, using the shared `createRepositoryReadinessDoctorGroup` helper from
+   `scripts/doctor-report.mjs`. It is distinct from the installation groups so a reader is never left
+   guessing which question a verdict answered.
+2. **Score exactly the eight ownership dimensions from `readiness-rubric`.** Report **eight** checks,
+   in fixed order, **never fewer** and never silently omit one: `context-routing`,
+   `capabilities-tools`, `domain-ownership`, `execution-proof`, `feedback-guardrails`,
+   `dependencies-supply-chain`, `delivery-authority`, `proportionality`. Cite the `readiness-rubric`
+   slug for the dimension definitions, the seven ship blockers, and the consequence-ordering
+   contract; do not restate or fork that vocabulary here.
+3. **`SKIP` carries a reason and is never blank.** A dimension with no applicable evidence renders
+   `SKIP` with a stated reason ("no deployment target configured, so delivery/authority was not
+   assessed"). An unassessed dimension is a known unknown, and the report says so. In Lisa versions
+   where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
+   with that reason.
+4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
+   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. Section order stays stable; the
+   findings **within** each dimension check order highest-consequence-first.
+5. **Persist to a versioned, relocatable artifact.** Writing the report to `.lisa/readiness.json`
+   (`schema_version: 1`, with `verdict`, `blocker_count`, and per-dimension findings) is resolved
+   through a single resolver so the location is one line to change. The write is atomic and must
+   never fail the run: a write error degrades to a `WARN` check rather than throwing.
+6. **Warn-only, always.** This gates a claim, not a process: readiness never hard-blocks and never
+   changes doctor's exit-code semantics (exit 1 iff some check is `FAIL`). Where a surface named here
+   is not installed, degrade — state what was assessed, state what was not, and continue.
+
 ### Upstream Lisa change-history diagnosis
 
 A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed

--- a/plugins/src/base/scripts/doctor-report.mjs
+++ b/plugins/src/base/scripts/doctor-report.mjs
@@ -119,6 +119,98 @@ export function createPluginSyncDoctorGroup(root = process.cwd()) {
 }
 
 /**
+ * The eight repository-readiness ownership dimensions, in fixed render order,
+ * defined once by the `readiness-rubric` rule. This group consumes that rubric;
+ * it does not redefine the vocabulary. Evidence gathering for each dimension is
+ * wired by later PRD #1739 tickets, so every dimension renders `SKIP` with a
+ * reason here — reported, never silently omitted, per the shipped contract.
+ * @type {readonly { id: string, question: string, skipReason: string }[]}
+ */
+const REPOSITORY_READINESS_DIMENSIONS = [
+  {
+    id: "context-routing",
+    question:
+      "Can an agent recover the real job from what is written down (integration-access-layer, wiki-knowledge-source, config-resolution)?",
+    skipReason:
+      "Context/routing evidence is assessed by the agent-ready wiring (RRR-4, #1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "capabilities-tools",
+    question:
+      "Is every tool the work needs provably reachable, not merely installed (tool-access-gate)?",
+    skipReason:
+      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "domain-ownership",
+    question:
+      "Are the business rules, glossary, and danger zones owned and written down (agent-ready domain phase wiki pages)?",
+    skipReason:
+      "Domain-ownership evidence sources from agent-ready's danger-zone wiki pages, read by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "execution-proof",
+    question:
+      "Can the claimed user-visible outcome be proved by running the system (verification, empirical-inquiry, claim-evidence-mapping)?",
+    skipReason:
+      "Execution/proof consumes qualification evidence and representative journeys wired by RRR-6 (#1858); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "feedback-guardrails",
+    question:
+      "Does a failing loop produce a named outcome and a runbook (automation-runbook-contract, observability-audit)?",
+    skipReason:
+      "Feedback/guardrails evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "dependencies-supply-chain",
+    question:
+      "Is there a confidence model for what the repo depends on (security-audit-handling)?",
+    skipReason:
+      "Dependencies/supply-chain evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "delivery-authority",
+    question:
+      "Does the thing that ships equal the thing that was validated, and does the shipping credential carry only the authority it needs (claim-archaeology, security-audit-handling)?",
+    skipReason:
+      "Delivery/authority blockers are populated by the blocker gate in RRR-5 (#1857); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "proportionality",
+    question:
+      "Is the machinery proportional to the job, or is there scaffolding to subtract (repo-scope-split, #1742 subtraction candidates)?",
+    skipReason:
+      "Proportionality reuses the scaffolding-subtraction candidates surfaced by the journey work (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+  },
+];
+
+/**
+ * Build the orthogonal "Repository readiness" doctor group ("may an agent fleet
+ * operate here unattended?"), scored against the eight `readiness-rubric`
+ * ownership dimensions. It is separate from the installation-readiness groups
+ * and is appended in a fixed position by the readiness-mode caller; the eight
+ * dimension checks render in fixed order. In this Lisa version every dimension
+ * is `SKIP` with a stated reason because the evidence-gathering surfaces ship
+ * with later PRD #1739 tickets — reported, never silently omitted.
+ * @param {string} root
+ * @returns {DoctorGroup}
+ */
+export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
+  void path.resolve(root);
+  return {
+    id: "repository-readiness",
+    title: "Repository readiness",
+    checks: REPOSITORY_READINESS_DIMENSIONS.map(dimension => ({
+      id: dimension.id,
+      status: "SKIP",
+      summary: dimension.question,
+      observed: dimension.skipReason,
+    })),
+  };
+}
+
+/**
  * @param {readonly DoctorGroup[]} groups
  * @returns {DoctorVerdict}
  */

--- a/plugins/src/base/skills/lisa-doctor/SKILL.md
+++ b/plugins/src/base/skills/lisa-doctor/SKILL.md
@@ -298,6 +298,41 @@ without turning the base doctor into a second `lisa-wiki-doctor`.
    - Never require a wiki plugin surface when `wiki/` is absent.
    - Never let wiki-specific checks downgrade unrelated non-wiki repositories.
 
+### Minimum repository-readiness checks
+
+The eight groups above answer one question: **is Lisa installed correctly here?** There is a second,
+orthogonal question — **may an agent fleet operate here unattended?** — and conflating them is how a
+brownfield onboarding ends in "we built a wiki, looks good" instead of a verdict someone can act on.
+`Repository readiness` is that second question, and it is opt-in behind the `--readiness` flag; the
+default doctor path never renders it and stays byte-identical.
+
+1. **Render one separately-titled group.** When readiness mode is requested, append a single
+   `Repository readiness` group (id `repository-readiness`) in a fixed position after the eight
+   installation groups, using the shared `createRepositoryReadinessDoctorGroup` helper from
+   `scripts/doctor-report.mjs`. It is distinct from the installation groups so a reader is never left
+   guessing which question a verdict answered.
+2. **Score exactly the eight ownership dimensions from `readiness-rubric`.** Report **eight** checks,
+   in fixed order, **never fewer** and never silently omit one: `context-routing`,
+   `capabilities-tools`, `domain-ownership`, `execution-proof`, `feedback-guardrails`,
+   `dependencies-supply-chain`, `delivery-authority`, `proportionality`. Cite the `readiness-rubric`
+   slug for the dimension definitions, the seven ship blockers, and the consequence-ordering
+   contract; do not restate or fork that vocabulary here.
+3. **`SKIP` carries a reason and is never blank.** A dimension with no applicable evidence renders
+   `SKIP` with a stated reason ("no deployment target configured, so delivery/authority was not
+   assessed"). An unassessed dimension is a known unknown, and the report says so. In Lisa versions
+   where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
+   with that reason.
+4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
+   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. Section order stays stable; the
+   findings **within** each dimension check order highest-consequence-first.
+5. **Persist to a versioned, relocatable artifact.** Writing the report to `.lisa/readiness.json`
+   (`schema_version: 1`, with `verdict`, `blocker_count`, and per-dimension findings) is resolved
+   through a single resolver so the location is one line to change. The write is atomic and must
+   never fail the run: a write error degrades to a `WARN` check rather than throwing.
+6. **Warn-only, always.** This gates a claim, not a process: readiness never hard-blocks and never
+   changes doctor's exit-code semantics (exit 1 iff some check is `FAIL`). Where a surface named here
+   is not installed, degrade — state what was assessed, state what was not, and continue.
+
 ### Upstream Lisa change-history diagnosis
 
 A failing or warning check has two possible causes: the project drifted, or **Lisa itself changed

--- a/src/cli/doctor-legacy-overlay.ts
+++ b/src/cli/doctor-legacy-overlay.ts
@@ -1,0 +1,60 @@
+import { existsSync } from "node:fs";
+import * as path from "node:path";
+import {
+  LISA_HOOKS_SUBDIR,
+  LISA_RULES_SUBDIR,
+} from "../codex/hooks-installer.js";
+import { LISA_SKILLS_SUBDIR } from "../codex/skills-installer.js";
+import type { DoctorCheck } from "./doctor.js";
+
+const LEGACY_CODEX_OVERLAY_CHECK_NAME = "Codex overlay current?";
+
+/**
+ * Detect the retired pre-2.198 project-level Codex overlay. Lisa now delivers
+ * Codex hooks and skills through the repository plugin marketplace
+ * (`.agents/plugins/marketplace.json` → `node_modules`), and postinstall
+ * applies deliberately skip agent emits — so a committed legacy overlay is
+ * never cleaned up automatically. Fresh clones/worktrees then load stale
+ * hooks/skills from it, and a later explicit apply retires them out from
+ * under whatever session is running (exit-127 hooks, vanished skills — the
+ * incident behind CodySwannGT/lisa#1632).
+ * @param targetPath - Project path to inspect
+ * @returns Doctor check result
+ */
+export function checkLegacyCodexOverlay(targetPath: string): DoctorCheck {
+  const codexDir = path.join(targetPath, ".codex");
+  if (!existsSync(codexDir)) {
+    return {
+      name: LEGACY_CODEX_OVERLAY_CHECK_NAME,
+      status: "ok",
+      detail: "No .codex directory present",
+    };
+  }
+
+  const legacyPaths = [
+    LISA_HOOKS_SUBDIR,
+    LISA_RULES_SUBDIR,
+    LISA_SKILLS_SUBDIR,
+  ].filter(subdir => existsSync(path.join(codexDir, subdir)));
+
+  if (legacyPaths.length === 0) {
+    return {
+      name: LEGACY_CODEX_OVERLAY_CHECK_NAME,
+      status: "ok",
+      detail: "No legacy project-level Codex overlay present",
+    };
+  }
+
+  const listed = legacyPaths
+    .map(subdir => path.join(".codex", subdir))
+    .join(", ");
+  return {
+    name: LEGACY_CODEX_OVERLAY_CHECK_NAME,
+    status: "warn",
+    detail:
+      `Legacy pre-2.198 Codex overlay present (${listed}). ` +
+      "Run `lisa apply` in the primary checkout and commit the removals — " +
+      "fresh clones/worktrees otherwise load stale hooks/skills that a later " +
+      "apply deletes mid-session (CodySwannGT/lisa#1632)",
+  };
+}

--- a/src/cli/doctor-readiness.ts
+++ b/src/cli/doctor-readiness.ts
@@ -1,0 +1,263 @@
+import { rename, writeFile } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
+import * as path from "node:path";
+import process from "node:process";
+import type { DoctorCheck } from "./doctor.js";
+import { getPackageVersion } from "./version.js";
+
+/** Doctor check name for the repository-readiness collector. */
+const REPOSITORY_READINESS_CHECK_NAME = "Repository readiness";
+
+/** Repo-relative display path for the persisted readiness report. */
+const READINESS_REPORT_DISPLAY_PATH = path.join(".lisa", "readiness.json");
+
+/**
+ * Schema version stamped into `.lisa/readiness.json`. Bump only alongside a
+ * deliberate shape change; readers key off this to stay forward-compatible.
+ */
+export const READINESS_SCHEMA_VERSION = 1;
+
+/** Verdict ladder reused from the shipped doctor surface (readiness-rubric). */
+type ReadinessVerdict = "READY" | "READY_WITH_WARNINGS" | "NOT_READY";
+
+/** Per-dimension status, mirroring the shared doctor `DOCTOR_STATUSES`. */
+type ReadinessStatus = "PASS" | "WARN" | "FAIL" | "SKIP";
+
+/** One readiness dimension descriptor. */
+interface ReadinessDimensionSpec {
+  readonly id: string;
+  readonly question: string;
+  readonly skipReason: string;
+}
+
+/**
+ * The eight ownership dimensions, in fixed render order, defined once by the
+ * `readiness-rubric` rule (RRR-1, #1853). This collector consumes that rubric —
+ * it does not redefine the vocabulary. Evidence gathering for each dimension is
+ * wired by later PRD #1739 tickets (RRR-4/5/6); until then every dimension
+ * renders `SKIP` with a reason, per the shipped never-silently-omit contract.
+ */
+const READINESS_DIMENSIONS: readonly ReadinessDimensionSpec[] = [
+  {
+    id: "context-routing",
+    question:
+      "Can an agent recover the real job from what is written down (integration-access-layer, wiki-knowledge-source, config-resolution)?",
+    skipReason:
+      "Context/routing evidence is assessed by the agent-ready wiring (RRR-4, #1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "capabilities-tools",
+    question:
+      "Is every tool the work needs provably reachable, not merely installed (tool-access-gate)?",
+    skipReason:
+      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "domain-ownership",
+    question:
+      "Are the business rules, glossary, and danger zones owned and written down (agent-ready domain phase wiki pages)?",
+    skipReason:
+      "Domain-ownership evidence sources from agent-ready's danger-zone wiki pages, read by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "execution-proof",
+    question:
+      "Can the claimed user-visible outcome be proved by running the system (verification, empirical-inquiry, claim-evidence-mapping)?",
+    skipReason:
+      "Execution/proof consumes qualification evidence and representative journeys wired by RRR-6 (#1858); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "feedback-guardrails",
+    question:
+      "Does a failing loop produce a named outcome and a runbook (automation-runbook-contract, observability-audit)?",
+    skipReason:
+      "Feedback/guardrails evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "dependencies-supply-chain",
+    question:
+      "Is there a confidence model for what the repo depends on (security-audit-handling)?",
+    skipReason:
+      "Dependencies/supply-chain evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "delivery-authority",
+    question:
+      "Does the thing that ships equal the thing that was validated, and does the shipping credential carry only the authority it needs (claim-archaeology, security-audit-handling)?",
+    skipReason:
+      "Delivery/authority blockers are populated by the blocker gate in RRR-5 (#1857); no readiness probe is wired in this Lisa version.",
+  },
+  {
+    id: "proportionality",
+    question:
+      "Is the machinery proportional to the job, or is there scaffolding to subtract (repo-scope-split, #1742 subtraction candidates)?",
+    skipReason:
+      "Proportionality reuses the scaffolding-subtraction candidates surfaced by the journey work (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+  },
+];
+
+/** The eight ownership dimension ids, in fixed render order. */
+export const READINESS_DIMENSION_IDS: readonly string[] =
+  READINESS_DIMENSIONS.map(dimension => dimension.id);
+
+/** A persisted per-dimension record inside `.lisa/readiness.json`. */
+interface ReadinessDimensionRecord {
+  readonly id: string;
+  readonly status: ReadinessStatus;
+  readonly findings: readonly unknown[];
+}
+
+/** The persisted `.lisa/readiness.json` shape (schema_version 1). */
+interface ReadinessReport {
+  readonly schema_version: number;
+  readonly generated_at: string;
+  readonly lisa_version: string;
+  readonly worker_signature: string;
+  readonly verdict: ReadinessVerdict;
+  readonly narrowed_claim: null;
+  readonly blockers: readonly unknown[];
+  readonly blocker_count: number;
+  readonly dimensions: readonly ReadinessDimensionRecord[];
+}
+
+/**
+ * Resolve the single location every reader and writer uses for the persisted
+ * readiness report. Centralizing the path here is intake decision O2's
+ * mitigation: relocating the artifact (for example to
+ * `wiki/state/agent-ready/readiness.json`) is a one-line change with no other
+ * caller to update.
+ * @param root - Project root to resolve the report under
+ * @returns Absolute path to `.lisa/readiness.json`
+ */
+export function resolveReadinessReportPath(root: string): string {
+  return path.join(root, ".lisa", "readiness.json");
+}
+
+/**
+ * Assess repository readiness and persist the report to `.lisa/readiness.json`.
+ *
+ * This is the flag-gated collector `runDoctor` appends only when
+ * `options.readiness` is true, so the default doctor path stays byte-identical.
+ * It is warn-only per intake decision O1: it never returns `fail` and never
+ * changes doctor's exit-code semantics. Every dimension is reported (never
+ * silently omitted); in this Lisa version each renders `SKIP` with a reason
+ * because the evidence-gathering surfaces ship with later PRD #1739 tickets.
+ * Persistence is atomic and never throws — a write error degrades the check to
+ * `warn` instead of aborting the run.
+ * @param targetPath - Project path to assess and persist under
+ * @returns Doctor check result
+ */
+export async function checkRepositoryReadiness(
+  targetPath: string
+): Promise<DoctorCheck> {
+  const dimensions: readonly ReadinessDimensionRecord[] =
+    READINESS_DIMENSIONS.map(dimension => ({
+      id: dimension.id,
+      status: "SKIP",
+      findings: [],
+    }));
+  const verdict = computeReadinessVerdict(dimensions);
+  const report: ReadinessReport = {
+    schema_version: READINESS_SCHEMA_VERSION,
+    generated_at: new Date().toISOString(),
+    lisa_version: resolveLisaVersion(),
+    worker_signature: currentWorkerSignature(),
+    verdict,
+    narrowed_claim: null,
+    blockers: [],
+    blocker_count: 0,
+    dimensions,
+  };
+
+  const reportPath = resolveReadinessReportPath(targetPath);
+  try {
+    await persistReadinessReport(reportPath, report);
+  } catch (error) {
+    return {
+      name: REPOSITORY_READINESS_CHECK_NAME,
+      status: "warn",
+      detail:
+        `Repository readiness assessed: ${verdict} (8 dimensions, all SKIP pending ` +
+        `evidence wiring). Could not persist ${READINESS_REPORT_DISPLAY_PATH}: ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  return {
+    name: REPOSITORY_READINESS_CHECK_NAME,
+    status: verdict === "READY" ? "ok" : "warn",
+    detail:
+      `Repository readiness assessed: ${verdict} across 8 ownership dimensions ` +
+      `(all SKIP pending evidence wiring in later PRD #1739 tickets; see readiness-rubric). ` +
+      `Report written to ${READINESS_REPORT_DISPLAY_PATH} (schema_version ${READINESS_SCHEMA_VERSION}).`,
+  };
+}
+
+/**
+ * Reduce per-dimension statuses to the shipped verdict ladder. FAIL wins over
+ * WARN, WARN over the rest; a report of only PASS/SKIP is READY.
+ * @param dimensions - Per-dimension records
+ * @returns Overall verdict
+ */
+function computeReadinessVerdict(
+  dimensions: readonly ReadinessDimensionRecord[]
+): ReadinessVerdict {
+  if (dimensions.some(dimension => dimension.status === "FAIL")) {
+    return "NOT_READY";
+  }
+  if (dimensions.some(dimension => dimension.status === "WARN")) {
+    return "READY_WITH_WARNINGS";
+  }
+  return "READY";
+}
+
+/**
+ * Atomically write the readiness report: write a sibling temp file, then rename
+ * it into place so a reader never observes a partial document.
+ * @param reportPath - Destination path
+ * @param report - Report to persist
+ */
+async function persistReadinessReport(
+  reportPath: string,
+  report: ReadinessReport
+): Promise<void> {
+  await mkdir(path.dirname(reportPath), { recursive: true });
+  const tempPath = `${reportPath}.tmp`;
+  await writeFile(tempPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  await rename(tempPath, reportPath);
+}
+
+/**
+ * Resolve Lisa's package version for the persisted stamp, degrading to
+ * `"unknown"` rather than throwing when package metadata cannot be read.
+ * @returns Lisa version string
+ */
+function resolveLisaVersion(): string {
+  try {
+    return getPackageVersion();
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Build the current runtime worker signature the readiness stamp records. This
+ * mirrors the worker-epoch host/model/version identity so #1740 can reuse the
+ * same stamp (sibling-boundary decision).
+ * @returns `host/model/version` signature string
+ */
+function currentWorkerSignature(): string {
+  const env = process["env"];
+  const host = (
+    env.LISA_WORKER_HOST ??
+    env.LISA_REMOTE_AGENT ??
+    (env.CODEX_HOME || env.CODEX_SANDBOX
+      ? "codex"
+      : env.CLAUDECODE
+        ? "claude"
+        : "unknown")
+  ).toLowerCase();
+  const model = env.LISA_WORKER_MODEL ?? env.CODEX_MODEL ?? "unknown";
+  const version = env.LISA_WORKER_VERSION ?? env.CODEX_VERSION ?? "unknown";
+  return `${host}/${model}/${version}`;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,18 +1,15 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import * as path from "node:path";
-import {
-  LISA_HOOKS_SUBDIR,
-  LISA_RULES_SUBDIR,
-} from "../codex/hooks-installer.js";
-import { LISA_SKILLS_SUBDIR } from "../codex/skills-installer.js";
 import { AGENTS_MD_FILENAME } from "../codex/agents-md-installer.js";
 import { CLAUDE_MD_FILENAME } from "../claude/claude-md-installer.js";
 import { migrateInstructionFiles } from "../core/instruction-files-migration.js";
 import { probeKaneReadiness } from "../core/kane-cli.js";
 import { createDetectorRegistry } from "../detection/index.js";
 import { checkKaneProvider } from "./doctor-kane.js";
+import { checkLegacyCodexOverlay } from "./doctor-legacy-overlay.js";
 import { checkLegacyMonitorThresholds } from "./doctor-monitor-thresholds.js";
+import { checkRepositoryReadiness } from "./doctor-readiness.js";
 import { checkWorkerEpoch } from "./doctor-worker-epoch.js";
 import { STARTERS } from "./starters.js";
 import { runUpdateCheck } from "./update-check.js";
@@ -41,6 +38,12 @@ export interface DoctorResult {
 export interface DoctorOptions {
   json?: boolean;
   offline?: boolean;
+  /**
+   * Add the orthogonal "Repository readiness" audit ("may an agent fleet
+   * operate here unattended?") and persist `.lisa/readiness.json`. Additive and
+   * warn-only: the default doctor path is byte-identical when this is unset.
+   */
+  readiness?: boolean;
 }
 
 /** Runtime collaborators for doctor. */
@@ -248,58 +251,6 @@ function checkWiki(targetPath: string): DoctorCheck {
   };
 }
 
-const LEGACY_CODEX_OVERLAY_CHECK_NAME = "Codex overlay current?";
-
-/**
- * Detect the retired pre-2.198 project-level Codex overlay. Lisa now delivers
- * Codex hooks and skills through the repository plugin marketplace
- * (`.agents/plugins/marketplace.json` → `node_modules`), and postinstall
- * applies deliberately skip agent emits — so a committed legacy overlay is
- * never cleaned up automatically. Fresh clones/worktrees then load stale
- * hooks/skills from it, and a later explicit apply retires them out from
- * under whatever session is running (exit-127 hooks, vanished skills — the
- * incident behind CodySwannGT/lisa#1632).
- * @param targetPath - Project path to inspect
- * @returns Doctor check result
- */
-function checkLegacyCodexOverlay(targetPath: string): DoctorCheck {
-  const codexDir = path.join(targetPath, ".codex");
-  if (!existsSync(codexDir)) {
-    return {
-      name: LEGACY_CODEX_OVERLAY_CHECK_NAME,
-      status: "ok",
-      detail: "No .codex directory present",
-    };
-  }
-
-  const legacyPaths = [
-    LISA_HOOKS_SUBDIR,
-    LISA_RULES_SUBDIR,
-    LISA_SKILLS_SUBDIR,
-  ].filter(subdir => existsSync(path.join(codexDir, subdir)));
-
-  if (legacyPaths.length === 0) {
-    return {
-      name: LEGACY_CODEX_OVERLAY_CHECK_NAME,
-      status: "ok",
-      detail: "No legacy project-level Codex overlay present",
-    };
-  }
-
-  const listed = legacyPaths
-    .map(subdir => path.join(".codex", subdir))
-    .join(", ");
-  return {
-    name: LEGACY_CODEX_OVERLAY_CHECK_NAME,
-    status: "warn",
-    detail:
-      `Legacy pre-2.198 Codex overlay present (${listed}). ` +
-      "Run `lisa apply` in the primary checkout and commit the removals — " +
-      "fresh clones/worktrees otherwise load stale hooks/skills that a later " +
-      "apply deletes mid-session (CodySwannGT/lisa#1632)",
-  };
-}
-
 /**
  * Determine whether a path looks like an agent-governed project, i.e. one that
  * should carry the canonical `AGENTS.md` / `CLAUDE.md` pointer pattern. True
@@ -379,6 +330,9 @@ export async function runDoctor(
     checkLegacyCodexOverlay(resolvedTarget),
     await checkStarterHealth(deps, options.offline === true),
     checkWiki(resolvedTarget),
+    ...(options.readiness === true
+      ? [await checkRepositoryReadiness(resolvedTarget)]
+      : []),
   ];
   const result = { checks };
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -145,6 +145,27 @@ function addKaneCommands(program: Command, deps: ProgramDependencies): void {
 }
 
 /**
+ * Register the `doctor` command, including the additive `--readiness` audit.
+ * @param program - Commander program to mutate
+ * @param deps - Program dependencies
+ */
+function addDoctorCommand(program: Command, deps: ProgramDependencies): void {
+  program
+    .command("doctor")
+    .description("Diagnose Lisa, project, starter, and wiki health")
+    .argument("[path]", "Project path to inspect")
+    .option("--json", "Emit JSON")
+    .option("--offline", "Skip network checks")
+    .option(
+      "--readiness",
+      "Also audit repository readiness for unattended fleet operation and persist .lisa/readiness.json"
+    )
+    .action(async (targetPath: string | undefined, options) => {
+      await deps.runDoctor(targetPath, options);
+    });
+}
+
+/**
  * Register CLI maintenance commands that do not run the root update warning.
  * @param program - Commander program to mutate
  * @param deps - Program dependencies
@@ -174,15 +195,7 @@ function addMaintenanceCommands(
       }
     });
 
-  program
-    .command("doctor")
-    .description("Diagnose Lisa, project, starter, and wiki health")
-    .argument("[path]", "Project path to inspect")
-    .option("--json", "Emit JSON")
-    .option("--offline", "Skip network checks")
-    .action(async (targetPath: string | undefined, options) => {
-      await deps.runDoctor(targetPath, options);
-    });
+  addDoctorCommand(program, deps);
 
   program
     .command("sync")

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -737,7 +737,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/scripts/cross-pollinate.mjs":
       "e9a536389d2581370f6c470b8a070aaae96660646efc528a7ff7fb25d324a903",
     "plugins/src/base/scripts/doctor-report.mjs":
-      "a33586c8a5c0843a75e20af64fb7c5d0b35052fb855eb966dc5b0bf75ccbd8a3",
+      "080286c469b034d22930bd5efb7e70e5227e93697a315469e9f8e6089eb37505",
     "plugins/src/base/scripts/install-remote-agent-aws.mjs":
       "5ef1c323d7cbfda8976f6fb0c24f7a8e5f5757475fd1d71c6e5bec91023cebe3",
     "plugins/src/base/scripts/plugin-sync-explain.mjs":
@@ -789,7 +789,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-debrief/SKILL.md":
       "47e4cda36b07994ff47ab15fb04a17dd6b0c310ad804f9cae9d69637edaaa72a",
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
-      "745543770f755f841d516bc4027ccfd1d7dfe23c25d27b209e2cd7329bdec22c",
+      "a9bac6af0746a222e9de7224e5f171411ee82e351f3449bcda4430b85f79486a",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
       "e8680c65da64351580658e423d2e30f565e9df52079f4deec44df84d4ab82982",
     "plugins/src/base/skills/lisa-epic-triage/SKILL.md":
@@ -7246,7 +7246,9 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/cli/cross-pollinate-cmd.ts": true,
     "src/cli/cross-pollinate-nudge.ts": true,
     "src/cli/doctor-kane.ts": true,
+    "src/cli/doctor-legacy-overlay.ts": true,
     "src/cli/doctor-monitor-thresholds.ts": true,
+    "src/cli/doctor-readiness.ts": true,
     "src/cli/doctor-worker-epoch.ts": true,
     "src/cli/doctor.ts": true,
     "src/cli/file-upstream-cmd.ts": true,
@@ -7522,6 +7524,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/check-learnings-budget-cmd.test.ts": true,
     "tests/unit/cli/doctor-kane.test.ts": true,
     "tests/unit/cli/doctor-monitor-thresholds.test.ts": true,
+    "tests/unit/cli/doctor-readiness.test.ts": true,
     "tests/unit/cli/doctor-worker-epoch.test.ts": true,
     "tests/unit/cli/doctor.test.ts": true,
     "tests/unit/cli/file-upstream-contract.test.ts": true,
@@ -7765,6 +7768,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/doctor-plugin-sync-guidance.test.ts": true,
     "tests/unit/strategies/doctor-project-readiness.test.ts": true,
     "tests/unit/strategies/doctor-report-rendering.test.ts": true,
+    "tests/unit/strategies/doctor-repository-readiness.test.ts": true,
     "tests/unit/strategies/doctor-scaffold.test.ts": true,
     "tests/unit/strategies/doctor-vendor-preflight.test.ts": true,
     "tests/unit/strategies/doctor-wiki-delegation.test.ts": true,

--- a/tests/unit/cli/doctor-readiness.test.ts
+++ b/tests/unit/cli/doctor-readiness.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit coverage for the repository-readiness doctor collector (RRR-3, #1855).
+ *
+ * PRD #1739 adds a second, orthogonal doctor question — "may an agent fleet
+ * operate here unattended?" — behind `lisa doctor --readiness`. This suite pins
+ * the additive, flag-gated collector: the default doctor path never gains the
+ * readiness check, the readiness mode emits exactly eight dimensions (SKIP with
+ * a reason while later tickets wire evidence), persistence lands at the single
+ * resolver's path with schema_version 1, and a write failure degrades to WARN
+ * rather than throwing. Warn-only per intake decision O1: the collector never
+ * returns `fail`.
+ * @module tests/unit/cli/doctor-readiness
+ */
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  READINESS_DIMENSION_IDS,
+  READINESS_SCHEMA_VERSION,
+  checkRepositoryReadiness,
+  resolveReadinessReportPath,
+} from "../../../src/cli/doctor-readiness.js";
+import { runDoctor } from "../../../src/cli/doctor.js";
+
+let tempDir: string | undefined;
+
+/**
+ * Resolve a temporary directory for one readiness test case.
+ * @returns Temporary directory path
+ */
+async function getTempDir(): Promise<string> {
+  tempDir ??= await mkdtemp(path.join(os.tmpdir(), "lisa-readiness-"));
+  return tempDir;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (tempDir) {
+    await chmod(path.join(tempDir, ".lisa"), 0o755).catch(() => {});
+    await rm(tempDir, { force: true, recursive: true });
+    tempDir = undefined;
+  }
+});
+
+describe("resolveReadinessReportPath", () => {
+  it("resolves the persistence location through one exported resolver", () => {
+    expect(resolveReadinessReportPath("/repo/root")).toBe(
+      path.join("/repo/root", ".lisa", "readiness.json")
+    );
+  });
+});
+
+describe("checkRepositoryReadiness", () => {
+  it("assesses exactly eight dimensions and never returns fail", async () => {
+    const cwd = await getTempDir();
+
+    const check = await checkRepositoryReadiness(cwd);
+
+    expect(check.status).not.toBe("fail");
+    expect(READINESS_DIMENSION_IDS).toHaveLength(8);
+    expect(new Set(READINESS_DIMENSION_IDS).size).toBe(8);
+  });
+
+  it("persists a schema_version 1 report with verdict, blocker_count, and per-dimension findings", async () => {
+    const cwd = await getTempDir();
+
+    await checkRepositoryReadiness(cwd);
+
+    const raw = await readFile(resolveReadinessReportPath(cwd), "utf8");
+    const report = JSON.parse(raw) as Record<string, unknown>;
+    expect(report.schema_version).toBe(READINESS_SCHEMA_VERSION);
+    expect(report.schema_version).toBe(1);
+    expect(report.verdict).toBe("READY");
+    expect(report.narrowed_claim).toBeNull();
+    expect(report.blockers).toEqual([]);
+    expect(report.blocker_count).toBe(0);
+    expect(typeof report.generated_at).toBe("string");
+    expect(typeof report.lisa_version).toBe("string");
+    expect(typeof report.worker_signature).toBe("string");
+    const dimensions = report.dimensions as Array<Record<string, unknown>>;
+    expect(dimensions).toHaveLength(8);
+    expect(dimensions.map(dimension => dimension.id)).toEqual([
+      ...READINESS_DIMENSION_IDS,
+    ]);
+    for (const dimension of dimensions) {
+      expect(dimension.status).toBe("SKIP");
+      expect(Array.isArray(dimension.findings)).toBe(true);
+    }
+  });
+
+  it("degrades to a WARN check instead of throwing when the report cannot be written", async () => {
+    const cwd = await getTempDir();
+    const lisaDir = path.join(cwd, ".lisa");
+    await mkdir(lisaDir, { recursive: true });
+    // Make .lisa read-only so the atomic write fails.
+    await chmod(lisaDir, 0o500);
+
+    const check = await checkRepositoryReadiness(cwd);
+
+    expect(check.status).toBe("warn");
+    expect(check.detail.toLowerCase()).toContain("readiness");
+    // Restore permissions so afterEach cleanup succeeds.
+    await chmod(lisaDir, 0o755);
+  });
+});
+
+describe("runDoctor readiness gating", () => {
+  it("omits the readiness check on the default path", async () => {
+    const cwd = await getTempDir();
+    await writeFile(path.join(cwd, ".lisa.config.json"), "{}\n");
+
+    const result = await runDoctor(
+      cwd,
+      { offline: true },
+      { runUpdateCheck: vi.fn(), write: vi.fn() }
+    );
+
+    expect(
+      result.checks.some(check => check.name === "Repository readiness")
+    ).toBe(false);
+  });
+
+  it("appends the readiness check only when --readiness is set", async () => {
+    const cwd = await getTempDir();
+    await writeFile(path.join(cwd, ".lisa.config.json"), "{}\n");
+
+    const result = await runDoctor(
+      cwd,
+      { offline: true, readiness: true },
+      { runUpdateCheck: vi.fn(), write: vi.fn() }
+    );
+
+    expect(
+      result.checks.some(check => check.name === "Repository readiness")
+    ).toBe(true);
+  });
+});

--- a/tests/unit/strategies/doctor-repository-readiness.test.ts
+++ b/tests/unit/strategies/doctor-repository-readiness.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression tests for the repository-readiness doctor render group and skill
+ * section (RRR-3, #1855).
+ *
+ * PRD #1739 adds a ninth, separately-titled doctor group — "Repository
+ * readiness" — that scores the eight ownership dimensions from the
+ * `readiness-rubric` rule and renders one check per dimension, never fewer.
+ * This suite proves the shared `doctor-report.mjs` renderer exposes the group,
+ * that the group holds exactly eight dimension checks in fixed order with a
+ * stated SKIP reason for every inapplicable dimension, and that the lisa-doctor
+ * skill documents the section identically across the fanned-out plugin copies.
+ * @module tests/unit/strategies/doctor-repository-readiness
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createRepositoryReadinessDoctorGroup,
+  renderDoctorReport,
+} from "../../../plugins/src/base/scripts/doctor-report.mjs";
+
+/** The eight ownership dimensions, in fixed render order (readiness-rubric). */
+const EXPECTED_DIMENSION_IDS = [
+  "context-routing",
+  "capabilities-tools",
+  "domain-ownership",
+  "execution-proof",
+  "feedback-guardrails",
+  "dependencies-supply-chain",
+  "delivery-authority",
+  "proportionality",
+] as const;
+
+/** Every plugin copy that must carry an identical lisa-doctor skill section. */
+const SKILL_ROOTS = [
+  "plugins/src/base/skills",
+  "plugins/lisa/skills",
+  "plugins/lisa-agy/skills",
+  "plugins/lisa-cursor/skills",
+  "plugins/lisa-copilot/skills",
+] as const;
+
+const readDoctorSkill = (root: string): string =>
+  readFileSync(path.resolve(root, "lisa-doctor", "SKILL.md"), "utf8");
+
+describe("repository-readiness doctor render group (#1855)", () => {
+  it("returns a separately-titled group with a stable id", () => {
+    const group = createRepositoryReadinessDoctorGroup(process.cwd());
+
+    expect(group.id).toBe("repository-readiness");
+    expect(group.title).toBe("Repository readiness");
+  });
+
+  it("scores exactly eight dimensions in fixed order, never fewer", () => {
+    const group = createRepositoryReadinessDoctorGroup(process.cwd());
+
+    expect(group.checks).toHaveLength(8);
+    expect(group.checks.map(check => check.id)).toEqual([
+      ...EXPECTED_DIMENSION_IDS,
+    ]);
+  });
+
+  it("emits SKIP with a stated reason for every inapplicable dimension", () => {
+    const group = createRepositoryReadinessDoctorGroup(process.cwd());
+
+    for (const check of group.checks) {
+      expect(check.status).toBe("SKIP");
+      expect(typeof check.observed).toBe("string");
+      expect((check.observed ?? "").length).toBeGreaterThan(0);
+    }
+  });
+
+  it("renders under the shared verdict/counts header as one titled group", () => {
+    const group = createRepositoryReadinessDoctorGroup(process.cwd());
+    const report = renderDoctorReport({ groups: [group] });
+
+    expect(report.text).toContain("Overall verdict: ");
+    expect(report.text).toContain("Counts: ");
+    expect(report.text).toContain("repository-readiness. Repository readiness");
+    for (const id of EXPECTED_DIMENSION_IDS) {
+      expect(report.text).toContain(`- SKIP ${id}:`);
+    }
+  });
+});
+
+describe.each(SKILL_ROOTS)(
+  "doctor repository-readiness skill section (%s)",
+  root => {
+    const content = readDoctorSkill(root);
+
+    it("defines one shared doctor repository-readiness section citing the rubric", () => {
+      expect(content).toContain("### Minimum repository-readiness checks");
+      expect(content).toMatch(/Repository readiness/);
+      expect(content).toMatch(/readiness-rubric/);
+      expect(content).toMatch(/--readiness/);
+    });
+
+    it("documents the eight dimensions and the SKIP-with-reason contract", () => {
+      for (const id of EXPECTED_DIMENSION_IDS) {
+        expect(content).toContain(id);
+      }
+      expect(content).toMatch(/eight/i);
+      expect(content).toMatch(/never (fewer|omit)/i);
+    });
+
+    it("documents the persisted .lisa/readiness.json artifact", () => {
+      expect(content).toMatch(/\.lisa\/readiness\.json/);
+      expect(content).toMatch(/schema_version/);
+    });
+  }
+);


### PR DESCRIPTION
## What & why

RRR-3 of PRD #1739 (repository-readiness rubric). `lisa doctor` already answers
"is Lisa installed correctly here?" This adds the orthogonal, opt-in question —
**"may an agent fleet operate here unattended?"** — behind `lisa doctor --readiness`,
scored against the eight `readiness-rubric` ownership dimensions (RRR-1, #1853),
and persists the result to `.lisa/readiness.json` so other surfaces can read a
blocker count.

Consumes the shipped rubric's dimensions, seven ship blockers, and
`READY`/`READY_WITH_WARNINGS`/`NOT_READY` verdict ladder — it does not redefine
them.

## Additive & flag-gated (byte-identical default)

- Plain `lisa doctor` renders **byte-identically** to before: the readiness check
  is appended to `runDoctor`'s fixed `checks` array **only** when `--readiness`
  is set, and exit-code semantics are unchanged (exit 1 iff a check is `fail`).
- **Proof:** `tests/unit/cli/doctor.test.ts` and
  `tests/unit/strategies/doctor-report-rendering.test.ts` pass **unmodified**
  (`git diff origin/main` on both is empty). New tests assert the default path
  never gains the readiness check and the flagged path adds exactly one.
- Warn-only per intake decision **O1**: the collector never returns `fail` and
  no Lisa surface hard-blocks on the readiness verdict.

## Changes

- **Shared renderer** — `createRepositoryReadinessDoctorGroup(root)` in
  `plugins/src/base/scripts/doctor-report.mjs`: a separately-titled "Repository
  readiness" group with the eight dimension checks in fixed order, each
  `SKIP`-with-reason while evidence-gathering (RRR-4/5/6) is unwired — reported,
  never silently omitted. Kept dependency-free; fanned out to all plugin copies.
- **CLI** — `DoctorOptions.readiness` + `--readiness`, and a
  `checkRepositoryReadiness` collector in a new `src/cli/doctor-readiness.ts`
  (mirroring `doctor-worker-epoch.ts`). Extracted the self-contained
  `checkLegacyCodexOverlay` into `src/cli/doctor-legacy-overlay.ts` (pure move,
  behavior preserved) to keep `doctor.ts` under its size ceiling.
- **Persistence (O2)** — writes `.lisa/readiness.json` (`schema_version: 1`;
  `verdict`, `blocker_count`, per-dimension findings; `blockers` empty and
  `narrowed_claim` null until RRR-5) through the single
  `resolveReadinessReportPath()` resolver, so relocating the artifact is a
  one-line change. The write is atomic (temp + rename) and never throws — a write
  failure degrades to a `WARN` check. `lisa_version` + `worker_signature` stamp
  the report for #1740 to reuse.
- **Skill** — "Minimum repository-readiness checks" section in
  `lisa-doctor/SKILL.md` across all fanned-out copies, citing `readiness-rubric`.

## Validation

- `bun run test` — 6626 passed. Focused doctor suites green (default + readiness
  + parity).
- `bun run typecheck`, `bun run lint`, `bun run check:plugins`,
  `generate-upstream-evidence-manifest --check` — all clean.
- Smoke: `lisa doctor --readiness` renders the "Repository readiness" group with
  all eight dimensions `SKIP`-with-reason and writes a `schema_version: 1`
  `.lisa/readiness.json` (verdict `READY`, `blocker_count` 0, ids in fixed order);
  plain `lisa doctor` output is unchanged.

## Out of scope (later RRR tickets)

Blocker gate + narrowed-claim population (RRR-5), journey execution / evidence
reading (RRR-6), agent-ready & setup-automations wiring (RRR-4/7).

Closes #1855

🤖 Generated with Claude Code
