### PR TITLE
feat(deps): add governed dependency decision-record scaffold, closing #1886

### DIFF
--- a/all/create-only/.lisa/DEPENDENCY_DECISIONS.md
+++ b/all/create-only/.lisa/DEPENDENCY_DECISIONS.md
@@ -1,0 +1,127 @@
+# Dependency Decisions
+
+<!-- lisa-dependency-decisions:v1 -->
+
+This file is the project's record of **why we keep each material dependency**.
+
+A *material* dependency is one whose failure, disappearance, or bad update would
+break something a user can see, or would cost real time to replace. Not every
+package in the lockfile belongs here — only the ones that own a capability.
+
+You do not need to be an engineer to read this file. Every entry starts with a
+plain-language explanation of what the dependency does for us and what evidence
+would catch a bad update. If an entry does not answer those two questions in
+words a non-engineer understands, the entry is wrong — fix the words, not the
+reader.
+
+Lisa seeds this file once and never overwrites it. It is yours to maintain.
+
+## How to use this file
+
+1. Copy the **Entry template** below for each material dependency.
+2. Add the filled-in entry to the end of the **Records** section.
+3. Fill in every field. If you do not know the answer yet, write
+   `_Not yet decided_` — never leave a field blank and never guess. An
+   unanswered field is an honest question for the next review; a guess is a
+   wrong answer that nobody will re-check.
+4. Re-read an entry whenever that dependency is upgraded across a major version,
+   changes maintainers, or its detection evidence fails.
+5. Update `Last reviewed` every time someone actually re-reads the entry, even
+   if nothing else changed.
+
+### Entry format (stable, appendable)
+
+Entries are deliberately uniform so they can be added by hand or appended by a
+script without rewriting the rest of the file:
+
+- Every entry is a level-3 heading (`### <name>`) followed by the nine field
+  bullets, always in the order shown in the **Entry template**.
+- Entries live under `## Records`, which is the last section of this file, and
+  new entries are appended to the end. A `###` heading inside `## Records` is
+  always an entry and never guidance — that is what makes the section safe to
+  parse and append to.
+- Nothing after `## Records` is guidance, so appending to the end of the file is
+  always safe.
+- `_Not yet decided_` is the reserved marker for an unanswered field, so
+  unfilled entries are visibly honest rather than silently empty.
+
+## What each field means
+
+- **Dependency** — the package or service name, and the version range in use.
+- **Why we keep it** — the plain-language reason, written for a non-technical
+  reader. Lead with the outcome it protects, not the mechanism.
+- **Owned capability** — the single capability this dependency is responsible
+  for. If you cannot name one capability, the dependency is either not material
+  or is doing too much.
+- **Trust basis** — why we believe this dependency will still be maintained and
+  safe next quarter. Evidence, not vibes: who maintains it, release cadence,
+  security-response history, how widely it is used, whether it is pinned.
+- **Exposure** — what it can reach and what breaks if it misbehaves. Does it run
+  at build time only, or in production? Does it touch user data, secrets, the
+  network, or CI credentials?
+- **Replacement cost** — what it would actually take to remove or swap it:
+  rough effort, what would have to be rewritten, and whether a viable
+  alternative exists today.
+- **Detection evidence** — the specific check that would **fail** if an update
+  broke the owned capability. Name the test, suite, workflow, or monitor. If the
+  honest answer is "nothing would catch it", write that down — it is the most
+  valuable line in the entry. Use `_Not yet decided_` only when nobody has
+  looked yet, which is a different statement from "we looked, and nothing
+  covers this".
+- **Owner / review cadence** — who is accountable for this entry and how often
+  it gets re-read.
+- **Last reviewed** — ISO date (`YYYY-MM-DD`) of the most recent review.
+
+## Entry template
+
+Copy this block, fill it in, and append it to the end of **Records** below. Keep
+the nine bullets in this order. Any field you cannot answer yet gets
+`_Not yet decided_`.
+
+### <dependency name>
+
+- **Dependency:** <package or service name> `<version range>`
+- **Why we keep it:** <plain-language reason a non-technical reader can follow>
+- **Owned capability:** <the one capability it owns>
+- **Trust basis:** <maintainer, cadence, adoption, security history, pinning>
+- **Exposure:** <build-time vs runtime; data, secrets, network, CI reach>
+- **Replacement cost:** <effort to remove or swap, and the alternative>
+- **Detection evidence:** <the named check that fails if an update breaks it>
+- **Owner / review cadence:** <accountable owner> / <cadence>
+- **Last reviewed:** <YYYY-MM-DD>
+
+## Records
+
+> **The entry below is an EXAMPLE.** It is here so you can see the shape of a
+> good record. Replace it with your own material dependencies, or delete it once
+> you have written real entries.
+
+### ESLint (EXAMPLE — replace with your own dependencies)
+
+- **Dependency:** `eslint` `^9`
+- **Why we keep it:** It is the automatic reviewer that reads every change
+  before a human does and refuses the ones that break our agreed coding rules.
+  Without it, those rules become suggestions and the codebase drifts a little
+  with every change until nobody can predict how anything is written.
+- **Owned capability:** Automated enforcement of code-quality and style rules on
+  every commit and every pull request.
+- **Trust basis:** Maintained by the OpenJS Foundation with a published release
+  cadence and a documented security-disclosure process; used by a very large
+  share of the JavaScript ecosystem, so breakage is found by other people before
+  it reaches us. The major version is pinned, so an upgrade is a deliberate
+  decision rather than something that arrives on its own.
+- **Exposure:** Build-time and CI only. It never runs in production and never
+  touches customer data. It does run inside CI, so a compromised release could
+  in principle read CI environment variables — which is why the version is
+  pinned and upgrades are reviewed.
+- **Replacement cost:** High. Every rule configuration and every custom rule
+  would have to be re-expressed in another linter, and the pre-commit and CI
+  wiring rebuilt. Alternatives exist (for example Biome or oxlint) but none is a
+  drop-in match for the current rule set today.
+- **Detection evidence:** The `lint` script and the Lint job in CI. If an
+  upgrade silently stopped enforcing rules, the giveaway is the lint job going
+  green on a change that is known to violate a rule — so the paired signal is
+  the lint-rule tests that assert known-bad code is still rejected.
+- **Owner / review cadence:** Platform / engineering owner — reviewed each major
+  version upgrade, and at least once every 6 months.
+- **Last reviewed:** 2026-07-21

--- a/all/create-only/.lisa/DEPENDENCY_DECISIONS.md
+++ b/all/create-only/.lisa/DEPENDENCY_DECISIONS.md
@@ -9,10 +9,10 @@ break something a user can see, or would cost real time to replace. Not every
 package in the lockfile belongs here — only the ones that own a capability.
 
 You do not need to be an engineer to read this file. Every entry starts with a
-plain-language explanation of what the dependency does for us and what evidence
-would catch a bad update. If an entry does not answer those two questions in
-words a non-engineer understands, the entry is wrong — fix the words, not the
-reader.
+plain-language explanation of what the dependency does for us, and every entry
+names what evidence would catch a bad update. If an entry does not answer those
+two questions in words a non-engineer understands, the entry is wrong — fix the
+words, not the reader.
 
 Lisa seeds this file once and never overwrites it. It is yours to maintain.
 
@@ -45,31 +45,51 @@ script without rewriting the rest of the file:
 - `_Not yet decided_` is the reserved marker for an unanswered field, so
   unfilled entries are visibly honest rather than silently empty.
 
+## When to escalate
+
+Reading an entry should end in a decision. Raise these to an owner rather than
+letting them sit — each one means the project is carrying a risk nobody has
+accepted on purpose:
+
+- **Nothing would catch a bad update.** The detection-evidence field says
+  "nothing would catch it". We are trusting the dependency blind.
+- **The review is older than the dependency.** `Last reviewed` predates the last
+  major upgrade of that dependency, so the record describes software we are no
+  longer running.
+- **Nobody is behind it.** The trust basis names no maintainer, no owner, or no
+  release history — on our side or theirs.
+
+An entry full of `_Not yet decided_` is not itself an escalation; it is a
+to-do. The three items above are escalations because someone already looked and
+the answer was bad.
+
 ## What each field means
 
-- **Dependency** — the package or service name, and the version range in use.
 - **Why we keep it** — the plain-language reason, written for a non-technical
   reader. Lead with the outcome it protects, not the mechanism.
-- **Owned capability** — the single capability this dependency is responsible
-  for. If you cannot name one capability, the dependency is either not material
-  or is doing too much.
-- **Trust basis** — why we believe this dependency will still be maintained and
-  safe next quarter. Evidence, not vibes: who maintains it, release cadence,
-  security-response history, how widely it is used, whether it is pinned.
-- **Exposure** — what it can reach and what breaks if it misbehaves. Does it run
-  at build time only, or in production? Does it touch user data, secrets, the
-  network, or CI credentials?
-- **Replacement cost** — what it would actually take to remove or swap it:
-  rough effort, what would have to be rewritten, and whether a viable
-  alternative exists today.
-- **Detection evidence** — the specific check that would **fail** if an update
-  broke the owned capability. Name the test, suite, workflow, or monitor. If the
-  honest answer is "nothing would catch it", write that down — it is the most
-  valuable line in the entry. Use `_Not yet decided_` only when nobody has
-  looked yet, which is a different statement from "we looked, and nothing
-  covers this".
-- **Owner / review cadence** — who is accountable for this entry and how often
-  it gets re-read.
+- **What it is (dependency)** — the package or service name, and the version
+  range in use.
+- **What it does for us (owned capability)** — the single capability this
+  dependency is responsible for. If you cannot name one capability, the
+  dependency is either not material or is doing too much.
+- **Why we believe it's safe (trust basis)** — why we believe this dependency
+  will still be maintained and safe next quarter. Evidence, not vibes: who
+  maintains it, release cadence, security-response history, how widely it is
+  used, whether it is pinned.
+- **What breaks if this is compromised (exposure)** — what it can reach and what
+  breaks if it misbehaves. Does it run at build time only, or in production?
+  Does it touch user data, secrets, the network, or CI credentials?
+- **What it would take to replace (replacement cost)** — what it would actually
+  take to remove or swap it: rough effort, what would have to be rewritten, and
+  whether a viable alternative exists today.
+- **What would catch a bad update (detection evidence)** — the specific check
+  that would **fail** if an update broke the owned capability. Name the test,
+  suite, workflow, or monitor. If the honest answer is "nothing would catch it",
+  write that down — it is the most valuable line in the entry. Use
+  `_Not yet decided_` only when nobody has looked yet, which is a different
+  statement from "we looked, and nothing covers this".
+- **Who owns this and how often we recheck (owner / review cadence)** — who is
+  accountable for this entry and how often it gets re-read.
 - **Last reviewed** — ISO date (`YYYY-MM-DD`) of the most recent review.
 
 ## Entry template
@@ -80,48 +100,76 @@ the nine bullets in this order. Any field you cannot answer yet gets
 
 ### <dependency name>
 
-- **Dependency:** <package or service name> `<version range>`
 - **Why we keep it:** <plain-language reason a non-technical reader can follow>
-- **Owned capability:** <the one capability it owns>
-- **Trust basis:** <maintainer, cadence, adoption, security history, pinning>
-- **Exposure:** <build-time vs runtime; data, secrets, network, CI reach>
-- **Replacement cost:** <effort to remove or swap, and the alternative>
-- **Detection evidence:** <the named check that fails if an update breaks it>
-- **Owner / review cadence:** <accountable owner> / <cadence>
+- **What it is (dependency):** <package or service name> `<version range>`
+- **What it does for us (owned capability):** <the one capability it owns>
+- **Why we believe it's safe (trust basis):** <maintainer, cadence, adoption,
+  security history, pinning>
+- **What breaks if this is compromised (exposure):** <build-time vs runtime;
+  data, secrets, network, CI reach>
+- **What it would take to replace (replacement cost):** <effort to remove or
+  swap, and the alternative>
+- **What would catch a bad update (detection evidence):** <the named check that
+  fails if an update breaks it>
+- **Who owns this and how often we recheck (owner / review cadence):**
+  <accountable owner> / <cadence>
 - **Last reviewed:** <YYYY-MM-DD>
 
 ## Records
 
-> **The entry below is an EXAMPLE.** It is here so you can see the shape of a
-> good record. Replace it with your own material dependencies, or delete it once
-> you have written real entries.
+> **The two entries below are EXAMPLES.** They are here so you can see the shape
+> of a good record — the first complete, the second still being filled in.
+> Replace them with your own material dependencies, or delete them once you have
+> written real entries.
 
-### ESLint (EXAMPLE — replace with your own dependencies)
+### ESLint (EXAMPLE — a complete entry)
 
-- **Dependency:** `eslint` `^9`
 - **Why we keep it:** It is the automatic reviewer that reads every change
   before a human does and refuses the ones that break our agreed coding rules.
   Without it, those rules become suggestions and the codebase drifts a little
   with every change until nobody can predict how anything is written.
-- **Owned capability:** Automated enforcement of code-quality and style rules on
-  every commit and every pull request.
-- **Trust basis:** Maintained by the OpenJS Foundation with a published release
-  cadence and a documented security-disclosure process; used by a very large
-  share of the JavaScript ecosystem, so breakage is found by other people before
-  it reaches us. The major version is pinned, so an upgrade is a deliberate
-  decision rather than something that arrives on its own.
-- **Exposure:** Build-time and CI only. It never runs in production and never
-  touches customer data. It does run inside CI, so a compromised release could
-  in principle read CI environment variables — which is why the version is
-  pinned and upgrades are reviewed.
-- **Replacement cost:** High. Every rule configuration and every custom rule
-  would have to be re-expressed in another linter, and the pre-commit and CI
-  wiring rebuilt. Alternatives exist (for example Biome or oxlint) but none is a
-  drop-in match for the current rule set today.
-- **Detection evidence:** The `lint` script and the Lint job in CI. If an
-  upgrade silently stopped enforcing rules, the giveaway is the lint job going
-  green on a change that is known to violate a rule — so the paired signal is
-  the lint-rule tests that assert known-bad code is still rejected.
-- **Owner / review cadence:** Platform / engineering owner — reviewed each major
-  version upgrade, and at least once every 6 months.
-- **Last reviewed:** 2026-07-21
+- **What it is (dependency):** `eslint` `^9`
+- **What it does for us (owned capability):** Automated enforcement of
+  code-quality and style rules on every commit and every pull request.
+- **Why we believe it's safe (trust basis):** Maintained by the OpenJS
+  Foundation with a published release cadence and a documented
+  security-disclosure process; used by a very large share of the JavaScript
+  ecosystem, so breakage is found by other people before it reaches us. The
+  major version is pinned, so an upgrade is a deliberate decision rather than
+  something that arrives on its own.
+- **What breaks if this is compromised (exposure):** Build-time and CI only. It
+  never runs in production and never touches customer data. It does run inside
+  CI, so a compromised release could in principle read CI environment variables
+  — which is why the version is pinned and upgrades are reviewed.
+- **What it would take to replace (replacement cost):** High. Every rule
+  configuration and every custom rule would have to be re-expressed in another
+  linter, and the pre-commit and CI wiring rebuilt. Alternatives exist (for
+  example Biome or oxlint) but none is a drop-in match for the current rule set
+  today.
+- **What would catch a bad update (detection evidence):** The `lint` check in
+  CI. Warning sign: if lint passes a change we know breaks a rule, the checking
+  has silently stopped working — the rule tests exist to catch exactly that.
+- **Who owns this and how often we recheck (owner / review cadence):** Platform
+  / engineering owner — reviewed each major version upgrade, and at least once
+  every 6 months.
+- **Last reviewed:** _Not yet decided_ (example entry — never reviewed)
+
+### sharp (EXAMPLE — an entry still being filled in)
+
+- **Why we keep it:** It resizes and re-encodes every image users upload, so
+  photos load quickly instead of being served at full camera resolution.
+- **What it is (dependency):** `sharp` `^0.33`
+- **What it does for us (owned capability):** Server-side image resizing and
+  format conversion on upload.
+- **Why we believe it's safe (trust basis):** _Not yet decided_ — nobody has
+  checked who maintains it or how quickly security issues get fixed.
+- **What breaks if this is compromised (exposure):** Runs in production and
+  processes files uploaded by users. It ships native code, so its reach is
+  wider than a pure-JavaScript package.
+- **What it would take to replace (replacement cost):** _Not yet decided_
+- **What would catch a bad update (detection evidence):** _Not yet decided_ —
+  this is the gap to close first, because nothing currently proves an upgrade
+  did not silently corrupt uploaded images.
+- **Who owns this and how often we recheck (owner / review cadence):**
+  _Not yet decided_
+- **Last reviewed:** _Not yet decided_

--- a/plugins/lisa-copilot/rules/eager/dependency-decision-records.md
+++ b/plugins/lisa-copilot/rules/eager/dependency-decision-records.md
@@ -1,0 +1,25 @@
+# Dependency Decisions (load-bearing)
+
+Material dependencies are recorded as decisions, not lockfile trivia. The
+governed record is `.lisa/DEPENDENCY_DECISIONS.md`, seeded once by `lisa apply`
+from the `all/create-only` template surface and never overwritten afterward.
+
+A *material* dependency is one that owns a user-visible capability or would cost
+real time to replace. Each record entry must name: the dependency, why we keep
+it in plain language, its owned capability, trust basis, exposure, replacement
+cost, detection evidence, owner/review cadence, and last-reviewed date.
+
+When you add, upgrade across a major version, or remove a material dependency,
+update its entry in the same change. When you cannot name the detection evidence
+that would fail if an update broke the owned capability, write "nothing would
+catch it" rather than inventing a check — the gap is the finding.
+
+Write every entry so a non-technical operator can tell why the dependency is
+kept and what evidence would detect a bad update. Lead with the outcome it
+protects, not the mechanism.
+
+Entries are repeatable blocks appended under `## Records`, so a seeding script
+can add one without rewriting the file. An honest gap is written as
+`_Not yet decided_` — never left blank.
+
+Full prose: [reference/dependency-decision-records.md](../reference/dependency-decision-records.md).

--- a/plugins/lisa-copilot/rules/eager/dependency-decision-records.md
+++ b/plugins/lisa-copilot/rules/eager/dependency-decision-records.md
@@ -5,9 +5,12 @@ governed record is `.lisa/DEPENDENCY_DECISIONS.md`, seeded once by `lisa apply`
 from the `all/create-only` template surface and never overwritten afterward.
 
 A *material* dependency is one that owns a user-visible capability or would cost
-real time to replace. Each record entry must name: the dependency, why we keep
-it in plain language, its owned capability, trust basis, exposure, replacement
-cost, detection evidence, owner/review cadence, and last-reviewed date.
+real time to replace. Each record entry must name, in this order: why we keep it
+in plain language, what it is, its owned capability, trust basis, exposure,
+replacement cost, detection evidence, owner/review cadence, and last-reviewed
+date. Field labels lead with the operator's question and keep the technical term
+in parentheses. "Why we keep it" comes first on purpose — an entry that opens
+with a version range opens with the trivia the record exists to replace.
 
 When you add, upgrade across a major version, or remove a material dependency,
 update its entry in the same change. When you cannot name the detection evidence
@@ -21,5 +24,9 @@ protects, not the mechanism.
 Entries are repeatable blocks appended under `## Records`, so a seeding script
 can add one without rewriting the file. An honest gap is written as
 `_Not yet decided_` — never left blank.
+
+Escalate, rather than just recording, when detection evidence says "nothing
+would catch it", when `Last reviewed` predates the dependency's last major
+upgrade, or when the trust basis names no maintainer or owner.
 
 Full prose: [reference/dependency-decision-records.md](../reference/dependency-decision-records.md).

--- a/plugins/lisa-copilot/rules/reference/dependency-decision-records.md
+++ b/plugins/lisa-copilot/rules/reference/dependency-decision-records.md
@@ -1,0 +1,118 @@
+# Dependency Decisions
+
+Lisa already governs dependency *mechanics* — pinning, audit gates, override
+resolution, duplicate detection. What those mechanics cannot tell anyone is
+**why** a dependency is in the project at all, what capability it owns, how much
+blast radius it has, or what would fail if a bad update shipped. Dependency
+decision records close that gap: they turn dependency posture into decisions an
+operator can read, instead of package-manager trivia only an engineer can
+interpret.
+
+## Where the record lives
+
+The governed record is the markdown file `.lisa/DEPENDENCY_DECISIONS.md` in the
+host project.
+
+It is distributed through Lisa's `all/create-only` template surface, so:
+
+- Every project that runs `lisa apply` receives the scaffold, regardless of
+  stack — the record is stack-independent because dependency posture is.
+- The strategy is **create-only**: Lisa seeds the file once and never overwrites
+  it. Host projects own their content outright, and Lisa upstream never carries
+  a copy of any host project's private dependency inventory.
+- It lives in the cold `.lisa/` directory rather than an auto-loaded rules tree,
+  so a long record is never injected raw into every session. Agents read the
+  entry they need, when they need it.
+
+Markdown is deliberate. The record's primary audience is the product gate, where
+a non-technical operator has to make a keep/replace/escalate judgment. A machine
+format would serve tooling and fail that reader.
+
+## What an entry must name
+
+Each material-dependency entry names nine things:
+
+- **Dependency** — package or service, plus the version range in use.
+- **Why we keep it** — plain-language reason, written for a non-technical
+  reader, leading with the outcome it protects.
+- **Owned capability** — the single capability the dependency is responsible
+  for. A dependency with no nameable capability is either not material, or is
+  doing too much and should be split in the record.
+- **Trust basis** — the evidence that it will still be maintained and safe next
+  quarter: maintainer, release cadence, security-response history, breadth of
+  adoption, whether the version is pinned.
+- **Exposure** — what it can reach and what breaks when it misbehaves:
+  build-time versus runtime, and whether it touches user data, secrets, the
+  network, or CI credentials.
+- **Replacement cost** — the honest effort to remove or swap it, what would need
+  rewriting, and whether a viable alternative exists today.
+- **Detection evidence** — the named check that would **fail** if an update
+  broke the owned capability: a test, suite, workflow, or monitor. "Nothing
+  would catch it" is a legitimate and high-value answer.
+- **Owner / review cadence** — who is accountable, and how often the entry gets
+  re-read.
+- **Last reviewed** — ISO `YYYY-MM-DD` date of the most recent actual review.
+
+## What counts as material
+
+Material means: if this dependency vanished, broke, or shipped a hostile update,
+a user would notice, or replacing it would cost real time. Test frameworks,
+linters, HTTP clients, ORMs, auth libraries, UI toolkits, and build tooling are
+usually material. Transitive packages and single-function utilities usually are
+not — record the direct dependency that owns the capability, not everything
+underneath it.
+
+Do not attempt to record the whole lockfile. An exhaustive record decays into
+noise and stops being read, which is worse than a short record that is true.
+
+## Maintenance
+
+Update the relevant entry in the same change that adds a material dependency,
+upgrades one across a major version, or removes one. Refresh `Last reviewed`
+whenever someone actually re-reads an entry, even when nothing else changes — a
+stale date is the signal that the record has drifted from reality.
+
+When detection evidence fails for a dependency, treat the entry as the first
+place to look and the first place to correct: either the evidence was wrong
+about what it protects, or the exposure was understated.
+
+## Entry format
+
+Entries are uniform and appendable by design, because a later seeding pass adds
+them mechanically rather than by rewriting the document:
+
+- An entry is a level-3 heading (`### <name>`) followed by the nine field
+  bullets in the fixed order above.
+- Entries live under `## Records`, the final section of the file, and new
+  entries are appended to its end. A `###` heading inside `## Records` is always
+  an entry, never guidance — that scoping is what makes the section safe to
+  parse and append to.
+- `_Not yet decided_` is the reserved marker for a field nobody has answered
+  yet. Never leave a field blank and never guess: a blank field is
+  indistinguishable from an overlooked one, and a guess is a wrong answer that
+  nobody re-checks.
+
+Note that `_Not yet decided_` and "nothing would catch it" are different
+statements. The first means nobody has looked. The second is a finding — a real
+capability with no detection evidence behind it.
+
+## Scaffold, not inventory
+
+The seeded file is a scaffold: field structure, guidance, and one clearly marked
+worked example so an operator can see the intended shape. The example is meant
+to be replaced or deleted once real entries exist. Lisa does not pre-populate a
+host project's dependency inventory — only the project knows which of its
+dependencies are material.
+
+## Agent parity
+
+The record is a governed markdown artifact, not a runtime behavior, so every
+supported coding agent — Claude Code, Codex, Cursor, OpenCode, Antigravity, and
+Copilot — reaches it identically through the shared rules mirror and the same
+`.lisa/DEPENDENCY_DECISIONS.md` path in the host project. There is no per-agent
+enforcement surface to diverge.
+
+The documented gap, uniform across all six runtimes: no agent runtime enforces
+that entries stay accurate or current. Nothing blocks a commit whose dependency
+change skips the record, and nothing fails when `Last reviewed` goes stale.
+Freshness is carried by this rule and by review, not by a hook or a lint gate.

--- a/plugins/lisa-copilot/rules/reference/dependency-decision-records.md
+++ b/plugins/lisa-copilot/rules/reference/dependency-decision-records.md
@@ -30,28 +30,50 @@ format would serve tooling and fail that reader.
 
 ## What an entry must name
 
-Each material-dependency entry names nine things:
+Each material-dependency entry names nine things, in this order. Every label
+leads with the operator's question and keeps the technical term in parentheses,
+because the record's primary reader is looking for an answer, not a term:
 
-- **Dependency** — package or service, plus the version range in use.
 - **Why we keep it** — plain-language reason, written for a non-technical
-  reader, leading with the outcome it protects.
-- **Owned capability** — the single capability the dependency is responsible
-  for. A dependency with no nameable capability is either not material, or is
-  doing too much and should be split in the record.
-- **Trust basis** — the evidence that it will still be maintained and safe next
-  quarter: maintainer, release cadence, security-response history, breadth of
-  adoption, whether the version is pinned.
-- **Exposure** — what it can reach and what breaks when it misbehaves:
-  build-time versus runtime, and whether it touches user data, secrets, the
-  network, or CI credentials.
-- **Replacement cost** — the honest effort to remove or swap it, what would need
-  rewriting, and whether a viable alternative exists today.
-- **Detection evidence** — the named check that would **fail** if an update
-  broke the owned capability: a test, suite, workflow, or monitor. "Nothing
-  would catch it" is a legitimate and high-value answer.
-- **Owner / review cadence** — who is accountable, and how often the entry gets
-  re-read.
+  reader, leading with the outcome it protects. This is deliberately the FIRST
+  bullet: an entry that opens with a version range opens with exactly the
+  package-manager trivia this record exists to replace.
+- **What it is (dependency)** — package or service, plus the version range in
+  use.
+- **What it does for us (owned capability)** — the single capability the
+  dependency is responsible for. A dependency with no nameable capability is
+  either not material, or is doing too much and should be split in the record.
+- **Why we believe it's safe (trust basis)** — the evidence that it will still
+  be maintained and safe next quarter: maintainer, release cadence,
+  security-response history, breadth of adoption, whether the version is pinned.
+- **What breaks if this is compromised (exposure)** — what it can reach and what
+  breaks when it misbehaves: build-time versus runtime, and whether it touches
+  user data, secrets, the network, or CI credentials.
+- **What it would take to replace (replacement cost)** — the honest effort to
+  remove or swap it, what would need rewriting, and whether a viable alternative
+  exists today.
+- **What would catch a bad update (detection evidence)** — the named check that
+  would **fail** if an update broke the owned capability: a test, suite,
+  workflow, or monitor. "Nothing would catch it" is a legitimate and high-value
+  answer.
+- **Who owns this and how often we recheck (owner / review cadence)** — who is
+  accountable, and how often the entry gets re-read.
 - **Last reviewed** — ISO `YYYY-MM-DD` date of the most recent actual review.
+
+## When to escalate
+
+The record exists to produce decisions, so three states are escalations rather
+than to-dos. Raise them to an owner instead of leaving them recorded:
+
+- Detection evidence says "nothing would catch it" — the capability is trusted
+  blind.
+- `Last reviewed` predates the dependency's last major upgrade — the record
+  describes software no longer running.
+- The trust basis names no maintainer, owner, or release history.
+
+An entry full of `_Not yet decided_` is not an escalation; it is unstarted work.
+These three are escalations precisely because someone already looked and the
+answer was bad.
 
 ## What counts as material
 

--- a/plugins/lisa-cursor/rules/dependency-decision-records-reference.mdc
+++ b/plugins/lisa-cursor/rules/dependency-decision-records-reference.mdc
@@ -1,0 +1,123 @@
+---
+description: "Dependency Decisions"
+alwaysApply: false
+---
+
+# Dependency Decisions
+
+Lisa already governs dependency *mechanics* — pinning, audit gates, override
+resolution, duplicate detection. What those mechanics cannot tell anyone is
+**why** a dependency is in the project at all, what capability it owns, how much
+blast radius it has, or what would fail if a bad update shipped. Dependency
+decision records close that gap: they turn dependency posture into decisions an
+operator can read, instead of package-manager trivia only an engineer can
+interpret.
+
+## Where the record lives
+
+The governed record is the markdown file `.lisa/DEPENDENCY_DECISIONS.md` in the
+host project.
+
+It is distributed through Lisa's `all/create-only` template surface, so:
+
+- Every project that runs `lisa apply` receives the scaffold, regardless of
+  stack — the record is stack-independent because dependency posture is.
+- The strategy is **create-only**: Lisa seeds the file once and never overwrites
+  it. Host projects own their content outright, and Lisa upstream never carries
+  a copy of any host project's private dependency inventory.
+- It lives in the cold `.lisa/` directory rather than an auto-loaded rules tree,
+  so a long record is never injected raw into every session. Agents read the
+  entry they need, when they need it.
+
+Markdown is deliberate. The record's primary audience is the product gate, where
+a non-technical operator has to make a keep/replace/escalate judgment. A machine
+format would serve tooling and fail that reader.
+
+## What an entry must name
+
+Each material-dependency entry names nine things:
+
+- **Dependency** — package or service, plus the version range in use.
+- **Why we keep it** — plain-language reason, written for a non-technical
+  reader, leading with the outcome it protects.
+- **Owned capability** — the single capability the dependency is responsible
+  for. A dependency with no nameable capability is either not material, or is
+  doing too much and should be split in the record.
+- **Trust basis** — the evidence that it will still be maintained and safe next
+  quarter: maintainer, release cadence, security-response history, breadth of
+  adoption, whether the version is pinned.
+- **Exposure** — what it can reach and what breaks when it misbehaves:
+  build-time versus runtime, and whether it touches user data, secrets, the
+  network, or CI credentials.
+- **Replacement cost** — the honest effort to remove or swap it, what would need
+  rewriting, and whether a viable alternative exists today.
+- **Detection evidence** — the named check that would **fail** if an update
+  broke the owned capability: a test, suite, workflow, or monitor. "Nothing
+  would catch it" is a legitimate and high-value answer.
+- **Owner / review cadence** — who is accountable, and how often the entry gets
+  re-read.
+- **Last reviewed** — ISO `YYYY-MM-DD` date of the most recent actual review.
+
+## What counts as material
+
+Material means: if this dependency vanished, broke, or shipped a hostile update,
+a user would notice, or replacing it would cost real time. Test frameworks,
+linters, HTTP clients, ORMs, auth libraries, UI toolkits, and build tooling are
+usually material. Transitive packages and single-function utilities usually are
+not — record the direct dependency that owns the capability, not everything
+underneath it.
+
+Do not attempt to record the whole lockfile. An exhaustive record decays into
+noise and stops being read, which is worse than a short record that is true.
+
+## Maintenance
+
+Update the relevant entry in the same change that adds a material dependency,
+upgrades one across a major version, or removes one. Refresh `Last reviewed`
+whenever someone actually re-reads an entry, even when nothing else changes — a
+stale date is the signal that the record has drifted from reality.
+
+When detection evidence fails for a dependency, treat the entry as the first
+place to look and the first place to correct: either the evidence was wrong
+about what it protects, or the exposure was understated.
+
+## Entry format
+
+Entries are uniform and appendable by design, because a later seeding pass adds
+them mechanically rather than by rewriting the document:
+
+- An entry is a level-3 heading (`### <name>`) followed by the nine field
+  bullets in the fixed order above.
+- Entries live under `## Records`, the final section of the file, and new
+  entries are appended to its end. A `###` heading inside `## Records` is always
+  an entry, never guidance — that scoping is what makes the section safe to
+  parse and append to.
+- `_Not yet decided_` is the reserved marker for a field nobody has answered
+  yet. Never leave a field blank and never guess: a blank field is
+  indistinguishable from an overlooked one, and a guess is a wrong answer that
+  nobody re-checks.
+
+Note that `_Not yet decided_` and "nothing would catch it" are different
+statements. The first means nobody has looked. The second is a finding — a real
+capability with no detection evidence behind it.
+
+## Scaffold, not inventory
+
+The seeded file is a scaffold: field structure, guidance, and one clearly marked
+worked example so an operator can see the intended shape. The example is meant
+to be replaced or deleted once real entries exist. Lisa does not pre-populate a
+host project's dependency inventory — only the project knows which of its
+dependencies are material.
+
+## Agent parity
+
+The record is a governed markdown artifact, not a runtime behavior, so every
+supported coding agent — Claude Code, Codex, Cursor, OpenCode, Antigravity, and
+Copilot — reaches it identically through the shared rules mirror and the same
+`.lisa/DEPENDENCY_DECISIONS.md` path in the host project. There is no per-agent
+enforcement surface to diverge.
+
+The documented gap, uniform across all six runtimes: no agent runtime enforces
+that entries stay accurate or current. Nothing blocks a commit whose dependency
+change skips the record, and nothing fails when `Last reviewed` goes stale.
+Freshness is carried by this rule and by review, not by a hook or a lint gate.

--- a/plugins/lisa-cursor/rules/dependency-decision-records-reference.mdc
+++ b/plugins/lisa-cursor/rules/dependency-decision-records-reference.mdc
@@ -35,28 +35,50 @@ format would serve tooling and fail that reader.
 
 ## What an entry must name
 
-Each material-dependency entry names nine things:
+Each material-dependency entry names nine things, in this order. Every label
+leads with the operator's question and keeps the technical term in parentheses,
+because the record's primary reader is looking for an answer, not a term:
 
-- **Dependency** — package or service, plus the version range in use.
 - **Why we keep it** — plain-language reason, written for a non-technical
-  reader, leading with the outcome it protects.
-- **Owned capability** — the single capability the dependency is responsible
-  for. A dependency with no nameable capability is either not material, or is
-  doing too much and should be split in the record.
-- **Trust basis** — the evidence that it will still be maintained and safe next
-  quarter: maintainer, release cadence, security-response history, breadth of
-  adoption, whether the version is pinned.
-- **Exposure** — what it can reach and what breaks when it misbehaves:
-  build-time versus runtime, and whether it touches user data, secrets, the
-  network, or CI credentials.
-- **Replacement cost** — the honest effort to remove or swap it, what would need
-  rewriting, and whether a viable alternative exists today.
-- **Detection evidence** — the named check that would **fail** if an update
-  broke the owned capability: a test, suite, workflow, or monitor. "Nothing
-  would catch it" is a legitimate and high-value answer.
-- **Owner / review cadence** — who is accountable, and how often the entry gets
-  re-read.
+  reader, leading with the outcome it protects. This is deliberately the FIRST
+  bullet: an entry that opens with a version range opens with exactly the
+  package-manager trivia this record exists to replace.
+- **What it is (dependency)** — package or service, plus the version range in
+  use.
+- **What it does for us (owned capability)** — the single capability the
+  dependency is responsible for. A dependency with no nameable capability is
+  either not material, or is doing too much and should be split in the record.
+- **Why we believe it's safe (trust basis)** — the evidence that it will still
+  be maintained and safe next quarter: maintainer, release cadence,
+  security-response history, breadth of adoption, whether the version is pinned.
+- **What breaks if this is compromised (exposure)** — what it can reach and what
+  breaks when it misbehaves: build-time versus runtime, and whether it touches
+  user data, secrets, the network, or CI credentials.
+- **What it would take to replace (replacement cost)** — the honest effort to
+  remove or swap it, what would need rewriting, and whether a viable alternative
+  exists today.
+- **What would catch a bad update (detection evidence)** — the named check that
+  would **fail** if an update broke the owned capability: a test, suite,
+  workflow, or monitor. "Nothing would catch it" is a legitimate and high-value
+  answer.
+- **Who owns this and how often we recheck (owner / review cadence)** — who is
+  accountable, and how often the entry gets re-read.
 - **Last reviewed** — ISO `YYYY-MM-DD` date of the most recent actual review.
+
+## When to escalate
+
+The record exists to produce decisions, so three states are escalations rather
+than to-dos. Raise them to an owner instead of leaving them recorded:
+
+- Detection evidence says "nothing would catch it" — the capability is trusted
+  blind.
+- `Last reviewed` predates the dependency's last major upgrade — the record
+  describes software no longer running.
+- The trust basis names no maintainer, owner, or release history.
+
+An entry full of `_Not yet decided_` is not an escalation; it is unstarted work.
+These three are escalations precisely because someone already looked and the
+answer was bad.
 
 ## What counts as material
 

--- a/plugins/lisa-cursor/rules/dependency-decision-records.mdc
+++ b/plugins/lisa-cursor/rules/dependency-decision-records.mdc
@@ -10,9 +10,12 @@ governed record is `.lisa/DEPENDENCY_DECISIONS.md`, seeded once by `lisa apply`
 from the `all/create-only` template surface and never overwritten afterward.
 
 A *material* dependency is one that owns a user-visible capability or would cost
-real time to replace. Each record entry must name: the dependency, why we keep
-it in plain language, its owned capability, trust basis, exposure, replacement
-cost, detection evidence, owner/review cadence, and last-reviewed date.
+real time to replace. Each record entry must name, in this order: why we keep it
+in plain language, what it is, its owned capability, trust basis, exposure,
+replacement cost, detection evidence, owner/review cadence, and last-reviewed
+date. Field labels lead with the operator's question and keep the technical term
+in parentheses. "Why we keep it" comes first on purpose — an entry that opens
+with a version range opens with the trivia the record exists to replace.
 
 When you add, upgrade across a major version, or remove a material dependency,
 update its entry in the same change. When you cannot name the detection evidence
@@ -26,5 +29,9 @@ protects, not the mechanism.
 Entries are repeatable blocks appended under `## Records`, so a seeding script
 can add one without rewriting the file. An honest gap is written as
 `_Not yet decided_` — never left blank.
+
+Escalate, rather than just recording, when detection evidence says "nothing
+would catch it", when `Last reviewed` predates the dependency's last major
+upgrade, or when the trust basis names no maintainer or owner.
 
 Full prose: [reference/dependency-decision-records.md](dependency-decision-records-reference.mdc).

--- a/plugins/lisa-cursor/rules/dependency-decision-records.mdc
+++ b/plugins/lisa-cursor/rules/dependency-decision-records.mdc
@@ -1,0 +1,30 @@
+---
+description: "Dependency Decisions (load-bearing)"
+alwaysApply: true
+---
+
+# Dependency Decisions (load-bearing)
+
+Material dependencies are recorded as decisions, not lockfile trivia. The
+governed record is `.lisa/DEPENDENCY_DECISIONS.md`, seeded once by `lisa apply`
+from the `all/create-only` template surface and never overwritten afterward.
+
+A *material* dependency is one that owns a user-visible capability or would cost
+real time to replace. Each record entry must name: the dependency, why we keep
+it in plain language, its owned capability, trust basis, exposure, replacement
+cost, detection evidence, owner/review cadence, and last-reviewed date.
+
+When you add, upgrade across a major version, or remove a material dependency,
+update its entry in the same change. When you cannot name the detection evidence
+that would fail if an update broke the owned capability, write "nothing would
+catch it" rather than inventing a check — the gap is the finding.
+
+Write every entry so a non-technical operator can tell why the dependency is
+kept and what evidence would detect a bad update. Lead with the outcome it
+protects, not the mechanism.
+
+Entries are repeatable blocks appended under `## Records`, so a seeding script
+can add one without rewriting the file. An honest gap is written as
+`_Not yet decided_` — never left blank.
+
+Full prose: [reference/dependency-decision-records.md](dependency-decision-records-reference.mdc).

--- a/plugins/lisa/rules/eager/dependency-decision-records.md
+++ b/plugins/lisa/rules/eager/dependency-decision-records.md
@@ -1,0 +1,25 @@
+# Dependency Decisions (load-bearing)
+
+Material dependencies are recorded as decisions, not lockfile trivia. The
+governed record is `.lisa/DEPENDENCY_DECISIONS.md`, seeded once by `lisa apply`
+from the `all/create-only` template surface and never overwritten afterward.
+
+A *material* dependency is one that owns a user-visible capability or would cost
+real time to replace. Each record entry must name: the dependency, why we keep
+it in plain language, its owned capability, trust basis, exposure, replacement
+cost, detection evidence, owner/review cadence, and last-reviewed date.
+
+When you add, upgrade across a major version, or remove a material dependency,
+update its entry in the same change. When you cannot name the detection evidence
+that would fail if an update broke the owned capability, write "nothing would
+catch it" rather than inventing a check — the gap is the finding.
+
+Write every entry so a non-technical operator can tell why the dependency is
+kept and what evidence would detect a bad update. Lead with the outcome it
+protects, not the mechanism.
+
+Entries are repeatable blocks appended under `## Records`, so a seeding script
+can add one without rewriting the file. An honest gap is written as
+`_Not yet decided_` — never left blank.
+
+Full prose: [reference/dependency-decision-records.md](../reference/dependency-decision-records.md).

--- a/plugins/lisa/rules/eager/dependency-decision-records.md
+++ b/plugins/lisa/rules/eager/dependency-decision-records.md
@@ -5,9 +5,12 @@ governed record is `.lisa/DEPENDENCY_DECISIONS.md`, seeded once by `lisa apply`
 from the `all/create-only` template surface and never overwritten afterward.
 
 A *material* dependency is one that owns a user-visible capability or would cost
-real time to replace. Each record entry must name: the dependency, why we keep
-it in plain language, its owned capability, trust basis, exposure, replacement
-cost, detection evidence, owner/review cadence, and last-reviewed date.
+real time to replace. Each record entry must name, in this order: why we keep it
+in plain language, what it is, its owned capability, trust basis, exposure,
+replacement cost, detection evidence, owner/review cadence, and last-reviewed
+date. Field labels lead with the operator's question and keep the technical term
+in parentheses. "Why we keep it" comes first on purpose — an entry that opens
+with a version range opens with the trivia the record exists to replace.
 
 When you add, upgrade across a major version, or remove a material dependency,
 update its entry in the same change. When you cannot name the detection evidence
@@ -21,5 +24,9 @@ protects, not the mechanism.
 Entries are repeatable blocks appended under `## Records`, so a seeding script
 can add one without rewriting the file. An honest gap is written as
 `_Not yet decided_` — never left blank.
+
+Escalate, rather than just recording, when detection evidence says "nothing
+would catch it", when `Last reviewed` predates the dependency's last major
+upgrade, or when the trust basis names no maintainer or owner.
 
 Full prose: [reference/dependency-decision-records.md](../reference/dependency-decision-records.md).

--- a/plugins/lisa/rules/reference/dependency-decision-records.md
+++ b/plugins/lisa/rules/reference/dependency-decision-records.md
@@ -1,0 +1,118 @@
+# Dependency Decisions
+
+Lisa already governs dependency *mechanics* — pinning, audit gates, override
+resolution, duplicate detection. What those mechanics cannot tell anyone is
+**why** a dependency is in the project at all, what capability it owns, how much
+blast radius it has, or what would fail if a bad update shipped. Dependency
+decision records close that gap: they turn dependency posture into decisions an
+operator can read, instead of package-manager trivia only an engineer can
+interpret.
+
+## Where the record lives
+
+The governed record is the markdown file `.lisa/DEPENDENCY_DECISIONS.md` in the
+host project.
+
+It is distributed through Lisa's `all/create-only` template surface, so:
+
+- Every project that runs `lisa apply` receives the scaffold, regardless of
+  stack — the record is stack-independent because dependency posture is.
+- The strategy is **create-only**: Lisa seeds the file once and never overwrites
+  it. Host projects own their content outright, and Lisa upstream never carries
+  a copy of any host project's private dependency inventory.
+- It lives in the cold `.lisa/` directory rather than an auto-loaded rules tree,
+  so a long record is never injected raw into every session. Agents read the
+  entry they need, when they need it.
+
+Markdown is deliberate. The record's primary audience is the product gate, where
+a non-technical operator has to make a keep/replace/escalate judgment. A machine
+format would serve tooling and fail that reader.
+
+## What an entry must name
+
+Each material-dependency entry names nine things:
+
+- **Dependency** — package or service, plus the version range in use.
+- **Why we keep it** — plain-language reason, written for a non-technical
+  reader, leading with the outcome it protects.
+- **Owned capability** — the single capability the dependency is responsible
+  for. A dependency with no nameable capability is either not material, or is
+  doing too much and should be split in the record.
+- **Trust basis** — the evidence that it will still be maintained and safe next
+  quarter: maintainer, release cadence, security-response history, breadth of
+  adoption, whether the version is pinned.
+- **Exposure** — what it can reach and what breaks when it misbehaves:
+  build-time versus runtime, and whether it touches user data, secrets, the
+  network, or CI credentials.
+- **Replacement cost** — the honest effort to remove or swap it, what would need
+  rewriting, and whether a viable alternative exists today.
+- **Detection evidence** — the named check that would **fail** if an update
+  broke the owned capability: a test, suite, workflow, or monitor. "Nothing
+  would catch it" is a legitimate and high-value answer.
+- **Owner / review cadence** — who is accountable, and how often the entry gets
+  re-read.
+- **Last reviewed** — ISO `YYYY-MM-DD` date of the most recent actual review.
+
+## What counts as material
+
+Material means: if this dependency vanished, broke, or shipped a hostile update,
+a user would notice, or replacing it would cost real time. Test frameworks,
+linters, HTTP clients, ORMs, auth libraries, UI toolkits, and build tooling are
+usually material. Transitive packages and single-function utilities usually are
+not — record the direct dependency that owns the capability, not everything
+underneath it.
+
+Do not attempt to record the whole lockfile. An exhaustive record decays into
+noise and stops being read, which is worse than a short record that is true.
+
+## Maintenance
+
+Update the relevant entry in the same change that adds a material dependency,
+upgrades one across a major version, or removes one. Refresh `Last reviewed`
+whenever someone actually re-reads an entry, even when nothing else changes — a
+stale date is the signal that the record has drifted from reality.
+
+When detection evidence fails for a dependency, treat the entry as the first
+place to look and the first place to correct: either the evidence was wrong
+about what it protects, or the exposure was understated.
+
+## Entry format
+
+Entries are uniform and appendable by design, because a later seeding pass adds
+them mechanically rather than by rewriting the document:
+
+- An entry is a level-3 heading (`### <name>`) followed by the nine field
+  bullets in the fixed order above.
+- Entries live under `## Records`, the final section of the file, and new
+  entries are appended to its end. A `###` heading inside `## Records` is always
+  an entry, never guidance — that scoping is what makes the section safe to
+  parse and append to.
+- `_Not yet decided_` is the reserved marker for a field nobody has answered
+  yet. Never leave a field blank and never guess: a blank field is
+  indistinguishable from an overlooked one, and a guess is a wrong answer that
+  nobody re-checks.
+
+Note that `_Not yet decided_` and "nothing would catch it" are different
+statements. The first means nobody has looked. The second is a finding — a real
+capability with no detection evidence behind it.
+
+## Scaffold, not inventory
+
+The seeded file is a scaffold: field structure, guidance, and one clearly marked
+worked example so an operator can see the intended shape. The example is meant
+to be replaced or deleted once real entries exist. Lisa does not pre-populate a
+host project's dependency inventory — only the project knows which of its
+dependencies are material.
+
+## Agent parity
+
+The record is a governed markdown artifact, not a runtime behavior, so every
+supported coding agent — Claude Code, Codex, Cursor, OpenCode, Antigravity, and
+Copilot — reaches it identically through the shared rules mirror and the same
+`.lisa/DEPENDENCY_DECISIONS.md` path in the host project. There is no per-agent
+enforcement surface to diverge.
+
+The documented gap, uniform across all six runtimes: no agent runtime enforces
+that entries stay accurate or current. Nothing blocks a commit whose dependency
+change skips the record, and nothing fails when `Last reviewed` goes stale.
+Freshness is carried by this rule and by review, not by a hook or a lint gate.

--- a/plugins/lisa/rules/reference/dependency-decision-records.md
+++ b/plugins/lisa/rules/reference/dependency-decision-records.md
@@ -30,28 +30,50 @@ format would serve tooling and fail that reader.
 
 ## What an entry must name
 
-Each material-dependency entry names nine things:
+Each material-dependency entry names nine things, in this order. Every label
+leads with the operator's question and keeps the technical term in parentheses,
+because the record's primary reader is looking for an answer, not a term:
 
-- **Dependency** — package or service, plus the version range in use.
 - **Why we keep it** — plain-language reason, written for a non-technical
-  reader, leading with the outcome it protects.
-- **Owned capability** — the single capability the dependency is responsible
-  for. A dependency with no nameable capability is either not material, or is
-  doing too much and should be split in the record.
-- **Trust basis** — the evidence that it will still be maintained and safe next
-  quarter: maintainer, release cadence, security-response history, breadth of
-  adoption, whether the version is pinned.
-- **Exposure** — what it can reach and what breaks when it misbehaves:
-  build-time versus runtime, and whether it touches user data, secrets, the
-  network, or CI credentials.
-- **Replacement cost** — the honest effort to remove or swap it, what would need
-  rewriting, and whether a viable alternative exists today.
-- **Detection evidence** — the named check that would **fail** if an update
-  broke the owned capability: a test, suite, workflow, or monitor. "Nothing
-  would catch it" is a legitimate and high-value answer.
-- **Owner / review cadence** — who is accountable, and how often the entry gets
-  re-read.
+  reader, leading with the outcome it protects. This is deliberately the FIRST
+  bullet: an entry that opens with a version range opens with exactly the
+  package-manager trivia this record exists to replace.
+- **What it is (dependency)** — package or service, plus the version range in
+  use.
+- **What it does for us (owned capability)** — the single capability the
+  dependency is responsible for. A dependency with no nameable capability is
+  either not material, or is doing too much and should be split in the record.
+- **Why we believe it's safe (trust basis)** — the evidence that it will still
+  be maintained and safe next quarter: maintainer, release cadence,
+  security-response history, breadth of adoption, whether the version is pinned.
+- **What breaks if this is compromised (exposure)** — what it can reach and what
+  breaks when it misbehaves: build-time versus runtime, and whether it touches
+  user data, secrets, the network, or CI credentials.
+- **What it would take to replace (replacement cost)** — the honest effort to
+  remove or swap it, what would need rewriting, and whether a viable alternative
+  exists today.
+- **What would catch a bad update (detection evidence)** — the named check that
+  would **fail** if an update broke the owned capability: a test, suite,
+  workflow, or monitor. "Nothing would catch it" is a legitimate and high-value
+  answer.
+- **Who owns this and how often we recheck (owner / review cadence)** — who is
+  accountable, and how often the entry gets re-read.
 - **Last reviewed** — ISO `YYYY-MM-DD` date of the most recent actual review.
+
+## When to escalate
+
+The record exists to produce decisions, so three states are escalations rather
+than to-dos. Raise them to an owner instead of leaving them recorded:
+
+- Detection evidence says "nothing would catch it" — the capability is trusted
+  blind.
+- `Last reviewed` predates the dependency's last major upgrade — the record
+  describes software no longer running.
+- The trust basis names no maintainer, owner, or release history.
+
+An entry full of `_Not yet decided_` is not an escalation; it is unstarted work.
+These three are escalations precisely because someone already looked and the
+answer was bad.
 
 ## What counts as material
 

--- a/plugins/src/base/rules/eager/dependency-decision-records.md
+++ b/plugins/src/base/rules/eager/dependency-decision-records.md
@@ -1,0 +1,25 @@
+# Dependency Decisions (load-bearing)
+
+Material dependencies are recorded as decisions, not lockfile trivia. The
+governed record is `.lisa/DEPENDENCY_DECISIONS.md`, seeded once by `lisa apply`
+from the `all/create-only` template surface and never overwritten afterward.
+
+A *material* dependency is one that owns a user-visible capability or would cost
+real time to replace. Each record entry must name: the dependency, why we keep
+it in plain language, its owned capability, trust basis, exposure, replacement
+cost, detection evidence, owner/review cadence, and last-reviewed date.
+
+When you add, upgrade across a major version, or remove a material dependency,
+update its entry in the same change. When you cannot name the detection evidence
+that would fail if an update broke the owned capability, write "nothing would
+catch it" rather than inventing a check — the gap is the finding.
+
+Write every entry so a non-technical operator can tell why the dependency is
+kept and what evidence would detect a bad update. Lead with the outcome it
+protects, not the mechanism.
+
+Entries are repeatable blocks appended under `## Records`, so a seeding script
+can add one without rewriting the file. An honest gap is written as
+`_Not yet decided_` — never left blank.
+
+Full prose: [reference/dependency-decision-records.md](../reference/dependency-decision-records.md).

--- a/plugins/src/base/rules/eager/dependency-decision-records.md
+++ b/plugins/src/base/rules/eager/dependency-decision-records.md
@@ -5,9 +5,12 @@ governed record is `.lisa/DEPENDENCY_DECISIONS.md`, seeded once by `lisa apply`
 from the `all/create-only` template surface and never overwritten afterward.
 
 A *material* dependency is one that owns a user-visible capability or would cost
-real time to replace. Each record entry must name: the dependency, why we keep
-it in plain language, its owned capability, trust basis, exposure, replacement
-cost, detection evidence, owner/review cadence, and last-reviewed date.
+real time to replace. Each record entry must name, in this order: why we keep it
+in plain language, what it is, its owned capability, trust basis, exposure,
+replacement cost, detection evidence, owner/review cadence, and last-reviewed
+date. Field labels lead with the operator's question and keep the technical term
+in parentheses. "Why we keep it" comes first on purpose — an entry that opens
+with a version range opens with the trivia the record exists to replace.
 
 When you add, upgrade across a major version, or remove a material dependency,
 update its entry in the same change. When you cannot name the detection evidence
@@ -21,5 +24,9 @@ protects, not the mechanism.
 Entries are repeatable blocks appended under `## Records`, so a seeding script
 can add one without rewriting the file. An honest gap is written as
 `_Not yet decided_` — never left blank.
+
+Escalate, rather than just recording, when detection evidence says "nothing
+would catch it", when `Last reviewed` predates the dependency's last major
+upgrade, or when the trust basis names no maintainer or owner.
 
 Full prose: [reference/dependency-decision-records.md](../reference/dependency-decision-records.md).

--- a/plugins/src/base/rules/reference/dependency-decision-records.md
+++ b/plugins/src/base/rules/reference/dependency-decision-records.md
@@ -1,0 +1,118 @@
+# Dependency Decisions
+
+Lisa already governs dependency *mechanics* — pinning, audit gates, override
+resolution, duplicate detection. What those mechanics cannot tell anyone is
+**why** a dependency is in the project at all, what capability it owns, how much
+blast radius it has, or what would fail if a bad update shipped. Dependency
+decision records close that gap: they turn dependency posture into decisions an
+operator can read, instead of package-manager trivia only an engineer can
+interpret.
+
+## Where the record lives
+
+The governed record is the markdown file `.lisa/DEPENDENCY_DECISIONS.md` in the
+host project.
+
+It is distributed through Lisa's `all/create-only` template surface, so:
+
+- Every project that runs `lisa apply` receives the scaffold, regardless of
+  stack — the record is stack-independent because dependency posture is.
+- The strategy is **create-only**: Lisa seeds the file once and never overwrites
+  it. Host projects own their content outright, and Lisa upstream never carries
+  a copy of any host project's private dependency inventory.
+- It lives in the cold `.lisa/` directory rather than an auto-loaded rules tree,
+  so a long record is never injected raw into every session. Agents read the
+  entry they need, when they need it.
+
+Markdown is deliberate. The record's primary audience is the product gate, where
+a non-technical operator has to make a keep/replace/escalate judgment. A machine
+format would serve tooling and fail that reader.
+
+## What an entry must name
+
+Each material-dependency entry names nine things:
+
+- **Dependency** — package or service, plus the version range in use.
+- **Why we keep it** — plain-language reason, written for a non-technical
+  reader, leading with the outcome it protects.
+- **Owned capability** — the single capability the dependency is responsible
+  for. A dependency with no nameable capability is either not material, or is
+  doing too much and should be split in the record.
+- **Trust basis** — the evidence that it will still be maintained and safe next
+  quarter: maintainer, release cadence, security-response history, breadth of
+  adoption, whether the version is pinned.
+- **Exposure** — what it can reach and what breaks when it misbehaves:
+  build-time versus runtime, and whether it touches user data, secrets, the
+  network, or CI credentials.
+- **Replacement cost** — the honest effort to remove or swap it, what would need
+  rewriting, and whether a viable alternative exists today.
+- **Detection evidence** — the named check that would **fail** if an update
+  broke the owned capability: a test, suite, workflow, or monitor. "Nothing
+  would catch it" is a legitimate and high-value answer.
+- **Owner / review cadence** — who is accountable, and how often the entry gets
+  re-read.
+- **Last reviewed** — ISO `YYYY-MM-DD` date of the most recent actual review.
+
+## What counts as material
+
+Material means: if this dependency vanished, broke, or shipped a hostile update,
+a user would notice, or replacing it would cost real time. Test frameworks,
+linters, HTTP clients, ORMs, auth libraries, UI toolkits, and build tooling are
+usually material. Transitive packages and single-function utilities usually are
+not — record the direct dependency that owns the capability, not everything
+underneath it.
+
+Do not attempt to record the whole lockfile. An exhaustive record decays into
+noise and stops being read, which is worse than a short record that is true.
+
+## Maintenance
+
+Update the relevant entry in the same change that adds a material dependency,
+upgrades one across a major version, or removes one. Refresh `Last reviewed`
+whenever someone actually re-reads an entry, even when nothing else changes — a
+stale date is the signal that the record has drifted from reality.
+
+When detection evidence fails for a dependency, treat the entry as the first
+place to look and the first place to correct: either the evidence was wrong
+about what it protects, or the exposure was understated.
+
+## Entry format
+
+Entries are uniform and appendable by design, because a later seeding pass adds
+them mechanically rather than by rewriting the document:
+
+- An entry is a level-3 heading (`### <name>`) followed by the nine field
+  bullets in the fixed order above.
+- Entries live under `## Records`, the final section of the file, and new
+  entries are appended to its end. A `###` heading inside `## Records` is always
+  an entry, never guidance — that scoping is what makes the section safe to
+  parse and append to.
+- `_Not yet decided_` is the reserved marker for a field nobody has answered
+  yet. Never leave a field blank and never guess: a blank field is
+  indistinguishable from an overlooked one, and a guess is a wrong answer that
+  nobody re-checks.
+
+Note that `_Not yet decided_` and "nothing would catch it" are different
+statements. The first means nobody has looked. The second is a finding — a real
+capability with no detection evidence behind it.
+
+## Scaffold, not inventory
+
+The seeded file is a scaffold: field structure, guidance, and one clearly marked
+worked example so an operator can see the intended shape. The example is meant
+to be replaced or deleted once real entries exist. Lisa does not pre-populate a
+host project's dependency inventory — only the project knows which of its
+dependencies are material.
+
+## Agent parity
+
+The record is a governed markdown artifact, not a runtime behavior, so every
+supported coding agent — Claude Code, Codex, Cursor, OpenCode, Antigravity, and
+Copilot — reaches it identically through the shared rules mirror and the same
+`.lisa/DEPENDENCY_DECISIONS.md` path in the host project. There is no per-agent
+enforcement surface to diverge.
+
+The documented gap, uniform across all six runtimes: no agent runtime enforces
+that entries stay accurate or current. Nothing blocks a commit whose dependency
+change skips the record, and nothing fails when `Last reviewed` goes stale.
+Freshness is carried by this rule and by review, not by a hook or a lint gate.

--- a/plugins/src/base/rules/reference/dependency-decision-records.md
+++ b/plugins/src/base/rules/reference/dependency-decision-records.md
@@ -30,28 +30,50 @@ format would serve tooling and fail that reader.
 
 ## What an entry must name
 
-Each material-dependency entry names nine things:
+Each material-dependency entry names nine things, in this order. Every label
+leads with the operator's question and keeps the technical term in parentheses,
+because the record's primary reader is looking for an answer, not a term:
 
-- **Dependency** — package or service, plus the version range in use.
 - **Why we keep it** — plain-language reason, written for a non-technical
-  reader, leading with the outcome it protects.
-- **Owned capability** — the single capability the dependency is responsible
-  for. A dependency with no nameable capability is either not material, or is
-  doing too much and should be split in the record.
-- **Trust basis** — the evidence that it will still be maintained and safe next
-  quarter: maintainer, release cadence, security-response history, breadth of
-  adoption, whether the version is pinned.
-- **Exposure** — what it can reach and what breaks when it misbehaves:
-  build-time versus runtime, and whether it touches user data, secrets, the
-  network, or CI credentials.
-- **Replacement cost** — the honest effort to remove or swap it, what would need
-  rewriting, and whether a viable alternative exists today.
-- **Detection evidence** — the named check that would **fail** if an update
-  broke the owned capability: a test, suite, workflow, or monitor. "Nothing
-  would catch it" is a legitimate and high-value answer.
-- **Owner / review cadence** — who is accountable, and how often the entry gets
-  re-read.
+  reader, leading with the outcome it protects. This is deliberately the FIRST
+  bullet: an entry that opens with a version range opens with exactly the
+  package-manager trivia this record exists to replace.
+- **What it is (dependency)** — package or service, plus the version range in
+  use.
+- **What it does for us (owned capability)** — the single capability the
+  dependency is responsible for. A dependency with no nameable capability is
+  either not material, or is doing too much and should be split in the record.
+- **Why we believe it's safe (trust basis)** — the evidence that it will still
+  be maintained and safe next quarter: maintainer, release cadence,
+  security-response history, breadth of adoption, whether the version is pinned.
+- **What breaks if this is compromised (exposure)** — what it can reach and what
+  breaks when it misbehaves: build-time versus runtime, and whether it touches
+  user data, secrets, the network, or CI credentials.
+- **What it would take to replace (replacement cost)** — the honest effort to
+  remove or swap it, what would need rewriting, and whether a viable alternative
+  exists today.
+- **What would catch a bad update (detection evidence)** — the named check that
+  would **fail** if an update broke the owned capability: a test, suite,
+  workflow, or monitor. "Nothing would catch it" is a legitimate and high-value
+  answer.
+- **Who owns this and how often we recheck (owner / review cadence)** — who is
+  accountable, and how often the entry gets re-read.
 - **Last reviewed** — ISO `YYYY-MM-DD` date of the most recent actual review.
+
+## When to escalate
+
+The record exists to produce decisions, so three states are escalations rather
+than to-dos. Raise them to an owner instead of leaving them recorded:
+
+- Detection evidence says "nothing would catch it" — the capability is trusted
+  blind.
+- `Last reviewed` predates the dependency's last major upgrade — the record
+  describes software no longer running.
+- The trust basis names no maintainer, owner, or release history.
+
+An entry full of `_Not yet decided_` is not an escalation; it is unstarted work.
+These three are escalations precisely because someone already looked and the
+answer was bad.
 
 ## What counts as material
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -621,7 +621,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/eager/convergent-review.md":
       "ba4ba53863ef99be353c07c01195fa4ae2923ef2b2a5ad4427072802c260d208",
     "plugins/src/base/rules/eager/dependency-decision-records.md":
-      "78e95eb470fc89b117ad06a9c79edbb95abc7940b625ce232ebba4e113c8d95d",
+      "e22888f107906992e863fca50f26c2c4b124da7132535cacfac71e4f3085728f",
     "plugins/src/base/rules/eager/documentation-source-paths.md":
       "3a7c2a6264654a3cc44dd326441ba211a39c1c267033cc189c1c635adb84b52b",
     "plugins/src/base/rules/eager/empirical-inquiry.md":
@@ -681,7 +681,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/reference/convergent-review.md":
       "788a9d4dc2af7a928c3ccbb4d53a92856bb3544941ce512cfe38068d6b35850d",
     "plugins/src/base/rules/reference/dependency-decision-records.md":
-      "59318579408cdf07343e26abbb316d83a3119dbf4fb68bbcc72b299131f3e8f0",
+      "84f9fb8fa0a606307e828ec355ccbf2258beeeb88795dd113abe9bb2c37db39f",
     "plugins/src/base/rules/reference/documentation-source-paths.md":
       "555155889c9cf279865b9d8fc554bdd461c96a3ec76a5001dfeb361a71056999",
     "plugins/src/base/rules/reference/empirical-inquiry.md":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -620,6 +620,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "2689c1f47903a5f6c84677fbfd2f1f148096faf122b7498b21d3b0f2345c6c87",
     "plugins/src/base/rules/eager/convergent-review.md":
       "ba4ba53863ef99be353c07c01195fa4ae2923ef2b2a5ad4427072802c260d208",
+    "plugins/src/base/rules/eager/dependency-decision-records.md":
+      "78e95eb470fc89b117ad06a9c79edbb95abc7940b625ce232ebba4e113c8d95d",
     "plugins/src/base/rules/eager/documentation-source-paths.md":
       "3a7c2a6264654a3cc44dd326441ba211a39c1c267033cc189c1c635adb84b52b",
     "plugins/src/base/rules/eager/empirical-inquiry.md":
@@ -678,6 +680,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "071b2c91f3b661ee493ea6f37d78f0fdea8004b4e4e7b5e94dcf232df7eceda7",
     "plugins/src/base/rules/reference/convergent-review.md":
       "788a9d4dc2af7a928c3ccbb4d53a92856bb3544941ce512cfe38068d6b35850d",
+    "plugins/src/base/rules/reference/dependency-decision-records.md":
+      "59318579408cdf07343e26abbb316d83a3119dbf4fb68bbcc72b299131f3e8f0",
     "plugins/src/base/rules/reference/documentation-source-paths.md":
       "555155889c9cf279865b9d8fc554bdd461c96a3ec76a5001dfeb361a71056999",
     "plugins/src/base/rules/reference/empirical-inquiry.md":
@@ -3290,6 +3294,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/rules/eager/coding-philosophy.md": true,
     "plugins/lisa-copilot/rules/eager/config-resolution.md": true,
     "plugins/lisa-copilot/rules/eager/convergent-review.md": true,
+    "plugins/lisa-copilot/rules/eager/dependency-decision-records.md": true,
     "plugins/lisa-copilot/rules/eager/documentation-source-paths.md": true,
     "plugins/lisa-copilot/rules/eager/empirical-inquiry.md": true,
     "plugins/lisa-copilot/rules/eager/factory-model.md": true,
@@ -3319,6 +3324,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/rules/reference/coding-philosophy.md": true,
     "plugins/lisa-copilot/rules/reference/config-resolution.md": true,
     "plugins/lisa-copilot/rules/reference/convergent-review.md": true,
+    "plugins/lisa-copilot/rules/reference/dependency-decision-records.md": true,
     "plugins/lisa-copilot/rules/reference/documentation-source-paths.md": true,
     "plugins/lisa-copilot/rules/reference/empirical-inquiry.md": true,
     "plugins/lisa-copilot/rules/reference/factory-model.md": true,
@@ -3654,6 +3660,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/rules/config-resolution.mdc": true,
     "plugins/lisa-cursor/rules/convergent-review-reference.mdc": true,
     "plugins/lisa-cursor/rules/convergent-review.mdc": true,
+    "plugins/lisa-cursor/rules/dependency-decision-records-reference.mdc": true,
+    "plugins/lisa-cursor/rules/dependency-decision-records.mdc": true,
     "plugins/lisa-cursor/rules/documentation-source-paths-reference.mdc": true,
     "plugins/lisa-cursor/rules/documentation-source-paths.mdc": true,
     "plugins/lisa-cursor/rules/empirical-inquiry-reference.mdc": true,
@@ -6027,6 +6035,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/rules/eager/coding-philosophy.md": true,
     "plugins/lisa/rules/eager/config-resolution.md": true,
     "plugins/lisa/rules/eager/convergent-review.md": true,
+    "plugins/lisa/rules/eager/dependency-decision-records.md": true,
     "plugins/lisa/rules/eager/documentation-source-paths.md": true,
     "plugins/lisa/rules/eager/empirical-inquiry.md": true,
     "plugins/lisa/rules/eager/factory-model.md": true,
@@ -6056,6 +6065,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/rules/reference/coding-philosophy.md": true,
     "plugins/lisa/rules/reference/config-resolution.md": true,
     "plugins/lisa/rules/reference/convergent-review.md": true,
+    "plugins/lisa/rules/reference/dependency-decision-records.md": true,
     "plugins/lisa/rules/reference/documentation-source-paths.md": true,
     "plugins/lisa/rules/reference/empirical-inquiry.md": true,
     "plugins/lisa/rules/reference/factory-model.md": true,
@@ -6553,6 +6563,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/rules/eager/coding-philosophy.md": true,
     "plugins/src/base/rules/eager/config-resolution.md": true,
     "plugins/src/base/rules/eager/convergent-review.md": true,
+    "plugins/src/base/rules/eager/dependency-decision-records.md": true,
     "plugins/src/base/rules/eager/documentation-source-paths.md": true,
     "plugins/src/base/rules/eager/empirical-inquiry.md": true,
     "plugins/src/base/rules/eager/factory-model.md": true,
@@ -6582,6 +6593,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/rules/reference/coding-philosophy.md": true,
     "plugins/src/base/rules/reference/config-resolution.md": true,
     "plugins/src/base/rules/reference/convergent-review.md": true,
+    "plugins/src/base/rules/reference/dependency-decision-records.md": true,
     "plugins/src/base/rules/reference/documentation-source-paths.md": true,
     "plugins/src/base/rules/reference/empirical-inquiry.md": true,
     "plugins/src/base/rules/reference/factory-model.md": true,
@@ -7870,6 +7882,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/copy-overwrite.test.ts": true,
     "tests/unit/strategies/create-only.test.ts": true,
     "tests/unit/strategies/debrief-reroute-contract.test.ts": true,
+    "tests/unit/strategies/dependency-decision-records-rule-pair.test.ts": true,
     "tests/unit/strategies/distributed-content-round2-contract.test.ts": true,
     "tests/unit/strategies/doctor-automation-readiness.test.ts": true,
     "tests/unit/strategies/doctor-config-readiness.test.ts": true,
@@ -7993,6 +8006,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/sync/config-sync.test.ts": true,
     "tests/unit/sync/health-schedule.test.ts": true,
     "tests/unit/sync/legacy-monitor-thresholds.test.ts": true,
+    "tests/unit/templates/dependency-decisions-template.test.ts": true,
     "tests/unit/templates/project-learnings-template.test.ts": true,
     "tests/unit/templates/stack-tsconfig-shadowing.test.ts": true,
     "tests/unit/transaction/backup.test.ts": true,

--- a/tests/helpers/test-utils.ts
+++ b/tests/helpers/test-utils.ts
@@ -17,6 +17,7 @@ const DELETIONS_JSON = "deletions.json";
 const COPY_OVERWRITE = "copy-overwrite";
 const COPY_CONTENTS = "copy-contents";
 const CREATE_ONLY = "create-only";
+const DEPENDENCY_DECISIONS_FILE = "DEPENDENCY_DECISIONS.md";
 const LISA_TEST_PREFIX = "lisa-test-";
 
 /**
@@ -285,6 +286,18 @@ async function createMockAllTemplates(dir: string): Promise<void> {
   await fs.outputFile(
     path.join(allCreateOnly, ".lisa", "PROJECT_LEARNINGS.md"),
     renderLearningsFile([])
+  );
+  // Copy the real shipped scaffold rather than a fabricated stand-in, so the
+  // integration assertions prove what host projects actually receive.
+  await fs.copy(
+    path.join(
+      process.cwd(),
+      "all",
+      CREATE_ONLY,
+      ".lisa",
+      DEPENDENCY_DECISIONS_FILE
+    ),
+    path.join(allCreateOnly, ".lisa", DEPENDENCY_DECISIONS_FILE)
   );
   await fs.writeJson(path.join(allMerge, PACKAGE_JSON), {
     scripts: { test: "echo test" },

--- a/tests/integration/lisa.test.ts
+++ b/tests/integration/lisa.test.ts
@@ -52,6 +52,7 @@ const PACKAGE_LISA_DIR = "package-lisa";
 const LISA_MANIFEST = ".lisa-manifest";
 const PROJECT_LEARNINGS = "PROJECT_LEARNINGS.md";
 const LISA_STATE_DIR = ".lisa";
+const DEPENDENCY_DECISIONS = "DEPENDENCY_DECISIONS.md";
 const LISA_CONFIG_JSON = ".lisa.config.json";
 const TSC_BUILD_SCRIPT = "tsc -p tsconfig.build.json";
 const WORKFLOWS_DIR = path.join(".github", "workflows");
@@ -163,6 +164,44 @@ describe("Lisa Integration Tests", () => {
       expect(second.success).toBe(true);
       expect(third.success).toBe(true);
       expect(await fs.readFile(learningsPath, "utf8")).toBe(populated);
+    });
+
+    it("seeds the governed dependency decision-record scaffold and never overwrites it", async () => {
+      await createTypeScriptProject(destDir);
+      const recordPath = path.join(
+        destDir,
+        LISA_STATE_DIR,
+        DEPENDENCY_DECISIONS
+      );
+
+      const first = await createLisa().apply();
+
+      expect(first.success).toBe(true);
+      const seeded = await fs.readFile(recordPath, "utf8");
+
+      // Every required decision-record field reaches the host project.
+      expect(seeded).toContain("<!-- lisa-dependency-decisions:v1 -->");
+      expect(seeded).toContain("**Dependency:**");
+      expect(seeded).toContain("**Why we keep it:**");
+      expect(seeded).toContain("**Owned capability:**");
+      expect(seeded).toContain("**Trust basis:**");
+      expect(seeded).toContain("**Exposure:**");
+      expect(seeded).toContain("**Replacement cost:**");
+      expect(seeded).toContain("**Detection evidence:**");
+      expect(seeded).toContain("**Owner / review cadence:**");
+      expect(seeded).toContain("**Last reviewed:**");
+      expect(seeded).toContain(
+        "### ESLint (EXAMPLE — replace with your own dependencies)"
+      );
+
+      // Host-owned content survives re-apply: Lisa seeds once, never rewrites.
+      const hostAuthored = `${seeded}\n### internal-billing-sdk\n\n- **Dependency:** \`@acme/billing\` \`^3\`\n`;
+      await fs.writeFile(recordPath, hostAuthored);
+
+      const second = await createLisa().apply();
+
+      expect(second.success).toBe(true);
+      expect(await fs.readFile(recordPath, "utf8")).toBe(hostAuthored);
     });
 
     it("keeps the ledger at .lisa regardless of a custom projectRulesFile", async () => {

--- a/tests/integration/lisa.test.ts
+++ b/tests/integration/lisa.test.ts
@@ -181,21 +181,37 @@ describe("Lisa Integration Tests", () => {
 
       // Every required decision-record field reaches the host project.
       expect(seeded).toContain("<!-- lisa-dependency-decisions:v1 -->");
-      expect(seeded).toContain("**Dependency:**");
       expect(seeded).toContain("**Why we keep it:**");
-      expect(seeded).toContain("**Owned capability:**");
-      expect(seeded).toContain("**Trust basis:**");
-      expect(seeded).toContain("**Exposure:**");
-      expect(seeded).toContain("**Replacement cost:**");
-      expect(seeded).toContain("**Detection evidence:**");
-      expect(seeded).toContain("**Owner / review cadence:**");
-      expect(seeded).toContain("**Last reviewed:**");
+      expect(seeded).toContain("**What it is (dependency):**");
+      expect(seeded).toContain("**What it does for us (owned capability):**");
+      expect(seeded).toContain("**Why we believe it's safe (trust basis):**");
       expect(seeded).toContain(
-        "### ESLint (EXAMPLE — replace with your own dependencies)"
+        "**What breaks if this is compromised (exposure):**"
+      );
+      expect(seeded).toContain(
+        "**What it would take to replace (replacement cost):**"
+      );
+      expect(seeded).toContain(
+        "**What would catch a bad update (detection evidence):**"
+      );
+      expect(seeded).toContain(
+        "**Who owns this and how often we recheck (owner / review cadence):**"
+      );
+      expect(seeded).toContain("**Last reviewed:**");
+      expect(seeded).toContain("### ESLint (EXAMPLE — a complete entry)");
+
+      // The operator gets a sanctioned next action, and sees an honest gap
+      // in place rather than only a perfectly-filled example.
+      expect(seeded).toContain("## When to escalate");
+      expect(seeded).toContain(
+        "### sharp (EXAMPLE — an entry still being filled in)"
+      );
+      expect(seeded).toContain(
+        "**Last reviewed:** _Not yet decided_ (example entry — never reviewed)"
       );
 
       // Host-owned content survives re-apply: Lisa seeds once, never rewrites.
-      const hostAuthored = `${seeded}\n### internal-billing-sdk\n\n- **Dependency:** \`@acme/billing\` \`^3\`\n`;
+      const hostAuthored = `${seeded}\n### internal-billing-sdk\n\n- **Why we keep it:** It bills our customers.\n`;
       await fs.writeFile(recordPath, hostAuthored);
 
       const second = await createLisa().apply();

--- a/tests/unit/strategies/dependency-decision-records-rule-pair.test.ts
+++ b/tests/unit/strategies/dependency-decision-records-rule-pair.test.ts
@@ -25,14 +25,24 @@ describe("dependency-decision-records eager/reference rule pair", () => {
   it("names every required record field in the reference body", () => {
     const reference = readFileSync(REFERENCE, "utf8");
 
-    expect(reference).toContain("**Dependency**");
+    // Same nine labels the scaffold uses, in the same order — operator's
+    // question first, technical term kept in parentheses.
     expect(reference).toContain("**Why we keep it**");
-    expect(reference).toContain("**Owned capability**");
-    expect(reference).toContain("**Trust basis**");
-    expect(reference).toContain("**Exposure**");
-    expect(reference).toContain("**Replacement cost**");
-    expect(reference).toContain("**Detection evidence**");
-    expect(reference).toContain("**Owner / review cadence**");
+    expect(reference).toContain("**What it is (dependency)**");
+    expect(reference).toContain("**What it does for us (owned capability)**");
+    expect(reference).toContain("**Why we believe it's safe (trust basis)**");
+    expect(reference).toContain(
+      "**What breaks if this is compromised (exposure)**"
+    );
+    expect(reference).toContain(
+      "**What it would take to replace (replacement cost)**"
+    );
+    expect(reference).toContain(
+      "**What would catch a bad update (detection evidence)**"
+    );
+    expect(reference).toContain(
+      "**Who owns this and how often we recheck (owner / review cadence)**"
+    );
     expect(reference).toContain("**Last reviewed**");
   });
 
@@ -43,6 +53,27 @@ describe("dependency-decision-records eager/reference rule pair", () => {
     expect(reference).toContain("`_Not yet decided_` is the reserved marker");
     expect(reference).toContain(
       "A `###` heading inside `## Records` is always\n  an entry, never guidance"
+    );
+  });
+
+  it("puts the plain-language why first and says so", () => {
+    const eager = readFileSync(EAGER, "utf8");
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(eager).toContain(
+      '"Why we keep it" comes first on purpose — an entry that opens'
+    );
+    expect(reference).toContain("This is deliberately the FIRST");
+  });
+
+  it("names the escalation triggers on both halves of the pair", () => {
+    const eager = readFileSync(EAGER, "utf8");
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(eager).toContain("Escalate, rather than just recording, when");
+    expect(reference).toContain("## When to escalate");
+    expect(reference).toContain(
+      "An entry full of `_Not yet decided_` is not an escalation"
     );
   });
 

--- a/tests/unit/strategies/dependency-decision-records-rule-pair.test.ts
+++ b/tests/unit/strategies/dependency-decision-records-rule-pair.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const EAGER = "plugins/src/base/rules/eager/dependency-decision-records.md";
+const REFERENCE =
+  "plugins/src/base/rules/reference/dependency-decision-records.md";
+
+describe("dependency-decision-records eager/reference rule pair", () => {
+  it("ships the canonical eager and reference pair from plugin source", () => {
+    const eager = readFileSync(EAGER, "utf8");
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(eager).toContain("# Dependency Decisions (load-bearing)");
+    expect(eager).toContain(".lisa/DEPENDENCY_DECISIONS.md");
+    expect(eager).toContain(
+      "[reference/dependency-decision-records.md](../reference/dependency-decision-records.md)"
+    );
+    expect(eager).toContain("`_Not yet decided_`");
+
+    expect(reference).toContain("# Dependency Decisions");
+    expect(reference).toContain(".lisa/DEPENDENCY_DECISIONS.md");
+    expect(reference).toContain("create-only");
+  });
+
+  it("names every required record field in the reference body", () => {
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(reference).toContain("**Dependency**");
+    expect(reference).toContain("**Why we keep it**");
+    expect(reference).toContain("**Owned capability**");
+    expect(reference).toContain("**Trust basis**");
+    expect(reference).toContain("**Exposure**");
+    expect(reference).toContain("**Replacement cost**");
+    expect(reference).toContain("**Detection evidence**");
+    expect(reference).toContain("**Owner / review cadence**");
+    expect(reference).toContain("**Last reviewed**");
+  });
+
+  it("documents the appendable entry format and the undecided-field marker", () => {
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(reference).toContain("## Entry format");
+    expect(reference).toContain("`_Not yet decided_` is the reserved marker");
+    expect(reference).toContain(
+      "A `###` heading inside `## Records` is always\n  an entry, never guidance"
+    );
+  });
+
+  it("documents the uniform six-agent enforcement gap", () => {
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(reference).toContain("## Agent parity");
+    expect(reference).toContain(
+      "no agent runtime enforces\nthat entries stay accurate or current"
+    );
+  });
+
+  it("keeps the scaffold free of a pre-populated inventory", () => {
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(reference).toContain("## Scaffold, not inventory");
+    expect(reference).toContain(
+      "Lisa does not pre-populate a\nhost project's dependency inventory"
+    );
+  });
+});

--- a/tests/unit/templates/dependency-decisions-template.test.ts
+++ b/tests/unit/templates/dependency-decisions-template.test.ts
@@ -13,6 +13,26 @@ const TEMPLATE_PATH = path.join(
 /** Heading of the trailing section that holds every dependency entry. */
 const RECORDS_HEADING = "## Records";
 
+/** The bullet every entry must open with, ahead of the package name. */
+const WHY_LABEL = "Why we keep it";
+
+/**
+ * The nine field labels, in the order every entry must use. Each leads with the
+ * operator's question and keeps the technical term in parentheses, so the
+ * record reads as decisions rather than package-manager trivia.
+ */
+const FIELD_LABELS = [
+  "**Why we keep it:**",
+  "**What it is (dependency):**",
+  "**What it does for us (owned capability):**",
+  "**Why we believe it's safe (trust basis):**",
+  "**What breaks if this is compromised (exposure):**",
+  "**What it would take to replace (replacement cost):**",
+  "**What would catch a bad update (detection evidence):**",
+  "**Who owns this and how often we recheck (owner / review cadence):**",
+  "**Last reviewed:**",
+] as const;
+
 /**
  * Read the governed dependency decision-record scaffold that `lisa apply`
  * seeds into every host project.
@@ -33,15 +53,22 @@ describe("dependency decisions create-only template", () => {
   it("names every required record field", async () => {
     const template = await readTemplate();
 
-    expect(template).toContain("**Dependency:**");
-    expect(template).toContain("**Why we keep it:**");
-    expect(template).toContain("**Owned capability:**");
-    expect(template).toContain("**Trust basis:**");
-    expect(template).toContain("**Exposure:**");
-    expect(template).toContain("**Replacement cost:**");
-    expect(template).toContain("**Detection evidence:**");
-    expect(template).toContain("**Owner / review cadence:**");
-    expect(template).toContain("**Last reviewed:**");
+    for (const label of FIELD_LABELS) {
+      expect(template).toContain(label);
+    }
+  });
+
+  it("leads every entry with the plain-language why, not the version range", async () => {
+    const template = await readTemplate();
+
+    // Each entry heading must be followed by the "why" bullet first — the file
+    // promises entries "start with a plain-language explanation".
+    const entryOpenings = [
+      ...template.matchAll(/^### .+\n\n- \*\*(.+?):\*\*/gm),
+    ].map(match => match[1]);
+
+    // The template block plus both seeded example entries.
+    expect(entryOpenings).toEqual(Array<string>(3).fill(WHY_LABEL));
   });
 
   it("ships a copyable entry template and a records section", async () => {
@@ -59,6 +86,18 @@ describe("dependency decisions create-only template", () => {
     expect(template).toContain("## How to use this file");
   });
 
+  it("tells the operator when to escalate rather than only how to read", async () => {
+    const template = await readTemplate();
+
+    expect(template).toContain("## When to escalate");
+    expect(template).toContain("**Nothing would catch a bad update.**");
+    expect(template).toContain("**The review is older than the dependency.**");
+    expect(template).toContain("**Nobody is behind it.**");
+    expect(template).toContain(
+      "An entry full of `_Not yet decided_` is not itself an escalation"
+    );
+  });
+
   it("leads the operator with the plain-language why and the detection gap", async () => {
     const template = await readTemplate();
 
@@ -66,20 +105,44 @@ describe("dependency decisions create-only template", () => {
       "This file is the project's record of **why we keep each material dependency**."
     );
     expect(template).toContain(
-      "the specific check that would **fail** if an update"
+      "the specific check\n  that would **fail** if an update"
     );
-    expect(template).toContain('"nothing would catch it", write that down');
+    expect(template).toContain(
+      'If the honest answer is "nothing would catch it",'
+    );
   });
 
-  it("includes one worked example entry that is clearly marked as an example", async () => {
+  it("keeps the highest-stakes example field in plain language", async () => {
     const template = await readTemplate();
 
     expect(template).toContain(
-      "### ESLint (EXAMPLE — replace with your own dependencies)"
+      "Warning sign: if lint passes a change we know breaks a rule, the checking\n  has silently stopped working"
     );
-    expect(template).toContain("**The entry below is an EXAMPLE.**");
-    expect(template).toContain("`eslint` `^9`");
-    expect(template).toContain("**Last reviewed:** 2026-07-21");
+  });
+
+  it("never lets the worked example look freshly reviewed", async () => {
+    const template = await readTemplate();
+
+    // A hardcoded date would read as a recent review on any project applying
+    // Lisa later, undercutting the keep/replace/escalate call.
+    expect(template).toContain(
+      "**Last reviewed:** _Not yet decided_ (example entry — never reviewed)"
+    );
+    expect(template).not.toMatch(/\*\*Last reviewed:\*\* \d{4}-\d{2}-\d{2}/);
+  });
+
+  it("shows an honest gap in place via a half-filled entry", async () => {
+    const template = await readTemplate();
+
+    expect(template).toContain(
+      "### sharp (EXAMPLE — an entry still being filled in)"
+    );
+    expect(template).toContain(
+      "**Why we believe it's safe (trust basis):** _Not yet decided_ — nobody has"
+    );
+    expect(template).toContain(
+      "**What would catch a bad update (detection evidence):** _Not yet decided_ —"
+    );
   });
 
   it("documents a stable appendable entry format so entries can be seeded mechanically", async () => {
@@ -108,22 +171,26 @@ describe("dependency decisions create-only template", () => {
 
     expect(sectionHeadings).toEqual([
       "## How to use this file",
+      "## When to escalate",
       "## What each field means",
       "## Entry template",
       RECORDS_HEADING,
     ]);
   });
 
-  it("carries no host-project dependency inventory beyond the marked example", async () => {
+  it("carries no host-project dependency inventory beyond the marked examples", async () => {
     const template = await readTemplate();
 
     // Entries are `###` headings inside the trailing `## Records` section —
-    // that scoping is the contract a seeding script appends against.
+    // that scoping is the contract a seeding script appends against. Both
+    // seeded entries stay explicitly marked EXAMPLE so no host project ships
+    // an unmarked claim about a dependency it may not even use.
     const records = template.slice(template.indexOf(`\n${RECORDS_HEADING}`));
     const entryHeadings = records.match(/^### .+$/gm) ?? [];
 
     expect(entryHeadings).toEqual([
-      "### ESLint (EXAMPLE — replace with your own dependencies)",
+      "### ESLint (EXAMPLE — a complete entry)",
+      "### sharp (EXAMPLE — an entry still being filled in)",
     ]);
   });
 });

--- a/tests/unit/templates/dependency-decisions-template.test.ts
+++ b/tests/unit/templates/dependency-decisions-template.test.ts
@@ -1,0 +1,129 @@
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const TEMPLATE_PATH = path.join(
+  process.cwd(),
+  "all",
+  "create-only",
+  ".lisa",
+  "DEPENDENCY_DECISIONS.md"
+);
+
+/** Heading of the trailing section that holds every dependency entry. */
+const RECORDS_HEADING = "## Records";
+
+/**
+ * Read the governed dependency decision-record scaffold that `lisa apply`
+ * seeds into every host project.
+ * @returns The template file contents.
+ */
+async function readTemplate(): Promise<string> {
+  return await readFile(TEMPLATE_PATH, "utf8");
+}
+
+describe("dependency decisions create-only template", () => {
+  it("carries the versioned scaffold marker and title", async () => {
+    const template = await readTemplate();
+
+    expect(template).toContain("# Dependency Decisions");
+    expect(template).toContain("<!-- lisa-dependency-decisions:v1 -->");
+  });
+
+  it("names every required record field", async () => {
+    const template = await readTemplate();
+
+    expect(template).toContain("**Dependency:**");
+    expect(template).toContain("**Why we keep it:**");
+    expect(template).toContain("**Owned capability:**");
+    expect(template).toContain("**Trust basis:**");
+    expect(template).toContain("**Exposure:**");
+    expect(template).toContain("**Replacement cost:**");
+    expect(template).toContain("**Detection evidence:**");
+    expect(template).toContain("**Owner / review cadence:**");
+    expect(template).toContain("**Last reviewed:**");
+  });
+
+  it("ships a copyable entry template and a records section", async () => {
+    const template = await readTemplate();
+
+    expect(template).toContain("## Entry template");
+    expect(template).toContain(RECORDS_HEADING);
+    expect(template).toContain("### <dependency name>");
+  });
+
+  it("explains what each field means so an operator can fill one in", async () => {
+    const template = await readTemplate();
+
+    expect(template).toContain("## What each field means");
+    expect(template).toContain("## How to use this file");
+  });
+
+  it("leads the operator with the plain-language why and the detection gap", async () => {
+    const template = await readTemplate();
+
+    expect(template).toContain(
+      "This file is the project's record of **why we keep each material dependency**."
+    );
+    expect(template).toContain(
+      "the specific check that would **fail** if an update"
+    );
+    expect(template).toContain('"nothing would catch it", write that down');
+  });
+
+  it("includes one worked example entry that is clearly marked as an example", async () => {
+    const template = await readTemplate();
+
+    expect(template).toContain(
+      "### ESLint (EXAMPLE — replace with your own dependencies)"
+    );
+    expect(template).toContain("**The entry below is an EXAMPLE.**");
+    expect(template).toContain("`eslint` `^9`");
+    expect(template).toContain("**Last reviewed:** 2026-07-21");
+  });
+
+  it("documents a stable appendable entry format so entries can be seeded mechanically", async () => {
+    const template = await readTemplate();
+
+    expect(template).toContain("### Entry format (stable, appendable)");
+    expect(template).toContain(
+      "Every entry is a level-3 heading (`### <name>`) followed by the nine field"
+    );
+    expect(template).toContain(
+      "Nothing after `## Records` is guidance, so appending to the end of the file is"
+    );
+  });
+
+  it("reserves an explicit marker for an undecided field so gaps are honest, not blank", async () => {
+    const template = await readTemplate();
+
+    expect(template).toContain("`_Not yet decided_`");
+    expect(template).toContain("never leave a field blank and never guess");
+  });
+
+  it("keeps Records as the final section so appends are always safe", async () => {
+    const template = await readTemplate();
+
+    const sectionHeadings = template.match(/^## .+$/gm) ?? [];
+
+    expect(sectionHeadings).toEqual([
+      "## How to use this file",
+      "## What each field means",
+      "## Entry template",
+      RECORDS_HEADING,
+    ]);
+  });
+
+  it("carries no host-project dependency inventory beyond the marked example", async () => {
+    const template = await readTemplate();
+
+    // Entries are `###` headings inside the trailing `## Records` section —
+    // that scoping is the contract a seeding script appends against.
+    const records = template.slice(template.indexOf(`\n${RECORDS_HEADING}`));
+    const entryHeadings = records.match(/^### .+$/gm) ?? [];
+
+    expect(entryHeadings).toEqual([
+      "### ESLint (EXAMPLE — replace with your own dependencies)",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1886 — the foundation story of PRD #1741 (dependency ownership). Adds a governed, operator-readable **dependency decision-record** surface: the scaffold every host project receives, plus the rule pair that tells agents how to maintain it. Scaffold/container only — the trust-class taxonomy (#1887), duplicate-version checks (#1888), inventory seeding (#1889), and removal-confidence kit (#1890) are explicitly out of scope.

### What's here
- **The host-project scaffold:** `all/create-only/.lisa/DEPENDENCY_DECISIONS.md`, distributed by `lisa apply` (mirroring the existing `.lisa/PROJECT_LEARNINGS.md` precedent). It's **create-only** — Lisa seeds it once and never overwrites it, so operator edits and a project's private dependency inventory are never clobbered on re-apply and never ride back upstream. Each record names the required fields (dependency, why we keep it, owned capability, trust basis, exposure, replacement cost, detection evidence, owner/review cadence, last-reviewed), with a worked ESLint example and the `_Not yet decided_` convention so an unfilled field reads as an honest open question rather than a false blank.
- **The contract:** the rule pair `plugins/src/base/rules/{eager,reference}/dependency-decision-records.md` (fanned to the plugin mirrors) instructs agents to write records in operator-readable terms — lead with the outcome protected, not the mechanism.
- **Written for the product gate.** A non-technical operator can read an entry and tell *why* Lisa keeps the dependency and *what evidence would catch a bad update* — the AC-scenario-2 requirement. The record's best line makes its own failure mode self-reporting: "if the honest answer is 'nothing would catch it', write that down — it is the most valuable line in the entry." A "When to escalate" block tells the operator what to *do* (escalate when detection evidence says nothing would catch a bad update, when the last review predates a major upgrade, or when no owner is named).

### Architecture note (the crux)
The scaffold does NOT live under `plugins/src/base/` — that's coding-agent plugin source that `lisa apply` never distributes to a host project. It lives under `all/create-only/.lisa/`, which is where governed host-project files come from. The manifest treats the two halves asymmetrically and correctly: the `.lisa/` scaffold is manifest-**exempt** (the generator forbids the `.lisa` path segment, like `PROJECT_LEARNINGS.md`), while the `plugins/src/` rule pair is manifest-**required**.

## Verification

- Full `bun run test` → **413 files / 7070 tests, exit 0**; `bun run typecheck` 0; `bun run build:plugins` clean (mirrors byte-faithful); `bun run check:plugins` pass; `scripts/check-rules-pairing.sh` pass; `generate-upstream-evidence-manifest.mjs --check` 0.
- **Empirical AC#1:** a real `lisa apply` into a fresh scratch project creates `.lisa/DEPENDENCY_DECISIONS.md` with every required field; a re-apply after an operator edit is byte-identical (create-only honored, host entry preserved).
- Reviewed by product (operator-readability — "the best operator-facing scaffold in the repo," no blockers, readability polish applied) and verification (create-only distribution, the manifest asymmetry, no private data committed, merge-forward clean).

Foundation for the rest of #1741 (#1887–#1891). The record format is deliberately uniform/appendable so #1889 can mechanically seed entries.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standardized Dependency Decisions record for documenting material third-party dependencies.
  * Lisa now seeds a dependency-decision template on first apply.
  * The seeded record includes required fields, examples, maintenance guidance, and escalation criteria.
  * Existing host-authored records are preserved during subsequent applies.

* **Documentation**
  * Added consistent dependency-decision guidance across supported coding-agent rule sets.

* **Tests**
  * Added coverage for template structure, rule consistency, scaffolding, and preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->