### PR TITLE
fix(automations): correct runtime rule-delivery parity

### DIFF
--- a/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
@@ -79,6 +79,15 @@ invent an artifact freshness, age, or TTL rule; the persisted contract defines n
 advisory is never a precondition and follows the same never-block-always-degrade posture as runbook
 scaffolding below.
 
+The readiness rule pair reaches each supported runtime through its native delivery path. Claude and
+Copilot carry the shared Markdown rule tree and inject its eager tier; Cursor receives transformed
+`.mdc` rules. Codex mirrors the shared parent rules into `.codex/lisa-rules` and injects the eager
+tier at session start. OpenCode mirrors the same tree into `.opencode/lisa-rules`, loads the eager
+tier through `opencode.json` instructions, and leaves the reference tier available on demand.
+Antigravity is the explicit representation gap: its artifact has no rules tree or eager-rule
+injection. It still receives this setup skill and its warning contract; the missing standalone rule
+surface is an accepted limitation, not a silent drop.
+
 ## The automations to create
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy

--- a/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
@@ -79,6 +79,15 @@ invent an artifact freshness, age, or TTL rule; the persisted contract defines n
 advisory is never a precondition and follows the same never-block-always-degrade posture as runbook
 scaffolding below.
 
+The readiness rule pair reaches each supported runtime through its native delivery path. Claude and
+Copilot carry the shared Markdown rule tree and inject its eager tier; Cursor receives transformed
+`.mdc` rules. Codex mirrors the shared parent rules into `.codex/lisa-rules` and injects the eager
+tier at session start. OpenCode mirrors the same tree into `.opencode/lisa-rules`, loads the eager
+tier through `opencode.json` instructions, and leaves the reference tier available on demand.
+Antigravity is the explicit representation gap: its artifact has no rules tree or eager-rule
+injection. It still receives this setup skill and its warning contract; the missing standalone rule
+surface is an accepted limitation, not a silent drop.
+
 ## The automations to create
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy

--- a/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
@@ -79,6 +79,15 @@ invent an artifact freshness, age, or TTL rule; the persisted contract defines n
 advisory is never a precondition and follows the same never-block-always-degrade posture as runbook
 scaffolding below.
 
+The readiness rule pair reaches each supported runtime through its native delivery path. Claude and
+Copilot carry the shared Markdown rule tree and inject its eager tier; Cursor receives transformed
+`.mdc` rules. Codex mirrors the shared parent rules into `.codex/lisa-rules` and injects the eager
+tier at session start. OpenCode mirrors the same tree into `.opencode/lisa-rules`, loads the eager
+tier through `opencode.json` instructions, and leaves the reference tier available on demand.
+Antigravity is the explicit representation gap: its artifact has no rules tree or eager-rule
+injection. It still receives this setup skill and its warning contract; the missing standalone rule
+surface is an accepted limitation, not a silent drop.
+
 ## The automations to create
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
@@ -79,6 +79,15 @@ invent an artifact freshness, age, or TTL rule; the persisted contract defines n
 advisory is never a precondition and follows the same never-block-always-degrade posture as runbook
 scaffolding below.
 
+The readiness rule pair reaches each supported runtime through its native delivery path. Claude and
+Copilot carry the shared Markdown rule tree and inject its eager tier; Cursor receives transformed
+`.mdc` rules. Codex mirrors the shared parent rules into `.codex/lisa-rules` and injects the eager
+tier at session start. OpenCode mirrors the same tree into `.opencode/lisa-rules`, loads the eager
+tier through `opencode.json` instructions, and leaves the reference tier available on demand.
+Antigravity is the explicit representation gap: its artifact has no rules tree or eager-rule
+injection. It still receives this setup skill and its warning contract; the missing standalone rule
+surface is an accepted limitation, not a silent drop.
+
 ## The automations to create
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy

--- a/plugins/lisa/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-automations/SKILL.md
@@ -79,6 +79,15 @@ invent an artifact freshness, age, or TTL rule; the persisted contract defines n
 advisory is never a precondition and follows the same never-block-always-degrade posture as runbook
 scaffolding below.
 
+The readiness rule pair reaches each supported runtime through its native delivery path. Claude and
+Copilot carry the shared Markdown rule tree and inject its eager tier; Cursor receives transformed
+`.mdc` rules. Codex mirrors the shared parent rules into `.codex/lisa-rules` and injects the eager
+tier at session start. OpenCode mirrors the same tree into `.opencode/lisa-rules`, loads the eager
+tier through `opencode.json` instructions, and leaves the reference tier available on demand.
+Antigravity is the explicit representation gap: its artifact has no rules tree or eager-rule
+injection. It still receives this setup skill and its warning contract; the missing standalone rule
+surface is an accepted limitation, not a silent drop.
+
 ## The automations to create
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy

--- a/plugins/src/base/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-automations/SKILL.md
@@ -79,6 +79,15 @@ invent an artifact freshness, age, or TTL rule; the persisted contract defines n
 advisory is never a precondition and follows the same never-block-always-degrade posture as runbook
 scaffolding below.
 
+The readiness rule pair reaches each supported runtime through its native delivery path. Claude and
+Copilot carry the shared Markdown rule tree and inject its eager tier; Cursor receives transformed
+`.mdc` rules. Codex mirrors the shared parent rules into `.codex/lisa-rules` and injects the eager
+tier at session start. OpenCode mirrors the same tree into `.opencode/lisa-rules`, loads the eager
+tier through `opencode.json` instructions, and leaves the reference tier available on demand.
+Antigravity is the explicit representation gap: its artifact has no rules tree or eager-rule
+injection. It still receives this setup skill and its warning contract; the missing standalone rule
+surface is an accepted limitation, not a silent drop.
+
 ## The automations to create
 
 Each automation runs **one cycle** of a Lisa command and respects that command's confirmation policy

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1025,7 +1025,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-atlassian/SKILL.md":
       "3820aecb57d184fde1cfa988e7e1402d8f2a766a0b3ffbb576de5a6a72b3d5c5",
     "plugins/src/base/skills/lisa-setup-automations/SKILL.md":
-      "d4d2deb758691fb636c7a742c96a2db8c70d13494aa0e0f96bc715fe4005f693",
+      "cb049745e52d933dfe801c7598692ebcda61ce374ccc0b8e28acbdbb36970bf8",
     "plugins/src/base/skills/lisa-setup-confluence/SKILL.md":
       "e92d762dbdaeae671c3e52dfe8e10d40a10b606b5e050589181a3898649faedc",
     "plugins/src/base/skills/lisa-setup-github-repo/SKILL.md":

--- a/tests/unit/strategies/setup-automations-readiness-warning.test.ts
+++ b/tests/unit/strategies/setup-automations-readiness-warning.test.ts
@@ -95,6 +95,23 @@ describe("setup-automations repository-readiness advisory (#1859)", () => {
       expect(flat).toMatch(/no readiness warning and no error/i);
       expect(flat).toMatch(/do not invent[^]{0,80}(freshness|age|TTL)/i);
     });
+
+    it("documents every runtime's rule-delivery path and the Antigravity gap", () => {
+      for (const runtime of [
+        "Claude",
+        "Codex",
+        "Cursor",
+        "OpenCode",
+        "Antigravity",
+        "Copilot",
+      ]) {
+        expect(skill).toContain(runtime);
+      }
+      expect(flat).toMatch(/Codex[^]{0,120}\.codex\/lisa-rules/i);
+      expect(flat).toMatch(/OpenCode[^]{0,120}\.opencode\/lisa-rules/i);
+      expect(flat).toMatch(/Antigravity[^]{0,120}representation gap/i);
+      expect(flat).toMatch(/accepted limitation[^]{0,40}not a silent drop/i);
+    });
   });
 
   it("documents the readiness vocabulary and concrete doctor artifact", () => {
@@ -144,7 +161,6 @@ const CLAUDE_ROOT = "plugins/lisa";
 const CURSOR_ROOT = "plugins/lisa-cursor";
 const AGY_ROOT = "plugins/lisa-agy";
 const COPILOT_ROOT = "plugins/lisa-copilot";
-const CODEX_ROOT = "plugins/lisa/.codex-plugin";
 
 const read = (rel: string): string => readFileSync(path.resolve(rel), "utf8");
 
@@ -201,15 +217,33 @@ describe("RRR rubric six-agent parity backstop (#1859)", () => {
     expect(source).toContain("narrowed claim");
   });
 
-  describe("representation gaps are documented, never silent", () => {
+  describe("runtime delivery is positive and representation gaps are explicit", () => {
     it("agy carries no rules tree, so the rubric cannot be a silent drop", () => {
       expect(existsSync(path.resolve(AGY_ROOT, "rules"))).toBe(false);
       const generator = read("scripts/generate-agy-plugin-artifacts.mjs");
       expect(generator).toMatch(/no full rules tree in agy artifacts/i);
     });
 
-    it("the Codex plugin carries no rules tree of its own", () => {
-      expect(existsSync(path.resolve(CODEX_ROOT, "rules"))).toBe(false);
+    it("Codex mirrors the shared rules and injects the eager tier", () => {
+      const installer = read("src/codex/hooks-installer.ts");
+      expect(installer).toContain("mirrorLisaRules");
+      expect(installer).toContain("LISA_RULES_SUBDIR");
+      expect(installer).toMatch(/id: "inject-rules"/);
+      expect(installer).toMatch(/event: "SessionStart"/);
+    });
+
+    it("OpenCode mirrors the shared rules and loads the eager tier natively", () => {
+      const installer = read("src/opencode/hooks-installer.ts");
+      expect(installer).toContain("mirrorLisaRules");
+      expect(installer).toContain("OPENCODE_LISA_RULES_SUBDIR");
+      expect(installer).toContain("OPENCODE_EAGER_RULES_INSTRUCTION");
+    });
+
+    it("the shared mirror preserves eager and reference rule tiers", () => {
+      const mirror = read("src/core/lisa-rules-mirror.ts");
+      expect(mirror).toContain(
+        'const RULE_SUBDIRS = ["eager", "reference"] as const'
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

- correct #1859's merged parity contract: Codex receives shared rules through `mirrorLisaRules` plus SessionStart `inject-rules`; it is not a representation gap
- document OpenCode's `.opencode/lisa-rules` + native-instructions path and identify Antigravity as the actual no-rules-tree/eager-injection limitation
- replace negative filesystem assertions with positive Codex/OpenCode delivery proof while preserving both eager and reference tiers

Closes #1859

## Context

PR #1883 merged while this independently reviewed blocking correction was still local. This focused follow-up contains only the 93-line reviewed delta on top of the #1883 merge and fixes the stale PR/ticket claim that “agy + Codex” were equivalent gaps.

## Test plan

- `bun run build:dist`
- focused 6-file Vitest suite — 292 passing
- full pre-push unit suite with coverage — 388 files, 6,844 passing
- integration suite — 9 files, 137 passing
- `bun run check:plugins`
- `bun run check:upstream-evidence-manifest`
- `scripts/check-rules-pairing.sh`

## Independent review

The correction was independently reviewed after the initial negative Codex assertion was rejected. Final disposition: **APPROVE** — all six runtime routes are represented accurately, the Antigravity limitation is delivered in every setup-skill mirror, and no remaining contract blocker was found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how repository-readiness guidance and rule content are delivered across supported runtimes.
  * Documented Antigravity’s lack of a standalone rules surface as a known limitation while preserving its setup guidance and warnings.

* **Tests**
  * Expanded coverage to verify runtime-specific rule delivery, including eager and reference guidance preservation.

* **Maintenance**
  * Updated stored evidence metadata for an Atlassian setup document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->