### PR TITLE
fix(doctor): detect templated release builds

### DIFF
--- a/src/cli/doctor-readiness-release-path.ts
+++ b/src/cli/doctor-readiness-release-path.ts
@@ -91,7 +91,7 @@ function isTemplatedPackageManagerBuild(run: string): boolean {
     if (
       (expression.includes("package_manager") ||
         expression.includes("package-manager")) &&
-      tail.startsWith("run build")
+      /^run\s+build(?:\s|$)/.test(tail)
     ) {
       return true;
     }

--- a/src/cli/doctor-readiness-release-path.ts
+++ b/src/cli/doctor-readiness-release-path.ts
@@ -66,8 +66,51 @@ function isValidatingCommand(run: string): boolean {
 const VALIDATING_WORKFLOW = /(quality|quality-rails|test|ci)\.ya?ml/;
 
 /** Commands that produce an artifact locally, inside the shipping job. */
-const LOCAL_BUILD_COMMAND =
-  /\b(npm pack|npm run build|yarn build|bun run build|bun run build:\w+|pnpm build|docker build|tsc)\b/;
+const LOCAL_BUILD_COMMANDS: readonly RegExp[] = [
+  /\b(npm pack|npm run build|yarn build|bun run build|bun run build:\w+|pnpm build|docker build|tsc)\b/,
+];
+
+/**
+ * Whether a templated package manager expression runs the standard build script.
+ * @param run - The step's `run` text
+ * @returns True for commands like `${{ inputs.package_manager }} run build`
+ */
+function isTemplatedPackageManagerBuild(run: string): boolean {
+  const lower = run.toLowerCase();
+  const scan = (cursor: number): boolean => {
+    const start = lower.indexOf("${{", cursor);
+    if (start < 0) {
+      return false;
+    }
+    const end = lower.indexOf("}}", start + 3);
+    if (end < 0) {
+      return false;
+    }
+    const expression = lower.slice(start + 3, end);
+    const tail = lower.slice(end + 2).trimStart();
+    if (
+      (expression.includes("package_manager") ||
+        expression.includes("package-manager")) &&
+      tail.startsWith("run build")
+    ) {
+      return true;
+    }
+    return scan(end + 2);
+  };
+  return scan(0);
+}
+
+/**
+ * Whether a command builds an artifact inside the shipping job.
+ * @param run - The step's `run` text
+ * @returns True when the command matches a known local build invocation
+ */
+function isLocalBuildCommand(run: string): boolean {
+  return (
+    LOCAL_BUILD_COMMANDS.some(pattern => pattern.test(run)) ||
+    isTemplatedPackageManagerBuild(run)
+  );
+}
 
 /** A publish argument naming a local path rather than a registry coordinate. */
 const LOCAL_PATH_ARGUMENT = /\s\.{0,2}\//;
@@ -273,7 +316,7 @@ function shipsSelfBuiltArtifact(
   if (downloadIndex >= 0) {
     const rebuildsAfterDownload = job.steps
       .slice(downloadIndex + 1)
-      .some(step => LOCAL_BUILD_COMMAND.test(step.run));
+      .some(step => isLocalBuildCommand(step.run));
     if (!rebuildsAfterDownload) {
       return false;
     }
@@ -281,7 +324,7 @@ function shipsSelfBuiltArtifact(
   return (
     LOCAL_PATH_ARGUMENT.test(publishStep.run) ||
     LOCAL_ARTIFACT_FILE.test(publishStep.run) ||
-    job.steps.some(step => LOCAL_BUILD_COMMAND.test(step.run))
+    job.steps.some(step => isLocalBuildCommand(step.run))
   );
 }
 

--- a/tests/unit/cli/doctor-readiness-delivery-artifact.test.ts
+++ b/tests/unit/cli/doctor-readiness-delivery-artifact.test.ts
@@ -281,6 +281,7 @@ describe("assessDeliveryAuthorityDimension — B2 artifact chain", () => {
     expect(assessReadiness([record]).blockers[0].id).toBe("B2");
   });
 
+  // Test hardened to kill mutant M001 (Risk Factor: Release artifact integrity / templated build detection).
   it("FAILs when a templated package-manager build happens after artifact download", async () => {
     const cwd = await getTempDir();
     await writeWorkflow(cwd, RELEASE_YML, [
@@ -293,7 +294,7 @@ describe("assessDeliveryAuthorityDimension — B2 artifact chain", () => {
       RUNS_ON,
       STEPS,
       DOWNLOAD_ARTIFACT_STEP,
-      "      - run: ${{ inputs.package_manager }} run build",
+      "      - run: ${{ inputs.package_manager }} run\t build",
       "      - run: npm publish ./rebuilt.tgz",
     ]);
 

--- a/tests/unit/cli/doctor-readiness-delivery-artifact.test.ts
+++ b/tests/unit/cli/doctor-readiness-delivery-artifact.test.ts
@@ -33,6 +33,8 @@ import {
   writeWorkflow,
 } from "../../helpers/readiness-workflow-fixtures.js";
 
+const DOWNLOAD_ARTIFACT_STEP = "      - uses: actions/download-artifact@v4";
+
 let tempDir: string | undefined;
 
 /**
@@ -73,7 +75,7 @@ describe("assessDeliveryAuthorityDimension — B2 artifact chain", () => {
       "    needs: [package]",
       RUNS_ON,
       STEPS,
-      "      - uses: actions/download-artifact@v4",
+      DOWNLOAD_ARTIFACT_STEP,
       RUN_PUBLISH,
     ]);
 
@@ -268,8 +270,30 @@ describe("assessDeliveryAuthorityDimension — B2 artifact chain", () => {
       PUBLISH_JOB,
       RUNS_ON,
       STEPS,
-      "      - uses: actions/download-artifact@v4",
+      DOWNLOAD_ARTIFACT_STEP,
       RUN_BUILD,
+      "      - run: npm publish ./rebuilt.tgz",
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    expect(assessReadiness([record]).blockers[0].id).toBe("B2");
+  });
+
+  it("FAILs when a templated package-manager build happens after artifact download", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, RELEASE_YML, [
+      RELEASE_NAME,
+      ON,
+      PUSH,
+      TAGS,
+      JOBS,
+      PUBLISH_JOB,
+      RUNS_ON,
+      STEPS,
+      DOWNLOAD_ARTIFACT_STEP,
+      "      - run: ${{ inputs.package_manager }} run build",
       "      - run: npm publish ./rebuilt.tgz",
     ]);
 


### PR DESCRIPTION
## Summary
- detect templated package-manager build commands like `${{ inputs.package_manager }} run build` as local release builds
- keep B2 standing when a release job rebuilds after downloading the validated artifact
- add regression coverage for the #1903 templated build false green

## Validation
- `bun test tests/unit/cli/doctor-readiness-delivery-artifact.test.ts`
- `bun run typecheck`
- `bun run build:dist`
- `bun run lint -- src/cli/doctor-readiness-release-path.ts tests/unit/cli/doctor-readiness-delivery-artifact.test.ts`
- pre-push: slow lint, knip, full unit coverage, integration tests

Work-Item: CodySwannGT/lisa#1903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-path checks to recognize templated package-manager build commands.
  * Correctly identifies workflows that rebuild artifacts after downloading a promoted artifact.
  * Enhanced delivery readiness validation for post-download rebuild scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->