### PR TITLE
fix: harden learnings ledger concurrent writes

### DIFF
--- a/src/core/learnings-document.ts
+++ b/src/core/learnings-document.ts
@@ -13,6 +13,7 @@ const FILE_HEADER = `# Project Learnings
 `;
 const JSON_FENCE_START = "```jsonl\n";
 const JSON_FENCE_END = "\n```\n";
+const CONFLICT_MARKER_PATTERN = /^(<<<<<<<|=======|>>>>>>>)(?: .*)?$/mu;
 
 /**
  * Render the complete file in one stable, machine-readable Markdown form.
@@ -33,6 +34,11 @@ export function parseLearningsFile(content: string): LearningEntry[] {
   if (estimateLearningTokens(content) > LEARNINGS_CONTRACT.maxTokens) {
     throw new Error(
       `Project learnings payload exceeds maxTokens ${LEARNINGS_CONTRACT.maxTokens}`
+    );
+  }
+  if (CONFLICT_MARKER_PATTERN.test(content)) {
+    throw new Error(
+      "Project learnings ledger corrupted by concurrent write: embedded conflict markers found; restore or recompact the ledger before writing"
     );
   }
   if (

--- a/src/core/learnings-writer.ts
+++ b/src/core/learnings-writer.ts
@@ -66,14 +66,74 @@ export async function persistConsolidatedLearning(
   const relativeFile = resolveProjectLearningsFile(config);
   const { root, target } = resolveSafeLearningTarget(projectRoot, relativeFile);
   // Fast budget fail on the lone entry before any directory is created.
-  buildNextDocument([], entry, []);
+  buildNextDocument([], entry, [], new Set());
   await assertSafeLearningParents(root, path.dirname(target));
   await fse.ensureDir(path.dirname(target));
+  return writeLearningEntriesAfterSafeParent(root, target, entry, supersede);
+}
+
+/**
+ * Snapshot any supersede targets after parent safety is proven, then write.
+ * @param root - Resolved project root
+ * @param target - Absolute learnings file path
+ * @param entry - New validated entry
+ * @param supersede - Ids of existing entries the new entry replaces
+ * @returns Absolute path to the persisted learnings file
+ */
+async function writeLearningEntriesAfterSafeParent(
+  root: string,
+  target: string,
+  entry: LearningEntry,
+  supersede: readonly string[]
+): Promise<string> {
+  if (supersede.length === 0) {
+    return writeLearningEntriesWithLock(
+      root,
+      target,
+      entry,
+      supersede,
+      new Set()
+    );
+  }
+  const preLockSupersedeIds = await readSupersedeIdsPresentBeforeLock(
+    target,
+    supersede
+  );
+  return writeLearningEntriesWithLock(
+    root,
+    target,
+    entry,
+    supersede,
+    preLockSupersedeIds
+  );
+}
+
+/**
+ * Perform the locked read-validate-write transaction for a learnings update.
+ * @param root - Resolved project root
+ * @param target - Absolute learnings file path
+ * @param entry - New validated entry
+ * @param supersede - Ids of existing entries the new entry replaces
+ * @param preLockSupersedeIds - Supersede ids observed before lock acquisition
+ * @returns Absolute path to the persisted learnings file
+ */
+function writeLearningEntriesWithLock(
+  root: string,
+  target: string,
+  entry: LearningEntry,
+  supersede: readonly string[],
+  preLockSupersedeIds: ReadonlySet<string>
+): Promise<string> {
   return withLearningTargetLock(target, async () => {
     await assertSafeLearningParents(root, path.dirname(target));
     const existing = await readExistingLearnings(target);
     const entries = existing === undefined ? [] : parseLearningsFile(existing);
-    const rendered = buildNextDocument(entries, entry, supersede);
+    const rendered = buildNextDocument(
+      entries,
+      entry,
+      supersede,
+      preLockSupersedeIds
+    );
     const temporary = path.join(
       path.dirname(target),
       `.${path.basename(target)}.${process.pid}.${crypto.randomUUID()}.tmp`
@@ -205,19 +265,22 @@ function renderConfirmedDocument(entries: readonly LearningEntry[]): string {
  * @param entries - Existing validated entries
  * @param entry - New validated entry
  * @param supersede - Ids of existing entries the new entry replaces
+ * @param preLockSupersedeIds - Supersede ids observed before lock acquisition
  * @returns Next canonical document
  */
 function buildNextDocument(
   entries: readonly LearningEntry[],
   entry: LearningEntry,
-  supersede: readonly string[]
+  supersede: readonly string[],
+  preLockSupersedeIds: ReadonlySet<string>
 ): string {
   const missing = supersede.filter(
     id => !entries.some(current => current.id === id)
   );
-  if (missing.length > 0) {
+  const unknown = missing.filter(id => !preLockSupersedeIds.has(id));
+  if (unknown.length > 0) {
     throw new Error(
-      `Cannot supersede unknown learning id(s): ${missing.join(", ")}`
+      `Cannot supersede unknown learning id(s): ${unknown.join(", ")}`
     );
   }
   const supersededIds = new Set(supersede);
@@ -231,6 +294,29 @@ function buildNextDocument(
   const rendered = renderLearningsFile(nextEntries);
   assertDocumentBudget(rendered, nextEntries.length, "Learnings file");
   return rendered;
+}
+
+/**
+ * Snapshot supersede ids that existed before waiting on the writer lock. When a
+ * concurrent writer removes one of those ids first, the later writer should
+ * still preserve its candidate instead of dropping the learning as stale.
+ * @param target - Resolved learnings file path
+ * @param supersede - Validated supersede ids requested by the caller
+ * @returns Supersede ids observed in the file before lock acquisition
+ */
+async function readSupersedeIdsPresentBeforeLock(
+  target: string,
+  supersede: readonly string[]
+): Promise<ReadonlySet<string>> {
+  if (supersede.length === 0) {
+    return new Set();
+  }
+  const existing = await readExistingLearnings(target);
+  if (existing === undefined) {
+    return new Set();
+  }
+  const existingIds = new Set(parseLearningsFile(existing).map(({ id }) => id));
+  return new Set(supersede.filter(id => existingIds.has(id)));
 }
 
 /**

--- a/tests/unit/core/learnings-budget-check.test.ts
+++ b/tests/unit/core/learnings-budget-check.test.ts
@@ -119,6 +119,24 @@ describe("checkLearningsBudget", () => {
     }
   });
 
+  it("returns a clear corruption violation for embedded conflict markers", async () => {
+    const fixture = writeFixture(
+      "conflicted.md",
+      renderLearningsFile([createEntry("conflicted-entry")]).replace(
+        '"rule":"r"',
+        '<<<<<<< HEAD\n"rule":"r"\n=======\n"rule":"other"\n>>>>>>> branch'
+      )
+    );
+
+    const result = await checkLearningsBudget(fixture);
+
+    expect(result.kind).toBe("violation");
+    if (result.kind === "violation") {
+      expect(result.detail).toMatch(/corrupted by concurrent write/i);
+      expect(result.detail).toMatch(/conflict markers/i);
+    }
+  });
+
   it("returns a violation for a non-regular file without blocking", async () => {
     const directory = createTemporaryDirectory();
 

--- a/tests/unit/core/learnings-concurrency.test.ts
+++ b/tests/unit/core/learnings-concurrency.test.ts
@@ -1,7 +1,7 @@
 /** Cross-process contention regression tests for the learnings writer. */
 import * as fs from "fs-extra";
 import { execFile } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { readFile, unlink, writeFile } from "node:fs/promises";
 import * as path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -21,6 +21,17 @@ if (projectRoot === undefined || serializedEntry === undefined) {
   throw new Error("Missing cross-process writer input");
 }
 await persistLearningEntry(projectRoot, JSON.parse(serializedEntry));
+`;
+const CROSS_PROCESS_CONSOLIDATING_WRITER = `
+import { persistConsolidatedLearning } from "./src/core/learnings-writer.ts";
+const projectRoot = process.env.LEARNINGS_PROJECT_ROOT;
+const serializedEntry = process.env.LEARNINGS_ENTRY_JSON;
+if (projectRoot === undefined || serializedEntry === undefined) {
+  throw new Error("Missing cross-process writer input");
+}
+await persistConsolidatedLearning(projectRoot, JSON.parse(serializedEntry), {
+  supersede: ["learning-base"],
+});
 `;
 
 /**
@@ -78,5 +89,63 @@ describe("learnings writer cross-process concurrency", () => {
     expect(persisted.map(entry => entry.id)).toEqual(
       entries.map(entry => entry.id)
     );
+  });
+
+  it("preserves concurrent supersede candidates when the shared target was already consumed", async () => {
+    const projectRoot = path.join(tempDir, "cross-process-supersede");
+    await fs.ensureDir(projectRoot);
+    await execFileAsync("bun", ["--eval", CROSS_PROCESS_WRITER], {
+      cwd: path.resolve("."),
+      env: {
+        ...process.env,
+        LEARNINGS_PROJECT_ROOT: projectRoot,
+        LEARNINGS_ENTRY_JSON: JSON.stringify({
+          ...numberedEntry(0),
+          id: "learning-base",
+        }),
+      },
+    });
+    const lockPath = path.join(
+      projectRoot,
+      ".lisa",
+      `${LEARNINGS_FILENAME}.lock`
+    );
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        token: "test-barrier",
+        pid: process.pid,
+        createdAt: Date.now(),
+      }),
+      "utf8"
+    );
+    const replacements = Array.from({ length: 2 }, (_unused, index) => ({
+      ...numberedEntry(index + 1),
+      id: `learning-consolidated-${index + 1}`,
+      rule: `Consolidated rule ${index + 1}.`,
+    }));
+    const writers = replacements.map(entry =>
+      execFileAsync("bun", ["--eval", CROSS_PROCESS_CONSOLIDATING_WRITER], {
+        cwd: path.resolve("."),
+        env: {
+          ...process.env,
+          LEARNINGS_PROJECT_ROOT: projectRoot,
+          LEARNINGS_ENTRY_JSON: JSON.stringify(entry),
+        },
+      })
+    );
+    await new Promise(resolve => setTimeout(resolve, 100));
+    await unlink(lockPath);
+    await Promise.all(writers);
+    const persisted = parseLearningsFile(
+      await readFile(
+        path.join(projectRoot, ".lisa", LEARNINGS_FILENAME),
+        "utf8"
+      )
+    );
+    expect(persisted.map(entry => entry.id)).toEqual([
+      "learning-consolidated-1",
+      "learning-consolidated-2",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- preserve concurrent `persistConsolidatedLearning` candidates when another writer already consumed the observed supersede target
- report embedded conflict markers as explicit learnings-ledger corruption instead of a generic parse failure
- add deterministic cross-process supersede and conflict-marker regressions

## Verification
- `bun test tests/unit/core/learnings-concurrency.test.ts tests/unit/core/learnings-consolidation.test.ts tests/unit/core/learnings-budget-check.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build:dist`
- pre-push: security audit, slow lint, knip, full unit coverage, integration tests, plugin parity

Closes #1995

Work-Item: CodySwannGT/lisa#1995
