### PR TITLE
fix(learnings): stop stale-lock reclaim from stealing a live lock, closing #1878

### DIFF
--- a/src/core/learnings-lock.ts
+++ b/src/core/learnings-lock.ts
@@ -125,25 +125,39 @@ async function releaseLock(lockPath: string, lease: LockLease): Promise<void> {
 }
 
 /**
+ * Snapshot of one lock observed to be reclaimable. The reclaim is anchored to
+ * this snapshot: a lock is only ever deleted while it still *is* the exact
+ * inode and ownership this observation judged stale.
+ */
+export interface StaleLockObservation {
+  /** Owner metadata when the lock was parseable; undefined when unowned. */
+  readonly owner: LockOwner | undefined;
+  /** Device of the inode that was judged stale. */
+  readonly dev: number;
+  /** Inode that was judged stale. */
+  readonly ino: number;
+}
+
+/**
  * Reclaim an expired lock only when its declared process is no longer live.
  * @param lockPath - Shared lock path
  */
 async function reclaimStaleLock(lockPath: string): Promise<void> {
-  const retainedOwnerPath = await staleOwnerPath(lockPath);
-  if (retainedOwnerPath === null) {
+  const observation = await observeStaleLock(lockPath);
+  if (observation === null) {
     return;
   }
-  await quarantineStaleLock(lockPath, retainedOwnerPath);
+  await reclaimObservedStaleLock(lockPath, observation);
 }
 
 /**
  * Determine whether a regular lock is reclaimable and retain its owner path.
  * @param lockPath - Shared lock path
- * @returns Owner path, undefined for unlinked ownership, or null when live
+ * @returns Observation of a reclaimable lock, or null when it is still held
  */
-async function staleOwnerPath(
+export async function observeStaleLock(
   lockPath: string
-): Promise<string | undefined | null> {
+): Promise<StaleLockObservation | null> {
   const before = await statFile(lockPath);
   if (before === undefined) {
     return null;
@@ -159,37 +173,77 @@ async function staleOwnerPath(
   if (owner === undefined && Date.now() - timestamp <= STALE_LOCK_MS) {
     return null;
   }
-  return owner === undefined ? undefined : `${lockPath}.${owner.token}.owner`;
+  return { owner, dev: Number(before.dev), ino: Number(before.ino) };
 }
 
 /**
  * Reclaim only the same lock inode retained in a safe quarantine link.
  * @param lockPath - Shared lock path
- * @param retainedOwnerPath - Optional owner hard link
+ * @param observation - Snapshot that judged this lock reclaimable
+ * @returns Whether the observed lock was reclaimed
  */
-async function quarantineStaleLock(
+export async function reclaimObservedStaleLock(
   lockPath: string,
-  retainedOwnerPath: string | undefined
-): Promise<void> {
-  const quarantine =
-    retainedOwnerPath !== undefined &&
-    (await sameFile(lockPath, retainedOwnerPath))
-      ? retainedOwnerPath
-      : `${lockPath}.${crypto.randomUUID()}.stale`;
-  const linked =
-    quarantine === retainedOwnerPath
-      ? true
-      : await publishOwnerLink(lockPath, quarantine);
-  if (!linked) {
-    return;
+  observation: StaleLockObservation
+): Promise<boolean> {
+  // Pin whatever currently sits at the lock path so its inode cannot be
+  // recycled underneath the checks below, then prove it is still the very
+  // inode and ownership this observation judged stale before deleting it.
+  const quarantine = `${lockPath}.${crypto.randomUUID()}.stale`;
+  if (!(await publishOwnerLink(lockPath, quarantine))) {
+    return false;
   }
   try {
-    if (await sameFile(lockPath, quarantine)) {
-      await removeFileIfPresent(lockPath);
+    if (!(await pinnedLockStillStale(lockPath, quarantine, observation))) {
+      return false;
     }
+    await removeFileIfPresent(lockPath);
+    if (observation.owner !== undefined) {
+      await removeFileIfPresent(`${lockPath}.${observation.owner.token}.owner`);
+    }
+    return true;
   } finally {
     await removeFileIfPresent(quarantine);
   }
+}
+
+/**
+ * Confirm the pinned inode is still the lock this observation judged stale.
+ * Identity alone is not enough: a released inode can be recycled by a live
+ * holder, so the pinned ownership must still match the observed ownership.
+ * @param lockPath - Shared lock path
+ * @param quarantine - Hard link pinning the inode currently at the lock path
+ * @param observation - Snapshot that judged the lock reclaimable
+ * @returns Whether the pinned lock is still safe to delete
+ */
+async function pinnedLockStillStale(
+  lockPath: string,
+  quarantine: string,
+  observation: StaleLockObservation
+): Promise<boolean> {
+  const pinned = await statFile(quarantine);
+  if (
+    pinned === undefined ||
+    !pinned.isFile() ||
+    Number(pinned.dev) !== observation.dev ||
+    Number(pinned.ino) !== observation.ino ||
+    !(await sameFile(lockPath, quarantine))
+  ) {
+    return false;
+  }
+  const owner = await readLockOwner(quarantine);
+  if (observation.owner === undefined) {
+    return (
+      owner === undefined && Date.now() - Number(pinned.mtimeMs) > STALE_LOCK_MS
+    );
+  }
+  return (
+    owner !== undefined &&
+    owner.token === observation.owner.token &&
+    owner.pid === observation.owner.pid &&
+    owner.createdAt === observation.owner.createdAt &&
+    !isProcessLive(owner.pid)
+  );
 }
 
 /**

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7816,6 +7816,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/core/learnings-confirm.test.ts": true,
     "tests/unit/core/learnings-consolidation.test.ts": true,
     "tests/unit/core/learnings-contract.test.ts": true,
+    "tests/unit/core/learnings-lock-reclaim.test.ts": true,
     "tests/unit/core/learnings-projection.test.ts": true,
     "tests/unit/core/learnings-writer.test.ts": true,
     "tests/unit/core/lisa-plugin-selection.test.ts": true,

--- a/tests/unit/core/learnings-lock-reclaim.test.ts
+++ b/tests/unit/core/learnings-lock-reclaim.test.ts
@@ -1,0 +1,144 @@
+/** Stale-lock reclaim must never delete a lock it did not judge stale. */
+import { spawnSync } from "node:child_process";
+import { link, lstat, readFile, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  observeStaleLock,
+  reclaimObservedStaleLock,
+} from "../../../src/core/learnings-lock.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+/**
+ * Produce a process id that is certainly no longer running.
+ * @returns Reaped child process id
+ */
+function reapedPid(): number {
+  const child = spawnSync(process.execPath, ["-e", "0"]);
+  if (child.pid === undefined) {
+    throw new Error("Could not spawn a probe process");
+  }
+  return child.pid;
+}
+
+/**
+ * Publish a lock exactly as the acquire path does: owner metadata written to a
+ * token sidecar, then hard-linked into the shared lock path.
+ * @param lockPath - Shared lock path
+ * @param pid - Process id recorded as the lock owner
+ * @param createdAt - Lock creation timestamp
+ * @returns Owner token and sidecar path
+ */
+async function publishLock(
+  lockPath: string,
+  pid: number,
+  createdAt: number = Date.now()
+): Promise<{ readonly token: string; readonly ownerPath: string }> {
+  const token = crypto.randomUUID();
+  const ownerPath = `${lockPath}.${token}.owner`;
+  await writeFile(ownerPath, JSON.stringify({ token, pid, createdAt }), {
+    encoding: "utf8",
+    flag: "wx",
+  });
+  await link(ownerPath, lockPath);
+  return { token, ownerPath };
+}
+
+describe("stale lock reclaim", () => {
+  let tempDir: string;
+  let lockPath: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    lockPath = path.join(tempDir, "TARGET.md.lock");
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  it("does not judge a live owner's lock stale", async () => {
+    await publishLock(lockPath, process.pid);
+    expect(await observeStaleLock(lockPath)).toBeNull();
+  });
+
+  it("does not judge a freshly created unowned lock stale", async () => {
+    await writeFile(lockPath, "not-json-owner-metadata", { encoding: "utf8" });
+    expect(await observeStaleLock(lockPath)).toBeNull();
+  });
+
+  it("does not judge an absent lock stale", async () => {
+    expect(await observeStaleLock(lockPath)).toBeNull();
+  });
+
+  it("reclaims a lock abandoned by a dead owner", async () => {
+    const { ownerPath } = await publishLock(lockPath, reapedPid());
+    const observation = await observeStaleLock(lockPath);
+    expect(observation).not.toBeNull();
+
+    expect(await reclaimObservedStaleLock(lockPath, observation!)).toBe(true);
+    await expect(lstat(lockPath)).rejects.toThrow(/ENOENT/u);
+    await expect(lstat(ownerPath)).rejects.toThrow(/ENOENT/u);
+  });
+
+  it("leaves a live holder's lock intact when the judged lock was already released", async () => {
+    // A dead owner's lock is observed as stale...
+    const stale = await publishLock(lockPath, reapedPid());
+    const observation = await observeStaleLock(lockPath);
+    expect(observation).not.toBeNull();
+
+    // ...but before the reclaim lands, that lock is released and a LIVE holder
+    // acquires the very same path. This is the cross-process race: the reclaim
+    // decision is older than the lock now sitting at `lockPath`.
+    await removeQuietly(lockPath);
+    await removeQuietly(stale.ownerPath);
+    const live = await publishLock(lockPath, process.pid);
+
+    expect(await reclaimObservedStaleLock(lockPath, observation!)).toBe(false);
+
+    // The live holder still owns an intact lock linked to its own sidecar.
+    const [lockStat, ownerStat] = await Promise.all([
+      lstat(lockPath),
+      lstat(live.ownerPath),
+    ]);
+    expect(lockStat.ino).toBe(ownerStat.ino);
+    expect(JSON.parse(await readFile(lockPath, "utf8"))).toMatchObject({
+      token: live.token,
+      pid: process.pid,
+    });
+  });
+
+  it("leaves a live holder's lock intact when only the judged sidecar is gone", async () => {
+    // The exact production interleaving: the observed owner released (removing
+    // its sidecar) and exited, so its sidecar is missing while a live holder's
+    // lock now occupies the path. The old fallback quarantined whatever sat at
+    // `lockPath`, which deleted the live lock.
+    const stale = await publishLock(lockPath, reapedPid());
+    const observation = await observeStaleLock(lockPath);
+    expect(observation).not.toBeNull();
+
+    await removeQuietly(stale.ownerPath);
+    await removeQuietly(lockPath);
+    const live = await publishLock(lockPath, process.pid);
+
+    expect(await reclaimObservedStaleLock(lockPath, observation!)).toBe(false);
+    expect(JSON.parse(await readFile(lockPath, "utf8"))).toMatchObject({
+      token: live.token,
+    });
+  });
+});
+
+/**
+ * Delete one path, tolerating an already-absent file.
+ * @param filePath - Path to remove
+ */
+async function removeQuietly(filePath: string): Promise<void> {
+  const { unlink } = await import("node:fs/promises");
+  try {
+    await unlink(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #1878. The intermittently-failing `learnings-concurrency` test was not a test flake — it was surfacing a **real correctness bug in the machine-managed learnings ledger's cross-process lock**: under concurrency, the stale-lock reclaim could delete a *live* holder's lock, and two writers would then read the same base document and the second rename would win — **silently losing a learning**.

### Root cause (the writer lock, not the test)
`src/core/learnings-lock.ts` reclaimed an abandoned lock in two **unanchored** steps — judge the lock stale, then delete "whatever currently sits at the lock path." Between those steps the observed lock could be released and a live process could acquire the very same path, so the reclaim quarantined and deleted a lock its holder still owned. That produced both the lost write and the secondary `ENOENT … unlink '…PROJECT_LEARNINGS.md.lock'` on the robbed writer's release.

### The fix — anchor the reclaim to the lock it judged
The reclaim now **pins the current inode via a fresh hard link**, then re-verifies before deleting that dev+ino still match the snapshot AND the owner token+pid+createdAt still match what was judged stale AND the pid is still dead — otherwise it aborts and leaves the lock alone. A genuine compare-before-delete, so a recycled identity can't be deleted underneath a live holder. No sleeps, no retry-until-green — the race is fixed, not masked. A genuinely-abandoned lock (dead owner) remains fully reclaimable.

## Verification

- **New deterministic reproduction** `tests/unit/core/learnings-lock-reclaim.test.ts` (red-legged, independently confirmed): with the pre-fix reclaim body it FAILS with the exact lock-theft signature ("leaves a live holder's lock intact when the judged lock was already released" — deleted anyway); with the fix it passes. It also pins that a dead-owner lock IS still reclaimed (no deadlock).
- **The original flake is gone under contention:** the cross-process test (10 concurrent writers/round) looped **120× with added CPU load → 120/120, zero lost writes** (the original flake was ~1/275).
- Full `bun run test` → **435 files / 7321 tests, exit 0**; `bun run typecheck` 0; `generate-upstream-evidence-manifest.mjs --check` 0. Merge-forward clean.

This de-flakes the required `Run Tests` gate AND closes a genuine durability gap in the learnings ledger — concurrent writers no longer lose an entry.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery of abandoned locks, allowing cleanup when the original owner is no longer running.
  - Added safeguards to prevent active locks from being removed, including during timing conflicts or lock replacement.
  - Preserved fresh and unowned locks during stale-lock evaluation.
  - Improved cleanup of associated lock metadata after successful recovery.

- **Tests**
  - Added coverage for live, fresh, abandoned, replaced, and partially missing lock scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->