### PR TITLE
fix(readiness): scan reusable workflow credential mappings

### DIFF
--- a/src/cli/doctor-readiness-credentials.ts
+++ b/src/cli/doctor-readiness-credentials.ts
@@ -69,9 +69,30 @@ interface SecretEnvironmentPair {
 }
 
 /**
- * Flatten every string a job declares — step commands, actions, `env`, and
- * `with` — into one searchable blob so a credential reference is found wherever
- * it is stated.
+ * Flatten a job's `secrets:` block to `key: value` lines for text search.
+ *
+ * The `inherit` scalar is deliberately excluded: it carries no secret names to
+ * search for, and is already reported on its own by
+ * {@link inheritedSecretViolations}.
+ * @param secrets - The job's `secrets` block
+ * @returns Newline-joined `key: value` lines (empty when there is nothing to flatten)
+ */
+function secretsBlockText(secrets: WorkflowBlock): string {
+  if (typeof secrets !== "object" || secrets === null) {
+    return "";
+  }
+  return Object.entries(secrets)
+    .map(
+      ([name, entry]) =>
+        `${name}: ${typeof entry === "string" ? entry : String(entry)}`
+    )
+    .join("\n");
+}
+
+/**
+ * Flatten every string a job declares — step commands, actions, `env`,
+ * `with`, and reusable-call `secrets:` mappings — into one searchable blob so
+ * a credential reference is found wherever it is stated.
  * @param job - The parsed job
  * @returns Newline-joined declared text
  */
@@ -80,6 +101,7 @@ function jobText(job: ParsedWorkflowJob): string {
     job.uses,
     job.env,
     job.inputs,
+    secretsBlockText(job.secrets),
     ...job.steps.flatMap(step => [step.run, step.uses, step.inputs]),
   ]
     .filter(part => part !== "")

--- a/src/cli/doctor-readiness-credentials.ts
+++ b/src/cli/doctor-readiness-credentials.ts
@@ -76,8 +76,12 @@ interface SecretEnvironmentPair {
  * @returns Newline-joined declared text
  */
 function jobText(job: ParsedWorkflowJob): string {
-  return job.steps
-    .flatMap(step => [step.run, step.uses, step.inputs])
+  return [
+    job.uses,
+    job.env,
+    job.inputs,
+    ...job.steps.flatMap(step => [step.run, step.uses, step.inputs]),
+  ]
     .filter(part => part !== "")
     .join("\n");
 }

--- a/src/cli/doctor-readiness-workflows.ts
+++ b/src/cli/doctor-readiness-workflows.ts
@@ -86,6 +86,12 @@ export interface ParsedWorkflowJob {
    */
   readonly env: string;
   /**
+   * The job-level `with:` block for reusable workflow calls, flattened to
+   * `key: value` lines. Reusable calls often map deployment credentials here
+   * rather than inside ordinary step inputs.
+   */
+  readonly inputs: string;
+  /**
    * Ids of the `services:` containers the job starts. A job that boots its own
    * database is operating on throwaway state by construction.
    */
@@ -255,6 +261,7 @@ function parseJobs(
         environment: asEnvironments(job.environment),
         ifCondition: asCondition(job.if),
         env: serializeBlock(job.env).join("\n"),
+        inputs: serializeBlock(job.with).join("\n"),
         services: isJsonObject(job.services) ? Object.keys(job.services) : [],
       },
     ];

--- a/tests/unit/cli/doctor-readiness-credentials-round2.test.ts
+++ b/tests/unit/cli/doctor-readiness-credentials-round2.test.ts
@@ -131,7 +131,7 @@ describe("assessDeliveryAuthorityDimension — B3 round-2 credentials", () => {
     expect(finding?.evidence).not.toContain("aws-access-key-id");
   });
 
-  it("FAILs with B3 when a reusable workflow call maps a static credential", async () => {
+  it("FAILs with B3 when a reusable workflow call maps a static credential via with:", async () => {
     const cwd = await getTempDir();
     await writeWorkflow(cwd, DEPLOY_YML, [
       DEPLOY_NAME,
@@ -141,6 +141,30 @@ describe("assessDeliveryAuthorityDimension — B3 round-2 credentials", () => {
       "    uses: ./.github/workflows/publish.yml",
       "    with:",
       "      registry-token: ${{ secrets.NPM_TOKEN }}",
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    const finding = asFindings(record.findings).find(
+      candidate => candidate.blocker === "B3"
+    );
+    expect(finding?.evidence).toContain("NPM_TOKEN");
+    expect(finding?.evidence).toContain("job `publish`");
+  });
+
+  // Covers the secrets:-only path CodeRabbit flagged as untested on PR #1990:
+  // jobText() previously omitted job-level `secrets:` mappings entirely, so a
+  // reusable-workflow call that only passes a static credential through
+  // `secrets:` (no `with:`) went undetected.
+  it("FAILs with B3 when a reusable workflow call maps a static credential via secrets:", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, DEPLOY_YML, [
+      DEPLOY_NAME,
+      ON_PUSH,
+      JOBS,
+      "  publish:",
+      "    uses: ./.github/workflows/publish.yml",
       "    secrets:",
       "      npm-token: ${{ secrets.NPM_TOKEN }}",
     ]);

--- a/tests/unit/cli/doctor-readiness-credentials-round2.test.ts
+++ b/tests/unit/cli/doctor-readiness-credentials-round2.test.ts
@@ -130,4 +130,28 @@ describe("assessDeliveryAuthorityDimension — B3 round-2 credentials", () => {
     expect(finding?.evidence).toContain("NPM_TOKEN");
     expect(finding?.evidence).not.toContain("aws-access-key-id");
   });
+
+  it("FAILs with B3 when a reusable workflow call maps a static credential", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, DEPLOY_YML, [
+      DEPLOY_NAME,
+      ON_PUSH,
+      JOBS,
+      "  publish:",
+      "    uses: ./.github/workflows/publish.yml",
+      "    with:",
+      "      registry-token: ${{ secrets.NPM_TOKEN }}",
+      "    secrets:",
+      "      npm-token: ${{ secrets.NPM_TOKEN }}",
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    const finding = asFindings(record.findings).find(
+      candidate => candidate.blocker === "B3"
+    );
+    expect(finding?.evidence).toContain("NPM_TOKEN");
+    expect(finding?.evidence).toContain("job `publish`");
+  });
 });


### PR DESCRIPTION
## Summary
- Parse job-level `with:` blocks on reusable workflow calls into the workflow model.
- Include job-level reusable-call inputs/env/uses text in B3 credential scanning.
- Add #1903 regression coverage for static credentials mapped through reusable workflow `with:`/`secrets:`.

Issue / Tracker link: Ships one bounded #1903 round-2 slice; broader backlog remains open.

## Test plan
- `bun test tests/unit/cli/doctor-readiness-credentials-round2.test.ts`
- `bun test tests/unit/cli/doctor-readiness-workflows.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build:dist`
- pre-push hook: security audit, slow lint, knip, unit coverage, integration tests, plugin parity

Work-Item: CodySwannGT/lisa#1903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved credential readiness checks to search more of a job’s declaration, including job-level workflow settings (such as inputs and environment values) and flattened reusable workflow wiring.
  - Enhanced detection and reporting for static credentials referenced in reusable workflow calls, with clearer evidence that includes the credential identifier and the relevant reusable job context.
- **Tests**
  - Added Round-2 regression coverage for credential-authority detection across reusable workflow paths where credentials are provided via configuration or secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->