### PR TITLE
fix(hooks): relax quoted heredoc classification

### DIFF
--- a/plugins/lisa-agy/hooks/parity-safety-net-heredoc.py
+++ b/plugins/lisa-agy/hooks/parity-safety-net-heredoc.py
@@ -28,6 +28,7 @@ class Marker:
     end: int
     delimiter: str
     strip_tabs: bool
+    quoted: bool
 
 
 def shell_tokens(prefix: str) -> list[str] | None:
@@ -357,7 +358,7 @@ def parse_marker(line: str, start: int, offset: int) -> Marker | None:
         final = index + len(delimiter)
     if not delimiter:
         return None
-    return Marker(offset + start, offset + final, delimiter, strip_tabs)
+    return Marker(offset + start, offset + final, delimiter, strip_tabs, quote is not None)
 
 
 def marker_is_closed(command: str, marker: Marker) -> bool:
@@ -368,6 +369,19 @@ def marker_is_closed(command: str, marker: Marker) -> bool:
         if candidate == marker.delimiter:
             return True
     return False
+
+
+def single_closed_quoted_nonwriter_heredoc(command: str, marker: Marker) -> bool:
+    """Allow guard scanning for inert quoted heredoc payloads outside gh writers."""
+    if not marker.quoted or not marker_is_closed(command, marker):
+        return False
+    line_end = command.find("\n", marker.start)
+    if line_end < 0:
+        line_end = len(command)
+    header = command[:line_end]
+    if has_active_command_substitution(header):
+        return False
+    return True
 
 
 def main() -> int:
@@ -401,6 +415,11 @@ def main() -> int:
         logical_command.splitlines()[0]
     ):
         return MALFORMED
+
+    if len(markers) == 1 and single_closed_quoted_nonwriter_heredoc(
+        logical_command, markers[0]
+    ):
+        return UNSUPPORTED
 
     # Nested substitution plus a heredoc is executable shell syntax unless it
     # matched the one exact quoted `--body "$(cat ...)"` form above.

--- a/plugins/lisa-agy/hooks/parity-safety-net.sh
+++ b/plugins/lisa-agy/hooks/parity-safety-net.sh
@@ -96,15 +96,21 @@ EOF
 # remain visible to every built-in and custom rule. Ambiguous or malformed
 # heredocs fail closed instead of guessing which text the shell would execute.
 #
-# block_heredoc() teaches the remediation the moment the wall is hit: heredoc
-# denials overwhelmingly come from `git commit -m "$(cat <<EOF …)"` attempts,
-# and a bare denial strands the agent with no path forward (gardener #1789).
+# block_heredoc() teaches the remediation the moment the wall is hit. Commit
+# heredocs need commit-message-file guidance; other heredocs should point agents
+# at script/payload files instead of implying every denial was a commit attempt.
 block_heredoc() {
-  block "$1
+  if printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])git[[:space:]]+([^;&|[:space:]]+[[:space:]]+)*commit([^[:alnum:]_-]|$)'; then
+    block "$1
 Heredoc commit invocations are blocked (the payload is executable shell).
 Fix: write the commit message to a file and run \`git commit -F <file>\`.
 Every commit must also carry a Co-authored-by trailer for a supported agent
 (Claude/Codex/OpenCode) — the commit-msg hook enforces this."
+  fi
+  block "$1
+Heredoc command invocations are blocked when Lisa cannot prove the payload is
+non-executable text.
+Fix: write the payload to a file and execute or pass that file explicitly."
 }
 
 command_for_guards="$command_str"

--- a/plugins/lisa-copilot/hooks/parity-safety-net-heredoc.py
+++ b/plugins/lisa-copilot/hooks/parity-safety-net-heredoc.py
@@ -28,6 +28,7 @@ class Marker:
     end: int
     delimiter: str
     strip_tabs: bool
+    quoted: bool
 
 
 def shell_tokens(prefix: str) -> list[str] | None:
@@ -357,7 +358,7 @@ def parse_marker(line: str, start: int, offset: int) -> Marker | None:
         final = index + len(delimiter)
     if not delimiter:
         return None
-    return Marker(offset + start, offset + final, delimiter, strip_tabs)
+    return Marker(offset + start, offset + final, delimiter, strip_tabs, quote is not None)
 
 
 def marker_is_closed(command: str, marker: Marker) -> bool:
@@ -368,6 +369,19 @@ def marker_is_closed(command: str, marker: Marker) -> bool:
         if candidate == marker.delimiter:
             return True
     return False
+
+
+def single_closed_quoted_nonwriter_heredoc(command: str, marker: Marker) -> bool:
+    """Allow guard scanning for inert quoted heredoc payloads outside gh writers."""
+    if not marker.quoted or not marker_is_closed(command, marker):
+        return False
+    line_end = command.find("\n", marker.start)
+    if line_end < 0:
+        line_end = len(command)
+    header = command[:line_end]
+    if has_active_command_substitution(header):
+        return False
+    return True
 
 
 def main() -> int:
@@ -401,6 +415,11 @@ def main() -> int:
         logical_command.splitlines()[0]
     ):
         return MALFORMED
+
+    if len(markers) == 1 and single_closed_quoted_nonwriter_heredoc(
+        logical_command, markers[0]
+    ):
+        return UNSUPPORTED
 
     # Nested substitution plus a heredoc is executable shell syntax unless it
     # matched the one exact quoted `--body "$(cat ...)"` form above.

--- a/plugins/lisa-copilot/hooks/parity-safety-net.sh
+++ b/plugins/lisa-copilot/hooks/parity-safety-net.sh
@@ -96,15 +96,21 @@ EOF
 # remain visible to every built-in and custom rule. Ambiguous or malformed
 # heredocs fail closed instead of guessing which text the shell would execute.
 #
-# block_heredoc() teaches the remediation the moment the wall is hit: heredoc
-# denials overwhelmingly come from `git commit -m "$(cat <<EOF …)"` attempts,
-# and a bare denial strands the agent with no path forward (gardener #1789).
+# block_heredoc() teaches the remediation the moment the wall is hit. Commit
+# heredocs need commit-message-file guidance; other heredocs should point agents
+# at script/payload files instead of implying every denial was a commit attempt.
 block_heredoc() {
-  block "$1
+  if printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])git[[:space:]]+([^;&|[:space:]]+[[:space:]]+)*commit([^[:alnum:]_-]|$)'; then
+    block "$1
 Heredoc commit invocations are blocked (the payload is executable shell).
 Fix: write the commit message to a file and run \`git commit -F <file>\`.
 Every commit must also carry a Co-authored-by trailer for a supported agent
 (Claude/Codex/OpenCode) — the commit-msg hook enforces this."
+  fi
+  block "$1
+Heredoc command invocations are blocked when Lisa cannot prove the payload is
+non-executable text.
+Fix: write the payload to a file and execute or pass that file explicitly."
 }
 
 command_for_guards="$command_str"

--- a/plugins/lisa-cursor/hooks/parity-safety-net-heredoc.py
+++ b/plugins/lisa-cursor/hooks/parity-safety-net-heredoc.py
@@ -28,6 +28,7 @@ class Marker:
     end: int
     delimiter: str
     strip_tabs: bool
+    quoted: bool
 
 
 def shell_tokens(prefix: str) -> list[str] | None:
@@ -357,7 +358,7 @@ def parse_marker(line: str, start: int, offset: int) -> Marker | None:
         final = index + len(delimiter)
     if not delimiter:
         return None
-    return Marker(offset + start, offset + final, delimiter, strip_tabs)
+    return Marker(offset + start, offset + final, delimiter, strip_tabs, quote is not None)
 
 
 def marker_is_closed(command: str, marker: Marker) -> bool:
@@ -368,6 +369,19 @@ def marker_is_closed(command: str, marker: Marker) -> bool:
         if candidate == marker.delimiter:
             return True
     return False
+
+
+def single_closed_quoted_nonwriter_heredoc(command: str, marker: Marker) -> bool:
+    """Allow guard scanning for inert quoted heredoc payloads outside gh writers."""
+    if not marker.quoted or not marker_is_closed(command, marker):
+        return False
+    line_end = command.find("\n", marker.start)
+    if line_end < 0:
+        line_end = len(command)
+    header = command[:line_end]
+    if has_active_command_substitution(header):
+        return False
+    return True
 
 
 def main() -> int:
@@ -401,6 +415,11 @@ def main() -> int:
         logical_command.splitlines()[0]
     ):
         return MALFORMED
+
+    if len(markers) == 1 and single_closed_quoted_nonwriter_heredoc(
+        logical_command, markers[0]
+    ):
+        return UNSUPPORTED
 
     # Nested substitution plus a heredoc is executable shell syntax unless it
     # matched the one exact quoted `--body "$(cat ...)"` form above.

--- a/plugins/lisa-cursor/hooks/parity-safety-net.sh
+++ b/plugins/lisa-cursor/hooks/parity-safety-net.sh
@@ -96,15 +96,21 @@ EOF
 # remain visible to every built-in and custom rule. Ambiguous or malformed
 # heredocs fail closed instead of guessing which text the shell would execute.
 #
-# block_heredoc() teaches the remediation the moment the wall is hit: heredoc
-# denials overwhelmingly come from `git commit -m "$(cat <<EOF …)"` attempts,
-# and a bare denial strands the agent with no path forward (gardener #1789).
+# block_heredoc() teaches the remediation the moment the wall is hit. Commit
+# heredocs need commit-message-file guidance; other heredocs should point agents
+# at script/payload files instead of implying every denial was a commit attempt.
 block_heredoc() {
-  block "$1
+  if printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])git[[:space:]]+([^;&|[:space:]]+[[:space:]]+)*commit([^[:alnum:]_-]|$)'; then
+    block "$1
 Heredoc commit invocations are blocked (the payload is executable shell).
 Fix: write the commit message to a file and run \`git commit -F <file>\`.
 Every commit must also carry a Co-authored-by trailer for a supported agent
 (Claude/Codex/OpenCode) — the commit-msg hook enforces this."
+  fi
+  block "$1
+Heredoc command invocations are blocked when Lisa cannot prove the payload is
+non-executable text.
+Fix: write the payload to a file and execute or pass that file explicitly."
 }
 
 command_for_guards="$command_str"

--- a/plugins/lisa/hooks/parity-safety-net-heredoc.py
+++ b/plugins/lisa/hooks/parity-safety-net-heredoc.py
@@ -28,6 +28,7 @@ class Marker:
     end: int
     delimiter: str
     strip_tabs: bool
+    quoted: bool
 
 
 def shell_tokens(prefix: str) -> list[str] | None:
@@ -357,7 +358,7 @@ def parse_marker(line: str, start: int, offset: int) -> Marker | None:
         final = index + len(delimiter)
     if not delimiter:
         return None
-    return Marker(offset + start, offset + final, delimiter, strip_tabs)
+    return Marker(offset + start, offset + final, delimiter, strip_tabs, quote is not None)
 
 
 def marker_is_closed(command: str, marker: Marker) -> bool:
@@ -368,6 +369,19 @@ def marker_is_closed(command: str, marker: Marker) -> bool:
         if candidate == marker.delimiter:
             return True
     return False
+
+
+def single_closed_quoted_nonwriter_heredoc(command: str, marker: Marker) -> bool:
+    """Allow guard scanning for inert quoted heredoc payloads outside gh writers."""
+    if not marker.quoted or not marker_is_closed(command, marker):
+        return False
+    line_end = command.find("\n", marker.start)
+    if line_end < 0:
+        line_end = len(command)
+    header = command[:line_end]
+    if has_active_command_substitution(header):
+        return False
+    return True
 
 
 def main() -> int:
@@ -401,6 +415,11 @@ def main() -> int:
         logical_command.splitlines()[0]
     ):
         return MALFORMED
+
+    if len(markers) == 1 and single_closed_quoted_nonwriter_heredoc(
+        logical_command, markers[0]
+    ):
+        return UNSUPPORTED
 
     # Nested substitution plus a heredoc is executable shell syntax unless it
     # matched the one exact quoted `--body "$(cat ...)"` form above.

--- a/plugins/lisa/hooks/parity-safety-net.sh
+++ b/plugins/lisa/hooks/parity-safety-net.sh
@@ -96,15 +96,21 @@ EOF
 # remain visible to every built-in and custom rule. Ambiguous or malformed
 # heredocs fail closed instead of guessing which text the shell would execute.
 #
-# block_heredoc() teaches the remediation the moment the wall is hit: heredoc
-# denials overwhelmingly come from `git commit -m "$(cat <<EOF …)"` attempts,
-# and a bare denial strands the agent with no path forward (gardener #1789).
+# block_heredoc() teaches the remediation the moment the wall is hit. Commit
+# heredocs need commit-message-file guidance; other heredocs should point agents
+# at script/payload files instead of implying every denial was a commit attempt.
 block_heredoc() {
-  block "$1
+  if printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])git[[:space:]]+([^;&|[:space:]]+[[:space:]]+)*commit([^[:alnum:]_-]|$)'; then
+    block "$1
 Heredoc commit invocations are blocked (the payload is executable shell).
 Fix: write the commit message to a file and run \`git commit -F <file>\`.
 Every commit must also carry a Co-authored-by trailer for a supported agent
 (Claude/Codex/OpenCode) — the commit-msg hook enforces this."
+  fi
+  block "$1
+Heredoc command invocations are blocked when Lisa cannot prove the payload is
+non-executable text.
+Fix: write the payload to a file and execute or pass that file explicitly."
 }
 
 command_for_guards="$command_str"

--- a/plugins/src/base/hooks/parity-safety-net-heredoc.py
+++ b/plugins/src/base/hooks/parity-safety-net-heredoc.py
@@ -28,6 +28,7 @@ class Marker:
     end: int
     delimiter: str
     strip_tabs: bool
+    quoted: bool
 
 
 def shell_tokens(prefix: str) -> list[str] | None:
@@ -357,7 +358,7 @@ def parse_marker(line: str, start: int, offset: int) -> Marker | None:
         final = index + len(delimiter)
     if not delimiter:
         return None
-    return Marker(offset + start, offset + final, delimiter, strip_tabs)
+    return Marker(offset + start, offset + final, delimiter, strip_tabs, quote is not None)
 
 
 def marker_is_closed(command: str, marker: Marker) -> bool:
@@ -368,6 +369,19 @@ def marker_is_closed(command: str, marker: Marker) -> bool:
         if candidate == marker.delimiter:
             return True
     return False
+
+
+def single_closed_quoted_nonwriter_heredoc(command: str, marker: Marker) -> bool:
+    """Allow guard scanning for inert quoted heredoc payloads outside gh writers."""
+    if not marker.quoted or not marker_is_closed(command, marker):
+        return False
+    line_end = command.find("\n", marker.start)
+    if line_end < 0:
+        line_end = len(command)
+    header = command[:line_end]
+    if has_active_command_substitution(header):
+        return False
+    return True
 
 
 def main() -> int:
@@ -401,6 +415,11 @@ def main() -> int:
         logical_command.splitlines()[0]
     ):
         return MALFORMED
+
+    if len(markers) == 1 and single_closed_quoted_nonwriter_heredoc(
+        logical_command, markers[0]
+    ):
+        return UNSUPPORTED
 
     # Nested substitution plus a heredoc is executable shell syntax unless it
     # matched the one exact quoted `--body "$(cat ...)"` form above.

--- a/plugins/src/base/hooks/parity-safety-net.sh
+++ b/plugins/src/base/hooks/parity-safety-net.sh
@@ -96,15 +96,21 @@ EOF
 # remain visible to every built-in and custom rule. Ambiguous or malformed
 # heredocs fail closed instead of guessing which text the shell would execute.
 #
-# block_heredoc() teaches the remediation the moment the wall is hit: heredoc
-# denials overwhelmingly come from `git commit -m "$(cat <<EOF …)"` attempts,
-# and a bare denial strands the agent with no path forward (gardener #1789).
+# block_heredoc() teaches the remediation the moment the wall is hit. Commit
+# heredocs need commit-message-file guidance; other heredocs should point agents
+# at script/payload files instead of implying every denial was a commit attempt.
 block_heredoc() {
-  block "$1
+  if printf '%s' "$command_str" | grep -Eq '(^|[^[:alnum:]_-])git[[:space:]]+([^;&|[:space:]]+[[:space:]]+)*commit([^[:alnum:]_-]|$)'; then
+    block "$1
 Heredoc commit invocations are blocked (the payload is executable shell).
 Fix: write the commit message to a file and run \`git commit -F <file>\`.
 Every commit must also carry a Co-authored-by trailer for a supported agent
 (Claude/Codex/OpenCode) — the commit-msg hook enforces this."
+  fi
+  block "$1
+Heredoc command invocations are blocked when Lisa cannot prove the payload is
+non-executable text.
+Fix: write the payload to a file and execute or pass that file explicitly."
 }
 
 command_for_guards="$command_str"

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -585,11 +585,11 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/install-pkgs.sh":
       "e9a13faba849a277410dde911ab102ee6f88ef915b33571bb1d4eef904172db5",
     "plugins/src/base/hooks/parity-safety-net-heredoc.py":
-      "c5301958ed8ca29b0de7b8521d299cdbc8c1c402df8d8fada6b5f173b6cf5dbe",
+      "5acc70d65304d8ef01bf3837cbf0fdc77aae6d6e47c0fec824692fe7091da20b",
     "plugins/src/base/hooks/parity-safety-net.agy.sh":
       "ce9bd2b4566ad9147e4ace56434cffbbe87edb4ccbb57549ab3fd9f4c671ced4",
     "plugins/src/base/hooks/parity-safety-net.sh":
-      "b83c5043a0f29b2d8851258acfe6906aab7922cd80f486e25220e55f26a8c0a5",
+      "f740f600b255742a50f28e5c9d09427c5783c4084e84052dca46bc1f0c94a187",
     "plugins/src/base/hooks/setup-jira-cli.sh":
       "a675f6b17ce7f0d6b9fb7daeba6d2bc59bcb48ef79b034076ea73b2b1e72ee09",
     "plugins/src/base/hooks/shell-write-nudge.sh":

--- a/tests/unit/hooks/parity-safety-net-heredoc.test.ts
+++ b/tests/unit/hooks/parity-safety-net-heredoc.test.ts
@@ -7,6 +7,8 @@
  * writer.
  */
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 
 const HOOK_PATH = path.resolve("plugins/lisa/hooks/parity-safety-net.sh");
@@ -16,14 +18,20 @@ const COMMENTED_MARKER = "gh issue create --body-file - # <<'EOF'";
 const HARMLESS_PROSE = "harmless prose";
 const OBFUSCATED_DELETE = "r''m -rf /";
 
-const runHook = (command: string): number | null =>
-  spawnSync("/bin/bash", [HOOK_PATH], {
+const runHook = (
+  command: string,
+  options: { env?: NodeJS.ProcessEnv } = {}
+): { status: number | null; stderr: string } => {
+  const result = spawnSync("/bin/bash", [HOOK_PATH], {
     input: JSON.stringify({
       tool_name: "Bash",
       tool_input: { command },
     }),
     encoding: "utf8",
-  }).status;
+    env: { ...process.env, ...options.env },
+  });
+  return { status: result.status, stderr: result.stderr };
+};
 
 describe("parity-safety-net heredoc grammar", () => {
   it("blocks an obfuscated command after a commented writer marker", () => {
@@ -33,7 +41,7 @@ describe("parity-safety-net heredoc grammar", () => {
       HEREDOC_TERMINATOR,
     ].join("\n");
 
-    expect(runHook(command)).toBe(EXIT_BLOCKED);
+    expect(runHook(command).status).toBe(EXIT_BLOCKED);
   });
 
   it("normalizes a quote-concatenated writer before comment classification", () => {
@@ -43,7 +51,7 @@ describe("parity-safety-net heredoc grammar", () => {
       HEREDOC_TERMINATOR,
     ].join("\n");
 
-    expect(runHook(command)).toBe(EXIT_BLOCKED);
+    expect(runHook(command).status).toBe(EXIT_BLOCKED);
   });
 
   it("blocks another command before an otherwise safe writer", () => {
@@ -53,7 +61,7 @@ describe("parity-safety-net heredoc grammar", () => {
       HEREDOC_TERMINATOR,
     ].join("\n");
 
-    expect(runHook(command)).toBe(EXIT_BLOCKED);
+    expect(runHook(command).status).toBe(EXIT_BLOCKED);
   });
 
   it("normalizes quote-concatenated commands in a prefixed writer", () => {
@@ -63,7 +71,7 @@ describe("parity-safety-net heredoc grammar", () => {
       HEREDOC_TERMINATOR,
     ].join("\n");
 
-    expect(runHook(command)).toBe(EXIT_BLOCKED);
+    expect(runHook(command).status).toBe(EXIT_BLOCKED);
   });
 
   it.each([
@@ -73,7 +81,7 @@ describe("parity-safety-net heredoc grammar", () => {
   ])("blocks a continued writer that misses the exact grammar", header => {
     const command = [header, HARMLESS_PROSE, HEREDOC_TERMINATOR].join("\n");
 
-    expect(runHook(command)).toBe(EXIT_BLOCKED);
+    expect(runHook(command).status).toBe(EXIT_BLOCKED);
   });
 
   it("blocks a continued writer with a commented fake marker", () => {
@@ -83,6 +91,60 @@ describe("parity-safety-net heredoc grammar", () => {
       HEREDOC_TERMINATOR,
     ].join("\n");
 
-    expect(runHook(command)).toBe(EXIT_BLOCKED);
+    expect(runHook(command).status).toBe(EXIT_BLOCKED);
+  });
+
+  it("allows inert quoted executable heredoc payloads to reach guard scanning", () => {
+    const command = [
+      "python3 <<'EOF'",
+      "print('Document `status:ready` and $(literal) without shell expansion')",
+      HEREDOC_TERMINATOR,
+    ].join("\n");
+
+    expect(runHook(command).status).toBe(0);
+  });
+
+  it("still applies custom rules to inert quoted executable heredoc payloads", () => {
+    const fixture = mkdtempSync(path.join(tmpdir(), "lisa-safety-rule-"));
+    const rulesPath = path.join(fixture, "rules.txt");
+    try {
+      writeFileSync(rulesPath, "DO_NOT_EXECUTE\n");
+      const command = [
+        "python3 <<'EOF'",
+        "print('DO_NOT_EXECUTE')",
+        HEREDOC_TERMINATOR,
+      ].join("\n");
+
+      expect(
+        runHook(command, {
+          env: { SAFETY_NET_RULES_FILE: rulesPath },
+        }).status
+      ).toBe(EXIT_BLOCKED);
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it("uses commit-specific remediation only for git commit heredoc denials", () => {
+    const commitCommand = [
+      'git commit -m "$(cat <<EOF',
+      "message",
+      HEREDOC_TERMINATOR,
+      ')"',
+    ].join("\n");
+    const scriptCommand = [
+      "python3 <<EOF",
+      "`status:ready`",
+      HEREDOC_TERMINATOR,
+    ].join("\n");
+
+    const commit = runHook(commitCommand);
+    const script = runHook(scriptCommand);
+
+    expect(commit.status).toBe(EXIT_BLOCKED);
+    expect(commit.stderr).toContain("git commit -F <file>");
+    expect(script.status).toBe(EXIT_BLOCKED);
+    expect(script.stderr).toContain("write the payload to a file");
+    expect(script.stderr).not.toContain("git commit -F <file>");
   });
 });


### PR DESCRIPTION
## Summary
- classify a single closed quoted non-writer heredoc as unsupported instead of malformed so inert payload backticks and `$()` text can proceed to normal guard scanning
- keep custom/built-in guard visibility for those payloads, and preserve fail-closed behavior for supported GitHub writer grammar misses, active header substitutions, unclosed heredocs, and multiple heredocs
- make heredoc block remediation specific to `git commit`; non-commit heredoc denials now tell agents to write the payload to a file instead

Work-Item: CodySwannGT/lisa#1958

## Validation
- `bun test tests/unit/hooks/parity-safety-net.test.ts tests/unit/hooks/parity-safety-net-heredoc.test.ts tests/unit/hooks/parity-safety-net-guards.test.ts tests/unit/opencode/parity-safety-net-plugin.test.ts tests/unit/agy/parity-safety-net-agy.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run check:plugins`
- `bun run check:upstream-evidence-manifest`
- pre-push: security audit, slow lint, knip, `vitest run --coverage` (442 files, 7569 tests), `vitest run tests/integration` (14 files, 147 tests), plugin parity drift


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved heredoc safety classification for quoted, non-executable payloads.
  - Added clearer remediation guidance for denied heredoc commands.
  - Git commit heredocs now provide commit-specific instructions, while other heredocs receive general file-based guidance.

- **Tests**
  - Expanded coverage for quoted heredocs, customized rules, denial messages, and command-specific remediation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->