### PR TITLE
fix(doctor): clarify B1 runbook-cleared skips

### DIFF
--- a/src/cli/doctor-readiness-domain.ts
+++ b/src/cli/doctor-readiness-domain.ts
@@ -158,12 +158,15 @@ function domainFinding(scan: OperationScan): Record<string, unknown> {
  * State why the dimension was not settled, naming what WAS looked at so an
  * operator can tell "nothing to report" from "never looked".
  * @param inspected - How many workflow files were read
+ * @param runbook - Whether a runbook is checked in
  * @returns The SKIP reason
  */
-function skipReason(inspected: number): string {
+function skipReason(inspected: number, runbook: boolean): string {
   return (
     `Read ${inspected} workflow file(s) for irreversible data-destroying ` +
-    "operations and found none running unattended and ungated. Whether this " +
+    "operations and found none that this file alone proves runs unattended, " +
+    `ungated, and with no way back (recovery runbook ` +
+    `${runbook ? "present" : "absent"}). Whether this ` +
     "repository's business rules, glossary, and danger zones are genuinely " +
     "owned and written down cannot be established by reading files offline — " +
     "that needs the agent-ready domain phase — so domain ownership is not " +
@@ -178,18 +181,20 @@ function skipReason(inspected: number): string {
  * @param guarded - The destructive commands something already guards
  * @param scan - The destructive-operation scan
  * @param inspected - How many workflow files were read
+ * @param runbook - Whether a runbook is checked in
  * @returns The SKIP dimension record
  */
 function skipRecord(
   guarded: readonly ScannedCommand[],
   scan: OperationScan,
-  inspected: number
+  inspected: number,
+  runbook: boolean
 ): ReadinessDimensionRecord {
   return {
     id: DOMAIN_OWNERSHIP_DIMENSION_ID,
     status: "SKIP",
     findings: [
-      { reason: skipReason(inspected), skip: true },
+      { reason: skipReason(inspected, runbook), skip: true },
       ...informationalFindings([
         ...guarded.map(
           entry =>
@@ -232,7 +237,8 @@ export async function assessDomainOwnershipDimension(
     return skipRecord(
       recoverable ? [...scan.gated, ...scan.ungated] : scan.gated,
       scan,
-      workflows.length
+      workflows.length,
+      recoverable
     );
   }
   return {

--- a/tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts
@@ -182,7 +182,12 @@ describe("assessDomainOwnershipDimension — an empty runbook directory suppress
     const record = await assessDomainOwnershipDimension(root);
 
     expect(record.status).toBe(SKIP);
-    for (const finding of asFindings(record.findings)) {
+    const findings = asFindings(record.findings);
+    expect(String(findings[0].reason)).toContain("recovery runbook present");
+    expect(String(findings[0].reason)).not.toContain(
+      "found none running unattended and ungated"
+    );
+    for (const finding of findings) {
       expect(Object.hasOwn(finding, "blocker")).toBe(false);
     }
   });


### PR DESCRIPTION
## Summary
- Clarify B1 SKIP wording so runbook-cleared destructive operations no longer read as if no unattended operation existed.
- Include the recovery-runbook present/absent state in the first operator-facing B1 finding, matching the honest shape already used by B4.
- Add focused coverage that a real checked-in runbook clears B1 while the reason says `recovery runbook present`.

## Verification
- `bun test tests/unit/cli/doctor-readiness-domain.test.ts tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts`
- `bun run typecheck`
- `bun run lint -- src/cli/doctor-readiness-domain.ts tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts`
- pre-push hook: security audit, slow lint, knip, full unit coverage, integration tests

Work-Item: CodySwannGT/lisa#1903

Note: this handles one B1/B4 honesty slice from #1903; the broader round-2 backlog remains open.