### PR TITLE
fix(doctor): respect configured default branch for B2

### DIFF
--- a/src/cli/doctor-readiness-delivery.ts
+++ b/src/cli/doctor-readiness-delivery.ts
@@ -24,6 +24,8 @@
  *    was validated.
  * @module cli/doctor-readiness-delivery
  */
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
 import {
   type CredentialFindings,
   detectCredentialFindings,
@@ -39,6 +41,7 @@ import {
   type ParsedWorkflow,
   parseRepositoryWorkflows,
 } from "./doctor-readiness-workflows.js";
+import { isJsonObject } from "../sync/json-path.js";
 
 /** The delivery/authority readiness dimension id (readiness-rubric, RRR-1). */
 export const DELIVERY_AUTHORITY_DIMENSION_ID = "delivery-authority";
@@ -60,13 +63,17 @@ interface ReleasePathSummary {
 /**
  * Assess every publishing job across every workflow.
  * @param workflows - Parsed workflows
+ * @param defaultBranches - Project-local default-like branch names
  * @returns What the release paths established, in aggregate
  */
 function summarizeReleasePaths(
-  workflows: readonly ParsedWorkflow[]
+  workflows: readonly ParsedWorkflow[],
+  defaultBranches?: readonly string[]
 ): ReleasePathSummary {
   const outcomes: readonly ReleasePathOutcome[] = workflows.flatMap(workflow =>
-    workflow.jobs.flatMap(job => assessReleasePaths(workflow, job))
+    workflow.jobs.flatMap(job =>
+      assessReleasePaths(workflow, job, defaultBranches)
+    )
   );
   return {
     violations: outcomes.flatMap(outcome =>
@@ -78,6 +85,32 @@ function summarizeReleasePaths(
     cleanCount: outcomes.filter(outcome => outcome.kind === "clean").length,
     publishStepCount: outcomes.length,
   };
+}
+
+/**
+ * Read the local production branch hint Lisa writes into project config. This
+ * stays offline and best-effort: unreadable or unusual config falls back to the
+ * built-in `main`/`master` defaults in the release-path assessor.
+ * @param root - Project root to inspect
+ * @returns Configured default-like branch names
+ */
+async function configuredDefaultBranches(
+  root: string
+): Promise<readonly string[]> {
+  try {
+    const raw = await readFile(path.join(root, ".lisa.config.json"), "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (!isJsonObject(parsed) || !isJsonObject(parsed.deploy)) {
+      return [];
+    }
+    const branches = parsed.deploy.branches;
+    if (!isJsonObject(branches)) {
+      return [];
+    }
+    return typeof branches.production === "string" ? [branches.production] : [];
+  } catch {
+    return [];
+  }
 }
 
 /**
@@ -283,7 +316,10 @@ export async function assessDeliveryAuthorityDimension(
   if (workflows.length === 0) {
     return noWorkflowsRecord();
   }
-  const summary = summarizeReleasePaths(workflows);
+  const summary = summarizeReleasePaths(
+    workflows,
+    await configuredDefaultBranches(root)
+  );
   const credentials = detectCredentialFindings(workflows);
   if (summary.violations.length > 0 || credentials.violations.length > 0) {
     return violationRecord(summary, credentials);

--- a/src/cli/doctor-readiness-release-path.ts
+++ b/src/cli/doctor-readiness-release-path.ts
@@ -92,11 +92,8 @@ function isLocalBuildCommand(run: string): boolean {
 const LOCAL_PATH_ARGUMENT = /\s\.{0,2}\//;
 
 const LOCAL_ARTIFACT_FILE = /\.(tgz|tar\.gz|zip|whl)\b/;
-
 export const PROMOTION_ACTION = "actions/download-artifact";
-
 const DEFAULT_BRANCHES = new Set(["main", "master"]);
-
 const MAX_STEP_LABEL = 80;
 
 /** What assessing one publishing step established. */
@@ -125,9 +122,7 @@ export function describeStep(step: ParsedWorkflowStep): string {
     : source;
 }
 
-/**
- * A rehearsal flag: the command goes through the motions and ships nothing.
- */
+/** A rehearsal flag: the command goes through the motions and ships nothing. */
 const DRY_RUN_FLAG = /--dry[-_]?run\b/;
 
 /**
@@ -189,17 +184,6 @@ export function findPublishSteps(
   job: ParsedWorkflowJob
 ): readonly ParsedWorkflowStep[] {
   return job.steps.filter(isPublishStep);
-}
-
-/**
- * Find the first step in a job that ships something.
- * @param job - The parsed job
- * @returns The first publishing step, or undefined when the job ships nothing
- */
-export function findPublishStep(
-  job: ParsedWorkflowJob
-): ParsedWorkflowStep | undefined {
-  return findPublishSteps(job)[0];
 }
 
 /**
@@ -318,9 +302,13 @@ function shipsSelfBuiltArtifact(
  * Decide whether a workflow's trigger makes in-file validation the expected
  * place for it — the only case where absent validation proves a bypass.
  * @param workflow - The workflow to classify
+ * @param defaultBranches - Project-local default-like branch names
  * @returns The reason validation may live elsewhere, or null when it must be here
  */
-function offlineUnresolvableTrigger(workflow: ParsedWorkflow): string | null {
+function offlineUnresolvableTrigger(
+  workflow: ParsedWorkflow,
+  defaultBranches?: readonly string[]
+): string | null {
   const events = workflow.on.events;
   if (events.length > 0 && events.every(event => event === "workflow_call")) {
     return (
@@ -346,9 +334,13 @@ function offlineUnresolvableTrigger(workflow: ParsedWorkflow): string | null {
     workflow.on.events.includes("push") &&
     workflow.on.pushBranches.length === 0 &&
     workflow.on.pushTags.length === 0;
-  const defaultBranchPush = workflow.on.pushBranches.some(branch =>
-    DEFAULT_BRANCHES.has(branch)
-  );
+  const defaultBranchPush = workflow.on.pushBranches.some(branch => {
+    const trimmed = branch.trim();
+    return (
+      DEFAULT_BRANCHES.has(trimmed) ||
+      (defaultBranches ?? []).some(candidate => candidate.trim() === trimmed)
+    );
+  });
   if (unfilteredPush || defaultBranchPush) {
     return (
       "it is triggered by a push to the default branch, where branch protection " +
@@ -360,27 +352,16 @@ function offlineUnresolvableTrigger(workflow: ParsedWorkflow): string | null {
 }
 
 /**
- * Assess one job's release path against B2.
- * @param workflow - The workflow declaring the job
- * @param job - The job to assess
- * @returns What this job established, or undefined when it ships nothing
- */
-export function assessReleasePath(
-  workflow: ParsedWorkflow,
-  job: ParsedWorkflowJob
-): ReleasePathOutcome | undefined {
-  return assessReleasePaths(workflow, job)[0];
-}
-
-/**
  * Assess every publishing step in one job against B2.
  * @param workflow - The workflow declaring the job
  * @param job - The job to assess
+ * @param defaultBranches - Project-local default-like branch names
  * @returns One outcome per publishing step, or an empty list when it ships nothing
  */
 export function assessReleasePaths(
   workflow: ParsedWorkflow,
-  job: ParsedWorkflowJob
+  job: ParsedWorkflowJob,
+  defaultBranches?: readonly string[]
 ): readonly ReleasePathOutcome[] {
   return findPublishSteps(job).map(publishStep => {
     const where = `${workflow.file} job \`${job.id}\` step \`${describeStep(publishStep)}\``;
@@ -388,7 +369,7 @@ export function assessReleasePaths(
     if (shipsSelfBuiltArtifact(job, publishStep)) {
       return validated
         ? rebuildPastValidation(where)
-        : unvalidatedSelfBuild(where, workflow);
+        : unvalidatedSelfBuild(where, workflow, defaultBranches);
     }
     if (validated || promotesValidatedArtifact(job, publishStep)) {
       return { kind: "clean" };
@@ -431,13 +412,15 @@ function rebuildPastValidation(where: string): ReleasePathOutcome {
  * a stated-reason SKIP when the proof could live somewhere not visible offline.
  * @param where - Evidence location label
  * @param workflow - The workflow declaring the job
+ * @param defaultBranches - Project-local default-like branch names
  * @returns The violation or unresolved outcome
  */
 function unvalidatedSelfBuild(
   where: string,
-  workflow: ParsedWorkflow
+  workflow: ParsedWorkflow,
+  defaultBranches?: readonly string[]
 ): ReleasePathOutcome {
-  const unresolvable = offlineUnresolvableTrigger(workflow);
+  const unresolvable = offlineUnresolvableTrigger(workflow, defaultBranches);
   if (unresolvable !== null) {
     return {
       kind: "unresolved",

--- a/tests/unit/cli/doctor-readiness-delivery-triggers.test.ts
+++ b/tests/unit/cli/doctor-readiness-delivery-triggers.test.ts
@@ -33,6 +33,7 @@ import {
   SHIP_JOB,
   SKIP,
   STEPS,
+  writeRepoJson,
   writeWorkflow,
 } from "../../helpers/readiness-workflow-fixtures.js";
 
@@ -139,6 +140,33 @@ describe("assessDeliveryAuthorityDimension — B2 never manufactures RED from ab
     // visible in the workflow file, so silence is not evidence of a bypass.
     expect(record.status).toBe(SKIP);
     expect(assessReadiness([record]).blockers).toEqual([]);
+  });
+
+  it("uses Lisa's configured production branch when detecting default-branch pushes", async () => {
+    const cwd = await getTempDir();
+    await writeRepoJson(cwd, ".lisa.config.json", {
+      deploy: { branches: { production: "develop" } },
+    });
+    await writeWorkflow(cwd, DEPLOY_YML, [
+      DEPLOY_NAME,
+      ON,
+      "  push:",
+      "    branches: [develop]",
+      JOBS,
+      SHIP_JOB,
+      RUNS_ON,
+      PERMISSIONS,
+      CONTENTS_READ,
+      STEPS,
+      RUN_BUILD,
+      RUN_CDK_DEPLOY,
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe(SKIP);
+    expect(assessReadiness([record]).blockers).toEqual([]);
+    expect(JSON.stringify(record.findings)).toContain("default branch");
   });
 
   it("SKIPs with a stated reason when workflows exist but nothing publishes", async () => {


### PR DESCRIPTION
## Summary

- Threads Lisa's local production branch hint into the B2 release-path trigger classifier.
- Keeps `main`/`master` fallback behavior when `.lisa.config.json` is absent or unreadable.
- Adds a regression proving `deploy.branches.production: "develop"` SKIPs as a default-branch push instead of false-failing B2.

Refs #1903

## Verification

- `bun test tests/unit/cli/doctor-readiness-delivery-triggers.test.ts`
- `bun run typecheck`
- `bun run build:dist`
- `bun run lint -- src/cli/doctor-readiness-delivery.ts src/cli/doctor-readiness-release-path.ts tests/unit/cli/doctor-readiness-delivery-triggers.test.ts`
- pre-push hook: security audit, slow lint, knip, full unit coverage, integration tests
