### PR TITLE
feat(ci): add the server-side work-item traceability gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- What changed and why. Write it for a non-technical reader. -->
+
+## Work item
+
+<!--
+Required. The Work-Item Traceability check reads this line and compares it to
+the Work-Item trailer on every branch-authored commit — they must match, and
+the referenced issue must be open and claimed (status:in-progress). Replace the
+placeholder below; exactly one Work-Item line may appear in this body.
+
+Format: owner/repo#123 (for example CodySwannGT/lisa#1978).
+-->
+
+Work-Item: CodySwannGT/lisa#0
+
+## Verification
+
+<!-- How you proved this works: commands run, output observed, tests added. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,111 @@ jobs:
       package_manager: 'bun'
       skip_jobs: ''
     secrets: inherit
+  # -----------------------------------------------------------------------------
+  # Server-side backstop for work-item traceability (#1978)
+  # -----------------------------------------------------------------------------
+  # The pre-push `validate-push` gate is client-side and fail-safe: since #1956
+  # it subtracts commits reachable from the remote default branch so a
+  # merge-sync does not drag the base branch's history into validation. #1956's
+  # security review proved that exclusion is locally bypassable — an agent owns
+  # its `.git`, so it can `update-ref refs/remotes/origin/<anything> <branch-tip>`
+  # and repoint the `refs/remotes/origin/HEAD` symref at it, which empties the
+  # branch-authored range and launders commits carrying a missing, mixed, or
+  # closed-issue Work-Item trailer past the hook.
+  #
+  # `validate-pr` is the designed backstop: it recomputes `rev-list base..head`
+  # from SHAs supplied by the GitHub event payload, with no exclusion logic and
+  # without ever reading a symref, so nothing in the pusher's repository can
+  # shrink the range. Impact of the bypass is bounded to traceability integrity
+  # (wrong/closed-issue attribution), not code execution — this job closes it
+  # anyway, because a client-side-only gate is not a gate.
+  #
+  # The gate fails safe by construction: an EMPTY range is a failure, not a
+  # pass. `validatePrData` throws "Pull request has no non-merge commit linked
+  # to a work item" when nothing survives, so the #1956 outcome that slips past
+  # the pre-push hook (range emptied to zero commits) is exactly the outcome
+  # that reddens here. There is no way to widen an exclusion into a green run.
+  #
+  # Not airtight, and deliberately so: this job inherits the validator's
+  # exemptions, so merge commits and `chore(release): x.y.z [skip ci]` subjects
+  # skip work-item validation entirely. It proves branch-authored commits are
+  # traceable — it does not prove every commit in the range was inspected.
+  work_item_traceability:
+    name: 🔗 Work-Item Traceability
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Only meaningful on pull_request: the range and the PR number both come
+    # from the event payload. workflow_dispatch runs report success.
+    if: ${{ github.event_name == 'pull_request' }}
+    # `gh pr view` needs pull-requests:read and `gh issue view` needs
+    # issues:read. The validator writes nothing — never grant more.
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # `rev-list base..head` needs both endpoints and everything between
+          # them. A shallow clone would make the range error out or silently
+          # under-report, which would void the gate. fetch-depth: 0 also brings
+          # every branch down as refs/remotes/origin/*, which the next step uses.
+          fetch-depth: 0
+          persist-credentials: false
+          # Check out the PR head itself, not the default synthetic
+          # refs/pull/N/merge: that ref does not exist while the PR has
+          # conflicts, and it can lag head.sha immediately after a push. Either
+          # would redden this job for a reason unrelated to traceability.
+          # Base resolution is unaffected — fetch-depth: 0 still fetches
+          # refs/remotes/origin/<base.ref> regardless of which ref is checked out.
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          # Read the pin from the canonical manifest (engines.node) rather than
+          # duplicating the literal — see the Duplicate Versions workflow.
+          node-version-file: 'package.json'
+
+      - name: 🔗 Resolve the branch-authored commit range
+        id: range
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Default to the payload's base.sha. Prefer the base branch's CURRENT
+          # tip when it descends from it: a PR that merge-synced the base branch
+          # carries the base's own commits (whose trailers reference other, often
+          # closed, work items) inside base.sha..head, and those are not
+          # branch-authored. Starting the range at the tip drops them by plain
+          # set subtraction — no exclusion logic, nothing for a pusher to steer.
+          # The tip is whatever CI fetched from GitHub, NOT the agent-repointable
+          # local origin/HEAD symref that #1956's bypass abused.
+          base="$PR_BASE_SHA"
+          tip="$(git rev-parse -q --verify "refs/remotes/origin/${PR_BASE_REF}" || true)"
+          # The ancestry check keeps this monotonic: if the base branch was
+          # rewritten or the ref is missing, fall back to base.sha rather than
+          # widening the exclusion to an unrelated history.
+          if [ -n "$tip" ] && git merge-base --is-ancestor "$base" "$tip"; then
+            base="$tip"
+          fi
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+          echo "Validating ${base}..${PR_HEAD_SHA}"
+
+      - name: 🔗 Validate Work-Item traceability
+        # Env-var form (equivalent to --base/--head/--pr-number) keeps event
+        # payload values out of the shell command entirely.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LISA_PR_BASE_SHA: ${{ steps.range.outputs.base }}
+          LISA_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          LISA_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/lisa-work-item.mjs validate-pr
+
   bin_smoke:
     name: Lisa CLI bin smoke
     runs-on: ubuntu-latest

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2160,6 +2160,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     ".entire/settings.json": true,
     ".github/GITHUB_ACTIONS.md": true,
     ".github/dependabot.yml": true,
+    ".github/pull_request_template.md": true,
     ".github/workflows/auto-update-pr-branches-dispatch.yml": true,
     ".github/workflows/auto-update-pr-branches.yml": true,
     ".github/workflows/build.yml": true,

--- a/tests/unit/hooks/work-item-wiring.test.ts
+++ b/tests/unit/hooks/work-item-wiring.test.ts
@@ -1,9 +1,77 @@
-import { readFileSync, statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { load as loadYaml } from "js-yaml";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { cleanGitEnv } from "../../helpers/test-utils.js";
 
 const read = (file: string): string => readFileSync(path.resolve(file), "utf8");
+
+// Absolute interpreter paths: a PATH-relative name would let a writable PATH
+// entry shadow the binary these tests depend on.
+const BASH = "/bin/bash";
+const GIT = "/usr/bin/git";
+
+/** Disposable repositories created by the CI-range cases, removed after them. */
+const roots: string[] = [];
+
+/**
+ * Run Git inside a disposable repository, throwing on failure.
+ *
+ * GIT_DIR / GIT_WORK_TREE leak in when this suite runs under a git hook and
+ * would retarget every command at the real repository, so they are stripped.
+ * @param root - Repository directory
+ * @param args - Git arguments
+ * @returns Trimmed stdout
+ */
+function runGit(root: string, args: string[]): string {
+  const result = spawnSync(GIT, args, {
+    cwd: root,
+    encoding: "utf8",
+    env: cleanGitEnv(process.env, {
+      GIT_AUTHOR_EMAIL: "lisa@example.test",
+      GIT_AUTHOR_NAME: "Lisa Test",
+      GIT_COMMITTER_EMAIL: "lisa@example.test",
+      GIT_COMMITTER_NAME: "Lisa Test",
+    }),
+  });
+  if (result.status !== 0)
+    throw new Error(result.stderr || `git ${args.join(" ")} failed`);
+  return result.stdout.trim();
+}
+
+/**
+ * Give a fresh repository three `main` commits and a `feature` branch forked
+ * two commits back.
+ * @param root - Repository directory
+ */
+function seedRepository(root: string): void {
+  runGit(root, ["init", "-q", "-b", "main"]);
+  for (const subject of ["base one", "base two", "base three"])
+    runGit(root, ["commit", "-q", "--allow-empty", "-m", subject]);
+  runGit(root, ["switch", "-q", "-c", "feature", "main~2"]);
+  runGit(root, ["commit", "-q", "--allow-empty", "-m", "branch work"]);
+}
+
+/** Minimal shape of the pieces of `ci.yml` this suite asserts on. */
+interface CiWorkflow {
+  readonly jobs?: Record<
+    string,
+    {
+      readonly if?: string;
+      readonly permissions?: Record<string, string>;
+      readonly steps?: {
+        readonly env?: Record<string, string>;
+        readonly run?: string;
+        readonly uses?: string;
+        readonly with?: Record<string, unknown>;
+      }[];
+    }
+  >;
+}
 
 describe("work-item Git enforcement wiring", () => {
   it.each([".husky", "typescript/copy-contents/.husky"])(
@@ -46,6 +114,183 @@ describe("work-item Git enforcement wiring", () => {
     }
     expect(installed).toContain("WORK_ITEM_TRACKING_OK");
     expect(installed).not.toContain("await main()");
+  });
+
+  /**
+   * #1978: the pre-push `validate-push` gate is client-side and fail-safe, and
+   * #1956's security review proved a local bypass — an agent repoints
+   * `refs/remotes/origin/HEAD` at a crafted tracking ref and the default-branch
+   * exclusion empties the branch-authored range. `validate-pr` recomputes
+   * `rev-list base..head` server-side with no exclusion and no symref, so it is
+   * the designed backstop; it only backstops anything if CI actually runs it.
+   */
+  describe("server-side validate-pr backstop in Lisa's own CI (#1978)", () => {
+    const ci = loadYaml(read(".github/workflows/ci.yml")) as CiWorkflow;
+    const job = ci.jobs?.["work_item_traceability"];
+    const steps = job?.steps ?? [];
+
+    it("runs validate-pr on pull requests only", () => {
+      expect(job).toBeDefined();
+      expect(job?.if).toContain("github.event_name == 'pull_request'");
+      expect(
+        steps.some(step =>
+          step.run?.includes("scripts/lisa-work-item.mjs validate-pr")
+        )
+      ).toBe(true);
+    });
+
+    it("checks out enough history for rev-list base..head to resolve", () => {
+      const checkout = steps.find(step => step.uses?.startsWith("actions/"));
+      expect(checkout?.uses).toContain("actions/checkout");
+      // A shallow clone cannot resolve `base..head`; the range would either
+      // error or silently under-report, voiding the gate.
+      expect(checkout?.with?.["fetch-depth"]).toBe(0);
+    });
+
+    it("checks out the PR head, not the synthetic merge ref", () => {
+      const checkout = steps.find(step => step.uses?.startsWith("actions/"));
+      // refs/pull/N/merge does not exist while the PR has conflicts and can lag
+      // head.sha right after a push — both would redden this job for reasons
+      // that have nothing to do with work-item traceability.
+      expect(checkout?.with?.["ref"]).toContain(
+        "github.event.pull_request.head.sha"
+      );
+    });
+
+    it("ships a PR template carrying the Work-Item line the validator demands", () => {
+      // `prWorkItem` requires EXACTLY ONE `Work-Item:` line in the PR body, and
+      // nothing else makes one appear — lisa-git-submit-pr never emits it. A
+      // template with zero or two lines fails every PR.
+      const template = read(".github/pull_request_template.md");
+      const lines = template
+        .split(/\r?\n/u)
+        .filter(line => /^Work-Item:\s*\S/u.test(line));
+
+      expect(lines).toHaveLength(1);
+    });
+
+    it("passes the server-supplied range and PR number through the env-var form", () => {
+      const validate = steps.find(step =>
+        step.run?.includes("scripts/lisa-work-item.mjs validate-pr")
+      );
+      // Env-var form (not shell-interpolated argv) keeps event payload values
+      // out of the `run:` string entirely.
+      expect(validate?.env?.["LISA_PR_BASE_SHA"]).toBeTruthy();
+      expect(validate?.env?.["LISA_PR_HEAD_SHA"]).toContain(
+        "github.event.pull_request.head.sha"
+      );
+      expect(validate?.env?.["LISA_PR_NUMBER"]).toContain(
+        "github.event.pull_request.number"
+      );
+      expect(validate?.env?.["GH_TOKEN"]).toBeTruthy();
+    });
+
+    /**
+     * The base-resolution step is shell embedded in YAML, so it would
+     * otherwise ship unexercised. These cases run the workflow's OWN `run:`
+     * block — read straight out of ci.yml — against disposable repositories.
+     */
+    describe("base resolution shell", () => {
+      const script =
+        steps.find(step => step.run?.includes("refs/remotes/origin/"))?.run ??
+        "";
+
+      afterAll(() => {
+        for (const root of roots)
+          rmSync(root, { force: true, recursive: true });
+      });
+
+      /**
+       * Create a repository with `main` at three commits and a `feature`
+       * branch forked two commits back — the shape of a PR whose base branch
+       * advanced after the PR opened.
+       * @returns The repository path and the SHAs the step reasons about
+       */
+      function scenario(): {
+        base: string;
+        head: string;
+        root: string;
+        tip: string;
+      } {
+        const root = mkdtempSync(path.join(tmpdir(), "lisa-ci-range-"));
+        roots.push(root);
+        seedRepository(root);
+        return {
+          base: runGit(root, ["rev-parse", "main~2"]),
+          head: runGit(root, ["rev-parse", "feature"]),
+          root,
+          tip: runGit(root, ["rev-parse", "main"]),
+        };
+      }
+
+      /**
+       * Execute the workflow's own base-resolution block and read what it
+       * exported.
+       * @param options - Repository path plus the env the step receives
+       * @param options.baseRef - `github.event.pull_request.base.ref`
+       * @param options.baseSha - `github.event.pull_request.base.sha`
+       * @param options.root - Repository the step runs in
+       * @returns The `base=` value written to `GITHUB_OUTPUT`
+       */
+      function resolveBase(options: {
+        baseRef: string;
+        baseSha: string;
+        root: string;
+      }): string {
+        const outputFile = path.join(options.root, "github-output");
+        const result = spawnSync(BASH, ["-c", script], {
+          cwd: options.root,
+          encoding: "utf8",
+          env: cleanGitEnv(process.env, {
+            GITHUB_OUTPUT: outputFile,
+            PR_BASE_REF: options.baseRef,
+            PR_BASE_SHA: options.baseSha,
+            PR_HEAD_SHA: "0".repeat(40),
+          }),
+        });
+        expect(result.stderr).toBe("");
+        expect(result.status).toBe(0);
+        return (/^base=(.+)$/mu.exec(readFileSync(outputFile, "utf8")) ??
+          [])[1] as string;
+      }
+
+      it("advances to the base-branch tip so merge-synced base commits leave the range", () => {
+        const { base, root, tip } = scenario();
+        // origin/main sits ahead of the payload's base.sha, exactly as it does
+        // on a PR whose base advanced and was then merge-synced in.
+        runGit(root, ["update-ref", "refs/remotes/origin/main", tip]);
+
+        expect(resolveBase({ baseRef: "main", baseSha: base, root })).toBe(tip);
+      });
+
+      it("keeps base.sha when the base branch was not fetched", () => {
+        const { base, root } = scenario();
+
+        expect(resolveBase({ baseRef: "main", baseSha: base, root })).toBe(
+          base
+        );
+      });
+
+      it("keeps base.sha when the tracked tip is not a descendant", () => {
+        const { root, tip } = scenario();
+        // Base branch rewound behind the payload's base.sha. A rewritten or
+        // unrelated base must never widen the exclusion — emptying the range is
+        // precisely the #1956 failure mode this job exists to catch.
+        runGit(root, ["update-ref", "refs/remotes/origin/main", `${tip}~1`]);
+
+        expect(resolveBase({ baseRef: "main", baseSha: tip, root })).toBe(tip);
+      });
+    });
+
+    it("grants the tracker reads the validator performs, and nothing more", () => {
+      // `gh pr view` needs pull-requests:read and `gh issue view` needs
+      // issues:read; the job writes nothing anywhere.
+      expect(job?.permissions).toEqual({
+        contents: "read",
+        issues: "read",
+        "pull-requests": "read",
+      });
+    });
   });
 
   it("gives Rails the same gates and a single stdin consumer", () => {

--- a/tests/unit/scripts/lisa-work-item.test.ts
+++ b/tests/unit/scripts/lisa-work-item.test.ts
@@ -297,6 +297,75 @@ function setOriginHead(fixture: Fixture): void {
   );
 }
 
+/**
+ * Reproduce finding F1 of #1956's security review: an agent with local repo
+ * control creates a tracking ref that already contains the branch tip and
+ * repoints `refs/remotes/origin/HEAD` at it. The guard's own checks still pass
+ * (the target is under `refs/remotes/origin/` and resolves), so `validate-push`
+ * subtracts the whole branch and the pushed range comes back EMPTY.
+ * @param fixture - Disposable repository
+ * @param tip - Commit the crafted "default branch" is made to contain
+ */
+function launderPushRange(fixture: Fixture, tip: string): void {
+  git(
+    fixture.root,
+    ["update-ref", "refs/remotes/origin/attacker", tip],
+    fixture.env
+  );
+  git(
+    fixture.root,
+    [
+      "symbolic-ref",
+      "refs/remotes/origin/HEAD",
+      "refs/remotes/origin/attacker",
+    ],
+    fixture.env
+  );
+}
+
+/** Seed a bound branch whose base is already published as origin/main. */
+function publishedBase(fixture: Fixture): string {
+  const base = git(fixture.root, ["rev-parse", "main"], fixture.env);
+  git(
+    fixture.root,
+    ["update-ref", "refs/remotes/origin/main", base],
+    fixture.env
+  );
+  if (command(fixture, ["bind", "acme/widgets#42"]).status !== 0)
+    throw new Error("expected the bind to succeed");
+  return base;
+}
+
+/** Run `validate-push` for an existing-branch push of base..head. */
+function pushRange(
+  fixture: Fixture,
+  base: string,
+  head: string,
+  env: NodeJS.ProcessEnv = {}
+): CommandResult {
+  return command(fixture, ["validate-push", "origin"], {
+    env: { FAKE_GH_PR_MISSING: "1", ...env },
+    input: `refs/heads/feature/tracked ${head} refs/heads/feature/tracked ${base}\n`,
+  });
+}
+
+/** Run `validate-pr` the way Lisa's CI job does — env-var form, numbered PR. */
+function prRange(
+  fixture: Fixture,
+  base: string,
+  head: string,
+  env: NodeJS.ProcessEnv = {}
+): CommandResult {
+  return command(fixture, ["validate-pr"], {
+    env: {
+      LISA_PR_BASE_SHA: base,
+      LISA_PR_HEAD_SHA: head,
+      LISA_PR_NUMBER: "7",
+      ...env,
+    },
+  });
+}
+
 describe("work-item binding and commit messages", () => {
   it("merges local config, writes worktree-private state atomically, and preserves the subject", () => {
     const fixture = createFixture(githubConfig("identity"));
@@ -1099,5 +1168,145 @@ describe("merge lane (#1956 R2): push-range base-branch exemption", () => {
     });
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("Mention the ticket");
+  });
+});
+
+/**
+ * #1978: `validate-push` is a client-side, fail-safe gate and #1956's security
+ * review (finding F1) proved an agent can launder branch-authored commits past
+ * it by repointing `refs/remotes/origin/HEAD`. `validate-pr` is the designed
+ * server-side backstop: it recomputes `rev-list base..head` with no exclusion
+ * and never reads a symref, so the launder cannot survive it. Each case here
+ * asserts BOTH halves of that claim on the same repository state — the push
+ * gate is laundered, the PR gate still fails.
+ */
+describe("server-side backstop (#1978): validate-pr defeats the #1956 symref launder", () => {
+  const CLOSED_ISSUE =
+    '{"number":42,"state":"CLOSED","labels":[{"name":"status:in-progress"},{"name":"type:Bug"}],"comments":[],"closedByPullRequestsReferences":[]}';
+
+  it("catches a branch-authored commit with no Work-Item trailer", () => {
+    const fixture = createFixture();
+    const base = publishedBase(fixture);
+    const head = commit(fixture, "feat: untracked change");
+    launderPushRange(fixture, head);
+
+    const pushed = pushRange(fixture, base, head);
+    expect(pushed.status).toBe(0);
+    expect(pushed.stdout).toContain("WORK_ITEM_TRACKING_OK 0 commit(s)");
+
+    const validated = prRange(fixture, base, head);
+    expect(validated.status).toBe(1);
+    expect(validated.stderr).toContain("Mention the ticket");
+  });
+
+  it("catches a branch-authored commit referencing a closed work item", () => {
+    const fixture = createFixture();
+    const base = publishedBase(fixture);
+    const head = commit(
+      fixture,
+      "feat: branch work\n\nWork-Item: acme/widgets#42"
+    );
+    launderPushRange(fixture, head);
+
+    const pushed = pushRange(fixture, base, head, {
+      FAKE_GH_ISSUE_JSON: CLOSED_ISSUE,
+    });
+    expect(pushed.status).toBe(0);
+    expect(pushed.stdout).toContain("WORK_ITEM_TRACKING_OK 0 commit(s)");
+
+    const validated = prRange(fixture, base, head, {
+      FAKE_GH_ISSUE_JSON: CLOSED_ISSUE,
+    });
+    expect(validated.status).toBe(1);
+    expect(validated.stderr).toContain("is closed");
+  });
+
+  it("catches mixed branch-authored Work-Item references", () => {
+    const fixture = createFixture();
+    const base = publishedBase(fixture);
+    commit(fixture, "feat: first ticket\n\nWork-Item: acme/widgets#42");
+    const head = commit(
+      fixture,
+      "fix: second ticket\n\nWork-Item: acme/widgets#43"
+    );
+    launderPushRange(fixture, head);
+
+    const pushed = pushRange(fixture, base, head);
+    expect(pushed.status).toBe(0);
+    expect(pushed.stdout).toContain("WORK_ITEM_TRACKING_OK 0 commit(s)");
+
+    const validated = prRange(fixture, base, head);
+    expect(validated.status).toBe(1);
+    expect(validated.stderr).toContain("mixed Work-Item references");
+  });
+
+  it("ignores a crafted origin/HEAD symref even when it is present in CI", () => {
+    const fixture = createFixture();
+    const base = publishedBase(fixture);
+    const head = commit(fixture, "feat: untracked change");
+    // Belt and braces: the symref lands in the checkout AND names the head.
+    // validate-pr must not consult it at all.
+    launderPushRange(fixture, head);
+    setOriginHead(fixture);
+    launderPushRange(fixture, head);
+
+    const validated = prRange(fixture, base, head);
+    expect(validated.status).toBe(1);
+    expect(validated.stderr).toContain("Mention the ticket");
+  });
+});
+
+/**
+ * The other half of #1978's acceptance criteria: the backstop must not punish
+ * legitimate work. A merge-synced PR carries foreign base commits (whose
+ * trailers reference other, often closed, work items) inside the branch, and
+ * they must stay out of the validated range — not through exclusion logic, but
+ * because the range starts at the CURRENT base-branch tip.
+ */
+describe("server-side backstop (#1978): merge-synced pull requests still pass", () => {
+  const PR_URL = "https://github.com/acme/code/pull/7";
+  const BACKLINKED_ISSUE = JSON.stringify({
+    number: 42,
+    state: "OPEN",
+    labels: [{ name: "status:in-progress" }, { name: "type:Bug" }],
+    comments: [{ body: `[lisa-pr-link] ${PR_URL}` }],
+    closedByPullRequestsReferences: [],
+  });
+
+  it("validates only branch-authored commits when the base tip is the range start", () => {
+    const fixture = createFixture();
+    const { head } = setupMergeLane(fixture);
+    const baseTip = git(
+      fixture.root,
+      ["rev-parse", "refs/remotes/origin/main"],
+      fixture.env
+    );
+
+    const validated = prRange(fixture, baseTip, head, {
+      FAKE_GH_ISSUE_JSON: BACKLINKED_ISSUE,
+    });
+    expect(validated.stderr).toBe("");
+    expect(validated.status).toBe(0);
+    // The merge commit is exempt; the two #42 commits are the branch's work.
+    expect(validated.stdout).toContain("WORK_ITEM_TRACKING_OK 2 commit(s)");
+  });
+
+  it("would fail against a stale pre-merge base, which is why CI resolves the base-branch tip", () => {
+    const fixture = createFixture();
+    const { head } = setupMergeLane(fixture);
+    const staleBase = git(
+      fixture.root,
+      ["rev-parse", "refs/remotes/origin/main^"],
+      fixture.env
+    );
+
+    // Documents the trap the CI job's base resolution exists to avoid: from a
+    // base predating the merge-sync, the foreign commit is inside base..head,
+    // so the gate blocks this branch over someone else's already-closed item.
+    const validated = prRange(fixture, staleBase, head, {
+      FAKE_GH_ISSUE_JSON: BACKLINKED_ISSUE,
+    });
+    expect(validated.status).toBe(1);
+    expect(validated.stderr).toContain("acme/widgets#99 is closed");
   });
 });


### PR DESCRIPTION
## Summary

Closes #1978.

#1956's push-range exclusion is deliberately client-side and fail-safe, and its security review confirmed a local bypass: repointing the remote-HEAD symref at a crafted tracking ref empties branch-authored commits out of the validated range. The designed backstop is `validate-pr`, which recomputes the range server-side with no exclusion — but **no workflow ever invoked it**.

This adds a pull-request-only `work_item_traceability` job that does.

## Work item

Work-Item: CodySwannGT/lisa#1978

## The ticket's premise was wrong, and it matters

The security review stated that "downstream project templates get that CI gate". A repo-wide grep found that is **not true**: the only hits for `validate-pr` are the script, its tests, and the learnings ledger. **Zero workflow files** wire it — not this repo's, and not `all/`, `typescript/`, `expo/`, `nestjs/`, `cdk/`, `rails/`, `phaser/`, or `plugins/src/`. The bypass is unbacked **fleet-wide**, not just here.

This PR closes it for this repo only. The job deliberately went into `ci.yml` rather than the shared `quality.yml`, which is consumed fleet-wide from its default branch — a job there reaches ~27 repos immediately and calls a tracker, failing every downstream PR without a claimed work item and CI credentials. #2009 tracks shipping it to the fleet as an opt-in `work_item_enforced` input.

## The one judgment call: base resolution

The AC says to use the payload's `base.sha` literally. This job instead prefers the base branch's **current tip**, but only when that tip is a descendant of `base.sha`.

Reason: `base.sha` can lag a merge-sync. When it does, the base branch's own commits land inside the validated range and the gate fails the PR over someone else's work item — a live shape in this repo, not theoretical (current `main` literally contains `Merge branch 'main' into fix/…`). The test `would fail against a stale pre-merge base` pins that.

Why it cannot re-open the bypass:

- The `merge-base --is-ancestor` guard is true only when the tip moved **forward** along the same history, never sideways or backwards. Reviewer independently mutated the guard's argument order — two tests failed, so the direction is load-bearing.
- The tip is fetched **from GitHub inside CI**, not read from the agent-repointable local symref that #1956 abused.
- Most importantly, **an emptied range is a failure, not a pass** — `validatePrData` throws when nothing survives the range. Even a worst-case widening cannot produce a green check.
- If the base ref is absent, the range degrades to `base.sha`; if `base.sha` itself is gone, the job goes red. Fail-safe in both directions.

## Verification

Tests execute the workflow's **own base-resolution shell**, parsed out of `ci.yml`, against disposable git repositories — embedded workflow shell normally ships untested.

Each fixture asserts **both gates against the same repository state**, which is the proof the ticket asked for: the #1956 F1 reproducer (`update-ref` + `symbolic-ref` launder) passes the client-side gate with `WORK_ITEM_TRACKING_OK 0 commit(s)` while this gate fails it.

| Case | Client-side | This gate |
|---|---|---|
| Branch-authored commit with no Work-Item trailer | passes (laundered) | fails |
| Commit referencing a closed work item | passes (laundered) | fails |
| Mixed Work-Item references | passes (laundered) | fails |
| Crafted `origin/HEAD` symref present in CI | — | ignored, still fails |
| Legitimate merge-synced range | — | passes, `WORK_ITEM_TRACKING_OK 2 commit(s)` |

Mutation-checked: deleting the ancestry guard kills a test; reversing its arguments kills two. All git-shelling tests strip `GIT_*` (hook-set `GIT_DIR`/`GIT_WORK_TREE` otherwise poison temp repos and make them pass standalone but fail under pre-push).

Gates: full suite **7677 passing / 447 files**, lint 0/0, typecheck clean, `actionlint` exit 0.

## Also included

A **pull request template**. The validator requires a `Work-Item:` line in the PR description, and nothing emitted one — the last five merged PRs include two (#2006, #2007) that would have failed the new check. The template's placeholder must be edited to the real ref, or the gate fails on a mismatch against the commit trailers.

## Not done here — please read before enabling

1. **This is not yet a *required* check.** The AC says "required CI check". The job produces the context `🔗 Work-Item Traceability`, but required contexts live in repo settings (`scripts/lisa-github-rulesets.sh`), not in this diff. Recommend adding it only after one real PR proves the flow green end to end.
2. **The gate runs the PR's own copy of the validator.** On `pull_request` events GitHub takes both the workflow and the script from the head branch, so an agent with write access to its branch could edit the validator to pass. Not a regression — there is no backstop at all today — but it means this layer is thinner than it looks. The reusable-workflow form in #2009 fixes it structurally, since a workflow referenced at `@main` executes the base repo's copy.
3. **Base retargeting may not re-trigger.** `on: pull_request` uses the default activity types, which exclude `edited`. Worth confirming empirically when the context is added to the ruleset.
4. **Inherited exemptions.** Merge commits and `chore(release):` subjects skip validation entirely — pre-existing in the shared validator, now noted in the workflow comment so no reader concludes the gate is airtight.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standardized pull request template with required summary, work-item, and verification details.
  * Added automated pull request checks to validate work-item traceability and commit history.
  * Improved validation for merged, synchronized, and potentially manipulated pull request histories.

* **Tests**
  * Expanded coverage for traceability checks, base-branch resolution, permissions, and security scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->