### PR TITLE
fix(doctor): detect round-2 static credential authority

### DIFF
--- a/src/cli/doctor-readiness-credentials.ts
+++ b/src/cli/doctor-readiness-credentials.ts
@@ -10,10 +10,11 @@
  *
  * Four declarations are treated as material over-authority: inherited secrets
  * (`secrets: inherit` hands a called workflow everything), `write-all`/`read-all`
- * blanket permission grants, a job that uses `GITHUB_TOKEN` with no
+ * blanket permission grants, a job that uses the repository token with no
  * `permissions` block at all (so it takes the repository default rather than a
- * stated minimum), and static long-lived AWS keys in a job that could have used
- * OIDC instead. Each is provable from the declaration alone.
+ * stated minimum), and static long-lived deployment credentials in jobs that
+ * should use a scoped or federated credential instead. Each is provable from
+ * the declaration alone.
  *
  * A fifth signal — one secret NAME appearing under several environments — is
  * reported as an *observation*, never a blocker: environment secrets are meant
@@ -36,11 +37,30 @@ const BLANKET_PERMISSIONS = new Set(["write-all", "read-all"]);
 /** Matches every `secrets.NAME` reference inside a job's declared text. */
 const SECRET_REFERENCE = /secrets\.(\w+)/g;
 
-/** Static AWS credential inputs that OIDC (`id-token: write`) would replace. */
-const STATIC_AWS_KEYS = ["aws-access-key-id", "aws-secret-access-key"];
+/** Static credential names and inputs that keyless or scoped auth should replace. */
+const STATIC_CREDENTIAL_KEYS = [
+  "aws-access-key-id",
+  "aws-secret-access-key",
+  "NPM_TOKEN",
+  "GCP_SERVICE_ACCOUNT_JSON",
+  "GOOGLE_APPLICATION_CREDENTIALS",
+  "AZURE_CREDENTIALS",
+  "ADMIN_PAT",
+  "BOT_ADMIN_PAT",
+  "GH_ADMIN_PAT",
+];
+
+/** Static cloud credential inputs that OIDC (`id-token: write`) can replace. */
+const OIDC_REPLACEABLE_KEYS = new Set([
+  "aws-access-key-id",
+  "aws-secret-access-key",
+  "GCP_SERVICE_ACCOUNT_JSON",
+  "GOOGLE_APPLICATION_CREDENTIALS",
+  "AZURE_CREDENTIALS",
+]);
 
 /** Matches a repository-token reference in either of its spellings. */
-const REPOSITORY_TOKEN = /GITHUB_TOKEN|github\.token/;
+const REPOSITORY_TOKEN = /\b(?:GITHUB_TOKEN|GH_TOKEN)\b|github\.token/;
 
 /** One secret referenced by one deployment environment. */
 interface SecretEnvironmentPair {
@@ -130,13 +150,14 @@ function unscopedTokenViolations(
   job: ParsedWorkflowJob,
   text: string
 ): readonly string[] {
+  const token = REPOSITORY_TOKEN.exec(text)?.[0];
   const unscoped =
-    REPOSITORY_TOKEN.test(text) &&
+    token !== undefined &&
     job.permissions === null &&
     workflow.permissions === null;
   return unscoped
     ? [
-        `${where} uses GITHUB_TOKEN with no \`permissions:\` block at either ` +
+        `${where} uses ${token} with no \`permissions:\` block at either ` +
           "scope, so it runs with the repository default rather than a stated minimum",
       ]
     : [];
@@ -157,17 +178,18 @@ function staticKeyViolations(
   job: ParsedWorkflowJob,
   text: string
 ): readonly string[] {
-  const staticKey = STATIC_AWS_KEYS.find(key => text.includes(key));
-  if (
-    staticKey === undefined ||
-    grantsOidc(job.permissions) ||
-    grantsOidc(workflow.permissions)
-  ) {
+  const oidcGranted =
+    grantsOidc(job.permissions) || grantsOidc(workflow.permissions);
+  const staticKey = STATIC_CREDENTIAL_KEYS.find(
+    key =>
+      text.includes(key) && !(oidcGranted && OIDC_REPLACEABLE_KEYS.has(key))
+  );
+  if (staticKey === undefined) {
     return [];
   }
   return [
     `${where} authenticates with the static long-lived credential ` +
-      `\`${staticKey}\` where keyless OIDC (\`id-token: write\`) would do`,
+      `\`${staticKey}\` instead of a scoped or federated deployment credential`,
   ];
 }
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7690,6 +7690,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/doctor-readiness-capabilities.test.ts": true,
     "tests/unit/cli/doctor-readiness-context-precision.test.ts": true,
     "tests/unit/cli/doctor-readiness-context.test.ts": true,
+    "tests/unit/cli/doctor-readiness-credentials-round2.test.ts": true,
     "tests/unit/cli/doctor-readiness-delivery-artifact.test.ts": true,
     "tests/unit/cli/doctor-readiness-delivery-triggers.test.ts": true,
     "tests/unit/cli/doctor-readiness-delivery.test.ts": true,

--- a/tests/unit/cli/doctor-readiness-credentials-round2.test.ts
+++ b/tests/unit/cli/doctor-readiness-credentials-round2.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Round-2 regression coverage for B3 credential-authority detection from #1903.
+ *
+ * These cases pin common credential spellings that the v1 producer missed while
+ * keeping the broader delivery-authority suite under its file-size budget.
+ * @module tests/unit/cli/doctor-readiness-credentials-round2
+ */
+import { rm } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { assessDeliveryAuthorityDimension } from "../../../src/cli/doctor-readiness-delivery.js";
+import {
+  asFindings,
+  CONTENTS_READ,
+  DEPLOY_NAME,
+  DEPLOY_YML,
+  FAIL,
+  JOBS,
+  makeScratchRepo,
+  ON_PUSH,
+  PERMISSIONS,
+  RUN_DEPLOY,
+  STEPS,
+  writeWorkflow,
+} from "../../helpers/readiness-workflow-fixtures.js";
+
+let tempDir: string | undefined;
+
+/**
+ * Resolve a scratch repository for one test case.
+ * @returns Temporary repository path
+ */
+async function getTempDir(): Promise<string> {
+  tempDir = await makeScratchRepo("credentials-round2");
+  return tempDir;
+}
+
+afterEach(async () => {
+  if (tempDir !== undefined) {
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+describe("assessDeliveryAuthorityDimension — B3 round-2 credentials", () => {
+  // Test hardened to kill mutant M001 (Risk Factor: Data security / credential authority).
+  it("FAILs with B3 when gh CLI uses GH_TOKEN with no permissions block", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, DEPLOY_YML, [
+      DEPLOY_NAME,
+      ON_PUSH,
+      JOBS,
+      "  comment:",
+      STEPS,
+      "      - run: gh pr comment 1 --body hi",
+      "        env:",
+      "          GH_TOKEN: ${{ github.token }}",
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    const finding = asFindings(record.findings).find(
+      candidate => candidate.blocker === "B3"
+    );
+    expect(finding?.evidence).toContain("GH_TOKEN");
+  });
+
+  // Test hardened to kill mutant M002 (Risk Factor: Data security / credential authority).
+  it.each([
+    ["NPM_TOKEN", "          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}"],
+    [
+      "GCP_SERVICE_ACCOUNT_JSON",
+      "          GCP_SERVICE_ACCOUNT_JSON: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}",
+    ],
+    [
+      "AZURE_CREDENTIALS",
+      "          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}",
+    ],
+    ["ADMIN_PAT", "          GH_TOKEN: ${{ secrets.ADMIN_PAT }}"],
+  ])("FAILs with B3 on static %s deployment credentials", async (key, line) => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, DEPLOY_YML, [
+      DEPLOY_NAME,
+      ON_PUSH,
+      JOBS,
+      "  ship:",
+      PERMISSIONS,
+      CONTENTS_READ,
+      STEPS,
+      RUN_DEPLOY,
+      "        env:",
+      line,
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    const finding = asFindings(record.findings).find(
+      candidate => candidate.blocker === "B3"
+    );
+    expect(finding?.evidence).toContain(key);
+  });
+
+  // Test hardened to kill mutant M003 (Risk Factor: Data security / credential authority).
+  it("reports a non-exempt static credential after an OIDC-exempt cloud key", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, DEPLOY_YML, [
+      DEPLOY_NAME,
+      ON_PUSH,
+      JOBS,
+      "  ship:",
+      "    permissions:",
+      "      contents: read",
+      "      id-token: write",
+      STEPS,
+      "      - uses: aws-actions/configure-aws-credentials@v4",
+      "        with:",
+      "          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}",
+      "      - run: npm publish --provenance",
+      "        env:",
+      "          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}",
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    const finding = asFindings(record.findings).find(
+      candidate => candidate.blocker === "B3"
+    );
+    expect(finding?.evidence).toContain("NPM_TOKEN");
+    expect(finding?.evidence).not.toContain("aws-access-key-id");
+  });
+});


### PR DESCRIPTION
## Summary
- Broadens B3 credential-authority detection to include `GH_TOKEN` repository-token usage.
- Flags common static deployment credentials from #1903: npm tokens, GCP service-account JSON, Azure credentials, and admin PAT-style secrets.
- Adds focused round-2 regression coverage and registers the new test in the upstream evidence manifest.

Refs CodySwannGT/lisa#1903

## Verification
- `bun test tests/unit/cli/doctor-readiness-delivery.test.ts tests/unit/cli/doctor-readiness-credentials-round2.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build:upstream-evidence-manifest && bun run check:upstream-evidence-manifest`
- `bun run build`
- pre-push: security audit, slow lint, knip, `vitest run --coverage`, and `vitest run tests/integration`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of overly broad deployment credentials in readiness checks.
  * Recognizes additional static credential names and repository token formats.
  * Provides more accurate evidence identifying the credential involved.
  * Correctly accounts for OIDC permissions at both workflow and job levels.

* **Tests**
  * Added regression coverage for credential-authority detection across multiple credential configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->