### PR TITLE
fix(release): realign package.json version with npm latest (2.287.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "brace-expansion": ">=5.0.6"
   },
   "name": "@codyswann/lisa",
-  "version": "2.286.14",
+  "version": "2.287.0",
   "description": "Claude Code governance framework that applies guardrails, guidance, and automated enforcement to projects",
   "main": "dist/index.js",
   "exports": {


### PR DESCRIPTION
## What

One-line realignment: `package.json` version `2.286.14 → 2.287.0`.

## Why

A concurrent-release race (full diagnosis in #1945) published **2.287.0** to npm and pushed tag `v2.287.0`, but its version-bump commit lost the push race and never landed on main. `standard-version` computes from package.json, so every release since bumps 2.286.x and npm rejects the publish as below `latest` — confirmed twice (2.286.13 on the original merge, 2.286.14 on a manual re-dispatch). The pipeline cannot self-heal.

After this merges, the next release computes **2.287.1** from the commits since the existing `v2.287.0` tag (which include the pending `fix(linear)` #1943) and publishes cleanly.

Closes #1945

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 2.287.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->