### PR TITLE
fix(learnings): derive the ledger byte budget from the entry cap + signal saturation

### DIFF
--- a/plugins/lisa-agy/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-persist-learning/SKILL.md
@@ -174,6 +174,20 @@ No learning content is ever committed without a PR — there is no other write p
    - **Related entry found** → consolidate via `persistConsolidatedLearning(projectRoot, entry, { supersede: [<related ids>] })`, merging the old entry's still-true content into the new rule. Never append a near-duplicate sibling — a sibling is a bug that fails review.
    - **No related entry** → append via `persistLearningEntry(projectRoot, entry)` and state in the PR body why appending was correct.
    - Entry mapping: `id` = the fingerprint; `rule`/`why`/`provenance` from the candidate; `first_learned` = `last_confirmed` = today (ISO date; on consolidation keep the superseded entry's earliest `first_learned`); `confidence` = the judge's `high`/`low`. The writer re-asserts the entry and token budgets — an over-budget failure means consolidate harder or drop, never truncate by hand.
+   - **On a budget-forced drop, signal saturation once (never silent).** When the writer's budget re-assertion cannot fit the entry even after consolidating harder — a durable capture has to be DROPPED for budget — the ledger is saturated, and that pressure must be visible to an operator instead of swallowed. Emit **exactly one** tracker signal via `lisa-tracker-write` (`issue_type: Task`; GitHub trackers carry the `type:Task` label), then continue — dropping the capture never blocks the build. Follow the same marker-dedupe discipline as every other comment here (match on the **marker, never the title**; **exactly one marker per body**; the eventual-consistency guard when the search index is stale), with **one deliberate difference: dedupe against OPEN signals only.** A *closed* saturation ticket means room was already reclaimed, so a fresh saturation is a new actionable event — searching closed tickets too (as the drop/upstream markers do) would permanently suppress every later saturation.
+
+     The saturation fingerprint keys on the **ledger, not the candidate**, so the signal fires once per saturation episode — never once per capture:
+
+     ```text
+     saturation-fingerprint = "sat-" + first 12 hex chars of sha1(<resolved learnings-file path>)
+     ```
+
+     ```markdown
+     <!-- [lisa-ledger-saturated] key=<saturation-fingerprint> -->
+     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This records budget pressure for the gardener's next audit — it is not itself a new learning.
+     ```
+
+     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy — chosen so the gardener reads it as budget-pressure evidence (its `projectLearnings` omission / promote-or-retire axis) rather than skipping it as learning-machinery noise. **Do not reuse a `[lisa-learning-*]` marker here** — that would make the gardener blind to the very pressure it exists to relieve. The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
 4. **Branch + commit.** Work on branch `learning/<fingerprint>`. Commit only the learnings file; verify with `git diff --name-only` that the diff touches nothing else.
 5. **PR body.** Exactly one marker line plus the reviewable story:
 

--- a/plugins/lisa-agy/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-persist-learning/SKILL.md
@@ -184,10 +184,10 @@ No learning content is ever committed without a PR — there is no other write p
 
      ```markdown
      <!-- [lisa-ledger-saturated] key=<saturation-fingerprint> -->
-     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This records budget pressure for the gardener's next audit — it is not itself a new learning.
+     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This is an operator-visible budget-pressure signal, not itself a new learning.
      ```
 
-     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy — chosen so the gardener reads it as budget-pressure evidence (its `projectLearnings` omission / promote-or-retire axis) rather than skipping it as learning-machinery noise. **Do not reuse a `[lisa-learning-*]` marker here** — that would make the gardener blind to the very pressure it exists to relieve. The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
+     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy. The gardener already derives budget pressure independently — it measures the entries its `projectLearnings` projection has to omit — so this ticket does not feed that measurement mechanically; its job is an idempotent, operator-visible notification that saturation happened. Keeping it outside `[lisa-learning-*]` matters so the audit tooling does not silently filter it as learning-machinery noise before an operator sees it. **Do not reuse a `[lisa-learning-*]` marker here.** The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
 4. **Branch + commit.** Work on branch `learning/<fingerprint>`. Commit only the learnings file; verify with `git diff --name-only` that the diff touches nothing else.
 5. **PR body.** Exactly one marker line plus the reviewable story:
 

--- a/plugins/lisa-copilot/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-persist-learning/SKILL.md
@@ -174,6 +174,20 @@ No learning content is ever committed without a PR — there is no other write p
    - **Related entry found** → consolidate via `persistConsolidatedLearning(projectRoot, entry, { supersede: [<related ids>] })`, merging the old entry's still-true content into the new rule. Never append a near-duplicate sibling — a sibling is a bug that fails review.
    - **No related entry** → append via `persistLearningEntry(projectRoot, entry)` and state in the PR body why appending was correct.
    - Entry mapping: `id` = the fingerprint; `rule`/`why`/`provenance` from the candidate; `first_learned` = `last_confirmed` = today (ISO date; on consolidation keep the superseded entry's earliest `first_learned`); `confidence` = the judge's `high`/`low`. The writer re-asserts the entry and token budgets — an over-budget failure means consolidate harder or drop, never truncate by hand.
+   - **On a budget-forced drop, signal saturation once (never silent).** When the writer's budget re-assertion cannot fit the entry even after consolidating harder — a durable capture has to be DROPPED for budget — the ledger is saturated, and that pressure must be visible to an operator instead of swallowed. Emit **exactly one** tracker signal via `lisa-tracker-write` (`issue_type: Task`; GitHub trackers carry the `type:Task` label), then continue — dropping the capture never blocks the build. Follow the same marker-dedupe discipline as every other comment here (match on the **marker, never the title**; **exactly one marker per body**; the eventual-consistency guard when the search index is stale), with **one deliberate difference: dedupe against OPEN signals only.** A *closed* saturation ticket means room was already reclaimed, so a fresh saturation is a new actionable event — searching closed tickets too (as the drop/upstream markers do) would permanently suppress every later saturation.
+
+     The saturation fingerprint keys on the **ledger, not the candidate**, so the signal fires once per saturation episode — never once per capture:
+
+     ```text
+     saturation-fingerprint = "sat-" + first 12 hex chars of sha1(<resolved learnings-file path>)
+     ```
+
+     ```markdown
+     <!-- [lisa-ledger-saturated] key=<saturation-fingerprint> -->
+     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This records budget pressure for the gardener's next audit — it is not itself a new learning.
+     ```
+
+     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy — chosen so the gardener reads it as budget-pressure evidence (its `projectLearnings` omission / promote-or-retire axis) rather than skipping it as learning-machinery noise. **Do not reuse a `[lisa-learning-*]` marker here** — that would make the gardener blind to the very pressure it exists to relieve. The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
 4. **Branch + commit.** Work on branch `learning/<fingerprint>`. Commit only the learnings file; verify with `git diff --name-only` that the diff touches nothing else.
 5. **PR body.** Exactly one marker line plus the reviewable story:
 

--- a/plugins/lisa-copilot/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-persist-learning/SKILL.md
@@ -184,10 +184,10 @@ No learning content is ever committed without a PR — there is no other write p
 
      ```markdown
      <!-- [lisa-ledger-saturated] key=<saturation-fingerprint> -->
-     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This records budget pressure for the gardener's next audit — it is not itself a new learning.
+     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This is an operator-visible budget-pressure signal, not itself a new learning.
      ```
 
-     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy — chosen so the gardener reads it as budget-pressure evidence (its `projectLearnings` omission / promote-or-retire axis) rather than skipping it as learning-machinery noise. **Do not reuse a `[lisa-learning-*]` marker here** — that would make the gardener blind to the very pressure it exists to relieve. The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
+     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy. The gardener already derives budget pressure independently — it measures the entries its `projectLearnings` projection has to omit — so this ticket does not feed that measurement mechanically; its job is an idempotent, operator-visible notification that saturation happened. Keeping it outside `[lisa-learning-*]` matters so the audit tooling does not silently filter it as learning-machinery noise before an operator sees it. **Do not reuse a `[lisa-learning-*]` marker here.** The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
 4. **Branch + commit.** Work on branch `learning/<fingerprint>`. Commit only the learnings file; verify with `git diff --name-only` that the diff touches nothing else.
 5. **PR body.** Exactly one marker line plus the reviewable story:
 

--- a/plugins/lisa-cursor/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-persist-learning/SKILL.md
@@ -174,6 +174,20 @@ No learning content is ever committed without a PR — there is no other write p
    - **Related entry found** → consolidate via `persistConsolidatedLearning(projectRoot, entry, { supersede: [<related ids>] })`, merging the old entry's still-true content into the new rule. Never append a near-duplicate sibling — a sibling is a bug that fails review.
    - **No related entry** → append via `persistLearningEntry(projectRoot, entry)` and state in the PR body why appending was correct.
    - Entry mapping: `id` = the fingerprint; `rule`/`why`/`provenance` from the candidate; `first_learned` = `last_confirmed` = today (ISO date; on consolidation keep the superseded entry's earliest `first_learned`); `confidence` = the judge's `high`/`low`. The writer re-asserts the entry and token budgets — an over-budget failure means consolidate harder or drop, never truncate by hand.
+   - **On a budget-forced drop, signal saturation once (never silent).** When the writer's budget re-assertion cannot fit the entry even after consolidating harder — a durable capture has to be DROPPED for budget — the ledger is saturated, and that pressure must be visible to an operator instead of swallowed. Emit **exactly one** tracker signal via `lisa-tracker-write` (`issue_type: Task`; GitHub trackers carry the `type:Task` label), then continue — dropping the capture never blocks the build. Follow the same marker-dedupe discipline as every other comment here (match on the **marker, never the title**; **exactly one marker per body**; the eventual-consistency guard when the search index is stale), with **one deliberate difference: dedupe against OPEN signals only.** A *closed* saturation ticket means room was already reclaimed, so a fresh saturation is a new actionable event — searching closed tickets too (as the drop/upstream markers do) would permanently suppress every later saturation.
+
+     The saturation fingerprint keys on the **ledger, not the candidate**, so the signal fires once per saturation episode — never once per capture:
+
+     ```text
+     saturation-fingerprint = "sat-" + first 12 hex chars of sha1(<resolved learnings-file path>)
+     ```
+
+     ```markdown
+     <!-- [lisa-ledger-saturated] key=<saturation-fingerprint> -->
+     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This records budget pressure for the gardener's next audit — it is not itself a new learning.
+     ```
+
+     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy — chosen so the gardener reads it as budget-pressure evidence (its `projectLearnings` omission / promote-or-retire axis) rather than skipping it as learning-machinery noise. **Do not reuse a `[lisa-learning-*]` marker here** — that would make the gardener blind to the very pressure it exists to relieve. The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
 4. **Branch + commit.** Work on branch `learning/<fingerprint>`. Commit only the learnings file; verify with `git diff --name-only` that the diff touches nothing else.
 5. **PR body.** Exactly one marker line plus the reviewable story:
 

--- a/plugins/lisa-cursor/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-persist-learning/SKILL.md
@@ -184,10 +184,10 @@ No learning content is ever committed without a PR — there is no other write p
 
      ```markdown
      <!-- [lisa-ledger-saturated] key=<saturation-fingerprint> -->
-     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This records budget pressure for the gardener's next audit — it is not itself a new learning.
+     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This is an operator-visible budget-pressure signal, not itself a new learning.
      ```
 
-     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy — chosen so the gardener reads it as budget-pressure evidence (its `projectLearnings` omission / promote-or-retire axis) rather than skipping it as learning-machinery noise. **Do not reuse a `[lisa-learning-*]` marker here** — that would make the gardener blind to the very pressure it exists to relieve. The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
+     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy. The gardener already derives budget pressure independently — it measures the entries its `projectLearnings` projection has to omit — so this ticket does not feed that measurement mechanically; its job is an idempotent, operator-visible notification that saturation happened. Keeping it outside `[lisa-learning-*]` matters so the audit tooling does not silently filter it as learning-machinery noise before an operator sees it. **Do not reuse a `[lisa-learning-*]` marker here.** The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
 4. **Branch + commit.** Work on branch `learning/<fingerprint>`. Commit only the learnings file; verify with `git diff --name-only` that the diff touches nothing else.
 5. **PR body.** Exactly one marker line plus the reviewable story:
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-persist-learning/SKILL.md
@@ -174,6 +174,20 @@ No learning content is ever committed without a PR — there is no other write p
    - **Related entry found** → consolidate via `persistConsolidatedLearning(projectRoot, entry, { supersede: [<related ids>] })`, merging the old entry's still-true content into the new rule. Never append a near-duplicate sibling — a sibling is a bug that fails review.
    - **No related entry** → append via `persistLearningEntry(projectRoot, entry)` and state in the PR body why appending was correct.
    - Entry mapping: `id` = the fingerprint; `rule`/`why`/`provenance` from the candidate; `first_learned` = `last_confirmed` = today (ISO date; on consolidation keep the superseded entry's earliest `first_learned`); `confidence` = the judge's `high`/`low`. The writer re-asserts the entry and token budgets — an over-budget failure means consolidate harder or drop, never truncate by hand.
+   - **On a budget-forced drop, signal saturation once (never silent).** When the writer's budget re-assertion cannot fit the entry even after consolidating harder — a durable capture has to be DROPPED for budget — the ledger is saturated, and that pressure must be visible to an operator instead of swallowed. Emit **exactly one** tracker signal via `lisa-tracker-write` (`issue_type: Task`; GitHub trackers carry the `type:Task` label), then continue — dropping the capture never blocks the build. Follow the same marker-dedupe discipline as every other comment here (match on the **marker, never the title**; **exactly one marker per body**; the eventual-consistency guard when the search index is stale), with **one deliberate difference: dedupe against OPEN signals only.** A *closed* saturation ticket means room was already reclaimed, so a fresh saturation is a new actionable event — searching closed tickets too (as the drop/upstream markers do) would permanently suppress every later saturation.
+
+     The saturation fingerprint keys on the **ledger, not the candidate**, so the signal fires once per saturation episode — never once per capture:
+
+     ```text
+     saturation-fingerprint = "sat-" + first 12 hex chars of sha1(<resolved learnings-file path>)
+     ```
+
+     ```markdown
+     <!-- [lisa-ledger-saturated] key=<saturation-fingerprint> -->
+     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This records budget pressure for the gardener's next audit — it is not itself a new learning.
+     ```
+
+     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy — chosen so the gardener reads it as budget-pressure evidence (its `projectLearnings` omission / promote-or-retire axis) rather than skipping it as learning-machinery noise. **Do not reuse a `[lisa-learning-*]` marker here** — that would make the gardener blind to the very pressure it exists to relieve. The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
 4. **Branch + commit.** Work on branch `learning/<fingerprint>`. Commit only the learnings file; verify with `git diff --name-only` that the diff touches nothing else.
 5. **PR body.** Exactly one marker line plus the reviewable story:
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-persist-learning/SKILL.md
@@ -184,10 +184,10 @@ No learning content is ever committed without a PR — there is no other write p
 
      ```markdown
      <!-- [lisa-ledger-saturated] key=<saturation-fingerprint> -->
-     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This records budget pressure for the gardener's next audit — it is not itself a new learning.
+     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This is an operator-visible budget-pressure signal, not itself a new learning.
      ```
 
-     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy — chosen so the gardener reads it as budget-pressure evidence (its `projectLearnings` omission / promote-or-retire axis) rather than skipping it as learning-machinery noise. **Do not reuse a `[lisa-learning-*]` marker here** — that would make the gardener blind to the very pressure it exists to relieve. The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
+     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy. The gardener already derives budget pressure independently — it measures the entries its `projectLearnings` projection has to omit — so this ticket does not feed that measurement mechanically; its job is an idempotent, operator-visible notification that saturation happened. Keeping it outside `[lisa-learning-*]` matters so the audit tooling does not silently filter it as learning-machinery noise before an operator sees it. **Do not reuse a `[lisa-learning-*]` marker here.** The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
 4. **Branch + commit.** Work on branch `learning/<fingerprint>`. Commit only the learnings file; verify with `git diff --name-only` that the diff touches nothing else.
 5. **PR body.** Exactly one marker line plus the reviewable story:
 

--- a/plugins/lisa/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa/skills/lisa-persist-learning/SKILL.md
@@ -174,6 +174,20 @@ No learning content is ever committed without a PR — there is no other write p
    - **Related entry found** → consolidate via `persistConsolidatedLearning(projectRoot, entry, { supersede: [<related ids>] })`, merging the old entry's still-true content into the new rule. Never append a near-duplicate sibling — a sibling is a bug that fails review.
    - **No related entry** → append via `persistLearningEntry(projectRoot, entry)` and state in the PR body why appending was correct.
    - Entry mapping: `id` = the fingerprint; `rule`/`why`/`provenance` from the candidate; `first_learned` = `last_confirmed` = today (ISO date; on consolidation keep the superseded entry's earliest `first_learned`); `confidence` = the judge's `high`/`low`. The writer re-asserts the entry and token budgets — an over-budget failure means consolidate harder or drop, never truncate by hand.
+   - **On a budget-forced drop, signal saturation once (never silent).** When the writer's budget re-assertion cannot fit the entry even after consolidating harder — a durable capture has to be DROPPED for budget — the ledger is saturated, and that pressure must be visible to an operator instead of swallowed. Emit **exactly one** tracker signal via `lisa-tracker-write` (`issue_type: Task`; GitHub trackers carry the `type:Task` label), then continue — dropping the capture never blocks the build. Follow the same marker-dedupe discipline as every other comment here (match on the **marker, never the title**; **exactly one marker per body**; the eventual-consistency guard when the search index is stale), with **one deliberate difference: dedupe against OPEN signals only.** A *closed* saturation ticket means room was already reclaimed, so a fresh saturation is a new actionable event — searching closed tickets too (as the drop/upstream markers do) would permanently suppress every later saturation.
+
+     The saturation fingerprint keys on the **ledger, not the candidate**, so the signal fires once per saturation episode — never once per capture:
+
+     ```text
+     saturation-fingerprint = "sat-" + first 12 hex chars of sha1(<resolved learnings-file path>)
+     ```
+
+     ```markdown
+     <!-- [lisa-ledger-saturated] key=<saturation-fingerprint> -->
+     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This records budget pressure for the gardener's next audit — it is not itself a new learning.
+     ```
+
+     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy — chosen so the gardener reads it as budget-pressure evidence (its `projectLearnings` omission / promote-or-retire axis) rather than skipping it as learning-machinery noise. **Do not reuse a `[lisa-learning-*]` marker here** — that would make the gardener blind to the very pressure it exists to relieve. The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
 4. **Branch + commit.** Work on branch `learning/<fingerprint>`. Commit only the learnings file; verify with `git diff --name-only` that the diff touches nothing else.
 5. **PR body.** Exactly one marker line plus the reviewable story:
 

--- a/plugins/lisa/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/lisa/skills/lisa-persist-learning/SKILL.md
@@ -184,10 +184,10 @@ No learning content is ever committed without a PR — there is no other write p
 
      ```markdown
      <!-- [lisa-ledger-saturated] key=<saturation-fingerprint> -->
-     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This records budget pressure for the gardener's next audit — it is not itself a new learning.
+     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This is an operator-visible budget-pressure signal, not itself a new learning.
      ```
 
-     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy — chosen so the gardener reads it as budget-pressure evidence (its `projectLearnings` omission / promote-or-retire axis) rather than skipping it as learning-machinery noise. **Do not reuse a `[lisa-learning-*]` marker here** — that would make the gardener blind to the very pressure it exists to relieve. The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
+     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy. The gardener already derives budget pressure independently — it measures the entries its `projectLearnings` projection has to omit — so this ticket does not feed that measurement mechanically; its job is an idempotent, operator-visible notification that saturation happened. Keeping it outside `[lisa-learning-*]` matters so the audit tooling does not silently filter it as learning-machinery noise before an operator sees it. **Do not reuse a `[lisa-learning-*]` marker here.** The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
 4. **Branch + commit.** Work on branch `learning/<fingerprint>`. Commit only the learnings file; verify with `git diff --name-only` that the diff touches nothing else.
 5. **PR body.** Exactly one marker line plus the reviewable story:
 

--- a/plugins/src/base/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/src/base/skills/lisa-persist-learning/SKILL.md
@@ -174,6 +174,20 @@ No learning content is ever committed without a PR — there is no other write p
    - **Related entry found** → consolidate via `persistConsolidatedLearning(projectRoot, entry, { supersede: [<related ids>] })`, merging the old entry's still-true content into the new rule. Never append a near-duplicate sibling — a sibling is a bug that fails review.
    - **No related entry** → append via `persistLearningEntry(projectRoot, entry)` and state in the PR body why appending was correct.
    - Entry mapping: `id` = the fingerprint; `rule`/`why`/`provenance` from the candidate; `first_learned` = `last_confirmed` = today (ISO date; on consolidation keep the superseded entry's earliest `first_learned`); `confidence` = the judge's `high`/`low`. The writer re-asserts the entry and token budgets — an over-budget failure means consolidate harder or drop, never truncate by hand.
+   - **On a budget-forced drop, signal saturation once (never silent).** When the writer's budget re-assertion cannot fit the entry even after consolidating harder — a durable capture has to be DROPPED for budget — the ledger is saturated, and that pressure must be visible to an operator instead of swallowed. Emit **exactly one** tracker signal via `lisa-tracker-write` (`issue_type: Task`; GitHub trackers carry the `type:Task` label), then continue — dropping the capture never blocks the build. Follow the same marker-dedupe discipline as every other comment here (match on the **marker, never the title**; **exactly one marker per body**; the eventual-consistency guard when the search index is stale), with **one deliberate difference: dedupe against OPEN signals only.** A *closed* saturation ticket means room was already reclaimed, so a fresh saturation is a new actionable event — searching closed tickets too (as the drop/upstream markers do) would permanently suppress every later saturation.
+
+     The saturation fingerprint keys on the **ledger, not the candidate**, so the signal fires once per saturation episode — never once per capture:
+
+     ```text
+     saturation-fingerprint = "sat-" + first 12 hex chars of sha1(<resolved learnings-file path>)
+     ```
+
+     ```markdown
+     <!-- [lisa-ledger-saturated] key=<saturation-fingerprint> -->
+     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This records budget pressure for the gardener's next audit — it is not itself a new learning.
+     ```
+
+     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy — chosen so the gardener reads it as budget-pressure evidence (its `projectLearnings` omission / promote-or-retire axis) rather than skipping it as learning-machinery noise. **Do not reuse a `[lisa-learning-*]` marker here** — that would make the gardener blind to the very pressure it exists to relieve. The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
 4. **Branch + commit.** Work on branch `learning/<fingerprint>`. Commit only the learnings file; verify with `git diff --name-only` that the diff touches nothing else.
 5. **PR body.** Exactly one marker line plus the reviewable story:
 

--- a/plugins/src/base/skills/lisa-persist-learning/SKILL.md
+++ b/plugins/src/base/skills/lisa-persist-learning/SKILL.md
@@ -184,10 +184,10 @@ No learning content is ever committed without a PR — there is no other write p
 
      ```markdown
      <!-- [lisa-ledger-saturated] key=<saturation-fingerprint> -->
-     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This records budget pressure for the gardener's next audit — it is not itself a new learning.
+     Learnings ledger saturated — a durable capture was dropped for budget. The projection is now omitting entries; promote or retire a learning to reclaim room. This is an operator-visible budget-pressure signal, not itself a new learning.
      ```
 
-     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy — chosen so the gardener reads it as budget-pressure evidence (its `projectLearnings` omission / promote-or-retire axis) rather than skipping it as learning-machinery noise. **Do not reuse a `[lisa-learning-*]` marker here** — that would make the gardener blind to the very pressure it exists to relieve. The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
+     The `[lisa-ledger-saturated]` marker sits **outside the `[lisa-learning-*]` namespace** that the gardener (`lisa-learnings-audit`) auto-excludes from candidacy. The gardener already derives budget pressure independently — it measures the entries its `projectLearnings` projection has to omit — so this ticket does not feed that measurement mechanically; its job is an idempotent, operator-visible notification that saturation happened. Keeping it outside `[lisa-learning-*]` matters so the audit tooling does not silently filter it as learning-machinery noise before an operator sees it. **Do not reuse a `[lisa-learning-*]` marker here.** The candidate itself is still dropped; this signal records the saturation, it does not persist the rule.
 4. **Branch + commit.** Work on branch `learning/<fingerprint>`. Commit only the learnings file; verify with `git diff --name-only` that the diff touches nothing else.
 5. **PR body.** Exactly one marker line plus the reviewable story:
 

--- a/src/core/learnings-contract.ts
+++ b/src/core/learnings-contract.ts
@@ -10,6 +10,23 @@ export const LEARNING_CONFIDENCE_VALUES = ["low", "medium", "high"] as const;
 /** Confidence vocabulary persisted in every learning entry. */
 export type LearningConfidence = (typeof LEARNING_CONFIDENCE_VALUES)[number];
 
+/** Maximum number of durable entries the ledger retains. */
+const MAX_ENTRIES = 20;
+
+/**
+ * Byte allowance provisioned per durable entry. The whole-file byte budget
+ * (`maxTokens`) is DERIVED from this times `maxEntries`, so the entry cap and
+ * the byte cap can never contradict: a ledger of exactly `maxEntries` real
+ * entries (~490 B average observed) always fits under `maxTokens`. This value
+ * covers the observed worst case (max ~606 B/entry) with headroom.
+ *
+ * Historically these were two independently hardcoded numbers — a 20-entry cap
+ * and a flat 4000-byte cap — that bound the ledger at ~8 entries, stranding
+ * valid captures far under the entry ceiling (CodySwannGT/lisa#1959). Deriving
+ * the byte cap from the entry cap removes that contradiction at the source.
+ */
+export const PER_ENTRY_BYTE_ALLOWANCE = 600;
+
 export const LEARNINGS_CONTRACT = Object.freeze({
   version: 1,
   fields: Object.freeze([
@@ -24,8 +41,8 @@ export const LEARNINGS_CONTRACT = Object.freeze({
   maxRuleCharacters: 240,
   maxRuleLines: 2,
   maxProvenanceReferences: 20,
-  maxEntries: 20,
-  maxTokens: 4000,
+  maxEntries: MAX_ENTRIES,
+  maxTokens: MAX_ENTRIES * PER_ENTRY_BYTE_ALLOWANCE,
   measurement: "utf8-bytes-upper-bound",
 } as const);
 

--- a/src/core/learnings-contract.ts
+++ b/src/core/learnings-contract.ts
@@ -14,11 +14,20 @@ export type LearningConfidence = (typeof LEARNING_CONFIDENCE_VALUES)[number];
 const MAX_ENTRIES = 20;
 
 /**
- * Byte allowance provisioned per durable entry. The whole-file byte budget
- * (`maxTokens`) is DERIVED from this times `maxEntries`, so the entry cap and
- * the byte cap can never contradict: a ledger of exactly `maxEntries` real
- * entries (~490 B average observed) always fits under `maxTokens`. This value
- * covers the observed worst case (max ~606 B/entry) with headroom.
+ * Average per-entry byte allowance used to DERIVE the whole-file byte budget
+ * (`maxTokens = maxEntries * PER_ENTRY_BYTE_ALLOWANCE`), so the entry cap and
+ * the byte cap can never contradict.
+ *
+ * This is an AVERAGE budget, not a per-entry maximum: `maxTokens` is enforced
+ * against the whole rendered document — every entry plus the ```jsonl framing
+ * (~72 B observed) — and there is NO per-entry byte cap (`rule` is char-capped
+ * at `maxRuleCharacters`; `why` is bounded only by the document total). At 600
+ * against a ~490 B observed average, each entry carries ~110 B of headroom, so
+ * a full 20-entry ledger budgets 12000 B while real content lands near 9800 B —
+ * the ~2.2 KB slack absorbs the document framing many times over and leaves room
+ * for larger-than-average entries. A single pathologically large `why` can
+ * consume a disproportionate share; that is intended — the document total is the
+ * real constraint, and the near-boundary regression test pins that behavior.
  *
  * Historically these were two independently hardcoded numbers — a 20-entry cap
  * and a flat 4000-byte cap — that bound the ledger at ~8 entries, stranding

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -971,7 +971,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-performance-review/SKILL.md":
       "351542c256e54940e6d672a70606b8414425c6435ae6f026841bcc02f9fce9c4",
     "plugins/src/base/skills/lisa-persist-learning/SKILL.md":
-      "79fe00903541330b7ca088ad3fde4fec32a2cff8954974bf0bd71910e0ff0eb8",
+      "1881564dd554ae5c2e0fd5f8b88add929726a2d257a79e68e970448f191f84a3",
     "plugins/src/base/skills/lisa-plan/SKILL.md":
       "9c372e106afd53ff988046119cf36b0f6519c4426775dd8ad3c9d9baeee5d3e2",
     "plugins/src/base/skills/lisa-plugin-sync-explain/SKILL.md":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -971,7 +971,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-performance-review/SKILL.md":
       "351542c256e54940e6d672a70606b8414425c6435ae6f026841bcc02f9fce9c4",
     "plugins/src/base/skills/lisa-persist-learning/SKILL.md":
-      "1881564dd554ae5c2e0fd5f8b88add929726a2d257a79e68e970448f191f84a3",
+      "d682b944ae099cdad8c91762b6665b8ef613b58bb8b041335841c116c94dd891",
     "plugins/src/base/skills/lisa-plan/SKILL.md":
       "9c372e106afd53ff988046119cf36b0f6519c4426775dd8ad3c9d9baeee5d3e2",
     "plugins/src/base/skills/lisa-plugin-sync-explain/SKILL.md":

--- a/tests/unit/core/learnings-contract.test.ts
+++ b/tests/unit/core/learnings-contract.test.ts
@@ -2,7 +2,10 @@
 import * as fs from "fs-extra";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { LEARNINGS_CONTRACT } from "../../../src/core/learnings-contract.js";
+import {
+  LEARNINGS_CONTRACT,
+  PER_ENTRY_BYTE_ALLOWANCE,
+} from "../../../src/core/learnings-contract.js";
 import {
   DEFAULT_PROJECT_LEARNINGS_FILE,
   DEFAULT_PROJECT_RULES_FILE,
@@ -58,9 +61,20 @@ describe("learnings contract", () => {
       maxRuleLines: 2,
       maxProvenanceReferences: 20,
       maxEntries: 20,
-      maxTokens: 4000,
+      maxTokens: 12000,
       measurement: "utf8-bytes-upper-bound",
     });
+  });
+
+  it("derives the byte budget from the entry cap so the two caps can never diverge", () => {
+    // #1959: maxTokens is DERIVED (maxEntries * PER_ENTRY_BYTE_ALLOWANCE), never
+    // an independently hardcoded number that could re-contradict the entry cap.
+    // Pin both the concrete allowance and the derivation relationship: a future
+    // edit that re-hardcodes maxTokens (e.g. back to a flat 4000) breaks this.
+    expect(PER_ENTRY_BYTE_ALLOWANCE).toBe(600);
+    expect(LEARNINGS_CONTRACT.maxTokens).toBe(
+      LEARNINGS_CONTRACT.maxEntries * PER_ENTRY_BYTE_ALLOWANCE
+    );
   });
 
   it("publishes the contract for the future CI budget reader", async () => {

--- a/tests/unit/scripts/check-learnings-budget.test.ts
+++ b/tests/unit/scripts/check-learnings-budget.test.ts
@@ -112,11 +112,16 @@ describe("check:learnings-budget", () => {
   });
 
   it("reports measured and allowed maxTokens values", () => {
-    const content = renderLearningsFile([
-      createEntry("token-heavy-one", { why: "x".repeat(2000) }),
-      createEntry("token-heavy-two", { why: "y".repeat(2000) }),
-    ]);
-    const measuredTokens = 4355;
+    // Overrun the byte budget without tripping the entry cap first: a handful
+    // of within-entry-cap entries whose bytes exceed the derived maxTokens.
+    const content = renderLearningsFile(
+      Array.from({ length: 5 }, (_unused, index) =>
+        createEntry(`token-heavy-${index}`, { why: "x".repeat(3000) })
+      )
+    );
+    const measuredTokens = Buffer.byteLength(content, "utf8");
+    // Guard the fixture stays a maxTokens case (over bytes, under entry cap).
+    expect(measuredTokens).toBeGreaterThan(LEARNINGS_CONTRACT.maxTokens);
     const fixture = writeFixture("over-tokens.md", content);
 
     const result = runCheck(fixture);
@@ -126,6 +131,31 @@ describe("check:learnings-budget", () => {
     expect(result.output).toContain("maxTokens");
     expect(result.output).toContain(String(measuredTokens));
     expect(result.output).toContain(String(LEARNINGS_CONTRACT.maxTokens));
+  });
+
+  it("fits a full ledger of real-sized entries once the byte budget derives from the entry cap (#1959 R1)", () => {
+    // A full ledger (maxEntries) of realistic ~466 B entries totals ~9.3 KB:
+    // above the retired flat 4000 B cap but below the derived budget
+    // (maxEntries * PER_ENTRY_BYTE_ALLOWANCE = 12000 B). On HEAD's flat cap
+    // this FAILS maxTokens though entry count == maxEntries; once the byte
+    // budget derives from the entry cap, a full ledger of real entries fits.
+    const RETIRED_FLAT_BUDGET = 4000;
+    const DERIVED_BUDGET = 12000; // maxEntries(20) * PER_ENTRY_BYTE_ALLOWANCE(600)
+    const entries = Array.from(
+      { length: LEARNINGS_CONTRACT.maxEntries },
+      (_unused, index) => realisticEntry(index)
+    );
+    const content = renderLearningsFile(entries);
+    const measured = Buffer.byteLength(content, "utf8");
+    expect(entries.length).toBe(LEARNINGS_CONTRACT.maxEntries);
+    expect(measured).toBeGreaterThan(RETIRED_FLAT_BUDGET);
+    expect(measured).toBeLessThan(DERIVED_BUDGET);
+    const fixture = writeFixture("full-real-ledger.md", content);
+
+    const result = runCheck(fixture);
+
+    expect(result.status).toBe(0);
+    expect(result.output).not.toContain("maxTokens exceeded");
   });
 
   it("rejects malformed JSONL with a path-specific diagnostic", () => {
@@ -284,6 +314,31 @@ function createEntry(
     last_confirmed: "2026-07-16",
     confidence: "low",
     ...overrides,
+  };
+}
+
+/**
+ * Build one schema-valid entry sized like a real captured learning (~466 B):
+ * a near-cap single-line rule, a causal `why`, and two provenance refs. Twenty
+ * of these total ~9.3 KB — the #1959 repro band above the retired flat cap and
+ * below the derived budget.
+ * @param index - Position used to keep ids and one provenance ref unique
+ * @returns Realistic learning entry for the full-ledger fixture
+ */
+function realisticEntry(index: number): LearningEntry {
+  const suffix = String(index).padStart(2, "0");
+  return {
+    id: `learning-realistic-${suffix}`,
+    rule:
+      "prefer a derived learnings byte budget over a flat hardcoded cap so the " +
+      "entry count and the byte ceiling can never contradict one another",
+    why:
+      "the two independently hardcoded caps bound the ledger near eight entries, " +
+      "stranding valid captures far under the twenty-entry ceiling",
+    provenance: ["CodySwannGT/lisa#1959", `CodySwannGT/lisa#${1500 + index}`],
+    first_learned: "2026-07-01",
+    last_confirmed: "2026-07-23",
+    confidence: "high",
   };
 }
 

--- a/tests/unit/scripts/check-learnings-budget.test.ts
+++ b/tests/unit/scripts/check-learnings-budget.test.ts
@@ -156,6 +156,20 @@ describe("check:learnings-budget", () => {
 
     expect(result.status).toBe(0);
     expect(result.output).not.toContain("maxTokens exceeded");
+
+    // Boundary: maxTokens gates the WHOLE rendered document (entries + jsonl
+    // framing), not just summed entry bytes, and it is an average allowance,
+    // not a per-entry cap. Pad one entry's why so the document lands on exactly
+    // maxTokens and confirm it still passes — the paired "over maxTokens" test
+    // below proves one byte more fails. This exercises the ceiling itself,
+    // closing the earlier ~2.7 KB-of-slack gap.
+    const pad = LEARNINGS_CONTRACT.maxTokens - measured;
+    entries[0] = { ...entries[0], why: `${entries[0].why}${"x".repeat(pad)}` };
+    const atLimit = renderLearningsFile(entries);
+    expect(Buffer.byteLength(atLimit, "utf8")).toBe(
+      LEARNINGS_CONTRACT.maxTokens
+    );
+    expect(runCheck(writeFixture("at-token-limit.md", atLimit)).status).toBe(0);
   });
 
   it("rejects malformed JSONL with a path-specific diagnostic", () => {


### PR DESCRIPTION
Closes #1959

Work-Item: CodySwannGT/lisa#1959

## What

The learnings ledger enforced two contradictory caps — a 20-entry cap and a flat 4000-UTF-8-byte cap. Real seven-field entries average ~490 bytes, so the byte cap bound first at ~10 entries (half the entry cap), silently shutting the capture pipeline, and saturation produced no signal. (This session's own five learner passes each hit exactly this — ~a dozen durable drafts stranded no-budget.)

**Fix 1 — derived budget (root cause):** `maxTokens` is now `MAX_ENTRIES * PER_ENTRY_BYTE_ALLOWANCE` (20 × 600 = 12000), derived from the *same* `MAX_ENTRIES` constant that sets `maxEntries`, so the two caps can never re-diverge. A contract test pins both the concrete allowance (600, covering the 606-byte worst-case real entry) and the derivation relationship, so a future edit can't silently re-hardcode a contradictory pair. 20 real entries now fit (~9800 B < 12000); the 20-entry cap and all per-field caps are unchanged.

**Fix 2 — saturation signal (the "no signal" half):** when a capture must drop a durable entry for budget, the learner emits exactly one idempotent tracker signal (`[lisa-ledger-saturated]`, keyed on the ledger path so it fires once per saturation episode, not per capture; deduped against open signals only, since a closed one means room was reclaimed). The marker sits outside the `[lisa-learning-*]` namespace the gardener auto-excludes, so it stays operator-visible rather than being filtered as learning-machinery noise; the gardener still derives budget pressure independently from its projection.

**Deferred (filed as follow-ups):** Fix 3 (durable overflow file the gardener drains) and Fix 4 (stable entry ids across supersede-in-place) — each is a distinct, more invasive change, and the derived budget already rescues the stranded backlog. A separately-discovered concurrent-writer corruption of the shared ledger file is #1995.

## Verification

- Independent verdict PASS: live budget proof — 20 real entries pass at 9311/12000, 21 entries fail on maxEntries, an over-length rule fails on the per-field cap; derivation pinned; saturation signal present + correctly namespaced across all 6 skill projections.
- Quality review APPROVE: the gardener-exclusion dodge confirmed against the explicit marker list, idempotency/no-spam/no-candidacy-loop all verified.
- Targeted suites 38/38; typecheck/lint/parity-drift/manifest/plugins green. The full-suite run showed failures only in subsystems this PR does not touch (concurrent-session mutation of the shared checkout — #1995; every such suite passes in isolation); the PR diff is `learnings-contract.ts` + 6 persist-learning SKILL projections + 2 test files + manifest, with zero intersection.
- Ledger content unmodified by this PR (fix is contract + skill, not data).

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an operator-visible alert when a learning entry is dropped because the ledger reaches its budget.
  * Alerts are deduplicated while an existing saturation task remains open and can reappear after resolution.
  * Saturation alerts no longer interfere with learning audit processing.

* **Improvements**
  * Increased the learning ledger capacity to support larger realistic entries.
  * Added safeguards to keep entry and overall budget limits aligned.

* **Tests**
  * Expanded coverage for budget enforcement, realistic ledger contents, and saturation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->