### PR TITLE
fix(ci): check Lisa's own learnings ledger against its in-tree contract

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -612,18 +612,44 @@ jobs:
         with:
           bun-version: '1.3.8'
 
-      # Pinned for reproducibility: the gate must not change behavior under
-      # unchanged host commits. Bump deliberately when the learnings contract
-      # changes. (Publishing npm and pushing this @main workflow are the same
-      # trust domain; the pin buys determinism, not a trust boundary.) The pin
-      # must be >= 2.243.0: earlier CLIs lack the relocated .lisa/ resolver or
-      # this subcommand, and pre-2.237.0 CLIs self-skip in non-interactive
-      # environments with exit 0, silently voiding the gate — which is why the
-      # marker grep below asserts the check actually ran.
+      # Host projects: pinned for reproducibility — the gate must not change
+      # behavior under unchanged host commits. Bump deliberately when the
+      # learnings contract changes. (Publishing npm and pushing this @main
+      # workflow are the same trust domain; the pin buys determinism, not a
+      # trust boundary.) The pin must be >= 2.243.0: earlier CLIs lack the
+      # relocated .lisa/ resolver or this subcommand, and pre-2.237.0 CLIs
+      # self-skip in non-interactive environments with exit 0, silently voiding
+      # the gate — which is why the marker grep below asserts the check ran.
+      #
+      # Lisa's own source repo: check against ITS OWN source contract instead of
+      # a previously-published pin. The pin necessarily lags by at least one
+      # release, so a commit that changes the budget and migrates the ledger in
+      # the same breath would be judged by the OLD budget — exactly the skew that
+      # failed the #2001 deploy (ledger already at 11577 for the derived 12000
+      # budget, pin still enforcing the flat 4000). Detection is content-based
+      # (not a repo-name match) so forks of the Lisa source behave identically;
+      # the checker imports only node: builtins and local sources, so it needs no
+      # `bun install`.
       - name: 📚 Check learnings budget
         run: |
           set -o pipefail
-          bunx @codyswann/lisa@2.297.0 check-learnings-budget | tee learnings-budget.out
+          if [ -f scripts/check-learnings-budget.ts ] && [ -f src/core/learnings-budget-check.ts ]; then
+            # Resolve the ledger the way the contract does. The bare script
+            # defaults to the shipped all/create-only TEMPLATE (0 entries, always
+            # passes) — passing the real path explicitly is what keeps this a gate
+            # and not a silent no-op.
+            ledger="$(jq -r '.learnings.file // ".lisa/PROJECT_LEARNINGS.md"' .lisa.config.json 2>/dev/null || echo '.lisa/PROJECT_LEARNINGS.md')"
+            [ -n "$ledger" ] && [ "$ledger" != "null" ] || ledger='.lisa/PROJECT_LEARNINGS.md'
+            echo "ℹ️ Lisa source repo — checking $ledger against the in-tree contract"
+            bun scripts/check-learnings-budget.ts "$ledger" | tee learnings-budget.out
+            # When the ledger exists, demand a real pass: "no learnings file"
+            # here would mean we resolved the wrong path and voided the gate.
+            if [ -f "$ledger" ]; then
+              grep -q "learnings budget passed" learnings-budget.out
+            fi
+          else
+            bunx @codyswann/lisa@2.297.0 check-learnings-budget | tee learnings-budget.out
+          fi
           grep -qE "learnings budget passed|no learnings file" learnings-budget.out
         working-directory: ${{ inputs.working_directory || '.' }}
 

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -492,6 +492,34 @@ describe("learnings-budget gate (#1730)", () => {
       expect(workflow).not.toContain("learnings-budget-relocated.out");
     }
   );
+
+  // The Lisa source repo must check its ledger against its OWN in-tree contract:
+  // the published pin necessarily lags a release, so a commit that raises the
+  // budget and migrates the ledger together would be judged by the stale budget
+  // (the #2001 deploy failure). Rails hosts never carry Lisa source, so only the
+  // TypeScript quality workflow grows the self-check branch.
+  it("checks the Lisa source repo against its in-tree contract, not the pin", () => {
+    const workflow = fs.readFileSync(QUALITY_YML, "utf8");
+
+    expect(workflow).toContain("scripts/check-learnings-budget.ts");
+    expect(workflow).toContain("src/core/learnings-budget-check.ts");
+    // Must pass an explicit resolved ledger: the bare no-arg form defaults to
+    // the shipped all/create-only TEMPLATE (0 entries) and would silently void
+    // the gate for Lisa itself.
+    expect(workflow).toContain(
+      'bun scripts/check-learnings-budget.ts "$ledger"'
+    );
+    expect(workflow).not.toMatch(
+      /bun scripts\/check-learnings-budget\.ts\s*\|/
+    );
+    // When the ledger exists, a real pass is required — "no learnings file"
+    // there would mean the path resolved wrong and the gate went vacuous.
+    expect(workflow).toContain('grep -q "learnings budget passed"');
+    // Host projects keep the deliberate, reproducible pin.
+    expect(workflow).toContain(
+      "bunx @codyswann/lisa@2.297.0 check-learnings-budget | tee learnings-budget.out"
+    );
+  });
 });
 
 describe("release and deploy workflows", () => {


### PR DESCRIPTION
## What

The Lisa source repo now checks its learnings ledger against its **own in-tree contract** instead of a previously-published pin. Host projects keep the deliberate, reproducible pin unchanged.

Closes #2005.

## Why — this caused a real deploy failure

The `📚 Learnings Budget` gate enforced the budget from a **pinned published package** (`bunx @codyswann/lisa@<ver>`) while reading the **ledger from the checkout**. The pin lags at least one release, so a change that raises the budget and migrates the ledger *together* gets judged by the **old** budget.

That is exactly what failed the **#2001 Release-and-Deploy**:

- #1959 derived `maxTokens` from the entry cap (`20 × 600 = 12000`) and expanded the ledger to 11577 B ("entry-cap-bound, not byte-bound").
- The gate still ran the stale `@2.243.0` pin enforcing `4000` → `maxTokens exceeded: measured 11577, allowed 4000` → **deploy failed**.
- It self-healed only once the pin reached `@2.297.0`.

Impact was transient (the next deploy, #2004 → v2.297.1, carried #2001's code), but the fragility recurs on **every future budget change**.

## How

- **Content-based self-detection** (`scripts/check-learnings-budget.ts` + `src/core/learnings-budget-check.ts`) — not a repo-name match, so forks of the Lisa source behave identically.
- No `bun install` needed: the checker imports only `node:` builtins and local sources (verified in a `node_modules`-free tree).
- **Vacuous-gate trap guarded.** The bare no-arg script defaults to the shipped `all/create-only` **template** (0 entries — always passes). I nearly shipped that. The self-branch instead resolves the real ledger (config override, else `.lisa/PROJECT_LEARNINGS.md`) and, when that file exists, requires an actual `learnings budget passed` — so a mis-resolved path can't silently void the gate.
- `quality-rails.yml` **intentionally unchanged**: it serves Rails host projects, which never carry Lisa source.

## Verification

- **Red-leg** (per the ledger's own "a control must prove it works" rule): an over-budget ledger (34779 B) → **exit 1**, no pass-marker. The gate is not vacuous.
- **Green-leg:** real ledger → `19/20 entries, 11577/12000 maxTokens — passed`, real-pass assertion holds.
- **Host branch:** simulated a project without Lisa source → correctly falls through to the pinned `bunx`.
- Regression test pins **both** branches, including a `not.toMatch` on the bare no-arg form.
- `tsc` clean, eslint clean, full unit + integration suites green in pre-push.

🤖 Generated with Claude Code
