### PR TITLE
perf(postinstall): inherit primary checkout plugin-sync state in linked worktrees

### DIFF
--- a/scripts/install-claude-plugins.sh
+++ b/scripts/install-claude-plugins.sh
@@ -300,11 +300,66 @@ if ! command -v claude &>/dev/null; then exit 0; fi
 # (a removed plugin comes back on the next install) survives at the cost of a
 # single `claude plugin list` call.
 LISA_VERSION="$(node -e "console.log(require('$LISA_DIR/package.json').version || '')" 2>/dev/null || true)"
+
+# Linked worktrees inherit the primary checkout's sync state. The marker is
+# gitignored on purpose (it records THIS machine's ~/.claude plugin state, so
+# it must not travel to other machines via git) — but that means every fresh
+# agent worktree (.claude/worktrees/<ticket>, ~/.codex/worktrees/<ticket>)
+# starts marker-less and paid the full sync: marketplace pulls plus a dozen
+# Claude CLI spawns per ticket. Derive the primary checkout from
+# --git-common-dir (the same defended pattern install-pkgs.sh uses to link
+# node_modules, add08b409) and read its marker instead. Worktrees never WRITE
+# the primary marker: a full sync run from a worktree reinstalls plugins for
+# the worktree's own projectPath only, so recording it as the primary's synced
+# state would let the primary skip the forced reinstall it still needs after a
+# version bump.
+IS_LINKED_WORKTREE=false
+PRIMARY_ROOT=""
+GIT_COMMON_DIR="$(git -C "$PROJECT_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+if [ -n "$GIT_COMMON_DIR" ]; then
+  PRIMARY_ROOT="$(dirname "$GIT_COMMON_DIR")"
+  if [ "$PRIMARY_ROOT" != "$PROJECT_ROOT" ] && [ -d "$PRIMARY_ROOT/.claude" ]; then
+    IS_LINKED_WORKTREE=true
+  else
+    PRIMARY_ROOT=""
+  fi
+fi
+
 PLUGIN_SYNC_MARKER="$PROJECT_ROOT/.claude/.lisa-plugins-synced"
+
+marker_current() {
+  [ -n "$LISA_VERSION" ] && [ -f "$1" ] \
+    && [ "$(cat "$1" 2>/dev/null)" = "$LISA_VERSION" ]
+}
+
 FORCE_PLUGIN_SYNC=true
-if [ -n "$LISA_VERSION" ] && [ -f "$PLUGIN_SYNC_MARKER" ] \
-  && [ "$(cat "$PLUGIN_SYNC_MARKER" 2>/dev/null)" = "$LISA_VERSION" ]; then
+if marker_current "$PLUGIN_SYNC_MARKER"; then
   FORCE_PLUGIN_SYNC=false
+elif [ "$IS_LINKED_WORKTREE" = "true" ] \
+  && marker_current "$PRIMARY_ROOT/.claude/.lisa-plugins-synced"; then
+  FORCE_PLUGIN_SYNC=false
+fi
+
+# In a linked worktree whose sync state is already settled (its own marker or
+# the primary checkout's marker is current for this Lisa version) there is
+# nothing left for this script to do: the marketplace cache is machine-global
+# (already refreshed when the primary synced), the heal migrations are gated
+# behind the same synced state, and per-worktree plugin registration is
+# handled by the coding agent's own startup — Claude Code auto-installs the
+# committed .claude/settings.json enabledPlugins for a new projectPath, and
+# Codex consumes the project-local .codex-plugin pointer, not Claude
+# project-scope registrations. Skipping here removes every Claude CLI spawn
+# from the fresh-worktree postinstall path. The #320 defense (refresh
+# marketplace whenever installs happened) is preserved: this path performs no
+# installs. Self-heal for the primary checkout is untouched. The worktree's
+# own marker is recorded so repeat installs (and health's root-confined
+# marker probe) see the settled state without reaching outside the project.
+if [ "$IS_LINKED_WORKTREE" = "true" ] && [ "$FORCE_PLUGIN_SYNC" != "true" ]; then
+  mkdir -p "$PROJECT_ROOT/.claude" 2>/dev/null \
+    && printf '%s' "$LISA_VERSION" > "$PLUGIN_SYNC_MARKER" 2>/dev/null \
+    || true
+  echo "Lisa plugins already in sync for ${LISA_VERSION} (primary checkout: ${PRIMARY_ROOT}); deferring worktree plugin registration to the coding agent's startup."
+  exit 0
 fi
 
 INSTALLED_PLUGINS_FOR_PROJECT=""
@@ -489,6 +544,10 @@ fi
 # Record the fully-synced Lisa version so same-version installs skip the
 # marketplace pulls and forced reinstalls above. Written last so any earlier
 # failure exits (set -e) without recording a sync that did not finish.
+# Always the project's OWN marker: a full sync run from a linked worktree only
+# reinstalled plugins for the worktree's projectPath, so recording it against
+# the primary checkout would let the primary skip the forced reinstall it
+# still needs after a version bump.
 if [ -n "$LISA_VERSION" ]; then
   mkdir -p "$PROJECT_ROOT/.claude" 2>/dev/null \
     && printf '%s' "$LISA_VERSION" > "$PLUGIN_SYNC_MARKER" 2>/dev/null \

--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -46,6 +46,7 @@ import {
 import { StrategyRegistry, type StrategyContext } from "../strategies/index.js";
 import type { IBackupService } from "../transaction/index.js";
 import { listFilesRecursive } from "../utils/file-operations.js";
+import { resolvePrimaryWorktreeRoot } from "../utils/linked-worktree.js";
 import {
   loadIgnorePatterns,
   type IgnorePatterns,
@@ -710,12 +711,16 @@ export class Lisa {
   ): Promise<void> {
     const { logger } = this.deps;
     const validPluginName = /^[\w@./-]+$/;
-    const { fullSync, toInstall, version } = await this.computePluginSyncPlan(
-      execAsync,
-      plugins
-    );
+    const { fullSync, toInstall, version, isLinkedWorktree } =
+      await this.computePluginSyncPlan(execAsync, plugins);
 
     if (!fullSync && toInstall.length === 0) {
+      if (isLinkedWorktree) {
+        // Record the settled state on the worktree's own marker so repeat
+        // applies (and health's root-confined marker probe) do not have to
+        // re-derive it from the primary checkout.
+        await this.writePluginSyncMarker(version);
+      }
       logger.info(
         pc.gray(`Plugins already in sync for Lisa ${version}; skipping`)
       );
@@ -744,6 +749,11 @@ export class Lisa {
     await this.updateLisaMarketplace(execAsync, true);
 
     if (fullSync) {
+      // Always the project's OWN marker (destDir): a full sync run from a
+      // linked worktree only reinstalled plugins for the worktree's
+      // projectPath, so recording it against the primary checkout would let
+      // the primary skip the forced reinstall it still needs after a
+      // version bump.
       await this.writePluginSyncMarker(version);
     }
   }
@@ -751,10 +761,23 @@ export class Lisa {
   /**
    * Decide whether this apply needs a full plugin sync and which plugins to
    * install.
+   *
+   * Linked worktrees inherit the primary checkout's sync state: the marker is
+   * gitignored (it records this machine's `~/.claude` plugin state), so a
+   * fresh agent worktree is always marker-less and would otherwise pay the
+   * full sync — marketplace pulls plus a Claude CLI spawn per plugin — on
+   * every ticket. When the primary checkout is already synced for this Lisa
+   * version, the worktree has nothing left to do: the marketplace cache is
+   * machine-global and per-worktree plugin registration is handled by the
+   * coding agent's own startup (Claude Code auto-installs the committed
+   * `enabledPlugins` for a new projectPath; Codex uses the project-local
+   * `.codex-plugin` pointer instead of Claude project-scope registrations).
+   * The #320 defense (refresh marketplace whenever installs happened) holds:
+   * the skip path performs no installs.
    * @param execAsync - Promisified exec function for running shell commands
    * @param plugins - Plugin identifiers from enabledPlugins
-   * @returns Sync plan: fullSync (version changed), plugins to install, and
-   *   the current Lisa version
+   * @returns Sync plan: fullSync (version changed), plugins to install, the
+   *   current Lisa version, and whether destDir is a linked worktree
    */
   private async computePluginSyncPlan(
     execAsync: PluginExecAsync,
@@ -763,12 +786,28 @@ export class Lisa {
     readonly fullSync: boolean;
     readonly toInstall: readonly string[];
     readonly version: string;
+    readonly isLinkedWorktree: boolean;
   }> {
     const version = getPackageVersion();
-    const syncedVersion = await readFile(this.pluginSyncMarkerPath(), "utf-8")
-      .then(content => content.trim())
-      .catch(() => null);
+    const primaryRoot = await resolvePrimaryWorktreeRoot(this.config.destDir);
+    const isLinkedWorktree = primaryRoot !== null;
+    const readMarker = async (markerPath: string): Promise<string | null> =>
+      readFile(markerPath, "utf-8")
+        .then(content => content.trim())
+        .catch(() => null);
+    const ownMarker = await readMarker(this.pluginSyncMarkerPath());
+    const syncedVersion =
+      ownMarker === version || primaryRoot === null
+        ? ownMarker
+        : await readMarker(
+            path.join(primaryRoot, ".claude", ".lisa-plugins-synced")
+          );
     const fullSync = syncedVersion !== version;
+    if (isLinkedWorktree && !fullSync) {
+      // Skip the `claude plugin list` probe too — registration for this
+      // worktree's projectPath is deferred to the coding agent's startup.
+      return { fullSync: false, toInstall: [], version, isLinkedWorktree };
+    }
     const installed = fullSync
       ? null
       : await this.readInstalledPluginIds(execAsync);
@@ -776,7 +815,7 @@ export class Lisa {
       installed === null
         ? plugins
         : plugins.filter(plugin => !installed.has(plugin));
-    return { fullSync, toInstall, version };
+    return { fullSync, toInstall, version, isLinkedWorktree };
   }
 
   /**

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1867,7 +1867,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/github-status-check.sh":
       "876914c369c5bd58f4a5f3c41d0c1264c6923f329a644f90640d15b434a0fbd1",
     "scripts/install-claude-plugins.sh":
-      "8c6bdb3d11e535414038df53202f0cf5f084a6b981ce7bf865adbfe2e1a36c66",
+      "3283dc0f93b1ea1c8948a132f9dcb354115a8cb826cf5efd4c8e7318bbf5cd59",
     "scripts/internal-agy-skill-policy.json":
       "c2ce87d2eeebfdc9f24d6486425c010cf9289376f8a459f4767ca22d2bf8670d",
     "scripts/internal-codex-skill-policy.json":
@@ -7600,6 +7600,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/utils/ignore-patterns.ts": true,
     "src/utils/index.ts": true,
     "src/utils/json-utils.ts": true,
+    "src/utils/linked-worktree.ts": true,
     "src/utils/package-manager-detect.ts": true,
     "src/utils/path-utils.ts": true,
     "src/utils/pm-env.ts": true,
@@ -8136,6 +8137,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/utils/file-operations.test.ts": true,
     "tests/unit/utils/ignore-patterns.test.ts": true,
     "tests/unit/utils/json-utils.test.ts": true,
+    "tests/unit/utils/linked-worktree.test.ts": true,
     "tests/unit/utils/postinstall-trampoline.test.ts": true,
     "tests/unit/utils/usage-accounting-backward-compatibility.test.ts": true,
     "tests/unit/utils/usage-accounting-rollup.test.ts": true,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from "./fibonacci.js";
 export * from "./file-operations.js";
 export * from "./json-utils.js";
+export * from "./linked-worktree.js";
 export * from "./path-utils.js";
 export * from "./usage-accounting.js";
 // Intentionally narrow: the reconciliation trampoline's dist-path resolver and

--- a/src/utils/linked-worktree.ts
+++ b/src/utils/linked-worktree.ts
@@ -1,0 +1,49 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+
+/**
+ * Resolve the primary checkout root when a directory is a linked git
+ * worktree.
+ *
+ * A linked worktree has a `.git` FILE containing
+ * `gitdir: <primary>/.git/worktrees/<name>`; a primary checkout has a `.git`
+ * directory. Parsing the file avoids spawning git — this runs inside
+ * package-manager lifecycle scripts where every child process is a
+ * measurable cost. Submodule `.git` files point at `.git/modules/<name>` and
+ * deliberately do not match. The primary is only returned when its `.claude`
+ * directory exists, mirroring install-claude-plugins.sh and the
+ * install-pkgs.sh node_modules link (add08b409).
+ * @param dir - Directory to inspect (typically the Lisa destDir)
+ * @returns Primary checkout root, or null when dir is not a linked worktree
+ *   of a reachable primary checkout
+ */
+export async function resolvePrimaryWorktreeRoot(
+  dir: string
+): Promise<string | null> {
+  const resolvedDir = path.resolve(dir);
+  const gitdirContent = await readFile(
+    path.join(resolvedDir, ".git"),
+    "utf-8"
+  ).catch(() => null);
+  if (gitdirContent === null) {
+    return null;
+  }
+  const gitdirMatch = /^gitdir:(.*)$/m.exec(gitdirContent);
+  const gitdirTarget = gitdirMatch?.[1]?.trim();
+  if (gitdirTarget === undefined || gitdirTarget === "") {
+    return null;
+  }
+  const gitdir = path.resolve(resolvedDir, gitdirTarget);
+  const worktreesMatch = /^(.*)[/\\]\.git[/\\]worktrees[/\\][^/\\]+$/.exec(
+    gitdir
+  );
+  if (!worktreesMatch?.[1]) {
+    return null;
+  }
+  const primaryRoot = worktreesMatch[1];
+  if (primaryRoot === resolvedDir) {
+    return null;
+  }
+  return existsSync(path.join(primaryRoot, ".claude")) ? primaryRoot : null;
+}

--- a/tests/unit/scripts/install-claude-plugins-self.test.ts
+++ b/tests/unit/scripts/install-claude-plugins-self.test.ts
@@ -233,6 +233,74 @@ exit 0
   );
 }
 
+/**
+ * Environment for spawning git in test fixtures: hook-set GIT_DIR /
+ * GIT_WORK_TREE / GIT_INDEX_FILE poison git commands aimed at a different
+ * repository, so strip every GIT_* key.
+ * @returns process.env minus GIT_* keys.
+ */
+function gitCleanEnv(): Record<string, string | undefined> {
+  return Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_"))
+  );
+}
+
+/**
+ * Create a real primary git checkout with a linked worktree.
+ * @param root - Fixture root.
+ * @param primaryMarkerVersion - Version recorded in the primary checkout's
+ *   plugin sync marker.
+ * @returns Absolute primary and worktree roots.
+ */
+async function writeLinkedWorktreeFixture(
+  root: string,
+  primaryMarkerVersion: string
+): Promise<{ primaryRoot: string; worktreeRoot: string }> {
+  const primaryRoot = path.join(root, "primary");
+  const worktreeRoot = path.join(root, "wt");
+  await mkdir(primaryRoot, { recursive: true });
+  const env = { ...gitCleanEnv(), HOME: root };
+  const git = async (...args: string[]): Promise<void> => {
+    await execFileAsync(
+      "git",
+      ["-c", "user.email=test@example.com", "-c", "user.name=Test", ...args],
+      { cwd: primaryRoot, env }
+    );
+  };
+  await git("init", "--template=", "-q");
+  await git("commit", "--allow-empty", "-m", "init", "-q", "--no-verify");
+  await git("worktree", "add", worktreeRoot, "-q");
+  await mkdir(path.join(primaryRoot, CLAUDE_DIR), { recursive: true });
+  await writeFile(
+    path.join(primaryRoot, CLAUDE_DIR, PLUGIN_SYNC_MARKER_FILE),
+    primaryMarkerVersion,
+    "utf8"
+  );
+  return { primaryRoot, worktreeRoot };
+}
+
+/**
+ * Stamp the fake installed Lisa package with the fixture version.
+ * @param root - Downstream fixture root.
+ */
+async function writeVersionedLisaPackageJson(root: string): Promise<void> {
+  await writeFile(
+    path.join(
+      root,
+      "node_modules",
+      CODYSWANN_SCOPE,
+      LISA_PACKAGE_DIR_NAME,
+      PACKAGE_JSON_FILE
+    ),
+    `${JSON.stringify(
+      { name: LISA_PACKAGE_NAME, version: FAKE_LISA_VERSION },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+}
+
 afterEach(async () => {
   await Promise.all(
     tempRoots.map(root => rm(root, { recursive: true, force: true }))
@@ -565,6 +633,94 @@ describe("install-claude-plugins self postinstall path", () => {
       "utf8"
     );
     expect(marker).toBe(FAKE_LISA_VERSION);
+  });
+
+  it("inherits the primary checkout's sync marker in a linked worktree and skips all Claude plugin work", async () => {
+    const root = await makeTempRoot();
+    const { primaryRoot, worktreeRoot } = await writeLinkedWorktreeFixture(
+      root,
+      FAKE_LISA_VERSION
+    );
+    const fakeBin = path.join(root, "bin");
+    const commandLog = path.join(root, COMMAND_LOG);
+    await writeDownstreamProject(worktreeRoot);
+    const installedScriptPath = await writeInstalledLisaScript(worktreeRoot);
+    await writeVersionedLisaPackageJson(worktreeRoot);
+    await writeFakeAgentBins(fakeBin);
+
+    const result = await execFileAsync("bash", [installedScriptPath], {
+      env: {
+        ...gitCleanEnv(),
+        HOME: root,
+        CI: "",
+        CODEX_THREAD_ID: "",
+        LISA_TEST_COMMAND_LOG: commandLog,
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+
+    const log = await readFile(commandLog, "utf8").catch(() => "");
+    expect(result.stdout).toContain(
+      "deferring worktree plugin registration to the coding agent's startup"
+    );
+    expect(log).not.toContain("claude plugin");
+    // The worktree records its own marker so repeat installs (and health's
+    // root-confined marker probe) see the settled state.
+    const worktreeMarker = await readFile(
+      path.join(worktreeRoot, CLAUDE_DIR, PLUGIN_SYNC_MARKER_FILE),
+      "utf8"
+    );
+    expect(worktreeMarker.trim()).toBe(FAKE_LISA_VERSION);
+    // The primary marker is untouched.
+    const primaryMarker = await readFile(
+      path.join(primaryRoot, CLAUDE_DIR, PLUGIN_SYNC_MARKER_FILE),
+      "utf8"
+    );
+    expect(primaryMarker.trim()).toBe(FAKE_LISA_VERSION);
+  });
+
+  it("runs a full sync from a linked worktree with a stale primary marker without recording the primary's marker", async () => {
+    const root = await makeTempRoot();
+    const { primaryRoot, worktreeRoot } = await writeLinkedWorktreeFixture(
+      root,
+      "1.0.0"
+    );
+    const fakeBin = path.join(root, "bin");
+    const commandLog = path.join(root, COMMAND_LOG);
+    await writeDownstreamProject(worktreeRoot);
+    const installedScriptPath = await writeInstalledLisaScript(worktreeRoot);
+    await writeVersionedLisaPackageJson(worktreeRoot);
+    await writeFakeAgentBins(fakeBin);
+
+    await execFileAsync("bash", [installedScriptPath], {
+      env: {
+        ...gitCleanEnv(),
+        HOME: root,
+        CI: "",
+        CODEX_THREAD_ID: "",
+        LISA_TEST_COMMAND_LOG: commandLog,
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+
+    const log = await readFile(commandLog, "utf8");
+    // Version changed: the worktree still performs its own full sync.
+    expect(log).toContain(CLAUDE_INSTALL_BASE);
+    expect(log).toContain("claude plugin marketplace update lisa");
+    // The worktree records its own marker...
+    const worktreeMarker = await readFile(
+      path.join(worktreeRoot, CLAUDE_DIR, PLUGIN_SYNC_MARKER_FILE),
+      "utf8"
+    );
+    expect(worktreeMarker.trim()).toBe(FAKE_LISA_VERSION);
+    // ...but never the primary's: this run only reinstalled plugins for the
+    // worktree's projectPath, so the primary still needs its own forced
+    // reinstall after the version bump.
+    const primaryMarker = await readFile(
+      path.join(primaryRoot, CLAUDE_DIR, PLUGIN_SYNC_MARKER_FILE),
+      "utf8"
+    );
+    expect(primaryMarker.trim()).toBe("1.0.0");
   });
 
   it("does not probe codex again once the retire marker exists", async () => {

--- a/tests/unit/utils/linked-worktree.test.ts
+++ b/tests/unit/utils/linked-worktree.test.ts
@@ -1,0 +1,97 @@
+/** Linked-worktree primary-root resolution coverage. */
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolvePrimaryWorktreeRoot } from "../../../src/utils/linked-worktree.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+describe("utils/linked-worktree", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await fs.realpath(await createTempDir());
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(root);
+  });
+
+  /**
+   * Lay out a primary checkout plus a linked worktree without spawning git.
+   * @param options - Fixture switches.
+   * @param options.primaryHasClaudeDir - Whether the primary gets a .claude
+   *   directory.
+   * @param options.relativeGitdir - Whether the worktree .git file uses a
+   *   relative gitdir path.
+   * @returns Absolute primary and worktree roots.
+   */
+  async function writeWorktreeFixture(options: {
+    primaryHasClaudeDir: boolean;
+    relativeGitdir?: boolean;
+  }): Promise<{ primary: string; worktree: string }> {
+    const primary = path.join(root, "primary");
+    const worktree = path.join(root, "wt");
+    const gitdir = path.join(primary, ".git", "worktrees", "wt");
+    await fs.mkdirp(gitdir);
+    await fs.mkdirp(worktree);
+    if (options.primaryHasClaudeDir) {
+      await fs.mkdirp(path.join(primary, ".claude"));
+    }
+    const target = options.relativeGitdir
+      ? path.relative(worktree, gitdir)
+      : gitdir;
+    await fs.writeFile(path.join(worktree, ".git"), `gitdir: ${target}\n`);
+    return { primary, worktree };
+  }
+
+  it("resolves the primary root from an absolute gitdir pointer", async () => {
+    const { primary, worktree } = await writeWorktreeFixture({
+      primaryHasClaudeDir: true,
+    });
+
+    expect(await resolvePrimaryWorktreeRoot(worktree)).toBe(primary);
+  });
+
+  it("resolves the primary root from a relative gitdir pointer", async () => {
+    const { primary, worktree } = await writeWorktreeFixture({
+      primaryHasClaudeDir: true,
+      relativeGitdir: true,
+    });
+
+    expect(await resolvePrimaryWorktreeRoot(worktree)).toBe(primary);
+  });
+
+  it("returns null when the primary checkout has no .claude directory", async () => {
+    const { worktree } = await writeWorktreeFixture({
+      primaryHasClaudeDir: false,
+    });
+
+    expect(await resolvePrimaryWorktreeRoot(worktree)).toBeNull();
+  });
+
+  it("returns null for a primary checkout (.git directory)", async () => {
+    const primary = path.join(root, "repo");
+    await fs.mkdirp(path.join(primary, ".git"));
+    await fs.mkdirp(path.join(primary, ".claude"));
+
+    expect(await resolvePrimaryWorktreeRoot(primary)).toBeNull();
+  });
+
+  it("returns null for a submodule-style gitdir pointer", async () => {
+    const submodule = path.join(root, "sub");
+    await fs.mkdirp(submodule);
+    await fs.writeFile(
+      path.join(submodule, ".git"),
+      `gitdir: ${path.join(root, ".git", "modules", "sub")}\n`
+    );
+
+    expect(await resolvePrimaryWorktreeRoot(submodule)).toBeNull();
+  });
+
+  it("returns null when no .git entry exists", async () => {
+    const plain = path.join(root, "plain");
+    await fs.mkdirp(plain);
+
+    expect(await resolvePrimaryWorktreeRoot(plain)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Fresh agent worktrees (`.claude/worktrees/<ticket>`, `~/.codex/worktrees/<ticket>`) no longer pay the full plugin sync on every boot: linked worktrees now derive the primary checkout from the gitdir pointer (the same defended pattern `install-pkgs.sh` uses to link node_modules, `add08b409`) and inherit its `.claude/.lisa-plugins-synced` state.
- A settled worktree skips **all** Claude CLI work in the postinstall — the marketplace cache is machine-global, heal migrations are gated behind the same synced state, and per-worktree plugin registration is handled by the coding agent's own startup (Claude Code auto-installs the committed `enabledPlugins` for a new projectPath; Codex uses the project-local `.codex-plugin` pointer).
- Implemented in both twins that share the marker contract: `scripts/install-claude-plugins.sh` and `Lisa.computePluginSyncPlan` (via a new shared `resolvePrimaryWorktreeRoot` util that parses the `.git` file instead of spawning git).

Closes CodySwannGT/lisa#1962

## Why

Measured on a real machine (2026-07-22): every fresh worktree boot ran the full sync — marketplace pulls plus a dozen `claude plugin` CLI spawns at ~13s each (the CLI reads/rewrites a 40MB `installed_plugins.json` that had accumulated 101,878 entries, 83% pointing at deleted worktrees) — ~9 minutes per `claude-ticket` / `codex-ticket` boot. The marker is gitignored **on purpose** (71596323c: it records the machine's `~/.claude` plugin state and must not travel to other machines), so every fresh worktree started marker-less and looked like a version change.

## Preserved defenses (history-audited)

| Behavior | Defense | Status |
|---|---|---|
| Version-gated sync + gitignored marker | `71596323c` | Preserved for primaries and cross-machine clones; worktrees inherit via gitdir, not git |
| Marketplace refresh whenever installs happened | #320 ("Unknown skill" in nightly CI) | Skip path performs no installs, so no refresh is owed; install paths unchanged |
| Package-side bootstrap apply | #1017 | Untouched |
| Self-heal (removed plugin comes back on next install) | `71596323c` | Untouched for primary checkouts; worktree registration owned by agent startup |
| Health probe root confinement | `read-only-fs.ts` guards | Worktree records its **own** marker on skip/full-sync so the in-root probe sees the settled state |
| Primary's forced reinstall after version bump | `71596323c` | A worktree full sync never records the primary's marker |

## Test plan

- `tests/unit/utils/linked-worktree.test.ts` — gitdir resolution: absolute + relative pointers, missing `.claude`, primary checkouts, submodule pointers, plain dirs (6 cases).
- `tests/unit/scripts/install-claude-plugins-self.test.ts` — two new end-to-end fixtures using a real `git worktree add`: (1) settled primary ⇒ zero `claude plugin` CLI calls, deferral logged, worktree marker recorded, primary marker untouched; (2) stale primary marker ⇒ full sync still runs, worktree marker recorded, primary marker **not** recorded.
- Full unit suite green locally (7,223 tests) including the pre-push coverage run.

🤖 Generated with Claude Code
