### PR TITLE
feat(skills): mandate post-merge Linear reconciliation on non-terminal merges

### DIFF
--- a/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -335,15 +335,20 @@ Linear's GitHub integration completes a linked Issue on merge to **any** branch
 — branch-name linkage alone triggers it, even when the PR body carries only the
 non-closing `Linear: <ID>` reference form (incident of record: TunnlAI backend
 PR #207 merged to `dev`; TUN-256 auto-completed and had to be manually
-reverted). When the driven PR's work item is a Linear Issue and `<baseRefName>`
-is **not** the production/terminal branch (resolve via `.lisa.config.json`
-`deploy.branches`, falling back to the repo default branch), re-read the
-Issue's native workflow `state` after `MERGED`. If Linear moved it to a
+reverted). Run this step **as soon as the PR reports `MERGED`**, before the
+deploy-run verification above can terminate the flow — a `blocked:deploy`
+outcome must never leave the merged Issue unreconciled. When the driven PR's
+work item is a Linear Issue and `<baseRefName>` **successfully resolves** via
+`.lisa.config.json` `deploy.branches` to an env below the production terminal,
+re-read the Issue's native workflow `state`. If Linear moved it to a
 `completed`-type state, revert it to the team's started/In Progress state and
 post a one-line reconciliation comment — per the `leaf-only-lifecycle` rule
-(native closure fires only at the production terminal). The full procedure is
-`lisa-linear-sync` Phase 4b; when the caller's flow already runs a `pr-merged`
-sync for this merge, confirming that sync ran satisfies this step.
+(native closure fires only at the production terminal). If the base branch
+cannot be resolved (unmapped or ambiguous), do **not** mutate the native
+`state` — post a reconciliation-suggestion comment and leave it untouched,
+matching Phase 4b's safe default. The full procedure is `lisa-linear-sync`
+Phase 4b; when the caller's flow already runs a `pr-merged` sync for this
+merge, confirming that sync ran satisfies this step.
 
 ## 4. Terminal states
 

--- a/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -329,6 +329,22 @@ a workflow is an action, so do **not** run `gh workflow run` / `workflow_dispatc
 it for the caller to act on, consistent with the report-mode contract (steps b–f
 of section 2 are diagnose-only).
 
+### c. Linear native-state reconciliation (non-terminal merges only)
+
+Linear's GitHub integration completes a linked Issue on merge to **any** branch
+— branch-name linkage alone triggers it, even when the PR body carries only the
+non-closing `Linear: <ID>` reference form (incident of record: TunnlAI backend
+PR #207 merged to `dev`; TUN-256 auto-completed and had to be manually
+reverted). When the driven PR's work item is a Linear Issue and `<baseRefName>`
+is **not** the production/terminal branch (resolve via `.lisa.config.json`
+`deploy.branches`, falling back to the repo default branch), re-read the
+Issue's native workflow `state` after `MERGED`. If Linear moved it to a
+`completed`-type state, revert it to the team's started/In Progress state and
+post a one-line reconciliation comment — per the `leaf-only-lifecycle` rule
+(native closure fires only at the production terminal). The full procedure is
+`lisa-linear-sync` Phase 4b; when the caller's flow already runs a `pr-merged`
+sync for this merge, confirming that sync ran satisfies this step.
+
 ## 4. Terminal states
 
 Loop until one of:

--- a/plugins/lisa-agy/skills/lisa-linear-sync/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-linear-sync/SKILL.md
@@ -21,7 +21,7 @@ Callers (planning skills, lifecycle skills) invoke this skill at:
 | Plan created | Plan contents (sections + ordered tasks) as a comment, suggest transition `Backlog → Todo` (label: `status:ready`) |
 | Implementation in progress | Branch URL + first commit, suggest transition `Todo → In Progress` (label: `status:in-progress`) |
 | PR ready for review | PR URL + summary, the implementation handoff comment, suggest transition `In Progress → In Review` (label: `status:code-review`) |
-| PR merged | Merge SHA + deploy environment (if known), suggest transition `In Review → Done` (label: `status:done`) |
+| PR merged | Merge SHA + deploy environment (if known), suggest transition `In Review → Done` (label: `status:done`), **then run Phase 4b — mandatory when the merge target is a non-terminal env branch** |
 
 This skill **suggests** transitions but does not auto-transition the native Linear `state` field. It DOES update the `status:*` label set when the caller asks (the build queue is keyed off labels). Native state transitions remain a human / triage decision.
 
@@ -94,7 +94,7 @@ Without `--update-label`, this skill posts the comment only and does NOT touch l
 
 ## Phase 4b — Reconcile Native Auto-Close (Linear-specific)
 
-Linear's GitHub integration completes a linked Issue on merge to **any branch** — unlike GitHub's default-branch-scoped `Closes` auto-close — so a magic word (`Closes`/`Fixes`/`Resolves ENG-123`) or branch-name linkage can natively move the Issue to a Done/Completed workflow `state` at a **non-terminal** env merge, front-running the env-keyed `status:*` label ladder. `git-submit-pr` prevents the magic-word case; this phase is the required post-merge repair for the residual (branch-linkage) case we cannot suppress server-side. Run it on a `pr-merged` sync whose resolved env is **intermediate** (below the production terminal `done`):
+Linear's GitHub integration completes a linked Issue on merge to **any branch** — unlike GitHub's default-branch-scoped `Closes` auto-close — so a magic word (`Closes`/`Fixes`/`Resolves ENG-123`) or branch-name linkage can natively move the Issue to a Done/Completed workflow `state` at a **non-terminal** env merge, front-running the env-keyed `status:*` label ladder. `git-submit-pr` prevents the magic-word case; this phase is the required post-merge repair for the residual (branch-linkage) case we cannot suppress server-side — branch linkage completes the Issue even when the PR body carries only the non-closing `Linear: <ID>` form. This phase is a **mandatory** numbered step of every `pr-merged` sync, not an optional backstop; run it whenever the resolved env is **intermediate** (below the production terminal `done`):
 
 1. Resolve the merged PR's base branch to its env via `.lisa.config.json` `deploy.branches` (`config-resolution`). If it maps to the production/terminal `done`, this phase is a **no-op** — native completion is correct there.
 2. **Uniform / single-environment no-op.** When the project's env-keyed `done` map is uniform — every environment resolves to the same `status:done`, as in this repo (`production: main` only) and TunnlAI/frontend — dev-merge == terminal, so native completion is correct. Do nothing. Only a **non-uniform** env→`done` map (distinct `status:on-dev`/`status:on-stg`/`status:done` rungs) can desync.

--- a/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -335,15 +335,20 @@ Linear's GitHub integration completes a linked Issue on merge to **any** branch
 — branch-name linkage alone triggers it, even when the PR body carries only the
 non-closing `Linear: <ID>` reference form (incident of record: TunnlAI backend
 PR #207 merged to `dev`; TUN-256 auto-completed and had to be manually
-reverted). When the driven PR's work item is a Linear Issue and `<baseRefName>`
-is **not** the production/terminal branch (resolve via `.lisa.config.json`
-`deploy.branches`, falling back to the repo default branch), re-read the
-Issue's native workflow `state` after `MERGED`. If Linear moved it to a
+reverted). Run this step **as soon as the PR reports `MERGED`**, before the
+deploy-run verification above can terminate the flow — a `blocked:deploy`
+outcome must never leave the merged Issue unreconciled. When the driven PR's
+work item is a Linear Issue and `<baseRefName>` **successfully resolves** via
+`.lisa.config.json` `deploy.branches` to an env below the production terminal,
+re-read the Issue's native workflow `state`. If Linear moved it to a
 `completed`-type state, revert it to the team's started/In Progress state and
 post a one-line reconciliation comment — per the `leaf-only-lifecycle` rule
-(native closure fires only at the production terminal). The full procedure is
-`lisa-linear-sync` Phase 4b; when the caller's flow already runs a `pr-merged`
-sync for this merge, confirming that sync ran satisfies this step.
+(native closure fires only at the production terminal). If the base branch
+cannot be resolved (unmapped or ambiguous), do **not** mutate the native
+`state` — post a reconciliation-suggestion comment and leave it untouched,
+matching Phase 4b's safe default. The full procedure is `lisa-linear-sync`
+Phase 4b; when the caller's flow already runs a `pr-merged` sync for this
+merge, confirming that sync ran satisfies this step.
 
 ## 4. Terminal states
 

--- a/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -329,6 +329,22 @@ a workflow is an action, so do **not** run `gh workflow run` / `workflow_dispatc
 it for the caller to act on, consistent with the report-mode contract (steps b–f
 of section 2 are diagnose-only).
 
+### c. Linear native-state reconciliation (non-terminal merges only)
+
+Linear's GitHub integration completes a linked Issue on merge to **any** branch
+— branch-name linkage alone triggers it, even when the PR body carries only the
+non-closing `Linear: <ID>` reference form (incident of record: TunnlAI backend
+PR #207 merged to `dev`; TUN-256 auto-completed and had to be manually
+reverted). When the driven PR's work item is a Linear Issue and `<baseRefName>`
+is **not** the production/terminal branch (resolve via `.lisa.config.json`
+`deploy.branches`, falling back to the repo default branch), re-read the
+Issue's native workflow `state` after `MERGED`. If Linear moved it to a
+`completed`-type state, revert it to the team's started/In Progress state and
+post a one-line reconciliation comment — per the `leaf-only-lifecycle` rule
+(native closure fires only at the production terminal). The full procedure is
+`lisa-linear-sync` Phase 4b; when the caller's flow already runs a `pr-merged`
+sync for this merge, confirming that sync ran satisfies this step.
+
 ## 4. Terminal states
 
 Loop until one of:

--- a/plugins/lisa-copilot/skills/lisa-linear-sync/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-linear-sync/SKILL.md
@@ -21,7 +21,7 @@ Callers (planning skills, lifecycle skills) invoke this skill at:
 | Plan created | Plan contents (sections + ordered tasks) as a comment, suggest transition `Backlog → Todo` (label: `status:ready`) |
 | Implementation in progress | Branch URL + first commit, suggest transition `Todo → In Progress` (label: `status:in-progress`) |
 | PR ready for review | PR URL + summary, the implementation handoff comment, suggest transition `In Progress → In Review` (label: `status:code-review`) |
-| PR merged | Merge SHA + deploy environment (if known), suggest transition `In Review → Done` (label: `status:done`) |
+| PR merged | Merge SHA + deploy environment (if known), suggest transition `In Review → Done` (label: `status:done`), **then run Phase 4b — mandatory when the merge target is a non-terminal env branch** |
 
 This skill **suggests** transitions but does not auto-transition the native Linear `state` field. It DOES update the `status:*` label set when the caller asks (the build queue is keyed off labels). Native state transitions remain a human / triage decision.
 
@@ -94,7 +94,7 @@ Without `--update-label`, this skill posts the comment only and does NOT touch l
 
 ## Phase 4b — Reconcile Native Auto-Close (Linear-specific)
 
-Linear's GitHub integration completes a linked Issue on merge to **any branch** — unlike GitHub's default-branch-scoped `Closes` auto-close — so a magic word (`Closes`/`Fixes`/`Resolves ENG-123`) or branch-name linkage can natively move the Issue to a Done/Completed workflow `state` at a **non-terminal** env merge, front-running the env-keyed `status:*` label ladder. `git-submit-pr` prevents the magic-word case; this phase is the required post-merge repair for the residual (branch-linkage) case we cannot suppress server-side. Run it on a `pr-merged` sync whose resolved env is **intermediate** (below the production terminal `done`):
+Linear's GitHub integration completes a linked Issue on merge to **any branch** — unlike GitHub's default-branch-scoped `Closes` auto-close — so a magic word (`Closes`/`Fixes`/`Resolves ENG-123`) or branch-name linkage can natively move the Issue to a Done/Completed workflow `state` at a **non-terminal** env merge, front-running the env-keyed `status:*` label ladder. `git-submit-pr` prevents the magic-word case; this phase is the required post-merge repair for the residual (branch-linkage) case we cannot suppress server-side — branch linkage completes the Issue even when the PR body carries only the non-closing `Linear: <ID>` form. This phase is a **mandatory** numbered step of every `pr-merged` sync, not an optional backstop; run it whenever the resolved env is **intermediate** (below the production terminal `done`):
 
 1. Resolve the merged PR's base branch to its env via `.lisa.config.json` `deploy.branches` (`config-resolution`). If it maps to the production/terminal `done`, this phase is a **no-op** — native completion is correct there.
 2. **Uniform / single-environment no-op.** When the project's env-keyed `done` map is uniform — every environment resolves to the same `status:done`, as in this repo (`production: main` only) and TunnlAI/frontend — dev-merge == terminal, so native completion is correct. Do nothing. Only a **non-uniform** env→`done` map (distinct `status:on-dev`/`status:on-stg`/`status:done` rungs) can desync.

--- a/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -335,15 +335,20 @@ Linear's GitHub integration completes a linked Issue on merge to **any** branch
 — branch-name linkage alone triggers it, even when the PR body carries only the
 non-closing `Linear: <ID>` reference form (incident of record: TunnlAI backend
 PR #207 merged to `dev`; TUN-256 auto-completed and had to be manually
-reverted). When the driven PR's work item is a Linear Issue and `<baseRefName>`
-is **not** the production/terminal branch (resolve via `.lisa.config.json`
-`deploy.branches`, falling back to the repo default branch), re-read the
-Issue's native workflow `state` after `MERGED`. If Linear moved it to a
+reverted). Run this step **as soon as the PR reports `MERGED`**, before the
+deploy-run verification above can terminate the flow — a `blocked:deploy`
+outcome must never leave the merged Issue unreconciled. When the driven PR's
+work item is a Linear Issue and `<baseRefName>` **successfully resolves** via
+`.lisa.config.json` `deploy.branches` to an env below the production terminal,
+re-read the Issue's native workflow `state`. If Linear moved it to a
 `completed`-type state, revert it to the team's started/In Progress state and
 post a one-line reconciliation comment — per the `leaf-only-lifecycle` rule
-(native closure fires only at the production terminal). The full procedure is
-`lisa-linear-sync` Phase 4b; when the caller's flow already runs a `pr-merged`
-sync for this merge, confirming that sync ran satisfies this step.
+(native closure fires only at the production terminal). If the base branch
+cannot be resolved (unmapped or ambiguous), do **not** mutate the native
+`state` — post a reconciliation-suggestion comment and leave it untouched,
+matching Phase 4b's safe default. The full procedure is `lisa-linear-sync`
+Phase 4b; when the caller's flow already runs a `pr-merged` sync for this
+merge, confirming that sync ran satisfies this step.
 
 ## 4. Terminal states
 

--- a/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -329,6 +329,22 @@ a workflow is an action, so do **not** run `gh workflow run` / `workflow_dispatc
 it for the caller to act on, consistent with the report-mode contract (steps b–f
 of section 2 are diagnose-only).
 
+### c. Linear native-state reconciliation (non-terminal merges only)
+
+Linear's GitHub integration completes a linked Issue on merge to **any** branch
+— branch-name linkage alone triggers it, even when the PR body carries only the
+non-closing `Linear: <ID>` reference form (incident of record: TunnlAI backend
+PR #207 merged to `dev`; TUN-256 auto-completed and had to be manually
+reverted). When the driven PR's work item is a Linear Issue and `<baseRefName>`
+is **not** the production/terminal branch (resolve via `.lisa.config.json`
+`deploy.branches`, falling back to the repo default branch), re-read the
+Issue's native workflow `state` after `MERGED`. If Linear moved it to a
+`completed`-type state, revert it to the team's started/In Progress state and
+post a one-line reconciliation comment — per the `leaf-only-lifecycle` rule
+(native closure fires only at the production terminal). The full procedure is
+`lisa-linear-sync` Phase 4b; when the caller's flow already runs a `pr-merged`
+sync for this merge, confirming that sync ran satisfies this step.
+
 ## 4. Terminal states
 
 Loop until one of:

--- a/plugins/lisa-cursor/skills/lisa-linear-sync/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-linear-sync/SKILL.md
@@ -21,7 +21,7 @@ Callers (planning skills, lifecycle skills) invoke this skill at:
 | Plan created | Plan contents (sections + ordered tasks) as a comment, suggest transition `Backlog → Todo` (label: `status:ready`) |
 | Implementation in progress | Branch URL + first commit, suggest transition `Todo → In Progress` (label: `status:in-progress`) |
 | PR ready for review | PR URL + summary, the implementation handoff comment, suggest transition `In Progress → In Review` (label: `status:code-review`) |
-| PR merged | Merge SHA + deploy environment (if known), suggest transition `In Review → Done` (label: `status:done`) |
+| PR merged | Merge SHA + deploy environment (if known), suggest transition `In Review → Done` (label: `status:done`), **then run Phase 4b — mandatory when the merge target is a non-terminal env branch** |
 
 This skill **suggests** transitions but does not auto-transition the native Linear `state` field. It DOES update the `status:*` label set when the caller asks (the build queue is keyed off labels). Native state transitions remain a human / triage decision.
 
@@ -94,7 +94,7 @@ Without `--update-label`, this skill posts the comment only and does NOT touch l
 
 ## Phase 4b — Reconcile Native Auto-Close (Linear-specific)
 
-Linear's GitHub integration completes a linked Issue on merge to **any branch** — unlike GitHub's default-branch-scoped `Closes` auto-close — so a magic word (`Closes`/`Fixes`/`Resolves ENG-123`) or branch-name linkage can natively move the Issue to a Done/Completed workflow `state` at a **non-terminal** env merge, front-running the env-keyed `status:*` label ladder. `git-submit-pr` prevents the magic-word case; this phase is the required post-merge repair for the residual (branch-linkage) case we cannot suppress server-side. Run it on a `pr-merged` sync whose resolved env is **intermediate** (below the production terminal `done`):
+Linear's GitHub integration completes a linked Issue on merge to **any branch** — unlike GitHub's default-branch-scoped `Closes` auto-close — so a magic word (`Closes`/`Fixes`/`Resolves ENG-123`) or branch-name linkage can natively move the Issue to a Done/Completed workflow `state` at a **non-terminal** env merge, front-running the env-keyed `status:*` label ladder. `git-submit-pr` prevents the magic-word case; this phase is the required post-merge repair for the residual (branch-linkage) case we cannot suppress server-side — branch linkage completes the Issue even when the PR body carries only the non-closing `Linear: <ID>` form. This phase is a **mandatory** numbered step of every `pr-merged` sync, not an optional backstop; run it whenever the resolved env is **intermediate** (below the production terminal `done`):
 
 1. Resolve the merged PR's base branch to its env via `.lisa.config.json` `deploy.branches` (`config-resolution`). If it maps to the production/terminal `done`, this phase is a **no-op** — native completion is correct there.
 2. **Uniform / single-environment no-op.** When the project's env-keyed `done` map is uniform — every environment resolves to the same `status:done`, as in this repo (`production: main` only) and TunnlAI/frontend — dev-merge == terminal, so native completion is correct. Do nothing. Only a **non-uniform** env→`done` map (distinct `status:on-dev`/`status:on-stg`/`status:done` rungs) can desync.

--- a/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -335,15 +335,20 @@ Linear's GitHub integration completes a linked Issue on merge to **any** branch
 — branch-name linkage alone triggers it, even when the PR body carries only the
 non-closing `Linear: <ID>` reference form (incident of record: TunnlAI backend
 PR #207 merged to `dev`; TUN-256 auto-completed and had to be manually
-reverted). When the driven PR's work item is a Linear Issue and `<baseRefName>`
-is **not** the production/terminal branch (resolve via `.lisa.config.json`
-`deploy.branches`, falling back to the repo default branch), re-read the
-Issue's native workflow `state` after `MERGED`. If Linear moved it to a
+reverted). Run this step **as soon as the PR reports `MERGED`**, before the
+deploy-run verification above can terminate the flow — a `blocked:deploy`
+outcome must never leave the merged Issue unreconciled. When the driven PR's
+work item is a Linear Issue and `<baseRefName>` **successfully resolves** via
+`.lisa.config.json` `deploy.branches` to an env below the production terminal,
+re-read the Issue's native workflow `state`. If Linear moved it to a
 `completed`-type state, revert it to the team's started/In Progress state and
 post a one-line reconciliation comment — per the `leaf-only-lifecycle` rule
-(native closure fires only at the production terminal). The full procedure is
-`lisa-linear-sync` Phase 4b; when the caller's flow already runs a `pr-merged`
-sync for this merge, confirming that sync ran satisfies this step.
+(native closure fires only at the production terminal). If the base branch
+cannot be resolved (unmapped or ambiguous), do **not** mutate the native
+`state` — post a reconciliation-suggestion comment and leave it untouched,
+matching Phase 4b's safe default. The full procedure is `lisa-linear-sync`
+Phase 4b; when the caller's flow already runs a `pr-merged` sync for this
+merge, confirming that sync ran satisfies this step.
 
 ## 4. Terminal states
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -329,6 +329,22 @@ a workflow is an action, so do **not** run `gh workflow run` / `workflow_dispatc
 it for the caller to act on, consistent with the report-mode contract (steps b–f
 of section 2 are diagnose-only).
 
+### c. Linear native-state reconciliation (non-terminal merges only)
+
+Linear's GitHub integration completes a linked Issue on merge to **any** branch
+— branch-name linkage alone triggers it, even when the PR body carries only the
+non-closing `Linear: <ID>` reference form (incident of record: TunnlAI backend
+PR #207 merged to `dev`; TUN-256 auto-completed and had to be manually
+reverted). When the driven PR's work item is a Linear Issue and `<baseRefName>`
+is **not** the production/terminal branch (resolve via `.lisa.config.json`
+`deploy.branches`, falling back to the repo default branch), re-read the
+Issue's native workflow `state` after `MERGED`. If Linear moved it to a
+`completed`-type state, revert it to the team's started/In Progress state and
+post a one-line reconciliation comment — per the `leaf-only-lifecycle` rule
+(native closure fires only at the production terminal). The full procedure is
+`lisa-linear-sync` Phase 4b; when the caller's flow already runs a `pr-merged`
+sync for this merge, confirming that sync ran satisfies this step.
+
 ## 4. Terminal states
 
 Loop until one of:

--- a/plugins/lisa/.codex-plugin/skills/lisa-linear-sync/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-linear-sync/SKILL.md
@@ -21,7 +21,7 @@ Callers (planning skills, lifecycle skills) invoke this skill at:
 | Plan created | Plan contents (sections + ordered tasks) as a comment, suggest transition `Backlog → Todo` (label: `status:ready`) |
 | Implementation in progress | Branch URL + first commit, suggest transition `Todo → In Progress` (label: `status:in-progress`) |
 | PR ready for review | PR URL + summary, the implementation handoff comment, suggest transition `In Progress → In Review` (label: `status:code-review`) |
-| PR merged | Merge SHA + deploy environment (if known), suggest transition `In Review → Done` (label: `status:done`) |
+| PR merged | Merge SHA + deploy environment (if known), suggest transition `In Review → Done` (label: `status:done`), **then run Phase 4b — mandatory when the merge target is a non-terminal env branch** |
 
 This skill **suggests** transitions but does not auto-transition the native Linear `state` field. It DOES update the `status:*` label set when the caller asks (the build queue is keyed off labels). Native state transitions remain a human / triage decision.
 
@@ -94,7 +94,7 @@ Without `--update-label`, this skill posts the comment only and does NOT touch l
 
 ## Phase 4b — Reconcile Native Auto-Close (Linear-specific)
 
-Linear's GitHub integration completes a linked Issue on merge to **any branch** — unlike GitHub's default-branch-scoped `Closes` auto-close — so a magic word (`Closes`/`Fixes`/`Resolves ENG-123`) or branch-name linkage can natively move the Issue to a Done/Completed workflow `state` at a **non-terminal** env merge, front-running the env-keyed `status:*` label ladder. `git-submit-pr` prevents the magic-word case; this phase is the required post-merge repair for the residual (branch-linkage) case we cannot suppress server-side. Run it on a `pr-merged` sync whose resolved env is **intermediate** (below the production terminal `done`):
+Linear's GitHub integration completes a linked Issue on merge to **any branch** — unlike GitHub's default-branch-scoped `Closes` auto-close — so a magic word (`Closes`/`Fixes`/`Resolves ENG-123`) or branch-name linkage can natively move the Issue to a Done/Completed workflow `state` at a **non-terminal** env merge, front-running the env-keyed `status:*` label ladder. `git-submit-pr` prevents the magic-word case; this phase is the required post-merge repair for the residual (branch-linkage) case we cannot suppress server-side — branch linkage completes the Issue even when the PR body carries only the non-closing `Linear: <ID>` form. This phase is a **mandatory** numbered step of every `pr-merged` sync, not an optional backstop; run it whenever the resolved env is **intermediate** (below the production terminal `done`):
 
 1. Resolve the merged PR's base branch to its env via `.lisa.config.json` `deploy.branches` (`config-resolution`). If it maps to the production/terminal `done`, this phase is a **no-op** — native completion is correct there.
 2. **Uniform / single-environment no-op.** When the project's env-keyed `done` map is uniform — every environment resolves to the same `status:done`, as in this repo (`production: main` only) and TunnlAI/frontend — dev-merge == terminal, so native completion is correct. Do nothing. Only a **non-uniform** env→`done` map (distinct `status:on-dev`/`status:on-stg`/`status:done` rungs) can desync.

--- a/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -335,15 +335,20 @@ Linear's GitHub integration completes a linked Issue on merge to **any** branch
 — branch-name linkage alone triggers it, even when the PR body carries only the
 non-closing `Linear: <ID>` reference form (incident of record: TunnlAI backend
 PR #207 merged to `dev`; TUN-256 auto-completed and had to be manually
-reverted). When the driven PR's work item is a Linear Issue and `<baseRefName>`
-is **not** the production/terminal branch (resolve via `.lisa.config.json`
-`deploy.branches`, falling back to the repo default branch), re-read the
-Issue's native workflow `state` after `MERGED`. If Linear moved it to a
+reverted). Run this step **as soon as the PR reports `MERGED`**, before the
+deploy-run verification above can terminate the flow — a `blocked:deploy`
+outcome must never leave the merged Issue unreconciled. When the driven PR's
+work item is a Linear Issue and `<baseRefName>` **successfully resolves** via
+`.lisa.config.json` `deploy.branches` to an env below the production terminal,
+re-read the Issue's native workflow `state`. If Linear moved it to a
 `completed`-type state, revert it to the team's started/In Progress state and
 post a one-line reconciliation comment — per the `leaf-only-lifecycle` rule
-(native closure fires only at the production terminal). The full procedure is
-`lisa-linear-sync` Phase 4b; when the caller's flow already runs a `pr-merged`
-sync for this merge, confirming that sync ran satisfies this step.
+(native closure fires only at the production terminal). If the base branch
+cannot be resolved (unmapped or ambiguous), do **not** mutate the native
+`state` — post a reconciliation-suggestion comment and leave it untouched,
+matching Phase 4b's safe default. The full procedure is `lisa-linear-sync`
+Phase 4b; when the caller's flow already runs a `pr-merged` sync for this
+merge, confirming that sync ran satisfies this step.
 
 ## 4. Terminal states
 

--- a/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -329,6 +329,22 @@ a workflow is an action, so do **not** run `gh workflow run` / `workflow_dispatc
 it for the caller to act on, consistent with the report-mode contract (steps b–f
 of section 2 are diagnose-only).
 
+### c. Linear native-state reconciliation (non-terminal merges only)
+
+Linear's GitHub integration completes a linked Issue on merge to **any** branch
+— branch-name linkage alone triggers it, even when the PR body carries only the
+non-closing `Linear: <ID>` reference form (incident of record: TunnlAI backend
+PR #207 merged to `dev`; TUN-256 auto-completed and had to be manually
+reverted). When the driven PR's work item is a Linear Issue and `<baseRefName>`
+is **not** the production/terminal branch (resolve via `.lisa.config.json`
+`deploy.branches`, falling back to the repo default branch), re-read the
+Issue's native workflow `state` after `MERGED`. If Linear moved it to a
+`completed`-type state, revert it to the team's started/In Progress state and
+post a one-line reconciliation comment — per the `leaf-only-lifecycle` rule
+(native closure fires only at the production terminal). The full procedure is
+`lisa-linear-sync` Phase 4b; when the caller's flow already runs a `pr-merged`
+sync for this merge, confirming that sync ran satisfies this step.
+
 ## 4. Terminal states
 
 Loop until one of:

--- a/plugins/lisa/skills/lisa-linear-sync/SKILL.md
+++ b/plugins/lisa/skills/lisa-linear-sync/SKILL.md
@@ -21,7 +21,7 @@ Callers (planning skills, lifecycle skills) invoke this skill at:
 | Plan created | Plan contents (sections + ordered tasks) as a comment, suggest transition `Backlog → Todo` (label: `status:ready`) |
 | Implementation in progress | Branch URL + first commit, suggest transition `Todo → In Progress` (label: `status:in-progress`) |
 | PR ready for review | PR URL + summary, the implementation handoff comment, suggest transition `In Progress → In Review` (label: `status:code-review`) |
-| PR merged | Merge SHA + deploy environment (if known), suggest transition `In Review → Done` (label: `status:done`) |
+| PR merged | Merge SHA + deploy environment (if known), suggest transition `In Review → Done` (label: `status:done`), **then run Phase 4b — mandatory when the merge target is a non-terminal env branch** |
 
 This skill **suggests** transitions but does not auto-transition the native Linear `state` field. It DOES update the `status:*` label set when the caller asks (the build queue is keyed off labels). Native state transitions remain a human / triage decision.
 
@@ -94,7 +94,7 @@ Without `--update-label`, this skill posts the comment only and does NOT touch l
 
 ## Phase 4b — Reconcile Native Auto-Close (Linear-specific)
 
-Linear's GitHub integration completes a linked Issue on merge to **any branch** — unlike GitHub's default-branch-scoped `Closes` auto-close — so a magic word (`Closes`/`Fixes`/`Resolves ENG-123`) or branch-name linkage can natively move the Issue to a Done/Completed workflow `state` at a **non-terminal** env merge, front-running the env-keyed `status:*` label ladder. `git-submit-pr` prevents the magic-word case; this phase is the required post-merge repair for the residual (branch-linkage) case we cannot suppress server-side. Run it on a `pr-merged` sync whose resolved env is **intermediate** (below the production terminal `done`):
+Linear's GitHub integration completes a linked Issue on merge to **any branch** — unlike GitHub's default-branch-scoped `Closes` auto-close — so a magic word (`Closes`/`Fixes`/`Resolves ENG-123`) or branch-name linkage can natively move the Issue to a Done/Completed workflow `state` at a **non-terminal** env merge, front-running the env-keyed `status:*` label ladder. `git-submit-pr` prevents the magic-word case; this phase is the required post-merge repair for the residual (branch-linkage) case we cannot suppress server-side — branch linkage completes the Issue even when the PR body carries only the non-closing `Linear: <ID>` form. This phase is a **mandatory** numbered step of every `pr-merged` sync, not an optional backstop; run it whenever the resolved env is **intermediate** (below the production terminal `done`):
 
 1. Resolve the merged PR's base branch to its env via `.lisa.config.json` `deploy.branches` (`config-resolution`). If it maps to the production/terminal `done`, this phase is a **no-op** — native completion is correct there.
 2. **Uniform / single-environment no-op.** When the project's env-keyed `done` map is uniform — every environment resolves to the same `status:done`, as in this repo (`production: main` only) and TunnlAI/frontend — dev-merge == terminal, so native completion is correct. Do nothing. Only a **non-uniform** env→`done` map (distinct `status:on-dev`/`status:on-stg`/`status:done` rungs) can desync.

--- a/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -335,15 +335,20 @@ Linear's GitHub integration completes a linked Issue on merge to **any** branch
 — branch-name linkage alone triggers it, even when the PR body carries only the
 non-closing `Linear: <ID>` reference form (incident of record: TunnlAI backend
 PR #207 merged to `dev`; TUN-256 auto-completed and had to be manually
-reverted). When the driven PR's work item is a Linear Issue and `<baseRefName>`
-is **not** the production/terminal branch (resolve via `.lisa.config.json`
-`deploy.branches`, falling back to the repo default branch), re-read the
-Issue's native workflow `state` after `MERGED`. If Linear moved it to a
+reverted). Run this step **as soon as the PR reports `MERGED`**, before the
+deploy-run verification above can terminate the flow — a `blocked:deploy`
+outcome must never leave the merged Issue unreconciled. When the driven PR's
+work item is a Linear Issue and `<baseRefName>` **successfully resolves** via
+`.lisa.config.json` `deploy.branches` to an env below the production terminal,
+re-read the Issue's native workflow `state`. If Linear moved it to a
 `completed`-type state, revert it to the team's started/In Progress state and
 post a one-line reconciliation comment — per the `leaf-only-lifecycle` rule
-(native closure fires only at the production terminal). The full procedure is
-`lisa-linear-sync` Phase 4b; when the caller's flow already runs a `pr-merged`
-sync for this merge, confirming that sync ran satisfies this step.
+(native closure fires only at the production terminal). If the base branch
+cannot be resolved (unmapped or ambiguous), do **not** mutate the native
+`state` — post a reconciliation-suggestion comment and leave it untouched,
+matching Phase 4b's safe default. The full procedure is `lisa-linear-sync`
+Phase 4b; when the caller's flow already runs a `pr-merged` sync for this
+merge, confirming that sync ran satisfies this step.
 
 ## 4. Terminal states
 

--- a/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -329,6 +329,22 @@ a workflow is an action, so do **not** run `gh workflow run` / `workflow_dispatc
 it for the caller to act on, consistent with the report-mode contract (steps b–f
 of section 2 are diagnose-only).
 
+### c. Linear native-state reconciliation (non-terminal merges only)
+
+Linear's GitHub integration completes a linked Issue on merge to **any** branch
+— branch-name linkage alone triggers it, even when the PR body carries only the
+non-closing `Linear: <ID>` reference form (incident of record: TunnlAI backend
+PR #207 merged to `dev`; TUN-256 auto-completed and had to be manually
+reverted). When the driven PR's work item is a Linear Issue and `<baseRefName>`
+is **not** the production/terminal branch (resolve via `.lisa.config.json`
+`deploy.branches`, falling back to the repo default branch), re-read the
+Issue's native workflow `state` after `MERGED`. If Linear moved it to a
+`completed`-type state, revert it to the team's started/In Progress state and
+post a one-line reconciliation comment — per the `leaf-only-lifecycle` rule
+(native closure fires only at the production terminal). The full procedure is
+`lisa-linear-sync` Phase 4b; when the caller's flow already runs a `pr-merged`
+sync for this merge, confirming that sync ran satisfies this step.
+
 ## 4. Terminal states
 
 Loop until one of:

--- a/plugins/src/base/skills/lisa-linear-sync/SKILL.md
+++ b/plugins/src/base/skills/lisa-linear-sync/SKILL.md
@@ -21,7 +21,7 @@ Callers (planning skills, lifecycle skills) invoke this skill at:
 | Plan created | Plan contents (sections + ordered tasks) as a comment, suggest transition `Backlog → Todo` (label: `status:ready`) |
 | Implementation in progress | Branch URL + first commit, suggest transition `Todo → In Progress` (label: `status:in-progress`) |
 | PR ready for review | PR URL + summary, the implementation handoff comment, suggest transition `In Progress → In Review` (label: `status:code-review`) |
-| PR merged | Merge SHA + deploy environment (if known), suggest transition `In Review → Done` (label: `status:done`) |
+| PR merged | Merge SHA + deploy environment (if known), suggest transition `In Review → Done` (label: `status:done`), **then run Phase 4b — mandatory when the merge target is a non-terminal env branch** |
 
 This skill **suggests** transitions but does not auto-transition the native Linear `state` field. It DOES update the `status:*` label set when the caller asks (the build queue is keyed off labels). Native state transitions remain a human / triage decision.
 
@@ -94,7 +94,7 @@ Without `--update-label`, this skill posts the comment only and does NOT touch l
 
 ## Phase 4b — Reconcile Native Auto-Close (Linear-specific)
 
-Linear's GitHub integration completes a linked Issue on merge to **any branch** — unlike GitHub's default-branch-scoped `Closes` auto-close — so a magic word (`Closes`/`Fixes`/`Resolves ENG-123`) or branch-name linkage can natively move the Issue to a Done/Completed workflow `state` at a **non-terminal** env merge, front-running the env-keyed `status:*` label ladder. `git-submit-pr` prevents the magic-word case; this phase is the required post-merge repair for the residual (branch-linkage) case we cannot suppress server-side. Run it on a `pr-merged` sync whose resolved env is **intermediate** (below the production terminal `done`):
+Linear's GitHub integration completes a linked Issue on merge to **any branch** — unlike GitHub's default-branch-scoped `Closes` auto-close — so a magic word (`Closes`/`Fixes`/`Resolves ENG-123`) or branch-name linkage can natively move the Issue to a Done/Completed workflow `state` at a **non-terminal** env merge, front-running the env-keyed `status:*` label ladder. `git-submit-pr` prevents the magic-word case; this phase is the required post-merge repair for the residual (branch-linkage) case we cannot suppress server-side — branch linkage completes the Issue even when the PR body carries only the non-closing `Linear: <ID>` form. This phase is a **mandatory** numbered step of every `pr-merged` sync, not an optional backstop; run it whenever the resolved env is **intermediate** (below the production terminal `done`):
 
 1. Resolve the merged PR's base branch to its env via `.lisa.config.json` `deploy.branches` (`config-resolution`). If it maps to the production/terminal `done`, this phase is a **no-op** — native completion is correct there.
 2. **Uniform / single-environment no-op.** When the project's env-keyed `done` map is uniform — every environment resolves to the same `status:done`, as in this repo (`production: main` only) and TunnlAI/frontend — dev-merge == terminal, so native completion is correct. Do nothing. Only a **non-uniform** env→`done` map (distinct `status:on-dev`/`status:on-stg`/`status:done` rungs) can desync.

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -805,7 +805,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
       "1702485809533a2e546a590b9d2f67cbb420c8f0cb0eac8609b0287b05122ad3",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
-      "e8680c65da64351580658e423d2e30f565e9df52079f4deec44df84d4ab82982",
+      "e750a25f81e110cbe93a003250b6829fbc372ab24766f8fe8a1c7e547d7dee49",
     "plugins/src/base/skills/lisa-epic-triage/SKILL.md":
       "d02760411249bddbd396f283191fe3e82bb7b95bf9393a19a7025dc5a57c3ab7",
     "plugins/src/base/skills/lisa-exploratory-qa/SKILL.md":
@@ -927,7 +927,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-linear-read-issue/SKILL.md":
       "a6b8241648ba4b7b9f1196a37e9924ffaccc5461f3ac2ee8ae283c58559e9717",
     "plugins/src/base/skills/lisa-linear-sync/SKILL.md":
-      "178b6dd6d766ba1503d32903d40019b9788dd1051d3988e6bc7c18ed2121407f",
+      "85fbf548b9d7972912fde717d1d6ca82c0350ad82f6d779d08c831b23b90ebd3",
     "plugins/src/base/skills/lisa-linear-to-tracker/SKILL.md":
       "6a096c6818c6a6b3938ed3b52f6e9be8416de3b61b0b5e23fabf0ae32a9756d8",
     "plugins/src/base/skills/lisa-linear-validate-issue/SKILL.md":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -805,7 +805,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
       "1702485809533a2e546a590b9d2f67cbb420c8f0cb0eac8609b0287b05122ad3",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
-      "e750a25f81e110cbe93a003250b6829fbc372ab24766f8fe8a1c7e547d7dee49",
+      "cd692a3343f2306a3d5b96a1cb9662e3abdc557df24d733138b23fde2aa8bad9",
     "plugins/src/base/skills/lisa-epic-triage/SKILL.md":
       "d02760411249bddbd396f283191fe3e82bb7b95bf9393a19a7025dc5a57c3ab7",
     "plugins/src/base/skills/lisa-exploratory-qa/SKILL.md":


### PR DESCRIPTION
## Summary

Linear's GitHub integration auto-completes a linked Issue when its PR merges to **any** branch — including non-terminal env branches like `dev` — via branch-name linkage alone, even when the PR body uses only the non-closing `Linear: <ID>` form. Incident of record: TunnlAI backend PR #207 merged to `dev` today auto-completed TUN-256, which had to be manually reverted.

Existing docs (`lisa-git-submit-pr`) warn about this and call `lisa-linear-sync` "the mandatory backstop", but no skill concretely instructed the reconciliation at the point where merges happen.

## Changes (source: `plugins/src/base` only; variants + manifest regenerated)

- **`lisa-drive-pr-to-merge/SKILL.md`** — new step **3c. Linear native-state reconciliation (non-terminal merges only)**: after `MERGED` onto a non-terminal base branch, re-read the Linear Issue's native workflow state; if Linear auto-completed it, revert to the team's started/In Progress state and post a one-line reconciliation comment, per the `leaf-only-lifecycle` rule (cited by slug). Delegates the full procedure to `lisa-linear-sync` Phase 4b.
- **`lisa-linear-sync/SKILL.md`** — the `pr-merged` milestone row now explicitly requires running Phase 4b when the merge target is a non-terminal env branch, and Phase 4b is marked a **mandatory** numbered step of every `pr-merged` sync (not an optional backstop), with the branch-linkage-despite-non-closing-reference failure mode named.
- Regenerated all plugin variants (`bun run build:plugins`) and `src/core/upstream-evidence-manifest.ts`; `bun run check:plugins` reports in sync.

Closes #1948

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added post-merge verification guidance for linked Linear issues on non-production branches.
  * Linear synchronization now requires reconciling issues that are automatically marked completed after intermediate-branch merges.
  * Clarified that reconciliation restores issues to Started/In Progress and records a brief comment.
* **Chores**
  * Updated internal evidence records for revised skill documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->