### PR TITLE
fix(doctor): unassessed readiness dimensions must not report READY (#1897)

### DIFF
--- a/plugins/lisa-agy/scripts/doctor-report.mjs
+++ b/plugins/lisa-agy/scripts/doctor-report.mjs
@@ -211,6 +211,22 @@ export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
 }
 
 /**
+ * Group id of the orthogonal repository-readiness assessment. Named once so the
+ * verdict scorer can hold that group — and only that group — to the stricter
+ * "assessed or it does not count" bar.
+ */
+const REPOSITORY_READINESS_GROUP_ID = "repository-readiness";
+
+/**
+ * Score the doctor groups onto the shipped verdict ladder.
+ *
+ * `SKIP` is benign for the installation groups — "no wiki/ directory here" is a
+ * genuine not-applicable, so an all-SKIP installation report is still `READY`.
+ * It is NOT benign for the repository-readiness group: there a `SKIP` means the
+ * ownership dimension was never assessed, and calling zero evidence `READY`
+ * emits a green unattended-fleet claim backed by nothing (#1897). So an
+ * unassessed readiness dimension downgrades to `READY_WITH_WARNINGS`, while a
+ * fully-`PASS` readiness group still reaches `READY`.
  * @param {readonly DoctorGroup[]} groups
  * @returns {DoctorVerdict}
  */
@@ -222,7 +238,11 @@ export function computeDoctorVerdict(groups) {
   if (checks.some(check => check.status === "WARN")) {
     return "READY_WITH_WARNINGS";
   }
-  return "READY";
+  const readinessUnassessed = groups
+    .filter(group => group.id === REPOSITORY_READINESS_GROUP_ID)
+    .flatMap(group => group.checks.map(normalizeCheck))
+    .some(check => check.status === "SKIP");
+  return readinessUnassessed ? "READY_WITH_WARNINGS" : "READY";
 }
 
 /**

--- a/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
@@ -323,8 +323,11 @@ default doctor path never renders it and stays byte-identical.
    where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
    with that reason.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
-   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. Section order stays stable; the
-   findings **within** each dimension check order highest-consequence-first.
+   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
+   evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed
+   (`SKIP`) dimension is silence, not health, so any readiness report carrying one tops out at
+   `READY_WITH_WARNINGS`; only a standing ship blocker yields `NOT_READY`. Section order stays
+   stable; the findings **within** each dimension check order highest-consequence-first.
 5. **Persist to a versioned, relocatable artifact.** Writing the report to `.lisa/readiness.json`
    (`schema_version: 1`, with `verdict`, `blocker_count`, and per-dimension findings) is resolved
    through a single resolver so the location is one line to change. The write is atomic and must

--- a/plugins/lisa-copilot/scripts/doctor-report.mjs
+++ b/plugins/lisa-copilot/scripts/doctor-report.mjs
@@ -211,6 +211,22 @@ export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
 }
 
 /**
+ * Group id of the orthogonal repository-readiness assessment. Named once so the
+ * verdict scorer can hold that group — and only that group — to the stricter
+ * "assessed or it does not count" bar.
+ */
+const REPOSITORY_READINESS_GROUP_ID = "repository-readiness";
+
+/**
+ * Score the doctor groups onto the shipped verdict ladder.
+ *
+ * `SKIP` is benign for the installation groups — "no wiki/ directory here" is a
+ * genuine not-applicable, so an all-SKIP installation report is still `READY`.
+ * It is NOT benign for the repository-readiness group: there a `SKIP` means the
+ * ownership dimension was never assessed, and calling zero evidence `READY`
+ * emits a green unattended-fleet claim backed by nothing (#1897). So an
+ * unassessed readiness dimension downgrades to `READY_WITH_WARNINGS`, while a
+ * fully-`PASS` readiness group still reaches `READY`.
  * @param {readonly DoctorGroup[]} groups
  * @returns {DoctorVerdict}
  */
@@ -222,7 +238,11 @@ export function computeDoctorVerdict(groups) {
   if (checks.some(check => check.status === "WARN")) {
     return "READY_WITH_WARNINGS";
   }
-  return "READY";
+  const readinessUnassessed = groups
+    .filter(group => group.id === REPOSITORY_READINESS_GROUP_ID)
+    .flatMap(group => group.checks.map(normalizeCheck))
+    .some(check => check.status === "SKIP");
+  return readinessUnassessed ? "READY_WITH_WARNINGS" : "READY";
 }
 
 /**

--- a/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
@@ -323,8 +323,11 @@ default doctor path never renders it and stays byte-identical.
    where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
    with that reason.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
-   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. Section order stays stable; the
-   findings **within** each dimension check order highest-consequence-first.
+   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
+   evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed
+   (`SKIP`) dimension is silence, not health, so any readiness report carrying one tops out at
+   `READY_WITH_WARNINGS`; only a standing ship blocker yields `NOT_READY`. Section order stays
+   stable; the findings **within** each dimension check order highest-consequence-first.
 5. **Persist to a versioned, relocatable artifact.** Writing the report to `.lisa/readiness.json`
    (`schema_version: 1`, with `verdict`, `blocker_count`, and per-dimension findings) is resolved
    through a single resolver so the location is one line to change. The write is atomic and must

--- a/plugins/lisa-cursor/scripts/doctor-report.mjs
+++ b/plugins/lisa-cursor/scripts/doctor-report.mjs
@@ -211,6 +211,22 @@ export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
 }
 
 /**
+ * Group id of the orthogonal repository-readiness assessment. Named once so the
+ * verdict scorer can hold that group — and only that group — to the stricter
+ * "assessed or it does not count" bar.
+ */
+const REPOSITORY_READINESS_GROUP_ID = "repository-readiness";
+
+/**
+ * Score the doctor groups onto the shipped verdict ladder.
+ *
+ * `SKIP` is benign for the installation groups — "no wiki/ directory here" is a
+ * genuine not-applicable, so an all-SKIP installation report is still `READY`.
+ * It is NOT benign for the repository-readiness group: there a `SKIP` means the
+ * ownership dimension was never assessed, and calling zero evidence `READY`
+ * emits a green unattended-fleet claim backed by nothing (#1897). So an
+ * unassessed readiness dimension downgrades to `READY_WITH_WARNINGS`, while a
+ * fully-`PASS` readiness group still reaches `READY`.
  * @param {readonly DoctorGroup[]} groups
  * @returns {DoctorVerdict}
  */
@@ -222,7 +238,11 @@ export function computeDoctorVerdict(groups) {
   if (checks.some(check => check.status === "WARN")) {
     return "READY_WITH_WARNINGS";
   }
-  return "READY";
+  const readinessUnassessed = groups
+    .filter(group => group.id === REPOSITORY_READINESS_GROUP_ID)
+    .flatMap(group => group.checks.map(normalizeCheck))
+    .some(check => check.status === "SKIP");
+  return readinessUnassessed ? "READY_WITH_WARNINGS" : "READY";
 }
 
 /**

--- a/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
@@ -323,8 +323,11 @@ default doctor path never renders it and stays byte-identical.
    where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
    with that reason.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
-   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. Section order stays stable; the
-   findings **within** each dimension check order highest-consequence-first.
+   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
+   evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed
+   (`SKIP`) dimension is silence, not health, so any readiness report carrying one tops out at
+   `READY_WITH_WARNINGS`; only a standing ship blocker yields `NOT_READY`. Section order stays
+   stable; the findings **within** each dimension check order highest-consequence-first.
 5. **Persist to a versioned, relocatable artifact.** Writing the report to `.lisa/readiness.json`
    (`schema_version: 1`, with `verdict`, `blocker_count`, and per-dimension findings) is resolved
    through a single resolver so the location is one line to change. The write is atomic and must

--- a/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
@@ -323,8 +323,11 @@ default doctor path never renders it and stays byte-identical.
    where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
    with that reason.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
-   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. Section order stays stable; the
-   findings **within** each dimension check order highest-consequence-first.
+   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
+   evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed
+   (`SKIP`) dimension is silence, not health, so any readiness report carrying one tops out at
+   `READY_WITH_WARNINGS`; only a standing ship blocker yields `NOT_READY`. Section order stays
+   stable; the findings **within** each dimension check order highest-consequence-first.
 5. **Persist to a versioned, relocatable artifact.** Writing the report to `.lisa/readiness.json`
    (`schema_version: 1`, with `verdict`, `blocker_count`, and per-dimension findings) is resolved
    through a single resolver so the location is one line to change. The write is atomic and must

--- a/plugins/lisa/scripts/doctor-report.mjs
+++ b/plugins/lisa/scripts/doctor-report.mjs
@@ -211,6 +211,22 @@ export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
 }
 
 /**
+ * Group id of the orthogonal repository-readiness assessment. Named once so the
+ * verdict scorer can hold that group — and only that group — to the stricter
+ * "assessed or it does not count" bar.
+ */
+const REPOSITORY_READINESS_GROUP_ID = "repository-readiness";
+
+/**
+ * Score the doctor groups onto the shipped verdict ladder.
+ *
+ * `SKIP` is benign for the installation groups — "no wiki/ directory here" is a
+ * genuine not-applicable, so an all-SKIP installation report is still `READY`.
+ * It is NOT benign for the repository-readiness group: there a `SKIP` means the
+ * ownership dimension was never assessed, and calling zero evidence `READY`
+ * emits a green unattended-fleet claim backed by nothing (#1897). So an
+ * unassessed readiness dimension downgrades to `READY_WITH_WARNINGS`, while a
+ * fully-`PASS` readiness group still reaches `READY`.
  * @param {readonly DoctorGroup[]} groups
  * @returns {DoctorVerdict}
  */
@@ -222,7 +238,11 @@ export function computeDoctorVerdict(groups) {
   if (checks.some(check => check.status === "WARN")) {
     return "READY_WITH_WARNINGS";
   }
-  return "READY";
+  const readinessUnassessed = groups
+    .filter(group => group.id === REPOSITORY_READINESS_GROUP_ID)
+    .flatMap(group => group.checks.map(normalizeCheck))
+    .some(check => check.status === "SKIP");
+  return readinessUnassessed ? "READY_WITH_WARNINGS" : "READY";
 }
 
 /**

--- a/plugins/lisa/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/skills/lisa-doctor/SKILL.md
@@ -323,8 +323,11 @@ default doctor path never renders it and stays byte-identical.
    where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
    with that reason.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
-   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. Section order stays stable; the
-   findings **within** each dimension check order highest-consequence-first.
+   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
+   evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed
+   (`SKIP`) dimension is silence, not health, so any readiness report carrying one tops out at
+   `READY_WITH_WARNINGS`; only a standing ship blocker yields `NOT_READY`. Section order stays
+   stable; the findings **within** each dimension check order highest-consequence-first.
 5. **Persist to a versioned, relocatable artifact.** Writing the report to `.lisa/readiness.json`
    (`schema_version: 1`, with `verdict`, `blocker_count`, and per-dimension findings) is resolved
    through a single resolver so the location is one line to change. The write is atomic and must

--- a/plugins/src/base/scripts/doctor-report.mjs
+++ b/plugins/src/base/scripts/doctor-report.mjs
@@ -211,6 +211,22 @@ export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
 }
 
 /**
+ * Group id of the orthogonal repository-readiness assessment. Named once so the
+ * verdict scorer can hold that group — and only that group — to the stricter
+ * "assessed or it does not count" bar.
+ */
+const REPOSITORY_READINESS_GROUP_ID = "repository-readiness";
+
+/**
+ * Score the doctor groups onto the shipped verdict ladder.
+ *
+ * `SKIP` is benign for the installation groups — "no wiki/ directory here" is a
+ * genuine not-applicable, so an all-SKIP installation report is still `READY`.
+ * It is NOT benign for the repository-readiness group: there a `SKIP` means the
+ * ownership dimension was never assessed, and calling zero evidence `READY`
+ * emits a green unattended-fleet claim backed by nothing (#1897). So an
+ * unassessed readiness dimension downgrades to `READY_WITH_WARNINGS`, while a
+ * fully-`PASS` readiness group still reaches `READY`.
  * @param {readonly DoctorGroup[]} groups
  * @returns {DoctorVerdict}
  */
@@ -222,7 +238,11 @@ export function computeDoctorVerdict(groups) {
   if (checks.some(check => check.status === "WARN")) {
     return "READY_WITH_WARNINGS";
   }
-  return "READY";
+  const readinessUnassessed = groups
+    .filter(group => group.id === REPOSITORY_READINESS_GROUP_ID)
+    .flatMap(group => group.checks.map(normalizeCheck))
+    .some(check => check.status === "SKIP");
+  return readinessUnassessed ? "READY_WITH_WARNINGS" : "READY";
 }
 
 /**

--- a/plugins/src/base/skills/lisa-doctor/SKILL.md
+++ b/plugins/src/base/skills/lisa-doctor/SKILL.md
@@ -323,8 +323,11 @@ default doctor path never renders it and stays byte-identical.
    where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
    with that reason.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
-   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. Section order stays stable; the
-   findings **within** each dimension check order highest-consequence-first.
+   severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
+   evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed
+   (`SKIP`) dimension is silence, not health, so any readiness report carrying one tops out at
+   `READY_WITH_WARNINGS`; only a standing ship blocker yields `NOT_READY`. Section order stays
+   stable; the findings **within** each dimension check order highest-consequence-first.
 5. **Persist to a versioned, relocatable artifact.** Writing the report to `.lisa/readiness.json`
    (`schema_version: 1`, with `verdict`, `blocker_count`, and per-dimension findings) is resolved
    through a single resolver so the location is one line to change. The write is atomic and must

--- a/src/cli/doctor-readiness-blockers.ts
+++ b/src/cli/doctor-readiness-blockers.ts
@@ -208,8 +208,12 @@ export function assessReadiness(
 /**
  * Reduce dimensions and standing blockers to the shipped verdict ladder. A
  * standing ship blocker is the only thing that yields `NOT_READY` (the rubric's
- * definition); otherwise any non-clean dimension is `READY_WITH_WARNINGS`, and
- * an all-clean report is `READY`. No new verdict enum (F2).
+ * definition). Below that, `READY` requires *positive* evidence: every dimension
+ * must have been assessed and come back `PASS`. Anything else — a `WARN`, a
+ * `FAIL`, an unassessed `SKIP`, or no dimensions at all — tops out at
+ * `READY_WITH_WARNINGS`, because the rubric defines READY as "eight dimensions
+ * assessed, no blocker stands" and an unassessed dimension is silence, not
+ * evidence (#1897). No new verdict enum (F2).
  * @param dimensions - Per-dimension records
  * @param blockers - Standing ship blockers
  * @returns Overall verdict
@@ -221,14 +225,10 @@ function computeReadinessVerdict(
   if (blockers.length > 0) {
     return "NOT_READY";
   }
-  if (
-    dimensions.some(
-      dimension => dimension.status === "FAIL" || dimension.status === "WARN"
-    )
-  ) {
-    return "READY_WITH_WARNINGS";
-  }
-  return "READY";
+  const everyDimensionAssessedClean =
+    dimensions.length > 0 &&
+    dimensions.every(dimension => dimension.status === "PASS");
+  return everyDimensionAssessedClean ? "READY" : "READY_WITH_WARNINGS";
 }
 
 /**

--- a/src/cli/doctor-readiness.ts
+++ b/src/cli/doctor-readiness.ts
@@ -6,6 +6,7 @@ import type { DoctorCheck } from "./doctor.js";
 import {
   assessReadiness,
   type DetectedBlocker,
+  type ReadinessDimensionInput,
   type ReadinessVerdict,
 } from "./doctor-readiness-blockers.js";
 import {
@@ -195,8 +196,8 @@ export async function checkRepositoryReadiness(
     dimensions,
   };
 
-  const unassessed = countUnassessedDimensions(dimensions);
-  const unassessedPhrase = `${unassessed} of ${dimensions.length} dimensions unassessed (SKIP)`;
+  const headline = formatReadinessHeadline(verdict, dimensions);
+  const blockerPhrase = `${blockers.length} standing ship blocker${blockers.length === 1 ? "" : "s"}`;
 
   const reportPath = resolveReadinessReportPath(targetPath);
   try {
@@ -206,7 +207,7 @@ export async function checkRepositoryReadiness(
       name: REPOSITORY_READINESS_CHECK_NAME,
       status: "warn",
       detail:
-        `Repository readiness assessed: ${verdict} (${unassessedPhrase}). ` +
+        `${headline} (${blockerPhrase}). ` +
         `Could not persist ${READINESS_REPORT_DISPLAY_PATH}: ` +
         `${error instanceof Error ? error.message : String(error)}`,
     };
@@ -216,26 +217,44 @@ export async function checkRepositoryReadiness(
     name: REPOSITORY_READINESS_CHECK_NAME,
     status: verdict === "READY" ? "ok" : "warn",
     detail:
-      `Repository readiness assessed: ${verdict} across ${dimensions.length} ownership dimensions ` +
-      `(${blockers.length} standing ship blocker${blockers.length === 1 ? "" : "s"}; ` +
-      `${unassessedPhrase} — no evidence was gathered for ${unassessed === 1 ? "it" : "them"}, ` +
-      `so this report does not establish unattended operation; see readiness-rubric). ` +
+      `${headline} (${blockerPhrase}; see readiness-rubric). ` +
       `Report written to ${READINESS_REPORT_DISPLAY_PATH} (schema_version ${READINESS_SCHEMA_VERSION}).`,
   };
 }
 
 /**
- * Count the dimensions that were never assessed. This is the number the operator
- * line must state: an unassessed dimension is silence, not evidence of health
- * (#1897), so its size is what tells a reader how much of the rubric this run
- * actually covered.
+ * Write the operator-facing headline for a readiness run, conclusion first.
+ *
+ * The reader at the gate is non-technical (`factory-model`), so the sentence
+ * leads with what it means rather than burying it after the mechanics. When any
+ * dimension was never assessed the headline says the readiness question is NOT
+ * ESTABLISHED and states how much was skipped — silence is reported as silence,
+ * never as health (#1897). Once every dimension has been assessed the
+ * not-established caveat is dropped entirely, because a fully assessed run must
+ * not carry a sentence contradicting its own verdict. The doctor renderer
+ * already prefixes the check name, so this text does not repeat it.
+ * @param verdict - The computed verdict for this run
  * @param dimensions - The per-dimension records for this run
- * @returns How many dimensions rendered `SKIP`
+ * @returns One operator-language clause, conclusion first, with no trailing period
  */
-function countUnassessedDimensions(
-  dimensions: readonly ReadinessDimensionRecord[]
-): number {
-  return dimensions.filter(dimension => dimension.status === "SKIP").length;
+export function formatReadinessHeadline(
+  verdict: ReadinessVerdict,
+  dimensions: readonly ReadinessDimensionInput[]
+): string {
+  const unassessed = dimensions.filter(
+    dimension => dimension.status === "SKIP"
+  ).length;
+  if (unassessed === 0) {
+    return (
+      `${verdict} — every dimension was assessed ` +
+      `across ${dimensions.length} ownership dimensions`
+    );
+  }
+  return (
+    `NOT ESTABLISHED (${verdict}) — ${unassessed} of ${dimensions.length} ` +
+    `dimensions ${unassessed === 1 ? "was" : "were"} never assessed, so this ` +
+    `cannot say whether an unattended fleet may operate here`
+  );
 }
 
 /**

--- a/src/cli/doctor-readiness.ts
+++ b/src/cli/doctor-readiness.ts
@@ -195,6 +195,9 @@ export async function checkRepositoryReadiness(
     dimensions,
   };
 
+  const unassessed = countUnassessedDimensions(dimensions);
+  const unassessedPhrase = `${unassessed} of ${dimensions.length} dimensions unassessed (SKIP)`;
+
   const reportPath = resolveReadinessReportPath(targetPath);
   try {
     await persistReadinessReport(reportPath, report);
@@ -203,8 +206,8 @@ export async function checkRepositoryReadiness(
       name: REPOSITORY_READINESS_CHECK_NAME,
       status: "warn",
       detail:
-        `Repository readiness assessed: ${verdict} (8 dimensions, all SKIP pending ` +
-        `evidence wiring). Could not persist ${READINESS_REPORT_DISPLAY_PATH}: ` +
+        `Repository readiness assessed: ${verdict} (${unassessedPhrase}). ` +
+        `Could not persist ${READINESS_REPORT_DISPLAY_PATH}: ` +
         `${error instanceof Error ? error.message : String(error)}`,
     };
   }
@@ -213,11 +216,26 @@ export async function checkRepositoryReadiness(
     name: REPOSITORY_READINESS_CHECK_NAME,
     status: verdict === "READY" ? "ok" : "warn",
     detail:
-      `Repository readiness assessed: ${verdict} across 8 ownership dimensions ` +
+      `Repository readiness assessed: ${verdict} across ${dimensions.length} ownership dimensions ` +
       `(${blockers.length} standing ship blocker${blockers.length === 1 ? "" : "s"}; ` +
-      `all SKIP pending evidence wiring in later PRD #1739 tickets; see readiness-rubric). ` +
+      `${unassessedPhrase} — no evidence was gathered for ${unassessed === 1 ? "it" : "them"}, ` +
+      `so this report does not establish unattended operation; see readiness-rubric). ` +
       `Report written to ${READINESS_REPORT_DISPLAY_PATH} (schema_version ${READINESS_SCHEMA_VERSION}).`,
   };
+}
+
+/**
+ * Count the dimensions that were never assessed. This is the number the operator
+ * line must state: an unassessed dimension is silence, not evidence of health
+ * (#1897), so its size is what tells a reader how much of the rubric this run
+ * actually covered.
+ * @param dimensions - The per-dimension records for this run
+ * @returns How many dimensions rendered `SKIP`
+ */
+function countUnassessedDimensions(
+  dimensions: readonly ReadinessDimensionRecord[]
+): number {
+  return dimensions.filter(dimension => dimension.status === "SKIP").length;
 }
 
 /**

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -739,7 +739,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/scripts/cross-pollinate.mjs":
       "e9a536389d2581370f6c470b8a070aaae96660646efc528a7ff7fb25d324a903",
     "plugins/src/base/scripts/doctor-report.mjs":
-      "080286c469b034d22930bd5efb7e70e5227e93697a315469e9f8e6089eb37505",
+      "ebad5a2724395911870b6be1dc81e3618031f7a6e04c51d3aef3efca72361929",
     "plugins/src/base/scripts/install-remote-agent-aws.mjs":
       "5ef1c323d7cbfda8976f6fb0c24f7a8e5f5757475fd1d71c6e5bec91023cebe3",
     "plugins/src/base/scripts/plugin-sync-explain.mjs":
@@ -791,7 +791,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-debrief/SKILL.md":
       "47e4cda36b07994ff47ab15fb04a17dd6b0c310ad804f9cae9d69637edaaa72a",
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
-      "a9bac6af0746a222e9de7224e5f171411ee82e351f3449bcda4430b85f79486a",
+      "a47f7ba3104121092e91b202646a74f83ec641cd24ad5807fc22adc65b6ccdc6",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
       "e8680c65da64351580658e423d2e30f565e9df52079f4deec44df84d4ab82982",
     "plugins/src/base/skills/lisa-epic-triage/SKILL.md":
@@ -7516,6 +7516,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/fixtures/automation-status/attention-needed-codex.json": true,
     "tests/fixtures/automation-status/partial-support-codex.json": true,
     "tests/fixtures/doctor/not-ready-missing-config.json": true,
+    "tests/fixtures/doctor/readiness/all-pass-assessed.json": true,
+    "tests/fixtures/doctor/readiness/all-skip-unassessed.json": true,
     "tests/fixtures/doctor/readiness/b1-silent-data-loss.json": true,
     "tests/fixtures/doctor/readiness/b2-release-bypasses-artifact.json": true,
     "tests/fixtures/doctor/readiness/b3-credential-authority.json": true,
@@ -7525,6 +7527,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/fixtures/doctor/readiness/b7-outcome-provable.json": true,
     "tests/fixtures/doctor/readiness/b7-outcome-unprovable.json": true,
     "tests/fixtures/doctor/readiness/malformed-blocker-without-evidence.json": true,
+    "tests/fixtures/doctor/readiness/mixed-pass-and-skip.json": true,
     "tests/fixtures/doctor/readiness/two-blockers-b2-b7.json": true,
     "tests/fixtures/doctor/ready-with-warnings-github-self-host.json": true,
     "tests/fixtures/harness-parity-council/first-round-failed.json": true,

--- a/tests/fixtures/doctor/readiness/all-pass-assessed.json
+++ b/tests/fixtures/doctor/readiness/all-pass-assessed.json
@@ -1,0 +1,52 @@
+{
+  "dimensions": [
+    {
+      "id": "context-routing",
+      "status": "PASS",
+      "observed": "Routing evidence was gathered and holds.",
+      "findings": []
+    },
+    {
+      "id": "capabilities-tools",
+      "status": "PASS",
+      "observed": "Every tool the work needs was proved reachable.",
+      "findings": []
+    },
+    {
+      "id": "domain-ownership",
+      "status": "PASS",
+      "observed": "Danger zones and glossary are owned and written down.",
+      "findings": []
+    },
+    {
+      "id": "execution-proof",
+      "status": "PASS",
+      "observed": "The claimed user-visible outcome was proved by running the system.",
+      "findings": []
+    },
+    {
+      "id": "feedback-guardrails",
+      "status": "PASS",
+      "observed": "A failing loop produces a named outcome and a runbook.",
+      "findings": []
+    },
+    {
+      "id": "dependencies-supply-chain",
+      "status": "PASS",
+      "observed": "A confidence model covers what the repo depends on.",
+      "findings": []
+    },
+    {
+      "id": "delivery-authority",
+      "status": "PASS",
+      "observed": "What ships equals what was validated.",
+      "findings": []
+    },
+    {
+      "id": "proportionality",
+      "status": "PASS",
+      "observed": "The machinery is proportional to the job.",
+      "findings": []
+    }
+  ]
+}

--- a/tests/fixtures/doctor/readiness/all-skip-unassessed.json
+++ b/tests/fixtures/doctor/readiness/all-skip-unassessed.json
@@ -1,0 +1,52 @@
+{
+  "dimensions": [
+    {
+      "id": "context-routing",
+      "status": "SKIP",
+      "observed": "No readiness probe wired in this Lisa version.",
+      "findings": []
+    },
+    {
+      "id": "capabilities-tools",
+      "status": "SKIP",
+      "observed": "No readiness probe wired in this Lisa version.",
+      "findings": []
+    },
+    {
+      "id": "domain-ownership",
+      "status": "SKIP",
+      "observed": "No readiness probe wired in this Lisa version.",
+      "findings": []
+    },
+    {
+      "id": "execution-proof",
+      "status": "SKIP",
+      "observed": "No readiness probe wired in this Lisa version.",
+      "findings": []
+    },
+    {
+      "id": "feedback-guardrails",
+      "status": "SKIP",
+      "observed": "No readiness probe wired in this Lisa version.",
+      "findings": []
+    },
+    {
+      "id": "dependencies-supply-chain",
+      "status": "SKIP",
+      "observed": "No readiness probe wired in this Lisa version.",
+      "findings": []
+    },
+    {
+      "id": "delivery-authority",
+      "status": "SKIP",
+      "observed": "No readiness probe wired in this Lisa version.",
+      "findings": []
+    },
+    {
+      "id": "proportionality",
+      "status": "SKIP",
+      "observed": "No readiness probe wired in this Lisa version.",
+      "findings": []
+    }
+  ]
+}

--- a/tests/fixtures/doctor/readiness/mixed-pass-and-skip.json
+++ b/tests/fixtures/doctor/readiness/mixed-pass-and-skip.json
@@ -1,0 +1,52 @@
+{
+  "dimensions": [
+    {
+      "id": "context-routing",
+      "status": "PASS",
+      "observed": "Routing evidence was gathered and holds.",
+      "findings": []
+    },
+    {
+      "id": "capabilities-tools",
+      "status": "PASS",
+      "observed": "Every tool the work needs was proved reachable.",
+      "findings": []
+    },
+    {
+      "id": "domain-ownership",
+      "status": "PASS",
+      "observed": "Danger zones and glossary are owned and written down.",
+      "findings": []
+    },
+    {
+      "id": "execution-proof",
+      "status": "PASS",
+      "observed": "The claimed user-visible outcome was proved by running the system.",
+      "findings": []
+    },
+    {
+      "id": "feedback-guardrails",
+      "status": "PASS",
+      "observed": "A failing loop produces a named outcome and a runbook.",
+      "findings": []
+    },
+    {
+      "id": "dependencies-supply-chain",
+      "status": "PASS",
+      "observed": "A confidence model covers what the repo depends on.",
+      "findings": []
+    },
+    {
+      "id": "delivery-authority",
+      "status": "SKIP",
+      "observed": "No deployment target is configured, so delivery/authority was not assessed.",
+      "findings": []
+    },
+    {
+      "id": "proportionality",
+      "status": "PASS",
+      "observed": "The machinery is proportional to the job.",
+      "findings": []
+    }
+  ]
+}

--- a/tests/unit/cli/doctor-readiness-blockers.test.ts
+++ b/tests/unit/cli/doctor-readiness-blockers.test.ts
@@ -237,6 +237,33 @@ describe("assessReadiness (blocker gate + narrowed claim)", () => {
     expect(assessment.verdict).toBe("READY_WITH_WARNINGS");
   });
 
+  it("never claims READY when even one dimension is unassessed (SKIP)", async () => {
+    const dimensions = await loadDimensions("mixed-pass-and-skip");
+
+    const assessment = assessReadiness(dimensions);
+
+    expect(assessment.blockers).toHaveLength(0);
+    expect(assessment.verdict).toBe("READY_WITH_WARNINGS");
+  });
+
+  it("never claims READY when a dimension is WARN", () => {
+    const assessment = assessReadiness([
+      { id: "context-routing", status: "PASS", findings: [] },
+      { id: "delivery-authority", status: "WARN", findings: [] },
+    ]);
+
+    expect(assessment.verdict).toBe("READY_WITH_WARNINGS");
+  });
+
+  it("never claims READY when there are no dimensions at all", () => {
+    // Zero dimensions is zero evidence — `every` on an empty list is vacuously
+    // true, so this rung needs its own guard and its own test.
+    const assessment = assessReadiness([]);
+
+    expect(assessment.blockers).toHaveLength(0);
+    expect(assessment.verdict).toBe("READY_WITH_WARNINGS");
+  });
+
   it("still reaches READY when every dimension is assessed PASS", async () => {
     const dimensions = await loadDimensions("all-pass-assessed");
 

--- a/tests/unit/cli/doctor-readiness-blockers.test.ts
+++ b/tests/unit/cli/doctor-readiness-blockers.test.ts
@@ -225,6 +225,28 @@ describe("assessReadiness (blocker gate + narrowed claim)", () => {
     expect(assessment.narrowed_claim).toBeNull();
   });
 
+  it("never claims READY when every dimension is unassessed (SKIP)", async () => {
+    // #1897: an all-SKIP assessment is zero evidence, not a clean bill of
+    // health. It must top out at READY_WITH_WARNINGS, never fall through to
+    // READY, or doctor emits a green unattended-fleet claim backed by nothing.
+    const dimensions = await loadDimensions("all-skip-unassessed");
+
+    const assessment = assessReadiness(dimensions);
+
+    expect(assessment.blockers).toHaveLength(0);
+    expect(assessment.verdict).toBe("READY_WITH_WARNINGS");
+  });
+
+  it("still reaches READY when every dimension is assessed PASS", async () => {
+    const dimensions = await loadDimensions("all-pass-assessed");
+
+    const assessment = assessReadiness(dimensions);
+
+    expect(assessment.blockers).toHaveLength(0);
+    expect(assessment.verdict).toBe("READY");
+    expect(assessment.narrowed_claim).toBeNull();
+  });
+
   it("degrades B7 to a non-standing skip when the #1738 contract is unavailable", async () => {
     const dimensions = await loadDimensions(FIXTURE_B7_UNPROVABLE);
 

--- a/tests/unit/cli/doctor-readiness.test.ts
+++ b/tests/unit/cli/doctor-readiness.test.ts
@@ -79,7 +79,9 @@ describe("checkRepositoryReadiness", () => {
     const report = JSON.parse(raw) as Record<string, unknown>;
     expect(report.schema_version).toBe(READINESS_SCHEMA_VERSION);
     expect(report.schema_version).toBe(1);
-    expect(report.verdict).toBe("READY");
+    // #1897: every dimension renders SKIP on this default path, so the report
+    // must NOT claim READY — unassessed is not evidence of readiness.
+    expect(report.verdict).toBe("READY_WITH_WARNINGS");
     expect(report.narrowed_claim).toBeNull();
     expect(report.blockers).toEqual([]);
     expect(report.blocker_count).toBe(0);
@@ -95,6 +97,19 @@ describe("checkRepositoryReadiness", () => {
       expect(dimension.status).toBe("SKIP");
       expect(Array.isArray(dimension.findings)).toBe(true);
     }
+  });
+
+  it("names the unassessed dimension count and asserts no unattended readiness", async () => {
+    const cwd = await getTempDir();
+
+    const check = await checkRepositoryReadiness(cwd);
+
+    // #1897: the operator-facing line must say how much was never assessed and
+    // must not turn that silence into a readiness claim.
+    expect(check.status).toBe("warn");
+    expect(check.detail).toContain("8 of 8 dimensions unassessed");
+    expect(check.detail).not.toMatch(/unattended fleet may run/i);
+    expect(check.detail).not.toMatch(/pending evidence wiring/i);
   });
 
   it("degrades to a WARN check instead of throwing when the report cannot be written", async () => {

--- a/tests/unit/cli/doctor-readiness.test.ts
+++ b/tests/unit/cli/doctor-readiness.test.ts
@@ -27,6 +27,7 @@ import {
   READINESS_DIMENSION_IDS,
   READINESS_SCHEMA_VERSION,
   checkRepositoryReadiness,
+  formatReadinessHeadline,
   resolveReadinessReportPath,
 } from "../../../src/cli/doctor-readiness.js";
 import { runDoctor } from "../../../src/cli/doctor.js";
@@ -56,6 +57,59 @@ describe("resolveReadinessReportPath", () => {
     expect(resolveReadinessReportPath("/repo/root")).toBe(
       path.join("/repo/root", ".lisa", "readiness.json")
     );
+  });
+});
+
+/** Operator-facing marker that the readiness question was not answered. */
+const NOT_ESTABLISHED = "NOT ESTABLISHED";
+
+/** A dimension record assessed clean, reused across the headline cases. */
+const ASSESSED_DIMENSION = {
+  id: "context-routing",
+  status: "PASS",
+  findings: [],
+} as const;
+
+/** A dimension record that was never assessed, reused across headline cases. */
+const UNASSESSED_DIMENSION = {
+  id: "delivery-authority",
+  status: "SKIP",
+  findings: [],
+} as const;
+
+describe("formatReadinessHeadline", () => {
+  it("leads with NOT ESTABLISHED and the unassessed count when anything was skipped", () => {
+    const headline = formatReadinessHeadline("READY_WITH_WARNINGS", [
+      ASSESSED_DIMENSION,
+      UNASSESSED_DIMENSION,
+      { id: "proportionality", status: "SKIP", findings: [] },
+    ]);
+
+    expect(headline).toContain(NOT_ESTABLISHED);
+    expect(headline).toContain("2 of 3 dimensions were never assessed");
+  });
+
+  it("agrees in number when exactly one dimension was never assessed", () => {
+    const headline = formatReadinessHeadline("READY_WITH_WARNINGS", [
+      ASSESSED_DIMENSION,
+      UNASSESSED_DIMENSION,
+    ]);
+
+    expect(headline).toContain("1 of 2 dimensions was never assessed");
+  });
+
+  it("drops the not-established caveat entirely once every dimension is assessed", () => {
+    // #1897 follow-up: a fully assessed READY run must not carry a sentence
+    // saying the report proves nothing — that contradicts its own verdict.
+    const headline = formatReadinessHeadline("READY", [
+      ASSESSED_DIMENSION,
+      { id: "delivery-authority", status: "PASS", findings: [] },
+    ]);
+
+    expect(headline).not.toContain(NOT_ESTABLISHED);
+    expect(headline).not.toContain("never assessed");
+    expect(headline).toContain("every dimension was assessed");
+    expect(headline).toContain("READY");
   });
 });
 
@@ -107,7 +161,8 @@ describe("checkRepositoryReadiness", () => {
     // #1897: the operator-facing line must say how much was never assessed and
     // must not turn that silence into a readiness claim.
     expect(check.status).toBe("warn");
-    expect(check.detail).toContain("8 of 8 dimensions unassessed");
+    expect(check.detail).toContain(NOT_ESTABLISHED);
+    expect(check.detail).toContain("8 of 8 dimensions were never assessed");
     expect(check.detail).not.toMatch(/unattended fleet may run/i);
     expect(check.detail).not.toMatch(/pending evidence wiring/i);
   });

--- a/tests/unit/strategies/doctor-report-rendering.test.ts
+++ b/tests/unit/strategies/doctor-report-rendering.test.ts
@@ -17,6 +17,7 @@ import {
   computeDoctorVerdict,
   countDoctorStatuses,
   createPluginSyncDoctorGroup,
+  createRepositoryReadinessDoctorGroup,
   renderDoctorReport,
 } from "../../../plugins/src/base/scripts/doctor-report.mjs";
 
@@ -142,6 +143,42 @@ describe("doctor report rendering (#750)", () => {
         },
       ])
     ).toBe("READY_WITH_WARNINGS");
+  });
+
+  it("never scores an unassessed repository-readiness group as READY (#1897)", () => {
+    // The eight readiness dimensions all render SKIP in this Lisa version. An
+    // unassessed dimension is silence, not evidence, so the agent-facing
+    // scorer must not turn it into a green unattended-fleet claim.
+    const group = createRepositoryReadinessDoctorGroup(process.cwd());
+
+    expect(group.checks).toHaveLength(8);
+    expect([...new Set(group.checks.map(check => check.status))]).toEqual([
+      "SKIP",
+    ]);
+    expect(computeDoctorVerdict([group])).toBe("READY_WITH_WARNINGS");
+  });
+
+  it("still scores a fully assessed repository-readiness group as READY (#1897)", () => {
+    expect(
+      computeDoctorVerdict([
+        {
+          id: "repository-readiness",
+          title: "Repository readiness",
+          checks: [
+            {
+              id: "context-routing",
+              status: "PASS",
+              summary: "routing evidence was gathered and holds",
+            },
+            {
+              id: "delivery-authority",
+              status: "PASS",
+              summary: "what ships equals what was validated",
+            },
+          ],
+        },
+      ])
+    ).toBe("READY");
   });
 
   it("counts statuses across all groups", () => {


### PR DESCRIPTION
## Summary

Closes #1897 — the false-green safety fix surfaced by PRD #1739's independent verification.

The readiness rubric treated an **unassessed (`SKIP`) dimension as neither FAIL nor WARN**, so a repository where *nothing* was assessed was affirmatively reported **`READY`** — a green "an unattended fleet may run here" claim backed by zero evidence. This closes that hole on **both** readiness scorers so the fix reaches parity across every coding agent:

- **CLI** (`src/cli/doctor-readiness-blockers.ts`) — `computeReadinessVerdict` now returns `READY` only when the dimension set is non-empty and **every** dimension is `PASS`; blockers still yield `NOT_READY` first; everything else (SKIP / WARN / FAIL / empty) tops out at the existing `READY_WITH_WARNINGS`. No new enum state, warn-only posture preserved, doctor exit codes unchanged.
- **Agent-facing scorer** (`plugins/src/base/scripts/doctor-report.mjs`) — `computeDoctorVerdict` (which the agents themselves run via `/lisa:doctor`) had the same false-green. It's narrowed to downgrade to `READY_WITH_WARNINGS` **only** when the `repository-readiness` group carries a `SKIP` — installation groups keep all-SKIP→READY, so no over-fire. Fanned out to `plugins/lisa`, `lisa-cursor`, `lisa-agy`, `lisa-copilot` (byte-identical).
- **Operator line** — conclusion-first for the non-technical operator: `Repository readiness: NOT ESTABLISHED (READY_WITH_WARNINGS) — 8 of 8 dimensions were never assessed, so this cannot say whether an unattended fleet may operate here …`. The "not established" caveat is dropped once every dimension is assessed (prevents a future self-contradicting green), with correct verb agreement.
- **Docs** — `lisa-doctor/SKILL.md` rule 4 updated: `READY` requires every dimension assessed and clean.

Scope is deliberately limited to the verdict algebra's treatment of SKIP. Wiring the B1–B6 dimension producers is FIX-1 (#1896); the blank-SKIP-reason contract is FIX-2 (#1898).

## Verification

- Full `bun run test` → **389 files / 6860 tests passed, exit 0** (independently reproduced).
- `bun run typecheck`, `bun run build:dist`, `bun run build:plugins` → exit 0.
- `node scripts/generate-upstream-evidence-manifest.mjs --check` → exit 0 (the two new fixtures + `mixed-pass-and-skip.json` registered).
- Empirical CLI journey on a fresh scratch repo: `node dist/index.js doctor --offline --readiness` → verdict `READY_WITH_WARNINGS`, conclusion-first line, status `warn` (never `fail`), exit 0.
- Empirical parity: source + all four fanned copies of `doctor-report.mjs` return `READY_WITH_WARNINGS` for an all-SKIP readiness group; installation-only SKIP still `READY`; all-PASS still `READY`.

TDD throughout (RED proven before GREEN); reviewed by independent quality + verification specialists (the parity gap and a stale-manifest gate were both caught and fixed before this PR).

Known scoped-out gap: an end-to-end all-PASS→`READY` CLI run isn't constructible until FIX-1 (#1896) wires real probes; `READY`-reachability is guarded at unit level (all-PASS fixture + `still scores a fully assessed…READY` test).

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository readiness now reports `READY` only when every readiness dimension is assessed and passes.
  * Unassessed or skipped dimensions now produce `READY_WITH_WARNINGS` instead of `READY`.
  * Readiness reports provide clearer conclusions, including the number of unassessed dimensions and blocker counts.
  * Verdict handling now consistently distinguishes warnings, blockers, and incomplete assessments.

* **Documentation**
  * Clarified readiness verdict definitions, evidence requirements, section ordering, and finding prioritization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->