### PR TITLE
feat(deps): define dependency trust classes and review requirements, closing #1887

### DIFF
--- a/plugins/lisa-agy/skills/lisa-task-decomposition/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-task-decomposition/SKILL.md
@@ -74,6 +74,31 @@ Each task must have a verification method. Choose the most appropriate:
 - Prefer independent tasks that can run in parallel where possible
 - Flag external dependencies (other teams, services, permissions, data) that may block progress
 
+### 4.5. Classify Any New Material Dependency
+
+Step 4 maps dependencies *between tasks*. This step covers third-party
+dependencies a task proposes to **add**.
+
+A dependency is **material** if its failure, disappearance, or bad update would
+break something a user can see, or would cost real time to replace. If a work
+unit proposes adding one, the work unit must, before it is buildable:
+
+1. **Name its trust class** — exactly one of: mature ecosystem primitive,
+   fast-moving standard implementation, build/development tool, runtime-critical
+   service client, thin wrapper suitable for in-house ownership, or
+   temporary/experimental dependency. See the `dependency-trust-classes` rule
+   for what each class means and why it is trusted.
+2. **State the class's required evidence** — the detection evidence that class
+   demands, and whether product/human ratification is required before the work
+   starts. Runtime-critical service clients and expiry extensions on temporary
+   dependencies always require ratification; a work unit that needs it and does
+   not say so is not ready.
+3. **Include updating `.lisa/DEPENDENCY_DECISIONS.md`** in its acceptance
+   criteria, so the record entry lands in the same change as the dependency.
+
+If nobody can pick a class, that is the finding — resolve it before accepting
+the work unit, not after the package is installed.
+
 ### 5. Determine Execution Order
 
 - Place foundational tasks first (types, schemas, interfaces, shared utilities)
@@ -121,6 +146,7 @@ Map each task to the skills needed to complete it. This enables delegation to sp
 - Every task must have at least one acceptance criterion that can be empirically verified
 - Do not create tasks that cannot be verified -- if you cannot define how to prove it is done, the task is not well-scoped
 - Every Task / Bug / Sub-task / Improvement is scoped to exactly one repo -- if the work spans repos, split into per-repo work units under a shared parent Story (see step 1.5)
+- Any task proposing a new material dependency names its trust class, states that class's required evidence and whether human ratification is needed, and updates `.lisa/DEPENDENCY_DECISIONS.md` in the same change (see step 4.5) -- a proposed material dependency with no named class is not ready to build
 - Keep tasks ordered so that no task references work that has not been completed by a prior task
 - Flag any task that requires access, permissions, or external input not yet available
 - Prefer more small tasks over fewer large tasks -- smaller tasks are easier to verify and less risky to fail

--- a/plugins/lisa-copilot/rules/eager/dependency-trust-classes.md
+++ b/plugins/lisa-copilot/rules/eager/dependency-trust-classes.md
@@ -1,0 +1,43 @@
+# Dependency Trust Classes (load-bearing)
+
+Every material dependency belongs to exactly one **trust class**. The class is
+the answer to the decision record's "Why we believe it's safe (trust basis)"
+field in `.lisa/DEPENDENCY_DECISIONS.md` — it says why we can trust a *kind* of
+dependency, so each entry does not re-argue trust from scratch.
+
+The six classes, from most to least self-evidently trustworthy:
+
+1. **Mature ecosystem primitive** — so widely used that other people hit the
+   breakage first.
+2. **Fast-moving standard implementation** — the standard implementation of
+   something we refuse to own, but it changes faster than we do.
+3. **Build/development tool** — never runs in production; a bad update costs
+   developer time, not users.
+4. **Runtime-critical service client** — reaches users, data, or money directly,
+   so it is the least trusted regardless of how mature it is.
+5. **Thin wrapper suitable for in-house ownership** — small enough that we could
+   own the code, so the question is whether it earns its keep, not whether it is
+   safe.
+6. **Temporary/experimental dependency** — not trusted at all; admitted on a
+   clock with a written expiry date and a named exit.
+
+Each class fixes five review inputs: capability owner, update cadence, detection
+evidence, replacement-cost threshold, and whether product/human ratification is
+required. Higher exposure and lower trust buy stronger evidence and mandatory
+ratification, not weaker: runtime-critical service clients always need human
+ratification to add or major-upgrade; temporary dependencies need it to live
+past their expiry date; thin wrappers need it to be kept rather than in-housed.
+
+Every class also names one **human-review trigger** — the observable event that
+takes the decision away from the agent. A class definition that cannot say what
+would trigger human review is not finished.
+
+A work item that proposes adding a new material dependency must name the
+dependency's trust class and update its `.lisa/DEPENDENCY_DECISIONS.md` entry in
+the same change. A proposal with no named class is not ready to build.
+
+Reclassify — do not quietly re-trust — when a dependency's exposure changes: a
+build tool that gains runtime reach or reads CI credentials becomes a
+runtime-critical service client, and its stronger requirements apply immediately.
+
+Full prose: [reference/dependency-trust-classes.md](../reference/dependency-trust-classes.md).

--- a/plugins/lisa-copilot/rules/reference/dependency-trust-classes.md
+++ b/plugins/lisa-copilot/rules/reference/dependency-trust-classes.md
@@ -1,0 +1,243 @@
+# Dependency Trust Classes
+
+Without named classes, every third-party package sits in one implicit bucket:
+"we installed it, so presumably it's fine." That bucket makes a payment SDK and
+a code formatter look identical at review time, and it forces every dependency
+conversation to re-argue trust from first principles.
+
+Trust classes fix that. Each class states, in plain language, **why we can trust
+that kind of dependency**, and names **the one event that would trigger human
+review**. A dependency's class is the answer to the
+"Why we believe it's safe (trust basis)" field in
+`.lisa/DEPENDENCY_DECISIONS.md` — the record says what
+this dependency is and what would catch a bad update; the class says what bar it
+had to clear to be here at all.
+
+Exactly one class per dependency. If two seem to fit, take the lower-trust one —
+the requirements are strictly stronger, and being over-careful about a formatter
+costs a review cycle while being under-careful about an auth client costs users.
+
+## The five review inputs
+
+Every class fixes the same five inputs. What changes between classes is how
+demanding each one is:
+
+- **Capability owner** — who is accountable when this breaks. A role for
+  high-trust classes; a named person for low-trust ones, because "the platform
+  team" cannot be paged at 2am.
+- **Update cadence** — how often the entry is re-read and the version re-judged.
+- **Detection evidence** — the named check that fails if an update breaks the
+  owned capability. Stronger classes demand evidence *we* own, not upstream's
+  test suite.
+- **Replacement-cost threshold** — the point past which the cost itself is the
+  finding. High replacement cost is acceptable in a high-trust class and is an
+  escalation in a low-trust one.
+- **Product/human ratification** — whether a human has to say yes before the
+  dependency is added, upgraded, or kept. This is the gate, and it is deliberate
+  that the lower-trust and higher-exposure classes carry it.
+
+## The six classes
+
+### 1. Mature ecosystem primitive
+
+**Why we can trust it:** so many other projects depend on it that a bad release
+is usually found, reported, and fixed by someone else before it reaches us. It
+has an identifiable maintaining organization, a published release cadence, and a
+documented process for handling security reports. Trust here comes from the size
+of the crowd standing in front of us, not from us having read the code.
+
+Examples in kind: a language's canonical test runner, a foundation-maintained
+linter, a mainstream UI framework.
+
+- **Capability owner:** a role or team is sufficient.
+- **Update cadence:** re-read at each major upgrade, and at least every 12
+  months.
+- **Detection evidence:** an existing CI check must fail if the owned capability
+  breaks. Naming an upstream test suite is acceptable here and only here.
+- **Replacement-cost threshold:** high replacement cost is accepted. That is the
+  bargain — we take deep coupling in exchange for the crowd's scrutiny.
+- **Ratification:** not required to add or to take a minor/patch upgrade.
+
+**Human review is triggered when:** maintainership changes hands or the project
+is archived, or a security advisory goes unfixed past the project's own
+published response window. Either event removes the crowd, which was the whole
+basis for the trust — reclassify rather than re-trust.
+
+### 2. Fast-moving standard implementation
+
+**Why we can trust it:** it is the standard implementation of a protocol, spec,
+or platform we have deliberately decided not to own — a cloud SDK, an API
+client, a framework tracking a moving platform. We trust the *standard*; we do
+not trust the release we happen to be on, because the project moves faster than
+our review cycle does. Trust here is conditional on us keeping up.
+
+- **Capability owner:** a named team that owns staying current.
+- **Update cadence:** re-read at every minor upgrade, and no less than
+  quarterly. A dependency in this class going quiet for a year is itself a
+  finding.
+- **Detection evidence:** an automated test **we** own that exercises the owned
+  capability. Upstream's suite does not count — it tests their contract, not our
+  use of it.
+- **Replacement-cost threshold:** replacement cost must stay moderate. Keep the
+  coupling behind our own boundary so a forced migration is a rewrite of the
+  boundary, not of the application.
+- **Ratification:** required for any major upgrade that changes user-visible
+  behavior.
+
+**Human review is triggered when:** two consecutive major versions ship that we
+did not adopt inside the cadence window. At that point we are pinned to
+unsupported software and the decision — catch up, replace, or accept the
+exposure — belongs to a human.
+
+### 3. Build/development tool
+
+**Why we can trust it:** it never runs in production and never touches customer
+data. If it ships a bad update, developers notice within one build, and the
+worst case is lost engineering time rather than a user-visible failure. The
+blast radius is what earns the trust, not the maintainer.
+
+- **Capability owner:** a role or team is sufficient.
+- **Update cadence:** re-read at each major upgrade, and at least every 12
+  months.
+- **Detection evidence:** the build, lint, or test job the tool powers. It fails
+  loudly and immediately, which is the point.
+- **Replacement-cost threshold:** high cost is accepted — swapping a build tool
+  is disruptive but never urgent.
+- **Ratification:** not required.
+
+**Human review is triggered when:** the tool gains reach it did not have —
+running in production, reading secrets, or reading CI credentials. The moment
+that happens the blast-radius argument is void: reclassify it as a
+runtime-critical service client and apply that class's requirements immediately.
+
+### 4. Runtime-critical service client
+
+**Why we can trust it:** honestly, we mostly don't. This class covers anything
+that reaches users, their data, or money in production — payment SDKs, auth
+libraries, database drivers, service clients on the request path. Even a mature,
+well-run project lands in this class if a bad update reaches production, because
+maturity does not shrink blast radius. Trust here is bought with our own
+evidence and a human's signature, not the vendor's reputation.
+
+- **Capability owner:** a named accountable person, not a team.
+- **Update cadence:** re-judged at every version change. Versions are pinned
+  exactly, so upgrades are always deliberate.
+- **Detection evidence:** an integration or end-to-end test that exercises the
+  real capability, **plus** a production monitor that would notice failure in
+  the wild. "Nothing would catch it" is not an acceptable answer in this class —
+  it is a blocker.
+- **Replacement-cost threshold:** replacement cost must be written down, never
+  `_Not yet decided_`. If nobody can estimate it, we do not know how trapped we
+  are, and that unknown is the finding.
+- **Ratification:** **product/human ratification is required** before adding the
+  dependency and before any major upgrade.
+
+**Human review is triggered when:** any version changes, any security advisory
+is published, or the vendor has a service incident. Every one of those is a
+human decision in this class — that is what makes it the strictest.
+
+### 5. Thin wrapper suitable for in-house ownership
+
+**Why we can trust it:** it is small enough that we could read all of it in an
+afternoon and own it outright. Safety is not really the question; whether it is
+earning its keep is. A dependency we could write in a day still costs us a
+supply-chain entry, a transitive tree, and an upgrade obligation forever.
+
+- **Capability owner:** the team that would inherit the code if we in-housed it.
+  If no team will claim it, do not add it.
+- **Update cadence:** re-read at every upgrade — there should be few.
+- **Detection evidence:** our own unit tests covering the wrapped behavior. They
+  are cheap here precisely because the surface is small, and they are what makes
+  in-housing a one-day job later instead of a rewrite.
+- **Replacement-cost threshold:** roughly one day. Under it, the default is to
+  in-house the code rather than take the dependency.
+- **Ratification:** **required to keep it** when replacement cost is under the
+  threshold. Note the inversion: the human signs off on the *exception* — taking
+  a dependency we could trivially own — not on the removal.
+
+**Human review is triggered when:** the package goes unmaintained, or its
+transitive dependency tree grows larger than the code it wraps. Either way we
+are now carrying more supply chain than capability, and in-housing should be
+reconsidered on purpose.
+
+### 6. Temporary/experimental dependency
+
+**Why we can trust it:** we don't, and we say so. This class exists so a spike,
+a prototype, or a stopgap can move fast without silently becoming permanent. It
+is admitted on a clock: a written expiry date and a named exit — replace,
+in-house, promote to another class, or remove.
+
+- **Capability owner:** the person who introduced it, by name. Ownership does
+  not transfer to a team while the dependency is in this class.
+- **Update cadence:** reviewed at the stated expiry date, which is at most one
+  quarter out. No expiry date means it does not belong in this class.
+- **Detection evidence:** "nothing would catch it" is tolerated **only** while
+  exposure stays out of production. The moment it reaches production, the
+  runtime-critical requirements apply.
+- **Replacement-cost threshold:** must be low by construction. Anything
+  expensive to remove is not temporary — it is a permanent dependency wearing a
+  temporary label, and it should be classified honestly on day one.
+- **Ratification:** **required to extend past the expiry date** or to promote it
+  into any other class. An expiry that slides without a human saying yes is how
+  a prototype becomes production.
+
+**Human review is triggered when:** the expiry date passes, or the dependency
+starts running in production or touching user data — whichever happens first.
+
+## Ratification, summarized
+
+Ratification is not a formality; it is the point where a human owns the residual
+risk. Required for:
+
+- **Runtime-critical service client** — to add, and for every major upgrade.
+- **Temporary/experimental dependency** — to extend past expiry or to promote.
+- **Thin wrapper suitable for in-house ownership** — to keep it rather than
+  in-house it.
+- **Fast-moving standard implementation** — for a major upgrade that changes
+  user-visible behavior.
+
+Not required for mature ecosystem primitives or build/development tools on
+routine adds and upgrades. Those two classes are where the crowd and the blast
+radius do the work a human would otherwise have to do.
+
+## Naming a class at planning time
+
+A work item that proposes adding a new material dependency must, before it is
+buildable, name the dependency's trust class and state that it will update the
+`.lisa/DEPENDENCY_DECISIONS.md` entry in the same change. This is enforced at
+decomposition time by the `lisa-task-decomposition` skill, which rejects a work
+unit proposing a material dependency with no named class.
+
+The class is what makes the rest of the ticket reviewable: it tells the reviewer
+which evidence to demand and whether a human has to ratify before the work
+starts, rather than discovering both at the end.
+
+Naming a class is not a formality either. If nobody can pick one, that is the
+finding — an unclassifiable dependency is usually one nobody has thought about,
+and it should be resolved before the work item is accepted rather than after the
+package is installed.
+
+## Reclassification
+
+Trust classes describe the dependency as it is used today, not as it was
+introduced. When exposure changes — a build tool starts running in production, a
+prototype ships to users, a thin wrapper grows a large transitive tree — move it
+to the correct class and apply the new requirements immediately. Update the
+`Last reviewed` date on the record entry when you do.
+
+Reclassifying downward (to a lower-trust class) is never a demotion of the
+dependency. It is an admission that its blast radius grew, which is a fact about
+us, not about the maintainers.
+
+## Agent parity
+
+Trust classes are a governed markdown rule and a decomposition-time expectation,
+not a runtime behavior, so Claude Code, Codex, Cursor, OpenCode, Antigravity,
+and Copilot all reach them identically through the shared rules mirror and the
+same `lisa-task-decomposition` skill.
+
+The documented gap, uniform across all six runtimes: no agent runtime enforces
+that a dependency carries a correct class. Nothing fails a build when a package
+is installed with no class named, and nothing detects that a build tool quietly
+started running in production. Classification is carried by this rule, the
+decomposition skill, and review — not by a hook or a lint gate.

--- a/plugins/lisa-copilot/skills/lisa-task-decomposition/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-task-decomposition/SKILL.md
@@ -74,6 +74,31 @@ Each task must have a verification method. Choose the most appropriate:
 - Prefer independent tasks that can run in parallel where possible
 - Flag external dependencies (other teams, services, permissions, data) that may block progress
 
+### 4.5. Classify Any New Material Dependency
+
+Step 4 maps dependencies *between tasks*. This step covers third-party
+dependencies a task proposes to **add**.
+
+A dependency is **material** if its failure, disappearance, or bad update would
+break something a user can see, or would cost real time to replace. If a work
+unit proposes adding one, the work unit must, before it is buildable:
+
+1. **Name its trust class** — exactly one of: mature ecosystem primitive,
+   fast-moving standard implementation, build/development tool, runtime-critical
+   service client, thin wrapper suitable for in-house ownership, or
+   temporary/experimental dependency. See the `dependency-trust-classes` rule
+   for what each class means and why it is trusted.
+2. **State the class's required evidence** — the detection evidence that class
+   demands, and whether product/human ratification is required before the work
+   starts. Runtime-critical service clients and expiry extensions on temporary
+   dependencies always require ratification; a work unit that needs it and does
+   not say so is not ready.
+3. **Include updating `.lisa/DEPENDENCY_DECISIONS.md`** in its acceptance
+   criteria, so the record entry lands in the same change as the dependency.
+
+If nobody can pick a class, that is the finding — resolve it before accepting
+the work unit, not after the package is installed.
+
 ### 5. Determine Execution Order
 
 - Place foundational tasks first (types, schemas, interfaces, shared utilities)
@@ -121,6 +146,7 @@ Map each task to the skills needed to complete it. This enables delegation to sp
 - Every task must have at least one acceptance criterion that can be empirically verified
 - Do not create tasks that cannot be verified -- if you cannot define how to prove it is done, the task is not well-scoped
 - Every Task / Bug / Sub-task / Improvement is scoped to exactly one repo -- if the work spans repos, split into per-repo work units under a shared parent Story (see step 1.5)
+- Any task proposing a new material dependency names its trust class, states that class's required evidence and whether human ratification is needed, and updates `.lisa/DEPENDENCY_DECISIONS.md` in the same change (see step 4.5) -- a proposed material dependency with no named class is not ready to build
 - Keep tasks ordered so that no task references work that has not been completed by a prior task
 - Flag any task that requires access, permissions, or external input not yet available
 - Prefer more small tasks over fewer large tasks -- smaller tasks are easier to verify and less risky to fail

--- a/plugins/lisa-cursor/rules/dependency-trust-classes-reference.mdc
+++ b/plugins/lisa-cursor/rules/dependency-trust-classes-reference.mdc
@@ -1,0 +1,248 @@
+---
+description: "Dependency Trust Classes"
+alwaysApply: false
+---
+
+# Dependency Trust Classes
+
+Without named classes, every third-party package sits in one implicit bucket:
+"we installed it, so presumably it's fine." That bucket makes a payment SDK and
+a code formatter look identical at review time, and it forces every dependency
+conversation to re-argue trust from first principles.
+
+Trust classes fix that. Each class states, in plain language, **why we can trust
+that kind of dependency**, and names **the one event that would trigger human
+review**. A dependency's class is the answer to the
+"Why we believe it's safe (trust basis)" field in
+`.lisa/DEPENDENCY_DECISIONS.md` — the record says what
+this dependency is and what would catch a bad update; the class says what bar it
+had to clear to be here at all.
+
+Exactly one class per dependency. If two seem to fit, take the lower-trust one —
+the requirements are strictly stronger, and being over-careful about a formatter
+costs a review cycle while being under-careful about an auth client costs users.
+
+## The five review inputs
+
+Every class fixes the same five inputs. What changes between classes is how
+demanding each one is:
+
+- **Capability owner** — who is accountable when this breaks. A role for
+  high-trust classes; a named person for low-trust ones, because "the platform
+  team" cannot be paged at 2am.
+- **Update cadence** — how often the entry is re-read and the version re-judged.
+- **Detection evidence** — the named check that fails if an update breaks the
+  owned capability. Stronger classes demand evidence *we* own, not upstream's
+  test suite.
+- **Replacement-cost threshold** — the point past which the cost itself is the
+  finding. High replacement cost is acceptable in a high-trust class and is an
+  escalation in a low-trust one.
+- **Product/human ratification** — whether a human has to say yes before the
+  dependency is added, upgraded, or kept. This is the gate, and it is deliberate
+  that the lower-trust and higher-exposure classes carry it.
+
+## The six classes
+
+### 1. Mature ecosystem primitive
+
+**Why we can trust it:** so many other projects depend on it that a bad release
+is usually found, reported, and fixed by someone else before it reaches us. It
+has an identifiable maintaining organization, a published release cadence, and a
+documented process for handling security reports. Trust here comes from the size
+of the crowd standing in front of us, not from us having read the code.
+
+Examples in kind: a language's canonical test runner, a foundation-maintained
+linter, a mainstream UI framework.
+
+- **Capability owner:** a role or team is sufficient.
+- **Update cadence:** re-read at each major upgrade, and at least every 12
+  months.
+- **Detection evidence:** an existing CI check must fail if the owned capability
+  breaks. Naming an upstream test suite is acceptable here and only here.
+- **Replacement-cost threshold:** high replacement cost is accepted. That is the
+  bargain — we take deep coupling in exchange for the crowd's scrutiny.
+- **Ratification:** not required to add or to take a minor/patch upgrade.
+
+**Human review is triggered when:** maintainership changes hands or the project
+is archived, or a security advisory goes unfixed past the project's own
+published response window. Either event removes the crowd, which was the whole
+basis for the trust — reclassify rather than re-trust.
+
+### 2. Fast-moving standard implementation
+
+**Why we can trust it:** it is the standard implementation of a protocol, spec,
+or platform we have deliberately decided not to own — a cloud SDK, an API
+client, a framework tracking a moving platform. We trust the *standard*; we do
+not trust the release we happen to be on, because the project moves faster than
+our review cycle does. Trust here is conditional on us keeping up.
+
+- **Capability owner:** a named team that owns staying current.
+- **Update cadence:** re-read at every minor upgrade, and no less than
+  quarterly. A dependency in this class going quiet for a year is itself a
+  finding.
+- **Detection evidence:** an automated test **we** own that exercises the owned
+  capability. Upstream's suite does not count — it tests their contract, not our
+  use of it.
+- **Replacement-cost threshold:** replacement cost must stay moderate. Keep the
+  coupling behind our own boundary so a forced migration is a rewrite of the
+  boundary, not of the application.
+- **Ratification:** required for any major upgrade that changes user-visible
+  behavior.
+
+**Human review is triggered when:** two consecutive major versions ship that we
+did not adopt inside the cadence window. At that point we are pinned to
+unsupported software and the decision — catch up, replace, or accept the
+exposure — belongs to a human.
+
+### 3. Build/development tool
+
+**Why we can trust it:** it never runs in production and never touches customer
+data. If it ships a bad update, developers notice within one build, and the
+worst case is lost engineering time rather than a user-visible failure. The
+blast radius is what earns the trust, not the maintainer.
+
+- **Capability owner:** a role or team is sufficient.
+- **Update cadence:** re-read at each major upgrade, and at least every 12
+  months.
+- **Detection evidence:** the build, lint, or test job the tool powers. It fails
+  loudly and immediately, which is the point.
+- **Replacement-cost threshold:** high cost is accepted — swapping a build tool
+  is disruptive but never urgent.
+- **Ratification:** not required.
+
+**Human review is triggered when:** the tool gains reach it did not have —
+running in production, reading secrets, or reading CI credentials. The moment
+that happens the blast-radius argument is void: reclassify it as a
+runtime-critical service client and apply that class's requirements immediately.
+
+### 4. Runtime-critical service client
+
+**Why we can trust it:** honestly, we mostly don't. This class covers anything
+that reaches users, their data, or money in production — payment SDKs, auth
+libraries, database drivers, service clients on the request path. Even a mature,
+well-run project lands in this class if a bad update reaches production, because
+maturity does not shrink blast radius. Trust here is bought with our own
+evidence and a human's signature, not the vendor's reputation.
+
+- **Capability owner:** a named accountable person, not a team.
+- **Update cadence:** re-judged at every version change. Versions are pinned
+  exactly, so upgrades are always deliberate.
+- **Detection evidence:** an integration or end-to-end test that exercises the
+  real capability, **plus** a production monitor that would notice failure in
+  the wild. "Nothing would catch it" is not an acceptable answer in this class —
+  it is a blocker.
+- **Replacement-cost threshold:** replacement cost must be written down, never
+  `_Not yet decided_`. If nobody can estimate it, we do not know how trapped we
+  are, and that unknown is the finding.
+- **Ratification:** **product/human ratification is required** before adding the
+  dependency and before any major upgrade.
+
+**Human review is triggered when:** any version changes, any security advisory
+is published, or the vendor has a service incident. Every one of those is a
+human decision in this class — that is what makes it the strictest.
+
+### 5. Thin wrapper suitable for in-house ownership
+
+**Why we can trust it:** it is small enough that we could read all of it in an
+afternoon and own it outright. Safety is not really the question; whether it is
+earning its keep is. A dependency we could write in a day still costs us a
+supply-chain entry, a transitive tree, and an upgrade obligation forever.
+
+- **Capability owner:** the team that would inherit the code if we in-housed it.
+  If no team will claim it, do not add it.
+- **Update cadence:** re-read at every upgrade — there should be few.
+- **Detection evidence:** our own unit tests covering the wrapped behavior. They
+  are cheap here precisely because the surface is small, and they are what makes
+  in-housing a one-day job later instead of a rewrite.
+- **Replacement-cost threshold:** roughly one day. Under it, the default is to
+  in-house the code rather than take the dependency.
+- **Ratification:** **required to keep it** when replacement cost is under the
+  threshold. Note the inversion: the human signs off on the *exception* — taking
+  a dependency we could trivially own — not on the removal.
+
+**Human review is triggered when:** the package goes unmaintained, or its
+transitive dependency tree grows larger than the code it wraps. Either way we
+are now carrying more supply chain than capability, and in-housing should be
+reconsidered on purpose.
+
+### 6. Temporary/experimental dependency
+
+**Why we can trust it:** we don't, and we say so. This class exists so a spike,
+a prototype, or a stopgap can move fast without silently becoming permanent. It
+is admitted on a clock: a written expiry date and a named exit — replace,
+in-house, promote to another class, or remove.
+
+- **Capability owner:** the person who introduced it, by name. Ownership does
+  not transfer to a team while the dependency is in this class.
+- **Update cadence:** reviewed at the stated expiry date, which is at most one
+  quarter out. No expiry date means it does not belong in this class.
+- **Detection evidence:** "nothing would catch it" is tolerated **only** while
+  exposure stays out of production. The moment it reaches production, the
+  runtime-critical requirements apply.
+- **Replacement-cost threshold:** must be low by construction. Anything
+  expensive to remove is not temporary — it is a permanent dependency wearing a
+  temporary label, and it should be classified honestly on day one.
+- **Ratification:** **required to extend past the expiry date** or to promote it
+  into any other class. An expiry that slides without a human saying yes is how
+  a prototype becomes production.
+
+**Human review is triggered when:** the expiry date passes, or the dependency
+starts running in production or touching user data — whichever happens first.
+
+## Ratification, summarized
+
+Ratification is not a formality; it is the point where a human owns the residual
+risk. Required for:
+
+- **Runtime-critical service client** — to add, and for every major upgrade.
+- **Temporary/experimental dependency** — to extend past expiry or to promote.
+- **Thin wrapper suitable for in-house ownership** — to keep it rather than
+  in-house it.
+- **Fast-moving standard implementation** — for a major upgrade that changes
+  user-visible behavior.
+
+Not required for mature ecosystem primitives or build/development tools on
+routine adds and upgrades. Those two classes are where the crowd and the blast
+radius do the work a human would otherwise have to do.
+
+## Naming a class at planning time
+
+A work item that proposes adding a new material dependency must, before it is
+buildable, name the dependency's trust class and state that it will update the
+`.lisa/DEPENDENCY_DECISIONS.md` entry in the same change. This is enforced at
+decomposition time by the `lisa-task-decomposition` skill, which rejects a work
+unit proposing a material dependency with no named class.
+
+The class is what makes the rest of the ticket reviewable: it tells the reviewer
+which evidence to demand and whether a human has to ratify before the work
+starts, rather than discovering both at the end.
+
+Naming a class is not a formality either. If nobody can pick one, that is the
+finding — an unclassifiable dependency is usually one nobody has thought about,
+and it should be resolved before the work item is accepted rather than after the
+package is installed.
+
+## Reclassification
+
+Trust classes describe the dependency as it is used today, not as it was
+introduced. When exposure changes — a build tool starts running in production, a
+prototype ships to users, a thin wrapper grows a large transitive tree — move it
+to the correct class and apply the new requirements immediately. Update the
+`Last reviewed` date on the record entry when you do.
+
+Reclassifying downward (to a lower-trust class) is never a demotion of the
+dependency. It is an admission that its blast radius grew, which is a fact about
+us, not about the maintainers.
+
+## Agent parity
+
+Trust classes are a governed markdown rule and a decomposition-time expectation,
+not a runtime behavior, so Claude Code, Codex, Cursor, OpenCode, Antigravity,
+and Copilot all reach them identically through the shared rules mirror and the
+same `lisa-task-decomposition` skill.
+
+The documented gap, uniform across all six runtimes: no agent runtime enforces
+that a dependency carries a correct class. Nothing fails a build when a package
+is installed with no class named, and nothing detects that a build tool quietly
+started running in production. Classification is carried by this rule, the
+decomposition skill, and review — not by a hook or a lint gate.

--- a/plugins/lisa-cursor/rules/dependency-trust-classes.mdc
+++ b/plugins/lisa-cursor/rules/dependency-trust-classes.mdc
@@ -1,0 +1,48 @@
+---
+description: "Dependency Trust Classes (load-bearing)"
+alwaysApply: true
+---
+
+# Dependency Trust Classes (load-bearing)
+
+Every material dependency belongs to exactly one **trust class**. The class is
+the answer to the decision record's "Why we believe it's safe (trust basis)"
+field in `.lisa/DEPENDENCY_DECISIONS.md` — it says why we can trust a *kind* of
+dependency, so each entry does not re-argue trust from scratch.
+
+The six classes, from most to least self-evidently trustworthy:
+
+1. **Mature ecosystem primitive** — so widely used that other people hit the
+   breakage first.
+2. **Fast-moving standard implementation** — the standard implementation of
+   something we refuse to own, but it changes faster than we do.
+3. **Build/development tool** — never runs in production; a bad update costs
+   developer time, not users.
+4. **Runtime-critical service client** — reaches users, data, or money directly,
+   so it is the least trusted regardless of how mature it is.
+5. **Thin wrapper suitable for in-house ownership** — small enough that we could
+   own the code, so the question is whether it earns its keep, not whether it is
+   safe.
+6. **Temporary/experimental dependency** — not trusted at all; admitted on a
+   clock with a written expiry date and a named exit.
+
+Each class fixes five review inputs: capability owner, update cadence, detection
+evidence, replacement-cost threshold, and whether product/human ratification is
+required. Higher exposure and lower trust buy stronger evidence and mandatory
+ratification, not weaker: runtime-critical service clients always need human
+ratification to add or major-upgrade; temporary dependencies need it to live
+past their expiry date; thin wrappers need it to be kept rather than in-housed.
+
+Every class also names one **human-review trigger** — the observable event that
+takes the decision away from the agent. A class definition that cannot say what
+would trigger human review is not finished.
+
+A work item that proposes adding a new material dependency must name the
+dependency's trust class and update its `.lisa/DEPENDENCY_DECISIONS.md` entry in
+the same change. A proposal with no named class is not ready to build.
+
+Reclassify — do not quietly re-trust — when a dependency's exposure changes: a
+build tool that gains runtime reach or reads CI credentials becomes a
+runtime-critical service client, and its stronger requirements apply immediately.
+
+Full prose: [reference/dependency-trust-classes.md](dependency-trust-classes-reference.mdc).

--- a/plugins/lisa-cursor/skills/lisa-task-decomposition/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-task-decomposition/SKILL.md
@@ -74,6 +74,31 @@ Each task must have a verification method. Choose the most appropriate:
 - Prefer independent tasks that can run in parallel where possible
 - Flag external dependencies (other teams, services, permissions, data) that may block progress
 
+### 4.5. Classify Any New Material Dependency
+
+Step 4 maps dependencies *between tasks*. This step covers third-party
+dependencies a task proposes to **add**.
+
+A dependency is **material** if its failure, disappearance, or bad update would
+break something a user can see, or would cost real time to replace. If a work
+unit proposes adding one, the work unit must, before it is buildable:
+
+1. **Name its trust class** — exactly one of: mature ecosystem primitive,
+   fast-moving standard implementation, build/development tool, runtime-critical
+   service client, thin wrapper suitable for in-house ownership, or
+   temporary/experimental dependency. See the `dependency-trust-classes` rule
+   for what each class means and why it is trusted.
+2. **State the class's required evidence** — the detection evidence that class
+   demands, and whether product/human ratification is required before the work
+   starts. Runtime-critical service clients and expiry extensions on temporary
+   dependencies always require ratification; a work unit that needs it and does
+   not say so is not ready.
+3. **Include updating `.lisa/DEPENDENCY_DECISIONS.md`** in its acceptance
+   criteria, so the record entry lands in the same change as the dependency.
+
+If nobody can pick a class, that is the finding — resolve it before accepting
+the work unit, not after the package is installed.
+
 ### 5. Determine Execution Order
 
 - Place foundational tasks first (types, schemas, interfaces, shared utilities)
@@ -121,6 +146,7 @@ Map each task to the skills needed to complete it. This enables delegation to sp
 - Every task must have at least one acceptance criterion that can be empirically verified
 - Do not create tasks that cannot be verified -- if you cannot define how to prove it is done, the task is not well-scoped
 - Every Task / Bug / Sub-task / Improvement is scoped to exactly one repo -- if the work spans repos, split into per-repo work units under a shared parent Story (see step 1.5)
+- Any task proposing a new material dependency names its trust class, states that class's required evidence and whether human ratification is needed, and updates `.lisa/DEPENDENCY_DECISIONS.md` in the same change (see step 4.5) -- a proposed material dependency with no named class is not ready to build
 - Keep tasks ordered so that no task references work that has not been completed by a prior task
 - Flag any task that requires access, permissions, or external input not yet available
 - Prefer more small tasks over fewer large tasks -- smaller tasks are easier to verify and less risky to fail

--- a/plugins/lisa/.codex-plugin/skills/lisa-task-decomposition/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-task-decomposition/SKILL.md
@@ -74,6 +74,31 @@ Each task must have a verification method. Choose the most appropriate:
 - Prefer independent tasks that can run in parallel where possible
 - Flag external dependencies (other teams, services, permissions, data) that may block progress
 
+### 4.5. Classify Any New Material Dependency
+
+Step 4 maps dependencies *between tasks*. This step covers third-party
+dependencies a task proposes to **add**.
+
+A dependency is **material** if its failure, disappearance, or bad update would
+break something a user can see, or would cost real time to replace. If a work
+unit proposes adding one, the work unit must, before it is buildable:
+
+1. **Name its trust class** — exactly one of: mature ecosystem primitive,
+   fast-moving standard implementation, build/development tool, runtime-critical
+   service client, thin wrapper suitable for in-house ownership, or
+   temporary/experimental dependency. See the `dependency-trust-classes` rule
+   for what each class means and why it is trusted.
+2. **State the class's required evidence** — the detection evidence that class
+   demands, and whether product/human ratification is required before the work
+   starts. Runtime-critical service clients and expiry extensions on temporary
+   dependencies always require ratification; a work unit that needs it and does
+   not say so is not ready.
+3. **Include updating `.lisa/DEPENDENCY_DECISIONS.md`** in its acceptance
+   criteria, so the record entry lands in the same change as the dependency.
+
+If nobody can pick a class, that is the finding — resolve it before accepting
+the work unit, not after the package is installed.
+
 ### 5. Determine Execution Order
 
 - Place foundational tasks first (types, schemas, interfaces, shared utilities)
@@ -121,6 +146,7 @@ Map each task to the skills needed to complete it. This enables delegation to sp
 - Every task must have at least one acceptance criterion that can be empirically verified
 - Do not create tasks that cannot be verified -- if you cannot define how to prove it is done, the task is not well-scoped
 - Every Task / Bug / Sub-task / Improvement is scoped to exactly one repo -- if the work spans repos, split into per-repo work units under a shared parent Story (see step 1.5)
+- Any task proposing a new material dependency names its trust class, states that class's required evidence and whether human ratification is needed, and updates `.lisa/DEPENDENCY_DECISIONS.md` in the same change (see step 4.5) -- a proposed material dependency with no named class is not ready to build
 - Keep tasks ordered so that no task references work that has not been completed by a prior task
 - Flag any task that requires access, permissions, or external input not yet available
 - Prefer more small tasks over fewer large tasks -- smaller tasks are easier to verify and less risky to fail

--- a/plugins/lisa/rules/eager/dependency-trust-classes.md
+++ b/plugins/lisa/rules/eager/dependency-trust-classes.md
@@ -1,0 +1,43 @@
+# Dependency Trust Classes (load-bearing)
+
+Every material dependency belongs to exactly one **trust class**. The class is
+the answer to the decision record's "Why we believe it's safe (trust basis)"
+field in `.lisa/DEPENDENCY_DECISIONS.md` — it says why we can trust a *kind* of
+dependency, so each entry does not re-argue trust from scratch.
+
+The six classes, from most to least self-evidently trustworthy:
+
+1. **Mature ecosystem primitive** — so widely used that other people hit the
+   breakage first.
+2. **Fast-moving standard implementation** — the standard implementation of
+   something we refuse to own, but it changes faster than we do.
+3. **Build/development tool** — never runs in production; a bad update costs
+   developer time, not users.
+4. **Runtime-critical service client** — reaches users, data, or money directly,
+   so it is the least trusted regardless of how mature it is.
+5. **Thin wrapper suitable for in-house ownership** — small enough that we could
+   own the code, so the question is whether it earns its keep, not whether it is
+   safe.
+6. **Temporary/experimental dependency** — not trusted at all; admitted on a
+   clock with a written expiry date and a named exit.
+
+Each class fixes five review inputs: capability owner, update cadence, detection
+evidence, replacement-cost threshold, and whether product/human ratification is
+required. Higher exposure and lower trust buy stronger evidence and mandatory
+ratification, not weaker: runtime-critical service clients always need human
+ratification to add or major-upgrade; temporary dependencies need it to live
+past their expiry date; thin wrappers need it to be kept rather than in-housed.
+
+Every class also names one **human-review trigger** — the observable event that
+takes the decision away from the agent. A class definition that cannot say what
+would trigger human review is not finished.
+
+A work item that proposes adding a new material dependency must name the
+dependency's trust class and update its `.lisa/DEPENDENCY_DECISIONS.md` entry in
+the same change. A proposal with no named class is not ready to build.
+
+Reclassify — do not quietly re-trust — when a dependency's exposure changes: a
+build tool that gains runtime reach or reads CI credentials becomes a
+runtime-critical service client, and its stronger requirements apply immediately.
+
+Full prose: [reference/dependency-trust-classes.md](../reference/dependency-trust-classes.md).

--- a/plugins/lisa/rules/reference/dependency-trust-classes.md
+++ b/plugins/lisa/rules/reference/dependency-trust-classes.md
@@ -1,0 +1,243 @@
+# Dependency Trust Classes
+
+Without named classes, every third-party package sits in one implicit bucket:
+"we installed it, so presumably it's fine." That bucket makes a payment SDK and
+a code formatter look identical at review time, and it forces every dependency
+conversation to re-argue trust from first principles.
+
+Trust classes fix that. Each class states, in plain language, **why we can trust
+that kind of dependency**, and names **the one event that would trigger human
+review**. A dependency's class is the answer to the
+"Why we believe it's safe (trust basis)" field in
+`.lisa/DEPENDENCY_DECISIONS.md` — the record says what
+this dependency is and what would catch a bad update; the class says what bar it
+had to clear to be here at all.
+
+Exactly one class per dependency. If two seem to fit, take the lower-trust one —
+the requirements are strictly stronger, and being over-careful about a formatter
+costs a review cycle while being under-careful about an auth client costs users.
+
+## The five review inputs
+
+Every class fixes the same five inputs. What changes between classes is how
+demanding each one is:
+
+- **Capability owner** — who is accountable when this breaks. A role for
+  high-trust classes; a named person for low-trust ones, because "the platform
+  team" cannot be paged at 2am.
+- **Update cadence** — how often the entry is re-read and the version re-judged.
+- **Detection evidence** — the named check that fails if an update breaks the
+  owned capability. Stronger classes demand evidence *we* own, not upstream's
+  test suite.
+- **Replacement-cost threshold** — the point past which the cost itself is the
+  finding. High replacement cost is acceptable in a high-trust class and is an
+  escalation in a low-trust one.
+- **Product/human ratification** — whether a human has to say yes before the
+  dependency is added, upgraded, or kept. This is the gate, and it is deliberate
+  that the lower-trust and higher-exposure classes carry it.
+
+## The six classes
+
+### 1. Mature ecosystem primitive
+
+**Why we can trust it:** so many other projects depend on it that a bad release
+is usually found, reported, and fixed by someone else before it reaches us. It
+has an identifiable maintaining organization, a published release cadence, and a
+documented process for handling security reports. Trust here comes from the size
+of the crowd standing in front of us, not from us having read the code.
+
+Examples in kind: a language's canonical test runner, a foundation-maintained
+linter, a mainstream UI framework.
+
+- **Capability owner:** a role or team is sufficient.
+- **Update cadence:** re-read at each major upgrade, and at least every 12
+  months.
+- **Detection evidence:** an existing CI check must fail if the owned capability
+  breaks. Naming an upstream test suite is acceptable here and only here.
+- **Replacement-cost threshold:** high replacement cost is accepted. That is the
+  bargain — we take deep coupling in exchange for the crowd's scrutiny.
+- **Ratification:** not required to add or to take a minor/patch upgrade.
+
+**Human review is triggered when:** maintainership changes hands or the project
+is archived, or a security advisory goes unfixed past the project's own
+published response window. Either event removes the crowd, which was the whole
+basis for the trust — reclassify rather than re-trust.
+
+### 2. Fast-moving standard implementation
+
+**Why we can trust it:** it is the standard implementation of a protocol, spec,
+or platform we have deliberately decided not to own — a cloud SDK, an API
+client, a framework tracking a moving platform. We trust the *standard*; we do
+not trust the release we happen to be on, because the project moves faster than
+our review cycle does. Trust here is conditional on us keeping up.
+
+- **Capability owner:** a named team that owns staying current.
+- **Update cadence:** re-read at every minor upgrade, and no less than
+  quarterly. A dependency in this class going quiet for a year is itself a
+  finding.
+- **Detection evidence:** an automated test **we** own that exercises the owned
+  capability. Upstream's suite does not count — it tests their contract, not our
+  use of it.
+- **Replacement-cost threshold:** replacement cost must stay moderate. Keep the
+  coupling behind our own boundary so a forced migration is a rewrite of the
+  boundary, not of the application.
+- **Ratification:** required for any major upgrade that changes user-visible
+  behavior.
+
+**Human review is triggered when:** two consecutive major versions ship that we
+did not adopt inside the cadence window. At that point we are pinned to
+unsupported software and the decision — catch up, replace, or accept the
+exposure — belongs to a human.
+
+### 3. Build/development tool
+
+**Why we can trust it:** it never runs in production and never touches customer
+data. If it ships a bad update, developers notice within one build, and the
+worst case is lost engineering time rather than a user-visible failure. The
+blast radius is what earns the trust, not the maintainer.
+
+- **Capability owner:** a role or team is sufficient.
+- **Update cadence:** re-read at each major upgrade, and at least every 12
+  months.
+- **Detection evidence:** the build, lint, or test job the tool powers. It fails
+  loudly and immediately, which is the point.
+- **Replacement-cost threshold:** high cost is accepted — swapping a build tool
+  is disruptive but never urgent.
+- **Ratification:** not required.
+
+**Human review is triggered when:** the tool gains reach it did not have —
+running in production, reading secrets, or reading CI credentials. The moment
+that happens the blast-radius argument is void: reclassify it as a
+runtime-critical service client and apply that class's requirements immediately.
+
+### 4. Runtime-critical service client
+
+**Why we can trust it:** honestly, we mostly don't. This class covers anything
+that reaches users, their data, or money in production — payment SDKs, auth
+libraries, database drivers, service clients on the request path. Even a mature,
+well-run project lands in this class if a bad update reaches production, because
+maturity does not shrink blast radius. Trust here is bought with our own
+evidence and a human's signature, not the vendor's reputation.
+
+- **Capability owner:** a named accountable person, not a team.
+- **Update cadence:** re-judged at every version change. Versions are pinned
+  exactly, so upgrades are always deliberate.
+- **Detection evidence:** an integration or end-to-end test that exercises the
+  real capability, **plus** a production monitor that would notice failure in
+  the wild. "Nothing would catch it" is not an acceptable answer in this class —
+  it is a blocker.
+- **Replacement-cost threshold:** replacement cost must be written down, never
+  `_Not yet decided_`. If nobody can estimate it, we do not know how trapped we
+  are, and that unknown is the finding.
+- **Ratification:** **product/human ratification is required** before adding the
+  dependency and before any major upgrade.
+
+**Human review is triggered when:** any version changes, any security advisory
+is published, or the vendor has a service incident. Every one of those is a
+human decision in this class — that is what makes it the strictest.
+
+### 5. Thin wrapper suitable for in-house ownership
+
+**Why we can trust it:** it is small enough that we could read all of it in an
+afternoon and own it outright. Safety is not really the question; whether it is
+earning its keep is. A dependency we could write in a day still costs us a
+supply-chain entry, a transitive tree, and an upgrade obligation forever.
+
+- **Capability owner:** the team that would inherit the code if we in-housed it.
+  If no team will claim it, do not add it.
+- **Update cadence:** re-read at every upgrade — there should be few.
+- **Detection evidence:** our own unit tests covering the wrapped behavior. They
+  are cheap here precisely because the surface is small, and they are what makes
+  in-housing a one-day job later instead of a rewrite.
+- **Replacement-cost threshold:** roughly one day. Under it, the default is to
+  in-house the code rather than take the dependency.
+- **Ratification:** **required to keep it** when replacement cost is under the
+  threshold. Note the inversion: the human signs off on the *exception* — taking
+  a dependency we could trivially own — not on the removal.
+
+**Human review is triggered when:** the package goes unmaintained, or its
+transitive dependency tree grows larger than the code it wraps. Either way we
+are now carrying more supply chain than capability, and in-housing should be
+reconsidered on purpose.
+
+### 6. Temporary/experimental dependency
+
+**Why we can trust it:** we don't, and we say so. This class exists so a spike,
+a prototype, or a stopgap can move fast without silently becoming permanent. It
+is admitted on a clock: a written expiry date and a named exit — replace,
+in-house, promote to another class, or remove.
+
+- **Capability owner:** the person who introduced it, by name. Ownership does
+  not transfer to a team while the dependency is in this class.
+- **Update cadence:** reviewed at the stated expiry date, which is at most one
+  quarter out. No expiry date means it does not belong in this class.
+- **Detection evidence:** "nothing would catch it" is tolerated **only** while
+  exposure stays out of production. The moment it reaches production, the
+  runtime-critical requirements apply.
+- **Replacement-cost threshold:** must be low by construction. Anything
+  expensive to remove is not temporary — it is a permanent dependency wearing a
+  temporary label, and it should be classified honestly on day one.
+- **Ratification:** **required to extend past the expiry date** or to promote it
+  into any other class. An expiry that slides without a human saying yes is how
+  a prototype becomes production.
+
+**Human review is triggered when:** the expiry date passes, or the dependency
+starts running in production or touching user data — whichever happens first.
+
+## Ratification, summarized
+
+Ratification is not a formality; it is the point where a human owns the residual
+risk. Required for:
+
+- **Runtime-critical service client** — to add, and for every major upgrade.
+- **Temporary/experimental dependency** — to extend past expiry or to promote.
+- **Thin wrapper suitable for in-house ownership** — to keep it rather than
+  in-house it.
+- **Fast-moving standard implementation** — for a major upgrade that changes
+  user-visible behavior.
+
+Not required for mature ecosystem primitives or build/development tools on
+routine adds and upgrades. Those two classes are where the crowd and the blast
+radius do the work a human would otherwise have to do.
+
+## Naming a class at planning time
+
+A work item that proposes adding a new material dependency must, before it is
+buildable, name the dependency's trust class and state that it will update the
+`.lisa/DEPENDENCY_DECISIONS.md` entry in the same change. This is enforced at
+decomposition time by the `lisa-task-decomposition` skill, which rejects a work
+unit proposing a material dependency with no named class.
+
+The class is what makes the rest of the ticket reviewable: it tells the reviewer
+which evidence to demand and whether a human has to ratify before the work
+starts, rather than discovering both at the end.
+
+Naming a class is not a formality either. If nobody can pick one, that is the
+finding — an unclassifiable dependency is usually one nobody has thought about,
+and it should be resolved before the work item is accepted rather than after the
+package is installed.
+
+## Reclassification
+
+Trust classes describe the dependency as it is used today, not as it was
+introduced. When exposure changes — a build tool starts running in production, a
+prototype ships to users, a thin wrapper grows a large transitive tree — move it
+to the correct class and apply the new requirements immediately. Update the
+`Last reviewed` date on the record entry when you do.
+
+Reclassifying downward (to a lower-trust class) is never a demotion of the
+dependency. It is an admission that its blast radius grew, which is a fact about
+us, not about the maintainers.
+
+## Agent parity
+
+Trust classes are a governed markdown rule and a decomposition-time expectation,
+not a runtime behavior, so Claude Code, Codex, Cursor, OpenCode, Antigravity,
+and Copilot all reach them identically through the shared rules mirror and the
+same `lisa-task-decomposition` skill.
+
+The documented gap, uniform across all six runtimes: no agent runtime enforces
+that a dependency carries a correct class. Nothing fails a build when a package
+is installed with no class named, and nothing detects that a build tool quietly
+started running in production. Classification is carried by this rule, the
+decomposition skill, and review — not by a hook or a lint gate.

--- a/plugins/lisa/skills/lisa-task-decomposition/SKILL.md
+++ b/plugins/lisa/skills/lisa-task-decomposition/SKILL.md
@@ -74,6 +74,31 @@ Each task must have a verification method. Choose the most appropriate:
 - Prefer independent tasks that can run in parallel where possible
 - Flag external dependencies (other teams, services, permissions, data) that may block progress
 
+### 4.5. Classify Any New Material Dependency
+
+Step 4 maps dependencies *between tasks*. This step covers third-party
+dependencies a task proposes to **add**.
+
+A dependency is **material** if its failure, disappearance, or bad update would
+break something a user can see, or would cost real time to replace. If a work
+unit proposes adding one, the work unit must, before it is buildable:
+
+1. **Name its trust class** — exactly one of: mature ecosystem primitive,
+   fast-moving standard implementation, build/development tool, runtime-critical
+   service client, thin wrapper suitable for in-house ownership, or
+   temporary/experimental dependency. See the `dependency-trust-classes` rule
+   for what each class means and why it is trusted.
+2. **State the class's required evidence** — the detection evidence that class
+   demands, and whether product/human ratification is required before the work
+   starts. Runtime-critical service clients and expiry extensions on temporary
+   dependencies always require ratification; a work unit that needs it and does
+   not say so is not ready.
+3. **Include updating `.lisa/DEPENDENCY_DECISIONS.md`** in its acceptance
+   criteria, so the record entry lands in the same change as the dependency.
+
+If nobody can pick a class, that is the finding — resolve it before accepting
+the work unit, not after the package is installed.
+
 ### 5. Determine Execution Order
 
 - Place foundational tasks first (types, schemas, interfaces, shared utilities)
@@ -121,6 +146,7 @@ Map each task to the skills needed to complete it. This enables delegation to sp
 - Every task must have at least one acceptance criterion that can be empirically verified
 - Do not create tasks that cannot be verified -- if you cannot define how to prove it is done, the task is not well-scoped
 - Every Task / Bug / Sub-task / Improvement is scoped to exactly one repo -- if the work spans repos, split into per-repo work units under a shared parent Story (see step 1.5)
+- Any task proposing a new material dependency names its trust class, states that class's required evidence and whether human ratification is needed, and updates `.lisa/DEPENDENCY_DECISIONS.md` in the same change (see step 4.5) -- a proposed material dependency with no named class is not ready to build
 - Keep tasks ordered so that no task references work that has not been completed by a prior task
 - Flag any task that requires access, permissions, or external input not yet available
 - Prefer more small tasks over fewer large tasks -- smaller tasks are easier to verify and less risky to fail

--- a/plugins/src/base/rules/eager/dependency-trust-classes.md
+++ b/plugins/src/base/rules/eager/dependency-trust-classes.md
@@ -1,0 +1,43 @@
+# Dependency Trust Classes (load-bearing)
+
+Every material dependency belongs to exactly one **trust class**. The class is
+the answer to the decision record's "Why we believe it's safe (trust basis)"
+field in `.lisa/DEPENDENCY_DECISIONS.md` — it says why we can trust a *kind* of
+dependency, so each entry does not re-argue trust from scratch.
+
+The six classes, from most to least self-evidently trustworthy:
+
+1. **Mature ecosystem primitive** — so widely used that other people hit the
+   breakage first.
+2. **Fast-moving standard implementation** — the standard implementation of
+   something we refuse to own, but it changes faster than we do.
+3. **Build/development tool** — never runs in production; a bad update costs
+   developer time, not users.
+4. **Runtime-critical service client** — reaches users, data, or money directly,
+   so it is the least trusted regardless of how mature it is.
+5. **Thin wrapper suitable for in-house ownership** — small enough that we could
+   own the code, so the question is whether it earns its keep, not whether it is
+   safe.
+6. **Temporary/experimental dependency** — not trusted at all; admitted on a
+   clock with a written expiry date and a named exit.
+
+Each class fixes five review inputs: capability owner, update cadence, detection
+evidence, replacement-cost threshold, and whether product/human ratification is
+required. Higher exposure and lower trust buy stronger evidence and mandatory
+ratification, not weaker: runtime-critical service clients always need human
+ratification to add or major-upgrade; temporary dependencies need it to live
+past their expiry date; thin wrappers need it to be kept rather than in-housed.
+
+Every class also names one **human-review trigger** — the observable event that
+takes the decision away from the agent. A class definition that cannot say what
+would trigger human review is not finished.
+
+A work item that proposes adding a new material dependency must name the
+dependency's trust class and update its `.lisa/DEPENDENCY_DECISIONS.md` entry in
+the same change. A proposal with no named class is not ready to build.
+
+Reclassify — do not quietly re-trust — when a dependency's exposure changes: a
+build tool that gains runtime reach or reads CI credentials becomes a
+runtime-critical service client, and its stronger requirements apply immediately.
+
+Full prose: [reference/dependency-trust-classes.md](../reference/dependency-trust-classes.md).

--- a/plugins/src/base/rules/reference/dependency-trust-classes.md
+++ b/plugins/src/base/rules/reference/dependency-trust-classes.md
@@ -1,0 +1,243 @@
+# Dependency Trust Classes
+
+Without named classes, every third-party package sits in one implicit bucket:
+"we installed it, so presumably it's fine." That bucket makes a payment SDK and
+a code formatter look identical at review time, and it forces every dependency
+conversation to re-argue trust from first principles.
+
+Trust classes fix that. Each class states, in plain language, **why we can trust
+that kind of dependency**, and names **the one event that would trigger human
+review**. A dependency's class is the answer to the
+"Why we believe it's safe (trust basis)" field in
+`.lisa/DEPENDENCY_DECISIONS.md` — the record says what
+this dependency is and what would catch a bad update; the class says what bar it
+had to clear to be here at all.
+
+Exactly one class per dependency. If two seem to fit, take the lower-trust one —
+the requirements are strictly stronger, and being over-careful about a formatter
+costs a review cycle while being under-careful about an auth client costs users.
+
+## The five review inputs
+
+Every class fixes the same five inputs. What changes between classes is how
+demanding each one is:
+
+- **Capability owner** — who is accountable when this breaks. A role for
+  high-trust classes; a named person for low-trust ones, because "the platform
+  team" cannot be paged at 2am.
+- **Update cadence** — how often the entry is re-read and the version re-judged.
+- **Detection evidence** — the named check that fails if an update breaks the
+  owned capability. Stronger classes demand evidence *we* own, not upstream's
+  test suite.
+- **Replacement-cost threshold** — the point past which the cost itself is the
+  finding. High replacement cost is acceptable in a high-trust class and is an
+  escalation in a low-trust one.
+- **Product/human ratification** — whether a human has to say yes before the
+  dependency is added, upgraded, or kept. This is the gate, and it is deliberate
+  that the lower-trust and higher-exposure classes carry it.
+
+## The six classes
+
+### 1. Mature ecosystem primitive
+
+**Why we can trust it:** so many other projects depend on it that a bad release
+is usually found, reported, and fixed by someone else before it reaches us. It
+has an identifiable maintaining organization, a published release cadence, and a
+documented process for handling security reports. Trust here comes from the size
+of the crowd standing in front of us, not from us having read the code.
+
+Examples in kind: a language's canonical test runner, a foundation-maintained
+linter, a mainstream UI framework.
+
+- **Capability owner:** a role or team is sufficient.
+- **Update cadence:** re-read at each major upgrade, and at least every 12
+  months.
+- **Detection evidence:** an existing CI check must fail if the owned capability
+  breaks. Naming an upstream test suite is acceptable here and only here.
+- **Replacement-cost threshold:** high replacement cost is accepted. That is the
+  bargain — we take deep coupling in exchange for the crowd's scrutiny.
+- **Ratification:** not required to add or to take a minor/patch upgrade.
+
+**Human review is triggered when:** maintainership changes hands or the project
+is archived, or a security advisory goes unfixed past the project's own
+published response window. Either event removes the crowd, which was the whole
+basis for the trust — reclassify rather than re-trust.
+
+### 2. Fast-moving standard implementation
+
+**Why we can trust it:** it is the standard implementation of a protocol, spec,
+or platform we have deliberately decided not to own — a cloud SDK, an API
+client, a framework tracking a moving platform. We trust the *standard*; we do
+not trust the release we happen to be on, because the project moves faster than
+our review cycle does. Trust here is conditional on us keeping up.
+
+- **Capability owner:** a named team that owns staying current.
+- **Update cadence:** re-read at every minor upgrade, and no less than
+  quarterly. A dependency in this class going quiet for a year is itself a
+  finding.
+- **Detection evidence:** an automated test **we** own that exercises the owned
+  capability. Upstream's suite does not count — it tests their contract, not our
+  use of it.
+- **Replacement-cost threshold:** replacement cost must stay moderate. Keep the
+  coupling behind our own boundary so a forced migration is a rewrite of the
+  boundary, not of the application.
+- **Ratification:** required for any major upgrade that changes user-visible
+  behavior.
+
+**Human review is triggered when:** two consecutive major versions ship that we
+did not adopt inside the cadence window. At that point we are pinned to
+unsupported software and the decision — catch up, replace, or accept the
+exposure — belongs to a human.
+
+### 3. Build/development tool
+
+**Why we can trust it:** it never runs in production and never touches customer
+data. If it ships a bad update, developers notice within one build, and the
+worst case is lost engineering time rather than a user-visible failure. The
+blast radius is what earns the trust, not the maintainer.
+
+- **Capability owner:** a role or team is sufficient.
+- **Update cadence:** re-read at each major upgrade, and at least every 12
+  months.
+- **Detection evidence:** the build, lint, or test job the tool powers. It fails
+  loudly and immediately, which is the point.
+- **Replacement-cost threshold:** high cost is accepted — swapping a build tool
+  is disruptive but never urgent.
+- **Ratification:** not required.
+
+**Human review is triggered when:** the tool gains reach it did not have —
+running in production, reading secrets, or reading CI credentials. The moment
+that happens the blast-radius argument is void: reclassify it as a
+runtime-critical service client and apply that class's requirements immediately.
+
+### 4. Runtime-critical service client
+
+**Why we can trust it:** honestly, we mostly don't. This class covers anything
+that reaches users, their data, or money in production — payment SDKs, auth
+libraries, database drivers, service clients on the request path. Even a mature,
+well-run project lands in this class if a bad update reaches production, because
+maturity does not shrink blast radius. Trust here is bought with our own
+evidence and a human's signature, not the vendor's reputation.
+
+- **Capability owner:** a named accountable person, not a team.
+- **Update cadence:** re-judged at every version change. Versions are pinned
+  exactly, so upgrades are always deliberate.
+- **Detection evidence:** an integration or end-to-end test that exercises the
+  real capability, **plus** a production monitor that would notice failure in
+  the wild. "Nothing would catch it" is not an acceptable answer in this class —
+  it is a blocker.
+- **Replacement-cost threshold:** replacement cost must be written down, never
+  `_Not yet decided_`. If nobody can estimate it, we do not know how trapped we
+  are, and that unknown is the finding.
+- **Ratification:** **product/human ratification is required** before adding the
+  dependency and before any major upgrade.
+
+**Human review is triggered when:** any version changes, any security advisory
+is published, or the vendor has a service incident. Every one of those is a
+human decision in this class — that is what makes it the strictest.
+
+### 5. Thin wrapper suitable for in-house ownership
+
+**Why we can trust it:** it is small enough that we could read all of it in an
+afternoon and own it outright. Safety is not really the question; whether it is
+earning its keep is. A dependency we could write in a day still costs us a
+supply-chain entry, a transitive tree, and an upgrade obligation forever.
+
+- **Capability owner:** the team that would inherit the code if we in-housed it.
+  If no team will claim it, do not add it.
+- **Update cadence:** re-read at every upgrade — there should be few.
+- **Detection evidence:** our own unit tests covering the wrapped behavior. They
+  are cheap here precisely because the surface is small, and they are what makes
+  in-housing a one-day job later instead of a rewrite.
+- **Replacement-cost threshold:** roughly one day. Under it, the default is to
+  in-house the code rather than take the dependency.
+- **Ratification:** **required to keep it** when replacement cost is under the
+  threshold. Note the inversion: the human signs off on the *exception* — taking
+  a dependency we could trivially own — not on the removal.
+
+**Human review is triggered when:** the package goes unmaintained, or its
+transitive dependency tree grows larger than the code it wraps. Either way we
+are now carrying more supply chain than capability, and in-housing should be
+reconsidered on purpose.
+
+### 6. Temporary/experimental dependency
+
+**Why we can trust it:** we don't, and we say so. This class exists so a spike,
+a prototype, or a stopgap can move fast without silently becoming permanent. It
+is admitted on a clock: a written expiry date and a named exit — replace,
+in-house, promote to another class, or remove.
+
+- **Capability owner:** the person who introduced it, by name. Ownership does
+  not transfer to a team while the dependency is in this class.
+- **Update cadence:** reviewed at the stated expiry date, which is at most one
+  quarter out. No expiry date means it does not belong in this class.
+- **Detection evidence:** "nothing would catch it" is tolerated **only** while
+  exposure stays out of production. The moment it reaches production, the
+  runtime-critical requirements apply.
+- **Replacement-cost threshold:** must be low by construction. Anything
+  expensive to remove is not temporary — it is a permanent dependency wearing a
+  temporary label, and it should be classified honestly on day one.
+- **Ratification:** **required to extend past the expiry date** or to promote it
+  into any other class. An expiry that slides without a human saying yes is how
+  a prototype becomes production.
+
+**Human review is triggered when:** the expiry date passes, or the dependency
+starts running in production or touching user data — whichever happens first.
+
+## Ratification, summarized
+
+Ratification is not a formality; it is the point where a human owns the residual
+risk. Required for:
+
+- **Runtime-critical service client** — to add, and for every major upgrade.
+- **Temporary/experimental dependency** — to extend past expiry or to promote.
+- **Thin wrapper suitable for in-house ownership** — to keep it rather than
+  in-house it.
+- **Fast-moving standard implementation** — for a major upgrade that changes
+  user-visible behavior.
+
+Not required for mature ecosystem primitives or build/development tools on
+routine adds and upgrades. Those two classes are where the crowd and the blast
+radius do the work a human would otherwise have to do.
+
+## Naming a class at planning time
+
+A work item that proposes adding a new material dependency must, before it is
+buildable, name the dependency's trust class and state that it will update the
+`.lisa/DEPENDENCY_DECISIONS.md` entry in the same change. This is enforced at
+decomposition time by the `lisa-task-decomposition` skill, which rejects a work
+unit proposing a material dependency with no named class.
+
+The class is what makes the rest of the ticket reviewable: it tells the reviewer
+which evidence to demand and whether a human has to ratify before the work
+starts, rather than discovering both at the end.
+
+Naming a class is not a formality either. If nobody can pick one, that is the
+finding — an unclassifiable dependency is usually one nobody has thought about,
+and it should be resolved before the work item is accepted rather than after the
+package is installed.
+
+## Reclassification
+
+Trust classes describe the dependency as it is used today, not as it was
+introduced. When exposure changes — a build tool starts running in production, a
+prototype ships to users, a thin wrapper grows a large transitive tree — move it
+to the correct class and apply the new requirements immediately. Update the
+`Last reviewed` date on the record entry when you do.
+
+Reclassifying downward (to a lower-trust class) is never a demotion of the
+dependency. It is an admission that its blast radius grew, which is a fact about
+us, not about the maintainers.
+
+## Agent parity
+
+Trust classes are a governed markdown rule and a decomposition-time expectation,
+not a runtime behavior, so Claude Code, Codex, Cursor, OpenCode, Antigravity,
+and Copilot all reach them identically through the shared rules mirror and the
+same `lisa-task-decomposition` skill.
+
+The documented gap, uniform across all six runtimes: no agent runtime enforces
+that a dependency carries a correct class. Nothing fails a build when a package
+is installed with no class named, and nothing detects that a build tool quietly
+started running in production. Classification is carried by this rule, the
+decomposition skill, and review — not by a hook or a lint gate.

--- a/plugins/src/base/skills/lisa-task-decomposition/SKILL.md
+++ b/plugins/src/base/skills/lisa-task-decomposition/SKILL.md
@@ -74,6 +74,31 @@ Each task must have a verification method. Choose the most appropriate:
 - Prefer independent tasks that can run in parallel where possible
 - Flag external dependencies (other teams, services, permissions, data) that may block progress
 
+### 4.5. Classify Any New Material Dependency
+
+Step 4 maps dependencies *between tasks*. This step covers third-party
+dependencies a task proposes to **add**.
+
+A dependency is **material** if its failure, disappearance, or bad update would
+break something a user can see, or would cost real time to replace. If a work
+unit proposes adding one, the work unit must, before it is buildable:
+
+1. **Name its trust class** — exactly one of: mature ecosystem primitive,
+   fast-moving standard implementation, build/development tool, runtime-critical
+   service client, thin wrapper suitable for in-house ownership, or
+   temporary/experimental dependency. See the `dependency-trust-classes` rule
+   for what each class means and why it is trusted.
+2. **State the class's required evidence** — the detection evidence that class
+   demands, and whether product/human ratification is required before the work
+   starts. Runtime-critical service clients and expiry extensions on temporary
+   dependencies always require ratification; a work unit that needs it and does
+   not say so is not ready.
+3. **Include updating `.lisa/DEPENDENCY_DECISIONS.md`** in its acceptance
+   criteria, so the record entry lands in the same change as the dependency.
+
+If nobody can pick a class, that is the finding — resolve it before accepting
+the work unit, not after the package is installed.
+
 ### 5. Determine Execution Order
 
 - Place foundational tasks first (types, schemas, interfaces, shared utilities)
@@ -121,6 +146,7 @@ Map each task to the skills needed to complete it. This enables delegation to sp
 - Every task must have at least one acceptance criterion that can be empirically verified
 - Do not create tasks that cannot be verified -- if you cannot define how to prove it is done, the task is not well-scoped
 - Every Task / Bug / Sub-task / Improvement is scoped to exactly one repo -- if the work spans repos, split into per-repo work units under a shared parent Story (see step 1.5)
+- Any task proposing a new material dependency names its trust class, states that class's required evidence and whether human ratification is needed, and updates `.lisa/DEPENDENCY_DECISIONS.md` in the same change (see step 4.5) -- a proposed material dependency with no named class is not ready to build
 - Keep tasks ordered so that no task references work that has not been completed by a prior task
 - Flag any task that requires access, permissions, or external input not yet available
 - Prefer more small tasks over fewer large tasks -- smaller tasks are easier to verify and less risky to fail

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -622,6 +622,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "ba4ba53863ef99be353c07c01195fa4ae2923ef2b2a5ad4427072802c260d208",
     "plugins/src/base/rules/eager/dependency-decision-records.md":
       "e22888f107906992e863fca50f26c2c4b124da7132535cacfac71e4f3085728f",
+    "plugins/src/base/rules/eager/dependency-trust-classes.md":
+      "43a0932a7b8d4fd075b66bfe778025d808a13d9aa61ae793e9eb2fc8a555a381",
     "plugins/src/base/rules/eager/documentation-source-paths.md":
       "3a7c2a6264654a3cc44dd326441ba211a39c1c267033cc189c1c635adb84b52b",
     "plugins/src/base/rules/eager/empirical-inquiry.md":
@@ -682,6 +684,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "788a9d4dc2af7a928c3ccbb4d53a92856bb3544941ce512cfe38068d6b35850d",
     "plugins/src/base/rules/reference/dependency-decision-records.md":
       "84f9fb8fa0a606307e828ec355ccbf2258beeeb88795dd113abe9bb2c37db39f",
+    "plugins/src/base/rules/reference/dependency-trust-classes.md":
+      "82216b80d4807e0ad302d04924032cc6a7a95b26f72ea853e378572a5c31821c",
     "plugins/src/base/rules/reference/documentation-source-paths.md":
       "555155889c9cf279865b9d8fc554bdd461c96a3ec76a5001dfeb361a71056999",
     "plugins/src/base/rules/reference/empirical-inquiry.md":
@@ -1053,7 +1057,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-sync-down/SKILL.md":
       "c32e6a4e3115ca32b7d335e90d0a73b243c6c631a2d192568423be0cb5944e84",
     "plugins/src/base/skills/lisa-task-decomposition/SKILL.md":
-      "bcc5940772c018e1b72a527b8378895596a4668844bc9d10599f47be5bd69172",
+      "b8f44d501e38a8ebd3c9b566b983d3e97f1292d28688ff1d42ec2c582abebf93",
     "plugins/src/base/skills/lisa-task-triage/SKILL.md":
       "c6e11b6d195560e6bd7b51fede65c155567c35208801a700a26d95679b03484e",
     "plugins/src/base/skills/lisa-tdd-implementation/SKILL.md":
@@ -3297,6 +3301,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/rules/eager/config-resolution.md": true,
     "plugins/lisa-copilot/rules/eager/convergent-review.md": true,
     "plugins/lisa-copilot/rules/eager/dependency-decision-records.md": true,
+    "plugins/lisa-copilot/rules/eager/dependency-trust-classes.md": true,
     "plugins/lisa-copilot/rules/eager/documentation-source-paths.md": true,
     "plugins/lisa-copilot/rules/eager/empirical-inquiry.md": true,
     "plugins/lisa-copilot/rules/eager/factory-model.md": true,
@@ -3327,6 +3332,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/rules/reference/config-resolution.md": true,
     "plugins/lisa-copilot/rules/reference/convergent-review.md": true,
     "plugins/lisa-copilot/rules/reference/dependency-decision-records.md": true,
+    "plugins/lisa-copilot/rules/reference/dependency-trust-classes.md": true,
     "plugins/lisa-copilot/rules/reference/documentation-source-paths.md": true,
     "plugins/lisa-copilot/rules/reference/empirical-inquiry.md": true,
     "plugins/lisa-copilot/rules/reference/factory-model.md": true,
@@ -3664,6 +3670,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/rules/convergent-review.mdc": true,
     "plugins/lisa-cursor/rules/dependency-decision-records-reference.mdc": true,
     "plugins/lisa-cursor/rules/dependency-decision-records.mdc": true,
+    "plugins/lisa-cursor/rules/dependency-trust-classes-reference.mdc": true,
+    "plugins/lisa-cursor/rules/dependency-trust-classes.mdc": true,
     "plugins/lisa-cursor/rules/documentation-source-paths-reference.mdc": true,
     "plugins/lisa-cursor/rules/documentation-source-paths.mdc": true,
     "plugins/lisa-cursor/rules/empirical-inquiry-reference.mdc": true,
@@ -6038,6 +6046,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/rules/eager/config-resolution.md": true,
     "plugins/lisa/rules/eager/convergent-review.md": true,
     "plugins/lisa/rules/eager/dependency-decision-records.md": true,
+    "plugins/lisa/rules/eager/dependency-trust-classes.md": true,
     "plugins/lisa/rules/eager/documentation-source-paths.md": true,
     "plugins/lisa/rules/eager/empirical-inquiry.md": true,
     "plugins/lisa/rules/eager/factory-model.md": true,
@@ -6068,6 +6077,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/rules/reference/config-resolution.md": true,
     "plugins/lisa/rules/reference/convergent-review.md": true,
     "plugins/lisa/rules/reference/dependency-decision-records.md": true,
+    "plugins/lisa/rules/reference/dependency-trust-classes.md": true,
     "plugins/lisa/rules/reference/documentation-source-paths.md": true,
     "plugins/lisa/rules/reference/empirical-inquiry.md": true,
     "plugins/lisa/rules/reference/factory-model.md": true,
@@ -6566,6 +6576,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/rules/eager/config-resolution.md": true,
     "plugins/src/base/rules/eager/convergent-review.md": true,
     "plugins/src/base/rules/eager/dependency-decision-records.md": true,
+    "plugins/src/base/rules/eager/dependency-trust-classes.md": true,
     "plugins/src/base/rules/eager/documentation-source-paths.md": true,
     "plugins/src/base/rules/eager/empirical-inquiry.md": true,
     "plugins/src/base/rules/eager/factory-model.md": true,
@@ -6596,6 +6607,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/rules/reference/config-resolution.md": true,
     "plugins/src/base/rules/reference/convergent-review.md": true,
     "plugins/src/base/rules/reference/dependency-decision-records.md": true,
+    "plugins/src/base/rules/reference/dependency-trust-classes.md": true,
     "plugins/src/base/rules/reference/documentation-source-paths.md": true,
     "plugins/src/base/rules/reference/empirical-inquiry.md": true,
     "plugins/src/base/rules/reference/factory-model.md": true,
@@ -7565,6 +7577,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/e2e/ui-version-status.spec.ts": true,
     "tests/fixtures/automation-status/attention-needed-codex.json": true,
     "tests/fixtures/automation-status/partial-support-codex.json": true,
+    "tests/fixtures/dependency-trust-classes/dependency-addition-ticket.md": true,
     "tests/fixtures/doctor/not-ready-missing-config.json": true,
     "tests/fixtures/doctor/readiness/all-pass-assessed.json": true,
     "tests/fixtures/doctor/readiness/all-skip-unassessed.json": true,
@@ -7912,6 +7925,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/create-only.test.ts": true,
     "tests/unit/strategies/debrief-reroute-contract.test.ts": true,
     "tests/unit/strategies/dependency-decision-records-rule-pair.test.ts": true,
+    "tests/unit/strategies/dependency-trust-classes-rule-pair.test.ts": true,
     "tests/unit/strategies/distributed-content-round2-contract.test.ts": true,
     "tests/unit/strategies/doctor-automation-readiness.test.ts": true,
     "tests/unit/strategies/doctor-config-readiness.test.ts": true,

--- a/tests/fixtures/dependency-trust-classes/dependency-addition-ticket.md
+++ b/tests/fixtures/dependency-trust-classes/dependency-addition-ticket.md
@@ -1,0 +1,51 @@
+# [api] Add Stripe SDK to process subscription payments
+
+**Labels:** `type:Task`, `priority:high`, `repo:api`
+
+## Context / Business Value
+
+Customers cannot pay us today. This work unit adds the payment client that
+charges a card and records the result, which is the last blocker on launching
+paid plans.
+
+## Proposed material dependency
+
+- **Dependency:** `stripe` (Node SDK)
+- **Trust class:** runtime-critical service client
+- **Why that class:** it runs on the production request path and reaches
+  customer payment data and money directly. Maturity does not lower the class —
+  blast radius sets it.
+
+### Required evidence for this trust class
+
+- **Capability owner:** a named accountable person, not a team — the payments
+  engineer who owns the billing service.
+- **Update cadence:** re-judged at every version change; the version is pinned
+  exactly so upgrades are always deliberate.
+- **Detection evidence:** an integration test that charges a card against
+  Stripe's test mode, plus a production monitor on the checkout success rate.
+  "Nothing would catch it" is not acceptable in this class.
+- **Replacement cost:** written down, not `_Not yet decided_` — roughly three
+  weeks to re-platform onto another processor, because webhook handling and
+  stored payment methods would both have to move.
+- **Product/human ratification:** **required** before this work starts, and
+  again before any major version upgrade.
+
+## Acceptance criteria
+
+```gherkin
+Scenario: A subscription charge succeeds
+  Given a customer with a valid saved payment method
+  When they confirm a subscription upgrade
+  Then the charge is recorded and the plan changes within one request
+
+Scenario: The dependency decision is recorded
+  Given the Stripe SDK is added in this change
+  When the change is reviewed
+  Then .lisa/DEPENDENCY_DECISIONS.md contains an entry naming its trust class,
+    its detection evidence, and its named accountable owner
+```
+
+- **Verification:** Integration test -- test-mode charge against the real SDK.
+- **Dependencies:** none.
+- **Skills:** lisa-tdd-implementation, lisa-test-strategy.

--- a/tests/unit/strategies/dependency-trust-classes-rule-pair.test.ts
+++ b/tests/unit/strategies/dependency-trust-classes-rule-pair.test.ts
@@ -1,0 +1,201 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const EAGER = "plugins/src/base/rules/eager/dependency-trust-classes.md";
+const REFERENCE =
+  "plugins/src/base/rules/reference/dependency-trust-classes.md";
+const DECOMPOSITION =
+  "plugins/src/base/skills/lisa-task-decomposition/SKILL.md";
+const TICKET_FIXTURE =
+  "tests/fixtures/dependency-trust-classes/dependency-addition-ticket.md";
+
+/**
+ * The six trust classes, spelled exactly as the taxonomy names them. Every
+ * surface — eager head, reference body, decomposition skill — has to use the
+ * same strings, because the class name is what a work item cites and what a
+ * decision record's trust-basis field resolves to. Drift in the wording is
+ * drift in the contract.
+ */
+const TRUST_CLASSES = [
+  "mature ecosystem primitive",
+  "fast-moving standard implementation",
+  "build/development tool",
+  "runtime-critical service client",
+  "thin wrapper suitable for in-house ownership",
+  "temporary/experimental dependency",
+] as const;
+
+/** Path to the governed decision record the trust class resolves against. */
+const RECORD_PATH = ".lisa/DEPENDENCY_DECISIONS.md";
+
+/** The record field a trust class is the answer to. */
+const TRUST_BASIS_FIELD = '"Why we believe it\'s safe (trust basis)"';
+
+describe("dependency-trust-classes eager/reference rule pair", () => {
+  it("ships the canonical eager and reference pair from plugin source", () => {
+    const eager = readFileSync(EAGER, "utf8");
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(eager).toContain("# Dependency Trust Classes (load-bearing)");
+    expect(eager).toContain(
+      "[reference/dependency-trust-classes.md](../reference/dependency-trust-classes.md)"
+    );
+    expect(reference).toContain("# Dependency Trust Classes");
+  });
+
+  it("names all six trust classes on both halves of the pair", () => {
+    const eager = readFileSync(EAGER, "utf8").toLowerCase();
+    const reference = readFileSync(REFERENCE, "utf8").toLowerCase();
+
+    for (const trustClass of TRUST_CLASSES) {
+      expect(eager).toContain(trustClass);
+      expect(reference).toContain(trustClass);
+    }
+  });
+
+  it("cross-references the decision record so a trust basis resolves to a class", () => {
+    const eager = readFileSync(EAGER, "utf8");
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(eager).toContain(RECORD_PATH);
+    expect(eager).toContain(TRUST_BASIS_FIELD);
+    expect(reference).toContain(RECORD_PATH);
+    expect(reference).toContain(TRUST_BASIS_FIELD);
+  });
+
+  it("states all five review inputs for the taxonomy", () => {
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(reference).toContain("## The five review inputs");
+    expect(reference).toContain("**Capability owner**");
+    expect(reference).toContain("**Update cadence**");
+    expect(reference).toContain("**Detection evidence**");
+    expect(reference).toContain("**Replacement-cost threshold**");
+    expect(reference).toContain("**Product/human ratification**");
+  });
+
+  it("gives every class its own five review inputs, not just the taxonomy", () => {
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    // Six classes, each restating the five inputs as its own bullet list.
+    for (const label of [
+      "**Capability owner:**",
+      "**Update cadence:**",
+      "**Detection evidence:**",
+      "**Replacement-cost threshold:**",
+      "**Ratification:**",
+    ]) {
+      expect(reference.split(label).length - 1).toBe(TRUST_CLASSES.length);
+    }
+  });
+
+  it("leads every class with why it is trusted and names its human-review trigger", () => {
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    // AC scenario 2: an operator reading a class definition can tell why the
+    // class is trusted and what would trigger human review. Both are required
+    // on all six, so neither can quietly go missing from one class.
+    expect(reference.split("**Why we can trust it:**").length - 1).toBe(
+      TRUST_CLASSES.length
+    );
+    expect(
+      reference.split("**Human review is triggered when:**").length - 1
+    ).toBe(TRUST_CLASSES.length);
+  });
+
+  it("requires human ratification on the lower-trust and higher-exposure classes", () => {
+    const eager = readFileSync(EAGER, "utf8");
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(eager).toContain(
+      "runtime-critical service clients always need human\nratification"
+    );
+    expect(reference).toContain("## Ratification, summarized");
+    expect(reference).toContain(
+      "**product/human ratification is required** before adding the\n  dependency and before any major upgrade"
+    );
+    expect(reference).toContain(
+      "**required to extend past the expiry date** or to promote it"
+    );
+    expect(reference).toContain(
+      "Not required for mature ecosystem primitives or build/development tools"
+    );
+  });
+
+  it("forbids blind detection evidence on the runtime-critical class", () => {
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(reference).toContain(
+      '"Nothing would catch it" is not an acceptable answer in this class'
+    );
+  });
+
+  it("requires reclassification instead of quiet re-trust when exposure changes", () => {
+    const eager = readFileSync(EAGER, "utf8");
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(eager).toContain("Reclassify — do not quietly re-trust —");
+    expect(reference).toContain("## Reclassification");
+  });
+
+  it("documents the uniform six-agent enforcement gap", () => {
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(reference).toContain("## Agent parity");
+    expect(reference).toContain(
+      "no agent runtime enforces\nthat a dependency carries a correct class"
+    );
+  });
+});
+
+describe("dependency trust classes wired into planning guidance", () => {
+  it("makes the decomposition skill demand a trust class for a new material dependency", () => {
+    const skill = readFileSync(DECOMPOSITION, "utf8");
+    const lowered = skill.toLowerCase();
+
+    expect(skill).toContain("### 4.5. Classify Any New Material Dependency");
+    expect(skill).toContain("**Name its trust class**");
+    for (const trustClass of TRUST_CLASSES) {
+      expect(lowered).toContain(trustClass);
+    }
+  });
+
+  it("makes the decomposition skill demand the record update and the ratification call", () => {
+    const skill = readFileSync(DECOMPOSITION, "utf8");
+
+    expect(skill).toContain(`\`${RECORD_PATH}\``);
+    expect(skill).toContain("**State the class's required evidence**");
+    expect(skill).toContain(
+      "a proposed material dependency with no named class is not ready to build"
+    );
+  });
+});
+
+describe("dependency-addition ticket fixture", () => {
+  it("names the dependency's trust class", () => {
+    const ticket = readFileSync(TICKET_FIXTURE, "utf8");
+
+    expect(ticket).toContain(
+      "**Trust class:** runtime-critical service client"
+    );
+    expect(ticket).toContain("**Why that class:**");
+  });
+
+  it("states the required review evidence for that class", () => {
+    const ticket = readFileSync(TICKET_FIXTURE, "utf8");
+
+    expect(ticket).toContain("### Required evidence for this trust class");
+    expect(ticket).toContain("**Capability owner:**");
+    expect(ticket).toContain("**Update cadence:**");
+    expect(ticket).toContain("**Detection evidence:**");
+    expect(ticket).toContain("**Replacement cost:**");
+    expect(ticket).toContain("**Product/human ratification:** **required**");
+  });
+
+  it("commits to updating the decision record in the same change", () => {
+    const ticket = readFileSync(TICKET_FIXTURE, "utf8");
+
+    expect(ticket).toContain(RECORD_PATH);
+    expect(ticket).toContain("naming its trust class");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1887 — story 2 of PRD #1741 (dependency ownership), building on #1886's decision-record scaffold. Replaces the single implicit "third-party code" risk bucket with a named trust-class taxonomy and per-class review requirements, so dependency decisions are consistent across agents, templates, and host projects.

### What's here
- **The trust-class rule pair** `plugins/src/base/rules/{eager,reference}/dependency-trust-classes.md` (fanned to all agent mirrors), mirroring #1886's governed rule-pair pattern. It defines **six classes** — mature ecosystem primitive, fast-moving standard implementation, build/development tool, runtime-critical service client, thin wrapper suitable for in-house ownership, and temporary/experimental — and the **five review inputs** each entry must carry (capability owner, update cadence, detection evidence, replacement-cost threshold, and the ratification/human-review trigger).
- **Operator-readable by design (AC scenario 2).** Each class leads with plain-language "why we can trust this kind of dependency" and names exactly what triggers human/product ratification. E.g. the mature-ecosystem-primitive class: *"Trust here comes from the size of the crowd standing in front of us, not from us having read the code"* — and its trigger: *"maintainership changes hands or the project is archived… either event removes the crowd, which was the whole basis for the trust — reclassify rather than re-trust."* Higher-blast-radius classes (runtime-critical service client) carry stronger evidence + mandatory ratification.
- **Planning integration (AC scenario 1).** `lisa-task-decomposition` guidance now requires a work item proposing a NEW material dependency to name the dependency's trust class and update the `.lisa/DEPENDENCY_DECISIONS.md` record. A worked ticket fixture (an "Add Stripe SDK" task classed as a runtime-critical service client — *"blast radius sets it, not maturity"* — with its per-class evidence) demonstrates the requirement.
- Cross-references #1886: a decision record's "Trust basis" field maps to a trust class.

## Verification

- Full `bun run test` → **427 files / 7172 tests, exit 0**; `bun run typecheck` 0; `bun run build:plugins` clean (mirrors byte-faithful); `bun run check:plugins` pass; `scripts/check-rules-pairing.sh` pass (eager↔reference); `generate-upstream-evidence-manifest.mjs --check` 0.
- All six required classes present with their five review inputs and an explicit human-review trigger; the dependency-addition ticket fixture names a trust class + required evidence (AC#1); each class reads plainly at the product gate (AC#2). A 201-line rule-pair test pins the structure.

Scaffold-only stays scaffold-only: automated duplicate detection (#1888), inventory reclassification (#1889), and the removal-confidence kit (#1890) remain out of scope. Next in the chain: #1888.

🤖 Generated with Claude Code
