### PR TITLE
feat(health): add optional agentic composition

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "check:workflow-inputs": "node scripts/detect-stale-workflow-inputs.mjs --project . --project typescript/create-only --project rails/create-only --json",
     "verify:health-contract": "bun run build:dist && node scripts/verify-health-contract-built.mjs",
     "verify:health-deterministic": "bun run build:dist && node scripts/verify-health-deterministic-built.mjs",
-    "verify:learner-frontmatter-built": "bun run build:dist && node scripts/verify-learner-frontmatter-built.mjs"
+    "verify:learner-frontmatter-built": "bun run build:dist && node scripts/verify-learner-frontmatter-built.mjs",
+    "verify:health-agentic": "bun run build:dist && node scripts/verify-health-agentic-built.mjs"
   },
   "engines": {
     "npm": "please-use-bun",

--- a/package.lisa.json
+++ b/package.lisa.json
@@ -14,6 +14,7 @@
       "verify:health-contract": "bun run build:dist && node scripts/verify-health-contract-built.mjs",
       "verify:health-deterministic": "bun run build:dist && node scripts/verify-health-deterministic-built.mjs",
       "verify:learner-frontmatter-built": "bun run build:dist && node scripts/verify-learner-frontmatter-built.mjs",
+      "verify:health-agentic": "bun run build:dist && node scripts/verify-health-agentic-built.mjs",
       "prepare": "$npm_execpath run build && husky install || true",
       "lisa:update": "npx @codyswann/lisa@latest ."
     },

--- a/scripts/verify-health-agentic-built.mjs
+++ b/scripts/verify-health-agentic-built.mjs
@@ -1,0 +1,842 @@
+#!/usr/bin/env node
+/** Empirical proof for the shipped optional agentic Health composition API. */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  readlink,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+let assertions = 0;
+const check = (condition, message) => {
+  assertions += 1;
+  assert.ok(condition, message);
+};
+const equal = (actual, expected, message) => {
+  assertions += 1;
+  assert.deepEqual(actual, expected, message);
+};
+const findingState = finding => ({
+  check: finding.check,
+  layer: finding.layer,
+  status: finding.status,
+  reason: finding.reason,
+});
+const deterministicState = result => ({
+  schemaVersion: result.schemaVersion,
+  projectRoot: result.projectRoot,
+  mode: result.mode,
+  startedAt: result.startedAt,
+  completedAt: result.completedAt,
+  summary: result.summary,
+  findings: result.findings,
+});
+const printStateDump = (name, payload) => {
+  const serialized = JSON.stringify({ name, ...payload });
+  check(
+    Buffer.byteLength(serialized, "utf8") <= 16 * 1024,
+    `${name} state dump stays within 16 KiB`
+  );
+  console.log(serialized);
+};
+
+const root = process.cwd();
+const workspace = await mkdtemp(path.join(tmpdir(), "lisa-health-agentic-"));
+const project = path.join(workspace, "host");
+const isolatedBin = path.join(workspace, "bin");
+const gitExecutable = execFileSync("which", ["git"], {
+  encoding: "utf8",
+}).trim();
+const healthFile = path.join(project, ".lisa", "health", "latest.json");
+const startedAt = Date.now();
+
+const run = (executable, argv, options = {}) =>
+  execFileSync(executable, argv, {
+    cwd: project,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+const git = (...argv) => run(gitExecutable, argv);
+
+/** Capture every non-git working-tree inode, mode, target, and file digest. */
+async function snapshotTree(directory) {
+  const records = [];
+  const visit = async (absolute, relative) => {
+    const entries = await readdir(absolute, { withFileTypes: true });
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      if (relative.length === 0 && entry.name === ".git") continue;
+      const childRelative =
+        relative.length === 0 ? entry.name : `${relative}/${entry.name}`;
+      const childAbsolute = path.join(absolute, entry.name);
+      const stat = await lstat(childAbsolute);
+      const mode = stat.mode & 0o7777;
+      if (stat.isSymbolicLink()) {
+        records.push([
+          childRelative,
+          "symlink",
+          mode,
+          await readlink(childAbsolute),
+        ]);
+      } else if (stat.isDirectory()) {
+        records.push([childRelative, "directory", mode]);
+        await visit(childAbsolute, childRelative);
+      } else if (stat.isFile()) {
+        records.push([
+          childRelative,
+          "file",
+          mode,
+          createHash("sha256")
+            .update(await readFile(childAbsolute))
+            .digest("hex"),
+        ]);
+      } else {
+        records.push([childRelative, "special", mode]);
+      }
+    }
+  };
+  await visit(directory, "");
+  return records;
+}
+
+/** Read the exact material ruleset documents shipped by the fixture stack. */
+async function rulesetDocuments() {
+  const groups = await Promise.all(
+    ["all", "typescript"].map(async type => {
+      const directory = path.join(root, type, "github-rulesets");
+      return Promise.all(
+        (await readdir(directory, { withFileTypes: true }))
+          .filter(entry => entry.isFile())
+          .map(async entry => {
+            const parsed = JSON.parse(
+              await readFile(path.join(directory, entry.name), "utf8")
+            );
+            return {
+              name: parsed.name,
+              target: parsed.target,
+              enforcement: parsed.enforcement,
+              conditions: parsed.conditions,
+              rules: parsed.rules,
+            };
+          })
+      );
+    })
+  );
+  return Object.values(
+    Object.fromEntries(groups.flat().map(document => [document.name, document]))
+  );
+}
+
+/** Run one collection and prove it cannot mutate project, storage, git, or exit state. */
+async function assertPureCollection(collect) {
+  const beforeTree = await snapshotTree(project);
+  const beforeStatus = git("status", "--porcelain=v1", "--untracked-files=all");
+  const beforeExitCode = process.exitCode;
+  const beforeHealthFile = await lstat(healthFile)
+    .then(() => true)
+    .catch(() => false);
+  const result = await collect();
+  equal(
+    await snapshotTree(project),
+    beforeTree,
+    "agentic composition preserves every working-tree inode and byte"
+  );
+  equal(
+    git("status", "--porcelain=v1", "--untracked-files=all"),
+    beforeStatus,
+    "agentic composition preserves git status"
+  );
+  equal(
+    process.exitCode,
+    beforeExitCode,
+    "agentic composition preserves process exit state"
+  );
+  equal(
+    await lstat(healthFile)
+      .then(() => true)
+      .catch(() => false),
+    beforeHealthFile,
+    "agentic composition never persists latest.json"
+  );
+  return result;
+}
+
+/** Return the artifact-first bounded evaluator used by the empirical journey. */
+function artifactEvaluator(request, signal) {
+  check(!signal.aborted, "evaluator receives a live abort signal");
+  check(Object.isFrozen(request), "evaluator request is frozen");
+  check(
+    Object.isFrozen(request.deterministicFindings) &&
+      request.deterministicFindings.every(Object.isFrozen),
+    "deterministic evidence is deeply frozen"
+  );
+  check(
+    Object.isFrozen(request.config) &&
+      Object.isFrozen(request.config.quality) &&
+      Object.isFrozen(request.config.quality.mutation) &&
+      Object.isFrozen(request.config.quality.mutation.gate),
+    "config projection is deeply frozen"
+  );
+  check(
+    Object.isFrozen(request.artifacts) &&
+      request.artifacts.every(Object.isFrozen),
+    "artifact evidence is deeply frozen"
+  );
+  equal(
+    Object.hasOwn(request, "projectRoot"),
+    false,
+    "bounded evaluator request exposes no filesystem capability"
+  );
+  equal(
+    Reflect.set(request.config.quality.mutation.gate, "enabled", true),
+    false,
+    "frozen config resists evaluator mutation"
+  );
+  if (request.artifacts.length > 0) {
+    equal(
+      Reflect.set(request.artifacts[0], "content", "tampered"),
+      false,
+      "frozen artifacts resist evaluator mutation"
+    );
+  }
+  check(
+    request.artifacts.every(
+      artifact =>
+        !path.isAbsolute(artifact.path) &&
+        !artifact.path.split("/").includes("..") &&
+        Buffer.byteLength(artifact.content, "utf8") <= 128 * 1024
+    ),
+    "every evaluator artifact is relative and individually bounded"
+  );
+  check(
+    request.artifacts.reduce(
+      (total, artifact) => total + Buffer.byteLength(artifact.content, "utf8"),
+      0
+    ) <=
+      512 * 1024,
+    "aggregate evaluator evidence is bounded"
+  );
+
+  const judgments = [];
+  const override = request.artifacts.find(
+    artifact => artifact.kind === "eslint-override"
+  );
+  const managedArtifact = request.artifacts.find(
+    artifact => artifact.kind === "managed-drift"
+  );
+  const workflows = request.artifacts.filter(
+    artifact => artifact.kind === "workflow"
+  );
+  const mutationDisabled =
+    request.config.quality.mutation.gate.enabled === false;
+  const managedDrift = request.deterministicFindings.find(
+    finding =>
+      finding.check === "templates.managed" && finding.status === "fail"
+  );
+
+  if (mutationDisabled) {
+    judgments.push({
+      check: "agentic.disabled-mutation-gate",
+      reason:
+        "The mutation-testing gate is disabled without a justification in the bounded configuration evidence.",
+    });
+  }
+  if (
+    override?.content.includes("no-explicit-any") === true &&
+    !/\b(?:reason|justification)\b/iu.test(override.content)
+  ) {
+    judgments.push({
+      check: "agentic.eslint.override",
+      reason:
+        "eslint.config.local.ts disables no-explicit-any without a recorded justification.",
+    });
+  }
+  for (const workflow of workflows) {
+    if (
+      /skip_jobs:\s*['"]?lint['"]?/u.test(workflow.content) &&
+      !/\b(?:reason|justification)\b/iu.test(workflow.content)
+    ) {
+      judgments.push({
+        check: "agentic.ci.skip.lint",
+        reason: `${workflow.path} skips lint without a recorded justification.`,
+      });
+    }
+  }
+  if (
+    managedDrift?.reason.includes("eslint.config.ts") === true &&
+    /\b(?:reason|justification)\b/iu.test(override?.content ?? "") &&
+    managedArtifact?.content.includes("no-explicit-any") === true &&
+    /["']off["']/u.test(managedArtifact.content)
+  ) {
+    judgments.push({
+      check: "agentic.intentional-drift",
+      reason:
+        "The bounded managed ESLint drift disables no-explicit-any despite the recorded temporary justification.",
+    });
+  }
+  return Promise.resolve({ status: "completed", judgments });
+}
+
+try {
+  await mkdir(project, { recursive: true });
+  await mkdir(isolatedBin, { recursive: true });
+  await symlink(gitExecutable, path.join(isolatedBin, "git"));
+  await writeFile(
+    path.join(project, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "agentic-health-fixture",
+        private: true,
+        devDependencies: { harperdb: "4.6.3", typescript: "5.9.3" },
+      },
+      null,
+      2
+    )}\n`
+  );
+  await writeFile(
+    path.join(project, ".lisa.config.json"),
+    `${JSON.stringify(
+      {
+        tracker: "github",
+        github: { org: "example", repo: "health-fixture" },
+        harness: "claude",
+      },
+      null,
+      2
+    )}\n`
+  );
+  await mkdir(path.join(project, "harper-app"), { recursive: true });
+  await writeFile(
+    path.join(project, "harper-app", "config.yaml"),
+    "graphqlSchema: ./schema.graphql\njsResource: true\nstatic: ./web\n"
+  );
+  await writeFile(
+    path.join(project, "harper-app", "schema.graphql"),
+    "type Query { health: Boolean! }\n"
+  );
+  git("init", "--initial-branch=main");
+  git("config", "user.name", "Lisa Health Verifier");
+  git("config", "user.email", "health-verifier@example.invalid");
+  git("add", ".");
+  git("commit", "-m", "fixture bootstrap");
+
+  run(
+    process.execPath,
+    [
+      path.join(root, "dist/index.js"),
+      "--no-update-check",
+      "apply",
+      "--yes",
+      "--harness=claude",
+      project,
+    ],
+    {
+      cwd: root,
+      env: {
+        ...process.env,
+        LISA_BOOTSTRAP: "1",
+        LISA_SKIP_UPDATE_CHECK: "1",
+        PATH: isolatedBin,
+      },
+    }
+  );
+  run(
+    process.execPath,
+    [path.join(root, "dist/index.js"), "sync", project, "--json"],
+    {
+      cwd: root,
+      env: {
+        ...process.env,
+        LISA_SKIP_UPDATE_CHECK: "1",
+        PATH: isolatedBin,
+      },
+    }
+  );
+  const version = JSON.parse(
+    await readFile(path.join(root, "package.json"), "utf8")
+  ).version;
+  await writeFile(
+    path.join(project, ".claude", ".lisa-plugins-synced"),
+    `${version}\n`
+  );
+  git("add", ".");
+  git("commit", "-m", "apply Lisa fixture");
+
+  const health = await import("@codyswann/lisa/health");
+  check(
+    typeof health.runHealth === "function",
+    "built package exports runHealth"
+  );
+  const expectedRulesets = await rulesetDocuments();
+  const settings = JSON.parse(
+    await readFile(path.join(project, ".claude", "settings.json"), "utf8")
+  );
+  const installedPlugins = Object.entries(settings.enabledPlugins)
+    .filter(([, enabled]) => enabled === true)
+    .map(([plugin]) => plugin);
+  const offline = {
+    readRulesets: async () => expectedRulesets,
+    readHooksPath: async () => ".husky",
+    readInstalledPlugins: async () => installedPlugins,
+  };
+
+  let disabledCalls = 0;
+  const deterministic = await assertPureCollection(() =>
+    health.runHealth(project, {
+      ...offline,
+      agentic: {
+        enabled: false,
+        evaluator: async () => {
+          disabledCalls += 1;
+          throw new Error("disabled evaluator must not run");
+        },
+      },
+    })
+  );
+  const full = await assertPureCollection(() =>
+    health.runHealth(project, {
+      ...offline,
+      agentic: { enabled: true, evaluator: artifactEvaluator },
+    })
+  );
+  const completedEmpty = await assertPureCollection(() =>
+    health.runHealth(project, {
+      ...offline,
+      agentic: {
+        enabled: true,
+        evaluator: async () => ({ status: "completed", judgments: [] }),
+      },
+    })
+  );
+  equal(disabledCalls, 0, "disabled agentic pass never calls evaluator");
+  equal(
+    deterministic.mode,
+    "deterministic",
+    "disabled pass stays deterministic"
+  );
+  equal(full.mode, "full", "enabled completed pass reports full mode");
+  equal(
+    completedEmpty.mode,
+    "full",
+    "completed evaluator with no judgments still reports full mode"
+  );
+  equal(
+    completedEmpty.findings.filter(finding => finding.layer === "agentic"),
+    [],
+    "completed evaluator with no judgments fabricates no agentic finding"
+  );
+  equal(
+    full.findings.filter(finding => finding.layer === "deterministic"),
+    deterministic.findings,
+    "composition preserves deterministic facts exactly"
+  );
+  check(
+    full.findings.some(
+      finding =>
+        finding.check === "agentic.disabled-mutation-gate" &&
+        finding.status === "warn"
+    ),
+    "config-backed disabled mutation gate reaches the evaluator"
+  );
+  check(
+    Object.isFrozen(full) &&
+      Object.isFrozen(full.findings) &&
+      full.findings.every(Object.isFrozen) &&
+      Object.isFrozen(full.summary) &&
+      Object.isFrozen(full.summary.counts),
+    "composed result is deeply frozen"
+  );
+  printStateDump("agentic-api-diff", {
+    disabled: {
+      mode: deterministic.mode,
+      agenticFindings: deterministic.findings
+        .filter(finding => finding.layer === "agentic")
+        .map(findingState),
+    },
+    enabled: {
+      mode: full.mode,
+      agenticFindings: full.findings
+        .filter(finding => finding.layer === "agentic")
+        .map(findingState),
+    },
+    completedWithNoJudgments: {
+      mode: completedEmpty.mode,
+      agenticFindings: completedEmpty.findings
+        .filter(finding => finding.layer === "agentic")
+        .map(findingState),
+    },
+    deterministicFindingsPreserved:
+      JSON.stringify(
+        full.findings.filter(finding => finding.layer === "deterministic")
+      ) === JSON.stringify(deterministic.findings),
+  });
+  console.log("[EVIDENCE: state-dump: agentic-api-diff]");
+
+  const localEslintPath = path.join(project, "eslint.config.local.ts");
+  const localEslintOriginal = await readFile(localEslintPath);
+  await writeFile(
+    localEslintPath,
+    'export default [{ rules: { "@typescript-eslint/no-explicit-any": "off" } }];\n'
+  );
+  const unjustified = await assertPureCollection(() =>
+    health.runHealth(project, {
+      ...offline,
+      agentic: { enabled: true, evaluator: artifactEvaluator },
+    })
+  );
+  const overrideWarning = unjustified.findings.find(
+    finding => finding.check === "agentic.eslint.override"
+  );
+  equal(overrideWarning?.layer, "agentic", "override warning is agentic");
+  equal(overrideWarning?.status, "warn", "override judgment can never fail");
+  check(
+    overrideWarning?.reason.includes("eslint.config.local.ts") === true,
+    "override warning carries operator-readable reasoning"
+  );
+  printStateDump("unjustified-override-warning", {
+    warning: findingState(overrideWarning),
+  });
+  console.log("[EVIDENCE: state-dump: unjustified-override-warning]");
+  await writeFile(localEslintPath, localEslintOriginal);
+
+  const ciPath = path.join(project, ".github", "workflows", "ci.yml");
+  const ciOriginal = await readFile(ciPath, "utf8");
+  await writeFile(
+    ciPath,
+    ciOriginal.replace("skip_jobs: ''", "skip_jobs: 'lint'")
+  );
+  const unreasonedSkip = await assertPureCollection(() =>
+    health.runHealth(project, {
+      ...offline,
+      agentic: { enabled: true, evaluator: artifactEvaluator },
+    })
+  );
+  check(
+    unreasonedSkip.findings.some(
+      finding =>
+        finding.check === "agentic.ci.skip.lint" &&
+        finding.reason.includes("ci.yml")
+    ),
+    "unreasoned skipped job produces a named warning"
+  );
+  await writeFile(
+    ciPath,
+    ciOriginal.replace(
+      "      skip_jobs: ''",
+      "      # justification: lint is temporarily enforced by a protected external gate\n      skip_jobs: 'lint'"
+    )
+  );
+  const reasonedSkip = await assertPureCollection(() =>
+    health.runHealth(project, {
+      ...offline,
+      agentic: { enabled: true, evaluator: artifactEvaluator },
+    })
+  );
+  check(
+    !reasonedSkip.findings.some(
+      finding => finding.check === "agentic.ci.skip.lint"
+    ),
+    "recorded skip justification clears the job warning"
+  );
+  printStateDump("skipped-job-reason-clears", {
+    undocumented: unreasonedSkip.findings
+      .filter(finding => finding.check === "agentic.ci.skip.lint")
+      .map(findingState),
+    documented: reasonedSkip.findings
+      .filter(finding => finding.check === "agentic.ci.skip.lint")
+      .map(findingState),
+  });
+  console.log("[EVIDENCE: state-dump: skipped-job-reason-clears]");
+  await writeFile(ciPath, ciOriginal);
+
+  const managedEslintPath = path.join(project, "eslint.config.ts");
+  const managedEslintOriginal = await readFile(managedEslintPath);
+  const managedJustification =
+    '// justification: temporary vendor migration\nexport default [{ rules: { "@typescript-eslint/no-explicit-any": "off" } }];\n';
+  await writeFile(localEslintPath, managedJustification);
+  const observedManagedArtifacts = [];
+  const managedEvidenceEvaluator = (request, signal) => {
+    const managed = request.artifacts.find(
+      artifact => artifact.kind === "managed-drift"
+    );
+    observedManagedArtifacts.push(managed);
+    return artifactEvaluator(request, signal);
+  };
+  const benignManagedContent = Buffer.concat([
+    managedEslintOriginal,
+    Buffer.from("\n// formatting-only managed drift\n"),
+  ]);
+  const suspiciousManagedContent = Buffer.concat([
+    managedEslintOriginal,
+    Buffer.from(
+      '\nvoid { "@typescript-eslint/no-explicit-any": "off" }; // suspicious managed drift\n'
+    ),
+  ]);
+  await writeFile(managedEslintPath, benignManagedContent);
+  const benignDrift = await assertPureCollection(() =>
+    health.runHealth(project, {
+      ...offline,
+      agentic: { enabled: true, evaluator: managedEvidenceEvaluator },
+    })
+  );
+  await writeFile(managedEslintPath, suspiciousManagedContent);
+  const suspiciousDrift = await assertPureCollection(() =>
+    health.runHealth(project, {
+      ...offline,
+      agentic: { enabled: true, evaluator: managedEvidenceEvaluator },
+    })
+  );
+  equal(
+    observedManagedArtifacts.map(artifact => artifact?.path),
+    ["eslint.config.ts", "eslint.config.ts"],
+    "both drift judgments inspect the bounded managed ESLint artifact"
+  );
+  equal(
+    observedManagedArtifacts.map(artifact => artifact?.content),
+    [
+      benignManagedContent.toString("utf8"),
+      suspiciousManagedContent.toString("utf8"),
+    ],
+    "managed-drift evidence carries the current confined content"
+  );
+  check(
+    benignDrift.findings.some(
+      finding =>
+        finding.check === "templates.managed" && finding.status === "fail"
+    ),
+    "benign agentic judgment cannot erase deterministic managed drift"
+  );
+  check(
+    !benignDrift.findings.some(
+      finding => finding.check === "agentic.intentional-drift"
+    ),
+    "benign managed content produces no drift judgment"
+  );
+  const suspiciousDriftWarning = suspiciousDrift.findings.find(
+    finding => finding.check === "agentic.intentional-drift"
+  );
+  equal(
+    suspiciousDriftWarning?.status,
+    "warn",
+    "suspicious rule-disabling managed content produces a warning"
+  );
+  equal(
+    await readFile(localEslintPath, "utf8"),
+    managedJustification,
+    "both managed-drift judgments use the same recorded justification"
+  );
+  printStateDump("managed-drift-content-judgment", {
+    sameJustification: true,
+    benign: {
+      contentSha256: createHash("sha256")
+        .update(benignManagedContent)
+        .digest("hex"),
+      warnings: benignDrift.findings
+        .filter(finding => finding.check === "agentic.intentional-drift")
+        .map(findingState),
+    },
+    suspicious: {
+      contentSha256: createHash("sha256")
+        .update(suspiciousManagedContent)
+        .digest("hex"),
+      warnings: suspiciousDrift.findings
+        .filter(finding => finding.check === "agentic.intentional-drift")
+        .map(findingState),
+    },
+  });
+  await writeFile(managedEslintPath, managedEslintOriginal);
+  await writeFile(localEslintPath, localEslintOriginal);
+
+  let timeoutEvaluatorStarted = 0;
+  let timeoutAbortObserved = 0;
+  let unavailableProjection;
+  const degradationCases = [
+    {
+      name: "unavailable",
+      evaluator: async () => ({ status: "unavailable" }),
+      timeoutMs: 1_000,
+    },
+    {
+      name: "throw",
+      evaluator: async () => {
+        throw new Error("secret evaluator failure must not escape");
+      },
+      timeoutMs: 1_000,
+    },
+    {
+      name: "malformed",
+      evaluator: async () => ({
+        status: "completed",
+        judgments: [{ check: "templates.managed", reason: "collision" }],
+      }),
+      timeoutMs: 1_000,
+    },
+    {
+      name: "timeout",
+      evaluator: async (_request, signal) =>
+        new Promise(resolve => {
+          timeoutEvaluatorStarted += 1;
+          signal.addEventListener(
+            "abort",
+            () => {
+              timeoutAbortObserved += 1;
+              resolve({
+                status: "completed",
+                judgments: [
+                  {
+                    check: "agentic.late-timeout",
+                    reason:
+                      "This late judgment must be discarded after cancellation.",
+                  },
+                ],
+              });
+            },
+            { once: true }
+          );
+        }),
+      timeoutMs: 400,
+    },
+  ];
+  for (const scenario of degradationCases) {
+    const scenarioStarted = Date.now();
+    const degraded = await assertPureCollection(() =>
+      health.runHealth(project, {
+        ...offline,
+        agentic: {
+          enabled: true,
+          evaluator: scenario.evaluator,
+          timeoutMs: scenario.timeoutMs,
+        },
+      })
+    );
+    equal(
+      degraded.mode,
+      "deterministic",
+      `${scenario.name} evaluator degrades to deterministic mode`
+    );
+    check(
+      degraded.findings.every(finding => finding.layer === "deterministic"),
+      `${scenario.name} evaluator fabricates no judgment finding`
+    );
+    check(
+      !JSON.stringify(degraded).includes("secret evaluator failure"),
+      `${scenario.name} evaluator leaks no raw failure`
+    );
+    if (scenario.name === "timeout") {
+      equal(
+        timeoutEvaluatorStarted,
+        1,
+        "timeout proof reaches the evaluator after evidence collection"
+      );
+      equal(
+        timeoutAbortObserved,
+        1,
+        "never-settling evaluator observes the shared abort signal"
+      );
+      check(
+        !degraded.findings.some(
+          finding => finding.check === "agentic.late-timeout"
+        ),
+        "a judgment resolved during abort is discarded"
+      );
+      check(
+        Date.now() - scenarioStarted < 1_500,
+        "never-settling evaluator returns inside its bounded deadline plus fixture overhead"
+      );
+    }
+    if (scenario.name === "unavailable") {
+      unavailableProjection = {
+        mode: degraded.mode,
+        findings: degraded.findings.map(findingState),
+      };
+    }
+  }
+  printStateDump("unavailable-evaluator-degrades", {
+    unavailable: unavailableProjection,
+    agenticFindings: unavailableProjection.findings.filter(
+      finding => finding.layer === "agentic"
+    ),
+  });
+  console.log("[EVIDENCE: state-dump: unavailable-evaluator-degrades]");
+
+  const escapingEvidence = path.join(workspace, "escaping-eslint-evidence.ts");
+  await writeFile(
+    escapingEvidence,
+    "// reason: this content is outside the project and must never reach the evaluator\nexport default [];\n"
+  );
+  await rm(localEslintPath, { force: true });
+  await symlink(escapingEvidence, localEslintPath);
+  let hostileEvaluatorCalls = 0;
+  const hostileNow = () => new Date("2026-07-20T12:00:00.000Z");
+  try {
+    const hostileBaseline = await assertPureCollection(() =>
+      health.runHealth(project, {
+        ...offline,
+        now: hostileNow,
+        agentic: { enabled: false },
+      })
+    );
+    const hostileDegraded = await assertPureCollection(() =>
+      health.runHealth(project, {
+        ...offline,
+        now: hostileNow,
+        agentic: {
+          enabled: true,
+          evaluator: async () => {
+            hostileEvaluatorCalls += 1;
+            return { status: "completed", judgments: [] };
+          },
+        },
+      })
+    );
+    equal(
+      hostileEvaluatorCalls,
+      0,
+      "escaping symlink evidence is rejected before evaluator invocation"
+    );
+    equal(
+      deterministicState(hostileDegraded),
+      deterministicState(hostileBaseline),
+      "unsafe evidence degrades to the exact deterministic-only projection"
+    );
+    equal(
+      hostileDegraded.mode,
+      "deterministic",
+      "unsafe evidence retains deterministic mode"
+    );
+    check(
+      hostileDegraded.findings.every(
+        finding => finding.layer === "deterministic"
+      ),
+      "unsafe evidence fabricates no agentic finding"
+    );
+  } finally {
+    await rm(localEslintPath, { force: true });
+    await writeFile(localEslintPath, localEslintOriginal);
+  }
+  equal(
+    await readFile(localEslintPath),
+    localEslintOriginal,
+    "hostile evidence fixture restores the original local override"
+  );
+  console.log("[EVIDENCE: hostile-agentic-degradation]");
+  console.log("[EVIDENCE: no-agentic-side-effects]");
+
+  const elapsedMs = Date.now() - startedAt;
+  check(elapsedMs < 120_000, "built agentic proof completes under two minutes");
+  check(assertions > 0, "proof must execute assertions");
+  console.log(`health-agentic assertions=${assertions} elapsedMs=${elapsedMs}`);
+} finally {
+  await rm(workspace, { recursive: true, force: true });
+}

--- a/scripts/verify-health-contract-built.mjs
+++ b/scripts/verify-health-contract-built.mjs
@@ -81,8 +81,8 @@ try {
     {
       check: "agent.review",
       layer: "agentic",
-      status: "fail",
-      reason: "The agent review found actionable drift.",
+      status: "warn",
+      reason: "The agent review found a concern for operator review.",
     },
   ];
   const full = health.validateHealthResult({
@@ -94,12 +94,32 @@ try {
     findings: fullFindings,
     summary: health.summarizeHealthFindings(fullFindings),
   });
-  equal(full.summary.counts, { pass: 1, warn: 0, fail: 1 });
-  equal(full.summary.verdict, "drift detected");
+  equal(full.summary.counts, { pass: 1, warn: 1, fail: 0 });
+  equal(full.summary.verdict, "in band");
   check(
     Object.isFrozen(full) && Object.isFrozen(full.findings),
     "result is frozen"
   );
+  const historicalFailFindings = [
+    fullFindings[0],
+    {
+      check: "agent.historical-review",
+      layer: "agentic",
+      status: "fail",
+      reason: "The v1 contract historically permits an agentic failure.",
+    },
+  ];
+  const historicalFull = health.validateHealthResult({
+    schemaVersion: 1,
+    runId: "health-run-historical-full",
+    mode: "full",
+    startedAt: "2026-07-20T12:04:00.000Z",
+    completedAt: "2026-07-20T12:05:00.000Z",
+    findings: historicalFailFindings,
+    summary: health.summarizeHealthFindings(historicalFailFindings),
+  });
+  equal(historicalFull.summary.counts, { pass: 1, warn: 0, fail: 1 });
+  equal(historicalFull.summary.verdict, "drift detected");
   console.log("[EVIDENCE: health-v1-built-contract]");
 
   const neverRunProject = await mkdtemp(

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1894,8 +1894,10 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "a286750ac2006dd84209bb713e85f994d8d15d9bb596ec3e287a187672e5072d",
     "scripts/update-test-skill-paths.mjs":
       "e26a3ac716c33013e22bf5223a58457452f5af2038218a0e3a51c244eab5ddc9",
+    "scripts/verify-health-agentic-built.mjs":
+      "3c064ad162fa633efcaa91327746157bc046cabd1c030b8bfa17227fed077200",
     "scripts/verify-health-contract-built.mjs":
-      "9e090e3378325c4193e96ba03acff17fb63e40c9e7f2dd89296f72353ab6ba88",
+      "5ebfec9b8a0e3004a5af65d2f2515526f7ff5817e61ae30042fb8be40d8f8d17",
     "scripts/verify-health-deterministic-built.mjs":
       "ab19427ec4b1dfaa06037cc23b7fc06319b4c12d8c6b67808dddd77e5367fd12",
     "scripts/verify-learner-frontmatter-built.mjs":
@@ -2043,7 +2045,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/package-lisa/package.lisa.json":
       "7e99286c549c79b1c02c07a4313dcfe5b41b4ebb80a6fbbb8741dd74dc5f454d",
     "ui/README.md":
-      "e055b899ec7d40e8035dbf91ce1621872296d4d6b460dd113f80c80aed7198df",
+      "56857365dbb1f28edf07779b04744ce8963ab9fd7655d6405a5ee70856296903",
     "ui/index.html":
       "74c35220d1b8b7d8041374196eba2c821eb90d1b57d884f12afb695f47f5016c",
   });
@@ -7233,6 +7235,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "scripts/test-intent-routing.sh": true,
     "scripts/update-node-version.ts": true,
     "scripts/update-test-skill-paths.mjs": true,
+    "scripts/verify-health-agentic-built.mjs": true,
     "scripts/verify-health-contract-built.mjs": true,
     "scripts/verify-health-deterministic-built.mjs": true,
     "scripts/verify-learner-frontmatter-built.mjs": true,
@@ -7380,6 +7383,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/detection/detectors/typescript.ts": true,
     "src/detection/index.ts": true,
     "src/errors/index.ts": true,
+    "src/health/agentic.ts": true,
     "src/health/contract.ts": true,
     "src/health/deadline.ts": true,
     "src/health/deterministic.ts": true,
@@ -7643,6 +7647,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/core/upstream-attribution-integrity.test.ts": true,
     "tests/unit/detection/detectors.test.ts": true,
     "tests/unit/governance-contracts.test.ts": true,
+    "tests/unit/health/agentic.test.ts": true,
     "tests/unit/health/contract.test.ts": true,
     "tests/unit/health/deterministic-regressions.test.ts": true,
     "tests/unit/health/deterministic.test.ts": true,

--- a/src/health/agentic.ts
+++ b/src/health/agentic.ts
@@ -1,0 +1,562 @@
+/** Optional, read-only agentic Health composition over deterministic facts. */
+/* eslint-disable functional/immutable-data, functional/no-let, jsdoc/require-param, jsdoc/require-param-description, jsdoc/require-returns, max-lines -- one auditable hostile boundary stays cohesive */
+import { lstat, readdir, realpath } from "node:fs/promises";
+import path from "node:path";
+import { isProxy } from "node:util/types";
+
+import {
+  hasUnsafeTextCharacter,
+  readStrictDenseArray,
+  readStrictProperty as read,
+  requireBoundedMachineId,
+  requireClosedString,
+  requireStrictRecord,
+} from "./strict-validation.js";
+import {
+  summarizeHealthFindings,
+  type HealthFinding,
+  type HealthResult,
+  validateHealthResult,
+} from "./contract.js";
+import {
+  runDeterministicHealth,
+  type DeterministicHealthOptions,
+} from "./deterministic.js";
+import { HealthDeadline } from "./deadline.js";
+import {
+  projectPathKind,
+  readProjectJsonObject,
+  readProjectText,
+  resolveProjectPath,
+} from "./read-only-fs.js";
+
+const DEFAULT_AGENTIC_TIMEOUT_MS = 60_000;
+const MAX_AGENTIC_ARTIFACTS = 67;
+const MAX_WORKFLOW_FILES = 64;
+const MAX_ARTIFACT_BYTES = 128 * 1024;
+const MAX_TOTAL_ARTIFACT_BYTES = 512 * 1024;
+const MAX_JUDGMENTS = 50;
+const MAX_FINAL_FINDINGS = 200;
+const MAX_CHECK_BYTES = 128;
+const MAX_REASON_BYTES = 2_000;
+const RESERVED_CHECK = "agentic.review-completed";
+const WORKFLOW_DIRECTORY = path.join(".github", "workflows");
+const CONFIG_PATH = ".lisa.config.json";
+const LOCAL_CONFIG_PATH = ".lisa.config.local.json";
+const WORKFLOW_CONTROL =
+  /^\s*(?:skip_jobs|verify_enforced|mutation(?:_gate)?(?:_enabled)?)\s*:/u;
+const YAML_COMMENT = /^\s*#/u;
+const JOB_IDENTIFIER = /^ {2}[a-zA-Z0-9_-]+:\s*(?:#.*)?$/u;
+const OVERRIDE_PATHS = [
+  {
+    kind: "eslint-override",
+    path: "eslint.config.local.ts",
+  },
+  {
+    kind: "eslint-ignore-override",
+    path: "eslint.ignore.config.local.json",
+  },
+] as const;
+
+/** Read-only evidence kinds exposed to an injected evaluator. */
+export type AgenticArtifactKind =
+  | "eslint-override"
+  | "eslint-ignore-override"
+  | "managed-drift"
+  | "workflow";
+
+/**
+ * One bounded, project-relative source artifact. Artifact content comes from
+ * the host project and must be treated as untrusted prompt material.
+ */
+export interface AgenticHealthArtifact {
+  readonly kind: AgenticArtifactKind;
+  readonly path: string;
+  readonly content: string;
+}
+
+/** Deeply frozen input passed to the evaluator without filesystem capability. */
+export interface AgenticHealthRequest {
+  readonly schemaVersion: 1;
+  readonly deterministicFindings: readonly HealthFinding[];
+  readonly config: {
+    readonly quality: {
+      readonly mutation: {
+        readonly gate: { readonly enabled: boolean | null };
+      };
+    };
+  };
+  readonly artifacts: readonly AgenticHealthArtifact[];
+}
+
+/**
+ * One optional warning proposed by an evaluator.
+ *
+ * At most 50 judgments are accepted. `check` must use the `agentic.` namespace,
+ * cannot be the reserved `agentic.review-completed` id, and is limited to 128
+ * UTF-8 bytes. `reason` must be trimmed, within 2,000 UTF-8 bytes, and contain
+ * no control or bidirectional-formatting characters. Lisa, rather than the
+ * evaluator, stamps every accepted judgment as agentic and warn.
+ */
+export interface AgenticHealthJudgment {
+  readonly check: string;
+  readonly reason: string;
+}
+
+/** Closed evaluator response; unavailable and completed are the only states. */
+export type AgenticHealthEvaluation =
+  | {
+      readonly status: "completed";
+      readonly judgments: readonly AgenticHealthJudgment[];
+    }
+  | { readonly status: "unavailable" };
+
+/**
+ * Injected harness-neutral judgment boundary.
+ *
+ * The callback is arbitrary JavaScript, not a security sandbox. Lisa supplies
+ * no filesystem capability, but consumers must still trust their evaluator.
+ * Evaluators must honor the AbortSignal and release their own timers, streams,
+ * and other resources when it aborts. Runtime output remains hostile-validated.
+ */
+export type AgenticHealthEvaluator = (
+  request: AgenticHealthRequest,
+  signal: AbortSignal
+) => Promise<AgenticHealthEvaluation>;
+
+/** Explicit optional agentic-pass configuration. */
+export interface AgenticHealthConfig {
+  readonly enabled: boolean;
+  readonly evaluator?: AgenticHealthEvaluator;
+  readonly timeoutMs?: number;
+}
+
+/** Deterministic options plus the optional agentic pass. */
+export interface HealthOptions extends DeterministicHealthOptions {
+  readonly agentic?: AgenticHealthConfig;
+}
+
+/** The sole project-config value disclosed to an evaluator. */
+interface AgenticConfigProjection {
+  readonly quality: {
+    readonly mutation: { readonly gate: { readonly enabled: boolean | null } };
+  };
+}
+
+/** One path-specific config read, distinguishing absence from invalid values. */
+interface MutationGateRead {
+  readonly present: boolean;
+  readonly enabled: boolean | null;
+}
+
+/** Read one optional fixed-path override artifact. */
+async function readOptionalArtifact(
+  projectRoot: string,
+  descriptor: Readonly<{ kind: AgenticArtifactKind; path: string }>
+): Promise<AgenticHealthArtifact | undefined> {
+  const kind = await projectPathKind(projectRoot, descriptor.path);
+  if (kind === "missing") return undefined;
+  if (kind !== "file") throw new Error("Unsafe agentic evidence path");
+  const content = await readProjectText(
+    projectRoot,
+    descriptor.path,
+    MAX_ARTIFACT_BYTES
+  );
+  if (content === undefined) return undefined;
+  return Object.freeze({ ...descriptor, content });
+}
+
+/** Enumerate bounded regular workflow files without following special paths. */
+async function workflowPaths(projectRoot: string): Promise<readonly string[]> {
+  const kind = await projectPathKind(projectRoot, WORKFLOW_DIRECTORY);
+  if (kind === "missing") return [];
+  if (kind !== "directory") throw new Error("Unsafe workflow evidence path");
+  const directory = resolveProjectPath(projectRoot, WORKFLOW_DIRECTORY);
+  const entries = await readdir(directory, { withFileTypes: true });
+  const workflows = entries
+    .filter(entry => /\.ya?ml$/u.test(entry.name))
+    .map(entry => {
+      if (!entry.isFile()) throw new Error("Unsafe workflow evidence file");
+      return path.join(WORKFLOW_DIRECTORY, entry.name);
+    })
+    .sort((left, right) => left.localeCompare(right));
+  if (workflows.length > MAX_WORKFLOW_FILES) {
+    throw new Error("Agentic workflow evidence exceeds file limit");
+  }
+  return workflows;
+}
+
+/** Reduce workflow YAML in one pass to controls, job ids, and comment blocks. */
+function workflowExcerpt(source: string): string {
+  const lines = source.split(/\r?\n/u);
+  const selected = new Map<number, string>();
+  let currentJob: Readonly<{ index: number; line: string }> | undefined;
+  let pendingComments: Array<Readonly<{ index: number; line: string }>> = [];
+  let captureFollowingComments = false;
+  lines.forEach((line, index) => {
+    if (JOB_IDENTIFIER.test(line)) {
+      currentJob = Object.freeze({ index, line });
+      pendingComments = [];
+      captureFollowingComments = false;
+      return;
+    }
+    if (YAML_COMMENT.test(line)) {
+      const comment = Object.freeze({ index, line });
+      pendingComments.push(comment);
+      if (captureFollowingComments) selected.set(index, line);
+      return;
+    }
+    if (WORKFLOW_CONTROL.test(line)) {
+      if (currentJob !== undefined) {
+        selected.set(currentJob.index, currentJob.line);
+      }
+      pendingComments.forEach(comment =>
+        selected.set(comment.index, comment.line)
+      );
+      selected.set(index, line);
+      pendingComments = [];
+      captureFollowingComments = true;
+      return;
+    }
+    pendingComments = [];
+    captureFollowingComments = false;
+  });
+  return [...selected.entries()]
+    .map(([index, line]) => `${index + 1}: ${line}`)
+    .join("\n");
+}
+
+/** Read current managed ESLint content only when deterministic drift names it. */
+async function readManagedDriftArtifact(
+  projectRoot: string,
+  deterministic: HealthResult
+): Promise<AgenticHealthArtifact | undefined> {
+  const finding = deterministic.findings.find(
+    candidate =>
+      candidate.check === "templates.managed" &&
+      candidate.status === "fail" &&
+      /(?:^|[ :,])eslint\.config\.ts(?:$|[ ,])/u.test(candidate.reason)
+  );
+  if (finding === undefined) return undefined;
+  return readOptionalArtifact(projectRoot, {
+    kind: "managed-drift",
+    path: "eslint.config.ts",
+  });
+}
+
+/** Resolve the allowlisted path without retaining unrelated config values. */
+function mutationGateRead(
+  config: Readonly<Record<string, unknown>>
+): MutationGateRead {
+  let current: unknown = config;
+  for (const field of ["quality", "mutation", "gate", "enabled"] as const) {
+    if (
+      current === null ||
+      typeof current !== "object" ||
+      Array.isArray(current)
+    ) {
+      return Object.freeze({ present: true, enabled: null });
+    }
+    if (!Object.prototype.hasOwnProperty.call(current, field)) {
+      return Object.freeze({ present: false, enabled: null });
+    }
+    current = (current as Readonly<Record<string, unknown>>)[field];
+  }
+  return Object.freeze({
+    present: true,
+    enabled: typeof current === "boolean" ? current : null,
+  });
+}
+
+/** Read the effective mutation-gate boolean with local-config precedence. */
+async function readAgenticConfig(
+  projectRoot: string
+): Promise<AgenticConfigProjection> {
+  const [committed, local] = await Promise.all([
+    readProjectJsonObject(projectRoot, CONFIG_PATH),
+    readProjectJsonObject(projectRoot, LOCAL_CONFIG_PATH),
+  ]);
+  const localGate = mutationGateRead(local ?? {});
+  const committedGate = mutationGateRead(committed ?? {});
+  const enabled = localGate.present ? localGate.enabled : committedGate.enabled;
+  return Object.freeze({
+    quality: Object.freeze({
+      mutation: Object.freeze({
+        gate: Object.freeze({ enabled }),
+      }),
+    }),
+  });
+}
+
+/** Collect confined project evidence with hard per-file and aggregate bounds. */
+async function collectAgenticArtifacts(
+  projectRoot: string,
+  deterministic: HealthResult
+): Promise<readonly AgenticHealthArtifact[]> {
+  const [overrides, managedDrift] = await Promise.all([
+    Promise.all(
+      OVERRIDE_PATHS.map(descriptor =>
+        readOptionalArtifact(projectRoot, descriptor)
+      )
+    ),
+    readManagedDriftArtifact(projectRoot, deterministic),
+  ]);
+  const workflows = (
+    await Promise.all(
+      (await workflowPaths(projectRoot)).map(async relativePath => {
+        const content = await readProjectText(
+          projectRoot,
+          relativePath,
+          MAX_ARTIFACT_BYTES
+        );
+        if (content === undefined) {
+          throw new Error("Workflow evidence disappeared during collection");
+        }
+        const excerpt = workflowExcerpt(content);
+        if (excerpt.length === 0) return undefined;
+        if (Buffer.byteLength(excerpt, "utf8") > MAX_ARTIFACT_BYTES) {
+          throw new Error("Workflow excerpt exceeds artifact size limit");
+        }
+        return Object.freeze({
+          kind: "workflow" as const,
+          path: relativePath.split(path.sep).join("/"),
+          content: excerpt,
+        });
+      })
+    )
+  ).filter(item => item !== undefined);
+  const artifacts = [
+    ...overrides.filter(item => item !== undefined),
+    ...(managedDrift === undefined ? [] : [managedDrift]),
+    ...workflows,
+  ].sort((left, right) => left.path.localeCompare(right.path));
+  if (artifacts.length > MAX_AGENTIC_ARTIFACTS) {
+    throw new Error("Agentic evidence exceeds artifact limit");
+  }
+  const totalBytes = artifacts.reduce(
+    (total, artifact) => total + Buffer.byteLength(artifact.content, "utf8"),
+    0
+  );
+  if (totalBytes > MAX_TOTAL_ARTIFACT_BYTES) {
+    throw new Error("Agentic evidence exceeds aggregate size limit");
+  }
+  return Object.freeze(artifacts);
+}
+
+/** Create a detached deeply frozen evaluator request. */
+function evaluatorRequest(
+  deterministic: HealthResult,
+  config: AgenticConfigProjection,
+  artifacts: readonly AgenticHealthArtifact[]
+): AgenticHealthRequest {
+  const deterministicFindings = deterministic.findings.map(finding =>
+    Object.freeze({ ...finding })
+  );
+  return Object.freeze({
+    schemaVersion: 1,
+    deterministicFindings: Object.freeze(deterministicFindings),
+    config,
+    artifacts: Object.freeze(
+      artifacts.map(artifact => Object.freeze({ ...artifact }))
+    ),
+  });
+}
+
+/** Validate one evaluator-produced warning without accepting attribution fields. */
+function validateJudgment(
+  candidate: unknown,
+  index: number
+): AgenticHealthJudgment {
+  const input = requireStrictRecord(
+    candidate,
+    ["check", "reason"] as const,
+    `agentic judgments[${index}]`
+  );
+  const check = requireBoundedMachineId(
+    read(input, "check"),
+    `agentic judgments[${index}].check`,
+    MAX_CHECK_BYTES
+  );
+  if (!check.startsWith("agentic.") || check === RESERVED_CHECK) {
+    throw new Error("Invalid agentic judgment check namespace");
+  }
+  const reason = read(input, "reason");
+  if (
+    typeof reason !== "string" ||
+    reason.trim() !== reason ||
+    reason.length === 0 ||
+    Buffer.byteLength(reason, "utf8") > MAX_REASON_BYTES ||
+    hasUnsafeTextCharacter(reason)
+  ) {
+    throw new Error("Invalid agentic judgment reason");
+  }
+  return Object.freeze({ check, reason });
+}
+
+/** Validate the evaluator's exact closed result union atomically. */
+function validateEvaluation(candidate: unknown): AgenticHealthEvaluation {
+  if (
+    candidate === null ||
+    typeof candidate !== "object" ||
+    isProxy(candidate)
+  ) {
+    throw new Error("Invalid agentic evaluation: expected a plain object");
+  }
+  const statusInput = requireStrictRecord(
+    candidate,
+    Object.prototype.hasOwnProperty.call(candidate, "judgments")
+      ? (["status", "judgments"] as const)
+      : (["status"] as const),
+    "agentic evaluation"
+  );
+  const status = requireClosedString(
+    read(statusInput, "status"),
+    ["completed", "unavailable"] as const,
+    "agentic evaluation.status"
+  );
+  if (status === "unavailable") {
+    if (Object.prototype.hasOwnProperty.call(candidate, "judgments")) {
+      throw new Error("Unavailable agentic evaluation cannot carry judgments");
+    }
+    return Object.freeze({ status });
+  }
+  if (!Object.prototype.hasOwnProperty.call(candidate, "judgments")) {
+    throw new Error("Completed agentic evaluation requires judgments");
+  }
+  const judgments = readStrictDenseArray(
+    read(statusInput, "judgments"),
+    0,
+    MAX_JUDGMENTS,
+    "agentic judgments"
+  ).map(validateJudgment);
+  const checks = judgments.map(judgment => judgment.check);
+  if (new Set(checks).size !== checks.length) {
+    throw new Error("Agentic judgment checks must be unique");
+  }
+  return Object.freeze({ status, judgments: Object.freeze(judgments) });
+}
+
+/** Compose completed, validated judgments without changing deterministic facts. */
+function composeFullResult(
+  deterministic: HealthResult,
+  evaluation: Extract<
+    AgenticHealthEvaluation,
+    { readonly status: "completed" }
+  >,
+  now: () => Date
+): HealthResult {
+  const deterministicChecks = new Set(
+    deterministic.findings.map(finding => finding.check)
+  );
+  if (
+    evaluation.judgments.some(judgment =>
+      deterministicChecks.has(judgment.check)
+    )
+  ) {
+    throw new Error(
+      "Agentic judgment check collides with deterministic output"
+    );
+  }
+  if (
+    deterministic.findings.length + evaluation.judgments.length >
+    MAX_FINAL_FINDINGS
+  ) {
+    throw new Error("Completed agentic output exceeds final finding capacity");
+  }
+  const warnings = [...evaluation.judgments]
+    .sort((left, right) =>
+      left.check === right.check
+        ? left.reason.localeCompare(right.reason)
+        : left.check.localeCompare(right.check)
+    )
+    .map(judgment =>
+      Object.freeze({
+        check: judgment.check,
+        layer: "agentic" as const,
+        status: "warn" as const,
+        reason: judgment.reason,
+      })
+    );
+  const findings = [...deterministic.findings, ...warnings];
+  const observedCompleted = now().toISOString();
+  const completedAt =
+    observedCompleted < deterministic.completedAt
+      ? deterministic.completedAt
+      : observedCompleted;
+  return validateHealthResult({
+    schemaVersion: 1,
+    runId: deterministic.runId,
+    mode: "full",
+    startedAt: deterministic.startedAt,
+    completedAt,
+    findings,
+    summary: summarizeHealthFindings(findings),
+  });
+}
+
+/** Resolve a canonical project directory for confined evidence collection. */
+async function canonicalProjectRoot(projectPath: string): Promise<string> {
+  const root = await realpath(path.resolve(projectPath));
+  if (!(await lstat(root)).isDirectory()) {
+    throw new Error("Health project root is not a directory");
+  }
+  return root;
+}
+
+/**
+ * Run deterministic health and, only when explicitly enabled and available,
+ * compose one bounded optional agentic review. Collection never persists.
+ */
+export async function runHealth(
+  projectPath: string,
+  options: HealthOptions = {}
+): Promise<HealthResult> {
+  const { agentic, ...deterministicOptions } = options;
+  const deterministic = await runDeterministicHealth(
+    projectPath,
+    deterministicOptions
+  );
+  if (agentic?.enabled !== true || agentic.evaluator === undefined) {
+    return deterministic;
+  }
+  const deadline = new HealthDeadline(
+    agentic.timeoutMs ?? DEFAULT_AGENTIC_TIMEOUT_MS
+  );
+  try {
+    const root = await deadline.run(
+      () => canonicalProjectRoot(projectPath),
+      undefined
+    );
+    if (root === undefined) return deterministic;
+    const evidence = await deadline.run(
+      async () =>
+        Promise.all([
+          readAgenticConfig(root),
+          collectAgenticArtifacts(root, deterministic),
+        ]),
+      undefined
+    );
+    if (evidence === undefined) return deterministic;
+    const [config, artifacts] = evidence;
+    const request = evaluatorRequest(deterministic, config, artifacts);
+    const evaluation = await deadline.run(
+      async () =>
+        validateEvaluation(await agentic.evaluator!(request, deadline.signal)),
+      undefined
+    );
+    if (evaluation === undefined || evaluation.status === "unavailable") {
+      return deterministic;
+    }
+    return composeFullResult(
+      deterministic,
+      evaluation,
+      options.now ?? (() => new Date())
+    );
+  } catch {
+    return deterministic;
+  } finally {
+    deadline.close();
+  }
+}
+
+/* eslint-enable functional/immutable-data, functional/no-let, jsdoc/require-param, jsdoc/require-param-description, jsdoc/require-returns, max-lines -- restore repository defaults */

--- a/src/health/contract.ts
+++ b/src/health/contract.ts
@@ -253,12 +253,9 @@ function assertModeLayers(
       "Invalid findings: deterministic mode permits deterministic findings only"
     );
   }
-  if (
-    mode === "full" &&
-    (!layers.has("deterministic") || !layers.has("agentic"))
-  ) {
+  if (mode === "full" && !layers.has("deterministic")) {
     throw new Error(
-      "Invalid findings: full mode requires both deterministic and agentic findings"
+      "Invalid findings: full mode requires deterministic findings"
     );
   }
 }

--- a/src/health/deadline.ts
+++ b/src/health/deadline.ts
@@ -24,7 +24,6 @@ export class HealthDeadline {
       this.signal.addEventListener("abort", () => resolve(), { once: true });
     });
     this.timer = setTimeout(() => this.controller.abort(), duration);
-    this.timer.unref();
   }
 
   /** Remaining whole milliseconds available to a bounded command. */

--- a/src/health/index.ts
+++ b/src/health/index.ts
@@ -1,3 +1,4 @@
 export * from "./contract.js";
+export * from "./agentic.js";
 export * from "./deterministic.js";
 export * from "./storage.js";

--- a/tests/unit/health/agentic.test.ts
+++ b/tests/unit/health/agentic.test.ts
@@ -1,0 +1,748 @@
+/* eslint-disable @eslint-community/eslint-comments/disable-enable-pair, jsdoc/require-jsdoc, max-lines, sonarjs/no-duplicate-string -- explicit hostile-boundary matrix */
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  deterministic: undefined as unknown,
+  runDeterministic: vi.fn(),
+}));
+
+vi.mock("../../../src/health/deterministic.js", () => ({
+  runDeterministicHealth: mocks.runDeterministic,
+}));
+
+import {
+  runHealth,
+  type AgenticHealthEvaluation,
+  type AgenticHealthEvaluator,
+  type AgenticHealthJudgment,
+  type AgenticHealthRequest,
+} from "../../../src/health/agentic.js";
+import {
+  summarizeHealthFindings,
+  type HealthResult,
+  validateHealthResult,
+} from "../../../src/health/contract.js";
+
+const STARTED_AT = "2026-07-20T12:00:00.000Z";
+const DETERMINISTIC_COMPLETED_AT = "2026-07-20T12:01:00.000Z";
+const AGENTIC_COMPLETED_AT = "2026-07-20T12:02:00.000Z";
+
+let projectRoot: string;
+
+function deterministicResult(
+  count = 1,
+  status: "pass" | "fail" = "pass"
+): HealthResult {
+  const findings = Array.from({ length: count }, (_unused, index) => ({
+    check: index === 0 ? "config.sync" : `deterministic.check-${index}`,
+    layer: "deterministic" as const,
+    status,
+    reason:
+      status === "pass"
+        ? "The deterministic check passed."
+        : "The deterministic check found intentional drift.",
+  }));
+  return validateHealthResult({
+    schemaVersion: 1,
+    runId: "health-run-agentic-unit",
+    mode: "deterministic",
+    startedAt: STARTED_AT,
+    completedAt: DETERMINISTIC_COMPLETED_AT,
+    findings,
+    summary: summarizeHealthFindings(findings),
+  });
+}
+
+function managedEslintDriftResult(): HealthResult {
+  const findings = [
+    {
+      check: "templates.managed",
+      layer: "deterministic" as const,
+      status: "fail" as const,
+      reason: "Managed files do not match templates: eslint.config.ts",
+    },
+  ];
+  return validateHealthResult({
+    schemaVersion: 1,
+    runId: "health-run-managed-drift",
+    mode: "deterministic",
+    startedAt: STARTED_AT,
+    completedAt: DETERMINISTIC_COMPLETED_AT,
+    findings,
+    summary: summarizeHealthFindings(findings),
+  });
+}
+
+async function writeFixture(): Promise<void> {
+  await mkdir(path.join(projectRoot, ".github", "workflows"), {
+    recursive: true,
+  });
+  await writeFile(
+    path.join(projectRoot, ".lisa.config.json"),
+    JSON.stringify({
+      quality: { mutation: { gate: { enabled: false } } },
+      privateToken: "config-secret-must-not-cross-boundary",
+    })
+  );
+  await writeFile(
+    path.join(projectRoot, "eslint.config.local.ts"),
+    "export default [{ rules: { noConsole: 'off' } }];\n"
+  );
+  await writeFile(
+    path.join(projectRoot, "eslint.ignore.config.local.json"),
+    '["generated/**"]\n'
+  );
+  await writeFile(
+    path.join(projectRoot, "eslint.config.ts"),
+    "export default ['managed-content-must-stay-gated'];\n"
+  );
+  await writeFile(
+    path.join(projectRoot, ".github", "workflows", "ci.yml"),
+    [
+      "name: private workflow name",
+      "jobs:",
+      "  quality:",
+      "    uses: org/private-repository/.github/workflows/quality.yml@main",
+      "    with:",
+      "      # temporarily skipped because the vendor is down",
+      "      # resume after vendor ticket VENDOR-42 closes",
+      "      skip_jobs: 'lint'",
+      "      # expires on 2026-07-21",
+      "      verify_enforced: false",
+      "      unrelated_secret: do-not-expose",
+      "  release:",
+      "    steps:",
+      "      - run: echo private-command",
+      "",
+    ].join("\n")
+  );
+}
+
+async function collect(
+  evaluator?: AgenticHealthEvaluator
+): Promise<HealthResult> {
+  return runHealth(projectRoot, {
+    now: () => new Date(AGENTIC_COMPLETED_AT),
+    agentic: { enabled: true, evaluator, timeoutMs: 200 },
+  });
+}
+
+beforeEach(async () => {
+  projectRoot = await realpath(
+    await mkdtemp(path.join(tmpdir(), "lisa-health-agentic-unit-"))
+  );
+  await writeFixture();
+  mocks.deterministic = deterministicResult();
+  mocks.runDeterministic.mockReset();
+  mocks.runDeterministic.mockImplementation(async () => mocks.deterministic);
+});
+
+afterEach(async () => {
+  await rm(projectRoot, { recursive: true, force: true });
+});
+
+describe("runHealth deterministic-first behavior", () => {
+  it("publishes the closed evaluator judgment and evaluation types", () => {
+    const judgment: AgenticHealthJudgment = {
+      check: "agentic.public-contract",
+      reason: "The public judgment shape is available.",
+    };
+    const evaluation: AgenticHealthEvaluation = {
+      status: "completed",
+      judgments: [judgment],
+    };
+
+    expect(evaluation).toEqual({ status: "completed", judgments: [judgment] });
+  });
+
+  it("returns the exact deterministic result when agentic review is disabled or absent", async () => {
+    const evaluator = vi.fn(async () => ({
+      status: "completed",
+      judgments: [],
+    }));
+    const disabled = await runHealth(projectRoot, {
+      agentic: { enabled: false, evaluator },
+    });
+    const unavailable = await collect();
+
+    expect(disabled).toBe(mocks.deterministic);
+    expect(unavailable).toBe(mocks.deterministic);
+    expect(evaluator).not.toHaveBeenCalled();
+    expect(mocks.runDeterministic).toHaveBeenCalledTimes(2);
+  });
+
+  it("composes frozen, sorted, warning-only judgments after deterministic facts", async () => {
+    let request: AgenticHealthRequest | undefined;
+    const beforeConfig = await readFile(
+      path.join(projectRoot, ".lisa.config.json"),
+      "utf8"
+    );
+    const result = await collect(async received => {
+      request = received;
+      return {
+        status: "completed",
+        judgments: [
+          { check: "agentic.workflow-skip", reason: "Lint is skipped." },
+          { check: "agentic.mutation-gate", reason: "Mutation is disabled." },
+        ],
+      };
+    });
+
+    expect(request).toBeDefined();
+    expect(Object.keys(request ?? {})).toEqual([
+      "schemaVersion",
+      "deterministicFindings",
+      "config",
+      "artifacts",
+    ]);
+    expect(request?.config).toEqual({
+      quality: { mutation: { gate: { enabled: false } } },
+    });
+    expect(JSON.stringify(request)).not.toContain("config-secret");
+    expect(JSON.stringify(request)).not.toContain(
+      "managed-content-must-stay-gated"
+    );
+    expect(Object.isFrozen(request)).toBe(true);
+    expect(Object.isFrozen(request?.deterministicFindings)).toBe(true);
+    expect(Object.isFrozen(request?.deterministicFindings[0])).toBe(true);
+    expect(Object.isFrozen(request?.config.quality.mutation.gate)).toBe(true);
+    expect(Object.isFrozen(request?.artifacts)).toBe(true);
+    expect(request?.artifacts.map(artifact => artifact.path)).toEqual([
+      ".github/workflows/ci.yml",
+      "eslint.config.local.ts",
+      "eslint.ignore.config.local.json",
+    ]);
+    const workflow = request?.artifacts.find(
+      artifact => artifact.kind === "workflow"
+    )?.content;
+    expect(workflow).toContain("quality:");
+    expect(workflow).toContain(
+      "# temporarily skipped because the vendor is down"
+    );
+    expect(workflow).toContain("# resume after vendor ticket VENDOR-42 closes");
+    expect(workflow).toContain("# expires on 2026-07-21");
+    expect(workflow).toContain("skip_jobs: 'lint'");
+    expect(workflow).toContain("verify_enforced: false");
+    expect(workflow).not.toContain("private workflow name");
+    expect(workflow).not.toContain("private-repository");
+    expect(workflow).not.toContain("do-not-expose");
+    expect(result.mode).toBe("full");
+    expect(result.completedAt).toBe(AGENTIC_COMPLETED_AT);
+    expect(result.findings.map(finding => finding.check)).toEqual([
+      "config.sync",
+      "agentic.mutation-gate",
+      "agentic.workflow-skip",
+    ]);
+    expect(result.findings.slice(1).map(finding => finding.status)).toEqual([
+      "warn",
+      "warn",
+    ]);
+    expect(result.summary).toEqual({
+      verdict: "in band",
+      counts: { pass: 1, warn: 2, fail: 0 },
+    });
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(
+      await readFile(path.join(projectRoot, ".lisa.config.json"), "utf8")
+    ).toBe(beforeConfig);
+  });
+
+  it("records a completed clean evaluation as full without fabricating a finding", async () => {
+    const result = await collect(async () => ({
+      status: "completed",
+      judgments: [],
+    }));
+
+    expect(result).not.toBe(mocks.deterministic);
+    expect(result.mode).toBe("full");
+    expect(result.findings).toEqual(
+      (mocks.deterministic as HealthResult).findings
+    );
+    expect(result.findings.some(finding => finding.layer === "agentic")).toBe(
+      false
+    );
+  });
+
+  it("projects explicit gate truth while keeping missing values unknown", async () => {
+    const projected: Array<boolean | null> = [];
+    const evaluator: AgenticHealthEvaluator = async request => {
+      projected.push(request.config.quality.mutation.gate.enabled);
+      return { status: "completed", judgments: [] };
+    };
+    await collect(evaluator);
+    await writeFile(
+      path.join(projectRoot, ".lisa.config.local.json"),
+      JSON.stringify({ quality: { mutation: { gate: { enabled: true } } } })
+    );
+    await collect(evaluator);
+    await rm(path.join(projectRoot, ".lisa.config.local.json"));
+    await writeFile(
+      path.join(projectRoot, ".lisa.config.json"),
+      JSON.stringify({ quality: { mutation: { gate: { enabled: true } } } })
+    );
+    await collect(evaluator);
+    await writeFile(
+      path.join(projectRoot, ".lisa.config.json"),
+      JSON.stringify({ quality: { mutation: { gate: { enabled: "false" } } } })
+    );
+    await collect(evaluator);
+    await rm(path.join(projectRoot, ".lisa.config.json"));
+    await collect(evaluator);
+
+    expect(projected).toEqual([false, true, true, null, null]);
+  });
+
+  it("observes completion only after the evaluator resolves", async () => {
+    let observed = DETERMINISTIC_COMPLETED_AT;
+    const result = await runHealth(projectRoot, {
+      now: () => new Date(observed),
+      agentic: {
+        enabled: true,
+        evaluator: async () => {
+          observed = AGENTIC_COMPLETED_AT;
+          return { status: "completed", judgments: [] };
+        },
+      },
+    });
+
+    expect(result.completedAt).toBe(AGENTIC_COMPLETED_AT);
+  });
+
+  it("preserves deterministic drift and keeps agentic judgments warning-only", async () => {
+    mocks.deterministic = deterministicResult(1, "fail");
+    const result = await collect(async () => ({
+      status: "completed",
+      judgments: [
+        { check: "agentic.context", reason: "Context needs review." },
+      ],
+    }));
+
+    expect(result.findings[0]).toEqual(
+      (mocks.deterministic as HealthResult).findings[0]
+    );
+    expect(result.findings.at(-1)?.status).toBe("warn");
+    expect(result.summary.verdict).toBe("drift detected");
+  });
+
+  it("exposes gated current managed drift so identical justification can be judged by content", async () => {
+    mocks.deterministic = managedEslintDriftResult();
+    await writeFile(
+      path.join(projectRoot, "eslint.config.local.ts"),
+      "// justification: temporary migration\nexport default [];\n"
+    );
+    const observedManagedContent: string[] = [];
+    const evaluator: AgenticHealthEvaluator = async request => {
+      const managed = request.artifacts.find(
+        artifact => artifact.kind === "managed-drift"
+      );
+      observedManagedContent.push(managed?.content ?? "missing");
+      return managed?.content.includes("disable-security-rule") === true
+        ? {
+            status: "completed",
+            judgments: [
+              {
+                check: "agentic.intentional-drift",
+                reason: "The current managed drift disables a security rule.",
+              },
+            ],
+          }
+        : { status: "completed", judgments: [] };
+    };
+
+    await writeFile(
+      path.join(projectRoot, "eslint.config.ts"),
+      "export default ['benign-formatting-drift'];\n"
+    );
+    const benign = await collect(evaluator);
+    await writeFile(
+      path.join(projectRoot, "eslint.config.ts"),
+      "export default ['disable-security-rule'];\n"
+    );
+    const suspicious = await collect(evaluator);
+
+    expect(observedManagedContent).toEqual([
+      "export default ['benign-formatting-drift'];\n",
+      "export default ['disable-security-rule'];\n",
+    ]);
+    expect(benign.mode).toBe("full");
+    expect(benign.findings).toHaveLength(1);
+    expect(suspicious.findings.at(-1)).toMatchObject({
+      check: "agentic.intentional-drift",
+      layer: "agentic",
+      status: "warn",
+    });
+  });
+});
+
+describe("runHealth hostile evaluator degradation", () => {
+  const invalidEvaluation = [
+    ["null", () => null],
+    ["scalar", () => "completed"],
+    ["unknown status", () => ({ status: "failed" })],
+    ["missing judgments", () => ({ status: "completed" })],
+    ["unavailable payload", () => ({ status: "unavailable", judgments: [] })],
+    [
+      "evaluator attribution",
+      () => ({
+        status: "completed",
+        judgments: [
+          {
+            check: "agentic.test",
+            layer: "agentic",
+            reason: "Evaluator attempted attribution.",
+          },
+        ],
+      }),
+    ],
+    [
+      "evaluator severity",
+      () => ({
+        status: "completed",
+        judgments: [
+          { check: "agentic.test", status: "fail", reason: "Forged severity." },
+        ],
+      }),
+    ],
+    [
+      "wrong namespace",
+      () => ({
+        status: "completed",
+        judgments: [{ check: "config.sync", reason: "Collision." }],
+      }),
+    ],
+    [
+      "reserved sentinel",
+      () => ({
+        status: "completed",
+        judgments: [
+          { check: "agentic.review-completed", reason: "Forged sentinel." },
+        ],
+      }),
+    ],
+    [
+      "duplicate checks",
+      () => ({
+        status: "completed",
+        judgments: [
+          { check: "agentic.same", reason: "First." },
+          { check: "agentic.same", reason: "Second." },
+        ],
+      }),
+    ],
+    [
+      "blank reason",
+      () => ({
+        status: "completed",
+        judgments: [{ check: "agentic.test", reason: " " }],
+      }),
+    ],
+    [
+      "controlled reason",
+      () => ({
+        status: "completed",
+        judgments: [{ check: "agentic.test", reason: "hidden\u0000text" }],
+      }),
+    ],
+    [
+      "oversized reason",
+      () => ({
+        status: "completed",
+        judgments: [{ check: "agentic.test", reason: "x".repeat(2_001) }],
+      }),
+    ],
+    [
+      "too many judgments",
+      () => ({
+        status: "completed",
+        judgments: Array.from({ length: 51 }, (_unused, index) => ({
+          check: `agentic.check-${index}`,
+          reason: "Too many.",
+        })),
+      }),
+    ],
+    [
+      "sparse judgments",
+      () => ({
+        status: "completed",
+        judgments: Object.assign(Array<unknown>(2), {
+          1: { check: "agentic.test", reason: "Sparse." },
+        }),
+      }),
+    ],
+  ] as const;
+
+  it.each(invalidEvaluation)(
+    "degrades malformed output atomically: %s",
+    async (_name, make) => {
+      const result = await collect(async () => make());
+      expect(result).toBe(mocks.deterministic);
+    }
+  );
+
+  it("rejects proxies before invoking hostile reflection traps", async () => {
+    let invoked = false;
+    const proxy = new Proxy(
+      { status: "completed", judgments: [] },
+      {
+        getOwnPropertyDescriptor: () => {
+          invoked = true;
+          throw new Error("must not run");
+        },
+      }
+    );
+    const result = await collect(async () => proxy);
+
+    expect(result).toBe(mocks.deterministic);
+    expect(invoked).toBe(false);
+  });
+
+  it("rejects accessors without invoking them", async () => {
+    let invoked = false;
+    const candidate = Object.defineProperty({}, "status", {
+      enumerable: true,
+      get: () => {
+        invoked = true;
+        return "unavailable";
+      },
+    });
+    const result = await collect(async () => candidate);
+
+    expect(result).toBe(mocks.deterministic);
+    expect(invoked).toBe(false);
+  });
+
+  it("does not let an evaluator mutate its frozen request", async () => {
+    const result = await collect(async request => {
+      (request.artifacts as AgenticHealthRequest["artifacts"] & unknown[]).push(
+        {
+          kind: "workflow",
+          path: "forged.yml",
+          content: "forged",
+        }
+      );
+      return { status: "completed", judgments: [] };
+    });
+
+    expect(result).toBe(mocks.deterministic);
+  });
+
+  it("degrades an agentic check collision with deterministic output", async () => {
+    const deterministic = deterministicResult();
+    mocks.deterministic = validateHealthResult({
+      ...deterministic,
+      findings: [
+        {
+          check: "agentic.context",
+          layer: "deterministic",
+          status: "pass",
+          reason: "A deterministic check owns this identifier.",
+        },
+      ],
+      summary: { verdict: "in band", counts: { pass: 1, warn: 0, fail: 0 } },
+    });
+    const result = await collect(async () => ({
+      status: "completed",
+      judgments: [
+        { check: "agentic.context", reason: "The evaluator collided." },
+      ],
+    }));
+
+    expect(result).toBe(mocks.deterministic);
+  });
+
+  it.each([
+    ["unavailable", async () => ({ status: "unavailable" })],
+    [
+      "throw",
+      async () => Promise.reject(new Error("private evaluator failure")),
+    ],
+  ])(
+    "returns the exact deterministic object when the evaluator is %s",
+    async (_name, evaluator) => {
+      expect(await collect(evaluator)).toBe(mocks.deterministic);
+    }
+  );
+
+  it("aborts a timed-out evaluator and returns exact deterministic output", async () => {
+    let aborted = false;
+    let evaluatorStarted!: () => void;
+    const started = new Promise<void>(resolve => {
+      evaluatorStarted = resolve;
+    });
+    const startedAt = performance.now();
+    const running = runHealth(projectRoot, {
+      agentic: {
+        enabled: true,
+        timeoutMs: 500,
+        evaluator: async (_request, signal) => {
+          evaluatorStarted();
+          return new Promise(resolve => {
+            signal.addEventListener(
+              "abort",
+              () => {
+                aborted = true;
+                resolve({ status: "unavailable" });
+              },
+              { once: true }
+            );
+          });
+        },
+      },
+    });
+    await started;
+    const result = await running;
+
+    expect(result).toBe(mocks.deterministic);
+    expect(aborted).toBe(true);
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
+  });
+
+  it("degrades when completed output exceeds the final 200-finding capacity", async () => {
+    mocks.deterministic = deterministicResult(151);
+    const result = await collect(async () => ({
+      status: "completed",
+      judgments: Array.from({ length: 50 }, (_unused, index) => ({
+        check: `agentic.capacity-${index}`,
+        reason: "Bounded warning.",
+      })),
+    }));
+
+    expect(result).toBe(mocks.deterministic);
+  });
+
+  it("accepts completed output at the exact 200-finding capacity", async () => {
+    mocks.deterministic = deterministicResult(150);
+    const result = await collect(async () => ({
+      status: "completed",
+      judgments: Array.from({ length: 50 }, (_unused, index) => ({
+        check: `agentic.capacity-${index}`,
+        reason: "Bounded warning.",
+      })),
+    }));
+
+    expect(result.mode).toBe("full");
+    expect(result.findings).toHaveLength(200);
+  });
+});
+
+describe("runHealth confined evidence collection", () => {
+  it("extracts a large control-heavy workflow in linear time", async () => {
+    const controls = Array.from(
+      { length: 3_000 },
+      (_unused, index) => `      skip_jobs: 'job-${index % 10}'`
+    ).join("\n");
+    await writeFile(
+      path.join(projectRoot, ".github", "workflows", "ci.yml"),
+      `jobs:\n  quality:\n${controls}\n`
+    );
+    const evaluator = vi.fn(async () => ({
+      status: "completed" as const,
+      judgments: [],
+    }));
+    const startedAt = performance.now();
+
+    const result = await runHealth(projectRoot, {
+      agentic: { enabled: true, evaluator, timeoutMs: 2_000 },
+    });
+
+    expect(result.mode).toBe("full");
+    expect(evaluator).toHaveBeenCalledTimes(1);
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
+  });
+
+  it("degrades before evaluation when line prefixes expand an excerpt past its byte limit", async () => {
+    const controls = Array.from({ length: 6_000 }, () => "      skip_jobs:");
+    const source = controls.join("\n");
+    const expanded = controls
+      .map((line, index) => `${index + 1}: ${line}`)
+      .join("\n");
+    expect(Buffer.byteLength(source, "utf8")).toBeLessThanOrEqual(128 * 1024);
+    expect(Buffer.byteLength(expanded, "utf8")).toBeGreaterThan(128 * 1024);
+    await writeFile(
+      path.join(projectRoot, ".github", "workflows", "ci.yml"),
+      source
+    );
+    const evaluator = vi.fn(async () => ({
+      status: "completed" as const,
+      judgments: [],
+    }));
+    const startedAt = performance.now();
+
+    const result = await runHealth(projectRoot, {
+      agentic: { enabled: true, evaluator, timeoutMs: 2_000 },
+    });
+
+    expect(result).toBe(mocks.deterministic);
+    expect(evaluator).not.toHaveBeenCalled();
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
+  });
+
+  it("degrades without calling the evaluator for an escaping symlink", async () => {
+    const evaluator = vi.fn(async () => ({
+      status: "completed",
+      judgments: [],
+    }));
+    const outside = path.join(
+      tmpdir(),
+      `lisa-health-outside-${process.pid}.ts`
+    );
+    await writeFile(outside, "private outside evidence");
+    await rm(path.join(projectRoot, "eslint.config.local.ts"));
+    await symlink(outside, path.join(projectRoot, "eslint.config.local.ts"));
+
+    try {
+      expect(await collect(evaluator)).toBe(mocks.deterministic);
+      expect(evaluator).not.toHaveBeenCalled();
+    } finally {
+      await rm(outside, { force: true });
+    }
+  });
+
+  it("degrades before evaluation for oversized or invalid UTF-8 evidence", async () => {
+    const evaluator = vi.fn(async () => ({
+      status: "completed",
+      judgments: [],
+    }));
+    await writeFile(
+      path.join(projectRoot, "eslint.config.local.ts"),
+      "x".repeat(128 * 1024 + 1)
+    );
+    expect(await collect(evaluator)).toBe(mocks.deterministic);
+    await writeFile(
+      path.join(projectRoot, "eslint.config.local.ts"),
+      Buffer.from([0xc3, 0x28])
+    );
+    expect(await collect(evaluator)).toBe(mocks.deterministic);
+    expect(evaluator).not.toHaveBeenCalled();
+  });
+
+  it("degrades when workflow enumeration exceeds its fixed limit", async () => {
+    const evaluator = vi.fn(async () => ({
+      status: "completed",
+      judgments: [],
+    }));
+    await Promise.all(
+      Array.from({ length: 65 }, (_unused, index) =>
+        writeFile(
+          path.join(projectRoot, ".github", "workflows", `extra-${index}.yml`),
+          "jobs:\n  quality:\n    with:\n      skip_jobs: ''\n"
+        )
+      )
+    );
+
+    expect(await collect(evaluator)).toBe(mocks.deterministic);
+    expect(evaluator).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/health/contract.test.ts
+++ b/tests/unit/health/contract.test.ts
@@ -57,7 +57,7 @@ describe("validateHealthResult", () => {
     expect(Object.isFrozen(validated.summary.counts)).toBe(true);
   });
 
-  it("accepts full mode only when both layers completed", () => {
+  it("accepts historical full results containing both layers", () => {
     const findings = [
       finding(),
       finding({ check: "agent.review", layer: "agentic", status: "warn" }),
@@ -76,6 +76,32 @@ describe("validateHealthResult", () => {
     ).toBe("full");
   });
 
+  it("accepts full mode with zero agentic findings after a clean evaluation", () => {
+    const validated = validateHealthResult(result({ mode: "full" }));
+
+    expect(validated.mode).toBe("full");
+    expect(validated.findings).toEqual([finding()]);
+  });
+
+  it.each(["pass", "fail"])(
+    "preserves historical agentic %s findings for storage compatibility",
+    status => {
+      const findings = [
+        finding(),
+        finding({ check: "agent.historical", layer: "agentic", status }),
+      ];
+      expect(() =>
+        validateHealthResult(
+          result({
+            mode: "full",
+            findings,
+            summary: summarizeHealthFindings(findings),
+          })
+        )
+      ).not.toThrow();
+    }
+  );
+
   it.each([
     [
       "empty",
@@ -88,7 +114,13 @@ describe("validateHealthResult", () => {
       "agentic deterministic",
       result({ findings: [finding({ layer: "agentic" })] }),
     ],
-    ["missing full layer", result({ mode: "full" })],
+    [
+      "full without deterministic layer",
+      result({
+        mode: "full",
+        findings: [finding({ layer: "agentic" })],
+      }),
+    ],
     ["duplicate check", result({ findings: [finding(), finding()] })],
     ["blank reason", result({ findings: [finding({ reason: " " })] })],
     [

--- a/tests/unit/health/package-surfaces.test.ts
+++ b/tests/unit/health/package-surfaces.test.ts
@@ -6,6 +6,8 @@ const VERIFY_SCRIPT =
 const HEALTH_EXPORT = "./dist/health/index.js";
 const DETERMINISTIC_VERIFY_SCRIPT =
   "bun run build:dist && node scripts/verify-health-deterministic-built.mjs";
+const AGENTIC_VERIFY_SCRIPT =
+  "bun run build:dist && node scripts/verify-health-agentic-built.mjs";
 
 describe("Health v1 package surfaces", () => {
   it("keeps the source package and forced package template synchronized", async () => {
@@ -33,6 +35,10 @@ describe("Health v1 package surfaces", () => {
     );
     expect(template.force.scripts["verify:health-deterministic"]).toBe(
       DETERMINISTIC_VERIFY_SCRIPT
+    );
+    expect(source.scripts["verify:health-agentic"]).toBe(AGENTIC_VERIFY_SCRIPT);
+    expect(template.force.scripts["verify:health-agentic"]).toBe(
+      AGENTIC_VERIFY_SCRIPT
     );
   });
 });

--- a/ui/README.md
+++ b/ui/README.md
@@ -126,14 +126,16 @@ product features, secrets, or business logic is never proposed.
 When the engine lands, `starter.*` should join the `lisa sync` registry so
 the section above governs it like every other setting.
 
-## Health (v1 contract available; consumers planned)
+## Health (contract, deterministic probes, and optional composition available)
 
 The **Health** section answers two questions with different lifecycles. Health
-v1 now defines its shared result and persistence contract at
-`@codyswann/lisa/health`: completed results are validated and atomically stored
-at the gitignored `.lisa/health/latest.json`; `health.schedule` is the only v1
-configuration key and accepts `off`, `daily`, or `weekly`. The button, probes,
-console readback, and scheduler remain downstream work.
+v1 now ships its shared result and persistence contract, deterministic fast
+path, and harness-neutral optional agentic composition API at
+`@codyswann/lisa/health`. Completed results can be validated and atomically
+stored at the gitignored `.lisa/health/latest.json`; `health.schedule` is the
+only v1 configuration key and accepts `off`, `daily`, or `weekly`. The
+`/lisa:health` skill and command, console button and readback, and scheduler
+remain downstream work.
 
 **Is Lisa on the latest version?** — always-on status. Lisa's CLI already
 checks npm on every invocation; the console surfaces the result permanently
@@ -155,14 +157,16 @@ the cron, and the CLI share a single implementation:
   `lisa sync --dry-run` (config fully populated, artifacts in sync), git
   hooks installed and unmodified, plugins enabled and version-current, CI
   workflow drift vs the stack template, rulesets present.
-- **Agentic layer** (judges what a diff can't): whether local overrides
+- **Optional agentic composition** (judges what a diff can't): whether local overrides
   (`eslint.config.local.ts`, grandfathered globs) still serve their original
   purpose, whether detected drift looks intentional or accidental, whether
-  skipped CI jobs and disabled gates have a recorded justification.
+  skipped CI jobs and disabled gates have a recorded justification. The
+  shipped composition API accepts an injected evaluator; harness orchestration
+  remains the responsibility of the downstream `/lisa:health` skill.
 
-Results render as a per-check table (pass / warn / fail, with the layer that
-produced each finding), and the last full check's date + verdict stays
-visible in the section.
+The downstream console will render results as a per-check table (pass / warn /
+fail, with the layer that produced each finding) and keep the last full check's
+date and verdict visible in the section.
 
 ### Remote-environment requirements
 


### PR DESCRIPTION
## Summary

- add the optional, injected agentic health-composition API under `@codyswann/lisa/health`
- preserve the deterministic fast path exactly when evaluation is disabled, unavailable, unsafe, malformed, timed out, or throws
- confine and freeze bounded project evidence; validate and stamp accepted judgments as agentic warnings
- add built-package journey proof, focused hostile-path tests, package-surface coverage, and public contract documentation

## Verification

- `bun run verify:health-agentic` — 164 assertions
- `bun run verify:health-contract` — 19 assertions
- `bun run verify:health-deterministic` — 83 assertions
- `bun run test` / `bun run test:cov` — 377 files, 6,641 tests
- typecheck, lint, slow lint, format, knip, plugin parity, workflow-input contract, upstream-evidence manifest, security audit, and diff checks
- `bun run test:integration` — 9 files, 137 tests
- independent exact-head review — SHIP

Closes #1522

Work-Item: CodySwannGT/lisa#1522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional agentic health reviews that safely extend deterministic health checks with evaluator-provided warnings.
  * Added bounded evidence collection, timeout handling, validation, and automatic fallback to deterministic results.
  * Exposed the agentic health API through the package health exports.

* **Documentation**
  * Updated Health documentation to describe deterministic checks, persistence, and optional agentic composition.

* **Verification**
  * Added comprehensive validation for agentic health behavior, evidence safety, evaluator failures, and package command integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->