### PR TITLE
fix(ci): prevent package-manager template injection

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -568,12 +568,14 @@ jobs:
 
       - name: 📦 Install dependencies
         if: steps.check_script.outputs.exists == 'true'
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package_manager }}
         run: |
-          if [ "${{ inputs.package_manager }}" = "npm" ]; then
+          if [ "$PACKAGE_MANAGER" = "npm" ]; then
             npm ci
-          elif [ "${{ inputs.package_manager }}" = "yarn" ]; then
+          elif [ "$PACKAGE_MANAGER" = "yarn" ]; then
             yarn install --frozen-lockfile
-          elif [ "${{ inputs.package_manager }}" = "bun" ]; then
+          elif [ "$PACKAGE_MANAGER" = "bun" ]; then
             bun install --frozen-lockfile
           fi
         working-directory: ${{ inputs.working_directory || '.' }}

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -330,6 +330,11 @@ describe("quality.yml reusable workflow", () => {
 
       const install = steps[installIndex];
       expect(install?.if).toBe("steps.check_script.outputs.exists == 'true'");
+      expect(install?.env?.PACKAGE_MANAGER).toBe(
+        "${{ inputs.package_manager }}"
+      );
+      expect(install?.run).not.toContain("${{ inputs.package_manager }}");
+      expect(install?.run).toContain('$PACKAGE_MANAGER" = "npm"');
       expect(install?.run).toContain("npm ci");
       expect(install?.run).toContain("yarn install --frozen-lockfile");
       expect(install?.run).toContain("bun install --frozen-lockfile");

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -334,8 +334,9 @@ describe("quality.yml reusable workflow", () => {
         "${{ inputs.package_manager }}"
       );
       expect(install?.run).not.toContain("${{ inputs.package_manager }}");
-      expect(install?.run).toContain('$PACKAGE_MANAGER" = "npm"');
-      expect(install?.run).toContain("npm ci");
+      expect(install?.run).toMatch(
+        /if \[\s*"\$PACKAGE_MANAGER"\s*=\s*"npm"\s*\]; then[\s\S]*npm ci/
+      );
       expect(install?.run).toContain("yarn install --frozen-lockfile");
       expect(install?.run).toContain("bun install --frozen-lockfile");
       expect(install?.["working-directory"]).toBe(


### PR DESCRIPTION
## Summary

- pass `inputs.package_manager` into the dependency-install step through `env`
- compare only `$PACKAGE_MANAGER` inside the shell body
- assert the run script contains no direct workflow-input interpolation

This addresses CodeRabbit's valid security finding on #1907, which auto-merged before the follow-up commit reached the branch.

## Verification

- focused parsed workflow contract: 40/40
- full suite: 398 files / 6,942 tests
- integration suite: 10 files / 141 tests
- typecheck, lint, formatting, actionlint (without shellcheck subprocess), knip, and security audit passed

Closes #1906

Work-Item: CodySwannGT/lisa#1906

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency installation across supported package managers in the end-to-end coverage workflow.
  * Ensured package manager selection is handled reliably without direct input interpolation.

* **Tests**
  * Expanded workflow validation to confirm the selected package manager is passed and used correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->