### PR TITLE
fix(release): recover the changelog-push retry from version-line rebase conflicts (#1884)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -665,10 +665,37 @@ jobs:
           source ./release-logger.sh
 
           target_ref="${{ github.ref_name }}"
+          version="${{ steps.version.outputs.version }}"
+
+          # Re-derive the release stamp on a freshly fetched tip. The initial
+          # release commit (Generate Changelog) stamps package.json,
+          # CHANGELOG.md, and every plugins/*/plugin.json version line. When a
+          # concurrent merge touches those same high-churn version lines,
+          # replaying the pre-stamped commit conflicts identically on every
+          # rebase attempt, so recovery discards it and regenerates the stamp
+          # from the pinned version instead. --release-as forces the exact
+          # version regardless of the current package.json, so this converges on
+          # the new tip rather than re-conflicting. (Per-branch releases are not
+          # expected to run concurrently, so re-stamping the pinned version is
+          # safe; the versioning scheme itself is out of scope here.)
+          restamp_release() {
+            git reset --hard "origin/$target_ref"
+            npx standard-version --release-as "$version" --skip.tag \
+              --releaseCommitMessageFormat "chore(release): {{currentTag}} [skip ci]"
+          }
 
           for attempt in 1 2 3; do
             git fetch origin "$target_ref"
-            git rebase "origin/$target_ref"
+
+            # Guard the rebase: this block runs under `set -eo pipefail`, so a
+            # bare `git rebase` that hits a content conflict would exit the step
+            # immediately, making the retry loop below dead code. Catching the
+            # non-zero exit with `if !` keeps `set -e` from bypassing recovery.
+            if ! git rebase "origin/$target_ref"; then
+              echo "::warning::Changelog rebase conflicted on attempt $attempt; re-stamping v$version against fresh $target_ref"
+              git rebase --abort 2>/dev/null || true
+              restamp_release
+            fi
 
             if git push origin "HEAD:$target_ref"; then
               log_release_event "changelog_push" "completed" "Changelog changes pushed successfully" \
@@ -678,7 +705,6 @@ jobs:
             fi
 
             echo "::warning::Changelog push attempt $attempt failed; retrying after refreshing $target_ref"
-            git rebase --abort 2>/dev/null || true
             sleep $((attempt * 5))
           done
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7566,6 +7566,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/integration/maestro-native-workflow.test.ts": true,
     "tests/integration/quality-workflow.test.ts": true,
     "tests/integration/release-changelog-entry.test.ts": true,
+    "tests/integration/release-changelog-push-recovery.test.ts": true,
     "tests/integration/release-notes-expansion.test.ts": true,
     "tests/unit/agy/block-no-verify-agy.test.ts": true,
     "tests/unit/agy/mcp-collect.test.ts": true,

--- a/tests/integration/release-changelog-push-recovery.test.ts
+++ b/tests/integration/release-changelog-push-recovery.test.ts
@@ -36,6 +36,18 @@ const PLUGIN_MANIFEST_REL = path.join(PLUGINS_DIR, PLUGIN_NAME, "plugin.json");
 /** Same path in git's forward-slash form for `git show`. */
 const PLUGIN_MANIFEST_GIT = PLUGIN_MANIFEST_REL.split(path.sep).join("/");
 
+// Hermetic git environment: pin config to /dev/null so the temp repos never
+// read the developer's global/system git config, and never inherit ambient
+// hooks. This keeps the reproduction deterministic under the full parallel
+// suite (where global-config reads add file-descriptor pressure and variance).
+const GIT_ENV: NodeJS.ProcessEnv = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+  GIT_CONFIG_NOSYSTEM: "1",
+  GIT_TERMINAL_PROMPT: "0",
+};
+
 /**
  * Extracts the real "Push Changelog Changes" step from release.yml and
  * substitutes the GitHub expression context this test drives it with, so the
@@ -80,7 +92,7 @@ const PRE_FIX_SCRIPT = [
 ].join("\n");
 
 const runGit = (cwd: string, args: string[]): string =>
-  execFileSync(GIT_BIN, args, { cwd, encoding: "utf8" });
+  execFileSync(GIT_BIN, args, { cwd, encoding: "utf8", env: GIT_ENV });
 
 const writeJsonVersion = (file: string, version: string): void => {
   const parsed = fs.existsSync(file)
@@ -163,7 +175,9 @@ const buildConflictRepo = (failPush: boolean): ConflictRepo => {
   );
 
   // PATH shims. `npx` stands in for standard-version's deterministic
-  // `--release-as` re-stamp; `sleep` no-ops the backoff.
+  // `--release-as` re-stamp; `sleep` no-ops the backoff. The re-stamp uses
+  // sed (not a spawned node) to keep the subprocess/FD footprint minimal under
+  // the full parallel suite.
   fs.writeFileSync(
     path.join(binDir, "npx"),
     [
@@ -178,15 +192,10 @@ const buildConflictRepo = (failPush: boolean): ConflictRepo => {
       '  if [ "$1" = "--release-as" ]; then ver="$2"; shift 2; else shift; fi',
       "done",
       'echo "$ver" >> "$REPRO_MARKER"',
-      "node -e '",
-      '  const fs = require("fs");',
-      "  const ver = process.argv[1];",
-      `  for (const f of ["${PACKAGE_JSON}", "${PLUGIN_MANIFEST_GIT}"]) {`,
-      '    const j = JSON.parse(fs.readFileSync(f, "utf8"));',
-      "    j.version = ver;",
-      '    fs.writeFileSync(f, JSON.stringify(j, null, 2) + "\\n");',
-      "  }",
-      '\' "$ver"',
+      `for f in "${PACKAGE_JSON}" "${PLUGIN_MANIFEST_GIT}"; do`,
+      `  sed -i.bak 's/"version": *"[^"]*"/"version": "'"$ver"'"/' "$f"`,
+      '  rm -f "$f.bak"',
+      "done",
       "git add -A",
       'git commit -q -m "chore(release): v$ver [skip ci]"',
       "exit 0",
@@ -234,7 +243,7 @@ const runStep = (
       cwd: repo.workDir,
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...GIT_ENV,
         PATH: `${repo.binDir}:${process.env.PATH ?? ""}`,
         REPRO_MARKER: repo.markerFile,
       },
@@ -251,6 +260,7 @@ const originPluginVersion = (repo: ConflictRepo): string => {
   const blob = execFileSync(GIT_BIN, ["show", `main:${PLUGIN_MANIFEST_GIT}`], {
     cwd: repo.originDir,
     encoding: "utf8",
+    env: GIT_ENV,
   });
   return (JSON.parse(blob) as { version: string }).version;
 };
@@ -300,6 +310,7 @@ describe("release changelog push recovery", () => {
       {
         cwd: repo.originDir,
         encoding: "utf8",
+        env: GIT_ENV,
       }
     );
     expect(pushed).not.toContain("<<<<<<<");

--- a/tests/integration/release-changelog-push-recovery.test.ts
+++ b/tests/integration/release-changelog-push-recovery.test.ts
@@ -36,12 +36,22 @@ const PLUGIN_MANIFEST_REL = path.join(PLUGINS_DIR, PLUGIN_NAME, "plugin.json");
 /** Same path in git's forward-slash form for `git show`. */
 const PLUGIN_MANIFEST_GIT = PLUGIN_MANIFEST_REL.split(path.sep).join("/");
 
-// Hermetic git environment: pin config to /dev/null so the temp repos never
-// read the developer's global/system git config, and never inherit ambient
-// hooks. This keeps the reproduction deterministic under the full parallel
-// suite (where global-config reads add file-descriptor pressure and variance).
+// Ambient env with every GIT_* variable stripped. This is the critical
+// isolation step: when this suite runs from git's own pre-push hook, git
+// exports GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE / GIT_PREFIX into the
+// environment. Inheriting them poisons every temp-repo git command (e.g.
+// `git init` fails "GIT_WORK_TREE not allowed without specifying GIT_DIR"),
+// which is exactly why the reproduction passed standalone but failed under
+// `git push`. Dropping them makes the temp repos hermetic from the caller.
+const AMBIENT_ENV: NodeJS.ProcessEnv = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_"))
+);
+
+// Hermetic git environment: no inherited GIT_* state, and config pinned to
+// /dev/null so the temp repos never read the developer's global/system config
+// or inherit ambient hooks.
 const GIT_ENV: NodeJS.ProcessEnv = {
-  ...process.env,
+  ...AMBIENT_ENV,
   GIT_CONFIG_GLOBAL: "/dev/null",
   GIT_CONFIG_SYSTEM: "/dev/null",
   GIT_CONFIG_NOSYSTEM: "1",

--- a/tests/integration/release-changelog-push-recovery.test.ts
+++ b/tests/integration/release-changelog-push-recovery.test.ts
@@ -46,6 +46,47 @@ const GIT_ENV: NodeJS.ProcessEnv = {
   GIT_CONFIG_SYSTEM: "/dev/null",
   GIT_CONFIG_NOSYSTEM: "1",
   GIT_TERMINAL_PROMPT: "0",
+  // Supply the commit identity via env so the temp repos need no `git config`
+  // spawns — fewer subprocesses is fewer chances to hit a transient fork
+  // failure under the full parallel suite.
+  GIT_AUTHOR_NAME: "Repro",
+  GIT_AUTHOR_EMAIL: "repro@example.com",
+  GIT_COMMITTER_NAME: "Repro",
+  GIT_COMMITTER_EMAIL: "repro@example.com",
+};
+
+// Codes a process-spawn can transiently fail with under heavy parallel load
+// (fork pressure, fd/inode ceilings). These are not logic errors — an immediate
+// bounded retry clears them, whereas a real failure repeats every attempt.
+const TRANSIENT_SPAWN_CODES = new Set([
+  "EAGAIN",
+  "EMFILE",
+  "ENFILE",
+  "ENOMEM",
+  "ETXTBSY",
+]);
+
+/**
+ * True when a spawn error/return looks like transient resource exhaustion
+ * rather than a deterministic failure.
+ * @param err The thrown error or spawnSync `.error`.
+ * @returns Whether the failure is worth retrying.
+ */
+const isTransientSpawn = (err: unknown): boolean => {
+  const code = (err as { code?: string })?.code ?? "";
+  const message = String((err as { message?: string })?.message ?? "");
+  return (
+    TRANSIENT_SPAWN_CODES.has(code) ||
+    [...TRANSIENT_SPAWN_CODES].some(c => message.includes(c))
+  );
+};
+
+/**
+ * Synchronous sleep with no subprocess, used to back off between spawn retries.
+ * @param ms Milliseconds to block.
+ */
+const sleepSync = (ms: number): void => {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 };
 
 /**
@@ -91,8 +132,23 @@ const PRE_FIX_SCRIPT = [
   "exit 1",
 ].join("\n");
 
-const runGit = (cwd: string, args: string[]): string =>
-  execFileSync(GIT_BIN, args, { cwd, encoding: "utf8", env: GIT_ENV });
+const runGit = (cwd: string, args: string[]): string => {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      return execFileSync(GIT_BIN, args, {
+        cwd,
+        encoding: "utf8",
+        env: GIT_ENV,
+      });
+    } catch (err) {
+      if (!isTransientSpawn(err)) throw err;
+      lastErr = err;
+      sleepSync(25 * (attempt + 1));
+    }
+  }
+  throw lastErr;
+};
 
 const writeJsonVersion = (file: string, version: string): void => {
   const parsed = fs.existsSync(file)
@@ -135,8 +191,6 @@ const buildConflictRepo = (failPush: boolean): ConflictRepo => {
   // Seed origin/main with the shared base version on package.json and a plugin
   // manifest — the high-churn version line that conflicts.
   runGit(root, ["clone", "-q", originDir, seedDir]);
-  runGit(seedDir, ["config", "user.email", "seed@example.com"]);
-  runGit(seedDir, ["config", "user.name", "Seed"]);
   runGit(seedDir, ["checkout", "-q", "-b", "main"]);
   fs.ensureDirSync(path.join(seedDir, PLUGINS_DIR, PLUGIN_NAME));
   writeJsonVersion(path.join(seedDir, PACKAGE_JSON), BASE_VERSION);
@@ -149,8 +203,6 @@ const buildConflictRepo = (failPush: boolean): ConflictRepo => {
   // Working clone = the release job workspace. Stamp the release commit that
   // Generate Changelog would have produced (v2.0.0), but do NOT push it.
   runGit(root, ["clone", "-q", originDir, workDir]);
-  runGit(workDir, ["config", "user.email", "release@example.com"]);
-  runGit(workDir, ["config", "user.name", "Release"]);
   writeJsonVersion(path.join(workDir, PACKAGE_JSON), RELEASE_VERSION);
   writeJsonVersion(path.join(workDir, PLUGIN_MANIFEST_REL), RELEASE_VERSION);
   runGit(workDir, ["add", "-A"]);
@@ -235,20 +287,29 @@ const runStep = (
   repo: ConflictRepo
 ): ReturnType<typeof spawnSync> => {
   const scriptFile = path.join(repo.workDir, "push-step.sh");
+  const options = {
+    cwd: repo.workDir,
+    encoding: "utf8" as const,
+    env: {
+      ...GIT_ENV,
+      PATH: `${repo.binDir}:${process.env.PATH ?? ""}`,
+      REPRO_MARKER: repo.markerFile,
+    },
+  };
+  let result: ReturnType<typeof spawnSync>;
   fs.writeFileSync(scriptFile, script);
-  return spawnSync(
-    BASH_BIN,
-    ["--noprofile", "--norc", "-eo", "pipefail", scriptFile],
-    {
-      cwd: repo.workDir,
-      encoding: "utf8",
-      env: {
-        ...GIT_ENV,
-        PATH: `${repo.binDir}:${process.env.PATH ?? ""}`,
-        REPRO_MARKER: repo.markerFile,
-      },
-    }
-  );
+  for (let attempt = 0; attempt < 5; attempt++) {
+    result = spawnSync(
+      BASH_BIN,
+      ["--noprofile", "--norc", "-eo", "pipefail", scriptFile],
+      options
+    );
+    // spawnSync surfaces a spawn failure on `.error` rather than throwing; only
+    // retry transient resource exhaustion, never a real non-zero exit status.
+    if (!result.error || !isTransientSpawn(result.error)) return result;
+    sleepSync(25 * (attempt + 1));
+  }
+  return result!;
 };
 
 /**

--- a/tests/integration/release-changelog-push-recovery.test.ts
+++ b/tests/integration/release-changelog-push-recovery.test.ts
@@ -1,0 +1,321 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import * as fs from "fs-extra";
+import yaml from "js-yaml";
+import { afterEach, describe, expect, it } from "vitest";
+
+// Derive the repo root from this test file's location so the test is portable
+// across worktrees and CI working directories.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const RELEASE_YML = path.join(REPO_ROOT, ".github", "workflows", "release.yml");
+
+/** Minimal shape of the parsed release workflow needed by these tests. */
+interface ReleaseWorkflow {
+  jobs: Record<
+    string,
+    { steps?: ReadonlyArray<{ name?: string; run?: string }> }
+  >;
+}
+
+const RELEASE_VERSION = "2.0.0";
+const CONCURRENT_VERSION = "1.0.1";
+const BASE_VERSION = "1.0.0";
+
+// Pinned binaries — resolving these via $PATH trips sonarjs/no-os-command-from-path.
+const GIT_BIN = "/usr/bin/git";
+const BASH_BIN = "/bin/bash";
+const PACKAGE_JSON = "package.json";
+const PLUGINS_DIR = "plugins";
+const PLUGIN_NAME = "a";
+/** Repo-relative path of the plugin manifest whose version line conflicts. */
+const PLUGIN_MANIFEST_REL = path.join(PLUGINS_DIR, PLUGIN_NAME, "plugin.json");
+/** Same path in git's forward-slash form for `git show`. */
+const PLUGIN_MANIFEST_GIT = PLUGIN_MANIFEST_REL.split(path.sep).join("/");
+
+/**
+ * Extracts the real "Push Changelog Changes" step from release.yml and
+ * substitutes the GitHub expression context this test drives it with, so the
+ * assertions exercise exactly what the workflow ships instead of a copy that
+ * can silently drift.
+ * @returns The step's shell body with `${{ ... }}` expressions resolved.
+ */
+const loadPushScript = (): string => {
+  const workflow = yaml.load(
+    fs.readFileSync(RELEASE_YML, "utf8")
+  ) as ReleaseWorkflow;
+  const steps = workflow.jobs.version.steps ?? [];
+  const run = steps.find(s => s.name === "Push Changelog Changes")?.run ?? "";
+  if (!run) {
+    throw new Error("Push Changelog Changes step not found in release.yml");
+  }
+  return run
+    .replace(/\$\{\{\s*github\.ref_name\s*\}\}/g, "main")
+    .replace(
+      /\$\{\{\s*steps\.version\.outputs\.version\s*\}\}/g,
+      RELEASE_VERSION
+    );
+};
+
+// The buggy pre-fix loop, preserved verbatim as a control so the test proves
+// the guard is what changed the outcome — a bare `git rebase` under
+// `set -eo pipefail` dies on the first content conflict before any retry runs.
+const PRE_FIX_SCRIPT = [
+  "source ./release-logger.sh",
+  'target_ref="main"',
+  "for attempt in 1 2 3; do",
+  '  git fetch origin "$target_ref"',
+  '  git rebase "origin/$target_ref"',
+  '  if git push origin "HEAD:$target_ref"; then',
+  "    exit 0",
+  "  fi",
+  '  echo "::warning::pre-fix attempt $attempt failed"',
+  "  git rebase --abort 2>/dev/null || true",
+  "  sleep 1",
+  "done",
+  "exit 1",
+].join("\n");
+
+const runGit = (cwd: string, args: string[]): string =>
+  execFileSync(GIT_BIN, args, { cwd, encoding: "utf8" });
+
+const writeJsonVersion = (file: string, version: string): void => {
+  const parsed = fs.existsSync(file)
+    ? (JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>)
+    : {};
+  parsed.version = version;
+  fs.writeFileSync(file, `${JSON.stringify(parsed, null, 2)}\n`);
+};
+
+/** Handles to a reproduction repo, its PATH shim dir, and the restamp marker. */
+interface ConflictRepo {
+  root: string;
+  workDir: string;
+  originDir: string;
+  binDir: string;
+  markerFile: string;
+}
+
+/**
+ * Builds a temp git topology that reproduces the release race: a working clone
+ * holding the pre-stamped release commit (v2.0.0 on the plugin version line)
+ * while `origin/main` has advanced with a concurrent merge that re-stamps the
+ * same line (v1.0.1). Rebasing the release commit onto that tip conflicts on
+ * the version line — the exact shape that killed run 29766412865.
+ * @param failPush When true, installs a git shim that fails every push so the
+ *   cap-exhaustion escalation path can be exercised.
+ * @returns Handles to the temp repo, PATH shim dir, and recovery marker file.
+ */
+const buildConflictRepo = (failPush: boolean): ConflictRepo => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "release-push-repro-"));
+  const originDir = path.join(root, "origin.git");
+  const seedDir = path.join(root, "seed");
+  const workDir = path.join(root, "work");
+  const binDir = path.join(root, "bin");
+  const markerFile = path.join(root, "restamp-marker.log");
+  fs.ensureDirSync(binDir);
+
+  runGit(root, ["init", "--bare", "-q", originDir]);
+
+  // Seed origin/main with the shared base version on package.json and a plugin
+  // manifest — the high-churn version line that conflicts.
+  runGit(root, ["clone", "-q", originDir, seedDir]);
+  runGit(seedDir, ["config", "user.email", "seed@example.com"]);
+  runGit(seedDir, ["config", "user.name", "Seed"]);
+  runGit(seedDir, ["checkout", "-q", "-b", "main"]);
+  fs.ensureDirSync(path.join(seedDir, PLUGINS_DIR, PLUGIN_NAME));
+  writeJsonVersion(path.join(seedDir, PACKAGE_JSON), BASE_VERSION);
+  writeJsonVersion(path.join(seedDir, PLUGIN_MANIFEST_REL), BASE_VERSION);
+  runGit(seedDir, ["add", "-A"]);
+  runGit(seedDir, ["commit", "-q", "-m", "chore: seed base version"]);
+  runGit(seedDir, ["push", "-q", "-u", "origin", "main"]);
+  runGit(originDir, ["symbolic-ref", "HEAD", "refs/heads/main"]);
+
+  // Working clone = the release job workspace. Stamp the release commit that
+  // Generate Changelog would have produced (v2.0.0), but do NOT push it.
+  runGit(root, ["clone", "-q", originDir, workDir]);
+  runGit(workDir, ["config", "user.email", "release@example.com"]);
+  runGit(workDir, ["config", "user.name", "Release"]);
+  writeJsonVersion(path.join(workDir, PACKAGE_JSON), RELEASE_VERSION);
+  writeJsonVersion(path.join(workDir, PLUGIN_MANIFEST_REL), RELEASE_VERSION);
+  runGit(workDir, ["add", "-A"]);
+  runGit(workDir, [
+    "commit",
+    "-q",
+    "-m",
+    `chore(release): v${RELEASE_VERSION} [skip ci]`,
+  ]);
+
+  // Concurrent merge lands on origin/main, re-stamping the same version line.
+  writeJsonVersion(path.join(seedDir, PLUGIN_MANIFEST_REL), CONCURRENT_VERSION);
+  writeJsonVersion(path.join(seedDir, PACKAGE_JSON), CONCURRENT_VERSION);
+  runGit(seedDir, ["add", "-A"]);
+  runGit(seedDir, ["commit", "-q", "-m", "chore: concurrent merge"]);
+  runGit(seedDir, ["push", "-q", "origin", "main"]);
+
+  // Stub release-logger.sh (sourced cwd-relative) with a no-op logger.
+  fs.writeFileSync(
+    path.join(workDir, "release-logger.sh"),
+    'log_release_event() { echo "log_release_event $*"; }\n'
+  );
+
+  // PATH shims. `npx` stands in for standard-version's deterministic
+  // `--release-as` re-stamp; `sleep` no-ops the backoff.
+  fs.writeFileSync(
+    path.join(binDir, "npx"),
+    [
+      "#!/usr/bin/env bash",
+      'if [ "$1" != "standard-version" ]; then',
+      '  echo "unexpected npx invocation: $*" >&2',
+      "  exit 1",
+      "fi",
+      "shift",
+      'ver=""',
+      'while [ "$#" -gt 0 ]; do',
+      '  if [ "$1" = "--release-as" ]; then ver="$2"; shift 2; else shift; fi',
+      "done",
+      'echo "$ver" >> "$REPRO_MARKER"',
+      "node -e '",
+      '  const fs = require("fs");',
+      "  const ver = process.argv[1];",
+      `  for (const f of ["${PACKAGE_JSON}", "${PLUGIN_MANIFEST_GIT}"]) {`,
+      '    const j = JSON.parse(fs.readFileSync(f, "utf8"));',
+      "    j.version = ver;",
+      '    fs.writeFileSync(f, JSON.stringify(j, null, 2) + "\\n");',
+      "  }",
+      '\' "$ver"',
+      "git add -A",
+      'git commit -q -m "chore(release): v$ver [skip ci]"',
+      "exit 0",
+    ].join("\n")
+  );
+  fs.writeFileSync(path.join(binDir, "sleep"), "#!/usr/bin/env bash\nexit 0\n");
+  if (failPush) {
+    // Force every push to fail so the cap-exhaustion escalation path is
+    // exercised. Non-push git subcommands pass through to the real binary.
+    fs.writeFileSync(
+      path.join(binDir, "git"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "push" ]; then',
+        '  echo "fatal: simulated push failure" >&2',
+        "  exit 1",
+        "fi",
+        `exec ${GIT_BIN} "$@"`,
+      ].join("\n")
+    );
+    fs.chmodSync(path.join(binDir, "git"), 0o700);
+  }
+  fs.chmodSync(path.join(binDir, "npx"), 0o700);
+  fs.chmodSync(path.join(binDir, "sleep"), 0o700);
+
+  return {
+    root,
+    workDir,
+    originDir,
+    binDir,
+    markerFile,
+  };
+};
+
+const runStep = (
+  script: string,
+  repo: ConflictRepo
+): ReturnType<typeof spawnSync> => {
+  const scriptFile = path.join(repo.workDir, "push-step.sh");
+  fs.writeFileSync(scriptFile, script);
+  return spawnSync(
+    BASH_BIN,
+    ["--noprofile", "--norc", "-eo", "pipefail", scriptFile],
+    {
+      cwd: repo.workDir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${repo.binDir}:${process.env.PATH ?? ""}`,
+        REPRO_MARKER: repo.markerFile,
+      },
+    }
+  );
+};
+
+/**
+ * Reads the plugin version line as origin/main currently records it.
+ * @param repo The temp repo handles.
+ * @returns The version string committed on origin/main.
+ */
+const originPluginVersion = (repo: ConflictRepo): string => {
+  const blob = execFileSync(GIT_BIN, ["show", `main:${PLUGIN_MANIFEST_GIT}`], {
+    cwd: repo.originDir,
+    encoding: "utf8",
+  });
+  return (JSON.parse(blob) as { version: string }).version;
+};
+
+describe("release changelog push recovery", () => {
+  let repos: ConflictRepo[] = [];
+
+  const track = (repo: ConflictRepo): ConflictRepo => {
+    repos.push(repo);
+    return repo;
+  };
+
+  afterEach(() => {
+    for (const repo of repos) {
+      fs.removeSync(repo.root);
+    }
+    repos = [];
+  });
+
+  it("pre-fix loop dies at the first rebase conflict without retrying", () => {
+    const repo = track(buildConflictRepo(false));
+    const result = runStep(PRE_FIX_SCRIPT, repo);
+
+    // `set -e` kills the step at the failing rebase: non-zero exit, no push,
+    // and the retry warning never printed.
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).not.toContain(
+      "pre-fix attempt 2 failed"
+    );
+    expect(originPluginVersion(repo)).toBe(CONCURRENT_VERSION);
+  });
+
+  it("recovers a version-line conflict by re-stamping the fresh tip", () => {
+    const repo = track(buildConflictRepo(false));
+    const result = runStep(loadPushScript(), repo);
+
+    // The guarded rebase does not exit the step; recovery resets to the fresh
+    // origin tip, re-stamps the pinned version, and pushes a clean release.
+    expect(result.status).toBe(0);
+    expect(originPluginVersion(repo)).toBe(RELEASE_VERSION);
+    // Proof the recovery path ran (the re-stamp shim was invoked).
+    expect(fs.readFileSync(repo.markerFile, "utf8")).toContain(RELEASE_VERSION);
+    // The pushed tip carries no unresolved conflict markers.
+    const pushed = execFileSync(
+      GIT_BIN,
+      ["show", `main:${PLUGIN_MANIFEST_GIT}`],
+      {
+        cwd: repo.originDir,
+        encoding: "utf8",
+      }
+    );
+    expect(pushed).not.toContain("<<<<<<<");
+  });
+
+  it("fails loudly when the retry cap is exhausted", () => {
+    const repo = track(buildConflictRepo(true));
+    const result = runStep(loadPushScript(), repo);
+
+    // The escalation path (deploy-autofix ticket) depends on a loud non-zero
+    // exit once the bounded retries are spent.
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}${result.stderr}`).toContain(
+      "Changelog push failed after bounded retries"
+    );
+    // Nothing was ever pushed: origin/main still holds the concurrent version.
+    expect(originPluginVersion(repo)).toBe(CONCURRENT_VERSION);
+  });
+});

--- a/tests/unit/config/release-push-retry.test.ts
+++ b/tests/unit/config/release-push-retry.test.ts
@@ -13,19 +13,48 @@ const RELEASE_WORKFLOW = path.join(
 );
 
 describe("release workflow changelog push", () => {
-  it("rebases and retries the standard-version push before failing", () => {
+  const pushStepRun = (): string => {
     const workflow = loadWorkflow(RELEASE_WORKFLOW);
     const versionSteps = workflow.jobs.version.steps ?? [];
     const pushStep = versionSteps.find(
       step => step.name === "Push Changelog Changes"
     );
+    return pushStep?.run ?? "";
+  };
 
-    expect(pushStep?.run).toContain("for attempt in 1 2 3");
-    expect(pushStep?.run).toContain('git fetch origin "$target_ref"');
-    expect(pushStep?.run).toContain('git rebase "origin/$target_ref"');
-    expect(pushStep?.run).toContain('git push origin "HEAD:$target_ref"');
-    expect(pushStep?.run).toContain(
-      "Changelog push failed after bounded retries"
+  it("keeps the bounded retry cap and its loud terminal failure", () => {
+    const run = pushStepRun();
+
+    expect(run).toContain("for attempt in 1 2 3");
+    expect(run).toContain('git fetch origin "$target_ref"');
+    expect(run).toContain('git push origin "HEAD:$target_ref"');
+    expect(run).toContain("Changelog push failed after bounded retries");
+    // Cap exhaustion must still fail the step so the deploy-autofix
+    // escalation path fires.
+    expect(run).toContain("exit 1");
+  });
+
+  it("guards the rebase so `set -e` cannot bypass the retry loop", () => {
+    const run = pushStepRun();
+
+    // GitHub runs the block under `set -eo pipefail`. A bare
+    // `git rebase "origin/$target_ref"` would exit the step on the first
+    // content conflict, making the loop dead code. The rebase must run inside
+    // a condition (`if ! git rebase ...`) so the non-zero exit is caught.
+    expect(run).toMatch(/if\s+!\s+git rebase "origin\/\$target_ref"/);
+  });
+
+  it("re-stamps against the fresh tip on conflict instead of replaying", () => {
+    const run = pushStepRun();
+
+    // Replaying the pre-stamped commit re-conflicts identically on the same
+    // plugin version lines every attempt. Recovery must reset to the fresh
+    // origin tip and regenerate the stamp from the pinned version so each
+    // retry converges.
+    expect(run).toContain('git reset --hard "origin/$target_ref"');
+    expect(run).toContain(
+      'npx standard-version --release-as "$version" --skip.tag'
     );
+    expect(run).toContain("git rebase --abort");
   });
 });


### PR DESCRIPTION
## Summary

Fixes the `release.yml` "Push Changelog Changes" step, whose bounded retry loop was **dead code for the most common release failure** — a content conflict on the high-churn `plugins/*/plugin.json` version-stamp lines. Surfaced while root-causing #1848 (run 29766412865).

This is a **release-pipeline change**, so it was implemented conservatively: every other behavior of the step is preserved verbatim, and the fix is proven by a reproduction test that drives the real workflow step against a throwaway git repo.

## Root cause (from the #1848 diagnosis)

Two coupled defects in the step:

1. **`set -e` bypass.** GitHub runs `run:` blocks under `set -eo pipefail`. The bare `git rebase "origin/$target_ref"` exited the step the instant a conflict occurred — **before** the "retrying" warning, the `git rebase --abort`, or the next attempt could run. The loop never iterated. Proof in run 29766412865: the log jumps straight from "Could not apply…" to `exit code 1` with no attempt-2 message.
2. **Non-converging retry.** Even if reached, a plain re-rebase replayed the same pre-stamped release commit and re-conflicted on the identical version lines every attempt.

## The fix

In the "Push Changelog Changes" step only (plus its test):

- **Guard the rebase** with `if ! git rebase "origin/$target_ref"; then …` so the non-zero exit no longer trips `set -e` and the loop body actually runs.
- **Converge on retry:** on conflict, `git rebase --abort`, `git reset --hard "origin/$target_ref"`, and re-derive the stamp with `npx standard-version --release-as "$version"` against the fresh tip. `--release-as` pins the exact version, so each attempt lands cleanly on the new tip instead of re-conflicting.
- **Keep the bounded 3-attempt cap**; on exhaustion still `exit 1` loudly so the deploy-autofix escalation path fires (the correct terminal state for a genuinely stuck release).

`release.yml` is a Lisa-owned workflow (listed in `typescript/deletions.json` — deleted from downstream projects, not a rendered template), so there is no template source to update.

## Reproduction proof (TDD)

`tests/integration/release-changelog-push-recovery.test.ts` extracts the **real** step from `release.yml` and drives it against a temp git repo whose `origin/main` re-stamps the same version line the pre-stamped release commit touches:

- **Control** — asserts the pre-fix loop dies at the first rebase without retrying.
- **Recovery** — asserts the shipped step resets, re-stamps, and pushes a clean release (no conflict markers), and that the recovery path actually ran.
- **Escalation** — asserts cap exhaustion still fails loudly (`exit 1`) with nothing pushed.

`tests/unit/config/release-push-retry.test.ts` asserts the static contract: the guarded rebase, the reset/re-stamp recovery, and the retained cap + loud terminal failure.

The reproduction is fully hermetic — it strips ambient `GIT_*` variables (git exports `GIT_DIR`/`GIT_WORK_TREE` into hook environments) so it behaves identically standalone and under the pre-push hook.

## Gates

- `bash -n` / `sh -n` + shellcheck clean on the step (only the pre-existing benign SC1091 external-`source` note).
- Full `vitest run --coverage` green (389 files / 6849 tests); typecheck + lint clean; upstream-evidence manifest fresh.

Closes #1884

🤖 Generated with Claude Code
