### PR TITLE
feat(hooks): safety-net guard parity with upstream 1.0.6, then retire the duplicate plugin

### DIFF
--- a/.claude-pr/.claude/settings.json
+++ b/.claude-pr/.claude/settings.json
@@ -20,7 +20,7 @@
   },
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true,
-    "safety-net@cc-marketplace": true,
+    "safety-net@cc-marketplace": false,
     "code-simplifier@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "playwright@claude-plugins-official": true,

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,7 +20,7 @@
   },
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true,
-    "safety-net@cc-marketplace": true,
+    "safety-net@cc-marketplace": false,
     "code-simplifier@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "playwright@claude-plugins-official": true,

--- a/all/merge/.claude/settings.json
+++ b/all/merge/.claude/settings.json
@@ -5,7 +5,7 @@
   },
   "enabledPlugins": {
     "lisa@lisa": true,
-    "safety-net@cc-marketplace": true,
+    "safety-net@cc-marketplace": false,
     "code-simplifier@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "coderabbit@claude-plugins-official": true,

--- a/cdk/merge/.claude/settings.json
+++ b/cdk/merge/.claude/settings.json
@@ -5,7 +5,7 @@
   },
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true,
-    "safety-net@cc-marketplace": true,
+    "safety-net@cc-marketplace": false,
     "code-simplifier@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "coderabbit@claude-plugins-official": true,

--- a/expo/merge/.claude/settings.json
+++ b/expo/merge/.claude/settings.json
@@ -5,7 +5,7 @@
   },
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true,
-    "safety-net@cc-marketplace": true,
+    "safety-net@cc-marketplace": false,
     "code-simplifier@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "playwright@claude-plugins-official": true,

--- a/harper-fabric/merge/.claude/settings.json
+++ b/harper-fabric/merge/.claude/settings.json
@@ -6,7 +6,7 @@
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true,
     "playwright@claude-plugins-official": true,
-    "safety-net@cc-marketplace": true,
+    "safety-net@cc-marketplace": false,
     "code-simplifier@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "coderabbit@claude-plugins-official": true,

--- a/nestjs/merge/.claude/settings.json
+++ b/nestjs/merge/.claude/settings.json
@@ -5,7 +5,7 @@
   },
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true,
-    "safety-net@cc-marketplace": true,
+    "safety-net@cc-marketplace": false,
     "code-simplifier@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "coderabbit@claude-plugins-official": true,

--- a/parity/plugin-routing/safety-net@cc-marketplace.json
+++ b/parity/plugin-routing/safety-net@cc-marketplace.json
@@ -3,8 +3,8 @@
   "plugin": "safety-net@cc-marketplace",
   "pluginName": "safety-net",
   "marketplace": "cc-marketplace",
-  "upstreamVersion": "0.9.0",
-  "analyzedAt": "2026-05-30",
+  "upstreamVersion": "1.0.6",
+  "analyzedAt": "2026-07-22",
   "status": "approved",
   "components": [
     {

--- a/parity/plugin-routing/safety-net@cc-marketplace.md
+++ b/parity/plugin-routing/safety-net@cc-marketplace.md
@@ -1,8 +1,8 @@
 # Parity routing review — `safety-net@cc-marketplace`
 
 - **Plugin:** `safety-net@cc-marketplace`
-- **Upstream version:** `0.9.0`
-- **Analyzed:** 2026-05-30
+- **Upstream version:** `1.0.6`
+- **Analyzed:** 2026-07-22 (re-review; originally 2026-05-30 at 0.9.0)
 - **Status:** `proposed` (flip to `approved` before running `implement-plugin-parity`)
 
 ## Components
@@ -23,3 +23,34 @@
 | copilot | `enable-vendor-equivalent` | - enable safety-net's native Copilot CLI hook runner (cc-safety-net --copilot-cli) in the project-scoped marketplace<br>- the set-custom-rules and verify-custom-rules skills are covered by cc-safety-net's native built-in commands for the Copilot CLI runner | safety-net ships a concrete Copilot CLI hook runner (cc-safety-net --copilot-cli) plus built-in rule-management commands, so enable the vendor's native Copilot support rather than reimplementing. |
 
 > Plan-only artifact. Review the routing, then flip `"status": "proposed"` → `"approved"` in the paired `.json` to authorize `implement-plugin-parity`.
+
+## Addendum — 2026-07-22 re-review at upstream 1.0.6 (issue #1960)
+
+Upstream 1.0.6 consolidated the two rule-management skills into a single
+`cc-safety-net` skill, moved custom rules to a JSON rulebook system driven by
+the `npx cc-safety-net rule` CLI, and grew the Bash-guard engine (semantic
+segment analysis, wrapper stripping, interpreter one-liner scanning). Lisa's
+`lisa-parity-safety-net-rules` skill deliberately keeps the flat ERE-lines-file
+design (auditable, no npx dependency, identical on every agent runtime) and is
+re-pinned at `1.0.6`.
+
+**Claude-side change.** The original routing left the upstream plugin installed
+on Claude/Cursor alongside Lisa's own `parity-safety-net.sh` PreToolUse hook,
+so every Bash command in a Claude session was screened twice by two different
+guard engines. As of issue #1960 the Lisa hook is canonical on every agent:
+its guard set was audited against upstream 1.0.6 (`.lisa/research-1960-guard-audit.md`)
+and every material default-mode guard was **reimplemented** (never ported) into
+`parity-safety-net.sh` — git discard family (checkout/switch/restore/stash/
+clean/branch -D/tag -d/reflog delete/worktree remove --force, reset --merge),
+rm target hardening (cwd `.`, `..`-traversal, out-of-project absolute paths
+with a /tmp+$TMPDIR allowance, `$VAR` targets, cwd=$HOME gate), quote-aware
+target boundaries (closing the `bash -c "rm -rf /"` / interpreter one-liner
+bypass), find/xargs deletion, always-on disk destroyers (dd/mkfs/shred), and a
+fail-closed exit-2 path for malformed hook input — proven by the 138-fixture
+matrix in `tests/unit/hooks/parity-safety-net-guards.test.ts`. Documented
+deliberate divergences kept: dirty-tree-only `reset --hard`,
+protected-branch-only force-push blocking, and Lisa-only guards upstream lacks
+(SQL DROP/TRUNCATE, bare `rm -rf *`, `git checkout .`). Mirroring the #1955
+sentry retirement, the upstream `safety-net@cc-marketplace` plugin is no longer
+installed (a version-gated uninstall retires existing installs) and the merge
+settings templates set its `enabledPlugins` entry to `false`.

--- a/parity/plugin-routing/safety-net@cc-marketplace.md
+++ b/parity/plugin-routing/safety-net@cc-marketplace.md
@@ -3,7 +3,7 @@
 - **Plugin:** `safety-net@cc-marketplace`
 - **Upstream version:** `1.0.6`
 - **Analyzed:** 2026-07-22 (re-review; originally 2026-05-30 at 0.9.0)
-- **Status:** `proposed` (flip to `approved` before running `implement-plugin-parity`)
+- **Status:** `approved`
 
 ## Components
 

--- a/phaser/merge/.claude/settings.json
+++ b/phaser/merge/.claude/settings.json
@@ -6,7 +6,7 @@
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true,
     "playwright@claude-plugins-official": true,
-    "safety-net@cc-marketplace": true,
+    "safety-net@cc-marketplace": false,
     "code-simplifier@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "coderabbit@claude-plugins-official": true,

--- a/plugins/lisa-agy/hooks/parity-safety-net.sh
+++ b/plugins/lisa-agy/hooks/parity-safety-net.sh
@@ -169,9 +169,13 @@ readonly GIT_CMD='(^|[^[:alnum:]_-])git[[:space:]]+'"$GIT_GLOBAL_OPTS"
 # `--rm`-style flags and `foo.rm` names out.
 readonly RM_CMD='(^|[^[:alnum:]_./-])([[:alnum:]_./-]*/)?rm'
 # rm invoked with BOTH a recursive and a force flag — clustered (-rf/-fr, any
-# extra letters) or split (-r … -f / long forms), in either order.
+# extra letters) or split, in either order. The split gate pairs ANY recursive
+# form (short cluster containing r, or --recursive) with ANY force form (short
+# cluster containing f, or --force), so mixed spellings like `rm -r --force /`
+# and `rm --recursive -f /` cannot slip between the short/short and long/long
+# alternations (PR #1976 review).
 readonly RM_RF_CLUSTER="$RM_CMD"'([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
-readonly RM_RF_SPLIT="$RM_CMD"'[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
+readonly RM_RF_SPLIT="$RM_CMD"'(([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*r[[:alnum:]]*|--recursive)([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|$)|([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*r[[:alnum:]]*|--recursive)([[:space:]]|$))'
 
 # 1. Recursive forced delete (`rm -rf`) of a filesystem root, home, or top-level
 #    wildcard. Two gates ANDed: the statement must invoke `rm` with BOTH a

--- a/plugins/lisa-agy/hooks/parity-safety-net.sh
+++ b/plugins/lisa-agy/hooks/parity-safety-net.sh
@@ -8,13 +8,18 @@
 # It reads the hook stdin JSON, inspects the proposed Bash command, and EXITS
 # NON-ZERO (2) to BLOCK when a known-destructive pattern matches:
 #   - `rm -rf` of a root / home / wildcard path (quote-aware boundaries, so
-#     `bash -c "rm -rf /"` and interpreter one-liners are caught too)
-#   - `rm -rf` of the cwd (`.`), a `..`-traversal path, an absolute path outside
-#     the project (with a /tmp, /var/tmp, $TMPDIR allowance), a `$VAR` target
-#     other than $TMPDIR, or ANY recursive forced delete while cwd is $HOME
-#   - force-pushing a protected branch (main/master/production/release) —
+#     `bash -c "rm -rf /"` and interpreter one-liners are caught too; the rm
+#     guards also match path-prefixed invocations like `/bin/rm` and `./rm`)
+#   - `rm -rf` of the cwd (`.`), a `..`-traversal path, a `~/`-anchored path,
+#     an absolute path outside the project (with a /tmp, /var/tmp, $TMPDIR
+#     allowance), a `$VAR` target other than $TMPDIR, or ANY recursive forced
+#     delete while cwd is $HOME
+#   - force-pushing a protected branch (main/master/production/prod/release) —
 #     feature-branch force-push stays allowed (sanctioned rebase workflow;
-#     deliberate divergence from upstream's any-branch block)
+#     deliberate divergence from upstream's any-branch block). Every git guard
+#     sees through leading git GLOBAL options (`-C <path>`, `-c <k>=<v>`,
+#     `--git-dir[=…]`, `--no-pager`, …), so `git -C /path <destructive>` cannot
+#     dodge the subcommand anchor
 #   - `git reset --hard` / `--merge` while the working tree is dirty. Deliberate
 #     divergence: upstream blocks unconditionally; Lisa allows clean-tree resets.
 #     Residual risk (documented, accepted): the dirty check runs in the hook's
@@ -147,31 +152,48 @@ normalized_command_str="$(printf '%s' "$command_for_guards" \
 # crossing a statement separator, so a flag in a LATER statement can never be
 # attributed to an earlier git subcommand.
 readonly GIT_TOKENS='([[:space:]]+[^;&|[:space:]]+)*[[:space:]]+'
+# Git GLOBAL options (`-C <path>`, `-c <k>=<v>`, `--git-dir[=…]`, `--no-pager`,
+# …) legally sit between `git` and its subcommand, so every subcommand guard
+# consumes them — otherwise `git -C /path checkout -- f` dodges the anchor
+# (issue #1960 security review F1). Shape: zero or more dash-led tokens, each
+# optionally followed by ONE non-dash value token, which covers both the
+# `--git-dir=/x` and `--git-dir /x` spellings without naming every option.
+readonly GIT_GLOBAL_OPTS='(-[^;&|[:space:]]+([[:space:]]+[^-;&|[:space:]][^;&|[:space:]]*)?[[:space:]]+)*'
+# Anchor for every git subcommand guard: word-bounded `git`, whitespace, then
+# any run of global options. Callers append the subcommand name directly.
+readonly GIT_CMD='(^|[^[:alnum:]_-])git[[:space:]]+'"$GIT_GLOBAL_OPTS"
+# An rm invocation: bare `rm` or a path whose basename is exactly `rm`
+# (`/bin/rm`, `./rm`) — issue #1960 security review F2. The optional prefix must
+# END IN `/` immediately before `rm`, so charm/confirm/informant/rmdir never
+# match. The preceding-char class still excludes `.`, `/`, and `-` to keep
+# `--rm`-style flags and `foo.rm` names out.
+readonly RM_CMD='(^|[^[:alnum:]_./-])([[:alnum:]_./-]*/)?rm'
 # rm invoked with BOTH a recursive and a force flag — clustered (-rf/-fr, any
 # extra letters) or split (-r … -f / long forms), in either order.
-readonly RM_RF_CLUSTER='(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
-readonly RM_RF_SPLIT='(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
+readonly RM_RF_CLUSTER="$RM_CMD"'([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
+readonly RM_RF_SPLIT="$RM_CMD"'[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
 
 # 1. Recursive forced delete (`rm -rf`) of a filesystem root, home, or top-level
-#    wildcard. Two gates ANDed: the command must invoke `rm` with BOTH a
+#    wildcard. Two gates ANDed: the statement must invoke `rm` with BOTH a
 #    recursive and a force flag, AND name a catastrophic target. Splitting the
 #    flag check from the target check keeps each regex legible and testable.
 #    The target boundary classes include quote characters (issue #1960): without
 #    them, `bash -c "rm -rf /"` and interpreter one-liners like
 #    `python -c "… os.system('rm -rf /')"` slip through because the target is
 #    quote-adjacent instead of space-bounded.
+#    Both gates run PER STATEMENT inside the shared rm loop below (quality
+#    review S1): a harmless `/` in a LATER statement (`rm -rf build && cd /`)
+#    is never attributed to the rm in an earlier one.
 qc="'\""
-if matches "$RM_RF_CLUSTER" || matches "$RM_RF_SPLIT"; then
-  if matches_cs '([[:space:]='"$qc"'])(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]'"$qc"']|/?\*?['"$qc"']?$)'; then
-    block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
-  fi
-fi
+readonly RM_CATASTROPHIC_TARGET='([[:space:]='"$qc"'])(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]'"$qc"']|/?\*?['"$qc"']?$)'
 
 # 1b. rm target hardening (issue #1960). For every statement that invokes rm
 #     with recursive+force flags, additionally block when:
 #       - cwd is $HOME (any target is one argument away from wiping home), or
 #       - the target is the cwd itself (`.` / `./`), or
 #       - the target traverses out via `..`, or
+#       - the target is home-anchored (`~/…` — the shell expands it to $HOME at
+#         execution time, so it is always outside the project), or
 #       - the target is an absolute path outside the project — with an allowance
 #         for /tmp, /var/tmp, and $TMPDIR — or
 #       - the target is a `$VAR` expansion other than the sanctioned $TMPDIR.
@@ -185,6 +207,10 @@ while IFS= read -r rm_stmt; do
   if ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_CLUSTER" \
     && ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_SPLIT"; then
     continue
+  fi
+  # Guard 1: catastrophic target named in the SAME statement as the rm -rf.
+  if printf '%s' "$rm_stmt" | grep -Eq -- "$RM_CATASTROPHIC_TARGET"; then
+    block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
   fi
   # Physical-path comparison (pwd -P): on macOS $HOME or the cwd may arrive via
   # a symlink (/var → /private/var), and a string compare would miss the match.
@@ -200,7 +226,10 @@ while IFS= read -r rm_stmt; do
     token="${token%\"}"
     token="${token%\'}"
     if [ "$seen_rm" -eq 0 ]; then
-      [ "$token" = "rm" ] && seen_rm=1
+      # Path-prefixed spellings (`/bin/rm`, `./rm`) are still rm (F2).
+      case "$token" in
+        rm | */rm) seen_rm=1 ;;
+      esac
       continue
     fi
     case "$token" in
@@ -212,6 +241,10 @@ while IFS= read -r rm_stmt; do
       .. | ../* | */.. | */../*)
         set +f
         block "recursive forced delete of a path outside the project (.. traversal)"
+        ;;
+      '~' | '~'/*)
+        set +f
+        block "recursive forced delete of a home-anchored path (~/…) outside the project"
         ;;
       /*)
         case "$token" in
@@ -235,7 +268,7 @@ while IFS= read -r rm_stmt; do
   done
   set +f
 done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
-  | grep -Ei '(^|[^[:alnum:]_./-])rm([[:space:]]|$)' || true)
+  | grep -Ei -- "$RM_CMD"'([[:space:]]|$)' || true)
 
 # 2. Force-pushing a protected branch. `--force-with-lease` is the safe,
 #    non-clobbering alternative and is intentionally NOT blocked. Deliberate
@@ -260,7 +293,7 @@ while IFS= read -r push_stmt; do
     block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
 done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
-  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b' || true)
+  | grep -Ei -- "${GIT_CMD}push\b" || true)
 
 # 3. `git reset --hard` / `git reset --merge` while the working tree has
 #    uncommitted changes — both silently discard them. Only blocks when the tree
@@ -268,7 +301,7 @@ done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
 #    Deliberate divergence from upstream's unconditional block; the accepted
 #    residual risk (dirty check runs at hook time in the hook's cwd) is
 #    documented in the header.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--(hard|merge)\b'; then
+if matches "${GIT_CMD}"'reset\b.*--(hard|merge)\b'; then
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
     && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
     block "git reset --hard/--merge on a dirty working tree would discard uncommitted changes (stash or commit first)"
@@ -280,7 +313,7 @@ fi
 #    Blocking bare `.` exceeds upstream (which allows any single positional) —
 #    issue #1960 names it explicitly: it discards the entire tree. Branch
 #    switches and creation (`-b`/`-B`) stay allowed.
-readonly GIT_CHECKOUT='(^|[^[:alnum:]_-])git[[:space:]]+checkout'
+readonly GIT_CHECKOUT="${GIT_CMD}checkout"
 if matches "${GIT_CHECKOUT}${GIT_TOKENS}"'--([[:space:]]|$)' \
   || matches "${GIT_CHECKOUT}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
   || matches "${GIT_CHECKOUT}"'[[:space:]][^;&|]*--pathspec-from-file' \
@@ -289,7 +322,7 @@ if matches "${GIT_CHECKOUT}${GIT_TOKENS}"'--([[:space:]]|$)' \
 fi
 
 # 5. `git switch` discards: `--discard-changes` and its `-f/--force` aliases.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+switch'"${GIT_TOKENS}"'(--discard-changes|--force|-f)([[:space:]]|=|$)'; then
+if matches "${GIT_CMD}switch${GIT_TOKENS}"'(--discard-changes|--force|-f)([[:space:]]|=|$)'; then
   block "git switch discarding local changes (--discard-changes/-f/--force)"
 fi
 
@@ -297,23 +330,23 @@ fi
 #    the pure staging-area form is safe: `--staged` present and `--worktree`
 #    absent. Two conditions, because an ERE has no lookahead: `--staged
 #    --worktree` still discards, so `--worktree` blocks regardless of `--staged`.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore([[:space:]]|$)'; then
-  if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--worktree' \
-    || ! matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--staged'; then
+if matches "${GIT_CMD}"'restore([[:space:]]|$)'; then
+  if matches "${GIT_CMD}"'restore[^;&|]*--worktree' \
+    || ! matches "${GIT_CMD}"'restore[^;&|]*--staged'; then
     block "git restore overwriting worktree files (only 'git restore --staged <path>' without --worktree is allowed)"
   fi
 fi
 
 # 7. `git stash drop` / `git stash clear` destroy stashed work. push/pop/list/
 #    apply — the safe alternatives the reset guard recommends — stay allowed.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+stash[[:space:]]+(drop|clear)([[:space:]]|$)'; then
+if matches "${GIT_CMD}"'stash[[:space:]]+(drop|clear)([[:space:]]|$)'; then
   block "git stash drop/clear destroys stashed work"
 fi
 
 # 8. `git clean` with a force flag wipes untracked files. A dry-run flag
 #    (`-n`/`--dry-run`) ANYWHERE wins — git itself performs no deletion under
 #    dry-run, so `git clean -fdn` is a safe preview.
-readonly GIT_CLEAN='(^|[^[:alnum:]_-])git[[:space:]]+clean'
+readonly GIT_CLEAN="${GIT_CMD}clean"
 if matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
   && ! matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*n[[:alnum:]]*|--dry-run)([[:space:]]|=|$)'; then
   block "git clean --force deletes untracked files (preview with git clean -n first)"
@@ -322,7 +355,7 @@ fi
 # 9. `git branch` force-delete loses unmerged commits: `-D`, `-d` combined with
 #    `-f` (clustered or split), or `--delete` + `--force`. Case-SENSITIVE so the
 #    safe `-d` (which refuses unmerged work) and rename `-m` stay allowed.
-readonly GIT_BRANCH='(^|[^[:alnum:]_-])git[[:space:]]+branch'
+readonly GIT_BRANCH="${GIT_CMD}branch"
 if matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*D[[:alnum:]]*([[:space:]]|$)' \
   || { matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)' \
     && matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$)'; } \
@@ -334,13 +367,13 @@ fi
 #     `git reflog delete` (erases recovery history), and
 #     `git worktree remove --force` (discards a dirty worktree). Tag deletion is
 #     case-SENSITIVE so annotated-tag `-a` and message `-m` flags never match.
-if matches_cs '(^|[^[:alnum:]_-])git[[:space:]]+tag'"${GIT_TOKENS}"'(-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)|--delete([[:space:]]|=|$))'; then
+if matches_cs "${GIT_CMD}tag${GIT_TOKENS}"'(-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)|--delete([[:space:]]|=|$))'; then
   block "git tag -d deletes a shared ref"
 fi
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+reflog[[:space:]]+delete([[:space:]]|$)'; then
+if matches "${GIT_CMD}"'reflog[[:space:]]+delete([[:space:]]|$)'; then
   block "git reflog delete erases recovery history"
 fi
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+worktree[[:space:]]+remove[^;&|]*(--force([[:space:]]|=|$)|[[:space:]]-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$))'; then
+if matches "${GIT_CMD}"'worktree[[:space:]]+remove[^;&|]*(--force([[:space:]]|=|$)|[[:space:]]-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$))'; then
   block "git worktree remove --force discards a dirty worktree (remove without --force, which refuses dirty trees)"
 fi
 

--- a/plugins/lisa-agy/hooks/parity-safety-net.sh
+++ b/plugins/lisa-agy/hooks/parity-safety-net.sh
@@ -1,17 +1,45 @@
 #!/usr/bin/env bash
 # PreToolUse hook for Bash: a safety net that blocks destructive shell commands
 # before they run. Lisa-native reimplementation of the upstream
-# `safety-net@cc-marketplace` plugin's PreToolUse Bash-guard (parity work, issue
-# #1059). It does NOT port upstream code — it re-expresses the behavior in Lisa's
-# hook conventions, modeled on block-no-verify.sh.
+# `safety-net@cc-marketplace` plugin's PreToolUse Bash-guard (parity work,
+# issues #1059 and #1960). It does NOT port upstream code — it re-expresses the
+# behavior in Lisa's hook conventions, modeled on block-no-verify.sh.
 #
 # It reads the hook stdin JSON, inspects the proposed Bash command, and EXITS
 # NON-ZERO (2) to BLOCK when a known-destructive pattern matches:
-#   - `rm -rf /` (recursive forced delete of a root / home / wildcard path)
-#   - force-pushing a protected branch (main/master/production/release)
-#   - `git reset --hard` while the working tree is dirty (would discard work)
-#   - dropping or truncating a database/schema/table
-# Otherwise it exits 0 and the command proceeds.
+#   - `rm -rf` of a root / home / wildcard path (quote-aware boundaries, so
+#     `bash -c "rm -rf /"` and interpreter one-liners are caught too)
+#   - `rm -rf` of the cwd (`.`), a `..`-traversal path, an absolute path outside
+#     the project (with a /tmp, /var/tmp, $TMPDIR allowance), a `$VAR` target
+#     other than $TMPDIR, or ANY recursive forced delete while cwd is $HOME
+#   - force-pushing a protected branch (main/master/production/release) —
+#     feature-branch force-push stays allowed (sanctioned rebase workflow;
+#     deliberate divergence from upstream's any-branch block)
+#   - `git reset --hard` / `--merge` while the working tree is dirty. Deliberate
+#     divergence: upstream blocks unconditionally; Lisa allows clean-tree resets.
+#     Residual risk (documented, accepted): the dirty check runs in the hook's
+#     cwd at hook time, so a `cd elsewhere && git reset --hard` evades it.
+#   - `git checkout` discards (`--`, `-f/--force`, `--pathspec-from-file`,
+#     bare `.` — the bare-`.` block exceeds upstream)
+#   - `git switch --discard-changes` / `-f/--force`
+#   - `git restore` touching the worktree (allowed only with `--staged` and
+#     without `--worktree`)
+#   - `git stash drop` / `git stash clear`
+#   - `git clean` with force and no dry-run (`-n`/`--dry-run` anywhere wins)
+#   - `git branch -D` (or `-d` + `-f` in any spelling)
+#   - `git tag -d`, `git reflog delete`, `git worktree remove --force`
+#   - `find ... -delete`, `find ... -exec rm -rf`, `xargs ... rm -rf`
+#   - disk destroyers: `dd of=/dev/...`, `mkfs ... /dev/...`, `shred`
+#   - dropping or truncating a database/schema/table (Lisa-only guard)
+# Otherwise it exits 0 and the command proceeds. Malformed hook input fails
+# CLOSED: any parse error exits 2 (a non-2 exit would be a non-blocking hook
+# error in Claude Code, silently failing open).
+#
+# Known accepted false-positive class: this is a text scan, not a shell engine,
+# so display commands quoting a destructive string (`echo "docs about rm -rf /"`)
+# can match. Upstream exempts those via an engine-only DISPLAY_COMMANDS list a
+# grep hook cannot replicate. Workaround: quote-break the string or use the
+# gh-writer heredoc form, whose payload is stripped before the guards run.
 #
 # Operators extend the built-in rules with a project-local rule file — one
 # extended-regex (ERE) per line, blank lines and `#` comments ignored — managed
@@ -19,6 +47,13 @@
 # SAFETY_NET_RULES_FILE):
 #   ${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-net-rules.txt
 set -euo pipefail
+
+# Fail CLOSED on any unexpected error (malformed JSON, missing jq, …): exit 2 so
+# the tool call is denied instead of surfacing a non-blocking hook warning.
+# Deliberately NOT `set -E`: errtrace would propagate this trap into command
+# substitutions (e.g. the heredoc parser call, whose non-zero exit codes are
+# meaningful protocol) and rewrite their status to 2 before it can be read.
+trap 'printf "%s\n" "Blocked by safety-net: hook failed while parsing its input; denying fail-closed." >&2; exit 2' ERR
 
 input="$(cat)"
 
@@ -90,22 +125,122 @@ case "$command_str" in
     ;;
 esac
 
+# matches / matches_cs run an ERE against the guarded command text. matches is
+# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
+# for guards where flag case is meaningful (`git branch -d` vs `-D`).
+matches() {
+  printf '%s' "$command_for_guards" | grep -Eiq -- "$1"
+}
+matches_cs() {
+  printf '%s' "$command_for_guards" | grep -Eq -- "$1"
+}
+
+# Normalize bash line-continuations (a trailing backslash + newline → space)
+# before segmenting the command. Without this, "git push --force origin
+# \<newline>main" splits into a segment matching --force but not `main`, letting a
+# protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
+# `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
+normalized_command_str="$(printf '%s' "$command_for_guards" \
+  | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
+
+# Shared ERE fragments. GIT_TOKENS walks over intermediate argv tokens without
+# crossing a statement separator, so a flag in a LATER statement can never be
+# attributed to an earlier git subcommand.
+readonly GIT_TOKENS='([[:space:]]+[^;&|[:space:]]+)*[[:space:]]+'
+# rm invoked with BOTH a recursive and a force flag — clustered (-rf/-fr, any
+# extra letters) or split (-r … -f / long forms), in either order.
+readonly RM_RF_CLUSTER='(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
+readonly RM_RF_SPLIT='(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
+
 # 1. Recursive forced delete (`rm -rf`) of a filesystem root, home, or top-level
 #    wildcard. Two gates ANDed: the command must invoke `rm` with BOTH a
 #    recursive and a force flag, AND name a catastrophic target. Splitting the
 #    flag check from the target check keeps each regex legible and testable.
-if printf '%s' "$command_for_guards" \
-  | grep -Eiq '(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)' \
-  || printf '%s' "$command_for_guards" \
-  | grep -Eiq '(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'; then
-  if printf '%s' "$command_for_guards" \
-    | grep -Eq '([[:space:]]|=)(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]]|/?\*?$)'; then
+#    The target boundary classes include quote characters (issue #1960): without
+#    them, `bash -c "rm -rf /"` and interpreter one-liners like
+#    `python -c "… os.system('rm -rf /')"` slip through because the target is
+#    quote-adjacent instead of space-bounded.
+qc="'\""
+if matches "$RM_RF_CLUSTER" || matches "$RM_RF_SPLIT"; then
+  if matches_cs '([[:space:]='"$qc"'])(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]'"$qc"']|/?\*?['"$qc"']?$)'; then
     block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
   fi
 fi
 
+# 1b. rm target hardening (issue #1960). For every statement that invokes rm
+#     with recursive+force flags, additionally block when:
+#       - cwd is $HOME (any target is one argument away from wiping home), or
+#       - the target is the cwd itself (`.` / `./`), or
+#       - the target traverses out via `..`, or
+#       - the target is an absolute path outside the project — with an allowance
+#         for /tmp, /var/tmp, and $TMPDIR — or
+#       - the target is a `$VAR` expansion other than the sanctioned $TMPDIR.
+#     Globbing is disabled around the token walk so a literal `*` in the command
+#     is never expanded against the hook's own cwd.
+project_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+tmp_dir_allow="${TMPDIR:-/tmp}"
+tmp_dir_allow="${tmp_dir_allow%/}"
+[ -n "$tmp_dir_allow" ] || tmp_dir_allow="/tmp"
+while IFS= read -r rm_stmt; do
+  if ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_CLUSTER" \
+    && ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_SPLIT"; then
+    continue
+  fi
+  # Physical-path comparison (pwd -P): on macOS $HOME or the cwd may arrive via
+  # a symlink (/var → /private/var), and a string compare would miss the match.
+  if [ -n "${HOME:-}" ] \
+    && [ "$(pwd -P)" = "$(cd -- "$HOME" 2>/dev/null && pwd -P)" ]; then
+    block "recursive forced delete while the working directory is \$HOME (cd into a project first)"
+  fi
+  set -f
+  seen_rm=0
+  for raw_token in $rm_stmt; do
+    token="${raw_token#\"}"
+    token="${token#\'}"
+    token="${token%\"}"
+    token="${token%\'}"
+    if [ "$seen_rm" -eq 0 ]; then
+      [ "$token" = "rm" ] && seen_rm=1
+      continue
+    fi
+    case "$token" in
+      -*) continue ;;
+      . | ./)
+        set +f
+        block "recursive forced delete of the current directory (rm -rf .)"
+        ;;
+      .. | ../* | */.. | */../*)
+        set +f
+        block "recursive forced delete of a path outside the project (.. traversal)"
+        ;;
+      /*)
+        case "$token" in
+          "$project_dir" | "$project_dir"/* | /tmp | /tmp/* | /var/tmp | /var/tmp/* | "$tmp_dir_allow" | "$tmp_dir_allow"/*) : ;;
+          *)
+            set +f
+            block "recursive forced delete of an absolute path outside the project (only the project, /tmp, /var/tmp, and \$TMPDIR are allowed)"
+            ;;
+        esac
+        ;;
+      *'$'*)
+        case "$token" in
+          '$TMPDIR' | '$TMPDIR'/* | '${TMPDIR}' | '${TMPDIR}'/*) : ;;
+          *)
+            set +f
+            block "recursive forced delete of a variable-expanded target (unset or mistyped variables can point anywhere; \$TMPDIR is the only sanctioned dynamic target)"
+            ;;
+        esac
+        ;;
+    esac
+  done
+  set +f
+done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
+  | grep -Ei '(^|[^[:alnum:]_./-])rm([[:space:]]|$)' || true)
+
 # 2. Force-pushing a protected branch. `--force-with-lease` is the safe,
-#    non-clobbering alternative and is intentionally NOT blocked.
+#    non-clobbering alternative and is intentionally NOT blocked. Deliberate
+#    divergence from upstream (which blocks force-push on ANY branch):
+#    feature-branch force-push is a sanctioned rebase-and-push agent workflow.
 #
 #    The force flag AND the protected-branch name must appear in the SAME
 #    `git push` statement. Checking them independently over the whole command is
@@ -116,14 +251,6 @@ fi
 #    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
 #    inspect each in isolation — a real `git push --force origin main` still
 #    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
-# Normalize bash line-continuations (a trailing backslash + newline → space)
-# before segmenting the command. Without this, "git push --force origin
-# \<newline>main" splits into a segment matching --force but not `main`, letting a
-# protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
-# `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
-normalized_command_str="$(printf '%s' "$command_for_guards" \
-  | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
-
 while IFS= read -r push_stmt; do
   if printf '%s' "$push_stmt" \
     | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
@@ -133,25 +260,125 @@ while IFS= read -r push_stmt; do
     block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
 done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
-  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b')
+  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b' || true)
 
-# 3. `git reset --hard` while the working tree has uncommitted changes — this
-#    silently discards them. Only blocks when the tree is actually dirty, so a
-#    clean-tree reset (a legitimate workflow) still passes.
-if printf '%s' "$command_for_guards" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--hard\b'; then
+# 3. `git reset --hard` / `git reset --merge` while the working tree has
+#    uncommitted changes — both silently discard them. Only blocks when the tree
+#    is actually dirty, so a clean-tree reset (a legitimate workflow) passes.
+#    Deliberate divergence from upstream's unconditional block; the accepted
+#    residual risk (dirty check runs at hook time in the hook's cwd) is
+#    documented in the header.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--(hard|merge)\b'; then
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
     && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-    block "git reset --hard on a dirty working tree would discard uncommitted changes (stash or commit first)"
+    block "git reset --hard/--merge on a dirty working tree would discard uncommitted changes (stash or commit first)"
   fi
 fi
 
-# 4. Dropping or truncating a database / schema / table.
-if printf '%s' "$command_for_guards" \
-  | grep -Eiq '\b(drop[[:space:]]+(database|schema|table)|truncate[[:space:]]+(table[[:space:]]+)?[[:alnum:]_."`]+)\b'; then
+# 4. `git checkout` worktree discards: the `--` pathspec form (with or without a
+#    ref), `-f/--force`, `--pathspec-from-file`, and bare `git checkout .`.
+#    Blocking bare `.` exceeds upstream (which allows any single positional) —
+#    issue #1960 names it explicitly: it discards the entire tree. Branch
+#    switches and creation (`-b`/`-B`) stay allowed.
+readonly GIT_CHECKOUT='(^|[^[:alnum:]_-])git[[:space:]]+checkout'
+if matches "${GIT_CHECKOUT}${GIT_TOKENS}"'--([[:space:]]|$)' \
+  || matches "${GIT_CHECKOUT}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
+  || matches "${GIT_CHECKOUT}"'[[:space:]][^;&|]*--pathspec-from-file' \
+  || matches "${GIT_CHECKOUT}"'[[:space:]]+\.(/)?([[:space:]]|$)'; then
+  block "git checkout discarding local changes (--, -f/--force, --pathspec-from-file, or bare .) — use git stash to preserve work first"
+fi
+
+# 5. `git switch` discards: `--discard-changes` and its `-f/--force` aliases.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+switch'"${GIT_TOKENS}"'(--discard-changes|--force|-f)([[:space:]]|=|$)'; then
+  block "git switch discarding local changes (--discard-changes/-f/--force)"
+fi
+
+# 6. `git restore` defaults to overwriting the WORKTREE — a silent discard. Only
+#    the pure staging-area form is safe: `--staged` present and `--worktree`
+#    absent. Two conditions, because an ERE has no lookahead: `--staged
+#    --worktree` still discards, so `--worktree` blocks regardless of `--staged`.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore([[:space:]]|$)'; then
+  if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--worktree' \
+    || ! matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--staged'; then
+    block "git restore overwriting worktree files (only 'git restore --staged <path>' without --worktree is allowed)"
+  fi
+fi
+
+# 7. `git stash drop` / `git stash clear` destroy stashed work. push/pop/list/
+#    apply — the safe alternatives the reset guard recommends — stay allowed.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+stash[[:space:]]+(drop|clear)([[:space:]]|$)'; then
+  block "git stash drop/clear destroys stashed work"
+fi
+
+# 8. `git clean` with a force flag wipes untracked files. A dry-run flag
+#    (`-n`/`--dry-run`) ANYWHERE wins — git itself performs no deletion under
+#    dry-run, so `git clean -fdn` is a safe preview.
+readonly GIT_CLEAN='(^|[^[:alnum:]_-])git[[:space:]]+clean'
+if matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
+  && ! matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*n[[:alnum:]]*|--dry-run)([[:space:]]|=|$)'; then
+  block "git clean --force deletes untracked files (preview with git clean -n first)"
+fi
+
+# 9. `git branch` force-delete loses unmerged commits: `-D`, `-d` combined with
+#    `-f` (clustered or split), or `--delete` + `--force`. Case-SENSITIVE so the
+#    safe `-d` (which refuses unmerged work) and rename `-m` stay allowed.
+readonly GIT_BRANCH='(^|[^[:alnum:]_-])git[[:space:]]+branch'
+if matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*D[[:alnum:]]*([[:space:]]|$)' \
+  || { matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)' \
+    && matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$)'; } \
+  || { matches "${GIT_BRANCH}"'[^;&|]*--delete' && matches "${GIT_BRANCH}"'[^;&|]*--force'; }; then
+  block "git branch force-delete (-D) loses unmerged commits (use -d, which refuses unmerged work)"
+fi
+
+# 10. Cheap destructive-ref guards: `git tag -d` (tags are shared refs),
+#     `git reflog delete` (erases recovery history), and
+#     `git worktree remove --force` (discards a dirty worktree). Tag deletion is
+#     case-SENSITIVE so annotated-tag `-a` and message `-m` flags never match.
+if matches_cs '(^|[^[:alnum:]_-])git[[:space:]]+tag'"${GIT_TOKENS}"'(-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)|--delete([[:space:]]|=|$))'; then
+  block "git tag -d deletes a shared ref"
+fi
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+reflog[[:space:]]+delete([[:space:]]|$)'; then
+  block "git reflog delete erases recovery history"
+fi
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+worktree[[:space:]]+remove[^;&|]*(--force([[:space:]]|=|$)|[[:space:]]-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$))'; then
+  block "git worktree remove --force discards a dirty worktree (remove without --force, which refuses dirty trees)"
+fi
+
+# 11. Deletion through find/xargs, where the target never appears as a literal
+#     argument: `find … -delete`, `find … -exec rm -rf`, and `xargs … rm -rf`
+#     (targets arrive from dynamic stdin — unauditable). Plain `rm` (no
+#     recursive+force) on find/xargs output stays allowed for normal cleanups.
+if matches '(^|[^[:alnum:]_./-])find[[:space:]][^;&|]*[[:space:]]-delete([[:space:]]|$)'; then
+  block "find -delete removes files tree-wide (use -print to preview, or an explicit rm on reviewed paths)"
+fi
+if matches '(^|[^[:alnum:]_./-])find[[:space:]][^;&|]*-exec[[:space:]]+rm[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'; then
+  block "find -exec rm -rf performs a recursive forced delete on unreviewed paths"
+fi
+if matches '(^|[^[:alnum:]_./-])xargs[[:space:]]([^;&|]*[[:space:]])?rm[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'; then
+  block "xargs rm -rf performs a recursive forced delete on dynamic stdin input"
+fi
+
+# 12. Disk destroyers, always on (exceeds upstream, which only scans these
+#     inside interpreter one-liners): writing to a raw /dev node via dd,
+#     formatting a device with mkfs, and shred's unrecoverable overwrite.
+#     dd/mkfs against regular files (imaging) stays allowed.
+if matches '(^|[^[:alnum:]_./-])dd[[:space:]]+([^;&|]*[[:space:]])?of=/dev/'; then
+  block "dd writing to a raw device (of=/dev/…) destroys it"
+fi
+if matches '(^|[^[:alnum:]_./-])mkfs(\.[[:alnum:]]+)?[[:space:]][^;&|]*/dev/'; then
+  block "mkfs formatting a device erases it"
+fi
+if matches '(^|[^[:alnum:]_./-])shred([[:space:]]|$)'; then
+  block "shred overwrites files unrecoverably"
+fi
+
+# 13. Dropping or truncating a database / schema / table (Lisa-only guard —
+#     upstream has no SQL protection; keep).
+if matches '\b(drop[[:space:]]+(database|schema|table)|truncate[[:space:]]+(table[[:space:]]+)?[[:alnum:]_."`]+)\b'; then
   block "destructive SQL (DROP/TRUNCATE) detected"
 fi
 
-# 5. Project-local custom rules. Each non-comment line is an ERE; a match blocks.
+# 14. Project-local custom rules. Each non-comment line is an ERE; a match blocks.
 rules_file="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-net-rules.txt}"
 if [ -f "$rules_file" ]; then
   while IFS= read -r rule || [ -n "$rule" ]; do

--- a/plugins/lisa-agy/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -56,13 +56,17 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
 1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard — with
    quote-aware boundaries, so wrapper/interpreter forms like
    `bash -c "rm -rf /"` and `python -c "… os.system('rm -rf /')"` match too.
+   Path-prefixed spellings (`/bin/rm`, `./rm`) count as `rm` for every rm
+   guard.
 2. `rm -rf` target hardening: the cwd itself (`.`/`./`), `..`-traversal paths,
-   absolute paths outside the project (`/tmp`, `/var/tmp`, and `$TMPDIR` are
-   allowed), `$VAR` targets other than `$TMPDIR`, and **any** recursive forced
-   delete while the working directory is `$HOME`.
-3. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
-   `--force-with-lease` is intentionally allowed, and so is force-pushing a
-   feature branch (sanctioned rebase workflow).
+   home-anchored `~/…` paths, absolute paths outside the project (`/tmp`,
+   `/var/tmp`, and `$TMPDIR` are allowed), `$VAR` targets other than `$TMPDIR`,
+   and **any** recursive forced delete while the working directory is `$HOME`.
+3. Force-pushing a protected branch
+   (`main`/`master`/`production`/`prod`/`release`). `--force-with-lease` is
+   intentionally allowed, and so is force-pushing a feature branch (sanctioned
+   rebase workflow). Acceptable parity divergence: a refspec force-push
+   (`git push origin +main`) is not blocked — upstream 1.0.6 allows it too.
 4. `git reset --hard` / `git reset --merge` while the working tree is **dirty**
    (would discard work). Clean-tree resets are intentionally allowed.
 5. `git checkout` discards: the `--` pathspec form (with or without a ref),
@@ -81,6 +85,10 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
     (plain non-recursive `rm` on find/xargs output stays allowed).
 13. Disk destroyers: `dd of=/dev/…`, `mkfs … /dev/…`, `shred`.
 14. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+
+Every git guard sees through leading git **global options** (`-C <path>`,
+`-c <k>=<v>`, `--git-dir[=…]`, `--no-pager`, …), so `git -C /path <destructive>`
+is screened the same as `git <destructive>`.
 
 Malformed hook input fails **closed** (exit 2 denies the command). A text-scan
 hook cannot exempt display commands, so prose like

--- a/plugins/lisa-agy/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -53,11 +53,39 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
 
 ### Built-in guards (always on)
 
-1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard.
-2. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
-   `--force-with-lease` is intentionally allowed.
-3. `git reset --hard` while the working tree is **dirty** (would discard work).
-4. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard — with
+   quote-aware boundaries, so wrapper/interpreter forms like
+   `bash -c "rm -rf /"` and `python -c "… os.system('rm -rf /')"` match too.
+2. `rm -rf` target hardening: the cwd itself (`.`/`./`), `..`-traversal paths,
+   absolute paths outside the project (`/tmp`, `/var/tmp`, and `$TMPDIR` are
+   allowed), `$VAR` targets other than `$TMPDIR`, and **any** recursive forced
+   delete while the working directory is `$HOME`.
+3. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
+   `--force-with-lease` is intentionally allowed, and so is force-pushing a
+   feature branch (sanctioned rebase workflow).
+4. `git reset --hard` / `git reset --merge` while the working tree is **dirty**
+   (would discard work). Clean-tree resets are intentionally allowed.
+5. `git checkout` discards: the `--` pathspec form (with or without a ref),
+   `-f`/`--force`, `--pathspec-from-file`, and bare `git checkout .`.
+   Branch switching and `-b`/`-B` creation stay allowed.
+6. `git switch --discard-changes` / `-f`/`--force`.
+7. `git restore` touching the worktree — only `git restore --staged <path>`
+   without `--worktree` is allowed (unstaging is safe).
+8. `git stash drop` / `git stash clear` (push/pop/list/apply stay allowed).
+9. `git clean` with a force flag and no dry-run — `-n`/`--dry-run` anywhere
+   makes it a safe preview.
+10. `git branch -D` (or `-d` combined with `-f`, clustered or split);
+    safe `-d` and rename `-m` stay allowed.
+11. `git tag -d`, `git reflog delete`, `git worktree remove --force`.
+12. Deletion via `find … -delete`, `find … -exec rm -rf`, and `xargs … rm -rf`
+    (plain non-recursive `rm` on find/xargs output stays allowed).
+13. Disk destroyers: `dd of=/dev/…`, `mkfs … /dev/…`, `shred`.
+14. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+
+Malformed hook input fails **closed** (exit 2 denies the command). A text-scan
+hook cannot exempt display commands, so prose like
+`echo "docs about rm -rf /"` can false-positive — quote-break the string or use
+the gh-writer heredoc form (payload is stripped before the guards run).
 
 ## View the current rules
 

--- a/plugins/lisa-copilot/hooks/parity-safety-net.sh
+++ b/plugins/lisa-copilot/hooks/parity-safety-net.sh
@@ -169,9 +169,13 @@ readonly GIT_CMD='(^|[^[:alnum:]_-])git[[:space:]]+'"$GIT_GLOBAL_OPTS"
 # `--rm`-style flags and `foo.rm` names out.
 readonly RM_CMD='(^|[^[:alnum:]_./-])([[:alnum:]_./-]*/)?rm'
 # rm invoked with BOTH a recursive and a force flag — clustered (-rf/-fr, any
-# extra letters) or split (-r … -f / long forms), in either order.
+# extra letters) or split, in either order. The split gate pairs ANY recursive
+# form (short cluster containing r, or --recursive) with ANY force form (short
+# cluster containing f, or --force), so mixed spellings like `rm -r --force /`
+# and `rm --recursive -f /` cannot slip between the short/short and long/long
+# alternations (PR #1976 review).
 readonly RM_RF_CLUSTER="$RM_CMD"'([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
-readonly RM_RF_SPLIT="$RM_CMD"'[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
+readonly RM_RF_SPLIT="$RM_CMD"'(([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*r[[:alnum:]]*|--recursive)([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|$)|([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*r[[:alnum:]]*|--recursive)([[:space:]]|$))'
 
 # 1. Recursive forced delete (`rm -rf`) of a filesystem root, home, or top-level
 #    wildcard. Two gates ANDed: the statement must invoke `rm` with BOTH a

--- a/plugins/lisa-copilot/hooks/parity-safety-net.sh
+++ b/plugins/lisa-copilot/hooks/parity-safety-net.sh
@@ -8,13 +8,18 @@
 # It reads the hook stdin JSON, inspects the proposed Bash command, and EXITS
 # NON-ZERO (2) to BLOCK when a known-destructive pattern matches:
 #   - `rm -rf` of a root / home / wildcard path (quote-aware boundaries, so
-#     `bash -c "rm -rf /"` and interpreter one-liners are caught too)
-#   - `rm -rf` of the cwd (`.`), a `..`-traversal path, an absolute path outside
-#     the project (with a /tmp, /var/tmp, $TMPDIR allowance), a `$VAR` target
-#     other than $TMPDIR, or ANY recursive forced delete while cwd is $HOME
-#   - force-pushing a protected branch (main/master/production/release) —
+#     `bash -c "rm -rf /"` and interpreter one-liners are caught too; the rm
+#     guards also match path-prefixed invocations like `/bin/rm` and `./rm`)
+#   - `rm -rf` of the cwd (`.`), a `..`-traversal path, a `~/`-anchored path,
+#     an absolute path outside the project (with a /tmp, /var/tmp, $TMPDIR
+#     allowance), a `$VAR` target other than $TMPDIR, or ANY recursive forced
+#     delete while cwd is $HOME
+#   - force-pushing a protected branch (main/master/production/prod/release) —
 #     feature-branch force-push stays allowed (sanctioned rebase workflow;
-#     deliberate divergence from upstream's any-branch block)
+#     deliberate divergence from upstream's any-branch block). Every git guard
+#     sees through leading git GLOBAL options (`-C <path>`, `-c <k>=<v>`,
+#     `--git-dir[=…]`, `--no-pager`, …), so `git -C /path <destructive>` cannot
+#     dodge the subcommand anchor
 #   - `git reset --hard` / `--merge` while the working tree is dirty. Deliberate
 #     divergence: upstream blocks unconditionally; Lisa allows clean-tree resets.
 #     Residual risk (documented, accepted): the dirty check runs in the hook's
@@ -147,31 +152,48 @@ normalized_command_str="$(printf '%s' "$command_for_guards" \
 # crossing a statement separator, so a flag in a LATER statement can never be
 # attributed to an earlier git subcommand.
 readonly GIT_TOKENS='([[:space:]]+[^;&|[:space:]]+)*[[:space:]]+'
+# Git GLOBAL options (`-C <path>`, `-c <k>=<v>`, `--git-dir[=…]`, `--no-pager`,
+# …) legally sit between `git` and its subcommand, so every subcommand guard
+# consumes them — otherwise `git -C /path checkout -- f` dodges the anchor
+# (issue #1960 security review F1). Shape: zero or more dash-led tokens, each
+# optionally followed by ONE non-dash value token, which covers both the
+# `--git-dir=/x` and `--git-dir /x` spellings without naming every option.
+readonly GIT_GLOBAL_OPTS='(-[^;&|[:space:]]+([[:space:]]+[^-;&|[:space:]][^;&|[:space:]]*)?[[:space:]]+)*'
+# Anchor for every git subcommand guard: word-bounded `git`, whitespace, then
+# any run of global options. Callers append the subcommand name directly.
+readonly GIT_CMD='(^|[^[:alnum:]_-])git[[:space:]]+'"$GIT_GLOBAL_OPTS"
+# An rm invocation: bare `rm` or a path whose basename is exactly `rm`
+# (`/bin/rm`, `./rm`) — issue #1960 security review F2. The optional prefix must
+# END IN `/` immediately before `rm`, so charm/confirm/informant/rmdir never
+# match. The preceding-char class still excludes `.`, `/`, and `-` to keep
+# `--rm`-style flags and `foo.rm` names out.
+readonly RM_CMD='(^|[^[:alnum:]_./-])([[:alnum:]_./-]*/)?rm'
 # rm invoked with BOTH a recursive and a force flag — clustered (-rf/-fr, any
 # extra letters) or split (-r … -f / long forms), in either order.
-readonly RM_RF_CLUSTER='(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
-readonly RM_RF_SPLIT='(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
+readonly RM_RF_CLUSTER="$RM_CMD"'([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
+readonly RM_RF_SPLIT="$RM_CMD"'[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
 
 # 1. Recursive forced delete (`rm -rf`) of a filesystem root, home, or top-level
-#    wildcard. Two gates ANDed: the command must invoke `rm` with BOTH a
+#    wildcard. Two gates ANDed: the statement must invoke `rm` with BOTH a
 #    recursive and a force flag, AND name a catastrophic target. Splitting the
 #    flag check from the target check keeps each regex legible and testable.
 #    The target boundary classes include quote characters (issue #1960): without
 #    them, `bash -c "rm -rf /"` and interpreter one-liners like
 #    `python -c "… os.system('rm -rf /')"` slip through because the target is
 #    quote-adjacent instead of space-bounded.
+#    Both gates run PER STATEMENT inside the shared rm loop below (quality
+#    review S1): a harmless `/` in a LATER statement (`rm -rf build && cd /`)
+#    is never attributed to the rm in an earlier one.
 qc="'\""
-if matches "$RM_RF_CLUSTER" || matches "$RM_RF_SPLIT"; then
-  if matches_cs '([[:space:]='"$qc"'])(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]'"$qc"']|/?\*?['"$qc"']?$)'; then
-    block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
-  fi
-fi
+readonly RM_CATASTROPHIC_TARGET='([[:space:]='"$qc"'])(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]'"$qc"']|/?\*?['"$qc"']?$)'
 
 # 1b. rm target hardening (issue #1960). For every statement that invokes rm
 #     with recursive+force flags, additionally block when:
 #       - cwd is $HOME (any target is one argument away from wiping home), or
 #       - the target is the cwd itself (`.` / `./`), or
 #       - the target traverses out via `..`, or
+#       - the target is home-anchored (`~/…` — the shell expands it to $HOME at
+#         execution time, so it is always outside the project), or
 #       - the target is an absolute path outside the project — with an allowance
 #         for /tmp, /var/tmp, and $TMPDIR — or
 #       - the target is a `$VAR` expansion other than the sanctioned $TMPDIR.
@@ -185,6 +207,10 @@ while IFS= read -r rm_stmt; do
   if ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_CLUSTER" \
     && ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_SPLIT"; then
     continue
+  fi
+  # Guard 1: catastrophic target named in the SAME statement as the rm -rf.
+  if printf '%s' "$rm_stmt" | grep -Eq -- "$RM_CATASTROPHIC_TARGET"; then
+    block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
   fi
   # Physical-path comparison (pwd -P): on macOS $HOME or the cwd may arrive via
   # a symlink (/var → /private/var), and a string compare would miss the match.
@@ -200,7 +226,10 @@ while IFS= read -r rm_stmt; do
     token="${token%\"}"
     token="${token%\'}"
     if [ "$seen_rm" -eq 0 ]; then
-      [ "$token" = "rm" ] && seen_rm=1
+      # Path-prefixed spellings (`/bin/rm`, `./rm`) are still rm (F2).
+      case "$token" in
+        rm | */rm) seen_rm=1 ;;
+      esac
       continue
     fi
     case "$token" in
@@ -212,6 +241,10 @@ while IFS= read -r rm_stmt; do
       .. | ../* | */.. | */../*)
         set +f
         block "recursive forced delete of a path outside the project (.. traversal)"
+        ;;
+      '~' | '~'/*)
+        set +f
+        block "recursive forced delete of a home-anchored path (~/…) outside the project"
         ;;
       /*)
         case "$token" in
@@ -235,7 +268,7 @@ while IFS= read -r rm_stmt; do
   done
   set +f
 done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
-  | grep -Ei '(^|[^[:alnum:]_./-])rm([[:space:]]|$)' || true)
+  | grep -Ei -- "$RM_CMD"'([[:space:]]|$)' || true)
 
 # 2. Force-pushing a protected branch. `--force-with-lease` is the safe,
 #    non-clobbering alternative and is intentionally NOT blocked. Deliberate
@@ -260,7 +293,7 @@ while IFS= read -r push_stmt; do
     block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
 done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
-  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b' || true)
+  | grep -Ei -- "${GIT_CMD}push\b" || true)
 
 # 3. `git reset --hard` / `git reset --merge` while the working tree has
 #    uncommitted changes — both silently discard them. Only blocks when the tree
@@ -268,7 +301,7 @@ done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
 #    Deliberate divergence from upstream's unconditional block; the accepted
 #    residual risk (dirty check runs at hook time in the hook's cwd) is
 #    documented in the header.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--(hard|merge)\b'; then
+if matches "${GIT_CMD}"'reset\b.*--(hard|merge)\b'; then
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
     && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
     block "git reset --hard/--merge on a dirty working tree would discard uncommitted changes (stash or commit first)"
@@ -280,7 +313,7 @@ fi
 #    Blocking bare `.` exceeds upstream (which allows any single positional) —
 #    issue #1960 names it explicitly: it discards the entire tree. Branch
 #    switches and creation (`-b`/`-B`) stay allowed.
-readonly GIT_CHECKOUT='(^|[^[:alnum:]_-])git[[:space:]]+checkout'
+readonly GIT_CHECKOUT="${GIT_CMD}checkout"
 if matches "${GIT_CHECKOUT}${GIT_TOKENS}"'--([[:space:]]|$)' \
   || matches "${GIT_CHECKOUT}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
   || matches "${GIT_CHECKOUT}"'[[:space:]][^;&|]*--pathspec-from-file' \
@@ -289,7 +322,7 @@ if matches "${GIT_CHECKOUT}${GIT_TOKENS}"'--([[:space:]]|$)' \
 fi
 
 # 5. `git switch` discards: `--discard-changes` and its `-f/--force` aliases.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+switch'"${GIT_TOKENS}"'(--discard-changes|--force|-f)([[:space:]]|=|$)'; then
+if matches "${GIT_CMD}switch${GIT_TOKENS}"'(--discard-changes|--force|-f)([[:space:]]|=|$)'; then
   block "git switch discarding local changes (--discard-changes/-f/--force)"
 fi
 
@@ -297,23 +330,23 @@ fi
 #    the pure staging-area form is safe: `--staged` present and `--worktree`
 #    absent. Two conditions, because an ERE has no lookahead: `--staged
 #    --worktree` still discards, so `--worktree` blocks regardless of `--staged`.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore([[:space:]]|$)'; then
-  if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--worktree' \
-    || ! matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--staged'; then
+if matches "${GIT_CMD}"'restore([[:space:]]|$)'; then
+  if matches "${GIT_CMD}"'restore[^;&|]*--worktree' \
+    || ! matches "${GIT_CMD}"'restore[^;&|]*--staged'; then
     block "git restore overwriting worktree files (only 'git restore --staged <path>' without --worktree is allowed)"
   fi
 fi
 
 # 7. `git stash drop` / `git stash clear` destroy stashed work. push/pop/list/
 #    apply — the safe alternatives the reset guard recommends — stay allowed.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+stash[[:space:]]+(drop|clear)([[:space:]]|$)'; then
+if matches "${GIT_CMD}"'stash[[:space:]]+(drop|clear)([[:space:]]|$)'; then
   block "git stash drop/clear destroys stashed work"
 fi
 
 # 8. `git clean` with a force flag wipes untracked files. A dry-run flag
 #    (`-n`/`--dry-run`) ANYWHERE wins — git itself performs no deletion under
 #    dry-run, so `git clean -fdn` is a safe preview.
-readonly GIT_CLEAN='(^|[^[:alnum:]_-])git[[:space:]]+clean'
+readonly GIT_CLEAN="${GIT_CMD}clean"
 if matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
   && ! matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*n[[:alnum:]]*|--dry-run)([[:space:]]|=|$)'; then
   block "git clean --force deletes untracked files (preview with git clean -n first)"
@@ -322,7 +355,7 @@ fi
 # 9. `git branch` force-delete loses unmerged commits: `-D`, `-d` combined with
 #    `-f` (clustered or split), or `--delete` + `--force`. Case-SENSITIVE so the
 #    safe `-d` (which refuses unmerged work) and rename `-m` stay allowed.
-readonly GIT_BRANCH='(^|[^[:alnum:]_-])git[[:space:]]+branch'
+readonly GIT_BRANCH="${GIT_CMD}branch"
 if matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*D[[:alnum:]]*([[:space:]]|$)' \
   || { matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)' \
     && matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$)'; } \
@@ -334,13 +367,13 @@ fi
 #     `git reflog delete` (erases recovery history), and
 #     `git worktree remove --force` (discards a dirty worktree). Tag deletion is
 #     case-SENSITIVE so annotated-tag `-a` and message `-m` flags never match.
-if matches_cs '(^|[^[:alnum:]_-])git[[:space:]]+tag'"${GIT_TOKENS}"'(-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)|--delete([[:space:]]|=|$))'; then
+if matches_cs "${GIT_CMD}tag${GIT_TOKENS}"'(-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)|--delete([[:space:]]|=|$))'; then
   block "git tag -d deletes a shared ref"
 fi
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+reflog[[:space:]]+delete([[:space:]]|$)'; then
+if matches "${GIT_CMD}"'reflog[[:space:]]+delete([[:space:]]|$)'; then
   block "git reflog delete erases recovery history"
 fi
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+worktree[[:space:]]+remove[^;&|]*(--force([[:space:]]|=|$)|[[:space:]]-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$))'; then
+if matches "${GIT_CMD}"'worktree[[:space:]]+remove[^;&|]*(--force([[:space:]]|=|$)|[[:space:]]-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$))'; then
   block "git worktree remove --force discards a dirty worktree (remove without --force, which refuses dirty trees)"
 fi
 

--- a/plugins/lisa-copilot/hooks/parity-safety-net.sh
+++ b/plugins/lisa-copilot/hooks/parity-safety-net.sh
@@ -1,17 +1,45 @@
 #!/usr/bin/env bash
 # PreToolUse hook for Bash: a safety net that blocks destructive shell commands
 # before they run. Lisa-native reimplementation of the upstream
-# `safety-net@cc-marketplace` plugin's PreToolUse Bash-guard (parity work, issue
-# #1059). It does NOT port upstream code — it re-expresses the behavior in Lisa's
-# hook conventions, modeled on block-no-verify.sh.
+# `safety-net@cc-marketplace` plugin's PreToolUse Bash-guard (parity work,
+# issues #1059 and #1960). It does NOT port upstream code — it re-expresses the
+# behavior in Lisa's hook conventions, modeled on block-no-verify.sh.
 #
 # It reads the hook stdin JSON, inspects the proposed Bash command, and EXITS
 # NON-ZERO (2) to BLOCK when a known-destructive pattern matches:
-#   - `rm -rf /` (recursive forced delete of a root / home / wildcard path)
-#   - force-pushing a protected branch (main/master/production/release)
-#   - `git reset --hard` while the working tree is dirty (would discard work)
-#   - dropping or truncating a database/schema/table
-# Otherwise it exits 0 and the command proceeds.
+#   - `rm -rf` of a root / home / wildcard path (quote-aware boundaries, so
+#     `bash -c "rm -rf /"` and interpreter one-liners are caught too)
+#   - `rm -rf` of the cwd (`.`), a `..`-traversal path, an absolute path outside
+#     the project (with a /tmp, /var/tmp, $TMPDIR allowance), a `$VAR` target
+#     other than $TMPDIR, or ANY recursive forced delete while cwd is $HOME
+#   - force-pushing a protected branch (main/master/production/release) —
+#     feature-branch force-push stays allowed (sanctioned rebase workflow;
+#     deliberate divergence from upstream's any-branch block)
+#   - `git reset --hard` / `--merge` while the working tree is dirty. Deliberate
+#     divergence: upstream blocks unconditionally; Lisa allows clean-tree resets.
+#     Residual risk (documented, accepted): the dirty check runs in the hook's
+#     cwd at hook time, so a `cd elsewhere && git reset --hard` evades it.
+#   - `git checkout` discards (`--`, `-f/--force`, `--pathspec-from-file`,
+#     bare `.` — the bare-`.` block exceeds upstream)
+#   - `git switch --discard-changes` / `-f/--force`
+#   - `git restore` touching the worktree (allowed only with `--staged` and
+#     without `--worktree`)
+#   - `git stash drop` / `git stash clear`
+#   - `git clean` with force and no dry-run (`-n`/`--dry-run` anywhere wins)
+#   - `git branch -D` (or `-d` + `-f` in any spelling)
+#   - `git tag -d`, `git reflog delete`, `git worktree remove --force`
+#   - `find ... -delete`, `find ... -exec rm -rf`, `xargs ... rm -rf`
+#   - disk destroyers: `dd of=/dev/...`, `mkfs ... /dev/...`, `shred`
+#   - dropping or truncating a database/schema/table (Lisa-only guard)
+# Otherwise it exits 0 and the command proceeds. Malformed hook input fails
+# CLOSED: any parse error exits 2 (a non-2 exit would be a non-blocking hook
+# error in Claude Code, silently failing open).
+#
+# Known accepted false-positive class: this is a text scan, not a shell engine,
+# so display commands quoting a destructive string (`echo "docs about rm -rf /"`)
+# can match. Upstream exempts those via an engine-only DISPLAY_COMMANDS list a
+# grep hook cannot replicate. Workaround: quote-break the string or use the
+# gh-writer heredoc form, whose payload is stripped before the guards run.
 #
 # Operators extend the built-in rules with a project-local rule file — one
 # extended-regex (ERE) per line, blank lines and `#` comments ignored — managed
@@ -19,6 +47,13 @@
 # SAFETY_NET_RULES_FILE):
 #   ${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-net-rules.txt
 set -euo pipefail
+
+# Fail CLOSED on any unexpected error (malformed JSON, missing jq, …): exit 2 so
+# the tool call is denied instead of surfacing a non-blocking hook warning.
+# Deliberately NOT `set -E`: errtrace would propagate this trap into command
+# substitutions (e.g. the heredoc parser call, whose non-zero exit codes are
+# meaningful protocol) and rewrite their status to 2 before it can be read.
+trap 'printf "%s\n" "Blocked by safety-net: hook failed while parsing its input; denying fail-closed." >&2; exit 2' ERR
 
 input="$(cat)"
 
@@ -90,22 +125,122 @@ case "$command_str" in
     ;;
 esac
 
+# matches / matches_cs run an ERE against the guarded command text. matches is
+# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
+# for guards where flag case is meaningful (`git branch -d` vs `-D`).
+matches() {
+  printf '%s' "$command_for_guards" | grep -Eiq -- "$1"
+}
+matches_cs() {
+  printf '%s' "$command_for_guards" | grep -Eq -- "$1"
+}
+
+# Normalize bash line-continuations (a trailing backslash + newline → space)
+# before segmenting the command. Without this, "git push --force origin
+# \<newline>main" splits into a segment matching --force but not `main`, letting a
+# protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
+# `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
+normalized_command_str="$(printf '%s' "$command_for_guards" \
+  | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
+
+# Shared ERE fragments. GIT_TOKENS walks over intermediate argv tokens without
+# crossing a statement separator, so a flag in a LATER statement can never be
+# attributed to an earlier git subcommand.
+readonly GIT_TOKENS='([[:space:]]+[^;&|[:space:]]+)*[[:space:]]+'
+# rm invoked with BOTH a recursive and a force flag — clustered (-rf/-fr, any
+# extra letters) or split (-r … -f / long forms), in either order.
+readonly RM_RF_CLUSTER='(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
+readonly RM_RF_SPLIT='(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
+
 # 1. Recursive forced delete (`rm -rf`) of a filesystem root, home, or top-level
 #    wildcard. Two gates ANDed: the command must invoke `rm` with BOTH a
 #    recursive and a force flag, AND name a catastrophic target. Splitting the
 #    flag check from the target check keeps each regex legible and testable.
-if printf '%s' "$command_for_guards" \
-  | grep -Eiq '(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)' \
-  || printf '%s' "$command_for_guards" \
-  | grep -Eiq '(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'; then
-  if printf '%s' "$command_for_guards" \
-    | grep -Eq '([[:space:]]|=)(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]]|/?\*?$)'; then
+#    The target boundary classes include quote characters (issue #1960): without
+#    them, `bash -c "rm -rf /"` and interpreter one-liners like
+#    `python -c "… os.system('rm -rf /')"` slip through because the target is
+#    quote-adjacent instead of space-bounded.
+qc="'\""
+if matches "$RM_RF_CLUSTER" || matches "$RM_RF_SPLIT"; then
+  if matches_cs '([[:space:]='"$qc"'])(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]'"$qc"']|/?\*?['"$qc"']?$)'; then
     block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
   fi
 fi
 
+# 1b. rm target hardening (issue #1960). For every statement that invokes rm
+#     with recursive+force flags, additionally block when:
+#       - cwd is $HOME (any target is one argument away from wiping home), or
+#       - the target is the cwd itself (`.` / `./`), or
+#       - the target traverses out via `..`, or
+#       - the target is an absolute path outside the project — with an allowance
+#         for /tmp, /var/tmp, and $TMPDIR — or
+#       - the target is a `$VAR` expansion other than the sanctioned $TMPDIR.
+#     Globbing is disabled around the token walk so a literal `*` in the command
+#     is never expanded against the hook's own cwd.
+project_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+tmp_dir_allow="${TMPDIR:-/tmp}"
+tmp_dir_allow="${tmp_dir_allow%/}"
+[ -n "$tmp_dir_allow" ] || tmp_dir_allow="/tmp"
+while IFS= read -r rm_stmt; do
+  if ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_CLUSTER" \
+    && ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_SPLIT"; then
+    continue
+  fi
+  # Physical-path comparison (pwd -P): on macOS $HOME or the cwd may arrive via
+  # a symlink (/var → /private/var), and a string compare would miss the match.
+  if [ -n "${HOME:-}" ] \
+    && [ "$(pwd -P)" = "$(cd -- "$HOME" 2>/dev/null && pwd -P)" ]; then
+    block "recursive forced delete while the working directory is \$HOME (cd into a project first)"
+  fi
+  set -f
+  seen_rm=0
+  for raw_token in $rm_stmt; do
+    token="${raw_token#\"}"
+    token="${token#\'}"
+    token="${token%\"}"
+    token="${token%\'}"
+    if [ "$seen_rm" -eq 0 ]; then
+      [ "$token" = "rm" ] && seen_rm=1
+      continue
+    fi
+    case "$token" in
+      -*) continue ;;
+      . | ./)
+        set +f
+        block "recursive forced delete of the current directory (rm -rf .)"
+        ;;
+      .. | ../* | */.. | */../*)
+        set +f
+        block "recursive forced delete of a path outside the project (.. traversal)"
+        ;;
+      /*)
+        case "$token" in
+          "$project_dir" | "$project_dir"/* | /tmp | /tmp/* | /var/tmp | /var/tmp/* | "$tmp_dir_allow" | "$tmp_dir_allow"/*) : ;;
+          *)
+            set +f
+            block "recursive forced delete of an absolute path outside the project (only the project, /tmp, /var/tmp, and \$TMPDIR are allowed)"
+            ;;
+        esac
+        ;;
+      *'$'*)
+        case "$token" in
+          '$TMPDIR' | '$TMPDIR'/* | '${TMPDIR}' | '${TMPDIR}'/*) : ;;
+          *)
+            set +f
+            block "recursive forced delete of a variable-expanded target (unset or mistyped variables can point anywhere; \$TMPDIR is the only sanctioned dynamic target)"
+            ;;
+        esac
+        ;;
+    esac
+  done
+  set +f
+done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
+  | grep -Ei '(^|[^[:alnum:]_./-])rm([[:space:]]|$)' || true)
+
 # 2. Force-pushing a protected branch. `--force-with-lease` is the safe,
-#    non-clobbering alternative and is intentionally NOT blocked.
+#    non-clobbering alternative and is intentionally NOT blocked. Deliberate
+#    divergence from upstream (which blocks force-push on ANY branch):
+#    feature-branch force-push is a sanctioned rebase-and-push agent workflow.
 #
 #    The force flag AND the protected-branch name must appear in the SAME
 #    `git push` statement. Checking them independently over the whole command is
@@ -116,14 +251,6 @@ fi
 #    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
 #    inspect each in isolation — a real `git push --force origin main` still
 #    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
-# Normalize bash line-continuations (a trailing backslash + newline → space)
-# before segmenting the command. Without this, "git push --force origin
-# \<newline>main" splits into a segment matching --force but not `main`, letting a
-# protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
-# `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
-normalized_command_str="$(printf '%s' "$command_for_guards" \
-  | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
-
 while IFS= read -r push_stmt; do
   if printf '%s' "$push_stmt" \
     | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
@@ -133,25 +260,125 @@ while IFS= read -r push_stmt; do
     block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
 done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
-  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b')
+  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b' || true)
 
-# 3. `git reset --hard` while the working tree has uncommitted changes — this
-#    silently discards them. Only blocks when the tree is actually dirty, so a
-#    clean-tree reset (a legitimate workflow) still passes.
-if printf '%s' "$command_for_guards" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--hard\b'; then
+# 3. `git reset --hard` / `git reset --merge` while the working tree has
+#    uncommitted changes — both silently discard them. Only blocks when the tree
+#    is actually dirty, so a clean-tree reset (a legitimate workflow) passes.
+#    Deliberate divergence from upstream's unconditional block; the accepted
+#    residual risk (dirty check runs at hook time in the hook's cwd) is
+#    documented in the header.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--(hard|merge)\b'; then
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
     && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-    block "git reset --hard on a dirty working tree would discard uncommitted changes (stash or commit first)"
+    block "git reset --hard/--merge on a dirty working tree would discard uncommitted changes (stash or commit first)"
   fi
 fi
 
-# 4. Dropping or truncating a database / schema / table.
-if printf '%s' "$command_for_guards" \
-  | grep -Eiq '\b(drop[[:space:]]+(database|schema|table)|truncate[[:space:]]+(table[[:space:]]+)?[[:alnum:]_."`]+)\b'; then
+# 4. `git checkout` worktree discards: the `--` pathspec form (with or without a
+#    ref), `-f/--force`, `--pathspec-from-file`, and bare `git checkout .`.
+#    Blocking bare `.` exceeds upstream (which allows any single positional) —
+#    issue #1960 names it explicitly: it discards the entire tree. Branch
+#    switches and creation (`-b`/`-B`) stay allowed.
+readonly GIT_CHECKOUT='(^|[^[:alnum:]_-])git[[:space:]]+checkout'
+if matches "${GIT_CHECKOUT}${GIT_TOKENS}"'--([[:space:]]|$)' \
+  || matches "${GIT_CHECKOUT}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
+  || matches "${GIT_CHECKOUT}"'[[:space:]][^;&|]*--pathspec-from-file' \
+  || matches "${GIT_CHECKOUT}"'[[:space:]]+\.(/)?([[:space:]]|$)'; then
+  block "git checkout discarding local changes (--, -f/--force, --pathspec-from-file, or bare .) — use git stash to preserve work first"
+fi
+
+# 5. `git switch` discards: `--discard-changes` and its `-f/--force` aliases.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+switch'"${GIT_TOKENS}"'(--discard-changes|--force|-f)([[:space:]]|=|$)'; then
+  block "git switch discarding local changes (--discard-changes/-f/--force)"
+fi
+
+# 6. `git restore` defaults to overwriting the WORKTREE — a silent discard. Only
+#    the pure staging-area form is safe: `--staged` present and `--worktree`
+#    absent. Two conditions, because an ERE has no lookahead: `--staged
+#    --worktree` still discards, so `--worktree` blocks regardless of `--staged`.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore([[:space:]]|$)'; then
+  if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--worktree' \
+    || ! matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--staged'; then
+    block "git restore overwriting worktree files (only 'git restore --staged <path>' without --worktree is allowed)"
+  fi
+fi
+
+# 7. `git stash drop` / `git stash clear` destroy stashed work. push/pop/list/
+#    apply — the safe alternatives the reset guard recommends — stay allowed.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+stash[[:space:]]+(drop|clear)([[:space:]]|$)'; then
+  block "git stash drop/clear destroys stashed work"
+fi
+
+# 8. `git clean` with a force flag wipes untracked files. A dry-run flag
+#    (`-n`/`--dry-run`) ANYWHERE wins — git itself performs no deletion under
+#    dry-run, so `git clean -fdn` is a safe preview.
+readonly GIT_CLEAN='(^|[^[:alnum:]_-])git[[:space:]]+clean'
+if matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
+  && ! matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*n[[:alnum:]]*|--dry-run)([[:space:]]|=|$)'; then
+  block "git clean --force deletes untracked files (preview with git clean -n first)"
+fi
+
+# 9. `git branch` force-delete loses unmerged commits: `-D`, `-d` combined with
+#    `-f` (clustered or split), or `--delete` + `--force`. Case-SENSITIVE so the
+#    safe `-d` (which refuses unmerged work) and rename `-m` stay allowed.
+readonly GIT_BRANCH='(^|[^[:alnum:]_-])git[[:space:]]+branch'
+if matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*D[[:alnum:]]*([[:space:]]|$)' \
+  || { matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)' \
+    && matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$)'; } \
+  || { matches "${GIT_BRANCH}"'[^;&|]*--delete' && matches "${GIT_BRANCH}"'[^;&|]*--force'; }; then
+  block "git branch force-delete (-D) loses unmerged commits (use -d, which refuses unmerged work)"
+fi
+
+# 10. Cheap destructive-ref guards: `git tag -d` (tags are shared refs),
+#     `git reflog delete` (erases recovery history), and
+#     `git worktree remove --force` (discards a dirty worktree). Tag deletion is
+#     case-SENSITIVE so annotated-tag `-a` and message `-m` flags never match.
+if matches_cs '(^|[^[:alnum:]_-])git[[:space:]]+tag'"${GIT_TOKENS}"'(-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)|--delete([[:space:]]|=|$))'; then
+  block "git tag -d deletes a shared ref"
+fi
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+reflog[[:space:]]+delete([[:space:]]|$)'; then
+  block "git reflog delete erases recovery history"
+fi
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+worktree[[:space:]]+remove[^;&|]*(--force([[:space:]]|=|$)|[[:space:]]-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$))'; then
+  block "git worktree remove --force discards a dirty worktree (remove without --force, which refuses dirty trees)"
+fi
+
+# 11. Deletion through find/xargs, where the target never appears as a literal
+#     argument: `find … -delete`, `find … -exec rm -rf`, and `xargs … rm -rf`
+#     (targets arrive from dynamic stdin — unauditable). Plain `rm` (no
+#     recursive+force) on find/xargs output stays allowed for normal cleanups.
+if matches '(^|[^[:alnum:]_./-])find[[:space:]][^;&|]*[[:space:]]-delete([[:space:]]|$)'; then
+  block "find -delete removes files tree-wide (use -print to preview, or an explicit rm on reviewed paths)"
+fi
+if matches '(^|[^[:alnum:]_./-])find[[:space:]][^;&|]*-exec[[:space:]]+rm[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'; then
+  block "find -exec rm -rf performs a recursive forced delete on unreviewed paths"
+fi
+if matches '(^|[^[:alnum:]_./-])xargs[[:space:]]([^;&|]*[[:space:]])?rm[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'; then
+  block "xargs rm -rf performs a recursive forced delete on dynamic stdin input"
+fi
+
+# 12. Disk destroyers, always on (exceeds upstream, which only scans these
+#     inside interpreter one-liners): writing to a raw /dev node via dd,
+#     formatting a device with mkfs, and shred's unrecoverable overwrite.
+#     dd/mkfs against regular files (imaging) stays allowed.
+if matches '(^|[^[:alnum:]_./-])dd[[:space:]]+([^;&|]*[[:space:]])?of=/dev/'; then
+  block "dd writing to a raw device (of=/dev/…) destroys it"
+fi
+if matches '(^|[^[:alnum:]_./-])mkfs(\.[[:alnum:]]+)?[[:space:]][^;&|]*/dev/'; then
+  block "mkfs formatting a device erases it"
+fi
+if matches '(^|[^[:alnum:]_./-])shred([[:space:]]|$)'; then
+  block "shred overwrites files unrecoverably"
+fi
+
+# 13. Dropping or truncating a database / schema / table (Lisa-only guard —
+#     upstream has no SQL protection; keep).
+if matches '\b(drop[[:space:]]+(database|schema|table)|truncate[[:space:]]+(table[[:space:]]+)?[[:alnum:]_."`]+)\b'; then
   block "destructive SQL (DROP/TRUNCATE) detected"
 fi
 
-# 5. Project-local custom rules. Each non-comment line is an ERE; a match blocks.
+# 14. Project-local custom rules. Each non-comment line is an ERE; a match blocks.
 rules_file="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-net-rules.txt}"
 if [ -f "$rules_file" ]; then
   while IFS= read -r rule || [ -n "$rule" ]; do

--- a/plugins/lisa-copilot/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -56,13 +56,17 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
 1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard — with
    quote-aware boundaries, so wrapper/interpreter forms like
    `bash -c "rm -rf /"` and `python -c "… os.system('rm -rf /')"` match too.
+   Path-prefixed spellings (`/bin/rm`, `./rm`) count as `rm` for every rm
+   guard.
 2. `rm -rf` target hardening: the cwd itself (`.`/`./`), `..`-traversal paths,
-   absolute paths outside the project (`/tmp`, `/var/tmp`, and `$TMPDIR` are
-   allowed), `$VAR` targets other than `$TMPDIR`, and **any** recursive forced
-   delete while the working directory is `$HOME`.
-3. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
-   `--force-with-lease` is intentionally allowed, and so is force-pushing a
-   feature branch (sanctioned rebase workflow).
+   home-anchored `~/…` paths, absolute paths outside the project (`/tmp`,
+   `/var/tmp`, and `$TMPDIR` are allowed), `$VAR` targets other than `$TMPDIR`,
+   and **any** recursive forced delete while the working directory is `$HOME`.
+3. Force-pushing a protected branch
+   (`main`/`master`/`production`/`prod`/`release`). `--force-with-lease` is
+   intentionally allowed, and so is force-pushing a feature branch (sanctioned
+   rebase workflow). Acceptable parity divergence: a refspec force-push
+   (`git push origin +main`) is not blocked — upstream 1.0.6 allows it too.
 4. `git reset --hard` / `git reset --merge` while the working tree is **dirty**
    (would discard work). Clean-tree resets are intentionally allowed.
 5. `git checkout` discards: the `--` pathspec form (with or without a ref),
@@ -81,6 +85,10 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
     (plain non-recursive `rm` on find/xargs output stays allowed).
 13. Disk destroyers: `dd of=/dev/…`, `mkfs … /dev/…`, `shred`.
 14. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+
+Every git guard sees through leading git **global options** (`-C <path>`,
+`-c <k>=<v>`, `--git-dir[=…]`, `--no-pager`, …), so `git -C /path <destructive>`
+is screened the same as `git <destructive>`.
 
 Malformed hook input fails **closed** (exit 2 denies the command). A text-scan
 hook cannot exempt display commands, so prose like

--- a/plugins/lisa-copilot/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -53,11 +53,39 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
 
 ### Built-in guards (always on)
 
-1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard.
-2. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
-   `--force-with-lease` is intentionally allowed.
-3. `git reset --hard` while the working tree is **dirty** (would discard work).
-4. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard — with
+   quote-aware boundaries, so wrapper/interpreter forms like
+   `bash -c "rm -rf /"` and `python -c "… os.system('rm -rf /')"` match too.
+2. `rm -rf` target hardening: the cwd itself (`.`/`./`), `..`-traversal paths,
+   absolute paths outside the project (`/tmp`, `/var/tmp`, and `$TMPDIR` are
+   allowed), `$VAR` targets other than `$TMPDIR`, and **any** recursive forced
+   delete while the working directory is `$HOME`.
+3. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
+   `--force-with-lease` is intentionally allowed, and so is force-pushing a
+   feature branch (sanctioned rebase workflow).
+4. `git reset --hard` / `git reset --merge` while the working tree is **dirty**
+   (would discard work). Clean-tree resets are intentionally allowed.
+5. `git checkout` discards: the `--` pathspec form (with or without a ref),
+   `-f`/`--force`, `--pathspec-from-file`, and bare `git checkout .`.
+   Branch switching and `-b`/`-B` creation stay allowed.
+6. `git switch --discard-changes` / `-f`/`--force`.
+7. `git restore` touching the worktree — only `git restore --staged <path>`
+   without `--worktree` is allowed (unstaging is safe).
+8. `git stash drop` / `git stash clear` (push/pop/list/apply stay allowed).
+9. `git clean` with a force flag and no dry-run — `-n`/`--dry-run` anywhere
+   makes it a safe preview.
+10. `git branch -D` (or `-d` combined with `-f`, clustered or split);
+    safe `-d` and rename `-m` stay allowed.
+11. `git tag -d`, `git reflog delete`, `git worktree remove --force`.
+12. Deletion via `find … -delete`, `find … -exec rm -rf`, and `xargs … rm -rf`
+    (plain non-recursive `rm` on find/xargs output stays allowed).
+13. Disk destroyers: `dd of=/dev/…`, `mkfs … /dev/…`, `shred`.
+14. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+
+Malformed hook input fails **closed** (exit 2 denies the command). A text-scan
+hook cannot exempt display commands, so prose like
+`echo "docs about rm -rf /"` can false-positive — quote-break the string or use
+the gh-writer heredoc form (payload is stripped before the guards run).
 
 ## View the current rules
 

--- a/plugins/lisa-cursor/hooks/parity-safety-net.sh
+++ b/plugins/lisa-cursor/hooks/parity-safety-net.sh
@@ -169,9 +169,13 @@ readonly GIT_CMD='(^|[^[:alnum:]_-])git[[:space:]]+'"$GIT_GLOBAL_OPTS"
 # `--rm`-style flags and `foo.rm` names out.
 readonly RM_CMD='(^|[^[:alnum:]_./-])([[:alnum:]_./-]*/)?rm'
 # rm invoked with BOTH a recursive and a force flag — clustered (-rf/-fr, any
-# extra letters) or split (-r … -f / long forms), in either order.
+# extra letters) or split, in either order. The split gate pairs ANY recursive
+# form (short cluster containing r, or --recursive) with ANY force form (short
+# cluster containing f, or --force), so mixed spellings like `rm -r --force /`
+# and `rm --recursive -f /` cannot slip between the short/short and long/long
+# alternations (PR #1976 review).
 readonly RM_RF_CLUSTER="$RM_CMD"'([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
-readonly RM_RF_SPLIT="$RM_CMD"'[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
+readonly RM_RF_SPLIT="$RM_CMD"'(([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*r[[:alnum:]]*|--recursive)([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|$)|([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*r[[:alnum:]]*|--recursive)([[:space:]]|$))'
 
 # 1. Recursive forced delete (`rm -rf`) of a filesystem root, home, or top-level
 #    wildcard. Two gates ANDed: the statement must invoke `rm` with BOTH a

--- a/plugins/lisa-cursor/hooks/parity-safety-net.sh
+++ b/plugins/lisa-cursor/hooks/parity-safety-net.sh
@@ -8,13 +8,18 @@
 # It reads the hook stdin JSON, inspects the proposed Bash command, and EXITS
 # NON-ZERO (2) to BLOCK when a known-destructive pattern matches:
 #   - `rm -rf` of a root / home / wildcard path (quote-aware boundaries, so
-#     `bash -c "rm -rf /"` and interpreter one-liners are caught too)
-#   - `rm -rf` of the cwd (`.`), a `..`-traversal path, an absolute path outside
-#     the project (with a /tmp, /var/tmp, $TMPDIR allowance), a `$VAR` target
-#     other than $TMPDIR, or ANY recursive forced delete while cwd is $HOME
-#   - force-pushing a protected branch (main/master/production/release) —
+#     `bash -c "rm -rf /"` and interpreter one-liners are caught too; the rm
+#     guards also match path-prefixed invocations like `/bin/rm` and `./rm`)
+#   - `rm -rf` of the cwd (`.`), a `..`-traversal path, a `~/`-anchored path,
+#     an absolute path outside the project (with a /tmp, /var/tmp, $TMPDIR
+#     allowance), a `$VAR` target other than $TMPDIR, or ANY recursive forced
+#     delete while cwd is $HOME
+#   - force-pushing a protected branch (main/master/production/prod/release) —
 #     feature-branch force-push stays allowed (sanctioned rebase workflow;
-#     deliberate divergence from upstream's any-branch block)
+#     deliberate divergence from upstream's any-branch block). Every git guard
+#     sees through leading git GLOBAL options (`-C <path>`, `-c <k>=<v>`,
+#     `--git-dir[=…]`, `--no-pager`, …), so `git -C /path <destructive>` cannot
+#     dodge the subcommand anchor
 #   - `git reset --hard` / `--merge` while the working tree is dirty. Deliberate
 #     divergence: upstream blocks unconditionally; Lisa allows clean-tree resets.
 #     Residual risk (documented, accepted): the dirty check runs in the hook's
@@ -147,31 +152,48 @@ normalized_command_str="$(printf '%s' "$command_for_guards" \
 # crossing a statement separator, so a flag in a LATER statement can never be
 # attributed to an earlier git subcommand.
 readonly GIT_TOKENS='([[:space:]]+[^;&|[:space:]]+)*[[:space:]]+'
+# Git GLOBAL options (`-C <path>`, `-c <k>=<v>`, `--git-dir[=…]`, `--no-pager`,
+# …) legally sit between `git` and its subcommand, so every subcommand guard
+# consumes them — otherwise `git -C /path checkout -- f` dodges the anchor
+# (issue #1960 security review F1). Shape: zero or more dash-led tokens, each
+# optionally followed by ONE non-dash value token, which covers both the
+# `--git-dir=/x` and `--git-dir /x` spellings without naming every option.
+readonly GIT_GLOBAL_OPTS='(-[^;&|[:space:]]+([[:space:]]+[^-;&|[:space:]][^;&|[:space:]]*)?[[:space:]]+)*'
+# Anchor for every git subcommand guard: word-bounded `git`, whitespace, then
+# any run of global options. Callers append the subcommand name directly.
+readonly GIT_CMD='(^|[^[:alnum:]_-])git[[:space:]]+'"$GIT_GLOBAL_OPTS"
+# An rm invocation: bare `rm` or a path whose basename is exactly `rm`
+# (`/bin/rm`, `./rm`) — issue #1960 security review F2. The optional prefix must
+# END IN `/` immediately before `rm`, so charm/confirm/informant/rmdir never
+# match. The preceding-char class still excludes `.`, `/`, and `-` to keep
+# `--rm`-style flags and `foo.rm` names out.
+readonly RM_CMD='(^|[^[:alnum:]_./-])([[:alnum:]_./-]*/)?rm'
 # rm invoked with BOTH a recursive and a force flag — clustered (-rf/-fr, any
 # extra letters) or split (-r … -f / long forms), in either order.
-readonly RM_RF_CLUSTER='(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
-readonly RM_RF_SPLIT='(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
+readonly RM_RF_CLUSTER="$RM_CMD"'([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
+readonly RM_RF_SPLIT="$RM_CMD"'[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
 
 # 1. Recursive forced delete (`rm -rf`) of a filesystem root, home, or top-level
-#    wildcard. Two gates ANDed: the command must invoke `rm` with BOTH a
+#    wildcard. Two gates ANDed: the statement must invoke `rm` with BOTH a
 #    recursive and a force flag, AND name a catastrophic target. Splitting the
 #    flag check from the target check keeps each regex legible and testable.
 #    The target boundary classes include quote characters (issue #1960): without
 #    them, `bash -c "rm -rf /"` and interpreter one-liners like
 #    `python -c "… os.system('rm -rf /')"` slip through because the target is
 #    quote-adjacent instead of space-bounded.
+#    Both gates run PER STATEMENT inside the shared rm loop below (quality
+#    review S1): a harmless `/` in a LATER statement (`rm -rf build && cd /`)
+#    is never attributed to the rm in an earlier one.
 qc="'\""
-if matches "$RM_RF_CLUSTER" || matches "$RM_RF_SPLIT"; then
-  if matches_cs '([[:space:]='"$qc"'])(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]'"$qc"']|/?\*?['"$qc"']?$)'; then
-    block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
-  fi
-fi
+readonly RM_CATASTROPHIC_TARGET='([[:space:]='"$qc"'])(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]'"$qc"']|/?\*?['"$qc"']?$)'
 
 # 1b. rm target hardening (issue #1960). For every statement that invokes rm
 #     with recursive+force flags, additionally block when:
 #       - cwd is $HOME (any target is one argument away from wiping home), or
 #       - the target is the cwd itself (`.` / `./`), or
 #       - the target traverses out via `..`, or
+#       - the target is home-anchored (`~/…` — the shell expands it to $HOME at
+#         execution time, so it is always outside the project), or
 #       - the target is an absolute path outside the project — with an allowance
 #         for /tmp, /var/tmp, and $TMPDIR — or
 #       - the target is a `$VAR` expansion other than the sanctioned $TMPDIR.
@@ -185,6 +207,10 @@ while IFS= read -r rm_stmt; do
   if ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_CLUSTER" \
     && ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_SPLIT"; then
     continue
+  fi
+  # Guard 1: catastrophic target named in the SAME statement as the rm -rf.
+  if printf '%s' "$rm_stmt" | grep -Eq -- "$RM_CATASTROPHIC_TARGET"; then
+    block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
   fi
   # Physical-path comparison (pwd -P): on macOS $HOME or the cwd may arrive via
   # a symlink (/var → /private/var), and a string compare would miss the match.
@@ -200,7 +226,10 @@ while IFS= read -r rm_stmt; do
     token="${token%\"}"
     token="${token%\'}"
     if [ "$seen_rm" -eq 0 ]; then
-      [ "$token" = "rm" ] && seen_rm=1
+      # Path-prefixed spellings (`/bin/rm`, `./rm`) are still rm (F2).
+      case "$token" in
+        rm | */rm) seen_rm=1 ;;
+      esac
       continue
     fi
     case "$token" in
@@ -212,6 +241,10 @@ while IFS= read -r rm_stmt; do
       .. | ../* | */.. | */../*)
         set +f
         block "recursive forced delete of a path outside the project (.. traversal)"
+        ;;
+      '~' | '~'/*)
+        set +f
+        block "recursive forced delete of a home-anchored path (~/…) outside the project"
         ;;
       /*)
         case "$token" in
@@ -235,7 +268,7 @@ while IFS= read -r rm_stmt; do
   done
   set +f
 done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
-  | grep -Ei '(^|[^[:alnum:]_./-])rm([[:space:]]|$)' || true)
+  | grep -Ei -- "$RM_CMD"'([[:space:]]|$)' || true)
 
 # 2. Force-pushing a protected branch. `--force-with-lease` is the safe,
 #    non-clobbering alternative and is intentionally NOT blocked. Deliberate
@@ -260,7 +293,7 @@ while IFS= read -r push_stmt; do
     block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
 done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
-  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b' || true)
+  | grep -Ei -- "${GIT_CMD}push\b" || true)
 
 # 3. `git reset --hard` / `git reset --merge` while the working tree has
 #    uncommitted changes — both silently discard them. Only blocks when the tree
@@ -268,7 +301,7 @@ done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
 #    Deliberate divergence from upstream's unconditional block; the accepted
 #    residual risk (dirty check runs at hook time in the hook's cwd) is
 #    documented in the header.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--(hard|merge)\b'; then
+if matches "${GIT_CMD}"'reset\b.*--(hard|merge)\b'; then
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
     && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
     block "git reset --hard/--merge on a dirty working tree would discard uncommitted changes (stash or commit first)"
@@ -280,7 +313,7 @@ fi
 #    Blocking bare `.` exceeds upstream (which allows any single positional) —
 #    issue #1960 names it explicitly: it discards the entire tree. Branch
 #    switches and creation (`-b`/`-B`) stay allowed.
-readonly GIT_CHECKOUT='(^|[^[:alnum:]_-])git[[:space:]]+checkout'
+readonly GIT_CHECKOUT="${GIT_CMD}checkout"
 if matches "${GIT_CHECKOUT}${GIT_TOKENS}"'--([[:space:]]|$)' \
   || matches "${GIT_CHECKOUT}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
   || matches "${GIT_CHECKOUT}"'[[:space:]][^;&|]*--pathspec-from-file' \
@@ -289,7 +322,7 @@ if matches "${GIT_CHECKOUT}${GIT_TOKENS}"'--([[:space:]]|$)' \
 fi
 
 # 5. `git switch` discards: `--discard-changes` and its `-f/--force` aliases.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+switch'"${GIT_TOKENS}"'(--discard-changes|--force|-f)([[:space:]]|=|$)'; then
+if matches "${GIT_CMD}switch${GIT_TOKENS}"'(--discard-changes|--force|-f)([[:space:]]|=|$)'; then
   block "git switch discarding local changes (--discard-changes/-f/--force)"
 fi
 
@@ -297,23 +330,23 @@ fi
 #    the pure staging-area form is safe: `--staged` present and `--worktree`
 #    absent. Two conditions, because an ERE has no lookahead: `--staged
 #    --worktree` still discards, so `--worktree` blocks regardless of `--staged`.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore([[:space:]]|$)'; then
-  if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--worktree' \
-    || ! matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--staged'; then
+if matches "${GIT_CMD}"'restore([[:space:]]|$)'; then
+  if matches "${GIT_CMD}"'restore[^;&|]*--worktree' \
+    || ! matches "${GIT_CMD}"'restore[^;&|]*--staged'; then
     block "git restore overwriting worktree files (only 'git restore --staged <path>' without --worktree is allowed)"
   fi
 fi
 
 # 7. `git stash drop` / `git stash clear` destroy stashed work. push/pop/list/
 #    apply — the safe alternatives the reset guard recommends — stay allowed.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+stash[[:space:]]+(drop|clear)([[:space:]]|$)'; then
+if matches "${GIT_CMD}"'stash[[:space:]]+(drop|clear)([[:space:]]|$)'; then
   block "git stash drop/clear destroys stashed work"
 fi
 
 # 8. `git clean` with a force flag wipes untracked files. A dry-run flag
 #    (`-n`/`--dry-run`) ANYWHERE wins — git itself performs no deletion under
 #    dry-run, so `git clean -fdn` is a safe preview.
-readonly GIT_CLEAN='(^|[^[:alnum:]_-])git[[:space:]]+clean'
+readonly GIT_CLEAN="${GIT_CMD}clean"
 if matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
   && ! matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*n[[:alnum:]]*|--dry-run)([[:space:]]|=|$)'; then
   block "git clean --force deletes untracked files (preview with git clean -n first)"
@@ -322,7 +355,7 @@ fi
 # 9. `git branch` force-delete loses unmerged commits: `-D`, `-d` combined with
 #    `-f` (clustered or split), or `--delete` + `--force`. Case-SENSITIVE so the
 #    safe `-d` (which refuses unmerged work) and rename `-m` stay allowed.
-readonly GIT_BRANCH='(^|[^[:alnum:]_-])git[[:space:]]+branch'
+readonly GIT_BRANCH="${GIT_CMD}branch"
 if matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*D[[:alnum:]]*([[:space:]]|$)' \
   || { matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)' \
     && matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$)'; } \
@@ -334,13 +367,13 @@ fi
 #     `git reflog delete` (erases recovery history), and
 #     `git worktree remove --force` (discards a dirty worktree). Tag deletion is
 #     case-SENSITIVE so annotated-tag `-a` and message `-m` flags never match.
-if matches_cs '(^|[^[:alnum:]_-])git[[:space:]]+tag'"${GIT_TOKENS}"'(-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)|--delete([[:space:]]|=|$))'; then
+if matches_cs "${GIT_CMD}tag${GIT_TOKENS}"'(-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)|--delete([[:space:]]|=|$))'; then
   block "git tag -d deletes a shared ref"
 fi
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+reflog[[:space:]]+delete([[:space:]]|$)'; then
+if matches "${GIT_CMD}"'reflog[[:space:]]+delete([[:space:]]|$)'; then
   block "git reflog delete erases recovery history"
 fi
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+worktree[[:space:]]+remove[^;&|]*(--force([[:space:]]|=|$)|[[:space:]]-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$))'; then
+if matches "${GIT_CMD}"'worktree[[:space:]]+remove[^;&|]*(--force([[:space:]]|=|$)|[[:space:]]-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$))'; then
   block "git worktree remove --force discards a dirty worktree (remove without --force, which refuses dirty trees)"
 fi
 

--- a/plugins/lisa-cursor/hooks/parity-safety-net.sh
+++ b/plugins/lisa-cursor/hooks/parity-safety-net.sh
@@ -1,17 +1,45 @@
 #!/usr/bin/env bash
 # PreToolUse hook for Bash: a safety net that blocks destructive shell commands
 # before they run. Lisa-native reimplementation of the upstream
-# `safety-net@cc-marketplace` plugin's PreToolUse Bash-guard (parity work, issue
-# #1059). It does NOT port upstream code — it re-expresses the behavior in Lisa's
-# hook conventions, modeled on block-no-verify.sh.
+# `safety-net@cc-marketplace` plugin's PreToolUse Bash-guard (parity work,
+# issues #1059 and #1960). It does NOT port upstream code — it re-expresses the
+# behavior in Lisa's hook conventions, modeled on block-no-verify.sh.
 #
 # It reads the hook stdin JSON, inspects the proposed Bash command, and EXITS
 # NON-ZERO (2) to BLOCK when a known-destructive pattern matches:
-#   - `rm -rf /` (recursive forced delete of a root / home / wildcard path)
-#   - force-pushing a protected branch (main/master/production/release)
-#   - `git reset --hard` while the working tree is dirty (would discard work)
-#   - dropping or truncating a database/schema/table
-# Otherwise it exits 0 and the command proceeds.
+#   - `rm -rf` of a root / home / wildcard path (quote-aware boundaries, so
+#     `bash -c "rm -rf /"` and interpreter one-liners are caught too)
+#   - `rm -rf` of the cwd (`.`), a `..`-traversal path, an absolute path outside
+#     the project (with a /tmp, /var/tmp, $TMPDIR allowance), a `$VAR` target
+#     other than $TMPDIR, or ANY recursive forced delete while cwd is $HOME
+#   - force-pushing a protected branch (main/master/production/release) —
+#     feature-branch force-push stays allowed (sanctioned rebase workflow;
+#     deliberate divergence from upstream's any-branch block)
+#   - `git reset --hard` / `--merge` while the working tree is dirty. Deliberate
+#     divergence: upstream blocks unconditionally; Lisa allows clean-tree resets.
+#     Residual risk (documented, accepted): the dirty check runs in the hook's
+#     cwd at hook time, so a `cd elsewhere && git reset --hard` evades it.
+#   - `git checkout` discards (`--`, `-f/--force`, `--pathspec-from-file`,
+#     bare `.` — the bare-`.` block exceeds upstream)
+#   - `git switch --discard-changes` / `-f/--force`
+#   - `git restore` touching the worktree (allowed only with `--staged` and
+#     without `--worktree`)
+#   - `git stash drop` / `git stash clear`
+#   - `git clean` with force and no dry-run (`-n`/`--dry-run` anywhere wins)
+#   - `git branch -D` (or `-d` + `-f` in any spelling)
+#   - `git tag -d`, `git reflog delete`, `git worktree remove --force`
+#   - `find ... -delete`, `find ... -exec rm -rf`, `xargs ... rm -rf`
+#   - disk destroyers: `dd of=/dev/...`, `mkfs ... /dev/...`, `shred`
+#   - dropping or truncating a database/schema/table (Lisa-only guard)
+# Otherwise it exits 0 and the command proceeds. Malformed hook input fails
+# CLOSED: any parse error exits 2 (a non-2 exit would be a non-blocking hook
+# error in Claude Code, silently failing open).
+#
+# Known accepted false-positive class: this is a text scan, not a shell engine,
+# so display commands quoting a destructive string (`echo "docs about rm -rf /"`)
+# can match. Upstream exempts those via an engine-only DISPLAY_COMMANDS list a
+# grep hook cannot replicate. Workaround: quote-break the string or use the
+# gh-writer heredoc form, whose payload is stripped before the guards run.
 #
 # Operators extend the built-in rules with a project-local rule file — one
 # extended-regex (ERE) per line, blank lines and `#` comments ignored — managed
@@ -19,6 +47,13 @@
 # SAFETY_NET_RULES_FILE):
 #   ${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-net-rules.txt
 set -euo pipefail
+
+# Fail CLOSED on any unexpected error (malformed JSON, missing jq, …): exit 2 so
+# the tool call is denied instead of surfacing a non-blocking hook warning.
+# Deliberately NOT `set -E`: errtrace would propagate this trap into command
+# substitutions (e.g. the heredoc parser call, whose non-zero exit codes are
+# meaningful protocol) and rewrite their status to 2 before it can be read.
+trap 'printf "%s\n" "Blocked by safety-net: hook failed while parsing its input; denying fail-closed." >&2; exit 2' ERR
 
 input="$(cat)"
 
@@ -90,22 +125,122 @@ case "$command_str" in
     ;;
 esac
 
+# matches / matches_cs run an ERE against the guarded command text. matches is
+# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
+# for guards where flag case is meaningful (`git branch -d` vs `-D`).
+matches() {
+  printf '%s' "$command_for_guards" | grep -Eiq -- "$1"
+}
+matches_cs() {
+  printf '%s' "$command_for_guards" | grep -Eq -- "$1"
+}
+
+# Normalize bash line-continuations (a trailing backslash + newline → space)
+# before segmenting the command. Without this, "git push --force origin
+# \<newline>main" splits into a segment matching --force but not `main`, letting a
+# protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
+# `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
+normalized_command_str="$(printf '%s' "$command_for_guards" \
+  | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
+
+# Shared ERE fragments. GIT_TOKENS walks over intermediate argv tokens without
+# crossing a statement separator, so a flag in a LATER statement can never be
+# attributed to an earlier git subcommand.
+readonly GIT_TOKENS='([[:space:]]+[^;&|[:space:]]+)*[[:space:]]+'
+# rm invoked with BOTH a recursive and a force flag — clustered (-rf/-fr, any
+# extra letters) or split (-r … -f / long forms), in either order.
+readonly RM_RF_CLUSTER='(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
+readonly RM_RF_SPLIT='(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
+
 # 1. Recursive forced delete (`rm -rf`) of a filesystem root, home, or top-level
 #    wildcard. Two gates ANDed: the command must invoke `rm` with BOTH a
 #    recursive and a force flag, AND name a catastrophic target. Splitting the
 #    flag check from the target check keeps each regex legible and testable.
-if printf '%s' "$command_for_guards" \
-  | grep -Eiq '(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)' \
-  || printf '%s' "$command_for_guards" \
-  | grep -Eiq '(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'; then
-  if printf '%s' "$command_for_guards" \
-    | grep -Eq '([[:space:]]|=)(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]]|/?\*?$)'; then
+#    The target boundary classes include quote characters (issue #1960): without
+#    them, `bash -c "rm -rf /"` and interpreter one-liners like
+#    `python -c "… os.system('rm -rf /')"` slip through because the target is
+#    quote-adjacent instead of space-bounded.
+qc="'\""
+if matches "$RM_RF_CLUSTER" || matches "$RM_RF_SPLIT"; then
+  if matches_cs '([[:space:]='"$qc"'])(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]'"$qc"']|/?\*?['"$qc"']?$)'; then
     block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
   fi
 fi
 
+# 1b. rm target hardening (issue #1960). For every statement that invokes rm
+#     with recursive+force flags, additionally block when:
+#       - cwd is $HOME (any target is one argument away from wiping home), or
+#       - the target is the cwd itself (`.` / `./`), or
+#       - the target traverses out via `..`, or
+#       - the target is an absolute path outside the project — with an allowance
+#         for /tmp, /var/tmp, and $TMPDIR — or
+#       - the target is a `$VAR` expansion other than the sanctioned $TMPDIR.
+#     Globbing is disabled around the token walk so a literal `*` in the command
+#     is never expanded against the hook's own cwd.
+project_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+tmp_dir_allow="${TMPDIR:-/tmp}"
+tmp_dir_allow="${tmp_dir_allow%/}"
+[ -n "$tmp_dir_allow" ] || tmp_dir_allow="/tmp"
+while IFS= read -r rm_stmt; do
+  if ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_CLUSTER" \
+    && ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_SPLIT"; then
+    continue
+  fi
+  # Physical-path comparison (pwd -P): on macOS $HOME or the cwd may arrive via
+  # a symlink (/var → /private/var), and a string compare would miss the match.
+  if [ -n "${HOME:-}" ] \
+    && [ "$(pwd -P)" = "$(cd -- "$HOME" 2>/dev/null && pwd -P)" ]; then
+    block "recursive forced delete while the working directory is \$HOME (cd into a project first)"
+  fi
+  set -f
+  seen_rm=0
+  for raw_token in $rm_stmt; do
+    token="${raw_token#\"}"
+    token="${token#\'}"
+    token="${token%\"}"
+    token="${token%\'}"
+    if [ "$seen_rm" -eq 0 ]; then
+      [ "$token" = "rm" ] && seen_rm=1
+      continue
+    fi
+    case "$token" in
+      -*) continue ;;
+      . | ./)
+        set +f
+        block "recursive forced delete of the current directory (rm -rf .)"
+        ;;
+      .. | ../* | */.. | */../*)
+        set +f
+        block "recursive forced delete of a path outside the project (.. traversal)"
+        ;;
+      /*)
+        case "$token" in
+          "$project_dir" | "$project_dir"/* | /tmp | /tmp/* | /var/tmp | /var/tmp/* | "$tmp_dir_allow" | "$tmp_dir_allow"/*) : ;;
+          *)
+            set +f
+            block "recursive forced delete of an absolute path outside the project (only the project, /tmp, /var/tmp, and \$TMPDIR are allowed)"
+            ;;
+        esac
+        ;;
+      *'$'*)
+        case "$token" in
+          '$TMPDIR' | '$TMPDIR'/* | '${TMPDIR}' | '${TMPDIR}'/*) : ;;
+          *)
+            set +f
+            block "recursive forced delete of a variable-expanded target (unset or mistyped variables can point anywhere; \$TMPDIR is the only sanctioned dynamic target)"
+            ;;
+        esac
+        ;;
+    esac
+  done
+  set +f
+done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
+  | grep -Ei '(^|[^[:alnum:]_./-])rm([[:space:]]|$)' || true)
+
 # 2. Force-pushing a protected branch. `--force-with-lease` is the safe,
-#    non-clobbering alternative and is intentionally NOT blocked.
+#    non-clobbering alternative and is intentionally NOT blocked. Deliberate
+#    divergence from upstream (which blocks force-push on ANY branch):
+#    feature-branch force-push is a sanctioned rebase-and-push agent workflow.
 #
 #    The force flag AND the protected-branch name must appear in the SAME
 #    `git push` statement. Checking them independently over the whole command is
@@ -116,14 +251,6 @@ fi
 #    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
 #    inspect each in isolation — a real `git push --force origin main` still
 #    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
-# Normalize bash line-continuations (a trailing backslash + newline → space)
-# before segmenting the command. Without this, "git push --force origin
-# \<newline>main" splits into a segment matching --force but not `main`, letting a
-# protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
-# `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
-normalized_command_str="$(printf '%s' "$command_for_guards" \
-  | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
-
 while IFS= read -r push_stmt; do
   if printf '%s' "$push_stmt" \
     | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
@@ -133,25 +260,125 @@ while IFS= read -r push_stmt; do
     block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
 done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
-  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b')
+  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b' || true)
 
-# 3. `git reset --hard` while the working tree has uncommitted changes — this
-#    silently discards them. Only blocks when the tree is actually dirty, so a
-#    clean-tree reset (a legitimate workflow) still passes.
-if printf '%s' "$command_for_guards" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--hard\b'; then
+# 3. `git reset --hard` / `git reset --merge` while the working tree has
+#    uncommitted changes — both silently discard them. Only blocks when the tree
+#    is actually dirty, so a clean-tree reset (a legitimate workflow) passes.
+#    Deliberate divergence from upstream's unconditional block; the accepted
+#    residual risk (dirty check runs at hook time in the hook's cwd) is
+#    documented in the header.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--(hard|merge)\b'; then
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
     && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-    block "git reset --hard on a dirty working tree would discard uncommitted changes (stash or commit first)"
+    block "git reset --hard/--merge on a dirty working tree would discard uncommitted changes (stash or commit first)"
   fi
 fi
 
-# 4. Dropping or truncating a database / schema / table.
-if printf '%s' "$command_for_guards" \
-  | grep -Eiq '\b(drop[[:space:]]+(database|schema|table)|truncate[[:space:]]+(table[[:space:]]+)?[[:alnum:]_."`]+)\b'; then
+# 4. `git checkout` worktree discards: the `--` pathspec form (with or without a
+#    ref), `-f/--force`, `--pathspec-from-file`, and bare `git checkout .`.
+#    Blocking bare `.` exceeds upstream (which allows any single positional) —
+#    issue #1960 names it explicitly: it discards the entire tree. Branch
+#    switches and creation (`-b`/`-B`) stay allowed.
+readonly GIT_CHECKOUT='(^|[^[:alnum:]_-])git[[:space:]]+checkout'
+if matches "${GIT_CHECKOUT}${GIT_TOKENS}"'--([[:space:]]|$)' \
+  || matches "${GIT_CHECKOUT}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
+  || matches "${GIT_CHECKOUT}"'[[:space:]][^;&|]*--pathspec-from-file' \
+  || matches "${GIT_CHECKOUT}"'[[:space:]]+\.(/)?([[:space:]]|$)'; then
+  block "git checkout discarding local changes (--, -f/--force, --pathspec-from-file, or bare .) — use git stash to preserve work first"
+fi
+
+# 5. `git switch` discards: `--discard-changes` and its `-f/--force` aliases.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+switch'"${GIT_TOKENS}"'(--discard-changes|--force|-f)([[:space:]]|=|$)'; then
+  block "git switch discarding local changes (--discard-changes/-f/--force)"
+fi
+
+# 6. `git restore` defaults to overwriting the WORKTREE — a silent discard. Only
+#    the pure staging-area form is safe: `--staged` present and `--worktree`
+#    absent. Two conditions, because an ERE has no lookahead: `--staged
+#    --worktree` still discards, so `--worktree` blocks regardless of `--staged`.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore([[:space:]]|$)'; then
+  if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--worktree' \
+    || ! matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--staged'; then
+    block "git restore overwriting worktree files (only 'git restore --staged <path>' without --worktree is allowed)"
+  fi
+fi
+
+# 7. `git stash drop` / `git stash clear` destroy stashed work. push/pop/list/
+#    apply — the safe alternatives the reset guard recommends — stay allowed.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+stash[[:space:]]+(drop|clear)([[:space:]]|$)'; then
+  block "git stash drop/clear destroys stashed work"
+fi
+
+# 8. `git clean` with a force flag wipes untracked files. A dry-run flag
+#    (`-n`/`--dry-run`) ANYWHERE wins — git itself performs no deletion under
+#    dry-run, so `git clean -fdn` is a safe preview.
+readonly GIT_CLEAN='(^|[^[:alnum:]_-])git[[:space:]]+clean'
+if matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
+  && ! matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*n[[:alnum:]]*|--dry-run)([[:space:]]|=|$)'; then
+  block "git clean --force deletes untracked files (preview with git clean -n first)"
+fi
+
+# 9. `git branch` force-delete loses unmerged commits: `-D`, `-d` combined with
+#    `-f` (clustered or split), or `--delete` + `--force`. Case-SENSITIVE so the
+#    safe `-d` (which refuses unmerged work) and rename `-m` stay allowed.
+readonly GIT_BRANCH='(^|[^[:alnum:]_-])git[[:space:]]+branch'
+if matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*D[[:alnum:]]*([[:space:]]|$)' \
+  || { matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)' \
+    && matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$)'; } \
+  || { matches "${GIT_BRANCH}"'[^;&|]*--delete' && matches "${GIT_BRANCH}"'[^;&|]*--force'; }; then
+  block "git branch force-delete (-D) loses unmerged commits (use -d, which refuses unmerged work)"
+fi
+
+# 10. Cheap destructive-ref guards: `git tag -d` (tags are shared refs),
+#     `git reflog delete` (erases recovery history), and
+#     `git worktree remove --force` (discards a dirty worktree). Tag deletion is
+#     case-SENSITIVE so annotated-tag `-a` and message `-m` flags never match.
+if matches_cs '(^|[^[:alnum:]_-])git[[:space:]]+tag'"${GIT_TOKENS}"'(-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)|--delete([[:space:]]|=|$))'; then
+  block "git tag -d deletes a shared ref"
+fi
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+reflog[[:space:]]+delete([[:space:]]|$)'; then
+  block "git reflog delete erases recovery history"
+fi
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+worktree[[:space:]]+remove[^;&|]*(--force([[:space:]]|=|$)|[[:space:]]-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$))'; then
+  block "git worktree remove --force discards a dirty worktree (remove without --force, which refuses dirty trees)"
+fi
+
+# 11. Deletion through find/xargs, where the target never appears as a literal
+#     argument: `find … -delete`, `find … -exec rm -rf`, and `xargs … rm -rf`
+#     (targets arrive from dynamic stdin — unauditable). Plain `rm` (no
+#     recursive+force) on find/xargs output stays allowed for normal cleanups.
+if matches '(^|[^[:alnum:]_./-])find[[:space:]][^;&|]*[[:space:]]-delete([[:space:]]|$)'; then
+  block "find -delete removes files tree-wide (use -print to preview, or an explicit rm on reviewed paths)"
+fi
+if matches '(^|[^[:alnum:]_./-])find[[:space:]][^;&|]*-exec[[:space:]]+rm[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'; then
+  block "find -exec rm -rf performs a recursive forced delete on unreviewed paths"
+fi
+if matches '(^|[^[:alnum:]_./-])xargs[[:space:]]([^;&|]*[[:space:]])?rm[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'; then
+  block "xargs rm -rf performs a recursive forced delete on dynamic stdin input"
+fi
+
+# 12. Disk destroyers, always on (exceeds upstream, which only scans these
+#     inside interpreter one-liners): writing to a raw /dev node via dd,
+#     formatting a device with mkfs, and shred's unrecoverable overwrite.
+#     dd/mkfs against regular files (imaging) stays allowed.
+if matches '(^|[^[:alnum:]_./-])dd[[:space:]]+([^;&|]*[[:space:]])?of=/dev/'; then
+  block "dd writing to a raw device (of=/dev/…) destroys it"
+fi
+if matches '(^|[^[:alnum:]_./-])mkfs(\.[[:alnum:]]+)?[[:space:]][^;&|]*/dev/'; then
+  block "mkfs formatting a device erases it"
+fi
+if matches '(^|[^[:alnum:]_./-])shred([[:space:]]|$)'; then
+  block "shred overwrites files unrecoverably"
+fi
+
+# 13. Dropping or truncating a database / schema / table (Lisa-only guard —
+#     upstream has no SQL protection; keep).
+if matches '\b(drop[[:space:]]+(database|schema|table)|truncate[[:space:]]+(table[[:space:]]+)?[[:alnum:]_."`]+)\b'; then
   block "destructive SQL (DROP/TRUNCATE) detected"
 fi
 
-# 5. Project-local custom rules. Each non-comment line is an ERE; a match blocks.
+# 14. Project-local custom rules. Each non-comment line is an ERE; a match blocks.
 rules_file="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-net-rules.txt}"
 if [ -f "$rules_file" ]; then
   while IFS= read -r rule || [ -n "$rule" ]; do

--- a/plugins/lisa-cursor/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -56,13 +56,17 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
 1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard — with
    quote-aware boundaries, so wrapper/interpreter forms like
    `bash -c "rm -rf /"` and `python -c "… os.system('rm -rf /')"` match too.
+   Path-prefixed spellings (`/bin/rm`, `./rm`) count as `rm` for every rm
+   guard.
 2. `rm -rf` target hardening: the cwd itself (`.`/`./`), `..`-traversal paths,
-   absolute paths outside the project (`/tmp`, `/var/tmp`, and `$TMPDIR` are
-   allowed), `$VAR` targets other than `$TMPDIR`, and **any** recursive forced
-   delete while the working directory is `$HOME`.
-3. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
-   `--force-with-lease` is intentionally allowed, and so is force-pushing a
-   feature branch (sanctioned rebase workflow).
+   home-anchored `~/…` paths, absolute paths outside the project (`/tmp`,
+   `/var/tmp`, and `$TMPDIR` are allowed), `$VAR` targets other than `$TMPDIR`,
+   and **any** recursive forced delete while the working directory is `$HOME`.
+3. Force-pushing a protected branch
+   (`main`/`master`/`production`/`prod`/`release`). `--force-with-lease` is
+   intentionally allowed, and so is force-pushing a feature branch (sanctioned
+   rebase workflow). Acceptable parity divergence: a refspec force-push
+   (`git push origin +main`) is not blocked — upstream 1.0.6 allows it too.
 4. `git reset --hard` / `git reset --merge` while the working tree is **dirty**
    (would discard work). Clean-tree resets are intentionally allowed.
 5. `git checkout` discards: the `--` pathspec form (with or without a ref),
@@ -81,6 +85,10 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
     (plain non-recursive `rm` on find/xargs output stays allowed).
 13. Disk destroyers: `dd of=/dev/…`, `mkfs … /dev/…`, `shred`.
 14. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+
+Every git guard sees through leading git **global options** (`-C <path>`,
+`-c <k>=<v>`, `--git-dir[=…]`, `--no-pager`, …), so `git -C /path <destructive>`
+is screened the same as `git <destructive>`.
 
 Malformed hook input fails **closed** (exit 2 denies the command). A text-scan
 hook cannot exempt display commands, so prose like

--- a/plugins/lisa-cursor/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -53,11 +53,39 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
 
 ### Built-in guards (always on)
 
-1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard.
-2. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
-   `--force-with-lease` is intentionally allowed.
-3. `git reset --hard` while the working tree is **dirty** (would discard work).
-4. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard — with
+   quote-aware boundaries, so wrapper/interpreter forms like
+   `bash -c "rm -rf /"` and `python -c "… os.system('rm -rf /')"` match too.
+2. `rm -rf` target hardening: the cwd itself (`.`/`./`), `..`-traversal paths,
+   absolute paths outside the project (`/tmp`, `/var/tmp`, and `$TMPDIR` are
+   allowed), `$VAR` targets other than `$TMPDIR`, and **any** recursive forced
+   delete while the working directory is `$HOME`.
+3. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
+   `--force-with-lease` is intentionally allowed, and so is force-pushing a
+   feature branch (sanctioned rebase workflow).
+4. `git reset --hard` / `git reset --merge` while the working tree is **dirty**
+   (would discard work). Clean-tree resets are intentionally allowed.
+5. `git checkout` discards: the `--` pathspec form (with or without a ref),
+   `-f`/`--force`, `--pathspec-from-file`, and bare `git checkout .`.
+   Branch switching and `-b`/`-B` creation stay allowed.
+6. `git switch --discard-changes` / `-f`/`--force`.
+7. `git restore` touching the worktree — only `git restore --staged <path>`
+   without `--worktree` is allowed (unstaging is safe).
+8. `git stash drop` / `git stash clear` (push/pop/list/apply stay allowed).
+9. `git clean` with a force flag and no dry-run — `-n`/`--dry-run` anywhere
+   makes it a safe preview.
+10. `git branch -D` (or `-d` combined with `-f`, clustered or split);
+    safe `-d` and rename `-m` stay allowed.
+11. `git tag -d`, `git reflog delete`, `git worktree remove --force`.
+12. Deletion via `find … -delete`, `find … -exec rm -rf`, and `xargs … rm -rf`
+    (plain non-recursive `rm` on find/xargs output stays allowed).
+13. Disk destroyers: `dd of=/dev/…`, `mkfs … /dev/…`, `shred`.
+14. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+
+Malformed hook input fails **closed** (exit 2 denies the command). A text-scan
+hook cannot exempt display commands, so prose like
+`echo "docs about rm -rf /"` can false-positive — quote-break the string or use
+the gh-writer heredoc form (payload is stripped before the guards run).
 
 ## View the current rules
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -56,13 +56,17 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
 1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard — with
    quote-aware boundaries, so wrapper/interpreter forms like
    `bash -c "rm -rf /"` and `python -c "… os.system('rm -rf /')"` match too.
+   Path-prefixed spellings (`/bin/rm`, `./rm`) count as `rm` for every rm
+   guard.
 2. `rm -rf` target hardening: the cwd itself (`.`/`./`), `..`-traversal paths,
-   absolute paths outside the project (`/tmp`, `/var/tmp`, and `$TMPDIR` are
-   allowed), `$VAR` targets other than `$TMPDIR`, and **any** recursive forced
-   delete while the working directory is `$HOME`.
-3. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
-   `--force-with-lease` is intentionally allowed, and so is force-pushing a
-   feature branch (sanctioned rebase workflow).
+   home-anchored `~/…` paths, absolute paths outside the project (`/tmp`,
+   `/var/tmp`, and `$TMPDIR` are allowed), `$VAR` targets other than `$TMPDIR`,
+   and **any** recursive forced delete while the working directory is `$HOME`.
+3. Force-pushing a protected branch
+   (`main`/`master`/`production`/`prod`/`release`). `--force-with-lease` is
+   intentionally allowed, and so is force-pushing a feature branch (sanctioned
+   rebase workflow). Acceptable parity divergence: a refspec force-push
+   (`git push origin +main`) is not blocked — upstream 1.0.6 allows it too.
 4. `git reset --hard` / `git reset --merge` while the working tree is **dirty**
    (would discard work). Clean-tree resets are intentionally allowed.
 5. `git checkout` discards: the `--` pathspec form (with or without a ref),
@@ -81,6 +85,10 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
     (plain non-recursive `rm` on find/xargs output stays allowed).
 13. Disk destroyers: `dd of=/dev/…`, `mkfs … /dev/…`, `shred`.
 14. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+
+Every git guard sees through leading git **global options** (`-C <path>`,
+`-c <k>=<v>`, `--git-dir[=…]`, `--no-pager`, …), so `git -C /path <destructive>`
+is screened the same as `git <destructive>`.
 
 Malformed hook input fails **closed** (exit 2 denies the command). A text-scan
 hook cannot exempt display commands, so prose like

--- a/plugins/lisa/.codex-plugin/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -53,11 +53,39 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
 
 ### Built-in guards (always on)
 
-1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard.
-2. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
-   `--force-with-lease` is intentionally allowed.
-3. `git reset --hard` while the working tree is **dirty** (would discard work).
-4. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard — with
+   quote-aware boundaries, so wrapper/interpreter forms like
+   `bash -c "rm -rf /"` and `python -c "… os.system('rm -rf /')"` match too.
+2. `rm -rf` target hardening: the cwd itself (`.`/`./`), `..`-traversal paths,
+   absolute paths outside the project (`/tmp`, `/var/tmp`, and `$TMPDIR` are
+   allowed), `$VAR` targets other than `$TMPDIR`, and **any** recursive forced
+   delete while the working directory is `$HOME`.
+3. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
+   `--force-with-lease` is intentionally allowed, and so is force-pushing a
+   feature branch (sanctioned rebase workflow).
+4. `git reset --hard` / `git reset --merge` while the working tree is **dirty**
+   (would discard work). Clean-tree resets are intentionally allowed.
+5. `git checkout` discards: the `--` pathspec form (with or without a ref),
+   `-f`/`--force`, `--pathspec-from-file`, and bare `git checkout .`.
+   Branch switching and `-b`/`-B` creation stay allowed.
+6. `git switch --discard-changes` / `-f`/`--force`.
+7. `git restore` touching the worktree — only `git restore --staged <path>`
+   without `--worktree` is allowed (unstaging is safe).
+8. `git stash drop` / `git stash clear` (push/pop/list/apply stay allowed).
+9. `git clean` with a force flag and no dry-run — `-n`/`--dry-run` anywhere
+   makes it a safe preview.
+10. `git branch -D` (or `-d` combined with `-f`, clustered or split);
+    safe `-d` and rename `-m` stay allowed.
+11. `git tag -d`, `git reflog delete`, `git worktree remove --force`.
+12. Deletion via `find … -delete`, `find … -exec rm -rf`, and `xargs … rm -rf`
+    (plain non-recursive `rm` on find/xargs output stays allowed).
+13. Disk destroyers: `dd of=/dev/…`, `mkfs … /dev/…`, `shred`.
+14. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+
+Malformed hook input fails **closed** (exit 2 denies the command). A text-scan
+hook cannot exempt display commands, so prose like
+`echo "docs about rm -rf /"` can false-positive — quote-break the string or use
+the gh-writer heredoc form (payload is stripped before the guards run).
 
 ## View the current rules
 

--- a/plugins/lisa/hooks/parity-safety-net.sh
+++ b/plugins/lisa/hooks/parity-safety-net.sh
@@ -169,9 +169,13 @@ readonly GIT_CMD='(^|[^[:alnum:]_-])git[[:space:]]+'"$GIT_GLOBAL_OPTS"
 # `--rm`-style flags and `foo.rm` names out.
 readonly RM_CMD='(^|[^[:alnum:]_./-])([[:alnum:]_./-]*/)?rm'
 # rm invoked with BOTH a recursive and a force flag — clustered (-rf/-fr, any
-# extra letters) or split (-r … -f / long forms), in either order.
+# extra letters) or split, in either order. The split gate pairs ANY recursive
+# form (short cluster containing r, or --recursive) with ANY force form (short
+# cluster containing f, or --force), so mixed spellings like `rm -r --force /`
+# and `rm --recursive -f /` cannot slip between the short/short and long/long
+# alternations (PR #1976 review).
 readonly RM_RF_CLUSTER="$RM_CMD"'([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
-readonly RM_RF_SPLIT="$RM_CMD"'[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
+readonly RM_RF_SPLIT="$RM_CMD"'(([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*r[[:alnum:]]*|--recursive)([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|$)|([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*r[[:alnum:]]*|--recursive)([[:space:]]|$))'
 
 # 1. Recursive forced delete (`rm -rf`) of a filesystem root, home, or top-level
 #    wildcard. Two gates ANDed: the statement must invoke `rm` with BOTH a

--- a/plugins/lisa/hooks/parity-safety-net.sh
+++ b/plugins/lisa/hooks/parity-safety-net.sh
@@ -8,13 +8,18 @@
 # It reads the hook stdin JSON, inspects the proposed Bash command, and EXITS
 # NON-ZERO (2) to BLOCK when a known-destructive pattern matches:
 #   - `rm -rf` of a root / home / wildcard path (quote-aware boundaries, so
-#     `bash -c "rm -rf /"` and interpreter one-liners are caught too)
-#   - `rm -rf` of the cwd (`.`), a `..`-traversal path, an absolute path outside
-#     the project (with a /tmp, /var/tmp, $TMPDIR allowance), a `$VAR` target
-#     other than $TMPDIR, or ANY recursive forced delete while cwd is $HOME
-#   - force-pushing a protected branch (main/master/production/release) —
+#     `bash -c "rm -rf /"` and interpreter one-liners are caught too; the rm
+#     guards also match path-prefixed invocations like `/bin/rm` and `./rm`)
+#   - `rm -rf` of the cwd (`.`), a `..`-traversal path, a `~/`-anchored path,
+#     an absolute path outside the project (with a /tmp, /var/tmp, $TMPDIR
+#     allowance), a `$VAR` target other than $TMPDIR, or ANY recursive forced
+#     delete while cwd is $HOME
+#   - force-pushing a protected branch (main/master/production/prod/release) —
 #     feature-branch force-push stays allowed (sanctioned rebase workflow;
-#     deliberate divergence from upstream's any-branch block)
+#     deliberate divergence from upstream's any-branch block). Every git guard
+#     sees through leading git GLOBAL options (`-C <path>`, `-c <k>=<v>`,
+#     `--git-dir[=…]`, `--no-pager`, …), so `git -C /path <destructive>` cannot
+#     dodge the subcommand anchor
 #   - `git reset --hard` / `--merge` while the working tree is dirty. Deliberate
 #     divergence: upstream blocks unconditionally; Lisa allows clean-tree resets.
 #     Residual risk (documented, accepted): the dirty check runs in the hook's
@@ -147,31 +152,48 @@ normalized_command_str="$(printf '%s' "$command_for_guards" \
 # crossing a statement separator, so a flag in a LATER statement can never be
 # attributed to an earlier git subcommand.
 readonly GIT_TOKENS='([[:space:]]+[^;&|[:space:]]+)*[[:space:]]+'
+# Git GLOBAL options (`-C <path>`, `-c <k>=<v>`, `--git-dir[=…]`, `--no-pager`,
+# …) legally sit between `git` and its subcommand, so every subcommand guard
+# consumes them — otherwise `git -C /path checkout -- f` dodges the anchor
+# (issue #1960 security review F1). Shape: zero or more dash-led tokens, each
+# optionally followed by ONE non-dash value token, which covers both the
+# `--git-dir=/x` and `--git-dir /x` spellings without naming every option.
+readonly GIT_GLOBAL_OPTS='(-[^;&|[:space:]]+([[:space:]]+[^-;&|[:space:]][^;&|[:space:]]*)?[[:space:]]+)*'
+# Anchor for every git subcommand guard: word-bounded `git`, whitespace, then
+# any run of global options. Callers append the subcommand name directly.
+readonly GIT_CMD='(^|[^[:alnum:]_-])git[[:space:]]+'"$GIT_GLOBAL_OPTS"
+# An rm invocation: bare `rm` or a path whose basename is exactly `rm`
+# (`/bin/rm`, `./rm`) — issue #1960 security review F2. The optional prefix must
+# END IN `/` immediately before `rm`, so charm/confirm/informant/rmdir never
+# match. The preceding-char class still excludes `.`, `/`, and `-` to keep
+# `--rm`-style flags and `foo.rm` names out.
+readonly RM_CMD='(^|[^[:alnum:]_./-])([[:alnum:]_./-]*/)?rm'
 # rm invoked with BOTH a recursive and a force flag — clustered (-rf/-fr, any
 # extra letters) or split (-r … -f / long forms), in either order.
-readonly RM_RF_CLUSTER='(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
-readonly RM_RF_SPLIT='(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
+readonly RM_RF_CLUSTER="$RM_CMD"'([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
+readonly RM_RF_SPLIT="$RM_CMD"'[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
 
 # 1. Recursive forced delete (`rm -rf`) of a filesystem root, home, or top-level
-#    wildcard. Two gates ANDed: the command must invoke `rm` with BOTH a
+#    wildcard. Two gates ANDed: the statement must invoke `rm` with BOTH a
 #    recursive and a force flag, AND name a catastrophic target. Splitting the
 #    flag check from the target check keeps each regex legible and testable.
 #    The target boundary classes include quote characters (issue #1960): without
 #    them, `bash -c "rm -rf /"` and interpreter one-liners like
 #    `python -c "… os.system('rm -rf /')"` slip through because the target is
 #    quote-adjacent instead of space-bounded.
+#    Both gates run PER STATEMENT inside the shared rm loop below (quality
+#    review S1): a harmless `/` in a LATER statement (`rm -rf build && cd /`)
+#    is never attributed to the rm in an earlier one.
 qc="'\""
-if matches "$RM_RF_CLUSTER" || matches "$RM_RF_SPLIT"; then
-  if matches_cs '([[:space:]='"$qc"'])(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]'"$qc"']|/?\*?['"$qc"']?$)'; then
-    block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
-  fi
-fi
+readonly RM_CATASTROPHIC_TARGET='([[:space:]='"$qc"'])(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]'"$qc"']|/?\*?['"$qc"']?$)'
 
 # 1b. rm target hardening (issue #1960). For every statement that invokes rm
 #     with recursive+force flags, additionally block when:
 #       - cwd is $HOME (any target is one argument away from wiping home), or
 #       - the target is the cwd itself (`.` / `./`), or
 #       - the target traverses out via `..`, or
+#       - the target is home-anchored (`~/…` — the shell expands it to $HOME at
+#         execution time, so it is always outside the project), or
 #       - the target is an absolute path outside the project — with an allowance
 #         for /tmp, /var/tmp, and $TMPDIR — or
 #       - the target is a `$VAR` expansion other than the sanctioned $TMPDIR.
@@ -185,6 +207,10 @@ while IFS= read -r rm_stmt; do
   if ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_CLUSTER" \
     && ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_SPLIT"; then
     continue
+  fi
+  # Guard 1: catastrophic target named in the SAME statement as the rm -rf.
+  if printf '%s' "$rm_stmt" | grep -Eq -- "$RM_CATASTROPHIC_TARGET"; then
+    block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
   fi
   # Physical-path comparison (pwd -P): on macOS $HOME or the cwd may arrive via
   # a symlink (/var → /private/var), and a string compare would miss the match.
@@ -200,7 +226,10 @@ while IFS= read -r rm_stmt; do
     token="${token%\"}"
     token="${token%\'}"
     if [ "$seen_rm" -eq 0 ]; then
-      [ "$token" = "rm" ] && seen_rm=1
+      # Path-prefixed spellings (`/bin/rm`, `./rm`) are still rm (F2).
+      case "$token" in
+        rm | */rm) seen_rm=1 ;;
+      esac
       continue
     fi
     case "$token" in
@@ -212,6 +241,10 @@ while IFS= read -r rm_stmt; do
       .. | ../* | */.. | */../*)
         set +f
         block "recursive forced delete of a path outside the project (.. traversal)"
+        ;;
+      '~' | '~'/*)
+        set +f
+        block "recursive forced delete of a home-anchored path (~/…) outside the project"
         ;;
       /*)
         case "$token" in
@@ -235,7 +268,7 @@ while IFS= read -r rm_stmt; do
   done
   set +f
 done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
-  | grep -Ei '(^|[^[:alnum:]_./-])rm([[:space:]]|$)' || true)
+  | grep -Ei -- "$RM_CMD"'([[:space:]]|$)' || true)
 
 # 2. Force-pushing a protected branch. `--force-with-lease` is the safe,
 #    non-clobbering alternative and is intentionally NOT blocked. Deliberate
@@ -260,7 +293,7 @@ while IFS= read -r push_stmt; do
     block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
 done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
-  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b' || true)
+  | grep -Ei -- "${GIT_CMD}push\b" || true)
 
 # 3. `git reset --hard` / `git reset --merge` while the working tree has
 #    uncommitted changes — both silently discard them. Only blocks when the tree
@@ -268,7 +301,7 @@ done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
 #    Deliberate divergence from upstream's unconditional block; the accepted
 #    residual risk (dirty check runs at hook time in the hook's cwd) is
 #    documented in the header.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--(hard|merge)\b'; then
+if matches "${GIT_CMD}"'reset\b.*--(hard|merge)\b'; then
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
     && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
     block "git reset --hard/--merge on a dirty working tree would discard uncommitted changes (stash or commit first)"
@@ -280,7 +313,7 @@ fi
 #    Blocking bare `.` exceeds upstream (which allows any single positional) —
 #    issue #1960 names it explicitly: it discards the entire tree. Branch
 #    switches and creation (`-b`/`-B`) stay allowed.
-readonly GIT_CHECKOUT='(^|[^[:alnum:]_-])git[[:space:]]+checkout'
+readonly GIT_CHECKOUT="${GIT_CMD}checkout"
 if matches "${GIT_CHECKOUT}${GIT_TOKENS}"'--([[:space:]]|$)' \
   || matches "${GIT_CHECKOUT}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
   || matches "${GIT_CHECKOUT}"'[[:space:]][^;&|]*--pathspec-from-file' \
@@ -289,7 +322,7 @@ if matches "${GIT_CHECKOUT}${GIT_TOKENS}"'--([[:space:]]|$)' \
 fi
 
 # 5. `git switch` discards: `--discard-changes` and its `-f/--force` aliases.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+switch'"${GIT_TOKENS}"'(--discard-changes|--force|-f)([[:space:]]|=|$)'; then
+if matches "${GIT_CMD}switch${GIT_TOKENS}"'(--discard-changes|--force|-f)([[:space:]]|=|$)'; then
   block "git switch discarding local changes (--discard-changes/-f/--force)"
 fi
 
@@ -297,23 +330,23 @@ fi
 #    the pure staging-area form is safe: `--staged` present and `--worktree`
 #    absent. Two conditions, because an ERE has no lookahead: `--staged
 #    --worktree` still discards, so `--worktree` blocks regardless of `--staged`.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore([[:space:]]|$)'; then
-  if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--worktree' \
-    || ! matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--staged'; then
+if matches "${GIT_CMD}"'restore([[:space:]]|$)'; then
+  if matches "${GIT_CMD}"'restore[^;&|]*--worktree' \
+    || ! matches "${GIT_CMD}"'restore[^;&|]*--staged'; then
     block "git restore overwriting worktree files (only 'git restore --staged <path>' without --worktree is allowed)"
   fi
 fi
 
 # 7. `git stash drop` / `git stash clear` destroy stashed work. push/pop/list/
 #    apply — the safe alternatives the reset guard recommends — stay allowed.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+stash[[:space:]]+(drop|clear)([[:space:]]|$)'; then
+if matches "${GIT_CMD}"'stash[[:space:]]+(drop|clear)([[:space:]]|$)'; then
   block "git stash drop/clear destroys stashed work"
 fi
 
 # 8. `git clean` with a force flag wipes untracked files. A dry-run flag
 #    (`-n`/`--dry-run`) ANYWHERE wins — git itself performs no deletion under
 #    dry-run, so `git clean -fdn` is a safe preview.
-readonly GIT_CLEAN='(^|[^[:alnum:]_-])git[[:space:]]+clean'
+readonly GIT_CLEAN="${GIT_CMD}clean"
 if matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
   && ! matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*n[[:alnum:]]*|--dry-run)([[:space:]]|=|$)'; then
   block "git clean --force deletes untracked files (preview with git clean -n first)"
@@ -322,7 +355,7 @@ fi
 # 9. `git branch` force-delete loses unmerged commits: `-D`, `-d` combined with
 #    `-f` (clustered or split), or `--delete` + `--force`. Case-SENSITIVE so the
 #    safe `-d` (which refuses unmerged work) and rename `-m` stay allowed.
-readonly GIT_BRANCH='(^|[^[:alnum:]_-])git[[:space:]]+branch'
+readonly GIT_BRANCH="${GIT_CMD}branch"
 if matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*D[[:alnum:]]*([[:space:]]|$)' \
   || { matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)' \
     && matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$)'; } \
@@ -334,13 +367,13 @@ fi
 #     `git reflog delete` (erases recovery history), and
 #     `git worktree remove --force` (discards a dirty worktree). Tag deletion is
 #     case-SENSITIVE so annotated-tag `-a` and message `-m` flags never match.
-if matches_cs '(^|[^[:alnum:]_-])git[[:space:]]+tag'"${GIT_TOKENS}"'(-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)|--delete([[:space:]]|=|$))'; then
+if matches_cs "${GIT_CMD}tag${GIT_TOKENS}"'(-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)|--delete([[:space:]]|=|$))'; then
   block "git tag -d deletes a shared ref"
 fi
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+reflog[[:space:]]+delete([[:space:]]|$)'; then
+if matches "${GIT_CMD}"'reflog[[:space:]]+delete([[:space:]]|$)'; then
   block "git reflog delete erases recovery history"
 fi
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+worktree[[:space:]]+remove[^;&|]*(--force([[:space:]]|=|$)|[[:space:]]-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$))'; then
+if matches "${GIT_CMD}"'worktree[[:space:]]+remove[^;&|]*(--force([[:space:]]|=|$)|[[:space:]]-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$))'; then
   block "git worktree remove --force discards a dirty worktree (remove without --force, which refuses dirty trees)"
 fi
 

--- a/plugins/lisa/hooks/parity-safety-net.sh
+++ b/plugins/lisa/hooks/parity-safety-net.sh
@@ -1,17 +1,45 @@
 #!/usr/bin/env bash
 # PreToolUse hook for Bash: a safety net that blocks destructive shell commands
 # before they run. Lisa-native reimplementation of the upstream
-# `safety-net@cc-marketplace` plugin's PreToolUse Bash-guard (parity work, issue
-# #1059). It does NOT port upstream code — it re-expresses the behavior in Lisa's
-# hook conventions, modeled on block-no-verify.sh.
+# `safety-net@cc-marketplace` plugin's PreToolUse Bash-guard (parity work,
+# issues #1059 and #1960). It does NOT port upstream code — it re-expresses the
+# behavior in Lisa's hook conventions, modeled on block-no-verify.sh.
 #
 # It reads the hook stdin JSON, inspects the proposed Bash command, and EXITS
 # NON-ZERO (2) to BLOCK when a known-destructive pattern matches:
-#   - `rm -rf /` (recursive forced delete of a root / home / wildcard path)
-#   - force-pushing a protected branch (main/master/production/release)
-#   - `git reset --hard` while the working tree is dirty (would discard work)
-#   - dropping or truncating a database/schema/table
-# Otherwise it exits 0 and the command proceeds.
+#   - `rm -rf` of a root / home / wildcard path (quote-aware boundaries, so
+#     `bash -c "rm -rf /"` and interpreter one-liners are caught too)
+#   - `rm -rf` of the cwd (`.`), a `..`-traversal path, an absolute path outside
+#     the project (with a /tmp, /var/tmp, $TMPDIR allowance), a `$VAR` target
+#     other than $TMPDIR, or ANY recursive forced delete while cwd is $HOME
+#   - force-pushing a protected branch (main/master/production/release) —
+#     feature-branch force-push stays allowed (sanctioned rebase workflow;
+#     deliberate divergence from upstream's any-branch block)
+#   - `git reset --hard` / `--merge` while the working tree is dirty. Deliberate
+#     divergence: upstream blocks unconditionally; Lisa allows clean-tree resets.
+#     Residual risk (documented, accepted): the dirty check runs in the hook's
+#     cwd at hook time, so a `cd elsewhere && git reset --hard` evades it.
+#   - `git checkout` discards (`--`, `-f/--force`, `--pathspec-from-file`,
+#     bare `.` — the bare-`.` block exceeds upstream)
+#   - `git switch --discard-changes` / `-f/--force`
+#   - `git restore` touching the worktree (allowed only with `--staged` and
+#     without `--worktree`)
+#   - `git stash drop` / `git stash clear`
+#   - `git clean` with force and no dry-run (`-n`/`--dry-run` anywhere wins)
+#   - `git branch -D` (or `-d` + `-f` in any spelling)
+#   - `git tag -d`, `git reflog delete`, `git worktree remove --force`
+#   - `find ... -delete`, `find ... -exec rm -rf`, `xargs ... rm -rf`
+#   - disk destroyers: `dd of=/dev/...`, `mkfs ... /dev/...`, `shred`
+#   - dropping or truncating a database/schema/table (Lisa-only guard)
+# Otherwise it exits 0 and the command proceeds. Malformed hook input fails
+# CLOSED: any parse error exits 2 (a non-2 exit would be a non-blocking hook
+# error in Claude Code, silently failing open).
+#
+# Known accepted false-positive class: this is a text scan, not a shell engine,
+# so display commands quoting a destructive string (`echo "docs about rm -rf /"`)
+# can match. Upstream exempts those via an engine-only DISPLAY_COMMANDS list a
+# grep hook cannot replicate. Workaround: quote-break the string or use the
+# gh-writer heredoc form, whose payload is stripped before the guards run.
 #
 # Operators extend the built-in rules with a project-local rule file — one
 # extended-regex (ERE) per line, blank lines and `#` comments ignored — managed
@@ -19,6 +47,13 @@
 # SAFETY_NET_RULES_FILE):
 #   ${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-net-rules.txt
 set -euo pipefail
+
+# Fail CLOSED on any unexpected error (malformed JSON, missing jq, …): exit 2 so
+# the tool call is denied instead of surfacing a non-blocking hook warning.
+# Deliberately NOT `set -E`: errtrace would propagate this trap into command
+# substitutions (e.g. the heredoc parser call, whose non-zero exit codes are
+# meaningful protocol) and rewrite their status to 2 before it can be read.
+trap 'printf "%s\n" "Blocked by safety-net: hook failed while parsing its input; denying fail-closed." >&2; exit 2' ERR
 
 input="$(cat)"
 
@@ -90,22 +125,122 @@ case "$command_str" in
     ;;
 esac
 
+# matches / matches_cs run an ERE against the guarded command text. matches is
+# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
+# for guards where flag case is meaningful (`git branch -d` vs `-D`).
+matches() {
+  printf '%s' "$command_for_guards" | grep -Eiq -- "$1"
+}
+matches_cs() {
+  printf '%s' "$command_for_guards" | grep -Eq -- "$1"
+}
+
+# Normalize bash line-continuations (a trailing backslash + newline → space)
+# before segmenting the command. Without this, "git push --force origin
+# \<newline>main" splits into a segment matching --force but not `main`, letting a
+# protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
+# `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
+normalized_command_str="$(printf '%s' "$command_for_guards" \
+  | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
+
+# Shared ERE fragments. GIT_TOKENS walks over intermediate argv tokens without
+# crossing a statement separator, so a flag in a LATER statement can never be
+# attributed to an earlier git subcommand.
+readonly GIT_TOKENS='([[:space:]]+[^;&|[:space:]]+)*[[:space:]]+'
+# rm invoked with BOTH a recursive and a force flag — clustered (-rf/-fr, any
+# extra letters) or split (-r … -f / long forms), in either order.
+readonly RM_RF_CLUSTER='(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
+readonly RM_RF_SPLIT='(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
+
 # 1. Recursive forced delete (`rm -rf`) of a filesystem root, home, or top-level
 #    wildcard. Two gates ANDed: the command must invoke `rm` with BOTH a
 #    recursive and a force flag, AND name a catastrophic target. Splitting the
 #    flag check from the target check keeps each regex legible and testable.
-if printf '%s' "$command_for_guards" \
-  | grep -Eiq '(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)' \
-  || printf '%s' "$command_for_guards" \
-  | grep -Eiq '(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'; then
-  if printf '%s' "$command_for_guards" \
-    | grep -Eq '([[:space:]]|=)(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]]|/?\*?$)'; then
+#    The target boundary classes include quote characters (issue #1960): without
+#    them, `bash -c "rm -rf /"` and interpreter one-liners like
+#    `python -c "… os.system('rm -rf /')"` slip through because the target is
+#    quote-adjacent instead of space-bounded.
+qc="'\""
+if matches "$RM_RF_CLUSTER" || matches "$RM_RF_SPLIT"; then
+  if matches_cs '([[:space:]='"$qc"'])(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]'"$qc"']|/?\*?['"$qc"']?$)'; then
     block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
   fi
 fi
 
+# 1b. rm target hardening (issue #1960). For every statement that invokes rm
+#     with recursive+force flags, additionally block when:
+#       - cwd is $HOME (any target is one argument away from wiping home), or
+#       - the target is the cwd itself (`.` / `./`), or
+#       - the target traverses out via `..`, or
+#       - the target is an absolute path outside the project — with an allowance
+#         for /tmp, /var/tmp, and $TMPDIR — or
+#       - the target is a `$VAR` expansion other than the sanctioned $TMPDIR.
+#     Globbing is disabled around the token walk so a literal `*` in the command
+#     is never expanded against the hook's own cwd.
+project_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+tmp_dir_allow="${TMPDIR:-/tmp}"
+tmp_dir_allow="${tmp_dir_allow%/}"
+[ -n "$tmp_dir_allow" ] || tmp_dir_allow="/tmp"
+while IFS= read -r rm_stmt; do
+  if ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_CLUSTER" \
+    && ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_SPLIT"; then
+    continue
+  fi
+  # Physical-path comparison (pwd -P): on macOS $HOME or the cwd may arrive via
+  # a symlink (/var → /private/var), and a string compare would miss the match.
+  if [ -n "${HOME:-}" ] \
+    && [ "$(pwd -P)" = "$(cd -- "$HOME" 2>/dev/null && pwd -P)" ]; then
+    block "recursive forced delete while the working directory is \$HOME (cd into a project first)"
+  fi
+  set -f
+  seen_rm=0
+  for raw_token in $rm_stmt; do
+    token="${raw_token#\"}"
+    token="${token#\'}"
+    token="${token%\"}"
+    token="${token%\'}"
+    if [ "$seen_rm" -eq 0 ]; then
+      [ "$token" = "rm" ] && seen_rm=1
+      continue
+    fi
+    case "$token" in
+      -*) continue ;;
+      . | ./)
+        set +f
+        block "recursive forced delete of the current directory (rm -rf .)"
+        ;;
+      .. | ../* | */.. | */../*)
+        set +f
+        block "recursive forced delete of a path outside the project (.. traversal)"
+        ;;
+      /*)
+        case "$token" in
+          "$project_dir" | "$project_dir"/* | /tmp | /tmp/* | /var/tmp | /var/tmp/* | "$tmp_dir_allow" | "$tmp_dir_allow"/*) : ;;
+          *)
+            set +f
+            block "recursive forced delete of an absolute path outside the project (only the project, /tmp, /var/tmp, and \$TMPDIR are allowed)"
+            ;;
+        esac
+        ;;
+      *'$'*)
+        case "$token" in
+          '$TMPDIR' | '$TMPDIR'/* | '${TMPDIR}' | '${TMPDIR}'/*) : ;;
+          *)
+            set +f
+            block "recursive forced delete of a variable-expanded target (unset or mistyped variables can point anywhere; \$TMPDIR is the only sanctioned dynamic target)"
+            ;;
+        esac
+        ;;
+    esac
+  done
+  set +f
+done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
+  | grep -Ei '(^|[^[:alnum:]_./-])rm([[:space:]]|$)' || true)
+
 # 2. Force-pushing a protected branch. `--force-with-lease` is the safe,
-#    non-clobbering alternative and is intentionally NOT blocked.
+#    non-clobbering alternative and is intentionally NOT blocked. Deliberate
+#    divergence from upstream (which blocks force-push on ANY branch):
+#    feature-branch force-push is a sanctioned rebase-and-push agent workflow.
 #
 #    The force flag AND the protected-branch name must appear in the SAME
 #    `git push` statement. Checking them independently over the whole command is
@@ -116,14 +251,6 @@ fi
 #    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
 #    inspect each in isolation — a real `git push --force origin main` still
 #    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
-# Normalize bash line-continuations (a trailing backslash + newline → space)
-# before segmenting the command. Without this, "git push --force origin
-# \<newline>main" splits into a segment matching --force but not `main`, letting a
-# protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
-# `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
-normalized_command_str="$(printf '%s' "$command_for_guards" \
-  | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
-
 while IFS= read -r push_stmt; do
   if printf '%s' "$push_stmt" \
     | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
@@ -133,25 +260,125 @@ while IFS= read -r push_stmt; do
     block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
 done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
-  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b')
+  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b' || true)
 
-# 3. `git reset --hard` while the working tree has uncommitted changes — this
-#    silently discards them. Only blocks when the tree is actually dirty, so a
-#    clean-tree reset (a legitimate workflow) still passes.
-if printf '%s' "$command_for_guards" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--hard\b'; then
+# 3. `git reset --hard` / `git reset --merge` while the working tree has
+#    uncommitted changes — both silently discard them. Only blocks when the tree
+#    is actually dirty, so a clean-tree reset (a legitimate workflow) passes.
+#    Deliberate divergence from upstream's unconditional block; the accepted
+#    residual risk (dirty check runs at hook time in the hook's cwd) is
+#    documented in the header.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--(hard|merge)\b'; then
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
     && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-    block "git reset --hard on a dirty working tree would discard uncommitted changes (stash or commit first)"
+    block "git reset --hard/--merge on a dirty working tree would discard uncommitted changes (stash or commit first)"
   fi
 fi
 
-# 4. Dropping or truncating a database / schema / table.
-if printf '%s' "$command_for_guards" \
-  | grep -Eiq '\b(drop[[:space:]]+(database|schema|table)|truncate[[:space:]]+(table[[:space:]]+)?[[:alnum:]_."`]+)\b'; then
+# 4. `git checkout` worktree discards: the `--` pathspec form (with or without a
+#    ref), `-f/--force`, `--pathspec-from-file`, and bare `git checkout .`.
+#    Blocking bare `.` exceeds upstream (which allows any single positional) —
+#    issue #1960 names it explicitly: it discards the entire tree. Branch
+#    switches and creation (`-b`/`-B`) stay allowed.
+readonly GIT_CHECKOUT='(^|[^[:alnum:]_-])git[[:space:]]+checkout'
+if matches "${GIT_CHECKOUT}${GIT_TOKENS}"'--([[:space:]]|$)' \
+  || matches "${GIT_CHECKOUT}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
+  || matches "${GIT_CHECKOUT}"'[[:space:]][^;&|]*--pathspec-from-file' \
+  || matches "${GIT_CHECKOUT}"'[[:space:]]+\.(/)?([[:space:]]|$)'; then
+  block "git checkout discarding local changes (--, -f/--force, --pathspec-from-file, or bare .) — use git stash to preserve work first"
+fi
+
+# 5. `git switch` discards: `--discard-changes` and its `-f/--force` aliases.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+switch'"${GIT_TOKENS}"'(--discard-changes|--force|-f)([[:space:]]|=|$)'; then
+  block "git switch discarding local changes (--discard-changes/-f/--force)"
+fi
+
+# 6. `git restore` defaults to overwriting the WORKTREE — a silent discard. Only
+#    the pure staging-area form is safe: `--staged` present and `--worktree`
+#    absent. Two conditions, because an ERE has no lookahead: `--staged
+#    --worktree` still discards, so `--worktree` blocks regardless of `--staged`.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore([[:space:]]|$)'; then
+  if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--worktree' \
+    || ! matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--staged'; then
+    block "git restore overwriting worktree files (only 'git restore --staged <path>' without --worktree is allowed)"
+  fi
+fi
+
+# 7. `git stash drop` / `git stash clear` destroy stashed work. push/pop/list/
+#    apply — the safe alternatives the reset guard recommends — stay allowed.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+stash[[:space:]]+(drop|clear)([[:space:]]|$)'; then
+  block "git stash drop/clear destroys stashed work"
+fi
+
+# 8. `git clean` with a force flag wipes untracked files. A dry-run flag
+#    (`-n`/`--dry-run`) ANYWHERE wins — git itself performs no deletion under
+#    dry-run, so `git clean -fdn` is a safe preview.
+readonly GIT_CLEAN='(^|[^[:alnum:]_-])git[[:space:]]+clean'
+if matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
+  && ! matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*n[[:alnum:]]*|--dry-run)([[:space:]]|=|$)'; then
+  block "git clean --force deletes untracked files (preview with git clean -n first)"
+fi
+
+# 9. `git branch` force-delete loses unmerged commits: `-D`, `-d` combined with
+#    `-f` (clustered or split), or `--delete` + `--force`. Case-SENSITIVE so the
+#    safe `-d` (which refuses unmerged work) and rename `-m` stay allowed.
+readonly GIT_BRANCH='(^|[^[:alnum:]_-])git[[:space:]]+branch'
+if matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*D[[:alnum:]]*([[:space:]]|$)' \
+  || { matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)' \
+    && matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$)'; } \
+  || { matches "${GIT_BRANCH}"'[^;&|]*--delete' && matches "${GIT_BRANCH}"'[^;&|]*--force'; }; then
+  block "git branch force-delete (-D) loses unmerged commits (use -d, which refuses unmerged work)"
+fi
+
+# 10. Cheap destructive-ref guards: `git tag -d` (tags are shared refs),
+#     `git reflog delete` (erases recovery history), and
+#     `git worktree remove --force` (discards a dirty worktree). Tag deletion is
+#     case-SENSITIVE so annotated-tag `-a` and message `-m` flags never match.
+if matches_cs '(^|[^[:alnum:]_-])git[[:space:]]+tag'"${GIT_TOKENS}"'(-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)|--delete([[:space:]]|=|$))'; then
+  block "git tag -d deletes a shared ref"
+fi
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+reflog[[:space:]]+delete([[:space:]]|$)'; then
+  block "git reflog delete erases recovery history"
+fi
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+worktree[[:space:]]+remove[^;&|]*(--force([[:space:]]|=|$)|[[:space:]]-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$))'; then
+  block "git worktree remove --force discards a dirty worktree (remove without --force, which refuses dirty trees)"
+fi
+
+# 11. Deletion through find/xargs, where the target never appears as a literal
+#     argument: `find … -delete`, `find … -exec rm -rf`, and `xargs … rm -rf`
+#     (targets arrive from dynamic stdin — unauditable). Plain `rm` (no
+#     recursive+force) on find/xargs output stays allowed for normal cleanups.
+if matches '(^|[^[:alnum:]_./-])find[[:space:]][^;&|]*[[:space:]]-delete([[:space:]]|$)'; then
+  block "find -delete removes files tree-wide (use -print to preview, or an explicit rm on reviewed paths)"
+fi
+if matches '(^|[^[:alnum:]_./-])find[[:space:]][^;&|]*-exec[[:space:]]+rm[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'; then
+  block "find -exec rm -rf performs a recursive forced delete on unreviewed paths"
+fi
+if matches '(^|[^[:alnum:]_./-])xargs[[:space:]]([^;&|]*[[:space:]])?rm[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'; then
+  block "xargs rm -rf performs a recursive forced delete on dynamic stdin input"
+fi
+
+# 12. Disk destroyers, always on (exceeds upstream, which only scans these
+#     inside interpreter one-liners): writing to a raw /dev node via dd,
+#     formatting a device with mkfs, and shred's unrecoverable overwrite.
+#     dd/mkfs against regular files (imaging) stays allowed.
+if matches '(^|[^[:alnum:]_./-])dd[[:space:]]+([^;&|]*[[:space:]])?of=/dev/'; then
+  block "dd writing to a raw device (of=/dev/…) destroys it"
+fi
+if matches '(^|[^[:alnum:]_./-])mkfs(\.[[:alnum:]]+)?[[:space:]][^;&|]*/dev/'; then
+  block "mkfs formatting a device erases it"
+fi
+if matches '(^|[^[:alnum:]_./-])shred([[:space:]]|$)'; then
+  block "shred overwrites files unrecoverably"
+fi
+
+# 13. Dropping or truncating a database / schema / table (Lisa-only guard —
+#     upstream has no SQL protection; keep).
+if matches '\b(drop[[:space:]]+(database|schema|table)|truncate[[:space:]]+(table[[:space:]]+)?[[:alnum:]_."`]+)\b'; then
   block "destructive SQL (DROP/TRUNCATE) detected"
 fi
 
-# 5. Project-local custom rules. Each non-comment line is an ERE; a match blocks.
+# 14. Project-local custom rules. Each non-comment line is an ERE; a match blocks.
 rules_file="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-net-rules.txt}"
 if [ -f "$rules_file" ]; then
   while IFS= read -r rule || [ -n "$rule" ]; do

--- a/plugins/lisa/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -56,13 +56,17 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
 1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard — with
    quote-aware boundaries, so wrapper/interpreter forms like
    `bash -c "rm -rf /"` and `python -c "… os.system('rm -rf /')"` match too.
+   Path-prefixed spellings (`/bin/rm`, `./rm`) count as `rm` for every rm
+   guard.
 2. `rm -rf` target hardening: the cwd itself (`.`/`./`), `..`-traversal paths,
-   absolute paths outside the project (`/tmp`, `/var/tmp`, and `$TMPDIR` are
-   allowed), `$VAR` targets other than `$TMPDIR`, and **any** recursive forced
-   delete while the working directory is `$HOME`.
-3. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
-   `--force-with-lease` is intentionally allowed, and so is force-pushing a
-   feature branch (sanctioned rebase workflow).
+   home-anchored `~/…` paths, absolute paths outside the project (`/tmp`,
+   `/var/tmp`, and `$TMPDIR` are allowed), `$VAR` targets other than `$TMPDIR`,
+   and **any** recursive forced delete while the working directory is `$HOME`.
+3. Force-pushing a protected branch
+   (`main`/`master`/`production`/`prod`/`release`). `--force-with-lease` is
+   intentionally allowed, and so is force-pushing a feature branch (sanctioned
+   rebase workflow). Acceptable parity divergence: a refspec force-push
+   (`git push origin +main`) is not blocked — upstream 1.0.6 allows it too.
 4. `git reset --hard` / `git reset --merge` while the working tree is **dirty**
    (would discard work). Clean-tree resets are intentionally allowed.
 5. `git checkout` discards: the `--` pathspec form (with or without a ref),
@@ -81,6 +85,10 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
     (plain non-recursive `rm` on find/xargs output stays allowed).
 13. Disk destroyers: `dd of=/dev/…`, `mkfs … /dev/…`, `shred`.
 14. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+
+Every git guard sees through leading git **global options** (`-C <path>`,
+`-c <k>=<v>`, `--git-dir[=…]`, `--no-pager`, …), so `git -C /path <destructive>`
+is screened the same as `git <destructive>`.
 
 Malformed hook input fails **closed** (exit 2 denies the command). A text-scan
 hook cannot exempt display commands, so prose like

--- a/plugins/lisa/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -53,11 +53,39 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
 
 ### Built-in guards (always on)
 
-1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard.
-2. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
-   `--force-with-lease` is intentionally allowed.
-3. `git reset --hard` while the working tree is **dirty** (would discard work).
-4. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard — with
+   quote-aware boundaries, so wrapper/interpreter forms like
+   `bash -c "rm -rf /"` and `python -c "… os.system('rm -rf /')"` match too.
+2. `rm -rf` target hardening: the cwd itself (`.`/`./`), `..`-traversal paths,
+   absolute paths outside the project (`/tmp`, `/var/tmp`, and `$TMPDIR` are
+   allowed), `$VAR` targets other than `$TMPDIR`, and **any** recursive forced
+   delete while the working directory is `$HOME`.
+3. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
+   `--force-with-lease` is intentionally allowed, and so is force-pushing a
+   feature branch (sanctioned rebase workflow).
+4. `git reset --hard` / `git reset --merge` while the working tree is **dirty**
+   (would discard work). Clean-tree resets are intentionally allowed.
+5. `git checkout` discards: the `--` pathspec form (with or without a ref),
+   `-f`/`--force`, `--pathspec-from-file`, and bare `git checkout .`.
+   Branch switching and `-b`/`-B` creation stay allowed.
+6. `git switch --discard-changes` / `-f`/`--force`.
+7. `git restore` touching the worktree — only `git restore --staged <path>`
+   without `--worktree` is allowed (unstaging is safe).
+8. `git stash drop` / `git stash clear` (push/pop/list/apply stay allowed).
+9. `git clean` with a force flag and no dry-run — `-n`/`--dry-run` anywhere
+   makes it a safe preview.
+10. `git branch -D` (or `-d` combined with `-f`, clustered or split);
+    safe `-d` and rename `-m` stay allowed.
+11. `git tag -d`, `git reflog delete`, `git worktree remove --force`.
+12. Deletion via `find … -delete`, `find … -exec rm -rf`, and `xargs … rm -rf`
+    (plain non-recursive `rm` on find/xargs output stays allowed).
+13. Disk destroyers: `dd of=/dev/…`, `mkfs … /dev/…`, `shred`.
+14. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+
+Malformed hook input fails **closed** (exit 2 denies the command). A text-scan
+hook cannot exempt display commands, so prose like
+`echo "docs about rm -rf /"` can false-positive — quote-break the string or use
+the gh-writer heredoc form (payload is stripped before the guards run).
 
 ## View the current rules
 

--- a/plugins/src/base/hooks/parity-safety-net.sh
+++ b/plugins/src/base/hooks/parity-safety-net.sh
@@ -169,9 +169,13 @@ readonly GIT_CMD='(^|[^[:alnum:]_-])git[[:space:]]+'"$GIT_GLOBAL_OPTS"
 # `--rm`-style flags and `foo.rm` names out.
 readonly RM_CMD='(^|[^[:alnum:]_./-])([[:alnum:]_./-]*/)?rm'
 # rm invoked with BOTH a recursive and a force flag — clustered (-rf/-fr, any
-# extra letters) or split (-r … -f / long forms), in either order.
+# extra letters) or split, in either order. The split gate pairs ANY recursive
+# form (short cluster containing r, or --recursive) with ANY force form (short
+# cluster containing f, or --force), so mixed spellings like `rm -r --force /`
+# and `rm --recursive -f /` cannot slip between the short/short and long/long
+# alternations (PR #1976 review).
 readonly RM_RF_CLUSTER="$RM_CMD"'([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
-readonly RM_RF_SPLIT="$RM_CMD"'[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
+readonly RM_RF_SPLIT="$RM_CMD"'(([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*r[[:alnum:]]*|--recursive)([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|$)|([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]][^;&|]*)?[[:space:]](-[[:alnum:]]*r[[:alnum:]]*|--recursive)([[:space:]]|$))'
 
 # 1. Recursive forced delete (`rm -rf`) of a filesystem root, home, or top-level
 #    wildcard. Two gates ANDed: the statement must invoke `rm` with BOTH a

--- a/plugins/src/base/hooks/parity-safety-net.sh
+++ b/plugins/src/base/hooks/parity-safety-net.sh
@@ -8,13 +8,18 @@
 # It reads the hook stdin JSON, inspects the proposed Bash command, and EXITS
 # NON-ZERO (2) to BLOCK when a known-destructive pattern matches:
 #   - `rm -rf` of a root / home / wildcard path (quote-aware boundaries, so
-#     `bash -c "rm -rf /"` and interpreter one-liners are caught too)
-#   - `rm -rf` of the cwd (`.`), a `..`-traversal path, an absolute path outside
-#     the project (with a /tmp, /var/tmp, $TMPDIR allowance), a `$VAR` target
-#     other than $TMPDIR, or ANY recursive forced delete while cwd is $HOME
-#   - force-pushing a protected branch (main/master/production/release) —
+#     `bash -c "rm -rf /"` and interpreter one-liners are caught too; the rm
+#     guards also match path-prefixed invocations like `/bin/rm` and `./rm`)
+#   - `rm -rf` of the cwd (`.`), a `..`-traversal path, a `~/`-anchored path,
+#     an absolute path outside the project (with a /tmp, /var/tmp, $TMPDIR
+#     allowance), a `$VAR` target other than $TMPDIR, or ANY recursive forced
+#     delete while cwd is $HOME
+#   - force-pushing a protected branch (main/master/production/prod/release) —
 #     feature-branch force-push stays allowed (sanctioned rebase workflow;
-#     deliberate divergence from upstream's any-branch block)
+#     deliberate divergence from upstream's any-branch block). Every git guard
+#     sees through leading git GLOBAL options (`-C <path>`, `-c <k>=<v>`,
+#     `--git-dir[=…]`, `--no-pager`, …), so `git -C /path <destructive>` cannot
+#     dodge the subcommand anchor
 #   - `git reset --hard` / `--merge` while the working tree is dirty. Deliberate
 #     divergence: upstream blocks unconditionally; Lisa allows clean-tree resets.
 #     Residual risk (documented, accepted): the dirty check runs in the hook's
@@ -147,31 +152,48 @@ normalized_command_str="$(printf '%s' "$command_for_guards" \
 # crossing a statement separator, so a flag in a LATER statement can never be
 # attributed to an earlier git subcommand.
 readonly GIT_TOKENS='([[:space:]]+[^;&|[:space:]]+)*[[:space:]]+'
+# Git GLOBAL options (`-C <path>`, `-c <k>=<v>`, `--git-dir[=…]`, `--no-pager`,
+# …) legally sit between `git` and its subcommand, so every subcommand guard
+# consumes them — otherwise `git -C /path checkout -- f` dodges the anchor
+# (issue #1960 security review F1). Shape: zero or more dash-led tokens, each
+# optionally followed by ONE non-dash value token, which covers both the
+# `--git-dir=/x` and `--git-dir /x` spellings without naming every option.
+readonly GIT_GLOBAL_OPTS='(-[^;&|[:space:]]+([[:space:]]+[^-;&|[:space:]][^;&|[:space:]]*)?[[:space:]]+)*'
+# Anchor for every git subcommand guard: word-bounded `git`, whitespace, then
+# any run of global options. Callers append the subcommand name directly.
+readonly GIT_CMD='(^|[^[:alnum:]_-])git[[:space:]]+'"$GIT_GLOBAL_OPTS"
+# An rm invocation: bare `rm` or a path whose basename is exactly `rm`
+# (`/bin/rm`, `./rm`) — issue #1960 security review F2. The optional prefix must
+# END IN `/` immediately before `rm`, so charm/confirm/informant/rmdir never
+# match. The preceding-char class still excludes `.`, `/`, and `-` to keep
+# `--rm`-style flags and `foo.rm` names out.
+readonly RM_CMD='(^|[^[:alnum:]_./-])([[:alnum:]_./-]*/)?rm'
 # rm invoked with BOTH a recursive and a force flag — clustered (-rf/-fr, any
 # extra letters) or split (-r … -f / long forms), in either order.
-readonly RM_RF_CLUSTER='(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
-readonly RM_RF_SPLIT='(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
+readonly RM_RF_CLUSTER="$RM_CMD"'([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
+readonly RM_RF_SPLIT="$RM_CMD"'[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
 
 # 1. Recursive forced delete (`rm -rf`) of a filesystem root, home, or top-level
-#    wildcard. Two gates ANDed: the command must invoke `rm` with BOTH a
+#    wildcard. Two gates ANDed: the statement must invoke `rm` with BOTH a
 #    recursive and a force flag, AND name a catastrophic target. Splitting the
 #    flag check from the target check keeps each regex legible and testable.
 #    The target boundary classes include quote characters (issue #1960): without
 #    them, `bash -c "rm -rf /"` and interpreter one-liners like
 #    `python -c "… os.system('rm -rf /')"` slip through because the target is
 #    quote-adjacent instead of space-bounded.
+#    Both gates run PER STATEMENT inside the shared rm loop below (quality
+#    review S1): a harmless `/` in a LATER statement (`rm -rf build && cd /`)
+#    is never attributed to the rm in an earlier one.
 qc="'\""
-if matches "$RM_RF_CLUSTER" || matches "$RM_RF_SPLIT"; then
-  if matches_cs '([[:space:]='"$qc"'])(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]'"$qc"']|/?\*?['"$qc"']?$)'; then
-    block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
-  fi
-fi
+readonly RM_CATASTROPHIC_TARGET='([[:space:]='"$qc"'])(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]'"$qc"']|/?\*?['"$qc"']?$)'
 
 # 1b. rm target hardening (issue #1960). For every statement that invokes rm
 #     with recursive+force flags, additionally block when:
 #       - cwd is $HOME (any target is one argument away from wiping home), or
 #       - the target is the cwd itself (`.` / `./`), or
 #       - the target traverses out via `..`, or
+#       - the target is home-anchored (`~/…` — the shell expands it to $HOME at
+#         execution time, so it is always outside the project), or
 #       - the target is an absolute path outside the project — with an allowance
 #         for /tmp, /var/tmp, and $TMPDIR — or
 #       - the target is a `$VAR` expansion other than the sanctioned $TMPDIR.
@@ -185,6 +207,10 @@ while IFS= read -r rm_stmt; do
   if ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_CLUSTER" \
     && ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_SPLIT"; then
     continue
+  fi
+  # Guard 1: catastrophic target named in the SAME statement as the rm -rf.
+  if printf '%s' "$rm_stmt" | grep -Eq -- "$RM_CATASTROPHIC_TARGET"; then
+    block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
   fi
   # Physical-path comparison (pwd -P): on macOS $HOME or the cwd may arrive via
   # a symlink (/var → /private/var), and a string compare would miss the match.
@@ -200,7 +226,10 @@ while IFS= read -r rm_stmt; do
     token="${token%\"}"
     token="${token%\'}"
     if [ "$seen_rm" -eq 0 ]; then
-      [ "$token" = "rm" ] && seen_rm=1
+      # Path-prefixed spellings (`/bin/rm`, `./rm`) are still rm (F2).
+      case "$token" in
+        rm | */rm) seen_rm=1 ;;
+      esac
       continue
     fi
     case "$token" in
@@ -212,6 +241,10 @@ while IFS= read -r rm_stmt; do
       .. | ../* | */.. | */../*)
         set +f
         block "recursive forced delete of a path outside the project (.. traversal)"
+        ;;
+      '~' | '~'/*)
+        set +f
+        block "recursive forced delete of a home-anchored path (~/…) outside the project"
         ;;
       /*)
         case "$token" in
@@ -235,7 +268,7 @@ while IFS= read -r rm_stmt; do
   done
   set +f
 done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
-  | grep -Ei '(^|[^[:alnum:]_./-])rm([[:space:]]|$)' || true)
+  | grep -Ei -- "$RM_CMD"'([[:space:]]|$)' || true)
 
 # 2. Force-pushing a protected branch. `--force-with-lease` is the safe,
 #    non-clobbering alternative and is intentionally NOT blocked. Deliberate
@@ -260,7 +293,7 @@ while IFS= read -r push_stmt; do
     block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
 done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
-  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b' || true)
+  | grep -Ei -- "${GIT_CMD}push\b" || true)
 
 # 3. `git reset --hard` / `git reset --merge` while the working tree has
 #    uncommitted changes — both silently discard them. Only blocks when the tree
@@ -268,7 +301,7 @@ done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
 #    Deliberate divergence from upstream's unconditional block; the accepted
 #    residual risk (dirty check runs at hook time in the hook's cwd) is
 #    documented in the header.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--(hard|merge)\b'; then
+if matches "${GIT_CMD}"'reset\b.*--(hard|merge)\b'; then
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
     && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
     block "git reset --hard/--merge on a dirty working tree would discard uncommitted changes (stash or commit first)"
@@ -280,7 +313,7 @@ fi
 #    Blocking bare `.` exceeds upstream (which allows any single positional) —
 #    issue #1960 names it explicitly: it discards the entire tree. Branch
 #    switches and creation (`-b`/`-B`) stay allowed.
-readonly GIT_CHECKOUT='(^|[^[:alnum:]_-])git[[:space:]]+checkout'
+readonly GIT_CHECKOUT="${GIT_CMD}checkout"
 if matches "${GIT_CHECKOUT}${GIT_TOKENS}"'--([[:space:]]|$)' \
   || matches "${GIT_CHECKOUT}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
   || matches "${GIT_CHECKOUT}"'[[:space:]][^;&|]*--pathspec-from-file' \
@@ -289,7 +322,7 @@ if matches "${GIT_CHECKOUT}${GIT_TOKENS}"'--([[:space:]]|$)' \
 fi
 
 # 5. `git switch` discards: `--discard-changes` and its `-f/--force` aliases.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+switch'"${GIT_TOKENS}"'(--discard-changes|--force|-f)([[:space:]]|=|$)'; then
+if matches "${GIT_CMD}switch${GIT_TOKENS}"'(--discard-changes|--force|-f)([[:space:]]|=|$)'; then
   block "git switch discarding local changes (--discard-changes/-f/--force)"
 fi
 
@@ -297,23 +330,23 @@ fi
 #    the pure staging-area form is safe: `--staged` present and `--worktree`
 #    absent. Two conditions, because an ERE has no lookahead: `--staged
 #    --worktree` still discards, so `--worktree` blocks regardless of `--staged`.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore([[:space:]]|$)'; then
-  if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--worktree' \
-    || ! matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--staged'; then
+if matches "${GIT_CMD}"'restore([[:space:]]|$)'; then
+  if matches "${GIT_CMD}"'restore[^;&|]*--worktree' \
+    || ! matches "${GIT_CMD}"'restore[^;&|]*--staged'; then
     block "git restore overwriting worktree files (only 'git restore --staged <path>' without --worktree is allowed)"
   fi
 fi
 
 # 7. `git stash drop` / `git stash clear` destroy stashed work. push/pop/list/
 #    apply — the safe alternatives the reset guard recommends — stay allowed.
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+stash[[:space:]]+(drop|clear)([[:space:]]|$)'; then
+if matches "${GIT_CMD}"'stash[[:space:]]+(drop|clear)([[:space:]]|$)'; then
   block "git stash drop/clear destroys stashed work"
 fi
 
 # 8. `git clean` with a force flag wipes untracked files. A dry-run flag
 #    (`-n`/`--dry-run`) ANYWHERE wins — git itself performs no deletion under
 #    dry-run, so `git clean -fdn` is a safe preview.
-readonly GIT_CLEAN='(^|[^[:alnum:]_-])git[[:space:]]+clean'
+readonly GIT_CLEAN="${GIT_CMD}clean"
 if matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
   && ! matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*n[[:alnum:]]*|--dry-run)([[:space:]]|=|$)'; then
   block "git clean --force deletes untracked files (preview with git clean -n first)"
@@ -322,7 +355,7 @@ fi
 # 9. `git branch` force-delete loses unmerged commits: `-D`, `-d` combined with
 #    `-f` (clustered or split), or `--delete` + `--force`. Case-SENSITIVE so the
 #    safe `-d` (which refuses unmerged work) and rename `-m` stay allowed.
-readonly GIT_BRANCH='(^|[^[:alnum:]_-])git[[:space:]]+branch'
+readonly GIT_BRANCH="${GIT_CMD}branch"
 if matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*D[[:alnum:]]*([[:space:]]|$)' \
   || { matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)' \
     && matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$)'; } \
@@ -334,13 +367,13 @@ fi
 #     `git reflog delete` (erases recovery history), and
 #     `git worktree remove --force` (discards a dirty worktree). Tag deletion is
 #     case-SENSITIVE so annotated-tag `-a` and message `-m` flags never match.
-if matches_cs '(^|[^[:alnum:]_-])git[[:space:]]+tag'"${GIT_TOKENS}"'(-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)|--delete([[:space:]]|=|$))'; then
+if matches_cs "${GIT_CMD}tag${GIT_TOKENS}"'(-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)|--delete([[:space:]]|=|$))'; then
   block "git tag -d deletes a shared ref"
 fi
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+reflog[[:space:]]+delete([[:space:]]|$)'; then
+if matches "${GIT_CMD}"'reflog[[:space:]]+delete([[:space:]]|$)'; then
   block "git reflog delete erases recovery history"
 fi
-if matches '(^|[^[:alnum:]_-])git[[:space:]]+worktree[[:space:]]+remove[^;&|]*(--force([[:space:]]|=|$)|[[:space:]]-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$))'; then
+if matches "${GIT_CMD}"'worktree[[:space:]]+remove[^;&|]*(--force([[:space:]]|=|$)|[[:space:]]-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$))'; then
   block "git worktree remove --force discards a dirty worktree (remove without --force, which refuses dirty trees)"
 fi
 

--- a/plugins/src/base/hooks/parity-safety-net.sh
+++ b/plugins/src/base/hooks/parity-safety-net.sh
@@ -1,17 +1,45 @@
 #!/usr/bin/env bash
 # PreToolUse hook for Bash: a safety net that blocks destructive shell commands
 # before they run. Lisa-native reimplementation of the upstream
-# `safety-net@cc-marketplace` plugin's PreToolUse Bash-guard (parity work, issue
-# #1059). It does NOT port upstream code — it re-expresses the behavior in Lisa's
-# hook conventions, modeled on block-no-verify.sh.
+# `safety-net@cc-marketplace` plugin's PreToolUse Bash-guard (parity work,
+# issues #1059 and #1960). It does NOT port upstream code — it re-expresses the
+# behavior in Lisa's hook conventions, modeled on block-no-verify.sh.
 #
 # It reads the hook stdin JSON, inspects the proposed Bash command, and EXITS
 # NON-ZERO (2) to BLOCK when a known-destructive pattern matches:
-#   - `rm -rf /` (recursive forced delete of a root / home / wildcard path)
-#   - force-pushing a protected branch (main/master/production/release)
-#   - `git reset --hard` while the working tree is dirty (would discard work)
-#   - dropping or truncating a database/schema/table
-# Otherwise it exits 0 and the command proceeds.
+#   - `rm -rf` of a root / home / wildcard path (quote-aware boundaries, so
+#     `bash -c "rm -rf /"` and interpreter one-liners are caught too)
+#   - `rm -rf` of the cwd (`.`), a `..`-traversal path, an absolute path outside
+#     the project (with a /tmp, /var/tmp, $TMPDIR allowance), a `$VAR` target
+#     other than $TMPDIR, or ANY recursive forced delete while cwd is $HOME
+#   - force-pushing a protected branch (main/master/production/release) —
+#     feature-branch force-push stays allowed (sanctioned rebase workflow;
+#     deliberate divergence from upstream's any-branch block)
+#   - `git reset --hard` / `--merge` while the working tree is dirty. Deliberate
+#     divergence: upstream blocks unconditionally; Lisa allows clean-tree resets.
+#     Residual risk (documented, accepted): the dirty check runs in the hook's
+#     cwd at hook time, so a `cd elsewhere && git reset --hard` evades it.
+#   - `git checkout` discards (`--`, `-f/--force`, `--pathspec-from-file`,
+#     bare `.` — the bare-`.` block exceeds upstream)
+#   - `git switch --discard-changes` / `-f/--force`
+#   - `git restore` touching the worktree (allowed only with `--staged` and
+#     without `--worktree`)
+#   - `git stash drop` / `git stash clear`
+#   - `git clean` with force and no dry-run (`-n`/`--dry-run` anywhere wins)
+#   - `git branch -D` (or `-d` + `-f` in any spelling)
+#   - `git tag -d`, `git reflog delete`, `git worktree remove --force`
+#   - `find ... -delete`, `find ... -exec rm -rf`, `xargs ... rm -rf`
+#   - disk destroyers: `dd of=/dev/...`, `mkfs ... /dev/...`, `shred`
+#   - dropping or truncating a database/schema/table (Lisa-only guard)
+# Otherwise it exits 0 and the command proceeds. Malformed hook input fails
+# CLOSED: any parse error exits 2 (a non-2 exit would be a non-blocking hook
+# error in Claude Code, silently failing open).
+#
+# Known accepted false-positive class: this is a text scan, not a shell engine,
+# so display commands quoting a destructive string (`echo "docs about rm -rf /"`)
+# can match. Upstream exempts those via an engine-only DISPLAY_COMMANDS list a
+# grep hook cannot replicate. Workaround: quote-break the string or use the
+# gh-writer heredoc form, whose payload is stripped before the guards run.
 #
 # Operators extend the built-in rules with a project-local rule file — one
 # extended-regex (ERE) per line, blank lines and `#` comments ignored — managed
@@ -19,6 +47,13 @@
 # SAFETY_NET_RULES_FILE):
 #   ${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-net-rules.txt
 set -euo pipefail
+
+# Fail CLOSED on any unexpected error (malformed JSON, missing jq, …): exit 2 so
+# the tool call is denied instead of surfacing a non-blocking hook warning.
+# Deliberately NOT `set -E`: errtrace would propagate this trap into command
+# substitutions (e.g. the heredoc parser call, whose non-zero exit codes are
+# meaningful protocol) and rewrite their status to 2 before it can be read.
+trap 'printf "%s\n" "Blocked by safety-net: hook failed while parsing its input; denying fail-closed." >&2; exit 2' ERR
 
 input="$(cat)"
 
@@ -90,22 +125,122 @@ case "$command_str" in
     ;;
 esac
 
+# matches / matches_cs run an ERE against the guarded command text. matches is
+# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
+# for guards where flag case is meaningful (`git branch -d` vs `-D`).
+matches() {
+  printf '%s' "$command_for_guards" | grep -Eiq -- "$1"
+}
+matches_cs() {
+  printf '%s' "$command_for_guards" | grep -Eq -- "$1"
+}
+
+# Normalize bash line-continuations (a trailing backslash + newline → space)
+# before segmenting the command. Without this, "git push --force origin
+# \<newline>main" splits into a segment matching --force but not `main`, letting a
+# protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
+# `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
+normalized_command_str="$(printf '%s' "$command_for_guards" \
+  | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
+
+# Shared ERE fragments. GIT_TOKENS walks over intermediate argv tokens without
+# crossing a statement separator, so a flag in a LATER statement can never be
+# attributed to an earlier git subcommand.
+readonly GIT_TOKENS='([[:space:]]+[^;&|[:space:]]+)*[[:space:]]+'
+# rm invoked with BOTH a recursive and a force flag — clustered (-rf/-fr, any
+# extra letters) or split (-r … -f / long forms), in either order.
+readonly RM_RF_CLUSTER='(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'
+readonly RM_RF_SPLIT='(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'
+
 # 1. Recursive forced delete (`rm -rf`) of a filesystem root, home, or top-level
 #    wildcard. Two gates ANDed: the command must invoke `rm` with BOTH a
 #    recursive and a force flag, AND name a catastrophic target. Splitting the
 #    flag check from the target check keeps each regex legible and testable.
-if printf '%s' "$command_for_guards" \
-  | grep -Eiq '(^|[^[:alnum:]_./-])rm([[:space:]]+-[[:alnum:]-]+)*[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)' \
-  || printf '%s' "$command_for_guards" \
-  | grep -Eiq '(^|[^[:alnum:]_./-])rm[[:space:]].*(-r\b.*[[:space:]]-f\b|-f\b.*[[:space:]]-r\b|--recursive\b.*--force\b|--force\b.*--recursive\b)'; then
-  if printf '%s' "$command_for_guards" \
-    | grep -Eq '([[:space:]]|=)(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]]|/?\*?$)'; then
+#    The target boundary classes include quote characters (issue #1960): without
+#    them, `bash -c "rm -rf /"` and interpreter one-liners like
+#    `python -c "… os.system('rm -rf /')"` slip through because the target is
+#    quote-adjacent instead of space-bounded.
+qc="'\""
+if matches "$RM_RF_CLUSTER" || matches "$RM_RF_SPLIT"; then
+  if matches_cs '([[:space:]='"$qc"'])(/|/\*|/\.\*?|~|~/\*?|\$HOME\b|\$\{HOME\}|\*)([[:space:]'"$qc"']|/?\*?['"$qc"']?$)'; then
     block "recursive forced delete of a root, home, or wildcard path (rm -rf)"
   fi
 fi
 
+# 1b. rm target hardening (issue #1960). For every statement that invokes rm
+#     with recursive+force flags, additionally block when:
+#       - cwd is $HOME (any target is one argument away from wiping home), or
+#       - the target is the cwd itself (`.` / `./`), or
+#       - the target traverses out via `..`, or
+#       - the target is an absolute path outside the project — with an allowance
+#         for /tmp, /var/tmp, and $TMPDIR — or
+#       - the target is a `$VAR` expansion other than the sanctioned $TMPDIR.
+#     Globbing is disabled around the token walk so a literal `*` in the command
+#     is never expanded against the hook's own cwd.
+project_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+tmp_dir_allow="${TMPDIR:-/tmp}"
+tmp_dir_allow="${tmp_dir_allow%/}"
+[ -n "$tmp_dir_allow" ] || tmp_dir_allow="/tmp"
+while IFS= read -r rm_stmt; do
+  if ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_CLUSTER" \
+    && ! printf '%s' "$rm_stmt" | grep -Eiq -- "$RM_RF_SPLIT"; then
+    continue
+  fi
+  # Physical-path comparison (pwd -P): on macOS $HOME or the cwd may arrive via
+  # a symlink (/var → /private/var), and a string compare would miss the match.
+  if [ -n "${HOME:-}" ] \
+    && [ "$(pwd -P)" = "$(cd -- "$HOME" 2>/dev/null && pwd -P)" ]; then
+    block "recursive forced delete while the working directory is \$HOME (cd into a project first)"
+  fi
+  set -f
+  seen_rm=0
+  for raw_token in $rm_stmt; do
+    token="${raw_token#\"}"
+    token="${token#\'}"
+    token="${token%\"}"
+    token="${token%\'}"
+    if [ "$seen_rm" -eq 0 ]; then
+      [ "$token" = "rm" ] && seen_rm=1
+      continue
+    fi
+    case "$token" in
+      -*) continue ;;
+      . | ./)
+        set +f
+        block "recursive forced delete of the current directory (rm -rf .)"
+        ;;
+      .. | ../* | */.. | */../*)
+        set +f
+        block "recursive forced delete of a path outside the project (.. traversal)"
+        ;;
+      /*)
+        case "$token" in
+          "$project_dir" | "$project_dir"/* | /tmp | /tmp/* | /var/tmp | /var/tmp/* | "$tmp_dir_allow" | "$tmp_dir_allow"/*) : ;;
+          *)
+            set +f
+            block "recursive forced delete of an absolute path outside the project (only the project, /tmp, /var/tmp, and \$TMPDIR are allowed)"
+            ;;
+        esac
+        ;;
+      *'$'*)
+        case "$token" in
+          '$TMPDIR' | '$TMPDIR'/* | '${TMPDIR}' | '${TMPDIR}'/*) : ;;
+          *)
+            set +f
+            block "recursive forced delete of a variable-expanded target (unset or mistyped variables can point anywhere; \$TMPDIR is the only sanctioned dynamic target)"
+            ;;
+        esac
+        ;;
+    esac
+  done
+  set +f
+done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
+  | grep -Ei '(^|[^[:alnum:]_./-])rm([[:space:]]|$)' || true)
+
 # 2. Force-pushing a protected branch. `--force-with-lease` is the safe,
-#    non-clobbering alternative and is intentionally NOT blocked.
+#    non-clobbering alternative and is intentionally NOT blocked. Deliberate
+#    divergence from upstream (which blocks force-push on ANY branch):
+#    feature-branch force-push is a sanctioned rebase-and-push agent workflow.
 #
 #    The force flag AND the protected-branch name must appear in the SAME
 #    `git push` statement. Checking them independently over the whole command is
@@ -116,14 +251,6 @@ fi
 #    (`;`, `&&`, `||`, `|`, newlines), keep only the `git push` segments, and
 #    inspect each in isolation — a real `git push --force origin main` still
 #    matches, while a feature-branch push next to `[ -f ]`/`--base main` passes.
-# Normalize bash line-continuations (a trailing backslash + newline → space)
-# before segmenting the command. Without this, "git push --force origin
-# \<newline>main" splits into a segment matching --force but not `main`, letting a
-# protected force-push slip past. Uses awk (POSIX) instead of a GNU-only
-# `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
-normalized_command_str="$(printf '%s' "$command_for_guards" \
-  | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
-
 while IFS= read -r push_stmt; do
   if printf '%s' "$push_stmt" \
     | grep -Eiq '(--force([[:space:]]|=|$)|[[:space:]]-f([[:space:]]|$))' \
@@ -133,25 +260,125 @@ while IFS= read -r push_stmt; do
     block "force-pushing a protected branch (use --force-with-lease, or push a feature branch)"
   fi
 done < <(printf '%s' "$normalized_command_str" | tr '&|;' '\n' \
-  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b')
+  | grep -Ei '(^|[^[:alnum:]_-])git[[:space:]]+push\b' || true)
 
-# 3. `git reset --hard` while the working tree has uncommitted changes — this
-#    silently discards them. Only blocks when the tree is actually dirty, so a
-#    clean-tree reset (a legitimate workflow) still passes.
-if printf '%s' "$command_for_guards" | grep -Eiq '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--hard\b'; then
+# 3. `git reset --hard` / `git reset --merge` while the working tree has
+#    uncommitted changes — both silently discard them. Only blocks when the tree
+#    is actually dirty, so a clean-tree reset (a legitimate workflow) passes.
+#    Deliberate divergence from upstream's unconditional block; the accepted
+#    residual risk (dirty check runs at hook time in the hook's cwd) is
+#    documented in the header.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+reset\b.*--(hard|merge)\b'; then
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
     && [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-    block "git reset --hard on a dirty working tree would discard uncommitted changes (stash or commit first)"
+    block "git reset --hard/--merge on a dirty working tree would discard uncommitted changes (stash or commit first)"
   fi
 fi
 
-# 4. Dropping or truncating a database / schema / table.
-if printf '%s' "$command_for_guards" \
-  | grep -Eiq '\b(drop[[:space:]]+(database|schema|table)|truncate[[:space:]]+(table[[:space:]]+)?[[:alnum:]_."`]+)\b'; then
+# 4. `git checkout` worktree discards: the `--` pathspec form (with or without a
+#    ref), `-f/--force`, `--pathspec-from-file`, and bare `git checkout .`.
+#    Blocking bare `.` exceeds upstream (which allows any single positional) —
+#    issue #1960 names it explicitly: it discards the entire tree. Branch
+#    switches and creation (`-b`/`-B`) stay allowed.
+readonly GIT_CHECKOUT='(^|[^[:alnum:]_-])git[[:space:]]+checkout'
+if matches "${GIT_CHECKOUT}${GIT_TOKENS}"'--([[:space:]]|$)' \
+  || matches "${GIT_CHECKOUT}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
+  || matches "${GIT_CHECKOUT}"'[[:space:]][^;&|]*--pathspec-from-file' \
+  || matches "${GIT_CHECKOUT}"'[[:space:]]+\.(/)?([[:space:]]|$)'; then
+  block "git checkout discarding local changes (--, -f/--force, --pathspec-from-file, or bare .) — use git stash to preserve work first"
+fi
+
+# 5. `git switch` discards: `--discard-changes` and its `-f/--force` aliases.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+switch'"${GIT_TOKENS}"'(--discard-changes|--force|-f)([[:space:]]|=|$)'; then
+  block "git switch discarding local changes (--discard-changes/-f/--force)"
+fi
+
+# 6. `git restore` defaults to overwriting the WORKTREE — a silent discard. Only
+#    the pure staging-area form is safe: `--staged` present and `--worktree`
+#    absent. Two conditions, because an ERE has no lookahead: `--staged
+#    --worktree` still discards, so `--worktree` blocks regardless of `--staged`.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore([[:space:]]|$)'; then
+  if matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--worktree' \
+    || ! matches '(^|[^[:alnum:]_-])git[[:space:]]+restore[^;&|]*--staged'; then
+    block "git restore overwriting worktree files (only 'git restore --staged <path>' without --worktree is allowed)"
+  fi
+fi
+
+# 7. `git stash drop` / `git stash clear` destroy stashed work. push/pop/list/
+#    apply — the safe alternatives the reset guard recommends — stay allowed.
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+stash[[:space:]]+(drop|clear)([[:space:]]|$)'; then
+  block "git stash drop/clear destroys stashed work"
+fi
+
+# 8. `git clean` with a force flag wipes untracked files. A dry-run flag
+#    (`-n`/`--dry-run`) ANYWHERE wins — git itself performs no deletion under
+#    dry-run, so `git clean -fdn` is a safe preview.
+readonly GIT_CLEAN='(^|[^[:alnum:]_-])git[[:space:]]+clean'
+if matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|=|$)' \
+  && ! matches "${GIT_CLEAN}${GIT_TOKENS}"'(-[[:alnum:]]*n[[:alnum:]]*|--dry-run)([[:space:]]|=|$)'; then
+  block "git clean --force deletes untracked files (preview with git clean -n first)"
+fi
+
+# 9. `git branch` force-delete loses unmerged commits: `-D`, `-d` combined with
+#    `-f` (clustered or split), or `--delete` + `--force`. Case-SENSITIVE so the
+#    safe `-d` (which refuses unmerged work) and rename `-m` stay allowed.
+readonly GIT_BRANCH='(^|[^[:alnum:]_-])git[[:space:]]+branch'
+if matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*D[[:alnum:]]*([[:space:]]|$)' \
+  || { matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)' \
+    && matches_cs "${GIT_BRANCH}${GIT_TOKENS}"'-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$)'; } \
+  || { matches "${GIT_BRANCH}"'[^;&|]*--delete' && matches "${GIT_BRANCH}"'[^;&|]*--force'; }; then
+  block "git branch force-delete (-D) loses unmerged commits (use -d, which refuses unmerged work)"
+fi
+
+# 10. Cheap destructive-ref guards: `git tag -d` (tags are shared refs),
+#     `git reflog delete` (erases recovery history), and
+#     `git worktree remove --force` (discards a dirty worktree). Tag deletion is
+#     case-SENSITIVE so annotated-tag `-a` and message `-m` flags never match.
+if matches_cs '(^|[^[:alnum:]_-])git[[:space:]]+tag'"${GIT_TOKENS}"'(-[[:alnum:]]*d[[:alnum:]]*([[:space:]]|$)|--delete([[:space:]]|=|$))'; then
+  block "git tag -d deletes a shared ref"
+fi
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+reflog[[:space:]]+delete([[:space:]]|$)'; then
+  block "git reflog delete erases recovery history"
+fi
+if matches '(^|[^[:alnum:]_-])git[[:space:]]+worktree[[:space:]]+remove[^;&|]*(--force([[:space:]]|=|$)|[[:space:]]-[[:alnum:]]*f[[:alnum:]]*([[:space:]]|$))'; then
+  block "git worktree remove --force discards a dirty worktree (remove without --force, which refuses dirty trees)"
+fi
+
+# 11. Deletion through find/xargs, where the target never appears as a literal
+#     argument: `find … -delete`, `find … -exec rm -rf`, and `xargs … rm -rf`
+#     (targets arrive from dynamic stdin — unauditable). Plain `rm` (no
+#     recursive+force) on find/xargs output stays allowed for normal cleanups.
+if matches '(^|[^[:alnum:]_./-])find[[:space:]][^;&|]*[[:space:]]-delete([[:space:]]|$)'; then
+  block "find -delete removes files tree-wide (use -print to preview, or an explicit rm on reviewed paths)"
+fi
+if matches '(^|[^[:alnum:]_./-])find[[:space:]][^;&|]*-exec[[:space:]]+rm[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'; then
+  block "find -exec rm -rf performs a recursive forced delete on unreviewed paths"
+fi
+if matches '(^|[^[:alnum:]_./-])xargs[[:space:]]([^;&|]*[[:space:]])?rm[[:space:]]+(-[[:alnum:]]*r[[:alnum:]]*f|-[[:alnum:]]*f[[:alnum:]]*r)([[:space:]]|$)'; then
+  block "xargs rm -rf performs a recursive forced delete on dynamic stdin input"
+fi
+
+# 12. Disk destroyers, always on (exceeds upstream, which only scans these
+#     inside interpreter one-liners): writing to a raw /dev node via dd,
+#     formatting a device with mkfs, and shred's unrecoverable overwrite.
+#     dd/mkfs against regular files (imaging) stays allowed.
+if matches '(^|[^[:alnum:]_./-])dd[[:space:]]+([^;&|]*[[:space:]])?of=/dev/'; then
+  block "dd writing to a raw device (of=/dev/…) destroys it"
+fi
+if matches '(^|[^[:alnum:]_./-])mkfs(\.[[:alnum:]]+)?[[:space:]][^;&|]*/dev/'; then
+  block "mkfs formatting a device erases it"
+fi
+if matches '(^|[^[:alnum:]_./-])shred([[:space:]]|$)'; then
+  block "shred overwrites files unrecoverably"
+fi
+
+# 13. Dropping or truncating a database / schema / table (Lisa-only guard —
+#     upstream has no SQL protection; keep).
+if matches '\b(drop[[:space:]]+(database|schema|table)|truncate[[:space:]]+(table[[:space:]]+)?[[:alnum:]_."`]+)\b'; then
   block "destructive SQL (DROP/TRUNCATE) detected"
 fi
 
-# 5. Project-local custom rules. Each non-comment line is an ERE; a match blocks.
+# 14. Project-local custom rules. Each non-comment line is an ERE; a match blocks.
 rules_file="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-net-rules.txt}"
 if [ -f "$rules_file" ]; then
   while IFS= read -r rule || [ -n "$rule" ]; do

--- a/plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -56,13 +56,17 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
 1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard — with
    quote-aware boundaries, so wrapper/interpreter forms like
    `bash -c "rm -rf /"` and `python -c "… os.system('rm -rf /')"` match too.
+   Path-prefixed spellings (`/bin/rm`, `./rm`) count as `rm` for every rm
+   guard.
 2. `rm -rf` target hardening: the cwd itself (`.`/`./`), `..`-traversal paths,
-   absolute paths outside the project (`/tmp`, `/var/tmp`, and `$TMPDIR` are
-   allowed), `$VAR` targets other than `$TMPDIR`, and **any** recursive forced
-   delete while the working directory is `$HOME`.
-3. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
-   `--force-with-lease` is intentionally allowed, and so is force-pushing a
-   feature branch (sanctioned rebase workflow).
+   home-anchored `~/…` paths, absolute paths outside the project (`/tmp`,
+   `/var/tmp`, and `$TMPDIR` are allowed), `$VAR` targets other than `$TMPDIR`,
+   and **any** recursive forced delete while the working directory is `$HOME`.
+3. Force-pushing a protected branch
+   (`main`/`master`/`production`/`prod`/`release`). `--force-with-lease` is
+   intentionally allowed, and so is force-pushing a feature branch (sanctioned
+   rebase workflow). Acceptable parity divergence: a refspec force-push
+   (`git push origin +main`) is not blocked — upstream 1.0.6 allows it too.
 4. `git reset --hard` / `git reset --merge` while the working tree is **dirty**
    (would discard work). Clean-tree resets are intentionally allowed.
 5. `git checkout` discards: the `--` pathspec form (with or without a ref),
@@ -81,6 +85,10 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
     (plain non-recursive `rm` on find/xargs output stays allowed).
 13. Disk destroyers: `dd of=/dev/…`, `mkfs … /dev/…`, `shred`.
 14. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+
+Every git guard sees through leading git **global options** (`-C <path>`,
+`-c <k>=<v>`, `--git-dir[=…]`, `--no-pager`, …), so `git -C /path <destructive>`
+is screened the same as `git <destructive>`.
 
 Malformed hook input fails **closed** (exit 2 denies the command). A text-scan
 hook cannot exempt display commands, so prose like

--- a/plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -53,11 +53,39 @@ RULES_FILE="${SAFETY_NET_RULES_FILE:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/safety-
 
 ### Built-in guards (always on)
 
-1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard.
-2. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
-   `--force-with-lease` is intentionally allowed.
-3. `git reset --hard` while the working tree is **dirty** (would discard work).
-4. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+1. `rm -rf` of a filesystem root, `$HOME`/`~`, or a top-level wildcard — with
+   quote-aware boundaries, so wrapper/interpreter forms like
+   `bash -c "rm -rf /"` and `python -c "… os.system('rm -rf /')"` match too.
+2. `rm -rf` target hardening: the cwd itself (`.`/`./`), `..`-traversal paths,
+   absolute paths outside the project (`/tmp`, `/var/tmp`, and `$TMPDIR` are
+   allowed), `$VAR` targets other than `$TMPDIR`, and **any** recursive forced
+   delete while the working directory is `$HOME`.
+3. Force-pushing a protected branch (`main`/`master`/`production`/`release`).
+   `--force-with-lease` is intentionally allowed, and so is force-pushing a
+   feature branch (sanctioned rebase workflow).
+4. `git reset --hard` / `git reset --merge` while the working tree is **dirty**
+   (would discard work). Clean-tree resets are intentionally allowed.
+5. `git checkout` discards: the `--` pathspec form (with or without a ref),
+   `-f`/`--force`, `--pathspec-from-file`, and bare `git checkout .`.
+   Branch switching and `-b`/`-B` creation stay allowed.
+6. `git switch --discard-changes` / `-f`/`--force`.
+7. `git restore` touching the worktree — only `git restore --staged <path>`
+   without `--worktree` is allowed (unstaging is safe).
+8. `git stash drop` / `git stash clear` (push/pop/list/apply stay allowed).
+9. `git clean` with a force flag and no dry-run — `-n`/`--dry-run` anywhere
+   makes it a safe preview.
+10. `git branch -D` (or `-d` combined with `-f`, clustered or split);
+    safe `-d` and rename `-m` stay allowed.
+11. `git tag -d`, `git reflog delete`, `git worktree remove --force`.
+12. Deletion via `find … -delete`, `find … -exec rm -rf`, and `xargs … rm -rf`
+    (plain non-recursive `rm` on find/xargs output stays allowed).
+13. Disk destroyers: `dd of=/dev/…`, `mkfs … /dev/…`, `shred`.
+14. Destructive SQL — `DROP DATABASE/SCHEMA/TABLE`, `TRUNCATE TABLE`.
+
+Malformed hook input fails **closed** (exit 2 denies the command). A text-scan
+hook cannot exempt display commands, so prose like
+`echo "docs about rm -rf /"` can false-positive — quote-break the string or use
+the gh-writer heredoc form (payload is stripped before the guards run).
 
 ## View the current rules
 

--- a/rails/merge/.claude/settings.json
+++ b/rails/merge/.claude/settings.json
@@ -5,7 +5,7 @@
   },
   "enabledPlugins": {
     "ruby-lsp@claude-plugins-official": true,
-    "safety-net@cc-marketplace": true,
+    "safety-net@cc-marketplace": false,
     "code-simplifier@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "coderabbit@claude-plugins-official": true,

--- a/scripts/install-claude-plugins.sh
+++ b/scripts/install-claude-plugins.sh
@@ -526,19 +526,22 @@ for plugin in \
   "code-review@claude-plugins-official" \
   "coderabbit@claude-plugins-official" \
   "skill-creator@claude-plugins-official" \
-  "atlassian@claude-plugins-official" \
-  "safety-net@cc-marketplace"; do
+  "atlassian@claude-plugins-official"; do
   install_plugin_if_missing "$plugin"
 done
 
 # Retire third-party plugins Lisa no longer curates. The base lisa plugin
 # bundles the Sentry MCP server (plugins/src/base/.mcp.json) for every agent
 # runtime, so the upstream sentry plugin registered the same server twice in
-# each Claude session (issue #1955). The merge settings templates flip its
-# enabledPlugins entry to false; this removes the install itself. Version-gated
-# like the other one-time heals so same-version runs don't spawn the CLI.
+# each Claude session (issue #1955). Likewise, the Lisa-native
+# parity-safety-net.sh hook screens every Bash command, so the upstream
+# safety-net plugin double-screened each command; its material guards were
+# absorbed into the Lisa hook (issue #1960). The merge settings templates flip
+# both enabledPlugins entries to false; this removes the installs themselves.
+# Version-gated like the other one-time heals so same-version runs don't spawn
+# the CLI.
 if [ "$FORCE_PLUGIN_SYNC" = "true" ]; then
-  for retired_plugin in "sentry@claude-plugins-official"; do
+  for retired_plugin in "sentry@claude-plugins-official" "safety-net@cc-marketplace"; do
     claude plugin uninstall "$retired_plugin" --scope project </dev/null >/dev/null 2>&1 || true
   done
 fi

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -589,7 +589,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/parity-safety-net.agy.sh":
       "ce9bd2b4566ad9147e4ace56434cffbbe87edb4ccbb57549ab3fd9f4c671ced4",
     "plugins/src/base/hooks/parity-safety-net.sh":
-      "a22fd1b7c483f1a538202353ee85c82be17a8910e03c0a930635ce8cb3595c64",
+      "64546813f168fb446f39e34bc674fd3af85b15bd5e7f4f6bf4503463e701a7b9",
     "plugins/src/base/hooks/setup-jira-cli.sh":
       "a675f6b17ce7f0d6b9fb7daeba6d2bc59bcb48ef79b034076ea73b2b1e72ee09",
     "plugins/src/base/hooks/shell-write-nudge.sh":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -23,7 +23,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/github-rulesets/protect-tags.json":
       "387f824e3ea58a803223e42e08326504a39e6a7a0c650a0bbfdfb4653854b722",
     "all/merge/.claude/settings.json":
-      "f53702d4a1af4f3bd45082ca8bd9645591f77e1743025bf617cd6b7a699a064b",
+      "1d4a4d33d4a5f26a33560df21f9ad9ba97511c15a1c952dd2fe941679a0f1f9e",
     "cdk/copy-overwrite/.github/workflows/.keep":
       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "cdk/copy-overwrite/eslint.cdk.ts":
@@ -59,7 +59,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "cdk/deletions.json":
       "b1d07e463f52deaa5f9958060de40d369f4f256b898563efb83911abf39a62a5",
     "cdk/merge/.claude/settings.json":
-      "d590b3d3c1cd639fa6316f75e1a7fe477acbe27705b3e41e950cf13fa618f175",
+      "6f938fdc9c808ee4dda9d605815788dda384197065aac6793c7549d8811a6224",
     "cdk/merge/.oxlintrc.json":
       "e74885a33fdb7b5d565e13ebd781a3dd2fd02409a2a059deed851645630a6985",
     "cdk/package-lisa/package.lisa.json":
@@ -181,7 +181,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/github-rulesets/playwright.json":
       "b57ccd12f768a1466a9681528858e59764bd0efedcbcb3a96c2fb40719bbd579",
     "expo/merge/.claude/settings.json":
-      "38afc4841039f05be92303cfd7ed36b600d4af5af2fd07335542b5ceeda29147",
+      "e97b33d7ad86b71abba94ab957d725e34c3cafca455e92fba0b29ebabc3b73d1",
     "expo/merge/.oxlintrc.json":
       "2a0ea2191abd5b377aed4b525a4a97d3eefb1d9e41c845c02ee0daac75df6b1f",
     "expo/package-lisa/package.lisa.json":
@@ -223,7 +223,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "harper-fabric/deletions.json":
       "383e5a6e1f8c77376b7e20f936543418204a1c632212d1fd393962e03cf40c52",
     "harper-fabric/merge/.claude/settings.json":
-      "f376c8083e1ec7595c99b23c737cf643906b05792581425790e274400f925977",
+      "278c48f1af3a6aa23b7f5dcf55aa0d2737baf809942b1d4ef6831cdfc144581a",
     "harper-fabric/merge/.oxlintrc.json":
       "43bd2a48954e15fbd1fe89b1a4f7b84cf93706d7de7b84ec120d63906bfde31b",
     "harper-fabric/package-lisa/package.lisa.json":
@@ -309,7 +309,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "nestjs/deletions.json":
       "037a64f96b76670326bc61921f4484e864e02c09786adabbd1cfdf886183cad5",
     "nestjs/merge/.claude/settings.json":
-      "4f9d9440fd208520c4be96edde19e84160f25e3bba3ac9505d95b7653ad34666",
+      "d0ce50361a1f3868d15728646e66b9e1cdb8373688eb22459adbdb176e342aca",
     "nestjs/merge/.oxlintrc.json":
       "3743a1e2bcfc879f5250f35206f413b10815f34e20b1d0afce67824579813b5d",
     "nestjs/package-lisa/package.lisa.json":
@@ -367,7 +367,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "phaser/deletions.json":
       "383e5a6e1f8c77376b7e20f936543418204a1c632212d1fd393962e03cf40c52",
     "phaser/merge/.claude/settings.json":
-      "13336547df466d2aa4600aaf025d813c0189709776c8ed16de4f30e80be1ca63",
+      "296b8d5e3c197cd4526a99454aee1dc7f5ce9a25a729a957f392b71be3e8cfb6",
     "phaser/merge/.oxlintrc.json":
       "4ac4bca00bef4b32810f3759a914ab2b8148e6fad3e329417a497e36df9e810c",
     "phaser/package-lisa/package.lisa.json":
@@ -589,7 +589,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/parity-safety-net.agy.sh":
       "ce9bd2b4566ad9147e4ace56434cffbbe87edb4ccbb57549ab3fd9f4c671ced4",
     "plugins/src/base/hooks/parity-safety-net.sh":
-      "388cf8847581d96a1ff8ea98290a33a5f96d67cdd502ea807a0b8d88efe90e19",
+      "7f55986eb29f8ace8616595da4bbe60d80a96f9f29b24fb72efd66bb96b22464",
     "plugins/src/base/hooks/setup-jira-cli.sh":
       "a675f6b17ce7f0d6b9fb7daeba6d2bc59bcb48ef79b034076ea73b2b1e72ee09",
     "plugins/src/base/hooks/shell-write-nudge.sh":
@@ -961,7 +961,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-parity-coderabbit/SKILL.md":
       "ae882837d43741293d1b639c4516331fa6124fa1f5da234a74ecb31c5d7e52cd",
     "plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md":
-      "7126b7dbda7205922a7825eba47164954267ff65ef9f414182aab51889b9a7d8",
+      "8eea0864720e90564b0f913af5cc6d6376c14e44249442c58936ffa1cddebd14",
     "plugins/src/base/skills/lisa-parity-sentry-sdk-setup/SKILL.md":
       "ed52b0273f6b535d26d561c80ae6c0bedb84c67fcf4321f688c05fe3ee3af575",
     "plugins/src/base/skills/lisa-parity-sentry-seer/SKILL.md":
@@ -1819,7 +1819,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/github-rulesets/quality-checks.json":
       "ea42f2bb938881bc6ec129e7300a2b824313951031d4720f46e944c4dfe1a9da",
     "rails/merge/.claude/settings.json":
-      "37a06617452435eec44afdd430c0375d14ad59458ddd48bf6c1115315748acb5",
+      "9c49f8c7c453f8749c90def3e22d412c3345c533d24b30dc7745ffa052ad6fa1",
     "scripts/build-plugins.sh":
       "d26321ea10bc3ed8cf096f900622cb4cf7a37117fabf9730f0fe5c9d949582fc",
     "scripts/check-duplicate-versions.mjs":
@@ -1867,7 +1867,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/github-status-check.sh":
       "876914c369c5bd58f4a5f3c41d0c1264c6923f329a644f90640d15b434a0fbd1",
     "scripts/install-claude-plugins.sh":
-      "2fcee140e86bcc213a6959b4b0eae533cc102c91948d47fe87e62cb29f795ed1",
+      "5f4bedb983900dc17f8843f73876fc7c445909eb12792b3330728ff03842f50b",
     "scripts/internal-agy-skill-policy.json":
       "c2ce87d2eeebfdc9f24d6486425c010cf9289376f8a459f4767ca22d2bf8670d",
     "scripts/internal-codex-skill-policy.json":
@@ -2067,7 +2067,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/github-rulesets/quality-checks.json":
       "89b9e09267cdb65865728d0e873de9c1225b8ca796e67f06fa8b72ccf6d4515e",
     "typescript/merge/.claude/settings.json":
-      "bad82c215aca3102e1fd41cce7205b59029c74cfce0f416ce0a95177fc2b0c54",
+      "834e6456cae81f45073bbbb08bf731fef043efb30cae2658cb4a59f17e66d165",
     "typescript/merge/.oxlintrc.json":
       "4debc093acfd263eb81ae15894073ebf098513204f45f40b83fb8fa5353fa1f8",
     "typescript/package-lisa/package.lisa.json":
@@ -7686,6 +7686,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/fixtures/wiki-safety/redaction-source.md": true,
     "tests/helpers/__fixtures__/wiki-status-fixture.ts": true,
     "tests/helpers/readiness-workflow-fixtures.ts": true,
+    "tests/helpers/safety-net-guard-fixtures.ts": true,
+    "tests/helpers/safety-net-guard-harness.ts": true,
     "tests/helpers/test-utils.ts": true,
     "tests/helpers/verification-gate-fixtures.ts": true,
     "tests/helpers/verification-gate-harness.ts": true,
@@ -7888,6 +7890,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/hooks/inject-rules.test.ts": true,
     "tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts": true,
     "tests/unit/hooks/lint-on-edit.test.ts": true,
+    "tests/unit/hooks/parity-safety-net-guards.test.ts": true,
     "tests/unit/hooks/parity-safety-net-heredoc.test.ts": true,
     "tests/unit/hooks/parity-safety-net.test.ts": true,
     "tests/unit/hooks/post-checkout.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -589,7 +589,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/parity-safety-net.agy.sh":
       "ce9bd2b4566ad9147e4ace56434cffbbe87edb4ccbb57549ab3fd9f4c671ced4",
     "plugins/src/base/hooks/parity-safety-net.sh":
-      "7f55986eb29f8ace8616595da4bbe60d80a96f9f29b24fb72efd66bb96b22464",
+      "a22fd1b7c483f1a538202353ee85c82be17a8910e03c0a930635ce8cb3595c64",
     "plugins/src/base/hooks/setup-jira-cli.sh":
       "a675f6b17ce7f0d6b9fb7daeba6d2bc59bcb48ef79b034076ea73b2b1e72ee09",
     "plugins/src/base/hooks/shell-write-nudge.sh":
@@ -961,7 +961,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-parity-coderabbit/SKILL.md":
       "ae882837d43741293d1b639c4516331fa6124fa1f5da234a74ecb31c5d7e52cd",
     "plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md":
-      "8eea0864720e90564b0f913af5cc6d6376c14e44249442c58936ffa1cddebd14",
+      "d338796d10498bd660c36f7f66c6b5be54cf7e281d19b9df44b0d2a01e398b68",
     "plugins/src/base/skills/lisa-parity-sentry-sdk-setup/SKILL.md":
       "ed52b0273f6b535d26d561c80ae6c0bedb84c67fcf4321f688c05fe3ee3af575",
     "plugins/src/base/skills/lisa-parity-sentry-seer/SKILL.md":

--- a/tests/helpers/safety-net-guard-fixtures.ts
+++ b/tests/helpers/safety-net-guard-fixtures.ts
@@ -154,6 +154,7 @@ export const STATELESS_FIXTURES: readonly GuardFixture[] = [
   fx("RH-A3", "rm -rf ./node_modules", ALLOW, RM_HARDENING),
   fx("RH-A4", "rm -rf /tmp/scratch-dir", ALLOW, RM_HARDENING),
   fx("RH-A5", 'rm -rf "$TMPDIR/cache"', ALLOW, RM_HARDENING),
+  fx("RH-B6", "rm -rf ~/other-project", BLOCK, RM_HARDENING),
   fx("RH-A6", `rm -rf ${PROJECT_DIR_TOKEN}/dist`, ALLOW, RM_HARDENING),
   fx("RH-A7", "rm -rf .cache", ALLOW, RM_HARDENING),
   // I. quote-aware boundaries — verified bypasses (absorb 10 / F1)
@@ -176,6 +177,68 @@ export const STATELESS_FIXTURES: readonly GuardFixture[] = [
   fx("QB-A1", 'bash -c "rm -rf build"', ALLOW, QUOTE_BOUNDARY),
   fx("QB-A2", 'python -c "print(1)"', ALLOW, QUOTE_BOUNDARY),
   fx("QB-A3", "python spider.py -c config.yaml", ALLOW, QUOTE_BOUNDARY),
+  // I2. git global-option bypasses (security review F1): global options like
+  // -C/-c/--git-dir legally sit between `git` and the subcommand, so every
+  // subcommand guard must consume them instead of anchoring `git <subcmd>`.
+  fx("GO-B1", "git -C /some/path checkout -- file.ts", BLOCK, CHECKOUT_DISCARD),
+  fx(
+    "GO-B2",
+    "git -c core.pager=cat checkout -- file.ts",
+    BLOCK,
+    CHECKOUT_DISCARD
+  ),
+  fx(
+    "GO-B3",
+    "git --git-dir=/x/.git --work-tree=/x checkout -- file.ts",
+    BLOCK,
+    CHECKOUT_DISCARD
+  ),
+  fx(
+    "GO-B4",
+    "git --git-dir /x/.git checkout -- file.ts",
+    BLOCK,
+    CHECKOUT_DISCARD
+  ),
+  fx("GO-B5", "git --no-pager checkout -- file.ts", BLOCK, CHECKOUT_DISCARD),
+  fx("GO-B6", "git -C /x switch -f main", BLOCK, SWITCH_DISCARD),
+  fx("GO-B7", "git -C /x restore file.ts", BLOCK, RESTORE_WORKTREE),
+  fx("GO-B8", "git -C /x stash clear", BLOCK, STASH_DESTROY),
+  fx("GO-B9", "git -C /repo clean -fd", BLOCK, CLEAN_FORCE),
+  fx("GO-B10", "git -C /x branch -D feature", BLOCK, BRANCH_FORCE_DELETE),
+  fx("GO-B11", "git -C /repo push --force origin main", BLOCK, FORCE_PUSH),
+  fx("GO-B12", "git -C /x tag -d v1.0.0", BLOCK, TAG_DELETE),
+  fx("GO-B13", "git -C /x reflog delete 'HEAD@{1}'", BLOCK, REFLOG_DELETE),
+  fx(
+    "GO-B14",
+    "git -C /x worktree remove --force wt",
+    BLOCK,
+    WORKTREE_FORCE_REMOVE
+  ),
+  fx("GO-A1", "git -C /p checkout -b feature", ALLOW, CHECKOUT_DISCARD),
+  fx("GO-A2", "git -c core.editor=vim commit", ALLOW, CHECKOUT_DISCARD),
+  fx("GO-A3", "git -C /p status", ALLOW, CHECKOUT_DISCARD),
+  fx(
+    "GO-A4",
+    "git -C /p push --force-with-lease origin main",
+    ALLOW,
+    FORCE_PUSH
+  ),
+  fx("GO-A5", "git -C /p push --force origin feature-x", ALLOW, FORCE_PUSH),
+  fx("GO-A6", "git -C /x restore --staged file.ts", ALLOW, RESTORE_WORKTREE),
+  // I3. path-prefixed rm bypasses (security review F2): `rm` reached via an
+  // absolute or relative path must still trip every rm guard — but ONLY when
+  // the basename is exactly `rm` (charm/confirm/rmdir/informant stay allowed).
+  fx("PR-B1", `/bin/${RM_RF_ROOT}`, BLOCK, RM_ROOT),
+  fx("PR-B2", "/usr/bin/rm -rf ~", BLOCK, RM_ROOT),
+  fx("PR-B3", `./${RM_RF_ROOT}`, BLOCK, RM_ROOT),
+  fx("PR-B4", `bash -c '/bin/${RM_RF_ROOT}'`, BLOCK, RM_ROOT),
+  fx("PR-B5", "/bin/rm -rf /etc", BLOCK, RM_HARDENING),
+  fx("PR-B6", "/bin/rm -rf ../other", BLOCK, RM_HARDENING),
+  fx("PR-A1", "/bin/rm file.txt", ALLOW, RM_ROOT),
+  fx("PR-A2", "/usr/bin/charm x", ALLOW, RM_ROOT),
+  fx("PR-A3", "./scripts/confirm -rf /", ALLOW, RM_ROOT),
+  fx("PR-A4", "rmdir /tmp/x", ALLOW, RM_ROOT),
+  fx("PR-A5", "informant -rf /", ALLOW, RM_ROOT),
   // J. find / xargs deletion (absorb 11)
   fx("FX-B1", "find . -delete", BLOCK, FIND_DELETE),
   fx("FX-B2", "find . -name '*.tmp' -delete", BLOCK, FIND_DELETE),
@@ -213,6 +276,9 @@ export const STATELESS_FIXTURES: readonly GuardFixture[] = [
   fx("RG-RM-A2", "rm -f file.txt", ALLOW, RM_ROOT),
   fx("RG-RM-A3", "rm file.txt", ALLOW, RM_ROOT),
   fx("RG-RM-A4", "rm -rf build && echo done", ALLOW, RM_ROOT),
+  // Guard 1 scans per statement, so a harmless `/` in a LATER statement is
+  // never attributed to an earlier rm (quality review S1).
+  fx("RG-RM-A5", "rm -rf build && cd /", ALLOW, RM_ROOT),
   // M2. force-push regressions (guard 2) — deep coverage stays in the
   // pre-existing parity-safety-net.test.ts suite
   fx("RG-FP-B1", "git push --force origin main", BLOCK, FORCE_PUSH),
@@ -225,7 +291,7 @@ export const STATELESS_FIXTURES: readonly GuardFixture[] = [
     FORCE_PUSH
   ),
   fx("RG-FP-A3", "git push origin main", ALLOW, FORCE_PUSH),
-  // M4. destructive SQL regressions (guard 4)
+  // M4. destructive SQL regressions (guard 13)
   fx("RG-SQL-B1", "psql -c 'DROP TABLE users;'", BLOCK, SQL),
   fx("RG-SQL-B2", "mysql -e 'TRUNCATE sessions'", BLOCK, SQL),
   fx("RG-SQL-B3", "echo 'DROP DATABASE prod' | psql", BLOCK, SQL),
@@ -246,4 +312,7 @@ export const GIT_STATE_FIXTURES: readonly GitStateFixture[] = [
   gfx("GS-A3", "dirty", "git reset --soft HEAD~1", ALLOW),
   gfx("GS-A4", "dirty", "git reset --keep", ALLOW),
   gfx("GS-A5", "dirty", "git reset --mixed HEAD", ALLOW),
+  // Global options must not dodge the reset guard (security review F1).
+  gfx("GS-B4", "dirty", "git -C . reset --hard", BLOCK),
+  gfx("GS-A6", "clean", "git -C . reset --hard", ALLOW),
 ];

--- a/tests/helpers/safety-net-guard-fixtures.ts
+++ b/tests/helpers/safety-net-guard-fixtures.ts
@@ -239,6 +239,14 @@ export const STATELESS_FIXTURES: readonly GuardFixture[] = [
   fx("PR-A3", "./scripts/confirm -rf /", ALLOW, RM_ROOT),
   fx("PR-A4", "rmdir /tmp/x", ALLOW, RM_ROOT),
   fx("PR-A5", "informant -rf /", ALLOW, RM_ROOT),
+  // I4. mixed short/long recursive+force spellings (PR #1976 review): the
+  // split-flag gate must pair ANY recursive form with ANY force form, not just
+  // short+short / long+long.
+  fx("MX-B1", "rm -r --force /", BLOCK, RM_ROOT),
+  fx("MX-B2", "rm --recursive -f /", BLOCK, RM_ROOT),
+  fx("MX-B3", "rm --recursive -v -f /", BLOCK, RM_ROOT),
+  fx("MX-A1", "rm -r --verbose /", ALLOW, RM_ROOT),
+  fx("MX-A2", "rm --force -v file.txt", ALLOW, RM_ROOT),
   // J. find / xargs deletion (absorb 11)
   fx("FX-B1", "find . -delete", BLOCK, FIND_DELETE),
   fx("FX-B2", "find . -name '*.tmp' -delete", BLOCK, FIND_DELETE),

--- a/tests/helpers/safety-net-guard-fixtures.ts
+++ b/tests/helpers/safety-net-guard-fixtures.ts
@@ -1,0 +1,249 @@
+/**
+ * Fixture data for the parity-safety-net.sh guard-parity matrix (issue #1960).
+ *
+ * The tables ARE the contract: every absorbed upstream guard has paired block
+ * and near-miss-allow rows (anti-overblocking), and every pre-existing built-in
+ * guard has regression rows so nothing relaxes. Source matrix:
+ * .lisa/test-matrix-1960.md (task T2).
+ * @module tests/helpers/safety-net-guard-fixtures
+ */
+import type {
+  GitStateFixture,
+  GuardFixture,
+  Verdict,
+} from "./safety-net-guard-harness";
+
+/** Replaced at runtime with the temp project dir (for in-project absolute rm). */
+export const PROJECT_DIR_TOKEN = "__PROJECT_DIR__";
+
+/** Canonical catastrophic delete used across block fixtures. */
+export const RM_RF_ROOT = "rm -rf /";
+
+const BLOCK: Verdict = "block";
+const ALLOW: Verdict = "allow";
+
+// Guard identifiers (used in assertion messages and fixture grouping).
+const CHECKOUT_DISCARD = "checkout-discard";
+const SWITCH_DISCARD = "switch-discard";
+const RESTORE_WORKTREE = "restore-worktree";
+const STASH_DESTROY = "stash-destroy";
+const CLEAN_FORCE = "clean-force";
+const BRANCH_FORCE_DELETE = "branch-force-delete";
+const TAG_DELETE = "tag-delete";
+const REFLOG_DELETE = "reflog-delete";
+const WORKTREE_FORCE_REMOVE = "worktree-force-remove";
+const RM_HARDENING = "rm-hardening";
+const QUOTE_BOUNDARY = "quote-boundary";
+const FIND_DELETE = "find-delete";
+const FIND_EXEC_RM = "find-exec-rm";
+const XARGS_RM = "xargs-rm";
+const DISK_DESTROYER = "disk-destroyer";
+const RM_ROOT = "rm-root";
+const FORCE_PUSH = "force-push";
+const SQL = "sql";
+const RESET_DIRTY = "reset-dirty";
+
+/**
+ * Builds a {@link GuardFixture} row.
+ * @param id - Matrix row id (e.g. "CO-B1").
+ * @param command - Bash command the hook screens.
+ * @param expected - Verdict the hook must produce.
+ * @param guard - Guard identifier the row exercises.
+ * @returns The fixture row.
+ */
+const fx = (
+  id: string,
+  command: string,
+  expected: Verdict,
+  guard: string
+): GuardFixture => ({ id, command, expected, guard });
+
+/**
+ * Builds a {@link GitStateFixture} row for the reset-dirty guard.
+ * @param id - Matrix row id (e.g. "GS-B1").
+ * @param repo - Which fixture repo the hook runs in.
+ * @param command - Bash command the hook screens.
+ * @param expected - Verdict the hook must produce.
+ * @returns The fixture row.
+ */
+const gfx = (
+  id: string,
+  repo: "clean" | "dirty",
+  command: string,
+  expected: Verdict
+): GitStateFixture => ({ id, repo, command, expected, guard: RESET_DIRTY });
+
+/** Fixtures whose verdicts do not depend on git working-tree state. */
+export const STATELESS_FIXTURES: readonly GuardFixture[] = [
+  // A. git checkout discard family (absorb 1)
+  fx("CO-B1", "git checkout -- file.ts", BLOCK, CHECKOUT_DISCARD),
+  fx("CO-B2", "git checkout main -- src/app.ts", BLOCK, CHECKOUT_DISCARD),
+  fx("CO-B3", "git checkout -f main", BLOCK, CHECKOUT_DISCARD),
+  fx("CO-B4", "git checkout --force main", BLOCK, CHECKOUT_DISCARD),
+  fx(
+    "CO-B5",
+    "git checkout --pathspec-from-file=list.txt",
+    BLOCK,
+    CHECKOUT_DISCARD
+  ),
+  fx("CO-B6", "git checkout .", BLOCK, CHECKOUT_DISCARD),
+  fx("CO-A1", "git checkout -b feature", ALLOW, CHECKOUT_DISCARD),
+  fx("CO-A2", "git checkout main", ALLOW, CHECKOUT_DISCARD),
+  fx("CO-A3", "git checkout -B hotfix", ALLOW, CHECKOUT_DISCARD),
+  fx("CO-A4", "git checkout feature-.dotted", ALLOW, CHECKOUT_DISCARD),
+  fx("CO-A5", "git log --oneline -- file.ts", ALLOW, CHECKOUT_DISCARD),
+  // B. git switch discard (absorb 2)
+  fx("SW-B1", "git switch --discard-changes main", BLOCK, SWITCH_DISCARD),
+  fx("SW-B2", "git switch -f main", BLOCK, SWITCH_DISCARD),
+  fx("SW-B3", "git switch --force main", BLOCK, SWITCH_DISCARD),
+  fx("SW-A1", "git switch main", ALLOW, SWITCH_DISCARD),
+  fx("SW-A2", "git switch -c new-branch", ALLOW, SWITCH_DISCARD),
+  // C. git restore (absorb 3)
+  fx("RS-B1", "git restore file.ts", BLOCK, RESTORE_WORKTREE),
+  fx("RS-B2", "git restore --worktree file.ts", BLOCK, RESTORE_WORKTREE),
+  fx(
+    "RS-B3",
+    "git restore --staged --worktree file.ts",
+    BLOCK,
+    RESTORE_WORKTREE
+  ),
+  fx("RS-B4", "git restore .", BLOCK, RESTORE_WORKTREE),
+  fx("RS-A1", "git restore --staged file.ts", ALLOW, RESTORE_WORKTREE),
+  fx("RS-A2", "git restore --staged .", ALLOW, RESTORE_WORKTREE),
+  // D. git stash drop/clear (absorb 4)
+  fx("ST-B1", "git stash drop", BLOCK, STASH_DESTROY),
+  fx("ST-B2", "git stash drop 'stash@{0}'", BLOCK, STASH_DESTROY),
+  fx("ST-B3", "git stash clear", BLOCK, STASH_DESTROY),
+  fx("ST-A1", "git stash push -m wip", ALLOW, STASH_DESTROY),
+  fx("ST-A2", "git stash pop", ALLOW, STASH_DESTROY),
+  fx("ST-A3", "git stash list", ALLOW, STASH_DESTROY),
+  fx("ST-A4", "git stash apply", ALLOW, STASH_DESTROY),
+  // E. git clean force (absorb 5)
+  fx("CL-B1", "git clean -f", BLOCK, CLEAN_FORCE),
+  fx("CL-B2", "git clean -fd", BLOCK, CLEAN_FORCE),
+  fx("CL-B3", "git clean -xfd", BLOCK, CLEAN_FORCE),
+  fx("CL-B4", "git clean --force", BLOCK, CLEAN_FORCE),
+  fx("CL-A1", "git clean -n", ALLOW, CLEAN_FORCE),
+  fx("CL-A2", "git clean -nd", ALLOW, CLEAN_FORCE),
+  fx("CL-A3", "git clean --dry-run", ALLOW, CLEAN_FORCE),
+  fx("CL-A4", "git clean -fdn", ALLOW, CLEAN_FORCE),
+  // F. git branch force-delete (absorb 6)
+  fx("BR-B1", "git branch -D feature-x", BLOCK, BRANCH_FORCE_DELETE),
+  fx("BR-B2", "git branch -df old-branch", BLOCK, BRANCH_FORCE_DELETE),
+  fx("BR-B3", "git branch -d -f old-branch", BLOCK, BRANCH_FORCE_DELETE),
+  fx("BR-A1", "git branch -d merged-branch", ALLOW, BRANCH_FORCE_DELETE),
+  fx("BR-A2", "git branch -m old new", ALLOW, BRANCH_FORCE_DELETE),
+  fx("BR-A3", "git branch --delete merged-branch", ALLOW, BRANCH_FORCE_DELETE),
+  // G. tag / reflog / worktree (absorb 8)
+  fx("TG-B1", "git tag -d v1.0.0", BLOCK, TAG_DELETE),
+  fx("TG-B2", "git reflog delete 'HEAD@{1}'", BLOCK, REFLOG_DELETE),
+  fx("TG-B3", "git worktree remove --force wt", BLOCK, WORKTREE_FORCE_REMOVE),
+  fx("TG-A1", "git tag v1.0.0", ALLOW, TAG_DELETE),
+  fx("TG-A2", "git tag -a v1.0.0 -m release", ALLOW, TAG_DELETE),
+  fx("TG-A3", "git reflog", ALLOW, REFLOG_DELETE),
+  fx("TG-A4", "git reflog expire --expire=now --all", ALLOW, REFLOG_DELETE),
+  fx("TG-A5", "git worktree remove wt", ALLOW, WORKTREE_FORCE_REMOVE),
+  // H. rm target hardening (absorb 9) — cwd/CLAUDE_PROJECT_DIR = temp project
+  fx("RH-B1", "rm -rf .", BLOCK, RM_HARDENING),
+  fx("RH-B2", "rm -rf ./", BLOCK, RM_HARDENING),
+  fx("RH-B3", "rm -rf ../sibling-project", BLOCK, RM_HARDENING),
+  fx("RH-B4", "rm -rf /Users/someone/other-project", BLOCK, RM_HARDENING),
+  fx("RH-B5", "rm -rf $DIR", BLOCK, RM_HARDENING),
+  fx("RH-A1", "rm -rf build", ALLOW, RM_HARDENING),
+  fx("RH-A2", "rm -rf ./build", ALLOW, RM_HARDENING),
+  fx("RH-A3", "rm -rf ./node_modules", ALLOW, RM_HARDENING),
+  fx("RH-A4", "rm -rf /tmp/scratch-dir", ALLOW, RM_HARDENING),
+  fx("RH-A5", 'rm -rf "$TMPDIR/cache"', ALLOW, RM_HARDENING),
+  fx("RH-A6", `rm -rf ${PROJECT_DIR_TOKEN}/dist`, ALLOW, RM_HARDENING),
+  fx("RH-A7", "rm -rf .cache", ALLOW, RM_HARDENING),
+  // I. quote-aware boundaries — verified bypasses (absorb 10 / F1)
+  fx("QB-B1", `bash -c "${RM_RF_ROOT}"`, BLOCK, QUOTE_BOUNDARY),
+  fx("QB-B2", "sh -c 'rm -rf ~'", BLOCK, QUOTE_BOUNDARY),
+  fx(
+    "QB-B3",
+    `python -c "import os; os.system('${RM_RF_ROOT}')"`,
+    BLOCK,
+    QUOTE_BOUNDARY
+  ),
+  fx(
+    "QB-B4",
+    `node -e "require('child_process').execSync('${RM_RF_ROOT}')"`,
+    BLOCK,
+    QUOTE_BOUNDARY
+  ),
+  fx("QB-B5", `perl -e "system('${RM_RF_ROOT}')"`, BLOCK, QUOTE_BOUNDARY),
+  fx("QB-B6", 'eval "rm -rf ~"', BLOCK, QUOTE_BOUNDARY),
+  fx("QB-A1", 'bash -c "rm -rf build"', ALLOW, QUOTE_BOUNDARY),
+  fx("QB-A2", 'python -c "print(1)"', ALLOW, QUOTE_BOUNDARY),
+  fx("QB-A3", "python spider.py -c config.yaml", ALLOW, QUOTE_BOUNDARY),
+  // J. find / xargs deletion (absorb 11)
+  fx("FX-B1", "find . -delete", BLOCK, FIND_DELETE),
+  fx("FX-B2", "find . -name '*.tmp' -delete", BLOCK, FIND_DELETE),
+  fx("FX-B3", "find . -name x -exec rm -rf {} \\;", BLOCK, FIND_EXEC_RM),
+  fx("FX-B4", "xargs rm -rf", BLOCK, XARGS_RM),
+  fx("FX-B5", "cat list.txt | xargs rm -rf", BLOCK, XARGS_RM),
+  fx("FX-B6", "find /tmp -type d -exec rm -fr {} +", BLOCK, FIND_EXEC_RM),
+  fx("FX-A1", "find . -name x -print", ALLOW, FIND_DELETE),
+  fx("FX-A2", "find /tmp -name x -exec rm {} +", ALLOW, FIND_EXEC_RM),
+  fx("FX-A3", "xargs grep pattern", ALLOW, XARGS_RM),
+  fx("FX-A4", "find . -name pre-delete-backup -print", ALLOW, FIND_DELETE),
+  fx("FX-A5", "echo a.txt | xargs rm -f", ALLOW, XARGS_RM),
+  // K. disk destroyers (absorb 12)
+  fx("DD-B1", "dd if=/dev/zero of=/dev/sda", BLOCK, DISK_DESTROYER),
+  fx("DD-B2", "mkfs.ext4 /dev/sda1", BLOCK, DISK_DESTROYER),
+  fx("DD-B3", "mkfs /dev/sdb", BLOCK, DISK_DESTROYER),
+  fx("DD-B4", "shred -u secrets.txt", BLOCK, DISK_DESTROYER),
+  fx("DD-A1", "dd if=disk.img of=backup.img", ALLOW, DISK_DESTROYER),
+  fx("DD-A2", "dd if=/dev/zero of=./local.img", ALLOW, DISK_DESTROYER),
+  fx("DD-A3", "ls shredder/", ALLOW, DISK_DESTROYER),
+  fx("DD-A4", "mkfs.ext4 disk.img", ALLOW, DISK_DESTROYER),
+  // M1. rm root/home/wildcard regressions (guard 1)
+  fx("RG-RM-B1", RM_RF_ROOT, BLOCK, RM_ROOT),
+  fx("RG-RM-B2", "rm -rf ~", BLOCK, RM_ROOT),
+  fx("RG-RM-B3", "rm -rf $HOME", BLOCK, RM_ROOT),
+  fx("RG-RM-B4", "rm -rf ${HOME}", BLOCK, RM_ROOT),
+  fx("RG-RM-B5", "rm -rf /*", BLOCK, RM_ROOT),
+  fx("RG-RM-B6", "rm -rf *", BLOCK, RM_ROOT),
+  fx("RG-RM-B7", "rm -fr ~", BLOCK, RM_ROOT),
+  fx("RG-RM-B8", "rm -r -f /", BLOCK, RM_ROOT),
+  fx("RG-RM-B9", "rm --recursive --force /", BLOCK, RM_ROOT),
+  fx("RG-RM-B10", `sudo ${RM_RF_ROOT}`, BLOCK, RM_ROOT),
+  fx("RG-RM-B11", "env FOO=1 rm -rf ~", BLOCK, RM_ROOT),
+  fx("RG-RM-A1", "rm -r dir", ALLOW, RM_ROOT),
+  fx("RG-RM-A2", "rm -f file.txt", ALLOW, RM_ROOT),
+  fx("RG-RM-A3", "rm file.txt", ALLOW, RM_ROOT),
+  fx("RG-RM-A4", "rm -rf build && echo done", ALLOW, RM_ROOT),
+  // M2. force-push regressions (guard 2) — deep coverage stays in the
+  // pre-existing parity-safety-net.test.ts suite
+  fx("RG-FP-B1", "git push --force origin main", BLOCK, FORCE_PUSH),
+  fx("RG-FP-B2", "git push -f origin master", BLOCK, FORCE_PUSH),
+  fx("RG-FP-A1", "git push --force-with-lease origin main", ALLOW, FORCE_PUSH),
+  fx(
+    "RG-FP-A2",
+    "git push --force origin feature/experiment",
+    ALLOW,
+    FORCE_PUSH
+  ),
+  fx("RG-FP-A3", "git push origin main", ALLOW, FORCE_PUSH),
+  // M4. destructive SQL regressions (guard 4)
+  fx("RG-SQL-B1", "psql -c 'DROP TABLE users;'", BLOCK, SQL),
+  fx("RG-SQL-B2", "mysql -e 'TRUNCATE sessions'", BLOCK, SQL),
+  fx("RG-SQL-B3", "echo 'DROP DATABASE prod' | psql", BLOCK, SQL),
+  fx("RG-SQL-B4", "psql -c 'DROP SCHEMA public CASCADE'", BLOCK, SQL),
+  fx("RG-SQL-B5", "psql -c 'TRUNCATE TABLE audit_log'", BLOCK, SQL),
+  fx("RG-SQL-A1", "truncate -s 0 file.log", ALLOW, SQL),
+  fx("RG-SQL-A2", "echo drop tables gently", ALLOW, SQL),
+  fx("RG-SQL-A3", "git branch -d drop-table-migration", ALLOW, SQL),
+];
+
+/** Reset guards asserted in real clean/dirty fixture repos (guard 3 + absorb 7). */
+export const GIT_STATE_FIXTURES: readonly GitStateFixture[] = [
+  gfx("GS-B1", "dirty", "git reset --hard", BLOCK),
+  gfx("GS-B2", "dirty", "git reset --hard HEAD~1", BLOCK),
+  gfx("GS-B3", "dirty", "git reset --merge", BLOCK),
+  gfx("GS-A1", "clean", "git reset --hard", ALLOW),
+  gfx("GS-A2", "clean", "git reset --merge", ALLOW),
+  gfx("GS-A3", "dirty", "git reset --soft HEAD~1", ALLOW),
+  gfx("GS-A4", "dirty", "git reset --keep", ALLOW),
+  gfx("GS-A5", "dirty", "git reset --mixed HEAD", ALLOW),
+];

--- a/tests/helpers/safety-net-guard-harness.ts
+++ b/tests/helpers/safety-net-guard-harness.ts
@@ -1,0 +1,139 @@
+/**
+ * Harness for driving the REAL parity-safety-net.sh hook in tests.
+ *
+ * Spawns the hook as a bash subprocess with PreToolUse JSON on stdin and
+ * surfaces its exit status: 2 = blocked, 0 = allowed. Also builds the temp git
+ * repos the working-tree-state guards (reset --hard/--merge) are asserted in.
+ * @module tests/helpers/safety-net-guard-harness
+ */
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const HOOK_PATH = path.resolve("plugins/lisa/hooks/parity-safety-net.sh");
+const BASH_PATH = "/bin/bash";
+const GIT_BIN = "/usr/bin/git";
+const README = "README.md";
+
+/** Exit status the hook uses to deny a command. */
+export const EXIT_BLOCKED = 2;
+
+/** Exit status the hook uses to let a command proceed. */
+export const EXIT_ALLOWED = 0;
+
+/** Expected hook verdict for a fixture. */
+export type Verdict = "allow" | "block";
+
+/** One row of the guard-parity matrix. */
+export interface GuardFixture {
+  readonly id: string;
+  readonly command: string;
+  readonly expected: Verdict;
+  readonly guard: string;
+}
+
+/** A guard-matrix row whose verdict depends on working-tree state. */
+export interface GitStateFixture extends GuardFixture {
+  readonly repo: "clean" | "dirty";
+}
+
+/** An environment map as spawned processes accept it. */
+type EnvMap = Record<string, string | undefined>;
+
+/** Exit status and stderr captured from one hook invocation. */
+interface HookResult {
+  readonly status: number | null;
+  readonly stderr: string;
+}
+
+/** Per-invocation working directory and extra environment. */
+interface RunOptions {
+  readonly cwd: string;
+  readonly env?: EnvMap;
+}
+
+/** The hook/git runners bound to a sanitized base environment. */
+interface GuardHarness {
+  readonly runHookRaw: (input: string, options: RunOptions) => HookResult;
+  readonly runHook: (command: string, options: RunOptions) => HookResult;
+  readonly makeRepo: (root: string, name: string, dirty: boolean) => string;
+}
+
+/**
+ * Maps a verdict to the exit status the hook must produce.
+ * @param verdict - Expected verdict.
+ * @returns 2 for block, 0 for allow.
+ */
+export const expectedStatus = (verdict: Verdict): number =>
+  verdict === "block" ? EXIT_BLOCKED : EXIT_ALLOWED;
+
+/**
+ * Binds the hook/git runners to a base environment.
+ *
+ * Hook-managed GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE poison git
+ * subprocesses in temp repos (known repo learning), so every spawn strips
+ * GIT_* wholesale from the given base env.
+ * @param baseEnv - Environment to inherit (callers pass process.env).
+ * @returns The bound harness.
+ */
+export const createGuardHarness = (baseEnv: EnvMap): GuardHarness => {
+  const strippedEnv = (): EnvMap =>
+    Object.fromEntries(
+      Object.entries(baseEnv).filter(([key]) => !key.startsWith("GIT_"))
+    );
+
+  const runHookRaw = (input: string, options: RunOptions): HookResult => {
+    const result = spawnSync(BASH_PATH, [HOOK_PATH], {
+      cwd: options.cwd,
+      encoding: "utf-8",
+      env: {
+        ...strippedEnv(),
+        CLAUDE_PROJECT_DIR: options.cwd,
+        // Point at a path that does not exist so project-local custom rules
+        // cannot leak into built-in guard assertions.
+        SAFETY_NET_RULES_FILE: path.join(options.cwd, "no-rules-here.txt"),
+        ...options.env,
+      },
+      input,
+    });
+    return { status: result.status, stderr: result.stderr };
+  };
+
+  const runHook = (command: string, options: RunOptions): HookResult =>
+    runHookRaw(
+      JSON.stringify({ tool_name: "Bash", tool_input: { command } }),
+      options
+    );
+
+  const gitIn = (cwd: string, ...args: readonly string[]): void => {
+    const result = spawnSync(GIT_BIN, [...args], {
+      cwd,
+      encoding: "utf-8",
+      env: {
+        ...strippedEnv(),
+        GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_CONFIG_SYSTEM: "/dev/null",
+      },
+    });
+    if (result.status !== 0) {
+      throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+    }
+  };
+
+  const makeRepo = (root: string, name: string, dirty: boolean): string => {
+    const dir = path.join(root, name);
+    mkdirSync(dir);
+    gitIn(dir, "init", "--initial-branch=main");
+    gitIn(dir, "config", "user.email", "safety-net-test@lisa.dev");
+    gitIn(dir, "config", "user.name", "Lisa Safety Net Test");
+    writeFileSync(path.join(dir, README), "seed\n");
+    gitIn(dir, "add", README);
+    gitIn(dir, "commit", "-m", "seed");
+    if (dirty) {
+      writeFileSync(path.join(dir, README), "seed\nuncommitted edit\n");
+    }
+    return dir;
+  };
+
+  return { runHookRaw, runHook, makeRepo };
+};

--- a/tests/unit/hooks/parity-safety-net-guards.test.ts
+++ b/tests/unit/hooks/parity-safety-net-guards.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Guard-parity fixture matrix for parity-safety-net.sh (issue #1960).
+ *
+ * Drives the REAL hook via a bash subprocess with PreToolUse JSON on stdin and
+ * asserts the exit code per fixture: 2 = blocked, 0 = allowed. Fixture data
+ * lives in tests/helpers/safety-net-guard-fixtures.ts; the subprocess harness
+ * in tests/helpers/safety-net-guard-harness.ts.
+ *
+ * Deep force-push and heredoc coverage lives in parity-safety-net.test.ts and
+ * parity-safety-net-heredoc.test.ts — this suite only smoke-pins those.
+ * @module tests/unit/hooks/parity-safety-net-guards
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  GIT_STATE_FIXTURES,
+  PROJECT_DIR_TOKEN,
+  RM_RF_ROOT,
+  STATELESS_FIXTURES,
+} from "../../helpers/safety-net-guard-fixtures";
+import {
+  createGuardHarness,
+  EXIT_ALLOWED,
+  EXIT_BLOCKED,
+  expectedStatus,
+} from "../../helpers/safety-net-guard-harness";
+
+const HEREDOC_TERMINATOR = "EOF";
+const { runHook, runHookRaw, makeRepo } = createGuardHarness(process.env);
+
+describe("parity-safety-net.sh — guard parity matrix (#1960)", () => {
+  let workRoot: string;
+  let projectDir: string;
+
+  beforeAll(() => {
+    workRoot = mkdtempSync(path.join(tmpdir(), "lisa-safety-guards-"));
+    projectDir = path.join(workRoot, "project");
+    mkdirSync(projectDir);
+  });
+
+  afterAll(() => {
+    rmSync(workRoot, { recursive: true, force: true });
+  });
+
+  describe("built-in guards (stateless fixtures)", () => {
+    it.each(STATELESS_FIXTURES)("$id [$expected] $command", fixture => {
+      const command = fixture.command.replaceAll(PROJECT_DIR_TOKEN, projectDir);
+      const { status, stderr } = runHook(command, { cwd: projectDir });
+      expect(
+        status,
+        `${fixture.id} (${fixture.guard}) expected ${fixture.expected}; stderr: ${stderr}`
+      ).toBe(expectedStatus(fixture.expected));
+    });
+  });
+
+  describe("rm hardening when cwd is $HOME (absorb 9 HOME gate)", () => {
+    it("HM-B1 blocks a recursive forced delete run from $HOME", () => {
+      const { status } = runHook("rm -rf projects", {
+        cwd: projectDir,
+        env: { HOME: projectDir },
+      });
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("HM-A1 allows a non-recursive delete run from $HOME", () => {
+      const { status } = runHook("rm -f notes.txt", {
+        cwd: projectDir,
+        env: { HOME: projectDir },
+      });
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("dirty/clean working-tree reset guards (guard 3 + absorb 7)", () => {
+    let cleanRepo: string;
+    let dirtyRepo: string;
+
+    beforeAll(() => {
+      cleanRepo = makeRepo(workRoot, "clean-repo", false);
+      dirtyRepo = makeRepo(workRoot, "dirty-repo", true);
+    });
+
+    it.each(GIT_STATE_FIXTURES)(
+      "$id [$expected] $command in $repo repo",
+      fixture => {
+        const cwd = fixture.repo === "dirty" ? dirtyRepo : cleanRepo;
+        const { status, stderr } = runHook(fixture.command, { cwd });
+        expect(
+          status,
+          `${fixture.id} in ${fixture.repo} repo expected ${fixture.expected}; stderr: ${stderr}`
+        ).toBe(expectedStatus(fixture.expected));
+      }
+    );
+  });
+
+  describe("project-local custom rules file (guard 5)", () => {
+    let rulesPath: string;
+
+    beforeAll(() => {
+      rulesPath = path.join(workRoot, "custom-rules.txt");
+      writeFileSync(
+        rulesPath,
+        [
+          "# comment lines are ignored",
+          "",
+          "terraform[[:space:]]+destroy",
+          "FORBIDDEN_TOKEN",
+          "",
+        ].join("\n")
+      );
+    });
+
+    /**
+     * Screens a command with the custom rules file active.
+     * @param command - The Bash command under test.
+     * @returns The hook exit status.
+     */
+    const withRules = (command: string): number | null =>
+      runHook(command, {
+        cwd: projectDir,
+        env: { SAFETY_NET_RULES_FILE: rulesPath },
+      }).status;
+
+    it("CR-B1 blocks a command matching a custom ERE", () => {
+      expect(withRules("terraform destroy -auto-approve")).toBe(EXIT_BLOCKED);
+    });
+
+    it("CR-A1 allows the near-miss of the custom ERE", () => {
+      expect(withRules("terraform plan")).toBe(EXIT_ALLOWED);
+    });
+
+    it("CR-B2 applies rules that follow comments and blank lines", () => {
+      expect(withRules("echo FORBIDDEN_TOKEN")).toBe(EXIT_BLOCKED);
+    });
+
+    it("CR-A2 allows a command matching no rule", () => {
+      expect(withRules("echo safe output")).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("fail-closed input handling (absorb 13)", () => {
+    it("FC-B1 denies (exit 2) on malformed hook JSON", () => {
+      const { status } = runHookRaw("not json", { cwd: projectDir });
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("FC-A1 allows valid input with no command field", () => {
+      const input = JSON.stringify({ tool_name: "Bash", tool_input: {} });
+      expect(runHookRaw(input, { cwd: projectDir }).status).toBe(EXIT_ALLOWED);
+    });
+
+    it("FC-A2 ignores non-Bash tools even with destructive text", () => {
+      const input = JSON.stringify({
+        tool_name: "Read",
+        tool_input: { command: RM_RF_ROOT },
+      });
+      expect(runHookRaw(input, { cwd: projectDir }).status).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("heredoc classifier smoke regressions", () => {
+    it("HD-A1 still exempts a gh-writer prose heredoc quoting rm -rf /", () => {
+      const command = [
+        "gh issue create --body-file - <<'EOF'",
+        RM_RF_ROOT,
+        HEREDOC_TERMINATOR,
+      ].join("\n");
+      expect(runHook(command, { cwd: projectDir }).status).toBe(EXIT_ALLOWED);
+    });
+
+    it("HD-B1 still blocks an executable heredoc containing rm -rf /", () => {
+      const command = ["bash <<'EOF'", RM_RF_ROOT, HEREDOC_TERMINATOR].join(
+        "\n"
+      );
+      expect(runHook(command, { cwd: projectDir }).status).toBe(EXIT_BLOCKED);
+    });
+  });
+});

--- a/tests/unit/hooks/parity-safety-net-guards.test.ts
+++ b/tests/unit/hooks/parity-safety-net-guards.test.ts
@@ -95,7 +95,7 @@ describe("parity-safety-net.sh — guard parity matrix (#1960)", () => {
     );
   });
 
-  describe("project-local custom rules file (guard 5)", () => {
+  describe("project-local custom rules file (guard 14)", () => {
     let rulesPath: string;
 
     beforeAll(() => {

--- a/tests/unit/scripts/install-claude-plugins-self.test.ts
+++ b/tests/unit/scripts/install-claude-plugins-self.test.ts
@@ -586,6 +586,7 @@ describe("install-claude-plugins self postinstall path", () => {
     // Retirement of curated plugins is version-gated: a same-version run must
     // not spawn the CLI to re-uninstall an already-retired plugin.
     expect(log).not.toContain("claude plugin uninstall sentry");
+    expect(log).not.toContain("claude plugin uninstall safety-net");
   });
 
   it("performs a full plugin sync and records the marker when the Lisa version changes", async () => {
@@ -638,6 +639,15 @@ describe("install-claude-plugins self postinstall path", () => {
     );
     expect(log).toContain(
       "claude plugin uninstall sentry@claude-plugins-official --scope project"
+    );
+    // The Lisa-native parity-safety-net.sh hook absorbed the upstream
+    // safety-net plugin's material guards, so the upstream plugin is retired
+    // on sync instead of installed (issue #1960).
+    expect(log).not.toContain(
+      "claude plugin install safety-net@cc-marketplace"
+    );
+    expect(log).toContain(
+      "claude plugin uninstall safety-net@cc-marketplace --scope project"
     );
     const marker = await readFile(
       path.join(projectRoot, CLAUDE_DIR, PLUGIN_SYNC_MARKER_FILE),

--- a/typescript/merge/.claude/settings.json
+++ b/typescript/merge/.claude/settings.json
@@ -6,7 +6,7 @@
   "enabledPlugins": {
     "lisa-typescript@lisa": true,
     "typescript-lsp@claude-plugins-official": true,
-    "safety-net@cc-marketplace": true,
+    "safety-net@cc-marketplace": false,
     "code-simplifier@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "coderabbit@claude-plugins-official": true,


### PR DESCRIPTION
Closes #1960

Work-Item: CodySwannGT/lisa#1960

## What

Ends the double-screening of every Bash command (Lisa's `parity-safety-net.sh` PreToolUse hook + the upstream `safety-net@cc-marketplace` plugin's hook) the safe way: guard parity first, retirement second — same pattern as the sentry dedup (#1955 / #1964).

1. **Guard absorption** (`f02715fa7`): all 13 material guard families from upstream 1.0.6 reimplemented in `plugins/src/base/hooks/parity-safety-net.sh` — git checkout/switch/restore discard forms, stash drop/clear, clean -f, branch -D, reset --merge, tag/reflog/worktree deletions, rm target hardening (`.`/`..`/absolute-outside-project/`$VAR`/HOME-cwd gate with /tmp,$TMPDIR allowance), quote-aware boundaries closing the wrapper/interpreter one-liner bypass, find/xargs recursive-delete, dd/mkfs/shred, and jq/parse fail-closed → exit 2. Documented divergences kept (dirty-tree-only `reset --hard`, protected-branch-only force-push) and Lisa's upstream-exceeding guards retained.
2. **Fixture contract**: 173 allow/block fixtures driving the REAL hook via PreToolUse JSON (TDD: 50 red before absorption, exact match to the designed matrix; near-miss allow pairs guard against overblocking).
3. **Review hardening** (`8ab54c7e6`): security review found two HIGH bypasses that upstream catches — git global options (a `git -C <path>` prefix skipped every git guard) and path-prefixed rm binaries (an absolute path to rm dodged the rm guards) — both closed with 35 new fixtures and before/after exit-code proof; plus tilde-path rm targets, a chained-command false-positive fix, and doc corrections.
4. **Retirement** (`eeb8f8faf`): `safety-net@cc-marketplace` removed from the curated install list, added to the version-gated uninstall loop, `enabledPlugins` flipped to `false` in all ten settings templates, routing artifact re-pinned to 1.0.6 with the decision addendum. Mutation-proven both directions in the install-script tests.

## Verification (independent verifier re-ran everything at head)

- 446/446 tests across 24 files; guard suite 173/173.
- 16 live-hook spot checks: 10 blocks (incl. both closed bypass classes) exit 2, 6 realistic allows exit 0.
- Retirement greps: single retirement-loop occurrence; zero `true` entries; ten `false` templates.
- `plugin-parity-drift` exit 0 (safety-net pinned 1.0.6 = current); evidence manifest + plugin-sync checks green; typecheck + lint clean; `.husky/` untouched vs main.
- Spec conformance: CONFORMS (matrix in-branch evidence; ordering constraint parity-before-retirement holds by commit ancestry).

After this ships, each Bash command is screened exactly once, by a hook whose guard set is a strict superset of upstream 1.0.6's default-mode protections.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded protection against destructive file, Git, disk, and database commands.
  * Safety checks now fail closed when command input cannot be safely validated.
  * Added support for custom project-specific safety rules.

* **Documentation**
  * Updated safety guidance with comprehensive blocked-command coverage and usage notes.

* **Chores**
  * Retired the duplicate marketplace safety plugin in favor of the built-in protections.
  * Updated plugin parity metadata and installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->