### PR TITLE
fix: tolerate learnings snapshot replacement race

### DIFF
--- a/src/core/learnings-writer.ts
+++ b/src/core/learnings-writer.ts
@@ -311,12 +311,40 @@ async function readSupersedeIdsPresentBeforeLock(
   if (supersede.length === 0) {
     return new Set();
   }
-  const existing = await readExistingLearnings(target);
+  const existing = await readSupersedeSnapshot(target);
   if (existing === undefined) {
     return new Set();
   }
+  if (existing === "changed-during-open") {
+    return new Set(supersede);
+  }
   const existingIds = new Set(parseLearningsFile(existing).map(({ id }) => id));
   return new Set(supersede.filter(id => existingIds.has(id)));
+}
+
+/**
+ * Read the advisory pre-lock supersede snapshot. If another writer swaps the
+ * file during this best-effort read, treat the requested supersede ids as
+ * plausibly observed so the later locked write preserves the candidate.
+ * @param target - Resolved learnings file path
+ * @returns Existing file content, a sentinel for indeterminate content, or
+ * undefined when the file does not exist
+ */
+async function readSupersedeSnapshot(
+  target: string
+): Promise<string | "changed-during-open" | undefined> {
+  try {
+    return await readExistingLearnings(target);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message ===
+        "Unsafe project learnings path: target changed during open"
+    ) {
+      return "changed-during-open";
+    }
+    throw error;
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #1995.

This follow-up handles the hosted CI race found after PR #2008 merged: if the advisory pre-lock supersede snapshot sees the learnings file replaced during open, it treats the requested supersede ids as plausibly observed so the later locked write preserves the candidate instead of failing before lock acquisition.

Verification:
- bun test tests/unit/core/learnings-concurrency.test.ts
- bun test tests/unit/core/learnings-consolidation.test.ts
- 30 repeated focused concurrency runs
- bun run typecheck
- bun run lint
- bun run test:unit
- pre-push: security audit, slow lint, knip, full coverage, integration tests, plugin parity

Work-Item: #1995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when learning data changes while being opened.
  * Preserves intended supersede operations instead of failing when the current state cannot be determined safely.
  * Continues to apply supersede changes only to entries confirmed to exist when a reliable snapshot is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->