### PR TITLE
feat(ui): add setup readiness projection

### DIFF
--- a/plugins/lisa-agy/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa-agy/scripts/automation-status-codex-adapter.mjs
@@ -11,9 +11,11 @@
  */
 
 import fs from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFile } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
 import { promisify } from "node:util";
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
@@ -34,6 +36,12 @@ const RUN_FAILURE_PATTERN =
 const NEGATED_FAILURE_PATTERN =
   /\b(no|without)\s+(?:recent\s+)?(?:fail(?:ure|ed)|errors?|exceptions?)\b/i;
 const execFileAsync = promisify(execFile);
+const MAX_SCHEDULER_ENTRIES = 1_000;
+const MAX_MATCHING_AUTOMATIONS = 100;
+const MAX_AUTOMATION_TOML_BYTES = 256 * 1024;
+const MAX_AUTOMATION_MEMORY_BYTES = 512 * 1024;
+const READ_CHUNK_BYTES = 64 * 1024;
+const UNSAFE_SCHEDULER_FILE = "Unsafe Codex scheduler file";
 
 /**
  * Git location env vars that, when inherited, override the `-C <dir>` flag and
@@ -101,7 +109,9 @@ async function execGitWithRetry(args, options, attempts = 4) {
       if (!transient || attempt >= attempts) {
         throw error;
       }
-      await new Promise(resolve => setTimeout(resolve, 2 ** attempt * 25));
+      await delay(2 ** attempt * 25, undefined, {
+        signal: options?.signal,
+      });
     }
   }
 }
@@ -223,29 +233,149 @@ export async function inspectCodexAutomationFleet(input) {
  * @param {{
  *   readonly automationsDir?: string
  *   readonly automationPrefix: string
+ *   readonly signal?: AbortSignal
  * }} input
  * @returns {Promise<readonly ObservedCodexAutomation[]>}
  */
 export async function listCodexAutomations(input) {
-  const automationsDir =
+  input.signal?.throwIfAborted();
+  const requestedRoot =
     input.automationsDir ?? resolveDefaultCodexAutomationsDir();
-  const dirEntries = await fs.readdir(automationsDir, {
-    withFileTypes: true,
-  });
-
-  const automationDirs = dirEntries
-    .filter(
-      entry =>
-        entry.isDirectory() && entry.name.startsWith(input.automationPrefix)
-    )
-    .map(entry => path.join(automationsDir, entry.name))
-    .sort((left, right) => left.localeCompare(right));
-
-  const automations = await Promise.all(
-    automationDirs.map(dir => readCodexAutomation(dir))
+  const automationsRoot = await fs.realpath(requestedRoot);
+  input.signal?.throwIfAborted();
+  const automationDirs = await listConfinedAutomationDirectories(
+    automationsRoot,
+    input.automationPrefix,
+    input.signal
   );
+  return await readCodexAutomations(automationDirs, input.signal);
+}
 
-  return automations.filter(Boolean);
+/**
+ * Enumerate a bounded number of direct, regular scheduler directories.
+ * @param {string} automationsRoot Canonical scheduler root.
+ * @param {string} automationPrefix Expected repository automation prefix.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @returns {Promise<readonly string[]>} Canonical matching directories.
+ */
+async function listConfinedAutomationDirectories(
+  automationsRoot,
+  automationPrefix,
+  signal
+) {
+  const directory = await fs.opendir(automationsRoot);
+  try {
+    const names = await readBoundedDirectoryNames(
+      directory,
+      automationPrefix,
+      signal
+    );
+    const directories = await Promise.all(
+      names.map(name => confinedAutomationDirectory(automationsRoot, name))
+    );
+    signal?.throwIfAborted();
+    return directories.toSorted((left, right) => left.localeCompare(right));
+  } finally {
+    await closeDirectory(directory);
+  }
+}
+
+/**
+ * Close a scheduler directory while tolerating runtimes that auto-close it
+ * after async iteration.
+ * @param {import("node:fs").Dir} directory Open scheduler directory handle.
+ * @returns {Promise<void>}
+ */
+async function closeDirectory(directory) {
+  try {
+    await directory.close();
+  } catch (error) {
+    if (error?.code !== "ERR_DIR_CLOSED") throw error;
+  }
+}
+
+/**
+ * Consume directory entries with total and prefix-match bounds.
+ * @param {import("node:fs").Dir} directory Open scheduler directory handle.
+ * @param {string} automationPrefix Expected repository automation prefix.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {number} [entryCount] Entries consumed so far.
+ * @param {readonly string[]} [matchingNames] Matching directory names.
+ * @returns {Promise<readonly string[]>} Bounded matching names.
+ */
+async function readBoundedDirectoryNames(
+  directory,
+  automationPrefix,
+  signal,
+  entryCount = 0,
+  matchingNames = []
+) {
+  signal?.throwIfAborted();
+  if (entryCount >= MAX_SCHEDULER_ENTRIES) {
+    const overflow = await directory.read();
+    if (overflow !== null) {
+      throw new Error("Codex scheduler enumeration exceeds entry limit");
+    }
+    return matchingNames;
+  }
+  const entry = await directory.read();
+  signal?.throwIfAborted();
+  if (entry === null) return matchingNames;
+  const matches =
+    entry.isDirectory() && entry.name.startsWith(automationPrefix);
+  const nextNames = matches ? [...matchingNames, entry.name] : matchingNames;
+  if (nextNames.length > MAX_MATCHING_AUTOMATIONS) {
+    throw new Error("Codex scheduler automation count exceeds limit");
+  }
+  return await readBoundedDirectoryNames(
+    directory,
+    automationPrefix,
+    signal,
+    entryCount + 1,
+    nextNames
+  );
+}
+
+/**
+ * Verify one direct scheduler entry remains a confined real directory.
+ * @param {string} automationsRoot Canonical scheduler root.
+ * @param {string} name Direct entry name.
+ * @returns {Promise<string>} Canonical automation directory.
+ */
+async function confinedAutomationDirectory(automationsRoot, name) {
+  const candidate = path.join(automationsRoot, name);
+  const stat = await fs.lstat(candidate);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error("Unsafe Codex scheduler directory");
+  }
+  const actual = await fs.realpath(candidate);
+  if (!actual.startsWith(`${automationsRoot}${path.sep}`)) {
+    throw new Error("Codex scheduler directory escapes root");
+  }
+  return actual;
+}
+
+/**
+ * Read scheduler entries sequentially to bound simultaneously open files.
+ * @param {readonly string[]} automationDirs Canonical automation directories.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {number} [index] Next directory index.
+ * @param {readonly ObservedCodexAutomation[]} [results] Completed observations.
+ * @returns {Promise<readonly ObservedCodexAutomation[]>} Observations.
+ */
+async function readCodexAutomations(
+  automationDirs,
+  signal,
+  index = 0,
+  results = []
+) {
+  signal?.throwIfAborted();
+  if (index >= automationDirs.length) return results;
+  const observation = await readCodexAutomation(automationDirs[index], signal);
+  return await readCodexAutomations(automationDirs, signal, index + 1, [
+    ...results,
+    observation,
+  ]);
 }
 
 /**
@@ -361,16 +491,130 @@ function findLatestAutomationMemoryBlock(lines) {
   };
 }
 
-async function readCodexAutomation(automationDir) {
-  const tomlPath = path.join(automationDir, "automation.toml");
-  const memoryPath = path.join(automationDir, "memory.md");
-  const tomlContent = await fs.readFile(tomlPath, "utf8");
+/**
+ * Read one stable bounded file without following a scheduler symlink or FIFO.
+ * @param {string} automationDir Canonical automation directory.
+ * @param {string} filename Direct scheduler filename.
+ * @param {number} maximumBytes Maximum allowed bytes.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {boolean} [optional] Whether a missing file resolves to undefined.
+ * @returns {Promise<string | undefined>} Strict UTF-8 contents.
+ */
+async function readConfinedSchedulerText(
+  automationDir,
+  filename,
+  maximumBytes,
+  signal,
+  optional = false
+) {
+  signal?.throwIfAborted();
+  const target = path.join(automationDir, filename);
+  const before = await fs.lstat(target).catch(error => {
+    if (optional && error?.code === "ENOENT") return null;
+    throw error;
+  });
+  if (before === null) return undefined;
+  assertBoundedSchedulerFile(before, maximumBytes);
+  const actual = await fs.realpath(target);
+  if (!actual.startsWith(`${automationDir}${path.sep}`)) {
+    throw new Error("Codex scheduler file escapes automation directory");
+  }
+  const handle = await fs.open(
+    target,
+    fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK
+  );
+  try {
+    const opened = await handle.stat();
+    assertBoundedSchedulerFile(opened, maximumBytes);
+    if (opened.dev !== before.dev || opened.ino !== before.ino) {
+      throw new Error("Codex scheduler file changed during inspection");
+    }
+    const bytes = await readBoundedSchedulerFile(handle, maximumBytes, signal);
+    const after = await handle.stat();
+    if (after.size !== opened.size || bytes.length !== after.size) {
+      throw new Error("Codex scheduler file changed during read");
+    }
+    signal?.throwIfAborted();
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Reject non-regular and oversized scheduler files before opening them.
+ * @param {import("node:fs").Stats} stat Scheduler file metadata.
+ * @param {number} maximumBytes Maximum allowed bytes.
+ * @returns {void}
+ */
+function assertBoundedSchedulerFile(stat, maximumBytes) {
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(UNSAFE_SCHEDULER_FILE);
+  }
+  if (stat.size > maximumBytes) {
+    throw new Error("Codex scheduler file exceeds size limit");
+  }
+}
+
+/**
+ * Read at most maximum plus one bytes from an already confined file handle.
+ * @param {import("node:fs/promises").FileHandle} handle Open file handle.
+ * @param {number} maximumBytes Maximum allowed bytes.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {number} [offset] Current file offset.
+ * @returns {Promise<Buffer>} Bounded bytes.
+ */
+async function readBoundedSchedulerFile(
+  handle,
+  maximumBytes,
+  signal,
+  offset = 0
+) {
+  signal?.throwIfAborted();
+  const remaining = maximumBytes + 1 - offset;
+  if (remaining <= 0) {
+    throw new Error("Codex scheduler file exceeds size limit");
+  }
+  const chunk = Buffer.allocUnsafe(Math.min(READ_CHUNK_BYTES, remaining));
+  const { bytesRead } = await handle.read(chunk, 0, chunk.length, offset);
+  signal?.throwIfAborted();
+  if (bytesRead === 0) return Buffer.alloc(0);
+  const current = chunk.subarray(0, bytesRead);
+  const tail = await readBoundedSchedulerFile(
+    handle,
+    maximumBytes,
+    signal,
+    offset + bytesRead
+  );
+  return Buffer.concat([current, tail], bytesRead + tail.length);
+}
+
+/**
+ * Read one confined Codex automation contract and optional memory.
+ * @param {string} automationDir Canonical automation directory.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @returns {Promise<ObservedCodexAutomation>} Normalized observation.
+ */
+async function readCodexAutomation(automationDir, signal) {
+  const tomlContent = await readConfinedSchedulerText(
+    automationDir,
+    "automation.toml",
+    MAX_AUTOMATION_TOML_BYTES,
+    signal
+  );
   const automation = parseAutomationToml(tomlContent);
-  const memoryContent = await fs.readFile(memoryPath, "utf8").catch(() => "");
+  const memoryContent =
+    (await readConfinedSchedulerText(
+      automationDir,
+      "memory.md",
+      MAX_AUTOMATION_MEMORY_BYTES,
+      signal,
+      true
+    )) ?? "";
   const memory = parseCodexAutomationMemory(memoryContent);
   const cwd = Array.isArray(automation.cwds) ? automation.cwds[0] : null;
   const normalizedCwd = typeof cwd === "string" ? cwd : null;
-  const cwdHealth = await inspectAutomationCwd(normalizedCwd);
+  const cwdHealth = await inspectAutomationCwd(normalizedCwd, signal);
 
   return {
     automationId:
@@ -546,7 +790,8 @@ function classifyAutomationRunSignal(input) {
   return null;
 }
 
-async function inspectAutomationCwd(cwd) {
+async function inspectAutomationCwd(cwd, signal) {
+  signal?.throwIfAborted();
   if (!cwd) {
     return {
       status: "missing",
@@ -560,6 +805,7 @@ async function inspectAutomationCwd(cwd) {
     }
     throw error;
   });
+  signal?.throwIfAborted();
 
   if (!stat) {
     return {
@@ -578,7 +824,7 @@ async function inspectAutomationCwd(cwd) {
   try {
     const { stdout } = await execGitWithRetry(
       ["-C", cwd, "rev-parse", "--is-inside-work-tree", "--is-bare-repository"],
-      { timeout: 5000 }
+      { timeout: 5000, signal }
     );
     const [insideWorkTree, bareRepository] = stdout.trim().split(/\r?\n/);
 
@@ -601,6 +847,7 @@ async function inspectAutomationCwd(cwd) {
       summary: `${cwd} is a valid Git work tree`,
     };
   } catch (error) {
+    signal?.throwIfAborted();
     return {
       status: "git_error",
       summary: `git could not inspect ${cwd}: ${String(error?.message ?? error)}`,

--- a/plugins/lisa-copilot/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa-copilot/scripts/automation-status-codex-adapter.mjs
@@ -11,9 +11,11 @@
  */
 
 import fs from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFile } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
 import { promisify } from "node:util";
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
@@ -34,6 +36,12 @@ const RUN_FAILURE_PATTERN =
 const NEGATED_FAILURE_PATTERN =
   /\b(no|without)\s+(?:recent\s+)?(?:fail(?:ure|ed)|errors?|exceptions?)\b/i;
 const execFileAsync = promisify(execFile);
+const MAX_SCHEDULER_ENTRIES = 1_000;
+const MAX_MATCHING_AUTOMATIONS = 100;
+const MAX_AUTOMATION_TOML_BYTES = 256 * 1024;
+const MAX_AUTOMATION_MEMORY_BYTES = 512 * 1024;
+const READ_CHUNK_BYTES = 64 * 1024;
+const UNSAFE_SCHEDULER_FILE = "Unsafe Codex scheduler file";
 
 /**
  * Git location env vars that, when inherited, override the `-C <dir>` flag and
@@ -101,7 +109,9 @@ async function execGitWithRetry(args, options, attempts = 4) {
       if (!transient || attempt >= attempts) {
         throw error;
       }
-      await new Promise(resolve => setTimeout(resolve, 2 ** attempt * 25));
+      await delay(2 ** attempt * 25, undefined, {
+        signal: options?.signal,
+      });
     }
   }
 }
@@ -223,29 +233,149 @@ export async function inspectCodexAutomationFleet(input) {
  * @param {{
  *   readonly automationsDir?: string
  *   readonly automationPrefix: string
+ *   readonly signal?: AbortSignal
  * }} input
  * @returns {Promise<readonly ObservedCodexAutomation[]>}
  */
 export async function listCodexAutomations(input) {
-  const automationsDir =
+  input.signal?.throwIfAborted();
+  const requestedRoot =
     input.automationsDir ?? resolveDefaultCodexAutomationsDir();
-  const dirEntries = await fs.readdir(automationsDir, {
-    withFileTypes: true,
-  });
-
-  const automationDirs = dirEntries
-    .filter(
-      entry =>
-        entry.isDirectory() && entry.name.startsWith(input.automationPrefix)
-    )
-    .map(entry => path.join(automationsDir, entry.name))
-    .sort((left, right) => left.localeCompare(right));
-
-  const automations = await Promise.all(
-    automationDirs.map(dir => readCodexAutomation(dir))
+  const automationsRoot = await fs.realpath(requestedRoot);
+  input.signal?.throwIfAborted();
+  const automationDirs = await listConfinedAutomationDirectories(
+    automationsRoot,
+    input.automationPrefix,
+    input.signal
   );
+  return await readCodexAutomations(automationDirs, input.signal);
+}
 
-  return automations.filter(Boolean);
+/**
+ * Enumerate a bounded number of direct, regular scheduler directories.
+ * @param {string} automationsRoot Canonical scheduler root.
+ * @param {string} automationPrefix Expected repository automation prefix.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @returns {Promise<readonly string[]>} Canonical matching directories.
+ */
+async function listConfinedAutomationDirectories(
+  automationsRoot,
+  automationPrefix,
+  signal
+) {
+  const directory = await fs.opendir(automationsRoot);
+  try {
+    const names = await readBoundedDirectoryNames(
+      directory,
+      automationPrefix,
+      signal
+    );
+    const directories = await Promise.all(
+      names.map(name => confinedAutomationDirectory(automationsRoot, name))
+    );
+    signal?.throwIfAborted();
+    return directories.toSorted((left, right) => left.localeCompare(right));
+  } finally {
+    await closeDirectory(directory);
+  }
+}
+
+/**
+ * Close a scheduler directory while tolerating runtimes that auto-close it
+ * after async iteration.
+ * @param {import("node:fs").Dir} directory Open scheduler directory handle.
+ * @returns {Promise<void>}
+ */
+async function closeDirectory(directory) {
+  try {
+    await directory.close();
+  } catch (error) {
+    if (error?.code !== "ERR_DIR_CLOSED") throw error;
+  }
+}
+
+/**
+ * Consume directory entries with total and prefix-match bounds.
+ * @param {import("node:fs").Dir} directory Open scheduler directory handle.
+ * @param {string} automationPrefix Expected repository automation prefix.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {number} [entryCount] Entries consumed so far.
+ * @param {readonly string[]} [matchingNames] Matching directory names.
+ * @returns {Promise<readonly string[]>} Bounded matching names.
+ */
+async function readBoundedDirectoryNames(
+  directory,
+  automationPrefix,
+  signal,
+  entryCount = 0,
+  matchingNames = []
+) {
+  signal?.throwIfAborted();
+  if (entryCount >= MAX_SCHEDULER_ENTRIES) {
+    const overflow = await directory.read();
+    if (overflow !== null) {
+      throw new Error("Codex scheduler enumeration exceeds entry limit");
+    }
+    return matchingNames;
+  }
+  const entry = await directory.read();
+  signal?.throwIfAborted();
+  if (entry === null) return matchingNames;
+  const matches =
+    entry.isDirectory() && entry.name.startsWith(automationPrefix);
+  const nextNames = matches ? [...matchingNames, entry.name] : matchingNames;
+  if (nextNames.length > MAX_MATCHING_AUTOMATIONS) {
+    throw new Error("Codex scheduler automation count exceeds limit");
+  }
+  return await readBoundedDirectoryNames(
+    directory,
+    automationPrefix,
+    signal,
+    entryCount + 1,
+    nextNames
+  );
+}
+
+/**
+ * Verify one direct scheduler entry remains a confined real directory.
+ * @param {string} automationsRoot Canonical scheduler root.
+ * @param {string} name Direct entry name.
+ * @returns {Promise<string>} Canonical automation directory.
+ */
+async function confinedAutomationDirectory(automationsRoot, name) {
+  const candidate = path.join(automationsRoot, name);
+  const stat = await fs.lstat(candidate);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error("Unsafe Codex scheduler directory");
+  }
+  const actual = await fs.realpath(candidate);
+  if (!actual.startsWith(`${automationsRoot}${path.sep}`)) {
+    throw new Error("Codex scheduler directory escapes root");
+  }
+  return actual;
+}
+
+/**
+ * Read scheduler entries sequentially to bound simultaneously open files.
+ * @param {readonly string[]} automationDirs Canonical automation directories.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {number} [index] Next directory index.
+ * @param {readonly ObservedCodexAutomation[]} [results] Completed observations.
+ * @returns {Promise<readonly ObservedCodexAutomation[]>} Observations.
+ */
+async function readCodexAutomations(
+  automationDirs,
+  signal,
+  index = 0,
+  results = []
+) {
+  signal?.throwIfAborted();
+  if (index >= automationDirs.length) return results;
+  const observation = await readCodexAutomation(automationDirs[index], signal);
+  return await readCodexAutomations(automationDirs, signal, index + 1, [
+    ...results,
+    observation,
+  ]);
 }
 
 /**
@@ -361,16 +491,130 @@ function findLatestAutomationMemoryBlock(lines) {
   };
 }
 
-async function readCodexAutomation(automationDir) {
-  const tomlPath = path.join(automationDir, "automation.toml");
-  const memoryPath = path.join(automationDir, "memory.md");
-  const tomlContent = await fs.readFile(tomlPath, "utf8");
+/**
+ * Read one stable bounded file without following a scheduler symlink or FIFO.
+ * @param {string} automationDir Canonical automation directory.
+ * @param {string} filename Direct scheduler filename.
+ * @param {number} maximumBytes Maximum allowed bytes.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {boolean} [optional] Whether a missing file resolves to undefined.
+ * @returns {Promise<string | undefined>} Strict UTF-8 contents.
+ */
+async function readConfinedSchedulerText(
+  automationDir,
+  filename,
+  maximumBytes,
+  signal,
+  optional = false
+) {
+  signal?.throwIfAborted();
+  const target = path.join(automationDir, filename);
+  const before = await fs.lstat(target).catch(error => {
+    if (optional && error?.code === "ENOENT") return null;
+    throw error;
+  });
+  if (before === null) return undefined;
+  assertBoundedSchedulerFile(before, maximumBytes);
+  const actual = await fs.realpath(target);
+  if (!actual.startsWith(`${automationDir}${path.sep}`)) {
+    throw new Error("Codex scheduler file escapes automation directory");
+  }
+  const handle = await fs.open(
+    target,
+    fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK
+  );
+  try {
+    const opened = await handle.stat();
+    assertBoundedSchedulerFile(opened, maximumBytes);
+    if (opened.dev !== before.dev || opened.ino !== before.ino) {
+      throw new Error("Codex scheduler file changed during inspection");
+    }
+    const bytes = await readBoundedSchedulerFile(handle, maximumBytes, signal);
+    const after = await handle.stat();
+    if (after.size !== opened.size || bytes.length !== after.size) {
+      throw new Error("Codex scheduler file changed during read");
+    }
+    signal?.throwIfAborted();
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Reject non-regular and oversized scheduler files before opening them.
+ * @param {import("node:fs").Stats} stat Scheduler file metadata.
+ * @param {number} maximumBytes Maximum allowed bytes.
+ * @returns {void}
+ */
+function assertBoundedSchedulerFile(stat, maximumBytes) {
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(UNSAFE_SCHEDULER_FILE);
+  }
+  if (stat.size > maximumBytes) {
+    throw new Error("Codex scheduler file exceeds size limit");
+  }
+}
+
+/**
+ * Read at most maximum plus one bytes from an already confined file handle.
+ * @param {import("node:fs/promises").FileHandle} handle Open file handle.
+ * @param {number} maximumBytes Maximum allowed bytes.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {number} [offset] Current file offset.
+ * @returns {Promise<Buffer>} Bounded bytes.
+ */
+async function readBoundedSchedulerFile(
+  handle,
+  maximumBytes,
+  signal,
+  offset = 0
+) {
+  signal?.throwIfAborted();
+  const remaining = maximumBytes + 1 - offset;
+  if (remaining <= 0) {
+    throw new Error("Codex scheduler file exceeds size limit");
+  }
+  const chunk = Buffer.allocUnsafe(Math.min(READ_CHUNK_BYTES, remaining));
+  const { bytesRead } = await handle.read(chunk, 0, chunk.length, offset);
+  signal?.throwIfAborted();
+  if (bytesRead === 0) return Buffer.alloc(0);
+  const current = chunk.subarray(0, bytesRead);
+  const tail = await readBoundedSchedulerFile(
+    handle,
+    maximumBytes,
+    signal,
+    offset + bytesRead
+  );
+  return Buffer.concat([current, tail], bytesRead + tail.length);
+}
+
+/**
+ * Read one confined Codex automation contract and optional memory.
+ * @param {string} automationDir Canonical automation directory.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @returns {Promise<ObservedCodexAutomation>} Normalized observation.
+ */
+async function readCodexAutomation(automationDir, signal) {
+  const tomlContent = await readConfinedSchedulerText(
+    automationDir,
+    "automation.toml",
+    MAX_AUTOMATION_TOML_BYTES,
+    signal
+  );
   const automation = parseAutomationToml(tomlContent);
-  const memoryContent = await fs.readFile(memoryPath, "utf8").catch(() => "");
+  const memoryContent =
+    (await readConfinedSchedulerText(
+      automationDir,
+      "memory.md",
+      MAX_AUTOMATION_MEMORY_BYTES,
+      signal,
+      true
+    )) ?? "";
   const memory = parseCodexAutomationMemory(memoryContent);
   const cwd = Array.isArray(automation.cwds) ? automation.cwds[0] : null;
   const normalizedCwd = typeof cwd === "string" ? cwd : null;
-  const cwdHealth = await inspectAutomationCwd(normalizedCwd);
+  const cwdHealth = await inspectAutomationCwd(normalizedCwd, signal);
 
   return {
     automationId:
@@ -546,7 +790,8 @@ function classifyAutomationRunSignal(input) {
   return null;
 }
 
-async function inspectAutomationCwd(cwd) {
+async function inspectAutomationCwd(cwd, signal) {
+  signal?.throwIfAborted();
   if (!cwd) {
     return {
       status: "missing",
@@ -560,6 +805,7 @@ async function inspectAutomationCwd(cwd) {
     }
     throw error;
   });
+  signal?.throwIfAborted();
 
   if (!stat) {
     return {
@@ -578,7 +824,7 @@ async function inspectAutomationCwd(cwd) {
   try {
     const { stdout } = await execGitWithRetry(
       ["-C", cwd, "rev-parse", "--is-inside-work-tree", "--is-bare-repository"],
-      { timeout: 5000 }
+      { timeout: 5000, signal }
     );
     const [insideWorkTree, bareRepository] = stdout.trim().split(/\r?\n/);
 
@@ -601,6 +847,7 @@ async function inspectAutomationCwd(cwd) {
       summary: `${cwd} is a valid Git work tree`,
     };
   } catch (error) {
+    signal?.throwIfAborted();
     return {
       status: "git_error",
       summary: `git could not inspect ${cwd}: ${String(error?.message ?? error)}`,

--- a/plugins/lisa-cursor/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa-cursor/scripts/automation-status-codex-adapter.mjs
@@ -11,9 +11,11 @@
  */
 
 import fs from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFile } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
 import { promisify } from "node:util";
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
@@ -34,6 +36,12 @@ const RUN_FAILURE_PATTERN =
 const NEGATED_FAILURE_PATTERN =
   /\b(no|without)\s+(?:recent\s+)?(?:fail(?:ure|ed)|errors?|exceptions?)\b/i;
 const execFileAsync = promisify(execFile);
+const MAX_SCHEDULER_ENTRIES = 1_000;
+const MAX_MATCHING_AUTOMATIONS = 100;
+const MAX_AUTOMATION_TOML_BYTES = 256 * 1024;
+const MAX_AUTOMATION_MEMORY_BYTES = 512 * 1024;
+const READ_CHUNK_BYTES = 64 * 1024;
+const UNSAFE_SCHEDULER_FILE = "Unsafe Codex scheduler file";
 
 /**
  * Git location env vars that, when inherited, override the `-C <dir>` flag and
@@ -101,7 +109,9 @@ async function execGitWithRetry(args, options, attempts = 4) {
       if (!transient || attempt >= attempts) {
         throw error;
       }
-      await new Promise(resolve => setTimeout(resolve, 2 ** attempt * 25));
+      await delay(2 ** attempt * 25, undefined, {
+        signal: options?.signal,
+      });
     }
   }
 }
@@ -223,29 +233,149 @@ export async function inspectCodexAutomationFleet(input) {
  * @param {{
  *   readonly automationsDir?: string
  *   readonly automationPrefix: string
+ *   readonly signal?: AbortSignal
  * }} input
  * @returns {Promise<readonly ObservedCodexAutomation[]>}
  */
 export async function listCodexAutomations(input) {
-  const automationsDir =
+  input.signal?.throwIfAborted();
+  const requestedRoot =
     input.automationsDir ?? resolveDefaultCodexAutomationsDir();
-  const dirEntries = await fs.readdir(automationsDir, {
-    withFileTypes: true,
-  });
-
-  const automationDirs = dirEntries
-    .filter(
-      entry =>
-        entry.isDirectory() && entry.name.startsWith(input.automationPrefix)
-    )
-    .map(entry => path.join(automationsDir, entry.name))
-    .sort((left, right) => left.localeCompare(right));
-
-  const automations = await Promise.all(
-    automationDirs.map(dir => readCodexAutomation(dir))
+  const automationsRoot = await fs.realpath(requestedRoot);
+  input.signal?.throwIfAborted();
+  const automationDirs = await listConfinedAutomationDirectories(
+    automationsRoot,
+    input.automationPrefix,
+    input.signal
   );
+  return await readCodexAutomations(automationDirs, input.signal);
+}
 
-  return automations.filter(Boolean);
+/**
+ * Enumerate a bounded number of direct, regular scheduler directories.
+ * @param {string} automationsRoot Canonical scheduler root.
+ * @param {string} automationPrefix Expected repository automation prefix.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @returns {Promise<readonly string[]>} Canonical matching directories.
+ */
+async function listConfinedAutomationDirectories(
+  automationsRoot,
+  automationPrefix,
+  signal
+) {
+  const directory = await fs.opendir(automationsRoot);
+  try {
+    const names = await readBoundedDirectoryNames(
+      directory,
+      automationPrefix,
+      signal
+    );
+    const directories = await Promise.all(
+      names.map(name => confinedAutomationDirectory(automationsRoot, name))
+    );
+    signal?.throwIfAborted();
+    return directories.toSorted((left, right) => left.localeCompare(right));
+  } finally {
+    await closeDirectory(directory);
+  }
+}
+
+/**
+ * Close a scheduler directory while tolerating runtimes that auto-close it
+ * after async iteration.
+ * @param {import("node:fs").Dir} directory Open scheduler directory handle.
+ * @returns {Promise<void>}
+ */
+async function closeDirectory(directory) {
+  try {
+    await directory.close();
+  } catch (error) {
+    if (error?.code !== "ERR_DIR_CLOSED") throw error;
+  }
+}
+
+/**
+ * Consume directory entries with total and prefix-match bounds.
+ * @param {import("node:fs").Dir} directory Open scheduler directory handle.
+ * @param {string} automationPrefix Expected repository automation prefix.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {number} [entryCount] Entries consumed so far.
+ * @param {readonly string[]} [matchingNames] Matching directory names.
+ * @returns {Promise<readonly string[]>} Bounded matching names.
+ */
+async function readBoundedDirectoryNames(
+  directory,
+  automationPrefix,
+  signal,
+  entryCount = 0,
+  matchingNames = []
+) {
+  signal?.throwIfAborted();
+  if (entryCount >= MAX_SCHEDULER_ENTRIES) {
+    const overflow = await directory.read();
+    if (overflow !== null) {
+      throw new Error("Codex scheduler enumeration exceeds entry limit");
+    }
+    return matchingNames;
+  }
+  const entry = await directory.read();
+  signal?.throwIfAborted();
+  if (entry === null) return matchingNames;
+  const matches =
+    entry.isDirectory() && entry.name.startsWith(automationPrefix);
+  const nextNames = matches ? [...matchingNames, entry.name] : matchingNames;
+  if (nextNames.length > MAX_MATCHING_AUTOMATIONS) {
+    throw new Error("Codex scheduler automation count exceeds limit");
+  }
+  return await readBoundedDirectoryNames(
+    directory,
+    automationPrefix,
+    signal,
+    entryCount + 1,
+    nextNames
+  );
+}
+
+/**
+ * Verify one direct scheduler entry remains a confined real directory.
+ * @param {string} automationsRoot Canonical scheduler root.
+ * @param {string} name Direct entry name.
+ * @returns {Promise<string>} Canonical automation directory.
+ */
+async function confinedAutomationDirectory(automationsRoot, name) {
+  const candidate = path.join(automationsRoot, name);
+  const stat = await fs.lstat(candidate);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error("Unsafe Codex scheduler directory");
+  }
+  const actual = await fs.realpath(candidate);
+  if (!actual.startsWith(`${automationsRoot}${path.sep}`)) {
+    throw new Error("Codex scheduler directory escapes root");
+  }
+  return actual;
+}
+
+/**
+ * Read scheduler entries sequentially to bound simultaneously open files.
+ * @param {readonly string[]} automationDirs Canonical automation directories.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {number} [index] Next directory index.
+ * @param {readonly ObservedCodexAutomation[]} [results] Completed observations.
+ * @returns {Promise<readonly ObservedCodexAutomation[]>} Observations.
+ */
+async function readCodexAutomations(
+  automationDirs,
+  signal,
+  index = 0,
+  results = []
+) {
+  signal?.throwIfAborted();
+  if (index >= automationDirs.length) return results;
+  const observation = await readCodexAutomation(automationDirs[index], signal);
+  return await readCodexAutomations(automationDirs, signal, index + 1, [
+    ...results,
+    observation,
+  ]);
 }
 
 /**
@@ -361,16 +491,130 @@ function findLatestAutomationMemoryBlock(lines) {
   };
 }
 
-async function readCodexAutomation(automationDir) {
-  const tomlPath = path.join(automationDir, "automation.toml");
-  const memoryPath = path.join(automationDir, "memory.md");
-  const tomlContent = await fs.readFile(tomlPath, "utf8");
+/**
+ * Read one stable bounded file without following a scheduler symlink or FIFO.
+ * @param {string} automationDir Canonical automation directory.
+ * @param {string} filename Direct scheduler filename.
+ * @param {number} maximumBytes Maximum allowed bytes.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {boolean} [optional] Whether a missing file resolves to undefined.
+ * @returns {Promise<string | undefined>} Strict UTF-8 contents.
+ */
+async function readConfinedSchedulerText(
+  automationDir,
+  filename,
+  maximumBytes,
+  signal,
+  optional = false
+) {
+  signal?.throwIfAborted();
+  const target = path.join(automationDir, filename);
+  const before = await fs.lstat(target).catch(error => {
+    if (optional && error?.code === "ENOENT") return null;
+    throw error;
+  });
+  if (before === null) return undefined;
+  assertBoundedSchedulerFile(before, maximumBytes);
+  const actual = await fs.realpath(target);
+  if (!actual.startsWith(`${automationDir}${path.sep}`)) {
+    throw new Error("Codex scheduler file escapes automation directory");
+  }
+  const handle = await fs.open(
+    target,
+    fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK
+  );
+  try {
+    const opened = await handle.stat();
+    assertBoundedSchedulerFile(opened, maximumBytes);
+    if (opened.dev !== before.dev || opened.ino !== before.ino) {
+      throw new Error("Codex scheduler file changed during inspection");
+    }
+    const bytes = await readBoundedSchedulerFile(handle, maximumBytes, signal);
+    const after = await handle.stat();
+    if (after.size !== opened.size || bytes.length !== after.size) {
+      throw new Error("Codex scheduler file changed during read");
+    }
+    signal?.throwIfAborted();
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Reject non-regular and oversized scheduler files before opening them.
+ * @param {import("node:fs").Stats} stat Scheduler file metadata.
+ * @param {number} maximumBytes Maximum allowed bytes.
+ * @returns {void}
+ */
+function assertBoundedSchedulerFile(stat, maximumBytes) {
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(UNSAFE_SCHEDULER_FILE);
+  }
+  if (stat.size > maximumBytes) {
+    throw new Error("Codex scheduler file exceeds size limit");
+  }
+}
+
+/**
+ * Read at most maximum plus one bytes from an already confined file handle.
+ * @param {import("node:fs/promises").FileHandle} handle Open file handle.
+ * @param {number} maximumBytes Maximum allowed bytes.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {number} [offset] Current file offset.
+ * @returns {Promise<Buffer>} Bounded bytes.
+ */
+async function readBoundedSchedulerFile(
+  handle,
+  maximumBytes,
+  signal,
+  offset = 0
+) {
+  signal?.throwIfAborted();
+  const remaining = maximumBytes + 1 - offset;
+  if (remaining <= 0) {
+    throw new Error("Codex scheduler file exceeds size limit");
+  }
+  const chunk = Buffer.allocUnsafe(Math.min(READ_CHUNK_BYTES, remaining));
+  const { bytesRead } = await handle.read(chunk, 0, chunk.length, offset);
+  signal?.throwIfAborted();
+  if (bytesRead === 0) return Buffer.alloc(0);
+  const current = chunk.subarray(0, bytesRead);
+  const tail = await readBoundedSchedulerFile(
+    handle,
+    maximumBytes,
+    signal,
+    offset + bytesRead
+  );
+  return Buffer.concat([current, tail], bytesRead + tail.length);
+}
+
+/**
+ * Read one confined Codex automation contract and optional memory.
+ * @param {string} automationDir Canonical automation directory.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @returns {Promise<ObservedCodexAutomation>} Normalized observation.
+ */
+async function readCodexAutomation(automationDir, signal) {
+  const tomlContent = await readConfinedSchedulerText(
+    automationDir,
+    "automation.toml",
+    MAX_AUTOMATION_TOML_BYTES,
+    signal
+  );
   const automation = parseAutomationToml(tomlContent);
-  const memoryContent = await fs.readFile(memoryPath, "utf8").catch(() => "");
+  const memoryContent =
+    (await readConfinedSchedulerText(
+      automationDir,
+      "memory.md",
+      MAX_AUTOMATION_MEMORY_BYTES,
+      signal,
+      true
+    )) ?? "";
   const memory = parseCodexAutomationMemory(memoryContent);
   const cwd = Array.isArray(automation.cwds) ? automation.cwds[0] : null;
   const normalizedCwd = typeof cwd === "string" ? cwd : null;
-  const cwdHealth = await inspectAutomationCwd(normalizedCwd);
+  const cwdHealth = await inspectAutomationCwd(normalizedCwd, signal);
 
   return {
     automationId:
@@ -546,7 +790,8 @@ function classifyAutomationRunSignal(input) {
   return null;
 }
 
-async function inspectAutomationCwd(cwd) {
+async function inspectAutomationCwd(cwd, signal) {
+  signal?.throwIfAborted();
   if (!cwd) {
     return {
       status: "missing",
@@ -560,6 +805,7 @@ async function inspectAutomationCwd(cwd) {
     }
     throw error;
   });
+  signal?.throwIfAborted();
 
   if (!stat) {
     return {
@@ -578,7 +824,7 @@ async function inspectAutomationCwd(cwd) {
   try {
     const { stdout } = await execGitWithRetry(
       ["-C", cwd, "rev-parse", "--is-inside-work-tree", "--is-bare-repository"],
-      { timeout: 5000 }
+      { timeout: 5000, signal }
     );
     const [insideWorkTree, bareRepository] = stdout.trim().split(/\r?\n/);
 
@@ -601,6 +847,7 @@ async function inspectAutomationCwd(cwd) {
       summary: `${cwd} is a valid Git work tree`,
     };
   } catch (error) {
+    signal?.throwIfAborted();
     return {
       status: "git_error",
       summary: `git could not inspect ${cwd}: ${String(error?.message ?? error)}`,

--- a/plugins/lisa/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/lisa/scripts/automation-status-codex-adapter.mjs
@@ -11,9 +11,11 @@
  */
 
 import fs from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFile } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
 import { promisify } from "node:util";
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
@@ -34,6 +36,12 @@ const RUN_FAILURE_PATTERN =
 const NEGATED_FAILURE_PATTERN =
   /\b(no|without)\s+(?:recent\s+)?(?:fail(?:ure|ed)|errors?|exceptions?)\b/i;
 const execFileAsync = promisify(execFile);
+const MAX_SCHEDULER_ENTRIES = 1_000;
+const MAX_MATCHING_AUTOMATIONS = 100;
+const MAX_AUTOMATION_TOML_BYTES = 256 * 1024;
+const MAX_AUTOMATION_MEMORY_BYTES = 512 * 1024;
+const READ_CHUNK_BYTES = 64 * 1024;
+const UNSAFE_SCHEDULER_FILE = "Unsafe Codex scheduler file";
 
 /**
  * Git location env vars that, when inherited, override the `-C <dir>` flag and
@@ -101,7 +109,9 @@ async function execGitWithRetry(args, options, attempts = 4) {
       if (!transient || attempt >= attempts) {
         throw error;
       }
-      await new Promise(resolve => setTimeout(resolve, 2 ** attempt * 25));
+      await delay(2 ** attempt * 25, undefined, {
+        signal: options?.signal,
+      });
     }
   }
 }
@@ -223,29 +233,149 @@ export async function inspectCodexAutomationFleet(input) {
  * @param {{
  *   readonly automationsDir?: string
  *   readonly automationPrefix: string
+ *   readonly signal?: AbortSignal
  * }} input
  * @returns {Promise<readonly ObservedCodexAutomation[]>}
  */
 export async function listCodexAutomations(input) {
-  const automationsDir =
+  input.signal?.throwIfAborted();
+  const requestedRoot =
     input.automationsDir ?? resolveDefaultCodexAutomationsDir();
-  const dirEntries = await fs.readdir(automationsDir, {
-    withFileTypes: true,
-  });
-
-  const automationDirs = dirEntries
-    .filter(
-      entry =>
-        entry.isDirectory() && entry.name.startsWith(input.automationPrefix)
-    )
-    .map(entry => path.join(automationsDir, entry.name))
-    .sort((left, right) => left.localeCompare(right));
-
-  const automations = await Promise.all(
-    automationDirs.map(dir => readCodexAutomation(dir))
+  const automationsRoot = await fs.realpath(requestedRoot);
+  input.signal?.throwIfAborted();
+  const automationDirs = await listConfinedAutomationDirectories(
+    automationsRoot,
+    input.automationPrefix,
+    input.signal
   );
+  return await readCodexAutomations(automationDirs, input.signal);
+}
 
-  return automations.filter(Boolean);
+/**
+ * Enumerate a bounded number of direct, regular scheduler directories.
+ * @param {string} automationsRoot Canonical scheduler root.
+ * @param {string} automationPrefix Expected repository automation prefix.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @returns {Promise<readonly string[]>} Canonical matching directories.
+ */
+async function listConfinedAutomationDirectories(
+  automationsRoot,
+  automationPrefix,
+  signal
+) {
+  const directory = await fs.opendir(automationsRoot);
+  try {
+    const names = await readBoundedDirectoryNames(
+      directory,
+      automationPrefix,
+      signal
+    );
+    const directories = await Promise.all(
+      names.map(name => confinedAutomationDirectory(automationsRoot, name))
+    );
+    signal?.throwIfAborted();
+    return directories.toSorted((left, right) => left.localeCompare(right));
+  } finally {
+    await closeDirectory(directory);
+  }
+}
+
+/**
+ * Close a scheduler directory while tolerating runtimes that auto-close it
+ * after async iteration.
+ * @param {import("node:fs").Dir} directory Open scheduler directory handle.
+ * @returns {Promise<void>}
+ */
+async function closeDirectory(directory) {
+  try {
+    await directory.close();
+  } catch (error) {
+    if (error?.code !== "ERR_DIR_CLOSED") throw error;
+  }
+}
+
+/**
+ * Consume directory entries with total and prefix-match bounds.
+ * @param {import("node:fs").Dir} directory Open scheduler directory handle.
+ * @param {string} automationPrefix Expected repository automation prefix.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {number} [entryCount] Entries consumed so far.
+ * @param {readonly string[]} [matchingNames] Matching directory names.
+ * @returns {Promise<readonly string[]>} Bounded matching names.
+ */
+async function readBoundedDirectoryNames(
+  directory,
+  automationPrefix,
+  signal,
+  entryCount = 0,
+  matchingNames = []
+) {
+  signal?.throwIfAborted();
+  if (entryCount >= MAX_SCHEDULER_ENTRIES) {
+    const overflow = await directory.read();
+    if (overflow !== null) {
+      throw new Error("Codex scheduler enumeration exceeds entry limit");
+    }
+    return matchingNames;
+  }
+  const entry = await directory.read();
+  signal?.throwIfAborted();
+  if (entry === null) return matchingNames;
+  const matches =
+    entry.isDirectory() && entry.name.startsWith(automationPrefix);
+  const nextNames = matches ? [...matchingNames, entry.name] : matchingNames;
+  if (nextNames.length > MAX_MATCHING_AUTOMATIONS) {
+    throw new Error("Codex scheduler automation count exceeds limit");
+  }
+  return await readBoundedDirectoryNames(
+    directory,
+    automationPrefix,
+    signal,
+    entryCount + 1,
+    nextNames
+  );
+}
+
+/**
+ * Verify one direct scheduler entry remains a confined real directory.
+ * @param {string} automationsRoot Canonical scheduler root.
+ * @param {string} name Direct entry name.
+ * @returns {Promise<string>} Canonical automation directory.
+ */
+async function confinedAutomationDirectory(automationsRoot, name) {
+  const candidate = path.join(automationsRoot, name);
+  const stat = await fs.lstat(candidate);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error("Unsafe Codex scheduler directory");
+  }
+  const actual = await fs.realpath(candidate);
+  if (!actual.startsWith(`${automationsRoot}${path.sep}`)) {
+    throw new Error("Codex scheduler directory escapes root");
+  }
+  return actual;
+}
+
+/**
+ * Read scheduler entries sequentially to bound simultaneously open files.
+ * @param {readonly string[]} automationDirs Canonical automation directories.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {number} [index] Next directory index.
+ * @param {readonly ObservedCodexAutomation[]} [results] Completed observations.
+ * @returns {Promise<readonly ObservedCodexAutomation[]>} Observations.
+ */
+async function readCodexAutomations(
+  automationDirs,
+  signal,
+  index = 0,
+  results = []
+) {
+  signal?.throwIfAborted();
+  if (index >= automationDirs.length) return results;
+  const observation = await readCodexAutomation(automationDirs[index], signal);
+  return await readCodexAutomations(automationDirs, signal, index + 1, [
+    ...results,
+    observation,
+  ]);
 }
 
 /**
@@ -361,16 +491,130 @@ function findLatestAutomationMemoryBlock(lines) {
   };
 }
 
-async function readCodexAutomation(automationDir) {
-  const tomlPath = path.join(automationDir, "automation.toml");
-  const memoryPath = path.join(automationDir, "memory.md");
-  const tomlContent = await fs.readFile(tomlPath, "utf8");
+/**
+ * Read one stable bounded file without following a scheduler symlink or FIFO.
+ * @param {string} automationDir Canonical automation directory.
+ * @param {string} filename Direct scheduler filename.
+ * @param {number} maximumBytes Maximum allowed bytes.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {boolean} [optional] Whether a missing file resolves to undefined.
+ * @returns {Promise<string | undefined>} Strict UTF-8 contents.
+ */
+async function readConfinedSchedulerText(
+  automationDir,
+  filename,
+  maximumBytes,
+  signal,
+  optional = false
+) {
+  signal?.throwIfAborted();
+  const target = path.join(automationDir, filename);
+  const before = await fs.lstat(target).catch(error => {
+    if (optional && error?.code === "ENOENT") return null;
+    throw error;
+  });
+  if (before === null) return undefined;
+  assertBoundedSchedulerFile(before, maximumBytes);
+  const actual = await fs.realpath(target);
+  if (!actual.startsWith(`${automationDir}${path.sep}`)) {
+    throw new Error("Codex scheduler file escapes automation directory");
+  }
+  const handle = await fs.open(
+    target,
+    fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK
+  );
+  try {
+    const opened = await handle.stat();
+    assertBoundedSchedulerFile(opened, maximumBytes);
+    if (opened.dev !== before.dev || opened.ino !== before.ino) {
+      throw new Error("Codex scheduler file changed during inspection");
+    }
+    const bytes = await readBoundedSchedulerFile(handle, maximumBytes, signal);
+    const after = await handle.stat();
+    if (after.size !== opened.size || bytes.length !== after.size) {
+      throw new Error("Codex scheduler file changed during read");
+    }
+    signal?.throwIfAborted();
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Reject non-regular and oversized scheduler files before opening them.
+ * @param {import("node:fs").Stats} stat Scheduler file metadata.
+ * @param {number} maximumBytes Maximum allowed bytes.
+ * @returns {void}
+ */
+function assertBoundedSchedulerFile(stat, maximumBytes) {
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(UNSAFE_SCHEDULER_FILE);
+  }
+  if (stat.size > maximumBytes) {
+    throw new Error("Codex scheduler file exceeds size limit");
+  }
+}
+
+/**
+ * Read at most maximum plus one bytes from an already confined file handle.
+ * @param {import("node:fs/promises").FileHandle} handle Open file handle.
+ * @param {number} maximumBytes Maximum allowed bytes.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {number} [offset] Current file offset.
+ * @returns {Promise<Buffer>} Bounded bytes.
+ */
+async function readBoundedSchedulerFile(
+  handle,
+  maximumBytes,
+  signal,
+  offset = 0
+) {
+  signal?.throwIfAborted();
+  const remaining = maximumBytes + 1 - offset;
+  if (remaining <= 0) {
+    throw new Error("Codex scheduler file exceeds size limit");
+  }
+  const chunk = Buffer.allocUnsafe(Math.min(READ_CHUNK_BYTES, remaining));
+  const { bytesRead } = await handle.read(chunk, 0, chunk.length, offset);
+  signal?.throwIfAborted();
+  if (bytesRead === 0) return Buffer.alloc(0);
+  const current = chunk.subarray(0, bytesRead);
+  const tail = await readBoundedSchedulerFile(
+    handle,
+    maximumBytes,
+    signal,
+    offset + bytesRead
+  );
+  return Buffer.concat([current, tail], bytesRead + tail.length);
+}
+
+/**
+ * Read one confined Codex automation contract and optional memory.
+ * @param {string} automationDir Canonical automation directory.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @returns {Promise<ObservedCodexAutomation>} Normalized observation.
+ */
+async function readCodexAutomation(automationDir, signal) {
+  const tomlContent = await readConfinedSchedulerText(
+    automationDir,
+    "automation.toml",
+    MAX_AUTOMATION_TOML_BYTES,
+    signal
+  );
   const automation = parseAutomationToml(tomlContent);
-  const memoryContent = await fs.readFile(memoryPath, "utf8").catch(() => "");
+  const memoryContent =
+    (await readConfinedSchedulerText(
+      automationDir,
+      "memory.md",
+      MAX_AUTOMATION_MEMORY_BYTES,
+      signal,
+      true
+    )) ?? "";
   const memory = parseCodexAutomationMemory(memoryContent);
   const cwd = Array.isArray(automation.cwds) ? automation.cwds[0] : null;
   const normalizedCwd = typeof cwd === "string" ? cwd : null;
-  const cwdHealth = await inspectAutomationCwd(normalizedCwd);
+  const cwdHealth = await inspectAutomationCwd(normalizedCwd, signal);
 
   return {
     automationId:
@@ -546,7 +790,8 @@ function classifyAutomationRunSignal(input) {
   return null;
 }
 
-async function inspectAutomationCwd(cwd) {
+async function inspectAutomationCwd(cwd, signal) {
+  signal?.throwIfAborted();
   if (!cwd) {
     return {
       status: "missing",
@@ -560,6 +805,7 @@ async function inspectAutomationCwd(cwd) {
     }
     throw error;
   });
+  signal?.throwIfAborted();
 
   if (!stat) {
     return {
@@ -578,7 +824,7 @@ async function inspectAutomationCwd(cwd) {
   try {
     const { stdout } = await execGitWithRetry(
       ["-C", cwd, "rev-parse", "--is-inside-work-tree", "--is-bare-repository"],
-      { timeout: 5000 }
+      { timeout: 5000, signal }
     );
     const [insideWorkTree, bareRepository] = stdout.trim().split(/\r?\n/);
 
@@ -601,6 +847,7 @@ async function inspectAutomationCwd(cwd) {
       summary: `${cwd} is a valid Git work tree`,
     };
   } catch (error) {
+    signal?.throwIfAborted();
     return {
       status: "git_error",
       summary: `git could not inspect ${cwd}: ${String(error?.message ?? error)}`,

--- a/plugins/src/base/scripts/automation-status-codex-adapter.mjs
+++ b/plugins/src/base/scripts/automation-status-codex-adapter.mjs
@@ -11,9 +11,11 @@
  */
 
 import fs from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFile } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
 import { promisify } from "node:util";
 
 import { compareAutomationFleet } from "./automation-status-contract-drift.mjs";
@@ -34,6 +36,12 @@ const RUN_FAILURE_PATTERN =
 const NEGATED_FAILURE_PATTERN =
   /\b(no|without)\s+(?:recent\s+)?(?:fail(?:ure|ed)|errors?|exceptions?)\b/i;
 const execFileAsync = promisify(execFile);
+const MAX_SCHEDULER_ENTRIES = 1_000;
+const MAX_MATCHING_AUTOMATIONS = 100;
+const MAX_AUTOMATION_TOML_BYTES = 256 * 1024;
+const MAX_AUTOMATION_MEMORY_BYTES = 512 * 1024;
+const READ_CHUNK_BYTES = 64 * 1024;
+const UNSAFE_SCHEDULER_FILE = "Unsafe Codex scheduler file";
 
 /**
  * Git location env vars that, when inherited, override the `-C <dir>` flag and
@@ -101,7 +109,9 @@ async function execGitWithRetry(args, options, attempts = 4) {
       if (!transient || attempt >= attempts) {
         throw error;
       }
-      await new Promise(resolve => setTimeout(resolve, 2 ** attempt * 25));
+      await delay(2 ** attempt * 25, undefined, {
+        signal: options?.signal,
+      });
     }
   }
 }
@@ -223,29 +233,149 @@ export async function inspectCodexAutomationFleet(input) {
  * @param {{
  *   readonly automationsDir?: string
  *   readonly automationPrefix: string
+ *   readonly signal?: AbortSignal
  * }} input
  * @returns {Promise<readonly ObservedCodexAutomation[]>}
  */
 export async function listCodexAutomations(input) {
-  const automationsDir =
+  input.signal?.throwIfAborted();
+  const requestedRoot =
     input.automationsDir ?? resolveDefaultCodexAutomationsDir();
-  const dirEntries = await fs.readdir(automationsDir, {
-    withFileTypes: true,
-  });
-
-  const automationDirs = dirEntries
-    .filter(
-      entry =>
-        entry.isDirectory() && entry.name.startsWith(input.automationPrefix)
-    )
-    .map(entry => path.join(automationsDir, entry.name))
-    .sort((left, right) => left.localeCompare(right));
-
-  const automations = await Promise.all(
-    automationDirs.map(dir => readCodexAutomation(dir))
+  const automationsRoot = await fs.realpath(requestedRoot);
+  input.signal?.throwIfAborted();
+  const automationDirs = await listConfinedAutomationDirectories(
+    automationsRoot,
+    input.automationPrefix,
+    input.signal
   );
+  return await readCodexAutomations(automationDirs, input.signal);
+}
 
-  return automations.filter(Boolean);
+/**
+ * Enumerate a bounded number of direct, regular scheduler directories.
+ * @param {string} automationsRoot Canonical scheduler root.
+ * @param {string} automationPrefix Expected repository automation prefix.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @returns {Promise<readonly string[]>} Canonical matching directories.
+ */
+async function listConfinedAutomationDirectories(
+  automationsRoot,
+  automationPrefix,
+  signal
+) {
+  const directory = await fs.opendir(automationsRoot);
+  try {
+    const names = await readBoundedDirectoryNames(
+      directory,
+      automationPrefix,
+      signal
+    );
+    const directories = await Promise.all(
+      names.map(name => confinedAutomationDirectory(automationsRoot, name))
+    );
+    signal?.throwIfAborted();
+    return directories.toSorted((left, right) => left.localeCompare(right));
+  } finally {
+    await closeDirectory(directory);
+  }
+}
+
+/**
+ * Close a scheduler directory while tolerating runtimes that auto-close it
+ * after async iteration.
+ * @param {import("node:fs").Dir} directory Open scheduler directory handle.
+ * @returns {Promise<void>}
+ */
+async function closeDirectory(directory) {
+  try {
+    await directory.close();
+  } catch (error) {
+    if (error?.code !== "ERR_DIR_CLOSED") throw error;
+  }
+}
+
+/**
+ * Consume directory entries with total and prefix-match bounds.
+ * @param {import("node:fs").Dir} directory Open scheduler directory handle.
+ * @param {string} automationPrefix Expected repository automation prefix.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {number} [entryCount] Entries consumed so far.
+ * @param {readonly string[]} [matchingNames] Matching directory names.
+ * @returns {Promise<readonly string[]>} Bounded matching names.
+ */
+async function readBoundedDirectoryNames(
+  directory,
+  automationPrefix,
+  signal,
+  entryCount = 0,
+  matchingNames = []
+) {
+  signal?.throwIfAborted();
+  if (entryCount >= MAX_SCHEDULER_ENTRIES) {
+    const overflow = await directory.read();
+    if (overflow !== null) {
+      throw new Error("Codex scheduler enumeration exceeds entry limit");
+    }
+    return matchingNames;
+  }
+  const entry = await directory.read();
+  signal?.throwIfAborted();
+  if (entry === null) return matchingNames;
+  const matches =
+    entry.isDirectory() && entry.name.startsWith(automationPrefix);
+  const nextNames = matches ? [...matchingNames, entry.name] : matchingNames;
+  if (nextNames.length > MAX_MATCHING_AUTOMATIONS) {
+    throw new Error("Codex scheduler automation count exceeds limit");
+  }
+  return await readBoundedDirectoryNames(
+    directory,
+    automationPrefix,
+    signal,
+    entryCount + 1,
+    nextNames
+  );
+}
+
+/**
+ * Verify one direct scheduler entry remains a confined real directory.
+ * @param {string} automationsRoot Canonical scheduler root.
+ * @param {string} name Direct entry name.
+ * @returns {Promise<string>} Canonical automation directory.
+ */
+async function confinedAutomationDirectory(automationsRoot, name) {
+  const candidate = path.join(automationsRoot, name);
+  const stat = await fs.lstat(candidate);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error("Unsafe Codex scheduler directory");
+  }
+  const actual = await fs.realpath(candidate);
+  if (!actual.startsWith(`${automationsRoot}${path.sep}`)) {
+    throw new Error("Codex scheduler directory escapes root");
+  }
+  return actual;
+}
+
+/**
+ * Read scheduler entries sequentially to bound simultaneously open files.
+ * @param {readonly string[]} automationDirs Canonical automation directories.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {number} [index] Next directory index.
+ * @param {readonly ObservedCodexAutomation[]} [results] Completed observations.
+ * @returns {Promise<readonly ObservedCodexAutomation[]>} Observations.
+ */
+async function readCodexAutomations(
+  automationDirs,
+  signal,
+  index = 0,
+  results = []
+) {
+  signal?.throwIfAborted();
+  if (index >= automationDirs.length) return results;
+  const observation = await readCodexAutomation(automationDirs[index], signal);
+  return await readCodexAutomations(automationDirs, signal, index + 1, [
+    ...results,
+    observation,
+  ]);
 }
 
 /**
@@ -361,16 +491,130 @@ function findLatestAutomationMemoryBlock(lines) {
   };
 }
 
-async function readCodexAutomation(automationDir) {
-  const tomlPath = path.join(automationDir, "automation.toml");
-  const memoryPath = path.join(automationDir, "memory.md");
-  const tomlContent = await fs.readFile(tomlPath, "utf8");
+/**
+ * Read one stable bounded file without following a scheduler symlink or FIFO.
+ * @param {string} automationDir Canonical automation directory.
+ * @param {string} filename Direct scheduler filename.
+ * @param {number} maximumBytes Maximum allowed bytes.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {boolean} [optional] Whether a missing file resolves to undefined.
+ * @returns {Promise<string | undefined>} Strict UTF-8 contents.
+ */
+async function readConfinedSchedulerText(
+  automationDir,
+  filename,
+  maximumBytes,
+  signal,
+  optional = false
+) {
+  signal?.throwIfAborted();
+  const target = path.join(automationDir, filename);
+  const before = await fs.lstat(target).catch(error => {
+    if (optional && error?.code === "ENOENT") return null;
+    throw error;
+  });
+  if (before === null) return undefined;
+  assertBoundedSchedulerFile(before, maximumBytes);
+  const actual = await fs.realpath(target);
+  if (!actual.startsWith(`${automationDir}${path.sep}`)) {
+    throw new Error("Codex scheduler file escapes automation directory");
+  }
+  const handle = await fs.open(
+    target,
+    fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK
+  );
+  try {
+    const opened = await handle.stat();
+    assertBoundedSchedulerFile(opened, maximumBytes);
+    if (opened.dev !== before.dev || opened.ino !== before.ino) {
+      throw new Error("Codex scheduler file changed during inspection");
+    }
+    const bytes = await readBoundedSchedulerFile(handle, maximumBytes, signal);
+    const after = await handle.stat();
+    if (after.size !== opened.size || bytes.length !== after.size) {
+      throw new Error("Codex scheduler file changed during read");
+    }
+    signal?.throwIfAborted();
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Reject non-regular and oversized scheduler files before opening them.
+ * @param {import("node:fs").Stats} stat Scheduler file metadata.
+ * @param {number} maximumBytes Maximum allowed bytes.
+ * @returns {void}
+ */
+function assertBoundedSchedulerFile(stat, maximumBytes) {
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(UNSAFE_SCHEDULER_FILE);
+  }
+  if (stat.size > maximumBytes) {
+    throw new Error("Codex scheduler file exceeds size limit");
+  }
+}
+
+/**
+ * Read at most maximum plus one bytes from an already confined file handle.
+ * @param {import("node:fs/promises").FileHandle} handle Open file handle.
+ * @param {number} maximumBytes Maximum allowed bytes.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @param {number} [offset] Current file offset.
+ * @returns {Promise<Buffer>} Bounded bytes.
+ */
+async function readBoundedSchedulerFile(
+  handle,
+  maximumBytes,
+  signal,
+  offset = 0
+) {
+  signal?.throwIfAborted();
+  const remaining = maximumBytes + 1 - offset;
+  if (remaining <= 0) {
+    throw new Error("Codex scheduler file exceeds size limit");
+  }
+  const chunk = Buffer.allocUnsafe(Math.min(READ_CHUNK_BYTES, remaining));
+  const { bytesRead } = await handle.read(chunk, 0, chunk.length, offset);
+  signal?.throwIfAborted();
+  if (bytesRead === 0) return Buffer.alloc(0);
+  const current = chunk.subarray(0, bytesRead);
+  const tail = await readBoundedSchedulerFile(
+    handle,
+    maximumBytes,
+    signal,
+    offset + bytesRead
+  );
+  return Buffer.concat([current, tail], bytesRead + tail.length);
+}
+
+/**
+ * Read one confined Codex automation contract and optional memory.
+ * @param {string} automationDir Canonical automation directory.
+ * @param {AbortSignal | undefined} signal Probe cancellation signal.
+ * @returns {Promise<ObservedCodexAutomation>} Normalized observation.
+ */
+async function readCodexAutomation(automationDir, signal) {
+  const tomlContent = await readConfinedSchedulerText(
+    automationDir,
+    "automation.toml",
+    MAX_AUTOMATION_TOML_BYTES,
+    signal
+  );
   const automation = parseAutomationToml(tomlContent);
-  const memoryContent = await fs.readFile(memoryPath, "utf8").catch(() => "");
+  const memoryContent =
+    (await readConfinedSchedulerText(
+      automationDir,
+      "memory.md",
+      MAX_AUTOMATION_MEMORY_BYTES,
+      signal,
+      true
+    )) ?? "";
   const memory = parseCodexAutomationMemory(memoryContent);
   const cwd = Array.isArray(automation.cwds) ? automation.cwds[0] : null;
   const normalizedCwd = typeof cwd === "string" ? cwd : null;
-  const cwdHealth = await inspectAutomationCwd(normalizedCwd);
+  const cwdHealth = await inspectAutomationCwd(normalizedCwd, signal);
 
   return {
     automationId:
@@ -546,7 +790,8 @@ function classifyAutomationRunSignal(input) {
   return null;
 }
 
-async function inspectAutomationCwd(cwd) {
+async function inspectAutomationCwd(cwd, signal) {
+  signal?.throwIfAborted();
   if (!cwd) {
     return {
       status: "missing",
@@ -560,6 +805,7 @@ async function inspectAutomationCwd(cwd) {
     }
     throw error;
   });
+  signal?.throwIfAborted();
 
   if (!stat) {
     return {
@@ -578,7 +824,7 @@ async function inspectAutomationCwd(cwd) {
   try {
     const { stdout } = await execGitWithRetry(
       ["-C", cwd, "rev-parse", "--is-inside-work-tree", "--is-bare-repository"],
-      { timeout: 5000 }
+      { timeout: 5000, signal }
     );
     const [insideWorkTree, bareRepository] = stdout.trim().split(/\r?\n/);
 
@@ -601,6 +847,7 @@ async function inspectAutomationCwd(cwd) {
       summary: `${cwd} is a valid Git work tree`,
     };
   } catch (error) {
+    signal?.throwIfAborted();
     return {
       status: "git_error",
       summary: `git could not inspect ${cwd}: ${String(error?.message ?? error)}`,

--- a/src/cli/ui-automations-adapters.ts
+++ b/src/cli/ui-automations-adapters.ts
@@ -14,8 +14,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 
 import type { JsonObject } from "../sync/json-path.js";
-import { isJsonObject } from "../sync/json-path.js";
-import { deepMerge, readJsonOrNull } from "../utils/index.js";
+import { readConfinedMergedConfig } from "./ui-confined-project-read.js";
 import type {
   AutomationProjectIdentity,
   ClaudeAutomationLister,
@@ -84,21 +83,45 @@ async function loadAdapterModule<T>(scriptName: string): Promise<T> {
   return import(pathToFileURL(scriptPath).href) as Promise<T>;
 }
 
+/** Minimal expected-fleet entry consumed by setup readiness. */
+export interface ExpectedAutomationEntry {
+  readonly id: string;
+  readonly automationId: string;
+}
+
+/**
+ * Resolve applicable automations through setup-automations' shared contract.
+ * @param config - Current merged Lisa config
+ * @param detectedTypes - Authoritatively detected project types
+ * @param gitRemoteUrl - Optional origin fallback for repository identity
+ * @returns Applicable expected entries; unsupported loops are excluded
+ */
+export async function resolveExpectedAutomationEntries(
+  config: JsonObject,
+  detectedTypes: readonly string[],
+  gitRemoteUrl?: string
+): Promise<readonly ExpectedAutomationEntry[]> {
+  const { resolveExpectedAutomationFleet } = await loadAdapterModule<{
+    resolveExpectedAutomationFleet: (input: {
+      readonly config: JsonObject;
+      readonly detectedTypes: readonly string[];
+      readonly gitRemoteUrl?: string;
+    }) => { readonly expected: readonly ExpectedAutomationEntry[] };
+  }>("automation-status-expected-fleet.mjs");
+  return resolveExpectedAutomationFleet({
+    config,
+    detectedTypes,
+    ...(gitRemoteUrl === undefined ? {} : { gitRemoteUrl }),
+  }).expected;
+}
+
 /**
  * Read merged Lisa config for identity resolution.
  * @param cwd - Project root
  * @returns Merged config object
  */
 async function readMergedConfig(cwd: string): Promise<JsonObject> {
-  const committed = await readJsonOrNull<unknown>(
-    path.join(cwd, ".lisa.config.json")
-  );
-  const local = await readJsonOrNull<unknown>(
-    path.join(cwd, ".lisa.config.local.json")
-  );
-  const committedObject = isJsonObject(committed) ? committed : {};
-  const localObject = isJsonObject(local) ? local : {};
-  return deepMerge(committedObject, localObject) as JsonObject;
+  return await readConfinedMergedConfig(cwd);
 }
 
 /**
@@ -107,13 +130,12 @@ async function readMergedConfig(cwd: string): Promise<JsonObject> {
  * @param signal - Abort signal
  * @returns Origin URL, or undefined when unavailable
  */
-async function readOriginRemote(
+export async function readOriginRemote(
   cwd: string,
   signal: AbortSignal
 ): Promise<string | undefined> {
   try {
     const { stdout } = await execFileAsync(
-      // eslint-disable-next-line sonarjs/no-os-command-from-path -- fixed user-installed git executable
       "git",
       ["-C", cwd, "remote", "get-url", "origin"],
       { cwd, signal, timeout: 2_500, encoding: "utf8" }
@@ -177,17 +199,23 @@ export const defaultResolveIdentity: ProjectIdentityResolver = async (
 /**
  * Default Codex directory readability check.
  * @param automationsDir - Directory to probe
+ * @param signal - Probe cancellation signal
  * @returns Whether the directory is readable
  */
-export const defaultCodexDirReadable: CodexDirReadableCheck =
-  async automationsDir => {
-    try {
-      await access(automationsDir, fsConstants.R_OK);
-      return true;
-    } catch {
-      return false;
-    }
-  };
+export const defaultCodexDirReadable: CodexDirReadableCheck = async (
+  automationsDir,
+  signal
+) => {
+  signal.throwIfAborted();
+  try {
+    await access(automationsDir, fsConstants.R_OK);
+    signal.throwIfAborted();
+    return true;
+  } catch {
+    signal.throwIfAborted();
+    return false;
+  }
+};
 
 /**
  * Default Claude `/schedule` reader — Node cannot invoke the interactive

--- a/src/cli/ui-automations.ts
+++ b/src/cli/ui-automations.ts
@@ -73,6 +73,7 @@ export type ProjectIdentityResolver = (
 export type CodexAutomationLister = (input: {
   readonly automationsDir?: string;
   readonly automationPrefix: string;
+  readonly signal?: AbortSignal;
 }) => Promise<readonly HarnessAutomationObservation[]>;
 
 /** List Claude `/schedule` automations matching a prefix (adapter seam). */
@@ -260,6 +261,7 @@ async function runAutomationsProbe(
         observations: await input.listCodex({
           automationsDir: input.automationsDir,
           automationPrefix: identity.value.automationPrefix,
+          signal: input.signal,
         }),
       });
     } catch (error) {

--- a/src/cli/ui-cmd.ts
+++ b/src/cli/ui-cmd.ts
@@ -14,8 +14,7 @@ import * as http from "node:http";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { runConfigSync } from "../sync/config-sync.js";
-import { isJsonObject, type JsonObject } from "../sync/json-path.js";
-import { deepMerge, readJsonOrNull } from "../utils/index.js";
+import type { JsonObject } from "../sync/json-path.js";
 import { printSyncReport } from "./sync-cmd.js";
 import {
   inspectRemoteEnvironment,
@@ -41,6 +40,12 @@ import {
   createUiHealthHandler,
   type UiHealthDependencies,
 } from "./ui-health.js";
+import {
+  createSetupReadinessReader,
+  readMergedUiConfig,
+  type SetupReadinessDependencies,
+  type SetupReadinessResult,
+} from "./ui-setup-readiness.js";
 export {
   createGithubAuthProbe,
   runProbe,
@@ -106,6 +111,8 @@ export interface UiRuntimeDependencies {
   readonly probes?: readonly StatusProbe[];
   /** Health storage and execution boundaries exposed by /api/health. */
   readonly health?: Partial<UiHealthDependencies>;
+  /** Read-only setup-readiness boundaries exposed by /api/setup-readiness. */
+  readonly setupReadiness?: SetupReadinessDependencies;
 }
 
 /**
@@ -135,23 +142,6 @@ export function findUiHtml(startDir: string): string {
     throw new Error("Unable to locate the packaged ui/index.html");
   }
   return findUiHtml(parent);
-}
-
-/**
- * Read the project's merged config view (local overlay wins per key).
- * @param destDir - Project root
- * @returns Merged config object
- */
-async function readMergedConfig(destDir: string): Promise<JsonObject> {
-  const committed = await readJsonOrNull<unknown>(
-    path.join(destDir, ".lisa.config.json")
-  );
-  const local = await readJsonOrNull<unknown>(
-    path.join(destDir, ".lisa.config.local.json")
-  );
-  const committedObject = isJsonObject(committed) ? committed : {};
-  const localObject = isJsonObject(local) ? local : {};
-  return deepMerge(committedObject, localObject) as JsonObject;
 }
 
 /**
@@ -198,6 +188,29 @@ function createStatusSnapshotReader(
         if (inFlight === pending) {
           inFlight = undefined;
         }
+      };
+      void pending.then(clear, clear);
+    }
+    return inFlight;
+  };
+}
+
+/**
+ * Coalesce concurrent first-open setup reads without caching later requests.
+ * @param readCurrent - Current projection reader
+ * @returns Single-flight reader that clears after settlement
+ */
+function createSetupReadinessSnapshotReader(
+  readCurrent: () => Promise<SetupReadinessResult>
+): () => Promise<SetupReadinessResult> {
+  // eslint-disable-next-line functional/no-let -- single-flight state clears after settlement
+  let inFlight: Promise<SetupReadinessResult> | undefined;
+  return () => {
+    if (inFlight === undefined) {
+      const pending = readCurrent();
+      inFlight = pending;
+      const clear = (): void => {
+        if (inFlight === pending) inFlight = undefined;
       };
       void pending.then(clear, clear);
     }
@@ -255,6 +268,54 @@ function serveStatus(
 }
 
 /**
+ * Serve a current, non-persisted Setup readiness projection.
+ * @param request - Incoming loopback request
+ * @param response - Response associated with the request
+ * @param readCurrent - Current projection reader
+ */
+function serveSetupReadiness(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  readCurrent: () => Promise<SetupReadinessResult>
+): void {
+  if (request.method === "HEAD") {
+    response.writeHead(200, {
+      "cache-control": NO_STORE,
+      "content-type": JSON_CONTENT_TYPE,
+    });
+    response.end();
+    return;
+  }
+  if (request.method !== "GET") {
+    response.writeHead(405, {
+      allow: "GET, HEAD",
+      "cache-control": NO_STORE,
+      "content-type": TEXT_CONTENT_TYPE,
+    });
+    response.end("Method not allowed");
+    return;
+  }
+  void readCurrent().then(
+    result => {
+      response.writeHead(200, {
+        "cache-control": NO_STORE,
+        "content-type": JSON_CONTENT_TYPE,
+      });
+      response.end(JSON.stringify(result));
+    },
+    () => {
+      response.writeHead(500, {
+        "cache-control": NO_STORE,
+        "content-type": JSON_CONTENT_TYPE,
+      });
+      response.end(
+        JSON.stringify({ error: "Unable to observe setup readiness" })
+      );
+    }
+  );
+}
+
+/**
  * Parse an HTTP request target without allowing malformed input to escape.
  * @param requestUrl - Raw request target supplied by Node HTTP
  * @returns Parsed pathname, or undefined for an invalid target
@@ -300,16 +361,21 @@ function isLoopbackHost(host: string | undefined): boolean {
  * @param probes - Live-status probes registered for this server
  * @param destDir - Project root served by this UI process
  * @param healthDependencies - Injectable Health v1 storage/run boundaries
+ * @param setupReadinessDependencies - Injectable read-only Setup boundaries
  * @returns Loopback HTTP request handler
  */
 function createUiRequestHandler(
   page: string,
   probes: readonly StatusProbe[],
   destDir: string,
-  healthDependencies: Partial<UiHealthDependencies> = {}
+  healthDependencies: Partial<UiHealthDependencies> = {},
+  setupReadinessDependencies: SetupReadinessDependencies = {}
 ): http.RequestListener {
   const readSnapshot = createStatusSnapshotReader(probes);
   const serveHealth = createUiHealthHandler(destDir, healthDependencies);
+  const readCurrentSetup = createSetupReadinessSnapshotReader(
+    createSetupReadinessReader(destDir, setupReadinessDependencies)
+  );
   validateStatusProbes(probes);
   return (request, response) => {
     if (!isLoopbackHost(request.headers.host)) {
@@ -333,6 +399,10 @@ function createUiRequestHandler(
     }
     if (pathname === "/api/health") {
       serveHealth(request, response);
+      return;
+    }
+    if (pathname === "/api/setup-readiness") {
+      serveSetupReadiness(request, response, readCurrentSetup);
       return;
     }
     if (pathname === "/" || pathname === "/index.html") {
@@ -369,7 +439,10 @@ export async function runUi(
   const moduleDir = path.dirname(fileURLToPath(import.meta.url));
   const htmlPath = findUiHtml(moduleDir);
   const html = await readFile(htmlPath, "utf8");
-  const config = await readMergedConfig(destDir);
+  // Keep the read-only console available when config is malformed or unsafe;
+  // probes receive no claims instead of importing untrusted evidence. The
+  // config write endpoint still reads the originals strictly and fails closed.
+  const config = await readMergedUiConfig(destDir).catch(() => ({}));
   const remoteEnvironment = await inspectRemoteEnvironment(
     destDir,
     config,
@@ -388,7 +461,13 @@ export async function runUi(
     createAutomationsProbe({ cwd: destDir }),
   ];
   const server = http.createServer(
-    createUiRequestHandler(page, probes, destDir, dependencies.health)
+    createUiRequestHandler(
+      page,
+      probes,
+      destDir,
+      dependencies.health,
+      dependencies.setupReadiness
+    )
   );
   await new Promise<void>(resolve => {
     server.listen(port, "127.0.0.1", resolve);

--- a/src/cli/ui-confined-project-read.ts
+++ b/src/cli/ui-confined-project-read.ts
@@ -1,0 +1,51 @@
+/** Bounded, no-follow local project reads shared by localhost UI probes. */
+import { realpath } from "node:fs/promises";
+import { readProjectText } from "../health/read-only-fs.js";
+import { isJsonObject, type JsonObject } from "../sync/json-path.js";
+import { deepMerge } from "../utils/index.js";
+
+/**
+ * Read one project-relative text file through deterministic Health confinement.
+ * @param projectRoot - Project root, canonicalized before the read
+ * @param relativePath - Strict project-relative path
+ * @returns Bounded UTF-8 text, or undefined when absent
+ */
+export async function readConfinedProjectText(
+  projectRoot: string,
+  relativePath: string
+): Promise<string | undefined> {
+  const root = await realpath(projectRoot);
+  return await readProjectText(root, relativePath);
+}
+
+/**
+ * Read and parse one confined JSON file.
+ * @param projectRoot - Project root
+ * @param relativePath - Strict project-relative JSON path
+ * @returns Parsed JSON, or undefined when absent
+ */
+export async function readConfinedProjectJson(
+  projectRoot: string,
+  relativePath: string
+): Promise<unknown | undefined> {
+  const text = await readConfinedProjectText(projectRoot, relativePath);
+  return text === undefined ? undefined : (JSON.parse(text) as unknown);
+}
+
+/**
+ * Read committed-plus-local Lisa config without following unsafe files.
+ * @param projectRoot - Project root
+ * @returns Merged config with the local overlay winning per key
+ */
+export async function readConfinedMergedConfig(
+  projectRoot: string
+): Promise<JsonObject> {
+  const [committed, local] = await Promise.all([
+    readConfinedProjectJson(projectRoot, ".lisa.config.json"),
+    readConfinedProjectJson(projectRoot, ".lisa.config.local.json"),
+  ]);
+  return deepMerge(
+    isJsonObject(committed) ? committed : {},
+    isJsonObject(local) ? local : {}
+  ) as JsonObject;
+}

--- a/src/cli/ui-deploy-pipeline.ts
+++ b/src/cli/ui-deploy-pipeline.ts
@@ -7,10 +7,11 @@
  * @module cli/ui-deploy-pipeline
  */
 import { execFile } from "node:child_process";
-import { access, readFile } from "node:fs/promises";
-import * as path from "node:path";
-import { isJsonObject, type JsonObject } from "../sync/json-path.js";
-import { deepMerge, readJsonOrNull } from "../utils/index.js";
+import { isJsonObject } from "../sync/json-path.js";
+import {
+  readConfinedMergedConfig,
+  readConfinedProjectText,
+} from "./ui-confined-project-read.js";
 import type { StatusProbe } from "./ui-status.js";
 import {
   buildDeployPipelineResult,
@@ -32,7 +33,7 @@ export {
   type GithubEnvironmentsLookup,
 } from "./ui-deploy-pipeline-model.js";
 
-const DEPLOY_YML_RELATIVE = path.join(".github", "workflows", "deploy.yml");
+const DEPLOY_YML_RELATIVE = ".github/workflows/deploy.yml";
 const DEFAULT_TIMEOUT_MS = 8_000;
 
 /** Injectable collaborators for focused unit tests. */
@@ -54,13 +55,7 @@ export type DeployPipelineDependencies = {
  * @returns File contents or null
  */
 async function readDeployWorkflowDefault(cwd: string): Promise<string | null> {
-  const filePath = path.join(cwd, DEPLOY_YML_RELATIVE);
-  try {
-    await access(filePath);
-  } catch {
-    return null;
-  }
-  return await readFile(filePath, "utf8");
+  return (await readConfinedProjectText(cwd, DEPLOY_YML_RELATIVE)) ?? null;
 }
 
 /**
@@ -71,16 +66,7 @@ async function readDeployWorkflowDefault(cwd: string): Promise<string | null> {
 async function readConfiguredEnvironmentsDefault(
   cwd: string
 ): Promise<readonly string[]> {
-  const committed = await readJsonOrNull<unknown>(
-    path.join(cwd, ".lisa.config.json")
-  );
-  const local = await readJsonOrNull<unknown>(
-    path.join(cwd, ".lisa.config.local.json")
-  );
-  const merged = deepMerge(
-    isJsonObject(committed) ? committed : {},
-    isJsonObject(local) ? local : {}
-  ) as JsonObject;
+  const merged = await readConfinedMergedConfig(cwd);
   const github = merged.github;
   if (!isJsonObject(github)) {
     return [];

--- a/src/cli/ui-detected-stacks.ts
+++ b/src/cli/ui-detected-stacks.ts
@@ -6,14 +6,158 @@
  * unknown; the runner maps a thrown detector error to unknown.
  * @module cli/ui-detected-stacks
  */
+import { realpath } from "node:fs/promises";
 import {
   createDetectorRegistry,
   type DetectorRegistry,
 } from "../detection/index.js";
+import type { ProjectType } from "../core/config.js";
+import { projectPathKind, readProjectText } from "../health/read-only-fs.js";
+import { isJsonObject } from "../sync/json-path.js";
 import type { StatusProbe } from "./ui-status.js";
 
 /** Probe id for the detected-stacks live-status entry. */
 export const DETECTED_STACKS_PROBE_ID = "detected-stacks";
+const PACKAGE_JSON_RELATIVE = "package.json";
+const HARPER_CONFIG_RELATIVE = "harper-app/config.yaml";
+const MARKER_NAMES = [
+  "tsconfig.json",
+  "app.json",
+  "eas.json",
+  "nest-cli.json",
+  "cdk.json",
+  HARPER_CONFIG_RELATIVE,
+  "harper-app/schema.graphql",
+  "bin/rails",
+  "config/application.rb",
+] as const;
+
+/** Bounded filesystem evidence consumed by setup stack classification. */
+type ConfinedDetectionSignals = {
+  readonly packageJson: unknown;
+  readonly dependencies: readonly string[];
+  readonly markers: ReadonlySet<string>;
+  readonly harperConfig: string | undefined;
+};
+
+/**
+ * Return whether a confined regular marker file exists.
+ * @param root - Canonical project root
+ * @param relativePath - Project-relative marker path
+ * @returns Whether the marker is a regular no-follow file
+ */
+async function confinedMarkerExists(
+  root: string,
+  relativePath: string
+): Promise<boolean> {
+  return (await projectPathKind(root, relativePath)) === "file";
+}
+
+/**
+ * Return package dependency names from a validated object.
+ * @param packageJson - Parsed package manifest
+ * @returns Production and development dependency names
+ */
+function dependencyNames(packageJson: unknown): readonly string[] {
+  if (!isJsonObject(packageJson)) return [];
+  return [packageJson.dependencies, packageJson.devDependencies].flatMap(
+    dependencies =>
+      isJsonObject(dependencies) ? Object.keys(dependencies) : []
+  );
+}
+
+/**
+ * Return whether a parsed package manifest describes a publishable package.
+ * @param packageJson - Parsed package manifest
+ * @returns Whether the npm-package detector signal is present
+ */
+function isPublishablePackage(packageJson: unknown): boolean {
+  return (
+    isJsonObject(packageJson) &&
+    packageJson.private !== true &&
+    (packageJson.main !== undefined ||
+      packageJson.bin !== undefined ||
+      packageJson.exports !== undefined ||
+      (Array.isArray(packageJson.files) && packageJson.files.length > 0))
+  );
+}
+
+/**
+ * Return detector results from confined filesystem signals.
+ * @param signals - Bounded package, marker, and Harper evidence
+ * @returns Direct detector matches before parent expansion
+ */
+function classifyDetectedTypes(
+  signals: ConfinedDetectionSignals
+): readonly ProjectType[] {
+  const hasMarker = (name: string): boolean => signals.markers.has(name);
+  const hasDependency = (name: string): boolean =>
+    signals.dependencies.includes(name);
+  const hasDependencyPrefix = (prefix: string): boolean =>
+    signals.dependencies.some(name => name.startsWith(prefix));
+  const harperConfigMatches =
+    signals.harperConfig?.includes("graphqlSchema:") === true &&
+    signals.harperConfig.includes("jsResource:") &&
+    signals.harperConfig.includes("static:");
+  return [
+    hasMarker("tsconfig.json") || hasDependency("typescript")
+      ? (["typescript"] as const)
+      : [],
+    isPublishablePackage(signals.packageJson) ? (["npm-package"] as const) : [],
+    hasMarker(HARPER_CONFIG_RELATIVE) &&
+    hasMarker("harper-app/schema.graphql") &&
+    (harperConfigMatches || hasDependency("harperdb"))
+      ? (["harper-fabric"] as const)
+      : [],
+    hasDependency("phaser") ? (["phaser"] as const) : [],
+    hasMarker("app.json") || hasMarker("eas.json") || hasDependency("expo")
+      ? (["expo"] as const)
+      : [],
+    hasMarker("nest-cli.json") || hasDependencyPrefix("@nestjs")
+      ? (["nestjs"] as const)
+      : [],
+    hasMarker("cdk.json") || hasDependencyPrefix("aws-cdk")
+      ? (["cdk"] as const)
+      : [],
+    hasMarker("bin/rails") || hasMarker("config/application.rb")
+      ? (["rails"] as const)
+      : [],
+  ].flat();
+}
+
+/**
+ * Detect setup-automation stacks using only bounded, no-follow project reads.
+ * This mirrors the authoritative detector signals without invoking their
+ * legacy unbounded readers on the setup-readiness request path.
+ * @param destDir - Project root
+ * @returns Expanded types in canonical detector-registry order
+ */
+export async function readConfinedDetectedStacks(
+  destDir: string
+): Promise<readonly ProjectType[]> {
+  const root = await realpath(destDir);
+  const packageText = await readProjectText(root, PACKAGE_JSON_RELATIVE);
+  const packageJson =
+    packageText === undefined
+      ? undefined
+      : (JSON.parse(packageText) as unknown);
+  const markerValues = await Promise.all(
+    MARKER_NAMES.map(name => confinedMarkerExists(root, name))
+  );
+  const markers = new Set(
+    MARKER_NAMES.filter((_name, index) => markerValues[index])
+  );
+  const harperConfig = markers.has(HARPER_CONFIG_RELATIVE)
+    ? await readProjectText(root, HARPER_CONFIG_RELATIVE)
+    : undefined;
+  const detected = classifyDetectedTypes({
+    packageJson,
+    dependencies: dependencyNames(packageJson),
+    markers,
+    harperConfig,
+  });
+  return createDetectorRegistry().expandAndOrderTypes([...detected]);
+}
 
 /**
  * Create the probe that reports the project's detected stacks.

--- a/src/cli/ui-github-repo-gh.ts
+++ b/src/cli/ui-github-repo-gh.ts
@@ -30,6 +30,12 @@ export interface GithubRulesetRow {
   readonly appliesTo: string;
   readonly enforces: string;
   readonly active: boolean;
+  /** Structured default-branch targeting retained beside display text. */
+  readonly targetsDefaultBranch?: boolean;
+  /** Structured pull-request enforcement retained beside display text. */
+  readonly requiresPullRequest?: boolean;
+  /** At least one required status-check context is configured. */
+  readonly requiresStatusChecks?: boolean;
 }
 
 /** One label present on the remote repository. */

--- a/src/cli/ui-github-repo-map.ts
+++ b/src/cli/ui-github-repo-map.ts
@@ -178,7 +178,7 @@ export function mapRulesetRow(raw: unknown): GithubRulesetRow {
   const includes = rulesetIncludes(Reflect.get(raw, "conditions"));
   return {
     name: requireString(raw, "name"),
-    appliesTo: formatAppliesTo(rulesetIncludes(Reflect.get(raw, "conditions"))),
+    appliesTo: formatAppliesTo(includes),
     enforces: ruleTypes.length > 0 ? ruleTypes.join(", ") : "—",
     active: Reflect.get(raw, "enforcement") === "active",
     targetsDefaultBranch: includes.includes("~DEFAULT_BRANCH"),

--- a/src/cli/ui-github-repo-map.ts
+++ b/src/cli/ui-github-repo-map.ts
@@ -144,6 +144,28 @@ function rulesetRuleTypes(rules: unknown): readonly string[] {
 }
 
 /**
+ * Whether a required-status-check rule contains at least one context.
+ * @param rules - Raw ruleset rules
+ * @returns Whether at least one required check context is configured
+ */
+function hasRequiredStatusChecks(rules: unknown): boolean {
+  if (!Array.isArray(rules)) return false;
+  return rules.some(rule => {
+    if (
+      rule === null ||
+      typeof rule !== "object" ||
+      Reflect.get(rule, "type") !== "required_status_checks"
+    ) {
+      return false;
+    }
+    const parameters = Reflect.get(rule, "parameters");
+    if (parameters === null || typeof parameters !== "object") return false;
+    const checks = Reflect.get(parameters, "required_status_checks");
+    return Array.isArray(checks) && checks.length > 0;
+  });
+}
+
+/**
  * Map a detailed ruleset payload into a panel row.
  * @param raw - One ruleset object from gh api
  * @returns Panel row
@@ -153,11 +175,15 @@ export function mapRulesetRow(raw: unknown): GithubRulesetRow {
     throw new TypeError("Ruleset entry was not an object");
   }
   const ruleTypes = rulesetRuleTypes(Reflect.get(raw, "rules"));
+  const includes = rulesetIncludes(Reflect.get(raw, "conditions"));
   return {
     name: requireString(raw, "name"),
     appliesTo: formatAppliesTo(rulesetIncludes(Reflect.get(raw, "conditions"))),
     enforces: ruleTypes.length > 0 ? ruleTypes.join(", ") : "—",
     active: Reflect.get(raw, "enforcement") === "active",
+    targetsDefaultBranch: includes.includes("~DEFAULT_BRANCH"),
+    requiresPullRequest: ruleTypes.includes("pull_request"),
+    requiresStatusChecks: hasRequiredStatusChecks(Reflect.get(raw, "rules")),
   };
 }
 

--- a/src/cli/ui-setup-readiness-config.ts
+++ b/src/cli/ui-setup-readiness-config.ts
@@ -1,5 +1,4 @@
 /** Config-backed Setup readiness findings with independent provider lanes. */
-/* eslint-disable jsdoc/require-param, jsdoc/require-returns -- typed config helpers are self-describing */
 import { isJsonObject, type JsonObject } from "../sync/json-path.js";
 import { SETUP_PROVIDER_REQUIREMENTS } from "../sync/registry.js";
 import { resolveMutationPolicy } from "./doctor-readiness-journey-freshness.js";
@@ -11,7 +10,12 @@ import {
 const EXPLORATION_CHECK = "setup.exploration";
 const STARTER_PROVENANCE_CHECK = "setup.starter-provenance";
 
-/** Return whether a dot path resolves to a non-empty string. */
+/**
+ * Return whether a dot path resolves to a non-empty string.
+ * @param config - Merged Lisa project configuration
+ * @param dotPath - Dot-delimited property path to inspect
+ * @returns Whether the property contains non-empty text
+ */
 function hasString(config: JsonObject, dotPath: string): boolean {
   const value = dotPath.split(".").reduce<unknown>((current, segment) => {
     if (!isJsonObject(current)) return undefined;
@@ -23,7 +27,14 @@ function hasString(config: JsonObject, dotPath: string): boolean {
 /** Provider lane whose requirements are owned by the sync registry. */
 type ProviderLane = keyof typeof SETUP_PROVIDER_REQUIREMENTS;
 
-/** Evaluate one provider lane from the shared sync-registry requirements. */
+/**
+ * Evaluate one provider lane from the shared sync-registry requirements.
+ * @param config - Merged Lisa project configuration
+ * @param lane - Provider lane to validate
+ * @param check - Setup finding identifier for the lane
+ * @param selectionHint - Operator-facing setup commands for invalid providers
+ * @returns Deterministic readiness finding for the provider lane
+ */
 function providerLaneFinding(
   config: JsonObject,
   lane: ProviderLane,
@@ -60,7 +71,11 @@ function providerLaneFinding(
       );
 }
 
-/** Read tracker readiness independently from the PRD source. */
+/**
+ * Read tracker readiness independently from the PRD source.
+ * @param config - Merged Lisa project configuration
+ * @returns Work-tracker readiness finding
+ */
 export function trackerFinding(config: JsonObject): SetupReadinessFinding {
   return providerLaneFinding(
     config,
@@ -70,7 +85,11 @@ export function trackerFinding(config: JsonObject): SetupReadinessFinding {
   );
 }
 
-/** Read PRD-source readiness independently from the work tracker. */
+/**
+ * Read PRD-source readiness independently from the work tracker.
+ * @param config - Merged Lisa project configuration
+ * @returns PRD-source readiness finding
+ */
 export function prdSourceFinding(config: JsonObject): SetupReadinessFinding {
   return providerLaneFinding(
     config,
@@ -80,7 +99,11 @@ export function prdSourceFinding(config: JsonObject): SetupReadinessFinding {
   );
 }
 
-/** Require an explicit exploration environment, policy, and test identity. */
+/**
+ * Require an explicit exploration environment, policy, and test identity.
+ * @param config - Merged Lisa project configuration
+ * @returns Exploration-environment readiness finding
+ */
 export function explorationFinding(config: JsonObject): SetupReadinessFinding {
   const exploration = config.exploration;
   if (!isJsonObject(exploration)) {
@@ -140,7 +163,11 @@ export function explorationFinding(config: JsonObject): SetupReadinessFinding {
       );
 }
 
-/** Require at least one bounded starter template provenance record. */
+/**
+ * Require at least one bounded starter template provenance record.
+ * @param config - Merged Lisa project configuration
+ * @returns Starter-provenance readiness finding
+ */
 export function starterProvenanceFinding(
   config: JsonObject
 ): SetupReadinessFinding {
@@ -173,5 +200,3 @@ export function starterProvenanceFinding(
         `${templates.length} starter template provenance record${templates.length === 1 ? " is" : "s are"} configured.`
       );
 }
-
-/* eslint-enable jsdoc/require-param, jsdoc/require-returns -- end typed config helper exception */

--- a/src/cli/ui-setup-readiness-config.ts
+++ b/src/cli/ui-setup-readiness-config.ts
@@ -1,0 +1,177 @@
+/** Config-backed Setup readiness findings with independent provider lanes. */
+/* eslint-disable jsdoc/require-param, jsdoc/require-returns -- typed config helpers are self-describing */
+import { isJsonObject, type JsonObject } from "../sync/json-path.js";
+import { SETUP_PROVIDER_REQUIREMENTS } from "../sync/registry.js";
+import { resolveMutationPolicy } from "./doctor-readiness-journey-freshness.js";
+import {
+  setupFinding,
+  type SetupReadinessFinding,
+} from "./ui-setup-readiness-contract.js";
+
+const EXPLORATION_CHECK = "setup.exploration";
+const STARTER_PROVENANCE_CHECK = "setup.starter-provenance";
+
+/** Return whether a dot path resolves to a non-empty string. */
+function hasString(config: JsonObject, dotPath: string): boolean {
+  const value = dotPath.split(".").reduce<unknown>((current, segment) => {
+    if (!isJsonObject(current)) return undefined;
+    return current[segment];
+  }, config);
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/** Provider lane whose requirements are owned by the sync registry. */
+type ProviderLane = keyof typeof SETUP_PROVIDER_REQUIREMENTS;
+
+/** Evaluate one provider lane from the shared sync-registry requirements. */
+function providerLaneFinding(
+  config: JsonObject,
+  lane: ProviderLane,
+  check: "setup.tracker" | "setup.prd-source",
+  selectionHint: string
+): SetupReadinessFinding {
+  const provider = config[lane];
+  const providers = SETUP_PROVIDER_REQUIREMENTS[lane];
+  if (typeof provider !== "string" || !Object.hasOwn(providers, provider)) {
+    return setupFinding(
+      check,
+      "fail",
+      `${lane === "tracker" ? "Work tracker" : "PRD source"} is missing or unsupported. Run ${selectionHint}.`
+    );
+  }
+  const requirement = providers[provider]!;
+  const missingAll = requirement.allOf.filter(key => !hasString(config, key));
+  const missingAny =
+    requirement.anyOf !== undefined &&
+    !requirement.anyOf.some(key => hasString(config, key))
+      ? [requirement.anyOf.join(" or ")]
+      : [];
+  const missing = [...missingAll, ...missingAny];
+  return missing.length === 0
+    ? setupFinding(
+        check,
+        "pass",
+        `${lane === "tracker" ? "Tracker" : "PRD source"} provider and required scope identifiers are configured.`
+      )
+    : setupFinding(
+        check,
+        "fail",
+        `Missing required configuration: ${missing.join(", ")}. Run ${requirement.setupHint}.`
+      );
+}
+
+/** Read tracker readiness independently from the PRD source. */
+export function trackerFinding(config: JsonObject): SetupReadinessFinding {
+  return providerLaneFinding(
+    config,
+    "tracker",
+    "setup.tracker",
+    "/lisa:setup:jira, /lisa:setup:github, or /lisa:setup:linear"
+  );
+}
+
+/** Read PRD-source readiness independently from the work tracker. */
+export function prdSourceFinding(config: JsonObject): SetupReadinessFinding {
+  return providerLaneFinding(
+    config,
+    "source",
+    "setup.prd-source",
+    "/lisa:setup:notion, /lisa:setup:confluence, /lisa:setup:linear, or /lisa:setup:github"
+  );
+}
+
+/** Require an explicit exploration environment, policy, and test identity. */
+export function explorationFinding(config: JsonObject): SetupReadinessFinding {
+  const exploration = config.exploration;
+  if (!isJsonObject(exploration)) {
+    return setupFinding(
+      EXPLORATION_CHECK,
+      "warn",
+      "Exploration environments are not configured in .lisa.config.json."
+    );
+  }
+  const environmentName = exploration.default;
+  const environments = exploration.environments;
+  if (
+    typeof environmentName !== "string" ||
+    environmentName.trim().length === 0 ||
+    !isJsonObject(environments) ||
+    !isJsonObject(environments[environmentName])
+  ) {
+    return setupFinding(
+      EXPLORATION_CHECK,
+      "warn",
+      "Exploration requires a default environment with a matching environments entry."
+    );
+  }
+  const environment = environments[environmentName];
+  const mutation = environment.mutation;
+  if (
+    typeof mutation !== "string" ||
+    !["forbidden", "read-only", "full"].includes(mutation)
+  ) {
+    return setupFinding(
+      EXPLORATION_CHECK,
+      "warn",
+      "The default exploration environment needs an explicit mutation policy."
+    );
+  }
+  if (
+    typeof environment.identity !== "string" ||
+    environment.identity.trim().length === 0
+  ) {
+    return setupFinding(
+      EXPLORATION_CHECK,
+      "warn",
+      "The default exploration environment needs a dedicated test identity reference."
+    );
+  }
+  const effective = resolveMutationPolicy(config);
+  return effective === mutation
+    ? setupFinding(
+        EXPLORATION_CHECK,
+        "pass",
+        `The default exploration environment has an explicit ${effective} policy and test identity reference.`
+      )
+    : setupFinding(
+        EXPLORATION_CHECK,
+        "warn",
+        `The configured mutation policy is unsafe for the selected environment and resolves to ${effective}.`
+      );
+}
+
+/** Require at least one bounded starter template provenance record. */
+export function starterProvenanceFinding(
+  config: JsonObject
+): SetupReadinessFinding {
+  const starter = config.starter;
+  const templates = isJsonObject(starter) ? starter.templates : undefined;
+  if (!Array.isArray(templates) || templates.length === 0) {
+    return setupFinding(
+      STARTER_PROVENANCE_CHECK,
+      "warn",
+      "Optional starter provenance is not recorded in starter.templates."
+    );
+  }
+  const invalid = templates.some(
+    template =>
+      !isJsonObject(template) ||
+      typeof template.repo !== "string" ||
+      template.repo.trim().length === 0 ||
+      typeof template.ref !== "string" ||
+      template.ref.trim().length === 0
+  );
+  return invalid
+    ? setupFinding(
+        STARTER_PROVENANCE_CHECK,
+        "warn",
+        "Starter provenance contains a template without both repo and ref."
+      )
+    : setupFinding(
+        STARTER_PROVENANCE_CHECK,
+        "pass",
+        `${templates.length} starter template provenance record${templates.length === 1 ? " is" : "s are"} configured.`
+      );
+}
+
+/* eslint-enable jsdoc/require-param, jsdoc/require-returns -- end typed config helper exception */

--- a/src/cli/ui-setup-readiness-contract.ts
+++ b/src/cli/ui-setup-readiness-contract.ts
@@ -1,5 +1,4 @@
 /** Strict transport contract for the console Setup readiness projection. */
-/* eslint-disable jsdoc/require-param, jsdoc/require-returns -- typed contract helpers are self-describing */
 import {
   summarizeHealthFindings,
   validateHealthResult,
@@ -45,7 +44,13 @@ export interface SetupReadinessResult {
   readonly findings: readonly SetupReadinessFinding[];
 }
 
-/** Create one operator-readable deterministic Setup finding. */
+/**
+ * Create one operator-readable deterministic Setup finding.
+ * @param check - Closed Setup checklist identifier
+ * @param status - Deterministic readiness status
+ * @param reason - Operator-readable evidence or remediation summary
+ * @returns Deterministic Setup readiness finding
+ */
 export function setupFinding(
   check: SetupReadinessCheck,
   status: HealthStatus,
@@ -102,5 +107,3 @@ export function validateSetupReadinessResult(
     findings: Object.freeze(findings),
   });
 }
-
-/* eslint-enable jsdoc/require-param, jsdoc/require-returns -- end typed contract helper exception */

--- a/src/cli/ui-setup-readiness-contract.ts
+++ b/src/cli/ui-setup-readiness-contract.ts
@@ -1,0 +1,106 @@
+/** Strict transport contract for the console Setup readiness projection. */
+/* eslint-disable jsdoc/require-param, jsdoc/require-returns -- typed contract helpers are self-describing */
+import {
+  summarizeHealthFindings,
+  validateHealthResult,
+  type HealthFinding,
+  type HealthStatus,
+} from "../health/contract.js";
+import {
+  readStrictDenseArray,
+  readStrictProperty,
+  requireCanonicalUtcTimestamp,
+  requireStrictRecord,
+} from "../health/strict-validation.js";
+
+/** Stable finding identifiers, in the existing checklist render order. */
+export const SETUP_READINESS_CHECKS = [
+  "setup.install",
+  "setup.sync",
+  "setup.agent-ready",
+  "setup.standards",
+  "setup.tracker",
+  "setup.prd-source",
+  "setup.github-governance",
+  "setup.secrets",
+  "setup.automations",
+  "setup.exploration",
+  "setup.wiki",
+  "setup.starter-provenance",
+] as const;
+
+/** One of the closed Setup checklist identifiers. */
+export type SetupReadinessCheck = (typeof SETUP_READINESS_CHECKS)[number];
+
+/** Setup finding reuses the closed Health finding shape without joining Health. */
+export type SetupReadinessFinding = HealthFinding & {
+  readonly check: SetupReadinessCheck;
+  readonly layer: "deterministic";
+};
+
+/** Current, non-persisted Setup readiness response. */
+export interface SetupReadinessResult {
+  readonly schemaVersion: 1;
+  readonly observedAt: string;
+  readonly findings: readonly SetupReadinessFinding[];
+}
+
+/** Create one operator-readable deterministic Setup finding. */
+export function setupFinding(
+  check: SetupReadinessCheck,
+  status: HealthStatus,
+  reason: string
+): SetupReadinessFinding {
+  return { check, layer: "deterministic", status, reason };
+}
+
+/**
+ * Validate, detach, and freeze a Setup readiness projection.
+ * @param candidate - Untrusted projection
+ * @returns Strict schema-v1 result with exactly the twelve checklist findings
+ */
+export function validateSetupReadinessResult(
+  candidate: unknown
+): SetupReadinessResult {
+  const record = requireStrictRecord(
+    candidate,
+    ["schemaVersion", "observedAt", "findings"] as const,
+    "SetupReadinessResult"
+  );
+  if (readStrictProperty(record, "schemaVersion") !== 1) {
+    throw new Error("Invalid setup readiness schemaVersion: expected 1");
+  }
+  const observedAt = requireCanonicalUtcTimestamp(
+    readStrictProperty(record, "observedAt"),
+    "observedAt"
+  );
+  const rawFindings = readStrictDenseArray(
+    readStrictProperty(record, "findings"),
+    SETUP_READINESS_CHECKS.length,
+    SETUP_READINESS_CHECKS.length,
+    "findings"
+  );
+  const validated = validateHealthResult({
+    schemaVersion: 1,
+    runId: "setup-readiness-validation",
+    mode: "deterministic",
+    startedAt: observedAt,
+    completedAt: observedAt,
+    findings: rawFindings,
+    summary: summarizeHealthFindings(rawFindings),
+  }).findings;
+  const actual = validated.map(finding => finding.check);
+  if (SETUP_READINESS_CHECKS.some((check, index) => actual[index] !== check)) {
+    throw new Error(
+      `Invalid setup readiness checks: expected ${SETUP_READINESS_CHECKS.join(", ")}`
+    );
+  }
+  const findings = validated as readonly SetupReadinessFinding[];
+  return Object.freeze({
+    schemaVersion: 1,
+    observedAt,
+    findings: Object.freeze(findings),
+  });
+}
+
+/* eslint-enable jsdoc/require-param, jsdoc/require-returns -- end typed contract helper exception */

--- a/src/cli/ui-setup-readiness-install.ts
+++ b/src/cli/ui-setup-readiness-install.ts
@@ -1,5 +1,4 @@
 /** Truthful, harness-aware installation evidence for Setup readiness. */
-/* eslint-disable jsdoc/require-param, jsdoc/require-returns -- typed evidence helpers are self-describing */
 import path from "node:path";
 import { realpath } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
@@ -50,13 +49,22 @@ const EXTERNAL_ONLY_HARNESSES = new Set<Harness>([
   "fleet",
 ]);
 
-/** Resolve the configured harness without accepting a malformed value. */
+/**
+ * Resolve the configured harness without accepting a malformed value.
+ * @param config - Merged Lisa project configuration
+ * @returns Normalized harness, or undefined for malformed configuration
+ */
 function configuredHarness(config: JsonObject): Harness | undefined {
   const raw = config.harness ?? DEFAULT_HARNESS;
   return typeof raw === "string" ? normalizeHarness(raw) : undefined;
 }
 
-/** Require one non-empty, confined regular project file. */
+/**
+ * Require one non-empty, confined regular project file.
+ * @param root - Canonical project root
+ * @param relativePath - Project-relative file path
+ * @returns Whether the confined file exists and contains non-whitespace text
+ */
 async function nonemptyProjectFile(
   root: string,
   relativePath: string
@@ -65,7 +73,11 @@ async function nonemptyProjectFile(
   return text !== undefined && text.trim().length > 0;
 }
 
-/** Validate one normalized path relative to an agent-owned manifest directory. */
+/**
+ * Validate one normalized path relative to an agent-owned manifest directory.
+ * @param value - Untrusted managed-manifest entry
+ * @returns Whether the value is a normalized relative path
+ */
 function validManifestEntry(value: unknown): value is string {
   if (
     typeof value !== "string" ||
@@ -83,7 +95,13 @@ function validManifestEntry(value: unknown): value is string {
   );
 }
 
-/** Refuse symlinked/special parents and final entries for one manifest file. */
+/**
+ * Refuse symlinked/special parents and final entries for one manifest file.
+ * @param root - Canonical project root
+ * @param configDir - Agent-owned configuration directory
+ * @param entry - Validated manifest-relative file path
+ * @returns Whether every parent and the final file are confined and regular
+ */
 async function manifestEntryIsRegular(
   root: string,
   configDir: string,
@@ -102,7 +120,13 @@ async function manifestEntryIsRegular(
   );
 }
 
-/** Validate a bounded managed-artifact manifest and every file it names. */
+/**
+ * Validate a bounded managed-artifact manifest and every file it names.
+ * @param root - Canonical project root
+ * @param configDir - Managed configuration directory
+ * @param expectedFiles - Optional authoritative set of required files
+ * @returns Whether the manifest is bounded, exact, and fully present
+ */
 async function managedManifestIsComplete(
   root: string,
   configDir: ".codex" | ".opencode",
@@ -146,6 +170,9 @@ async function managedManifestIsComplete(
  * Derive Codex's exact current managed-file set from the same selected plugin
  * and agent discovery contract used by apply. No project file is trusted as a
  * declaration of completeness.
+ * @param projectRoot - Project root to inspect
+ * @param config - Merged Lisa project configuration
+ * @returns Frozen authoritative Codex managed-file paths
  */
 export async function expectedCodexManagedFiles(
   projectRoot: string,
@@ -176,7 +203,13 @@ export async function expectedCodexManagedFiles(
   ]);
 }
 
-/** Convert one boolean observation into a stable drift label. */
+/**
+ * Convert one boolean observation into a stable drift label.
+ * @param applicable - Whether the surface applies to the selected harness
+ * @param label - Stable operator-facing drift label
+ * @param observe - Read-only observation for the surface
+ * @returns Empty when inapplicable or present, otherwise the drift label
+ */
 async function evidenceDrift(
   applicable: boolean,
   label: string,
@@ -186,7 +219,13 @@ async function evidenceDrift(
   return (await observe()) ? [] : [label];
 }
 
-/** Collect missing or unsafe project-owned surfaces for one harness. */
+/**
+ * Collect missing or unsafe project-owned surfaces for one harness.
+ * @param root - Canonical project root
+ * @param harness - Normalized configured harness
+ * @param config - Merged Lisa project configuration
+ * @returns Stable labels for missing or unsafe harness surfaces
+ */
 async function projectSurfaceDrift(
   root: string,
   harness: Harness,
@@ -245,6 +284,10 @@ async function projectSurfaceDrift(
 /**
  * Establish only installation state that Lisa can observe authoritatively.
  * External plugin/runtime state remains non-pass when no bounded reader exists.
+ * @param projectRoot - Project root to inspect
+ * @param config - Merged Lisa project configuration
+ * @param health - Current deterministic Health evidence, when available
+ * @returns Installation readiness finding for the configured harness
  */
 export async function installFinding(
   projectRoot: string,
@@ -320,4 +363,3 @@ export async function installFinding(
     `Lisa's required project-owned ${harness} installation surfaces are present and complete.`
   );
 }
-/* eslint-enable jsdoc/require-param, jsdoc/require-returns -- restore repository documentation defaults */

--- a/src/cli/ui-setup-readiness-install.ts
+++ b/src/cli/ui-setup-readiness-install.ts
@@ -1,0 +1,323 @@
+/** Truthful, harness-aware installation evidence for Setup readiness. */
+/* eslint-disable jsdoc/require-param, jsdoc/require-returns -- typed evidence helpers are self-describing */
+import path from "node:path";
+import { realpath } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import {
+  discoverLisaAgents,
+  LISA_AGENTS_SUBDIR,
+} from "../codex/agent-installer.js";
+import {
+  DEFAULT_HARNESS,
+  harnessIncludesAgent,
+  type Harness,
+} from "../core/config.js";
+import {
+  projectPluginFilter,
+  selectProjectLisaPluginsFromState,
+} from "../core/lisa-plugin-selection.js";
+import { normalizeHarness } from "../core/project-config.js";
+import type { HealthResult } from "../health/contract.js";
+import {
+  projectPathKind,
+  projectRegularFileExists,
+  readProjectJsonObject,
+  readProjectText,
+} from "../health/read-only-fs.js";
+import type { JsonObject } from "../sync/json-path.js";
+import {
+  setupFinding,
+  type SetupReadinessFinding,
+} from "./ui-setup-readiness-contract.js";
+import { healthEvidenceFinding } from "./ui-setup-readiness-local.js";
+import { readConfinedDetectedStacks } from "./ui-detected-stacks.js";
+
+/** Fixed Health checks that establish common project-owned apply surfaces. */
+export const INSTALL_HEALTH_CHECKS = [
+  "project.state",
+  "templates.managed",
+  "package.conformance",
+  "hooks.managed",
+] as const;
+
+const MAX_MANAGED_FILES = 2_048;
+const INSTALL_CHECK = "setup.install";
+const EXTERNAL_ONLY_HARNESSES = new Set<Harness>([
+  "cursor",
+  "agy",
+  "copilot",
+  "fleet",
+]);
+
+/** Resolve the configured harness without accepting a malformed value. */
+function configuredHarness(config: JsonObject): Harness | undefined {
+  const raw = config.harness ?? DEFAULT_HARNESS;
+  return typeof raw === "string" ? normalizeHarness(raw) : undefined;
+}
+
+/** Require one non-empty, confined regular project file. */
+async function nonemptyProjectFile(
+  root: string,
+  relativePath: string
+): Promise<boolean> {
+  const text = await readProjectText(root, relativePath);
+  return text !== undefined && text.trim().length > 0;
+}
+
+/** Validate one normalized path relative to an agent-owned manifest directory. */
+function validManifestEntry(value: unknown): value is string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.includes("\\") ||
+    path.posix.isAbsolute(value)
+  ) {
+    return false;
+  }
+  const segments = value.split("/");
+  return (
+    segments.every(
+      segment => segment !== "" && segment !== "." && segment !== ".."
+    ) && path.posix.normalize(value) === value
+  );
+}
+
+/** Refuse symlinked/special parents and final entries for one manifest file. */
+async function manifestEntryIsRegular(
+  root: string,
+  configDir: string,
+  entry: string
+): Promise<boolean> {
+  const segments = [configDir, ...entry.split("/")];
+  const parents = segments
+    .slice(0, -1)
+    .map((_, index) => segments.slice(0, index + 1).join("/"));
+  const kinds = await Promise.all(
+    parents.map(parent => projectPathKind(root, parent))
+  );
+  return (
+    kinds.every(kind => kind === "directory") &&
+    (await projectRegularFileExists(root, `${configDir}/${entry}`))
+  );
+}
+
+/** Validate a bounded managed-artifact manifest and every file it names. */
+async function managedManifestIsComplete(
+  root: string,
+  configDir: ".codex" | ".opencode",
+  expectedFiles?: readonly string[]
+): Promise<boolean> {
+  const manifest = await readProjectJsonObject(
+    root,
+    `${configDir}/.lisa-managed.json`
+  );
+  const files = manifest?.files;
+  if (
+    !Array.isArray(files) ||
+    files.length === 0 ||
+    files.length > MAX_MANAGED_FILES ||
+    !files.every(validManifestEntry) ||
+    new Set(files).size !== files.length
+  ) {
+    return false;
+  }
+  if (expectedFiles !== undefined) {
+    const observed = [...files].sort((left, right) =>
+      left.localeCompare(right)
+    );
+    const expected = [...expectedFiles].sort((left, right) =>
+      left.localeCompare(right)
+    );
+    if (
+      observed.length !== expected.length ||
+      observed.some((entry, index) => entry !== expected[index])
+    ) {
+      return false;
+    }
+  }
+  const present = await Promise.all(
+    files.map(entry => manifestEntryIsRegular(root, configDir, entry))
+  );
+  return present.every(Boolean);
+}
+
+/**
+ * Derive Codex's exact current managed-file set from the same selected plugin
+ * and agent discovery contract used by apply. No project file is trusted as a
+ * declaration of completeness.
+ */
+export async function expectedCodexManagedFiles(
+  projectRoot: string,
+  config: JsonObject
+): Promise<readonly string[]> {
+  const root = await realpath(projectRoot);
+  const lisaRoot = await realpath(
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+  );
+  const [detectedTypes, wikiKind] = await Promise.all([
+    readConfinedDetectedStacks(root),
+    projectPathKind(root, "wiki/lisa-wiki.config.json"),
+  ]);
+  const plugins = selectProjectLisaPluginsFromState(
+    config,
+    detectedTypes,
+    wikiKind === "file"
+  );
+  const agents = await discoverLisaAgents(
+    lisaRoot,
+    projectPluginFilter(plugins)
+  );
+  return Object.freeze([
+    ...agents.map(agent =>
+      path.posix.join(LISA_AGENTS_SUBDIR, `${agent.id}.toml`)
+    ),
+    "config.toml",
+  ]);
+}
+
+/** Convert one boolean observation into a stable drift label. */
+async function evidenceDrift(
+  applicable: boolean,
+  label: string,
+  observe: () => Promise<boolean>
+): Promise<readonly string[]> {
+  if (!applicable) return [];
+  return (await observe()) ? [] : [label];
+}
+
+/** Collect missing or unsafe project-owned surfaces for one harness. */
+async function projectSurfaceDrift(
+  root: string,
+  harness: Harness,
+  config: JsonObject
+): Promise<readonly string[]> {
+  const includes = (agent: Exclude<Harness, "cursor" | "fleet">): boolean =>
+    harnessIncludesAgent(harness, agent);
+  const needsAgents =
+    includes("claude") ||
+    includes("codex") ||
+    includes("agy") ||
+    includes("copilot") ||
+    includes("opencode");
+  const codexFiles = includes("codex")
+    ? await expectedCodexManagedFiles(root, config)
+    : undefined;
+
+  const observations = await Promise.all([
+    evidenceDrift(
+      needsAgents,
+      "AGENTS.md",
+      async () => await nonemptyProjectFile(root, "AGENTS.md")
+    ),
+    evidenceDrift(
+      includes("claude"),
+      "CLAUDE.md canonical AGENTS.md pointer",
+      async () =>
+        (await readProjectText(root, "CLAUDE.md"))?.includes("@AGENTS.md") ===
+        true
+    ),
+    evidenceDrift(
+      includes("codex"),
+      ".codex managed-artifact manifest",
+      async () => await managedManifestIsComplete(root, ".codex", codexFiles)
+    ),
+    evidenceDrift(
+      includes("copilot"),
+      ".github/copilot-instructions.md",
+      async () =>
+        await nonemptyProjectFile(root, ".github/copilot-instructions.md")
+    ),
+    evidenceDrift(
+      includes("opencode"),
+      ".opencode managed-artifact manifest",
+      async () => await managedManifestIsComplete(root, ".opencode")
+    ),
+    evidenceDrift(
+      includes("opencode"),
+      "opencode.json",
+      async () => await nonemptyProjectFile(root, "opencode.json")
+    ),
+  ]);
+  return observations.flat();
+}
+
+/**
+ * Establish only installation state that Lisa can observe authoritatively.
+ * External plugin/runtime state remains non-pass when no bounded reader exists.
+ */
+export async function installFinding(
+  projectRoot: string,
+  config: JsonObject,
+  health: HealthResult | undefined
+): Promise<SetupReadinessFinding> {
+  const common = healthEvidenceFinding(
+    INSTALL_CHECK,
+    health,
+    INSTALL_HEALTH_CHECKS,
+    "Lisa's common project templates, package, and git hooks are current.",
+    "fail"
+  );
+  if (common.status !== "pass") return common;
+
+  const harness = configuredHarness(config);
+  if (harness === undefined) {
+    return setupFinding(
+      INSTALL_CHECK,
+      "fail",
+      "The configured Lisa harness is missing or invalid; run lisa sync and lisa apply."
+    );
+  }
+
+  try {
+    const root = await realpath(projectRoot);
+    const drift = await projectSurfaceDrift(root, harness, config);
+    if (drift.length > 0) {
+      return setupFinding(
+        INSTALL_CHECK,
+        "fail",
+        `Configured-harness project surfaces are missing or unsafe: ${drift.join(", ")}. Run lisa apply.`
+      );
+    }
+  } catch {
+    return setupFinding(
+      INSTALL_CHECK,
+      "fail",
+      "Configured-harness project surfaces could not be inspected safely; replace symlinks, special files, or oversized files and run lisa apply."
+    );
+  }
+
+  if (harnessIncludesAgent(harness, "claude")) {
+    const claudePlugins = healthEvidenceFinding(
+      INSTALL_CHECK,
+      health,
+      ["plugins.current"],
+      "Claude's enabled and installed Lisa plugins are current.",
+      "warn"
+    );
+    if (claudePlugins.status !== "pass") return claudePlugins;
+  }
+
+  if (harnessIncludesAgent(harness, "opencode")) {
+    return setupFinding(
+      INSTALL_CHECK,
+      "warn",
+      "OpenCode's declared managed files are present, but their completeness against the current emit catalog cannot yet be established authoritatively."
+    );
+  }
+
+  if (EXTERNAL_ONLY_HARNESSES.has(harness)) {
+    return setupFinding(
+      INSTALL_CHECK,
+      "warn",
+      `Lisa's project-owned ${harness} surfaces are current, but external ${harness} plugin/runtime installation cannot yet be observed authoritatively.`
+    );
+  }
+
+  return setupFinding(
+    INSTALL_CHECK,
+    "pass",
+    `Lisa's required project-owned ${harness} installation surfaces are present and complete.`
+  );
+}
+/* eslint-enable jsdoc/require-param, jsdoc/require-returns -- restore repository documentation defaults */

--- a/src/cli/ui-setup-readiness-local.ts
+++ b/src/cli/ui-setup-readiness-local.ts
@@ -1,0 +1,327 @@
+/** Local filesystem and deterministic-Health evidence for Setup readiness. */
+/* eslint-disable jsdoc/require-param, jsdoc/require-returns -- bounded local evidence readers remain cohesive */
+import { readdir, realpath } from "node:fs/promises";
+import path from "node:path";
+import type { HealthResult, HealthStatus } from "../health/contract.js";
+import {
+  projectPathKind,
+  projectRegularFileExists,
+  readProjectText,
+  resolveProjectPath,
+} from "../health/read-only-fs.js";
+import { requireCanonicalUtcTimestamp } from "../health/strict-validation.js";
+import {
+  setupFinding,
+  type SetupReadinessCheck,
+  type SetupReadinessFinding,
+} from "./ui-setup-readiness-contract.js";
+
+const AGENT_READY_CHECK = "setup.agent-ready";
+const WIKI_CHECK = "setup.wiki";
+
+/** Fixed Health checks that establish local standards/governance conformance. */
+export const STANDARDS_HEALTH_CHECKS = [
+  "templates.managed",
+  "package.conformance",
+  "hooks.managed",
+  "config.sync",
+  "instructions.canonical",
+  "ci.workflows",
+] as const;
+
+/** Never upgrade standards adoption without current lint/test preservation proof. */
+export function standardsFinding(
+  health: HealthResult | undefined
+): SetupReadinessFinding {
+  const managed = healthEvidenceFinding(
+    "setup.standards",
+    health,
+    STANDARDS_HEALTH_CHECKS,
+    "Managed standards surfaces are current.",
+    "fail"
+  );
+  return managed.status === "pass"
+    ? setupFinding(
+        "setup.standards",
+        "warn",
+        "Managed standards surfaces are current, but bounded current lint, test, and behavior-preservation proof is unavailable."
+      )
+    : managed;
+}
+
+/** Project workflow secret available without explicit provisioning. */
+const IMPLICIT_WORKFLOW_SECRETS = new Set(["GITHUB_TOKEN"]);
+
+/** Whether an unknown field is non-empty operator text. */
+function hasText(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/** Canonicalize one strictly source-confined evidence path. */
+function normalizeSourceEvidencePath(value: unknown): string | undefined {
+  if (!hasText(value) || value.includes("\\") || path.posix.isAbsolute(value)) {
+    return undefined;
+  }
+  const segments = value.split("/");
+  if (
+    segments.some(
+      segment => segment === "" || segment === "." || segment === ".."
+    )
+  ) {
+    return undefined;
+  }
+  const normalized = path.posix.normalize(value);
+  return normalized === value && normalized.startsWith("wiki/sources/")
+    ? normalized
+    : undefined;
+}
+
+/** Refuse symlinks in every parent and inspect the final file with no-follow. */
+async function sourceEvidenceIsRegular(
+  root: string,
+  evidencePath: string
+): Promise<boolean> {
+  const segments = evidencePath.split("/");
+  const parents = segments
+    .slice(0, -1)
+    .map((_, index) => segments.slice(0, index + 1).join("/"));
+  const parentKinds = await Promise.all(
+    parents.map(parent => projectPathKind(root, parent))
+  );
+  if (!parentKinds.every(kind => kind === "directory")) return false;
+  return await projectRegularFileExists(root, evidencePath);
+}
+
+/** Validate one complete agent-ready source row and its confined evidence. */
+async function sourceRowIsComplete(
+  root: string,
+  source: unknown
+): Promise<"complete" | "incomplete" | "invalid"> {
+  if (source === null || typeof source !== "object" || Array.isArray(source)) {
+    return "invalid";
+  }
+  const probe = Reflect.get(source, "read_only_probe");
+  const evidence = Reflect.get(source, "sanitized_evidence");
+  const terminalStatus = Reflect.get(source, "terminal_status");
+  const openGap = Reflect.get(source, "open_gap");
+  if (
+    !hasText(Reflect.get(source, "source_id")) ||
+    !hasText(Reflect.get(source, "scope")) ||
+    probe === null ||
+    typeof probe !== "object" ||
+    Array.isArray(probe) ||
+    !hasText(Reflect.get(probe, "command")) ||
+    !hasText(Reflect.get(probe, "observed")) ||
+    typeof terminalStatus !== "string" ||
+    !["complete", "partial", "unavailable", "pending"].includes(
+      terminalStatus
+    ) ||
+    (openGap !== null && !hasText(openGap)) ||
+    !Array.isArray(evidence) ||
+    evidence.length === 0 ||
+    evidence.some(item => normalizeSourceEvidencePath(item) === undefined)
+  ) {
+    return "invalid";
+  }
+  const canonicalEvidence = evidence.map(item =>
+    normalizeSourceEvidencePath(item)
+  );
+  const regularFiles = await Promise.all(
+    canonicalEvidence.map(item => sourceEvidenceIsRegular(root, item!))
+  );
+  if (!regularFiles.every(Boolean)) return "invalid";
+  return terminalStatus === "complete" && openGap === null
+    ? "complete"
+    : "incomplete";
+}
+
+/** Aggregate stable check IDs without interpreting human-readable reasons. */
+export function healthEvidenceFinding(
+  check: SetupReadinessCheck,
+  health: HealthResult | undefined,
+  requiredChecks: readonly string[],
+  passReason: string,
+  unavailableStatus: HealthStatus = "warn"
+): SetupReadinessFinding {
+  const byCheck = new Map(
+    (health?.findings ?? []).map(finding => [finding.check, finding])
+  );
+  const unavailable = requiredChecks.filter(id => !byCheck.has(id));
+  if (unavailable.length > 0) {
+    return setupFinding(
+      check,
+      unavailableStatus,
+      `Required deterministic evidence is unavailable: ${unavailable.join(", ")}.`
+    );
+  }
+  const nonPassing = requiredChecks.filter(
+    id => byCheck.get(id)?.status !== "pass"
+  );
+  if (nonPassing.length === 0) {
+    return setupFinding(check, "pass", passReason);
+  }
+  const hasFailure = nonPassing.some(id => byCheck.get(id)?.status === "fail");
+  return setupFinding(
+    check,
+    hasFailure ? "fail" : "warn",
+    `Deterministic setup evidence is not passing: ${nonPassing.join(", ")}.`
+  );
+}
+
+/** Require a complete source registry and no open knowledge gaps. */
+// eslint-disable-next-line max-lines-per-function, sonarjs/cognitive-complexity -- one bounded registry-and-evidence validation transaction stays auditable together
+export async function agentReadyFinding(
+  projectRoot: string
+): Promise<SetupReadinessFinding> {
+  try {
+    const root = await realpath(projectRoot);
+    const [registryText, gapsText] = await Promise.all([
+      readProjectText(root, "wiki/state/agent-ready/sources.json"),
+      readProjectText(root, "wiki/gaps.md"),
+    ]);
+    if (registryText === undefined || gapsText === undefined) {
+      return setupFinding(
+        AGENT_READY_CHECK,
+        "warn",
+        "Agent-ready evidence is incomplete: run /lisa:agent-ready to create the source registry and wiki/gaps.md."
+      );
+    }
+    const parsed = JSON.parse(registryText) as unknown;
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed) ||
+      Reflect.get(parsed, "schema_version") !== 1
+    ) {
+      return setupFinding(
+        AGENT_READY_CHECK,
+        "fail",
+        "The agent-ready source registry is malformed or unsupported."
+      );
+    }
+    requireCanonicalUtcTimestamp(
+      Reflect.get(parsed, "updated_at"),
+      "agent-ready updated_at"
+    );
+    const sources = Reflect.get(parsed, "sources");
+    if (!Array.isArray(sources) || sources.length === 0) {
+      return setupFinding(
+        AGENT_READY_CHECK,
+        "warn",
+        "The agent-ready source registry has no inventoried sources."
+      );
+    }
+    const sourceIds = sources.flatMap(source => {
+      if (source === null || typeof source !== "object") return [];
+      const id = Reflect.get(source, "source_id");
+      return typeof id === "string" ? [id] : [];
+    });
+    const validations = await Promise.all(
+      sources.map(source => sourceRowIsComplete(root, source))
+    );
+    if (validations.includes("invalid")) {
+      return setupFinding(
+        AGENT_READY_CHECK,
+        "fail",
+        "The agent-ready source registry has an invalid row or missing, unsafe, or non-file sanitized evidence."
+      );
+    }
+    const incomplete = validations.filter(
+      value => value === "incomplete"
+    ).length;
+    if (new Set(sourceIds).size !== sources.length) {
+      return setupFinding(
+        AGENT_READY_CHECK,
+        "fail",
+        "The agent-ready source registry has missing or duplicate source identifiers."
+      );
+    }
+    const openGaps = [...gapsText.matchAll(/\*\*Status\*\*:\s*open\b/giu)]
+      .length;
+    if (incomplete > 0 || openGaps > 0) {
+      return setupFinding(
+        AGENT_READY_CHECK,
+        "warn",
+        `Knowledge convergence is incomplete: ${incomplete} source record${incomplete === 1 ? "" : "s"} incomplete and ${openGaps} open gap${openGaps === 1 ? "" : "s"}.`
+      );
+    }
+    return setupFinding(
+      AGENT_READY_CHECK,
+      "pass",
+      `All ${sources.length} inventoried sources are complete and wiki/gaps.md has no open gaps.`
+    );
+  } catch {
+    return setupFinding(
+      AGENT_READY_CHECK,
+      "fail",
+      "Agent-ready evidence is unreadable; re-run /lisa:agent-ready."
+    );
+  }
+}
+
+/** Require the optional wiki to exist before accepting the Health wiki check. */
+export async function wikiSetupFinding(
+  projectRoot: string,
+  health: HealthResult | undefined
+): Promise<SetupReadinessFinding> {
+  try {
+    const root = await realpath(projectRoot);
+    if ((await projectPathKind(root, "wiki")) !== "directory") {
+      return setupFinding(
+        WIKI_CHECK,
+        "warn",
+        "Optional LLM wiki is not installed. Run /lisa:wiki:install."
+      );
+    }
+  } catch {
+    return setupFinding(
+      WIKI_CHECK,
+      "fail",
+      "The wiki path is unsafe or unreadable."
+    );
+  }
+  return healthEvidenceFinding(
+    WIKI_CHECK,
+    health,
+    ["project.wiki"],
+    "The optional LLM wiki contract files are installed."
+  );
+}
+
+/** Read names referenced as `secrets.NAME` from current workflow files. */
+export async function readWorkflowSecretNames(
+  projectRoot: string
+): Promise<readonly string[]> {
+  try {
+    const root = await realpath(projectRoot);
+    if ((await projectPathKind(root, ".github/workflows")) !== "directory") {
+      return [];
+    }
+    const directory = resolveProjectPath(root, ".github/workflows");
+    const entries = await readdir(directory, { withFileTypes: true });
+    const workflowNames = entries
+      .filter(entry => entry.isFile() && /\.(?:ya?ml)$/iu.test(entry.name))
+      .map(entry => `.github/workflows/${entry.name}`)
+      .sort((left, right) => left.localeCompare(right));
+    if (workflowNames.length > 100) {
+      throw new Error("Workflow secret inventory exceeds the bounded reader");
+    }
+    const contents = await Promise.all(
+      workflowNames.map(name => readProjectText(root, name, 256 * 1024))
+    );
+    const names = contents.flatMap(content =>
+      content === undefined
+        ? []
+        : [...content.matchAll(/\bsecrets\.([A-Z][A-Z0-9_]*)\b/gu)].map(
+            match => match[1]!
+          )
+    );
+    return [...new Set(names)]
+      .filter(name => !IMPLICIT_WORKFLOW_SECRETS.has(name))
+      .sort((left, right) => left.localeCompare(right));
+  } catch {
+    return [];
+  }
+}
+
+/* eslint-enable jsdoc/require-param, jsdoc/require-returns -- end typed evidence helper exception */

--- a/src/cli/ui-setup-readiness-local.ts
+++ b/src/cli/ui-setup-readiness-local.ts
@@ -1,5 +1,4 @@
 /** Local filesystem and deterministic-Health evidence for Setup readiness. */
-/* eslint-disable jsdoc/require-param, jsdoc/require-returns -- bounded local evidence readers remain cohesive */
 import { readdir, realpath } from "node:fs/promises";
 import path from "node:path";
 import type { HealthResult, HealthStatus } from "../health/contract.js";
@@ -29,7 +28,11 @@ export const STANDARDS_HEALTH_CHECKS = [
   "ci.workflows",
 ] as const;
 
-/** Never upgrade standards adoption without current lint/test preservation proof. */
+/**
+ * Never upgrade standards adoption without current lint/test preservation proof.
+ * @param health - Current deterministic Health evidence, when available
+ * @returns Standards-adoption readiness finding
+ */
 export function standardsFinding(
   health: HealthResult | undefined
 ): SetupReadinessFinding {
@@ -52,12 +55,20 @@ export function standardsFinding(
 /** Project workflow secret available without explicit provisioning. */
 const IMPLICIT_WORKFLOW_SECRETS = new Set(["GITHUB_TOKEN"]);
 
-/** Whether an unknown field is non-empty operator text. */
+/**
+ * Whether an unknown field is non-empty operator text.
+ * @param value - Untrusted field value
+ * @returns Whether the value contains non-whitespace text
+ */
 function hasText(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-/** Canonicalize one strictly source-confined evidence path. */
+/**
+ * Canonicalize one strictly source-confined evidence path.
+ * @param value - Untrusted source evidence path
+ * @returns Normalized wiki/sources path, or undefined when invalid
+ */
 function normalizeSourceEvidencePath(value: unknown): string | undefined {
   if (!hasText(value) || value.includes("\\") || path.posix.isAbsolute(value)) {
     return undefined;
@@ -76,7 +87,12 @@ function normalizeSourceEvidencePath(value: unknown): string | undefined {
     : undefined;
 }
 
-/** Refuse symlinks in every parent and inspect the final file with no-follow. */
+/**
+ * Refuse symlinks in every parent and inspect the final file with no-follow.
+ * @param root - Canonical project root
+ * @param evidencePath - Normalized project-relative evidence path
+ * @returns Whether the evidence path has safe parents and a regular final file
+ */
 async function sourceEvidenceIsRegular(
   root: string,
   evidencePath: string
@@ -92,7 +108,12 @@ async function sourceEvidenceIsRegular(
   return await projectRegularFileExists(root, evidencePath);
 }
 
-/** Validate one complete agent-ready source row and its confined evidence. */
+/**
+ * Validate one complete agent-ready source row and its confined evidence.
+ * @param root - Canonical project root
+ * @param source - Untrusted source-registry row
+ * @returns Completeness classification for the source row
+ */
 async function sourceRowIsComplete(
   root: string,
   source: unknown
@@ -135,7 +156,15 @@ async function sourceRowIsComplete(
     : "incomplete";
 }
 
-/** Aggregate stable check IDs without interpreting human-readable reasons. */
+/**
+ * Aggregate stable check IDs without interpreting human-readable reasons.
+ * @param check - Setup checklist identifier being evaluated
+ * @param health - Current deterministic Health evidence, when available
+ * @param requiredChecks - Health check identifiers required for readiness
+ * @param passReason - Operator-readable reason used when every check passes
+ * @param unavailableStatus - Status used when required evidence is absent
+ * @returns Setup finding derived from the required Health checks
+ */
 export function healthEvidenceFinding(
   check: SetupReadinessCheck,
   health: HealthResult | undefined,
@@ -168,7 +197,11 @@ export function healthEvidenceFinding(
   );
 }
 
-/** Require a complete source registry and no open knowledge gaps. */
+/**
+ * Require a complete source registry and no open knowledge gaps.
+ * @param projectRoot - Project root containing agent-ready evidence
+ * @returns Agent-readiness finding from confined registry and gap evidence
+ */
 // eslint-disable-next-line max-lines-per-function, sonarjs/cognitive-complexity -- one bounded registry-and-evidence validation transaction stays auditable together
 export async function agentReadyFinding(
   projectRoot: string
@@ -259,7 +292,12 @@ export async function agentReadyFinding(
   }
 }
 
-/** Require the optional wiki to exist before accepting the Health wiki check. */
+/**
+ * Require the optional wiki to exist before accepting the Health wiki check.
+ * @param projectRoot - Project root containing the optional wiki
+ * @param health - Current deterministic Health evidence, when available
+ * @returns Wiki setup readiness finding
+ */
 export async function wikiSetupFinding(
   projectRoot: string,
   health: HealthResult | undefined
@@ -288,7 +326,11 @@ export async function wikiSetupFinding(
   );
 }
 
-/** Read names referenced as `secrets.NAME` from current workflow files. */
+/**
+ * Read names referenced as `secrets.NAME` from current workflow files.
+ * @param projectRoot - Project root containing GitHub workflows
+ * @returns Sorted unique explicit workflow secret names
+ */
 export async function readWorkflowSecretNames(
   projectRoot: string
 ): Promise<readonly string[]> {
@@ -323,5 +365,3 @@ export async function readWorkflowSecretNames(
     return [];
   }
 }
-
-/* eslint-enable jsdoc/require-param, jsdoc/require-returns -- end typed evidence helper exception */

--- a/src/cli/ui-setup-readiness-remote.ts
+++ b/src/cli/ui-setup-readiness-remote.ts
@@ -1,5 +1,4 @@
 /** Presence-only GitHub and scheduler evidence for Setup readiness. */
-/* eslint-disable jsdoc/require-param, jsdoc/require-returns -- typed remote-evidence helpers are self-describing */
 import type { ProbeResult } from "./ui-status.js";
 import type { HealthResult } from "../health/contract.js";
 import type { GithubRepoPanelValue } from "./ui-github-repo.js";
@@ -14,7 +13,13 @@ const GITHUB_GOVERNANCE_CHECK = "setup.github-governance";
 const SECRETS_CHECK = "setup.secrets";
 const AUTOMATIONS_CHECK = "setup.automations";
 
-/** Map bounded GitHub live data to governance readiness. */
+/**
+ * Map bounded GitHub live data to governance readiness.
+ * @param health - Current deterministic Health evidence, when available
+ * @param github - Live GitHub repository observation
+ * @param deployPipeline - Live deployment-pipeline observation
+ * @returns GitHub governance readiness finding
+ */
 // eslint-disable-next-line sonarjs/cognitive-complexity -- independent canonical, live-repo, secret, and deployment gates stay visible together
 export function githubGovernanceFinding(
   health: HealthResult | undefined,
@@ -84,7 +89,12 @@ export function githubGovernanceFinding(
       );
 }
 
-/** Map only workflow-referenced secret names to presence readiness. */
+/**
+ * Map only workflow-referenced secret names to presence readiness.
+ * @param github - Live GitHub repository observation
+ * @param expectedSecretNames - Secret names referenced by confined workflows
+ * @returns Repository-secret presence readiness finding
+ */
 export function secretsFinding(
   github: ProbeResult<GithubRepoPanelValue>,
   expectedSecretNames: readonly string[]
@@ -122,7 +132,12 @@ export function secretsFinding(
       );
 }
 
-/** Require the exact six core scheduler entries with observed cadences. */
+/**
+ * Require the exact six core scheduler entries with observed cadences.
+ * @param result - Live harness scheduler observation
+ * @param expectedAutomationIds - Applicable authoritative automation IDs
+ * @returns Harness automation readiness finding
+ */
 export function automationsFinding(
   result: ProbeResult<AutomationsProbeValue>,
   expectedAutomationIds: readonly string[] | undefined
@@ -178,5 +193,3 @@ export function automationsFinding(
         `Missing, disabled, or cadence-unreadable automation entries: ${missing.join(", ")}. Run /lisa:setup-automations.`
       );
 }
-
-/* eslint-enable jsdoc/require-param, jsdoc/require-returns -- end typed remote-evidence helper exception */

--- a/src/cli/ui-setup-readiness-remote.ts
+++ b/src/cli/ui-setup-readiness-remote.ts
@@ -1,0 +1,182 @@
+/** Presence-only GitHub and scheduler evidence for Setup readiness. */
+/* eslint-disable jsdoc/require-param, jsdoc/require-returns -- typed remote-evidence helpers are self-describing */
+import type { ProbeResult } from "./ui-status.js";
+import type { HealthResult } from "../health/contract.js";
+import type { GithubRepoPanelValue } from "./ui-github-repo.js";
+import type { AutomationsProbeValue } from "./ui-automations.js";
+import type { DeployPipelineValue } from "./ui-deploy-pipeline.js";
+import {
+  setupFinding,
+  type SetupReadinessFinding,
+} from "./ui-setup-readiness-contract.js";
+
+const GITHUB_GOVERNANCE_CHECK = "setup.github-governance";
+const SECRETS_CHECK = "setup.secrets";
+const AUTOMATIONS_CHECK = "setup.automations";
+
+/** Map bounded GitHub live data to governance readiness. */
+// eslint-disable-next-line sonarjs/cognitive-complexity -- independent canonical, live-repo, secret, and deployment gates stay visible together
+export function githubGovernanceFinding(
+  health: HealthResult | undefined,
+  github: ProbeResult<GithubRepoPanelValue>,
+  deployPipeline: ProbeResult<DeployPipelineValue>
+): SetupReadinessFinding {
+  if (github.state !== "value") {
+    return setupFinding(
+      GITHUB_GOVERNANCE_CHECK,
+      "warn",
+      `GitHub governance could not be established (${github.reason}).`
+    );
+  }
+  const settings = github.value.settings;
+  const mergeSettingsReady =
+    settings.allow_merge_commit === false &&
+    settings.allow_squash_merge === true &&
+    settings.allow_rebase_merge === false &&
+    settings.allow_auto_merge === true &&
+    settings.allow_update_branch === true &&
+    settings.delete_branch_on_merge === true &&
+    settings.secret_scanning === true;
+  const activeRuleset = github.value.rulesets.some(
+    row =>
+      row.active &&
+      row.targetsDefaultBranch === true &&
+      row.requiresPullRequest === true &&
+      row.requiresStatusChecks === true
+  );
+  const canonicalRulesetStatus = health?.findings.find(
+    finding => finding.check === "github.rulesets"
+  )?.status;
+  const deployKey = github.value.secrets.some(
+    secret => secret.name === "DEPLOY_KEY" && secret.set
+  );
+  const holds =
+    deployPipeline.state === "value"
+      ? deployPipeline.value.stages.filter(stage =>
+          stage.id.startsWith("hold:")
+        )
+      : [];
+  const approvalGates =
+    holds.length > 0 && holds.every(stage => stage.active === true);
+  const missing = [
+    ...(mergeSettingsReady ? [] : ["merge and security settings"]),
+    ...(activeRuleset
+      ? []
+      : [
+          "an active default-branch ruleset requiring pull requests and status checks",
+        ]),
+    ...(canonicalRulesetStatus === "pass"
+      ? []
+      : ["passing canonical github.rulesets Health evidence"]),
+    ...(deployKey ? [] : ["the write deploy key"]),
+    ...(approvalGates ? [] : ["deployment environment approval gates"]),
+  ];
+  return missing.length === 0
+    ? setupFinding(
+        GITHUB_GOVERNANCE_CHECK,
+        "pass",
+        "GitHub merge/security settings, rulesets, write deploy key, and deployment approval gates were observed."
+      )
+    : setupFinding(
+        GITHUB_GOVERNANCE_CHECK,
+        canonicalRulesetStatus === "fail" ? "fail" : "warn",
+        `GitHub governance is incomplete: ${missing.join(" and ")}. Run /lisa:setup:github-repo.`
+      );
+}
+
+/** Map only workflow-referenced secret names to presence readiness. */
+export function secretsFinding(
+  github: ProbeResult<GithubRepoPanelValue>,
+  expectedSecretNames: readonly string[]
+): SetupReadinessFinding {
+  if (expectedSecretNames.length === 0) {
+    return setupFinding(
+      SECRETS_CHECK,
+      "warn",
+      "No explicit CI secret requirements could be established from current workflow references."
+    );
+  }
+  if (github.state !== "value") {
+    return setupFinding(
+      SECRETS_CHECK,
+      "warn",
+      `Repository secret presence could not be established (${github.reason}); no secret values were read.`
+    );
+  }
+  const presence = new Map(
+    github.value.secrets.map(secret => [secret.name, secret.set])
+  );
+  const missing = expectedSecretNames.filter(
+    name => presence.get(name) !== true
+  );
+  return missing.length === 0
+    ? setupFinding(
+        SECRETS_CHECK,
+        "pass",
+        `${expectedSecretNames.length} workflow-referenced repository secret name${expectedSecretNames.length === 1 ? " is" : "s are"} present; values were not read.`
+      )
+    : setupFinding(
+        SECRETS_CHECK,
+        "warn",
+        `Missing workflow-referenced repository secret names: ${missing.join(", ")}. Values were not read.`
+      );
+}
+
+/** Require the exact six core scheduler entries with observed cadences. */
+export function automationsFinding(
+  result: ProbeResult<AutomationsProbeValue>,
+  expectedAutomationIds: readonly string[] | undefined
+): SetupReadinessFinding {
+  if (
+    expectedAutomationIds === undefined ||
+    expectedAutomationIds.length === 0
+  ) {
+    return setupFinding(
+      AUTOMATIONS_CHECK,
+      "warn",
+      "Applicable automation contracts could not be resolved from project configuration and detected stacks."
+    );
+  }
+  if (result.state !== "value") {
+    return setupFinding(
+      AUTOMATIONS_CHECK,
+      "warn",
+      `Harness scheduler state is unavailable (${result.reason}). Run /lisa:setup-automations.`
+    );
+  }
+  const entries = result.value.automations.flatMap(value => {
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      return [];
+    }
+    const id = Reflect.get(value, "id");
+    const cadence = Reflect.get(value, "cadence");
+    const status = Reflect.get(value, "status");
+    return typeof id === "string" ? [{ id, cadence, status }] : [];
+  });
+  const missing = expectedAutomationIds.filter(expectedId => {
+    return !entries.some(entry => {
+      const disabled =
+        typeof entry.status === "string" &&
+        ["disabled", "inactive", "paused"].includes(entry.status.toLowerCase());
+      return (
+        entry.id === expectedId &&
+        typeof entry.cadence === "string" &&
+        entry.cadence.trim().length > 0 &&
+        !disabled
+      );
+    });
+  });
+  return missing.length === 0
+    ? setupFinding(
+        AUTOMATIONS_CHECK,
+        "pass",
+        `All ${expectedAutomationIds.length} applicable Lisa scheduler entries are present with observed cadences.`
+      )
+    : setupFinding(
+        AUTOMATIONS_CHECK,
+        "warn",
+        `Missing, disabled, or cadence-unreadable automation entries: ${missing.join(", ")}. Run /lisa:setup-automations.`
+      );
+}
+
+/* eslint-enable jsdoc/require-param, jsdoc/require-returns -- end typed remote-evidence helper exception */

--- a/src/cli/ui-setup-readiness.ts
+++ b/src/cli/ui-setup-readiness.ts
@@ -1,0 +1,233 @@
+/** Current read-only Setup checklist readiness projection for `lisa ui`. */
+/* eslint-disable jsdoc/require-param, jsdoc/require-returns -- typed projection helpers are self-describing */
+import { realpath } from "node:fs/promises";
+import * as path from "node:path";
+import { runDeterministicHealth } from "../health/deterministic.js";
+import type { HealthResult } from "../health/contract.js";
+import type { JsonObject } from "../sync/json-path.js";
+import {
+  createAutomationsProbe,
+  type AutomationsProbeValue,
+} from "./ui-automations.js";
+import {
+  readOriginRemote,
+  resolveExpectedAutomationEntries,
+} from "./ui-automations-adapters.js";
+import { readConfinedDetectedStacks } from "./ui-detected-stacks.js";
+import { readConfinedMergedConfig } from "./ui-confined-project-read.js";
+import {
+  explorationFinding,
+  prdSourceFinding,
+  starterProvenanceFinding,
+  trackerFinding,
+} from "./ui-setup-readiness-config.js";
+import {
+  healthEvidenceFinding,
+  readWorkflowSecretNames,
+  standardsFinding,
+  agentReadyFinding,
+  wikiSetupFinding,
+} from "./ui-setup-readiness-local.js";
+import { installFinding } from "./ui-setup-readiness-install.js";
+import {
+  automationsFinding,
+  githubGovernanceFinding,
+  secretsFinding,
+} from "./ui-setup-readiness-remote.js";
+import {
+  validateSetupReadinessResult,
+  type SetupReadinessResult,
+} from "./ui-setup-readiness-contract.js";
+import {
+  createGithubRepoProbe,
+  type GithubRepoPanelValue,
+} from "./ui-github-repo.js";
+import {
+  createDeployPipelineProbe,
+  type DeployPipelineValue,
+} from "./ui-deploy-pipeline.js";
+import { runProbe, type ProbeResult } from "./ui-status.js";
+
+/** Bounded inputs captured for one projection. */
+export interface SetupReadinessObservations {
+  readonly config: JsonObject;
+  readonly health?: HealthResult;
+  readonly github: ProbeResult<GithubRepoPanelValue>;
+  readonly deployPipeline: ProbeResult<DeployPipelineValue>;
+  readonly automations: ProbeResult<AutomationsProbeValue>;
+  readonly expectedAutomationIds?: readonly string[];
+  readonly expectedSecretNames: readonly string[];
+  readonly observedAt?: Date;
+}
+
+/** Injectable readers for endpoint and focused integration tests. */
+export interface SetupReadinessDependencies {
+  readonly readConfig?: (projectRoot: string) => Promise<JsonObject>;
+  readonly readHealth?: (projectRoot: string) => Promise<HealthResult>;
+  readonly readGithub?: (
+    projectRoot: string,
+    config: JsonObject
+  ) => Promise<ProbeResult<GithubRepoPanelValue>>;
+  readonly readDeployPipeline?: (
+    projectRoot: string
+  ) => Promise<ProbeResult<DeployPipelineValue>>;
+  readonly readAutomations?: (
+    projectRoot: string
+  ) => Promise<ProbeResult<AutomationsProbeValue>>;
+  readonly readExpectedAutomationIds?: (
+    projectRoot: string,
+    config: JsonObject
+  ) => Promise<readonly string[]>;
+  readonly readExpectedSecretNames?: (
+    projectRoot: string
+  ) => Promise<readonly string[]>;
+  readonly now?: () => Date;
+}
+
+/** Read the same committed-plus-local merged config used by the console. */
+export async function readMergedUiConfig(
+  projectRoot: string
+): Promise<JsonObject> {
+  return await readConfinedMergedConfig(projectRoot);
+}
+
+/** Produce the exact twelve findings from already captured observations. */
+export async function projectSetupReadiness(
+  projectRoot: string,
+  observations: SetupReadinessObservations
+): Promise<SetupReadinessResult> {
+  const [install, agentReady, wiki] = await Promise.all([
+    installFinding(projectRoot, observations.config, observations.health),
+    agentReadyFinding(projectRoot),
+    wikiSetupFinding(projectRoot, observations.health),
+  ]);
+  const findings = [
+    install,
+    healthEvidenceFinding(
+      "setup.sync",
+      observations.health,
+      ["config.required", "config.sync"],
+      "Required Lisa config and mirrored artifacts are populated and synchronized.",
+      "fail"
+    ),
+    agentReady,
+    standardsFinding(observations.health),
+    trackerFinding(observations.config),
+    prdSourceFinding(observations.config),
+    githubGovernanceFinding(
+      observations.health,
+      observations.github,
+      observations.deployPipeline
+    ),
+    secretsFinding(observations.github, observations.expectedSecretNames),
+    automationsFinding(
+      observations.automations,
+      observations.expectedAutomationIds
+    ),
+    explorationFinding(observations.config),
+    wiki,
+    starterProvenanceFinding(observations.config),
+  ];
+  return validateSetupReadinessResult({
+    schemaVersion: 1,
+    observedAt: (observations.observedAt ?? new Date()).toISOString(),
+    findings,
+  });
+}
+
+/** Convert a failed bounded read into an explicit unknown probe state. */
+function unknownProbe(reason: string): ProbeResult<never> {
+  return {
+    state: "unknown",
+    reason,
+    message: "The setup readiness capability could not be observed.",
+  };
+}
+
+/** Resolve applicable automation IDs with the same origin fallback as identity. */
+async function readDefaultExpectedAutomationIds(
+  root: string,
+  config: JsonObject
+): Promise<readonly string[]> {
+  const stacks = await readConfinedDetectedStacks(root);
+  const gitRemoteUrl = await readOriginRemote(root, AbortSignal.timeout(2_500));
+  return (
+    await resolveExpectedAutomationEntries(config, stacks, gitRemoteUrl)
+  ).map(entry => entry.automationId);
+}
+
+/** Create a safe-to-repeat reader for one localhost UI server. */
+export function createSetupReadinessReader(
+  projectPath: string,
+  dependencies: SetupReadinessDependencies = {}
+): () => Promise<SetupReadinessResult> {
+  const readConfig = dependencies.readConfig ?? readMergedUiConfig;
+  const readHealth =
+    dependencies.readHealth ??
+    (async (root: string) =>
+      await runDeterministicHealth(root, { deadlineMs: 20_000 }));
+  const readGithub =
+    dependencies.readGithub ??
+    (async (root: string, config: JsonObject) =>
+      await runProbe(createGithubRepoProbe(root, config)));
+  const readAutomations =
+    dependencies.readAutomations ??
+    (async (root: string) =>
+      await runProbe(createAutomationsProbe({ cwd: root })));
+  const readDeployPipeline =
+    dependencies.readDeployPipeline ??
+    (async (root: string) => await runProbe(createDeployPipelineProbe(root)));
+  const readExpectedAutomationIds =
+    dependencies.readExpectedAutomationIds ?? readDefaultExpectedAutomationIds;
+  const readSecrets =
+    dependencies.readExpectedSecretNames ?? readWorkflowSecretNames;
+  return async () => {
+    const projectRoot = await realpath(path.resolve(projectPath));
+    const config = await readConfig(projectRoot).catch(() => ({}));
+    const [
+      health,
+      github,
+      deployPipeline,
+      automations,
+      expectedAutomationIds,
+      expectedSecretNames,
+    ] = await Promise.all([
+      readHealth(projectRoot).catch(() => undefined),
+      readGithub(projectRoot, config).catch(() =>
+        unknownProbe("github-read-failed")
+      ),
+      readDeployPipeline(projectRoot).catch(() =>
+        unknownProbe("deploy-pipeline-read-failed")
+      ),
+      readAutomations(projectRoot).catch(() =>
+        unknownProbe("scheduler-read-failed")
+      ),
+      readExpectedAutomationIds(projectRoot, config).catch(() => undefined),
+      readSecrets(projectRoot).catch(() => []),
+    ]);
+    return await projectSetupReadiness(projectRoot, {
+      config,
+      ...(health === undefined ? {} : { health }),
+      github,
+      deployPipeline,
+      automations,
+      ...(expectedAutomationIds === undefined ? {} : { expectedAutomationIds }),
+      expectedSecretNames,
+      ...(dependencies.now === undefined
+        ? {}
+        : { observedAt: dependencies.now() }),
+    });
+  };
+}
+
+export type {
+  SetupReadinessCheck,
+  SetupReadinessFinding,
+  SetupReadinessResult,
+} from "./ui-setup-readiness-contract.js";
+export {
+  SETUP_READINESS_CHECKS,
+  validateSetupReadinessResult,
+} from "./ui-setup-readiness-contract.js";
+
+/* eslint-enable jsdoc/require-param, jsdoc/require-returns -- end typed projection helper exception */

--- a/src/cli/ui-setup-readiness.ts
+++ b/src/cli/ui-setup-readiness.ts
@@ -1,5 +1,4 @@
 /** Current read-only Setup checklist readiness projection for `lisa ui`. */
-/* eslint-disable jsdoc/require-param, jsdoc/require-returns -- typed projection helpers are self-describing */
 import { realpath } from "node:fs/promises";
 import * as path from "node:path";
 import { runDeterministicHealth } from "../health/deterministic.js";
@@ -48,6 +47,8 @@ import {
 } from "./ui-deploy-pipeline.js";
 import { runProbe, type ProbeResult } from "./ui-status.js";
 
+const ORIGIN_REMOTE_TIMEOUT_MS = 2_500;
+
 /** Bounded inputs captured for one projection. */
 export interface SetupReadinessObservations {
   readonly config: JsonObject;
@@ -84,14 +85,23 @@ export interface SetupReadinessDependencies {
   readonly now?: () => Date;
 }
 
-/** Read the same committed-plus-local merged config used by the console. */
+/**
+ * Read the same committed-plus-local merged config used by the console.
+ * @param projectRoot - Project root whose Lisa config should be read.
+ * @returns The bounded merged UI configuration.
+ */
 export async function readMergedUiConfig(
   projectRoot: string
 ): Promise<JsonObject> {
   return await readConfinedMergedConfig(projectRoot);
 }
 
-/** Produce the exact twelve findings from already captured observations. */
+/**
+ * Produce the exact twelve findings from already captured observations.
+ * @param projectRoot - Canonical project root for local evidence checks.
+ * @param observations - Bounded observations captured for this projection.
+ * @returns The validated twelve-finding readiness result.
+ */
 export async function projectSetupReadiness(
   projectRoot: string,
   observations: SetupReadinessObservations
@@ -135,7 +145,11 @@ export async function projectSetupReadiness(
   });
 }
 
-/** Convert a failed bounded read into an explicit unknown probe state. */
+/**
+ * Convert a failed bounded read into an explicit unknown probe state.
+ * @param reason - Stable machine-readable failure reason.
+ * @returns An unknown probe result that cannot be mistaken for success.
+ */
 function unknownProbe(reason: string): ProbeResult<never> {
   return {
     state: "unknown",
@@ -144,19 +158,32 @@ function unknownProbe(reason: string): ProbeResult<never> {
   };
 }
 
-/** Resolve applicable automation IDs with the same origin fallback as identity. */
+/**
+ * Resolve applicable automation IDs with the same origin fallback as identity.
+ * @param root - Canonical project root.
+ * @param config - Bounded merged Lisa configuration.
+ * @returns Expected automation identifiers for the current project.
+ */
 async function readDefaultExpectedAutomationIds(
   root: string,
   config: JsonObject
 ): Promise<readonly string[]> {
   const stacks = await readConfinedDetectedStacks(root);
-  const gitRemoteUrl = await readOriginRemote(root, AbortSignal.timeout(2_500));
+  const gitRemoteUrl = await readOriginRemote(
+    root,
+    AbortSignal.timeout(ORIGIN_REMOTE_TIMEOUT_MS)
+  );
   return (
     await resolveExpectedAutomationEntries(config, stacks, gitRemoteUrl)
   ).map(entry => entry.automationId);
 }
 
-/** Create a safe-to-repeat reader for one localhost UI server. */
+/**
+ * Create a safe-to-repeat reader for one localhost UI server.
+ * @param projectPath - Project path served by the local UI.
+ * @param dependencies - Optional bounded reader overrides for verification.
+ * @returns A read-only readiness projection reader.
+ */
 export function createSetupReadinessReader(
   projectPath: string,
   dependencies: SetupReadinessDependencies = {}
@@ -229,5 +256,3 @@ export {
   SETUP_READINESS_CHECKS,
   validateSetupReadinessResult,
 } from "./ui-setup-readiness-contract.js";
-
-/* eslint-enable jsdoc/require-param, jsdoc/require-returns -- end typed projection helper exception */

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -727,7 +727,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/scripts/automation-status-claude-adapter.mjs":
       "b1054acf4a5cbbe5354bd62a22b96533bcbc69b6cb9245976ceb8af638a04494",
     "plugins/src/base/scripts/automation-status-codex-adapter.mjs":
-      "55bc37e79237e14e2a6b7f32ac0d9bfad607f2b22fe2c75fc1ab0b2c3a9dccea",
+      "ba1d8891f3369865d307e00699d5817172f64947d5b0c4e569e2f8e5bb46a9f5",
     "plugins/src/base/scripts/automation-status-contract-drift.mjs":
       "5f3f327fddedd6870017a86f2702d9cbb17352384fb225ab353eed54241182ef",
     "plugins/src/base/scripts/automation-status-expected-fleet.mjs":
@@ -2053,7 +2053,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "ui/README.md":
       "deeb35e767ea5dd2883268835ea3ad21cbad9fa63ec8d8ff5e200f0e2a7d2751",
     "ui/index.html":
-      "8dcbeda2160ce6c443382613a2319fe6253ffe2c0cdeea567034400cdea91152",
+      "2abf4253d9d576b4e16d41efd30a7f3b334c1a1ec2caad442929ab82bd28fc8d",
   });
 
 /** Exact paths tracked by the public Lisa repository at generation time. */
@@ -7309,6 +7309,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/cli/ui-ci-quality-jobs.ts": true,
     "src/cli/ui-cmd.ts": true,
     "src/cli/ui-config-write.ts": true,
+    "src/cli/ui-confined-project-read.ts": true,
     "src/cli/ui-deploy-pipeline-model.ts": true,
     "src/cli/ui-deploy-pipeline.ts": true,
     "src/cli/ui-detected-stacks.ts": true,
@@ -7321,6 +7322,12 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/cli/ui-lisa-version.ts": true,
     "src/cli/ui-observability-checks.ts": true,
     "src/cli/ui-observability-providers.ts": true,
+    "src/cli/ui-setup-readiness-config.ts": true,
+    "src/cli/ui-setup-readiness-contract.ts": true,
+    "src/cli/ui-setup-readiness-install.ts": true,
+    "src/cli/ui-setup-readiness-local.ts": true,
+    "src/cli/ui-setup-readiness-remote.ts": true,
+    "src/cli/ui-setup-readiness.ts": true,
     "src/cli/ui-status-json.ts": true,
     "src/cli/ui-status.ts": true,
     "src/cli/update-check.ts": true,
@@ -7603,6 +7610,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/ui-ci-quality-jobs.test.ts": true,
     "tests/unit/cli/ui-cmd.test.ts": true,
     "tests/unit/cli/ui-config-write.test.ts": true,
+    "tests/unit/cli/ui-confined-project-read.test.ts": true,
     "tests/unit/cli/ui-deploy-pipeline-probe.test.ts": true,
     "tests/unit/cli/ui-detected-stacks-probe.test.ts": true,
     "tests/unit/cli/ui-enabled-plugins-probe.test.ts": true,
@@ -7612,6 +7620,9 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/ui-health.test.ts": true,
     "tests/unit/cli/ui-lisa-version-probe.test.ts": true,
     "tests/unit/cli/ui-observability-providers-probe.test.ts": true,
+    "tests/unit/cli/ui-setup-readiness-endpoint-confinement.test.ts": true,
+    "tests/unit/cli/ui-setup-readiness-endpoint.test.ts": true,
+    "tests/unit/cli/ui-setup-readiness.test.ts": true,
     "tests/unit/cli/ui-status-contract.test.ts": true,
     "tests/unit/cli/ui-status-endpoint.test.ts": true,
     "tests/unit/cli/ui-status-http-edge.test.ts": true,
@@ -7797,6 +7808,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/automation-run-record.test.ts": true,
     "tests/unit/strategies/automation-runbook-contract-rule.test.ts": true,
     "tests/unit/strategies/automation-status-claude-adapter.test.ts": true,
+    "tests/unit/strategies/automation-status-codex-adapter-confinement.test.ts": true,
     "tests/unit/strategies/automation-status-codex-adapter.test.ts": true,
     "tests/unit/strategies/automation-status-codex-command-memory.test.ts": true,
     "tests/unit/strategies/automation-status-codex-cwd.test.ts": true,

--- a/src/health/read-only-fs.ts
+++ b/src/health/read-only-fs.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 
 const DEFAULT_MAX_BYTES = 512 * 1024;
 const READ_CHUNK_BYTES = 64 * 1024;
+const UNSAFE_PROJECT_FILE = "Unsafe health project file";
 
 /** Stable metadata and bytes captured from one confined regular file. */
 export interface ProjectFileSnapshot {
@@ -39,10 +40,52 @@ export function resolveProjectPath(root: string, relativePath: string): string {
  */
 function assertBoundedFile(stat: Stats, maximumBytes: number): void {
   if (!stat.isFile() || stat.isSymbolicLink()) {
-    throw new Error("Unsafe health project file");
+    throw new Error(UNSAFE_PROJECT_FILE);
   }
   if (stat.size > maximumBytes) {
     throw new Error("Health project file exceeds size limit");
+  }
+}
+
+/**
+ * Test for one confined regular file while refusing to follow its final link.
+ * @param root - Canonical project root
+ * @param relativePath - Project-relative path
+ * @returns Whether a stable regular file exists
+ */
+export async function projectRegularFileExists(
+  root: string,
+  relativePath: string
+): Promise<boolean> {
+  const target = resolveProjectPath(root, relativePath);
+  try {
+    const before = await lstat(target);
+    if (!before.isFile() || before.isSymbolicLink()) {
+      throw new Error(UNSAFE_PROJECT_FILE);
+    }
+    const actual = await realpath(target);
+    if (!actual.startsWith(`${root}${path.sep}`)) {
+      throw new Error("Unsafe health project file escapes project root");
+    }
+    const handle = await open(
+      target,
+      constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK
+    );
+    try {
+      const opened = await handle.stat();
+      if (!opened.isFile() || opened.isSymbolicLink()) {
+        throw new Error(UNSAFE_PROJECT_FILE);
+      }
+      if (opened.dev !== before.dev || opened.ino !== before.ino) {
+        throw new Error("Health project file changed during inspection");
+      }
+      return true;
+    } finally {
+      await handle.close();
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
   }
 }
 

--- a/src/sync/registry.ts
+++ b/src/sync/registry.ts
@@ -69,6 +69,56 @@ const WHEN_TRACKER_LINEAR = "tracker=linear";
 const WHEN_SOURCE_LINEAR = "source=linear";
 const WHEN_SOURCE_NOTION = "source=notion";
 
+/** One provider's exact setup scope contract. */
+export interface SetupProviderRequirement {
+  readonly allOf: readonly string[];
+  readonly anyOf?: readonly string[];
+  readonly setupHint: string;
+}
+
+/**
+ * Authoritative tracker/PRD-source setup requirements. Config sync and
+ * read-only readiness consumers share this map so provider lanes cannot drift.
+ */
+export const SETUP_PROVIDER_REQUIREMENTS: Readonly<{
+  tracker: Readonly<Record<string, SetupProviderRequirement>>;
+  source: Readonly<Record<string, SetupProviderRequirement>>;
+}> = {
+  tracker: {
+    github: {
+      allOf: ["github.org", "github.repo"],
+      setupHint: "/lisa:setup:github",
+    },
+    jira: {
+      allOf: ["jira.project", "atlassian.cloudId"],
+      setupHint: "/lisa:setup:jira",
+    },
+    linear: {
+      allOf: ["linear.workspace", "linear.teamKey"],
+      setupHint: "/lisa:setup:linear",
+    },
+  },
+  source: {
+    github: {
+      allOf: ["github.org", "github.repo"],
+      setupHint: "/lisa:setup:github",
+    },
+    notion: {
+      allOf: ["notion.workspaceId", "notion.prdDatabaseId"],
+      setupHint: "/lisa:setup:notion",
+    },
+    linear: {
+      allOf: ["linear.workspace"],
+      setupHint: "/lisa:setup:linear",
+    },
+    confluence: {
+      allOf: ["atlassian.cloudId"],
+      anyOf: ["confluence.spaceKey", "confluence.parentPageId"],
+      setupHint: "/lisa:setup:confluence",
+    },
+  },
+};
+
 const COVERAGE_DEFAULTS: JsonValue = {
   global: { statements: 70, branches: 70, functions: 70, lines: 70 },
 };
@@ -266,43 +316,43 @@ export const SYNC_REGISTRY: readonly SyncedSetting[] = [
 export const REQUIRED_KEYS: readonly RequiredKey[] = [
   { key: "tracker", setupHint: "/lisa:setup:jira | github | linear" },
   {
-    key: "jira.project",
+    key: SETUP_PROVIDER_REQUIREMENTS.tracker.jira!.allOf[0]!,
     relevantWhen: [WHEN_TRACKER_JIRA],
-    setupHint: "/lisa:setup:jira",
+    setupHint: SETUP_PROVIDER_REQUIREMENTS.tracker.jira!.setupHint,
   },
   {
-    key: "atlassian.cloudId",
+    key: SETUP_PROVIDER_REQUIREMENTS.tracker.jira!.allOf[1]!,
     relevantWhen: [WHEN_TRACKER_JIRA, "source=confluence"],
     setupHint: "/lisa:setup:atlassian",
   },
   {
-    key: "github.org",
+    key: SETUP_PROVIDER_REQUIREMENTS.tracker.github!.allOf[0]!,
     relevantWhen: [WHEN_TRACKER_GITHUB, WHEN_SOURCE_GITHUB],
-    setupHint: "/lisa:setup:github",
+    setupHint: SETUP_PROVIDER_REQUIREMENTS.tracker.github!.setupHint,
   },
   {
-    key: "github.repo",
+    key: SETUP_PROVIDER_REQUIREMENTS.tracker.github!.allOf[1]!,
     relevantWhen: [WHEN_TRACKER_GITHUB, WHEN_SOURCE_GITHUB],
-    setupHint: "/lisa:setup:github",
+    setupHint: SETUP_PROVIDER_REQUIREMENTS.tracker.github!.setupHint,
   },
   {
-    key: "linear.workspace",
+    key: SETUP_PROVIDER_REQUIREMENTS.tracker.linear!.allOf[0]!,
     relevantWhen: [WHEN_TRACKER_LINEAR, WHEN_SOURCE_LINEAR],
-    setupHint: "/lisa:setup:linear",
+    setupHint: SETUP_PROVIDER_REQUIREMENTS.tracker.linear!.setupHint,
   },
   {
-    key: "linear.teamKey",
+    key: SETUP_PROVIDER_REQUIREMENTS.tracker.linear!.allOf[1]!,
     relevantWhen: [WHEN_TRACKER_LINEAR],
-    setupHint: "/lisa:setup:linear",
+    setupHint: SETUP_PROVIDER_REQUIREMENTS.tracker.linear!.setupHint,
   },
   {
-    key: "notion.workspaceId",
+    key: SETUP_PROVIDER_REQUIREMENTS.source.notion!.allOf[0]!,
     relevantWhen: [WHEN_SOURCE_NOTION],
-    setupHint: "/lisa:setup:notion",
+    setupHint: SETUP_PROVIDER_REQUIREMENTS.source.notion!.setupHint,
   },
   {
-    key: "notion.prdDatabaseId",
+    key: SETUP_PROVIDER_REQUIREMENTS.source.notion!.allOf[1]!,
     relevantWhen: [WHEN_SOURCE_NOTION],
-    setupHint: "/lisa:setup:notion",
+    setupHint: SETUP_PROVIDER_REQUIREMENTS.source.notion!.setupHint,
   },
 ];

--- a/tests/unit/cli/ui-automations-probe.test.ts
+++ b/tests/unit/cli/ui-automations-probe.test.ts
@@ -5,7 +5,7 @@
  * resolve to unknown with a reason; only `lisa-auto-<project>-` matches appear.
  * @module tests/unit/cli/ui-automations-probe
  */
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -17,6 +17,10 @@ import {
   type HarnessAutomationObservation,
   type ProjectIdentityResolver,
 } from "../../../src/cli/ui-automations.js";
+import {
+  defaultResolveIdentity,
+  resolveExpectedAutomationEntries,
+} from "../../../src/cli/ui-automations-adapters.js";
 import { runProbe } from "../../../src/cli/ui-status.js";
 
 const AUTOMATIONS_PROBE_ID = "automations";
@@ -79,6 +83,43 @@ function fixedClaudeReader(
 }
 
 describe("createAutomationsProbe", () => {
+  it("rejects unsafe project config before scheduler identity resolution", async () => {
+    const project = await makeTempDir();
+    const outside = await makeTempDir();
+    const target = path.join(outside, "config.json");
+    await writeFile(target, '{"github":{"org":"unsafe","repo":"unsafe"}}\n');
+    await symlink(target, path.join(project, ".lisa.config.json"));
+
+    await expect(
+      defaultResolveIdentity(project, AbortSignal.timeout(1_000))
+    ).rejects.toThrow(/Unsafe/u);
+  });
+
+  it("uses the GitHub origin for Jira and Notion fleets without github config", async () => {
+    const expected = await resolveExpectedAutomationEntries(
+      {
+        tracker: "jira",
+        source: "notion",
+        jira: { project: "ENG" },
+        notion: { workspaceId: "workspace", prdDatabaseId: "database" },
+      },
+      ["typescript"],
+      "git@github.com:Acme/service.git"
+    );
+
+    expect(expected).toContainEqual(
+      expect.objectContaining({
+        id: "intake-repair",
+        automationId: "lisa-auto-acme-service-intake-repair",
+      })
+    );
+    expect(
+      expected.every(entry =>
+        entry.automationId.startsWith("lisa-auto-acme-service-")
+      )
+    ).toBe(true);
+  });
+
   it("lists matching Codex automations with real cadence", async () => {
     const probe = createAutomationsProbe({
       cwd: await makeTempDir(),

--- a/tests/unit/cli/ui-confined-project-read.test.ts
+++ b/tests/unit/cli/ui-confined-project-read.test.ts
@@ -1,0 +1,58 @@
+/** Red-leg coverage for bounded localhost project reads. */
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readConfinedMergedConfig } from "../../../src/cli/ui-confined-project-read.js";
+
+const roots: string[] = [];
+const CONFIG_RELATIVE = ".lisa.config.json";
+
+/**
+ * Create a disposable fixture root tracked for cleanup.
+ * @param prefix - Temporary-directory prefix
+ * @returns Created fixture root
+ */
+async function temporaryRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map(root => rm(root, { recursive: true, force: true }))
+  );
+});
+
+describe("confined UI project reads", () => {
+  it("rejects an external config symlink instead of importing its values", async () => {
+    const project = await temporaryRoot("lisa-ui-confined-project-");
+    const outside = await temporaryRoot("lisa-ui-confined-outside-");
+    const target = path.join(outside, "config.json");
+    await writeFile(target, '{"tracker":"github"}\n');
+    await symlink(target, path.join(project, CONFIG_RELATIVE));
+
+    await expect(readConfinedMergedConfig(project)).rejects.toThrow(/Unsafe/u);
+  });
+
+  it("rejects a FIFO without opening or blocking on it", async () => {
+    const project = await temporaryRoot("lisa-ui-confined-fifo-");
+    execFileSync("/usr/bin/mkfifo", [path.join(project, CONFIG_RELATIVE)]);
+
+    await expect(readConfinedMergedConfig(project)).rejects.toThrow(/Unsafe/u);
+  });
+
+  it("rejects oversized config before JSON parsing", async () => {
+    const project = await temporaryRoot("lisa-ui-confined-oversize-");
+    await writeFile(
+      path.join(project, CONFIG_RELATIVE),
+      "x".repeat(512 * 1024 + 1)
+    );
+
+    await expect(readConfinedMergedConfig(project)).rejects.toThrow(
+      /exceeds size limit/u
+    );
+  });
+});

--- a/tests/unit/cli/ui-deploy-pipeline-probe.test.ts
+++ b/tests/unit/cli/ui-deploy-pipeline-probe.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   assembleDeployPipelineStages,
@@ -277,5 +280,25 @@ describe("createDeployPipelineProbe", () => {
       })
     );
     expect(listGithubEnvironments).not.toHaveBeenCalled();
+  });
+
+  it("degrades oversized deploy workflow evidence without parsing it", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "lisa-ui-deploy-confined-"));
+    try {
+      await mkdir(path.join(root, ".github/workflows"), { recursive: true });
+      await writeFile(
+        path.join(root, ".github/workflows/deploy.yml"),
+        "x".repeat(512 * 1024 + 1)
+      );
+
+      const result = await runProbe(createDeployPipelineProbe(root));
+
+      expect(result).toMatchObject({
+        state: "unknown",
+        reason: "probe-failed",
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/cli/ui-detected-stacks-probe.test.ts
+++ b/tests/unit/cli/ui-detected-stacks-probe.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import type { Server } from "node:http";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
@@ -9,6 +9,7 @@ import {
   runProbe,
   runUi,
 } from "../../../src/cli/ui-cmd.js";
+import { readConfinedDetectedStacks } from "../../../src/cli/ui-detected-stacks.js";
 import { DetectorRegistry } from "../../../src/detection/index.js";
 
 /** Holder for per-test temp resources. */
@@ -36,6 +37,23 @@ afterEach(async () => {
 });
 
 describe("createDetectedStacksProbe", () => {
+  it("rejects package evidence that is an external symlink", async () => {
+    const outside = await mkdtemp(
+      path.join(tmpdir(), "lisa-detected-stacks-outside-")
+    );
+    try {
+      const target = path.join(outside, "package.json");
+      await writeFile(target, '{"dependencies":{"expo":"latest"}}\n');
+      await symlink(target, path.join(resources.dir, "package.json"));
+
+      await expect(readConfinedDetectedStacks(resources.dir)).rejects.toThrow(
+        /Unsafe/u
+      );
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
   it("registers with the detected-stacks id and a bounded timeout", () => {
     const probe = createDetectedStacksProbe(resources.dir);
 

--- a/tests/unit/cli/ui-github-repo-map.test.ts
+++ b/tests/unit/cli/ui-github-repo-map.test.ts
@@ -58,13 +58,25 @@ describe("mapRulesetRow", () => {
             include: ["~DEFAULT_BRANCH", "refs/heads/main", "refs/tags/v*"],
           },
         },
-        rules: [{ type: "deletion" }, { type: "pull_request" }],
+        rules: [
+          { type: "deletion" },
+          { type: "pull_request" },
+          {
+            type: "required_status_checks",
+            parameters: {
+              required_status_checks: [{ context: "CI" }],
+            },
+          },
+        ],
       })
     ).toEqual({
       name: "base",
       appliesTo: "default · main · v*",
-      enforces: "deletion, pull_request",
+      enforces: "deletion, pull_request, required_status_checks",
       active: true,
+      targetsDefaultBranch: true,
+      requiresPullRequest: true,
+      requiresStatusChecks: true,
     });
   });
 });

--- a/tests/unit/cli/ui-setup-readiness-endpoint-confinement.test.ts
+++ b/tests/unit/cli/ui-setup-readiness-endpoint-confinement.test.ts
@@ -1,5 +1,4 @@
 /** Endpoint red leg for setup-readiness config confinement. */
-/* eslint-disable jsdoc/require-jsdoc -- focused endpoint fixture helpers are local to this suite */
 import { execFileSync } from "node:child_process";
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -15,12 +14,21 @@ const SCHEDULER_PREFIX = "lisa-auto-external-repo-";
 const SCHEDULER_ID = `${SCHEDULER_PREFIX}intake-tickets`;
 const SCHEDULER_TOML = "automation.toml";
 
+/**
+ * Create and track one disposable fixture root.
+ * @param prefix - Temporary-directory prefix.
+ * @returns Absolute fixture root path.
+ */
 async function temporaryRoot(prefix: string): Promise<string> {
   const root = await mkdtemp(path.join(tmpdir(), prefix));
   roots.push(root);
   return root;
 }
 
+/**
+ * Build the minimal deterministic Health fixture for endpoint probes.
+ * @returns Stable deterministic Health result.
+ */
 function health(): HealthResult {
   return {
     schemaVersion: 1,
@@ -166,5 +174,3 @@ describe("GET /api/setup-readiness confinement", () => {
     }
   );
 });
-
-/* eslint-enable jsdoc/require-jsdoc -- end focused endpoint fixture exception */

--- a/tests/unit/cli/ui-setup-readiness-endpoint-confinement.test.ts
+++ b/tests/unit/cli/ui-setup-readiness-endpoint-confinement.test.ts
@@ -1,0 +1,170 @@
+/** Endpoint red leg for setup-readiness config confinement. */
+/* eslint-disable jsdoc/require-jsdoc -- focused endpoint fixture helpers are local to this suite */
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createSetupReadinessReader } from "../../../src/cli/ui-setup-readiness.js";
+import { readWorkflowSecretNames } from "../../../src/cli/ui-setup-readiness-local.js";
+import type { HealthResult } from "../../../src/health/contract.js";
+
+const roots: string[] = [];
+const SCHEDULER_PREFIX = "lisa-auto-external-repo-";
+const SCHEDULER_ID = `${SCHEDULER_PREFIX}intake-tickets`;
+const SCHEDULER_TOML = "automation.toml";
+
+async function temporaryRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function health(): HealthResult {
+  return {
+    schemaVersion: 1,
+    runId: "endpoint-confinement-health",
+    mode: "deterministic",
+    startedAt: "2026-07-21T13:00:00.000Z",
+    completedAt: "2026-07-21T13:00:01.000Z",
+    findings: [],
+    summary: {
+      verdict: "out of band",
+      counts: { pass: 0, warn: 0, fail: 0 },
+    },
+  };
+}
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await Promise.all(
+    roots.splice(0).map(root => rm(root, { recursive: true, force: true }))
+  );
+});
+
+describe("GET /api/setup-readiness confinement", () => {
+  it("fails config-backed rows closed for an external config symlink", async () => {
+    const projectRoot = await temporaryRoot("lisa-ui-setup-project-");
+    const outside = await temporaryRoot("lisa-ui-setup-outside-");
+    const target = path.join(outside, "config.json");
+    await writeFile(
+      target,
+      JSON.stringify({
+        tracker: "github",
+        source: "github",
+        github: { org: "external", repo: "external" },
+        starter: { templates: [{ repo: "external/repo", ref: "main" }] },
+      })
+    );
+    await symlink(target, path.join(projectRoot, ".lisa.config.json"));
+    const unavailable = {
+      state: "unknown" as const,
+      reason: "fixture-unavailable",
+      message: "Unavailable fixture",
+    };
+    const readReadiness = createSetupReadinessReader(projectRoot, {
+      readHealth: async () => health(),
+      readGithub: async () => unavailable,
+      readDeployPipeline: async () => unavailable,
+      readAutomations: async () => unavailable,
+      readExpectedAutomationIds: async () => [],
+      readExpectedSecretNames: async () => [],
+    });
+    const body = await readReadiness();
+    const statuses = new Map(
+      body.findings.map((finding: { check: string; status: string }) => [
+        finding.check,
+        finding.status,
+      ])
+    );
+
+    expect(statuses.get("setup.tracker")).not.toBe("pass");
+    expect(statuses.get("setup.prd-source")).not.toBe("pass");
+    expect(statuses.get("setup.starter-provenance")).not.toBe("pass");
+  });
+
+  it("does not import unsafe or oversized workflow secret evidence", async () => {
+    const projectRoot = await temporaryRoot("lisa-ui-workflow-project-");
+    const outside = await temporaryRoot("lisa-ui-workflow-outside-");
+    const workflowRoot = path.join(projectRoot, ".github/workflows");
+    const externalWorkflow = path.join(outside, "external.yml");
+    await mkdir(workflowRoot, { recursive: true });
+    await writeFile(externalWorkflow, "run: ${{ secrets.EXTERNAL_TOKEN }}\n");
+    await symlink(externalWorkflow, path.join(workflowRoot, "external.yml"));
+    execFileSync("/usr/bin/mkfifo", [path.join(workflowRoot, "pipe.yml")]);
+    await writeFile(
+      path.join(workflowRoot, "oversized.yml"),
+      "x".repeat(256 * 1024 + 1)
+    );
+
+    await expect(readWorkflowSecretNames(projectRoot)).resolves.toEqual([]);
+  });
+
+  it.each(["external-symlink", "fifo", "oversized"] as const)(
+    "keeps setup.automations non-pass for default %s scheduler evidence",
+    async evidenceKind => {
+      const projectRoot = await temporaryRoot("lisa-ui-scheduler-project-");
+      const codexHome = await temporaryRoot("lisa-ui-scheduler-home-");
+      const automationsRoot = path.join(codexHome, "automations");
+      const automationRoot = path.join(automationsRoot, SCHEDULER_ID);
+      const automationToml = [
+        "version = 1",
+        `id = "${SCHEDULER_ID}"`,
+        'kind = "cron"',
+        'status = "ACTIVE"',
+        'rrule = "FREQ=HOURLY;INTERVAL=1"',
+        'prompt = "Use the Lisa intake skill."',
+        "",
+      ].join("\n");
+      await mkdir(automationRoot, { recursive: true });
+      await writeFile(
+        path.join(projectRoot, ".lisa.config.json"),
+        JSON.stringify({
+          tracker: "github",
+          source: "github",
+          github: { org: "external", repo: "repo" },
+        })
+      );
+      if (evidenceKind === "external-symlink") {
+        const outside = await temporaryRoot("lisa-ui-scheduler-outside-");
+        const target = path.join(outside, SCHEDULER_TOML);
+        await writeFile(target, automationToml);
+        await symlink(target, path.join(automationRoot, SCHEDULER_TOML));
+      } else {
+        await writeFile(
+          path.join(automationRoot, SCHEDULER_TOML),
+          evidenceKind === "oversized"
+            ? "x".repeat(256 * 1024 + 1)
+            : automationToml
+        );
+      }
+      if (evidenceKind === "fifo") {
+        execFileSync("/usr/bin/mkfifo", [
+          path.join(automationRoot, "memory.md"),
+        ]);
+      }
+      vi.stubEnv("CODEX_HOME", codexHome);
+      const unavailable = {
+        state: "unknown" as const,
+        reason: "fixture-unavailable",
+        message: "Unavailable fixture",
+      };
+      const readReadiness = createSetupReadinessReader(projectRoot, {
+        readHealth: async () => health(),
+        readGithub: async () => unavailable,
+        readDeployPipeline: async () => unavailable,
+        readExpectedAutomationIds: async () => [SCHEDULER_ID],
+        readExpectedSecretNames: async () => [],
+      });
+
+      const result = await readReadiness();
+
+      expect(
+        result.findings.find(finding => finding.check === "setup.automations")
+      ).toMatchObject({ status: expect.not.stringMatching(/^pass$/u) });
+    }
+  );
+});
+
+/* eslint-enable jsdoc/require-jsdoc -- end focused endpoint fixture exception */

--- a/tests/unit/cli/ui-setup-readiness-endpoint.test.ts
+++ b/tests/unit/cli/ui-setup-readiness-endpoint.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-jsdoc -- focused endpoint fixture helpers are local to this suite */
 import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import type { Server } from "node:http";
 import { tmpdir } from "node:os";
@@ -30,6 +29,10 @@ afterEach(async () => {
   await rm(projectRoot, { recursive: true, force: true });
 });
 
+/**
+ * Build passing deterministic Health evidence for endpoint fixtures.
+ * @returns Stable deterministic Health result.
+ */
 function health(): HealthResult {
   const checks = [
     "project.state",
@@ -63,6 +66,10 @@ function health(): HealthResult {
   };
 }
 
+/**
+ * Build a governed GitHub repository fixture.
+ * @returns Passing GitHub repository panel value.
+ */
 function github(): GithubRepoPanelValue {
   return {
     owner: "owner",
@@ -99,6 +106,10 @@ function github(): GithubRepoPanelValue {
   } as GithubRepoPanelValue;
 }
 
+/**
+ * Build the complete expected scheduler fixture.
+ * @returns Active automation observations.
+ */
 function automations(): AutomationsProbeValue {
   const prefix = "lisa-auto-repo-";
   const suffixes = [
@@ -122,6 +133,10 @@ function automations(): AutomationsProbeValue {
   };
 }
 
+/**
+ * Read the bound loopback server port.
+ * @returns Current server port, or zero before binding.
+ */
 function port(): number {
   const address = server?.address();
   return typeof address === "object" && address !== null ? address.port : 0;
@@ -273,5 +288,3 @@ describe("GET /api/setup-readiness", () => {
     expect(readConfig).toHaveBeenCalledTimes(2);
   });
 });
-
-/* eslint-enable jsdoc/require-jsdoc -- end focused endpoint fixture exception */

--- a/tests/unit/cli/ui-setup-readiness-endpoint.test.ts
+++ b/tests/unit/cli/ui-setup-readiness-endpoint.test.ts
@@ -1,0 +1,277 @@
+/* eslint-disable jsdoc/require-jsdoc -- focused endpoint fixture helpers are local to this suite */
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import type { Server } from "node:http";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runUi } from "../../../src/cli/ui-cmd.js";
+import type { AutomationsProbeValue } from "../../../src/cli/ui-automations.js";
+import type { GithubRepoPanelValue } from "../../../src/cli/ui-github-repo.js";
+import { SETUP_READINESS_CHECKS } from "../../../src/cli/ui-setup-readiness.js";
+import type { HealthResult } from "../../../src/health/contract.js";
+
+const ENDPOINT = "/api/setup-readiness";
+let projectRoot = "";
+let server: Server | undefined;
+
+beforeEach(async () => {
+  projectRoot = await mkdtemp(path.join(tmpdir(), "lisa-ui-setup-endpoint-"));
+  vi.spyOn(console, "log").mockImplementation(() => undefined);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (server !== undefined) {
+    server.closeAllConnections();
+    await new Promise(resolve => server?.close(resolve));
+    server = undefined;
+  }
+  await rm(projectRoot, { recursive: true, force: true });
+});
+
+function health(): HealthResult {
+  const checks = [
+    "project.state",
+    "templates.managed",
+    "package.conformance",
+    "hooks.managed",
+    "plugins.current",
+    "config.required",
+    "config.sync",
+    "instructions.canonical",
+    "ci.workflows",
+    "github.rulesets",
+    "project.wiki",
+  ];
+  return {
+    schemaVersion: 1,
+    runId: "endpoint-health",
+    mode: "deterministic",
+    startedAt: "2026-07-21T13:00:00.000Z",
+    completedAt: "2026-07-21T13:00:01.000Z",
+    findings: checks.map(check => ({
+      check,
+      layer: "deterministic" as const,
+      status: "pass" as const,
+      reason: "Observed fixture evidence.",
+    })),
+    summary: {
+      verdict: "in band",
+      counts: { pass: checks.length, warn: 0, fail: 0 },
+    },
+  };
+}
+
+function github(): GithubRepoPanelValue {
+  return {
+    owner: "owner",
+    repo: "repo",
+    settings: {
+      allow_merge_commit: false,
+      allow_squash_merge: true,
+      allow_rebase_merge: false,
+      allow_auto_merge: true,
+      allow_update_branch: true,
+      delete_branch_on_merge: true,
+      merge_commit_title: "PR_TITLE",
+      has_issues: true,
+      has_wiki: false,
+      secret_scanning: true,
+      default_branch: "main",
+    },
+    rulesets: [
+      {
+        name: "main",
+        appliesTo: "default",
+        enforces: "pull_request",
+        active: true,
+        targetsDefaultBranch: true,
+        requiresPullRequest: true,
+        requiresStatusChecks: true,
+      },
+    ],
+    labels: [],
+    secrets: [
+      { name: "DEPLOY_KEY", purpose: "release", set: true },
+      { name: "SONAR_TOKEN", purpose: "quality", set: true },
+    ],
+  } as GithubRepoPanelValue;
+}
+
+function automations(): AutomationsProbeValue {
+  const prefix = "lisa-auto-repo-";
+  const suffixes = [
+    "intake-repair",
+    "intake-prd",
+    "intake-tickets",
+    "monitor",
+    "exploratory-prds",
+    "exploratory-bugs",
+  ];
+  return {
+    prefix,
+    runtime: "codex",
+    automations: suffixes.map(suffix => ({
+      id: `${prefix}${suffix}`,
+      cadence: "daily",
+      runtime: "codex",
+      status: "active",
+      lastRunAt: null,
+    })),
+  };
+}
+
+function port(): number {
+  const address = server?.address();
+  return typeof address === "object" && address !== null ? address.port : 0;
+}
+
+describe("GET /api/setup-readiness", () => {
+  it("returns current state on first open without Health storage or mutation", async () => {
+    const sentinel = path.join(projectRoot, "sentinel.txt");
+    await writeFile(sentinel, "unchanged\n");
+    const beforeFiles = (await readdir(projectRoot, { recursive: true })).sort(
+      (left, right) => left.localeCompare(right)
+    );
+    const readHealth = vi.fn(async () => health());
+    const readGithub = vi.fn(async () => ({
+      state: "value" as const,
+      value: github(),
+    }));
+    const readAutomations = vi.fn(async () => ({
+      state: "value" as const,
+      value: automations(),
+    }));
+    const readDeployPipeline = vi.fn(async () => ({
+      state: "value" as const,
+      value: {
+        stages: [
+          {
+            id: "hold:production",
+            name: "Release approval",
+            description: "Observed approval hold",
+            environment: "production",
+            active: true as const,
+            reason: "",
+          },
+        ],
+      },
+    }));
+    server = await runUi(
+      projectRoot,
+      { port: "0", sync: false },
+      {
+        probes: [],
+        setupReadiness: {
+          readConfig: async () => ({
+            tracker: "github",
+            source: "github",
+            github: { org: "owner", repo: "repo" },
+          }),
+          readHealth,
+          readGithub,
+          readDeployPipeline,
+          readAutomations,
+          readExpectedAutomationIds: async () =>
+            automations().automations.map(entry =>
+              typeof entry === "object" && entry !== null
+                ? String(Reflect.get(entry, "id"))
+                : ""
+            ),
+          readExpectedSecretNames: async () => ["SONAR_TOKEN"],
+          now: () => new Date("2026-07-21T13:00:02.000Z"),
+        },
+      }
+    );
+
+    const response = await fetch(`http://127.0.0.1:${port()}${ENDPOINT}`);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(
+      body.findings.map((finding: { check: string }) => finding.check)
+    ).toEqual(SETUP_READINESS_CHECKS);
+    expect(
+      body.findings.find(
+        (finding: { check: string }) =>
+          finding.check === "setup.github-governance"
+      )
+    ).toMatchObject({ status: "pass" });
+    expect(readHealth).toHaveBeenCalledOnce();
+    expect(readGithub).toHaveBeenCalledOnce();
+    expect(readDeployPipeline).toHaveBeenCalledOnce();
+    expect(readAutomations).toHaveBeenCalledOnce();
+    expect(await readFile(sentinel, "utf8")).toBe("unchanged\n");
+    expect(
+      (await readdir(projectRoot, { recursive: true })).sort((left, right) =>
+        left.localeCompare(right)
+      )
+    ).toEqual(beforeFiles);
+    expect(beforeFiles).not.toContain(".lisa/health/latest.json");
+  });
+
+  it("supports HEAD, rejects mutation methods, and never invokes readers", async () => {
+    const readHealth = vi.fn(async () => health());
+    server = await runUi(
+      projectRoot,
+      { port: "0", sync: false },
+      { probes: [], setupReadiness: { readHealth } }
+    );
+    const base = `http://127.0.0.1:${port()}${ENDPOINT}`;
+
+    const head = await fetch(base, { method: "HEAD" });
+    const post = await fetch(base, { method: "POST" });
+
+    expect(head.status).toBe(200);
+    expect(post.status).toBe(405);
+    expect(post.headers.get("allow")).toBe("GET, HEAD");
+    expect(readHealth).not.toHaveBeenCalled();
+  });
+
+  it("recomputes current config-backed findings after each settled read", async () => {
+    let trackerConfigured = false;
+    const readConfig = vi.fn(async () => ({
+      ...(trackerConfigured ? { tracker: "github" } : {}),
+      source: "github",
+      github: { org: "owner", repo: "repo" },
+    }));
+    const unavailable = {
+      state: "unknown" as const,
+      reason: "fixture-unavailable",
+      message: "Unavailable fixture",
+    };
+    server = await runUi(
+      projectRoot,
+      { port: "0", sync: false },
+      {
+        probes: [],
+        setupReadiness: {
+          readConfig,
+          readHealth: async () => health(),
+          readGithub: async () => unavailable,
+          readDeployPipeline: async () => unavailable,
+          readAutomations: async () => unavailable,
+          readExpectedAutomationIds: async () => [],
+          readExpectedSecretNames: async () => [],
+        },
+      }
+    );
+    const endpoint = `http://127.0.0.1:${port()}${ENDPOINT}`;
+    const trackerStatus = async (): Promise<string> => {
+      const response = await fetch(endpoint);
+      const body = await response.json();
+      return body.findings.find(
+        (finding: { check: string }) => finding.check === "setup.tracker"
+      ).status as string;
+    };
+
+    expect(await trackerStatus()).toBe("fail");
+    trackerConfigured = true;
+    expect(await trackerStatus()).toBe("pass");
+    expect(readConfig).toHaveBeenCalledTimes(2);
+  });
+});
+
+/* eslint-enable jsdoc/require-jsdoc -- end focused endpoint fixture exception */

--- a/tests/unit/cli/ui-setup-readiness.test.ts
+++ b/tests/unit/cli/ui-setup-readiness.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable jsdoc/require-jsdoc, sonarjs/no-duplicate-string, max-lines -- explicit contract fixtures favor local readability */
+/* eslint-disable sonarjs/no-duplicate-string, max-lines -- explicit contract fixtures favor local readability */
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
@@ -35,6 +35,38 @@ import type { ProbeResult } from "../../../src/cli/ui-status.js";
 
 let tempDir: string | undefined;
 
+const EXPECTED_BASE_CODEX_MANAGED_FILES = [
+  "agents/lisa/architecture-specialist.toml",
+  "agents/lisa/bug-fixer.toml",
+  "agents/lisa/builder.toml",
+  "agents/lisa/confluence-prd-intake.toml",
+  "agents/lisa/debug-specialist.toml",
+  "agents/lisa/git-history-analyzer.toml",
+  "agents/lisa/github-agent.toml",
+  "agents/lisa/github-build-intake.toml",
+  "agents/lisa/github-prd-intake.toml",
+  "agents/lisa/jira-agent.toml",
+  "agents/lisa/jira-build-intake.toml",
+  "agents/lisa/learner.toml",
+  "agents/lisa/learning-judge.toml",
+  "agents/lisa/learnings-synthesizer.toml",
+  "agents/lisa/linear-agent.toml",
+  "agents/lisa/linear-build-intake.toml",
+  "agents/lisa/linear-prd-intake.toml",
+  "agents/lisa/notion-prd-intake.toml",
+  "agents/lisa/performance-specialist.toml",
+  "agents/lisa/pr-mining-specialist.toml",
+  "agents/lisa/product-specialist.toml",
+  "agents/lisa/quality-specialist.toml",
+  "agents/lisa/security-specialist.toml",
+  "agents/lisa/skill-evaluator.toml",
+  "agents/lisa/spec-conformance-specialist.toml",
+  "agents/lisa/test-specialist.toml",
+  "agents/lisa/tracker-mining-specialist.toml",
+  "agents/lisa/verification-specialist.toml",
+  "config.toml",
+] as const;
+
 afterEach(async () => {
   if (tempDir !== undefined) {
     await rm(tempDir, { recursive: true, force: true });
@@ -42,6 +74,11 @@ afterEach(async () => {
   }
 });
 
+/**
+ * Build deterministic Health evidence for setup-readiness fixtures.
+ * @param status - Status assigned to every fixture finding.
+ * @returns Stable deterministic Health result.
+ */
 function healthResult(status: "pass" | "warn" = "pass"): HealthResult {
   const checks = [
     "project.state",
@@ -79,10 +116,22 @@ function healthResult(status: "pass" | "warn" = "pass"): HealthResult {
   };
 }
 
+/**
+ * Build an unavailable probe fixture.
+ * @param reason - Stable unavailable reason.
+ * @returns Unknown probe result.
+ */
 function unknown(reason: string): ProbeResult<never> {
   return { state: "unknown", reason, message: "Unavailable fixture" };
 }
 
+/**
+ * Write one managed harness surface and its manifest.
+ * @param root - Fixture project root.
+ * @param configDir - Harness-owned configuration directory.
+ * @param files - Relative managed files to create.
+ * @returns A promise that settles after every fixture file is written.
+ */
 async function writeManagedSurface(
   root: string,
   configDir: ".codex" | ".opencode",
@@ -102,6 +151,12 @@ async function writeManagedSurface(
   );
 }
 
+/**
+ * Write the authoritative project-owned surfaces for one harness fixture.
+ * @param root - Fixture project root.
+ * @param harness - Harness whose observable surfaces should be written.
+ * @returns A promise that settles after fixture creation.
+ */
 async function writeHarnessSurfaces(
   root: string,
   harness: Harness
@@ -124,7 +179,7 @@ async function writeHarnessSurfaces(
     await writeManagedSurface(
       root,
       ".codex",
-      await expectedCodexManagedFiles(root, { harness })
+      EXPECTED_BASE_CODEX_MANAGED_FILES
     );
   }
   if (includes("copilot")) {
@@ -140,6 +195,12 @@ async function writeHarnessSurfaces(
   }
 }
 
+/**
+ * Override one deterministic Health finding in the stable fixture.
+ * @param check - Finding identifier to override.
+ * @param status - Replacement finding status.
+ * @returns Health result with the requested override.
+ */
 function healthWithStatus(
   check: string,
   status: "pass" | "warn" | "fail"
@@ -153,6 +214,11 @@ function healthWithStatus(
   };
 }
 
+/**
+ * Build a passing GitHub repository probe fixture.
+ * @param setSecrets - Repository secret names visible to the probe.
+ * @returns GitHub repository probe value.
+ */
 function githubValue(
   setSecrets: readonly string[] = []
 ): ProbeResult<GithubRepoPanelValue> {
@@ -316,6 +382,11 @@ describe("review red legs", () => {
     for (const [harness, expected] of expectations) {
       const root = path.join(tempDir, harness);
       await mkdir(root);
+      if (harness === "codex") {
+        expect(await expectedCodexManagedFiles(root, { harness })).toEqual(
+          EXPECTED_BASE_CODEX_MANAGED_FILES
+        );
+      }
       await writeHarnessSurfaces(root, harness);
       const finding = await installFinding(root, { harness }, healthResult());
       expect(finding.status, harness).toBe(expected);
@@ -666,4 +737,4 @@ describe("truthful unavailable and reversible evidence", () => {
   });
 });
 
-/* eslint-enable jsdoc/require-jsdoc, sonarjs/no-duplicate-string, max-lines -- end explicit contract fixture exceptions */
+/* eslint-enable sonarjs/no-duplicate-string, max-lines -- end explicit contract fixture exceptions */

--- a/tests/unit/cli/ui-setup-readiness.test.ts
+++ b/tests/unit/cli/ui-setup-readiness.test.ts
@@ -1,0 +1,669 @@
+/* eslint-disable jsdoc/require-jsdoc, sonarjs/no-duplicate-string, max-lines -- explicit contract fixtures favor local readability */
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { HealthResult } from "../../../src/health/contract.js";
+import type { JsonObject } from "../../../src/sync/json-path.js";
+import {
+  prdSourceFinding,
+  trackerFinding,
+} from "../../../src/cli/ui-setup-readiness-config.js";
+import {
+  agentReadyFinding,
+  readWorkflowSecretNames,
+  standardsFinding,
+} from "../../../src/cli/ui-setup-readiness-local.js";
+import {
+  expectedCodexManagedFiles,
+  installFinding,
+} from "../../../src/cli/ui-setup-readiness-install.js";
+import type { Harness } from "../../../src/core/config.js";
+import {
+  automationsFinding,
+  githubGovernanceFinding,
+  secretsFinding,
+} from "../../../src/cli/ui-setup-readiness-remote.js";
+import {
+  SETUP_READINESS_CHECKS,
+  projectSetupReadiness,
+  validateSetupReadinessResult,
+} from "../../../src/cli/ui-setup-readiness.js";
+import type { GithubRepoPanelValue } from "../../../src/cli/ui-github-repo.js";
+import type { ProbeResult } from "../../../src/cli/ui-status.js";
+
+let tempDir: string | undefined;
+
+afterEach(async () => {
+  if (tempDir !== undefined) {
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+function healthResult(status: "pass" | "warn" = "pass"): HealthResult {
+  const checks = [
+    "project.state",
+    "templates.managed",
+    "package.conformance",
+    "hooks.managed",
+    "plugins.current",
+    "config.required",
+    "config.sync",
+    "instructions.canonical",
+    "ci.workflows",
+    "github.rulesets",
+    "project.wiki",
+  ];
+  return {
+    schemaVersion: 1,
+    runId: "setup-test",
+    mode: "deterministic",
+    startedAt: "2026-07-21T12:00:00.000Z",
+    completedAt: "2026-07-21T12:00:01.000Z",
+    findings: checks.map(check => ({
+      check,
+      layer: "deterministic" as const,
+      status,
+      reason: "Stable fixture observation.",
+    })),
+    summary: {
+      verdict: "in band",
+      counts: {
+        pass: status === "pass" ? checks.length : 0,
+        warn: status === "warn" ? checks.length : 0,
+        fail: 0,
+      },
+    },
+  };
+}
+
+function unknown(reason: string): ProbeResult<never> {
+  return { state: "unknown", reason, message: "Unavailable fixture" };
+}
+
+async function writeManagedSurface(
+  root: string,
+  configDir: ".codex" | ".opencode",
+  files: readonly string[] = ["agents/lisa.md"]
+): Promise<void> {
+  await Promise.all(
+    files.map(async file => {
+      await mkdir(path.dirname(path.join(root, configDir, file)), {
+        recursive: true,
+      });
+      await writeFile(path.join(root, configDir, file), "managed\n");
+    })
+  );
+  await writeFile(
+    path.join(root, configDir, ".lisa-managed.json"),
+    JSON.stringify({ files })
+  );
+}
+
+async function writeHarnessSurfaces(
+  root: string,
+  harness: Harness
+): Promise<void> {
+  const includes = (agent: Exclude<Harness, "cursor" | "fleet">): boolean =>
+    harness === "fleet" || harness === agent;
+  if (
+    includes("claude") ||
+    includes("codex") ||
+    includes("agy") ||
+    includes("copilot") ||
+    includes("opencode")
+  ) {
+    await writeFile(path.join(root, "AGENTS.md"), "# Project agent rules\n");
+  }
+  if (includes("claude")) {
+    await writeFile(path.join(root, "CLAUDE.md"), "@AGENTS.md\n");
+  }
+  if (includes("codex")) {
+    await writeManagedSurface(
+      root,
+      ".codex",
+      await expectedCodexManagedFiles(root, { harness })
+    );
+  }
+  if (includes("copilot")) {
+    await mkdir(path.join(root, ".github"), { recursive: true });
+    await writeFile(
+      path.join(root, ".github/copilot-instructions.md"),
+      "Read AGENTS.md\n"
+    );
+  }
+  if (includes("opencode")) {
+    await writeManagedSurface(root, ".opencode");
+    await writeFile(path.join(root, "opencode.json"), "{}\n");
+  }
+}
+
+function healthWithStatus(
+  check: string,
+  status: "pass" | "warn" | "fail"
+): HealthResult {
+  const base = healthResult();
+  return {
+    ...base,
+    findings: base.findings.map(finding =>
+      finding.check === check ? { ...finding, status } : finding
+    ),
+  };
+}
+
+function githubValue(
+  setSecrets: readonly string[] = []
+): ProbeResult<GithubRepoPanelValue> {
+  return {
+    state: "value",
+    value: {
+      owner: "owner",
+      repo: "repo",
+      settings: {
+        allow_merge_commit: false,
+        allow_squash_merge: true,
+        allow_rebase_merge: false,
+        allow_auto_merge: true,
+        allow_update_branch: true,
+        delete_branch_on_merge: true,
+        merge_commit_title: "PR_TITLE",
+        has_issues: true,
+        has_wiki: false,
+        secret_scanning: true,
+        default_branch: "main",
+      },
+      rulesets: [
+        {
+          name: "main",
+          appliesTo: "default",
+          enforces: "pull_request, required_status_checks",
+          active: true,
+          targetsDefaultBranch: true,
+          requiresPullRequest: true,
+          requiresStatusChecks: true,
+        },
+      ],
+      labels: [],
+      secrets: ["DEPLOY_KEY", "SONAR_TOKEN", "SNYK_TOKEN", "FOSSA_API_KEY"].map(
+        name => ({
+          name,
+          purpose: "fixture",
+          set: setSecrets.includes(name),
+        })
+      ),
+    } as GithubRepoPanelValue,
+  };
+}
+
+describe("Setup readiness contract", () => {
+  it("returns exactly the twelve stable checklist IDs in order", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "lisa-setup-contract-"));
+
+    const result = await projectSetupReadiness(tempDir, {
+      config: {},
+      health: healthResult(),
+      github: unknown("not-authenticated"),
+      deployPipeline: unknown("not-authenticated"),
+      automations: unknown("scheduler-unavailable"),
+      expectedSecretNames: [],
+      observedAt: new Date("2026-07-21T12:00:02.000Z"),
+    });
+
+    expect(result.findings.map(finding => finding.check)).toEqual(
+      SETUP_READINESS_CHECKS
+    );
+    expect(result.findings).toHaveLength(12);
+    expect(
+      result.findings.every(finding => finding.layer === "deterministic")
+    ).toBe(true);
+  });
+
+  it("rejects missing, reordered, or extra checklist findings", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "lisa-setup-contract-"));
+    const valid = await projectSetupReadiness(tempDir, {
+      config: {},
+      health: healthResult(),
+      github: unknown("not-authenticated"),
+      deployPipeline: unknown("not-authenticated"),
+      automations: unknown("scheduler-unavailable"),
+      expectedSecretNames: [],
+      observedAt: new Date("2026-07-21T12:00:02.000Z"),
+    });
+    const reversed = [...valid.findings].reverse();
+
+    expect(() =>
+      validateSetupReadinessResult({
+        ...valid,
+        findings: valid.findings.slice(1),
+      })
+    ).toThrow(/12 entries/u);
+    expect(() =>
+      validateSetupReadinessResult({ ...valid, findings: reversed })
+    ).toThrow(/expected setup.install/u);
+    expect(() =>
+      validateSetupReadinessResult({
+        ...valid,
+        findings: [...valid.findings, valid.findings[0]],
+      })
+    ).toThrow(/12 entries/u);
+  });
+});
+
+describe("independent config readiness", () => {
+  it("reverses tracker and PRD source independently", () => {
+    const trackerOnly: JsonObject = {
+      tracker: "github",
+      github: { org: "owner", repo: "repo" },
+    };
+    const sourceOnly: JsonObject = {
+      source: "notion",
+      notion: { workspaceId: "workspace", prdDatabaseId: "database" },
+    };
+
+    expect(trackerFinding(trackerOnly).status).toBe("pass");
+    expect(prdSourceFinding(trackerOnly)).toMatchObject({
+      status: "fail",
+      check: "setup.prd-source",
+      reason: expect.stringContaining("PRD source"),
+    });
+    expect(trackerFinding(sourceOnly)).toMatchObject({
+      status: "fail",
+      check: "setup.tracker",
+    });
+    expect(prdSourceFinding(sourceOnly).status).toBe("pass");
+  });
+});
+
+describe("review red legs", () => {
+  it("requires config.required as well as config.sync", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "lisa-setup-sync-"));
+    const result = await projectSetupReadiness(tempDir, {
+      config: {},
+      health: healthWithStatus("config.required", "fail"),
+      github: unknown("not-authenticated"),
+      deployPipeline: unknown("not-authenticated"),
+      automations: unknown("scheduler-unavailable"),
+      expectedSecretNames: [],
+      observedAt: new Date("2026-07-21T12:00:02.000Z"),
+    });
+
+    expect(
+      result.findings.find(finding => finding.check === "setup.sync")
+    ).toMatchObject({ status: "fail" });
+  });
+
+  it("keeps standards explicitly non-pass without current execution proof", () => {
+    expect(standardsFinding(healthResult())).toMatchObject({
+      status: "warn",
+      reason: expect.stringContaining("lint, test, and behavior-preservation"),
+    });
+  });
+
+  it("requires only authoritative project and external evidence per harness", async () => {
+    const pluginUnavailable = healthWithStatus("plugins.current", "warn");
+    tempDir = await mkdtemp(path.join(tmpdir(), "lisa-install-harnesses-"));
+    const expectations: ReadonlyArray<readonly [Harness, "pass" | "warn"]> = [
+      ["claude", "pass"],
+      ["codex", "pass"],
+      ["cursor", "warn"],
+      ["agy", "warn"],
+      ["copilot", "warn"],
+      ["opencode", "warn"],
+      ["fleet", "warn"],
+    ];
+    for (const [harness, expected] of expectations) {
+      const root = path.join(tempDir, harness);
+      await mkdir(root);
+      await writeHarnessSurfaces(root, harness);
+      const finding = await installFinding(root, { harness }, healthResult());
+      expect(finding.status, harness).toBe(expected);
+    }
+
+    const claude = path.join(tempDir, "claude");
+    expect((await installFinding(claude, {}, pluginUnavailable)).status).toBe(
+      "warn"
+    );
+    expect((await installFinding(claude, {}, healthResult())).status).toBe(
+      "pass"
+    );
+  });
+
+  it("fails closed when managed harness evidence is missing, unsafe, or invalid", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "lisa-install-managed-"));
+    const root = path.join(tempDir, "codex");
+    await mkdir(root);
+    await writeHarnessSurfaces(root, "codex");
+    expect(
+      (await installFinding(root, { harness: "codex" }, healthResult())).status
+    ).toBe("pass");
+
+    await rm(path.join(root, ".codex/config.toml"));
+    expect(
+      (await installFinding(root, { harness: "codex" }, healthResult())).status
+    ).toBe("fail");
+
+    await writeFile(path.join(root, ".codex/config.toml"), "managed\n");
+    await writeFile(
+      path.join(root, ".codex/.lisa-managed.json"),
+      JSON.stringify({ files: ["config.toml"] })
+    );
+    expect(
+      (await installFinding(root, { harness: "codex" }, healthResult())).status
+    ).toBe("fail");
+
+    await writeFile(
+      path.join(root, ".codex/.lisa-managed.json"),
+      JSON.stringify({ files: [] })
+    );
+    expect(
+      (await installFinding(root, { harness: "codex" }, healthResult())).status
+    ).toBe("fail");
+
+    await writeFile(
+      path.join(root, ".codex/.lisa-managed.json"),
+      JSON.stringify({ files: ["../outside.md"] })
+    );
+    expect(
+      (await installFinding(root, { harness: "codex" }, healthResult())).status
+    ).toBe("fail");
+
+    await rm(path.join(root, ".codex/.lisa-managed.json"));
+    await symlink(
+      path.join(root, ".codex/config.toml"),
+      path.join(root, ".codex/.lisa-managed.json")
+    );
+    expect(
+      (await installFinding(root, { harness: "codex" }, healthResult())).status
+    ).toBe("fail");
+  });
+
+  it("keeps OpenCode non-pass and fails obvious declared-file drift", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "lisa-install-opencode-"));
+    await writeHarnessSurfaces(tempDir, "opencode");
+    expect(
+      (await installFinding(tempDir, { harness: "opencode" }, healthResult()))
+        .status
+    ).toBe("warn");
+
+    await rm(path.join(tempDir, ".opencode/agents/lisa.md"));
+    expect(
+      (await installFinding(tempDir, { harness: "opencode" }, healthResult()))
+        .status
+    ).toBe("fail");
+  });
+
+  it("does not invent a project-local Cursor surface to manufacture a pass", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "lisa-install-cursor-"));
+    const finding = await installFinding(
+      tempDir,
+      { harness: "cursor" },
+      healthResult()
+    );
+    expect(finding).toMatchObject({
+      status: "warn",
+      reason: expect.stringContaining("cannot yet be observed authoritatively"),
+    });
+  });
+
+  it("requires default-branch PR and status-check governance semantics", () => {
+    const github = githubValue(["DEPLOY_KEY"]);
+    const deploy = {
+      state: "value" as const,
+      value: {
+        stages: [
+          {
+            id: "hold:production",
+            name: "Release approval",
+            description: "Observed approval hold",
+            environment: "production",
+            active: true as const,
+            reason: "",
+          },
+        ],
+      },
+    };
+    expect(githubGovernanceFinding(healthResult(), github, deploy).status).toBe(
+      "pass"
+    );
+    if (github.state !== "value") throw new Error("Fixture must be concrete");
+    const wrongBranch = {
+      ...github,
+      value: {
+        ...github.value,
+        rulesets: github.value.rulesets.map(row => ({
+          ...row,
+          targetsDefaultBranch: false,
+        })),
+      } as GithubRepoPanelValue,
+    };
+
+    expect(
+      githubGovernanceFinding(healthResult(), wrongBranch, deploy)
+    ).toMatchObject({
+      status: "warn",
+      reason: expect.stringContaining("default-branch"),
+    });
+  });
+
+  it("requires canonical ruleset Health evidence despite plausible live data", () => {
+    const github = githubValue(["DEPLOY_KEY"]);
+    const deploy = {
+      state: "value" as const,
+      value: {
+        stages: [
+          {
+            id: "hold:production",
+            name: "Release approval",
+            description: "Observed approval hold",
+            environment: "production",
+            active: true as const,
+            reason: "",
+          },
+        ],
+      },
+    };
+
+    for (const status of ["warn", "fail"] as const) {
+      const finding = githubGovernanceFinding(
+        healthWithStatus("github.rulesets", status),
+        github,
+        deploy
+      );
+      expect(finding.status).not.toBe("pass");
+      expect(finding.reason).toContain("canonical github.rulesets");
+      expect(finding.reason).not.toContain("Stable fixture observation");
+    }
+  });
+
+  it("requires only automation entries applicable to detected stacks", () => {
+    const prefix = "lisa-auto-repo-";
+    const expected = [
+      "intake-repair",
+      "intake-prd",
+      "intake-tickets",
+      "monitor",
+      "exploratory-prds",
+    ].map(suffix => `${prefix}${suffix}`);
+    const result = {
+      state: "value" as const,
+      value: {
+        prefix,
+        runtime: "codex" as const,
+        automations: expected.map(id => ({
+          id,
+          cadence: "daily",
+          runtime: "codex",
+          status: "active",
+          lastRunAt: null,
+        })),
+      },
+    };
+
+    expect(automationsFinding(result, expected).status).toBe("pass");
+  });
+});
+
+describe("truthful unavailable and reversible evidence", () => {
+  it("never marks missing capabilities complete", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "lisa-setup-missing-"));
+    const result = await projectSetupReadiness(tempDir, {
+      config: {},
+      github: unknown("not-authenticated"),
+      deployPipeline: unknown("not-authenticated"),
+      automations: unknown("scheduler-unavailable"),
+      expectedSecretNames: [],
+      observedAt: new Date("2026-07-21T12:00:02.000Z"),
+    });
+    const status = new Map(
+      result.findings.map(finding => [finding.check, finding.status])
+    );
+
+    [
+      "setup.install",
+      "setup.agent-ready",
+      "setup.tracker",
+      "setup.prd-source",
+      "setup.github-governance",
+      "setup.secrets",
+      "setup.automations",
+      "setup.exploration",
+      "setup.wiki",
+      "setup.starter-provenance",
+    ].forEach(check => expect(status.get(check)).not.toBe("pass"));
+  });
+
+  it("moves agent-ready pending to pass and back from its own files", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "lisa-agent-ready-"));
+    expect((await agentReadyFinding(tempDir)).status).toBe("warn");
+    await mkdir(path.join(tempDir, "wiki/state/agent-ready"), {
+      recursive: true,
+    });
+    await mkdir(path.join(tempDir, "wiki/sources/repository"), {
+      recursive: true,
+    });
+    await writeFile(
+      path.join(tempDir, "wiki/sources/repository/source.md"),
+      "# Sanitized source\n"
+    );
+    await writeFile(
+      path.join(tempDir, "wiki/state/agent-ready/sources.json"),
+      JSON.stringify({
+        schema_version: 1,
+        updated_at: "2026-07-21T12:00:00.000Z",
+        sources: [
+          {
+            source_id: "repository",
+            scope: "local repository and full git history",
+            read_only_probe: {
+              command: "git log --all",
+              observed: "history read successfully",
+            },
+            terminal_status: "complete",
+            sanitized_evidence: ["wiki/sources/repository/source.md"],
+            open_gap: null,
+          },
+        ],
+      })
+    );
+    await writeFile(path.join(tempDir, "wiki/gaps.md"), "# Gaps\n\nNone.\n");
+    expect((await agentReadyFinding(tempDir)).status).toBe("pass");
+
+    await writeFile(
+      path.join(tempDir, "wiki/gaps.md"),
+      "### missing-owner\n- **Status**: open\n"
+    );
+    expect((await agentReadyFinding(tempDir)).status).toBe("warn");
+
+    await rm(path.join(tempDir, "wiki/sources/repository/source.md"));
+    expect((await agentReadyFinding(tempDir)).status).toBe("fail");
+  });
+
+  it("rejects traversal outside wiki/sources even when the target is a file", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "lisa-agent-ready-traversal-"));
+    await mkdir(path.join(tempDir, "wiki/state/agent-ready"), {
+      recursive: true,
+    });
+    await writeFile(path.join(tempDir, "package.json"), "{}\n");
+    await writeFile(path.join(tempDir, "wiki/gaps.md"), "# Gaps\n\nNone.\n");
+    await writeFile(
+      path.join(tempDir, "wiki/state/agent-ready/sources.json"),
+      JSON.stringify({
+        schema_version: 1,
+        updated_at: "2026-07-21T12:00:00.000Z",
+        sources: [
+          {
+            source_id: "repository",
+            scope: "local repository",
+            read_only_probe: { command: "git log", observed: "read" },
+            terminal_status: "complete",
+            sanitized_evidence: ["wiki/../package.json"],
+            open_gap: null,
+          },
+        ],
+      })
+    );
+
+    expect(await agentReadyFinding(tempDir)).toMatchObject({ status: "fail" });
+  });
+
+  it("rejects a wiki/sources evidence symlink to another file", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "lisa-agent-ready-symlink-"));
+    await mkdir(path.join(tempDir, "wiki/state/agent-ready"), {
+      recursive: true,
+    });
+    await mkdir(path.join(tempDir, "wiki/sources/repository"), {
+      recursive: true,
+    });
+    await writeFile(path.join(tempDir, "package.json"), "{}\n");
+    await symlink(
+      path.join(tempDir, "package.json"),
+      path.join(tempDir, "wiki/sources/repository/source.md")
+    );
+    await writeFile(path.join(tempDir, "wiki/gaps.md"), "# Gaps\n\nNone.\n");
+    await writeFile(
+      path.join(tempDir, "wiki/state/agent-ready/sources.json"),
+      JSON.stringify({
+        schema_version: 1,
+        updated_at: "2026-07-21T12:00:00.000Z",
+        sources: [
+          {
+            source_id: "repository",
+            scope: "local repository",
+            read_only_probe: { command: "git log", observed: "read" },
+            terminal_status: "complete",
+            sanitized_evidence: ["wiki/sources/repository/source.md"],
+            open_gap: null,
+          },
+        ],
+      })
+    );
+
+    expect(await agentReadyFinding(tempDir)).toMatchObject({ status: "fail" });
+  });
+
+  it("requires only workflow-established secret names and never values", () => {
+    const finding = secretsFinding(githubValue(["SONAR_TOKEN"]), [
+      "SONAR_TOKEN",
+    ]);
+
+    expect(finding.status).toBe("pass");
+    expect(finding.reason).not.toContain("SNYK_TOKEN");
+    expect(finding.reason).not.toContain("FOSSA_API_KEY");
+    expect(JSON.stringify(finding)).not.toContain("sensitive-value");
+  });
+
+  it("derives secret names from workflows and excludes implicit GITHUB_TOKEN", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "lisa-workflow-secrets-"));
+    await mkdir(path.join(tempDir, ".github/workflows"), { recursive: true });
+    await writeFile(
+      path.join(tempDir, ".github/workflows/ci.yml"),
+      "env:\n  BUILTIN: ${{ secrets.GITHUB_TOKEN }}\n  SONAR: ${{ secrets.SONAR_TOKEN }}\n"
+    );
+
+    expect(await readWorkflowSecretNames(tempDir)).toEqual(["SONAR_TOKEN"]);
+  });
+});
+
+/* eslint-enable jsdoc/require-jsdoc, sonarjs/no-duplicate-string, max-lines -- end explicit contract fixture exceptions */

--- a/tests/unit/strategies/automation-status-codex-adapter-confinement.test.ts
+++ b/tests/unit/strategies/automation-status-codex-adapter-confinement.test.ts
@@ -1,0 +1,134 @@
+/** Scheduler confinement regressions for the authoritative Codex adapter. */
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { listCodexAutomations } from "../../../plugins/src/base/scripts/automation-status-codex-adapter.mjs";
+
+const AUTOMATION_PREFIX = "lisa-auto-confined-repo-";
+const AUTOMATION_ID = `${AUTOMATION_PREFIX}intake-tickets`;
+const AUTOMATION_TOML = "automation.toml";
+const AUTOMATION_MEMORY = "memory.md";
+const roots: string[] = [];
+
+/**
+ * Create a disposable scheduler fixture root.
+ * @returns Created fixture root
+ */
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "lisa-codex-confined-"));
+  roots.push(root);
+  return root;
+}
+
+/**
+ * Return the minimal valid TOML consumed by the adapter.
+ * @returns Valid automation contract
+ */
+function automationToml(): string {
+  return [
+    "version = 1",
+    `id = "${AUTOMATION_ID}"`,
+    'kind = "cron"',
+    'status = "ACTIVE"',
+    'rrule = "FREQ=HOURLY;INTERVAL=1"',
+    'prompt = "Use the Lisa intake skill."',
+    "",
+  ].join("\n");
+}
+
+/**
+ * Create one matching scheduler directory and return it.
+ * @param root - Scheduler root
+ * @returns Created automation directory
+ */
+async function automationDirectory(root: string): Promise<string> {
+  const directory = path.join(root, AUTOMATION_ID);
+  await mkdir(directory);
+  return directory;
+}
+
+/**
+ * List the matching fixture through the authoritative adapter.
+ * @param root - Scheduler root
+ * @returns Adapter result
+ */
+async function listFixture(root: string): Promise<unknown> {
+  return await listCodexAutomations({
+    automationsDir: root,
+    automationPrefix: AUTOMATION_PREFIX,
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map(root => rm(root, { recursive: true, force: true }))
+  );
+});
+
+describe("Codex scheduler adapter confinement", () => {
+  it("rejects an external automation.toml symlink", async () => {
+    const root = await temporaryRoot();
+    const outside = await temporaryRoot();
+    const directory = await automationDirectory(root);
+    const target = path.join(outside, AUTOMATION_TOML);
+    await writeFile(target, automationToml());
+    await symlink(target, path.join(directory, AUTOMATION_TOML));
+
+    await expect(listFixture(root)).rejects.toThrow(
+      /Unsafe Codex scheduler file/u
+    );
+  });
+
+  it("rejects a memory FIFO without opening or blocking on it", async () => {
+    const root = await temporaryRoot();
+    const directory = await automationDirectory(root);
+    await writeFile(path.join(directory, AUTOMATION_TOML), automationToml());
+    execFileSync("/usr/bin/mkfifo", [path.join(directory, AUTOMATION_MEMORY)]);
+
+    await expect(listFixture(root)).rejects.toThrow(
+      /Unsafe Codex scheduler file/u
+    );
+  });
+
+  it.each([
+    [AUTOMATION_TOML, 256 * 1024 + 1],
+    [AUTOMATION_MEMORY, 512 * 1024 + 1],
+  ])("rejects oversized %s evidence", async (filename, size) => {
+    const root = await temporaryRoot();
+    const directory = await automationDirectory(root);
+    if (filename === AUTOMATION_MEMORY) {
+      await writeFile(path.join(directory, AUTOMATION_TOML), automationToml());
+    }
+    await writeFile(path.join(directory, filename), "x".repeat(size));
+
+    await expect(listFixture(root)).rejects.toThrow(/exceeds size limit/u);
+  });
+
+  it("bounds total scheduler directory enumeration", async () => {
+    const root = await temporaryRoot();
+    await Promise.all(
+      Array.from({ length: 1_001 }, (_value, index) =>
+        writeFile(path.join(root, `unrelated-${index}`), "")
+      )
+    );
+
+    await expect(listFixture(root)).rejects.toThrow(/entry limit/u);
+  });
+
+  it("honors an already-aborted request before opening scheduler resources", async () => {
+    const root = await temporaryRoot();
+    const controller = new AbortController();
+    controller.abort(new Error("request cancelled"));
+
+    await expect(
+      listCodexAutomations({
+        automationsDir: root,
+        automationPrefix: AUTOMATION_PREFIX,
+        signal: controller.signal,
+      })
+    ).rejects.toThrow("request cancelled");
+  });
+});

--- a/ui/index.html
+++ b/ui/index.html
@@ -1523,7 +1523,7 @@
             items: [
               {
                 label: "Install Lisa and apply templates",
-                desc: "Detects the project’s stacks, applies their templates, installs plugins and git hooks.",
+                desc: "Detects the project’s stacks, applies project-owned templates, agent surfaces, and git hooks. External plugin/runtime installation is reported separately and never inferred from project files.",
                 command: "bun add -d @codyswann/lisa && bunx lisa",
                 done: true,
               },


### PR DESCRIPTION
## Summary

- expose the strict twelve-finding setup-readiness projection through the loopback Lisa UI endpoint
- confine local project and scheduler evidence reads with bounded, no-follow, cancellation-aware adapters
- keep external harness state and standards freshness truthfully non-pass until authoritative proof exists
- preserve Claude, Codex, Cursor, OpenCode, Antigravity, and Copilot parity where their surfaces can represent the behavior

## Verification

- 6,902 unit tests passed with coverage
- 140 integration tests passed
- Bun-native scheduler suites: 14 passed
- focused readiness/confinement tests: 32 passed
- lint: 0 warnings, 0 errors
- typecheck, slow lint, formatting, build, security audit, dead-code, manifest, rule-pairing, workflow-input, learnings, and learner-frontmatter checks passed
- independent implementation review: APPROVE

Work-Item: CodySwannGT/lisa#1892

Closes #1892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setup-readiness view available through the UI, covering configuration, installation, health, governance, secrets, automations, documentation, and provenance checks.
  * Added detection of project stacks and expected automation entries.
  * Repository ruleset details now show default-branch targeting, pull-request requirements, and status-check requirements.
* **Bug Fixes**
  * Improved resilience and safety when reading project, workflow, and automation data, including protection against unsafe files, path escapes, oversized content, and stalled reads.
  * Automation inspections can now be cancelled promptly.
* **Documentation**
  * Clarified setup checklist messaging about project templates, agents, hooks, and external runtime installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->