### PR TITLE
feat(core): deployStatusSync config schema + env-join deploy ladder resolver (DSS-1)

### DIFF
--- a/.lisa/plan-1967.md
+++ b/.lisa/plan-1967.md
@@ -1,0 +1,184 @@
+# Plan: dss-1-config-schema — CodySwannGT/lisa#1967
+
+Branch: `claude/1967-deploy-status-sync-config` (off origin/main; target_branch=main).
+Work item bound: CodySwannGT/lisa#1967 (verified readback). Roster: `.lisa/roster.md`.
+Task tool unavailable in this runtime (TaskCreate not exposed) — this file is the persisted task list, updated as tasks progress.
+
+## T1 — Research + architecture design [owner: Explore → lisa:architecture-specialist] — status: research done, design in progress
+
+```json
+{
+  "plan": "dss-1-config-schema",
+  "type": "task",
+  "acceptance_criteria": ["relevant_documentation filled for T2 (existing config readers, done-map defaults, rule-pair layout, test conventions)", "module placement + public API decided and recorded here"],
+  "relevant_documentation": "done-map defaults: src/sync/registry.ts:126-136 (BUILD_LABEL_DEFAULTS, private), jira.workflow:250-261, github.labels:268-273, linear.labels:274-282; deploy.branches reader: src/cli/doctor-readiness-delivery.ts:97-114 (best-effort); config typing: src/core/project-config.ts:99-108 (ProjectConfig) + validated-section model src/core/project-config-kane.ts (PRODUCTION_ENVIRONMENTS:24); error style: project-config.ts:455, workflow join errors reusable-claude-sync-down-branches.yml:135,138; deploy.order semantics: reference/config-resolution.md:560-598; sole-alias prose: eager/config-resolution.md:79; JSON guards: src/sync/json-path.ts; tests mirror src path, vitest, pure-object model tests/unit/core/project-config-kane.test.ts; rule edits => build:upstream-evidence-manifest + build:plugins same commit; NO env-ladder code exists in src/ (deploy.order is the rank surface); alias checks scattered: kane.ts:24, kane-cli.ts:88, doctor-readiness-journey-freshness.ts:131",
+  "testing_requirements": [],
+  "skills": [],
+  "learnings": [],
+  "required_access": [],
+  "verification": { "type": "documentation", "command": "read this file section T1", "expected": "design section names module path, exported API, and integration points" }
+}
+```
+
+## T2 — TDD implement resolver + config schema + rule pair [owner: lisa:builder] — status: complete
+
+```json
+{
+  "plan": "dss-1-config-schema",
+  "type": "story",
+  "acceptance_criteria": [
+    "resolver returns ordered ladder (dev,staging,production) with branch+done status per rung for full 3-env config",
+    "env in done-map without branch -> decision-ready error naming env + exact config key, operator-readable",
+    "production-only config -> single-rung ladder flagged terminal-only",
+    "prod/production sole alias resolves to one production rung; no other alias",
+    "deployStatusSync section schema (tier, provisioned ids, linear binding labels|states, verifiedAt) documented in eager+reference config-resolution.md pair",
+    "evidence manifest regenerated in same commit as rule/template edits"
+  ],
+  "relevant_documentation": "filled by T1",
+  "testing_requirements": ["unit tests: full ladder, collapse, inconsistent join, alias, error-text readability; no e2e harness applies (CLI/library surface — recorded absence in roster.md)"],
+  "skills": ["lisa:lisa-tdd-implementation"],
+  "learnings": [
+    { "kind": "gotcha", "note": "Array.prototype.toSorted is unavailable (tsconfig lib < ES2023); house immutable-sort pattern is [...arr].sort(comparator), which satisfies both functional/immutable-data and sonarjs/no-misleading-array-reverse", "evidence": "src/core/deploy-status-sync.ts orderEnvironments" },
+    { "kind": "gotcha", "note": "max-lines (300, skipComments) blocked adding a validated section to project-config.ts; extracted validateSafeRelativeMarkdownPath + containsControlCharacter to src/core/config-path-validation.ts (kane-style sibling-module precedent) instead of an eslint-disable", "evidence": "commit a8bc3991c" },
+    { "kind": "gotcha", "note": "evidence manifest inventories plugins/src AND src/ AND tests/ — regenerate after any tracked source/test change (T3 corrected: the earlier 'plugins/src only' claim was wrong; UPSTREAM_SURFACE_MANIFEST also inventories src/ and tests/, and tests/unit/scripts/upstream-evidence-manifest.test.ts goes red on any new tracked file)", "evidence": "T3 finding 1: full suite red until build:upstream-evidence-manifest re-run after T2's new src/tests files" },
+    { "kind": "mistake", "note": "ran manifest regen before staging new files; reported suite green without re-running at final HEAD — the generator walks git ls-files so untracked/unstaged new files are invisible; always `git add` new files BEFORE build:upstream-evidence-manifest and re-run the full suite at the exact commit HEAD being reported", "evidence": "T4 verifier observed 1 failed / 7261 passed at e67dcbeb2 vs builder-reported 7262 passed; manifest was missing the two split test files" }
+  ],
+  "required_access": [],
+  "verification": { "type": "cli-test", "command": "see T2 completion proof entry below (bun -e against 4 fixture configs: full, missing-branch, single-env, alias)", "expected": "ladder output / decision-ready error per completion condition in roster.md" }
+}
+```
+
+### T2 completion (builder)
+
+**Commits** (branch `claude/1967-deploy-status-sync-config`, not pushed):
+
+- `a8bc3991c` feat(core): add deploy-status-sync ladder resolver and config schema — `src/core/deploy-status-sync.ts` (new), `src/core/config-path-validation.ts` (new, extracted from project-config to hold max-lines), `src/core/project-config.ts` (deployStatusSync wiring), `src/sync/registry.ts` (value-identical default-table refactor), `tests/unit/core/deploy-status-sync.test.ts` (25 tests, TDD RED→GREEN)
+- `03eab138f` docs(rules): document deployStatusSync schema and deploy ladder resolution — rule pair `plugins/src/base/rules/{eager,reference}/config-resolution.md` + regenerated plugin copies + `src/core/upstream-evidence-manifest.ts` (same commit)
+
+**Quality gates**: `bun run lint` clean, `bun run typecheck` clean, `bunx vitest run tests/unit` 428 files / 7246 tests green (includes the new 25 and all sync/core suites).
+
+**Design deviations**: none. (config-path-validation.ts extraction is housekeeping forced by the max-lines budget; behavior unchanged.)
+
+**Proof entry for T4** (run from repo root; exercises the actual resolver, prints ladder/error for the four fixture shapes):
+
+```sh
+bun -e '
+import { resolveDeployLadder } from "./src/core/deploy-status-sync.ts";
+const src = ".lisa.config.json";
+const show = (label, fn) => { try { console.log(label, JSON.stringify(fn())); } catch (e) { console.log(label, "ERROR:", e.message); } };
+show("full:", () => resolveDeployLadder({ deploy: { branches: { dev: "dev", staging: "staging", production: "main" } } }, "github", src));
+show("missing-branch:", () => resolveDeployLadder({ deploy: { branches: { dev: "dev", production: "main" } }, github: { labels: { build: { done: { staging: "status:on-stg" } } } } }, "github", src));
+show("single-env:", () => resolveDeployLadder({ deploy: { branches: { production: "main" } } }, "github", src));
+show("alias:", () => resolveDeployLadder({ deploy: { branches: { prod: "main" } } }, "jira", src));
+'
+```
+
+Expected output (observed 2026-07-22):
+
+- `full:` 3 rungs ordered dev→staging→production with branches dev/staging/main and doneStatus `status:on-dev`/`status:on-stg`/`status:done`, `terminalOnly:false`
+- `missing-branch:` ERROR `Invalid deploy configuration in .lisa.config.json: a done status ("status:on-stg") is configured for environment "staging", but deploy.branches has no "staging" entry. Add deploy.branches.staging (the git branch that deploys to staging) or remove "staging" from the done map.`
+- `single-env:` one rung `{env:"production",branch:"main",doneStatus:"status:done"}`, `terminalOnly:true`
+- `alias:` one rung `{env:"prod",branch:"main",doneStatus:"Done"}` (jira default via sole prod↔production alias), `terminalOnly:true`
+
+## T3 — Team review + implement valid suggestions [owner: lisa:test-specialist, lisa:quality-specialist, code-simplifier] — status: pending
+
+```json
+{
+  "plan": "dss-1-config-schema",
+  "type": "task",
+  "acceptance_criteria": ["each reviewer produces findings with severity+failure scenario per convergent-review", "valid findings fixed; invalid pushed back with evidence; dispositions recorded here"],
+  "relevant_documentation": "T1 findings",
+  "testing_requirements": ["quality gates re-run after fixes"],
+  "skills": [],
+  "learnings": [],
+  "required_access": [],
+  "verification": { "type": "documentation", "command": "read T3 dispositions", "expected": "every finding has fixed|deferred|pushed-back with reason" }
+}
+```
+
+## T3 dispositions
+
+Consolidated review (product/coderabbit/local/quality + simplifier), lead dispositions applied by builder. All fixes in commit `e67dcbeb2` (fix(core): harden deploy ladder resolution per T3 review); gates green (lint, typecheck, full tests/unit 7262 passed).
+
+| # | Finding | Disposition | Fix |
+| --- | --- | --- | --- |
+| 1 | CRITICAL: evidence manifest stale — full suite red (manifest inventories src/ + tests/ too, not just plugins/src) | fixed | `bun run build:upstream-evidence-manifest` re-run + committed; T2 learning corrected in metadata |
+| 2 | deploy.order duplicates pass set-comparison → duplicate rungs | fixed | `assertOrderMatchesBranches` now requires `orderSet.size === order.length` + `=== branchEnvs.length`; test pins exact mismatch error for `["dev","dev","production"]` |
+| 3 | terminalOnly mislabels a skip-collapsed non-terminal sole rung | fixed (lead-approved design deviation, rationale appended to T1 design) | terminalOnly = one rung AND rung.env === highest-ranked env; reference doc wording updated; 3 cases pinned (production-only true, solo-dev true, dev/qa-skip false) |
+| 4 | non-string deploy.order entries silently filtered (fail-not-guess violation) | fixed | `readOrder` errors: `Invalid deploy.order in <source>: every entry must be an environment name string; found <entry>.` — doc'd in error catalog + test |
+| 5 | regression pins (a)–(f) | fixed (tests only) | configured done "production" + branches.prod exact error; 2-env alias canonical ordering; order ["prod"] vs {production} mismatch; non-string branch value error pinned; single-custom-env-no-vocab empty ladder; validator it.each catalog (null/array section, provisioned non-object, tier empty/whitespace) |
+| 6 | dedup helpers | fixed | `optionalString` + `containsControlCharacter` moved into extracted module, renamed `config-field-validation.ts`; imports updated in project-config.ts + deploy-status-sync.ts; kane copies untouched (out of scope) |
+| 7 | small cleanups | fixed | `stringRecord()` helper; removed unnecessary cast (isJsonObject narrows); `ordered.at(-1)`; `branchEnvs.includes()`; provisioned flatMap-filter instead of `?? ""` |
+| D1 | improve non-string-branch error to say "is not a string" | deferred (follow-up candidate, no blocking scenario) | — |
+| D2 | consolidate kane's duplicate optionalString/containsControlCharacter | deferred (out of story scope, no blocking scenario) | — |
+
+Pushed back: none. Note: quality reviewer left `git stash stash@{0}` ("quality-review: revert manifest regen probe") — intentionally NOT dropped (Safety Net blocks stash drops); left in place.
+
+Test layout note: the T2 single test file was split into `deploy-status-sync.test.ts` (ladders), `deploy-status-sync-errors.test.ts` (error catalog), `deploy-status-sync-config.test.ts` (validator + wiring + default vocab) to stay under the 300 max-lines budget after adding the T3 pins. 41 tests total (was 25).
+
+## T4 — Empirical verification + verdict [owner: lisa:verification-specialist (non-implementer)] — status: pending
+
+```json
+{
+  "plan": "dss-1-config-schema",
+  "type": "task",
+  "acceptance_criteria": ["proof command run against actual resolver, output in transcript", "verification-status.json schema v2 written with claims bound to cli boundary, all pass"],
+  "relevant_documentation": "roster.md completion condition",
+  "testing_requirements": [],
+  "required_access": [],
+  "skills": [],
+  "learnings": [],
+  "verification": { "type": "cli-test", "command": "as recorded by T2 (exact entry)", "expected": "4/4 fixture behaviors observed; verdict status=pass" }
+}
+```
+
+## T5 — PR, merge, evidence, learnings [owner: lead + lisa:learner] — status: pending
+
+```json
+{
+  "plan": "dss-1-config-schema",
+  "type": "task",
+  "acceptance_criteria": ["PR opened via lisa-git-submit-pr work_item_ref=CodySwannGT/lisa#1967 target_branch=main", "driven to merge; two-way linkage verified", "usage entry recorded on #1967", "learner captured MLD to ledger", "issue transitioned per env-keyed done (single-env: status:done + native close)"],
+  "relevant_documentation": "",
+  "testing_requirements": [],
+  "required_access": [{ "tool": "github", "probe": "gh issue view 1967", "status": "pass" }],
+  "skills": ["lisa:lisa-git-submit-pr", "lisa:lisa-drive-pr-to-merge"],
+  "learnings": [],
+  "verification": { "type": "cli-test", "command": "gh pr view <n> --json state,mergedAt; git merge-base --is-ancestor <head> origin/main", "expected": "MERGED + ancestry true + release run fired" }
+}
+```
+
+## T1 design
+
+**1. Module + tests.** `src/core/deploy-status-sync.ts`; tests `tests/unit/core/deploy-status-sync.test.ts` (vitest, pure-object, no fs — mirror `project-config-kane.test.ts`). Follows the validated-optional-section precedent; imports only `../sync/json-path.js` (leaf: `JsonValue`, `isJsonObject`, `getAtPath`).
+
+**2. Public API** (all exported; input = parsed `JsonValue` config + tracker discriminator, never file paths):
+```ts
+export type Tracker = "jira" | "github" | "linear";
+export interface DeployLadderRung { readonly env: string; readonly branch: string; readonly doneStatus: string; }
+export interface DeployLadder { readonly rungs: readonly DeployLadderRung[]; readonly terminalOnly: boolean; }
+export function resolveDeployLadder(config: JsonValue, tracker: Tracker, source: string): DeployLadder;
+export interface DeployStatusSyncConfig { readonly tier?: string; readonly provisioned?: Readonly<Record<string, string>>; readonly linearBinding?: "labels" | "states"; readonly verifiedAt?: string; }
+export function validateDeployStatusSyncConfig(value: unknown, source: string): DeployStatusSyncConfig | undefined;
+export const ENV_DONE_LABEL_DEFAULTS; export const JIRA_DONE_STATUS_DEFAULTS;
+```
+Wiring like kane: `ProjectConfig` gains `readonly deployStatusSync?: DeployStatusSyncConfig` (project-config.ts:100-109) and the parse path calls the validator beside `validateVerificationConfig` (project-config.ts:314). Validators throw plain `Error` in house style `Invalid <field> in <source>: ...`; kane-style field checks (non-empty trimmed strings, no control chars); `linearBinding` enum `labels|states`; `verifiedAt` strict ISO-8601 UTC; unknown fields inside the section ignored in the typed view (raw JSON round-trip preserves them). Empty/absent `deploy` → empty ladder (`rungs: [], terminalOnly: false`), not an error.
+
+**3. Done-map sourcing.** Tracker→key: github `github.labels.build.done`, linear `linear.labels.build.done`, jira `jira.workflow.done`; per-env value = configured entry else default entry. Defaults come from constants **exported by this module** and consumed by `src/sync/registry.ts` (`BUILD_LABEL_DEFAULTS.done` → `ENV_DONE_LABEL_DEFAULTS`, jira.workflow `done` → `JIRA_DONE_STATUS_DEFAULTS`) — identical values, pure refactor, registry tests stay green. Rationale: a `SYNC_REGISTRY.find()` lookup would create a runtime ESM cycle (project-config → deploy-status-sync → registry → project-config, registry.ts:13); a shared constant keeps one source of truth without the cycle and without duplicating the tables.
+
+**4. Ladder ordering.** Env universe = keys of `deploy.branches`. Order: `deploy.order` when present (validated: env-name set must exactly match `deploy.branches` per reference/config-resolution.md:592-593); else canonical `dev < staging < production` filtered to configured envs; a custom env name with no `deploy.order` and >1 env is a decision-ready error (mirrors the sync-down Action's fail-not-guess). Branch with NO done status (configured or default — only possible for custom env names): **skip the rung**, don't error — a branch-only env is a deploy target without tracker vocabulary, and the AC only errors the done-without-branch direction; skipping keeps the join total. Explicitly-configured done entry whose env has no branch: **error** (AC). Default-table done entries for unconfigured envs are fallbacks and never trigger the error (else every 1-env project would fail). `terminalOnly = rungs.length === 1`; a string-valued `done` binds only the terminal rung.
+
+**5. Alias.** Compute the union of env keys across the joined surfaces (`deploy.branches`, configured done map, `deploy.order`). Iff exactly one of `prod`/`production` appears in that union, the two spellings match as one env everywhere in the join (so `branches.prod` meets default `done.production`); rung `env` reports the configured spelling; terminal/canonical-order checks accept both. If both appear, no aliasing (distinct envs; ranking then requires `deploy.order`). No other alias. Do **not** consolidate the three ad-hoc checks (project-config-kane.ts:24, kane-cli.ts:88, doctor-readiness-journey-freshness.ts:131) — out of story scope; recorded as follow-up candidate.
+
+**6. Error templates** (verbatim):
+- done-without-branch: `Invalid deploy configuration in <source>: a done status ("<status>") is configured for environment "<env>", but deploy.branches has no "<env>" entry. Add deploy.branches.<env> (the git branch that deploys to <env>) or remove "<env>" from the done map.`
+- order/branches mismatch: `Invalid deploy.order in <source>: its environment names must exactly match the keys of deploy.branches. deploy.order has [<order-envs>]; deploy.branches has [<branch-envs>].`
+- unrankable custom env: `Invalid deploy configuration in <source>: cannot order environment "<env>". Set deploy.order (environments listed lowest first, e.g. ["dev","staging","production"]) so Lisa knows the promotion order.`
+
+**7. Rule-pair edits** (source of truth: `plugins/src/base/rules/`; same commit must run `bun run build:plugins` AND `bun run build:upstream-evidence-manifest`):
+- eager/config-resolution.md — +3-4 lines near the deploy prose: `deployStatusSync` optional block (`tier`, `provisioned` ids, `linearBinding: labels|states`, `verifiedAt`); env ladder = `deploy.order` else `dev<staging<production` over `deploy.branches ⋈ done map`; a configured done status whose env has no branch is a config error; the sole `prod`↔`production` alias applies to the join.
+- reference/config-resolution.md — new `### Deploy status sync (deployStatusSync)` inserted after `### Env order (sync-down chain)` (before `### What's configurable...`, ~:599): schema field table with types/defaults, ladder algorithm (env universe, configured-vs-default done sourcing, skip rule, single-rung terminal-only collapse), alias behavior, and the error catalog verbatim.
+
+**T3 amendment (lead-approved deviation).** `terminalOnly` is NOT `rungs.length === 1`: it is exactly-one-rung AND that rung's env is the highest-ranked env of the configured universe (post-alias). Rationale: protects DSS-2 terminal native closure — a skip-collapsed ladder (e.g. `branches {dev,qa}`, `order ["dev","qa"]`, qa has no done vocab → sole `dev` rung) must not be reported terminal-only, or downstream would native-close work items at `status:on-dev`. Production-only stays true; a solo-dev universe stays true (dev IS its own terminal); a sole surviving lower rung is false. Also amended: `optionalString`/`containsControlCharacter` live in the shared `src/core/config-field-validation.ts` (renamed from config-path-validation.ts), so deploy-status-sync.ts imports that module in addition to `../sync/json-path.js`.
+
+**8. Out of scope / stability contract.** No CLI wiring, no SYNC_REGISTRY entry for `deployStatusSync` (machine-written by the DSS setup story, not a synced default), no sync-down workflow changes, no doctor changes, no alias-check consolidation. DSS-2/5 will import: `resolveDeployLadder`, `DeployLadder`, `DeployLadderRung`, `Tracker`, `DeployStatusSyncConfig`, `validateDeployStatusSyncConfig` — these names/signatures are the stable surface; additive evolution only. Constraints held: no new runtime deps; registry refactor is value-identical; unknown config fields preserved.

--- a/.lisa/roster.md
+++ b/.lisa/roster.md
@@ -1,171 +1,47 @@
-# Lisa Implement Roster Decision
+# Roster Decision — plan: dss-1-config-schema (CodySwannGT/lisa#1967)
 
-Work item: queue campaign starting `CodySwannGT/lisa#1546`
-Plan: `implement-ready-queue-1546`
-Runtime: Cursor (Task tool specialists)
-Recorded: 2026-07-18T20:55:00Z
+Runtime: Claude Code, Agent tool subagent types enumerated 2026-07-22.
+(Replaces the stale 2026-07-18 Cursor-run roster for #1546, which completed.)
 
-## Queue (status:ready)
+INCLUDE - Explore - mandatory read-only research agent; gathers relevant_documentation for every task before implementation.
+INCLUDE - lisa:architecture-specialist - designs the resolver module placement/API against existing config-resolution machinery (src/sync/registry.ts, doctor readers).
+INCLUDE - lisa:builder - TDD implementation of the resolver, config schema, and rule-pair docs (story is a Build).
+INCLUDE - lisa:test-specialist - reviews test matrix (ladder, collapse, inconsistent join, alias, operator-readable errors) beyond builder's own tests.
+INCLUDE - lisa:quality-specialist - post-implementation quality review (coding philosophy, immutability, docs).
+INCLUDE - code-simplifier:code-simplifier - simplification pass on new code before PR.
+INCLUDE - coderabbit:code-reviewer - PR review layer (runs in PR loop via drive-pr-to-merge).
+INCLUDE - lisa:verification-specialist - independent empirical verification + verification-status.json verdict (must not be the implementer).
+INCLUDE - lisa:learner - capture-only MLD ledger persistence at task end.
+INCLUDE - general-purpose - fallback for bounded transactional chores (input-resolver already used; tracker sync/evidence posting) where no specialist fits.
+EXCLUDE - lisa:bug-fixer - work type is Build, not Fix; no reproduction sub-flow needed.
+EXCLUDE - lisa:debug-specialist - no defect to root-cause.
+EXCLUDE - lisa:performance-specialist - config resolver is trivial-scale; no perf surface.
+EXCLUDE - lisa:security-specialist - no auth/secrets/input-trust surface in a local config resolver; PR-level scanners still run in CI.
+EXCLUDE - lisa:product-specialist - no user-facing UX; operator-readable error text is covered by AC + quality review.
+EXCLUDE - lisa:spec-conformance-specialist - single-story scope; spec conformance is covered by AC-driven verification here, full-PRD conformance belongs to DSS-9.
+EXCLUDE - lisa:git-history-analyzer - context bundle already carries the needed history (#1953/#1954).
+EXCLUDE - lisa:github-agent / jira-agent / linear-agent / *-build-intake / *-prd-intake - lifecycle dispatchers; this flow is already dispatched.
+EXCLUDE - lisa:learning-judge / learnings-synthesizer / pr-mining-specialist / tracker-mining-specialist / skill-evaluator - debrief/gardener flows, not in-story.
+EXCLUDE - claude-code-guide - no Claude-product questions in scope.
+EXCLUDE - hookify:conversation-analyzer - no hook-authoring task.
+EXCLUDE - statusline-setup - irrelevant.
+EXCLUDE - Plan - decomposition already done at PRD planning; architecture-specialist covers design.
+EXCLUDE - claude - generic catch-all; specific specialists selected instead.
+EXCLUDE - casey/chief/felix/lex/mark/parker/sally - tunnl-backend domain agents; wrong project (added via /add-dir, not this repo).
 
-1. #1546 Wire the top-bar version status to the existing npm update check
-2. #1545 Detect connected observability providers
-3. #1544 Populate the automations section from the harness scheduler
-4. #1543 Populate the GitHub repository panel from live gh api reads
-5. #1542 Compute deploy pipeline stages from deploy.yml and github.environments
-6. #1541 Compute the CI quality-jobs Active column from ci.yml
-7. #1540 Wire the plugins & MCP section to .claude/settings.json enabledPlugins
+## Flow determination
+Flow: Implement. Work type: **Build** (type:Story, feature work, no bug/repro). Readiness gate: work item has AC, Validation Journey, no open blockers, claimed + bound — PASS.
 
-SKIP this session: #1539 (status:in-progress, other branch). BLOCKED/human-needed and unlabeled self-hardening issues are out of the formal ready queue.
+## Base branch resolution (Target Backend Environment)
+Ticket has no `## Target Backend Environment` section and no env signals in title/body (evidence scan: no deploy.branches key token, no env hostname). Fallback: remote default branch `main` reverse-maps uniquely to `production` in deploy.branches {production: main}. Recorded as: `Assumption: production — remote default branch main`. Base branch = main; PR target_branch=main.
 
-## Base branch assumption
+## Completion condition (Verify contract)
+End state: a resolver module in the Lisa package computes the env join from real `.lisa.config.json` fixtures.
+Proof command (runs the actual system, not tests): a CLI/tsx invocation of the resolver (exact entry recorded at build time) against four fixture configs prints: (a) ordered ladder dev→staging→production with branch+done status per rung; (b) decision-ready error naming env "staging" + exact config key for the missing-branch fixture; (c) single-rung terminal-only ladder for production-only fixture; (d) single production rung for prod/production alias fixture.
+Constraints: no existing config-resolution behavior changes (src/sync/registry.ts default semantics untouched); rule pair eager+reference both updated; evidence manifest regenerated in same commit; no new runtime dependency.
 
-Ticket #1546 names target environment `dev` (local-only UI on 127.0.0.1). `.lisa.config.json` `deploy.branches` only maps `production → main`. Interpreting `dev` as local verification (not a missing deploy branch); PR base = remote default `main`.
-
-## Runtime agent inventory
-
-INCLUDE|EXCLUDE - agent type - reason
-
-INCLUDE - generalPurpose - Explore/research equivalent; plan naming, branch sync, task planning when no narrower specialist fits
-INCLUDE - architecture-specialist - design approach, file map, reuse of checkVersion / live-status probe
-INCLUDE - builder - TDD implementation of #1546 and subsequent ready items
-INCLUDE - test-specialist - unit + Playwright regression for version status surface
-INCLUDE - product-specialist - acceptance criteria / Validation Journey alignment
-INCLUDE - verification-specialist - local empirical proof + verification-status.json
-INCLUDE - quality-specialist - correctness / coverage / philosophy review
-INCLUDE - code-reviewer - PR-oriented code review before merge drive
-INCLUDE - code-simplifier - clarify recently modified code after green tests
-INCLUDE - security-specialist - threat pass on live probe / npm registry reads
-INCLUDE - learner - post-task learnings review (required by implement skill)
-INCLUDE - github-agent - claim/sync issue labels, PR linkage, done transitions between queue items
-INCLUDE - debug-specialist - only if reproduction or verification fails
-INCLUDE - performance-specialist - only if version probe or UI polling shows latency issues
-INCLUDE - spec-conformance-specialist - verify shipped work matches ticket AC before done
-EXCLUDE - bug-fixer - work type is Build, not Fix; builder covers TDD
-EXCLUDE - bugbot - only when explicitly requested
-EXCLUDE - security-review - only when explicitly requested; security-specialist covers inline
-EXCLUDE - best-of-n-runner - no parallel experiment need
-EXCLUDE - cursor-guide - not a Cursor product question
-EXCLUDE - *-prd-intake / *-build-intake - this is implement, not intake
-EXCLUDE - jira-agent / linear-agent / confluence-* / notion-* - tracker is github
-EXCLUDE - pr-mining-specialist / tracker-mining-specialist / learnings-synthesizer - debrief-only
-EXCLUDE - skill-evaluator - no new skill authoring in this flow
-EXCLUDE - git-history-analyzer - architecture-specialist + generalPurpose cover needed history
-
-## Effective completion (queue)
-
-Queue is clean when `gh issue list --label status:ready --state open` returns zero issues (or only items that transitioned to blocked with human_needed / linked dependency). Per-issue: verification-status.json all-pass, PR merged to main, tracker sync to env-keyed done.
-
----
-
-Work item: `CodySwannGT/lisa#1539` — plan: `wire-stacks-detector-registry-1539`
-
-Runtime: Claude Code implicit-team model (Agent tool). No shared task-list tool in this runtime (TaskCreate/TaskList absent) — task plan persisted in `.lisa/plan-1539.md`; verification verdict in `.lisa/verification-status.json`.
-
-- `INCLUDE - Explore - read-only research; already served as the bounded input-resolver for this flow.`
-- `INCLUDE - lisa:builder - owns the TDD implementation of the detected-stacks probe + UI wiring (Build work type).`
-- `INCLUDE - lisa:test-specialist - authors the Playwright regression spec codifying the validation journey, alongside unit tests.`
-- `INCLUDE - lisa:product-specialist - reviews behavior against the Gherkin AC from the user's perspective (parallel review lane).`
-- `INCLUDE - lisa:quality-specialist - coding-philosophy/correctness review (parallel review lane).`
-- `INCLUDE - coderabbit:code-reviewer - CodeRabbit review lane per the project review-parallelization rule.`
-- `INCLUDE - lisa:spec-conformance-specialist - verifies shipped work matches the spec exactly (AC, Out of Scope, journey assertions).`
-- `INCLUDE - lisa:verification-specialist - independent empirical verification (live browser journey, doctor agreement) + writes verification-status.json; never the implementer.`
-- `INCLUDE - lisa:learner - collects and routes task learnings before team shutdown.`
-- `INCLUDE - general-purpose - fallback for bounded mechanical chores only when no specialist fits; not a build lane.`
-- `EXCLUDE - lisa:architecture-specialist - design fully pinned by the ticket + shipped #1537 probe contract; no open architectural decision.`
-- `EXCLUDE - lisa:security-specialist - no new external input surface: /api/status pre-exists; new probe reads local filesystem only, loopback-bound.`
-- `EXCLUDE - lisa:performance-specialist - bounded 5s-timeout filesystem probe already used by lisa doctor; no perf-sensitive path.`
-- `EXCLUDE - lisa:debug-specialist / lisa:bug-fixer - Build flow, not Fix; no bug to reproduce.`
-- `EXCLUDE - lisa:git-history-analyzer - relationship search already documented in the ticket and re-verified at triage.`
-- `EXCLUDE - lisa:github-agent - its lifecycle is already running in this lead session via intake dispatch; spawning it would nest lifecycles.`
-- `EXCLUDE - lisa:jira-agent / lisa:linear-agent - wrong tracker (tracker=github).`
-- `EXCLUDE - lisa:*-build-intake / lisa:*-prd-intake - queue scanners, not per-item workers; the item is already claimed.`
-- `EXCLUDE - lisa:learnings-synthesizer / lisa:pr-mining-specialist / lisa:tracker-mining-specialist - Debrief-flow agents, out of scope for a build ticket.`
-- `EXCLUDE - lisa:skill-evaluator - reached through the learner flow, not a team lane.`
-- `EXCLUDE - code-simplifier:code-simplifier - small change; quality-specialist + CodeRabbit cover simplification.`
-- `EXCLUDE - claude-code-guide / hookify:conversation-analyzer / statusline-setup - unrelated utilities.`
-- `EXCLUDE - claude - generic catch-all; specific specialists selected.`
-- `EXCLUDE - Plan - decomposition exists; this IS the leaf work item.`
-
-Base-branch resolution (recorded assumption): ticket env is `dev — local only; there is no deployed environment for this surface`. Merged `deploy.branches` maps only `production → main` (single-env repo; the npm release IS the deploy). Surface has no deployable environment → base = remote default `main` per the no-environment fallback. PR targets `main`.
-
----
-
-# Roster Decision — plan: `sll-self-learning-loop-1548` (PRD #1548 open descendants)
-
-Recorded: 2026-07-19. Runtime: Claude Code implicit-team model; no TaskCreate/TaskList in this runtime — task plan persisted in `.lisa/plan-1548.md`. Model floor per /goal: never below Opus 4.8 — every teammate spawn uses `model: opus`; the highest-complexity design/build lanes (#1589 gate, #1574/#1580 archaeology, #1582 attribution) inherit the lead's Fable 5 (model omitted).
-
-INCLUDE - Explore - Mandatory read-only research; feeds every task's metadata.relevant_documentation.
-INCLUDE - general-purpose - Bounded lead-session chores the skill assigns (input resolution done; branch sync, preflight probes); never a build lane.
-INCLUDE - lisa:architecture-specialist - Designs cross-cutting seams: vendor transition-history substrate ops, archaeology gate seam, attribution procedure, auto-merge-off mode.
-INCLUDE - lisa:builder - Primary TDD implementer for all Build leaves (one instance per phase batch).
-INCLUDE - lisa:test-specialist - Test strategy + regression coverage for contract/script/workflow-template/skill changes.
-INCLUDE - lisa:quality-specialist - Review lane (correctness, philosophy, coverage) — parallel with the other reviewers.
-INCLUDE - lisa:product-specialist - Reviews operator-facing text surfaces (dropped-with-reason notes, upstream ticket bodies, rule prose) for three-audience readability.
-INCLUDE - coderabbit:code-reviewer - Independent review lane per Agent Team Workflows parallel-review rule.
-INCLUDE - lisa:spec-conformance-specialist - Per-batch conformance check against each ticket's Gherkin AC; catches scope drift across 18 leaves.
-INCLUDE - lisa:verification-specialist - Independent empirical verification + writes .lisa/verification-status.json; never the implementer.
-INCLUDE - lisa:learner - Mandatory per-task learnings review before team dismissal.
-INCLUDE - lisa:skill-evaluator - Reached via learner; ALSO research input for #1589 (the gate reuses its discipline).
-INCLUDE - lisa:git-history-analyzer - Research input for SLL-3 archaeology (#1574/#1580) and #1582 doctor-attribution generalization.
-INCLUDE - lisa:security-specialist - Reviews #1581 (host CI workflow-template step) and #1583 (auto-filing upstream tickets) for permission/credential hazards.
-EXCLUDE - lisa:bug-fixer - Build work type, not Fix; no reproduction sub-flow.
-EXCLUDE - lisa:debug-specialist - No live defect; roster will be amended before spawning if CI failures need root-causing.
-EXCLUDE - lisa:performance-specialist - No perf-sensitive surface; archaeology cost budget (#1584) is a design constraint, not a perf investigation.
-EXCLUDE - lisa:jira-agent / lisa:github-agent / lisa:linear-agent - Lifecycle wrappers; we are already inside Implement.
-EXCLUDE - lisa:*-build-intake / lisa:*-prd-intake / lisa:tracker-* intake surfaces - Queue scanners; dispatch already happened via /goal.
-EXCLUDE - lisa:learnings-synthesizer / lisa:pr-mining-specialist / lisa:tracker-mining-specialist - Debrief-flow specialists.
-EXCLUDE - Plan - Decomposition exists as the SLL tree.
-EXCLUDE - claude / claude-code-guide / hookify:conversation-analyzer / statusline-setup / code-simplifier:code-simplifier - Generic or unrelated; review lanes bounded to product/quality/coderabbit/spec-conformance to control cycle time per the convergent-review principle.
-
-Scope: 18 in-scope leaves in 5 PR batches (see plan-1548.md). #1585 excluded — superseded by gardener #1735 (same rationale as parent #1556); being closed with a supersession comment. #1579 in scope per the #1729 amendment carve-in. Ledger path always via the executable contract resolver. Base branch: main (single-env; ticket `dev` values are placeholder enum per #1561/#1564 self-notes).
-
----
-
-# Roster Decision — plan: `improve-harness-skill-1744` (CodySwannGT/lisa#1744)
-
-Recorded: 2026-07-20. Runtime: Claude Code implicit-team model (Agent tool); no TaskCreate/TaskList in this runtime — task plan persisted in `.lisa/plan-1744.md`. Model floor per /goal: never below Opus 4.8 — mechanical/bounded lanes use `model: opus`; the skill-authoring build lane and spec-conformance lane inherit the lead's Fable 5 (model omitted).
-
-INCLUDE - general-purpose - bounded input-resolver (already run) and lead-session legwork (branch/env resolution, preflight probes); never a build lane.
-INCLUDE - Explore - mandatory read-only research: existing skill/command conventions, plugin fanout surfaces, adjacent skills (debrief, attribute-failure, rework-triage, learnings ladder) to ground the new skill and avoid overlap.
-INCLUDE - lisa:architecture-specialist - designs SKILL.md structure, command wiring, six-agent parity surfaces, idempotency marker, and template embedding before implementation.
-INCLUDE - lisa:builder - implements the skill + command + regenerated plugin artifacts from acceptance criteria.
-INCLUDE - lisa:quality-specialist - review lane: correctness/philosophy/convention compliance of skill text and wiring.
-INCLUDE - coderabbit:code-reviewer - independent review lane per Agent Team Workflows parallel-review rule.
-INCLUDE - lisa:product-specialist - operator-readability lane: result-record/job-contract templates must read for non-technical gate operators.
-INCLUDE - lisa:spec-conformance-specialist - verifies shipped work against the 4 Gherkin scenarios, Out of Scope, and cross-cutting invariants (headless-safe, idempotent marker, parity).
-INCLUDE - lisa:verification-specialist - independent empirical verification (build:plugins, check:plugins, artifact presence across agent surfaces, skill loadability) + writes .lisa/verification-status.json; never the implementer.
-INCLUDE - lisa:learner - captures task learnings to the ledger before team dismissal.
-EXCLUDE - lisa:bug-fixer / lisa:debug-specialist - Build flow, no defect to reproduce.
-EXCLUDE - lisa:performance-specialist - markdown skill authoring; no runtime perf surface.
-EXCLUDE - lisa:security-specialist - no new credential/permission/attack surface; skill is documentation-plane and files tickets via existing tracker-write.
-EXCLUDE - lisa:test-specialist - deliverable is a skill document + generated artifacts; artifact-parity checks covered by builder + verification-specialist (check:plugins, existing artifact tests).
-EXCLUDE - lisa:git-history-analyzer - referenced BY the new skill's content but not needed to author it; Explore covers context.
-EXCLUDE - lisa:github-agent / lisa:jira-agent / lisa:linear-agent - lifecycle wrappers; already inside Implement via intake dispatch.
-EXCLUDE - lisa:*-build-intake / lisa:*-prd-intake - queue scanners; item already claimed.
-EXCLUDE - lisa:learnings-synthesizer / lisa:pr-mining-specialist / lisa:tracker-mining-specialist - Debrief-flow agents, out of scope per ticket.
-EXCLUDE - lisa:learning-judge / lisa:skill-evaluator - gardener/judgment lanes reached via learner, not team lanes here.
-EXCLUDE - code-simplifier:code-simplifier - prose deliverable; quality-specialist covers refinement.
-EXCLUDE - claude / claude-code-guide / hookify:conversation-analyzer / statusline-setup / Plan / fork - generic or unrelated; decomposition exists (this IS the leaf).
-
-Base-branch resolution: ticket Target Backend Environment = `production`; `deploy.branches` maps `production → main` → base = `main`. PR targets `main`.
-
----
-
-# Roster Decision — plan: `readiness-warning-parity-1859` (CodySwannGT/lisa#1859)
-
-Recorded: 2026-07-21. Runtime: Codex collaboration. The runtime exposes one
-delegation type, the generic collaboration agent; it exposes no distinct native
-specialist-type selector.
-
-INCLUDE - generic collaboration agent - the only exposed type; use bounded role assignments for the mandatory read-only Explore pass, implementation support, independent review/verification, and learner review.
-EXCLUDE - no additional runtime agent types - none are exposed by the current collaboration surface; Lisa specialist skills may guide assignments but are not separately spawnable agent types here.
-
-Required assignments: one read-only Explore/research pass before planning; one
-independent review/verification pass after implementation; one learner pass
-before shutdown. The lead owns branch sync, implementation integration, tracker
-transitions, PR merge drive, and release proof.
-
-Work type: Build. Target environment is the human-confirmed configured key
-`production`; `.lisa.config.json` maps it uniquely to remote `main`. The existing
-feature branch `1859-setup-automations-warn` is reused and must be rebased onto
-`origin/main` before source work.
+## Tool access preflight (tool-access-gate)
+- gh CLI (GitHub API): PROBE `gh issue view 1967` — PASS (input-resolver transaction succeeded this session).
+- git remote fetch/push: PROBE `git fetch origin` — PASS (fetched this session for branch fix/worktree-plugin-sync-marker; re-verified at branch setup).
+- bun/node/tsc toolchain: PROBE `bun --version` / builds run this session — PASS.
+- No external systems required (no AWS/Figma/Sentry/DB/browser). Regression-coverage note: not a user-visible UI surface; no e2e harness applies (checked: this repo has no .maestro/, no Playwright suite for the CLI). Highest practical observation level = CLI proof + unit tests. Recorded per the regression-spec absence path.

--- a/plugins/lisa-copilot/rules/eager/config-resolution.md
+++ b/plugins/lisa-copilot/rules/eager/config-resolution.md
@@ -86,4 +86,12 @@ A non-integration environment bug is fixed, merged, and verified on that
 environment branch first, then
 forward cherry-picked down to the integration branch via a linked follow-up.
 
+## Deploy status sync
+
+`deployStatusSync` is an optional machine-written config block (`tier`, `provisioned` ids,
+`linearBinding: labels|states`, `verifiedAt`). The deploy ladder is `deploy.order` (else canonical
+`dev < staging < production`) over `deploy.branches` joined with the tracker's env-keyed done map;
+a configured done status whose env has no branch is a config error, and the sole
+`prod` ↔ `production` alias applies to the join.
+
 Full reference: [reference/config-resolution.md](../reference/config-resolution.md).

--- a/plugins/lisa-copilot/rules/reference/config-resolution.md
+++ b/plugins/lisa-copilot/rules/reference/config-resolution.md
@@ -623,8 +623,11 @@ terminal (highest) rung; lower rungs fall back to the default table. An env
 with a branch but no done status anywhere (possible only for custom names
 outside the default tables) is **skipped**, not an error; an explicitly
 configured done status whose env has no branch **is** a config error. A ladder
-that resolves to exactly one rung is flagged terminal-only. Absent or empty
-`deploy` yields an empty ladder, never an error.
+is flagged terminal-only when it resolves to exactly one rung **and** that
+rung's env is the highest-ranked environment of the configured universe
+(post-alias) — a sole surviving lower rung after skips is NOT terminal-only,
+so downstream native closure never fires on an intermediate environment.
+Absent or empty `deploy` yields an empty ladder, never an error.
 
 **Alias.** Iff exactly one of `prod` / `production` appears across the
 configured surfaces (`deploy.branches`, the configured done map,
@@ -636,7 +639,8 @@ and no aliasing occurs. No other alias exists.
 **Error catalog** (verbatim):
 
 - `Invalid deploy configuration in <source>: a done status ("<status>") is configured for environment "<env>", but deploy.branches has no "<env>" entry. Add deploy.branches.<env> (the git branch that deploys to <env>) or remove "<env>" from the done map.`
-- `Invalid deploy.order in <source>: its environment names must exactly match the keys of deploy.branches. deploy.order has [<order-envs>]; deploy.branches has [<branch-envs>].`
+- `Invalid deploy.order in <source>: its environment names must exactly match the keys of deploy.branches. deploy.order has [<order-envs>]; deploy.branches has [<branch-envs>].` (also raised for duplicate `deploy.order` entries)
+- `Invalid deploy.order in <source>: every entry must be an environment name string; found <entry>.`
 - `Invalid deploy configuration in <source>: cannot order environment "<env>". Set deploy.order (environments listed lowest first, e.g. ["dev","staging","production"]) so Lisa knows the promotion order.`
 
 ### What's configurable, what's not

--- a/plugins/lisa-copilot/rules/reference/config-resolution.md
+++ b/plugins/lisa-copilot/rules/reference/config-resolution.md
@@ -596,6 +596,49 @@ This is the same `deploy.branches` map already used by env-keyed `done` (reverse
 env from PR base branch) and the build flow (forward: base branch from env);
 `deploy.order` only adds the ranking those two directions never needed.
 
+### Deploy status sync (deployStatusSync)
+
+`deployStatusSync` is an **optional, machine-written** section recorded by the
+deploy-status-sync setup flow. Humans never need to author it; unknown fields
+inside it are preserved on round-trip.
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `tier` | string | — | Provisioning tier chosen at setup time |
+| `provisioned` | object (string → string) | — | Provisioned tracker artifact ids, keyed by artifact name |
+| `linearBinding` | `"labels"` \| `"states"` | — | Whether Linear deploy statuses are represented as labels or workflow states |
+| `verifiedAt` | string | — | Strict ISO-8601 UTC timestamp (`Z` suffix, e.g. `2026-01-01T00:00:00Z`) of the last successful verification |
+
+**Ladder resolution.** The environment universe is the keys of
+`deploy.branches`. Each env's done status comes from the tracker's env-keyed
+done map — `github.labels.build.done`, `linear.labels.build.done`, or
+`jira.workflow.done` — with configured entries winning over the built-in
+defaults (`status:on-dev` / `status:on-stg` / `status:done` for label trackers;
+`On Dev` / `On Stg` / `Done` for JIRA). Environments are ordered by
+`deploy.order` when present (its env-name set must exactly match the keys of
+`deploy.branches`); otherwise by the canonical `dev < staging < production`
+rank, and an unrankable custom env name with more than one env configured is a
+config error rather than a guess. A string-valued `done` binds only the
+terminal (highest) rung; lower rungs fall back to the default table. An env
+with a branch but no done status anywhere (possible only for custom names
+outside the default tables) is **skipped**, not an error; an explicitly
+configured done status whose env has no branch **is** a config error. A ladder
+that resolves to exactly one rung is flagged terminal-only. Absent or empty
+`deploy` yields an empty ladder, never an error.
+
+**Alias.** Iff exactly one of `prod` / `production` appears across the
+configured surfaces (`deploy.branches`, the configured done map,
+`deploy.order`), the two spellings join as one environment — so
+`branches.prod` meets the default `done.production` — and rungs report the
+configured spelling. When both spellings appear they are distinct environments
+and no aliasing occurs. No other alias exists.
+
+**Error catalog** (verbatim):
+
+- `Invalid deploy configuration in <source>: a done status ("<status>") is configured for environment "<env>", but deploy.branches has no "<env>" entry. Add deploy.branches.<env> (the git branch that deploys to <env>) or remove "<env>" from the done map.`
+- `Invalid deploy.order in <source>: its environment names must exactly match the keys of deploy.branches. deploy.order has [<order-envs>]; deploy.branches has [<branch-envs>].`
+- `Invalid deploy configuration in <source>: cannot order environment "<env>". Set deploy.order (environments listed lowest first, e.g. ["dev","staging","production"]) so Lisa knows the promotion order.`
+
 ### What's configurable, what's not
 
 - **Status / label NAMES** are configurable per project — that's the point of the vocabulary maps.

--- a/plugins/lisa-cursor/rules/config-resolution-reference.mdc
+++ b/plugins/lisa-cursor/rules/config-resolution-reference.mdc
@@ -601,6 +601,49 @@ This is the same `deploy.branches` map already used by env-keyed `done` (reverse
 env from PR base branch) and the build flow (forward: base branch from env);
 `deploy.order` only adds the ranking those two directions never needed.
 
+### Deploy status sync (deployStatusSync)
+
+`deployStatusSync` is an **optional, machine-written** section recorded by the
+deploy-status-sync setup flow. Humans never need to author it; unknown fields
+inside it are preserved on round-trip.
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `tier` | string | — | Provisioning tier chosen at setup time |
+| `provisioned` | object (string → string) | — | Provisioned tracker artifact ids, keyed by artifact name |
+| `linearBinding` | `"labels"` \| `"states"` | — | Whether Linear deploy statuses are represented as labels or workflow states |
+| `verifiedAt` | string | — | Strict ISO-8601 UTC timestamp (`Z` suffix, e.g. `2026-01-01T00:00:00Z`) of the last successful verification |
+
+**Ladder resolution.** The environment universe is the keys of
+`deploy.branches`. Each env's done status comes from the tracker's env-keyed
+done map — `github.labels.build.done`, `linear.labels.build.done`, or
+`jira.workflow.done` — with configured entries winning over the built-in
+defaults (`status:on-dev` / `status:on-stg` / `status:done` for label trackers;
+`On Dev` / `On Stg` / `Done` for JIRA). Environments are ordered by
+`deploy.order` when present (its env-name set must exactly match the keys of
+`deploy.branches`); otherwise by the canonical `dev < staging < production`
+rank, and an unrankable custom env name with more than one env configured is a
+config error rather than a guess. A string-valued `done` binds only the
+terminal (highest) rung; lower rungs fall back to the default table. An env
+with a branch but no done status anywhere (possible only for custom names
+outside the default tables) is **skipped**, not an error; an explicitly
+configured done status whose env has no branch **is** a config error. A ladder
+that resolves to exactly one rung is flagged terminal-only. Absent or empty
+`deploy` yields an empty ladder, never an error.
+
+**Alias.** Iff exactly one of `prod` / `production` appears across the
+configured surfaces (`deploy.branches`, the configured done map,
+`deploy.order`), the two spellings join as one environment — so
+`branches.prod` meets the default `done.production` — and rungs report the
+configured spelling. When both spellings appear they are distinct environments
+and no aliasing occurs. No other alias exists.
+
+**Error catalog** (verbatim):
+
+- `Invalid deploy configuration in <source>: a done status ("<status>") is configured for environment "<env>", but deploy.branches has no "<env>" entry. Add deploy.branches.<env> (the git branch that deploys to <env>) or remove "<env>" from the done map.`
+- `Invalid deploy.order in <source>: its environment names must exactly match the keys of deploy.branches. deploy.order has [<order-envs>]; deploy.branches has [<branch-envs>].`
+- `Invalid deploy configuration in <source>: cannot order environment "<env>". Set deploy.order (environments listed lowest first, e.g. ["dev","staging","production"]) so Lisa knows the promotion order.`
+
 ### What's configurable, what's not
 
 - **Status / label NAMES** are configurable per project — that's the point of the vocabulary maps.

--- a/plugins/lisa-cursor/rules/config-resolution-reference.mdc
+++ b/plugins/lisa-cursor/rules/config-resolution-reference.mdc
@@ -628,8 +628,11 @@ terminal (highest) rung; lower rungs fall back to the default table. An env
 with a branch but no done status anywhere (possible only for custom names
 outside the default tables) is **skipped**, not an error; an explicitly
 configured done status whose env has no branch **is** a config error. A ladder
-that resolves to exactly one rung is flagged terminal-only. Absent or empty
-`deploy` yields an empty ladder, never an error.
+is flagged terminal-only when it resolves to exactly one rung **and** that
+rung's env is the highest-ranked environment of the configured universe
+(post-alias) — a sole surviving lower rung after skips is NOT terminal-only,
+so downstream native closure never fires on an intermediate environment.
+Absent or empty `deploy` yields an empty ladder, never an error.
 
 **Alias.** Iff exactly one of `prod` / `production` appears across the
 configured surfaces (`deploy.branches`, the configured done map,
@@ -641,7 +644,8 @@ and no aliasing occurs. No other alias exists.
 **Error catalog** (verbatim):
 
 - `Invalid deploy configuration in <source>: a done status ("<status>") is configured for environment "<env>", but deploy.branches has no "<env>" entry. Add deploy.branches.<env> (the git branch that deploys to <env>) or remove "<env>" from the done map.`
-- `Invalid deploy.order in <source>: its environment names must exactly match the keys of deploy.branches. deploy.order has [<order-envs>]; deploy.branches has [<branch-envs>].`
+- `Invalid deploy.order in <source>: its environment names must exactly match the keys of deploy.branches. deploy.order has [<order-envs>]; deploy.branches has [<branch-envs>].` (also raised for duplicate `deploy.order` entries)
+- `Invalid deploy.order in <source>: every entry must be an environment name string; found <entry>.`
 - `Invalid deploy configuration in <source>: cannot order environment "<env>". Set deploy.order (environments listed lowest first, e.g. ["dev","staging","production"]) so Lisa knows the promotion order.`
 
 ### What's configurable, what's not

--- a/plugins/lisa-cursor/rules/config-resolution.mdc
+++ b/plugins/lisa-cursor/rules/config-resolution.mdc
@@ -91,4 +91,12 @@ A non-integration environment bug is fixed, merged, and verified on that
 environment branch first, then
 forward cherry-picked down to the integration branch via a linked follow-up.
 
+## Deploy status sync
+
+`deployStatusSync` is an optional machine-written config block (`tier`, `provisioned` ids,
+`linearBinding: labels|states`, `verifiedAt`). The deploy ladder is `deploy.order` (else canonical
+`dev < staging < production`) over `deploy.branches` joined with the tracker's env-keyed done map;
+a configured done status whose env has no branch is a config error, and the sole
+`prod` ↔ `production` alias applies to the join.
+
 Full reference: [reference/config-resolution.md](config-resolution-reference.mdc).

--- a/plugins/lisa/rules/eager/config-resolution.md
+++ b/plugins/lisa/rules/eager/config-resolution.md
@@ -86,4 +86,12 @@ A non-integration environment bug is fixed, merged, and verified on that
 environment branch first, then
 forward cherry-picked down to the integration branch via a linked follow-up.
 
+## Deploy status sync
+
+`deployStatusSync` is an optional machine-written config block (`tier`, `provisioned` ids,
+`linearBinding: labels|states`, `verifiedAt`). The deploy ladder is `deploy.order` (else canonical
+`dev < staging < production`) over `deploy.branches` joined with the tracker's env-keyed done map;
+a configured done status whose env has no branch is a config error, and the sole
+`prod` ↔ `production` alias applies to the join.
+
 Full reference: [reference/config-resolution.md](../reference/config-resolution.md).

--- a/plugins/lisa/rules/reference/config-resolution.md
+++ b/plugins/lisa/rules/reference/config-resolution.md
@@ -623,8 +623,11 @@ terminal (highest) rung; lower rungs fall back to the default table. An env
 with a branch but no done status anywhere (possible only for custom names
 outside the default tables) is **skipped**, not an error; an explicitly
 configured done status whose env has no branch **is** a config error. A ladder
-that resolves to exactly one rung is flagged terminal-only. Absent or empty
-`deploy` yields an empty ladder, never an error.
+is flagged terminal-only when it resolves to exactly one rung **and** that
+rung's env is the highest-ranked environment of the configured universe
+(post-alias) — a sole surviving lower rung after skips is NOT terminal-only,
+so downstream native closure never fires on an intermediate environment.
+Absent or empty `deploy` yields an empty ladder, never an error.
 
 **Alias.** Iff exactly one of `prod` / `production` appears across the
 configured surfaces (`deploy.branches`, the configured done map,
@@ -636,7 +639,8 @@ and no aliasing occurs. No other alias exists.
 **Error catalog** (verbatim):
 
 - `Invalid deploy configuration in <source>: a done status ("<status>") is configured for environment "<env>", but deploy.branches has no "<env>" entry. Add deploy.branches.<env> (the git branch that deploys to <env>) or remove "<env>" from the done map.`
-- `Invalid deploy.order in <source>: its environment names must exactly match the keys of deploy.branches. deploy.order has [<order-envs>]; deploy.branches has [<branch-envs>].`
+- `Invalid deploy.order in <source>: its environment names must exactly match the keys of deploy.branches. deploy.order has [<order-envs>]; deploy.branches has [<branch-envs>].` (also raised for duplicate `deploy.order` entries)
+- `Invalid deploy.order in <source>: every entry must be an environment name string; found <entry>.`
 - `Invalid deploy configuration in <source>: cannot order environment "<env>". Set deploy.order (environments listed lowest first, e.g. ["dev","staging","production"]) so Lisa knows the promotion order.`
 
 ### What's configurable, what's not

--- a/plugins/lisa/rules/reference/config-resolution.md
+++ b/plugins/lisa/rules/reference/config-resolution.md
@@ -596,6 +596,49 @@ This is the same `deploy.branches` map already used by env-keyed `done` (reverse
 env from PR base branch) and the build flow (forward: base branch from env);
 `deploy.order` only adds the ranking those two directions never needed.
 
+### Deploy status sync (deployStatusSync)
+
+`deployStatusSync` is an **optional, machine-written** section recorded by the
+deploy-status-sync setup flow. Humans never need to author it; unknown fields
+inside it are preserved on round-trip.
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `tier` | string | — | Provisioning tier chosen at setup time |
+| `provisioned` | object (string → string) | — | Provisioned tracker artifact ids, keyed by artifact name |
+| `linearBinding` | `"labels"` \| `"states"` | — | Whether Linear deploy statuses are represented as labels or workflow states |
+| `verifiedAt` | string | — | Strict ISO-8601 UTC timestamp (`Z` suffix, e.g. `2026-01-01T00:00:00Z`) of the last successful verification |
+
+**Ladder resolution.** The environment universe is the keys of
+`deploy.branches`. Each env's done status comes from the tracker's env-keyed
+done map — `github.labels.build.done`, `linear.labels.build.done`, or
+`jira.workflow.done` — with configured entries winning over the built-in
+defaults (`status:on-dev` / `status:on-stg` / `status:done` for label trackers;
+`On Dev` / `On Stg` / `Done` for JIRA). Environments are ordered by
+`deploy.order` when present (its env-name set must exactly match the keys of
+`deploy.branches`); otherwise by the canonical `dev < staging < production`
+rank, and an unrankable custom env name with more than one env configured is a
+config error rather than a guess. A string-valued `done` binds only the
+terminal (highest) rung; lower rungs fall back to the default table. An env
+with a branch but no done status anywhere (possible only for custom names
+outside the default tables) is **skipped**, not an error; an explicitly
+configured done status whose env has no branch **is** a config error. A ladder
+that resolves to exactly one rung is flagged terminal-only. Absent or empty
+`deploy` yields an empty ladder, never an error.
+
+**Alias.** Iff exactly one of `prod` / `production` appears across the
+configured surfaces (`deploy.branches`, the configured done map,
+`deploy.order`), the two spellings join as one environment — so
+`branches.prod` meets the default `done.production` — and rungs report the
+configured spelling. When both spellings appear they are distinct environments
+and no aliasing occurs. No other alias exists.
+
+**Error catalog** (verbatim):
+
+- `Invalid deploy configuration in <source>: a done status ("<status>") is configured for environment "<env>", but deploy.branches has no "<env>" entry. Add deploy.branches.<env> (the git branch that deploys to <env>) or remove "<env>" from the done map.`
+- `Invalid deploy.order in <source>: its environment names must exactly match the keys of deploy.branches. deploy.order has [<order-envs>]; deploy.branches has [<branch-envs>].`
+- `Invalid deploy configuration in <source>: cannot order environment "<env>". Set deploy.order (environments listed lowest first, e.g. ["dev","staging","production"]) so Lisa knows the promotion order.`
+
 ### What's configurable, what's not
 
 - **Status / label NAMES** are configurable per project — that's the point of the vocabulary maps.

--- a/plugins/src/base/rules/eager/config-resolution.md
+++ b/plugins/src/base/rules/eager/config-resolution.md
@@ -86,4 +86,12 @@ A non-integration environment bug is fixed, merged, and verified on that
 environment branch first, then
 forward cherry-picked down to the integration branch via a linked follow-up.
 
+## Deploy status sync
+
+`deployStatusSync` is an optional machine-written config block (`tier`, `provisioned` ids,
+`linearBinding: labels|states`, `verifiedAt`). The deploy ladder is `deploy.order` (else canonical
+`dev < staging < production`) over `deploy.branches` joined with the tracker's env-keyed done map;
+a configured done status whose env has no branch is a config error, and the sole
+`prod` ↔ `production` alias applies to the join.
+
 Full reference: [reference/config-resolution.md](../reference/config-resolution.md).

--- a/plugins/src/base/rules/reference/config-resolution.md
+++ b/plugins/src/base/rules/reference/config-resolution.md
@@ -623,8 +623,11 @@ terminal (highest) rung; lower rungs fall back to the default table. An env
 with a branch but no done status anywhere (possible only for custom names
 outside the default tables) is **skipped**, not an error; an explicitly
 configured done status whose env has no branch **is** a config error. A ladder
-that resolves to exactly one rung is flagged terminal-only. Absent or empty
-`deploy` yields an empty ladder, never an error.
+is flagged terminal-only when it resolves to exactly one rung **and** that
+rung's env is the highest-ranked environment of the configured universe
+(post-alias) — a sole surviving lower rung after skips is NOT terminal-only,
+so downstream native closure never fires on an intermediate environment.
+Absent or empty `deploy` yields an empty ladder, never an error.
 
 **Alias.** Iff exactly one of `prod` / `production` appears across the
 configured surfaces (`deploy.branches`, the configured done map,
@@ -636,7 +639,8 @@ and no aliasing occurs. No other alias exists.
 **Error catalog** (verbatim):
 
 - `Invalid deploy configuration in <source>: a done status ("<status>") is configured for environment "<env>", but deploy.branches has no "<env>" entry. Add deploy.branches.<env> (the git branch that deploys to <env>) or remove "<env>" from the done map.`
-- `Invalid deploy.order in <source>: its environment names must exactly match the keys of deploy.branches. deploy.order has [<order-envs>]; deploy.branches has [<branch-envs>].`
+- `Invalid deploy.order in <source>: its environment names must exactly match the keys of deploy.branches. deploy.order has [<order-envs>]; deploy.branches has [<branch-envs>].` (also raised for duplicate `deploy.order` entries)
+- `Invalid deploy.order in <source>: every entry must be an environment name string; found <entry>.`
 - `Invalid deploy configuration in <source>: cannot order environment "<env>". Set deploy.order (environments listed lowest first, e.g. ["dev","staging","production"]) so Lisa knows the promotion order.`
 
 ### What's configurable, what's not

--- a/plugins/src/base/rules/reference/config-resolution.md
+++ b/plugins/src/base/rules/reference/config-resolution.md
@@ -596,6 +596,49 @@ This is the same `deploy.branches` map already used by env-keyed `done` (reverse
 env from PR base branch) and the build flow (forward: base branch from env);
 `deploy.order` only adds the ranking those two directions never needed.
 
+### Deploy status sync (deployStatusSync)
+
+`deployStatusSync` is an **optional, machine-written** section recorded by the
+deploy-status-sync setup flow. Humans never need to author it; unknown fields
+inside it are preserved on round-trip.
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `tier` | string | — | Provisioning tier chosen at setup time |
+| `provisioned` | object (string → string) | — | Provisioned tracker artifact ids, keyed by artifact name |
+| `linearBinding` | `"labels"` \| `"states"` | — | Whether Linear deploy statuses are represented as labels or workflow states |
+| `verifiedAt` | string | — | Strict ISO-8601 UTC timestamp (`Z` suffix, e.g. `2026-01-01T00:00:00Z`) of the last successful verification |
+
+**Ladder resolution.** The environment universe is the keys of
+`deploy.branches`. Each env's done status comes from the tracker's env-keyed
+done map — `github.labels.build.done`, `linear.labels.build.done`, or
+`jira.workflow.done` — with configured entries winning over the built-in
+defaults (`status:on-dev` / `status:on-stg` / `status:done` for label trackers;
+`On Dev` / `On Stg` / `Done` for JIRA). Environments are ordered by
+`deploy.order` when present (its env-name set must exactly match the keys of
+`deploy.branches`); otherwise by the canonical `dev < staging < production`
+rank, and an unrankable custom env name with more than one env configured is a
+config error rather than a guess. A string-valued `done` binds only the
+terminal (highest) rung; lower rungs fall back to the default table. An env
+with a branch but no done status anywhere (possible only for custom names
+outside the default tables) is **skipped**, not an error; an explicitly
+configured done status whose env has no branch **is** a config error. A ladder
+that resolves to exactly one rung is flagged terminal-only. Absent or empty
+`deploy` yields an empty ladder, never an error.
+
+**Alias.** Iff exactly one of `prod` / `production` appears across the
+configured surfaces (`deploy.branches`, the configured done map,
+`deploy.order`), the two spellings join as one environment — so
+`branches.prod` meets the default `done.production` — and rungs report the
+configured spelling. When both spellings appear they are distinct environments
+and no aliasing occurs. No other alias exists.
+
+**Error catalog** (verbatim):
+
+- `Invalid deploy configuration in <source>: a done status ("<status>") is configured for environment "<env>", but deploy.branches has no "<env>" entry. Add deploy.branches.<env> (the git branch that deploys to <env>) or remove "<env>" from the done map.`
+- `Invalid deploy.order in <source>: its environment names must exactly match the keys of deploy.branches. deploy.order has [<order-envs>]; deploy.branches has [<branch-envs>].`
+- `Invalid deploy configuration in <source>: cannot order environment "<env>". Set deploy.order (environments listed lowest first, e.g. ["dev","staging","production"]) so Lisa knows the promotion order.`
+
 ### What's configurable, what's not
 
 - **Status / label NAMES** are configurable per project — that's the point of the vocabulary maps.

--- a/src/core/config-field-validation.ts
+++ b/src/core/config-field-validation.ts
@@ -1,10 +1,11 @@
 /**
- * Shared validation for path-typed `.lisa.config.json` fields.
+ * Shared validation for `.lisa.config.json` field values.
  *
- * Extracted from `project-config.ts` so every configurable file destination
- * (`projectRulesFile`, `learnings.file`, …) funnels through one hardened
- * safe-relative-Markdown-path check without growing the config module.
- * @module core/config-path-validation
+ * Extracted from `project-config.ts` so path-typed destinations
+ * (`projectRulesFile`, `learnings.file`, …) and string-typed section fields
+ * (`deployStatusSync.*`) funnel through the same hardened checks without
+ * growing the config module.
+ * @module core/config-field-validation
  */
 import * as path from "node:path";
 
@@ -18,6 +19,32 @@ function containsControlCharacter(value: string): boolean {
     const code = character.charCodeAt(0);
     return code <= 31 || code === 127;
   });
+}
+
+/**
+ * Validate an optional non-empty trimmed string field.
+ * @param value - Untrusted field value
+ * @param source - Config source shown in errors
+ * @param field - Dotted field name
+ * @returns Valid string or undefined
+ */
+export function optionalString(
+  value: unknown,
+  source: string,
+  field: string
+): string | undefined {
+  if (value === undefined) return undefined;
+  if (
+    typeof value !== "string" ||
+    value.trim() !== value ||
+    value.length === 0 ||
+    containsControlCharacter(value)
+  ) {
+    throw new Error(
+      `Invalid ${field} in ${source}: expected a non-empty string`
+    );
+  }
+  return value;
 }
 
 /**

--- a/src/core/config-path-validation.ts
+++ b/src/core/config-path-validation.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared validation for path-typed `.lisa.config.json` fields.
+ *
+ * Extracted from `project-config.ts` so every configurable file destination
+ * (`projectRulesFile`, `learnings.file`, …) funnels through one hardened
+ * safe-relative-Markdown-path check without growing the config module.
+ * @module core/config-path-validation
+ */
+import * as path from "node:path";
+
+/**
+ * Whether a path contains an ASCII control character.
+ * @param value - Configured path
+ * @returns True when any control character is present
+ */
+function containsControlCharacter(value: string): boolean {
+  return Array.from(value).some(character => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+}
+
+/**
+ * Validate a configurable destination as a safe, relative, non-traversing
+ * Markdown path. Shared by every path-typed config field; the `field` label is
+ * interpolated into each diagnostic so callers get a field-specific message.
+ * @param value - Raw configured path
+ * @param source - Config source for errors
+ * @param field - Config field name used in error messages
+ * @returns Validated project-relative path
+ */
+export function validateSafeRelativeMarkdownPath(
+  value: unknown,
+  source: string,
+  field: string
+): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.trim() !== value ||
+    value.includes("\\") ||
+    containsControlCharacter(value) ||
+    /^[a-z]:/iu.test(value) ||
+    path.posix.isAbsolute(value) ||
+    path.win32.isAbsolute(value)
+  ) {
+    throw new Error(
+      `Invalid ${field} in ${source}: expected a safe relative POSIX path`
+    );
+  }
+  const segments = value.split("/");
+  if (
+    segments.some(
+      segment => segment === "" || segment === "." || segment === ".."
+    )
+  ) {
+    throw new Error(
+      `Invalid ${field} in ${source}: path traversal is not allowed`
+    );
+  }
+  if (path.posix.extname(value).toLowerCase() !== ".md") {
+    throw new Error(`Invalid ${field} in ${source}: expected a Markdown file`);
+  }
+  return value;
+}

--- a/src/core/deploy-status-sync.ts
+++ b/src/core/deploy-status-sync.ts
@@ -11,7 +11,13 @@
  * imported the registry).
  * @module core/deploy-status-sync
  */
-import { getAtPath, isJsonObject, type JsonValue } from "../sync/json-path.js";
+import {
+  getAtPath,
+  isJsonObject,
+  type JsonObject,
+  type JsonValue,
+} from "../sync/json-path.js";
+import { optionalString } from "./config-field-validation.js";
 
 /** Tracker vendors whose done vocabulary can bind a deploy ladder. */
 export type Tracker = "jira" | "github" | "linear";
@@ -92,18 +98,26 @@ const CANONICAL_ENV_RANKS: Readonly<Record<string, number>> = {
 };
 
 /**
+ * Keep only the string-valued entries of a JSON object record.
+ * @param value - JSON object record
+ * @returns Record of the string-valued entries
+ */
+function stringRecord(value: JsonObject): Readonly<Record<string, string>> {
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string"
+    )
+  );
+}
+
+/**
  * Read `deploy.branches` as an env → branch map, ignoring non-string values.
  * @param config - Parsed config value
  * @returns Env-to-branch record (empty when the section is absent)
  */
 function readBranches(config: JsonValue): Readonly<Record<string, string>> {
   const branches = getAtPath(config, "deploy.branches");
-  if (!isJsonObject(branches)) return {};
-  return Object.fromEntries(
-    Object.entries(branches).filter(
-      (entry): entry is [string, string] => typeof entry[1] === "string"
-    )
-  );
+  return isJsonObject(branches) ? stringRecord(branches) : {};
 }
 
 /** The configured done vocabulary: an env-keyed map or a terminal string. */
@@ -125,13 +139,7 @@ function readConfiguredDone(
   const done = getAtPath(config, DONE_MAP_PATHS[tracker]);
   if (typeof done === "string") return { terminal: done };
   if (!isJsonObject(done)) return {};
-  return {
-    map: Object.fromEntries(
-      Object.entries(done).filter(
-        (entry): entry is [string, string] => typeof entry[1] === "string"
-      )
-    ),
-  };
+  return { map: stringRecord(done) };
 }
 
 /**
@@ -144,11 +152,11 @@ function readConfiguredDone(
  */
 function assertDoneEnvsHaveBranches(
   doneMap: Readonly<Record<string, string>>,
-  branchEnvs: ReadonlySet<string>,
+  branchEnvs: readonly string[],
   source: string
 ): void {
   for (const [env, status] of Object.entries(doneMap)) {
-    if (!branchEnvs.has(env)) {
+    if (!branchEnvs.includes(env)) {
       throw new Error(
         `Invalid deploy configuration in ${source}: a done status ("${status}") is configured for environment "${env}", but deploy.branches has no "${env}" entry. Add deploy.branches.${env} (the git branch that deploys to ${env}) or remove "${env}" from the done map.`
       );
@@ -157,20 +165,35 @@ function assertDoneEnvsHaveBranches(
 }
 
 /**
- * Read `deploy.order` as a string array, if present.
+ * Read `deploy.order` as a string array, if present. A non-string entry is a
+ * decision-ready error, never silently dropped — dropping one would silently
+ * change the promotion order.
  * @param config - Parsed config value
+ * @param source - Config source shown in errors
  * @returns Ordered env names (lowest first), or undefined when absent
  */
-function readOrder(config: JsonValue): readonly string[] | undefined {
+function readOrder(
+  config: JsonValue,
+  source: string
+): readonly string[] | undefined {
   const order = getAtPath(config, "deploy.order");
   if (!Array.isArray(order)) return undefined;
-  return order.filter((entry): entry is string => typeof entry === "string");
+  return order.map(entry => {
+    if (typeof entry !== "string") {
+      throw new Error(
+        `Invalid deploy.order in ${source}: every entry must be an environment name string; found ${JSON.stringify(entry)}.`
+      );
+    }
+    return entry;
+  });
 }
 
 /**
- * Require `deploy.order` to name exactly the `deploy.branches` env set.
+ * Require `deploy.order` to name exactly the `deploy.branches` env set, with
+ * no duplicate entries — a duplicate would otherwise survive set comparison
+ * and produce duplicate rungs.
  * @param order - Configured order
- * @param branchEnvs - Environments present in `deploy.branches`
+ * @param branchEnvs - Environments present in `deploy.branches` (dupe-free)
  * @param source - Config source shown in errors
  */
 function assertOrderMatchesBranches(
@@ -179,9 +202,9 @@ function assertOrderMatchesBranches(
   source: string
 ): void {
   const orderSet = new Set(order);
-  const branchSet = new Set(branchEnvs);
   const matches =
-    orderSet.size === branchSet.size &&
+    orderSet.size === order.length &&
+    orderSet.size === branchEnvs.length &&
     branchEnvs.every(env => orderSet.has(env));
   if (!matches) {
     throw new Error(
@@ -234,6 +257,7 @@ function orderEnvironments(
  * @param done - Configured done vocabulary
  * @param defaults - Tracker default done vocabulary
  * @param canonical - Alias-aware canonical name resolver
+ * @param terminalEnv - Highest-ranked env of the configured universe
  * @returns The joined rungs, lowest environment first
  */
 function buildRungs(
@@ -241,9 +265,9 @@ function buildRungs(
   branches: Readonly<Record<string, string>>,
   done: ConfiguredDone,
   defaults: Readonly<Record<string, string>>,
-  canonical: (env: string) => string
+  canonical: (env: string) => string,
+  terminalEnv: string | undefined
 ): readonly DeployLadderRung[] {
-  const terminalEnv = orderedEnvs[orderedEnvs.length - 1];
   return orderedEnvs.flatMap(env => {
     const branch = branches[env];
     const terminal = env === terminalEnv ? done.terminal : undefined;
@@ -277,7 +301,7 @@ export function resolveDeployLadder(
   const branchEnvs = Object.keys(branches);
   if (branchEnvs.length === 0) return { rungs: [], terminalOnly: false };
   const done = readConfiguredDone(config, tracker);
-  const order = readOrder(config);
+  const order = readOrder(config, source);
   const union = new Set([
     ...branchEnvs,
     ...Object.keys(done.map ?? {}),
@@ -287,59 +311,29 @@ export function resolveDeployLadder(
   const canonical = (env: string): string =>
     soleProdAlias && env === "prod" ? "production" : env;
   if (done.map !== undefined) {
-    assertDoneEnvsHaveBranches(done.map, new Set(branchEnvs), source);
+    assertDoneEnvsHaveBranches(done.map, branchEnvs, source);
   }
   const ordered = orderEnvironments(branchEnvs, order, canonical, source);
+  const terminalEnv = ordered.at(-1);
   const rungs = buildRungs(
     ordered,
     branches,
     done,
     DONE_DEFAULTS[tracker],
-    canonical
+    canonical,
+    terminalEnv
   );
-  return { rungs, terminalOnly: rungs.length === 1 };
+  // terminalOnly guards DSS-2's native closure: a sole surviving LOWER rung
+  // (skip-collapsed ladder) must never be treated as the terminal env.
+  const terminalOnly =
+    rungs.length === 1 &&
+    rungs[0] !== undefined &&
+    rungs[0].env === terminalEnv;
+  return { rungs, terminalOnly };
 }
 
 /** Strict ISO-8601 UTC timestamp (`Z` suffix, optional milliseconds). */
 const ISO_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/u;
-
-/**
- * Whether a string contains an ASCII control character.
- * @param value - Candidate string
- * @returns True when a control character is present
- */
-function containsControlCharacter(value: string): boolean {
-  return Array.from(value).some(character => {
-    const codePoint = character.codePointAt(0) ?? 0;
-    return codePoint < 32 || codePoint === 127;
-  });
-}
-
-/**
- * Validate an optional non-empty trimmed string field.
- * @param value - Untrusted field value
- * @param source - Config source shown in errors
- * @param field - Dotted field name
- * @returns Valid string or undefined
- */
-function optionalString(
-  value: unknown,
-  source: string,
-  field: string
-): string | undefined {
-  if (value === undefined) return undefined;
-  if (
-    typeof value !== "string" ||
-    value.trim() !== value ||
-    value.length === 0 ||
-    containsControlCharacter(value)
-  ) {
-    throw new Error(
-      `Invalid ${field} in ${source}: expected a non-empty string`
-    );
-  }
-  return value;
-}
 
 /**
  * Validate the optional provisioned-artifact id map.
@@ -358,10 +352,14 @@ function validateProvisioned(
     );
   }
   return Object.fromEntries(
-    Object.entries(value).map(([key, id]) => [
-      key,
-      optionalString(id, source, `deployStatusSync.provisioned.${key}`) ?? "",
-    ])
+    Object.entries(value).flatMap(([key, id]) => {
+      const valid = optionalString(
+        id,
+        source,
+        `deployStatusSync.provisioned.${key}`
+      );
+      return valid === undefined ? [] : [[key, valid] as const];
+    })
   );
 }
 
@@ -425,11 +423,10 @@ export function validateDeployStatusSyncConfig(
       `Invalid deployStatusSync in ${source}: expected an object`
     );
   }
-  const input = value as Record<string, unknown>;
-  const tier = optionalString(input.tier, source, "deployStatusSync.tier");
-  const provisioned = validateProvisioned(input.provisioned, source);
-  const linearBinding = validateLinearBinding(input.linearBinding, source);
-  const verifiedAt = validateVerifiedAt(input.verifiedAt, source);
+  const tier = optionalString(value.tier, source, "deployStatusSync.tier");
+  const provisioned = validateProvisioned(value.provisioned, source);
+  const linearBinding = validateLinearBinding(value.linearBinding, source);
+  const verifiedAt = validateVerifiedAt(value.verifiedAt, source);
   return {
     ...(tier === undefined ? {} : { tier }),
     ...(provisioned === undefined ? {} : { provisioned }),

--- a/src/core/deploy-status-sync.ts
+++ b/src/core/deploy-status-sync.ts
@@ -1,0 +1,439 @@
+/**
+ * Deploy-status-sync ladder resolution and config schema (DSS-1).
+ *
+ * Pure, fs-free helpers that turn a parsed `.lisa.config.json` value into the
+ * ordered environment ladder (env → deploy branch → tracker done status) the
+ * deploy-status-sync flows walk, plus the validator for the optional
+ * `deployStatusSync` section. The default done vocabularies live here — and
+ * are consumed by `src/sync/registry.ts` — so the ladder resolver and the
+ * sync registry share one source of truth without a runtime module cycle
+ * (registry → project-config → this module would cycle if this module
+ * imported the registry).
+ * @module core/deploy-status-sync
+ */
+import { getAtPath, isJsonObject, type JsonValue } from "../sync/json-path.js";
+
+/** Tracker vendors whose done vocabulary can bind a deploy ladder. */
+export type Tracker = "jira" | "github" | "linear";
+
+/** One environment step of the deploy ladder. */
+export interface DeployLadderRung {
+  /** Environment name as configured (e.g. `dev`, `prod`) */
+  readonly env: string;
+  /** Git branch that deploys to this environment */
+  readonly branch: string;
+  /** Tracker status/label a work item earns when deployed here */
+  readonly doneStatus: string;
+}
+
+/** The resolved promotion ladder, ordered lowest environment first. */
+export interface DeployLadder {
+  /** Ordered rungs (lowest environment first) */
+  readonly rungs: readonly DeployLadderRung[];
+  /** True when the ladder collapsed to a single terminal rung */
+  readonly terminalOnly: boolean;
+}
+
+/** Optional machine-written `deployStatusSync` section of the config. */
+export interface DeployStatusSyncConfig {
+  /** Provisioning tier chosen at setup time */
+  readonly tier?: string;
+  /** Provisioned tracker artifact ids, keyed by artifact name */
+  readonly provisioned?: Readonly<Record<string, string>>;
+  /** How Linear deploy statuses are represented */
+  readonly linearBinding?: "labels" | "states";
+  /** ISO-8601 UTC timestamp of the last successful verification */
+  readonly verifiedAt?: string;
+}
+
+/**
+ * Default env-keyed done labels for label-driven trackers (GitHub, Linear).
+ * Mirrored into the sync registry's `github.labels` / `linear.labels`
+ * defaults — keep value-identical with what `lisa sync` populates.
+ */
+export const ENV_DONE_LABEL_DEFAULTS = {
+  dev: "status:on-dev",
+  staging: "status:on-stg",
+  production: "status:done",
+} as const;
+
+/**
+ * Default env-keyed done statuses for JIRA workflows. Mirrored into the sync
+ * registry's `jira.workflow` default — keep value-identical with what
+ * `lisa sync` populates.
+ */
+export const JIRA_DONE_STATUS_DEFAULTS = {
+  dev: "On Dev",
+  staging: "On Stg",
+  production: "Done",
+} as const;
+
+/** Config dot-path of each tracker's env-keyed done vocabulary. */
+const DONE_MAP_PATHS: Readonly<Record<Tracker, string>> = {
+  github: "github.labels.build.done",
+  linear: "linear.labels.build.done",
+  jira: "jira.workflow.done",
+};
+
+/** Default done vocabulary per tracker, used when config has no entry. */
+const DONE_DEFAULTS: Readonly<
+  Record<Tracker, Readonly<Record<string, string>>>
+> = {
+  github: ENV_DONE_LABEL_DEFAULTS,
+  linear: ENV_DONE_LABEL_DEFAULTS,
+  jira: JIRA_DONE_STATUS_DEFAULTS,
+};
+
+/** Canonical promotion rank when `deploy.order` is absent (lowest first). */
+const CANONICAL_ENV_RANKS: Readonly<Record<string, number>> = {
+  dev: 0,
+  staging: 1,
+  production: 2,
+};
+
+/**
+ * Read `deploy.branches` as an env → branch map, ignoring non-string values.
+ * @param config - Parsed config value
+ * @returns Env-to-branch record (empty when the section is absent)
+ */
+function readBranches(config: JsonValue): Readonly<Record<string, string>> {
+  const branches = getAtPath(config, "deploy.branches");
+  if (!isJsonObject(branches)) return {};
+  return Object.fromEntries(
+    Object.entries(branches).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string"
+    )
+  );
+}
+
+/** The configured done vocabulary: an env-keyed map or a terminal string. */
+interface ConfiguredDone {
+  readonly map?: Readonly<Record<string, string>>;
+  readonly terminal?: string;
+}
+
+/**
+ * Read the tracker's configured done vocabulary from config, if any.
+ * @param config - Parsed config value
+ * @param tracker - Tracker whose vocabulary path applies
+ * @returns Configured env-keyed map, terminal string, or neither
+ */
+function readConfiguredDone(
+  config: JsonValue,
+  tracker: Tracker
+): ConfiguredDone {
+  const done = getAtPath(config, DONE_MAP_PATHS[tracker]);
+  if (typeof done === "string") return { terminal: done };
+  if (!isJsonObject(done)) return {};
+  return {
+    map: Object.fromEntries(
+      Object.entries(done).filter(
+        (entry): entry is [string, string] => typeof entry[1] === "string"
+      )
+    ),
+  };
+}
+
+/**
+ * Reject a configured done entry whose environment has no deploy branch.
+ * Only explicitly-configured entries can trigger this — default-table
+ * entries are fallbacks and never error.
+ * @param doneMap - Configured env-keyed done map
+ * @param branchEnvs - Environments present in `deploy.branches`
+ * @param source - Config source shown in errors
+ */
+function assertDoneEnvsHaveBranches(
+  doneMap: Readonly<Record<string, string>>,
+  branchEnvs: ReadonlySet<string>,
+  source: string
+): void {
+  for (const [env, status] of Object.entries(doneMap)) {
+    if (!branchEnvs.has(env)) {
+      throw new Error(
+        `Invalid deploy configuration in ${source}: a done status ("${status}") is configured for environment "${env}", but deploy.branches has no "${env}" entry. Add deploy.branches.${env} (the git branch that deploys to ${env}) or remove "${env}" from the done map.`
+      );
+    }
+  }
+}
+
+/**
+ * Read `deploy.order` as a string array, if present.
+ * @param config - Parsed config value
+ * @returns Ordered env names (lowest first), or undefined when absent
+ */
+function readOrder(config: JsonValue): readonly string[] | undefined {
+  const order = getAtPath(config, "deploy.order");
+  if (!Array.isArray(order)) return undefined;
+  return order.filter((entry): entry is string => typeof entry === "string");
+}
+
+/**
+ * Require `deploy.order` to name exactly the `deploy.branches` env set.
+ * @param order - Configured order
+ * @param branchEnvs - Environments present in `deploy.branches`
+ * @param source - Config source shown in errors
+ */
+function assertOrderMatchesBranches(
+  order: readonly string[],
+  branchEnvs: readonly string[],
+  source: string
+): void {
+  const orderSet = new Set(order);
+  const branchSet = new Set(branchEnvs);
+  const matches =
+    orderSet.size === branchSet.size &&
+    branchEnvs.every(env => orderSet.has(env));
+  if (!matches) {
+    throw new Error(
+      `Invalid deploy.order in ${source}: its environment names must exactly match the keys of deploy.branches. deploy.order has [${order.join(", ")}]; deploy.branches has [${branchEnvs.join(", ")}].`
+    );
+  }
+}
+
+/**
+ * Order the configured environments lowest-first. `deploy.order` wins when
+ * present; otherwise the canonical `dev < staging < production` rank applies
+ * and any unrankable custom name (with more than one env) is a
+ * decision-ready error rather than a guess.
+ * @param branchEnvs - Environments present in `deploy.branches`
+ * @param order - Configured `deploy.order`, if any
+ * @param canonical - Alias-aware canonical name resolver
+ * @param source - Config source shown in errors
+ * @returns Environments ordered lowest first
+ */
+function orderEnvironments(
+  branchEnvs: readonly string[],
+  order: readonly string[] | undefined,
+  canonical: (env: string) => string,
+  source: string
+): readonly string[] {
+  if (order !== undefined) {
+    assertOrderMatchesBranches(order, branchEnvs, source);
+    return order;
+  }
+  if (branchEnvs.length <= 1) return branchEnvs;
+  const ranked = branchEnvs.map(env => {
+    const rank = CANONICAL_ENV_RANKS[canonical(env)];
+    if (rank === undefined) {
+      throw new Error(
+        `Invalid deploy configuration in ${source}: cannot order environment "${env}". Set deploy.order (environments listed lowest first, e.g. ["dev","staging","production"]) so Lisa knows the promotion order.`
+      );
+    }
+    return { env, rank };
+  });
+  return [...ranked].sort((a, b) => a.rank - b.rank).map(entry => entry.env);
+}
+
+/**
+ * Join ordered environments with their branch and done status. An env whose
+ * done status resolves nowhere (possible only for custom names outside the
+ * default tables) is skipped — a branch-only env is a deploy target without
+ * tracker vocabulary, not an error.
+ * @param orderedEnvs - Environments ordered lowest first
+ * @param branches - Env-to-branch record
+ * @param done - Configured done vocabulary
+ * @param defaults - Tracker default done vocabulary
+ * @param canonical - Alias-aware canonical name resolver
+ * @returns The joined rungs, lowest environment first
+ */
+function buildRungs(
+  orderedEnvs: readonly string[],
+  branches: Readonly<Record<string, string>>,
+  done: ConfiguredDone,
+  defaults: Readonly<Record<string, string>>,
+  canonical: (env: string) => string
+): readonly DeployLadderRung[] {
+  const terminalEnv = orderedEnvs[orderedEnvs.length - 1];
+  return orderedEnvs.flatMap(env => {
+    const branch = branches[env];
+    const terminal = env === terminalEnv ? done.terminal : undefined;
+    const doneStatus = done.map?.[env] ?? terminal ?? defaults[canonical(env)];
+    return doneStatus === undefined || branch === undefined
+      ? []
+      : [{ env, branch, doneStatus }];
+  });
+}
+
+/**
+ * Resolve the deploy promotion ladder for a tracker from parsed config.
+ *
+ * The env universe is the keys of `deploy.branches`, joined with the
+ * tracker's done vocabulary (configured entries win over the default
+ * tables). `prod` ↔ `production` alias as one env iff exactly one spelling
+ * appears across the configured surfaces (branches, done map, order); the
+ * rung reports the configured spelling. Absent or empty `deploy` yields an
+ * empty ladder, never an error.
+ * @param config - Parsed `.lisa.config.json` value
+ * @param tracker - Tracker whose done vocabulary binds the ladder
+ * @param source - Config source shown in errors
+ * @returns The ordered ladder with its terminal-only collapse flag
+ */
+export function resolveDeployLadder(
+  config: JsonValue,
+  tracker: Tracker,
+  source: string
+): DeployLadder {
+  const branches = readBranches(config);
+  const branchEnvs = Object.keys(branches);
+  if (branchEnvs.length === 0) return { rungs: [], terminalOnly: false };
+  const done = readConfiguredDone(config, tracker);
+  const order = readOrder(config);
+  const union = new Set([
+    ...branchEnvs,
+    ...Object.keys(done.map ?? {}),
+    ...(order ?? []),
+  ]);
+  const soleProdAlias = union.has("prod") && !union.has("production");
+  const canonical = (env: string): string =>
+    soleProdAlias && env === "prod" ? "production" : env;
+  if (done.map !== undefined) {
+    assertDoneEnvsHaveBranches(done.map, new Set(branchEnvs), source);
+  }
+  const ordered = orderEnvironments(branchEnvs, order, canonical, source);
+  const rungs = buildRungs(
+    ordered,
+    branches,
+    done,
+    DONE_DEFAULTS[tracker],
+    canonical
+  );
+  return { rungs, terminalOnly: rungs.length === 1 };
+}
+
+/** Strict ISO-8601 UTC timestamp (`Z` suffix, optional milliseconds). */
+const ISO_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/u;
+
+/**
+ * Whether a string contains an ASCII control character.
+ * @param value - Candidate string
+ * @returns True when a control character is present
+ */
+function containsControlCharacter(value: string): boolean {
+  return Array.from(value).some(character => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint < 32 || codePoint === 127;
+  });
+}
+
+/**
+ * Validate an optional non-empty trimmed string field.
+ * @param value - Untrusted field value
+ * @param source - Config source shown in errors
+ * @param field - Dotted field name
+ * @returns Valid string or undefined
+ */
+function optionalString(
+  value: unknown,
+  source: string,
+  field: string
+): string | undefined {
+  if (value === undefined) return undefined;
+  if (
+    typeof value !== "string" ||
+    value.trim() !== value ||
+    value.length === 0 ||
+    containsControlCharacter(value)
+  ) {
+    throw new Error(
+      `Invalid ${field} in ${source}: expected a non-empty string`
+    );
+  }
+  return value;
+}
+
+/**
+ * Validate the optional provisioned-artifact id map.
+ * @param value - Untrusted field value
+ * @param source - Config source shown in errors
+ * @returns Valid id record or undefined
+ */
+function validateProvisioned(
+  value: unknown,
+  source: string
+): Readonly<Record<string, string>> | undefined {
+  if (value === undefined) return undefined;
+  if (!isJsonObject(value)) {
+    throw new Error(
+      `Invalid deployStatusSync.provisioned in ${source}: expected an object`
+    );
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([key, id]) => [
+      key,
+      optionalString(id, source, `deployStatusSync.provisioned.${key}`) ?? "",
+    ])
+  );
+}
+
+/**
+ * Validate the optional Linear binding mode.
+ * @param value - Untrusted field value
+ * @param source - Config source shown in errors
+ * @returns Valid binding or undefined
+ */
+function validateLinearBinding(
+  value: unknown,
+  source: string
+): "labels" | "states" | undefined {
+  if (value === undefined) return undefined;
+  if (value !== "labels" && value !== "states") {
+    throw new Error(
+      `Invalid deployStatusSync.linearBinding in ${source}: expected "labels" or "states"`
+    );
+  }
+  return value;
+}
+
+/**
+ * Validate the optional verification timestamp as strict ISO-8601 UTC.
+ * @param value - Untrusted field value
+ * @param source - Config source shown in errors
+ * @returns Valid timestamp or undefined
+ */
+function validateVerifiedAt(
+  value: unknown,
+  source: string
+): string | undefined {
+  if (value === undefined) return undefined;
+  if (
+    typeof value !== "string" ||
+    !ISO_UTC_PATTERN.test(value) ||
+    Number.isNaN(Date.parse(value))
+  ) {
+    throw new Error(
+      `Invalid deployStatusSync.verifiedAt in ${source}: expected an ISO-8601 UTC timestamp (e.g. 2026-01-01T00:00:00Z)`
+    );
+  }
+  return value;
+}
+
+/**
+ * Validate the optional `deployStatusSync` config section. Unknown fields
+ * inside the section are ignored in the typed view; the raw JSON round-trip
+ * preserves them.
+ * @param value - Untrusted section value
+ * @param source - Config source shown in errors
+ * @returns Typed section, or undefined when absent
+ */
+export function validateDeployStatusSyncConfig(
+  value: unknown,
+  source: string
+): DeployStatusSyncConfig | undefined {
+  if (value === undefined) return undefined;
+  if (!isJsonObject(value)) {
+    throw new Error(
+      `Invalid deployStatusSync in ${source}: expected an object`
+    );
+  }
+  const input = value as Record<string, unknown>;
+  const tier = optionalString(input.tier, source, "deployStatusSync.tier");
+  const provisioned = validateProvisioned(input.provisioned, source);
+  const linearBinding = validateLinearBinding(input.linearBinding, source);
+  const verifiedAt = validateVerifiedAt(input.verifiedAt, source);
+  return {
+    ...(tier === undefined ? {} : { tier }),
+    ...(provisioned === undefined ? {} : { provisioned }),
+    ...(linearBinding === undefined ? {} : { linearBinding }),
+    ...(verifiedAt === undefined ? {} : { verifiedAt }),
+  };
+}

--- a/src/core/project-config.ts
+++ b/src/core/project-config.ts
@@ -18,7 +18,7 @@ import {
   LEGACY_HARNESS_ALIASES,
   type Harness,
 } from "./config.js";
-import { validateSafeRelativeMarkdownPath } from "./config-path-validation.js";
+import { validateSafeRelativeMarkdownPath } from "./config-field-validation.js";
 import {
   validateDeployStatusSyncConfig,
   type DeployStatusSyncConfig,

--- a/src/core/project-config.ts
+++ b/src/core/project-config.ts
@@ -18,6 +18,11 @@ import {
   LEGACY_HARNESS_ALIASES,
   type Harness,
 } from "./config.js";
+import { validateSafeRelativeMarkdownPath } from "./config-path-validation.js";
+import {
+  validateDeployStatusSyncConfig,
+  type DeployStatusSyncConfig,
+} from "./deploy-status-sync.js";
 import {
   validateVerificationConfig,
   type VerificationConfig,
@@ -106,6 +111,8 @@ export interface ProjectConfig {
   readonly learnings?: LearningsConfig;
   /** Optional empirical verification provider configuration. */
   readonly verification?: VerificationConfig;
+  /** Optional machine-written deploy-status-sync provisioning record. */
+  readonly deployStatusSync?: DeployStatusSyncConfig;
 }
 
 /**
@@ -312,11 +319,16 @@ export function validateProjectConfig(
       : validateProjectRulesFile(obj.projectRulesFile, configPath);
   const learnings = validateLearningsConfig(obj.learnings, configPath);
   const verification = validateVerificationConfig(obj.verification, configPath);
+  const deployStatusSync = validateDeployStatusSyncConfig(
+    obj.deployStatusSync,
+    configPath
+  );
   return {
     ...(harness === undefined ? {} : { harness }),
     ...(projectRulesFile === undefined ? {} : { projectRulesFile }),
     ...(learnings === undefined ? {} : { learnings }),
     ...(verification === undefined ? {} : { verification }),
+    ...(deployStatusSync === undefined ? {} : { deployStatusSync }),
   };
 }
 
@@ -348,50 +360,6 @@ function validateOptionalHarness(
   throw new Error(
     `Invalid harness in ${configPath}: expected ${allowed}, got ${JSON.stringify(value)}`
   );
-}
-
-/**
- * Validate a configurable destination as a safe, relative, non-traversing
- * Markdown path. Shared by every path-typed config field; the `field` label is
- * interpolated into each diagnostic so callers get a field-specific message.
- * @param value - Raw configured path
- * @param source - Config source for errors
- * @param field - Config field name used in error messages
- * @returns Validated project-relative path
- */
-function validateSafeRelativeMarkdownPath(
-  value: unknown,
-  source: string,
-  field: string
-): string {
-  if (
-    typeof value !== "string" ||
-    value.length === 0 ||
-    value.trim() !== value ||
-    value.includes("\\") ||
-    containsControlCharacter(value) ||
-    /^[a-z]:/iu.test(value) ||
-    path.posix.isAbsolute(value) ||
-    path.win32.isAbsolute(value)
-  ) {
-    throw new Error(
-      `Invalid ${field} in ${source}: expected a safe relative POSIX path`
-    );
-  }
-  const segments = value.split("/");
-  if (
-    segments.some(
-      segment => segment === "" || segment === "." || segment === ".."
-    )
-  ) {
-    throw new Error(
-      `Invalid ${field} in ${source}: path traversal is not allowed`
-    );
-  }
-  if (path.posix.extname(value).toLowerCase() !== ".md") {
-    throw new Error(`Invalid ${field} in ${source}: expected a Markdown file`);
-  }
-  return value;
 }
 
 /**
@@ -479,18 +447,6 @@ function validateLearningsConfig(
     return {};
   }
   return { file: validateLearningsFile(file, source) };
-}
-
-/**
- * Whether a path contains an ASCII control character.
- * @param value - Configured path
- * @returns True when any control character is present
- */
-function containsControlCharacter(value: string): boolean {
-  return Array.from(value).some(character => {
-    const code = character.charCodeAt(0);
-    return code <= 31 || code === 127;
-  });
 }
 
 /**

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -681,7 +681,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/reference/coding-philosophy.md":
       "fed8381f16a5d6793a49d84d5813d62125808cb2f4981a558b119cf63e2586d9",
     "plugins/src/base/rules/reference/config-resolution.md":
-      "dd1bdc9024147e42aad78332d98735871860e3e161807f7fbc8e373bc29a84a1",
+      "ffb231a7218235b5a8e8c4945f899e49f609b939e401e7c38bbed43ce8ab805e",
     "plugins/src/base/rules/reference/convergent-review.md":
       "788a9d4dc2af7a928c3ccbb4d53a92856bb3544941ce512cfe38068d6b35850d",
     "plugins/src/base/rules/reference/dependency-decision-records.md":
@@ -7473,7 +7473,9 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/copilot/copilot-instructions-installer.ts": true,
     "src/copilot/plugin-installer.ts": true,
     "src/core/bootstrap-environment.ts": true,
+    "src/core/config-field-validation.ts": true,
     "src/core/config.ts": true,
+    "src/core/deploy-status-sync.ts": true,
     "src/core/git-service.ts": true,
     "src/core/index.ts": true,
     "src/core/instruction-files-migration.ts": true,
@@ -7838,6 +7840,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/config/vitest-nestjs.test.ts": true,
     "tests/unit/config/vitest-typescript.test.ts": true,
     "tests/unit/core/bootstrap-environment.test.ts": true,
+    "tests/unit/core/deploy-status-sync.test.ts": true,
     "tests/unit/core/instruction-files-migration.test.ts": true,
     "tests/unit/core/kane-cli.test.ts": true,
     "tests/unit/core/kane-pilot.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -617,7 +617,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/eager/coding-philosophy.md":
       "cf2c52032e0368d81f17f002fed5c957ab350d01fc4a43f66b5f366516bac54a",
     "plugins/src/base/rules/eager/config-resolution.md":
-      "8d292784056d0cc62d78cc079286a2fdd6381e14452615b7aa8db0d31c3ff2ca",
+      "1e6324bd037ea08b6c0179999578788e9f20ae2d256547527abf623a7d0dbc2f",
     "plugins/src/base/rules/eager/convergent-review.md":
       "ba4ba53863ef99be353c07c01195fa4ae2923ef2b2a5ad4427072802c260d208",
     "plugins/src/base/rules/eager/dependency-decision-records.md":
@@ -681,7 +681,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/reference/coding-philosophy.md":
       "fed8381f16a5d6793a49d84d5813d62125808cb2f4981a558b119cf63e2586d9",
     "plugins/src/base/rules/reference/config-resolution.md":
-      "071b2c91f3b661ee493ea6f37d78f0fdea8004b4e4e7b5e94dcf232df7eceda7",
+      "dd1bdc9024147e42aad78332d98735871860e3e161807f7fbc8e373bc29a84a1",
     "plugins/src/base/rules/reference/convergent-review.md":
       "788a9d4dc2af7a928c3ccbb4d53a92856bb3544941ce512cfe38068d6b35850d",
     "plugins/src/base/rules/reference/dependency-decision-records.md":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7840,6 +7840,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/config/vitest-nestjs.test.ts": true,
     "tests/unit/config/vitest-typescript.test.ts": true,
     "tests/unit/core/bootstrap-environment.test.ts": true,
+    "tests/unit/core/deploy-status-sync-config.test.ts": true,
+    "tests/unit/core/deploy-status-sync-errors.test.ts": true,
     "tests/unit/core/deploy-status-sync.test.ts": true,
     "tests/unit/core/instruction-files-migration.test.ts": true,
     "tests/unit/core/kane-cli.test.ts": true,

--- a/src/sync/registry.ts
+++ b/src/sync/registry.ts
@@ -10,6 +10,10 @@
  * completely missing.
  * @module sync/registry
  */
+import {
+  ENV_DONE_LABEL_DEFAULTS,
+  JIRA_DONE_STATUS_DEFAULTS,
+} from "../core/deploy-status-sync.js";
 import { DEFAULT_PROJECT_RULES_FILE } from "../core/project-config.js";
 import { validateHealthSchedule } from "../health/contract.js";
 import type { JsonValue } from "./json-path.js";
@@ -128,11 +132,7 @@ const BUILD_LABEL_DEFAULTS = {
   claimed: "status:in-progress",
   blocked: "status:blocked",
   human_needed: "human-needed",
-  done: {
-    dev: "status:on-dev",
-    staging: "status:on-stg",
-    production: "status:done",
-  },
+  done: ENV_DONE_LABEL_DEFAULTS,
 } as const;
 
 const PRD_LABEL_DEFAULTS: JsonValue = {
@@ -254,7 +254,7 @@ export const SYNC_REGISTRY: readonly SyncedSetting[] = [
       claimed: "In Progress",
       review: "Code Review",
       blocked: "Blocked",
-      done: { dev: "On Dev", staging: "On Stg", production: "Done" },
+      done: JIRA_DONE_STATUS_DEFAULTS,
     },
     relevantWhen: ["jira", WHEN_TRACKER_JIRA],
     description: "JIRA workflow status names per lifecycle role",

--- a/tests/unit/core/deploy-status-sync-config.test.ts
+++ b/tests/unit/core/deploy-status-sync-config.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  ENV_DONE_LABEL_DEFAULTS,
+  JIRA_DONE_STATUS_DEFAULTS,
+  validateDeployStatusSyncConfig,
+} from "../../../src/core/deploy-status-sync.js";
+import { validateProjectConfig } from "../../../src/core/project-config.js";
+
+const SOURCE = ".lisa.config.json";
+const LINEAR_BINDING_ERROR =
+  'Invalid deployStatusSync.linearBinding in .lisa.config.json: expected "labels" or "states"';
+
+describe("default done vocabularies", () => {
+  it("exports the shared label defaults consumed by the sync registry", () => {
+    expect(ENV_DONE_LABEL_DEFAULTS).toEqual({
+      dev: "status:on-dev",
+      staging: "status:on-stg",
+      production: "status:done",
+    });
+    expect(JIRA_DONE_STATUS_DEFAULTS).toEqual({
+      dev: "On Dev",
+      staging: "On Stg",
+      production: "Done",
+    });
+  });
+});
+
+describe("validateDeployStatusSyncConfig", () => {
+  it("returns the typed section for a fully valid value", () => {
+    expect(
+      validateDeployStatusSyncConfig(
+        {
+          tier: "team",
+          provisioned: { "jira:On Dev": "10012" },
+          linearBinding: "labels",
+          verifiedAt: "2026-07-01T12:00:00Z",
+        },
+        SOURCE
+      )
+    ).toEqual({
+      tier: "team",
+      provisioned: { "jira:On Dev": "10012" },
+      linearBinding: "labels",
+      verifiedAt: "2026-07-01T12:00:00Z",
+    });
+  });
+
+  it("passes undefined through and accepts an empty section", () => {
+    expect(validateDeployStatusSyncConfig(undefined, SOURCE)).toBeUndefined();
+    expect(validateDeployStatusSyncConfig({}, SOURCE)).toEqual({});
+  });
+
+  it.each([["gold"], [null], [["labels"]]])(
+    "rejects non-object section %#",
+    section => {
+      expect(() => validateDeployStatusSyncConfig(section, SOURCE)).toThrow(
+        "Invalid deployStatusSync in .lisa.config.json: expected an object"
+      );
+    }
+  );
+
+  it("rejects an unknown linearBinding value", () => {
+    expect(() =>
+      validateDeployStatusSyncConfig({ linearBinding: "webhooks" }, SOURCE)
+    ).toThrow(LINEAR_BINDING_ERROR);
+  });
+
+  it.each(["2026-07-01", "2026-13-01T00:00:00Z", "2026-07-01T12:00:00+00:00"])(
+    "rejects non-ISO-8601-UTC verifiedAt %s",
+    verifiedAt => {
+      expect(() =>
+        validateDeployStatusSyncConfig({ verifiedAt }, SOURCE)
+      ).toThrow(
+        "Invalid deployStatusSync.verifiedAt in .lisa.config.json: expected an ISO-8601 UTC timestamp (e.g. 2026-01-01T00:00:00Z)"
+      );
+    }
+  );
+
+  it.each([["ids"], [["a"]], [null]])(
+    "rejects non-object provisioned %#",
+    provisioned => {
+      expect(() =>
+        validateDeployStatusSyncConfig({ provisioned }, SOURCE)
+      ).toThrow(
+        "Invalid deployStatusSync.provisioned in .lisa.config.json: expected an object"
+      );
+    }
+  );
+
+  it("rejects a non-string provisioned id", () => {
+    expect(() =>
+      validateDeployStatusSyncConfig(
+        { provisioned: { "jira:Done": 10001 } },
+        SOURCE
+      )
+    ).toThrow(
+      "Invalid deployStatusSync.provisioned.jira:Done in .lisa.config.json: expected a non-empty string"
+    );
+  });
+
+  it.each([[""], ["  padded  "]])("rejects invalid tier %#", tier => {
+    expect(() => validateDeployStatusSyncConfig({ tier }, SOURCE)).toThrow(
+      "Invalid deployStatusSync.tier in .lisa.config.json: expected a non-empty string"
+    );
+  });
+});
+
+describe("project config deployStatusSync wiring", () => {
+  it("parses the section beside the other validated sections", () => {
+    expect(
+      validateProjectConfig({ deployStatusSync: { tier: "team" } }, SOURCE)
+    ).toMatchObject({ deployStatusSync: { tier: "team" } });
+  });
+
+  it("rejects an invalid nested section during parse", () => {
+    expect(() =>
+      validateProjectConfig(
+        { deployStatusSync: { linearBinding: "webhooks" } },
+        SOURCE
+      )
+    ).toThrow(LINEAR_BINDING_ERROR);
+  });
+});

--- a/tests/unit/core/deploy-status-sync-errors.test.ts
+++ b/tests/unit/core/deploy-status-sync-errors.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { resolveDeployLadder } from "../../../src/core/deploy-status-sync.js";
+import type { JsonValue } from "../../../src/sync/json-path.js";
+
+const SOURCE = ".lisa.config.json";
+
+// Hardcoded expected error text — never computed from the module under test.
+const STAGING_WITHOUT_BRANCH_ERROR =
+  'Invalid deploy configuration in .lisa.config.json: a done status ("status:on-stg") is configured for environment "staging", but deploy.branches has no "staging" entry. Add deploy.branches.staging (the git branch that deploys to staging) or remove "staging" from the done map.';
+
+describe("resolveDeployLadder errors", () => {
+  it("rejects a configured done status whose environment has no branch", () => {
+    const config: JsonValue = {
+      deploy: { branches: { dev: "dev", production: "main" } },
+      github: { labels: { build: { done: { staging: "status:on-stg" } } } },
+    };
+    expect(() => resolveDeployLadder(config, "github", SOURCE)).toThrow(
+      STAGING_WITHOUT_BRANCH_ERROR
+    );
+  });
+
+  it("rejects a configured production done entry beside branches.prod (both spellings block the alias)", () => {
+    const config: JsonValue = {
+      deploy: { branches: { prod: "main" } },
+      github: { labels: { build: { done: { production: "status:done" } } } },
+    };
+    expect(() => resolveDeployLadder(config, "github", SOURCE)).toThrow(
+      'Invalid deploy configuration in .lisa.config.json: a done status ("status:done") is configured for environment "production", but deploy.branches has no "production" entry. Add deploy.branches.production (the git branch that deploys to production) or remove "production" from the done map.'
+    );
+  });
+
+  it("rejects a non-string branch value by erroring its configured done entry", () => {
+    const config: JsonValue = {
+      deploy: { branches: { dev: "dev", staging: 42, production: "main" } },
+      github: { labels: { build: { done: { staging: "status:on-stg" } } } },
+    };
+    expect(() => resolveDeployLadder(config, "github", SOURCE)).toThrow(
+      STAGING_WITHOUT_BRANCH_ERROR
+    );
+  });
+
+  it("rejects deploy.order whose env set differs from deploy.branches", () => {
+    const config: JsonValue = {
+      deploy: {
+        branches: { dev: "dev", staging: "staging", production: "main" },
+        order: ["dev", "production"],
+      },
+    };
+    expect(() => resolveDeployLadder(config, "github", SOURCE)).toThrow(
+      "Invalid deploy.order in .lisa.config.json: its environment names must exactly match the keys of deploy.branches. deploy.order has [dev, production]; deploy.branches has [dev, staging, production]."
+    );
+  });
+
+  it("rejects deploy.order containing duplicate environment names", () => {
+    const config: JsonValue = {
+      deploy: {
+        branches: { dev: "dev", production: "main" },
+        order: ["dev", "dev", "production"],
+      },
+    };
+    expect(() => resolveDeployLadder(config, "github", SOURCE)).toThrow(
+      "Invalid deploy.order in .lisa.config.json: its environment names must exactly match the keys of deploy.branches. deploy.order has [dev, dev, production]; deploy.branches has [dev, production]."
+    );
+  });
+
+  it("rejects a prod-spelled deploy.order against production-spelled branches (no aliasing)", () => {
+    const config: JsonValue = {
+      deploy: { branches: { production: "main" }, order: ["prod"] },
+    };
+    expect(() => resolveDeployLadder(config, "github", SOURCE)).toThrow(
+      "Invalid deploy.order in .lisa.config.json: its environment names must exactly match the keys of deploy.branches. deploy.order has [prod]; deploy.branches has [production]."
+    );
+  });
+
+  it("rejects a non-string deploy.order entry decision-readably", () => {
+    const config: JsonValue = {
+      deploy: {
+        branches: { dev: "dev", production: "main" },
+        order: ["dev", 2, "production"],
+      },
+    };
+    expect(() => resolveDeployLadder(config, "github", SOURCE)).toThrow(
+      "Invalid deploy.order in .lisa.config.json: every entry must be an environment name string; found 2."
+    );
+  });
+
+  it("rejects an unorderable custom environment when deploy.order is absent", () => {
+    const config: JsonValue = {
+      deploy: { branches: { dev: "dev", qa: "qa" } },
+    };
+    expect(() => resolveDeployLadder(config, "github", SOURCE)).toThrow(
+      'Invalid deploy configuration in .lisa.config.json: cannot order environment "qa". Set deploy.order (environments listed lowest first, e.g. ["dev","staging","production"]) so Lisa knows the promotion order.'
+    );
+  });
+});

--- a/tests/unit/core/deploy-status-sync.test.ts
+++ b/tests/unit/core/deploy-status-sync.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from "vitest";
+import {
+  ENV_DONE_LABEL_DEFAULTS,
+  JIRA_DONE_STATUS_DEFAULTS,
+  resolveDeployLadder,
+  validateDeployStatusSyncConfig,
+} from "../../../src/core/deploy-status-sync.js";
+import { validateProjectConfig } from "../../../src/core/project-config.js";
+import type { JsonValue } from "../../../src/sync/json-path.js";
+
+const SOURCE = ".lisa.config.json";
+
+// Hardcoded known values — never computed from the module under test.
+const DEV_LABEL = "status:on-dev";
+const STAGING_LABEL = "status:on-stg";
+const PRODUCTION_LABEL = "status:done";
+const STAGING_BRANCH = "staging";
+const LIVE_LABEL = "status:live";
+
+const FULL_BRANCHES = {
+  deploy: {
+    branches: { dev: "dev", staging: STAGING_BRANCH, production: "main" },
+  },
+} satisfies JsonValue;
+
+describe("default done vocabularies", () => {
+  it("exports the shared label defaults consumed by the sync registry", () => {
+    expect(ENV_DONE_LABEL_DEFAULTS).toEqual({
+      dev: DEV_LABEL,
+      staging: STAGING_LABEL,
+      production: PRODUCTION_LABEL,
+    });
+    expect(JIRA_DONE_STATUS_DEFAULTS).toEqual({
+      dev: "On Dev",
+      staging: "On Stg",
+      production: "Done",
+    });
+  });
+});
+
+describe("resolveDeployLadder", () => {
+  it("returns the ordered 3-env ladder from label defaults for github", () => {
+    expect(resolveDeployLadder(FULL_BRANCHES, "github", SOURCE)).toEqual({
+      rungs: [
+        { env: "dev", branch: "dev", doneStatus: DEV_LABEL },
+        { env: "staging", branch: STAGING_BRANCH, doneStatus: STAGING_LABEL },
+        { env: "production", branch: "main", doneStatus: PRODUCTION_LABEL },
+      ],
+      terminalOnly: false,
+    });
+  });
+
+  it("sources jira done statuses, configured entries winning over defaults", () => {
+    const config: JsonValue = {
+      ...FULL_BRANCHES,
+      jira: { workflow: { done: { dev: "Deployed Dev" } } },
+    };
+    expect(resolveDeployLadder(config, "jira", SOURCE)).toEqual({
+      rungs: [
+        { env: "dev", branch: "dev", doneStatus: "Deployed Dev" },
+        { env: "staging", branch: STAGING_BRANCH, doneStatus: "On Stg" },
+        { env: "production", branch: "main", doneStatus: "Done" },
+      ],
+      terminalOnly: false,
+    });
+  });
+
+  it("sources linear done labels from linear.labels.build.done", () => {
+    const config: JsonValue = {
+      ...FULL_BRANCHES,
+      linear: {
+        labels: {
+          build: {
+            done: {
+              dev: "status:dev-live",
+              staging: "status:stg-live",
+              production: LIVE_LABEL,
+            },
+          },
+        },
+      },
+    };
+    expect(resolveDeployLadder(config, "linear", SOURCE)).toEqual({
+      rungs: [
+        { env: "dev", branch: "dev", doneStatus: "status:dev-live" },
+        {
+          env: "staging",
+          branch: STAGING_BRANCH,
+          doneStatus: "status:stg-live",
+        },
+        { env: "production", branch: "main", doneStatus: LIVE_LABEL },
+      ],
+      terminalOnly: false,
+    });
+  });
+
+  it("rejects a configured done status whose environment has no branch", () => {
+    const config: JsonValue = {
+      deploy: { branches: { dev: "dev", production: "main" } },
+      github: { labels: { build: { done: { staging: STAGING_LABEL } } } },
+    };
+    expect(() => resolveDeployLadder(config, "github", SOURCE)).toThrow(
+      'Invalid deploy configuration in .lisa.config.json: a done status ("status:on-stg") is configured for environment "staging", but deploy.branches has no "staging" entry. Add deploy.branches.staging (the git branch that deploys to staging) or remove "staging" from the done map.'
+    );
+  });
+
+  it("collapses a production-only config to a single terminal-only rung", () => {
+    const config: JsonValue = { deploy: { branches: { production: "main" } } };
+    expect(resolveDeployLadder(config, "github", SOURCE)).toEqual({
+      rungs: [
+        { env: "production", branch: "main", doneStatus: PRODUCTION_LABEL },
+      ],
+      terminalOnly: true,
+    });
+  });
+
+  it("joins branches.prod with the default production done entry via the sole alias", () => {
+    const config: JsonValue = { deploy: { branches: { prod: "main" } } };
+    expect(resolveDeployLadder(config, "github", SOURCE)).toEqual({
+      rungs: [{ env: "prod", branch: "main", doneStatus: PRODUCTION_LABEL }],
+      terminalOnly: true,
+    });
+    expect(resolveDeployLadder(config, "jira", SOURCE)).toEqual({
+      rungs: [{ env: "prod", branch: "main", doneStatus: "Done" }],
+      terminalOnly: true,
+    });
+  });
+
+  it("does not alias when both prod and production are configured", () => {
+    const config: JsonValue = {
+      deploy: {
+        branches: { prod: "release", production: "main" },
+        order: ["prod", "production"],
+      },
+      github: {
+        labels: {
+          build: {
+            done: { prod: "status:on-prod", production: PRODUCTION_LABEL },
+          },
+        },
+      },
+    };
+    expect(resolveDeployLadder(config, "github", SOURCE)).toEqual({
+      rungs: [
+        { env: "prod", branch: "release", doneStatus: "status:on-prod" },
+        { env: "production", branch: "main", doneStatus: PRODUCTION_LABEL },
+      ],
+      terminalOnly: false,
+    });
+  });
+
+  it("respects deploy.order over key order and canonical ranking", () => {
+    const config: JsonValue = {
+      deploy: {
+        branches: { production: "main", qa: "qa", dev: "dev" },
+        order: ["dev", "qa", "production"],
+      },
+      github: { labels: { build: { done: { qa: "status:on-qa" } } } },
+    };
+    expect(resolveDeployLadder(config, "github", SOURCE)).toEqual({
+      rungs: [
+        { env: "dev", branch: "dev", doneStatus: DEV_LABEL },
+        { env: "qa", branch: "qa", doneStatus: "status:on-qa" },
+        { env: "production", branch: "main", doneStatus: PRODUCTION_LABEL },
+      ],
+      terminalOnly: false,
+    });
+  });
+
+  it("rejects deploy.order whose env set differs from deploy.branches", () => {
+    const config: JsonValue = {
+      deploy: { ...FULL_BRANCHES.deploy, order: ["dev", "production"] },
+    };
+    expect(() => resolveDeployLadder(config, "github", SOURCE)).toThrow(
+      "Invalid deploy.order in .lisa.config.json: its environment names must exactly match the keys of deploy.branches. deploy.order has [dev, production]; deploy.branches has [dev, staging, production]."
+    );
+  });
+
+  it("rejects an unorderable custom environment when deploy.order is absent", () => {
+    const config: JsonValue = {
+      deploy: { branches: { dev: "dev", qa: "qa" } },
+    };
+    expect(() => resolveDeployLadder(config, "github", SOURCE)).toThrow(
+      'Invalid deploy configuration in .lisa.config.json: cannot order environment "qa". Set deploy.order (environments listed lowest first, e.g. ["dev","staging","production"]) so Lisa knows the promotion order.'
+    );
+  });
+
+  it("skips a custom-env rung that has a branch but no done status", () => {
+    const config: JsonValue = {
+      deploy: {
+        branches: { dev: "dev", qa: "qa", production: "main" },
+        order: ["dev", "qa", "production"],
+      },
+    };
+    expect(resolveDeployLadder(config, "github", SOURCE)).toEqual({
+      rungs: [
+        { env: "dev", branch: "dev", doneStatus: DEV_LABEL },
+        { env: "production", branch: "main", doneStatus: PRODUCTION_LABEL },
+      ],
+      terminalOnly: false,
+    });
+  });
+
+  it("returns an empty ladder when deploy is absent or has no branches", () => {
+    expect(resolveDeployLadder({}, "github", SOURCE)).toEqual({
+      rungs: [],
+      terminalOnly: false,
+    });
+    expect(resolveDeployLadder({ deploy: {} }, "jira", SOURCE)).toEqual({
+      rungs: [],
+      terminalOnly: false,
+    });
+  });
+
+  it("binds a string-valued done to the terminal rung only", () => {
+    const config: JsonValue = {
+      deploy: {
+        branches: { dev: "dev", staging: STAGING_BRANCH, production: "main" },
+      },
+      jira: { workflow: { done: "Shipped" } },
+    };
+    expect(resolveDeployLadder(config, "jira", SOURCE)).toEqual({
+      rungs: [
+        { env: "dev", branch: "dev", doneStatus: "On Dev" },
+        { env: "staging", branch: STAGING_BRANCH, doneStatus: "On Stg" },
+        { env: "production", branch: "main", doneStatus: "Shipped" },
+      ],
+      terminalOnly: false,
+    });
+  });
+
+  it("allows a single custom environment with a configured done status", () => {
+    const config: JsonValue = {
+      deploy: { branches: { edge: "main" } },
+      github: { labels: { build: { done: { edge: LIVE_LABEL } } } },
+    };
+    expect(resolveDeployLadder(config, "github", SOURCE)).toEqual({
+      rungs: [{ env: "edge", branch: "main", doneStatus: LIVE_LABEL }],
+      terminalOnly: true,
+    });
+  });
+});
+
+describe("validateDeployStatusSyncConfig", () => {
+  it("returns the typed section for a fully valid value", () => {
+    expect(
+      validateDeployStatusSyncConfig(
+        {
+          tier: "team",
+          provisioned: { "jira:On Dev": "10012" },
+          linearBinding: "labels",
+          verifiedAt: "2026-07-01T12:00:00Z",
+        },
+        SOURCE
+      )
+    ).toEqual({
+      tier: "team",
+      provisioned: { "jira:On Dev": "10012" },
+      linearBinding: "labels",
+      verifiedAt: "2026-07-01T12:00:00Z",
+    });
+  });
+
+  it("passes undefined through and accepts an empty section", () => {
+    expect(validateDeployStatusSyncConfig(undefined, SOURCE)).toBeUndefined();
+    expect(validateDeployStatusSyncConfig({}, SOURCE)).toEqual({});
+  });
+
+  it("rejects a non-object section", () => {
+    expect(() => validateDeployStatusSyncConfig("gold", SOURCE)).toThrow(
+      "Invalid deployStatusSync in .lisa.config.json: expected an object"
+    );
+  });
+
+  it("rejects an unknown linearBinding value", () => {
+    expect(() =>
+      validateDeployStatusSyncConfig({ linearBinding: "webhooks" }, SOURCE)
+    ).toThrow(
+      'Invalid deployStatusSync.linearBinding in .lisa.config.json: expected "labels" or "states"'
+    );
+  });
+
+  it.each(["2026-07-01", "2026-13-01T00:00:00Z", "2026-07-01T12:00:00+00:00"])(
+    "rejects non-ISO-8601-UTC verifiedAt %s",
+    verifiedAt => {
+      expect(() =>
+        validateDeployStatusSyncConfig({ verifiedAt }, SOURCE)
+      ).toThrow(
+        "Invalid deployStatusSync.verifiedAt in .lisa.config.json: expected an ISO-8601 UTC timestamp (e.g. 2026-01-01T00:00:00Z)"
+      );
+    }
+  );
+
+  it("rejects a non-string provisioned id", () => {
+    expect(() =>
+      validateDeployStatusSyncConfig(
+        { provisioned: { "jira:Done": 10001 } },
+        SOURCE
+      )
+    ).toThrow(
+      "Invalid deployStatusSync.provisioned.jira:Done in .lisa.config.json: expected a non-empty string"
+    );
+  });
+});
+
+describe("project config deployStatusSync wiring", () => {
+  it("parses the section beside the other validated sections", () => {
+    expect(
+      validateProjectConfig({ deployStatusSync: { tier: "team" } }, SOURCE)
+    ).toMatchObject({ deployStatusSync: { tier: "team" } });
+  });
+
+  it("rejects an invalid nested section during parse", () => {
+    expect(() =>
+      validateProjectConfig(
+        { deployStatusSync: { linearBinding: "webhooks" } },
+        SOURCE
+      )
+    ).toThrow(
+      'Invalid deployStatusSync.linearBinding in .lisa.config.json: expected "labels" or "states"'
+    );
+  });
+});

--- a/tests/unit/core/deploy-status-sync.test.ts
+++ b/tests/unit/core/deploy-status-sync.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  ENV_DONE_LABEL_DEFAULTS,
-  JIRA_DONE_STATUS_DEFAULTS,
-  resolveDeployLadder,
-  validateDeployStatusSyncConfig,
-} from "../../../src/core/deploy-status-sync.js";
-import { validateProjectConfig } from "../../../src/core/project-config.js";
+import { resolveDeployLadder } from "../../../src/core/deploy-status-sync.js";
 import type { JsonValue } from "../../../src/sync/json-path.js";
 
 const SOURCE = ".lisa.config.json";
@@ -22,21 +16,6 @@ const FULL_BRANCHES = {
     branches: { dev: "dev", staging: STAGING_BRANCH, production: "main" },
   },
 } satisfies JsonValue;
-
-describe("default done vocabularies", () => {
-  it("exports the shared label defaults consumed by the sync registry", () => {
-    expect(ENV_DONE_LABEL_DEFAULTS).toEqual({
-      dev: DEV_LABEL,
-      staging: STAGING_LABEL,
-      production: PRODUCTION_LABEL,
-    });
-    expect(JIRA_DONE_STATUS_DEFAULTS).toEqual({
-      dev: "On Dev",
-      staging: "On Stg",
-      production: "Done",
-    });
-  });
-});
 
 describe("resolveDeployLadder", () => {
   it("returns the ordered 3-env ladder from label defaults for github", () => {
@@ -94,16 +73,6 @@ describe("resolveDeployLadder", () => {
     });
   });
 
-  it("rejects a configured done status whose environment has no branch", () => {
-    const config: JsonValue = {
-      deploy: { branches: { dev: "dev", production: "main" } },
-      github: { labels: { build: { done: { staging: STAGING_LABEL } } } },
-    };
-    expect(() => resolveDeployLadder(config, "github", SOURCE)).toThrow(
-      'Invalid deploy configuration in .lisa.config.json: a done status ("status:on-stg") is configured for environment "staging", but deploy.branches has no "staging" entry. Add deploy.branches.staging (the git branch that deploys to staging) or remove "staging" from the done map.'
-    );
-  });
-
   it("collapses a production-only config to a single terminal-only rung", () => {
     const config: JsonValue = { deploy: { branches: { production: "main" } } };
     expect(resolveDeployLadder(config, "github", SOURCE)).toEqual({
@@ -111,6 +80,24 @@ describe("resolveDeployLadder", () => {
         { env: "production", branch: "main", doneStatus: PRODUCTION_LABEL },
       ],
       terminalOnly: true,
+    });
+  });
+
+  it("flags a solo dev universe terminal-only (dev is its own terminal)", () => {
+    const config: JsonValue = { deploy: { branches: { dev: "trunk" } } };
+    expect(resolveDeployLadder(config, "github", SOURCE)).toEqual({
+      rungs: [{ env: "dev", branch: "trunk", doneStatus: DEV_LABEL }],
+      terminalOnly: true,
+    });
+  });
+
+  it("does NOT flag terminal-only when the sole rung is not the highest env", () => {
+    const config: JsonValue = {
+      deploy: { branches: { dev: "dev", qa: "qa" }, order: ["dev", "qa"] },
+    };
+    expect(resolveDeployLadder(config, "github", SOURCE)).toEqual({
+      rungs: [{ env: "dev", branch: "dev", doneStatus: DEV_LABEL }],
+      terminalOnly: false,
     });
   });
 
@@ -123,6 +110,19 @@ describe("resolveDeployLadder", () => {
     expect(resolveDeployLadder(config, "jira", SOURCE)).toEqual({
       rungs: [{ env: "prod", branch: "main", doneStatus: "Done" }],
       terminalOnly: true,
+    });
+  });
+
+  it("ranks an aliased prod through canonical ordering in a 2-env ladder", () => {
+    const config: JsonValue = {
+      deploy: { branches: { prod: "main", dev: "dev" } },
+    };
+    expect(resolveDeployLadder(config, "github", SOURCE)).toEqual({
+      rungs: [
+        { env: "dev", branch: "dev", doneStatus: DEV_LABEL },
+        { env: "prod", branch: "main", doneStatus: PRODUCTION_LABEL },
+      ],
+      terminalOnly: false,
     });
   });
 
@@ -167,24 +167,6 @@ describe("resolveDeployLadder", () => {
     });
   });
 
-  it("rejects deploy.order whose env set differs from deploy.branches", () => {
-    const config: JsonValue = {
-      deploy: { ...FULL_BRANCHES.deploy, order: ["dev", "production"] },
-    };
-    expect(() => resolveDeployLadder(config, "github", SOURCE)).toThrow(
-      "Invalid deploy.order in .lisa.config.json: its environment names must exactly match the keys of deploy.branches. deploy.order has [dev, production]; deploy.branches has [dev, staging, production]."
-    );
-  });
-
-  it("rejects an unorderable custom environment when deploy.order is absent", () => {
-    const config: JsonValue = {
-      deploy: { branches: { dev: "dev", qa: "qa" } },
-    };
-    expect(() => resolveDeployLadder(config, "github", SOURCE)).toThrow(
-      'Invalid deploy configuration in .lisa.config.json: cannot order environment "qa". Set deploy.order (environments listed lowest first, e.g. ["dev","staging","production"]) so Lisa knows the promotion order.'
-    );
-  });
-
   it("skips a custom-env rung that has a branch but no done status", () => {
     const config: JsonValue = {
       deploy: {
@@ -212,11 +194,17 @@ describe("resolveDeployLadder", () => {
     });
   });
 
+  it("returns an empty ladder for a single custom env with no done vocabulary", () => {
+    const config: JsonValue = { deploy: { branches: { edge: "main" } } };
+    expect(resolveDeployLadder(config, "github", SOURCE)).toEqual({
+      rungs: [],
+      terminalOnly: false,
+    });
+  });
+
   it("binds a string-valued done to the terminal rung only", () => {
     const config: JsonValue = {
-      deploy: {
-        branches: { dev: "dev", staging: STAGING_BRANCH, production: "main" },
-      },
+      ...FULL_BRANCHES,
       jira: { workflow: { done: "Shipped" } },
     };
     expect(resolveDeployLadder(config, "jira", SOURCE)).toEqual({
@@ -238,86 +226,5 @@ describe("resolveDeployLadder", () => {
       rungs: [{ env: "edge", branch: "main", doneStatus: LIVE_LABEL }],
       terminalOnly: true,
     });
-  });
-});
-
-describe("validateDeployStatusSyncConfig", () => {
-  it("returns the typed section for a fully valid value", () => {
-    expect(
-      validateDeployStatusSyncConfig(
-        {
-          tier: "team",
-          provisioned: { "jira:On Dev": "10012" },
-          linearBinding: "labels",
-          verifiedAt: "2026-07-01T12:00:00Z",
-        },
-        SOURCE
-      )
-    ).toEqual({
-      tier: "team",
-      provisioned: { "jira:On Dev": "10012" },
-      linearBinding: "labels",
-      verifiedAt: "2026-07-01T12:00:00Z",
-    });
-  });
-
-  it("passes undefined through and accepts an empty section", () => {
-    expect(validateDeployStatusSyncConfig(undefined, SOURCE)).toBeUndefined();
-    expect(validateDeployStatusSyncConfig({}, SOURCE)).toEqual({});
-  });
-
-  it("rejects a non-object section", () => {
-    expect(() => validateDeployStatusSyncConfig("gold", SOURCE)).toThrow(
-      "Invalid deployStatusSync in .lisa.config.json: expected an object"
-    );
-  });
-
-  it("rejects an unknown linearBinding value", () => {
-    expect(() =>
-      validateDeployStatusSyncConfig({ linearBinding: "webhooks" }, SOURCE)
-    ).toThrow(
-      'Invalid deployStatusSync.linearBinding in .lisa.config.json: expected "labels" or "states"'
-    );
-  });
-
-  it.each(["2026-07-01", "2026-13-01T00:00:00Z", "2026-07-01T12:00:00+00:00"])(
-    "rejects non-ISO-8601-UTC verifiedAt %s",
-    verifiedAt => {
-      expect(() =>
-        validateDeployStatusSyncConfig({ verifiedAt }, SOURCE)
-      ).toThrow(
-        "Invalid deployStatusSync.verifiedAt in .lisa.config.json: expected an ISO-8601 UTC timestamp (e.g. 2026-01-01T00:00:00Z)"
-      );
-    }
-  );
-
-  it("rejects a non-string provisioned id", () => {
-    expect(() =>
-      validateDeployStatusSyncConfig(
-        { provisioned: { "jira:Done": 10001 } },
-        SOURCE
-      )
-    ).toThrow(
-      "Invalid deployStatusSync.provisioned.jira:Done in .lisa.config.json: expected a non-empty string"
-    );
-  });
-});
-
-describe("project config deployStatusSync wiring", () => {
-  it("parses the section beside the other validated sections", () => {
-    expect(
-      validateProjectConfig({ deployStatusSync: { tier: "team" } }, SOURCE)
-    ).toMatchObject({ deployStatusSync: { tier: "team" } });
-  });
-
-  it("rejects an invalid nested section during parse", () => {
-    expect(() =>
-      validateProjectConfig(
-        { deployStatusSync: { linearBinding: "webhooks" } },
-        SOURCE
-      )
-    ).toThrow(
-      'Invalid deployStatusSync.linearBinding in .lisa.config.json: expected "labels" or "states"'
-    );
   });
 });


### PR DESCRIPTION
## Summary

- New `src/core/deploy-status-sync.ts`: pure, fs-free resolver computing the env join of `deploy.branches ⋈ env-keyed done map` (github/linear `labels.build.done`, jira `jira.workflow.done`) into an ordered deploy ladder (`deploy.order` when present, else canonical dev < staging < production), with the config-resolution sole-alias rule (`prod` ↔ `production` only when exactly one spelling is configured), decision-ready operator errors, single-env terminal-only collapse, and the new `deployStatusSync` config section (`tier`, `provisioned`, `linearBinding: labels|states`, `verifiedAt`) wired into `ProjectConfig` kane-style.
- `src/sync/registry.ts` now imports the done-map default tables from the new module (value-identical refactor; avoids duplicating the vocabulary and an ESM cycle).
- Rule pair updated: `plugins/src/base/rules/{eager,reference}/config-resolution.md` document the section, ladder algorithm, alias semantics, and verbatim error catalog; generated plugin copies + upstream evidence manifest regenerated in the same commits.
- 41 unit tests across three files (ladder ×3 trackers, join errors, duplicate/malformed `deploy.order`, alias matrix incl. both-spellings-configured, terminalOnly semantics incl. skip-collapse, validator catalog, registry value-identity).

Closes CodySwannGT/lisa#1967

Part of Epic #1966 / PRD #1965 (DSS-1 — foundation for the deploy-branch → tracker-status sync tiers).

## Review & verification

- Three-specialist review panel (test, quality, simplifier): 7 findings fixed (incl. a real `deploy.order` duplicate-rung defect and a `terminalOnly` semantic hazard that would have mis-driven terminal closure in DSS-2), 2 deferred on record, 0 pushed back.
- Independent verification (schema v2 verdict, PASS at head 16cb61136): CLI-boundary proof of all five ACs with saved evidence; full suite 7262/7262 green; manifest `--check` exit 0; spec ruling on the alias AC recorded on the issue.

## Test plan

- `bunx vitest run tests/unit/core/deploy-status-sync*.test.ts` (41 tests)
- `bun run test:unit` full suite green; `bun run lint`; `bun run typecheck`
- CI: quality gates + "Plugin artifacts match source" + manifest staleness check must pass on this PR

🤖 Generated with Claude Code
