### PR TITLE
feat(deps): add confidence-rebuild kit for dependency internalization, closing #1890

### DIFF
--- a/plugins/lisa-agy/skills/lisa-task-decomposition/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-task-decomposition/SKILL.md
@@ -99,6 +99,43 @@ unit proposes adding one, the work unit must, before it is buildable:
 If nobody can pick a class, that is the finding — resolve it before accepting
 the work unit, not after the package is installed.
 
+### 4.6. Inherit the Confidence-Rebuild Kit When Ownership Moves In-House
+
+Step 4.5 covers dependencies a task proposes to **add**. This step covers
+dependencies a task proposes to **remove, replace, or internalize** — vendor,
+fork-and-maintain, or reimplement ourselves.
+
+When ownership moves in-house, the risk stops being "do we trust upstream" and
+becomes "did we prove we rebuilt the capability." A work unit that moves a
+material dependency in-house **inherits all seven acceptance criteria** of the
+`dependency-internalization-kit` rule, each written as an acceptance criterion
+of the work unit:
+
+1. **Real corpus** — did we test it on real inputs, not toy examples?
+2. **Conformance fixtures** — does the new code do what the dependency did?
+3. **Negative fixtures** — does it still reject what it should reject?
+4. **Coverage as a gap detector** — what behavior is still untested?
+5. **Provenance and license review** — where did this code come from, and are we
+   allowed to use it?
+6. **Migration and update plan** — how do existing call sites move, and how does
+   the new code stay current?
+7. **Rollback or replacement criteria** — what would make us go back, and to
+   what?
+
+The only way out is an **explicit non-material justification** written into the
+work unit — one reviewable sentence saying why this dependency's failure or
+disappearance breaks nothing a user can see and costs no real time to replace.
+Silence is not a justification.
+
+**Do not over-apply the kit.** A routine version bump of a trusted dependency
+**within its existing trust class** does not move ownership, so it does not
+inherit the kit — its bar is that trust class's own detection evidence and
+cadence. The same is true of swapping one third-party dependency for another,
+which moves trust to a different upstream rather than in-house. Add the kit only
+when ownership moves in-house; the exception is a bump taken *as* a fork or
+declined *in favor of* owning the code, which is an internalization regardless of
+how the ticket is titled.
+
 ### 5. Determine Execution Order
 
 - Place foundational tasks first (types, schemas, interfaces, shared utilities)
@@ -147,6 +184,7 @@ Map each task to the skills needed to complete it. This enables delegation to sp
 - Do not create tasks that cannot be verified -- if you cannot define how to prove it is done, the task is not well-scoped
 - Every Task / Bug / Sub-task / Improvement is scoped to exactly one repo -- if the work spans repos, split into per-repo work units under a shared parent Story (see step 1.5)
 - Any task proposing a new material dependency names its trust class, states that class's required evidence and whether human ratification is needed, and updates `.lisa/DEPENDENCY_DECISIONS.md` in the same change (see step 4.5) -- a proposed material dependency with no named class is not ready to build
+- Any task removing, replacing, or internalizing a material dependency carries all seven confidence-rebuild kit criteria -- corpus, conformance, negative fixtures, coverage-as-gap-detector, provenance/license, migration/update plan, and rollback criteria (see step 4.6) -- unless it explicitly justifies why the dependency is non-material; a within-trust-class version bump does not carry the kit
 - Keep tasks ordered so that no task references work that has not been completed by a prior task
 - Flag any task that requires access, permissions, or external input not yet available
 - Prefer more small tasks over fewer large tasks -- smaller tasks are easier to verify and less risky to fail

--- a/plugins/lisa-copilot/rules/eager/dependency-internalization-kit.md
+++ b/plugins/lisa-copilot/rules/eager/dependency-internalization-kit.md
@@ -1,0 +1,42 @@
+# Dependency Internalization Kit (load-bearing)
+
+When a work item **removes, replaces, or internalizes** a material dependency,
+ownership of that capability moves in-house. The risk moves with it: we stop
+trusting an upstream project and start having to **prove we rebuilt the
+capability correctly**. The confidence-rebuild kit is the standing acceptance
+bar for that proof, so internalization work never has to guess at its own tests.
+
+The kit is seven required evidence types. Each leads with the plain question it
+answers:
+
+1. **Real corpus** — did we test it on real inputs, not toy examples?
+2. **Conformance fixtures** — does the new code do what the dependency did?
+3. **Negative fixtures** — does it still reject what it should reject?
+4. **Coverage as a gap detector** — what behavior is still untested?
+5. **Provenance and license review** — where did this code come from, and are we
+   allowed to use it?
+6. **Migration and update plan** — how do existing call sites move, and how does
+   the new code stay current?
+7. **Rollback or replacement criteria** — what would make us go back, and to
+   what?
+
+All seven are required. A partial kit is the finding: dropping the corpus leaves
+a toy-example pass, dropping negative fixtures leaves code that accepts garbage,
+and dropping rollback criteria leaves nobody able to say the internalization
+failed.
+
+**When the kit applies:** ownership moves in-house — the dependency is removed,
+replaced with our own code, vendored, or forked and maintained by us. That is
+usually a move into the `thin wrapper suitable for in-house ownership` trust
+class, or out of the dependency set entirely.
+
+**When the kit does NOT apply:** a routine version bump of a trusted dependency
+**within its existing trust class**. Ownership does not move, so there is no
+rebuilt capability to prove. Applying the kit there is over-application — it
+buys no confidence and makes ordinary upkeep expensive.
+
+A work item that removes, replaces, or internalizes a material dependency
+inherits all seven criteria unless it explicitly justifies why the dependency is
+**non-material**. Silence is not a justification.
+
+Full prose: [reference/dependency-internalization-kit.md](../reference/dependency-internalization-kit.md).

--- a/plugins/lisa-copilot/rules/reference/dependency-internalization-kit.md
+++ b/plugins/lisa-copilot/rules/reference/dependency-internalization-kit.md
@@ -1,0 +1,197 @@
+# Dependency Internalization Kit
+
+Taking a dependency is a decision about trust: we believe someone else's code
+works. Dropping one reverses that decision without reversing the obligation —
+the capability still has to work, and now it is ours. The risk does not
+disappear at the moment the package is uninstalled; it **changes shape**, from
+"is upstream trustworthy?" to "did we actually rebuild what upstream did?"
+
+The confidence-rebuild kit is the standing answer to that second question. It is
+a reusable set of acceptance criteria that any removal, replacement, or
+internalization work item inherits, so the evidence bar is decided once instead
+of guessed at per ticket by whoever happens to write the tests.
+
+The kit pairs with the other two dependency surfaces:
+`.lisa/DEPENDENCY_DECISIONS.md` records *what we decided*, the
+[dependency-trust-classes](dependency-trust-classes.md) rule says *what bar the
+dependency had to clear to be there*, and this kit says *what proof we owe when
+we take the capability back*.
+
+## The seven required evidence types
+
+Each is stated as the plain question it answers, because the person deciding
+whether a removal is safe to ship is often not the person who wrote the code.
+
+### 1. Real corpus — did we test it on real inputs, not toy examples?
+
+The replacement must be exercised against **representative real inputs** drawn
+from actual usage: production samples, recorded fixtures, historical files, real
+config, the actual shapes the old dependency saw. Hand-written happy-path
+examples are not a corpus. They are written by the same person who wrote the
+implementation, from the same mental model, so they agree with the bug.
+
+The acceptance criterion names where the corpus came from and roughly how big it
+is. "We ran it on the 400 config files already in the repo" is a corpus. "We
+tested it with `{a: 1}`" is not.
+
+If real inputs cannot be obtained — because they are sensitive, or the capability
+is new-shaped — say so explicitly and name what stands in for them. An unstated
+absence reads as coverage that does not exist.
+
+### 2. Conformance fixtures — does the new code do what the dependency did?
+
+The replacement must be shown to **match the old dependency's behavior** on the
+behavior we actually rely on. The strongest form is a differential test: run both
+implementations over the corpus and assert the outputs agree, while the
+dependency is still installed. That is why the kit belongs on the *removal*
+ticket and not a follow-up — once the dependency is gone, the oracle is gone too.
+
+Where a differential run is impossible, conformance fixtures are captured from
+the old dependency's output *before* removal and asserted against afterwards.
+
+Deliberate divergences are allowed and must be **written down** as divergences.
+An intentional behavior change that nobody recorded is indistinguishable from a
+regression six months later.
+
+### 3. Negative fixtures — does it still reject what it should reject?
+
+Most dependencies do half their work by **refusing** things: rejecting malformed
+input, erroring on out-of-range values, failing closed on bad credentials.
+Conformance fixtures over valid input never test that half, and a replacement
+that accepts everything passes them all.
+
+Negative fixtures assert the replacement still fails on what the dependency
+failed on — and fails the same *way* where callers depend on the error type or
+message. This is the criterion most often dropped, and its absence is how a
+validation library gets internalized into a function that returns `true`.
+
+### 4. Coverage as a gap detector — what behavior is still untested?
+
+Coverage on internalization work is used to **find untested behavior**, not to
+report a number. The criterion is a review of the uncovered lines and branches
+with a stated disposition for each: tested, deliberately untested with a reason,
+or a gap to close before shipping.
+
+A coverage percentage on its own proves nothing here — new code written
+alongside its own tests reaches a high number trivially while the branch that
+matters is the one nobody thought of. The evidence is the *gap list*, and it is
+acceptable for that list to end with "none".
+
+### 5. Provenance and license review — where did this code come from, and are we allowed to use it?
+
+Internalized code has a source: written from scratch against a spec, adapted
+from the dependency's implementation, vendored wholesale, or copied from docs or
+an answer online. The work item must **say which**, because that is what
+determines our license obligation.
+
+Adapting or vendoring carries the upstream license with it — attribution,
+notice files, and copyleft terms follow the code even when the package does not.
+A permissive license is not "no obligation"; it is usually an attribution
+obligation.
+
+The criterion states the origin, the license, and what we have to do about it. If
+the answer is "written from scratch without reading their source," say that too —
+it is the cleanest provenance available and worth recording.
+
+### 6. Migration and update plan — how do existing call sites move, and how does the new code stay current?
+
+Two halves, both required:
+
+- **Migration**: every existing call site is enumerated and moved, in this change
+  or on a named schedule. A replacement nobody calls is not an internalization —
+  it is a second implementation, and the dependency is still installed.
+- **Staying current**: the capability the dependency tracked usually keeps
+  moving — a spec revises, a format gains a version, a platform changes. Name
+  who watches for that and what triggers an update. "Upstream did this for us"
+  was a real service, and dropping the dependency dropped it.
+
+### 7. Rollback or replacement criteria — what would make us go back, and to what?
+
+Written **before** the removal ships, while it is still a technical judgment
+rather than an argument during an incident. The criterion names:
+
+- the observable conditions that mean the internalization failed — defect rate,
+  a class of input we cannot handle, maintenance cost we are not paying;
+- what we do when they are met — reinstall the dependency, or pick a different
+  one, named;
+- how long the rollback stays cheap, and what makes it expensive.
+
+"We will fix forward" is a valid answer only if someone wrote it down on purpose.
+
+## Applying the kit — and not over-applying it
+
+The distinction the kit turns on is **whether ownership moves in-house**.
+
+**Inherits the kit** — ownership moves:
+
+- removing a material dependency and doing the work ourselves;
+- replacing it with our own implementation;
+- vendoring its source into the repo;
+- forking it and maintaining the fork.
+
+Each of those lands the capability in the
+`thin wrapper suitable for in-house ownership` trust class or removes it from
+the dependency set entirely, and either way we now own the behavior.
+
+**Does not inherit the kit** — ownership does not move:
+
+- a routine version bump of a trusted dependency **within its existing trust
+  class**, major or minor. The version-bump bar is the trust class's own
+  detection evidence and cadence, which already exist;
+- swapping one third-party dependency for another third-party dependency, where
+  trust simply moves to a different upstream. That is a trust-class decision and
+  a decision-record update, not an internalization;
+- adding a new dependency, which is covered by the trust-class rule.
+
+Over-applying the kit is a real failure, not a harmless excess of caution. A
+version bump forced to produce a corpus, conformance fixtures, and rollback
+criteria costs days for evidence that proves nothing — nobody rebuilt anything —
+and it teaches planners that the kit is boilerplate to be dispensed with, which
+is exactly how it stops being applied when it matters.
+
+The one exception: a version bump that **reclassifies** the dependency into
+in-house ownership — a bump taken as a fork, or an upgrade we decline in favor of
+owning the code — is an internalization wearing a bump's clothing, and it
+inherits the kit.
+
+## The non-material escape hatch
+
+A work item that removes a dependency inherits the kit **unless it explicitly
+justifies why the dependency is non-material**. A dependency is non-material when
+its failure or disappearance would not break anything a user can see and would
+not cost real time to replace — a one-line utility, a dev-only convenience, a
+package nothing imports anymore.
+
+The justification is written in the work item, in one sentence, and it is
+reviewable. What is not acceptable is silence: a removal ticket with no kit and
+no stated reason is not ready to build. That is the whole enforcement mechanism —
+the planner must either carry the criteria or say on the record why they do not
+apply.
+
+## For the operator at the gate
+
+The kit exists so that a removal ticket **explains how confidence will be rebuilt
+before the dependency is dropped**, in language that does not require reading the
+code. The seven questions are the readable form: did we test it on real inputs,
+does it do what the old one did, does it still reject bad input, what is still
+untested, where did the code come from and may we use it, how do callers move and
+how does it stay current, and what would make us go back.
+
+An operator who can read answers to those seven can judge the removal without
+being an engineer. A removal ticket that cannot answer them is not a plan — it is
+an intention.
+
+## Agent parity
+
+The kit is a governed markdown rule plus a decomposition-time expectation, not a
+runtime behavior, so Claude Code, Codex, Cursor, OpenCode, Antigravity, and
+Copilot all reach it identically through the shared rules mirror and the same
+`lisa-task-decomposition` skill. Cursor receives the pair flattened into two
+`.mdc` rules; Antigravity has no separate rules tree of its own and inherits the
+same content through the shared mirror — no runtime is missing the kit.
+
+The documented gap, uniform across all six runtimes: nothing enforces that a
+removal ticket actually carries the kit. No hook or lint gate fails a build when
+a dependency is deleted from a manifest with no corpus, no conformance fixtures,
+and no rollback criteria. Inheritance is carried by this rule, the decomposition
+skill, and review — the same posture as the trust-class rule it extends.

--- a/plugins/lisa-copilot/skills/lisa-task-decomposition/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-task-decomposition/SKILL.md
@@ -99,6 +99,43 @@ unit proposes adding one, the work unit must, before it is buildable:
 If nobody can pick a class, that is the finding — resolve it before accepting
 the work unit, not after the package is installed.
 
+### 4.6. Inherit the Confidence-Rebuild Kit When Ownership Moves In-House
+
+Step 4.5 covers dependencies a task proposes to **add**. This step covers
+dependencies a task proposes to **remove, replace, or internalize** — vendor,
+fork-and-maintain, or reimplement ourselves.
+
+When ownership moves in-house, the risk stops being "do we trust upstream" and
+becomes "did we prove we rebuilt the capability." A work unit that moves a
+material dependency in-house **inherits all seven acceptance criteria** of the
+`dependency-internalization-kit` rule, each written as an acceptance criterion
+of the work unit:
+
+1. **Real corpus** — did we test it on real inputs, not toy examples?
+2. **Conformance fixtures** — does the new code do what the dependency did?
+3. **Negative fixtures** — does it still reject what it should reject?
+4. **Coverage as a gap detector** — what behavior is still untested?
+5. **Provenance and license review** — where did this code come from, and are we
+   allowed to use it?
+6. **Migration and update plan** — how do existing call sites move, and how does
+   the new code stay current?
+7. **Rollback or replacement criteria** — what would make us go back, and to
+   what?
+
+The only way out is an **explicit non-material justification** written into the
+work unit — one reviewable sentence saying why this dependency's failure or
+disappearance breaks nothing a user can see and costs no real time to replace.
+Silence is not a justification.
+
+**Do not over-apply the kit.** A routine version bump of a trusted dependency
+**within its existing trust class** does not move ownership, so it does not
+inherit the kit — its bar is that trust class's own detection evidence and
+cadence. The same is true of swapping one third-party dependency for another,
+which moves trust to a different upstream rather than in-house. Add the kit only
+when ownership moves in-house; the exception is a bump taken *as* a fork or
+declined *in favor of* owning the code, which is an internalization regardless of
+how the ticket is titled.
+
 ### 5. Determine Execution Order
 
 - Place foundational tasks first (types, schemas, interfaces, shared utilities)
@@ -147,6 +184,7 @@ Map each task to the skills needed to complete it. This enables delegation to sp
 - Do not create tasks that cannot be verified -- if you cannot define how to prove it is done, the task is not well-scoped
 - Every Task / Bug / Sub-task / Improvement is scoped to exactly one repo -- if the work spans repos, split into per-repo work units under a shared parent Story (see step 1.5)
 - Any task proposing a new material dependency names its trust class, states that class's required evidence and whether human ratification is needed, and updates `.lisa/DEPENDENCY_DECISIONS.md` in the same change (see step 4.5) -- a proposed material dependency with no named class is not ready to build
+- Any task removing, replacing, or internalizing a material dependency carries all seven confidence-rebuild kit criteria -- corpus, conformance, negative fixtures, coverage-as-gap-detector, provenance/license, migration/update plan, and rollback criteria (see step 4.6) -- unless it explicitly justifies why the dependency is non-material; a within-trust-class version bump does not carry the kit
 - Keep tasks ordered so that no task references work that has not been completed by a prior task
 - Flag any task that requires access, permissions, or external input not yet available
 - Prefer more small tasks over fewer large tasks -- smaller tasks are easier to verify and less risky to fail

--- a/plugins/lisa-cursor/rules/dependency-internalization-kit-reference.mdc
+++ b/plugins/lisa-cursor/rules/dependency-internalization-kit-reference.mdc
@@ -1,0 +1,202 @@
+---
+description: "Dependency Internalization Kit"
+alwaysApply: false
+---
+
+# Dependency Internalization Kit
+
+Taking a dependency is a decision about trust: we believe someone else's code
+works. Dropping one reverses that decision without reversing the obligation —
+the capability still has to work, and now it is ours. The risk does not
+disappear at the moment the package is uninstalled; it **changes shape**, from
+"is upstream trustworthy?" to "did we actually rebuild what upstream did?"
+
+The confidence-rebuild kit is the standing answer to that second question. It is
+a reusable set of acceptance criteria that any removal, replacement, or
+internalization work item inherits, so the evidence bar is decided once instead
+of guessed at per ticket by whoever happens to write the tests.
+
+The kit pairs with the other two dependency surfaces:
+`.lisa/DEPENDENCY_DECISIONS.md` records *what we decided*, the
+[dependency-trust-classes](dependency-trust-classes.mdc) rule says *what bar the
+dependency had to clear to be there*, and this kit says *what proof we owe when
+we take the capability back*.
+
+## The seven required evidence types
+
+Each is stated as the plain question it answers, because the person deciding
+whether a removal is safe to ship is often not the person who wrote the code.
+
+### 1. Real corpus — did we test it on real inputs, not toy examples?
+
+The replacement must be exercised against **representative real inputs** drawn
+from actual usage: production samples, recorded fixtures, historical files, real
+config, the actual shapes the old dependency saw. Hand-written happy-path
+examples are not a corpus. They are written by the same person who wrote the
+implementation, from the same mental model, so they agree with the bug.
+
+The acceptance criterion names where the corpus came from and roughly how big it
+is. "We ran it on the 400 config files already in the repo" is a corpus. "We
+tested it with `{a: 1}`" is not.
+
+If real inputs cannot be obtained — because they are sensitive, or the capability
+is new-shaped — say so explicitly and name what stands in for them. An unstated
+absence reads as coverage that does not exist.
+
+### 2. Conformance fixtures — does the new code do what the dependency did?
+
+The replacement must be shown to **match the old dependency's behavior** on the
+behavior we actually rely on. The strongest form is a differential test: run both
+implementations over the corpus and assert the outputs agree, while the
+dependency is still installed. That is why the kit belongs on the *removal*
+ticket and not a follow-up — once the dependency is gone, the oracle is gone too.
+
+Where a differential run is impossible, conformance fixtures are captured from
+the old dependency's output *before* removal and asserted against afterwards.
+
+Deliberate divergences are allowed and must be **written down** as divergences.
+An intentional behavior change that nobody recorded is indistinguishable from a
+regression six months later.
+
+### 3. Negative fixtures — does it still reject what it should reject?
+
+Most dependencies do half their work by **refusing** things: rejecting malformed
+input, erroring on out-of-range values, failing closed on bad credentials.
+Conformance fixtures over valid input never test that half, and a replacement
+that accepts everything passes them all.
+
+Negative fixtures assert the replacement still fails on what the dependency
+failed on — and fails the same *way* where callers depend on the error type or
+message. This is the criterion most often dropped, and its absence is how a
+validation library gets internalized into a function that returns `true`.
+
+### 4. Coverage as a gap detector — what behavior is still untested?
+
+Coverage on internalization work is used to **find untested behavior**, not to
+report a number. The criterion is a review of the uncovered lines and branches
+with a stated disposition for each: tested, deliberately untested with a reason,
+or a gap to close before shipping.
+
+A coverage percentage on its own proves nothing here — new code written
+alongside its own tests reaches a high number trivially while the branch that
+matters is the one nobody thought of. The evidence is the *gap list*, and it is
+acceptable for that list to end with "none".
+
+### 5. Provenance and license review — where did this code come from, and are we allowed to use it?
+
+Internalized code has a source: written from scratch against a spec, adapted
+from the dependency's implementation, vendored wholesale, or copied from docs or
+an answer online. The work item must **say which**, because that is what
+determines our license obligation.
+
+Adapting or vendoring carries the upstream license with it — attribution,
+notice files, and copyleft terms follow the code even when the package does not.
+A permissive license is not "no obligation"; it is usually an attribution
+obligation.
+
+The criterion states the origin, the license, and what we have to do about it. If
+the answer is "written from scratch without reading their source," say that too —
+it is the cleanest provenance available and worth recording.
+
+### 6. Migration and update plan — how do existing call sites move, and how does the new code stay current?
+
+Two halves, both required:
+
+- **Migration**: every existing call site is enumerated and moved, in this change
+  or on a named schedule. A replacement nobody calls is not an internalization —
+  it is a second implementation, and the dependency is still installed.
+- **Staying current**: the capability the dependency tracked usually keeps
+  moving — a spec revises, a format gains a version, a platform changes. Name
+  who watches for that and what triggers an update. "Upstream did this for us"
+  was a real service, and dropping the dependency dropped it.
+
+### 7. Rollback or replacement criteria — what would make us go back, and to what?
+
+Written **before** the removal ships, while it is still a technical judgment
+rather than an argument during an incident. The criterion names:
+
+- the observable conditions that mean the internalization failed — defect rate,
+  a class of input we cannot handle, maintenance cost we are not paying;
+- what we do when they are met — reinstall the dependency, or pick a different
+  one, named;
+- how long the rollback stays cheap, and what makes it expensive.
+
+"We will fix forward" is a valid answer only if someone wrote it down on purpose.
+
+## Applying the kit — and not over-applying it
+
+The distinction the kit turns on is **whether ownership moves in-house**.
+
+**Inherits the kit** — ownership moves:
+
+- removing a material dependency and doing the work ourselves;
+- replacing it with our own implementation;
+- vendoring its source into the repo;
+- forking it and maintaining the fork.
+
+Each of those lands the capability in the
+`thin wrapper suitable for in-house ownership` trust class or removes it from
+the dependency set entirely, and either way we now own the behavior.
+
+**Does not inherit the kit** — ownership does not move:
+
+- a routine version bump of a trusted dependency **within its existing trust
+  class**, major or minor. The version-bump bar is the trust class's own
+  detection evidence and cadence, which already exist;
+- swapping one third-party dependency for another third-party dependency, where
+  trust simply moves to a different upstream. That is a trust-class decision and
+  a decision-record update, not an internalization;
+- adding a new dependency, which is covered by the trust-class rule.
+
+Over-applying the kit is a real failure, not a harmless excess of caution. A
+version bump forced to produce a corpus, conformance fixtures, and rollback
+criteria costs days for evidence that proves nothing — nobody rebuilt anything —
+and it teaches planners that the kit is boilerplate to be dispensed with, which
+is exactly how it stops being applied when it matters.
+
+The one exception: a version bump that **reclassifies** the dependency into
+in-house ownership — a bump taken as a fork, or an upgrade we decline in favor of
+owning the code — is an internalization wearing a bump's clothing, and it
+inherits the kit.
+
+## The non-material escape hatch
+
+A work item that removes a dependency inherits the kit **unless it explicitly
+justifies why the dependency is non-material**. A dependency is non-material when
+its failure or disappearance would not break anything a user can see and would
+not cost real time to replace — a one-line utility, a dev-only convenience, a
+package nothing imports anymore.
+
+The justification is written in the work item, in one sentence, and it is
+reviewable. What is not acceptable is silence: a removal ticket with no kit and
+no stated reason is not ready to build. That is the whole enforcement mechanism —
+the planner must either carry the criteria or say on the record why they do not
+apply.
+
+## For the operator at the gate
+
+The kit exists so that a removal ticket **explains how confidence will be rebuilt
+before the dependency is dropped**, in language that does not require reading the
+code. The seven questions are the readable form: did we test it on real inputs,
+does it do what the old one did, does it still reject bad input, what is still
+untested, where did the code come from and may we use it, how do callers move and
+how does it stay current, and what would make us go back.
+
+An operator who can read answers to those seven can judge the removal without
+being an engineer. A removal ticket that cannot answer them is not a plan — it is
+an intention.
+
+## Agent parity
+
+The kit is a governed markdown rule plus a decomposition-time expectation, not a
+runtime behavior, so Claude Code, Codex, Cursor, OpenCode, Antigravity, and
+Copilot all reach it identically through the shared rules mirror and the same
+`lisa-task-decomposition` skill. Cursor receives the pair flattened into two
+`.mdc` rules; Antigravity has no separate rules tree of its own and inherits the
+same content through the shared mirror — no runtime is missing the kit.
+
+The documented gap, uniform across all six runtimes: nothing enforces that a
+removal ticket actually carries the kit. No hook or lint gate fails a build when
+a dependency is deleted from a manifest with no corpus, no conformance fixtures,
+and no rollback criteria. Inheritance is carried by this rule, the decomposition
+skill, and review — the same posture as the trust-class rule it extends.

--- a/plugins/lisa-cursor/rules/dependency-internalization-kit.mdc
+++ b/plugins/lisa-cursor/rules/dependency-internalization-kit.mdc
@@ -1,0 +1,47 @@
+---
+description: "Dependency Internalization Kit (load-bearing)"
+alwaysApply: true
+---
+
+# Dependency Internalization Kit (load-bearing)
+
+When a work item **removes, replaces, or internalizes** a material dependency,
+ownership of that capability moves in-house. The risk moves with it: we stop
+trusting an upstream project and start having to **prove we rebuilt the
+capability correctly**. The confidence-rebuild kit is the standing acceptance
+bar for that proof, so internalization work never has to guess at its own tests.
+
+The kit is seven required evidence types. Each leads with the plain question it
+answers:
+
+1. **Real corpus** — did we test it on real inputs, not toy examples?
+2. **Conformance fixtures** — does the new code do what the dependency did?
+3. **Negative fixtures** — does it still reject what it should reject?
+4. **Coverage as a gap detector** — what behavior is still untested?
+5. **Provenance and license review** — where did this code come from, and are we
+   allowed to use it?
+6. **Migration and update plan** — how do existing call sites move, and how does
+   the new code stay current?
+7. **Rollback or replacement criteria** — what would make us go back, and to
+   what?
+
+All seven are required. A partial kit is the finding: dropping the corpus leaves
+a toy-example pass, dropping negative fixtures leaves code that accepts garbage,
+and dropping rollback criteria leaves nobody able to say the internalization
+failed.
+
+**When the kit applies:** ownership moves in-house — the dependency is removed,
+replaced with our own code, vendored, or forked and maintained by us. That is
+usually a move into the `thin wrapper suitable for in-house ownership` trust
+class, or out of the dependency set entirely.
+
+**When the kit does NOT apply:** a routine version bump of a trusted dependency
+**within its existing trust class**. Ownership does not move, so there is no
+rebuilt capability to prove. Applying the kit there is over-application — it
+buys no confidence and makes ordinary upkeep expensive.
+
+A work item that removes, replaces, or internalizes a material dependency
+inherits all seven criteria unless it explicitly justifies why the dependency is
+**non-material**. Silence is not a justification.
+
+Full prose: [reference/dependency-internalization-kit.md](dependency-internalization-kit-reference.mdc).

--- a/plugins/lisa-cursor/skills/lisa-task-decomposition/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-task-decomposition/SKILL.md
@@ -99,6 +99,43 @@ unit proposes adding one, the work unit must, before it is buildable:
 If nobody can pick a class, that is the finding — resolve it before accepting
 the work unit, not after the package is installed.
 
+### 4.6. Inherit the Confidence-Rebuild Kit When Ownership Moves In-House
+
+Step 4.5 covers dependencies a task proposes to **add**. This step covers
+dependencies a task proposes to **remove, replace, or internalize** — vendor,
+fork-and-maintain, or reimplement ourselves.
+
+When ownership moves in-house, the risk stops being "do we trust upstream" and
+becomes "did we prove we rebuilt the capability." A work unit that moves a
+material dependency in-house **inherits all seven acceptance criteria** of the
+`dependency-internalization-kit` rule, each written as an acceptance criterion
+of the work unit:
+
+1. **Real corpus** — did we test it on real inputs, not toy examples?
+2. **Conformance fixtures** — does the new code do what the dependency did?
+3. **Negative fixtures** — does it still reject what it should reject?
+4. **Coverage as a gap detector** — what behavior is still untested?
+5. **Provenance and license review** — where did this code come from, and are we
+   allowed to use it?
+6. **Migration and update plan** — how do existing call sites move, and how does
+   the new code stay current?
+7. **Rollback or replacement criteria** — what would make us go back, and to
+   what?
+
+The only way out is an **explicit non-material justification** written into the
+work unit — one reviewable sentence saying why this dependency's failure or
+disappearance breaks nothing a user can see and costs no real time to replace.
+Silence is not a justification.
+
+**Do not over-apply the kit.** A routine version bump of a trusted dependency
+**within its existing trust class** does not move ownership, so it does not
+inherit the kit — its bar is that trust class's own detection evidence and
+cadence. The same is true of swapping one third-party dependency for another,
+which moves trust to a different upstream rather than in-house. Add the kit only
+when ownership moves in-house; the exception is a bump taken *as* a fork or
+declined *in favor of* owning the code, which is an internalization regardless of
+how the ticket is titled.
+
 ### 5. Determine Execution Order
 
 - Place foundational tasks first (types, schemas, interfaces, shared utilities)
@@ -147,6 +184,7 @@ Map each task to the skills needed to complete it. This enables delegation to sp
 - Do not create tasks that cannot be verified -- if you cannot define how to prove it is done, the task is not well-scoped
 - Every Task / Bug / Sub-task / Improvement is scoped to exactly one repo -- if the work spans repos, split into per-repo work units under a shared parent Story (see step 1.5)
 - Any task proposing a new material dependency names its trust class, states that class's required evidence and whether human ratification is needed, and updates `.lisa/DEPENDENCY_DECISIONS.md` in the same change (see step 4.5) -- a proposed material dependency with no named class is not ready to build
+- Any task removing, replacing, or internalizing a material dependency carries all seven confidence-rebuild kit criteria -- corpus, conformance, negative fixtures, coverage-as-gap-detector, provenance/license, migration/update plan, and rollback criteria (see step 4.6) -- unless it explicitly justifies why the dependency is non-material; a within-trust-class version bump does not carry the kit
 - Keep tasks ordered so that no task references work that has not been completed by a prior task
 - Flag any task that requires access, permissions, or external input not yet available
 - Prefer more small tasks over fewer large tasks -- smaller tasks are easier to verify and less risky to fail

--- a/plugins/lisa/.codex-plugin/skills/lisa-task-decomposition/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-task-decomposition/SKILL.md
@@ -99,6 +99,43 @@ unit proposes adding one, the work unit must, before it is buildable:
 If nobody can pick a class, that is the finding — resolve it before accepting
 the work unit, not after the package is installed.
 
+### 4.6. Inherit the Confidence-Rebuild Kit When Ownership Moves In-House
+
+Step 4.5 covers dependencies a task proposes to **add**. This step covers
+dependencies a task proposes to **remove, replace, or internalize** — vendor,
+fork-and-maintain, or reimplement ourselves.
+
+When ownership moves in-house, the risk stops being "do we trust upstream" and
+becomes "did we prove we rebuilt the capability." A work unit that moves a
+material dependency in-house **inherits all seven acceptance criteria** of the
+`dependency-internalization-kit` rule, each written as an acceptance criterion
+of the work unit:
+
+1. **Real corpus** — did we test it on real inputs, not toy examples?
+2. **Conformance fixtures** — does the new code do what the dependency did?
+3. **Negative fixtures** — does it still reject what it should reject?
+4. **Coverage as a gap detector** — what behavior is still untested?
+5. **Provenance and license review** — where did this code come from, and are we
+   allowed to use it?
+6. **Migration and update plan** — how do existing call sites move, and how does
+   the new code stay current?
+7. **Rollback or replacement criteria** — what would make us go back, and to
+   what?
+
+The only way out is an **explicit non-material justification** written into the
+work unit — one reviewable sentence saying why this dependency's failure or
+disappearance breaks nothing a user can see and costs no real time to replace.
+Silence is not a justification.
+
+**Do not over-apply the kit.** A routine version bump of a trusted dependency
+**within its existing trust class** does not move ownership, so it does not
+inherit the kit — its bar is that trust class's own detection evidence and
+cadence. The same is true of swapping one third-party dependency for another,
+which moves trust to a different upstream rather than in-house. Add the kit only
+when ownership moves in-house; the exception is a bump taken *as* a fork or
+declined *in favor of* owning the code, which is an internalization regardless of
+how the ticket is titled.
+
 ### 5. Determine Execution Order
 
 - Place foundational tasks first (types, schemas, interfaces, shared utilities)
@@ -147,6 +184,7 @@ Map each task to the skills needed to complete it. This enables delegation to sp
 - Do not create tasks that cannot be verified -- if you cannot define how to prove it is done, the task is not well-scoped
 - Every Task / Bug / Sub-task / Improvement is scoped to exactly one repo -- if the work spans repos, split into per-repo work units under a shared parent Story (see step 1.5)
 - Any task proposing a new material dependency names its trust class, states that class's required evidence and whether human ratification is needed, and updates `.lisa/DEPENDENCY_DECISIONS.md` in the same change (see step 4.5) -- a proposed material dependency with no named class is not ready to build
+- Any task removing, replacing, or internalizing a material dependency carries all seven confidence-rebuild kit criteria -- corpus, conformance, negative fixtures, coverage-as-gap-detector, provenance/license, migration/update plan, and rollback criteria (see step 4.6) -- unless it explicitly justifies why the dependency is non-material; a within-trust-class version bump does not carry the kit
 - Keep tasks ordered so that no task references work that has not been completed by a prior task
 - Flag any task that requires access, permissions, or external input not yet available
 - Prefer more small tasks over fewer large tasks -- smaller tasks are easier to verify and less risky to fail

--- a/plugins/lisa/rules/eager/dependency-internalization-kit.md
+++ b/plugins/lisa/rules/eager/dependency-internalization-kit.md
@@ -1,0 +1,42 @@
+# Dependency Internalization Kit (load-bearing)
+
+When a work item **removes, replaces, or internalizes** a material dependency,
+ownership of that capability moves in-house. The risk moves with it: we stop
+trusting an upstream project and start having to **prove we rebuilt the
+capability correctly**. The confidence-rebuild kit is the standing acceptance
+bar for that proof, so internalization work never has to guess at its own tests.
+
+The kit is seven required evidence types. Each leads with the plain question it
+answers:
+
+1. **Real corpus** — did we test it on real inputs, not toy examples?
+2. **Conformance fixtures** — does the new code do what the dependency did?
+3. **Negative fixtures** — does it still reject what it should reject?
+4. **Coverage as a gap detector** — what behavior is still untested?
+5. **Provenance and license review** — where did this code come from, and are we
+   allowed to use it?
+6. **Migration and update plan** — how do existing call sites move, and how does
+   the new code stay current?
+7. **Rollback or replacement criteria** — what would make us go back, and to
+   what?
+
+All seven are required. A partial kit is the finding: dropping the corpus leaves
+a toy-example pass, dropping negative fixtures leaves code that accepts garbage,
+and dropping rollback criteria leaves nobody able to say the internalization
+failed.
+
+**When the kit applies:** ownership moves in-house — the dependency is removed,
+replaced with our own code, vendored, or forked and maintained by us. That is
+usually a move into the `thin wrapper suitable for in-house ownership` trust
+class, or out of the dependency set entirely.
+
+**When the kit does NOT apply:** a routine version bump of a trusted dependency
+**within its existing trust class**. Ownership does not move, so there is no
+rebuilt capability to prove. Applying the kit there is over-application — it
+buys no confidence and makes ordinary upkeep expensive.
+
+A work item that removes, replaces, or internalizes a material dependency
+inherits all seven criteria unless it explicitly justifies why the dependency is
+**non-material**. Silence is not a justification.
+
+Full prose: [reference/dependency-internalization-kit.md](../reference/dependency-internalization-kit.md).

--- a/plugins/lisa/rules/reference/dependency-internalization-kit.md
+++ b/plugins/lisa/rules/reference/dependency-internalization-kit.md
@@ -1,0 +1,197 @@
+# Dependency Internalization Kit
+
+Taking a dependency is a decision about trust: we believe someone else's code
+works. Dropping one reverses that decision without reversing the obligation —
+the capability still has to work, and now it is ours. The risk does not
+disappear at the moment the package is uninstalled; it **changes shape**, from
+"is upstream trustworthy?" to "did we actually rebuild what upstream did?"
+
+The confidence-rebuild kit is the standing answer to that second question. It is
+a reusable set of acceptance criteria that any removal, replacement, or
+internalization work item inherits, so the evidence bar is decided once instead
+of guessed at per ticket by whoever happens to write the tests.
+
+The kit pairs with the other two dependency surfaces:
+`.lisa/DEPENDENCY_DECISIONS.md` records *what we decided*, the
+[dependency-trust-classes](dependency-trust-classes.md) rule says *what bar the
+dependency had to clear to be there*, and this kit says *what proof we owe when
+we take the capability back*.
+
+## The seven required evidence types
+
+Each is stated as the plain question it answers, because the person deciding
+whether a removal is safe to ship is often not the person who wrote the code.
+
+### 1. Real corpus — did we test it on real inputs, not toy examples?
+
+The replacement must be exercised against **representative real inputs** drawn
+from actual usage: production samples, recorded fixtures, historical files, real
+config, the actual shapes the old dependency saw. Hand-written happy-path
+examples are not a corpus. They are written by the same person who wrote the
+implementation, from the same mental model, so they agree with the bug.
+
+The acceptance criterion names where the corpus came from and roughly how big it
+is. "We ran it on the 400 config files already in the repo" is a corpus. "We
+tested it with `{a: 1}`" is not.
+
+If real inputs cannot be obtained — because they are sensitive, or the capability
+is new-shaped — say so explicitly and name what stands in for them. An unstated
+absence reads as coverage that does not exist.
+
+### 2. Conformance fixtures — does the new code do what the dependency did?
+
+The replacement must be shown to **match the old dependency's behavior** on the
+behavior we actually rely on. The strongest form is a differential test: run both
+implementations over the corpus and assert the outputs agree, while the
+dependency is still installed. That is why the kit belongs on the *removal*
+ticket and not a follow-up — once the dependency is gone, the oracle is gone too.
+
+Where a differential run is impossible, conformance fixtures are captured from
+the old dependency's output *before* removal and asserted against afterwards.
+
+Deliberate divergences are allowed and must be **written down** as divergences.
+An intentional behavior change that nobody recorded is indistinguishable from a
+regression six months later.
+
+### 3. Negative fixtures — does it still reject what it should reject?
+
+Most dependencies do half their work by **refusing** things: rejecting malformed
+input, erroring on out-of-range values, failing closed on bad credentials.
+Conformance fixtures over valid input never test that half, and a replacement
+that accepts everything passes them all.
+
+Negative fixtures assert the replacement still fails on what the dependency
+failed on — and fails the same *way* where callers depend on the error type or
+message. This is the criterion most often dropped, and its absence is how a
+validation library gets internalized into a function that returns `true`.
+
+### 4. Coverage as a gap detector — what behavior is still untested?
+
+Coverage on internalization work is used to **find untested behavior**, not to
+report a number. The criterion is a review of the uncovered lines and branches
+with a stated disposition for each: tested, deliberately untested with a reason,
+or a gap to close before shipping.
+
+A coverage percentage on its own proves nothing here — new code written
+alongside its own tests reaches a high number trivially while the branch that
+matters is the one nobody thought of. The evidence is the *gap list*, and it is
+acceptable for that list to end with "none".
+
+### 5. Provenance and license review — where did this code come from, and are we allowed to use it?
+
+Internalized code has a source: written from scratch against a spec, adapted
+from the dependency's implementation, vendored wholesale, or copied from docs or
+an answer online. The work item must **say which**, because that is what
+determines our license obligation.
+
+Adapting or vendoring carries the upstream license with it — attribution,
+notice files, and copyleft terms follow the code even when the package does not.
+A permissive license is not "no obligation"; it is usually an attribution
+obligation.
+
+The criterion states the origin, the license, and what we have to do about it. If
+the answer is "written from scratch without reading their source," say that too —
+it is the cleanest provenance available and worth recording.
+
+### 6. Migration and update plan — how do existing call sites move, and how does the new code stay current?
+
+Two halves, both required:
+
+- **Migration**: every existing call site is enumerated and moved, in this change
+  or on a named schedule. A replacement nobody calls is not an internalization —
+  it is a second implementation, and the dependency is still installed.
+- **Staying current**: the capability the dependency tracked usually keeps
+  moving — a spec revises, a format gains a version, a platform changes. Name
+  who watches for that and what triggers an update. "Upstream did this for us"
+  was a real service, and dropping the dependency dropped it.
+
+### 7. Rollback or replacement criteria — what would make us go back, and to what?
+
+Written **before** the removal ships, while it is still a technical judgment
+rather than an argument during an incident. The criterion names:
+
+- the observable conditions that mean the internalization failed — defect rate,
+  a class of input we cannot handle, maintenance cost we are not paying;
+- what we do when they are met — reinstall the dependency, or pick a different
+  one, named;
+- how long the rollback stays cheap, and what makes it expensive.
+
+"We will fix forward" is a valid answer only if someone wrote it down on purpose.
+
+## Applying the kit — and not over-applying it
+
+The distinction the kit turns on is **whether ownership moves in-house**.
+
+**Inherits the kit** — ownership moves:
+
+- removing a material dependency and doing the work ourselves;
+- replacing it with our own implementation;
+- vendoring its source into the repo;
+- forking it and maintaining the fork.
+
+Each of those lands the capability in the
+`thin wrapper suitable for in-house ownership` trust class or removes it from
+the dependency set entirely, and either way we now own the behavior.
+
+**Does not inherit the kit** — ownership does not move:
+
+- a routine version bump of a trusted dependency **within its existing trust
+  class**, major or minor. The version-bump bar is the trust class's own
+  detection evidence and cadence, which already exist;
+- swapping one third-party dependency for another third-party dependency, where
+  trust simply moves to a different upstream. That is a trust-class decision and
+  a decision-record update, not an internalization;
+- adding a new dependency, which is covered by the trust-class rule.
+
+Over-applying the kit is a real failure, not a harmless excess of caution. A
+version bump forced to produce a corpus, conformance fixtures, and rollback
+criteria costs days for evidence that proves nothing — nobody rebuilt anything —
+and it teaches planners that the kit is boilerplate to be dispensed with, which
+is exactly how it stops being applied when it matters.
+
+The one exception: a version bump that **reclassifies** the dependency into
+in-house ownership — a bump taken as a fork, or an upgrade we decline in favor of
+owning the code — is an internalization wearing a bump's clothing, and it
+inherits the kit.
+
+## The non-material escape hatch
+
+A work item that removes a dependency inherits the kit **unless it explicitly
+justifies why the dependency is non-material**. A dependency is non-material when
+its failure or disappearance would not break anything a user can see and would
+not cost real time to replace — a one-line utility, a dev-only convenience, a
+package nothing imports anymore.
+
+The justification is written in the work item, in one sentence, and it is
+reviewable. What is not acceptable is silence: a removal ticket with no kit and
+no stated reason is not ready to build. That is the whole enforcement mechanism —
+the planner must either carry the criteria or say on the record why they do not
+apply.
+
+## For the operator at the gate
+
+The kit exists so that a removal ticket **explains how confidence will be rebuilt
+before the dependency is dropped**, in language that does not require reading the
+code. The seven questions are the readable form: did we test it on real inputs,
+does it do what the old one did, does it still reject bad input, what is still
+untested, where did the code come from and may we use it, how do callers move and
+how does it stay current, and what would make us go back.
+
+An operator who can read answers to those seven can judge the removal without
+being an engineer. A removal ticket that cannot answer them is not a plan — it is
+an intention.
+
+## Agent parity
+
+The kit is a governed markdown rule plus a decomposition-time expectation, not a
+runtime behavior, so Claude Code, Codex, Cursor, OpenCode, Antigravity, and
+Copilot all reach it identically through the shared rules mirror and the same
+`lisa-task-decomposition` skill. Cursor receives the pair flattened into two
+`.mdc` rules; Antigravity has no separate rules tree of its own and inherits the
+same content through the shared mirror — no runtime is missing the kit.
+
+The documented gap, uniform across all six runtimes: nothing enforces that a
+removal ticket actually carries the kit. No hook or lint gate fails a build when
+a dependency is deleted from a manifest with no corpus, no conformance fixtures,
+and no rollback criteria. Inheritance is carried by this rule, the decomposition
+skill, and review — the same posture as the trust-class rule it extends.

--- a/plugins/lisa/skills/lisa-task-decomposition/SKILL.md
+++ b/plugins/lisa/skills/lisa-task-decomposition/SKILL.md
@@ -99,6 +99,43 @@ unit proposes adding one, the work unit must, before it is buildable:
 If nobody can pick a class, that is the finding — resolve it before accepting
 the work unit, not after the package is installed.
 
+### 4.6. Inherit the Confidence-Rebuild Kit When Ownership Moves In-House
+
+Step 4.5 covers dependencies a task proposes to **add**. This step covers
+dependencies a task proposes to **remove, replace, or internalize** — vendor,
+fork-and-maintain, or reimplement ourselves.
+
+When ownership moves in-house, the risk stops being "do we trust upstream" and
+becomes "did we prove we rebuilt the capability." A work unit that moves a
+material dependency in-house **inherits all seven acceptance criteria** of the
+`dependency-internalization-kit` rule, each written as an acceptance criterion
+of the work unit:
+
+1. **Real corpus** — did we test it on real inputs, not toy examples?
+2. **Conformance fixtures** — does the new code do what the dependency did?
+3. **Negative fixtures** — does it still reject what it should reject?
+4. **Coverage as a gap detector** — what behavior is still untested?
+5. **Provenance and license review** — where did this code come from, and are we
+   allowed to use it?
+6. **Migration and update plan** — how do existing call sites move, and how does
+   the new code stay current?
+7. **Rollback or replacement criteria** — what would make us go back, and to
+   what?
+
+The only way out is an **explicit non-material justification** written into the
+work unit — one reviewable sentence saying why this dependency's failure or
+disappearance breaks nothing a user can see and costs no real time to replace.
+Silence is not a justification.
+
+**Do not over-apply the kit.** A routine version bump of a trusted dependency
+**within its existing trust class** does not move ownership, so it does not
+inherit the kit — its bar is that trust class's own detection evidence and
+cadence. The same is true of swapping one third-party dependency for another,
+which moves trust to a different upstream rather than in-house. Add the kit only
+when ownership moves in-house; the exception is a bump taken *as* a fork or
+declined *in favor of* owning the code, which is an internalization regardless of
+how the ticket is titled.
+
 ### 5. Determine Execution Order
 
 - Place foundational tasks first (types, schemas, interfaces, shared utilities)
@@ -147,6 +184,7 @@ Map each task to the skills needed to complete it. This enables delegation to sp
 - Do not create tasks that cannot be verified -- if you cannot define how to prove it is done, the task is not well-scoped
 - Every Task / Bug / Sub-task / Improvement is scoped to exactly one repo -- if the work spans repos, split into per-repo work units under a shared parent Story (see step 1.5)
 - Any task proposing a new material dependency names its trust class, states that class's required evidence and whether human ratification is needed, and updates `.lisa/DEPENDENCY_DECISIONS.md` in the same change (see step 4.5) -- a proposed material dependency with no named class is not ready to build
+- Any task removing, replacing, or internalizing a material dependency carries all seven confidence-rebuild kit criteria -- corpus, conformance, negative fixtures, coverage-as-gap-detector, provenance/license, migration/update plan, and rollback criteria (see step 4.6) -- unless it explicitly justifies why the dependency is non-material; a within-trust-class version bump does not carry the kit
 - Keep tasks ordered so that no task references work that has not been completed by a prior task
 - Flag any task that requires access, permissions, or external input not yet available
 - Prefer more small tasks over fewer large tasks -- smaller tasks are easier to verify and less risky to fail

--- a/plugins/src/base/rules/eager/dependency-internalization-kit.md
+++ b/plugins/src/base/rules/eager/dependency-internalization-kit.md
@@ -1,0 +1,42 @@
+# Dependency Internalization Kit (load-bearing)
+
+When a work item **removes, replaces, or internalizes** a material dependency,
+ownership of that capability moves in-house. The risk moves with it: we stop
+trusting an upstream project and start having to **prove we rebuilt the
+capability correctly**. The confidence-rebuild kit is the standing acceptance
+bar for that proof, so internalization work never has to guess at its own tests.
+
+The kit is seven required evidence types. Each leads with the plain question it
+answers:
+
+1. **Real corpus** — did we test it on real inputs, not toy examples?
+2. **Conformance fixtures** — does the new code do what the dependency did?
+3. **Negative fixtures** — does it still reject what it should reject?
+4. **Coverage as a gap detector** — what behavior is still untested?
+5. **Provenance and license review** — where did this code come from, and are we
+   allowed to use it?
+6. **Migration and update plan** — how do existing call sites move, and how does
+   the new code stay current?
+7. **Rollback or replacement criteria** — what would make us go back, and to
+   what?
+
+All seven are required. A partial kit is the finding: dropping the corpus leaves
+a toy-example pass, dropping negative fixtures leaves code that accepts garbage,
+and dropping rollback criteria leaves nobody able to say the internalization
+failed.
+
+**When the kit applies:** ownership moves in-house — the dependency is removed,
+replaced with our own code, vendored, or forked and maintained by us. That is
+usually a move into the `thin wrapper suitable for in-house ownership` trust
+class, or out of the dependency set entirely.
+
+**When the kit does NOT apply:** a routine version bump of a trusted dependency
+**within its existing trust class**. Ownership does not move, so there is no
+rebuilt capability to prove. Applying the kit there is over-application — it
+buys no confidence and makes ordinary upkeep expensive.
+
+A work item that removes, replaces, or internalizes a material dependency
+inherits all seven criteria unless it explicitly justifies why the dependency is
+**non-material**. Silence is not a justification.
+
+Full prose: [reference/dependency-internalization-kit.md](../reference/dependency-internalization-kit.md).

--- a/plugins/src/base/rules/reference/dependency-internalization-kit.md
+++ b/plugins/src/base/rules/reference/dependency-internalization-kit.md
@@ -1,0 +1,197 @@
+# Dependency Internalization Kit
+
+Taking a dependency is a decision about trust: we believe someone else's code
+works. Dropping one reverses that decision without reversing the obligation —
+the capability still has to work, and now it is ours. The risk does not
+disappear at the moment the package is uninstalled; it **changes shape**, from
+"is upstream trustworthy?" to "did we actually rebuild what upstream did?"
+
+The confidence-rebuild kit is the standing answer to that second question. It is
+a reusable set of acceptance criteria that any removal, replacement, or
+internalization work item inherits, so the evidence bar is decided once instead
+of guessed at per ticket by whoever happens to write the tests.
+
+The kit pairs with the other two dependency surfaces:
+`.lisa/DEPENDENCY_DECISIONS.md` records *what we decided*, the
+[dependency-trust-classes](dependency-trust-classes.md) rule says *what bar the
+dependency had to clear to be there*, and this kit says *what proof we owe when
+we take the capability back*.
+
+## The seven required evidence types
+
+Each is stated as the plain question it answers, because the person deciding
+whether a removal is safe to ship is often not the person who wrote the code.
+
+### 1. Real corpus — did we test it on real inputs, not toy examples?
+
+The replacement must be exercised against **representative real inputs** drawn
+from actual usage: production samples, recorded fixtures, historical files, real
+config, the actual shapes the old dependency saw. Hand-written happy-path
+examples are not a corpus. They are written by the same person who wrote the
+implementation, from the same mental model, so they agree with the bug.
+
+The acceptance criterion names where the corpus came from and roughly how big it
+is. "We ran it on the 400 config files already in the repo" is a corpus. "We
+tested it with `{a: 1}`" is not.
+
+If real inputs cannot be obtained — because they are sensitive, or the capability
+is new-shaped — say so explicitly and name what stands in for them. An unstated
+absence reads as coverage that does not exist.
+
+### 2. Conformance fixtures — does the new code do what the dependency did?
+
+The replacement must be shown to **match the old dependency's behavior** on the
+behavior we actually rely on. The strongest form is a differential test: run both
+implementations over the corpus and assert the outputs agree, while the
+dependency is still installed. That is why the kit belongs on the *removal*
+ticket and not a follow-up — once the dependency is gone, the oracle is gone too.
+
+Where a differential run is impossible, conformance fixtures are captured from
+the old dependency's output *before* removal and asserted against afterwards.
+
+Deliberate divergences are allowed and must be **written down** as divergences.
+An intentional behavior change that nobody recorded is indistinguishable from a
+regression six months later.
+
+### 3. Negative fixtures — does it still reject what it should reject?
+
+Most dependencies do half their work by **refusing** things: rejecting malformed
+input, erroring on out-of-range values, failing closed on bad credentials.
+Conformance fixtures over valid input never test that half, and a replacement
+that accepts everything passes them all.
+
+Negative fixtures assert the replacement still fails on what the dependency
+failed on — and fails the same *way* where callers depend on the error type or
+message. This is the criterion most often dropped, and its absence is how a
+validation library gets internalized into a function that returns `true`.
+
+### 4. Coverage as a gap detector — what behavior is still untested?
+
+Coverage on internalization work is used to **find untested behavior**, not to
+report a number. The criterion is a review of the uncovered lines and branches
+with a stated disposition for each: tested, deliberately untested with a reason,
+or a gap to close before shipping.
+
+A coverage percentage on its own proves nothing here — new code written
+alongside its own tests reaches a high number trivially while the branch that
+matters is the one nobody thought of. The evidence is the *gap list*, and it is
+acceptable for that list to end with "none".
+
+### 5. Provenance and license review — where did this code come from, and are we allowed to use it?
+
+Internalized code has a source: written from scratch against a spec, adapted
+from the dependency's implementation, vendored wholesale, or copied from docs or
+an answer online. The work item must **say which**, because that is what
+determines our license obligation.
+
+Adapting or vendoring carries the upstream license with it — attribution,
+notice files, and copyleft terms follow the code even when the package does not.
+A permissive license is not "no obligation"; it is usually an attribution
+obligation.
+
+The criterion states the origin, the license, and what we have to do about it. If
+the answer is "written from scratch without reading their source," say that too —
+it is the cleanest provenance available and worth recording.
+
+### 6. Migration and update plan — how do existing call sites move, and how does the new code stay current?
+
+Two halves, both required:
+
+- **Migration**: every existing call site is enumerated and moved, in this change
+  or on a named schedule. A replacement nobody calls is not an internalization —
+  it is a second implementation, and the dependency is still installed.
+- **Staying current**: the capability the dependency tracked usually keeps
+  moving — a spec revises, a format gains a version, a platform changes. Name
+  who watches for that and what triggers an update. "Upstream did this for us"
+  was a real service, and dropping the dependency dropped it.
+
+### 7. Rollback or replacement criteria — what would make us go back, and to what?
+
+Written **before** the removal ships, while it is still a technical judgment
+rather than an argument during an incident. The criterion names:
+
+- the observable conditions that mean the internalization failed — defect rate,
+  a class of input we cannot handle, maintenance cost we are not paying;
+- what we do when they are met — reinstall the dependency, or pick a different
+  one, named;
+- how long the rollback stays cheap, and what makes it expensive.
+
+"We will fix forward" is a valid answer only if someone wrote it down on purpose.
+
+## Applying the kit — and not over-applying it
+
+The distinction the kit turns on is **whether ownership moves in-house**.
+
+**Inherits the kit** — ownership moves:
+
+- removing a material dependency and doing the work ourselves;
+- replacing it with our own implementation;
+- vendoring its source into the repo;
+- forking it and maintaining the fork.
+
+Each of those lands the capability in the
+`thin wrapper suitable for in-house ownership` trust class or removes it from
+the dependency set entirely, and either way we now own the behavior.
+
+**Does not inherit the kit** — ownership does not move:
+
+- a routine version bump of a trusted dependency **within its existing trust
+  class**, major or minor. The version-bump bar is the trust class's own
+  detection evidence and cadence, which already exist;
+- swapping one third-party dependency for another third-party dependency, where
+  trust simply moves to a different upstream. That is a trust-class decision and
+  a decision-record update, not an internalization;
+- adding a new dependency, which is covered by the trust-class rule.
+
+Over-applying the kit is a real failure, not a harmless excess of caution. A
+version bump forced to produce a corpus, conformance fixtures, and rollback
+criteria costs days for evidence that proves nothing — nobody rebuilt anything —
+and it teaches planners that the kit is boilerplate to be dispensed with, which
+is exactly how it stops being applied when it matters.
+
+The one exception: a version bump that **reclassifies** the dependency into
+in-house ownership — a bump taken as a fork, or an upgrade we decline in favor of
+owning the code — is an internalization wearing a bump's clothing, and it
+inherits the kit.
+
+## The non-material escape hatch
+
+A work item that removes a dependency inherits the kit **unless it explicitly
+justifies why the dependency is non-material**. A dependency is non-material when
+its failure or disappearance would not break anything a user can see and would
+not cost real time to replace — a one-line utility, a dev-only convenience, a
+package nothing imports anymore.
+
+The justification is written in the work item, in one sentence, and it is
+reviewable. What is not acceptable is silence: a removal ticket with no kit and
+no stated reason is not ready to build. That is the whole enforcement mechanism —
+the planner must either carry the criteria or say on the record why they do not
+apply.
+
+## For the operator at the gate
+
+The kit exists so that a removal ticket **explains how confidence will be rebuilt
+before the dependency is dropped**, in language that does not require reading the
+code. The seven questions are the readable form: did we test it on real inputs,
+does it do what the old one did, does it still reject bad input, what is still
+untested, where did the code come from and may we use it, how do callers move and
+how does it stay current, and what would make us go back.
+
+An operator who can read answers to those seven can judge the removal without
+being an engineer. A removal ticket that cannot answer them is not a plan — it is
+an intention.
+
+## Agent parity
+
+The kit is a governed markdown rule plus a decomposition-time expectation, not a
+runtime behavior, so Claude Code, Codex, Cursor, OpenCode, Antigravity, and
+Copilot all reach it identically through the shared rules mirror and the same
+`lisa-task-decomposition` skill. Cursor receives the pair flattened into two
+`.mdc` rules; Antigravity has no separate rules tree of its own and inherits the
+same content through the shared mirror — no runtime is missing the kit.
+
+The documented gap, uniform across all six runtimes: nothing enforces that a
+removal ticket actually carries the kit. No hook or lint gate fails a build when
+a dependency is deleted from a manifest with no corpus, no conformance fixtures,
+and no rollback criteria. Inheritance is carried by this rule, the decomposition
+skill, and review — the same posture as the trust-class rule it extends.

--- a/plugins/src/base/skills/lisa-task-decomposition/SKILL.md
+++ b/plugins/src/base/skills/lisa-task-decomposition/SKILL.md
@@ -99,6 +99,43 @@ unit proposes adding one, the work unit must, before it is buildable:
 If nobody can pick a class, that is the finding — resolve it before accepting
 the work unit, not after the package is installed.
 
+### 4.6. Inherit the Confidence-Rebuild Kit When Ownership Moves In-House
+
+Step 4.5 covers dependencies a task proposes to **add**. This step covers
+dependencies a task proposes to **remove, replace, or internalize** — vendor,
+fork-and-maintain, or reimplement ourselves.
+
+When ownership moves in-house, the risk stops being "do we trust upstream" and
+becomes "did we prove we rebuilt the capability." A work unit that moves a
+material dependency in-house **inherits all seven acceptance criteria** of the
+`dependency-internalization-kit` rule, each written as an acceptance criterion
+of the work unit:
+
+1. **Real corpus** — did we test it on real inputs, not toy examples?
+2. **Conformance fixtures** — does the new code do what the dependency did?
+3. **Negative fixtures** — does it still reject what it should reject?
+4. **Coverage as a gap detector** — what behavior is still untested?
+5. **Provenance and license review** — where did this code come from, and are we
+   allowed to use it?
+6. **Migration and update plan** — how do existing call sites move, and how does
+   the new code stay current?
+7. **Rollback or replacement criteria** — what would make us go back, and to
+   what?
+
+The only way out is an **explicit non-material justification** written into the
+work unit — one reviewable sentence saying why this dependency's failure or
+disappearance breaks nothing a user can see and costs no real time to replace.
+Silence is not a justification.
+
+**Do not over-apply the kit.** A routine version bump of a trusted dependency
+**within its existing trust class** does not move ownership, so it does not
+inherit the kit — its bar is that trust class's own detection evidence and
+cadence. The same is true of swapping one third-party dependency for another,
+which moves trust to a different upstream rather than in-house. Add the kit only
+when ownership moves in-house; the exception is a bump taken *as* a fork or
+declined *in favor of* owning the code, which is an internalization regardless of
+how the ticket is titled.
+
 ### 5. Determine Execution Order
 
 - Place foundational tasks first (types, schemas, interfaces, shared utilities)
@@ -147,6 +184,7 @@ Map each task to the skills needed to complete it. This enables delegation to sp
 - Do not create tasks that cannot be verified -- if you cannot define how to prove it is done, the task is not well-scoped
 - Every Task / Bug / Sub-task / Improvement is scoped to exactly one repo -- if the work spans repos, split into per-repo work units under a shared parent Story (see step 1.5)
 - Any task proposing a new material dependency names its trust class, states that class's required evidence and whether human ratification is needed, and updates `.lisa/DEPENDENCY_DECISIONS.md` in the same change (see step 4.5) -- a proposed material dependency with no named class is not ready to build
+- Any task removing, replacing, or internalizing a material dependency carries all seven confidence-rebuild kit criteria -- corpus, conformance, negative fixtures, coverage-as-gap-detector, provenance/license, migration/update plan, and rollback criteria (see step 4.6) -- unless it explicitly justifies why the dependency is non-material; a within-trust-class version bump does not carry the kit
 - Keep tasks ordered so that no task references work that has not been completed by a prior task
 - Flag any task that requires access, permissions, or external input not yet available
 - Prefer more small tasks over fewer large tasks -- smaller tasks are easier to verify and less risky to fail

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -622,6 +622,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "ba4ba53863ef99be353c07c01195fa4ae2923ef2b2a5ad4427072802c260d208",
     "plugins/src/base/rules/eager/dependency-decision-records.md":
       "e22888f107906992e863fca50f26c2c4b124da7132535cacfac71e4f3085728f",
+    "plugins/src/base/rules/eager/dependency-internalization-kit.md":
+      "9e2cc78afffc477c14718390ed88c42f781911c51fb7c13dada497f9e956b1a3",
     "plugins/src/base/rules/eager/dependency-trust-classes.md":
       "43a0932a7b8d4fd075b66bfe778025d808a13d9aa61ae793e9eb2fc8a555a381",
     "plugins/src/base/rules/eager/documentation-source-paths.md":
@@ -684,6 +686,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "788a9d4dc2af7a928c3ccbb4d53a92856bb3544941ce512cfe38068d6b35850d",
     "plugins/src/base/rules/reference/dependency-decision-records.md":
       "84f9fb8fa0a606307e828ec355ccbf2258beeeb88795dd113abe9bb2c37db39f",
+    "plugins/src/base/rules/reference/dependency-internalization-kit.md":
+      "8c8e9bddbe2165905c3919ae9dd3d131b557cf9c7eb370393dfa85827076c73b",
     "plugins/src/base/rules/reference/dependency-trust-classes.md":
       "82216b80d4807e0ad302d04924032cc6a7a95b26f72ea853e378572a5c31821c",
     "plugins/src/base/rules/reference/documentation-source-paths.md":
@@ -1057,7 +1061,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-sync-down/SKILL.md":
       "c32e6a4e3115ca32b7d335e90d0a73b243c6c631a2d192568423be0cb5944e84",
     "plugins/src/base/skills/lisa-task-decomposition/SKILL.md":
-      "b8f44d501e38a8ebd3c9b566b983d3e97f1292d28688ff1d42ec2c582abebf93",
+      "d4c8bd6b36d827e609178e5192270a21bb392aa825a902f61e33a9fe73cda10c",
     "plugins/src/base/skills/lisa-task-triage/SKILL.md":
       "c6e11b6d195560e6bd7b51fede65c155567c35208801a700a26d95679b03484e",
     "plugins/src/base/skills/lisa-tdd-implementation/SKILL.md":
@@ -3304,6 +3308,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/rules/eager/config-resolution.md": true,
     "plugins/lisa-copilot/rules/eager/convergent-review.md": true,
     "plugins/lisa-copilot/rules/eager/dependency-decision-records.md": true,
+    "plugins/lisa-copilot/rules/eager/dependency-internalization-kit.md": true,
     "plugins/lisa-copilot/rules/eager/dependency-trust-classes.md": true,
     "plugins/lisa-copilot/rules/eager/documentation-source-paths.md": true,
     "plugins/lisa-copilot/rules/eager/empirical-inquiry.md": true,
@@ -3335,6 +3340,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/rules/reference/config-resolution.md": true,
     "plugins/lisa-copilot/rules/reference/convergent-review.md": true,
     "plugins/lisa-copilot/rules/reference/dependency-decision-records.md": true,
+    "plugins/lisa-copilot/rules/reference/dependency-internalization-kit.md": true,
     "plugins/lisa-copilot/rules/reference/dependency-trust-classes.md": true,
     "plugins/lisa-copilot/rules/reference/documentation-source-paths.md": true,
     "plugins/lisa-copilot/rules/reference/empirical-inquiry.md": true,
@@ -3673,6 +3679,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/rules/convergent-review.mdc": true,
     "plugins/lisa-cursor/rules/dependency-decision-records-reference.mdc": true,
     "plugins/lisa-cursor/rules/dependency-decision-records.mdc": true,
+    "plugins/lisa-cursor/rules/dependency-internalization-kit-reference.mdc": true,
+    "plugins/lisa-cursor/rules/dependency-internalization-kit.mdc": true,
     "plugins/lisa-cursor/rules/dependency-trust-classes-reference.mdc": true,
     "plugins/lisa-cursor/rules/dependency-trust-classes.mdc": true,
     "plugins/lisa-cursor/rules/documentation-source-paths-reference.mdc": true,
@@ -6049,6 +6057,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/rules/eager/config-resolution.md": true,
     "plugins/lisa/rules/eager/convergent-review.md": true,
     "plugins/lisa/rules/eager/dependency-decision-records.md": true,
+    "plugins/lisa/rules/eager/dependency-internalization-kit.md": true,
     "plugins/lisa/rules/eager/dependency-trust-classes.md": true,
     "plugins/lisa/rules/eager/documentation-source-paths.md": true,
     "plugins/lisa/rules/eager/empirical-inquiry.md": true,
@@ -6080,6 +6089,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/rules/reference/config-resolution.md": true,
     "plugins/lisa/rules/reference/convergent-review.md": true,
     "plugins/lisa/rules/reference/dependency-decision-records.md": true,
+    "plugins/lisa/rules/reference/dependency-internalization-kit.md": true,
     "plugins/lisa/rules/reference/dependency-trust-classes.md": true,
     "plugins/lisa/rules/reference/documentation-source-paths.md": true,
     "plugins/lisa/rules/reference/empirical-inquiry.md": true,
@@ -6579,6 +6589,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/rules/eager/config-resolution.md": true,
     "plugins/src/base/rules/eager/convergent-review.md": true,
     "plugins/src/base/rules/eager/dependency-decision-records.md": true,
+    "plugins/src/base/rules/eager/dependency-internalization-kit.md": true,
     "plugins/src/base/rules/eager/dependency-trust-classes.md": true,
     "plugins/src/base/rules/eager/documentation-source-paths.md": true,
     "plugins/src/base/rules/eager/empirical-inquiry.md": true,
@@ -6610,6 +6621,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/rules/reference/config-resolution.md": true,
     "plugins/src/base/rules/reference/convergent-review.md": true,
     "plugins/src/base/rules/reference/dependency-decision-records.md": true,
+    "plugins/src/base/rules/reference/dependency-internalization-kit.md": true,
     "plugins/src/base/rules/reference/dependency-trust-classes.md": true,
     "plugins/src/base/rules/reference/documentation-source-paths.md": true,
     "plugins/src/base/rules/reference/empirical-inquiry.md": true,
@@ -7582,6 +7594,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/e2e/ui-version-status.spec.ts": true,
     "tests/fixtures/automation-status/attention-needed-codex.json": true,
     "tests/fixtures/automation-status/partial-support-codex.json": true,
+    "tests/fixtures/dependency-internalization-kit/dependency-internalization-ticket.md": true,
+    "tests/fixtures/dependency-internalization-kit/version-bump-ticket.md": true,
     "tests/fixtures/dependency-trust-classes/dependency-addition-ticket.md": true,
     "tests/fixtures/doctor/not-ready-missing-config.json": true,
     "tests/fixtures/doctor/readiness/all-pass-assessed.json": true,
@@ -7946,6 +7960,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/create-only.test.ts": true,
     "tests/unit/strategies/debrief-reroute-contract.test.ts": true,
     "tests/unit/strategies/dependency-decision-records-rule-pair.test.ts": true,
+    "tests/unit/strategies/dependency-internalization-kit-rule-pair.test.ts": true,
     "tests/unit/strategies/dependency-trust-classes-rule-pair.test.ts": true,
     "tests/unit/strategies/distributed-content-round2-contract.test.ts": true,
     "tests/unit/strategies/doctor-automation-readiness.test.ts": true,

--- a/tests/fixtures/dependency-internalization-kit/dependency-internalization-ticket.md
+++ b/tests/fixtures/dependency-internalization-kit/dependency-internalization-ticket.md
@@ -1,0 +1,71 @@
+# [api] Replace the `slugify` dependency with an in-house slug builder
+
+**Labels:** `type:Task`, `priority:medium`, `repo:api`
+
+## Context / Business Value
+
+`slugify` is 60 lines of transliteration behind a package we upgrade twice a
+year. We already patch around two of its behaviors. This work unit takes the
+capability in-house so the slug rules stop being someone else's decision.
+
+## Dependency ownership move
+
+- **Dependency:** `slugify`
+- **Move:** removed and reimplemented in-house.
+- **Trust class after the move:** thin wrapper suitable for in-house ownership —
+  the capability leaves the dependency set and we own the code.
+- **Material?** Yes. Every public content URL is built from it, so a behavior
+  change is user-visible. The confidence-rebuild kit is inherited in full.
+
+## Acceptance criteria (confidence-rebuild kit)
+
+```gherkin
+Scenario: Real corpus -- did we test it on real inputs, not toy examples?
+  Given the 12,400 published titles already in the content table
+  When the in-house slug builder runs over all of them
+  Then every title produces a slug and the corpus source is named in the PR
+
+Scenario: Conformance fixtures -- does the new code do what the dependency did?
+  Given slugify is still installed during this change
+  When both implementations run over the real corpus
+  Then the outputs match on every title, and each deliberate divergence is
+    written down as a divergence rather than silently accepted
+
+Scenario: Negative fixtures -- does it still reject what it should reject?
+  Given inputs the dependency refused: empty strings, control characters, and
+    strings that transliterate to nothing
+  When the in-house builder receives them
+  Then it fails the same way, with the same error type callers already handle
+
+Scenario: Coverage as a gap detector -- what behavior is still untested?
+  Given coverage is collected over the new slug module
+  When the uncovered lines and branches are reviewed
+  Then each one has a stated disposition -- tested, deliberately untested with a
+    reason, or a gap closed before merge -- rather than a coverage percentage
+
+Scenario: Provenance and license review -- where did this code come from, and are we allowed to use it?
+  Given the in-house implementation was written from the Unicode transliteration
+    spec without copying slugify's source
+  When the change is reviewed
+  Then the work item states the origin and the license obligation it creates,
+    and no upstream notice or attribution requirement is carried in unrecorded
+
+Scenario: Migration and update plan -- how do existing call sites move, and how does the new code stay current?
+  Given the 31 call sites that import slugify today
+  When this change ships
+  Then all 31 import the in-house builder, the package is removed from the
+    manifest, and the work item names who watches the Unicode transliteration
+    tables for revisions and what triggers an update
+
+Scenario: Rollback or replacement criteria -- what would make us go back, and to what?
+  Given the internalization has shipped
+  When slug defects exceed one per release, or an input class appears that the
+    in-house builder cannot handle
+  Then we reinstall slugify at the pinned version, which stays a one-commit
+    revert for the two releases the old call sites remain in history
+```
+
+- **Verification:** Differential test over the real corpus while both
+  implementations are installed.
+- **Dependencies:** none.
+- **Skills:** lisa-tdd-implementation, lisa-test-strategy.

--- a/tests/fixtures/dependency-internalization-kit/version-bump-ticket.md
+++ b/tests/fixtures/dependency-internalization-kit/version-bump-ticket.md
@@ -1,0 +1,43 @@
+# [api] Bump `slugify` from 1.6.5 to 1.6.6
+
+**Labels:** `type:Task`, `priority:low`, `repo:api`
+
+## Context / Business Value
+
+Routine upkeep. 1.6.6 is a patch release fixing transliteration of two Turkish
+characters we do not currently emit. Nothing about how we use the package
+changes.
+
+## Dependency ownership move
+
+- **Dependency:** `slugify`
+- **Move:** none. Version bump only.
+- **Trust class:** thin wrapper suitable for in-house ownership — unchanged
+  before and after this bump.
+- **Ownership stays with upstream**, so the confidence-rebuild kit does **not**
+  apply. The bar here is this trust class's own detection evidence and cadence,
+  which already exist: our unit tests over the wrapped behavior, re-read at every
+  upgrade.
+
+Applying the internalization kit to this ticket would be over-application — no
+capability was rebuilt, so a corpus, conformance fixtures, and rollback criteria
+would prove nothing and cost days.
+
+## Acceptance criteria
+
+```gherkin
+Scenario: The existing slug tests still pass on the new version
+  Given slugify is upgraded to 1.6.6
+  When the existing unit tests over the wrapped slug behavior run
+  Then they pass unchanged, with no new fixtures added
+
+Scenario: The decision record reflects the review
+  Given the version changed
+  When the change is reviewed
+  Then .lisa/DEPENDENCY_DECISIONS.md has its Last reviewed date updated and its
+    trust class left unchanged
+```
+
+- **Verification:** Existing unit test suite.
+- **Dependencies:** none.
+- **Skills:** lisa-tdd-implementation.

--- a/tests/unit/strategies/dependency-internalization-kit-rule-pair.test.ts
+++ b/tests/unit/strategies/dependency-internalization-kit-rule-pair.test.ts
@@ -1,0 +1,318 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const EAGER = "plugins/src/base/rules/eager/dependency-internalization-kit.md";
+const REFERENCE =
+  "plugins/src/base/rules/reference/dependency-internalization-kit.md";
+const DECOMPOSITION =
+  "plugins/src/base/skills/lisa-task-decomposition/SKILL.md";
+const INTERNALIZATION_FIXTURE =
+  "tests/fixtures/dependency-internalization-kit/dependency-internalization-ticket.md";
+const BUMP_FIXTURE =
+  "tests/fixtures/dependency-internalization-kit/version-bump-ticket.md";
+
+/**
+ * Collapses markdown soft-wrapping so prose assertions survive reflowing by the
+ * formatter. The contract is the sentence, not where the line happened to break.
+ *
+ * @param text - Raw markdown source read from a rule, skill, or fixture file.
+ * @returns The same text with every run of whitespace collapsed to one space.
+ */
+const flat = (text: string): string => text.replace(/\s+/gu, " ");
+
+/**
+ * The seven evidence types, each paired with the plain question it answers.
+ * The question is the operator-readable half — a non-technical reader judges a
+ * removal by whether these seven have answers — so both halves are asserted on
+ * every surface. Drift in either is drift in the contract.
+ */
+const KIT_CRITERIA = [
+  ["Real corpus", "did we test it on real inputs, not toy examples?"],
+  ["Conformance fixtures", "does the new code do what the dependency did?"],
+  ["Negative fixtures", "does it still reject what it should reject?"],
+  ["Coverage as a gap detector", "what behavior is still untested?"],
+  [
+    "Provenance and license review",
+    "where did this code come from, and are we allowed to use it?",
+  ],
+  [
+    "Migration and update plan",
+    "how do existing call sites move, and how does the new code stay current?",
+  ],
+  [
+    "Rollback or replacement criteria",
+    "what would make us go back, and to what?",
+  ],
+] as const;
+
+/** The trust class an internalized capability lands in. */
+const IN_HOUSE_CLASS = "thin wrapper suitable for in-house ownership";
+
+describe("dependency-internalization-kit eager/reference rule pair", () => {
+  it("ships the canonical eager and reference pair from plugin source", () => {
+    const eager = readFileSync(EAGER, "utf8");
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(eager).toContain("# Dependency Internalization Kit (load-bearing)");
+    expect(eager).toContain(
+      "[reference/dependency-internalization-kit.md](../reference/dependency-internalization-kit.md)"
+    );
+    expect(reference).toContain("# Dependency Internalization Kit");
+  });
+
+  it("names all seven evidence types on both halves of the pair", () => {
+    const eager = readFileSync(EAGER, "utf8").toLowerCase();
+    const reference = readFileSync(REFERENCE, "utf8").toLowerCase();
+
+    for (const [name] of KIT_CRITERIA) {
+      expect(eager).toContain(name.toLowerCase());
+      expect(reference).toContain(name.toLowerCase());
+    }
+  });
+
+  it("leads every evidence type with the plain question it answers", () => {
+    const eager = readFileSync(EAGER, "utf8");
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    // Operator-readability: the seven are legible to a non-technical reader
+    // only because each one leads with its question. Asserted on both halves so
+    // a question cannot go missing from the summary or the prose.
+    for (const [name, question] of KIT_CRITERIA) {
+      expect(flat(eager)).toContain(`**${name}** — ${question}`);
+      expect(flat(reference)).toContain(`${name} — ${question}`);
+    }
+  });
+
+  it("gives each of the seven its own reference section", () => {
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(reference).toContain("## The seven required evidence types");
+    for (const [index, [name]] of KIT_CRITERIA.entries()) {
+      expect(reference).toContain(`### ${index + 1}. ${name} —`);
+    }
+  });
+
+  it("requires all seven and refuses a partial kit", () => {
+    const eager = readFileSync(EAGER, "utf8");
+
+    expect(eager).toContain("All seven are required.");
+    expect(eager).toContain("A partial kit is the finding");
+  });
+
+  it("frames the risk shift that makes the kit necessary", () => {
+    const eager = readFileSync(EAGER, "utf8");
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(flat(eager)).toContain(
+      "**prove we rebuilt the capability correctly**"
+    );
+    expect(reference).toContain(
+      '"is upstream trustworthy?" to "did we actually rebuild what upstream did?"'
+    );
+  });
+
+  it("draws the ownership boundary: in-house moves inherit, version bumps do not", () => {
+    const eager = readFileSync(EAGER, "utf8");
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(eager).toContain(
+      "**When the kit applies:** ownership moves in-house"
+    );
+    expect(eager).toContain("**When the kit does NOT apply:**");
+    expect(flat(eager)).toContain(
+      "**within its existing trust class**. Ownership does not move"
+    );
+    expect(eager).toContain(IN_HOUSE_CLASS);
+
+    expect(reference).toContain(
+      "## Applying the kit — and not over-applying it"
+    );
+    expect(reference).toContain("**Inherits the kit** — ownership moves:");
+    expect(reference).toContain(
+      "**Does not inherit the kit** — ownership does not move:"
+    );
+    expect(reference).toContain(
+      "Over-applying the kit is a real failure, not a harmless excess of caution."
+    );
+  });
+
+  it("keeps a bump that becomes a fork inside the kit", () => {
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(flat(reference)).toContain(
+      "is an internalization wearing a bump's clothing, and it inherits the kit"
+    );
+  });
+
+  it("allows only an explicit non-material justification as an escape hatch", () => {
+    const eager = readFileSync(EAGER, "utf8");
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(flat(eager)).toContain(
+      "**non-material**. Silence is not a justification."
+    );
+    expect(reference).toContain("## The non-material escape hatch");
+    expect(flat(reference)).toContain(
+      "a removal ticket with no kit and no stated reason is not ready to build"
+    );
+  });
+
+  it("states the operator-facing promise the kit exists to keep", () => {
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(reference).toContain("## For the operator at the gate");
+    expect(flat(reference)).toContain(
+      "**explains how confidence will be rebuilt before the dependency is dropped**"
+    );
+  });
+
+  it("documents the uniform six-agent enforcement gap", () => {
+    const reference = readFileSync(REFERENCE, "utf8");
+
+    expect(reference).toContain("## Agent parity");
+    expect(flat(reference)).toContain(
+      "Antigravity has no separate rules tree of its own and inherits the same content through the shared mirror"
+    );
+    expect(flat(reference)).toContain(
+      "nothing enforces that a removal ticket actually carries the kit"
+    );
+  });
+});
+
+describe("confidence-rebuild kit wired into planning guidance", () => {
+  it("adds a decomposition step for dependencies moving in-house", () => {
+    const skill = readFileSync(DECOMPOSITION, "utf8");
+
+    expect(skill).toContain(
+      "### 4.6. Inherit the Confidence-Rebuild Kit When Ownership Moves In-House"
+    );
+    expect(skill).toContain("**inherits all seven acceptance criteria**");
+    expect(skill).toContain("`dependency-internalization-kit`");
+  });
+
+  it("enumerates all seven criteria with their plain questions in the skill", () => {
+    const skill = readFileSync(DECOMPOSITION, "utf8");
+    for (const [name, question] of KIT_CRITERIA) {
+      expect(flat(skill)).toContain(`**${name}** — ${question}`);
+    }
+  });
+
+  it("makes the version-bump boundary explicit so the kit is not over-applied", () => {
+    const skill = readFileSync(DECOMPOSITION, "utf8");
+
+    expect(skill).toContain("**Do not over-apply the kit.**");
+    expect(flat(skill)).toContain(
+      "**within its existing trust class** does not move ownership, so it does not inherit the kit"
+    );
+    expect(flat(skill)).toContain(
+      "a bump taken *as* a fork or declined *in favor of* owning the code, which is an internalization"
+    );
+  });
+
+  it("requires an explicit non-material justification to skip the kit", () => {
+    const skill = readFileSync(DECOMPOSITION, "utf8");
+
+    expect(skill).toContain("**explicit non-material justification**");
+    expect(skill).toContain("Silence is not a justification.");
+    expect(skill).toContain(
+      "unless it explicitly justifies why the dependency is non-material; a within-trust-class version bump does not carry the kit"
+    );
+  });
+});
+
+describe("dependency-internalization ticket fixture", () => {
+  it("declares the ownership move and that the dependency is material", () => {
+    const ticket = readFileSync(INTERNALIZATION_FIXTURE, "utf8");
+
+    expect(ticket).toContain("**Move:** removed and reimplemented in-house.");
+    expect(ticket).toContain(
+      `**Trust class after the move:** ${IN_HOUSE_CLASS}`
+    );
+    expect(ticket).toContain("**Material?** Yes.");
+    expect(ticket).toContain(
+      "The confidence-rebuild kit is inherited in full."
+    );
+  });
+
+  it("carries all seven kit criteria as Gherkin acceptance criteria", () => {
+    const ticket = readFileSync(INTERNALIZATION_FIXTURE, "utf8");
+    for (const [name, question] of KIT_CRITERIA) {
+      expect(flat(ticket)).toContain(`Scenario: ${name} -- ${question}`);
+    }
+    // Seven criteria, seven scenarios -- no extras masking a missing one.
+    expect(ticket.split("Scenario:").length - 1).toBe(KIT_CRITERIA.length);
+  });
+
+  it("names a real corpus rather than hand-written examples", () => {
+    const ticket = readFileSync(INTERNALIZATION_FIXTURE, "utf8");
+
+    expect(ticket).toContain(
+      "Given the 12,400 published titles already in the content table"
+    );
+  });
+
+  it("runs conformance differentially while the dependency is still installed", () => {
+    const ticket = readFileSync(INTERNALIZATION_FIXTURE, "utf8");
+
+    expect(ticket).toContain(
+      "Given slugify is still installed during this change"
+    );
+    expect(ticket).toContain("the outputs match on every title");
+  });
+
+  it("treats coverage as a gap list rather than a percentage", () => {
+    const ticket = readFileSync(INTERNALIZATION_FIXTURE, "utf8");
+
+    expect(ticket).toContain("rather than a coverage percentage");
+  });
+
+  it("names concrete rollback conditions and what we roll back to", () => {
+    const ticket = readFileSync(INTERNALIZATION_FIXTURE, "utf8");
+
+    expect(ticket).toContain("Then we reinstall slugify at the pinned version");
+  });
+});
+
+describe("version-bump ticket fixture", () => {
+  it("stays inside its existing trust class", () => {
+    const ticket = readFileSync(BUMP_FIXTURE, "utf8");
+
+    expect(ticket).toContain("**Move:** none. Version bump only.");
+    expect(flat(ticket)).toContain("unchanged before and after this bump");
+  });
+
+  it("does NOT carry the confidence-rebuild kit", () => {
+    const ticket = readFileSync(BUMP_FIXTURE, "utf8");
+
+    expect(flat(ticket)).toContain(
+      "the confidence-rebuild kit does **not** apply"
+    );
+
+    // The negative proof: none of the seven criteria appear as acceptance
+    // criteria on an ordinary bump. Scenario titles are checked rather than
+    // free prose, because the ticket names the kit once to explain its absence.
+    for (const [name] of KIT_CRITERIA) {
+      expect(ticket).not.toContain(`Scenario: ${name}`);
+    }
+    expect(ticket.split("Scenario:").length - 1).toBe(2);
+  });
+
+  it("says why over-applying the kit here would be wrong", () => {
+    const ticket = readFileSync(BUMP_FIXTURE, "utf8");
+
+    expect(flat(ticket)).toContain(
+      "would be over-application — no capability was rebuilt"
+    );
+  });
+
+  it("keeps the lightweight bar the trust class already sets", () => {
+    const ticket = readFileSync(BUMP_FIXTURE, "utf8");
+
+    expect(flat(ticket)).toContain(
+      "our unit tests over the wrapped behavior, re-read at every upgrade"
+    );
+    expect(ticket).toContain(
+      "Then they pass unchanged, with no new fixtures added"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1890 — story 5 of PRD #1741. When a dependency's ownership moves in-house, the risk flips from *trusting an upstream package* to *proving Lisa rebuilt the capability correctly*. This adds a reusable confidence-rebuild kit — an acceptance bar — that planners must embed in dependency removal/replacement/internalization work, so that proof is required rather than guessed at.

### What's here
- **The kit rule pair** `plugins/src/base/rules/{eager,reference}/dependency-internalization-kit.md` (fanned to all agent mirrors), mirroring #1887's pattern. It requires all **seven evidence types**, each led by the plain question it answers so a non-technical operator can read the acceptance bar:
  1. **Real corpus** — did we test it on real inputs, not toy examples?
  2. **Conformance fixtures** — does the new code do what the dependency did?
  3. **Negative fixtures** — does it still reject what it should reject?
  4. **Coverage as a gap detector** — what behavior is still untested? (used to find gaps, not as a vanity number)
  5. **Provenance and license review** — where did this code come from, and are we allowed to use it?
  6. **Migration and update plan** — how do existing call sites move, and how does the new code stay current?
  7. **Rollback or replacement criteria** — what would make us go back, and to what?
- **Planning wire (AC#1):** `lisa-task-decomposition` now makes a work item that removes/replaces/internalizes a material dependency INHERIT the kit's acceptance criteria.
- **The boundary that keeps it lightweight (AC#2):** an explicit "Applying the kit — and not over-applying it" section, plus a non-material escape hatch — a routine version bump of a trusted dep *within its existing trust class* does NOT get the kit; only an in-house ownership move does. A `version-bump-ticket.md` fixture + test pins that a bump does not inherit the kit, alongside the internalization fixture that does.
- Cross-references #1886/#1887: internalization is what moves a dependency into the "thin wrapper suitable for in-house ownership" trust class.

## Verification

- Full `bun run test` → **432 files / 7255 tests, exit 0**; `bun run typecheck` 0; `bun run build:plugins` clean (mirrors byte-faithful); `bun run check:plugins` pass; `scripts/check-rules-pairing.sh` pass; `generate-upstream-evidence-manifest.mjs --check` 0.
- The internalization ticket fixture carries all seven acceptance criteria; the version-bump fixture carries none; a 25-test rule-pair suite pins both directions and the ownership boundary.

Out of scope (correctly not done): performing any specific dependency removal, security/audit gate changes, SBOM tooling. Next and last in the chain: #1891 (verify parity, fixtures, operator docs).

🤖 Generated with Claude Code
