### PR TITLE
fix(work-item): accept bare repo-name labels for repo scope (Sentry-origin Linear bugs)

### DIFF
--- a/all/copy-overwrite/scripts/lisa-work-item.mjs
+++ b/all/copy-overwrite/scripts/lisa-work-item.mjs
@@ -427,7 +427,7 @@ function namesFrom(value) {
 
 function assertRepoScope(ref, contract, labels, components = []) {
   // #1957: mirror the intake-side scoping rule uniformly across trackers
-  // (plugins/lisa/rules/reference/config-resolution.md:949,:973): a work item
+  // (plugins/lisa/rules/reference/config-resolution.md:949,:968): a work item
   // is repo-scoped by the label `repo:<name>` OR the bare `<name>` label
   // (Sentry-provenance items carry only the bare repo name). The match is the
   // exact repo short name, case-insensitive via namesFrom's lowercasing —

--- a/all/copy-overwrite/scripts/lisa-work-item.mjs
+++ b/all/copy-overwrite/scripts/lisa-work-item.mjs
@@ -426,15 +426,24 @@ function namesFrom(value) {
 }
 
 function assertRepoScope(ref, contract, labels, components = []) {
-  const expected = `repo:${contract.identityRepo}`.toLowerCase();
+  // #1957: mirror the intake-side scoping rule uniformly across trackers
+  // (plugins/lisa/rules/reference/config-resolution.md:949,:973): a work item
+  // is repo-scoped by the label `repo:<name>` OR the bare `<name>` label
+  // (Sentry-provenance items carry only the bare repo name). The match is the
+  // exact repo short name, case-insensitive via namesFrom's lowercasing —
+  // never substring or prefix. Jira additionally accepts a component equal to
+  // the bare name.
+  const bare = contract.identityRepo.toLowerCase();
+  const expected = `repo:${bare}`;
   const labelNames = namesFrom(labels);
   const componentNames = namesFrom(components);
   if (
     !labelNames.includes(expected) &&
-    !componentNames.includes(contract.identityRepo.toLowerCase())
+    !labelNames.includes(bare) &&
+    !componentNames.includes(bare)
   ) {
     throw new TrackingError(
-      `Work item ${ref} is not scoped to repository ${contract.identityRepo}; require label ${expected}`
+      `Work item ${ref} is not scoped to repository ${contract.identityRepo}; require label ${expected} or bare label ${bare}`
     );
   }
 }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -5,7 +5,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-contents/gitignore":
       "06b56376465d5421db55d0b04958bbc79fdbf33b42f0559fe5ef6875ced1160f",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
-      "e41e9534988ce69a836664437a78f3a3f3dc7ebbe396c86cdab0ea63fb7c19da",
+      "f12006df4ed9974f65d955718af7dcc8a079799d02c58bd38b2d9c49f271db72",
     "all/create-only/.claude/rules/PROJECT_RULES.md":
       "6e1c7923ad2a15356babc60c97e7f97be728d790af285b6a7cd7d1b4d39cd97f",
     "all/create-only/.lisaignore":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -5,7 +5,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-contents/gitignore":
       "06b56376465d5421db55d0b04958bbc79fdbf33b42f0559fe5ef6875ced1160f",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
-      "f12006df4ed9974f65d955718af7dcc8a079799d02c58bd38b2d9c49f271db72",
+      "5eb31c284e820a51312d4484f0669128007326af55ee515923fec33700d003a1",
     "all/create-only/.claude/rules/PROJECT_RULES.md":
       "6e1c7923ad2a15356babc60c97e7f97be728d790af285b6a7cd7d1b4d39cd97f",
     "all/create-only/.lisaignore":

--- a/tests/unit/scripts/lisa-work-item.test.ts
+++ b/tests/unit/scripts/lisa-work-item.test.ts
@@ -169,6 +169,24 @@ function githubConfig(repository = "widgets"): object {
   return { tracker: "github", github: { org: "acme", repo: repository } };
 }
 
+/** Build a claimed, leaf Linear issue payload carrying the given labels. */
+function linearIssueResponse(labels: string[]): string {
+  return JSON.stringify({
+    data: {
+      issue: {
+        id: "id-12",
+        identifier: "LIN-12",
+        team: { key: "LIN" },
+        state: { type: "started" },
+        labels: { nodes: labels.map(name => ({ name })) },
+        children: { nodes: [] },
+        attachments: { nodes: [] },
+        comments: { nodes: [] },
+      },
+    },
+  });
+}
+
 /** Add one empty fixture commit and return its object ID. */
 function commit(fixture: Fixture, message: string): string {
   git(
@@ -447,6 +465,30 @@ describe("work-item binding and commit messages", () => {
     });
     expect(parent.status).toBe(1);
     expect(parent.stderr).toContain("is a container");
+  });
+
+  it("accepts a GitHub issue scoped by the bare repo-name label (#1957)", () => {
+    const fixture = createFixture({
+      tracker: "github",
+      github: { org: "acme", repo: "identity", queueRepo: "acme/widgets" },
+    });
+    const bare = command(fixture, ["bind", "acme/widgets#42"], {
+      env: {
+        FAKE_GH_ISSUE_JSON: JSON.stringify({
+          number: 42,
+          url: "https://github.com/acme/widgets/issues/42",
+          state: "OPEN",
+          labels: [
+            { name: "identity" },
+            { name: "status:in-progress" },
+            { name: "type:Bug" },
+          ],
+          comments: [],
+          closedByPullRequestsReferences: [],
+        }),
+      },
+    });
+    expect(bare.status).toBe(0);
   });
 
   it("exempts only the exact release subject", () => {
@@ -828,6 +870,80 @@ describe("provider liveness", () => {
     });
     expect(parent.status).toBe(1);
     expect(parent.stderr).toContain("is a container");
+  });
+
+  it("accepts a Linear issue scoped by the bare repo-name label (#1957)", () => {
+    const fixture = createFixture({
+      tracker: "linear",
+      repo: "widgets",
+      linear: { workspace: "acme", teamKey: "LIN" },
+    });
+
+    const bare = command(fixture, ["bind", "LIN-12"], {
+      env: {
+        FAKE_CURL_JSON: linearIssueResponse([
+          "widgets",
+          "status:in-progress",
+          "type:Task",
+        ]),
+      },
+    });
+    expect(bare.status).toBe(0);
+
+    const mixedCase = command(fixture, ["bind", "LIN-12"], {
+      env: {
+        FAKE_CURL_JSON: linearIssueResponse([
+          "Widgets",
+          "status:in-progress",
+          "type:Task",
+        ]),
+      },
+    });
+    expect(mixedCase.status).toBe(0);
+  });
+
+  it("still rejects Linear issues whose bare labels do not name this repository (#1957 controls)", () => {
+    const fixture = createFixture({
+      tracker: "linear",
+      repo: "widgets",
+      linear: { workspace: "acme", teamKey: "LIN" },
+    });
+
+    const unscoped = command(fixture, ["bind", "LIN-12"], {
+      env: {
+        FAKE_CURL_JSON: linearIssueResponse([
+          "status:in-progress",
+          "type:Task",
+        ]),
+      },
+    });
+    expect(unscoped.status).toBe(1);
+    expect(unscoped.stderr).toContain("not scoped to repository widgets");
+
+    const wrongRepo = command(fixture, ["bind", "LIN-12"], {
+      env: {
+        FAKE_CURL_JSON: linearIssueResponse([
+          "backend",
+          "repo:backend",
+          "status:in-progress",
+          "type:Task",
+        ]),
+      },
+    });
+    expect(wrongRepo.status).toBe(1);
+    expect(wrongRepo.stderr).toContain("not scoped to repository widgets");
+
+    const unrelated = command(fixture, ["bind", "LIN-12"], {
+      env: {
+        FAKE_CURL_JSON: linearIssueResponse([
+          "sentry",
+          "status:in-progress",
+          "type:Task",
+        ]),
+      },
+    });
+    expect(unrelated.status).toBe(1);
+    expect(unrelated.stderr).toContain("not scoped to repository widgets");
   });
 });
 


### PR DESCRIPTION
Closes #1957

Work-Item: CodySwannGT/lisa#1957

## What

Sentry-origin Linear bugs carry a bare repo-name label (`frontend`) by documented triage taxonomy — bare = Sentry provenance, `repo:*` = planned work — but `assertRepoScope()` only accepted `repo:<name>` labels or a *component* named `<name>`, and the Linear lane passes labels only (Linear has no components). Every Sentry-origin Linear bug was therefore unbindable without manual dual-labeling (observed live: TUN-242 in TunnlAI/frontend).

**Fix (issue's Option A, applied uniformly):** a third acceptance arm in `assertRepoScope` — a bare label exactly equal (case-insensitive, whole-string; no substring/prefix matching) to the repository's short name now satisfies repo scope, mirroring the intake-side rule that repo-scoped queries match both `repo:<name>` and bare `<name>` (config-resolution.md). All vendors share the one function, so GitHub/Jira lanes gain the same alias Jira already had via components. The rejection message now names both accepted forms. Read-side only: bind accepts the taxonomy, never rewrites labels.

**Option B (auto-adding `repo:*` at claim time) rejected:** it mutates tracker labels and collapses the provenance taxonomy the bare label exists to preserve.

## Verification (independent, re-run at head)

- Full suite 7607/7607 (445 files); targeted suite 27/27.
- Live bind simulations: bare-label Linear bind succeeds (exact and mixed-case); wrong-repo bare label rejects with the two-form message; GitHub queue-repo lane with bare label binds.
- Security-lens review (quality specialist): 17 hostile inputs — `frontend-app`, `myfrontend`, padded, prefixed variants — all rejected; exact-match boundary holds; `repositoryIsIdentity` skip semantics unchanged; mutation-proof (accept-any-label mutant) killed by 4 controls.
- Shim `scripts/lisa-work-item.mjs` untouched; drift gate exit 0; manifest/typecheck/lint green.

🤖 Generated with Claude Code
