### PR TITLE
docs(verification): drive stateful surfaces into the state that can break

### DIFF
--- a/plugins/lisa-agy/skills/lisa-verification-lifecycle/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-verification-lifecycle/SKILL.md
@@ -66,6 +66,8 @@ For a user-visible Fix, or a Build change that affects user-visible behavior, th
 
 The lead cannot waive, defer, or demote this regression spec as optional, "if cheap", or equivalent. The only acceptable exits are a recorded absence of an end-to-end harness for the platform, or a genuine technical blocker that is captured before merge as a linked build-ready follow-up ticket referenced from the PR and source work item.
 
+A claim that the change is "behavior-preserving", a "no-visual-regression" refactor, or "mechanical" does NOT narrow the verification plan — it widens it to the states that can change. Static, resting-state evidence (a default-mount render, even captured at multiple breakpoints) cannot prove that a scroll-bounded, overflowing, expandable, or otherwise stateful surface is unbroken. Plan to drive the surface *into* the state that would reveal the regression — expand the tallest section, overflow the container past its bounded height, open the sheet at a short viewport, scroll to the pinned edge — and observe it there. If the state that could break cannot be reached with available tooling, record that gap explicitly; never certify parity from the resting state alone.
+
 ### 6. Execute
 
 After implementation, run the verification plan. Execute each verification type in order.

--- a/plugins/lisa-copilot/skills/lisa-verification-lifecycle/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-verification-lifecycle/SKILL.md
@@ -66,6 +66,8 @@ For a user-visible Fix, or a Build change that affects user-visible behavior, th
 
 The lead cannot waive, defer, or demote this regression spec as optional, "if cheap", or equivalent. The only acceptable exits are a recorded absence of an end-to-end harness for the platform, or a genuine technical blocker that is captured before merge as a linked build-ready follow-up ticket referenced from the PR and source work item.
 
+A claim that the change is "behavior-preserving", a "no-visual-regression" refactor, or "mechanical" does NOT narrow the verification plan — it widens it to the states that can change. Static, resting-state evidence (a default-mount render, even captured at multiple breakpoints) cannot prove that a scroll-bounded, overflowing, expandable, or otherwise stateful surface is unbroken. Plan to drive the surface *into* the state that would reveal the regression — expand the tallest section, overflow the container past its bounded height, open the sheet at a short viewport, scroll to the pinned edge — and observe it there. If the state that could break cannot be reached with available tooling, record that gap explicitly; never certify parity from the resting state alone.
+
 ### 6. Execute
 
 After implementation, run the verification plan. Execute each verification type in order.

--- a/plugins/lisa-cursor/skills/lisa-verification-lifecycle/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-verification-lifecycle/SKILL.md
@@ -66,6 +66,8 @@ For a user-visible Fix, or a Build change that affects user-visible behavior, th
 
 The lead cannot waive, defer, or demote this regression spec as optional, "if cheap", or equivalent. The only acceptable exits are a recorded absence of an end-to-end harness for the platform, or a genuine technical blocker that is captured before merge as a linked build-ready follow-up ticket referenced from the PR and source work item.
 
+A claim that the change is "behavior-preserving", a "no-visual-regression" refactor, or "mechanical" does NOT narrow the verification plan — it widens it to the states that can change. Static, resting-state evidence (a default-mount render, even captured at multiple breakpoints) cannot prove that a scroll-bounded, overflowing, expandable, or otherwise stateful surface is unbroken. Plan to drive the surface *into* the state that would reveal the regression — expand the tallest section, overflow the container past its bounded height, open the sheet at a short viewport, scroll to the pinned edge — and observe it there. If the state that could break cannot be reached with available tooling, record that gap explicitly; never certify parity from the resting state alone.
+
 ### 6. Execute
 
 After implementation, run the verification plan. Execute each verification type in order.

--- a/plugins/lisa-expo-agy/skills/atomic-design-gluestack/SKILL.md
+++ b/plugins/lisa-expo-agy/skills/atomic-design-gluestack/SKILL.md
@@ -326,6 +326,7 @@ When creating or reviewing components, verify:
 | Organism in atoms folder | Misclassification | Move to organisms folder |
 | Template with business logic | Templates handle layout only | Move logic to page |
 | Importing organism in atom | Wrong dependency direction | Restructure component hierarchy |
+| Spacing refactor inside a bounded-height sheet/modal | Wrapping siblings in new flex containers (e.g. margin→gap conversion) changes overflow distribution and can push a sticky footer/header out of view — pixel-faithful at rest, broken once content overflows | Route the surface through the bounded-scroll pattern: `flex-1` + `min-h-0` scroll body with a `shrink-0` pinned footer, and verify in the content-overflow state, not just the default mount |
 
 ## Testing by Atomic Level
 

--- a/plugins/lisa-expo-copilot/skills/atomic-design-gluestack/SKILL.md
+++ b/plugins/lisa-expo-copilot/skills/atomic-design-gluestack/SKILL.md
@@ -326,6 +326,7 @@ When creating or reviewing components, verify:
 | Organism in atoms folder | Misclassification | Move to organisms folder |
 | Template with business logic | Templates handle layout only | Move logic to page |
 | Importing organism in atom | Wrong dependency direction | Restructure component hierarchy |
+| Spacing refactor inside a bounded-height sheet/modal | Wrapping siblings in new flex containers (e.g. margin→gap conversion) changes overflow distribution and can push a sticky footer/header out of view — pixel-faithful at rest, broken once content overflows | Route the surface through the bounded-scroll pattern: `flex-1` + `min-h-0` scroll body with a `shrink-0` pinned footer, and verify in the content-overflow state, not just the default mount |
 
 ## Testing by Atomic Level
 

--- a/plugins/lisa-expo-cursor/skills/atomic-design-gluestack/SKILL.md
+++ b/plugins/lisa-expo-cursor/skills/atomic-design-gluestack/SKILL.md
@@ -326,6 +326,7 @@ When creating or reviewing components, verify:
 | Organism in atoms folder | Misclassification | Move to organisms folder |
 | Template with business logic | Templates handle layout only | Move logic to page |
 | Importing organism in atom | Wrong dependency direction | Restructure component hierarchy |
+| Spacing refactor inside a bounded-height sheet/modal | Wrapping siblings in new flex containers (e.g. margin→gap conversion) changes overflow distribution and can push a sticky footer/header out of view — pixel-faithful at rest, broken once content overflows | Route the surface through the bounded-scroll pattern: `flex-1` + `min-h-0` scroll body with a `shrink-0` pinned footer, and verify in the content-overflow state, not just the default mount |
 
 ## Testing by Atomic Level
 

--- a/plugins/lisa-expo/.codex-plugin/skills/atomic-design-gluestack/SKILL.md
+++ b/plugins/lisa-expo/.codex-plugin/skills/atomic-design-gluestack/SKILL.md
@@ -325,6 +325,7 @@ When creating or reviewing components, verify:
 | Organism in atoms folder | Misclassification | Move to organisms folder |
 | Template with business logic | Templates handle layout only | Move logic to page |
 | Importing organism in atom | Wrong dependency direction | Restructure component hierarchy |
+| Spacing refactor inside a bounded-height sheet/modal | Wrapping siblings in new flex containers (e.g. margin→gap conversion) changes overflow distribution and can push a sticky footer/header out of view — pixel-faithful at rest, broken once content overflows | Route the surface through the bounded-scroll pattern: `flex-1` + `min-h-0` scroll body with a `shrink-0` pinned footer, and verify in the content-overflow state, not just the default mount |
 
 ## Testing by Atomic Level
 

--- a/plugins/lisa-expo/skills/atomic-design-gluestack/SKILL.md
+++ b/plugins/lisa-expo/skills/atomic-design-gluestack/SKILL.md
@@ -326,6 +326,7 @@ When creating or reviewing components, verify:
 | Organism in atoms folder | Misclassification | Move to organisms folder |
 | Template with business logic | Templates handle layout only | Move logic to page |
 | Importing organism in atom | Wrong dependency direction | Restructure component hierarchy |
+| Spacing refactor inside a bounded-height sheet/modal | Wrapping siblings in new flex containers (e.g. margin→gap conversion) changes overflow distribution and can push a sticky footer/header out of view — pixel-faithful at rest, broken once content overflows | Route the surface through the bounded-scroll pattern: `flex-1` + `min-h-0` scroll body with a `shrink-0` pinned footer, and verify in the content-overflow state, not just the default mount |
 
 ## Testing by Atomic Level
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-verification-lifecycle/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-verification-lifecycle/SKILL.md
@@ -66,6 +66,8 @@ For a user-visible Fix, or a Build change that affects user-visible behavior, th
 
 The lead cannot waive, defer, or demote this regression spec as optional, "if cheap", or equivalent. The only acceptable exits are a recorded absence of an end-to-end harness for the platform, or a genuine technical blocker that is captured before merge as a linked build-ready follow-up ticket referenced from the PR and source work item.
 
+A claim that the change is "behavior-preserving", a "no-visual-regression" refactor, or "mechanical" does NOT narrow the verification plan — it widens it to the states that can change. Static, resting-state evidence (a default-mount render, even captured at multiple breakpoints) cannot prove that a scroll-bounded, overflowing, expandable, or otherwise stateful surface is unbroken. Plan to drive the surface *into* the state that would reveal the regression — expand the tallest section, overflow the container past its bounded height, open the sheet at a short viewport, scroll to the pinned edge — and observe it there. If the state that could break cannot be reached with available tooling, record that gap explicitly; never certify parity from the resting state alone.
+
 ### 6. Execute
 
 After implementation, run the verification plan. Execute each verification type in order.

--- a/plugins/lisa/skills/lisa-verification-lifecycle/SKILL.md
+++ b/plugins/lisa/skills/lisa-verification-lifecycle/SKILL.md
@@ -66,6 +66,8 @@ For a user-visible Fix, or a Build change that affects user-visible behavior, th
 
 The lead cannot waive, defer, or demote this regression spec as optional, "if cheap", or equivalent. The only acceptable exits are a recorded absence of an end-to-end harness for the platform, or a genuine technical blocker that is captured before merge as a linked build-ready follow-up ticket referenced from the PR and source work item.
 
+A claim that the change is "behavior-preserving", a "no-visual-regression" refactor, or "mechanical" does NOT narrow the verification plan — it widens it to the states that can change. Static, resting-state evidence (a default-mount render, even captured at multiple breakpoints) cannot prove that a scroll-bounded, overflowing, expandable, or otherwise stateful surface is unbroken. Plan to drive the surface *into* the state that would reveal the regression — expand the tallest section, overflow the container past its bounded height, open the sheet at a short viewport, scroll to the pinned edge — and observe it there. If the state that could break cannot be reached with available tooling, record that gap explicitly; never certify parity from the resting state alone.
+
 ### 6. Execute
 
 After implementation, run the verification plan. Execute each verification type in order.

--- a/plugins/src/base/skills/lisa-verification-lifecycle/SKILL.md
+++ b/plugins/src/base/skills/lisa-verification-lifecycle/SKILL.md
@@ -66,6 +66,8 @@ For a user-visible Fix, or a Build change that affects user-visible behavior, th
 
 The lead cannot waive, defer, or demote this regression spec as optional, "if cheap", or equivalent. The only acceptable exits are a recorded absence of an end-to-end harness for the platform, or a genuine technical blocker that is captured before merge as a linked build-ready follow-up ticket referenced from the PR and source work item.
 
+A claim that the change is "behavior-preserving", a "no-visual-regression" refactor, or "mechanical" does NOT narrow the verification plan — it widens it to the states that can change. Static, resting-state evidence (a default-mount render, even captured at multiple breakpoints) cannot prove that a scroll-bounded, overflowing, expandable, or otherwise stateful surface is unbroken. Plan to drive the surface *into* the state that would reveal the regression — expand the tallest section, overflow the container past its bounded height, open the sheet at a short viewport, scroll to the pinned edge — and observe it there. If the state that could break cannot be reached with available tooling, record that gap explicitly; never certify parity from the resting state alone.
+
 ### 6. Execute
 
 After implementation, run the verification plan. Execute each verification type in order.

--- a/plugins/src/expo/skills/atomic-design-gluestack/SKILL.md
+++ b/plugins/src/expo/skills/atomic-design-gluestack/SKILL.md
@@ -326,6 +326,7 @@ When creating or reviewing components, verify:
 | Organism in atoms folder | Misclassification | Move to organisms folder |
 | Template with business logic | Templates handle layout only | Move logic to page |
 | Importing organism in atom | Wrong dependency direction | Restructure component hierarchy |
+| Spacing refactor inside a bounded-height sheet/modal | Wrapping siblings in new flex containers (e.g. margin→gap conversion) changes overflow distribution and can push a sticky footer/header out of view — pixel-faithful at rest, broken once content overflows | Route the surface through the bounded-scroll pattern: `flex-1` + `min-h-0` scroll body with a `shrink-0` pinned footer, and verify in the content-overflow state, not just the default mount |
 
 ## Testing by Atomic Level
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1105,7 +1105,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-validate-tracker-mapping/SKILL.md":
       "ab45fdc00294c4ca9698093cb294a2aaf39a73d714fe1aa6ad686c6c34e157ba",
     "plugins/src/base/skills/lisa-verification-lifecycle/SKILL.md":
-      "0b0ffc4f7b13020bcfcf58837e34b482e1f51ff96da9b1b716f2bb29dbd6313a",
+      "6302896b70d8211e2f412deea8be3e42e68cf36d566759af3c937ccf5287b91c",
     "plugins/src/base/skills/lisa-verify-prd/SKILL.md":
       "82f0a34e530d1940c38c9a2ee5f0d139cab4054616bdd34e73082753442871ab",
     "plugins/src/base/skills/lisa-verify-workflow-change/SKILL.md":
@@ -1133,7 +1133,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/expo/skills/apollo-client/references/mutation-patterns.md":
       "987b90aed8aef765d1555ea02b28738fbc8d6eeac734272de4da8981747182fd",
     "plugins/src/expo/skills/atomic-design-gluestack/SKILL.md":
-      "d299b32e79f78ed2346cef838cda57d93ee7e2368c5d5d2cf01b727ec7b6753a",
+      "bc6ddd15b3a533d510e58e27e448cc22f57009bd90a4c4e5af836cac92157802",
     "plugins/src/expo/skills/atomic-design-gluestack/references/atomic-levels.md":
       "c01c1bcd68c128e10086195467564be196f78f4f771169d827da707a677ecde3",
     "plugins/src/expo/skills/atomic-design-gluestack/references/folder-structure.md":


### PR DESCRIPTION
Adds two durable verification lessons (from frontend-v2 SE-5580/SE-5564):

- **lisa-verification-lifecycle** (Plan step): a "behavior-preserving"/"no-regression"/"mechanical refactor" claim widens the verification plan to the states that can change — static resting-state evidence can't prove a scroll/overflow/expandable surface unbroken; drive it into the state that would reveal the regression.
- **Expo atomic-design skill**: bounded-sheet flex invariant (`flex-1` + `min-h-0` body, `shrink-0` pinned footer).

Regenerates the plugin mirrors + upstream-evidence manifest. No dependency/security changes — supersedes #1936 (which mistakenly added an audit waiver for advisories main had already fixed; the js-yaml security-floor test correctly rejected it).

Closes #1937