### PR TITLE
fix(cdk): grant the release job the token permissions its nested workflows request

### DIFF
--- a/cdk/create-only/.github/workflows/deploy.yml
+++ b/cdk/create-only/.github/workflows/deploy.yml
@@ -68,6 +68,9 @@ jobs:
     # Reference to the quality checks workflow
     uses: CodySwannGT/lisa/.github/workflows/release.yml@main
     needs: [determine_environment]
+    permissions:
+      contents: write
+      pull-requests: read
     with:
       environment: ${{ needs.determine_environment.outputs.environment }}
       release_strategy: 'standard-version'

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -47,7 +47,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "cdk/create-only/.github/workflows/ci.yml":
       "04cca8fbcb7a5c6da1aeb2b2d00d7a328d15618e4252f1d9dd495052d264d0f5",
     "cdk/create-only/.github/workflows/deploy.yml":
-      "5b31ed443511cae5a742238509f1210bb991575deae613aea73c41513c8fe3b8",
+      "2746e78fb0fbe7b23b30bbcb0f83171e16f6804fd467b3d41d3c69970572af3f",
     "cdk/create-only/cdk.json":
       "f89030d8fe145a1dbabd59d89ddee4e16984f222d737f7fcf6b778d911e9fe40",
     "cdk/create-only/tsconfig.local.json":


### PR DESCRIPTION
## Summary
The cdk deploy template's `release` job calls the reusable `release.yml` without a `permissions` block. `release.yml` nests `quality.yml` with `permissions: {contents: read, pull-requests: read}` and has a `version` job requesting `contents: write`; a nested reusable workflow may never request more than its caller granted. On any consumer repo whose default `GITHUB_TOKEN` policy is restricted read (the GitHub default for new orgs), every run of the generated workflow dies at startup validation — `startup_failure`, zero jobs.

The expo and nestjs deploy templates already carry exactly this grant (added in e79198735 "fix(workflows): harden deploy template contracts"); the cdk template was missed in that sweep. This brings it in line.

## Evidence
Observed downstream in TunnlAI/infrastructure (generated from this template): 38/38 "Release and Deploy" runs since repo creation ended in `startup_failure`. Bisection via `workflow_dispatch` on a test branch isolated the nested `permissions` block as the trigger; re-adding only this grant to the caller job made the full nested tree start and run (downstream fix: TunnlAI/infrastructure#49).

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow permissions to support publishing releases and reading pull request information.
  * No changes were made to deployment settings or release configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->