### PR TITLE
feat(doctor): bridge agent readiness scorer to CLI findings, closing #1902

### DIFF
--- a/plugins/lisa-agy/scripts/doctor-report.mjs
+++ b/plugins/lisa-agy/scripts/doctor-report.mjs
@@ -6,7 +6,7 @@
  * repo adds real readiness probes. Keep this file dependency-free so future
  * doctor scripts can reuse it from plugin distributions and downstream repos.
  */
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
@@ -121,9 +121,12 @@ export function createPluginSyncDoctorGroup(root = process.cwd()) {
 /**
  * The eight repository-readiness ownership dimensions, in fixed render order,
  * defined once by the `readiness-rubric` rule. This group consumes that rubric;
- * it does not redefine the vocabulary. Evidence gathering for each dimension is
- * wired by later PRD #1739 tickets, so every dimension renders `SKIP` with a
- * reason here — reported, never silently omitted, per the shipped contract.
+ * it does not redefine the vocabulary. Evidence gathering lives in the
+ * TypeScript CLI producers, which persist the authoritative per-dimension
+ * result to `.lisa/readiness.json`; this surface projects that result. When no
+ * usable report is on disk, each dimension renders `SKIP` carrying the reason
+ * it was not assessed — reported, never silently omitted, per the shipped
+ * contract.
  * @type {readonly { id: string, question: string, skipReason: string }[]}
  */
 const REPOSITORY_READINESS_DIMENSIONS = [
@@ -132,81 +135,222 @@ const REPOSITORY_READINESS_DIMENSIONS = [
     question:
       "Can an agent recover the real job from what is written down (integration-access-layer, wiki-knowledge-source, config-resolution)?",
     skipReason:
-      "Context/routing evidence is assessed by the agent-ready wiring (RRR-4, #1856); no readiness probe is wired in this Lisa version.",
+      "Context/routing evidence is assessed by the agent-ready wiring (RRR-4, #1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "capabilities-tools",
     question:
       "Is every tool the work needs provably reachable, not merely installed (tool-access-gate)?",
     skipReason:
-      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "domain-ownership",
     question:
       "Are the business rules, glossary, and danger zones owned and written down (agent-ready domain phase wiki pages)?",
     skipReason:
-      "Domain-ownership evidence sources from agent-ready's danger-zone wiki pages, read by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+      "Domain-ownership evidence sources from agent-ready's danger-zone wiki pages, read by RRR-4 (#1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "execution-proof",
     question:
       "Can the claimed user-visible outcome be proved by running the system (verification, empirical-inquiry, claim-evidence-mapping)?",
     skipReason:
-      "Execution/proof consumes qualification evidence and representative journeys wired by RRR-6 (#1858); no readiness probe is wired in this Lisa version.",
+      "Execution/proof consumes qualification evidence and representative journeys wired by RRR-6 (#1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "feedback-guardrails",
     question:
       "Does a failing loop produce a named outcome and a runbook (automation-runbook-contract, observability-audit)?",
     skipReason:
-      "Feedback/guardrails evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+      "Feedback/guardrails evidence is assessed by RRR-4 (#1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "dependencies-supply-chain",
     question:
       "Is there a confidence model for what the repo depends on (security-audit-handling)?",
     skipReason:
-      "Dependencies/supply-chain evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+      "Dependencies/supply-chain evidence is assessed by RRR-4 (#1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "delivery-authority",
     question:
       "Does the thing that ships equal the thing that was validated, and does the shipping credential carry only the authority it needs (claim-archaeology, security-audit-handling)?",
     skipReason:
-      "Delivery/authority blockers are populated by the blocker gate in RRR-5 (#1857); no readiness probe is wired in this Lisa version.",
+      "Delivery/authority blockers are populated by the blocker gate in RRR-5 (#1857); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "proportionality",
     question:
       "Is the machinery proportional to the job, or is there scaffolding to subtract (repo-scope-split, #1742 subtraction candidates)?",
     skipReason:
-      "Proportionality reuses the scaffolding-subtraction candidates surfaced by the journey work (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+      "Proportionality reuses the scaffolding-subtraction candidates surfaced by the journey work (RRR-6, #1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
 ];
+
+/**
+ * `schema_version` this surface knows how to project. A report stamped with any
+ * other version is treated as unreadable rather than guessed at: the whole point
+ * of the version stamp is that a reader may not invent a mapping it was never
+ * told about.
+ */
+const READINESS_REPORT_SCHEMA_VERSION = 1;
+
+/**
+ * Longest operator-facing summary projected out of a CLI finding. Findings can
+ * carry kilobytes of concatenated evidence (every offending workflow job, for
+ * example); the doctor line is a headline, and the full text stays available in
+ * `.lisa/readiness.json`.
+ */
+const READINESS_SUMMARY_MAX_LENGTH = 320;
+
+/**
+ * Resolve the single location the CLI writes the readiness report to. This
+ * mirrors the CLI's `resolveReadinessReportPath` so relocating the artifact
+ * stays a two-line change across both scorers.
+ * @param {string} repoRoot
+ * @returns {string}
+ */
+function resolveReadinessReportPath(repoRoot) {
+  return path.join(repoRoot, ".lisa", "readiness.json");
+}
+
+/**
+ * Read the CLI-authored readiness report, or `null` when there is nothing
+ * trustworthy to project. Absence, unparseable JSON, an unknown
+ * `schema_version`, and a missing `dimensions` array are all the same answer —
+ * "the CLI readiness pass has not produced a result this surface can read" —
+ * and none of them is evidence about the repository itself.
+ * @param {string} repoRoot
+ * @returns {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] } | null}
+ */
+function readReadinessReport(repoRoot) {
+  const reportPath = resolveReadinessReportPath(repoRoot);
+  if (!existsSync(reportPath)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(reportPath, "utf8"));
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      parsed.schema_version !== READINESS_REPORT_SCHEMA_VERSION ||
+      !Array.isArray(parsed.dimensions)
+    ) {
+      return null;
+    }
+    return {
+      dimensions: parsed.dimensions,
+      blockers: Array.isArray(parsed.blockers) ? parsed.blockers : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pull the operator-facing sentence out of a dimension's findings. The CLI
+ * producers write human text under `evidence` (an assessed dimension) or
+ * `reason` (a deliberately-unassessed one); the rest of the finding is machine
+ * bookkeeping the blocker engine owns.
+ * @param {readonly unknown[]} findings
+ * @returns {string}
+ */
+function summarizeReadinessFindings(findings) {
+  const sentences = findings
+    .filter(finding => finding !== null && typeof finding === "object")
+    .flatMap(finding => [finding.evidence, finding.reason])
+    .filter(text => typeof text === "string" && text.trim().length > 0)
+    .map(text => text.trim());
+  if (sentences.length === 0) {
+    return "";
+  }
+  const joined = sentences.join(" ");
+  return joined.length > READINESS_SUMMARY_MAX_LENGTH
+    ? `${joined.slice(0, READINESS_SUMMARY_MAX_LENGTH - 1).trimEnd()}…`
+    : joined;
+}
+
+/**
+ * Project one CLI dimension record into this surface's check shape, or `null`
+ * when the record is absent or carries a status outside the shipped vocabulary
+ * (the caller then falls back to the reasoned SKIP).
+ * @param {{ id: string, question: string, skipReason: string }} dimension
+ * @param {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] }} report
+ * @returns {DoctorCheck | null}
+ */
+function projectReadinessDimension(dimension, report) {
+  const record = report.dimensions.find(
+    entry =>
+      entry !== null && typeof entry === "object" && entry.id === dimension.id
+  );
+  if (!record || !DOCTOR_STATUSES.includes(record.status)) {
+    return null;
+  }
+  const findings = Array.isArray(record.findings) ? record.findings : [];
+  const summary = summarizeReadinessFindings(findings);
+  const blockerIds = report.blockers
+    .filter(
+      blocker =>
+        blocker !== null &&
+        typeof blocker === "object" &&
+        (blocker.dimension_id === dimension.id ||
+          (Array.isArray(blocker.owning_dimensions) &&
+            blocker.owning_dimensions.includes(dimension.id)))
+    )
+    .map(blocker => String(blocker.id))
+    .filter((id, index, ids) => ids.indexOf(id) === index);
+
+  return {
+    id: dimension.id,
+    status: record.status,
+    summary: summary.length > 0 ? summary : dimension.question,
+    observed: `${dimension.question} Projected from \`.lisa/readiness.json\` (schema_version ${READINESS_REPORT_SCHEMA_VERSION}), the report the Lisa CLI readiness pass wrote.`,
+    ...(blockerIds.length > 0
+      ? {
+          remediation: `Standing ship blocker(s): ${blockerIds.join(", ")}. See \`.lisa/readiness.json\` for the full evidence and the \`readiness-rubric\` rule for the blocker definitions.`,
+        }
+      : {}),
+  };
+}
 
 /**
  * Build the orthogonal "Repository readiness" doctor group ("may an agent fleet
  * operate here unattended?"), scored against the eight `readiness-rubric`
  * ownership dimensions. It is separate from the installation-readiness groups
  * and is appended in a fixed position by the readiness-mode caller; the eight
- * dimension checks render in fixed order. In this Lisa version every dimension
- * is `SKIP` with a stated reason because the evidence-gathering surfaces ship
- * with later PRD #1739 tickets — reported, never silently omitted.
+ * dimension checks render in fixed order.
+ *
+ * The blocker engine and the evidence producers live in the TypeScript CLI,
+ * which is the single source of truth; this surface is a bridge, not a second
+ * implementation (#1902). It projects whatever the CLI persisted to
+ * `.lisa/readiness.json` so an operator running `/lisa:doctor` through any
+ * coding agent gets the same readiness answer the CLI gives. When no usable
+ * report exists, every unmatched dimension renders `SKIP` with its reason:
+ * absence means the readiness pass has not run, never that the repository is
+ * clean, so a pass or fail is never manufactured from it.
  * @param {string} root
  * @returns {DoctorGroup}
  */
 export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
-  void path.resolve(root);
+  const report = readReadinessReport(path.resolve(root));
   return {
     id: "repository-readiness",
     title: "Repository readiness",
-    checks: REPOSITORY_READINESS_DIMENSIONS.map(dimension => ({
-      id: dimension.id,
-      status: "SKIP",
-      summary: dimension.question,
-      observed: dimension.skipReason,
-    })),
+    checks: REPOSITORY_READINESS_DIMENSIONS.map(
+      dimension =>
+        (report === null
+          ? null
+          : projectReadinessDimension(dimension, report)) ?? {
+          id: dimension.id,
+          status: "SKIP",
+          summary: dimension.question,
+          observed:
+            report === null
+              ? dimension.skipReason
+              : `${dimension.question} \`.lisa/readiness.json\` carries no usable record for this dimension, so it was not assessed here. Re-run \`lisa doctor --offline --readiness\` to regenerate the report.`,
+        }
+    ),
   };
 }
 

--- a/plugins/lisa-agy/scripts/doctor-report.mjs
+++ b/plugins/lisa-agy/scripts/doctor-report.mjs
@@ -321,9 +321,37 @@ function applyNotEstablishedCaveat(check, checks) {
 }
 
 /**
- * Collect the ids of the standing ship blockers a dimension owns. Blockers with
- * no usable id are dropped rather than stringified, so a malformed record can
- * never render "Standing ship blocker(s): undefined" at an operator.
+ * Decide whether a standing blocker was evidenced in this dimension.
+ *
+ * `dimension_id` is the authority: the CLI's `buildDetectedBlocker` documents it
+ * as "the dimension the evidencing finding was found in". `owning_dimensions` is
+ * the blocker's static spec and can name dimensions that did NOT evidence it —
+ * B4 is specced as `[domain-ownership, feedback-guardrails]` while only the
+ * guardrails producer ever emits the B4 finding. Escalating on the spec would
+ * stamp `FAIL` on a dimension whose own recorded evidence says it found nothing,
+ * contradicting both that evidence and the CLI's per-dimension result. The spec
+ * is used only as a fallback, for a blocker record carrying no attribution.
+ * @param {Record<string, unknown>} blocker
+ * @param {{ id: string }} dimension
+ * @returns {boolean}
+ */
+function blockerEvidencedIn(blocker, dimension) {
+  if (
+    typeof blocker.dimension_id === "string" &&
+    blocker.dimension_id.length > 0
+  ) {
+    return blocker.dimension_id === dimension.id;
+  }
+  return (
+    Array.isArray(blocker.owning_dimensions) &&
+    blocker.owning_dimensions.includes(dimension.id)
+  );
+}
+
+/**
+ * Collect the ids of the standing ship blockers evidenced in a dimension.
+ * Blockers with no usable id are dropped rather than stringified, so a malformed
+ * record can never render "Standing ship blocker(s): undefined" at an operator.
  * @param {{ id: string }} dimension
  * @param {{ blockers: readonly Record<string, unknown>[] }} report
  * @returns {readonly string[]}
@@ -334,9 +362,7 @@ function standingBlockerIds(dimension, report) {
       blocker =>
         blocker !== null &&
         typeof blocker === "object" &&
-        (blocker.dimension_id === dimension.id ||
-          (Array.isArray(blocker.owning_dimensions) &&
-            blocker.owning_dimensions.includes(dimension.id)))
+        blockerEvidencedIn(blocker, dimension)
     )
     .map(blocker => blocker.id)
     .filter(id => typeof id === "string" && id.length > 0)

--- a/plugins/lisa-agy/scripts/doctor-report.mjs
+++ b/plugins/lisa-agy/scripts/doctor-report.mjs
@@ -142,7 +142,7 @@ const REPOSITORY_READINESS_DIMENSIONS = [
     question:
       "Is every tool the work needs provably reachable, not merely installed (tool-access-gate)?",
     skipReason:
-      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
+      "Tool reachability needs a live read-only probe and can never be established from an offline read: the `tool-access-gate` rule names presence — a binary on `PATH`, a dependency in a manifest, a configured MCP server — as the anti-pattern, because it proves a tool was declared, never that a request through it succeeded. This dimension is therefore a deliberate, permanent reasoned SKIP on an offline pass rather than a not-yet-wired one; only a run that actually exercises the tools can answer it.",
   },
   {
     id: "domain-ownership",
@@ -222,7 +222,7 @@ function resolveReadinessReportPath(repoRoot) {
  * "the CLI readiness pass has not produced a result this surface can read" —
  * and none of them is evidence about the repository itself.
  * @param {string} repoRoot
- * @returns {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] } | null}
+ * @returns {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[], narrowedClaim: string, provenance: string } | null}
  */
 function readReadinessReport(repoRoot) {
   const reportPath = resolveReadinessReportPath(repoRoot);
@@ -242,6 +242,15 @@ function readReadinessReport(repoRoot) {
     return {
       dimensions: parsed.dimensions,
       blockers: Array.isArray(parsed.blockers) ? parsed.blockers : [],
+      // The narrowed claim is the sentence `readiness-rubric` requires whenever
+      // a blocker stands ("...IS ready for supervised, single-ticket agent
+      // work..."). Dropping it would hand the agent operator a bare NOT_READY
+      // where the CLI hands them the fallback they can actually act on.
+      narrowedClaim:
+        typeof parsed.narrowed_claim === "string" ? parsed.narrowed_claim : "",
+      // Stamped into every projected check so a months-old report cannot read
+      // as current truth: this surface reflects a file, not a live assessment.
+      provenance: describeReportProvenance(parsed),
     };
   } catch {
     return null;
@@ -249,17 +258,36 @@ function readReadinessReport(repoRoot) {
 }
 
 /**
+ * Describe when the projected report was produced and by which Lisa version.
+ * @param {Record<string, unknown>} parsed
+ * @returns {string}
+ */
+function describeReportProvenance(parsed) {
+  const generatedAt =
+    typeof parsed.generated_at === "string" && parsed.generated_at.length > 0
+      ? parsed.generated_at
+      : "an unrecorded time";
+  const version =
+    typeof parsed.lisa_version === "string" && parsed.lisa_version.length > 0
+      ? ` by Lisa ${parsed.lisa_version}`
+      : "";
+  return `generated ${generatedAt}${version}`;
+}
+
+/**
  * Pull the operator-facing sentence out of a dimension's findings. The CLI
- * producers write human text under `evidence` (an assessed dimension) or
- * `reason` (a deliberately-unassessed one); the rest of the finding is machine
- * bookkeeping the blocker engine owns.
+ * producers write human text under `evidence` (an assessed dimension),
+ * `reason` (a deliberately-unassessed one), or `observation` (a neutral note);
+ * the rest of the finding is machine bookkeeping the blocker engine owns.
+ * Reading only two of the three would print the dimension's question under a
+ * FAIL, which reads as "nothing to report" exactly when there is most to say.
  * @param {readonly unknown[]} findings
  * @returns {string}
  */
 function summarizeReadinessFindings(findings) {
   const sentences = findings
     .filter(finding => finding !== null && typeof finding === "object")
-    .flatMap(finding => [finding.evidence, finding.reason])
+    .flatMap(finding => [finding.evidence, finding.reason, finding.observation])
     .filter(text => typeof text === "string" && text.trim().length > 0)
     .map(text => text.trim());
   if (sentences.length === 0) {
@@ -272,11 +300,55 @@ function summarizeReadinessFindings(findings) {
 }
 
 /**
+ * Carry the CLI's not-established caveat onto every unassessed dimension. The
+ * CLI headline says it out loud — "N of 8 dimensions were never assessed, so
+ * this cannot say whether an unattended fleet may operate here" — and a reader
+ * who sees a lone `SKIP` line without it can mistake silence for a clean bill
+ * of health on that dimension.
+ * @param {DoctorCheck} check
+ * @param {readonly DoctorCheck[]} checks
+ * @returns {DoctorCheck}
+ */
+function applyNotEstablishedCaveat(check, checks) {
+  const unassessed = checks.filter(entry => entry.status === "SKIP").length;
+  if (check.status !== "SKIP" || unassessed === 0) {
+    return check;
+  }
+  return {
+    ...check,
+    observed: `${check.observed} NOT ESTABLISHED: ${unassessed} of ${checks.length} dimensions were never assessed, so this cannot say whether an unattended fleet may operate here.`,
+  };
+}
+
+/**
+ * Collect the ids of the standing ship blockers a dimension owns. Blockers with
+ * no usable id are dropped rather than stringified, so a malformed record can
+ * never render "Standing ship blocker(s): undefined" at an operator.
+ * @param {{ id: string }} dimension
+ * @param {{ blockers: readonly Record<string, unknown>[] }} report
+ * @returns {readonly string[]}
+ */
+function standingBlockerIds(dimension, report) {
+  return report.blockers
+    .filter(
+      blocker =>
+        blocker !== null &&
+        typeof blocker === "object" &&
+        (blocker.dimension_id === dimension.id ||
+          (Array.isArray(blocker.owning_dimensions) &&
+            blocker.owning_dimensions.includes(dimension.id)))
+    )
+    .map(blocker => blocker.id)
+    .filter(id => typeof id === "string" && id.length > 0)
+    .filter((id, index, ids) => ids.indexOf(id) === index);
+}
+
+/**
  * Project one CLI dimension record into this surface's check shape, or `null`
  * when the record is absent or carries a status outside the shipped vocabulary
  * (the caller then falls back to the reasoned SKIP).
  * @param {{ id: string, question: string, skipReason: string }} dimension
- * @param {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] }} report
+ * @param {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[], narrowedClaim: string, provenance: string }} report
  * @returns {DoctorCheck | null}
  */
 function projectReadinessDimension(dimension, report) {
@@ -289,26 +361,27 @@ function projectReadinessDimension(dimension, report) {
   }
   const findings = Array.isArray(record.findings) ? record.findings : [];
   const summary = summarizeReadinessFindings(findings);
-  const blockerIds = report.blockers
-    .filter(
-      blocker =>
-        blocker !== null &&
-        typeof blocker === "object" &&
-        (blocker.dimension_id === dimension.id ||
-          (Array.isArray(blocker.owning_dimensions) &&
-            blocker.owning_dimensions.includes(dimension.id)))
-    )
-    .map(blocker => String(blocker.id))
-    .filter((id, index, ids) => ids.indexOf(id) === index);
+  const blockerIds = standingBlockerIds(dimension, report);
 
   return {
     id: dimension.id,
-    status: record.status,
+    // A standing blocker outranks the recorded label. Three CLI producers (B1
+    // domain-ownership, B4 feedback-guardrails, B6 context-routing) record
+    // `WARN` while standing a blocker, each stating in-line that "the blocker
+    // engine never reads this status, so the finding flips the repository to
+    // NOT_READY exactly as a FAIL would". Projecting that `WARN` verbatim would
+    // score READY_WITH_WARNINGS on a repository the CLI calls NOT_READY — the
+    // precise disagreement this bridge exists to eliminate. This still reflects
+    // the CLI's decision rather than re-scoring: the CLI decided the blocker
+    // stands and wrote it into `blockers[]`.
+    status: blockerIds.length > 0 ? "FAIL" : record.status,
     summary: summary.length > 0 ? summary : dimension.question,
-    observed: `${dimension.question} Projected from \`.lisa/readiness.json\` (schema_version ${READINESS_REPORT_SCHEMA_VERSION}), the report the Lisa CLI readiness pass wrote.`,
+    observed: `${dimension.question} Projected from \`.lisa/readiness.json\` (schema_version ${READINESS_REPORT_SCHEMA_VERSION}, ${report.provenance}), the report the Lisa CLI readiness pass wrote.`,
     ...(blockerIds.length > 0
       ? {
-          remediation: `Standing ship blocker(s): ${blockerIds.join(", ")}. See \`.lisa/readiness.json\` for the full evidence and the \`readiness-rubric\` rule for the blocker definitions.`,
+          remediation:
+            `Standing ship blocker(s): ${blockerIds.join(", ")}. See \`.lisa/readiness.json\` for the full evidence and the \`readiness-rubric\` rule for the blocker definitions.` +
+            (report.narrowedClaim.length > 0 ? ` ${report.narrowedClaim}` : ""),
         }
       : {}),
   };
@@ -334,23 +407,24 @@ function projectReadinessDimension(dimension, report) {
  */
 export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
   const report = readReadinessReport(path.resolve(root));
+  const checks = REPOSITORY_READINESS_DIMENSIONS.map(
+    dimension =>
+      (report === null
+        ? null
+        : projectReadinessDimension(dimension, report)) ?? {
+        id: dimension.id,
+        status: "SKIP",
+        summary: dimension.question,
+        observed:
+          report === null
+            ? dimension.skipReason
+            : `${dimension.question} \`.lisa/readiness.json\` carries no usable record for this dimension, so it was not assessed here. Re-run \`lisa doctor --offline --readiness\` to regenerate the report.`,
+      }
+  );
   return {
     id: "repository-readiness",
     title: "Repository readiness",
-    checks: REPOSITORY_READINESS_DIMENSIONS.map(
-      dimension =>
-        (report === null
-          ? null
-          : projectReadinessDimension(dimension, report)) ?? {
-          id: dimension.id,
-          status: "SKIP",
-          summary: dimension.question,
-          observed:
-            report === null
-              ? dimension.skipReason
-              : `${dimension.question} \`.lisa/readiness.json\` carries no usable record for this dimension, so it was not assessed here. Re-run \`lisa doctor --offline --readiness\` to regenerate the report.`,
-        }
-    ),
+    checks: checks.map(check => applyNotEstablishedCaveat(check, checks)),
   };
 }
 

--- a/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
@@ -319,9 +319,18 @@ default doctor path never renders it and stays byte-identical.
    contract; do not restate or fork that vocabulary here.
 3. **`SKIP` carries a reason and is never blank.** A dimension with no applicable evidence renders
    `SKIP` with a stated reason ("no deployment target configured, so delivery/authority was not
-   assessed"). An unassessed dimension is a known unknown, and the report says so. In Lisa versions
-   where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
-   with that reason.
+   assessed"). An unassessed dimension is a known unknown, and the report says so.
+
+   **This surface reflects the CLI; it does not re-score.** The evidence producers and the blocker
+   engine live in the Lisa CLI, which is the single source of truth. When `.lisa/readiness.json` is
+   present and readable (parses, matching `schema_version`, carries a `dimensions` array), this group
+   **projects** each recorded dimension's status and its operator-facing evidence/reason text, so an
+   operator running `/lisa:doctor` through any coding agent sees the same readiness answer the CLI
+   gives. When the report is absent, unparseable, or stamped with an unknown `schema_version` — or
+   records nothing for a given dimension — that dimension falls back to `SKIP` with the reason it was
+   not assessed. Absence means the readiness pass has not run, never that the repository is clean: a
+   pass or a fail is never manufactured from a missing report. Run
+   `lisa doctor --offline --readiness` to produce the report first.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
    severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
    evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed

--- a/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
@@ -331,6 +331,15 @@ default doctor path never renders it and stays byte-identical.
    not assessed. Absence means the readiness pass has not run, never that the repository is clean: a
    pass or a fail is never manufactured from a missing report. Run
    `lisa doctor --offline --readiness` to produce the report first.
+
+   **A standing blocker outranks the recorded status.** Some CLI producers record `WARN` while
+   standing a ship blocker — the blocker engine never reads the per-dimension status, so the finding
+   flips the repository to `NOT_READY` exactly as a `FAIL` would. A dimension that owns an entry in
+   the report's `blockers[]` therefore projects as `FAIL` regardless of its recorded label, and its
+   remediation names the blocker ids and repeats the report's `narrowed_claim` (the "IS ready for
+   supervised, single-ticket agent work" fallback `readiness-rubric` requires whenever a blocker
+   stands). Projected checks also carry the report's `generated_at`/`lisa_version` so a stale report
+   cannot read as current truth, and unassessed dimensions carry the CLI's not-established caveat.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
    severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
    evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed

--- a/plugins/lisa-copilot/scripts/doctor-report.mjs
+++ b/plugins/lisa-copilot/scripts/doctor-report.mjs
@@ -6,7 +6,7 @@
  * repo adds real readiness probes. Keep this file dependency-free so future
  * doctor scripts can reuse it from plugin distributions and downstream repos.
  */
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
@@ -121,9 +121,12 @@ export function createPluginSyncDoctorGroup(root = process.cwd()) {
 /**
  * The eight repository-readiness ownership dimensions, in fixed render order,
  * defined once by the `readiness-rubric` rule. This group consumes that rubric;
- * it does not redefine the vocabulary. Evidence gathering for each dimension is
- * wired by later PRD #1739 tickets, so every dimension renders `SKIP` with a
- * reason here — reported, never silently omitted, per the shipped contract.
+ * it does not redefine the vocabulary. Evidence gathering lives in the
+ * TypeScript CLI producers, which persist the authoritative per-dimension
+ * result to `.lisa/readiness.json`; this surface projects that result. When no
+ * usable report is on disk, each dimension renders `SKIP` carrying the reason
+ * it was not assessed — reported, never silently omitted, per the shipped
+ * contract.
  * @type {readonly { id: string, question: string, skipReason: string }[]}
  */
 const REPOSITORY_READINESS_DIMENSIONS = [
@@ -132,81 +135,222 @@ const REPOSITORY_READINESS_DIMENSIONS = [
     question:
       "Can an agent recover the real job from what is written down (integration-access-layer, wiki-knowledge-source, config-resolution)?",
     skipReason:
-      "Context/routing evidence is assessed by the agent-ready wiring (RRR-4, #1856); no readiness probe is wired in this Lisa version.",
+      "Context/routing evidence is assessed by the agent-ready wiring (RRR-4, #1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "capabilities-tools",
     question:
       "Is every tool the work needs provably reachable, not merely installed (tool-access-gate)?",
     skipReason:
-      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "domain-ownership",
     question:
       "Are the business rules, glossary, and danger zones owned and written down (agent-ready domain phase wiki pages)?",
     skipReason:
-      "Domain-ownership evidence sources from agent-ready's danger-zone wiki pages, read by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+      "Domain-ownership evidence sources from agent-ready's danger-zone wiki pages, read by RRR-4 (#1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "execution-proof",
     question:
       "Can the claimed user-visible outcome be proved by running the system (verification, empirical-inquiry, claim-evidence-mapping)?",
     skipReason:
-      "Execution/proof consumes qualification evidence and representative journeys wired by RRR-6 (#1858); no readiness probe is wired in this Lisa version.",
+      "Execution/proof consumes qualification evidence and representative journeys wired by RRR-6 (#1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "feedback-guardrails",
     question:
       "Does a failing loop produce a named outcome and a runbook (automation-runbook-contract, observability-audit)?",
     skipReason:
-      "Feedback/guardrails evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+      "Feedback/guardrails evidence is assessed by RRR-4 (#1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "dependencies-supply-chain",
     question:
       "Is there a confidence model for what the repo depends on (security-audit-handling)?",
     skipReason:
-      "Dependencies/supply-chain evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+      "Dependencies/supply-chain evidence is assessed by RRR-4 (#1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "delivery-authority",
     question:
       "Does the thing that ships equal the thing that was validated, and does the shipping credential carry only the authority it needs (claim-archaeology, security-audit-handling)?",
     skipReason:
-      "Delivery/authority blockers are populated by the blocker gate in RRR-5 (#1857); no readiness probe is wired in this Lisa version.",
+      "Delivery/authority blockers are populated by the blocker gate in RRR-5 (#1857); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "proportionality",
     question:
       "Is the machinery proportional to the job, or is there scaffolding to subtract (repo-scope-split, #1742 subtraction candidates)?",
     skipReason:
-      "Proportionality reuses the scaffolding-subtraction candidates surfaced by the journey work (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+      "Proportionality reuses the scaffolding-subtraction candidates surfaced by the journey work (RRR-6, #1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
 ];
+
+/**
+ * `schema_version` this surface knows how to project. A report stamped with any
+ * other version is treated as unreadable rather than guessed at: the whole point
+ * of the version stamp is that a reader may not invent a mapping it was never
+ * told about.
+ */
+const READINESS_REPORT_SCHEMA_VERSION = 1;
+
+/**
+ * Longest operator-facing summary projected out of a CLI finding. Findings can
+ * carry kilobytes of concatenated evidence (every offending workflow job, for
+ * example); the doctor line is a headline, and the full text stays available in
+ * `.lisa/readiness.json`.
+ */
+const READINESS_SUMMARY_MAX_LENGTH = 320;
+
+/**
+ * Resolve the single location the CLI writes the readiness report to. This
+ * mirrors the CLI's `resolveReadinessReportPath` so relocating the artifact
+ * stays a two-line change across both scorers.
+ * @param {string} repoRoot
+ * @returns {string}
+ */
+function resolveReadinessReportPath(repoRoot) {
+  return path.join(repoRoot, ".lisa", "readiness.json");
+}
+
+/**
+ * Read the CLI-authored readiness report, or `null` when there is nothing
+ * trustworthy to project. Absence, unparseable JSON, an unknown
+ * `schema_version`, and a missing `dimensions` array are all the same answer —
+ * "the CLI readiness pass has not produced a result this surface can read" —
+ * and none of them is evidence about the repository itself.
+ * @param {string} repoRoot
+ * @returns {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] } | null}
+ */
+function readReadinessReport(repoRoot) {
+  const reportPath = resolveReadinessReportPath(repoRoot);
+  if (!existsSync(reportPath)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(reportPath, "utf8"));
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      parsed.schema_version !== READINESS_REPORT_SCHEMA_VERSION ||
+      !Array.isArray(parsed.dimensions)
+    ) {
+      return null;
+    }
+    return {
+      dimensions: parsed.dimensions,
+      blockers: Array.isArray(parsed.blockers) ? parsed.blockers : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pull the operator-facing sentence out of a dimension's findings. The CLI
+ * producers write human text under `evidence` (an assessed dimension) or
+ * `reason` (a deliberately-unassessed one); the rest of the finding is machine
+ * bookkeeping the blocker engine owns.
+ * @param {readonly unknown[]} findings
+ * @returns {string}
+ */
+function summarizeReadinessFindings(findings) {
+  const sentences = findings
+    .filter(finding => finding !== null && typeof finding === "object")
+    .flatMap(finding => [finding.evidence, finding.reason])
+    .filter(text => typeof text === "string" && text.trim().length > 0)
+    .map(text => text.trim());
+  if (sentences.length === 0) {
+    return "";
+  }
+  const joined = sentences.join(" ");
+  return joined.length > READINESS_SUMMARY_MAX_LENGTH
+    ? `${joined.slice(0, READINESS_SUMMARY_MAX_LENGTH - 1).trimEnd()}…`
+    : joined;
+}
+
+/**
+ * Project one CLI dimension record into this surface's check shape, or `null`
+ * when the record is absent or carries a status outside the shipped vocabulary
+ * (the caller then falls back to the reasoned SKIP).
+ * @param {{ id: string, question: string, skipReason: string }} dimension
+ * @param {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] }} report
+ * @returns {DoctorCheck | null}
+ */
+function projectReadinessDimension(dimension, report) {
+  const record = report.dimensions.find(
+    entry =>
+      entry !== null && typeof entry === "object" && entry.id === dimension.id
+  );
+  if (!record || !DOCTOR_STATUSES.includes(record.status)) {
+    return null;
+  }
+  const findings = Array.isArray(record.findings) ? record.findings : [];
+  const summary = summarizeReadinessFindings(findings);
+  const blockerIds = report.blockers
+    .filter(
+      blocker =>
+        blocker !== null &&
+        typeof blocker === "object" &&
+        (blocker.dimension_id === dimension.id ||
+          (Array.isArray(blocker.owning_dimensions) &&
+            blocker.owning_dimensions.includes(dimension.id)))
+    )
+    .map(blocker => String(blocker.id))
+    .filter((id, index, ids) => ids.indexOf(id) === index);
+
+  return {
+    id: dimension.id,
+    status: record.status,
+    summary: summary.length > 0 ? summary : dimension.question,
+    observed: `${dimension.question} Projected from \`.lisa/readiness.json\` (schema_version ${READINESS_REPORT_SCHEMA_VERSION}), the report the Lisa CLI readiness pass wrote.`,
+    ...(blockerIds.length > 0
+      ? {
+          remediation: `Standing ship blocker(s): ${blockerIds.join(", ")}. See \`.lisa/readiness.json\` for the full evidence and the \`readiness-rubric\` rule for the blocker definitions.`,
+        }
+      : {}),
+  };
+}
 
 /**
  * Build the orthogonal "Repository readiness" doctor group ("may an agent fleet
  * operate here unattended?"), scored against the eight `readiness-rubric`
  * ownership dimensions. It is separate from the installation-readiness groups
  * and is appended in a fixed position by the readiness-mode caller; the eight
- * dimension checks render in fixed order. In this Lisa version every dimension
- * is `SKIP` with a stated reason because the evidence-gathering surfaces ship
- * with later PRD #1739 tickets — reported, never silently omitted.
+ * dimension checks render in fixed order.
+ *
+ * The blocker engine and the evidence producers live in the TypeScript CLI,
+ * which is the single source of truth; this surface is a bridge, not a second
+ * implementation (#1902). It projects whatever the CLI persisted to
+ * `.lisa/readiness.json` so an operator running `/lisa:doctor` through any
+ * coding agent gets the same readiness answer the CLI gives. When no usable
+ * report exists, every unmatched dimension renders `SKIP` with its reason:
+ * absence means the readiness pass has not run, never that the repository is
+ * clean, so a pass or fail is never manufactured from it.
  * @param {string} root
  * @returns {DoctorGroup}
  */
 export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
-  void path.resolve(root);
+  const report = readReadinessReport(path.resolve(root));
   return {
     id: "repository-readiness",
     title: "Repository readiness",
-    checks: REPOSITORY_READINESS_DIMENSIONS.map(dimension => ({
-      id: dimension.id,
-      status: "SKIP",
-      summary: dimension.question,
-      observed: dimension.skipReason,
-    })),
+    checks: REPOSITORY_READINESS_DIMENSIONS.map(
+      dimension =>
+        (report === null
+          ? null
+          : projectReadinessDimension(dimension, report)) ?? {
+          id: dimension.id,
+          status: "SKIP",
+          summary: dimension.question,
+          observed:
+            report === null
+              ? dimension.skipReason
+              : `${dimension.question} \`.lisa/readiness.json\` carries no usable record for this dimension, so it was not assessed here. Re-run \`lisa doctor --offline --readiness\` to regenerate the report.`,
+        }
+    ),
   };
 }
 

--- a/plugins/lisa-copilot/scripts/doctor-report.mjs
+++ b/plugins/lisa-copilot/scripts/doctor-report.mjs
@@ -321,9 +321,37 @@ function applyNotEstablishedCaveat(check, checks) {
 }
 
 /**
- * Collect the ids of the standing ship blockers a dimension owns. Blockers with
- * no usable id are dropped rather than stringified, so a malformed record can
- * never render "Standing ship blocker(s): undefined" at an operator.
+ * Decide whether a standing blocker was evidenced in this dimension.
+ *
+ * `dimension_id` is the authority: the CLI's `buildDetectedBlocker` documents it
+ * as "the dimension the evidencing finding was found in". `owning_dimensions` is
+ * the blocker's static spec and can name dimensions that did NOT evidence it —
+ * B4 is specced as `[domain-ownership, feedback-guardrails]` while only the
+ * guardrails producer ever emits the B4 finding. Escalating on the spec would
+ * stamp `FAIL` on a dimension whose own recorded evidence says it found nothing,
+ * contradicting both that evidence and the CLI's per-dimension result. The spec
+ * is used only as a fallback, for a blocker record carrying no attribution.
+ * @param {Record<string, unknown>} blocker
+ * @param {{ id: string }} dimension
+ * @returns {boolean}
+ */
+function blockerEvidencedIn(blocker, dimension) {
+  if (
+    typeof blocker.dimension_id === "string" &&
+    blocker.dimension_id.length > 0
+  ) {
+    return blocker.dimension_id === dimension.id;
+  }
+  return (
+    Array.isArray(blocker.owning_dimensions) &&
+    blocker.owning_dimensions.includes(dimension.id)
+  );
+}
+
+/**
+ * Collect the ids of the standing ship blockers evidenced in a dimension.
+ * Blockers with no usable id are dropped rather than stringified, so a malformed
+ * record can never render "Standing ship blocker(s): undefined" at an operator.
  * @param {{ id: string }} dimension
  * @param {{ blockers: readonly Record<string, unknown>[] }} report
  * @returns {readonly string[]}
@@ -334,9 +362,7 @@ function standingBlockerIds(dimension, report) {
       blocker =>
         blocker !== null &&
         typeof blocker === "object" &&
-        (blocker.dimension_id === dimension.id ||
-          (Array.isArray(blocker.owning_dimensions) &&
-            blocker.owning_dimensions.includes(dimension.id)))
+        blockerEvidencedIn(blocker, dimension)
     )
     .map(blocker => blocker.id)
     .filter(id => typeof id === "string" && id.length > 0)

--- a/plugins/lisa-copilot/scripts/doctor-report.mjs
+++ b/plugins/lisa-copilot/scripts/doctor-report.mjs
@@ -142,7 +142,7 @@ const REPOSITORY_READINESS_DIMENSIONS = [
     question:
       "Is every tool the work needs provably reachable, not merely installed (tool-access-gate)?",
     skipReason:
-      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
+      "Tool reachability needs a live read-only probe and can never be established from an offline read: the `tool-access-gate` rule names presence — a binary on `PATH`, a dependency in a manifest, a configured MCP server — as the anti-pattern, because it proves a tool was declared, never that a request through it succeeded. This dimension is therefore a deliberate, permanent reasoned SKIP on an offline pass rather than a not-yet-wired one; only a run that actually exercises the tools can answer it.",
   },
   {
     id: "domain-ownership",
@@ -222,7 +222,7 @@ function resolveReadinessReportPath(repoRoot) {
  * "the CLI readiness pass has not produced a result this surface can read" —
  * and none of them is evidence about the repository itself.
  * @param {string} repoRoot
- * @returns {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] } | null}
+ * @returns {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[], narrowedClaim: string, provenance: string } | null}
  */
 function readReadinessReport(repoRoot) {
   const reportPath = resolveReadinessReportPath(repoRoot);
@@ -242,6 +242,15 @@ function readReadinessReport(repoRoot) {
     return {
       dimensions: parsed.dimensions,
       blockers: Array.isArray(parsed.blockers) ? parsed.blockers : [],
+      // The narrowed claim is the sentence `readiness-rubric` requires whenever
+      // a blocker stands ("...IS ready for supervised, single-ticket agent
+      // work..."). Dropping it would hand the agent operator a bare NOT_READY
+      // where the CLI hands them the fallback they can actually act on.
+      narrowedClaim:
+        typeof parsed.narrowed_claim === "string" ? parsed.narrowed_claim : "",
+      // Stamped into every projected check so a months-old report cannot read
+      // as current truth: this surface reflects a file, not a live assessment.
+      provenance: describeReportProvenance(parsed),
     };
   } catch {
     return null;
@@ -249,17 +258,36 @@ function readReadinessReport(repoRoot) {
 }
 
 /**
+ * Describe when the projected report was produced and by which Lisa version.
+ * @param {Record<string, unknown>} parsed
+ * @returns {string}
+ */
+function describeReportProvenance(parsed) {
+  const generatedAt =
+    typeof parsed.generated_at === "string" && parsed.generated_at.length > 0
+      ? parsed.generated_at
+      : "an unrecorded time";
+  const version =
+    typeof parsed.lisa_version === "string" && parsed.lisa_version.length > 0
+      ? ` by Lisa ${parsed.lisa_version}`
+      : "";
+  return `generated ${generatedAt}${version}`;
+}
+
+/**
  * Pull the operator-facing sentence out of a dimension's findings. The CLI
- * producers write human text under `evidence` (an assessed dimension) or
- * `reason` (a deliberately-unassessed one); the rest of the finding is machine
- * bookkeeping the blocker engine owns.
+ * producers write human text under `evidence` (an assessed dimension),
+ * `reason` (a deliberately-unassessed one), or `observation` (a neutral note);
+ * the rest of the finding is machine bookkeeping the blocker engine owns.
+ * Reading only two of the three would print the dimension's question under a
+ * FAIL, which reads as "nothing to report" exactly when there is most to say.
  * @param {readonly unknown[]} findings
  * @returns {string}
  */
 function summarizeReadinessFindings(findings) {
   const sentences = findings
     .filter(finding => finding !== null && typeof finding === "object")
-    .flatMap(finding => [finding.evidence, finding.reason])
+    .flatMap(finding => [finding.evidence, finding.reason, finding.observation])
     .filter(text => typeof text === "string" && text.trim().length > 0)
     .map(text => text.trim());
   if (sentences.length === 0) {
@@ -272,11 +300,55 @@ function summarizeReadinessFindings(findings) {
 }
 
 /**
+ * Carry the CLI's not-established caveat onto every unassessed dimension. The
+ * CLI headline says it out loud — "N of 8 dimensions were never assessed, so
+ * this cannot say whether an unattended fleet may operate here" — and a reader
+ * who sees a lone `SKIP` line without it can mistake silence for a clean bill
+ * of health on that dimension.
+ * @param {DoctorCheck} check
+ * @param {readonly DoctorCheck[]} checks
+ * @returns {DoctorCheck}
+ */
+function applyNotEstablishedCaveat(check, checks) {
+  const unassessed = checks.filter(entry => entry.status === "SKIP").length;
+  if (check.status !== "SKIP" || unassessed === 0) {
+    return check;
+  }
+  return {
+    ...check,
+    observed: `${check.observed} NOT ESTABLISHED: ${unassessed} of ${checks.length} dimensions were never assessed, so this cannot say whether an unattended fleet may operate here.`,
+  };
+}
+
+/**
+ * Collect the ids of the standing ship blockers a dimension owns. Blockers with
+ * no usable id are dropped rather than stringified, so a malformed record can
+ * never render "Standing ship blocker(s): undefined" at an operator.
+ * @param {{ id: string }} dimension
+ * @param {{ blockers: readonly Record<string, unknown>[] }} report
+ * @returns {readonly string[]}
+ */
+function standingBlockerIds(dimension, report) {
+  return report.blockers
+    .filter(
+      blocker =>
+        blocker !== null &&
+        typeof blocker === "object" &&
+        (blocker.dimension_id === dimension.id ||
+          (Array.isArray(blocker.owning_dimensions) &&
+            blocker.owning_dimensions.includes(dimension.id)))
+    )
+    .map(blocker => blocker.id)
+    .filter(id => typeof id === "string" && id.length > 0)
+    .filter((id, index, ids) => ids.indexOf(id) === index);
+}
+
+/**
  * Project one CLI dimension record into this surface's check shape, or `null`
  * when the record is absent or carries a status outside the shipped vocabulary
  * (the caller then falls back to the reasoned SKIP).
  * @param {{ id: string, question: string, skipReason: string }} dimension
- * @param {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] }} report
+ * @param {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[], narrowedClaim: string, provenance: string }} report
  * @returns {DoctorCheck | null}
  */
 function projectReadinessDimension(dimension, report) {
@@ -289,26 +361,27 @@ function projectReadinessDimension(dimension, report) {
   }
   const findings = Array.isArray(record.findings) ? record.findings : [];
   const summary = summarizeReadinessFindings(findings);
-  const blockerIds = report.blockers
-    .filter(
-      blocker =>
-        blocker !== null &&
-        typeof blocker === "object" &&
-        (blocker.dimension_id === dimension.id ||
-          (Array.isArray(blocker.owning_dimensions) &&
-            blocker.owning_dimensions.includes(dimension.id)))
-    )
-    .map(blocker => String(blocker.id))
-    .filter((id, index, ids) => ids.indexOf(id) === index);
+  const blockerIds = standingBlockerIds(dimension, report);
 
   return {
     id: dimension.id,
-    status: record.status,
+    // A standing blocker outranks the recorded label. Three CLI producers (B1
+    // domain-ownership, B4 feedback-guardrails, B6 context-routing) record
+    // `WARN` while standing a blocker, each stating in-line that "the blocker
+    // engine never reads this status, so the finding flips the repository to
+    // NOT_READY exactly as a FAIL would". Projecting that `WARN` verbatim would
+    // score READY_WITH_WARNINGS on a repository the CLI calls NOT_READY — the
+    // precise disagreement this bridge exists to eliminate. This still reflects
+    // the CLI's decision rather than re-scoring: the CLI decided the blocker
+    // stands and wrote it into `blockers[]`.
+    status: blockerIds.length > 0 ? "FAIL" : record.status,
     summary: summary.length > 0 ? summary : dimension.question,
-    observed: `${dimension.question} Projected from \`.lisa/readiness.json\` (schema_version ${READINESS_REPORT_SCHEMA_VERSION}), the report the Lisa CLI readiness pass wrote.`,
+    observed: `${dimension.question} Projected from \`.lisa/readiness.json\` (schema_version ${READINESS_REPORT_SCHEMA_VERSION}, ${report.provenance}), the report the Lisa CLI readiness pass wrote.`,
     ...(blockerIds.length > 0
       ? {
-          remediation: `Standing ship blocker(s): ${blockerIds.join(", ")}. See \`.lisa/readiness.json\` for the full evidence and the \`readiness-rubric\` rule for the blocker definitions.`,
+          remediation:
+            `Standing ship blocker(s): ${blockerIds.join(", ")}. See \`.lisa/readiness.json\` for the full evidence and the \`readiness-rubric\` rule for the blocker definitions.` +
+            (report.narrowedClaim.length > 0 ? ` ${report.narrowedClaim}` : ""),
         }
       : {}),
   };
@@ -334,23 +407,24 @@ function projectReadinessDimension(dimension, report) {
  */
 export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
   const report = readReadinessReport(path.resolve(root));
+  const checks = REPOSITORY_READINESS_DIMENSIONS.map(
+    dimension =>
+      (report === null
+        ? null
+        : projectReadinessDimension(dimension, report)) ?? {
+        id: dimension.id,
+        status: "SKIP",
+        summary: dimension.question,
+        observed:
+          report === null
+            ? dimension.skipReason
+            : `${dimension.question} \`.lisa/readiness.json\` carries no usable record for this dimension, so it was not assessed here. Re-run \`lisa doctor --offline --readiness\` to regenerate the report.`,
+      }
+  );
   return {
     id: "repository-readiness",
     title: "Repository readiness",
-    checks: REPOSITORY_READINESS_DIMENSIONS.map(
-      dimension =>
-        (report === null
-          ? null
-          : projectReadinessDimension(dimension, report)) ?? {
-          id: dimension.id,
-          status: "SKIP",
-          summary: dimension.question,
-          observed:
-            report === null
-              ? dimension.skipReason
-              : `${dimension.question} \`.lisa/readiness.json\` carries no usable record for this dimension, so it was not assessed here. Re-run \`lisa doctor --offline --readiness\` to regenerate the report.`,
-        }
-    ),
+    checks: checks.map(check => applyNotEstablishedCaveat(check, checks)),
   };
 }
 

--- a/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
@@ -319,9 +319,18 @@ default doctor path never renders it and stays byte-identical.
    contract; do not restate or fork that vocabulary here.
 3. **`SKIP` carries a reason and is never blank.** A dimension with no applicable evidence renders
    `SKIP` with a stated reason ("no deployment target configured, so delivery/authority was not
-   assessed"). An unassessed dimension is a known unknown, and the report says so. In Lisa versions
-   where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
-   with that reason.
+   assessed"). An unassessed dimension is a known unknown, and the report says so.
+
+   **This surface reflects the CLI; it does not re-score.** The evidence producers and the blocker
+   engine live in the Lisa CLI, which is the single source of truth. When `.lisa/readiness.json` is
+   present and readable (parses, matching `schema_version`, carries a `dimensions` array), this group
+   **projects** each recorded dimension's status and its operator-facing evidence/reason text, so an
+   operator running `/lisa:doctor` through any coding agent sees the same readiness answer the CLI
+   gives. When the report is absent, unparseable, or stamped with an unknown `schema_version` — or
+   records nothing for a given dimension — that dimension falls back to `SKIP` with the reason it was
+   not assessed. Absence means the readiness pass has not run, never that the repository is clean: a
+   pass or a fail is never manufactured from a missing report. Run
+   `lisa doctor --offline --readiness` to produce the report first.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
    severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
    evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed

--- a/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
@@ -331,6 +331,15 @@ default doctor path never renders it and stays byte-identical.
    not assessed. Absence means the readiness pass has not run, never that the repository is clean: a
    pass or a fail is never manufactured from a missing report. Run
    `lisa doctor --offline --readiness` to produce the report first.
+
+   **A standing blocker outranks the recorded status.** Some CLI producers record `WARN` while
+   standing a ship blocker — the blocker engine never reads the per-dimension status, so the finding
+   flips the repository to `NOT_READY` exactly as a `FAIL` would. A dimension that owns an entry in
+   the report's `blockers[]` therefore projects as `FAIL` regardless of its recorded label, and its
+   remediation names the blocker ids and repeats the report's `narrowed_claim` (the "IS ready for
+   supervised, single-ticket agent work" fallback `readiness-rubric` requires whenever a blocker
+   stands). Projected checks also carry the report's `generated_at`/`lisa_version` so a stale report
+   cannot read as current truth, and unassessed dimensions carry the CLI's not-established caveat.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
    severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
    evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed

--- a/plugins/lisa-cursor/scripts/doctor-report.mjs
+++ b/plugins/lisa-cursor/scripts/doctor-report.mjs
@@ -6,7 +6,7 @@
  * repo adds real readiness probes. Keep this file dependency-free so future
  * doctor scripts can reuse it from plugin distributions and downstream repos.
  */
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
@@ -121,9 +121,12 @@ export function createPluginSyncDoctorGroup(root = process.cwd()) {
 /**
  * The eight repository-readiness ownership dimensions, in fixed render order,
  * defined once by the `readiness-rubric` rule. This group consumes that rubric;
- * it does not redefine the vocabulary. Evidence gathering for each dimension is
- * wired by later PRD #1739 tickets, so every dimension renders `SKIP` with a
- * reason here — reported, never silently omitted, per the shipped contract.
+ * it does not redefine the vocabulary. Evidence gathering lives in the
+ * TypeScript CLI producers, which persist the authoritative per-dimension
+ * result to `.lisa/readiness.json`; this surface projects that result. When no
+ * usable report is on disk, each dimension renders `SKIP` carrying the reason
+ * it was not assessed — reported, never silently omitted, per the shipped
+ * contract.
  * @type {readonly { id: string, question: string, skipReason: string }[]}
  */
 const REPOSITORY_READINESS_DIMENSIONS = [
@@ -132,81 +135,222 @@ const REPOSITORY_READINESS_DIMENSIONS = [
     question:
       "Can an agent recover the real job from what is written down (integration-access-layer, wiki-knowledge-source, config-resolution)?",
     skipReason:
-      "Context/routing evidence is assessed by the agent-ready wiring (RRR-4, #1856); no readiness probe is wired in this Lisa version.",
+      "Context/routing evidence is assessed by the agent-ready wiring (RRR-4, #1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "capabilities-tools",
     question:
       "Is every tool the work needs provably reachable, not merely installed (tool-access-gate)?",
     skipReason:
-      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "domain-ownership",
     question:
       "Are the business rules, glossary, and danger zones owned and written down (agent-ready domain phase wiki pages)?",
     skipReason:
-      "Domain-ownership evidence sources from agent-ready's danger-zone wiki pages, read by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+      "Domain-ownership evidence sources from agent-ready's danger-zone wiki pages, read by RRR-4 (#1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "execution-proof",
     question:
       "Can the claimed user-visible outcome be proved by running the system (verification, empirical-inquiry, claim-evidence-mapping)?",
     skipReason:
-      "Execution/proof consumes qualification evidence and representative journeys wired by RRR-6 (#1858); no readiness probe is wired in this Lisa version.",
+      "Execution/proof consumes qualification evidence and representative journeys wired by RRR-6 (#1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "feedback-guardrails",
     question:
       "Does a failing loop produce a named outcome and a runbook (automation-runbook-contract, observability-audit)?",
     skipReason:
-      "Feedback/guardrails evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+      "Feedback/guardrails evidence is assessed by RRR-4 (#1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "dependencies-supply-chain",
     question:
       "Is there a confidence model for what the repo depends on (security-audit-handling)?",
     skipReason:
-      "Dependencies/supply-chain evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+      "Dependencies/supply-chain evidence is assessed by RRR-4 (#1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "delivery-authority",
     question:
       "Does the thing that ships equal the thing that was validated, and does the shipping credential carry only the authority it needs (claim-archaeology, security-audit-handling)?",
     skipReason:
-      "Delivery/authority blockers are populated by the blocker gate in RRR-5 (#1857); no readiness probe is wired in this Lisa version.",
+      "Delivery/authority blockers are populated by the blocker gate in RRR-5 (#1857); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "proportionality",
     question:
       "Is the machinery proportional to the job, or is there scaffolding to subtract (repo-scope-split, #1742 subtraction candidates)?",
     skipReason:
-      "Proportionality reuses the scaffolding-subtraction candidates surfaced by the journey work (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+      "Proportionality reuses the scaffolding-subtraction candidates surfaced by the journey work (RRR-6, #1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
 ];
+
+/**
+ * `schema_version` this surface knows how to project. A report stamped with any
+ * other version is treated as unreadable rather than guessed at: the whole point
+ * of the version stamp is that a reader may not invent a mapping it was never
+ * told about.
+ */
+const READINESS_REPORT_SCHEMA_VERSION = 1;
+
+/**
+ * Longest operator-facing summary projected out of a CLI finding. Findings can
+ * carry kilobytes of concatenated evidence (every offending workflow job, for
+ * example); the doctor line is a headline, and the full text stays available in
+ * `.lisa/readiness.json`.
+ */
+const READINESS_SUMMARY_MAX_LENGTH = 320;
+
+/**
+ * Resolve the single location the CLI writes the readiness report to. This
+ * mirrors the CLI's `resolveReadinessReportPath` so relocating the artifact
+ * stays a two-line change across both scorers.
+ * @param {string} repoRoot
+ * @returns {string}
+ */
+function resolveReadinessReportPath(repoRoot) {
+  return path.join(repoRoot, ".lisa", "readiness.json");
+}
+
+/**
+ * Read the CLI-authored readiness report, or `null` when there is nothing
+ * trustworthy to project. Absence, unparseable JSON, an unknown
+ * `schema_version`, and a missing `dimensions` array are all the same answer —
+ * "the CLI readiness pass has not produced a result this surface can read" —
+ * and none of them is evidence about the repository itself.
+ * @param {string} repoRoot
+ * @returns {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] } | null}
+ */
+function readReadinessReport(repoRoot) {
+  const reportPath = resolveReadinessReportPath(repoRoot);
+  if (!existsSync(reportPath)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(reportPath, "utf8"));
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      parsed.schema_version !== READINESS_REPORT_SCHEMA_VERSION ||
+      !Array.isArray(parsed.dimensions)
+    ) {
+      return null;
+    }
+    return {
+      dimensions: parsed.dimensions,
+      blockers: Array.isArray(parsed.blockers) ? parsed.blockers : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pull the operator-facing sentence out of a dimension's findings. The CLI
+ * producers write human text under `evidence` (an assessed dimension) or
+ * `reason` (a deliberately-unassessed one); the rest of the finding is machine
+ * bookkeeping the blocker engine owns.
+ * @param {readonly unknown[]} findings
+ * @returns {string}
+ */
+function summarizeReadinessFindings(findings) {
+  const sentences = findings
+    .filter(finding => finding !== null && typeof finding === "object")
+    .flatMap(finding => [finding.evidence, finding.reason])
+    .filter(text => typeof text === "string" && text.trim().length > 0)
+    .map(text => text.trim());
+  if (sentences.length === 0) {
+    return "";
+  }
+  const joined = sentences.join(" ");
+  return joined.length > READINESS_SUMMARY_MAX_LENGTH
+    ? `${joined.slice(0, READINESS_SUMMARY_MAX_LENGTH - 1).trimEnd()}…`
+    : joined;
+}
+
+/**
+ * Project one CLI dimension record into this surface's check shape, or `null`
+ * when the record is absent or carries a status outside the shipped vocabulary
+ * (the caller then falls back to the reasoned SKIP).
+ * @param {{ id: string, question: string, skipReason: string }} dimension
+ * @param {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] }} report
+ * @returns {DoctorCheck | null}
+ */
+function projectReadinessDimension(dimension, report) {
+  const record = report.dimensions.find(
+    entry =>
+      entry !== null && typeof entry === "object" && entry.id === dimension.id
+  );
+  if (!record || !DOCTOR_STATUSES.includes(record.status)) {
+    return null;
+  }
+  const findings = Array.isArray(record.findings) ? record.findings : [];
+  const summary = summarizeReadinessFindings(findings);
+  const blockerIds = report.blockers
+    .filter(
+      blocker =>
+        blocker !== null &&
+        typeof blocker === "object" &&
+        (blocker.dimension_id === dimension.id ||
+          (Array.isArray(blocker.owning_dimensions) &&
+            blocker.owning_dimensions.includes(dimension.id)))
+    )
+    .map(blocker => String(blocker.id))
+    .filter((id, index, ids) => ids.indexOf(id) === index);
+
+  return {
+    id: dimension.id,
+    status: record.status,
+    summary: summary.length > 0 ? summary : dimension.question,
+    observed: `${dimension.question} Projected from \`.lisa/readiness.json\` (schema_version ${READINESS_REPORT_SCHEMA_VERSION}), the report the Lisa CLI readiness pass wrote.`,
+    ...(blockerIds.length > 0
+      ? {
+          remediation: `Standing ship blocker(s): ${blockerIds.join(", ")}. See \`.lisa/readiness.json\` for the full evidence and the \`readiness-rubric\` rule for the blocker definitions.`,
+        }
+      : {}),
+  };
+}
 
 /**
  * Build the orthogonal "Repository readiness" doctor group ("may an agent fleet
  * operate here unattended?"), scored against the eight `readiness-rubric`
  * ownership dimensions. It is separate from the installation-readiness groups
  * and is appended in a fixed position by the readiness-mode caller; the eight
- * dimension checks render in fixed order. In this Lisa version every dimension
- * is `SKIP` with a stated reason because the evidence-gathering surfaces ship
- * with later PRD #1739 tickets — reported, never silently omitted.
+ * dimension checks render in fixed order.
+ *
+ * The blocker engine and the evidence producers live in the TypeScript CLI,
+ * which is the single source of truth; this surface is a bridge, not a second
+ * implementation (#1902). It projects whatever the CLI persisted to
+ * `.lisa/readiness.json` so an operator running `/lisa:doctor` through any
+ * coding agent gets the same readiness answer the CLI gives. When no usable
+ * report exists, every unmatched dimension renders `SKIP` with its reason:
+ * absence means the readiness pass has not run, never that the repository is
+ * clean, so a pass or fail is never manufactured from it.
  * @param {string} root
  * @returns {DoctorGroup}
  */
 export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
-  void path.resolve(root);
+  const report = readReadinessReport(path.resolve(root));
   return {
     id: "repository-readiness",
     title: "Repository readiness",
-    checks: REPOSITORY_READINESS_DIMENSIONS.map(dimension => ({
-      id: dimension.id,
-      status: "SKIP",
-      summary: dimension.question,
-      observed: dimension.skipReason,
-    })),
+    checks: REPOSITORY_READINESS_DIMENSIONS.map(
+      dimension =>
+        (report === null
+          ? null
+          : projectReadinessDimension(dimension, report)) ?? {
+          id: dimension.id,
+          status: "SKIP",
+          summary: dimension.question,
+          observed:
+            report === null
+              ? dimension.skipReason
+              : `${dimension.question} \`.lisa/readiness.json\` carries no usable record for this dimension, so it was not assessed here. Re-run \`lisa doctor --offline --readiness\` to regenerate the report.`,
+        }
+    ),
   };
 }
 

--- a/plugins/lisa-cursor/scripts/doctor-report.mjs
+++ b/plugins/lisa-cursor/scripts/doctor-report.mjs
@@ -321,9 +321,37 @@ function applyNotEstablishedCaveat(check, checks) {
 }
 
 /**
- * Collect the ids of the standing ship blockers a dimension owns. Blockers with
- * no usable id are dropped rather than stringified, so a malformed record can
- * never render "Standing ship blocker(s): undefined" at an operator.
+ * Decide whether a standing blocker was evidenced in this dimension.
+ *
+ * `dimension_id` is the authority: the CLI's `buildDetectedBlocker` documents it
+ * as "the dimension the evidencing finding was found in". `owning_dimensions` is
+ * the blocker's static spec and can name dimensions that did NOT evidence it —
+ * B4 is specced as `[domain-ownership, feedback-guardrails]` while only the
+ * guardrails producer ever emits the B4 finding. Escalating on the spec would
+ * stamp `FAIL` on a dimension whose own recorded evidence says it found nothing,
+ * contradicting both that evidence and the CLI's per-dimension result. The spec
+ * is used only as a fallback, for a blocker record carrying no attribution.
+ * @param {Record<string, unknown>} blocker
+ * @param {{ id: string }} dimension
+ * @returns {boolean}
+ */
+function blockerEvidencedIn(blocker, dimension) {
+  if (
+    typeof blocker.dimension_id === "string" &&
+    blocker.dimension_id.length > 0
+  ) {
+    return blocker.dimension_id === dimension.id;
+  }
+  return (
+    Array.isArray(blocker.owning_dimensions) &&
+    blocker.owning_dimensions.includes(dimension.id)
+  );
+}
+
+/**
+ * Collect the ids of the standing ship blockers evidenced in a dimension.
+ * Blockers with no usable id are dropped rather than stringified, so a malformed
+ * record can never render "Standing ship blocker(s): undefined" at an operator.
  * @param {{ id: string }} dimension
  * @param {{ blockers: readonly Record<string, unknown>[] }} report
  * @returns {readonly string[]}
@@ -334,9 +362,7 @@ function standingBlockerIds(dimension, report) {
       blocker =>
         blocker !== null &&
         typeof blocker === "object" &&
-        (blocker.dimension_id === dimension.id ||
-          (Array.isArray(blocker.owning_dimensions) &&
-            blocker.owning_dimensions.includes(dimension.id)))
+        blockerEvidencedIn(blocker, dimension)
     )
     .map(blocker => blocker.id)
     .filter(id => typeof id === "string" && id.length > 0)

--- a/plugins/lisa-cursor/scripts/doctor-report.mjs
+++ b/plugins/lisa-cursor/scripts/doctor-report.mjs
@@ -142,7 +142,7 @@ const REPOSITORY_READINESS_DIMENSIONS = [
     question:
       "Is every tool the work needs provably reachable, not merely installed (tool-access-gate)?",
     skipReason:
-      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
+      "Tool reachability needs a live read-only probe and can never be established from an offline read: the `tool-access-gate` rule names presence — a binary on `PATH`, a dependency in a manifest, a configured MCP server — as the anti-pattern, because it proves a tool was declared, never that a request through it succeeded. This dimension is therefore a deliberate, permanent reasoned SKIP on an offline pass rather than a not-yet-wired one; only a run that actually exercises the tools can answer it.",
   },
   {
     id: "domain-ownership",
@@ -222,7 +222,7 @@ function resolveReadinessReportPath(repoRoot) {
  * "the CLI readiness pass has not produced a result this surface can read" —
  * and none of them is evidence about the repository itself.
  * @param {string} repoRoot
- * @returns {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] } | null}
+ * @returns {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[], narrowedClaim: string, provenance: string } | null}
  */
 function readReadinessReport(repoRoot) {
   const reportPath = resolveReadinessReportPath(repoRoot);
@@ -242,6 +242,15 @@ function readReadinessReport(repoRoot) {
     return {
       dimensions: parsed.dimensions,
       blockers: Array.isArray(parsed.blockers) ? parsed.blockers : [],
+      // The narrowed claim is the sentence `readiness-rubric` requires whenever
+      // a blocker stands ("...IS ready for supervised, single-ticket agent
+      // work..."). Dropping it would hand the agent operator a bare NOT_READY
+      // where the CLI hands them the fallback they can actually act on.
+      narrowedClaim:
+        typeof parsed.narrowed_claim === "string" ? parsed.narrowed_claim : "",
+      // Stamped into every projected check so a months-old report cannot read
+      // as current truth: this surface reflects a file, not a live assessment.
+      provenance: describeReportProvenance(parsed),
     };
   } catch {
     return null;
@@ -249,17 +258,36 @@ function readReadinessReport(repoRoot) {
 }
 
 /**
+ * Describe when the projected report was produced and by which Lisa version.
+ * @param {Record<string, unknown>} parsed
+ * @returns {string}
+ */
+function describeReportProvenance(parsed) {
+  const generatedAt =
+    typeof parsed.generated_at === "string" && parsed.generated_at.length > 0
+      ? parsed.generated_at
+      : "an unrecorded time";
+  const version =
+    typeof parsed.lisa_version === "string" && parsed.lisa_version.length > 0
+      ? ` by Lisa ${parsed.lisa_version}`
+      : "";
+  return `generated ${generatedAt}${version}`;
+}
+
+/**
  * Pull the operator-facing sentence out of a dimension's findings. The CLI
- * producers write human text under `evidence` (an assessed dimension) or
- * `reason` (a deliberately-unassessed one); the rest of the finding is machine
- * bookkeeping the blocker engine owns.
+ * producers write human text under `evidence` (an assessed dimension),
+ * `reason` (a deliberately-unassessed one), or `observation` (a neutral note);
+ * the rest of the finding is machine bookkeeping the blocker engine owns.
+ * Reading only two of the three would print the dimension's question under a
+ * FAIL, which reads as "nothing to report" exactly when there is most to say.
  * @param {readonly unknown[]} findings
  * @returns {string}
  */
 function summarizeReadinessFindings(findings) {
   const sentences = findings
     .filter(finding => finding !== null && typeof finding === "object")
-    .flatMap(finding => [finding.evidence, finding.reason])
+    .flatMap(finding => [finding.evidence, finding.reason, finding.observation])
     .filter(text => typeof text === "string" && text.trim().length > 0)
     .map(text => text.trim());
   if (sentences.length === 0) {
@@ -272,11 +300,55 @@ function summarizeReadinessFindings(findings) {
 }
 
 /**
+ * Carry the CLI's not-established caveat onto every unassessed dimension. The
+ * CLI headline says it out loud — "N of 8 dimensions were never assessed, so
+ * this cannot say whether an unattended fleet may operate here" — and a reader
+ * who sees a lone `SKIP` line without it can mistake silence for a clean bill
+ * of health on that dimension.
+ * @param {DoctorCheck} check
+ * @param {readonly DoctorCheck[]} checks
+ * @returns {DoctorCheck}
+ */
+function applyNotEstablishedCaveat(check, checks) {
+  const unassessed = checks.filter(entry => entry.status === "SKIP").length;
+  if (check.status !== "SKIP" || unassessed === 0) {
+    return check;
+  }
+  return {
+    ...check,
+    observed: `${check.observed} NOT ESTABLISHED: ${unassessed} of ${checks.length} dimensions were never assessed, so this cannot say whether an unattended fleet may operate here.`,
+  };
+}
+
+/**
+ * Collect the ids of the standing ship blockers a dimension owns. Blockers with
+ * no usable id are dropped rather than stringified, so a malformed record can
+ * never render "Standing ship blocker(s): undefined" at an operator.
+ * @param {{ id: string }} dimension
+ * @param {{ blockers: readonly Record<string, unknown>[] }} report
+ * @returns {readonly string[]}
+ */
+function standingBlockerIds(dimension, report) {
+  return report.blockers
+    .filter(
+      blocker =>
+        blocker !== null &&
+        typeof blocker === "object" &&
+        (blocker.dimension_id === dimension.id ||
+          (Array.isArray(blocker.owning_dimensions) &&
+            blocker.owning_dimensions.includes(dimension.id)))
+    )
+    .map(blocker => blocker.id)
+    .filter(id => typeof id === "string" && id.length > 0)
+    .filter((id, index, ids) => ids.indexOf(id) === index);
+}
+
+/**
  * Project one CLI dimension record into this surface's check shape, or `null`
  * when the record is absent or carries a status outside the shipped vocabulary
  * (the caller then falls back to the reasoned SKIP).
  * @param {{ id: string, question: string, skipReason: string }} dimension
- * @param {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] }} report
+ * @param {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[], narrowedClaim: string, provenance: string }} report
  * @returns {DoctorCheck | null}
  */
 function projectReadinessDimension(dimension, report) {
@@ -289,26 +361,27 @@ function projectReadinessDimension(dimension, report) {
   }
   const findings = Array.isArray(record.findings) ? record.findings : [];
   const summary = summarizeReadinessFindings(findings);
-  const blockerIds = report.blockers
-    .filter(
-      blocker =>
-        blocker !== null &&
-        typeof blocker === "object" &&
-        (blocker.dimension_id === dimension.id ||
-          (Array.isArray(blocker.owning_dimensions) &&
-            blocker.owning_dimensions.includes(dimension.id)))
-    )
-    .map(blocker => String(blocker.id))
-    .filter((id, index, ids) => ids.indexOf(id) === index);
+  const blockerIds = standingBlockerIds(dimension, report);
 
   return {
     id: dimension.id,
-    status: record.status,
+    // A standing blocker outranks the recorded label. Three CLI producers (B1
+    // domain-ownership, B4 feedback-guardrails, B6 context-routing) record
+    // `WARN` while standing a blocker, each stating in-line that "the blocker
+    // engine never reads this status, so the finding flips the repository to
+    // NOT_READY exactly as a FAIL would". Projecting that `WARN` verbatim would
+    // score READY_WITH_WARNINGS on a repository the CLI calls NOT_READY — the
+    // precise disagreement this bridge exists to eliminate. This still reflects
+    // the CLI's decision rather than re-scoring: the CLI decided the blocker
+    // stands and wrote it into `blockers[]`.
+    status: blockerIds.length > 0 ? "FAIL" : record.status,
     summary: summary.length > 0 ? summary : dimension.question,
-    observed: `${dimension.question} Projected from \`.lisa/readiness.json\` (schema_version ${READINESS_REPORT_SCHEMA_VERSION}), the report the Lisa CLI readiness pass wrote.`,
+    observed: `${dimension.question} Projected from \`.lisa/readiness.json\` (schema_version ${READINESS_REPORT_SCHEMA_VERSION}, ${report.provenance}), the report the Lisa CLI readiness pass wrote.`,
     ...(blockerIds.length > 0
       ? {
-          remediation: `Standing ship blocker(s): ${blockerIds.join(", ")}. See \`.lisa/readiness.json\` for the full evidence and the \`readiness-rubric\` rule for the blocker definitions.`,
+          remediation:
+            `Standing ship blocker(s): ${blockerIds.join(", ")}. See \`.lisa/readiness.json\` for the full evidence and the \`readiness-rubric\` rule for the blocker definitions.` +
+            (report.narrowedClaim.length > 0 ? ` ${report.narrowedClaim}` : ""),
         }
       : {}),
   };
@@ -334,23 +407,24 @@ function projectReadinessDimension(dimension, report) {
  */
 export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
   const report = readReadinessReport(path.resolve(root));
+  const checks = REPOSITORY_READINESS_DIMENSIONS.map(
+    dimension =>
+      (report === null
+        ? null
+        : projectReadinessDimension(dimension, report)) ?? {
+        id: dimension.id,
+        status: "SKIP",
+        summary: dimension.question,
+        observed:
+          report === null
+            ? dimension.skipReason
+            : `${dimension.question} \`.lisa/readiness.json\` carries no usable record for this dimension, so it was not assessed here. Re-run \`lisa doctor --offline --readiness\` to regenerate the report.`,
+      }
+  );
   return {
     id: "repository-readiness",
     title: "Repository readiness",
-    checks: REPOSITORY_READINESS_DIMENSIONS.map(
-      dimension =>
-        (report === null
-          ? null
-          : projectReadinessDimension(dimension, report)) ?? {
-          id: dimension.id,
-          status: "SKIP",
-          summary: dimension.question,
-          observed:
-            report === null
-              ? dimension.skipReason
-              : `${dimension.question} \`.lisa/readiness.json\` carries no usable record for this dimension, so it was not assessed here. Re-run \`lisa doctor --offline --readiness\` to regenerate the report.`,
-        }
-    ),
+    checks: checks.map(check => applyNotEstablishedCaveat(check, checks)),
   };
 }
 

--- a/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
@@ -319,9 +319,18 @@ default doctor path never renders it and stays byte-identical.
    contract; do not restate or fork that vocabulary here.
 3. **`SKIP` carries a reason and is never blank.** A dimension with no applicable evidence renders
    `SKIP` with a stated reason ("no deployment target configured, so delivery/authority was not
-   assessed"). An unassessed dimension is a known unknown, and the report says so. In Lisa versions
-   where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
-   with that reason.
+   assessed"). An unassessed dimension is a known unknown, and the report says so.
+
+   **This surface reflects the CLI; it does not re-score.** The evidence producers and the blocker
+   engine live in the Lisa CLI, which is the single source of truth. When `.lisa/readiness.json` is
+   present and readable (parses, matching `schema_version`, carries a `dimensions` array), this group
+   **projects** each recorded dimension's status and its operator-facing evidence/reason text, so an
+   operator running `/lisa:doctor` through any coding agent sees the same readiness answer the CLI
+   gives. When the report is absent, unparseable, or stamped with an unknown `schema_version` — or
+   records nothing for a given dimension — that dimension falls back to `SKIP` with the reason it was
+   not assessed. Absence means the readiness pass has not run, never that the repository is clean: a
+   pass or a fail is never manufactured from a missing report. Run
+   `lisa doctor --offline --readiness` to produce the report first.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
    severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
    evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed

--- a/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
@@ -331,6 +331,15 @@ default doctor path never renders it and stays byte-identical.
    not assessed. Absence means the readiness pass has not run, never that the repository is clean: a
    pass or a fail is never manufactured from a missing report. Run
    `lisa doctor --offline --readiness` to produce the report first.
+
+   **A standing blocker outranks the recorded status.** Some CLI producers record `WARN` while
+   standing a ship blocker — the blocker engine never reads the per-dimension status, so the finding
+   flips the repository to `NOT_READY` exactly as a `FAIL` would. A dimension that owns an entry in
+   the report's `blockers[]` therefore projects as `FAIL` regardless of its recorded label, and its
+   remediation names the blocker ids and repeats the report's `narrowed_claim` (the "IS ready for
+   supervised, single-ticket agent work" fallback `readiness-rubric` requires whenever a blocker
+   stands). Projected checks also carry the report's `generated_at`/`lisa_version` so a stale report
+   cannot read as current truth, and unassessed dimensions carry the CLI's not-established caveat.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
    severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
    evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed

--- a/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
@@ -319,9 +319,18 @@ default doctor path never renders it and stays byte-identical.
    contract; do not restate or fork that vocabulary here.
 3. **`SKIP` carries a reason and is never blank.** A dimension with no applicable evidence renders
    `SKIP` with a stated reason ("no deployment target configured, so delivery/authority was not
-   assessed"). An unassessed dimension is a known unknown, and the report says so. In Lisa versions
-   where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
-   with that reason.
+   assessed"). An unassessed dimension is a known unknown, and the report says so.
+
+   **This surface reflects the CLI; it does not re-score.** The evidence producers and the blocker
+   engine live in the Lisa CLI, which is the single source of truth. When `.lisa/readiness.json` is
+   present and readable (parses, matching `schema_version`, carries a `dimensions` array), this group
+   **projects** each recorded dimension's status and its operator-facing evidence/reason text, so an
+   operator running `/lisa:doctor` through any coding agent sees the same readiness answer the CLI
+   gives. When the report is absent, unparseable, or stamped with an unknown `schema_version` — or
+   records nothing for a given dimension — that dimension falls back to `SKIP` with the reason it was
+   not assessed. Absence means the readiness pass has not run, never that the repository is clean: a
+   pass or a fail is never manufactured from a missing report. Run
+   `lisa doctor --offline --readiness` to produce the report first.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
    severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
    evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed

--- a/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
@@ -331,6 +331,15 @@ default doctor path never renders it and stays byte-identical.
    not assessed. Absence means the readiness pass has not run, never that the repository is clean: a
    pass or a fail is never manufactured from a missing report. Run
    `lisa doctor --offline --readiness` to produce the report first.
+
+   **A standing blocker outranks the recorded status.** Some CLI producers record `WARN` while
+   standing a ship blocker — the blocker engine never reads the per-dimension status, so the finding
+   flips the repository to `NOT_READY` exactly as a `FAIL` would. A dimension that owns an entry in
+   the report's `blockers[]` therefore projects as `FAIL` regardless of its recorded label, and its
+   remediation names the blocker ids and repeats the report's `narrowed_claim` (the "IS ready for
+   supervised, single-ticket agent work" fallback `readiness-rubric` requires whenever a blocker
+   stands). Projected checks also carry the report's `generated_at`/`lisa_version` so a stale report
+   cannot read as current truth, and unassessed dimensions carry the CLI's not-established caveat.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
    severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
    evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed

--- a/plugins/lisa/scripts/doctor-report.mjs
+++ b/plugins/lisa/scripts/doctor-report.mjs
@@ -6,7 +6,7 @@
  * repo adds real readiness probes. Keep this file dependency-free so future
  * doctor scripts can reuse it from plugin distributions and downstream repos.
  */
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
@@ -121,9 +121,12 @@ export function createPluginSyncDoctorGroup(root = process.cwd()) {
 /**
  * The eight repository-readiness ownership dimensions, in fixed render order,
  * defined once by the `readiness-rubric` rule. This group consumes that rubric;
- * it does not redefine the vocabulary. Evidence gathering for each dimension is
- * wired by later PRD #1739 tickets, so every dimension renders `SKIP` with a
- * reason here — reported, never silently omitted, per the shipped contract.
+ * it does not redefine the vocabulary. Evidence gathering lives in the
+ * TypeScript CLI producers, which persist the authoritative per-dimension
+ * result to `.lisa/readiness.json`; this surface projects that result. When no
+ * usable report is on disk, each dimension renders `SKIP` carrying the reason
+ * it was not assessed — reported, never silently omitted, per the shipped
+ * contract.
  * @type {readonly { id: string, question: string, skipReason: string }[]}
  */
 const REPOSITORY_READINESS_DIMENSIONS = [
@@ -132,81 +135,222 @@ const REPOSITORY_READINESS_DIMENSIONS = [
     question:
       "Can an agent recover the real job from what is written down (integration-access-layer, wiki-knowledge-source, config-resolution)?",
     skipReason:
-      "Context/routing evidence is assessed by the agent-ready wiring (RRR-4, #1856); no readiness probe is wired in this Lisa version.",
+      "Context/routing evidence is assessed by the agent-ready wiring (RRR-4, #1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "capabilities-tools",
     question:
       "Is every tool the work needs provably reachable, not merely installed (tool-access-gate)?",
     skipReason:
-      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "domain-ownership",
     question:
       "Are the business rules, glossary, and danger zones owned and written down (agent-ready domain phase wiki pages)?",
     skipReason:
-      "Domain-ownership evidence sources from agent-ready's danger-zone wiki pages, read by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+      "Domain-ownership evidence sources from agent-ready's danger-zone wiki pages, read by RRR-4 (#1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "execution-proof",
     question:
       "Can the claimed user-visible outcome be proved by running the system (verification, empirical-inquiry, claim-evidence-mapping)?",
     skipReason:
-      "Execution/proof consumes qualification evidence and representative journeys wired by RRR-6 (#1858); no readiness probe is wired in this Lisa version.",
+      "Execution/proof consumes qualification evidence and representative journeys wired by RRR-6 (#1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "feedback-guardrails",
     question:
       "Does a failing loop produce a named outcome and a runbook (automation-runbook-contract, observability-audit)?",
     skipReason:
-      "Feedback/guardrails evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+      "Feedback/guardrails evidence is assessed by RRR-4 (#1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "dependencies-supply-chain",
     question:
       "Is there a confidence model for what the repo depends on (security-audit-handling)?",
     skipReason:
-      "Dependencies/supply-chain evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+      "Dependencies/supply-chain evidence is assessed by RRR-4 (#1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "delivery-authority",
     question:
       "Does the thing that ships equal the thing that was validated, and does the shipping credential carry only the authority it needs (claim-archaeology, security-audit-handling)?",
     skipReason:
-      "Delivery/authority blockers are populated by the blocker gate in RRR-5 (#1857); no readiness probe is wired in this Lisa version.",
+      "Delivery/authority blockers are populated by the blocker gate in RRR-5 (#1857); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "proportionality",
     question:
       "Is the machinery proportional to the job, or is there scaffolding to subtract (repo-scope-split, #1742 subtraction candidates)?",
     skipReason:
-      "Proportionality reuses the scaffolding-subtraction candidates surfaced by the journey work (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+      "Proportionality reuses the scaffolding-subtraction candidates surfaced by the journey work (RRR-6, #1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
 ];
+
+/**
+ * `schema_version` this surface knows how to project. A report stamped with any
+ * other version is treated as unreadable rather than guessed at: the whole point
+ * of the version stamp is that a reader may not invent a mapping it was never
+ * told about.
+ */
+const READINESS_REPORT_SCHEMA_VERSION = 1;
+
+/**
+ * Longest operator-facing summary projected out of a CLI finding. Findings can
+ * carry kilobytes of concatenated evidence (every offending workflow job, for
+ * example); the doctor line is a headline, and the full text stays available in
+ * `.lisa/readiness.json`.
+ */
+const READINESS_SUMMARY_MAX_LENGTH = 320;
+
+/**
+ * Resolve the single location the CLI writes the readiness report to. This
+ * mirrors the CLI's `resolveReadinessReportPath` so relocating the artifact
+ * stays a two-line change across both scorers.
+ * @param {string} repoRoot
+ * @returns {string}
+ */
+function resolveReadinessReportPath(repoRoot) {
+  return path.join(repoRoot, ".lisa", "readiness.json");
+}
+
+/**
+ * Read the CLI-authored readiness report, or `null` when there is nothing
+ * trustworthy to project. Absence, unparseable JSON, an unknown
+ * `schema_version`, and a missing `dimensions` array are all the same answer —
+ * "the CLI readiness pass has not produced a result this surface can read" —
+ * and none of them is evidence about the repository itself.
+ * @param {string} repoRoot
+ * @returns {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] } | null}
+ */
+function readReadinessReport(repoRoot) {
+  const reportPath = resolveReadinessReportPath(repoRoot);
+  if (!existsSync(reportPath)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(reportPath, "utf8"));
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      parsed.schema_version !== READINESS_REPORT_SCHEMA_VERSION ||
+      !Array.isArray(parsed.dimensions)
+    ) {
+      return null;
+    }
+    return {
+      dimensions: parsed.dimensions,
+      blockers: Array.isArray(parsed.blockers) ? parsed.blockers : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pull the operator-facing sentence out of a dimension's findings. The CLI
+ * producers write human text under `evidence` (an assessed dimension) or
+ * `reason` (a deliberately-unassessed one); the rest of the finding is machine
+ * bookkeeping the blocker engine owns.
+ * @param {readonly unknown[]} findings
+ * @returns {string}
+ */
+function summarizeReadinessFindings(findings) {
+  const sentences = findings
+    .filter(finding => finding !== null && typeof finding === "object")
+    .flatMap(finding => [finding.evidence, finding.reason])
+    .filter(text => typeof text === "string" && text.trim().length > 0)
+    .map(text => text.trim());
+  if (sentences.length === 0) {
+    return "";
+  }
+  const joined = sentences.join(" ");
+  return joined.length > READINESS_SUMMARY_MAX_LENGTH
+    ? `${joined.slice(0, READINESS_SUMMARY_MAX_LENGTH - 1).trimEnd()}…`
+    : joined;
+}
+
+/**
+ * Project one CLI dimension record into this surface's check shape, or `null`
+ * when the record is absent or carries a status outside the shipped vocabulary
+ * (the caller then falls back to the reasoned SKIP).
+ * @param {{ id: string, question: string, skipReason: string }} dimension
+ * @param {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] }} report
+ * @returns {DoctorCheck | null}
+ */
+function projectReadinessDimension(dimension, report) {
+  const record = report.dimensions.find(
+    entry =>
+      entry !== null && typeof entry === "object" && entry.id === dimension.id
+  );
+  if (!record || !DOCTOR_STATUSES.includes(record.status)) {
+    return null;
+  }
+  const findings = Array.isArray(record.findings) ? record.findings : [];
+  const summary = summarizeReadinessFindings(findings);
+  const blockerIds = report.blockers
+    .filter(
+      blocker =>
+        blocker !== null &&
+        typeof blocker === "object" &&
+        (blocker.dimension_id === dimension.id ||
+          (Array.isArray(blocker.owning_dimensions) &&
+            blocker.owning_dimensions.includes(dimension.id)))
+    )
+    .map(blocker => String(blocker.id))
+    .filter((id, index, ids) => ids.indexOf(id) === index);
+
+  return {
+    id: dimension.id,
+    status: record.status,
+    summary: summary.length > 0 ? summary : dimension.question,
+    observed: `${dimension.question} Projected from \`.lisa/readiness.json\` (schema_version ${READINESS_REPORT_SCHEMA_VERSION}), the report the Lisa CLI readiness pass wrote.`,
+    ...(blockerIds.length > 0
+      ? {
+          remediation: `Standing ship blocker(s): ${blockerIds.join(", ")}. See \`.lisa/readiness.json\` for the full evidence and the \`readiness-rubric\` rule for the blocker definitions.`,
+        }
+      : {}),
+  };
+}
 
 /**
  * Build the orthogonal "Repository readiness" doctor group ("may an agent fleet
  * operate here unattended?"), scored against the eight `readiness-rubric`
  * ownership dimensions. It is separate from the installation-readiness groups
  * and is appended in a fixed position by the readiness-mode caller; the eight
- * dimension checks render in fixed order. In this Lisa version every dimension
- * is `SKIP` with a stated reason because the evidence-gathering surfaces ship
- * with later PRD #1739 tickets — reported, never silently omitted.
+ * dimension checks render in fixed order.
+ *
+ * The blocker engine and the evidence producers live in the TypeScript CLI,
+ * which is the single source of truth; this surface is a bridge, not a second
+ * implementation (#1902). It projects whatever the CLI persisted to
+ * `.lisa/readiness.json` so an operator running `/lisa:doctor` through any
+ * coding agent gets the same readiness answer the CLI gives. When no usable
+ * report exists, every unmatched dimension renders `SKIP` with its reason:
+ * absence means the readiness pass has not run, never that the repository is
+ * clean, so a pass or fail is never manufactured from it.
  * @param {string} root
  * @returns {DoctorGroup}
  */
 export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
-  void path.resolve(root);
+  const report = readReadinessReport(path.resolve(root));
   return {
     id: "repository-readiness",
     title: "Repository readiness",
-    checks: REPOSITORY_READINESS_DIMENSIONS.map(dimension => ({
-      id: dimension.id,
-      status: "SKIP",
-      summary: dimension.question,
-      observed: dimension.skipReason,
-    })),
+    checks: REPOSITORY_READINESS_DIMENSIONS.map(
+      dimension =>
+        (report === null
+          ? null
+          : projectReadinessDimension(dimension, report)) ?? {
+          id: dimension.id,
+          status: "SKIP",
+          summary: dimension.question,
+          observed:
+            report === null
+              ? dimension.skipReason
+              : `${dimension.question} \`.lisa/readiness.json\` carries no usable record for this dimension, so it was not assessed here. Re-run \`lisa doctor --offline --readiness\` to regenerate the report.`,
+        }
+    ),
   };
 }
 

--- a/plugins/lisa/scripts/doctor-report.mjs
+++ b/plugins/lisa/scripts/doctor-report.mjs
@@ -321,9 +321,37 @@ function applyNotEstablishedCaveat(check, checks) {
 }
 
 /**
- * Collect the ids of the standing ship blockers a dimension owns. Blockers with
- * no usable id are dropped rather than stringified, so a malformed record can
- * never render "Standing ship blocker(s): undefined" at an operator.
+ * Decide whether a standing blocker was evidenced in this dimension.
+ *
+ * `dimension_id` is the authority: the CLI's `buildDetectedBlocker` documents it
+ * as "the dimension the evidencing finding was found in". `owning_dimensions` is
+ * the blocker's static spec and can name dimensions that did NOT evidence it —
+ * B4 is specced as `[domain-ownership, feedback-guardrails]` while only the
+ * guardrails producer ever emits the B4 finding. Escalating on the spec would
+ * stamp `FAIL` on a dimension whose own recorded evidence says it found nothing,
+ * contradicting both that evidence and the CLI's per-dimension result. The spec
+ * is used only as a fallback, for a blocker record carrying no attribution.
+ * @param {Record<string, unknown>} blocker
+ * @param {{ id: string }} dimension
+ * @returns {boolean}
+ */
+function blockerEvidencedIn(blocker, dimension) {
+  if (
+    typeof blocker.dimension_id === "string" &&
+    blocker.dimension_id.length > 0
+  ) {
+    return blocker.dimension_id === dimension.id;
+  }
+  return (
+    Array.isArray(blocker.owning_dimensions) &&
+    blocker.owning_dimensions.includes(dimension.id)
+  );
+}
+
+/**
+ * Collect the ids of the standing ship blockers evidenced in a dimension.
+ * Blockers with no usable id are dropped rather than stringified, so a malformed
+ * record can never render "Standing ship blocker(s): undefined" at an operator.
  * @param {{ id: string }} dimension
  * @param {{ blockers: readonly Record<string, unknown>[] }} report
  * @returns {readonly string[]}
@@ -334,9 +362,7 @@ function standingBlockerIds(dimension, report) {
       blocker =>
         blocker !== null &&
         typeof blocker === "object" &&
-        (blocker.dimension_id === dimension.id ||
-          (Array.isArray(blocker.owning_dimensions) &&
-            blocker.owning_dimensions.includes(dimension.id)))
+        blockerEvidencedIn(blocker, dimension)
     )
     .map(blocker => blocker.id)
     .filter(id => typeof id === "string" && id.length > 0)

--- a/plugins/lisa/scripts/doctor-report.mjs
+++ b/plugins/lisa/scripts/doctor-report.mjs
@@ -142,7 +142,7 @@ const REPOSITORY_READINESS_DIMENSIONS = [
     question:
       "Is every tool the work needs provably reachable, not merely installed (tool-access-gate)?",
     skipReason:
-      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
+      "Tool reachability needs a live read-only probe and can never be established from an offline read: the `tool-access-gate` rule names presence — a binary on `PATH`, a dependency in a manifest, a configured MCP server — as the anti-pattern, because it proves a tool was declared, never that a request through it succeeded. This dimension is therefore a deliberate, permanent reasoned SKIP on an offline pass rather than a not-yet-wired one; only a run that actually exercises the tools can answer it.",
   },
   {
     id: "domain-ownership",
@@ -222,7 +222,7 @@ function resolveReadinessReportPath(repoRoot) {
  * "the CLI readiness pass has not produced a result this surface can read" —
  * and none of them is evidence about the repository itself.
  * @param {string} repoRoot
- * @returns {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] } | null}
+ * @returns {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[], narrowedClaim: string, provenance: string } | null}
  */
 function readReadinessReport(repoRoot) {
   const reportPath = resolveReadinessReportPath(repoRoot);
@@ -242,6 +242,15 @@ function readReadinessReport(repoRoot) {
     return {
       dimensions: parsed.dimensions,
       blockers: Array.isArray(parsed.blockers) ? parsed.blockers : [],
+      // The narrowed claim is the sentence `readiness-rubric` requires whenever
+      // a blocker stands ("...IS ready for supervised, single-ticket agent
+      // work..."). Dropping it would hand the agent operator a bare NOT_READY
+      // where the CLI hands them the fallback they can actually act on.
+      narrowedClaim:
+        typeof parsed.narrowed_claim === "string" ? parsed.narrowed_claim : "",
+      // Stamped into every projected check so a months-old report cannot read
+      // as current truth: this surface reflects a file, not a live assessment.
+      provenance: describeReportProvenance(parsed),
     };
   } catch {
     return null;
@@ -249,17 +258,36 @@ function readReadinessReport(repoRoot) {
 }
 
 /**
+ * Describe when the projected report was produced and by which Lisa version.
+ * @param {Record<string, unknown>} parsed
+ * @returns {string}
+ */
+function describeReportProvenance(parsed) {
+  const generatedAt =
+    typeof parsed.generated_at === "string" && parsed.generated_at.length > 0
+      ? parsed.generated_at
+      : "an unrecorded time";
+  const version =
+    typeof parsed.lisa_version === "string" && parsed.lisa_version.length > 0
+      ? ` by Lisa ${parsed.lisa_version}`
+      : "";
+  return `generated ${generatedAt}${version}`;
+}
+
+/**
  * Pull the operator-facing sentence out of a dimension's findings. The CLI
- * producers write human text under `evidence` (an assessed dimension) or
- * `reason` (a deliberately-unassessed one); the rest of the finding is machine
- * bookkeeping the blocker engine owns.
+ * producers write human text under `evidence` (an assessed dimension),
+ * `reason` (a deliberately-unassessed one), or `observation` (a neutral note);
+ * the rest of the finding is machine bookkeeping the blocker engine owns.
+ * Reading only two of the three would print the dimension's question under a
+ * FAIL, which reads as "nothing to report" exactly when there is most to say.
  * @param {readonly unknown[]} findings
  * @returns {string}
  */
 function summarizeReadinessFindings(findings) {
   const sentences = findings
     .filter(finding => finding !== null && typeof finding === "object")
-    .flatMap(finding => [finding.evidence, finding.reason])
+    .flatMap(finding => [finding.evidence, finding.reason, finding.observation])
     .filter(text => typeof text === "string" && text.trim().length > 0)
     .map(text => text.trim());
   if (sentences.length === 0) {
@@ -272,11 +300,55 @@ function summarizeReadinessFindings(findings) {
 }
 
 /**
+ * Carry the CLI's not-established caveat onto every unassessed dimension. The
+ * CLI headline says it out loud — "N of 8 dimensions were never assessed, so
+ * this cannot say whether an unattended fleet may operate here" — and a reader
+ * who sees a lone `SKIP` line without it can mistake silence for a clean bill
+ * of health on that dimension.
+ * @param {DoctorCheck} check
+ * @param {readonly DoctorCheck[]} checks
+ * @returns {DoctorCheck}
+ */
+function applyNotEstablishedCaveat(check, checks) {
+  const unassessed = checks.filter(entry => entry.status === "SKIP").length;
+  if (check.status !== "SKIP" || unassessed === 0) {
+    return check;
+  }
+  return {
+    ...check,
+    observed: `${check.observed} NOT ESTABLISHED: ${unassessed} of ${checks.length} dimensions were never assessed, so this cannot say whether an unattended fleet may operate here.`,
+  };
+}
+
+/**
+ * Collect the ids of the standing ship blockers a dimension owns. Blockers with
+ * no usable id are dropped rather than stringified, so a malformed record can
+ * never render "Standing ship blocker(s): undefined" at an operator.
+ * @param {{ id: string }} dimension
+ * @param {{ blockers: readonly Record<string, unknown>[] }} report
+ * @returns {readonly string[]}
+ */
+function standingBlockerIds(dimension, report) {
+  return report.blockers
+    .filter(
+      blocker =>
+        blocker !== null &&
+        typeof blocker === "object" &&
+        (blocker.dimension_id === dimension.id ||
+          (Array.isArray(blocker.owning_dimensions) &&
+            blocker.owning_dimensions.includes(dimension.id)))
+    )
+    .map(blocker => blocker.id)
+    .filter(id => typeof id === "string" && id.length > 0)
+    .filter((id, index, ids) => ids.indexOf(id) === index);
+}
+
+/**
  * Project one CLI dimension record into this surface's check shape, or `null`
  * when the record is absent or carries a status outside the shipped vocabulary
  * (the caller then falls back to the reasoned SKIP).
  * @param {{ id: string, question: string, skipReason: string }} dimension
- * @param {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] }} report
+ * @param {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[], narrowedClaim: string, provenance: string }} report
  * @returns {DoctorCheck | null}
  */
 function projectReadinessDimension(dimension, report) {
@@ -289,26 +361,27 @@ function projectReadinessDimension(dimension, report) {
   }
   const findings = Array.isArray(record.findings) ? record.findings : [];
   const summary = summarizeReadinessFindings(findings);
-  const blockerIds = report.blockers
-    .filter(
-      blocker =>
-        blocker !== null &&
-        typeof blocker === "object" &&
-        (blocker.dimension_id === dimension.id ||
-          (Array.isArray(blocker.owning_dimensions) &&
-            blocker.owning_dimensions.includes(dimension.id)))
-    )
-    .map(blocker => String(blocker.id))
-    .filter((id, index, ids) => ids.indexOf(id) === index);
+  const blockerIds = standingBlockerIds(dimension, report);
 
   return {
     id: dimension.id,
-    status: record.status,
+    // A standing blocker outranks the recorded label. Three CLI producers (B1
+    // domain-ownership, B4 feedback-guardrails, B6 context-routing) record
+    // `WARN` while standing a blocker, each stating in-line that "the blocker
+    // engine never reads this status, so the finding flips the repository to
+    // NOT_READY exactly as a FAIL would". Projecting that `WARN` verbatim would
+    // score READY_WITH_WARNINGS on a repository the CLI calls NOT_READY — the
+    // precise disagreement this bridge exists to eliminate. This still reflects
+    // the CLI's decision rather than re-scoring: the CLI decided the blocker
+    // stands and wrote it into `blockers[]`.
+    status: blockerIds.length > 0 ? "FAIL" : record.status,
     summary: summary.length > 0 ? summary : dimension.question,
-    observed: `${dimension.question} Projected from \`.lisa/readiness.json\` (schema_version ${READINESS_REPORT_SCHEMA_VERSION}), the report the Lisa CLI readiness pass wrote.`,
+    observed: `${dimension.question} Projected from \`.lisa/readiness.json\` (schema_version ${READINESS_REPORT_SCHEMA_VERSION}, ${report.provenance}), the report the Lisa CLI readiness pass wrote.`,
     ...(blockerIds.length > 0
       ? {
-          remediation: `Standing ship blocker(s): ${blockerIds.join(", ")}. See \`.lisa/readiness.json\` for the full evidence and the \`readiness-rubric\` rule for the blocker definitions.`,
+          remediation:
+            `Standing ship blocker(s): ${blockerIds.join(", ")}. See \`.lisa/readiness.json\` for the full evidence and the \`readiness-rubric\` rule for the blocker definitions.` +
+            (report.narrowedClaim.length > 0 ? ` ${report.narrowedClaim}` : ""),
         }
       : {}),
   };
@@ -334,23 +407,24 @@ function projectReadinessDimension(dimension, report) {
  */
 export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
   const report = readReadinessReport(path.resolve(root));
+  const checks = REPOSITORY_READINESS_DIMENSIONS.map(
+    dimension =>
+      (report === null
+        ? null
+        : projectReadinessDimension(dimension, report)) ?? {
+        id: dimension.id,
+        status: "SKIP",
+        summary: dimension.question,
+        observed:
+          report === null
+            ? dimension.skipReason
+            : `${dimension.question} \`.lisa/readiness.json\` carries no usable record for this dimension, so it was not assessed here. Re-run \`lisa doctor --offline --readiness\` to regenerate the report.`,
+      }
+  );
   return {
     id: "repository-readiness",
     title: "Repository readiness",
-    checks: REPOSITORY_READINESS_DIMENSIONS.map(
-      dimension =>
-        (report === null
-          ? null
-          : projectReadinessDimension(dimension, report)) ?? {
-          id: dimension.id,
-          status: "SKIP",
-          summary: dimension.question,
-          observed:
-            report === null
-              ? dimension.skipReason
-              : `${dimension.question} \`.lisa/readiness.json\` carries no usable record for this dimension, so it was not assessed here. Re-run \`lisa doctor --offline --readiness\` to regenerate the report.`,
-        }
-    ),
+    checks: checks.map(check => applyNotEstablishedCaveat(check, checks)),
   };
 }
 

--- a/plugins/lisa/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/skills/lisa-doctor/SKILL.md
@@ -319,9 +319,18 @@ default doctor path never renders it and stays byte-identical.
    contract; do not restate or fork that vocabulary here.
 3. **`SKIP` carries a reason and is never blank.** A dimension with no applicable evidence renders
    `SKIP` with a stated reason ("no deployment target configured, so delivery/authority was not
-   assessed"). An unassessed dimension is a known unknown, and the report says so. In Lisa versions
-   where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
-   with that reason.
+   assessed"). An unassessed dimension is a known unknown, and the report says so.
+
+   **This surface reflects the CLI; it does not re-score.** The evidence producers and the blocker
+   engine live in the Lisa CLI, which is the single source of truth. When `.lisa/readiness.json` is
+   present and readable (parses, matching `schema_version`, carries a `dimensions` array), this group
+   **projects** each recorded dimension's status and its operator-facing evidence/reason text, so an
+   operator running `/lisa:doctor` through any coding agent sees the same readiness answer the CLI
+   gives. When the report is absent, unparseable, or stamped with an unknown `schema_version` — or
+   records nothing for a given dimension — that dimension falls back to `SKIP` with the reason it was
+   not assessed. Absence means the readiness pass has not run, never that the repository is clean: a
+   pass or a fail is never manufactured from a missing report. Run
+   `lisa doctor --offline --readiness` to produce the report first.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
    severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
    evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed

--- a/plugins/lisa/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/skills/lisa-doctor/SKILL.md
@@ -331,6 +331,15 @@ default doctor path never renders it and stays byte-identical.
    not assessed. Absence means the readiness pass has not run, never that the repository is clean: a
    pass or a fail is never manufactured from a missing report. Run
    `lisa doctor --offline --readiness` to produce the report first.
+
+   **A standing blocker outranks the recorded status.** Some CLI producers record `WARN` while
+   standing a ship blocker — the blocker engine never reads the per-dimension status, so the finding
+   flips the repository to `NOT_READY` exactly as a `FAIL` would. A dimension that owns an entry in
+   the report's `blockers[]` therefore projects as `FAIL` regardless of its recorded label, and its
+   remediation names the blocker ids and repeats the report's `narrowed_claim` (the "IS ready for
+   supervised, single-ticket agent work" fallback `readiness-rubric` requires whenever a blocker
+   stands). Projected checks also carry the report's `generated_at`/`lisa_version` so a stale report
+   cannot read as current truth, and unassessed dimensions carry the CLI's not-established caveat.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
    severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
    evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed

--- a/plugins/src/base/scripts/doctor-report.mjs
+++ b/plugins/src/base/scripts/doctor-report.mjs
@@ -6,7 +6,7 @@
  * repo adds real readiness probes. Keep this file dependency-free so future
  * doctor scripts can reuse it from plugin distributions and downstream repos.
  */
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
@@ -121,9 +121,12 @@ export function createPluginSyncDoctorGroup(root = process.cwd()) {
 /**
  * The eight repository-readiness ownership dimensions, in fixed render order,
  * defined once by the `readiness-rubric` rule. This group consumes that rubric;
- * it does not redefine the vocabulary. Evidence gathering for each dimension is
- * wired by later PRD #1739 tickets, so every dimension renders `SKIP` with a
- * reason here — reported, never silently omitted, per the shipped contract.
+ * it does not redefine the vocabulary. Evidence gathering lives in the
+ * TypeScript CLI producers, which persist the authoritative per-dimension
+ * result to `.lisa/readiness.json`; this surface projects that result. When no
+ * usable report is on disk, each dimension renders `SKIP` carrying the reason
+ * it was not assessed — reported, never silently omitted, per the shipped
+ * contract.
  * @type {readonly { id: string, question: string, skipReason: string }[]}
  */
 const REPOSITORY_READINESS_DIMENSIONS = [
@@ -132,81 +135,222 @@ const REPOSITORY_READINESS_DIMENSIONS = [
     question:
       "Can an agent recover the real job from what is written down (integration-access-layer, wiki-knowledge-source, config-resolution)?",
     skipReason:
-      "Context/routing evidence is assessed by the agent-ready wiring (RRR-4, #1856); no readiness probe is wired in this Lisa version.",
+      "Context/routing evidence is assessed by the agent-ready wiring (RRR-4, #1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "capabilities-tools",
     question:
       "Is every tool the work needs provably reachable, not merely installed (tool-access-gate)?",
     skipReason:
-      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "domain-ownership",
     question:
       "Are the business rules, glossary, and danger zones owned and written down (agent-ready domain phase wiki pages)?",
     skipReason:
-      "Domain-ownership evidence sources from agent-ready's danger-zone wiki pages, read by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+      "Domain-ownership evidence sources from agent-ready's danger-zone wiki pages, read by RRR-4 (#1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "execution-proof",
     question:
       "Can the claimed user-visible outcome be proved by running the system (verification, empirical-inquiry, claim-evidence-mapping)?",
     skipReason:
-      "Execution/proof consumes qualification evidence and representative journeys wired by RRR-6 (#1858); no readiness probe is wired in this Lisa version.",
+      "Execution/proof consumes qualification evidence and representative journeys wired by RRR-6 (#1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "feedback-guardrails",
     question:
       "Does a failing loop produce a named outcome and a runbook (automation-runbook-contract, observability-audit)?",
     skipReason:
-      "Feedback/guardrails evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+      "Feedback/guardrails evidence is assessed by RRR-4 (#1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "dependencies-supply-chain",
     question:
       "Is there a confidence model for what the repo depends on (security-audit-handling)?",
     skipReason:
-      "Dependencies/supply-chain evidence is assessed by RRR-4 (#1856); no readiness probe is wired in this Lisa version.",
+      "Dependencies/supply-chain evidence is assessed by RRR-4 (#1856); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "delivery-authority",
     question:
       "Does the thing that ships equal the thing that was validated, and does the shipping credential carry only the authority it needs (claim-archaeology, security-audit-handling)?",
     skipReason:
-      "Delivery/authority blockers are populated by the blocker gate in RRR-5 (#1857); no readiness probe is wired in this Lisa version.",
+      "Delivery/authority blockers are populated by the blocker gate in RRR-5 (#1857); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
   {
     id: "proportionality",
     question:
       "Is the machinery proportional to the job, or is there scaffolding to subtract (repo-scope-split, #1742 subtraction candidates)?",
     skipReason:
-      "Proportionality reuses the scaffolding-subtraction candidates surfaced by the journey work (RRR-6, #1858); no readiness probe is wired in this Lisa version.",
+      "Proportionality reuses the scaffolding-subtraction candidates surfaced by the journey work (RRR-6, #1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
   },
 ];
+
+/**
+ * `schema_version` this surface knows how to project. A report stamped with any
+ * other version is treated as unreadable rather than guessed at: the whole point
+ * of the version stamp is that a reader may not invent a mapping it was never
+ * told about.
+ */
+const READINESS_REPORT_SCHEMA_VERSION = 1;
+
+/**
+ * Longest operator-facing summary projected out of a CLI finding. Findings can
+ * carry kilobytes of concatenated evidence (every offending workflow job, for
+ * example); the doctor line is a headline, and the full text stays available in
+ * `.lisa/readiness.json`.
+ */
+const READINESS_SUMMARY_MAX_LENGTH = 320;
+
+/**
+ * Resolve the single location the CLI writes the readiness report to. This
+ * mirrors the CLI's `resolveReadinessReportPath` so relocating the artifact
+ * stays a two-line change across both scorers.
+ * @param {string} repoRoot
+ * @returns {string}
+ */
+function resolveReadinessReportPath(repoRoot) {
+  return path.join(repoRoot, ".lisa", "readiness.json");
+}
+
+/**
+ * Read the CLI-authored readiness report, or `null` when there is nothing
+ * trustworthy to project. Absence, unparseable JSON, an unknown
+ * `schema_version`, and a missing `dimensions` array are all the same answer —
+ * "the CLI readiness pass has not produced a result this surface can read" —
+ * and none of them is evidence about the repository itself.
+ * @param {string} repoRoot
+ * @returns {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] } | null}
+ */
+function readReadinessReport(repoRoot) {
+  const reportPath = resolveReadinessReportPath(repoRoot);
+  if (!existsSync(reportPath)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(reportPath, "utf8"));
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      parsed.schema_version !== READINESS_REPORT_SCHEMA_VERSION ||
+      !Array.isArray(parsed.dimensions)
+    ) {
+      return null;
+    }
+    return {
+      dimensions: parsed.dimensions,
+      blockers: Array.isArray(parsed.blockers) ? parsed.blockers : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pull the operator-facing sentence out of a dimension's findings. The CLI
+ * producers write human text under `evidence` (an assessed dimension) or
+ * `reason` (a deliberately-unassessed one); the rest of the finding is machine
+ * bookkeeping the blocker engine owns.
+ * @param {readonly unknown[]} findings
+ * @returns {string}
+ */
+function summarizeReadinessFindings(findings) {
+  const sentences = findings
+    .filter(finding => finding !== null && typeof finding === "object")
+    .flatMap(finding => [finding.evidence, finding.reason])
+    .filter(text => typeof text === "string" && text.trim().length > 0)
+    .map(text => text.trim());
+  if (sentences.length === 0) {
+    return "";
+  }
+  const joined = sentences.join(" ");
+  return joined.length > READINESS_SUMMARY_MAX_LENGTH
+    ? `${joined.slice(0, READINESS_SUMMARY_MAX_LENGTH - 1).trimEnd()}…`
+    : joined;
+}
+
+/**
+ * Project one CLI dimension record into this surface's check shape, or `null`
+ * when the record is absent or carries a status outside the shipped vocabulary
+ * (the caller then falls back to the reasoned SKIP).
+ * @param {{ id: string, question: string, skipReason: string }} dimension
+ * @param {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] }} report
+ * @returns {DoctorCheck | null}
+ */
+function projectReadinessDimension(dimension, report) {
+  const record = report.dimensions.find(
+    entry =>
+      entry !== null && typeof entry === "object" && entry.id === dimension.id
+  );
+  if (!record || !DOCTOR_STATUSES.includes(record.status)) {
+    return null;
+  }
+  const findings = Array.isArray(record.findings) ? record.findings : [];
+  const summary = summarizeReadinessFindings(findings);
+  const blockerIds = report.blockers
+    .filter(
+      blocker =>
+        blocker !== null &&
+        typeof blocker === "object" &&
+        (blocker.dimension_id === dimension.id ||
+          (Array.isArray(blocker.owning_dimensions) &&
+            blocker.owning_dimensions.includes(dimension.id)))
+    )
+    .map(blocker => String(blocker.id))
+    .filter((id, index, ids) => ids.indexOf(id) === index);
+
+  return {
+    id: dimension.id,
+    status: record.status,
+    summary: summary.length > 0 ? summary : dimension.question,
+    observed: `${dimension.question} Projected from \`.lisa/readiness.json\` (schema_version ${READINESS_REPORT_SCHEMA_VERSION}), the report the Lisa CLI readiness pass wrote.`,
+    ...(blockerIds.length > 0
+      ? {
+          remediation: `Standing ship blocker(s): ${blockerIds.join(", ")}. See \`.lisa/readiness.json\` for the full evidence and the \`readiness-rubric\` rule for the blocker definitions.`,
+        }
+      : {}),
+  };
+}
 
 /**
  * Build the orthogonal "Repository readiness" doctor group ("may an agent fleet
  * operate here unattended?"), scored against the eight `readiness-rubric`
  * ownership dimensions. It is separate from the installation-readiness groups
  * and is appended in a fixed position by the readiness-mode caller; the eight
- * dimension checks render in fixed order. In this Lisa version every dimension
- * is `SKIP` with a stated reason because the evidence-gathering surfaces ship
- * with later PRD #1739 tickets — reported, never silently omitted.
+ * dimension checks render in fixed order.
+ *
+ * The blocker engine and the evidence producers live in the TypeScript CLI,
+ * which is the single source of truth; this surface is a bridge, not a second
+ * implementation (#1902). It projects whatever the CLI persisted to
+ * `.lisa/readiness.json` so an operator running `/lisa:doctor` through any
+ * coding agent gets the same readiness answer the CLI gives. When no usable
+ * report exists, every unmatched dimension renders `SKIP` with its reason:
+ * absence means the readiness pass has not run, never that the repository is
+ * clean, so a pass or fail is never manufactured from it.
  * @param {string} root
  * @returns {DoctorGroup}
  */
 export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
-  void path.resolve(root);
+  const report = readReadinessReport(path.resolve(root));
   return {
     id: "repository-readiness",
     title: "Repository readiness",
-    checks: REPOSITORY_READINESS_DIMENSIONS.map(dimension => ({
-      id: dimension.id,
-      status: "SKIP",
-      summary: dimension.question,
-      observed: dimension.skipReason,
-    })),
+    checks: REPOSITORY_READINESS_DIMENSIONS.map(
+      dimension =>
+        (report === null
+          ? null
+          : projectReadinessDimension(dimension, report)) ?? {
+          id: dimension.id,
+          status: "SKIP",
+          summary: dimension.question,
+          observed:
+            report === null
+              ? dimension.skipReason
+              : `${dimension.question} \`.lisa/readiness.json\` carries no usable record for this dimension, so it was not assessed here. Re-run \`lisa doctor --offline --readiness\` to regenerate the report.`,
+        }
+    ),
   };
 }
 

--- a/plugins/src/base/scripts/doctor-report.mjs
+++ b/plugins/src/base/scripts/doctor-report.mjs
@@ -321,9 +321,37 @@ function applyNotEstablishedCaveat(check, checks) {
 }
 
 /**
- * Collect the ids of the standing ship blockers a dimension owns. Blockers with
- * no usable id are dropped rather than stringified, so a malformed record can
- * never render "Standing ship blocker(s): undefined" at an operator.
+ * Decide whether a standing blocker was evidenced in this dimension.
+ *
+ * `dimension_id` is the authority: the CLI's `buildDetectedBlocker` documents it
+ * as "the dimension the evidencing finding was found in". `owning_dimensions` is
+ * the blocker's static spec and can name dimensions that did NOT evidence it —
+ * B4 is specced as `[domain-ownership, feedback-guardrails]` while only the
+ * guardrails producer ever emits the B4 finding. Escalating on the spec would
+ * stamp `FAIL` on a dimension whose own recorded evidence says it found nothing,
+ * contradicting both that evidence and the CLI's per-dimension result. The spec
+ * is used only as a fallback, for a blocker record carrying no attribution.
+ * @param {Record<string, unknown>} blocker
+ * @param {{ id: string }} dimension
+ * @returns {boolean}
+ */
+function blockerEvidencedIn(blocker, dimension) {
+  if (
+    typeof blocker.dimension_id === "string" &&
+    blocker.dimension_id.length > 0
+  ) {
+    return blocker.dimension_id === dimension.id;
+  }
+  return (
+    Array.isArray(blocker.owning_dimensions) &&
+    blocker.owning_dimensions.includes(dimension.id)
+  );
+}
+
+/**
+ * Collect the ids of the standing ship blockers evidenced in a dimension.
+ * Blockers with no usable id are dropped rather than stringified, so a malformed
+ * record can never render "Standing ship blocker(s): undefined" at an operator.
  * @param {{ id: string }} dimension
  * @param {{ blockers: readonly Record<string, unknown>[] }} report
  * @returns {readonly string[]}
@@ -334,9 +362,7 @@ function standingBlockerIds(dimension, report) {
       blocker =>
         blocker !== null &&
         typeof blocker === "object" &&
-        (blocker.dimension_id === dimension.id ||
-          (Array.isArray(blocker.owning_dimensions) &&
-            blocker.owning_dimensions.includes(dimension.id)))
+        blockerEvidencedIn(blocker, dimension)
     )
     .map(blocker => blocker.id)
     .filter(id => typeof id === "string" && id.length > 0)

--- a/plugins/src/base/scripts/doctor-report.mjs
+++ b/plugins/src/base/scripts/doctor-report.mjs
@@ -142,7 +142,7 @@ const REPOSITORY_READINESS_DIMENSIONS = [
     question:
       "Is every tool the work needs provably reachable, not merely installed (tool-access-gate)?",
     skipReason:
-      "Capabilities/tools evidence is gathered by the journey-execution wiring (RRR-6, #1858); no usable `.lisa/readiness.json` was found, so this dimension was not assessed here. Run `lisa doctor --offline --readiness` to produce the report, then re-run doctor.",
+      "Tool reachability needs a live read-only probe and can never be established from an offline read: the `tool-access-gate` rule names presence — a binary on `PATH`, a dependency in a manifest, a configured MCP server — as the anti-pattern, because it proves a tool was declared, never that a request through it succeeded. This dimension is therefore a deliberate, permanent reasoned SKIP on an offline pass rather than a not-yet-wired one; only a run that actually exercises the tools can answer it.",
   },
   {
     id: "domain-ownership",
@@ -222,7 +222,7 @@ function resolveReadinessReportPath(repoRoot) {
  * "the CLI readiness pass has not produced a result this surface can read" —
  * and none of them is evidence about the repository itself.
  * @param {string} repoRoot
- * @returns {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] } | null}
+ * @returns {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[], narrowedClaim: string, provenance: string } | null}
  */
 function readReadinessReport(repoRoot) {
   const reportPath = resolveReadinessReportPath(repoRoot);
@@ -242,6 +242,15 @@ function readReadinessReport(repoRoot) {
     return {
       dimensions: parsed.dimensions,
       blockers: Array.isArray(parsed.blockers) ? parsed.blockers : [],
+      // The narrowed claim is the sentence `readiness-rubric` requires whenever
+      // a blocker stands ("...IS ready for supervised, single-ticket agent
+      // work..."). Dropping it would hand the agent operator a bare NOT_READY
+      // where the CLI hands them the fallback they can actually act on.
+      narrowedClaim:
+        typeof parsed.narrowed_claim === "string" ? parsed.narrowed_claim : "",
+      // Stamped into every projected check so a months-old report cannot read
+      // as current truth: this surface reflects a file, not a live assessment.
+      provenance: describeReportProvenance(parsed),
     };
   } catch {
     return null;
@@ -249,17 +258,36 @@ function readReadinessReport(repoRoot) {
 }
 
 /**
+ * Describe when the projected report was produced and by which Lisa version.
+ * @param {Record<string, unknown>} parsed
+ * @returns {string}
+ */
+function describeReportProvenance(parsed) {
+  const generatedAt =
+    typeof parsed.generated_at === "string" && parsed.generated_at.length > 0
+      ? parsed.generated_at
+      : "an unrecorded time";
+  const version =
+    typeof parsed.lisa_version === "string" && parsed.lisa_version.length > 0
+      ? ` by Lisa ${parsed.lisa_version}`
+      : "";
+  return `generated ${generatedAt}${version}`;
+}
+
+/**
  * Pull the operator-facing sentence out of a dimension's findings. The CLI
- * producers write human text under `evidence` (an assessed dimension) or
- * `reason` (a deliberately-unassessed one); the rest of the finding is machine
- * bookkeeping the blocker engine owns.
+ * producers write human text under `evidence` (an assessed dimension),
+ * `reason` (a deliberately-unassessed one), or `observation` (a neutral note);
+ * the rest of the finding is machine bookkeeping the blocker engine owns.
+ * Reading only two of the three would print the dimension's question under a
+ * FAIL, which reads as "nothing to report" exactly when there is most to say.
  * @param {readonly unknown[]} findings
  * @returns {string}
  */
 function summarizeReadinessFindings(findings) {
   const sentences = findings
     .filter(finding => finding !== null && typeof finding === "object")
-    .flatMap(finding => [finding.evidence, finding.reason])
+    .flatMap(finding => [finding.evidence, finding.reason, finding.observation])
     .filter(text => typeof text === "string" && text.trim().length > 0)
     .map(text => text.trim());
   if (sentences.length === 0) {
@@ -272,11 +300,55 @@ function summarizeReadinessFindings(findings) {
 }
 
 /**
+ * Carry the CLI's not-established caveat onto every unassessed dimension. The
+ * CLI headline says it out loud — "N of 8 dimensions were never assessed, so
+ * this cannot say whether an unattended fleet may operate here" — and a reader
+ * who sees a lone `SKIP` line without it can mistake silence for a clean bill
+ * of health on that dimension.
+ * @param {DoctorCheck} check
+ * @param {readonly DoctorCheck[]} checks
+ * @returns {DoctorCheck}
+ */
+function applyNotEstablishedCaveat(check, checks) {
+  const unassessed = checks.filter(entry => entry.status === "SKIP").length;
+  if (check.status !== "SKIP" || unassessed === 0) {
+    return check;
+  }
+  return {
+    ...check,
+    observed: `${check.observed} NOT ESTABLISHED: ${unassessed} of ${checks.length} dimensions were never assessed, so this cannot say whether an unattended fleet may operate here.`,
+  };
+}
+
+/**
+ * Collect the ids of the standing ship blockers a dimension owns. Blockers with
+ * no usable id are dropped rather than stringified, so a malformed record can
+ * never render "Standing ship blocker(s): undefined" at an operator.
+ * @param {{ id: string }} dimension
+ * @param {{ blockers: readonly Record<string, unknown>[] }} report
+ * @returns {readonly string[]}
+ */
+function standingBlockerIds(dimension, report) {
+  return report.blockers
+    .filter(
+      blocker =>
+        blocker !== null &&
+        typeof blocker === "object" &&
+        (blocker.dimension_id === dimension.id ||
+          (Array.isArray(blocker.owning_dimensions) &&
+            blocker.owning_dimensions.includes(dimension.id)))
+    )
+    .map(blocker => blocker.id)
+    .filter(id => typeof id === "string" && id.length > 0)
+    .filter((id, index, ids) => ids.indexOf(id) === index);
+}
+
+/**
  * Project one CLI dimension record into this surface's check shape, or `null`
  * when the record is absent or carries a status outside the shipped vocabulary
  * (the caller then falls back to the reasoned SKIP).
  * @param {{ id: string, question: string, skipReason: string }} dimension
- * @param {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[] }} report
+ * @param {{ dimensions: readonly Record<string, unknown>[], blockers: readonly Record<string, unknown>[], narrowedClaim: string, provenance: string }} report
  * @returns {DoctorCheck | null}
  */
 function projectReadinessDimension(dimension, report) {
@@ -289,26 +361,27 @@ function projectReadinessDimension(dimension, report) {
   }
   const findings = Array.isArray(record.findings) ? record.findings : [];
   const summary = summarizeReadinessFindings(findings);
-  const blockerIds = report.blockers
-    .filter(
-      blocker =>
-        blocker !== null &&
-        typeof blocker === "object" &&
-        (blocker.dimension_id === dimension.id ||
-          (Array.isArray(blocker.owning_dimensions) &&
-            blocker.owning_dimensions.includes(dimension.id)))
-    )
-    .map(blocker => String(blocker.id))
-    .filter((id, index, ids) => ids.indexOf(id) === index);
+  const blockerIds = standingBlockerIds(dimension, report);
 
   return {
     id: dimension.id,
-    status: record.status,
+    // A standing blocker outranks the recorded label. Three CLI producers (B1
+    // domain-ownership, B4 feedback-guardrails, B6 context-routing) record
+    // `WARN` while standing a blocker, each stating in-line that "the blocker
+    // engine never reads this status, so the finding flips the repository to
+    // NOT_READY exactly as a FAIL would". Projecting that `WARN` verbatim would
+    // score READY_WITH_WARNINGS on a repository the CLI calls NOT_READY — the
+    // precise disagreement this bridge exists to eliminate. This still reflects
+    // the CLI's decision rather than re-scoring: the CLI decided the blocker
+    // stands and wrote it into `blockers[]`.
+    status: blockerIds.length > 0 ? "FAIL" : record.status,
     summary: summary.length > 0 ? summary : dimension.question,
-    observed: `${dimension.question} Projected from \`.lisa/readiness.json\` (schema_version ${READINESS_REPORT_SCHEMA_VERSION}), the report the Lisa CLI readiness pass wrote.`,
+    observed: `${dimension.question} Projected from \`.lisa/readiness.json\` (schema_version ${READINESS_REPORT_SCHEMA_VERSION}, ${report.provenance}), the report the Lisa CLI readiness pass wrote.`,
     ...(blockerIds.length > 0
       ? {
-          remediation: `Standing ship blocker(s): ${blockerIds.join(", ")}. See \`.lisa/readiness.json\` for the full evidence and the \`readiness-rubric\` rule for the blocker definitions.`,
+          remediation:
+            `Standing ship blocker(s): ${blockerIds.join(", ")}. See \`.lisa/readiness.json\` for the full evidence and the \`readiness-rubric\` rule for the blocker definitions.` +
+            (report.narrowedClaim.length > 0 ? ` ${report.narrowedClaim}` : ""),
         }
       : {}),
   };
@@ -334,23 +407,24 @@ function projectReadinessDimension(dimension, report) {
  */
 export function createRepositoryReadinessDoctorGroup(root = process.cwd()) {
   const report = readReadinessReport(path.resolve(root));
+  const checks = REPOSITORY_READINESS_DIMENSIONS.map(
+    dimension =>
+      (report === null
+        ? null
+        : projectReadinessDimension(dimension, report)) ?? {
+        id: dimension.id,
+        status: "SKIP",
+        summary: dimension.question,
+        observed:
+          report === null
+            ? dimension.skipReason
+            : `${dimension.question} \`.lisa/readiness.json\` carries no usable record for this dimension, so it was not assessed here. Re-run \`lisa doctor --offline --readiness\` to regenerate the report.`,
+      }
+  );
   return {
     id: "repository-readiness",
     title: "Repository readiness",
-    checks: REPOSITORY_READINESS_DIMENSIONS.map(
-      dimension =>
-        (report === null
-          ? null
-          : projectReadinessDimension(dimension, report)) ?? {
-          id: dimension.id,
-          status: "SKIP",
-          summary: dimension.question,
-          observed:
-            report === null
-              ? dimension.skipReason
-              : `${dimension.question} \`.lisa/readiness.json\` carries no usable record for this dimension, so it was not assessed here. Re-run \`lisa doctor --offline --readiness\` to regenerate the report.`,
-        }
-    ),
+    checks: checks.map(check => applyNotEstablishedCaveat(check, checks)),
   };
 }
 

--- a/plugins/src/base/skills/lisa-doctor/SKILL.md
+++ b/plugins/src/base/skills/lisa-doctor/SKILL.md
@@ -319,9 +319,18 @@ default doctor path never renders it and stays byte-identical.
    contract; do not restate or fork that vocabulary here.
 3. **`SKIP` carries a reason and is never blank.** A dimension with no applicable evidence renders
    `SKIP` with a stated reason ("no deployment target configured, so delivery/authority was not
-   assessed"). An unassessed dimension is a known unknown, and the report says so. In Lisa versions
-   where the evidence-gathering surfaces (RRR-4/5/6) are not yet wired, every dimension renders `SKIP`
-   with that reason.
+   assessed"). An unassessed dimension is a known unknown, and the report says so.
+
+   **This surface reflects the CLI; it does not re-score.** The evidence producers and the blocker
+   engine live in the Lisa CLI, which is the single source of truth. When `.lisa/readiness.json` is
+   present and readable (parses, matching `schema_version`, carries a `dimensions` array), this group
+   **projects** each recorded dimension's status and its operator-facing evidence/reason text, so an
+   operator running `/lisa:doctor` through any coding agent sees the same readiness answer the CLI
+   gives. When the report is absent, unparseable, or stamped with an unknown `schema_version` — or
+   records nothing for a given dimension — that dimension falls back to `SKIP` with the reason it was
+   not assessed. Absence means the readiness pass has not run, never that the repository is clean: a
+   pass or a fail is never manufactured from a missing report. Run
+   `lisa doctor --offline --readiness` to produce the report first.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
    severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
    evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed

--- a/plugins/src/base/skills/lisa-doctor/SKILL.md
+++ b/plugins/src/base/skills/lisa-doctor/SKILL.md
@@ -331,6 +331,15 @@ default doctor path never renders it and stays byte-identical.
    not assessed. Absence means the readiness pass has not run, never that the repository is clean: a
    pass or a fail is never manufactured from a missing report. Run
    `lisa doctor --offline --readiness` to produce the report first.
+
+   **A standing blocker outranks the recorded status.** Some CLI producers record `WARN` while
+   standing a ship blocker — the blocker engine never reads the per-dimension status, so the finding
+   flips the repository to `NOT_READY` exactly as a `FAIL` would. A dimension that owns an entry in
+   the report's `blockers[]` therefore projects as `FAIL` regardless of its recorded label, and its
+   remediation names the blocker ids and repeats the report's `narrowed_claim` (the "IS ready for
+   supervised, single-ticket agent work" fallback `readiness-rubric` requires whenever a blocker
+   stands). Projected checks also carry the report's `generated_at`/`lisa_version` so a stale report
+   cannot read as current truth, and unassessed dimensions carry the CLI's not-established caveat.
 4. **Reuse the shipped verdict ladder and consequence ordering.** No new verdict value and no new
    severity: reuse `READY` / `READY_WITH_WARNINGS` / `NOT_READY`. `READY` requires *positive*
    evidence — every readiness dimension assessed and clean, with no blocker standing. An unassessed

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -739,7 +739,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/scripts/cross-pollinate.mjs":
       "e9a536389d2581370f6c470b8a070aaae96660646efc528a7ff7fb25d324a903",
     "plugins/src/base/scripts/doctor-report.mjs":
-      "c40c10a30fe07db6d6bd4abb7df23964b20f4901ae29a60b2f946feb118c4e3d",
+      "f183e62848ac539da56a525fe2105fc6251a49e555a01dd1bba10d9227b1a6bf",
     "plugins/src/base/scripts/install-remote-agent-aws.mjs":
       "5ef1c323d7cbfda8976f6fb0c24f7a8e5f5757475fd1d71c6e5bec91023cebe3",
     "plugins/src/base/scripts/plugin-sync-explain.mjs":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -739,7 +739,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/scripts/cross-pollinate.mjs":
       "e9a536389d2581370f6c470b8a070aaae96660646efc528a7ff7fb25d324a903",
     "plugins/src/base/scripts/doctor-report.mjs":
-      "36ceac6ce746ea5c4cf13727cef8de6d113cf372d737493f1c45bda892086092",
+      "c40c10a30fe07db6d6bd4abb7df23964b20f4901ae29a60b2f946feb118c4e3d",
     "plugins/src/base/scripts/install-remote-agent-aws.mjs":
       "5ef1c323d7cbfda8976f6fb0c24f7a8e5f5757475fd1d71c6e5bec91023cebe3",
     "plugins/src/base/scripts/plugin-sync-explain.mjs":
@@ -791,7 +791,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-debrief/SKILL.md":
       "47e4cda36b07994ff47ab15fb04a17dd6b0c310ad804f9cae9d69637edaaa72a",
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
-      "e834cabbe39eb02abf07c527229c8dd594208751060331d7cf61a9f03e7563b6",
+      "1702485809533a2e546a590b9d2f67cbb420c8f0cb0eac8609b0287b05122ad3",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
       "e8680c65da64351580658e423d2e30f565e9df52079f4deec44df84d4ab82982",
     "plugins/src/base/skills/lisa-epic-triage/SKILL.md":
@@ -7876,7 +7876,9 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/doctor-fixture-smoke-and-parity.test.ts": true,
     "tests/unit/strategies/doctor-plugin-sync-guidance.test.ts": true,
     "tests/unit/strategies/doctor-project-readiness.test.ts": true,
+    "tests/unit/strategies/doctor-readiness-blocker-projection.test.ts": true,
     "tests/unit/strategies/doctor-readiness-report-bridge.test.ts": true,
+    "tests/unit/strategies/doctor-readiness-report-fixtures.ts": true,
     "tests/unit/strategies/doctor-report-rendering.test.ts": true,
     "tests/unit/strategies/doctor-repository-readiness.test.ts": true,
     "tests/unit/strategies/doctor-scaffold.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -739,7 +739,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/scripts/cross-pollinate.mjs":
       "e9a536389d2581370f6c470b8a070aaae96660646efc528a7ff7fb25d324a903",
     "plugins/src/base/scripts/doctor-report.mjs":
-      "ebad5a2724395911870b6be1dc81e3618031f7a6e04c51d3aef3efca72361929",
+      "36ceac6ce746ea5c4cf13727cef8de6d113cf372d737493f1c45bda892086092",
     "plugins/src/base/scripts/install-remote-agent-aws.mjs":
       "5ef1c323d7cbfda8976f6fb0c24f7a8e5f5757475fd1d71c6e5bec91023cebe3",
     "plugins/src/base/scripts/plugin-sync-explain.mjs":
@@ -791,7 +791,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-debrief/SKILL.md":
       "47e4cda36b07994ff47ab15fb04a17dd6b0c310ad804f9cae9d69637edaaa72a",
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
-      "a47f7ba3104121092e91b202646a74f83ec641cd24ad5807fc22adc65b6ccdc6",
+      "e834cabbe39eb02abf07c527229c8dd594208751060331d7cf61a9f03e7563b6",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
       "e8680c65da64351580658e423d2e30f565e9df52079f4deec44df84d4ab82982",
     "plugins/src/base/skills/lisa-epic-triage/SKILL.md":
@@ -7876,6 +7876,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/doctor-fixture-smoke-and-parity.test.ts": true,
     "tests/unit/strategies/doctor-plugin-sync-guidance.test.ts": true,
     "tests/unit/strategies/doctor-project-readiness.test.ts": true,
+    "tests/unit/strategies/doctor-readiness-report-bridge.test.ts": true,
     "tests/unit/strategies/doctor-report-rendering.test.ts": true,
     "tests/unit/strategies/doctor-repository-readiness.test.ts": true,
     "tests/unit/strategies/doctor-scaffold.test.ts": true,

--- a/tests/unit/strategies/doctor-readiness-blocker-projection.test.ts
+++ b/tests/unit/strategies/doctor-readiness-blocker-projection.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Regression tests for standing-blocker projection and provenance in the
+ * agent-facing readiness bridge (#1902).
+ *
+ * Three CLI producers — B1 (`doctor-readiness-domain.ts`), B4
+ * (`-guardrails.ts`), and B6 (`-context.ts`) — deliberately record `WARN` while
+ * standing a ship blocker, each stating in-line that "the blocker engine never
+ * reads this status, so the finding flips the repository to NOT_READY exactly
+ * as a FAIL would". Taking that recorded label at face value made the agent
+ * surface answer READY_WITH_WARNINGS on a repository the CLI calls NOT_READY —
+ * the precise disagreement #1902 exists to eliminate. This suite locks the
+ * blocker-outranks-status rule, plus the operator-facing text (narrowed claim,
+ * report provenance, full finding evidence) that rides along with it.
+ * @module tests/unit/strategies/doctor-readiness-blocker-projection
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  computeDoctorVerdict,
+  createRepositoryReadinessDoctorGroup,
+} from "../../../plugins/src/base/scripts/doctor-report.mjs";
+import {
+  CONTEXT_ROUTING,
+  DELIVERY_AUTHORITY,
+  FIXTURE_GENERATED_AT,
+  FIXTURE_LISA_VERSION,
+  passingDimensions,
+  PROPORTIONALITY,
+  readinessReport,
+  withDimension,
+  writeReadinessReport,
+} from "./doctor-readiness-report-fixtures.js";
+
+/** The supervised-work fallback `readiness-rubric` requires under a blocker. */
+const NARROWED_CLAIM =
+  "This repository is NOT ready for unattended fleet operation because 1 ship blocker stands: B6. It IS ready for supervised, single-ticket agent work.";
+
+/**
+ * A report recording context-routing `WARN` while B6 stands — the exact shape
+ * the B6 producer persists.
+ * @returns The report serialized as JSON
+ */
+const warnDimensionOwningB6 = (): string =>
+  readinessReport({
+    verdict: "NOT_READY",
+    narrowedClaim: NARROWED_CLAIM,
+    blockers: [
+      {
+        id: "B6",
+        label: "Documented guarantees name mechanisms that do not exist",
+        dimension_id: CONTEXT_ROUTING,
+        owning_dimensions: [CONTEXT_ROUTING],
+      },
+    ],
+    dimensions: withDimension(CONTEXT_ROUTING, {
+      status: "WARN",
+      findings: [
+        {
+          blocker: "B6",
+          evidence: "AGENTS.md names a `wiki/index.md` that is absent",
+        },
+      ],
+    }),
+  });
+
+let root = "";
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "lisa-readiness-blockers-"));
+});
+
+afterEach(() => {
+  rmSync(root, { force: true, recursive: true });
+});
+
+describe("standing blockers outrank the recorded status (#1902)", () => {
+  it("projects a WARN dimension owning a standing blocker as FAIL", () => {
+    writeReadinessReport(root, warnDimensionOwningB6());
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+    const check = group.checks.find(entry => entry.id === CONTEXT_ROUTING);
+
+    expect(check?.status).toBe("FAIL");
+    expect(computeDoctorVerdict([group])).toBe("NOT_READY");
+  });
+
+  it("names the standing blocker ids in the dimension remediation", () => {
+    writeReadinessReport(root, warnDimensionOwningB6());
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+    const check = group.checks.find(entry => entry.id === CONTEXT_ROUTING);
+
+    expect(check?.remediation).toContain("B6");
+    expect(check?.remediation).not.toContain("undefined");
+  });
+
+  it("surfaces the CLI narrowed claim so the operator gets the same guidance", () => {
+    writeReadinessReport(root, warnDimensionOwningB6());
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+    const check = group.checks.find(entry => entry.id === CONTEXT_ROUTING);
+
+    expect(check?.remediation).toContain(
+      "It IS ready for supervised, single-ticket agent work."
+    );
+  });
+
+  it("skips blockers carrying no usable id rather than printing undefined", () => {
+    writeReadinessReport(
+      root,
+      readinessReport({
+        verdict: "NOT_READY",
+        blockers: [
+          { label: "malformed blocker", dimension_id: DELIVERY_AUTHORITY },
+          { id: "B3", dimension_id: DELIVERY_AUTHORITY },
+        ],
+        dimensions: withDimension(DELIVERY_AUTHORITY, { status: "FAIL" }),
+      })
+    );
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+    const check = group.checks.find(entry => entry.id === DELIVERY_AUTHORITY);
+
+    expect(check?.remediation).toContain("B3");
+    expect(check?.remediation).not.toContain("undefined");
+  });
+
+  it("leaves a clean report free of blocker remediation", () => {
+    writeReadinessReport(
+      root,
+      readinessReport({ verdict: "READY", dimensions: passingDimensions })
+    );
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+    const check = group.checks.find(entry => entry.id === CONTEXT_ROUTING);
+
+    expect(check?.remediation).toBeUndefined();
+    expect(computeDoctorVerdict([group])).toBe("READY");
+  });
+});
+
+describe("projected checks carry provenance and full evidence (#1902)", () => {
+  it("stamps the report generation time and Lisa version into observed", () => {
+    writeReadinessReport(
+      root,
+      readinessReport({ verdict: "READY", dimensions: passingDimensions })
+    );
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+    const check = group.checks.find(entry => entry.id === CONTEXT_ROUTING);
+
+    expect(check?.observed).toContain(FIXTURE_GENERATED_AT);
+    expect(check?.observed).toContain(FIXTURE_LISA_VERSION);
+  });
+
+  it("carries the not-established caveat onto an unassessed dimension", () => {
+    writeReadinessReport(
+      root,
+      readinessReport({
+        verdict: "READY_WITH_WARNINGS",
+        dimensions: withDimension(PROPORTIONALITY, {
+          status: "SKIP",
+          findings: [{ reason: "no scaffolding scan on an offline pass" }],
+        }),
+      })
+    );
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+    const check = group.checks.find(entry => entry.id === PROPORTIONALITY);
+
+    expect(check?.observed).toContain(
+      "NOT ESTABLISHED: 1 of 8 dimensions were never assessed"
+    );
+  });
+
+  it("reads a finding that carries only an observation into the summary", () => {
+    writeReadinessReport(
+      root,
+      readinessReport({
+        verdict: "READY_WITH_WARNINGS",
+        dimensions: withDimension(PROPORTIONALITY, {
+          status: "WARN",
+          findings: [{ observation: "three unused template stacks" }],
+        }),
+      })
+    );
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+    const check = group.checks.find(entry => entry.id === PROPORTIONALITY);
+
+    expect(check?.summary).toContain("three unused template stacks");
+  });
+
+  it("truncates an oversized evidence string instead of flooding the report", () => {
+    writeReadinessReport(
+      root,
+      readinessReport({
+        verdict: "READY",
+        dimensions: withDimension(CONTEXT_ROUTING, {
+          findings: [{ evidence: "x".repeat(900) }],
+        }),
+      })
+    );
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+    const check = group.checks.find(entry => entry.id === CONTEXT_ROUTING);
+
+    expect(check?.summary).toHaveLength(320);
+    expect(check?.summary.endsWith("…")).toBe(true);
+  });
+});

--- a/tests/unit/strategies/doctor-readiness-blocker-projection.test.ts
+++ b/tests/unit/strategies/doctor-readiness-blocker-projection.test.ts
@@ -26,6 +26,8 @@ import {
 import {
   CONTEXT_ROUTING,
   DELIVERY_AUTHORITY,
+  DOMAIN_OWNERSHIP,
+  FEEDBACK_GUARDRAILS,
   FIXTURE_GENERATED_AT,
   FIXTURE_LISA_VERSION,
   passingDimensions,
@@ -127,6 +129,80 @@ describe("standing blockers outrank the recorded status (#1902)", () => {
 
     expect(check?.remediation).toContain("B3");
     expect(check?.remediation).not.toContain("undefined");
+  });
+
+  it("escalates only the dimension the CLI attributed the finding to", () => {
+    // B4 is specced with `owning_dimensions: [domain-ownership,
+    // feedback-guardrails]`, but only the guardrails producer emits the B4
+    // finding, so the CLI stamps that dimension as `dimension_id` and lets
+    // the domain-ownership producer record its own (clean) result. Escalating
+    // every co-owning dimension would stamp FAIL on a dimension whose own
+    // evidence says it found nothing — self-contradictory, and a per-dimension
+    // disagreement with the CLI.
+    writeReadinessReport(
+      root,
+      readinessReport({
+        verdict: "NOT_READY",
+        blockers: [
+          {
+            id: "B4",
+            label: "A consequential operation has no gate and no recovery",
+            dimension_id: FEEDBACK_GUARDRAILS,
+            owning_dimensions: [DOMAIN_OWNERSHIP, FEEDBACK_GUARDRAILS],
+          },
+        ],
+        dimensions: passingDimensions.map(dimension => {
+          if (dimension.id === FEEDBACK_GUARDRAILS) {
+            return {
+              ...dimension,
+              status: "WARN",
+              findings: [
+                { blocker: "B4", evidence: "deploy.yml runs ungated" },
+              ],
+            };
+          }
+          return dimension.id === DOMAIN_OWNERSHIP
+            ? {
+                ...dimension,
+                status: "SKIP",
+                findings: [
+                  { reason: "read 43 workflows and found none ungated" },
+                ],
+              }
+            : dimension;
+        }),
+      })
+    );
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+    const statuses = Object.fromEntries(
+      group.checks.map(check => [check.id, check.status])
+    );
+
+    expect(statuses[FEEDBACK_GUARDRAILS]).toBe("FAIL");
+    expect(statuses[DOMAIN_OWNERSHIP]).toBe("SKIP");
+    expect(computeDoctorVerdict([group])).toBe("NOT_READY");
+  });
+
+  it("falls back to owning_dimensions when a blocker records no dimension_id", () => {
+    writeReadinessReport(
+      root,
+      readinessReport({
+        verdict: "NOT_READY",
+        blockers: [
+          { id: "B5", owning_dimensions: ["dependencies-supply-chain"] },
+        ],
+        dimensions: passingDimensions,
+      })
+    );
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+    const check = group.checks.find(
+      entry => entry.id === "dependencies-supply-chain"
+    );
+
+    expect(check?.status).toBe("FAIL");
+    expect(computeDoctorVerdict([group])).toBe("NOT_READY");
   });
 
   it("leaves a clean report free of blocker remediation", () => {

--- a/tests/unit/strategies/doctor-readiness-report-bridge.test.ts
+++ b/tests/unit/strategies/doctor-readiness-report-bridge.test.ts
@@ -8,10 +8,12 @@
  * group projects the CLI's per-dimension result when the report is on disk, and
  * degrades to today's reasoned SKIP when it is absent, stale, or unparseable.
  * Never manufacture a pass or a fail from absence: a missing report means the
- * CLI readiness pass has not run, not that the repository is clean.
+ * CLI readiness pass has not run, not that the repository is clean. The
+ * standing-blocker half of the contract lives in the sibling
+ * `doctor-readiness-blocker-projection` suite.
  * @module tests/unit/strategies/doctor-readiness-report-bridge
  */
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -21,63 +23,18 @@ import {
   computeDoctorVerdict,
   createRepositoryReadinessDoctorGroup,
 } from "../../../plugins/src/base/scripts/doctor-report.mjs";
-
-/** The dimension these fixtures drive a standing ship blocker through. */
-const DELIVERY_AUTHORITY = "delivery-authority";
-
-/** The eight ownership dimensions, in fixed render order (readiness-rubric). */
-const DIMENSION_IDS = [
-  "context-routing",
-  "capabilities-tools",
-  "domain-ownership",
-  "execution-proof",
-  "feedback-guardrails",
-  "dependencies-supply-chain",
+import {
+  CONTEXT_ROUTING,
   DELIVERY_AUTHORITY,
-  "proportionality",
-] as const;
+  DIMENSION_IDS,
+  passingDimensions,
+  PROPORTIONALITY,
+  readinessReport,
+  withDimension,
+  writeReadinessReport,
+} from "./doctor-readiness-report-fixtures.js";
 
 let root = "";
-
-const writeReadinessReport = (contents: string): void => {
-  mkdirSync(path.join(root, ".lisa"), { recursive: true });
-  writeFileSync(path.join(root, ".lisa", "readiness.json"), contents, "utf8");
-};
-
-/**
- * Build a persisted-report fixture in the CLI's shape.
- * @param root0 - Fixture inputs
- * @param root0.dimensions - Per-dimension records to persist
- * @param root0.verdict - Report-level verdict
- * @param root0.blockers - Detected blockers to persist
- * @returns The report serialized as JSON
- */
-const readinessReport = ({
-  dimensions,
-  verdict,
-  blockers = [],
-}: {
-  dimensions: readonly { id: string; status: string; findings: unknown[] }[];
-  verdict: string;
-  blockers?: readonly Record<string, unknown>[];
-}): string =>
-  JSON.stringify({
-    schema_version: 1,
-    generated_at: "2026-07-21T00:00:00.000Z",
-    lisa_version: "2.281.0",
-    worker_signature: "claude/unknown/unknown",
-    verdict,
-    narrowed_claim: null,
-    blockers,
-    blocker_count: blockers.length,
-    dimensions,
-  });
-
-const passingDimensions = DIMENSION_IDS.map(id => ({
-  id,
-  status: "PASS",
-  findings: [{ evidence: `dimension ${id} assessed clean`, checked: [] }],
-}));
 
 beforeEach(() => {
   root = mkdtempSync(path.join(tmpdir(), "lisa-readiness-bridge-"));
@@ -90,46 +47,27 @@ afterEach(() => {
 describe("agent readiness group bridges .lisa/readiness.json (#1902)", () => {
   it("projects a FAIL dimension from the CLI report instead of SKIP", () => {
     writeReadinessReport(
+      root,
       readinessReport({
         verdict: "NOT_READY",
-        blockers: [
-          {
-            id: "B3",
-            label: "Credentials carry material unintended authority",
-            dimension_id: DELIVERY_AUTHORITY,
-            owning_dimensions: [DELIVERY_AUTHORITY],
-          },
-        ],
-        dimensions: DIMENSION_IDS.map(id =>
-          id === DELIVERY_AUTHORITY
-            ? {
-                id,
-                status: "FAIL",
-                findings: [
-                  {
-                    blocker: "B3",
-                    evidence:
-                      "release.yml job `quality` declares `secrets: inherit`",
-                  },
-                ],
-              }
-            : {
-                id,
-                status: "PASS",
-                findings: [{ evidence: `dimension ${id} assessed clean` }],
-              }
-        ),
+        dimensions: withDimension(DELIVERY_AUTHORITY, {
+          status: "FAIL",
+          findings: [
+            {
+              blocker: "B3",
+              evidence: "release.yml job `quality` declares `secrets: inherit`",
+            },
+          ],
+        }),
       })
     );
 
     const group = createRepositoryReadinessDoctorGroup(root);
-    const check = group.checks.find(
-      entry => entry.id === DELIVERY_AUTHORITY
-    ) as { id: string; status: string; summary: string };
+    const check = group.checks.find(entry => entry.id === DELIVERY_AUTHORITY);
 
     expect(group.checks).toHaveLength(8);
-    expect(check.status).toBe("FAIL");
-    expect(check.summary).toContain(
+    expect(check?.status).toBe("FAIL");
+    expect(check?.summary).toContain(
       "release.yml job `quality` declares `secrets: inherit`"
     );
     expect(computeDoctorVerdict([group])).toBe("NOT_READY");
@@ -137,6 +75,7 @@ describe("agent readiness group bridges .lisa/readiness.json (#1902)", () => {
 
   it("reaches READY when the CLI report is clean across all eight dimensions", () => {
     writeReadinessReport(
+      root,
       readinessReport({ verdict: "READY", dimensions: passingDimensions })
     );
 
@@ -149,32 +88,14 @@ describe("agent readiness group bridges .lisa/readiness.json (#1902)", () => {
     expect(computeDoctorVerdict([group])).toBe("READY");
   });
 
-  it("projects WARN and SKIP dimension statuses verbatim", () => {
+  it("projects WARN and SKIP dimension statuses verbatim absent a blocker", () => {
     writeReadinessReport(
+      root,
       readinessReport({
         verdict: "READY_WITH_WARNINGS",
-        dimensions: DIMENSION_IDS.map(id => {
-          if (id === "capabilities-tools") {
-            return {
-              id,
-              status: "SKIP",
-              findings: [
-                { reason: "tool reachability needs a live probe", skip: true },
-              ],
-            };
-          }
-          if (id === "proportionality") {
-            return {
-              id,
-              status: "WARN",
-              findings: [{ evidence: "scaffolding to subtract remains" }],
-            };
-          }
-          return {
-            id,
-            status: "PASS",
-            findings: [{ evidence: `dimension ${id} assessed clean` }],
-          };
+        dimensions: withDimension(PROPORTIONALITY, {
+          status: "WARN",
+          findings: [{ evidence: "scaffolding to subtract remains" }],
         }),
       })
     );
@@ -184,9 +105,8 @@ describe("agent readiness group bridges .lisa/readiness.json (#1902)", () => {
       group.checks.map(check => [check.id, check.status])
     );
 
-    expect(statuses["capabilities-tools"]).toBe("SKIP");
-    expect(statuses["proportionality"]).toBe("WARN");
-    expect(statuses["context-routing"]).toBe("PASS");
+    expect(statuses[PROPORTIONALITY]).toBe("WARN");
+    expect(statuses[CONTEXT_ROUTING]).toBe("PASS");
     expect(computeDoctorVerdict([group])).toBe("READY_WITH_WARNINGS");
   });
 
@@ -202,7 +122,7 @@ describe("agent readiness group bridges .lisa/readiness.json (#1902)", () => {
   });
 
   it("reasoned-SKIPs when the report is unparseable", () => {
-    writeReadinessReport("{ not json");
+    writeReadinessReport(root, "{ not json");
 
     const group = createRepositoryReadinessDoctorGroup(root);
 
@@ -214,6 +134,7 @@ describe("agent readiness group bridges .lisa/readiness.json (#1902)", () => {
 
   it("reasoned-SKIPs when the report carries an unknown schema_version", () => {
     writeReadinessReport(
+      root,
       JSON.stringify({
         schema_version: 99,
         verdict: "READY",
@@ -231,10 +152,11 @@ describe("agent readiness group bridges .lisa/readiness.json (#1902)", () => {
 
   it("reasoned-SKIPs a dimension the report never recorded", () => {
     writeReadinessReport(
+      root,
       readinessReport({
         verdict: "READY",
         dimensions: passingDimensions.filter(
-          dimension => dimension.id !== "proportionality"
+          dimension => dimension.id !== PROPORTIONALITY
         ),
       })
     );
@@ -245,8 +167,39 @@ describe("agent readiness group bridges .lisa/readiness.json (#1902)", () => {
     );
 
     expect(group.checks).toHaveLength(8);
-    expect(statuses["proportionality"]).toBe("SKIP");
-    expect(statuses["context-routing"]).toBe("PASS");
+    expect(statuses[PROPORTIONALITY]).toBe("SKIP");
+    expect(statuses[CONTEXT_ROUTING]).toBe("PASS");
+    expect(computeDoctorVerdict([group])).toBe("READY_WITH_WARNINGS");
+  });
+
+  it("degrades a status outside the shipped vocabulary to SKIP", () => {
+    writeReadinessReport(
+      root,
+      readinessReport({
+        verdict: "READY",
+        dimensions: withDimension("execution-proof", { status: "UNKNOWN" }),
+      })
+    );
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+    const check = group.checks.find(entry => entry.id === "execution-proof");
+
+    expect(check?.status).toBe("SKIP");
+    expect(computeDoctorVerdict([group])).toBe("READY_WITH_WARNINGS");
+  });
+
+  it("reasoned-SKIPs every dimension when the report records none", () => {
+    writeReadinessReport(
+      root,
+      readinessReport({ verdict: "READY", dimensions: [] })
+    );
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+
+    expect(group.checks).toHaveLength(8);
+    expect([...new Set(group.checks.map(check => check.status))]).toEqual([
+      "SKIP",
+    ]);
     expect(computeDoctorVerdict([group])).toBe("READY_WITH_WARNINGS");
   });
 });

--- a/tests/unit/strategies/doctor-readiness-report-bridge.test.ts
+++ b/tests/unit/strategies/doctor-readiness-report-bridge.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Regression tests for the agent-facing readiness bridge (#1902).
+ *
+ * PRD #1739 ships two readiness scorers: the TypeScript CLI (blocker-engine
+ * backed, persists `.lisa/readiness.json`) and the `.mjs` scorer the coding
+ * agents run through `/lisa:doctor`. #1897 brought the verdict *algebra* to
+ * parity; this suite proves the readiness *content* agrees too — the agent
+ * group projects the CLI's per-dimension result when the report is on disk, and
+ * degrades to today's reasoned SKIP when it is absent, stale, or unparseable.
+ * Never manufacture a pass or a fail from absence: a missing report means the
+ * CLI readiness pass has not run, not that the repository is clean.
+ * @module tests/unit/strategies/doctor-readiness-report-bridge
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  computeDoctorVerdict,
+  createRepositoryReadinessDoctorGroup,
+} from "../../../plugins/src/base/scripts/doctor-report.mjs";
+
+/** The dimension these fixtures drive a standing ship blocker through. */
+const DELIVERY_AUTHORITY = "delivery-authority";
+
+/** The eight ownership dimensions, in fixed render order (readiness-rubric). */
+const DIMENSION_IDS = [
+  "context-routing",
+  "capabilities-tools",
+  "domain-ownership",
+  "execution-proof",
+  "feedback-guardrails",
+  "dependencies-supply-chain",
+  DELIVERY_AUTHORITY,
+  "proportionality",
+] as const;
+
+let root = "";
+
+const writeReadinessReport = (contents: string): void => {
+  mkdirSync(path.join(root, ".lisa"), { recursive: true });
+  writeFileSync(path.join(root, ".lisa", "readiness.json"), contents, "utf8");
+};
+
+/**
+ * Build a persisted-report fixture in the CLI's shape.
+ * @param root0 - Fixture inputs
+ * @param root0.dimensions - Per-dimension records to persist
+ * @param root0.verdict - Report-level verdict
+ * @param root0.blockers - Detected blockers to persist
+ * @returns The report serialized as JSON
+ */
+const readinessReport = ({
+  dimensions,
+  verdict,
+  blockers = [],
+}: {
+  dimensions: readonly { id: string; status: string; findings: unknown[] }[];
+  verdict: string;
+  blockers?: readonly Record<string, unknown>[];
+}): string =>
+  JSON.stringify({
+    schema_version: 1,
+    generated_at: "2026-07-21T00:00:00.000Z",
+    lisa_version: "2.281.0",
+    worker_signature: "claude/unknown/unknown",
+    verdict,
+    narrowed_claim: null,
+    blockers,
+    blocker_count: blockers.length,
+    dimensions,
+  });
+
+const passingDimensions = DIMENSION_IDS.map(id => ({
+  id,
+  status: "PASS",
+  findings: [{ evidence: `dimension ${id} assessed clean`, checked: [] }],
+}));
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "lisa-readiness-bridge-"));
+});
+
+afterEach(() => {
+  rmSync(root, { force: true, recursive: true });
+});
+
+describe("agent readiness group bridges .lisa/readiness.json (#1902)", () => {
+  it("projects a FAIL dimension from the CLI report instead of SKIP", () => {
+    writeReadinessReport(
+      readinessReport({
+        verdict: "NOT_READY",
+        blockers: [
+          {
+            id: "B3",
+            label: "Credentials carry material unintended authority",
+            dimension_id: DELIVERY_AUTHORITY,
+            owning_dimensions: [DELIVERY_AUTHORITY],
+          },
+        ],
+        dimensions: DIMENSION_IDS.map(id =>
+          id === DELIVERY_AUTHORITY
+            ? {
+                id,
+                status: "FAIL",
+                findings: [
+                  {
+                    blocker: "B3",
+                    evidence:
+                      "release.yml job `quality` declares `secrets: inherit`",
+                  },
+                ],
+              }
+            : {
+                id,
+                status: "PASS",
+                findings: [{ evidence: `dimension ${id} assessed clean` }],
+              }
+        ),
+      })
+    );
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+    const check = group.checks.find(
+      entry => entry.id === DELIVERY_AUTHORITY
+    ) as { id: string; status: string; summary: string };
+
+    expect(group.checks).toHaveLength(8);
+    expect(check.status).toBe("FAIL");
+    expect(check.summary).toContain(
+      "release.yml job `quality` declares `secrets: inherit`"
+    );
+    expect(computeDoctorVerdict([group])).toBe("NOT_READY");
+  });
+
+  it("reaches READY when the CLI report is clean across all eight dimensions", () => {
+    writeReadinessReport(
+      readinessReport({ verdict: "READY", dimensions: passingDimensions })
+    );
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+
+    expect(group.checks.map(check => check.id)).toEqual([...DIMENSION_IDS]);
+    expect([...new Set(group.checks.map(check => check.status))]).toEqual([
+      "PASS",
+    ]);
+    expect(computeDoctorVerdict([group])).toBe("READY");
+  });
+
+  it("projects WARN and SKIP dimension statuses verbatim", () => {
+    writeReadinessReport(
+      readinessReport({
+        verdict: "READY_WITH_WARNINGS",
+        dimensions: DIMENSION_IDS.map(id => {
+          if (id === "capabilities-tools") {
+            return {
+              id,
+              status: "SKIP",
+              findings: [
+                { reason: "tool reachability needs a live probe", skip: true },
+              ],
+            };
+          }
+          if (id === "proportionality") {
+            return {
+              id,
+              status: "WARN",
+              findings: [{ evidence: "scaffolding to subtract remains" }],
+            };
+          }
+          return {
+            id,
+            status: "PASS",
+            findings: [{ evidence: `dimension ${id} assessed clean` }],
+          };
+        }),
+      })
+    );
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+    const statuses = Object.fromEntries(
+      group.checks.map(check => [check.id, check.status])
+    );
+
+    expect(statuses["capabilities-tools"]).toBe("SKIP");
+    expect(statuses["proportionality"]).toBe("WARN");
+    expect(statuses["context-routing"]).toBe("PASS");
+    expect(computeDoctorVerdict([group])).toBe("READY_WITH_WARNINGS");
+  });
+
+  it("reasoned-SKIPs every dimension when no report exists", () => {
+    const group = createRepositoryReadinessDoctorGroup(root);
+
+    expect(group.checks).toHaveLength(8);
+    for (const check of group.checks) {
+      expect(check.status).toBe("SKIP");
+      expect((check.observed ?? "").length).toBeGreaterThan(0);
+    }
+    expect(computeDoctorVerdict([group])).toBe("READY_WITH_WARNINGS");
+  });
+
+  it("reasoned-SKIPs when the report is unparseable", () => {
+    writeReadinessReport("{ not json");
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+
+    expect([...new Set(group.checks.map(check => check.status))]).toEqual([
+      "SKIP",
+    ]);
+    expect(computeDoctorVerdict([group])).toBe("READY_WITH_WARNINGS");
+  });
+
+  it("reasoned-SKIPs when the report carries an unknown schema_version", () => {
+    writeReadinessReport(
+      JSON.stringify({
+        schema_version: 99,
+        verdict: "READY",
+        dimensions: passingDimensions,
+      })
+    );
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+
+    expect([...new Set(group.checks.map(check => check.status))]).toEqual([
+      "SKIP",
+    ]);
+    expect(computeDoctorVerdict([group])).toBe("READY_WITH_WARNINGS");
+  });
+
+  it("reasoned-SKIPs a dimension the report never recorded", () => {
+    writeReadinessReport(
+      readinessReport({
+        verdict: "READY",
+        dimensions: passingDimensions.filter(
+          dimension => dimension.id !== "proportionality"
+        ),
+      })
+    );
+
+    const group = createRepositoryReadinessDoctorGroup(root);
+    const statuses = Object.fromEntries(
+      group.checks.map(check => [check.id, check.status])
+    );
+
+    expect(group.checks).toHaveLength(8);
+    expect(statuses["proportionality"]).toBe("SKIP");
+    expect(statuses["context-routing"]).toBe("PASS");
+    expect(computeDoctorVerdict([group])).toBe("READY_WITH_WARNINGS");
+  });
+});

--- a/tests/unit/strategies/doctor-readiness-report-fixtures.ts
+++ b/tests/unit/strategies/doctor-readiness-report-fixtures.ts
@@ -21,13 +21,19 @@ export const CONTEXT_ROUTING = "context-routing";
 /** Dimension the scaffolding-subtraction findings land on. */
 export const PROPORTIONALITY = "proportionality";
 
+/** Dimension whose producer evidences B4. */
+export const FEEDBACK_GUARDRAILS = "feedback-guardrails";
+
+/** Dimension that co-owns B4 in the spec but never evidences it. */
+export const DOMAIN_OWNERSHIP = "domain-ownership";
+
 /** The eight ownership dimensions, in fixed render order (readiness-rubric). */
 export const DIMENSION_IDS = [
   CONTEXT_ROUTING,
   "capabilities-tools",
-  "domain-ownership",
+  DOMAIN_OWNERSHIP,
   "execution-proof",
-  "feedback-guardrails",
+  FEEDBACK_GUARDRAILS,
   "dependencies-supply-chain",
   DELIVERY_AUTHORITY,
   PROPORTIONALITY,

--- a/tests/unit/strategies/doctor-readiness-report-fixtures.ts
+++ b/tests/unit/strategies/doctor-readiness-report-fixtures.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared `.lisa/readiness.json` fixtures for the agent-facing readiness bridge
+ * (#1902).
+ *
+ * Two suites drive the bridge — the projection/degrade contract and the
+ * standing-blocker contract — and both need a report in the CLI's exact
+ * persisted shape. Building that shape once here is what keeps the two suites
+ * from drifting into two different ideas of what the CLI writes, which is the
+ * same class of divergence #1902 exists to close.
+ * @module tests/unit/strategies/doctor-readiness-report-fixtures
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+/** Dimension owning the delivery/authority blockers (B2, B3). */
+export const DELIVERY_AUTHORITY = "delivery-authority";
+
+/** Dimension owning B6, recorded `WARN` by its producer while B6 stands. */
+export const CONTEXT_ROUTING = "context-routing";
+
+/** Dimension the scaffolding-subtraction findings land on. */
+export const PROPORTIONALITY = "proportionality";
+
+/** The eight ownership dimensions, in fixed render order (readiness-rubric). */
+export const DIMENSION_IDS = [
+  CONTEXT_ROUTING,
+  "capabilities-tools",
+  "domain-ownership",
+  "execution-proof",
+  "feedback-guardrails",
+  "dependencies-supply-chain",
+  DELIVERY_AUTHORITY,
+  PROPORTIONALITY,
+] as const;
+
+/** `generated_at` stamped into every fixture report. */
+export const FIXTURE_GENERATED_AT = "2026-07-21T00:00:00.000Z";
+
+/** `lisa_version` stamped into every fixture report. */
+export const FIXTURE_LISA_VERSION = "2.281.0";
+
+/** A per-dimension record in the CLI's persisted shape. */
+export interface FixtureDimension {
+  readonly id: string;
+  readonly status: string;
+  readonly findings: readonly unknown[];
+}
+
+/** All eight dimensions recorded clean, the clean-repository baseline. */
+export const passingDimensions: readonly FixtureDimension[] = DIMENSION_IDS.map(
+  id => ({
+    id,
+    status: "PASS",
+    findings: [{ evidence: `dimension ${id} assessed clean`, checked: [] }],
+  })
+);
+
+/**
+ * Serialize a readiness report in the CLI's persisted shape (schema_version 1).
+ * @param root0 - Fixture inputs
+ * @param root0.dimensions - Per-dimension records to persist
+ * @param root0.verdict - Report-level verdict
+ * @param root0.blockers - Detected blockers to persist, defaulting to none
+ * @param root0.narrowedClaim - The supervised-work fallback sentence, if any
+ * @returns The report serialized as JSON
+ */
+export const readinessReport = ({
+  dimensions,
+  verdict,
+  blockers = [],
+  narrowedClaim = null,
+}: {
+  dimensions: readonly FixtureDimension[];
+  verdict: string;
+  blockers?: readonly Record<string, unknown>[];
+  narrowedClaim?: string | null;
+}): string =>
+  JSON.stringify({
+    schema_version: 1,
+    generated_at: FIXTURE_GENERATED_AT,
+    lisa_version: FIXTURE_LISA_VERSION,
+    worker_signature: "claude/unknown/unknown",
+    verdict,
+    narrowed_claim: narrowedClaim,
+    blockers,
+    blocker_count: blockers.length,
+    dimensions,
+  });
+
+/**
+ * Write a readiness report under a scratch project root.
+ * @param root - Scratch project root to write the report under
+ * @param contents - Raw file contents, so malformed fixtures stay expressible
+ */
+export const writeReadinessReport = (root: string, contents: string): void => {
+  mkdirSync(path.join(root, ".lisa"), { recursive: true });
+  writeFileSync(path.join(root, ".lisa", "readiness.json"), contents, "utf8");
+};
+
+/**
+ * Replace one dimension's record, leaving the other seven clean.
+ * @param id - Dimension id to override
+ * @param overrides - Fields to apply to that dimension's record
+ * @returns All eight dimensions with the override applied
+ */
+export const withDimension = (
+  id: string,
+  overrides: Partial<FixtureDimension>
+): readonly FixtureDimension[] =>
+  passingDimensions.map(dimension =>
+    dimension.id === id ? { ...dimension, ...overrides } : dimension
+  );

--- a/tests/unit/strategies/doctor-report-rendering.test.ts
+++ b/tests/unit/strategies/doctor-report-rendering.test.ts
@@ -146,10 +146,17 @@ describe("doctor report rendering (#750)", () => {
   });
 
   it("never scores an unassessed repository-readiness group as READY (#1897)", () => {
-    // The eight readiness dimensions all render SKIP in this Lisa version. An
-    // unassessed dimension is silence, not evidence, so the agent-facing
-    // scorer must not turn it into a green unattended-fleet claim.
-    const group = createRepositoryReadinessDoctorGroup(process.cwd());
+    // A root with no `.lisa/readiness.json` leaves all eight dimensions
+    // unassessed. An unassessed dimension is silence, not evidence, so the
+    // agent-facing scorer must not turn it into a green unattended-fleet claim.
+    // The root is a scratch directory rather than `process.cwd()` so the
+    // assertion cannot flip on a developer machine where the Lisa CLI has
+    // already written a readiness report (#1902).
+    const unassessedRoot = mkdtempSync(
+      path.join(tmpdir(), "lisa-doctor-unassessed-")
+    );
+    const group = createRepositoryReadinessDoctorGroup(unassessedRoot);
+    rmSync(unassessedRoot, { force: true, recursive: true });
 
     expect(group.checks).toHaveLength(8);
     expect([...new Set(group.checks.map(check => check.status))]).toEqual([

--- a/tests/unit/strategies/doctor-repository-readiness.test.ts
+++ b/tests/unit/strategies/doctor-repository-readiness.test.ts
@@ -11,10 +11,11 @@
  * skill documents the section identically across the fanned-out plugin copies.
  * @module tests/unit/strategies/doctor-repository-readiness
  */
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   createRepositoryReadinessDoctorGroup,
@@ -45,16 +46,33 @@ const SKILL_ROOTS = [
 const readDoctorSkill = (root: string): string =>
   readFileSync(path.resolve(root, "lisa-doctor", "SKILL.md"), "utf8");
 
+/**
+ * A scratch root with no `.lisa/readiness.json`. Since #1902 the group projects
+ * the CLI-authored report when one is present, so the unassessed-dimension
+ * contract has to be asserted against a root that provably has no report —
+ * `process.cwd()` would flip these assertions on any machine where the Lisa CLI
+ * readiness pass has already run.
+ */
+let root = "";
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "lisa-readiness-group-"));
+});
+
+afterEach(() => {
+  rmSync(root, { force: true, recursive: true });
+});
+
 describe("repository-readiness doctor render group (#1855)", () => {
   it("returns a separately-titled group with a stable id", () => {
-    const group = createRepositoryReadinessDoctorGroup(process.cwd());
+    const group = createRepositoryReadinessDoctorGroup(root);
 
     expect(group.id).toBe("repository-readiness");
     expect(group.title).toBe("Repository readiness");
   });
 
   it("scores exactly eight dimensions in fixed order, never fewer", () => {
-    const group = createRepositoryReadinessDoctorGroup(process.cwd());
+    const group = createRepositoryReadinessDoctorGroup(root);
 
     expect(group.checks).toHaveLength(8);
     expect(group.checks.map(check => check.id)).toEqual([
@@ -63,7 +81,7 @@ describe("repository-readiness doctor render group (#1855)", () => {
   });
 
   it("emits SKIP with a stated reason for every inapplicable dimension", () => {
-    const group = createRepositoryReadinessDoctorGroup(process.cwd());
+    const group = createRepositoryReadinessDoctorGroup(root);
 
     for (const check of group.checks) {
       expect(check.status).toBe("SKIP");
@@ -73,7 +91,7 @@ describe("repository-readiness doctor render group (#1855)", () => {
   });
 
   it("renders under the shared verdict/counts header as one titled group", () => {
-    const group = createRepositoryReadinessDoctorGroup(process.cwd());
+    const group = createRepositoryReadinessDoctorGroup(root);
     const report = renderDoctorReport({ groups: [group] });
 
     expect(report.text).toContain("Overall verdict: ");


### PR DESCRIPTION
## Summary

Closes #1902. Brings the **agent-facing** readiness scorer into parity with the CLI, so an operator running `/lisa:doctor` through any coding agent sees the same eight-dimension readiness answer as the TypeScript CLI — the content-level completion of the parity that #1897 started at the verdict-algebra level.

Before this, `plugins/src/base/scripts/doctor-report.mjs` hardcoded all eight readiness dimensions as SKIP, so the CLI would report `delivery-authority: FAIL / B3` on a repo while the agent surface said SKIP / READY_WITH_WARNINGS for the same repo. This bridges the two — it **reflects** the CLI's written result, it does not re-score.

### What it does
- `createRepositoryReadinessDoctorGroup(root)` now reads `<root>/.lisa/readiness.json` (the authoritative per-dimension result the CLI writes) and projects each dimension into the agent group when the file parses, `schema_version === 1`, and `dimensions` is an array.
- **A standing blocker outranks the recorded status.** Three CLI producers (B1/B4/B6) deliberately emit `WARN` while standing a blocker — their contract is "the blocker engine never reads this status; the finding flips the repo to NOT_READY exactly as FAIL would." So a dimension owning a standing blocker projects as `FAIL`, and the agent verdict matches the CLI's NOT_READY (it previously softened to READY_WITH_WARNINGS while its own remediation line named the standing blocker).
- **Escalation is attribution-scoped.** A dimension is escalated only when a blocker's `dimension_id` (the dimension the CLI attributed the evidencing finding to) matches — never on the static `owning_dimensions` spec alone. So B4 (which owns both `domain-ownership` and `feedback-guardrails` but is only ever emitted by the guardrails producer) fails `feedback-guardrails` and leaves `domain-ownership` exactly as the CLI recorded it, rather than stamping a clean dimension FAIL against its own evidence.
- Surfaces the CLI's operator guidance: the `narrowed_claim` ("…IS ready for supervised, single-ticket agent work…") and the not-established caveat, plus report provenance (`generated_at`/`lisa_version`) so staleness is visible.
- **Never manufactures from absence.** Absent / unparseable / wrong-schema / dimension-not-recorded → a reasoned SKIP, never a fabricated pass or fail; a blocker naming a dimension the report never recorded stays SKIP.

### Governing discipline
Faithful per-dimension agreement with the CLI is the criterion. The scorer adds no blocker engine, no detection, no thresholds — it reflects the single source of truth the CLI persists. Reviewed across two rounds (quality + verification) that caught both directions of the faithfulness failure: a stated FAIL being softened, and a stated clean being hardened — both fixed.

## Verification

- Full `bun run test` → **411 files / 7048 tests, exit 0**; `bun run typecheck` 0; `bun run build:plugins` clean; `generate-upstream-evidence-manifest.mjs --check` 0. All four fanned copies byte-identical to source.
- **Empirical, both directions:** a WARN dimension owning a standing blocker → agent FAIL / NOT_READY (was READY_WITH_WARNINGS); a two-dimension B4 → `feedback-guardrails=FAIL`, `domain-ownership=SKIP` (matches CLI); a real CLI both-directions run (clean → SKIP; seed `secrets: inherit` → FAIL/NOT_READY; revert → restores); absence/malformed → reasoned SKIP with no crash (12 malformed fixtures).
- Fixed a latent flake this change exposed: two existing suites asserted the all-SKIP contract against `process.cwd()` (which flips wherever a `.lisa/readiness.json` exists) — repointed to deterministic scratch roots.
- `lisa-doctor/SKILL.md` documents "this surface reflects the CLI; it does not re-score," the blocker-outranks-status rule, and the absence contract.

Completes the six-agent readiness parity of PRD #1739. Detection-completeness follow-ups remain in #1903.

🤖 Generated with Claude Code
