### PR TITLE
fix(security): floor fast-xml-parser at 5.10.1

### DIFF
--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -99,14 +99,14 @@
     "resolutions": {
       "@isaacs/brace-expansion": "^5.0.1",
       "eslint-plugin-react-hooks": "^7.0.0",
-      "fast-xml-parser": "^5.3.6",
+      "fast-xml-parser": "^5.10.1",
       "tar": ">=7.5.11",
       "websocket-driver": ">=0.7.5"
     },
     "overrides": {
       "@isaacs/brace-expansion": "^5.0.1",
       "eslint-plugin-react-hooks": "^7.0.0",
-      "fast-xml-parser": "^5.3.6",
+      "fast-xml-parser": "^5.10.1",
       "zod-validation-error": "^4.0.0",
       "tar": ">=7.5.11",
       "websocket-driver": ">=0.7.5"

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -185,7 +185,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/merge/.oxlintrc.json":
       "2a0ea2191abd5b377aed4b525a4a97d3eefb1d9e41c845c02ee0daac75df6b1f",
     "expo/package-lisa/package.lisa.json":
-      "f374cd1cda0e505f5c725b490c4a1467e64da9aa38584092331682330372161a",
+      "bd2a5220b83c55f777c24fccf07f58bb277b526edc31a472232a8f34a8cfedd2",
     "harper-fabric/copy-contents/.prettierignore":
       "478c782f4c5611187e21584dfd5522e37fc636c5eb03394fea3db45321c6712c",
     "harper-fabric/copy-contents/gitignore":
@@ -7786,6 +7786,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/config/eslint-plugin-phaser.test.ts": true,
     "tests/unit/config/eslint-test-files-override.test.ts": true,
     "tests/unit/config/expo-eslint-local-config.test.ts": true,
+    "tests/unit/config/fast-xml-parser-security-floor.test.ts": true,
     "tests/unit/config/gitleaks-template.test.ts": true,
     "tests/unit/config/harper-fabric-template.test.ts": true,
     "tests/unit/config/jest-base.test.ts": true,

--- a/tests/unit/config/fast-xml-parser-security-floor.test.ts
+++ b/tests/unit/config/fast-xml-parser-security-floor.test.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const ADVISORY_ID = "GHSA-8r6m-32jq-jx6q";
+const AUDIT_IGNORE_FILES = [
+  "audit.ignore.config.json",
+  "audit.ignore.local.json",
+] as const;
+
+/** Shape of the audit exclusion files consumed by Lisa security checks. */
+interface AuditIgnoreConfig {
+  readonly exclusions: readonly { readonly id: string }[];
+}
+
+describe("fast-xml-parser security floor", () => {
+  it.each(AUDIT_IGNORE_FILES)("does not suppress the advisory in %s", file => {
+    const absolutePath = path.join(REPO_ROOT, file);
+    if (!fs.existsSync(absolutePath)) return;
+    const config = JSON.parse(
+      fs.readFileSync(absolutePath, "utf8")
+    ) as AuditIgnoreConfig;
+
+    expect(config.exclusions.map(exclusion => exclusion.id)).not.toContain(
+      ADVISORY_ID
+    );
+  });
+});

--- a/tests/unit/config/postinstall-ci-guard.test.ts
+++ b/tests/unit/config/postinstall-ci-guard.test.ts
@@ -17,6 +17,7 @@ const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const CI_GUARD_PREFIX = '[ -n "$CI" ] ||';
 const LISA_MARKER = "node_modules/@codyswann/lisa/dist/index.js";
 const LISA_BOOTSTRAP_PREFIX = "LISA_BOOTSTRAP=1 node";
+const EXPO_PACKAGE_TEMPLATE = "expo/package-lisa/package.lisa.json";
 
 /**
  * Minimal shape of a package.lisa.json for the assertions below.
@@ -49,7 +50,7 @@ function readTemplateJson(relativePath: string): unknown {
 const TEMPLATE_PATHS = [
   "package.lisa.json",
   "typescript/package-lisa/package.lisa.json",
-  "expo/package-lisa/package.lisa.json",
+  EXPO_PACKAGE_TEMPLATE,
   "nestjs/package-lisa/package.lisa.json",
   "cdk/package-lisa/package.lisa.json",
   "harper-fabric/package-lisa/package.lisa.json",
@@ -146,11 +147,15 @@ describe("package.lisa.json templates carry force-governed CVE floors", () => {
   });
 
   it("expo template floors websocket-driver (RN-firebase GHSA-xv26-6w52-cph6)", () => {
-    const template = readTemplateJson(
-      "expo/package-lisa/package.lisa.json"
-    ) as OverridesShape;
+    const template = readTemplateJson(EXPO_PACKAGE_TEMPLATE) as OverridesShape;
     expect(template.force?.overrides?.["websocket-driver"]).toBe(">=0.7.5");
     expect(template.force?.resolutions?.["websocket-driver"]).toBe(">=0.7.5");
+  });
+
+  it("expo template floors fast-xml-parser (GHSA-8r6m-32jq-jx6q)", () => {
+    const template = readTemplateJson(EXPO_PACKAGE_TEMPLATE) as OverridesShape;
+    expect(template.force?.overrides?.["fast-xml-parser"]).toBe("^5.10.1");
+    expect(template.force?.resolutions?.["fast-xml-parser"]).toBe("^5.10.1");
   });
 });
 

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -1270,6 +1270,8 @@ describe("PackageLisaStrategy", () => {
         scripts: Record<string, string>;
         dependencies: Record<string, string>;
         devDependencies: Record<string, string>;
+        resolutions: Record<string, string>;
+        overrides: Record<string, string>;
       };
       defaults: {
         dependencies: Record<string, string>;
@@ -1283,6 +1285,46 @@ describe("PackageLisaStrategy", () => {
       const template = readExpoTemplate();
 
       expect(template.force.scripts).toMatchObject(expectedMaestroScripts);
+    });
+
+    it("repairs the fast-xml-parser advisory floor during full and postinstall applies", async () => {
+      const vulnerableFloor = "^5.3.6";
+      const patchedFloor = "^5.10.1";
+      const destPath = path.join(projectDir, "package.json");
+      await createExpoProject(projectDir);
+      await fs.writeJson(destPath, {
+        name: "expo-security-fixture",
+        dependencies: { expo: "~57.0.0" },
+        resolutions: { "fast-xml-parser": vulnerableFloor },
+        overrides: { "fast-xml-parser": vulnerableFloor },
+      });
+
+      await strategy.apply(
+        expoSource,
+        destPath,
+        "package.json",
+        createContext({ lisaDir: repoRoot })
+      );
+
+      let content = await fs.readJson(destPath);
+      expect(content.resolutions["fast-xml-parser"]).toBe(patchedFloor);
+      expect(content.overrides["fast-xml-parser"]).toBe(patchedFloor);
+
+      await fs.writeJson(destPath, {
+        ...content,
+        resolutions: { "fast-xml-parser": vulnerableFloor },
+        overrides: { "fast-xml-parser": vulnerableFloor },
+      });
+      await strategy.apply(
+        expoSource,
+        destPath,
+        "package.json",
+        createContext({ lisaDir: repoRoot, skipGitCheck: true })
+      );
+
+      content = await fs.readJson(destPath);
+      expect(content.resolutions["fast-xml-parser"]).toBe(patchedFloor);
+      expect(content.overrides["fast-xml-parser"]).toBe(patchedFloor);
     });
 
     it("repairs unpinned Maestro commands when applying the Expo template", async () => {


### PR DESCRIPTION
## Summary

- raise the canonical Expo `force.resolutions` and `force.overrides` fast-xml-parser floors from `^5.3.6` to `^5.10.1`
- prove full and postinstall-safe Lisa apply paths repair vulnerable host ranges
- prohibit suppressing GHSA-8r6m-32jq-jx6q and refresh the upstream evidence manifest

## Verification

- RED: real-template and real-apply contracts failed on `^5.3.6` (2 expected failures; 88 sibling tests passed)
- GREEN: focused contracts 90/90
- full Lisa suite: 435 files / 7,319 tests
- build + plugin parity, typecheck, normal/slow lint, format, knip, workflow-input, duplicate-version, and evidence-manifest checks
- disposable `TunnlAI/frontend@1aa83e5`: source-built Lisa apply raised both pins; lock resolved exactly `fast-xml-parser@5.10.1`; frozen reinstall preserved identical package/lock SHA-256s; live `bun audit --json` returned zero target-advisory findings

Closes #1925

Work-Item: CodySwannGT/lisa#1925