### PR TITLE
feat(ui): derive Setup checklist readiness

### DIFF
--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2055,7 +2055,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "ui/README.md":
       "deeb35e767ea5dd2883268835ea3ad21cbad9fa63ec8d8ff5e200f0e2a7d2751",
     "ui/index.html":
-      "a6741c556f79d05e5063500b795c7066b05280d166ead6b83047a308ba7cef91",
+      "a66598558cb95873aa674055d3bc3335654f7c615013bae0fa8effa35f64c351",
   });
 
 /** Exact paths tracked by the public Lisa repository at generation time. */
@@ -7549,6 +7549,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/e2e/ui-observability-providers.spec.ts": true,
     "tests/e2e/ui-plugins.spec.ts": true,
     "tests/e2e/ui-readonly-affordance.spec.ts": true,
+    "tests/e2e/ui-setup-readiness.spec.ts": true,
     "tests/e2e/ui-stacks.spec.ts": true,
     "tests/e2e/ui-version-status.spec.ts": true,
     "tests/fixtures/automation-status/attention-needed-codex.json": true,
@@ -7676,6 +7677,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/ui-observability-providers-probe.test.ts": true,
     "tests/unit/cli/ui-setup-readiness-endpoint-confinement.test.ts": true,
     "tests/unit/cli/ui-setup-readiness-endpoint.test.ts": true,
+    "tests/unit/cli/ui-setup-readiness-renderer.test.ts": true,
     "tests/unit/cli/ui-setup-readiness.test.ts": true,
     "tests/unit/cli/ui-status-contract.test.ts": true,
     "tests/unit/cli/ui-status-endpoint.test.ts": true,

--- a/tests/e2e/fixtures/ui-live-status-server.ts
+++ b/tests/e2e/fixtures/ui-live-status-server.ts
@@ -42,7 +42,29 @@ const probes: readonly StatusProbe[] = [
   },
 ];
 
-const server = await runUi(process.cwd(), { port, sync: false }, { probes });
+const unavailable = {
+  state: "unknown" as const,
+  reason: "fixture-unavailable",
+  message: "Unavailable in the shared browser fixture",
+};
+const server = await runUi(
+  process.cwd(),
+  { port, sync: false },
+  {
+    probes,
+    setupReadiness: {
+      readConfig: async () => ({}),
+      readHealth: async () => {
+        throw new Error("No Health fixture");
+      },
+      readGithub: async () => unavailable,
+      readDeployPipeline: async () => unavailable,
+      readAutomations: async () => unavailable,
+      readExpectedAutomationIds: async () => [],
+      readExpectedSecretNames: async () => [],
+    },
+  }
+);
 
 const close = (): void => {
   server.close(() => process.exit(0));

--- a/tests/e2e/ui-readonly-affordance.spec.ts
+++ b/tests/e2e/ui-readonly-affordance.spec.ts
@@ -33,15 +33,12 @@ test("renders mutating console controls as honest read-only affordances", async 
   const firstChecklistRow = page.locator("#section-setup .check-item").first();
   const beforeClass = await firstChecklistRow.getAttribute("class");
   await expect(firstChecklistButton).toBeDisabled();
-  await expect(firstChecklistButton).toHaveAttribute(
+  await expect(firstChecklistButton).not.toHaveAttribute(
     "title",
     "read-only: setup checklist state has not shipped yet"
   );
-  await expect(
-    firstChecklistRow.locator(".status-why", {
-      hasText: "read-only: setup checklist state has not shipped yet",
-    })
-  ).toBeVisible();
+  await expect(firstChecklistButton).toHaveAttribute("title", /.+/u);
+  await expect(firstChecklistRow.locator(".status-why")).toBeVisible();
   await firstChecklistButton.click({ force: true });
   await expect(firstChecklistRow).toHaveClass(beforeClass ?? "");
 

--- a/tests/e2e/ui-setup-readiness.spec.ts
+++ b/tests/e2e/ui-setup-readiness.spec.ts
@@ -1,0 +1,296 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const CHECKS = [
+  "setup.install",
+  "setup.sync",
+  "setup.agent-ready",
+  "setup.standards",
+  "setup.tracker",
+  "setup.prd-source",
+  "setup.github-governance",
+  "setup.secrets",
+  "setup.automations",
+  "setup.exploration",
+  "setup.wiki",
+  "setup.starter-provenance",
+] as const;
+
+type Status = "pass" | "warn" | "fail";
+interface Finding {
+  check: string;
+  layer: string;
+  status: string;
+  reason: string;
+}
+interface Readiness {
+  schemaVersion: number;
+  observedAt: string;
+  findings: Finding[];
+}
+
+/** Build one exact current Setup readiness response. */
+function readiness(
+  overrides: Readonly<Record<string, Status>> = {}
+): Readiness {
+  return {
+    schemaVersion: 1,
+    observedAt: "2026-07-21T19:00:00.000Z",
+    findings: CHECKS.map(check => ({
+      check,
+      layer: "deterministic",
+      status: overrides[check] ?? "warn",
+      reason: `${check} is ${overrides[check] ?? "warn"}.`,
+    })),
+  };
+}
+
+/** Route one browser page to a controlled Setup response. */
+async function routeReadiness(page: Page, body: object): Promise<void> {
+  await page.route("**/api/setup-readiness", async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+  });
+}
+
+/** Assert that an unusable response cannot leave any checklist row green. */
+async function expectFailedClosed(page: Page): Promise<void> {
+  const rows = page.locator("#section-setup [data-setup-check]");
+  await expect(rows).toHaveCount(12);
+  await expect(page.locator("#section-setup .check-item.done")).toHaveCount(0);
+  const reasons = await rows.locator(".status-why").allTextContents();
+  expect(new Set(reasons)).toEqual(
+    new Set([
+      "Setup readiness is unavailable. Re-open the console after checking the local Lisa service.",
+    ])
+  );
+}
+
+test("renders exact named findings and survives a later live-status render", async ({
+  page,
+}) => {
+  let releaseStatus: () => void = () => undefined;
+  const statusGate = new Promise<void>(resolve => {
+    releaseStatus = resolve;
+  });
+  await page.route("**/api/status", async route => {
+    await statusGate;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: "{}",
+    });
+  });
+  await routeReadiness(
+    page,
+    readiness({
+      "setup.install": "pass",
+      "setup.sync": "pass",
+      "setup.tracker": "fail",
+    })
+  );
+
+  await page.goto("/#setup");
+  const rows = page.locator("#section-setup [data-setup-check]");
+  await expect(rows).toHaveCount(12);
+  expect(
+    await rows.evaluateAll(nodes =>
+      nodes.map(node => (node as HTMLElement).dataset.setupCheck)
+    )
+  ).toEqual(CHECKS);
+  await expect(page.locator('[data-setup-check="setup.install"]')).toHaveClass(
+    /done/u
+  );
+  await expect(page.locator('[data-setup-check="setup.sync"]')).toHaveClass(
+    /done/u
+  );
+  const tracker = page.locator('[data-setup-check="setup.tracker"]');
+  await expect(tracker).not.toHaveClass(/done/u);
+  await expect(tracker.locator(".badge")).toHaveText("pending");
+  await expect(tracker.locator(".status-why")).toHaveText(
+    "setup.tracker is fail."
+  );
+  await expect(
+    page.locator('[data-setup-checklist="Required"] .note')
+  ).toHaveText("2 of 10 complete");
+  await expect(
+    page.locator('[data-setup-checklist="Optional"] .note')
+  ).toHaveText("0 of 2 complete");
+
+  releaseStatus();
+  await expect(page.locator('[data-setup-check="setup.install"]')).toHaveClass(
+    /done/u
+  );
+  await expect(tracker.locator(".status-why")).toHaveText(
+    "setup.tracker is fail."
+  );
+});
+
+test("applies setup truth after status-driven whole-page renders finish first", async ({
+  page,
+}) => {
+  let releaseSetup: () => void = () => undefined;
+  const setupGate = new Promise<void>(resolve => {
+    releaseSetup = resolve;
+  });
+  await page.route("**/api/setup-readiness", async route => {
+    await setupGate;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(readiness({ "setup.install": "pass" })),
+    });
+  });
+
+  await page.goto("/#setup");
+  await expect(
+    page.locator('[data-setup-check="setup.install"] .status-why')
+  ).toHaveText("Checking current setup readiness.");
+  releaseSetup();
+  await expect(page.locator('[data-setup-check="setup.install"]')).toHaveClass(
+    /done/u
+  );
+});
+
+const malformedCases: ReadonlyArray<{
+  name: string;
+  body: () => Readiness;
+}> = [
+  {
+    name: "missing finding",
+    body: () => {
+      const value = readiness({ "setup.install": "pass" });
+      value.findings.pop();
+      return value;
+    },
+  },
+  {
+    name: "extra finding",
+    body: () => {
+      const value = readiness({ "setup.install": "pass" });
+      value.findings.push({ ...value.findings[0]!, check: "setup.extra" });
+      return value;
+    },
+  },
+  {
+    name: "reordered findings",
+    body: () => {
+      const value = readiness({ "setup.install": "pass" });
+      [value.findings[0], value.findings[1]] = [
+        value.findings[1]!,
+        value.findings[0]!,
+      ];
+      return value;
+    },
+  },
+  {
+    name: "duplicate finding",
+    body: () => {
+      const value = readiness({ "setup.install": "pass" });
+      value.findings[1] = { ...value.findings[0]! };
+      return value;
+    },
+  },
+  {
+    name: "invalid timestamp",
+    body: () => ({ ...readiness(), observedAt: "not-a-timestamp" }),
+  },
+  {
+    name: "invalid layer",
+    body: () => {
+      const value = readiness({ "setup.install": "pass" });
+      value.findings[0]!.layer = "agentic";
+      return value;
+    },
+  },
+  {
+    name: "invalid status",
+    body: () => {
+      const value = readiness({ "setup.install": "pass" });
+      value.findings[0]!.status = "unknown";
+      return value;
+    },
+  },
+  {
+    name: "unsafe reason",
+    body: () => {
+      const value = readiness({ "setup.install": "pass" });
+      value.findings[0]!.reason = " padded ";
+      return value;
+    },
+  },
+];
+
+for (const scenario of malformedCases) {
+  test(`${scenario.name} fails every Setup row closed`, async ({ page }) => {
+    await routeReadiness(page, scenario.body());
+    await page.goto("/#setup");
+    await expectFailedClosed(page);
+  });
+}
+
+test("invalid JSON fails every Setup row closed", async ({ page }) => {
+  await page.route("**/api/setup-readiness", async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: "{",
+    });
+  });
+  await page.goto("/#setup");
+  await expectFailedClosed(page);
+});
+
+test("transport failure fails every Setup row closed", async ({ page }) => {
+  await page.route("**/api/setup-readiness", async route => {
+    await route.fulfill({ status: 503, body: "Unavailable" });
+  });
+  await page.goto("/#setup");
+  await expectFailedClosed(page);
+});
+
+test("reopening Setup refreshes and reverses one row without stale green", async ({
+  page,
+}) => {
+  let trackerStatus: Status = "fail";
+  let requestCount = 0;
+  let releaseThird: () => void = () => undefined;
+  const thirdGate = new Promise<void>(resolve => {
+    releaseThird = resolve;
+  });
+  await page.route("**/api/setup-readiness", async route => {
+    requestCount += 1;
+    if (requestCount === 3) await thirdGate;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(readiness({ "setup.tracker": trackerStatus })),
+    });
+  });
+  const tracker = page.locator('[data-setup-check="setup.tracker"]');
+
+  await page.goto("/#setup");
+  await expect(tracker).not.toHaveClass(/done/u);
+  expect(requestCount).toBe(1);
+
+  await page.locator('[data-section="overview"]').click();
+  trackerStatus = "pass";
+  await page.locator('[data-section="setup"]').click();
+  await expect(tracker).toHaveClass(/done/u);
+  expect(requestCount).toBe(2);
+
+  await page.locator('[data-section="overview"]').click();
+  trackerStatus = "fail";
+  await page.locator('[data-section="setup"]').click();
+  await expect(tracker).not.toHaveClass(/done/u);
+  await expect(tracker.locator(".status-why")).toHaveText(
+    "Checking current setup readiness."
+  );
+  releaseThird();
+  await expect(tracker.locator(".status-why")).toHaveText(
+    "setup.tracker is fail."
+  );
+  expect(requestCount).toBe(3);
+});

--- a/tests/unit/cli/ui-setup-readiness-renderer.test.ts
+++ b/tests/unit/cli/ui-setup-readiness-renderer.test.ts
@@ -1,0 +1,28 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { SETUP_READINESS_CHECKS } from "../../../src/cli/ui-setup-readiness.js";
+
+describe("Setup readiness renderer source", () => {
+  it("maps every checklist row exactly once without hardcoded truth", async () => {
+    const html = await readFile(
+      path.resolve(import.meta.dirname, "../../../ui/index.html"),
+      "utf8"
+    );
+    const start = html.indexOf("DATA.sections.setup = {");
+    const end = html.indexOf("const AUTOMATION_COL", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const setup = html.slice(start, end);
+    const checks = Array.from(
+      setup.matchAll(/\bid: "(setup\.[^"]+)"/gu),
+      match => match[1]
+    );
+
+    expect(checks).toEqual(SETUP_READINESS_CHECKS);
+    expect(setup).not.toMatch(/\b(?:done|why):/u);
+    expect(html).not.toContain(
+      "read-only: setup checklist state has not shipped yet"
+    );
+  });
+});

--- a/ui/index.html
+++ b/ui/index.html
@@ -1522,68 +1522,65 @@
             card: "Required",
             items: [
               {
+                id: "setup.install",
                 label: "Install Lisa and apply templates",
                 desc: "Detects the project’s stacks, applies project-owned templates, agent surfaces, and git hooks. External plugin/runtime installation is reported separately and never inferred from project files.",
                 command: "bun add -d @codyswann/lisa && bunx lisa",
-                done: true,
               },
               {
+                id: "setup.sync",
                 label: "Populate configuration",
                 desc: "Fills every missing .lisa.config.json setting (absorbing existing artifact values first) and syncs mirrored files. No unset configs.",
                 command: "lisa sync",
-                done: true,
               },
               {
+                id: "setup.agent-ready",
                 label: "Make the project agent-ready (brownfield)",
                 desc: "Builds the knowledge wiki through read-only, redacted ingestion; records every source as complete, partial, or unavailable; and writes wiki/gaps.md. Answer inline, re-run in a new session, repeat until every source is complete and zero gaps remain. Greenfield projects are ready by construction.",
                 command: "/lisa:agent-ready",
-                done: false,
-                why: "wiki/gaps.md has 2 open gaps",
               },
               {
+                id: "setup.standards",
                 label: "Adopt the standards (conformance refactor)",
                 desc: "Apply Lisa's full lint rules, guardrails, and thresholds — the project goes red by design — then agents refactor to automated conformance without changing business logic. Empirical product verification remains a separate Verify-factory gate.",
                 command:
                   "/lisa:improve:* · /lisa:fix:linter-error · lisa standards-proof",
-                done: false,
-                why: "blocked by agent-ready",
               },
               {
+                id: "setup.tracker",
                 label: "Connect the work tracker",
                 desc: "Verifies the workflow status names and writes the tracker section. This project: JIRA, project ACME.",
                 command: "/lisa:setup:jira | github | linear",
-                done: true,
               },
               {
+                id: "setup.prd-source",
                 label: "Connect the PRD source",
                 desc: "Wires the product-requirements queue and its lifecycle vocabulary. This project: Notion.",
                 command: "/lisa:setup:notion | confluence | linear | github",
-                done: true,
               },
               {
+                id: "setup.github-governance",
                 label: "Apply GitHub repository governance",
                 desc: "Repo settings (merge-only), rulesets with required checks, write deploy key, deployment environments with approval gates.",
                 command: "/lisa:setup:github-repo",
-                done: true,
               },
               {
+                id: "setup.secrets",
                 label: "Provision CI secrets",
                 desc: "CLAUDE_CODE_OAUTH_TOKEN, GITGUARDIAN_API_KEY, SONAR_TOKEN, per-environment AWS accounts, and the optional scanners.",
                 command: "gh secret set …",
-                done: false,
-                why: "2 missing: SNYK_TOKEN, FOSSA_API_KEY",
               },
               {
+                id: "setup.automations",
                 label: "Schedule the automations",
                 desc: "Creates the six-automation fleet — intake, repair, and the QA / Product Planning / Monitoring loops — on the harness’s native scheduler.",
                 command: "/lisa:setup-automations",
-                done: false,
               },
               {
+                id: "setup.exploration",
                 label: "Configure exploration environments",
                 desc: "Per-environment mutation policy and test identity so agents can use the product safely (production defaults to forbidden).",
                 command: ".lisa.config.json exploration.*",
-                done: false,
               },
             ],
           },
@@ -1592,17 +1589,17 @@
             card: "Optional",
             items: [
               {
+                id: "setup.wiki",
                 label: "Install the LLM wiki",
                 desc: "In-repo knowledge base agents read and maintain.",
                 command: "/lisa:wiki:install",
-                done: false,
                 optional: true,
               },
               {
+                id: "setup.starter-provenance",
                 label: "Record starter provenance",
                 desc: "Which starter repo(s) this project descends from, enabling starter sync (planned).",
                 command: ".lisa.config.json starter.*",
-                done: false,
                 optional: true,
               },
             ],
@@ -5085,6 +5082,30 @@
       let healthChipState = { state: "idle" };
       /* Durable Health view model projected by every whole-page render. */
       let healthViewState = { state: "idle" };
+      const SETUP_READINESS_CHECKS = [
+        "setup.install",
+        "setup.sync",
+        "setup.agent-ready",
+        "setup.standards",
+        "setup.tracker",
+        "setup.prd-source",
+        "setup.github-governance",
+        "setup.secrets",
+        "setup.automations",
+        "setup.exploration",
+        "setup.wiki",
+        "setup.starter-provenance",
+      ];
+      const SETUP_READINESS_UNAVAILABLE =
+        "Setup readiness is unavailable. Re-open the console after checking the local Lisa service.";
+      /* Durable Setup state survives every whole-page live-status re-render. */
+      let setupReadinessState = {
+        state: "loading",
+        findings: new Map(),
+        message: "Checking current setup readiness.",
+      };
+      let setupReadinessGeneration = 0;
+      let setupReadinessInFlight = null;
 
       function el(tag, cls, html) {
         const node = document.createElement(tag);
@@ -5711,6 +5732,7 @@
 
       function buildChecklist(block) {
         const card = el("div", "card");
+        card.dataset.setupChecklist = block.card;
         const head = el("div", "card-head");
         const note = el("span", "note");
         const countDone = () =>
@@ -5724,35 +5746,38 @@
         card.appendChild(head);
         const body = el("div", "card-body");
         block.items.forEach(item => {
-          const row = el("div", "check-item" + (item.done ? " done" : ""));
+          const finding = setupReadinessState.findings.get(item.id);
+          const isDone = finding && finding.status === "pass";
+          const reason =
+            setupReadinessState.state === "result" && finding
+              ? finding.reason
+              : setupReadinessState.message;
+          const row = el("div", "check-item" + (isDone ? " done" : ""));
+          row.dataset.setupCheck = item.id;
           const right = el("div", "check-right");
-          const refreshRight = () => {
-            const isDone = row.classList.contains("done");
-            right.innerHTML = "";
-            right.appendChild(
-              el(
-                "span",
-                "badge " +
-                  (isDone ? "pass" : item.optional ? "default" : "warn"),
-                isDone ? "done" : item.optional ? "not set up" : "pending"
-              )
-            );
-            if (!isDone && item.why) {
-              right.appendChild(el("span", "status-why", esc(item.why)));
-            }
-            right.appendChild(
-              el(
-                "span",
-                "status-why",
-                "read-only: setup checklist state has not shipped yet"
-              )
-            );
-          };
+          right.appendChild(
+            el(
+              "span",
+              "badge " +
+                (isDone
+                  ? "pass"
+                  : finding?.status === "fail"
+                    ? "fail"
+                    : "warn"),
+              isDone ? "done" : "pending"
+            )
+          );
+          if (!isDone) {
+            right.appendChild(el("span", "status-why", esc(reason)));
+          }
           const ck = el("button", "ck");
           ck.type = "button";
           ck.disabled = true;
-          ck.title = "read-only: setup checklist state has not shipped yet";
-          ck.setAttribute("aria-label", item.label + " checklist status");
+          ck.title = reason;
+          ck.setAttribute(
+            "aria-label",
+            item.label + ": " + (isDone ? "done" : "pending") + ". " + reason
+          );
           row.appendChild(ck);
           const content = el("div", "check-content");
           const lab = el("div", "check-label", esc(item.label));
@@ -5765,7 +5790,6 @@
             content.appendChild(el("span", "keychip", esc(item.command)));
           }
           row.appendChild(content);
-          refreshRight();
           row.appendChild(right);
           body.appendChild(row);
         });
@@ -5947,6 +5971,7 @@
 
       let activeSection = "overview";
       function showSection(sid) {
+        const previousSection = activeSection;
         activeSection = sid;
         document
           .querySelectorAll(".section")
@@ -5962,6 +5987,11 @@
           history.replaceState(null, "", "#" + sid);
         applyFilter(document.getElementById("search").value);
         window.scrollTo({ top: 0 });
+        if (sid === "setup" && previousSection !== "setup") {
+          void hydrateSetupReadiness({
+            refresh: setupReadinessGeneration > 0,
+          });
+        }
       }
 
       function applyFilter(query) {
@@ -6677,6 +6707,128 @@
         }
       }
 
+      /** Validate the strict three-field Setup readiness transport contract. */
+      function requireSetupReadinessResult(candidate) {
+        const isObject = value =>
+          value !== null && typeof value === "object" && !Array.isArray(value);
+        const hasExactKeys = (value, keys) =>
+          isObject(value) &&
+          Object.keys(value).sort().join(",") === [...keys].sort().join(",");
+        const canonicalUtc = value => {
+          if (
+            typeof value !== "string" ||
+            !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+          ) {
+            return false;
+          }
+          const instant = new Date(value);
+          return (
+            !Number.isNaN(instant.valueOf()) && instant.toISOString() === value
+          );
+        };
+        const readableReason = value =>
+          typeof value === "string" &&
+          value.trim() === value &&
+          value.length > 0 &&
+          new TextEncoder().encode(value).length <= 2000 &&
+          !Array.from(value).some(character => {
+            const codePoint = character.codePointAt(0) ?? 0;
+            return (
+              codePoint <= 0x1f ||
+              (codePoint >= 0x7f && codePoint <= 0x9f) ||
+              (codePoint >= 0x202a && codePoint <= 0x202e) ||
+              (codePoint >= 0x2066 && codePoint <= 0x2069)
+            );
+          });
+        if (
+          !hasExactKeys(candidate, [
+            "schemaVersion",
+            "observedAt",
+            "findings",
+          ]) ||
+          candidate.schemaVersion !== 1 ||
+          !canonicalUtc(candidate.observedAt) ||
+          !Array.isArray(candidate.findings) ||
+          candidate.findings.length !== SETUP_READINESS_CHECKS.length
+        ) {
+          throw new TypeError(
+            "Setup readiness response is not valid schema v1 JSON"
+          );
+        }
+        const findings = new Map();
+        candidate.findings.forEach((finding, index) => {
+          if (
+            !hasExactKeys(finding, ["check", "layer", "status", "reason"]) ||
+            finding.check !== SETUP_READINESS_CHECKS[index] ||
+            finding.layer !== "deterministic" ||
+            !["pass", "warn", "fail"].includes(finding.status) ||
+            !readableReason(finding.reason)
+          ) {
+            throw new TypeError(
+              "Setup readiness response contains an invalid finding"
+            );
+          }
+          findings.set(finding.check, finding);
+        });
+        return findings;
+      }
+
+      /** Rebuild only the two Setup checklist cards from durable readiness state. */
+      function repaintSetupChecklist() {
+        const section = document.getElementById("section-setup");
+        if (!section) return;
+        const blocks = DATA.sections.setup.blocks.filter(
+          block => block.type === "checklist"
+        );
+        const cards = section.querySelectorAll("[data-setup-checklist]");
+        blocks.forEach((block, index) => {
+          if (cards[index]) cards[index].replaceWith(buildChecklist(block));
+        });
+      }
+
+      /** Read current Setup readiness with same-entry dedupe and stale-response protection. */
+      function hydrateSetupReadiness({ refresh = false } = {}) {
+        if (!refresh && setupReadinessInFlight) {
+          return setupReadinessInFlight;
+        }
+        setupReadinessState = {
+          state: "loading",
+          findings: new Map(),
+          message: "Checking current setup readiness.",
+        };
+        repaintSetupChecklist();
+        const generation = ++setupReadinessGeneration;
+        const request = (async () => {
+          let nextState;
+          try {
+            const response = await fetch("/api/setup-readiness", {
+              cache: "no-store",
+            });
+            if (!response.ok) throw new Error(SETUP_READINESS_UNAVAILABLE);
+            nextState = {
+              state: "result",
+              findings: requireSetupReadinessResult(await response.json()),
+              message: "",
+            };
+          } catch {
+            nextState = {
+              state: "error",
+              findings: new Map(),
+              message: SETUP_READINESS_UNAVAILABLE,
+            };
+          }
+          if (generation === setupReadinessGeneration) {
+            setupReadinessState = nextState;
+            repaintSetupChecklist();
+          }
+          if (setupReadinessInFlight === request) {
+            setupReadinessInFlight = null;
+          }
+        })();
+        setupReadinessInFlight = request;
+        return request;
+      }
+
       /** Run exactly one deterministic Health v1 check through the local server. */
       async function runHealthCheck() {
         const button = document.getElementById("runHealthCheckButton");
@@ -7224,11 +7376,11 @@
       function boot() {
         hydrateFromLiveConfig();
         renderAll();
-        void hydrateLiveStatuses();
-        void hydrateHealth();
         showSection(location.hash ? location.hash.slice(1) : "overview");
         if (!document.getElementById("section-" + activeSection))
           showSection("overview");
+        void hydrateLiveStatuses();
+        void hydrateHealth();
       }
       if (document.readyState === "loading") {
         document.addEventListener("DOMContentLoaded", boot);


### PR DESCRIPTION
## Summary

- map the existing 12 Setup checklist rows to the strict /api/setup-readiness contract
- render only pass findings as done and show exact reasons for every pending row
- fail closed on transport or schema errors and preserve truth across whole-page hydration rerenders
- refresh readiness when Setup is reopened without allowing stale responses to overwrite newer state
- add static and Playwright coverage for ordering, counts, races, malformed responses, and state reversal

## Verification

- 425 Vitest files / 7,136 tests passed
- pre-push coverage: 84.72% statements, 76.53% branches, 88.67% functions, 85.49% lines
- 14 integration files / 146 tests passed
- focused Setup Playwright: 14/14 passed
- lint, slow lint, typecheck, build, Knip, formatting, rule pairing, and manifest checks passed
- independent verifier passed a real built-console lisa sync pending-to-done journey

Closes #1531