### PR TITLE
feat(automations): warn on readiness blockers and document the readiness rubric (#1859)

### DIFF
--- a/.lisa/plan-1859.md
+++ b/.lisa/plan-1859.md
@@ -1,0 +1,70 @@
+# Plan: readiness warning parity (#1859)
+
+Work item: `CodySwannGT/lisa#1859`
+Work type: Build
+Target: human-confirmed `production` -> `main`
+Branch: `1859-setup-automations-warn` rebased onto `origin/main`
+
+## Relevant documentation and code
+
+- `plugins/src/base/skills/lisa-setup-automations/SKILL.md` is the declarative
+  source. Its existing never-block-always-degrade rule is the behavior boundary.
+- `src/cli/doctor-readiness.ts` owns schema version 1, the persisted report
+  shape, and `resolveReadinessReportPath`; this ticket consumes the report and
+  does not create a second readiness assessment.
+- `src/cli/doctor-readiness-blockers.ts` defines the closed B1-B7 blocker set and
+  operator-facing blocker labels.
+- `tests/unit/strategies/agent-ready-readiness-consumption.test.ts` is the
+  established six-output semantic parity pattern.
+- `scripts/build-plugins.sh` fans source content to Claude Code, Codex, Cursor,
+  Antigravity, Copilot, and the canonical skill OpenCode consumes.
+- `scripts/check-plugins-sync.sh` is the authoritative local mirror-parity gate;
+  `plugin-parity-drift` checks third-party version pins and cannot prove this
+  source fan-out.
+- `wiki/schema/llm-wiki-contract.md`, `wiki/projects/registry.md`, `README.md`,
+  and `wiki/documentation/overview.md` were read in full before wiki edits.
+- `wiki/concepts/lisa-vocabulary.md` and `wiki/index.md` own the vocabulary and
+  index surfaces required by the repository wiki contract.
+
+## Plan
+
+1. RED: add a six-output semantic contract test for one structurally valid
+   positive report, silent degradation for missing/unreadable/malformed data,
+   and the explicit continue-without-skipping posture.
+2. GREEN: add a repository-readiness advisory phase to the source
+   `lisa-setup-automations` skill. Read the canonical persisted report once;
+   warn only for schema 1 `NOT_READY` data whose positive integer count matches
+   valid B1-B7 blocker records and has a non-empty narrowed claim. Never rerun
+   doctor, invent freshness, block setup, or skip registration/runbook work.
+3. Document installation readiness, repository readiness, and ship blocker in
+   the vocabulary, distinguishing blocking finding, break-out, safe-block, and
+   `NOT_READY`. Update the wiki overview and index. Keep the conceptual root
+   README free of exact flags/paths per its explicit policy; canonical concrete
+   documentation belongs in the wiki overview.
+4. Regenerate every supported plugin artifact, then regenerate the upstream
+   evidence manifest after the new test is tracked.
+5. Run focused tests, plugin/manifest/rule-pair gates, full quality gates, and an
+   independent review/verification pass. Publish empirical evidence and drive
+   the PR through merge, release, npm publication, and tracker closeout.
+
+## Effective completion condition
+
+`bunx vitest run tests/unit/strategies/setup-automations-readiness-warning.test.ts`
+must name and pass the advisory scenarios against all six delivered skill
+surfaces. A valid seeded three-blocker report must contractually produce one
+operator warning containing the count, B1-B7 ids/labels, and narrowed claim,
+while explicitly continuing every setup step. Missing, unreadable, malformed,
+unsupported, or internally inconsistent reports must contractually produce no
+readiness warning and no error. `bun run check:plugins` and
+`bun run check:upstream-evidence-manifest` must both exit 0. No new readiness
+detector, verdict, enforcement key, artifact path, freshness threshold, or
+hard setup gate may be introduced.
+
+## Verification limitation
+
+The current Codex runtime exposes no native automation mutation tool, so it
+cannot execute a real scheduler registration journey from this session. That
+does not change the ticket's declarative output: the semantic contract test and
+generated-surface inspection prove the shipped instructions. The verifier must
+state that native scheduler execution is not established rather than implying
+it ran.

--- a/.lisa/roster.md
+++ b/.lisa/roster.md
@@ -148,3 +148,24 @@ EXCLUDE - code-simplifier:code-simplifier - prose deliverable; quality-specialis
 EXCLUDE - claude / claude-code-guide / hookify:conversation-analyzer / statusline-setup / Plan / fork - generic or unrelated; decomposition exists (this IS the leaf).
 
 Base-branch resolution: ticket Target Backend Environment = `production`; `deploy.branches` maps `production → main` → base = `main`. PR targets `main`.
+
+---
+
+# Roster Decision — plan: `readiness-warning-parity-1859` (CodySwannGT/lisa#1859)
+
+Recorded: 2026-07-21. Runtime: Codex collaboration. The runtime exposes one
+delegation type, the generic collaboration agent; it exposes no distinct native
+specialist-type selector.
+
+INCLUDE - generic collaboration agent - the only exposed type; use bounded role assignments for the mandatory read-only Explore pass, implementation support, independent review/verification, and learner review.
+EXCLUDE - no additional runtime agent types - none are exposed by the current collaboration surface; Lisa specialist skills may guide assignments but are not separately spawnable agent types here.
+
+Required assignments: one read-only Explore/research pass before planning; one
+independent review/verification pass after implementation; one learner pass
+before shutdown. The lead owns branch sync, implementation integration, tracker
+transitions, PR merge drive, and release proof.
+
+Work type: Build. Target environment is the human-confirmed configured key
+`production`; `.lisa.config.json` maps it uniquely to remote `main`. The existing
+feature branch `1859-setup-automations-warn` is reused and must be rebased onto
+`origin/main` before source work.

--- a/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
@@ -49,6 +49,36 @@ without a human between the loops and the pipeline. Pass `false` explicitly to o
 human triage. The two auto-start flags affect **only** the two exploratory automations; the intake
 gates' adversarial validation remains the quality control either way.
 
+## Repository-readiness advisory
+
+Before creating or updating registrations, locate the standing repository-readiness report through
+RRR-3's canonical `resolveReadinessReportPath` contract (currently `.lisa/readiness.json` under the
+resolved project root). This consumes the shared report; it never creates a second readiness
+assessment. Read the report exactly once. Do not re-run `lisa doctor --readiness`, because doing so
+would execute journeys and replace the standing evidence the operator is about to act on.
+
+A report is usable for this advisory only when all of these are true:
+
+- the file parses to a JSON object whose `schema_version` is `1` and whose `verdict` is `NOT_READY`;
+- `blocker_count` is a positive integer and the `blockers` array length exactly equals
+  `blocker_count`;
+- each blocker has a unique `id` in the closed set B1 through B7 (duplicate blocker ids make the
+  report internally inconsistent, and uniqueness caps the count at seven) and a non-empty
+  operator-facing `label`; and
+- `narrowed_claim` is a non-empty string.
+
+For one usable report, emit exactly one warning naming the blocker count, each blocker's `id` and
+`label`, and the narrowed claim. For example: "Repository readiness warning — 3 standing ship
+blockers: B2 Release path bypasses validation; B4 Failing loop has no recovery; B7 Operability
+cannot be proved. Narrowed claim: ready for supervised changes only." This is a warning only:
+setup continues, and no registration or runbook step is skipped because blockers stand.
+
+Treat a missing or unreadable file, invalid JSON, unsupported schema, or internally inconsistent
+report as unavailable: emit no readiness warning and no error, then continue setup normally. Do not
+invent an artifact freshness, age, or TTL rule; the persisted contract defines no such field. This
+advisory is never a precondition and follows the same never-block-always-degrade posture as runbook
+scaffolding below.
+
 ## The automations to create
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy

--- a/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
@@ -49,6 +49,36 @@ without a human between the loops and the pipeline. Pass `false` explicitly to o
 human triage. The two auto-start flags affect **only** the two exploratory automations; the intake
 gates' adversarial validation remains the quality control either way.
 
+## Repository-readiness advisory
+
+Before creating or updating registrations, locate the standing repository-readiness report through
+RRR-3's canonical `resolveReadinessReportPath` contract (currently `.lisa/readiness.json` under the
+resolved project root). This consumes the shared report; it never creates a second readiness
+assessment. Read the report exactly once. Do not re-run `lisa doctor --readiness`, because doing so
+would execute journeys and replace the standing evidence the operator is about to act on.
+
+A report is usable for this advisory only when all of these are true:
+
+- the file parses to a JSON object whose `schema_version` is `1` and whose `verdict` is `NOT_READY`;
+- `blocker_count` is a positive integer and the `blockers` array length exactly equals
+  `blocker_count`;
+- each blocker has a unique `id` in the closed set B1 through B7 (duplicate blocker ids make the
+  report internally inconsistent, and uniqueness caps the count at seven) and a non-empty
+  operator-facing `label`; and
+- `narrowed_claim` is a non-empty string.
+
+For one usable report, emit exactly one warning naming the blocker count, each blocker's `id` and
+`label`, and the narrowed claim. For example: "Repository readiness warning — 3 standing ship
+blockers: B2 Release path bypasses validation; B4 Failing loop has no recovery; B7 Operability
+cannot be proved. Narrowed claim: ready for supervised changes only." This is a warning only:
+setup continues, and no registration or runbook step is skipped because blockers stand.
+
+Treat a missing or unreadable file, invalid JSON, unsupported schema, or internally inconsistent
+report as unavailable: emit no readiness warning and no error, then continue setup normally. Do not
+invent an artifact freshness, age, or TTL rule; the persisted contract defines no such field. This
+advisory is never a precondition and follows the same never-block-always-degrade posture as runbook
+scaffolding below.
+
 ## The automations to create
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy

--- a/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
@@ -49,6 +49,36 @@ without a human between the loops and the pipeline. Pass `false` explicitly to o
 human triage. The two auto-start flags affect **only** the two exploratory automations; the intake
 gates' adversarial validation remains the quality control either way.
 
+## Repository-readiness advisory
+
+Before creating or updating registrations, locate the standing repository-readiness report through
+RRR-3's canonical `resolveReadinessReportPath` contract (currently `.lisa/readiness.json` under the
+resolved project root). This consumes the shared report; it never creates a second readiness
+assessment. Read the report exactly once. Do not re-run `lisa doctor --readiness`, because doing so
+would execute journeys and replace the standing evidence the operator is about to act on.
+
+A report is usable for this advisory only when all of these are true:
+
+- the file parses to a JSON object whose `schema_version` is `1` and whose `verdict` is `NOT_READY`;
+- `blocker_count` is a positive integer and the `blockers` array length exactly equals
+  `blocker_count`;
+- each blocker has a unique `id` in the closed set B1 through B7 (duplicate blocker ids make the
+  report internally inconsistent, and uniqueness caps the count at seven) and a non-empty
+  operator-facing `label`; and
+- `narrowed_claim` is a non-empty string.
+
+For one usable report, emit exactly one warning naming the blocker count, each blocker's `id` and
+`label`, and the narrowed claim. For example: "Repository readiness warning — 3 standing ship
+blockers: B2 Release path bypasses validation; B4 Failing loop has no recovery; B7 Operability
+cannot be proved. Narrowed claim: ready for supervised changes only." This is a warning only:
+setup continues, and no registration or runbook step is skipped because blockers stand.
+
+Treat a missing or unreadable file, invalid JSON, unsupported schema, or internally inconsistent
+report as unavailable: emit no readiness warning and no error, then continue setup normally. Do not
+invent an artifact freshness, age, or TTL rule; the persisted contract defines no such field. This
+advisory is never a precondition and follows the same never-block-always-degrade posture as runbook
+scaffolding below.
+
 ## The automations to create
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
@@ -49,6 +49,36 @@ without a human between the loops and the pipeline. Pass `false` explicitly to o
 human triage. The two auto-start flags affect **only** the two exploratory automations; the intake
 gates' adversarial validation remains the quality control either way.
 
+## Repository-readiness advisory
+
+Before creating or updating registrations, locate the standing repository-readiness report through
+RRR-3's canonical `resolveReadinessReportPath` contract (currently `.lisa/readiness.json` under the
+resolved project root). This consumes the shared report; it never creates a second readiness
+assessment. Read the report exactly once. Do not re-run `lisa doctor --readiness`, because doing so
+would execute journeys and replace the standing evidence the operator is about to act on.
+
+A report is usable for this advisory only when all of these are true:
+
+- the file parses to a JSON object whose `schema_version` is `1` and whose `verdict` is `NOT_READY`;
+- `blocker_count` is a positive integer and the `blockers` array length exactly equals
+  `blocker_count`;
+- each blocker has a unique `id` in the closed set B1 through B7 (duplicate blocker ids make the
+  report internally inconsistent, and uniqueness caps the count at seven) and a non-empty
+  operator-facing `label`; and
+- `narrowed_claim` is a non-empty string.
+
+For one usable report, emit exactly one warning naming the blocker count, each blocker's `id` and
+`label`, and the narrowed claim. For example: "Repository readiness warning — 3 standing ship
+blockers: B2 Release path bypasses validation; B4 Failing loop has no recovery; B7 Operability
+cannot be proved. Narrowed claim: ready for supervised changes only." This is a warning only:
+setup continues, and no registration or runbook step is skipped because blockers stand.
+
+Treat a missing or unreadable file, invalid JSON, unsupported schema, or internally inconsistent
+report as unavailable: emit no readiness warning and no error, then continue setup normally. Do not
+invent an artifact freshness, age, or TTL rule; the persisted contract defines no such field. This
+advisory is never a precondition and follows the same never-block-always-degrade posture as runbook
+scaffolding below.
+
 ## The automations to create
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy

--- a/plugins/lisa/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-automations/SKILL.md
@@ -49,6 +49,36 @@ without a human between the loops and the pipeline. Pass `false` explicitly to o
 human triage. The two auto-start flags affect **only** the two exploratory automations; the intake
 gates' adversarial validation remains the quality control either way.
 
+## Repository-readiness advisory
+
+Before creating or updating registrations, locate the standing repository-readiness report through
+RRR-3's canonical `resolveReadinessReportPath` contract (currently `.lisa/readiness.json` under the
+resolved project root). This consumes the shared report; it never creates a second readiness
+assessment. Read the report exactly once. Do not re-run `lisa doctor --readiness`, because doing so
+would execute journeys and replace the standing evidence the operator is about to act on.
+
+A report is usable for this advisory only when all of these are true:
+
+- the file parses to a JSON object whose `schema_version` is `1` and whose `verdict` is `NOT_READY`;
+- `blocker_count` is a positive integer and the `blockers` array length exactly equals
+  `blocker_count`;
+- each blocker has a unique `id` in the closed set B1 through B7 (duplicate blocker ids make the
+  report internally inconsistent, and uniqueness caps the count at seven) and a non-empty
+  operator-facing `label`; and
+- `narrowed_claim` is a non-empty string.
+
+For one usable report, emit exactly one warning naming the blocker count, each blocker's `id` and
+`label`, and the narrowed claim. For example: "Repository readiness warning — 3 standing ship
+blockers: B2 Release path bypasses validation; B4 Failing loop has no recovery; B7 Operability
+cannot be proved. Narrowed claim: ready for supervised changes only." This is a warning only:
+setup continues, and no registration or runbook step is skipped because blockers stand.
+
+Treat a missing or unreadable file, invalid JSON, unsupported schema, or internally inconsistent
+report as unavailable: emit no readiness warning and no error, then continue setup normally. Do not
+invent an artifact freshness, age, or TTL rule; the persisted contract defines no such field. This
+advisory is never a precondition and follows the same never-block-always-degrade posture as runbook
+scaffolding below.
+
 ## The automations to create
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy

--- a/plugins/src/base/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-automations/SKILL.md
@@ -49,6 +49,36 @@ without a human between the loops and the pipeline. Pass `false` explicitly to o
 human triage. The two auto-start flags affect **only** the two exploratory automations; the intake
 gates' adversarial validation remains the quality control either way.
 
+## Repository-readiness advisory
+
+Before creating or updating registrations, locate the standing repository-readiness report through
+RRR-3's canonical `resolveReadinessReportPath` contract (currently `.lisa/readiness.json` under the
+resolved project root). This consumes the shared report; it never creates a second readiness
+assessment. Read the report exactly once. Do not re-run `lisa doctor --readiness`, because doing so
+would execute journeys and replace the standing evidence the operator is about to act on.
+
+A report is usable for this advisory only when all of these are true:
+
+- the file parses to a JSON object whose `schema_version` is `1` and whose `verdict` is `NOT_READY`;
+- `blocker_count` is a positive integer and the `blockers` array length exactly equals
+  `blocker_count`;
+- each blocker has a unique `id` in the closed set B1 through B7 (duplicate blocker ids make the
+  report internally inconsistent, and uniqueness caps the count at seven) and a non-empty
+  operator-facing `label`; and
+- `narrowed_claim` is a non-empty string.
+
+For one usable report, emit exactly one warning naming the blocker count, each blocker's `id` and
+`label`, and the narrowed claim. For example: "Repository readiness warning — 3 standing ship
+blockers: B2 Release path bypasses validation; B4 Failing loop has no recovery; B7 Operability
+cannot be proved. Narrowed claim: ready for supervised changes only." This is a warning only:
+setup continues, and no registration or runbook step is skipped because blockers stand.
+
+Treat a missing or unreadable file, invalid JSON, unsupported schema, or internally inconsistent
+report as unavailable: emit no readiness warning and no error, then continue setup normally. Do not
+invent an artifact freshness, age, or TTL rule; the persisted contract defines no such field. This
+advisory is never a precondition and follows the same never-block-always-degrade posture as runbook
+scaffolding below.
+
 ## The automations to create
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1025,7 +1025,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-atlassian/SKILL.md":
       "3820aecb57d184fde1cfa988e7e1402d8f2a766a0b3ffbb576de5a6a72b3d5c5",
     "plugins/src/base/skills/lisa-setup-automations/SKILL.md":
-      "b7dff30df2abe6832b39b2eab8b77adc5da14acf8b44ba59603afb619b92b8fa",
+      "d4d2deb758691fb636c7a742c96a2db8c70d13494aa0e0f96bc715fe4005f693",
     "plugins/src/base/skills/lisa-setup-confluence/SKILL.md":
       "e92d762dbdaeae671c3e52dfe8e10d40a10b606b5e050589181a3898649faedc",
     "plugins/src/base/skills/lisa-setup-github-repo/SKILL.md":
@@ -7910,6 +7910,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/repo-scope-claim.test.ts": true,
     "tests/unit/strategies/rework-triage-skill.test.ts": true,
     "tests/unit/strategies/security-two-bucket-contract.test.ts": true,
+    "tests/unit/strategies/setup-automations-readiness-warning.test.ts": true,
     "tests/unit/strategies/setup-confluence-verified-parent.test.ts": true,
     "tests/unit/strategies/setup-github-prd-verified-label.test.ts": true,
     "tests/unit/strategies/setup-github-project-verification.test.ts": true,

--- a/tests/unit/strategies/setup-automations-readiness-warning.test.ts
+++ b/tests/unit/strategies/setup-automations-readiness-warning.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Contract coverage for setup-automations' repository-readiness advisory
+ * (RRR-7, #1859).
+ *
+ * The setup skill consumes the persisted RRR-3 report; it never reimplements
+ * readiness or turns the warn-only claim gate into a setup precondition. These
+ * assertions pin the valid-report boundary, silent degradation, operator
+ * wording, and six-agent delivery parity.
+ * @module tests/unit/strategies/setup-automations-readiness-warning
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SKILL_ROOTS = [
+  "plugins/src/base/skills",
+  "plugins/lisa/skills",
+  "plugins/lisa/.codex-plugin/skills",
+  "plugins/lisa-cursor/skills",
+  "plugins/lisa-agy/skills",
+  "plugins/lisa-copilot/skills",
+] as const;
+
+/**
+ * Read one delivered setup-automations skill.
+ * @param root - Delivered skill root
+ * @returns The skill markdown
+ */
+const readSkill = (root: string): string =>
+  readFileSync(
+    path.resolve(root, "lisa-setup-automations", "SKILL.md"),
+    "utf8"
+  );
+
+/**
+ * Collapse markdown whitespace so prose assertions survive wrapping.
+ * @param value - Markdown to normalize
+ * @returns Markdown with whitespace runs collapsed
+ */
+const squash = (value: string): string => value.replace(/\s+/g, " ");
+
+describe("setup-automations repository-readiness advisory (#1859)", () => {
+  describe.each(SKILL_ROOTS)("%s", root => {
+    const skill = readSkill(root);
+    const flat = squash(skill);
+
+    it("consumes the canonical persisted report exactly once without rerunning doctor", () => {
+      expect(skill).toContain("resolveReadinessReportPath");
+      expect(skill).toContain(".lisa/readiness.json");
+      expect(flat).toMatch(/read (the )?report exactly once/i);
+      expect(flat).toMatch(/do not (re-)?run `?lisa doctor --readiness`?/i);
+    });
+
+    it("warns only for one internally consistent schema-version 1 blocker report", () => {
+      expect(skill).toContain("schema_version");
+      expect(skill).toContain("blocker_count");
+      expect(skill).toContain("narrowed_claim");
+      expect(flat).toMatch(/schema_version[^]{0,30}(equal|===|is) `?1`?/i);
+      expect(flat).toMatch(/verdict[^]{0,30}NOT_READY/i);
+      expect(flat).toMatch(/positive integer/i);
+      expect(flat).toMatch(/blockers[^]{0,80}length[^]{0,40}blocker_count/i);
+      expect(flat).toMatch(/B1[^]{0,20}B7/i);
+      expect(flat).toMatch(/unique `?id`?/i);
+      expect(flat).toMatch(
+        /duplicate blocker ids[^]{0,80}internally inconsistent/i
+      );
+      expect(flat).toMatch(/caps the count at seven/i);
+      expect(flat).toMatch(/non-empty[^]{0,40}narrowed_claim/i);
+    });
+
+    it("names the count, blocker ids and labels, and narrowed claim", () => {
+      expect(flat).toMatch(/warning[^]{0,120}blocker count/i);
+      expect(flat).toMatch(/each blocker[^]{0,80}`?id`?[^]{0,80}`?label`?/i);
+      expect(flat).toMatch(/warning[^]{0,220}narrowed claim/i);
+    });
+
+    it("is warning-only and continues every registration and runbook step", () => {
+      expect(flat).toMatch(/warning only|advisory only/i);
+      expect(flat).toMatch(/setup continues/i);
+      expect(flat).toMatch(/no (registration or runbook )?step is skipped/i);
+      expect(flat).toMatch(/never a precondition/i);
+    });
+
+    it("silently ignores every unusable report shape", () => {
+      for (const condition of [
+        "missing",
+        "unreadable",
+        "invalid JSON",
+        "unsupported schema",
+        "internally inconsistent",
+      ]) {
+        expect(skill).toContain(condition);
+      }
+      expect(flat).toMatch(/no readiness warning and no error/i);
+      expect(flat).toMatch(/do not invent[^]{0,80}(freshness|age|TTL)/i);
+    });
+  });
+
+  it("documents the readiness vocabulary and concrete doctor artifact", () => {
+    const vocabulary = readFileSync(
+      path.resolve("wiki/concepts/lisa-vocabulary.md"),
+      "utf8"
+    );
+    const overview = readFileSync(
+      path.resolve("wiki/documentation/overview.md"),
+      "utf8"
+    );
+    const index = readFileSync(path.resolve("wiki/index.md"), "utf8");
+
+    expect(vocabulary).toMatch(/## Installation Readiness/);
+    expect(vocabulary).toMatch(/## Repository Readiness/);
+    expect(vocabulary).toMatch(/## Ship Blocker/);
+    for (const distinctTerm of [
+      "blocking finding",
+      "break-out",
+      "safe-block",
+      "NOT_READY",
+    ]) {
+      expect(vocabulary).toContain(distinctTerm);
+    }
+    expect(overview).toContain("lisa doctor [path] --readiness");
+    expect(overview).toContain(".lisa/readiness.json");
+    expect(overview).toContain("schema_version");
+    expect(overview).toContain("resolveReadinessReportPath");
+    expect(index).toMatch(
+      /installation readiness.*repository readiness.*ship blocker/i
+    );
+  });
+});
+
+/**
+ * RRR-7's second obligation: the readiness rubric RRR-1..RRR-6 built must reach
+ * every coding agent identically, not just Claude. RRR-4 (the agent-ready skill)
+ * and RRR-3 (the doctor readiness surface) already carry their own six-root
+ * parity pins; the rubric rule pairs the vocabulary distinguishes were the one
+ * fanned surface with no cross-root backstop. This block is that backstop,
+ * reusing the BCE-7 parity-pin pattern: every rule ships body-identical in the
+ * roots that can represent a rules tree, and the roots that structurally cannot
+ * are asserted as documented gaps, never silent drops.
+ */
+const SRC = "plugins/src/base";
+const CLAUDE_ROOT = "plugins/lisa";
+const CURSOR_ROOT = "plugins/lisa-cursor";
+const AGY_ROOT = "plugins/lisa-agy";
+const COPILOT_ROOT = "plugins/lisa-copilot";
+const CODEX_ROOT = "plugins/lisa/.codex-plugin";
+
+const read = (rel: string): string => readFileSync(path.resolve(rel), "utf8");
+
+/**
+ * Strip a leading YAML frontmatter block so per-agent frontmatter transforms do
+ * not read as body drift.
+ * @param text - Raw file contents
+ * @returns Body with any frontmatter removed
+ */
+const body = (text: string): string => {
+  if (!text.startsWith("---\n")) return text.trim();
+  const end = text.indexOf("\n---", 3);
+  return end === -1 ? text.trim() : text.slice(end + 4).trim();
+};
+
+/**
+ * Empty every markdown link target so Cursor's flattened `.mdc` link rewrites do
+ * not read as prose drift — the words must still match.
+ * @param text - Raw file contents
+ * @returns Body with every markdown link target emptied
+ */
+const proseOnly = (text: string): string =>
+  body(text).replace(/\]\([^)]*\)/g, "]()");
+
+/** The rule pairs the readiness vocabulary distinguishes, both fanned surfaces. */
+const RRR_RULE_SLUGS = ["readiness-rubric", "convergent-review"] as const;
+const RULE_TIERS = ["eager", "reference"] as const;
+
+describe("RRR rubric six-agent parity backstop (#1859)", () => {
+  describe.each(RRR_RULE_SLUGS)("rule pair %s", slug => {
+    describe.each(RULE_TIERS)("%s tier", tier => {
+      const rel = `rules/${tier}/${slug}.md`;
+      const source = read(`${SRC}/${rel}`);
+
+      it("ships byte-identical in the Claude and Copilot roots", () => {
+        expect(existsSync(path.resolve(CLAUDE_ROOT, rel))).toBe(true);
+        expect(read(`${CLAUDE_ROOT}/${rel}`)).toBe(source);
+        expect(read(`${COPILOT_ROOT}/${rel}`)).toBe(source);
+      });
+
+      it("ships in the Cursor root as an .mdc rule with the same body", () => {
+        const cursorName =
+          tier === "reference" ? `${slug}-reference.mdc` : `${slug}.mdc`;
+        const cursor = read(`${CURSOR_ROOT}/rules/${cursorName}`);
+        expect(proseOnly(cursor)).toBe(proseOnly(source));
+      });
+    });
+  });
+
+  it("keeps the readiness verdict ladder identical across every rule mirror", () => {
+    const source = read(`${SRC}/rules/reference/readiness-rubric.md`);
+    expect(source).toContain("seven ship blockers");
+    expect(source).toMatch(/B1[\s\S]{0,2000}B7/);
+    expect(source).toContain("narrowed claim");
+  });
+
+  describe("representation gaps are documented, never silent", () => {
+    it("agy carries no rules tree, so the rubric cannot be a silent drop", () => {
+      expect(existsSync(path.resolve(AGY_ROOT, "rules"))).toBe(false);
+      const generator = read("scripts/generate-agy-plugin-artifacts.mjs");
+      expect(generator).toMatch(/no full rules tree in agy artifacts/i);
+    });
+
+    it("the Codex plugin carries no rules tree of its own", () => {
+      expect(existsSync(path.resolve(CODEX_ROOT, "rules"))).toBe(false);
+    });
+  });
+});

--- a/wiki/concepts/lisa-vocabulary.md
+++ b/wiki/concepts/lisa-vocabulary.md
@@ -28,6 +28,28 @@ A strategy defines how Lisa applies a file to a downstream project: overwrite, c
 
 A quality gate is an automated check that must pass before a change can progress.
 
+## Installation Readiness
+
+Installation readiness answers: "Is Lisa installed and configured correctly in this project?" It is
+the question answered by the shipped `lisa doctor` groups. It does not establish that an unattended
+agent fleet can safely own the repository.
+
+## Repository Readiness
+
+Repository readiness answers: "May an agent fleet operate this repository unattended?" It applies
+the eight ownership dimensions in the `readiness-rubric` rule. Installation readiness and repository
+readiness are orthogonal: a project can pass installation checks while repository evidence still
+requires supervised operation.
+
+## Ship Blocker
+
+A ship blocker is one of the readiness rubric's closed B1-B7 conditions that, standing alone, makes
+repository readiness `NOT_READY` and requires a narrowed claim describing what operation remains
+safe. It is not a `convergent-review` blocking finding (a review result), a `tool-access-gate`
+break-out (leaving a flow to obtain access), or a `leaf-only-lifecycle` safe-block (a tracker state
+that preserves incomplete work). `NOT_READY` is the overall readiness verdict; a ship blocker is the
+repository condition that causes it.
+
 ## Automation Checkout
 
 An automation checkout is the durable local Git work tree used by recurring Codex automations for a project. It should be synced to the default remote branch at the start of each run and verified as a non-bare Git work tree before the automation is saved or executed.

--- a/wiki/documentation/overview.md
+++ b/wiki/documentation/overview.md
@@ -85,9 +85,17 @@ Lisa also ships small maintenance commands:
 
 ```bash
 lisa doctor [path]
+lisa doctor [path] --readiness
 lisa version
 lisa update
 ```
+
+The additive `--readiness` mode asks the repository-level question: may an agent fleet operate here
+unattended? It persists the schema-versioned result at `.lisa/readiness.json`, including
+`schema_version`, `verdict`, `blocker_count`, the standing blocker records, and the narrowed claim.
+Consumers use the exported `resolveReadinessReportPath` contract rather than inventing another
+location, so a future relocation changes the resolver instead of every reader. The default
+`lisa doctor [path]` path remains the installation-readiness check and does not write this report.
 
 Every normal command performs a timeout-bound npm latest-version check before it runs. The project-local cache lives under `node_modules/.cache`; the check is non-fatal when offline and can be skipped with `--no-update-check` or `LISA_SKIP_UPDATE_CHECK=1`. `lisa update --yes` updates this project's dependency and triggers the same automatic apply path.
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -54,6 +54,7 @@ Last updated by connector ingest on 2026-06-14 for Lisa `2.165.6` and current mo
 ## Concepts
 
 - [Lisa Vocabulary](concepts/lisa-vocabulary.md)
+  - Distinguishes installation readiness, repository readiness, and the ship blocker condition that produces a narrowed `NOT_READY` claim.
 - [Coding-Agent Feature Taxonomy](concepts/coding-agent-feature-taxonomy.md)
 - [Bounded-Claims Evidence System](concepts/bounded-claims-evidence-system.md)
   - What "verified" means: the claim-boundary taxonomy, the four evidence disciplines, the `verification.gate.enforceBoundaries` / `security.review.unprovenBucket` flip points, and the advisory→blocking ratchet.


### PR DESCRIPTION
## Summary

Closes the **RRR decomposition of PRD #1739** — this is RRR-7, the final ticket
(#1853–#1859). It makes the repository-readiness verdict visible at the moment it
matters (turning on the automation fleet), fans the rubric out to all six agents,
and documents the readiness vocabulary for a non-technical operator.

### Warn surface (never-block, always-degrade)

`lisa-setup-automations` now reads the standing RRR-3 readiness report through the
canonical `resolveReadinessReportPath` contract **exactly once** (never re-running
`lisa doctor --readiness`). For one internally consistent schema-version-1
`NOT_READY` report it emits a **single warning** naming the blocker count, each
blocker's `id` and `label`, and the `narrowed_claim` — then **continues**. No
registration or runbook step is skipped. Missing, unreadable, invalid-JSON,
unsupported-schema, or internally inconsistent reports degrade **silently** — no
warning, no error. The advisory is warning-only, **never a precondition**, keeping
parity with the existing never-block-always-degrade posture.

### Six-agent parity backstop

New `RRR rubric six-agent parity backstop` (reusing the BCE-7 parity-pin pattern)
pins the `readiness-rubric` and `convergent-review` rule pairs **body-identical**
across every root that can represent a rules tree (Claude + Copilot verbatim,
Cursor `.mdc`), and asserts the agy and Codex no-rules-tree structure as
**documented gaps**, never silent drops. `check:plugins` reports zero drift.

### Docs / vocabulary

- `wiki/concepts/lisa-vocabulary.md`: **installation readiness** vs **repository
  readiness** as distinct questions, plus **ship blocker** as net-new vocabulary
  distinguished from `convergent-review` blocking findings, `tool-access-gate`
  break-out, `leaf-only-lifecycle` safe-block, and doctor's `NOT_READY`.
- `wiki/documentation/overview.md`: documents `lisa doctor [path] --readiness` and
  the `.lisa/readiness.json` artifact (`schema_version`, `verdict`, `blocker_count`,
  narrowed claim, `resolveReadinessReportPath`).
- `wiki/index.md`: linked.

### Manifest

`src/core/upstream-evidence-manifest.ts` regenerated in-commit (base skill hash +
new test surface entry); CI staleness check passes.

## Test plan

- `setup-automations-readiness-warning.test.ts` — 42 assertions: valid-report
  boundary, silent degradation on every unusable shape, operator wording, six-root
  delivery parity, vocabulary + doctor-artifact docs, and the RRR rubric parity
  backstop. ✅
- Full `tests/unit/strategies` suite (4008) ✅; doctor CLI pins
  (`doctor.test`, `doctor-readiness`, `-blockers`, `-journey`, 51) ✅; all prior
  RRR pins (readiness-rubric, repository/project readiness, agent-ready
  consumption, report-rendering, BCE parity) unmodified and green ✅.
- `typecheck` ✅ · `check:plugins` in sync ✅ · manifest `--check` OK ✅.

## Provenance

PRD #1739 (harness-engineering adoption). Completes the RRR decomposition
#1853–#1859. Out of scope (per intake): no new detection/verdict logic, no
blocking/`readiness.enforce` key, no non-dogfood fleet assessment.

Closes #1859

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setup automation skills now provide a non-blocking warning when a valid repository-readiness report identifies ship blockers.
  * Setup continues normally when readiness data is unavailable, invalid, or unsupported.

* **Documentation**
  * Added guidance for installation readiness, repository readiness, and ship blockers.
  * Documented the repository readiness check and its persisted report.

* **Tests**
  * Added coverage for warning behavior, graceful degradation, and consistency across supported skill variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->