### PR TITLE
fix(doctor): assess every publish step

### DIFF
--- a/src/cli/doctor-readiness-delivery.ts
+++ b/src/cli/doctor-readiness-delivery.ts
@@ -30,7 +30,7 @@ import {
 } from "./doctor-readiness-credentials.js";
 import { informationalFindings } from "./doctor-readiness-shared.js";
 import {
-  assessReleasePath,
+  assessReleasePaths,
   PROMOTION_ACTION,
   type ReleasePathOutcome,
 } from "./doctor-readiness-release-path.js";
@@ -66,10 +66,7 @@ function summarizeReleasePaths(
   workflows: readonly ParsedWorkflow[]
 ): ReleasePathSummary {
   const outcomes: readonly ReleasePathOutcome[] = workflows.flatMap(workflow =>
-    workflow.jobs.flatMap(job => {
-      const outcome = assessReleasePath(workflow, job);
-      return outcome ? [outcome] : [];
-    })
+    workflow.jobs.flatMap(job => assessReleasePaths(workflow, job))
   );
   return {
     violations: outcomes.flatMap(outcome =>

--- a/src/cli/doctor-readiness-delivery.ts
+++ b/src/cli/doctor-readiness-delivery.ts
@@ -54,7 +54,7 @@ interface ReleasePathSummary {
   readonly violations: readonly string[];
   readonly unresolved: readonly string[];
   readonly cleanCount: number;
-  readonly publishJobCount: number;
+  readonly publishStepCount: number;
 }
 
 /**
@@ -76,7 +76,7 @@ function summarizeReleasePaths(
       outcome.kind === "unresolved" ? [outcome.reason] : []
     ),
     cleanCount: outcomes.filter(outcome => outcome.kind === "clean").length,
-    publishJobCount: outcomes.length,
+    publishStepCount: outcomes.length,
   };
 }
 
@@ -175,7 +175,7 @@ function cleanRecord(
     findings: [
       {
         evidence:
-          `Inspected ${summary.publishJobCount} publishing job(s) across ` +
+          `Inspected ${summary.publishStepCount} publishing step(s) across ` +
           `${workflows.length} workflow file(s): each is preceded by a test ` +
           `run or promotes the CI-built artifact via \`${PROMOTION_ACTION}\`. ` +
           "No workflow declares blanket permissions, inherited secrets, or " +
@@ -291,7 +291,7 @@ export async function assessDeliveryAuthorityDimension(
   if (summary.unresolved.length > 0) {
     return unresolvedRecord(summary.unresolved, credentials);
   }
-  if (summary.publishJobCount === 0) {
+  if (summary.publishStepCount === 0) {
     return noReleasePathRecord(workflows, credentials);
   }
   return cleanRecord(summary, workflows, credentials);

--- a/src/cli/doctor-readiness-release-path.ts
+++ b/src/cli/doctor-readiness-release-path.ts
@@ -1,22 +1,6 @@
 /**
  * Release-path assessment for the delivery/authority readiness dimension — ship
  * blocker B2 (PRD #1739, #1896).
- *
- * B2 asks whether the thing that ships equals the thing that was validated. The
- * question is answered offline, from the workflow files alone, which imposes a
- * hard discipline: **absence of evidence is not evidence of a bypass.** A
- * reusable `workflow_call` publish workflow has no validating job of its own
- * because validation is the caller's obligation; a `workflow_run`-triggered
- * deploy is gated by the upstream workflow that fired it; a default-branch push
- * may be gated by branch protection. None of those are visible here, so none of
- * them may be reported as a violation.
- *
- * The rule is therefore: stand B2 only when the bypass is provable from the file
- * alone — a job that self-builds AND publishes with no validating ancestor, in a
- * workflow whose trigger makes in-file validation the expected place for it
- * (a tag push, `workflow_dispatch`, `schedule`, a non-default-branch push, or an
- * unstated trigger). Everything else that cannot be settled offline returns a
- * stated-reason SKIP, never a FAIL.
  * @module cli/doctor-readiness-release-path
  */
 import type {
@@ -25,7 +9,6 @@ import type {
   ParsedWorkflowStep,
 } from "./doctor-readiness-workflows.js";
 
-/** Commands that put an artifact in front of users. */
 const PUBLISH_VERBS = [
   "npm publish",
   "docker push",
@@ -35,17 +18,11 @@ const PUBLISH_VERBS = [
   "eas submit",
 ];
 
-/** Publish actions that put release artifacts in front of users. */
 const DOCKER_BUILD_PUSH_ACTION = "docker/build-push-action";
 const PYPI_PUBLISH_ACTION = "pypa/gh-action-pypi-publish";
 const GITHUB_RELEASE_ACTION = "softprops/action-gh-release";
 
-/**
- * Commands that actually run a test suite. Deliberately narrow: the invariant B2
- * protects is "this artifact was *tested*", and a loose substring match (`echo
- * "test the release notes"`, or a lint step) would manufacture false
- * reassurance — the wrong direction to err for a gate.
- */
+/** Commands that actually run a test suite. */
 const VALIDATING_COMMANDS: readonly RegExp[] = [
   /\b(npm|yarn|pnpm|bun|npx|bunx)\s+(run\s+)?test\b/,
   /\btest:[\w:-]+/,
@@ -112,28 +89,20 @@ function isLocalBuildCommand(run: string): boolean {
   );
 }
 
-/** A publish argument naming a local path rather than a registry coordinate. */
 const LOCAL_PATH_ARGUMENT = /\s\.{0,2}\//;
 
-/** A publish argument naming a packaged artifact file on disk. */
 const LOCAL_ARTIFACT_FILE = /\.(tgz|tar\.gz|zip|whl)\b/;
 
-/** The action that promotes the artifact CI already built and validated. */
 export const PROMOTION_ACTION = "actions/download-artifact";
 
-/** Branch names treated as the repository's default branch. */
 const DEFAULT_BRANCHES = new Set(["main", "master"]);
 
-/** Longest step description carried into persisted evidence. */
 const MAX_STEP_LABEL = 80;
 
-/** What assessing one publishing job established. */
+/** What assessing one publishing step established. */
 export type ReleasePathOutcome =
-  /** The bypass is provable from this file alone. */
   | { readonly kind: "violation"; readonly evidence: string }
-  /** The proof, if any, lives somewhere not resolvable offline. */
   | { readonly kind: "unresolved"; readonly reason: string }
-  /** Validation provably precedes the publish, or the artifact is promoted. */
   | { readonly kind: "clean" };
 
 /**
@@ -323,10 +292,14 @@ function shipsSelfBuiltArtifact(
   }
   const publishIndex = job.steps.indexOf(publishStep);
   const stepsThroughPublish = job.steps.slice(0, publishIndex + 1);
-  const downloadIndex = job.steps.findIndex(step =>
-    step.uses.includes(PROMOTION_ACTION)
-  );
-  if (downloadIndex >= 0 && downloadIndex < publishIndex) {
+  const downloadIndex = job.steps
+    .slice(0, publishIndex)
+    .reduce(
+      (latest, step, index) =>
+        step.uses.includes(PROMOTION_ACTION) ? index : latest,
+      -1
+    );
+  if (downloadIndex >= 0) {
     const rebuildsAfterDownload = stepsThroughPublish
       .slice(downloadIndex + 1)
       .some(step => isLocalBuildCommand(step.run));
@@ -417,7 +390,7 @@ export function assessReleasePaths(
         ? rebuildPastValidation(where)
         : unvalidatedSelfBuild(where, workflow);
     }
-    if (validated || promotesValidatedArtifact(job)) {
+    if (validated || promotesValidatedArtifact(job, publishStep)) {
       return { kind: "clean" };
     }
     // Neither built here nor promoted from CI, and nothing validating precedes it:
@@ -486,8 +459,14 @@ function unvalidatedSelfBuild(
 /**
  * Whether the job promotes the artifact CI already built and validated.
  * @param job - The publishing job
+ * @param publishStep - The step that ships
  * @returns True when a download-artifact step is present
  */
-function promotesValidatedArtifact(job: ParsedWorkflowJob): boolean {
-  return job.steps.some(step => step.uses.includes(PROMOTION_ACTION));
+function promotesValidatedArtifact(
+  job: ParsedWorkflowJob,
+  publishStep: ParsedWorkflowStep
+): boolean {
+  return job.steps
+    .slice(0, job.steps.indexOf(publishStep))
+    .some(step => step.uses.includes(PROMOTION_ACTION));
 }

--- a/src/cli/doctor-readiness-release-path.ts
+++ b/src/cli/doctor-readiness-release-path.ts
@@ -212,14 +212,25 @@ function isPublishStep(step: ParsedWorkflowStep): boolean {
 }
 
 /**
+ * Find every step in a job that ships something.
+ * @param job - The parsed job
+ * @returns The publishing steps, in execution order
+ */
+export function findPublishSteps(
+  job: ParsedWorkflowJob
+): readonly ParsedWorkflowStep[] {
+  return job.steps.filter(isPublishStep);
+}
+
+/**
  * Find the first step in a job that ships something.
  * @param job - The parsed job
- * @returns The publishing step, or undefined when the job ships nothing
+ * @returns The first publishing step, or undefined when the job ships nothing
  */
 export function findPublishStep(
   job: ParsedWorkflowJob
 ): ParsedWorkflowStep | undefined {
-  return job.steps.find(isPublishStep);
+  return findPublishSteps(job)[0];
 }
 
 /**
@@ -310,11 +321,13 @@ function shipsSelfBuiltArtifact(
   if (actionId(publishStep.uses) === DOCKER_BUILD_PUSH_ACTION) {
     return true;
   }
+  const publishIndex = job.steps.indexOf(publishStep);
+  const stepsThroughPublish = job.steps.slice(0, publishIndex + 1);
   const downloadIndex = job.steps.findIndex(step =>
     step.uses.includes(PROMOTION_ACTION)
   );
-  if (downloadIndex >= 0) {
-    const rebuildsAfterDownload = job.steps
+  if (downloadIndex >= 0 && downloadIndex < publishIndex) {
+    const rebuildsAfterDownload = stepsThroughPublish
       .slice(downloadIndex + 1)
       .some(step => isLocalBuildCommand(step.run));
     if (!rebuildsAfterDownload) {
@@ -324,7 +337,7 @@ function shipsSelfBuiltArtifact(
   return (
     LOCAL_PATH_ARGUMENT.test(publishStep.run) ||
     LOCAL_ARTIFACT_FILE.test(publishStep.run) ||
-    job.steps.some(step => isLocalBuildCommand(step.run))
+    stepsThroughPublish.some(step => isLocalBuildCommand(step.run))
   );
 }
 
@@ -383,30 +396,41 @@ export function assessReleasePath(
   workflow: ParsedWorkflow,
   job: ParsedWorkflowJob
 ): ReleasePathOutcome | undefined {
-  const publishStep = findPublishStep(job);
-  if (!publishStep) {
-    return undefined;
-  }
-  const where = `${workflow.file} job \`${job.id}\` step \`${describeStep(publishStep)}\``;
-  const validated = validationPrecedesPublish(workflow, job, publishStep);
-  if (shipsSelfBuiltArtifact(job, publishStep)) {
-    return validated
-      ? rebuildPastValidation(where)
-      : unvalidatedSelfBuild(where, workflow);
-  }
-  if (validated || promotesValidatedArtifact(job)) {
-    return { kind: "clean" };
-  }
-  // Neither built here nor promoted from CI, and nothing validating precedes it:
-  // the link between what ships and what was validated is simply not observable
-  // in this file. That is unestablished, not clean.
-  return {
-    kind: "unresolved",
-    reason:
-      `${where} neither builds its own artifact nor promotes a CI-built one via ` +
-      `\`${PROMOTION_ACTION}\`, and no validating job precedes it, so what it ` +
-      "ships cannot be tied to anything that was validated",
-  };
+  return assessReleasePaths(workflow, job)[0];
+}
+
+/**
+ * Assess every publishing step in one job against B2.
+ * @param workflow - The workflow declaring the job
+ * @param job - The job to assess
+ * @returns One outcome per publishing step, or an empty list when it ships nothing
+ */
+export function assessReleasePaths(
+  workflow: ParsedWorkflow,
+  job: ParsedWorkflowJob
+): readonly ReleasePathOutcome[] {
+  return findPublishSteps(job).map(publishStep => {
+    const where = `${workflow.file} job \`${job.id}\` step \`${describeStep(publishStep)}\``;
+    const validated = validationPrecedesPublish(workflow, job, publishStep);
+    if (shipsSelfBuiltArtifact(job, publishStep)) {
+      return validated
+        ? rebuildPastValidation(where)
+        : unvalidatedSelfBuild(where, workflow);
+    }
+    if (validated || promotesValidatedArtifact(job)) {
+      return { kind: "clean" };
+    }
+    // Neither built here nor promoted from CI, and nothing validating precedes it:
+    // the link between what ships and what was validated is simply not observable
+    // in this file. That is unestablished, not clean.
+    return {
+      kind: "unresolved",
+      reason:
+        `${where} neither builds its own artifact nor promotes a CI-built one via ` +
+        `\`${PROMOTION_ACTION}\`, and no validating job precedes it, so what it ` +
+        "ships cannot be tied to anything that was validated",
+    };
+  });
 }
 
 /**

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7692,6 +7692,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/doctor-readiness-context.test.ts": true,
     "tests/unit/cli/doctor-readiness-credentials-round2.test.ts": true,
     "tests/unit/cli/doctor-readiness-delivery-artifact.test.ts": true,
+    "tests/unit/cli/doctor-readiness-delivery-multiple-publish.test.ts": true,
     "tests/unit/cli/doctor-readiness-delivery-triggers.test.ts": true,
     "tests/unit/cli/doctor-readiness-delivery.test.ts": true,
     "tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts": true,

--- a/tests/unit/cli/doctor-readiness-delivery-multiple-publish.test.ts
+++ b/tests/unit/cli/doctor-readiness-delivery-multiple-publish.test.ts
@@ -66,11 +66,14 @@ describe("assessDeliveryAuthorityDimension — multiple publish steps", () => {
     ]);
 
     const record = await assessDeliveryAuthorityDimension(cwd);
+    const findings = asFindings(record.findings);
+    const evidence = String(findings[0].evidence);
 
     expect(record.status).toBe(FAIL);
+    expect(assessReadiness([record]).blockers).toHaveLength(1);
     expect(assessReadiness([record]).blockers[0].id).toBe("B2");
-    expect(String(asFindings(record.findings)[0].evidence)).toContain(
-      "docker push ghcr.io/acme/app:latest"
-    );
+    expect(findings).toHaveLength(1);
+    expect(evidence).toContain("docker push ghcr.io/acme/app:latest");
+    expect(evidence).not.toContain("npm publish --provenance");
   });
 });

--- a/tests/unit/cli/doctor-readiness-delivery-multiple-publish.test.ts
+++ b/tests/unit/cli/doctor-readiness-delivery-multiple-publish.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression coverage for B2 jobs that publish more than one artifact.
+ *
+ * A release job can ship multiple things to different registries. The delivery
+ * authority producer must assess each publish step, because a clean first
+ * publish must not hide an unvalidated second one.
+ * @module tests/unit/cli/doctor-readiness-delivery-multiple-publish
+ */
+import { rm } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { assessReadiness } from "../../../src/cli/doctor-readiness-blockers.js";
+import { assessDeliveryAuthorityDimension } from "../../../src/cli/doctor-readiness-delivery.js";
+import {
+  asFindings,
+  FAIL,
+  JOBS,
+  makeScratchRepo,
+  ON,
+  PUBLISH_JOB,
+  PUSH,
+  RELEASE_NAME,
+  RELEASE_YML,
+  RUNS_ON,
+  STEPS,
+  TAGS,
+  writeWorkflow,
+} from "../../helpers/readiness-workflow-fixtures.js";
+
+const DOWNLOAD_ARTIFACT_STEP = "      - uses: actions/download-artifact@v4";
+
+let tempDir: string | undefined;
+
+/**
+ * Resolve a scratch repository for one test case.
+ * @returns Temporary directory path
+ */
+async function getTempDir(): Promise<string> {
+  tempDir ??= await makeScratchRepo("multi-publish");
+  return tempDir;
+}
+
+afterEach(async () => {
+  if (tempDir) {
+    await rm(tempDir, { force: true, recursive: true });
+    tempDir = undefined;
+  }
+});
+
+describe("assessDeliveryAuthorityDimension — multiple publish steps", () => {
+  it("FAILs when a later publish step ships an unvalidated second artifact", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, RELEASE_YML, [
+      RELEASE_NAME,
+      ON,
+      PUSH,
+      TAGS,
+      JOBS,
+      PUBLISH_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: npm test",
+      DOWNLOAD_ARTIFACT_STEP,
+      "      - run: npm publish --provenance",
+      "      - run: docker build -t ghcr.io/acme/app:latest .",
+      "      - run: docker push ghcr.io/acme/app:latest",
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    expect(assessReadiness([record]).blockers[0].id).toBe("B2");
+    expect(String(asFindings(record.findings)[0].evidence)).toContain(
+      "docker push ghcr.io/acme/app:latest"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Assess every publishing step in a release job instead of only the first detected publish.
- Scope self-built artifact detection to the steps that have actually run before each publish, so a clean first publish cannot hide a later rebuild-and-push.
- Add focused regression coverage for a validated npm publish followed by an unvalidated Docker image publish in the same job.
- Regenerate the upstream evidence manifest for the new test surface.

## Verification

- `bun test tests/unit/cli/doctor-readiness-delivery-artifact.test.ts tests/unit/cli/doctor-readiness-delivery-multiple-publish.test.ts`
- `bun run lint -- src/cli/doctor-readiness-release-path.ts src/cli/doctor-readiness-delivery.ts tests/unit/cli/doctor-readiness-delivery-artifact.test.ts tests/unit/cli/doctor-readiness-delivery-multiple-publish.test.ts`
- `bun run typecheck`
- `bun run build:dist`
- `bun test tests/unit/scripts/upstream-evidence-manifest.test.ts`
- pre-push: security audit, slow lint, knip, `vitest run --coverage`, `vitest run tests/integration`

Work-Item: CodySwannGT/lisa#1903


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-readiness checks for jobs with multiple publishing steps by evaluating each step independently.
  * Enhanced self-build/offline bypass logic to focus on the relevant publish step in the job execution timeline.
  * Updated delivery assessments to aggregate all publishing-step outcomes and evidence correctly (including later unvalidated steps).
* **Tests**
  * Added a unit test covering multiple publish/shipping-related steps, ensuring Docker push evidence is included while npm publish with provenance evidence is excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->