### PR TITLE
Catch B4 durable-trigger guardrail bypass

### DIFF
--- a/src/cli/doctor-readiness-guardrails.ts
+++ b/src/cli/doctor-readiness-guardrails.ts
@@ -143,7 +143,7 @@ function lifecycleDeferral(workflow: ParsedWorkflow): string | null {
   const events = workflow.on.events.filter(event =>
     EPHEMERAL_LIFECYCLE_EVENTS.includes(event)
   );
-  if (events.length === 0) {
+  if (events.length === 0 || events.length < workflow.on.events.length) {
     return null;
   }
   return (

--- a/tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts
+++ b/tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts
@@ -94,6 +94,31 @@ describe("assessFeedbackGuardrailsDimension — ephemeral environments stay clea
     expectNoBlocker(record.findings);
   });
 
+  it("stands B4 when the same destructive operation is also reachable from a durable push trigger", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      DEPLOY_NAME_LINE,
+      "on:",
+      "  push:",
+      "    branches: [main]",
+      "  pull_request:",
+      JOBS,
+      INFRA_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: terraform destroy -auto-approve -var-file=prod.tfvars",
+    ]);
+
+    const record = await assessFeedbackGuardrailsDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+  });
+
   it("does not stand B4 for a `serverless remove` of a per-PR stage", async () => {
     const root = await getTempDir();
     await writeWorkflow(root, DEPLOY_YML, [


### PR DESCRIPTION
## Summary
- Treat lifecycle-trigger deferral as PR/delete-only, so a mixed `push` + `pull_request` workflow is assessed through its durable trigger.
- Add B4 regression coverage for a production `terraform destroy` reachable from `push: main`.

## Verification
- `bun test tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts`
- `bun test tests/unit/cli/doctor-readiness-guardrails.test.ts tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build:dist`
- pre-push: security audit, slow lint, knip, full unit coverage, integration tests, plugin parity

Work-Item: CodySwannGT/lisa#1903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workflow readiness checks to correctly handle workflows combining ephemeral lifecycle events with durable triggers.
  - Destructive operations triggered by durable events are now properly flagged for review, even when pull request events are also present.

- **Tests**
  - Added coverage verifying that applicable destructive workflows receive the expected warning and blocker finding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->