### PR TITLE
fix(migrations): retire stale esbuild exclusion securely

### DIFF
--- a/all/copy-overwrite/scripts/lisa-work-item.mjs
+++ b/all/copy-overwrite/scripts/lisa-work-item.mjs
@@ -46,6 +46,24 @@ function git(args, options = {}) {
   return run("git", args, options).stdout.trim();
 }
 
+function curlConfigValue(value) {
+  return `"${String(value)
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n")}"`;
+}
+
+function secureCurl(args, entries, options = {}) {
+  const input = `${entries
+    .map(([name, value]) => `${name} = ${curlConfigValue(value)}`)
+    .join("\n")}\n`;
+  return run("curl", ["-fsS", "--config", "-", ...args], {
+    ...options,
+    input,
+  });
+}
+
 function projectRoot() {
   return git(["rev-parse", "--show-toplevel"]);
 }
@@ -536,15 +554,11 @@ function jiraIssue(ref, contract) {
   const credentials = jiraCredentials(contract);
   if (credentials) {
     const url = `${credentials.baseUrl}/rest/api/3/issue/${encodeURIComponent(ref)}?fields=project,status,labels,components,issuetype,subtasks,comment`;
-    const result = run(
-      "curl",
+    const result = secureCurl(
+      [url],
       [
-        "-fsS",
-        "-u",
-        `${credentials.login}:${credentials.token}`,
-        "-H",
-        "Accept: application/json",
-        url,
+        ["user", `${credentials.login}:${credentials.token}`],
+        ["header", "Accept: application/json"],
       ],
       { allowFailure: true }
     );
@@ -680,19 +694,13 @@ function linearIssue(ref, contract) {
   const query =
     "query($id:String!){issue(id:$id){id identifier team{key} state{type} labels{nodes{name}} children{nodes{state{type}}} attachments{nodes{url}} comments{nodes{body}}}}";
   const payload = JSON.stringify({ query, variables: { id: ref } });
-  const result = run(
-    "curl",
+  const result = secureCurl(
+    ["https://api.linear.app/graphql"],
     [
-      "-fsS",
-      "-X",
-      "POST",
-      "-H",
-      "Content-Type: application/json",
-      "-H",
-      `Authorization: ${token}`,
-      "--data-binary",
-      payload,
-      "https://api.linear.app/graphql",
+      ["request", "POST"],
+      ["header", "Content-Type: application/json"],
+      ["header", `Authorization: ${token}`],
+      ["data-binary", payload],
     ],
     { allowFailure: true }
   );
@@ -790,15 +798,11 @@ function assertBacklink(
   const credentials = jiraCredentials(contract);
   if (credentials) {
     const url = `${credentials.baseUrl}/rest/api/3/issue/${encodeURIComponent(ref)}/remotelink`;
-    const result = run(
-      "curl",
+    const result = secureCurl(
+      [url],
       [
-        "-fsS",
-        "-u",
-        `${credentials.login}:${credentials.token}`,
-        "-H",
-        "Accept: application/json",
-        url,
+        ["user", `${credentials.login}:${credentials.token}`],
+        ["header", "Accept: application/json"],
       ],
       { allowFailure: true }
     );
@@ -1092,7 +1096,7 @@ function main() {
 }
 
 try {
-  await main();
+  main();
 } catch (error) {
   const detail = error instanceof Error ? error.message : String(error);
   console.error(

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -5,7 +5,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-contents/gitignore":
       "06b56376465d5421db55d0b04958bbc79fdbf33b42f0559fe5ef6875ced1160f",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
-      "f88f69d44693084428f44e3f2b80afecda08c7ee8747588f40277fdc9396fd8f",
+      "4c263fef48c03b3b6c623ea8a6cd55505bfaf28197e5072226ea35f9f3d26885",
     "all/create-only/.claude/rules/PROJECT_RULES.md":
       "6e1c7923ad2a15356babc60c97e7f97be728d790af285b6a7cd7d1b4d39cd97f",
     "all/create-only/.lisaignore":
@@ -7866,6 +7866,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/hooks/verification-failure-mode-fixtures.test.ts": true,
     "tests/unit/hooks/work-item-wiring.test.ts": true,
     "tests/unit/hooks/worktree-create.test.ts": true,
+    "tests/unit/migrations/ensure-audit-ignore-local-exclusions-esbuild.test.ts": true,
     "tests/unit/migrations/ensure-audit-ignore-local-exclusions.test.ts": true,
     "tests/unit/migrations/ensure-jest-rn-mock-accessibility-manager.test.ts": true,
     "tests/unit/migrations/ensure-lisa-postinstall.test.ts": true,

--- a/src/migrations/ensure-audit-ignore-local-exclusions.ts
+++ b/src/migrations/ensure-audit-ignore-local-exclusions.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import * as fse from "fs-extra";
+import { gte, minVersion, valid } from "semver";
 import type { ProjectType } from "../core/config.js";
 import { readJson, readJsonOrNull, writeJson } from "../utils/json-utils.js";
 import type {
@@ -10,6 +11,8 @@ import type {
 
 const AUDIT_CONFIG = "audit.ignore.config.json";
 const AUDIT_LOCAL = "audit.ignore.local.json";
+const ESBUILD_ADVISORY = "GHSA-gv7w-rqvm-qjhr";
+const ESBUILD_PATCHED_VERSION = "0.28.1";
 
 /**
  * One exclusion entry (partial — we only read `id` to detect duplicates).
@@ -31,6 +34,12 @@ interface Exclusion {
 interface AuditIgnoreLike {
   readonly exclusions?: readonly Exclusion[];
   readonly [key: string]: unknown;
+}
+
+/** Package-manager constraints relevant to the esbuild advisory cleanup. */
+interface PackageJsonLike {
+  readonly overrides?: Readonly<Record<string, unknown>>;
+  readonly resolutions?: Readonly<Record<string, unknown>>;
 }
 
 /**
@@ -99,6 +108,41 @@ async function readLocalJson<T>(filePath: string): Promise<T | null> {
     return null;
   }
   return readJson<T>(filePath);
+}
+
+/**
+ * Report whether the host both enforces and has installed a patched esbuild.
+ * Requiring both signals prevents removal while the dependency tree is stale or
+ * a permissive package-manager constraint could still select a vulnerable build.
+ * @param projectDir - Host project receiving the migration
+ * @returns Whether constraints and installed package are both patched
+ */
+async function hasPatchedEsbuild(projectDir: string): Promise<boolean> {
+  const packageJson = await readJsonOrNull<PackageJsonLike>(
+    path.join(projectDir, "package.json")
+  );
+  const installed = await readJsonOrNull<{ readonly version?: string }>(
+    path.join(projectDir, "node_modules", "esbuild", "package.json")
+  );
+  const ranges = [
+    packageJson?.overrides?.esbuild,
+    packageJson?.resolutions?.esbuild,
+  ].filter((range): range is string => typeof range === "string");
+  if (ranges.length === 0 || !valid(installed?.version)) {
+    return false;
+  }
+  const constraintsArePatched = ranges.every(range => {
+    try {
+      const minimum = minVersion(range);
+      return minimum !== null && gte(minimum, ESBUILD_PATCHED_VERSION);
+    } catch {
+      return false;
+    }
+  });
+  return (
+    constraintsArePatched &&
+    gte(installed?.version ?? "0.0.0", ESBUILD_PATCHED_VERSION)
+  );
 }
 
 /**
@@ -177,13 +221,23 @@ export class EnsureAuditIgnoreLocalExclusionsMigration implements Migration {
    * @returns True when there is work to do
    */
   async applies(ctx: MigrationContext): Promise<boolean> {
-    if (this.snapshot.length === 0) {
-      return false;
-    }
     const localPath = path.join(ctx.projectDir, AUDIT_LOCAL);
     const local = await readLocalJson<AuditIgnoreLike>(localPath);
+    const patchedEsbuild = await hasPatchedEsbuild(ctx.projectDir);
+    if (
+      patchedEsbuild &&
+      local?.exclusions?.some(entry => entry.id === ESBUILD_ADVISORY)
+    ) {
+      return true;
+    }
+    const snapshot = patchedEsbuild
+      ? this.snapshot.filter(entry => entry.id !== ESBUILD_ADVISORY)
+      : this.snapshot;
+    if (snapshot.length === 0) {
+      return false;
+    }
     const localIds = collectIds(local);
-    return this.snapshot.some(entry => {
+    return snapshot.some(entry => {
       const id = entry.id;
       return typeof id === "string" && !localIds.has(id);
     });
@@ -200,34 +254,49 @@ export class EnsureAuditIgnoreLocalExclusionsMigration implements Migration {
     const localPath = path.join(ctx.projectDir, AUDIT_LOCAL);
     const local = await readLocalJson<AuditIgnoreLike>(localPath);
     const existing = Array.isArray(local?.exclusions) ? local.exclusions : [];
-    const localIds = collectIds(local);
+    const patchedEsbuild = await hasPatchedEsbuild(ctx.projectDir);
+    const retained = patchedEsbuild
+      ? existing.filter(entry => entry.id !== ESBUILD_ADVISORY)
+      : existing;
+    const removed = existing.length - retained.length;
+    const localIds = collectIds({ exclusions: retained });
 
     const seenIds = new Set(localIds);
     const additions = this.snapshot.filter(entry => {
       const id = entry.id;
-      if (typeof id !== "string" || seenIds.has(id)) {
+      if (
+        typeof id !== "string" ||
+        seenIds.has(id) ||
+        (patchedEsbuild && id === ESBUILD_ADVISORY)
+      ) {
         return false;
       }
       seenIds.add(id);
       return true;
     });
 
-    if (additions.length === 0) {
+    if (additions.length === 0 && removed === 0) {
       return { name: this.name, action: "noop" };
     }
 
     const merged: AuditIgnoreLike = {
       ...(local ?? {}),
-      exclusions: [...existing, ...additions],
+      exclusions: [...retained, ...additions],
     };
 
     const addedIds = additions
       .map(entry => entry.id)
       .filter((id): id is string => typeof id === "string");
-    const message = `Relocated ${additions.length} exclusion(s) into audit.ignore.local.json (${addedIds.join(", ")})`;
+    const actions = [
+      additions.length > 0
+        ? `relocated ${additions.length} exclusion(s) (${addedIds.join(", ")})`
+        : "",
+      removed > 0 ? `removed ${removed} patched esbuild exclusion(s)` : "",
+    ].filter(Boolean);
+    const message = `${actions.join(" and ")} in audit.ignore.local.json`;
 
     if (ctx.dryRun) {
-      ctx.logger.dry(`Would relocate exclusions: ${addedIds.join(", ")}`);
+      ctx.logger.dry(`Would ${actions.join(" and ")}`);
       return {
         name: this.name,
         action: "applied",

--- a/tests/unit/hooks/work-item-wiring.test.ts
+++ b/tests/unit/hooks/work-item-wiring.test.ts
@@ -26,6 +26,7 @@ describe("work-item Git enforcement wiring", () => {
     }
   );
 
+  // Test hardened to kill mutant M001 (Risk Factor: Correctness / executable entrypoint).
   it("ships the validator to Lisa itself and downstream projects", () => {
     expect(read("scripts/lisa-work-item.mjs")).toContain(
       "../all/copy-overwrite/scripts/lisa-work-item.mjs"

--- a/tests/unit/hooks/work-item-wiring.test.ts
+++ b/tests/unit/hooks/work-item-wiring.test.ts
@@ -44,6 +44,7 @@ describe("work-item Git enforcement wiring", () => {
       expect(installed).toContain(`command === "${command}"`);
     }
     expect(installed).toContain("WORK_ITEM_TRACKING_OK");
+    expect(installed).not.toContain("await main()");
   });
 
   it("gives Rails the same gates and a single stdin consumer", () => {

--- a/tests/unit/migrations/ensure-audit-ignore-local-exclusions-esbuild.test.ts
+++ b/tests/unit/migrations/ensure-audit-ignore-local-exclusions-esbuild.test.ts
@@ -1,0 +1,122 @@
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { SilentLogger } from "../../../src/logging/silent-logger.js";
+import { EnsureAuditIgnoreLocalExclusionsMigration } from "../../../src/migrations/ensure-audit-ignore-local-exclusions.js";
+import type { MigrationContext } from "../../../src/migrations/migration.interface.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const AUDIT_CONFIG = "audit.ignore.config.json";
+const AUDIT_LOCAL = "audit.ignore.local.json";
+const ESBUILD_GHSA = "GHSA-gv7w-rqvm-qjhr";
+
+describe("esbuild audit exclusion migration", () => {
+  let migration: EnsureAuditIgnoreLocalExclusionsMigration;
+  let tempDir: string;
+  let lisaDir: string;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    migration = new EnsureAuditIgnoreLocalExclusionsMigration();
+    tempDir = await createTempDir();
+    lisaDir = path.join(tempDir, "lisa");
+    projectDir = path.join(tempDir, "project");
+    await fs.ensureDir(path.join(lisaDir, "typescript", "copy-overwrite"));
+    await fs.ensureDir(projectDir);
+    await fs.writeJson(
+      path.join(lisaDir, "typescript", "copy-overwrite", AUDIT_CONFIG),
+      { exclusions: [] }
+    );
+  });
+
+  afterEach(async () => cleanupTempDir(tempDir));
+
+  /**
+   * Build a migration context for the disposable host.
+   * @returns Migration context rooted in the test fixture
+   */
+  function context(): MigrationContext {
+    return {
+      projectDir,
+      lisaDir,
+      detectedTypes: ["typescript"],
+      dryRun: false,
+      logger: new SilentLogger(),
+    };
+  }
+
+  /**
+   * Seed the host's enforced and installed esbuild versions.
+   * @param range - Package-manager constraint
+   * @param version - Installed esbuild version
+   */
+  async function seedEsbuild(range: string, version: string): Promise<void> {
+    await fs.writeJson(path.join(projectDir, "package.json"), {
+      overrides: { esbuild: range },
+      resolutions: { esbuild: range },
+    });
+    await fs.ensureDir(path.join(projectDir, "node_modules", "esbuild"));
+    await fs.writeJson(
+      path.join(projectDir, "node_modules", "esbuild", "package.json"),
+      { name: "esbuild", version }
+    );
+  }
+
+  it("does not emit the stale exclusion when enforcement and installation are patched", async () => {
+    await seedEsbuild(">=0.28.1", "0.28.1");
+    await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+      exclusions: [{ id: ESBUILD_GHSA, package: "esbuild", reason: "old" }],
+    });
+
+    await migration.beforeStrategies(context());
+
+    expect(await migration.applies(context())).toBe(false);
+    expect((await migration.apply(context())).action).toBe("noop");
+    expect(await fs.pathExists(path.join(projectDir, AUDIT_LOCAL))).toBe(false);
+  });
+
+  it("removes an existing stale exclusion when enforcement and installation are patched", async () => {
+    await seedEsbuild("^0.28.1", "0.28.2");
+    const retained = {
+      id: "KEEP-ME",
+      package: "other",
+      reason: "still applicable",
+    };
+    await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+      exclusions: [{ id: ESBUILD_GHSA, package: "esbuild", reason: "old" }],
+    });
+    await fs.writeJson(path.join(projectDir, AUDIT_LOCAL), {
+      exclusions: [
+        retained,
+        { id: ESBUILD_GHSA, package: "esbuild", reason: "generated" },
+      ],
+    });
+
+    await migration.beforeStrategies(context());
+
+    expect(await migration.applies(context())).toBe(true);
+    expect((await migration.apply(context())).action).toBe("applied");
+    expect(await fs.readJson(path.join(projectDir, AUDIT_LOCAL))).toEqual({
+      exclusions: [retained],
+    });
+  });
+
+  it("retains and relocates the exclusion while the enforced installation is vulnerable", async () => {
+    await seedEsbuild("^0.27.0", "0.27.4");
+    const exclusion = {
+      id: ESBUILD_GHSA,
+      package: "esbuild",
+      reason: "vulnerable installation",
+    };
+    await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+      exclusions: [exclusion],
+    });
+
+    await migration.beforeStrategies(context());
+
+    expect(await migration.applies(context())).toBe(true);
+    expect((await migration.apply(context())).action).toBe("applied");
+    expect(await fs.readJson(path.join(projectDir, AUDIT_LOCAL))).toEqual({
+      exclusions: [exclusion],
+    });
+  });
+});

--- a/tests/unit/migrations/ensure-audit-ignore-local-exclusions-esbuild.test.ts
+++ b/tests/unit/migrations/ensure-audit-ignore-local-exclusions-esbuild.test.ts
@@ -46,13 +46,18 @@ describe("esbuild audit exclusion migration", () => {
 
   /**
    * Seed the host's enforced and installed esbuild versions.
-   * @param range - Package-manager constraint
+   * @param overrideRange - npm override constraint
    * @param version - Installed esbuild version
+   * @param resolutionRange - Yarn/Bun resolution constraint
    */
-  async function seedEsbuild(range: string, version: string): Promise<void> {
+  async function seedEsbuild(
+    overrideRange: string,
+    version: string,
+    resolutionRange = overrideRange
+  ): Promise<void> {
     await fs.writeJson(path.join(projectDir, "package.json"), {
-      overrides: { esbuild: range },
-      resolutions: { esbuild: range },
+      overrides: { esbuild: overrideRange },
+      resolutions: { esbuild: resolutionRange },
     });
     await fs.ensureDir(path.join(projectDir, "node_modules", "esbuild"));
     await fs.writeJson(
@@ -106,6 +111,26 @@ describe("esbuild audit exclusion migration", () => {
       id: ESBUILD_GHSA,
       package: "esbuild",
       reason: "vulnerable installation",
+    };
+    await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
+      exclusions: [exclusion],
+    });
+
+    await migration.beforeStrategies(context());
+
+    expect(await migration.applies(context())).toBe(true);
+    expect((await migration.apply(context())).action).toBe("applied");
+    expect(await fs.readJson(path.join(projectDir, AUDIT_LOCAL))).toEqual({
+      exclusions: [exclusion],
+    });
+  });
+
+  it("retains the exclusion when only one package-manager constraint is patched", async () => {
+    await seedEsbuild(">=0.28.1", "0.28.1", "^0.27.0");
+    const exclusion = {
+      id: ESBUILD_GHSA,
+      package: "esbuild",
+      reason: "one constraint remains vulnerable",
     };
     await fs.writeJson(path.join(projectDir, AUDIT_CONFIG), {
       exclusions: [exclusion],

--- a/tests/unit/scripts/lisa-work-item.test.ts
+++ b/tests/unit/scripts/lisa-work-item.test.ts
@@ -589,6 +589,7 @@ describe("provider liveness", () => {
     expect(epic.stderr).toContain("is a container");
   });
 
+  // Test hardened to kill mutant M001 (Risk Factor: Data security / credential secrecy).
   it("uses canonical Atlassian credentials and requests Jira status in curl fallback", () => {
     const fixture = createFixture({
       tracker: "jira",
@@ -615,6 +616,7 @@ describe("provider liveness", () => {
     expect(result.status).toBe(0);
     const invocation = readFileSync(log, "utf8");
     expect(invocation).not.toContain("fake-atlassian-key");
+    expect(invocation).toContain("--config -");
     expect(invocation).toContain("api.atlassian.com/ex/jira/cloud-123");
     expect(invocation).toContain(
       "fields=project,status,labels,components,issuetype,subtasks,comment"
@@ -641,6 +643,7 @@ describe("provider liveness", () => {
     expect(terminal.stderr).toContain("is terminal");
   });
 
+  // Test hardened to kill mutant M002 (Risk Factor: Data security / credential secrecy).
   it("passes Linear authorization through curl stdin rather than process argv", () => {
     const fixture = createFixture({
       tracker: "linear",
@@ -663,7 +666,9 @@ describe("provider liveness", () => {
     });
 
     expect(result.status).toBe(0);
-    expect(readFileSync(argsLog, "utf8")).not.toContain("secret-linear-key");
+    const invocation = readFileSync(argsLog, "utf8");
+    expect(invocation).not.toContain("secret-linear-key");
+    expect(invocation).toContain("--config -");
     expect(readFileSync(stdinLog, "utf8")).toContain(
       'header = "Authorization: secret-linear-key"'
     );

--- a/tests/unit/scripts/lisa-work-item.test.ts
+++ b/tests/unit/scripts/lisa-work-item.test.ts
@@ -598,24 +598,29 @@ describe("provider liveness", () => {
     });
     rmSync(path.join(fixture.bin, "acli"));
     const log = path.join(fixture.root, "curl.log");
+    const stdinLog = path.join(fixture.root, "curl.stdin.log");
     executable(
       path.join(fixture.bin, "curl"),
-      `printf '%s\\n' "$*" > "\${FAKE_CURL_LOG}"\nprintf '%s\\n' '{"key":"LAS-12","fields":{"project":{"key":"LAS"},"status":{"name":"In Progress","statusCategory":{"key":"indeterminate"}},"labels":["repo:widgets"],"issuetype":{"name":"Task"},"subtasks":[],"comment":{"comments":[]}}}'`
+      `printf '%s\\n' "$*" > "\${FAKE_CURL_LOG}"\ncat > "\${FAKE_CURL_STDIN_LOG}"\nprintf '%s\\n' '{"key":"LAS-12","fields":{"project":{"key":"LAS"},"status":{"name":"In Progress","statusCategory":{"key":"indeterminate"}},"labels":["repo:widgets"],"issuetype":{"name":"Task"},"subtasks":[],"comment":{"comments":[]}}}'`
     );
 
     const result = command(fixture, ["bind", "LAS-12"], {
       env: {
         ATLASSIAN_API_TOKEN: "fake-atlassian-key",
         FAKE_CURL_LOG: log,
+        FAKE_CURL_STDIN_LOG: stdinLog,
         PATH: `${fixture.bin}:/usr/bin:/bin`,
       },
     });
     expect(result.status).toBe(0);
     const invocation = readFileSync(log, "utf8");
-    expect(invocation).toContain("agent@acme.test:fake-atlassian-key");
+    expect(invocation).not.toContain("fake-atlassian-key");
     expect(invocation).toContain("api.atlassian.com/ex/jira/cloud-123");
     expect(invocation).toContain(
       "fields=project,status,labels,components,issuetype,subtasks,comment"
+    );
+    expect(readFileSync(stdinLog, "utf8")).toContain(
+      'user = "agent@acme.test:fake-atlassian-key"'
     );
   });
 
@@ -634,6 +639,34 @@ describe("provider liveness", () => {
     });
     expect(terminal.status).toBe(1);
     expect(terminal.stderr).toContain("is terminal");
+  });
+
+  it("passes Linear authorization through curl stdin rather than process argv", () => {
+    const fixture = createFixture({
+      tracker: "linear",
+      repo: "widgets",
+      linear: { workspace: "acme", teamKey: "LIN" },
+    });
+    const argsLog = path.join(fixture.root, "curl.args.log");
+    const stdinLog = path.join(fixture.root, "curl.stdin.log");
+    executable(
+      path.join(fixture.bin, "curl"),
+      `printf '%s\\n' "$*" > "\${FAKE_CURL_ARGS_LOG}"\ncat > "\${FAKE_CURL_STDIN_LOG}"\nprintf '%s\\n' "$FAKE_CURL_JSON"`
+    );
+
+    const result = command(fixture, ["bind", "LIN-12"], {
+      env: {
+        FAKE_CURL_ARGS_LOG: argsLog,
+        FAKE_CURL_STDIN_LOG: stdinLog,
+        LINEAR_API_KEY: "secret-linear-key",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(argsLog, "utf8")).not.toContain("secret-linear-key");
+    expect(readFileSync(stdinLog, "utf8")).toContain(
+      'header = "Authorization: secret-linear-key"'
+    );
   });
 
   it("rejects wrong-repo, unclaimed, and container Linear issues", () => {


### PR DESCRIPTION
Closes #1929

Work-Item: CodySwannGT/lisa#1929

## Summary
- suppress relocation and remove the historical esbuild GHSA exclusion only when both package-manager enforcement and the installed esbuild are patched
- pass Jira and Linear curl authentication through stdin config so credentials never enter process argv
- remove the unnecessary top-level `await main()` from the distributed work-item gate

## Verification
- failing-first focused regression: 5 failures on the 2.286.4 baseline; 38/38 focused tests after repair
- hosted exact-head CI: 7,344/7,344 unit tests and 147/147 integration tests
- lint, slow lint, typecheck, formatting, knip, plugin sync, rules/workflow/manifest/version checks
- disposable historical-host apply: exclusion count 0, esbuild 0.28.1, frozen lock hash `d19a98a31069a52e929f00d0782b57932406f025a9fb608ecdc4050cc8200a64`