### PR TITLE
fix: keep preview substrings from hiding durable operations

### DIFF
--- a/src/cli/doctor-readiness-operations.ts
+++ b/src/cli/doctor-readiness-operations.ts
@@ -79,7 +79,6 @@ const EPHEMERAL_TARGETS: readonly RegExp[] = [
   /\b127\.0\.0\.1\b/,
   /(^|[^a-z0-9])(tmp|temp)([^a-z0-9]|$)/,
   /(^|[^a-z0-9])pr-/,
-  /\bpreview\b/,
   /github\.event\.number/,
   /\bpull_request\b/,
 ];

--- a/tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts
@@ -134,6 +134,28 @@ describe("assessDomainOwnershipDimension — ephemeral CI evidence outside the c
       expect(Object.hasOwn(finding, "blocker")).toBe(false);
     }
   });
+
+  it("stands B1 for a durable bucket whose name only contains `preview`", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: aws s3 rm s3://acme-customer-preview-recordings --recursive",
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+  });
 });
 
 describe("assessDomainOwnershipDimension — an empty runbook directory suppresses nothing", () => {

--- a/tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts
+++ b/tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts
@@ -155,6 +155,28 @@ describe("assessFeedbackGuardrailsDimension — ephemeral environments stay clea
     expectNoBlocker(record.findings);
   });
 
+  it("stands B4 for a durable stack whose name only contains `preview`", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      DEPLOY_NAME_LINE,
+      ON_PUSH,
+      JOBS,
+      INFRA_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: cdk destroy CustomerPreviewStack --force",
+    ]);
+
+    const record = await assessFeedbackGuardrailsDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+  });
+
   it("does not stand B4 for an integration job applying test tfvars", async () => {
     const root = await getTempDir();
     await writeWorkflow(root, DEPLOY_YML, [


### PR DESCRIPTION
## Summary

- Tightens the shared B1/B4 ephemeral target screen so a durable resource whose name merely contains `preview` is not treated as throwaway.
- Adds B1 and B4 regression coverage for `acme-customer-preview-recordings` and `CustomerPreviewStack`, while preserving existing per-PR preview teardown skips.

## Verification

- `bun test tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts`
- `bun run typecheck`
- `bun run build:dist`
- `bun run lint`
- `git push` pre-push stack: security audit, slow lint, knip, `vitest run --coverage`, `vitest run tests/integration`, plugin parity

## Notes

A raw `bun test` run under Bun reported existing standards/Kane/health failures before this PR push; the repo pre-push suite uses the configured Vitest runner and passed.

Work-Item: #1903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness checks to distinguish GitHub pull-request and event workflows from durable environments.
  * Preview-only names now correctly trigger warnings when they refer to durable storage wipe targets or infrastructure stacks.
  * Updated readiness results to report the appropriate warnings for these potentially destructive scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->