### PR TITLE
fix(safety-net): close the residual heredoc-classifier lexer divergences

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -115,6 +115,7 @@
     "handlebars": ">=4.7.9",
     "lodash": ">=4.18.1",
     "multer": ">=2.2.0",
+    "postcss": ">=8.5.12",
     "undici": ">=6.27.0",
     "vite": "^8.0.16",
     "ws": ">=8.21.0",
@@ -2212,8 +2213,6 @@
 
     "eslint-plugin-sonarjs/ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
-    "eslint-plugin-tailwindcss/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
-
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
@@ -2348,8 +2347,6 @@
 
     "tailwindcss/jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
 
-    "tailwindcss/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
-
     "tailwindcss/resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
     "test-exclude/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
@@ -2420,8 +2417,6 @@
 
     "eslint-plugin-jsdoc/espree/eslint-visitor-keys": ["eslint-visitor-keys@5.0.0", "", {}, "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q=="],
 
-    "eslint-plugin-tailwindcss/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
     "find-cache-dir/make-dir/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
     "find-cache-dir/pkg-dir/find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
@@ -2463,8 +2458,6 @@
     "standard-version/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "sucrase/tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
-
-    "tailwindcss/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "vite": "$vite",
     "ws": ">=8.21.0",
     "multer": ">=2.2.0",
+    "postcss": ">=8.5.12",
     "undici": ">=6.27.0",
     "form-data": ">=4.0.6",
     "brace-expansion": ">=5.0.6"
@@ -108,6 +109,7 @@
     "vite": "$vite",
     "ws": ">=8.21.0",
     "multer": ">=2.2.0",
+    "postcss": ">=8.5.12",
     "undici": ">=6.27.0",
     "form-data": ">=4.0.6",
     "brace-expansion": ">=5.0.6"

--- a/plugins/lisa-agy/hooks/parity-safety-net-heredoc.py
+++ b/plugins/lisa-agy/hooks/parity-safety-net-heredoc.py
@@ -1,5 +1,64 @@
 #!/usr/bin/env python3
-"""Classify the only heredoc forms whose payload is non-executable text."""
+"""Classify the only heredoc forms whose payload is non-executable text.
+
+SCOPE — read this before hardening anything here (issue #1993).
+
+This module is a HEURISTIC RE-IMPLEMENTATION of bash's here-doc lexing, not an
+adversary-resistant control. Every divergence between this Python model and real
+bash is, by construction, a potential mis-classification, and five rounds of
+fix-then-re-attack on issue #1958 plus three more here (#1993) established that
+enumerating those divergences is an open-ended arms race. Treat the class as
+CLOSED: a newly found member is documented, not chased, unless someone first
+demonstrates it defeats the CONTENT GUARDS, which are the layer that matters.
+
+The one hard guarantee, and the reason a mis-classification is survivable:
+
+    Exit SAFE(0) is the ONLY path that strips payload text, and it requires the
+    narrow, fully-quoted `gh issue|pr create/edit/comment` + `<<'EOF'` grammar in
+    ``classify_safe``. EVERY other path — UNSUPPORTED(10) and MALFORMED(20) —
+    hands the RAW, unmodified command to the content guards. So a here-doc the
+    classifier mis-reads degrades to the guards; it does not bypass them. Any
+    change here must preserve that property: widen ``classify_safe`` only with
+    proof, and keep every other exit raw-pass-through.
+
+Known accepted bypass class (measured, deliberately not chased further):
+R5a — a trailing backslash on the last body line is a bash continuation that
+swallows the terminator; R5b — an odd apostrophe in an unquoted body poisons a
+flat quote scanner past the terminator; R5c — `<<\\DELIM` is a quoted delimiter
+this parser did not model. All three are FIXED below, but they are members of a
+family, not the family itself. Each requires deliberately-crafted input; none is
+a shape an agent emits by accident; and post-#1982 every destructive class the
+safety net exists to stop is independently blocked by the content guards on the
+raw text.
+
+The two bash invariants this file relies on — both measured directly against
+/bin/bash, not inferred — so a future round starts from a spec:
+
+1. UNQUOTED delimiter (`<<EOF`): the body performs NO quote or comment
+   processing (`'`, `"`, `#` are literal data bytes) but STILL expands `$(...)`,
+   backticks and parameters, and bash removes `\\<newline>` continuations BEFORE
+   matching the delimiter. Measured: `cat <<EOF` / `foo\\` / `EOF` / `bar` emits
+   `fooEOF\\nbar` — the here-doc never terminated.
+2. QUOTED delimiter in any spelling (`<<'EOF'`, `<<"EOF"`, `<<\\EOF`): the body is
+   fully literal, no expansion of any kind, and backslash is DATA rather than an
+   escape — so the delimiter IS matched per physical line there. Measured: the
+   same trailing-backslash shape under `<<'EOF'` emits `foo\\` and then fails on
+   `bar: command not found`.
+
+That asymmetry is why the continuation handling in ``terminator_line_index`` is
+conditioned on ``Marker.quoted`` rather than applied uniformly.
+
+``Marker.quoted`` means "bash makes this BODY literal" and nothing more. The
+three spellings above are interchangeable for body semantics ONLY — they are NOT
+interchangeable on the writer path. ``classify_safe`` still demands the literal
+``<<'DELIM'`` spelling, so `<<"EOF"` and `<<\\EOF` can never reach SAFE(0); since
+#1993 they additionally record a Marker, which arms the writer-owns-a-real-marker
+and multi-marker rules and lands a `gh … <<\\EOF` writer on MALFORMED(20) where it
+used to be UNSUPPORTED(10). That is a deliberate, test-pinned over-block: the
+documented payload-strip workaround is spelled `<<'EOF'`. Widening
+``classify_safe`` to admit other spellings is a separate change needing its own
+proof — do not do it as a side effect of body-semantics work.
+"""
 
 from __future__ import annotations
 
@@ -494,6 +553,105 @@ def collapse_body_continuations(body: str) -> str:
     return "".join(result)
 
 
+def trailing_continuation(line: str) -> str | None:
+    """Strip a bash ``\\<newline>`` continuation backslash, or ``None``.
+
+    A here-doc body line ends in a continuation exactly when it ends in an ODD
+    run of backslashes: each pair is one escaped literal backslash, so a leftover
+    single backslash is the one that escapes the following newline. Parity of the
+    TRAILING run is sufficient — any backslash earlier in the line is separated
+    from the run by a non-backslash byte, which ends that escape.
+    """
+    stripped = line.rstrip("\\")
+    if (len(line) - len(stripped)) % 2 == 0:
+        return None
+    return line[:-1]
+
+
+def terminator_line_index(command: str, marker: Marker) -> int | None:
+    """Index of the physical line that closes ``marker``, or ``None``.
+
+    THE single home of "where does this here-doc body end", consulted by the
+    closure check, the body scanner, the literal-body strip and the body
+    neutraliser so no two of them can ever disagree about the window (issue
+    #1993 R5a).
+
+    Bash removes ``\\<newline>`` continuations from an UNQUOTED here-doc body
+    BEFORE it matches the delimiter, so a trailing backslash on the last body
+    line JOINS that line to the delimiter line and the here-doc is NOT closed
+    there — the real body swallows the apparent terminator and keeps consuming
+    following lines, where a ``$(...)`` the classifier believed was ordinary
+    post-here-doc text is expanded and EXECUTED. Matching the delimiter per
+    PHYSICAL line therefore under-reads the body window for unquoted delimiters.
+    Measured ground truth: ``cat <<EOF`` / ``foo\\`` / ``EOF`` / ``bar`` prints
+    ``fooEOF\\nbar`` (never terminated), while the same shape with ``<<'EOF'``
+    prints ``foo\\`` and then fails on ``bar: command not found``.
+
+    A QUOTED (or backslash-quoted) delimiter makes the body fully literal —
+    backslash is DATA there, not an escape — so those markers keep the exact
+    per-physical-line match, which the same measurement proves correct.
+    """
+    lines = bash_lines(command)
+    marker_line = command.count("\n", 0, marker.start)
+    pending: list[str] = []
+    for index in range(marker_line + 1, len(lines)):
+        line = lines[index]
+        if not marker.quoted:
+            continued = trailing_continuation(line)
+            if continued is not None:
+                pending.append(continued)
+                continue
+        candidate = "".join(pending) + line
+        pending = []
+        if marker.strip_tabs:
+            candidate = candidate.lstrip("\t")
+        if candidate == marker.delimiter:
+            return index
+    return None
+
+
+def neutralize_heredoc_bodies(command: str, markers: list[Marker]) -> str:
+    """Blank every real here-doc body window, preserving offsets.
+
+    ``has_active_command_substitution`` runs ONE flat single/double-quote state
+    machine across the whole command — including here-doc bodies, where bash
+    applies NO quote processing at all. An odd apostrophe in an unquoted body
+    (``it's fine``) therefore opens a phantom single-quoted string in the flat
+    scanner that persists PAST the terminator, hiding a live ``$(...)`` on a
+    FOLLOWING command line that bash happily executes (issue #1993 R5b). The
+    trigger is precisely an odd ``'`` count: an even ``''``, an odd ``"``, a
+    ``#``, an ANSI-C ``$'a`` and a lone trailing backslash all leave the flat
+    state correct, which is what pins the defect to this one branch.
+
+    ``strip_provably_literal_body`` cannot fix this: it bails whenever the marker
+    is unquoted, so the poisoning body is exactly the one it never touches. So
+    blank the body window of EVERY marker bash really treats as a here-doc
+    redirection before the flat scan runs. Bytes are replaced with spaces and
+    newlines are preserved, so marker offsets and line numbering stay valid for
+    every later walker.
+
+    Blanking loses nothing: a substitution INSIDE an unquoted body is still
+    caught by ``unquoted_heredoc_body_has_substitution`` (scanned with correct
+    here-doc-body semantics), and a quoted body is genuinely inert to bash. A
+    marker that is not closed blanks to end of command — that command is
+    MALFORMED on the closure check regardless, and its trailing region is still
+    body-scanned. As everywhere else, a marker nested inside an open quoted
+    string is NOT a here-doc to bash and is skipped, so its "body" stays fully
+    visible to the flat scan (issue #1958 Finding 1).
+    """
+    lines = bash_lines(command)
+    blanked = list(lines)
+    for marker in markers:
+        if cross_line_quote_state(command, marker.start) != "plain":
+            continue
+        marker_line = command.count("\n", 0, marker.start)
+        end = terminator_line_index(command, marker)
+        stop = len(lines) if end is None else end
+        for index in range(marker_line + 1, stop):
+            blanked[index] = " " * len(lines[index])
+    return "\n".join(blanked)
+
+
 def body_line_has_substitution(line: str) -> bool:
     """True if an unquoted-heredoc-body line contains an active substitution.
 
@@ -553,22 +711,22 @@ def unquoted_heredoc_body_has_substitution(
         if cross_line_quote_state(command, marker.start) != "plain":
             continue
         marker_line = command.count("\n", 0, marker.start)
-        body_lines: list[str] = []
-        for index in range(marker_line + 1, len(lines)):
-            candidate = (
-                lines[index].lstrip("\t") if marker.strip_tabs else lines[index]
-            )
-            if candidate == marker.delimiter:
-                break
-            body_lines.append(lines[index])
+        end = terminator_line_index(command, marker)
+        stop = len(lines) if end is None else end
+        body_lines = lines[marker_line + 1 : stop]
         # Join the raw body window under bash's unquoted-here-doc ``\<newline>``
         # removal BEFORE scanning, so a ``$(`` a caller split across a line
         # continuation is seen as the one contiguous token bash executes. The
-        # terminator was matched per physical line above (bash matches the
-        # delimiter before continuation processing), so continuations are joined
-        # only WITHIN the body window, never across the delimiter. This does not
-        # rely on ``collapse_line_continuations`` — whose flat quote state a body
-        # apostrophe corrupts — which is the whole point of Finding R4.
+        # window itself comes from ``terminator_line_index``, which applies that
+        # SAME removal before matching the delimiter — because bash does (issue
+        # #1993 R5a). An earlier revision matched the terminator per physical
+        # line here on the belief that bash matches the delimiter before
+        # continuation processing; that is false for an unquoted delimiter, and
+        # it let a trailing backslash on the last body line swallow the
+        # terminator so this scan stopped short of the region bash still treats
+        # as body. This does not rely on ``collapse_line_continuations`` — whose
+        # flat quote state a body apostrophe corrupts — which is the whole point
+        # of Finding R4.
         body = collapse_body_continuations("\n".join(body_lines))
         if body_line_has_substitution(body):
             return True
@@ -595,16 +753,42 @@ def parse_marker(line: str, start: int, offset: int) -> Marker | None:
         delimiter = line[index:end]
         final = end + 1
         # Deliberate POSIX divergence, fail-safe: POSIX makes the body
-        # non-expanding when ANY part of the delimiter is quoted — including
-        # `<<\EOF` (invisible to this parser: backslash is not a quote char and
-        # the identifier regex rejects it, so no Marker is recorded and the
-        # body stays raw-visible to every guard) and partial forms like
-        # `<<EO'F'` (mis-tokenized as delimiter EO, so the terminator never
-        # matches and the command fails closed as MALFORMED). Only a delimiter
-        # this parser can PROVE was one full quote pair earns quoted=True, and
-        # trailing word characters after the closing quote (`<<'EOF'X` — real
-        # bash delimiter EOFX) keep it conservative too: the next character
-        # must end the token.
+        # non-expanding when ANY part of the delimiter is quoted. Partial forms
+        # like `<<EO'F'` stay unmodelled (mis-tokenized as delimiter EO, so the
+        # terminator never matches and the command fails closed as MALFORMED).
+        # Only a delimiter this parser can PROVE was one full quote pair earns
+        # quoted=True, and trailing word characters after the closing quote
+        # (`<<'EOF'X` — real bash delimiter EOFX) keep it conservative too: the
+        # next character must end the token.
+        quoted = final >= len(line) or line[final] in " \t;&|)<>#"
+    elif line[index] == "\\":
+        # `<<\DELIM` is a BACKSLASH-quoted delimiter: bash and POSIX make its
+        # body fully literal, exactly like `<<'DELIM'` (measured: `cat <<\EOF`
+        # with body `it's $(echo RAN)` prints that text verbatim, unexpanded).
+        # This spelling used to record NO Marker at all, on the rationale that an
+        # unmodelled body stays raw-visible to every content guard. That covers
+        # the body's own contents but NOT the body's ability to corrupt the flat
+        # scanner's quote state for text AFTER the terminator: an apostrophe in
+        # an invisible body still opened a phantom string that hid a live
+        # `$(...)` on a following line (issue #1993 R5c). Recording it as the
+        # quoted marker bash actually treats it as is both more faithful and
+        # what brings it under `neutralize_heredoc_bodies`. The same
+        # token-must-end discipline as the quote-pair branch applies, so exotic
+        # spellings (`<<\EOF'x'` — real bash delimiter EOFx) stay conservative.
+        # quoted=True here is a statement about BODY semantics only. Recording a
+        # Marker where there was none also arms the writer-owns-a-real-marker and
+        # multi-marker rules, so `gh issue create --body-file - <<\EOF` and
+        # `cat <<\A <<B` now fail closed at MALFORMED instead of passing through
+        # at UNSUPPORTED. Both are valid, harmless bash, so that is a real
+        # over-block — accepted and test-pinned, because `classify_safe` requires
+        # the literal `<<'DELIM'` spelling and `<<\EOF` can never reach SAFE
+        # anyway. The documented payload-strip workaround is `<<'EOF'`.
+        index += 1
+        match = re.match(r"[A-Za-z_][A-Za-z0-9_]*", line[index:])
+        if match is None:
+            return None
+        delimiter = match.group(0)
+        final = index + len(delimiter)
         quoted = final >= len(line) or line[final] in " \t;&|)<>#"
     else:
         match = re.match(r"[A-Za-z_][A-Za-z0-9_]*", line[index:])
@@ -698,21 +882,22 @@ def strip_provably_literal_body(command: str, markers: list[Marker]) -> str:
         return command
     lines = bash_lines(command)
     marker_line = command.count("\n", 0, marker.start)
-    for index in range(marker_line + 1, len(lines)):
-        candidate = lines[index].lstrip("\t") if marker.strip_tabs else lines[index]
-        if candidate == marker.delimiter:
-            return "\n".join(lines[: marker_line + 1] + lines[index:])
-    return command
+    end = terminator_line_index(command, marker)
+    if end is None:
+        return command
+    return "\n".join(lines[: marker_line + 1] + lines[end:])
 
 
 def marker_is_closed(command: str, marker: Marker) -> bool:
-    marker_line = command.count("\n", 0, marker.start)
-    lines = bash_lines(command)
-    for line in lines[marker_line + 1 :]:
-        candidate = line.lstrip("\t") if marker.strip_tabs else line
-        if candidate == marker.delimiter:
-            return True
-    return False
+    """True when bash really terminates this here-doc inside the command.
+
+    Delegates to ``terminator_line_index`` so the closure verdict and the body
+    window are decided by one rule. For an unquoted delimiter that rule removes
+    ``\\<newline>`` continuations first, so a trailing backslash on the last body
+    line correctly reads as NOT closed — which is what bash does, and what makes
+    the swallowed-terminator shape fail closed as MALFORMED (issue #1993 R5a).
+    """
+    return terminator_line_index(command, marker) is not None
 
 
 def main() -> int:
@@ -748,11 +933,18 @@ def main() -> int:
         return MALFORMED
 
     # Nested substitution plus a heredoc is executable shell syntax unless it
-    # matched the one exact quoted `--body "$(cat ...)"` form above. The body
-    # of a single provably-literal heredoc is excluded from this scan (its
-    # tokens are inert data); the text outside that window is still scanned.
+    # matched the one exact quoted `--body "$(cat ...)"` form above. Here-doc
+    # bodies are neutralised before the flat scan: bash applies NO quote
+    # processing inside a body, so leaving those bytes in a flat quote state
+    # machine let an odd body apostrophe poison the scanner PAST the terminator
+    # and hide a live substitution on a following command line (issue #1993
+    # R5b). Neutralising preserves offsets, so the narrower literal-body strip
+    # still applies on top; the text outside every body window is still scanned,
+    # and in-body substitutions are covered by the body-semantics scan below.
     if has_active_command_substitution(
-        strip_provably_literal_body(logical_command, markers)
+        strip_provably_literal_body(
+            neutralize_heredoc_bodies(logical_command, markers), markers
+        )
     ) or unquoted_heredoc_body_has_substitution(logical_command, markers):
         return MALFORMED
     if len(markers) > 1:

--- a/plugins/lisa-agy/hooks/parity-safety-net.sh
+++ b/plugins/lisa-agy/hooks/parity-safety-net.sh
@@ -54,7 +54,27 @@
 # would never expand — a single-quoted `echo '$(rm -rf /)'` or an escaped
 # `echo "\$(rm -rf /)"` — because the scan has no quote-context awareness. That
 # over-block stays inside this accepted class. Workaround: quote-break the string
-# or use the gh-writer heredoc form, whose payload is stripped before the guards run.
+# or use the gh-writer heredoc form, whose payload is stripped before the guards
+# run — spelled with a QUOTE-PAIR delimiter (`<<'EOF'`). That exact spelling is
+# what the SAFE path recognises; `<<"EOF"` and `<<\EOF` do not reach it, and
+# since #1993 a `gh … <<\EOF` writer fails closed instead (see parse_marker).
+#
+# Known accepted BYPASS class (the symmetric error direction, issue #1993): the
+# heredoc classifier in parity-safety-net-heredoc.py re-implements bash's
+# here-doc lexing in Python, and any divergence from real bash is a shape it
+# mis-classifies. Five rounds on #1958 and three more on #1993 (R5a swallowed
+# terminator, R5b body-apostrophe quote-state poisoning, R5c backslash-quoted
+# delimiter) established that enumerating those divergences is an open-ended
+# arms race, so the class is CLOSED as accepted rather than chased further. This
+# is survivable because of where a mis-classification lands: ONLY the narrow
+# gh-writer SAFE path strips payload text, and every other classifier exit hands
+# the RAW command to the guards below. A missed here-doc therefore degrades to
+# the content guards; it does not bypass them. Since #1982 taught those guards to
+# see through substitution wrappers, every destructive class this net exists to
+# stop is blocked on the raw text regardless of how the here-doc was read. The
+# net catches ACCIDENTAL catastrophic commands; it is not a wall against an
+# adversary who knows bash's lexer, and it was never the only thing standing
+# between an agent and arbitrary execution.
 #
 # Operators extend the built-in rules with a project-local rule file — one
 # extended-regex (ERE) per line, blank lines and `#` comments ignored — managed

--- a/plugins/lisa-agy/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -103,7 +103,44 @@ same reason the rm guard treats substitution-wrapping as verdict-neutral (issue
 #1982): an executable `echo "$(rm -rf /)"` is blocked, and so are inert twins the
 shell would never expand — a single-quoted `echo '$(rm -rf /)'` or an escaped
 `echo "\$(rm -rf /)"` — since the scan has no quote-context awareness. The same
-quote-break or heredoc workaround applies.
+quote-break or heredoc workaround applies. Spell that heredoc workaround with a
+**quote-pair** delimiter (`gh issue create --body-file - <<'EOF'`) — only that
+spelling reaches the payload-strip path. `<<"EOF"` and `<<\EOF` do not, and a
+`gh … <<\EOF` writer now fails closed instead.
+
+## What this does and does not defend against
+
+Read this before treating the safety net as a wall.
+
+**What it is for:** stopping *accidental* catastrophic commands — an agent (or a
+human) that reaches for `rm -rf /`, force-pushes `main`, drops a table, or writes
+to a raw device by mistake. Within that job the guards above are the floor and
+they are always on.
+
+**What it is not:** a security boundary against a deliberate adversary. Two
+structural reasons, both accepted rather than open bugs:
+
+- **It is a text scan, not a shell engine.** It has no quote-context awareness,
+  which produces the false positives described above and means an operation
+  spelled in a way the patterns do not anticipate is not matched.
+- **The here-doc classifier re-implements bash's lexer in Python** to decide
+  which payload text is inert data. Every divergence from real bash is a shape it
+  mis-classifies. Eight distinct divergences were found and fixed across issues
+  #1958 and #1993; the class is open-ended, so it is now closed as an accepted
+  limitation rather than chased indefinitely.
+
+**Why that is tolerable:** a here-doc mis-classification degrades to the content
+guards rather than bypassing them. Only the narrow `gh issue|pr` writer form ever
+strips payload text; every other path passes the **raw** command to the guards,
+and since issue #1982 those guards see through substitution wrappers. So a
+mis-read here-doc costs no guard coverage for any destructive class listed above.
+
+**The honest bottom line:** an agent that is actively trying to run something
+destructive has many paths that never involve a here-doc at all — the safety net
+does not claim to close them. Do not rely on it as the only control over what an
+agent may execute; treat it as the last line of defence against mistakes, and
+keep the real boundary (credentials, permissions, environment isolation) outside
+the agent.
 
 ## View the current rules
 

--- a/plugins/lisa-copilot/hooks/parity-safety-net-heredoc.py
+++ b/plugins/lisa-copilot/hooks/parity-safety-net-heredoc.py
@@ -1,5 +1,64 @@
 #!/usr/bin/env python3
-"""Classify the only heredoc forms whose payload is non-executable text."""
+"""Classify the only heredoc forms whose payload is non-executable text.
+
+SCOPE — read this before hardening anything here (issue #1993).
+
+This module is a HEURISTIC RE-IMPLEMENTATION of bash's here-doc lexing, not an
+adversary-resistant control. Every divergence between this Python model and real
+bash is, by construction, a potential mis-classification, and five rounds of
+fix-then-re-attack on issue #1958 plus three more here (#1993) established that
+enumerating those divergences is an open-ended arms race. Treat the class as
+CLOSED: a newly found member is documented, not chased, unless someone first
+demonstrates it defeats the CONTENT GUARDS, which are the layer that matters.
+
+The one hard guarantee, and the reason a mis-classification is survivable:
+
+    Exit SAFE(0) is the ONLY path that strips payload text, and it requires the
+    narrow, fully-quoted `gh issue|pr create/edit/comment` + `<<'EOF'` grammar in
+    ``classify_safe``. EVERY other path — UNSUPPORTED(10) and MALFORMED(20) —
+    hands the RAW, unmodified command to the content guards. So a here-doc the
+    classifier mis-reads degrades to the guards; it does not bypass them. Any
+    change here must preserve that property: widen ``classify_safe`` only with
+    proof, and keep every other exit raw-pass-through.
+
+Known accepted bypass class (measured, deliberately not chased further):
+R5a — a trailing backslash on the last body line is a bash continuation that
+swallows the terminator; R5b — an odd apostrophe in an unquoted body poisons a
+flat quote scanner past the terminator; R5c — `<<\\DELIM` is a quoted delimiter
+this parser did not model. All three are FIXED below, but they are members of a
+family, not the family itself. Each requires deliberately-crafted input; none is
+a shape an agent emits by accident; and post-#1982 every destructive class the
+safety net exists to stop is independently blocked by the content guards on the
+raw text.
+
+The two bash invariants this file relies on — both measured directly against
+/bin/bash, not inferred — so a future round starts from a spec:
+
+1. UNQUOTED delimiter (`<<EOF`): the body performs NO quote or comment
+   processing (`'`, `"`, `#` are literal data bytes) but STILL expands `$(...)`,
+   backticks and parameters, and bash removes `\\<newline>` continuations BEFORE
+   matching the delimiter. Measured: `cat <<EOF` / `foo\\` / `EOF` / `bar` emits
+   `fooEOF\\nbar` — the here-doc never terminated.
+2. QUOTED delimiter in any spelling (`<<'EOF'`, `<<"EOF"`, `<<\\EOF`): the body is
+   fully literal, no expansion of any kind, and backslash is DATA rather than an
+   escape — so the delimiter IS matched per physical line there. Measured: the
+   same trailing-backslash shape under `<<'EOF'` emits `foo\\` and then fails on
+   `bar: command not found`.
+
+That asymmetry is why the continuation handling in ``terminator_line_index`` is
+conditioned on ``Marker.quoted`` rather than applied uniformly.
+
+``Marker.quoted`` means "bash makes this BODY literal" and nothing more. The
+three spellings above are interchangeable for body semantics ONLY — they are NOT
+interchangeable on the writer path. ``classify_safe`` still demands the literal
+``<<'DELIM'`` spelling, so `<<"EOF"` and `<<\\EOF` can never reach SAFE(0); since
+#1993 they additionally record a Marker, which arms the writer-owns-a-real-marker
+and multi-marker rules and lands a `gh … <<\\EOF` writer on MALFORMED(20) where it
+used to be UNSUPPORTED(10). That is a deliberate, test-pinned over-block: the
+documented payload-strip workaround is spelled `<<'EOF'`. Widening
+``classify_safe`` to admit other spellings is a separate change needing its own
+proof — do not do it as a side effect of body-semantics work.
+"""
 
 from __future__ import annotations
 
@@ -494,6 +553,105 @@ def collapse_body_continuations(body: str) -> str:
     return "".join(result)
 
 
+def trailing_continuation(line: str) -> str | None:
+    """Strip a bash ``\\<newline>`` continuation backslash, or ``None``.
+
+    A here-doc body line ends in a continuation exactly when it ends in an ODD
+    run of backslashes: each pair is one escaped literal backslash, so a leftover
+    single backslash is the one that escapes the following newline. Parity of the
+    TRAILING run is sufficient — any backslash earlier in the line is separated
+    from the run by a non-backslash byte, which ends that escape.
+    """
+    stripped = line.rstrip("\\")
+    if (len(line) - len(stripped)) % 2 == 0:
+        return None
+    return line[:-1]
+
+
+def terminator_line_index(command: str, marker: Marker) -> int | None:
+    """Index of the physical line that closes ``marker``, or ``None``.
+
+    THE single home of "where does this here-doc body end", consulted by the
+    closure check, the body scanner, the literal-body strip and the body
+    neutraliser so no two of them can ever disagree about the window (issue
+    #1993 R5a).
+
+    Bash removes ``\\<newline>`` continuations from an UNQUOTED here-doc body
+    BEFORE it matches the delimiter, so a trailing backslash on the last body
+    line JOINS that line to the delimiter line and the here-doc is NOT closed
+    there — the real body swallows the apparent terminator and keeps consuming
+    following lines, where a ``$(...)`` the classifier believed was ordinary
+    post-here-doc text is expanded and EXECUTED. Matching the delimiter per
+    PHYSICAL line therefore under-reads the body window for unquoted delimiters.
+    Measured ground truth: ``cat <<EOF`` / ``foo\\`` / ``EOF`` / ``bar`` prints
+    ``fooEOF\\nbar`` (never terminated), while the same shape with ``<<'EOF'``
+    prints ``foo\\`` and then fails on ``bar: command not found``.
+
+    A QUOTED (or backslash-quoted) delimiter makes the body fully literal —
+    backslash is DATA there, not an escape — so those markers keep the exact
+    per-physical-line match, which the same measurement proves correct.
+    """
+    lines = bash_lines(command)
+    marker_line = command.count("\n", 0, marker.start)
+    pending: list[str] = []
+    for index in range(marker_line + 1, len(lines)):
+        line = lines[index]
+        if not marker.quoted:
+            continued = trailing_continuation(line)
+            if continued is not None:
+                pending.append(continued)
+                continue
+        candidate = "".join(pending) + line
+        pending = []
+        if marker.strip_tabs:
+            candidate = candidate.lstrip("\t")
+        if candidate == marker.delimiter:
+            return index
+    return None
+
+
+def neutralize_heredoc_bodies(command: str, markers: list[Marker]) -> str:
+    """Blank every real here-doc body window, preserving offsets.
+
+    ``has_active_command_substitution`` runs ONE flat single/double-quote state
+    machine across the whole command — including here-doc bodies, where bash
+    applies NO quote processing at all. An odd apostrophe in an unquoted body
+    (``it's fine``) therefore opens a phantom single-quoted string in the flat
+    scanner that persists PAST the terminator, hiding a live ``$(...)`` on a
+    FOLLOWING command line that bash happily executes (issue #1993 R5b). The
+    trigger is precisely an odd ``'`` count: an even ``''``, an odd ``"``, a
+    ``#``, an ANSI-C ``$'a`` and a lone trailing backslash all leave the flat
+    state correct, which is what pins the defect to this one branch.
+
+    ``strip_provably_literal_body`` cannot fix this: it bails whenever the marker
+    is unquoted, so the poisoning body is exactly the one it never touches. So
+    blank the body window of EVERY marker bash really treats as a here-doc
+    redirection before the flat scan runs. Bytes are replaced with spaces and
+    newlines are preserved, so marker offsets and line numbering stay valid for
+    every later walker.
+
+    Blanking loses nothing: a substitution INSIDE an unquoted body is still
+    caught by ``unquoted_heredoc_body_has_substitution`` (scanned with correct
+    here-doc-body semantics), and a quoted body is genuinely inert to bash. A
+    marker that is not closed blanks to end of command — that command is
+    MALFORMED on the closure check regardless, and its trailing region is still
+    body-scanned. As everywhere else, a marker nested inside an open quoted
+    string is NOT a here-doc to bash and is skipped, so its "body" stays fully
+    visible to the flat scan (issue #1958 Finding 1).
+    """
+    lines = bash_lines(command)
+    blanked = list(lines)
+    for marker in markers:
+        if cross_line_quote_state(command, marker.start) != "plain":
+            continue
+        marker_line = command.count("\n", 0, marker.start)
+        end = terminator_line_index(command, marker)
+        stop = len(lines) if end is None else end
+        for index in range(marker_line + 1, stop):
+            blanked[index] = " " * len(lines[index])
+    return "\n".join(blanked)
+
+
 def body_line_has_substitution(line: str) -> bool:
     """True if an unquoted-heredoc-body line contains an active substitution.
 
@@ -553,22 +711,22 @@ def unquoted_heredoc_body_has_substitution(
         if cross_line_quote_state(command, marker.start) != "plain":
             continue
         marker_line = command.count("\n", 0, marker.start)
-        body_lines: list[str] = []
-        for index in range(marker_line + 1, len(lines)):
-            candidate = (
-                lines[index].lstrip("\t") if marker.strip_tabs else lines[index]
-            )
-            if candidate == marker.delimiter:
-                break
-            body_lines.append(lines[index])
+        end = terminator_line_index(command, marker)
+        stop = len(lines) if end is None else end
+        body_lines = lines[marker_line + 1 : stop]
         # Join the raw body window under bash's unquoted-here-doc ``\<newline>``
         # removal BEFORE scanning, so a ``$(`` a caller split across a line
         # continuation is seen as the one contiguous token bash executes. The
-        # terminator was matched per physical line above (bash matches the
-        # delimiter before continuation processing), so continuations are joined
-        # only WITHIN the body window, never across the delimiter. This does not
-        # rely on ``collapse_line_continuations`` — whose flat quote state a body
-        # apostrophe corrupts — which is the whole point of Finding R4.
+        # window itself comes from ``terminator_line_index``, which applies that
+        # SAME removal before matching the delimiter — because bash does (issue
+        # #1993 R5a). An earlier revision matched the terminator per physical
+        # line here on the belief that bash matches the delimiter before
+        # continuation processing; that is false for an unquoted delimiter, and
+        # it let a trailing backslash on the last body line swallow the
+        # terminator so this scan stopped short of the region bash still treats
+        # as body. This does not rely on ``collapse_line_continuations`` — whose
+        # flat quote state a body apostrophe corrupts — which is the whole point
+        # of Finding R4.
         body = collapse_body_continuations("\n".join(body_lines))
         if body_line_has_substitution(body):
             return True
@@ -595,16 +753,42 @@ def parse_marker(line: str, start: int, offset: int) -> Marker | None:
         delimiter = line[index:end]
         final = end + 1
         # Deliberate POSIX divergence, fail-safe: POSIX makes the body
-        # non-expanding when ANY part of the delimiter is quoted — including
-        # `<<\EOF` (invisible to this parser: backslash is not a quote char and
-        # the identifier regex rejects it, so no Marker is recorded and the
-        # body stays raw-visible to every guard) and partial forms like
-        # `<<EO'F'` (mis-tokenized as delimiter EO, so the terminator never
-        # matches and the command fails closed as MALFORMED). Only a delimiter
-        # this parser can PROVE was one full quote pair earns quoted=True, and
-        # trailing word characters after the closing quote (`<<'EOF'X` — real
-        # bash delimiter EOFX) keep it conservative too: the next character
-        # must end the token.
+        # non-expanding when ANY part of the delimiter is quoted. Partial forms
+        # like `<<EO'F'` stay unmodelled (mis-tokenized as delimiter EO, so the
+        # terminator never matches and the command fails closed as MALFORMED).
+        # Only a delimiter this parser can PROVE was one full quote pair earns
+        # quoted=True, and trailing word characters after the closing quote
+        # (`<<'EOF'X` — real bash delimiter EOFX) keep it conservative too: the
+        # next character must end the token.
+        quoted = final >= len(line) or line[final] in " \t;&|)<>#"
+    elif line[index] == "\\":
+        # `<<\DELIM` is a BACKSLASH-quoted delimiter: bash and POSIX make its
+        # body fully literal, exactly like `<<'DELIM'` (measured: `cat <<\EOF`
+        # with body `it's $(echo RAN)` prints that text verbatim, unexpanded).
+        # This spelling used to record NO Marker at all, on the rationale that an
+        # unmodelled body stays raw-visible to every content guard. That covers
+        # the body's own contents but NOT the body's ability to corrupt the flat
+        # scanner's quote state for text AFTER the terminator: an apostrophe in
+        # an invisible body still opened a phantom string that hid a live
+        # `$(...)` on a following line (issue #1993 R5c). Recording it as the
+        # quoted marker bash actually treats it as is both more faithful and
+        # what brings it under `neutralize_heredoc_bodies`. The same
+        # token-must-end discipline as the quote-pair branch applies, so exotic
+        # spellings (`<<\EOF'x'` — real bash delimiter EOFx) stay conservative.
+        # quoted=True here is a statement about BODY semantics only. Recording a
+        # Marker where there was none also arms the writer-owns-a-real-marker and
+        # multi-marker rules, so `gh issue create --body-file - <<\EOF` and
+        # `cat <<\A <<B` now fail closed at MALFORMED instead of passing through
+        # at UNSUPPORTED. Both are valid, harmless bash, so that is a real
+        # over-block — accepted and test-pinned, because `classify_safe` requires
+        # the literal `<<'DELIM'` spelling and `<<\EOF` can never reach SAFE
+        # anyway. The documented payload-strip workaround is `<<'EOF'`.
+        index += 1
+        match = re.match(r"[A-Za-z_][A-Za-z0-9_]*", line[index:])
+        if match is None:
+            return None
+        delimiter = match.group(0)
+        final = index + len(delimiter)
         quoted = final >= len(line) or line[final] in " \t;&|)<>#"
     else:
         match = re.match(r"[A-Za-z_][A-Za-z0-9_]*", line[index:])
@@ -698,21 +882,22 @@ def strip_provably_literal_body(command: str, markers: list[Marker]) -> str:
         return command
     lines = bash_lines(command)
     marker_line = command.count("\n", 0, marker.start)
-    for index in range(marker_line + 1, len(lines)):
-        candidate = lines[index].lstrip("\t") if marker.strip_tabs else lines[index]
-        if candidate == marker.delimiter:
-            return "\n".join(lines[: marker_line + 1] + lines[index:])
-    return command
+    end = terminator_line_index(command, marker)
+    if end is None:
+        return command
+    return "\n".join(lines[: marker_line + 1] + lines[end:])
 
 
 def marker_is_closed(command: str, marker: Marker) -> bool:
-    marker_line = command.count("\n", 0, marker.start)
-    lines = bash_lines(command)
-    for line in lines[marker_line + 1 :]:
-        candidate = line.lstrip("\t") if marker.strip_tabs else line
-        if candidate == marker.delimiter:
-            return True
-    return False
+    """True when bash really terminates this here-doc inside the command.
+
+    Delegates to ``terminator_line_index`` so the closure verdict and the body
+    window are decided by one rule. For an unquoted delimiter that rule removes
+    ``\\<newline>`` continuations first, so a trailing backslash on the last body
+    line correctly reads as NOT closed — which is what bash does, and what makes
+    the swallowed-terminator shape fail closed as MALFORMED (issue #1993 R5a).
+    """
+    return terminator_line_index(command, marker) is not None
 
 
 def main() -> int:
@@ -748,11 +933,18 @@ def main() -> int:
         return MALFORMED
 
     # Nested substitution plus a heredoc is executable shell syntax unless it
-    # matched the one exact quoted `--body "$(cat ...)"` form above. The body
-    # of a single provably-literal heredoc is excluded from this scan (its
-    # tokens are inert data); the text outside that window is still scanned.
+    # matched the one exact quoted `--body "$(cat ...)"` form above. Here-doc
+    # bodies are neutralised before the flat scan: bash applies NO quote
+    # processing inside a body, so leaving those bytes in a flat quote state
+    # machine let an odd body apostrophe poison the scanner PAST the terminator
+    # and hide a live substitution on a following command line (issue #1993
+    # R5b). Neutralising preserves offsets, so the narrower literal-body strip
+    # still applies on top; the text outside every body window is still scanned,
+    # and in-body substitutions are covered by the body-semantics scan below.
     if has_active_command_substitution(
-        strip_provably_literal_body(logical_command, markers)
+        strip_provably_literal_body(
+            neutralize_heredoc_bodies(logical_command, markers), markers
+        )
     ) or unquoted_heredoc_body_has_substitution(logical_command, markers):
         return MALFORMED
     if len(markers) > 1:

--- a/plugins/lisa-copilot/hooks/parity-safety-net.sh
+++ b/plugins/lisa-copilot/hooks/parity-safety-net.sh
@@ -54,7 +54,27 @@
 # would never expand — a single-quoted `echo '$(rm -rf /)'` or an escaped
 # `echo "\$(rm -rf /)"` — because the scan has no quote-context awareness. That
 # over-block stays inside this accepted class. Workaround: quote-break the string
-# or use the gh-writer heredoc form, whose payload is stripped before the guards run.
+# or use the gh-writer heredoc form, whose payload is stripped before the guards
+# run — spelled with a QUOTE-PAIR delimiter (`<<'EOF'`). That exact spelling is
+# what the SAFE path recognises; `<<"EOF"` and `<<\EOF` do not reach it, and
+# since #1993 a `gh … <<\EOF` writer fails closed instead (see parse_marker).
+#
+# Known accepted BYPASS class (the symmetric error direction, issue #1993): the
+# heredoc classifier in parity-safety-net-heredoc.py re-implements bash's
+# here-doc lexing in Python, and any divergence from real bash is a shape it
+# mis-classifies. Five rounds on #1958 and three more on #1993 (R5a swallowed
+# terminator, R5b body-apostrophe quote-state poisoning, R5c backslash-quoted
+# delimiter) established that enumerating those divergences is an open-ended
+# arms race, so the class is CLOSED as accepted rather than chased further. This
+# is survivable because of where a mis-classification lands: ONLY the narrow
+# gh-writer SAFE path strips payload text, and every other classifier exit hands
+# the RAW command to the guards below. A missed here-doc therefore degrades to
+# the content guards; it does not bypass them. Since #1982 taught those guards to
+# see through substitution wrappers, every destructive class this net exists to
+# stop is blocked on the raw text regardless of how the here-doc was read. The
+# net catches ACCIDENTAL catastrophic commands; it is not a wall against an
+# adversary who knows bash's lexer, and it was never the only thing standing
+# between an agent and arbitrary execution.
 #
 # Operators extend the built-in rules with a project-local rule file — one
 # extended-regex (ERE) per line, blank lines and `#` comments ignored — managed

--- a/plugins/lisa-copilot/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -103,7 +103,44 @@ same reason the rm guard treats substitution-wrapping as verdict-neutral (issue
 #1982): an executable `echo "$(rm -rf /)"` is blocked, and so are inert twins the
 shell would never expand — a single-quoted `echo '$(rm -rf /)'` or an escaped
 `echo "\$(rm -rf /)"` — since the scan has no quote-context awareness. The same
-quote-break or heredoc workaround applies.
+quote-break or heredoc workaround applies. Spell that heredoc workaround with a
+**quote-pair** delimiter (`gh issue create --body-file - <<'EOF'`) — only that
+spelling reaches the payload-strip path. `<<"EOF"` and `<<\EOF` do not, and a
+`gh … <<\EOF` writer now fails closed instead.
+
+## What this does and does not defend against
+
+Read this before treating the safety net as a wall.
+
+**What it is for:** stopping *accidental* catastrophic commands — an agent (or a
+human) that reaches for `rm -rf /`, force-pushes `main`, drops a table, or writes
+to a raw device by mistake. Within that job the guards above are the floor and
+they are always on.
+
+**What it is not:** a security boundary against a deliberate adversary. Two
+structural reasons, both accepted rather than open bugs:
+
+- **It is a text scan, not a shell engine.** It has no quote-context awareness,
+  which produces the false positives described above and means an operation
+  spelled in a way the patterns do not anticipate is not matched.
+- **The here-doc classifier re-implements bash's lexer in Python** to decide
+  which payload text is inert data. Every divergence from real bash is a shape it
+  mis-classifies. Eight distinct divergences were found and fixed across issues
+  #1958 and #1993; the class is open-ended, so it is now closed as an accepted
+  limitation rather than chased indefinitely.
+
+**Why that is tolerable:** a here-doc mis-classification degrades to the content
+guards rather than bypassing them. Only the narrow `gh issue|pr` writer form ever
+strips payload text; every other path passes the **raw** command to the guards,
+and since issue #1982 those guards see through substitution wrappers. So a
+mis-read here-doc costs no guard coverage for any destructive class listed above.
+
+**The honest bottom line:** an agent that is actively trying to run something
+destructive has many paths that never involve a here-doc at all — the safety net
+does not claim to close them. Do not rely on it as the only control over what an
+agent may execute; treat it as the last line of defence against mistakes, and
+keep the real boundary (credentials, permissions, environment isolation) outside
+the agent.
 
 ## View the current rules
 

--- a/plugins/lisa-cursor/hooks/parity-safety-net-heredoc.py
+++ b/plugins/lisa-cursor/hooks/parity-safety-net-heredoc.py
@@ -1,5 +1,64 @@
 #!/usr/bin/env python3
-"""Classify the only heredoc forms whose payload is non-executable text."""
+"""Classify the only heredoc forms whose payload is non-executable text.
+
+SCOPE — read this before hardening anything here (issue #1993).
+
+This module is a HEURISTIC RE-IMPLEMENTATION of bash's here-doc lexing, not an
+adversary-resistant control. Every divergence between this Python model and real
+bash is, by construction, a potential mis-classification, and five rounds of
+fix-then-re-attack on issue #1958 plus three more here (#1993) established that
+enumerating those divergences is an open-ended arms race. Treat the class as
+CLOSED: a newly found member is documented, not chased, unless someone first
+demonstrates it defeats the CONTENT GUARDS, which are the layer that matters.
+
+The one hard guarantee, and the reason a mis-classification is survivable:
+
+    Exit SAFE(0) is the ONLY path that strips payload text, and it requires the
+    narrow, fully-quoted `gh issue|pr create/edit/comment` + `<<'EOF'` grammar in
+    ``classify_safe``. EVERY other path — UNSUPPORTED(10) and MALFORMED(20) —
+    hands the RAW, unmodified command to the content guards. So a here-doc the
+    classifier mis-reads degrades to the guards; it does not bypass them. Any
+    change here must preserve that property: widen ``classify_safe`` only with
+    proof, and keep every other exit raw-pass-through.
+
+Known accepted bypass class (measured, deliberately not chased further):
+R5a — a trailing backslash on the last body line is a bash continuation that
+swallows the terminator; R5b — an odd apostrophe in an unquoted body poisons a
+flat quote scanner past the terminator; R5c — `<<\\DELIM` is a quoted delimiter
+this parser did not model. All three are FIXED below, but they are members of a
+family, not the family itself. Each requires deliberately-crafted input; none is
+a shape an agent emits by accident; and post-#1982 every destructive class the
+safety net exists to stop is independently blocked by the content guards on the
+raw text.
+
+The two bash invariants this file relies on — both measured directly against
+/bin/bash, not inferred — so a future round starts from a spec:
+
+1. UNQUOTED delimiter (`<<EOF`): the body performs NO quote or comment
+   processing (`'`, `"`, `#` are literal data bytes) but STILL expands `$(...)`,
+   backticks and parameters, and bash removes `\\<newline>` continuations BEFORE
+   matching the delimiter. Measured: `cat <<EOF` / `foo\\` / `EOF` / `bar` emits
+   `fooEOF\\nbar` — the here-doc never terminated.
+2. QUOTED delimiter in any spelling (`<<'EOF'`, `<<"EOF"`, `<<\\EOF`): the body is
+   fully literal, no expansion of any kind, and backslash is DATA rather than an
+   escape — so the delimiter IS matched per physical line there. Measured: the
+   same trailing-backslash shape under `<<'EOF'` emits `foo\\` and then fails on
+   `bar: command not found`.
+
+That asymmetry is why the continuation handling in ``terminator_line_index`` is
+conditioned on ``Marker.quoted`` rather than applied uniformly.
+
+``Marker.quoted`` means "bash makes this BODY literal" and nothing more. The
+three spellings above are interchangeable for body semantics ONLY — they are NOT
+interchangeable on the writer path. ``classify_safe`` still demands the literal
+``<<'DELIM'`` spelling, so `<<"EOF"` and `<<\\EOF` can never reach SAFE(0); since
+#1993 they additionally record a Marker, which arms the writer-owns-a-real-marker
+and multi-marker rules and lands a `gh … <<\\EOF` writer on MALFORMED(20) where it
+used to be UNSUPPORTED(10). That is a deliberate, test-pinned over-block: the
+documented payload-strip workaround is spelled `<<'EOF'`. Widening
+``classify_safe`` to admit other spellings is a separate change needing its own
+proof — do not do it as a side effect of body-semantics work.
+"""
 
 from __future__ import annotations
 
@@ -494,6 +553,105 @@ def collapse_body_continuations(body: str) -> str:
     return "".join(result)
 
 
+def trailing_continuation(line: str) -> str | None:
+    """Strip a bash ``\\<newline>`` continuation backslash, or ``None``.
+
+    A here-doc body line ends in a continuation exactly when it ends in an ODD
+    run of backslashes: each pair is one escaped literal backslash, so a leftover
+    single backslash is the one that escapes the following newline. Parity of the
+    TRAILING run is sufficient — any backslash earlier in the line is separated
+    from the run by a non-backslash byte, which ends that escape.
+    """
+    stripped = line.rstrip("\\")
+    if (len(line) - len(stripped)) % 2 == 0:
+        return None
+    return line[:-1]
+
+
+def terminator_line_index(command: str, marker: Marker) -> int | None:
+    """Index of the physical line that closes ``marker``, or ``None``.
+
+    THE single home of "where does this here-doc body end", consulted by the
+    closure check, the body scanner, the literal-body strip and the body
+    neutraliser so no two of them can ever disagree about the window (issue
+    #1993 R5a).
+
+    Bash removes ``\\<newline>`` continuations from an UNQUOTED here-doc body
+    BEFORE it matches the delimiter, so a trailing backslash on the last body
+    line JOINS that line to the delimiter line and the here-doc is NOT closed
+    there — the real body swallows the apparent terminator and keeps consuming
+    following lines, where a ``$(...)`` the classifier believed was ordinary
+    post-here-doc text is expanded and EXECUTED. Matching the delimiter per
+    PHYSICAL line therefore under-reads the body window for unquoted delimiters.
+    Measured ground truth: ``cat <<EOF`` / ``foo\\`` / ``EOF`` / ``bar`` prints
+    ``fooEOF\\nbar`` (never terminated), while the same shape with ``<<'EOF'``
+    prints ``foo\\`` and then fails on ``bar: command not found``.
+
+    A QUOTED (or backslash-quoted) delimiter makes the body fully literal —
+    backslash is DATA there, not an escape — so those markers keep the exact
+    per-physical-line match, which the same measurement proves correct.
+    """
+    lines = bash_lines(command)
+    marker_line = command.count("\n", 0, marker.start)
+    pending: list[str] = []
+    for index in range(marker_line + 1, len(lines)):
+        line = lines[index]
+        if not marker.quoted:
+            continued = trailing_continuation(line)
+            if continued is not None:
+                pending.append(continued)
+                continue
+        candidate = "".join(pending) + line
+        pending = []
+        if marker.strip_tabs:
+            candidate = candidate.lstrip("\t")
+        if candidate == marker.delimiter:
+            return index
+    return None
+
+
+def neutralize_heredoc_bodies(command: str, markers: list[Marker]) -> str:
+    """Blank every real here-doc body window, preserving offsets.
+
+    ``has_active_command_substitution`` runs ONE flat single/double-quote state
+    machine across the whole command — including here-doc bodies, where bash
+    applies NO quote processing at all. An odd apostrophe in an unquoted body
+    (``it's fine``) therefore opens a phantom single-quoted string in the flat
+    scanner that persists PAST the terminator, hiding a live ``$(...)`` on a
+    FOLLOWING command line that bash happily executes (issue #1993 R5b). The
+    trigger is precisely an odd ``'`` count: an even ``''``, an odd ``"``, a
+    ``#``, an ANSI-C ``$'a`` and a lone trailing backslash all leave the flat
+    state correct, which is what pins the defect to this one branch.
+
+    ``strip_provably_literal_body`` cannot fix this: it bails whenever the marker
+    is unquoted, so the poisoning body is exactly the one it never touches. So
+    blank the body window of EVERY marker bash really treats as a here-doc
+    redirection before the flat scan runs. Bytes are replaced with spaces and
+    newlines are preserved, so marker offsets and line numbering stay valid for
+    every later walker.
+
+    Blanking loses nothing: a substitution INSIDE an unquoted body is still
+    caught by ``unquoted_heredoc_body_has_substitution`` (scanned with correct
+    here-doc-body semantics), and a quoted body is genuinely inert to bash. A
+    marker that is not closed blanks to end of command — that command is
+    MALFORMED on the closure check regardless, and its trailing region is still
+    body-scanned. As everywhere else, a marker nested inside an open quoted
+    string is NOT a here-doc to bash and is skipped, so its "body" stays fully
+    visible to the flat scan (issue #1958 Finding 1).
+    """
+    lines = bash_lines(command)
+    blanked = list(lines)
+    for marker in markers:
+        if cross_line_quote_state(command, marker.start) != "plain":
+            continue
+        marker_line = command.count("\n", 0, marker.start)
+        end = terminator_line_index(command, marker)
+        stop = len(lines) if end is None else end
+        for index in range(marker_line + 1, stop):
+            blanked[index] = " " * len(lines[index])
+    return "\n".join(blanked)
+
+
 def body_line_has_substitution(line: str) -> bool:
     """True if an unquoted-heredoc-body line contains an active substitution.
 
@@ -553,22 +711,22 @@ def unquoted_heredoc_body_has_substitution(
         if cross_line_quote_state(command, marker.start) != "plain":
             continue
         marker_line = command.count("\n", 0, marker.start)
-        body_lines: list[str] = []
-        for index in range(marker_line + 1, len(lines)):
-            candidate = (
-                lines[index].lstrip("\t") if marker.strip_tabs else lines[index]
-            )
-            if candidate == marker.delimiter:
-                break
-            body_lines.append(lines[index])
+        end = terminator_line_index(command, marker)
+        stop = len(lines) if end is None else end
+        body_lines = lines[marker_line + 1 : stop]
         # Join the raw body window under bash's unquoted-here-doc ``\<newline>``
         # removal BEFORE scanning, so a ``$(`` a caller split across a line
         # continuation is seen as the one contiguous token bash executes. The
-        # terminator was matched per physical line above (bash matches the
-        # delimiter before continuation processing), so continuations are joined
-        # only WITHIN the body window, never across the delimiter. This does not
-        # rely on ``collapse_line_continuations`` — whose flat quote state a body
-        # apostrophe corrupts — which is the whole point of Finding R4.
+        # window itself comes from ``terminator_line_index``, which applies that
+        # SAME removal before matching the delimiter — because bash does (issue
+        # #1993 R5a). An earlier revision matched the terminator per physical
+        # line here on the belief that bash matches the delimiter before
+        # continuation processing; that is false for an unquoted delimiter, and
+        # it let a trailing backslash on the last body line swallow the
+        # terminator so this scan stopped short of the region bash still treats
+        # as body. This does not rely on ``collapse_line_continuations`` — whose
+        # flat quote state a body apostrophe corrupts — which is the whole point
+        # of Finding R4.
         body = collapse_body_continuations("\n".join(body_lines))
         if body_line_has_substitution(body):
             return True
@@ -595,16 +753,42 @@ def parse_marker(line: str, start: int, offset: int) -> Marker | None:
         delimiter = line[index:end]
         final = end + 1
         # Deliberate POSIX divergence, fail-safe: POSIX makes the body
-        # non-expanding when ANY part of the delimiter is quoted — including
-        # `<<\EOF` (invisible to this parser: backslash is not a quote char and
-        # the identifier regex rejects it, so no Marker is recorded and the
-        # body stays raw-visible to every guard) and partial forms like
-        # `<<EO'F'` (mis-tokenized as delimiter EO, so the terminator never
-        # matches and the command fails closed as MALFORMED). Only a delimiter
-        # this parser can PROVE was one full quote pair earns quoted=True, and
-        # trailing word characters after the closing quote (`<<'EOF'X` — real
-        # bash delimiter EOFX) keep it conservative too: the next character
-        # must end the token.
+        # non-expanding when ANY part of the delimiter is quoted. Partial forms
+        # like `<<EO'F'` stay unmodelled (mis-tokenized as delimiter EO, so the
+        # terminator never matches and the command fails closed as MALFORMED).
+        # Only a delimiter this parser can PROVE was one full quote pair earns
+        # quoted=True, and trailing word characters after the closing quote
+        # (`<<'EOF'X` — real bash delimiter EOFX) keep it conservative too: the
+        # next character must end the token.
+        quoted = final >= len(line) or line[final] in " \t;&|)<>#"
+    elif line[index] == "\\":
+        # `<<\DELIM` is a BACKSLASH-quoted delimiter: bash and POSIX make its
+        # body fully literal, exactly like `<<'DELIM'` (measured: `cat <<\EOF`
+        # with body `it's $(echo RAN)` prints that text verbatim, unexpanded).
+        # This spelling used to record NO Marker at all, on the rationale that an
+        # unmodelled body stays raw-visible to every content guard. That covers
+        # the body's own contents but NOT the body's ability to corrupt the flat
+        # scanner's quote state for text AFTER the terminator: an apostrophe in
+        # an invisible body still opened a phantom string that hid a live
+        # `$(...)` on a following line (issue #1993 R5c). Recording it as the
+        # quoted marker bash actually treats it as is both more faithful and
+        # what brings it under `neutralize_heredoc_bodies`. The same
+        # token-must-end discipline as the quote-pair branch applies, so exotic
+        # spellings (`<<\EOF'x'` — real bash delimiter EOFx) stay conservative.
+        # quoted=True here is a statement about BODY semantics only. Recording a
+        # Marker where there was none also arms the writer-owns-a-real-marker and
+        # multi-marker rules, so `gh issue create --body-file - <<\EOF` and
+        # `cat <<\A <<B` now fail closed at MALFORMED instead of passing through
+        # at UNSUPPORTED. Both are valid, harmless bash, so that is a real
+        # over-block — accepted and test-pinned, because `classify_safe` requires
+        # the literal `<<'DELIM'` spelling and `<<\EOF` can never reach SAFE
+        # anyway. The documented payload-strip workaround is `<<'EOF'`.
+        index += 1
+        match = re.match(r"[A-Za-z_][A-Za-z0-9_]*", line[index:])
+        if match is None:
+            return None
+        delimiter = match.group(0)
+        final = index + len(delimiter)
         quoted = final >= len(line) or line[final] in " \t;&|)<>#"
     else:
         match = re.match(r"[A-Za-z_][A-Za-z0-9_]*", line[index:])
@@ -698,21 +882,22 @@ def strip_provably_literal_body(command: str, markers: list[Marker]) -> str:
         return command
     lines = bash_lines(command)
     marker_line = command.count("\n", 0, marker.start)
-    for index in range(marker_line + 1, len(lines)):
-        candidate = lines[index].lstrip("\t") if marker.strip_tabs else lines[index]
-        if candidate == marker.delimiter:
-            return "\n".join(lines[: marker_line + 1] + lines[index:])
-    return command
+    end = terminator_line_index(command, marker)
+    if end is None:
+        return command
+    return "\n".join(lines[: marker_line + 1] + lines[end:])
 
 
 def marker_is_closed(command: str, marker: Marker) -> bool:
-    marker_line = command.count("\n", 0, marker.start)
-    lines = bash_lines(command)
-    for line in lines[marker_line + 1 :]:
-        candidate = line.lstrip("\t") if marker.strip_tabs else line
-        if candidate == marker.delimiter:
-            return True
-    return False
+    """True when bash really terminates this here-doc inside the command.
+
+    Delegates to ``terminator_line_index`` so the closure verdict and the body
+    window are decided by one rule. For an unquoted delimiter that rule removes
+    ``\\<newline>`` continuations first, so a trailing backslash on the last body
+    line correctly reads as NOT closed — which is what bash does, and what makes
+    the swallowed-terminator shape fail closed as MALFORMED (issue #1993 R5a).
+    """
+    return terminator_line_index(command, marker) is not None
 
 
 def main() -> int:
@@ -748,11 +933,18 @@ def main() -> int:
         return MALFORMED
 
     # Nested substitution plus a heredoc is executable shell syntax unless it
-    # matched the one exact quoted `--body "$(cat ...)"` form above. The body
-    # of a single provably-literal heredoc is excluded from this scan (its
-    # tokens are inert data); the text outside that window is still scanned.
+    # matched the one exact quoted `--body "$(cat ...)"` form above. Here-doc
+    # bodies are neutralised before the flat scan: bash applies NO quote
+    # processing inside a body, so leaving those bytes in a flat quote state
+    # machine let an odd body apostrophe poison the scanner PAST the terminator
+    # and hide a live substitution on a following command line (issue #1993
+    # R5b). Neutralising preserves offsets, so the narrower literal-body strip
+    # still applies on top; the text outside every body window is still scanned,
+    # and in-body substitutions are covered by the body-semantics scan below.
     if has_active_command_substitution(
-        strip_provably_literal_body(logical_command, markers)
+        strip_provably_literal_body(
+            neutralize_heredoc_bodies(logical_command, markers), markers
+        )
     ) or unquoted_heredoc_body_has_substitution(logical_command, markers):
         return MALFORMED
     if len(markers) > 1:

--- a/plugins/lisa-cursor/hooks/parity-safety-net.sh
+++ b/plugins/lisa-cursor/hooks/parity-safety-net.sh
@@ -54,7 +54,27 @@
 # would never expand — a single-quoted `echo '$(rm -rf /)'` or an escaped
 # `echo "\$(rm -rf /)"` — because the scan has no quote-context awareness. That
 # over-block stays inside this accepted class. Workaround: quote-break the string
-# or use the gh-writer heredoc form, whose payload is stripped before the guards run.
+# or use the gh-writer heredoc form, whose payload is stripped before the guards
+# run — spelled with a QUOTE-PAIR delimiter (`<<'EOF'`). That exact spelling is
+# what the SAFE path recognises; `<<"EOF"` and `<<\EOF` do not reach it, and
+# since #1993 a `gh … <<\EOF` writer fails closed instead (see parse_marker).
+#
+# Known accepted BYPASS class (the symmetric error direction, issue #1993): the
+# heredoc classifier in parity-safety-net-heredoc.py re-implements bash's
+# here-doc lexing in Python, and any divergence from real bash is a shape it
+# mis-classifies. Five rounds on #1958 and three more on #1993 (R5a swallowed
+# terminator, R5b body-apostrophe quote-state poisoning, R5c backslash-quoted
+# delimiter) established that enumerating those divergences is an open-ended
+# arms race, so the class is CLOSED as accepted rather than chased further. This
+# is survivable because of where a mis-classification lands: ONLY the narrow
+# gh-writer SAFE path strips payload text, and every other classifier exit hands
+# the RAW command to the guards below. A missed here-doc therefore degrades to
+# the content guards; it does not bypass them. Since #1982 taught those guards to
+# see through substitution wrappers, every destructive class this net exists to
+# stop is blocked on the raw text regardless of how the here-doc was read. The
+# net catches ACCIDENTAL catastrophic commands; it is not a wall against an
+# adversary who knows bash's lexer, and it was never the only thing standing
+# between an agent and arbitrary execution.
 #
 # Operators extend the built-in rules with a project-local rule file — one
 # extended-regex (ERE) per line, blank lines and `#` comments ignored — managed

--- a/plugins/lisa-cursor/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -103,7 +103,44 @@ same reason the rm guard treats substitution-wrapping as verdict-neutral (issue
 #1982): an executable `echo "$(rm -rf /)"` is blocked, and so are inert twins the
 shell would never expand — a single-quoted `echo '$(rm -rf /)'` or an escaped
 `echo "\$(rm -rf /)"` — since the scan has no quote-context awareness. The same
-quote-break or heredoc workaround applies.
+quote-break or heredoc workaround applies. Spell that heredoc workaround with a
+**quote-pair** delimiter (`gh issue create --body-file - <<'EOF'`) — only that
+spelling reaches the payload-strip path. `<<"EOF"` and `<<\EOF` do not, and a
+`gh … <<\EOF` writer now fails closed instead.
+
+## What this does and does not defend against
+
+Read this before treating the safety net as a wall.
+
+**What it is for:** stopping *accidental* catastrophic commands — an agent (or a
+human) that reaches for `rm -rf /`, force-pushes `main`, drops a table, or writes
+to a raw device by mistake. Within that job the guards above are the floor and
+they are always on.
+
+**What it is not:** a security boundary against a deliberate adversary. Two
+structural reasons, both accepted rather than open bugs:
+
+- **It is a text scan, not a shell engine.** It has no quote-context awareness,
+  which produces the false positives described above and means an operation
+  spelled in a way the patterns do not anticipate is not matched.
+- **The here-doc classifier re-implements bash's lexer in Python** to decide
+  which payload text is inert data. Every divergence from real bash is a shape it
+  mis-classifies. Eight distinct divergences were found and fixed across issues
+  #1958 and #1993; the class is open-ended, so it is now closed as an accepted
+  limitation rather than chased indefinitely.
+
+**Why that is tolerable:** a here-doc mis-classification degrades to the content
+guards rather than bypassing them. Only the narrow `gh issue|pr` writer form ever
+strips payload text; every other path passes the **raw** command to the guards,
+and since issue #1982 those guards see through substitution wrappers. So a
+mis-read here-doc costs no guard coverage for any destructive class listed above.
+
+**The honest bottom line:** an agent that is actively trying to run something
+destructive has many paths that never involve a here-doc at all — the safety net
+does not claim to close them. Do not rely on it as the only control over what an
+agent may execute; treat it as the last line of defence against mistakes, and
+keep the real boundary (credentials, permissions, environment isolation) outside
+the agent.
 
 ## View the current rules
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -103,7 +103,44 @@ same reason the rm guard treats substitution-wrapping as verdict-neutral (issue
 #1982): an executable `echo "$(rm -rf /)"` is blocked, and so are inert twins the
 shell would never expand — a single-quoted `echo '$(rm -rf /)'` or an escaped
 `echo "\$(rm -rf /)"` — since the scan has no quote-context awareness. The same
-quote-break or heredoc workaround applies.
+quote-break or heredoc workaround applies. Spell that heredoc workaround with a
+**quote-pair** delimiter (`gh issue create --body-file - <<'EOF'`) — only that
+spelling reaches the payload-strip path. `<<"EOF"` and `<<\EOF` do not, and a
+`gh … <<\EOF` writer now fails closed instead.
+
+## What this does and does not defend against
+
+Read this before treating the safety net as a wall.
+
+**What it is for:** stopping *accidental* catastrophic commands — an agent (or a
+human) that reaches for `rm -rf /`, force-pushes `main`, drops a table, or writes
+to a raw device by mistake. Within that job the guards above are the floor and
+they are always on.
+
+**What it is not:** a security boundary against a deliberate adversary. Two
+structural reasons, both accepted rather than open bugs:
+
+- **It is a text scan, not a shell engine.** It has no quote-context awareness,
+  which produces the false positives described above and means an operation
+  spelled in a way the patterns do not anticipate is not matched.
+- **The here-doc classifier re-implements bash's lexer in Python** to decide
+  which payload text is inert data. Every divergence from real bash is a shape it
+  mis-classifies. Eight distinct divergences were found and fixed across issues
+  #1958 and #1993; the class is open-ended, so it is now closed as an accepted
+  limitation rather than chased indefinitely.
+
+**Why that is tolerable:** a here-doc mis-classification degrades to the content
+guards rather than bypassing them. Only the narrow `gh issue|pr` writer form ever
+strips payload text; every other path passes the **raw** command to the guards,
+and since issue #1982 those guards see through substitution wrappers. So a
+mis-read here-doc costs no guard coverage for any destructive class listed above.
+
+**The honest bottom line:** an agent that is actively trying to run something
+destructive has many paths that never involve a here-doc at all — the safety net
+does not claim to close them. Do not rely on it as the only control over what an
+agent may execute; treat it as the last line of defence against mistakes, and
+keep the real boundary (credentials, permissions, environment isolation) outside
+the agent.
 
 ## View the current rules
 

--- a/plugins/lisa/hooks/parity-safety-net-heredoc.py
+++ b/plugins/lisa/hooks/parity-safety-net-heredoc.py
@@ -1,5 +1,64 @@
 #!/usr/bin/env python3
-"""Classify the only heredoc forms whose payload is non-executable text."""
+"""Classify the only heredoc forms whose payload is non-executable text.
+
+SCOPE — read this before hardening anything here (issue #1993).
+
+This module is a HEURISTIC RE-IMPLEMENTATION of bash's here-doc lexing, not an
+adversary-resistant control. Every divergence between this Python model and real
+bash is, by construction, a potential mis-classification, and five rounds of
+fix-then-re-attack on issue #1958 plus three more here (#1993) established that
+enumerating those divergences is an open-ended arms race. Treat the class as
+CLOSED: a newly found member is documented, not chased, unless someone first
+demonstrates it defeats the CONTENT GUARDS, which are the layer that matters.
+
+The one hard guarantee, and the reason a mis-classification is survivable:
+
+    Exit SAFE(0) is the ONLY path that strips payload text, and it requires the
+    narrow, fully-quoted `gh issue|pr create/edit/comment` + `<<'EOF'` grammar in
+    ``classify_safe``. EVERY other path — UNSUPPORTED(10) and MALFORMED(20) —
+    hands the RAW, unmodified command to the content guards. So a here-doc the
+    classifier mis-reads degrades to the guards; it does not bypass them. Any
+    change here must preserve that property: widen ``classify_safe`` only with
+    proof, and keep every other exit raw-pass-through.
+
+Known accepted bypass class (measured, deliberately not chased further):
+R5a — a trailing backslash on the last body line is a bash continuation that
+swallows the terminator; R5b — an odd apostrophe in an unquoted body poisons a
+flat quote scanner past the terminator; R5c — `<<\\DELIM` is a quoted delimiter
+this parser did not model. All three are FIXED below, but they are members of a
+family, not the family itself. Each requires deliberately-crafted input; none is
+a shape an agent emits by accident; and post-#1982 every destructive class the
+safety net exists to stop is independently blocked by the content guards on the
+raw text.
+
+The two bash invariants this file relies on — both measured directly against
+/bin/bash, not inferred — so a future round starts from a spec:
+
+1. UNQUOTED delimiter (`<<EOF`): the body performs NO quote or comment
+   processing (`'`, `"`, `#` are literal data bytes) but STILL expands `$(...)`,
+   backticks and parameters, and bash removes `\\<newline>` continuations BEFORE
+   matching the delimiter. Measured: `cat <<EOF` / `foo\\` / `EOF` / `bar` emits
+   `fooEOF\\nbar` — the here-doc never terminated.
+2. QUOTED delimiter in any spelling (`<<'EOF'`, `<<"EOF"`, `<<\\EOF`): the body is
+   fully literal, no expansion of any kind, and backslash is DATA rather than an
+   escape — so the delimiter IS matched per physical line there. Measured: the
+   same trailing-backslash shape under `<<'EOF'` emits `foo\\` and then fails on
+   `bar: command not found`.
+
+That asymmetry is why the continuation handling in ``terminator_line_index`` is
+conditioned on ``Marker.quoted`` rather than applied uniformly.
+
+``Marker.quoted`` means "bash makes this BODY literal" and nothing more. The
+three spellings above are interchangeable for body semantics ONLY — they are NOT
+interchangeable on the writer path. ``classify_safe`` still demands the literal
+``<<'DELIM'`` spelling, so `<<"EOF"` and `<<\\EOF` can never reach SAFE(0); since
+#1993 they additionally record a Marker, which arms the writer-owns-a-real-marker
+and multi-marker rules and lands a `gh … <<\\EOF` writer on MALFORMED(20) where it
+used to be UNSUPPORTED(10). That is a deliberate, test-pinned over-block: the
+documented payload-strip workaround is spelled `<<'EOF'`. Widening
+``classify_safe`` to admit other spellings is a separate change needing its own
+proof — do not do it as a side effect of body-semantics work.
+"""
 
 from __future__ import annotations
 
@@ -494,6 +553,105 @@ def collapse_body_continuations(body: str) -> str:
     return "".join(result)
 
 
+def trailing_continuation(line: str) -> str | None:
+    """Strip a bash ``\\<newline>`` continuation backslash, or ``None``.
+
+    A here-doc body line ends in a continuation exactly when it ends in an ODD
+    run of backslashes: each pair is one escaped literal backslash, so a leftover
+    single backslash is the one that escapes the following newline. Parity of the
+    TRAILING run is sufficient — any backslash earlier in the line is separated
+    from the run by a non-backslash byte, which ends that escape.
+    """
+    stripped = line.rstrip("\\")
+    if (len(line) - len(stripped)) % 2 == 0:
+        return None
+    return line[:-1]
+
+
+def terminator_line_index(command: str, marker: Marker) -> int | None:
+    """Index of the physical line that closes ``marker``, or ``None``.
+
+    THE single home of "where does this here-doc body end", consulted by the
+    closure check, the body scanner, the literal-body strip and the body
+    neutraliser so no two of them can ever disagree about the window (issue
+    #1993 R5a).
+
+    Bash removes ``\\<newline>`` continuations from an UNQUOTED here-doc body
+    BEFORE it matches the delimiter, so a trailing backslash on the last body
+    line JOINS that line to the delimiter line and the here-doc is NOT closed
+    there — the real body swallows the apparent terminator and keeps consuming
+    following lines, where a ``$(...)`` the classifier believed was ordinary
+    post-here-doc text is expanded and EXECUTED. Matching the delimiter per
+    PHYSICAL line therefore under-reads the body window for unquoted delimiters.
+    Measured ground truth: ``cat <<EOF`` / ``foo\\`` / ``EOF`` / ``bar`` prints
+    ``fooEOF\\nbar`` (never terminated), while the same shape with ``<<'EOF'``
+    prints ``foo\\`` and then fails on ``bar: command not found``.
+
+    A QUOTED (or backslash-quoted) delimiter makes the body fully literal —
+    backslash is DATA there, not an escape — so those markers keep the exact
+    per-physical-line match, which the same measurement proves correct.
+    """
+    lines = bash_lines(command)
+    marker_line = command.count("\n", 0, marker.start)
+    pending: list[str] = []
+    for index in range(marker_line + 1, len(lines)):
+        line = lines[index]
+        if not marker.quoted:
+            continued = trailing_continuation(line)
+            if continued is not None:
+                pending.append(continued)
+                continue
+        candidate = "".join(pending) + line
+        pending = []
+        if marker.strip_tabs:
+            candidate = candidate.lstrip("\t")
+        if candidate == marker.delimiter:
+            return index
+    return None
+
+
+def neutralize_heredoc_bodies(command: str, markers: list[Marker]) -> str:
+    """Blank every real here-doc body window, preserving offsets.
+
+    ``has_active_command_substitution`` runs ONE flat single/double-quote state
+    machine across the whole command — including here-doc bodies, where bash
+    applies NO quote processing at all. An odd apostrophe in an unquoted body
+    (``it's fine``) therefore opens a phantom single-quoted string in the flat
+    scanner that persists PAST the terminator, hiding a live ``$(...)`` on a
+    FOLLOWING command line that bash happily executes (issue #1993 R5b). The
+    trigger is precisely an odd ``'`` count: an even ``''``, an odd ``"``, a
+    ``#``, an ANSI-C ``$'a`` and a lone trailing backslash all leave the flat
+    state correct, which is what pins the defect to this one branch.
+
+    ``strip_provably_literal_body`` cannot fix this: it bails whenever the marker
+    is unquoted, so the poisoning body is exactly the one it never touches. So
+    blank the body window of EVERY marker bash really treats as a here-doc
+    redirection before the flat scan runs. Bytes are replaced with spaces and
+    newlines are preserved, so marker offsets and line numbering stay valid for
+    every later walker.
+
+    Blanking loses nothing: a substitution INSIDE an unquoted body is still
+    caught by ``unquoted_heredoc_body_has_substitution`` (scanned with correct
+    here-doc-body semantics), and a quoted body is genuinely inert to bash. A
+    marker that is not closed blanks to end of command — that command is
+    MALFORMED on the closure check regardless, and its trailing region is still
+    body-scanned. As everywhere else, a marker nested inside an open quoted
+    string is NOT a here-doc to bash and is skipped, so its "body" stays fully
+    visible to the flat scan (issue #1958 Finding 1).
+    """
+    lines = bash_lines(command)
+    blanked = list(lines)
+    for marker in markers:
+        if cross_line_quote_state(command, marker.start) != "plain":
+            continue
+        marker_line = command.count("\n", 0, marker.start)
+        end = terminator_line_index(command, marker)
+        stop = len(lines) if end is None else end
+        for index in range(marker_line + 1, stop):
+            blanked[index] = " " * len(lines[index])
+    return "\n".join(blanked)
+
+
 def body_line_has_substitution(line: str) -> bool:
     """True if an unquoted-heredoc-body line contains an active substitution.
 
@@ -553,22 +711,22 @@ def unquoted_heredoc_body_has_substitution(
         if cross_line_quote_state(command, marker.start) != "plain":
             continue
         marker_line = command.count("\n", 0, marker.start)
-        body_lines: list[str] = []
-        for index in range(marker_line + 1, len(lines)):
-            candidate = (
-                lines[index].lstrip("\t") if marker.strip_tabs else lines[index]
-            )
-            if candidate == marker.delimiter:
-                break
-            body_lines.append(lines[index])
+        end = terminator_line_index(command, marker)
+        stop = len(lines) if end is None else end
+        body_lines = lines[marker_line + 1 : stop]
         # Join the raw body window under bash's unquoted-here-doc ``\<newline>``
         # removal BEFORE scanning, so a ``$(`` a caller split across a line
         # continuation is seen as the one contiguous token bash executes. The
-        # terminator was matched per physical line above (bash matches the
-        # delimiter before continuation processing), so continuations are joined
-        # only WITHIN the body window, never across the delimiter. This does not
-        # rely on ``collapse_line_continuations`` — whose flat quote state a body
-        # apostrophe corrupts — which is the whole point of Finding R4.
+        # window itself comes from ``terminator_line_index``, which applies that
+        # SAME removal before matching the delimiter — because bash does (issue
+        # #1993 R5a). An earlier revision matched the terminator per physical
+        # line here on the belief that bash matches the delimiter before
+        # continuation processing; that is false for an unquoted delimiter, and
+        # it let a trailing backslash on the last body line swallow the
+        # terminator so this scan stopped short of the region bash still treats
+        # as body. This does not rely on ``collapse_line_continuations`` — whose
+        # flat quote state a body apostrophe corrupts — which is the whole point
+        # of Finding R4.
         body = collapse_body_continuations("\n".join(body_lines))
         if body_line_has_substitution(body):
             return True
@@ -595,16 +753,42 @@ def parse_marker(line: str, start: int, offset: int) -> Marker | None:
         delimiter = line[index:end]
         final = end + 1
         # Deliberate POSIX divergence, fail-safe: POSIX makes the body
-        # non-expanding when ANY part of the delimiter is quoted — including
-        # `<<\EOF` (invisible to this parser: backslash is not a quote char and
-        # the identifier regex rejects it, so no Marker is recorded and the
-        # body stays raw-visible to every guard) and partial forms like
-        # `<<EO'F'` (mis-tokenized as delimiter EO, so the terminator never
-        # matches and the command fails closed as MALFORMED). Only a delimiter
-        # this parser can PROVE was one full quote pair earns quoted=True, and
-        # trailing word characters after the closing quote (`<<'EOF'X` — real
-        # bash delimiter EOFX) keep it conservative too: the next character
-        # must end the token.
+        # non-expanding when ANY part of the delimiter is quoted. Partial forms
+        # like `<<EO'F'` stay unmodelled (mis-tokenized as delimiter EO, so the
+        # terminator never matches and the command fails closed as MALFORMED).
+        # Only a delimiter this parser can PROVE was one full quote pair earns
+        # quoted=True, and trailing word characters after the closing quote
+        # (`<<'EOF'X` — real bash delimiter EOFX) keep it conservative too: the
+        # next character must end the token.
+        quoted = final >= len(line) or line[final] in " \t;&|)<>#"
+    elif line[index] == "\\":
+        # `<<\DELIM` is a BACKSLASH-quoted delimiter: bash and POSIX make its
+        # body fully literal, exactly like `<<'DELIM'` (measured: `cat <<\EOF`
+        # with body `it's $(echo RAN)` prints that text verbatim, unexpanded).
+        # This spelling used to record NO Marker at all, on the rationale that an
+        # unmodelled body stays raw-visible to every content guard. That covers
+        # the body's own contents but NOT the body's ability to corrupt the flat
+        # scanner's quote state for text AFTER the terminator: an apostrophe in
+        # an invisible body still opened a phantom string that hid a live
+        # `$(...)` on a following line (issue #1993 R5c). Recording it as the
+        # quoted marker bash actually treats it as is both more faithful and
+        # what brings it under `neutralize_heredoc_bodies`. The same
+        # token-must-end discipline as the quote-pair branch applies, so exotic
+        # spellings (`<<\EOF'x'` — real bash delimiter EOFx) stay conservative.
+        # quoted=True here is a statement about BODY semantics only. Recording a
+        # Marker where there was none also arms the writer-owns-a-real-marker and
+        # multi-marker rules, so `gh issue create --body-file - <<\EOF` and
+        # `cat <<\A <<B` now fail closed at MALFORMED instead of passing through
+        # at UNSUPPORTED. Both are valid, harmless bash, so that is a real
+        # over-block — accepted and test-pinned, because `classify_safe` requires
+        # the literal `<<'DELIM'` spelling and `<<\EOF` can never reach SAFE
+        # anyway. The documented payload-strip workaround is `<<'EOF'`.
+        index += 1
+        match = re.match(r"[A-Za-z_][A-Za-z0-9_]*", line[index:])
+        if match is None:
+            return None
+        delimiter = match.group(0)
+        final = index + len(delimiter)
         quoted = final >= len(line) or line[final] in " \t;&|)<>#"
     else:
         match = re.match(r"[A-Za-z_][A-Za-z0-9_]*", line[index:])
@@ -698,21 +882,22 @@ def strip_provably_literal_body(command: str, markers: list[Marker]) -> str:
         return command
     lines = bash_lines(command)
     marker_line = command.count("\n", 0, marker.start)
-    for index in range(marker_line + 1, len(lines)):
-        candidate = lines[index].lstrip("\t") if marker.strip_tabs else lines[index]
-        if candidate == marker.delimiter:
-            return "\n".join(lines[: marker_line + 1] + lines[index:])
-    return command
+    end = terminator_line_index(command, marker)
+    if end is None:
+        return command
+    return "\n".join(lines[: marker_line + 1] + lines[end:])
 
 
 def marker_is_closed(command: str, marker: Marker) -> bool:
-    marker_line = command.count("\n", 0, marker.start)
-    lines = bash_lines(command)
-    for line in lines[marker_line + 1 :]:
-        candidate = line.lstrip("\t") if marker.strip_tabs else line
-        if candidate == marker.delimiter:
-            return True
-    return False
+    """True when bash really terminates this here-doc inside the command.
+
+    Delegates to ``terminator_line_index`` so the closure verdict and the body
+    window are decided by one rule. For an unquoted delimiter that rule removes
+    ``\\<newline>`` continuations first, so a trailing backslash on the last body
+    line correctly reads as NOT closed — which is what bash does, and what makes
+    the swallowed-terminator shape fail closed as MALFORMED (issue #1993 R5a).
+    """
+    return terminator_line_index(command, marker) is not None
 
 
 def main() -> int:
@@ -748,11 +933,18 @@ def main() -> int:
         return MALFORMED
 
     # Nested substitution plus a heredoc is executable shell syntax unless it
-    # matched the one exact quoted `--body "$(cat ...)"` form above. The body
-    # of a single provably-literal heredoc is excluded from this scan (its
-    # tokens are inert data); the text outside that window is still scanned.
+    # matched the one exact quoted `--body "$(cat ...)"` form above. Here-doc
+    # bodies are neutralised before the flat scan: bash applies NO quote
+    # processing inside a body, so leaving those bytes in a flat quote state
+    # machine let an odd body apostrophe poison the scanner PAST the terminator
+    # and hide a live substitution on a following command line (issue #1993
+    # R5b). Neutralising preserves offsets, so the narrower literal-body strip
+    # still applies on top; the text outside every body window is still scanned,
+    # and in-body substitutions are covered by the body-semantics scan below.
     if has_active_command_substitution(
-        strip_provably_literal_body(logical_command, markers)
+        strip_provably_literal_body(
+            neutralize_heredoc_bodies(logical_command, markers), markers
+        )
     ) or unquoted_heredoc_body_has_substitution(logical_command, markers):
         return MALFORMED
     if len(markers) > 1:

--- a/plugins/lisa/hooks/parity-safety-net.sh
+++ b/plugins/lisa/hooks/parity-safety-net.sh
@@ -54,7 +54,27 @@
 # would never expand — a single-quoted `echo '$(rm -rf /)'` or an escaped
 # `echo "\$(rm -rf /)"` — because the scan has no quote-context awareness. That
 # over-block stays inside this accepted class. Workaround: quote-break the string
-# or use the gh-writer heredoc form, whose payload is stripped before the guards run.
+# or use the gh-writer heredoc form, whose payload is stripped before the guards
+# run — spelled with a QUOTE-PAIR delimiter (`<<'EOF'`). That exact spelling is
+# what the SAFE path recognises; `<<"EOF"` and `<<\EOF` do not reach it, and
+# since #1993 a `gh … <<\EOF` writer fails closed instead (see parse_marker).
+#
+# Known accepted BYPASS class (the symmetric error direction, issue #1993): the
+# heredoc classifier in parity-safety-net-heredoc.py re-implements bash's
+# here-doc lexing in Python, and any divergence from real bash is a shape it
+# mis-classifies. Five rounds on #1958 and three more on #1993 (R5a swallowed
+# terminator, R5b body-apostrophe quote-state poisoning, R5c backslash-quoted
+# delimiter) established that enumerating those divergences is an open-ended
+# arms race, so the class is CLOSED as accepted rather than chased further. This
+# is survivable because of where a mis-classification lands: ONLY the narrow
+# gh-writer SAFE path strips payload text, and every other classifier exit hands
+# the RAW command to the guards below. A missed here-doc therefore degrades to
+# the content guards; it does not bypass them. Since #1982 taught those guards to
+# see through substitution wrappers, every destructive class this net exists to
+# stop is blocked on the raw text regardless of how the here-doc was read. The
+# net catches ACCIDENTAL catastrophic commands; it is not a wall against an
+# adversary who knows bash's lexer, and it was never the only thing standing
+# between an agent and arbitrary execution.
 #
 # Operators extend the built-in rules with a project-local rule file — one
 # extended-regex (ERE) per line, blank lines and `#` comments ignored — managed

--- a/plugins/lisa/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -103,7 +103,44 @@ same reason the rm guard treats substitution-wrapping as verdict-neutral (issue
 #1982): an executable `echo "$(rm -rf /)"` is blocked, and so are inert twins the
 shell would never expand — a single-quoted `echo '$(rm -rf /)'` or an escaped
 `echo "\$(rm -rf /)"` — since the scan has no quote-context awareness. The same
-quote-break or heredoc workaround applies.
+quote-break or heredoc workaround applies. Spell that heredoc workaround with a
+**quote-pair** delimiter (`gh issue create --body-file - <<'EOF'`) — only that
+spelling reaches the payload-strip path. `<<"EOF"` and `<<\EOF` do not, and a
+`gh … <<\EOF` writer now fails closed instead.
+
+## What this does and does not defend against
+
+Read this before treating the safety net as a wall.
+
+**What it is for:** stopping *accidental* catastrophic commands — an agent (or a
+human) that reaches for `rm -rf /`, force-pushes `main`, drops a table, or writes
+to a raw device by mistake. Within that job the guards above are the floor and
+they are always on.
+
+**What it is not:** a security boundary against a deliberate adversary. Two
+structural reasons, both accepted rather than open bugs:
+
+- **It is a text scan, not a shell engine.** It has no quote-context awareness,
+  which produces the false positives described above and means an operation
+  spelled in a way the patterns do not anticipate is not matched.
+- **The here-doc classifier re-implements bash's lexer in Python** to decide
+  which payload text is inert data. Every divergence from real bash is a shape it
+  mis-classifies. Eight distinct divergences were found and fixed across issues
+  #1958 and #1993; the class is open-ended, so it is now closed as an accepted
+  limitation rather than chased indefinitely.
+
+**Why that is tolerable:** a here-doc mis-classification degrades to the content
+guards rather than bypassing them. Only the narrow `gh issue|pr` writer form ever
+strips payload text; every other path passes the **raw** command to the guards,
+and since issue #1982 those guards see through substitution wrappers. So a
+mis-read here-doc costs no guard coverage for any destructive class listed above.
+
+**The honest bottom line:** an agent that is actively trying to run something
+destructive has many paths that never involve a here-doc at all — the safety net
+does not claim to close them. Do not rely on it as the only control over what an
+agent may execute; treat it as the last line of defence against mistakes, and
+keep the real boundary (credentials, permissions, environment isolation) outside
+the agent.
 
 ## View the current rules
 

--- a/plugins/src/base/hooks/parity-safety-net-heredoc.py
+++ b/plugins/src/base/hooks/parity-safety-net-heredoc.py
@@ -1,5 +1,64 @@
 #!/usr/bin/env python3
-"""Classify the only heredoc forms whose payload is non-executable text."""
+"""Classify the only heredoc forms whose payload is non-executable text.
+
+SCOPE — read this before hardening anything here (issue #1993).
+
+This module is a HEURISTIC RE-IMPLEMENTATION of bash's here-doc lexing, not an
+adversary-resistant control. Every divergence between this Python model and real
+bash is, by construction, a potential mis-classification, and five rounds of
+fix-then-re-attack on issue #1958 plus three more here (#1993) established that
+enumerating those divergences is an open-ended arms race. Treat the class as
+CLOSED: a newly found member is documented, not chased, unless someone first
+demonstrates it defeats the CONTENT GUARDS, which are the layer that matters.
+
+The one hard guarantee, and the reason a mis-classification is survivable:
+
+    Exit SAFE(0) is the ONLY path that strips payload text, and it requires the
+    narrow, fully-quoted `gh issue|pr create/edit/comment` + `<<'EOF'` grammar in
+    ``classify_safe``. EVERY other path — UNSUPPORTED(10) and MALFORMED(20) —
+    hands the RAW, unmodified command to the content guards. So a here-doc the
+    classifier mis-reads degrades to the guards; it does not bypass them. Any
+    change here must preserve that property: widen ``classify_safe`` only with
+    proof, and keep every other exit raw-pass-through.
+
+Known accepted bypass class (measured, deliberately not chased further):
+R5a — a trailing backslash on the last body line is a bash continuation that
+swallows the terminator; R5b — an odd apostrophe in an unquoted body poisons a
+flat quote scanner past the terminator; R5c — `<<\\DELIM` is a quoted delimiter
+this parser did not model. All three are FIXED below, but they are members of a
+family, not the family itself. Each requires deliberately-crafted input; none is
+a shape an agent emits by accident; and post-#1982 every destructive class the
+safety net exists to stop is independently blocked by the content guards on the
+raw text.
+
+The two bash invariants this file relies on — both measured directly against
+/bin/bash, not inferred — so a future round starts from a spec:
+
+1. UNQUOTED delimiter (`<<EOF`): the body performs NO quote or comment
+   processing (`'`, `"`, `#` are literal data bytes) but STILL expands `$(...)`,
+   backticks and parameters, and bash removes `\\<newline>` continuations BEFORE
+   matching the delimiter. Measured: `cat <<EOF` / `foo\\` / `EOF` / `bar` emits
+   `fooEOF\\nbar` — the here-doc never terminated.
+2. QUOTED delimiter in any spelling (`<<'EOF'`, `<<"EOF"`, `<<\\EOF`): the body is
+   fully literal, no expansion of any kind, and backslash is DATA rather than an
+   escape — so the delimiter IS matched per physical line there. Measured: the
+   same trailing-backslash shape under `<<'EOF'` emits `foo\\` and then fails on
+   `bar: command not found`.
+
+That asymmetry is why the continuation handling in ``terminator_line_index`` is
+conditioned on ``Marker.quoted`` rather than applied uniformly.
+
+``Marker.quoted`` means "bash makes this BODY literal" and nothing more. The
+three spellings above are interchangeable for body semantics ONLY — they are NOT
+interchangeable on the writer path. ``classify_safe`` still demands the literal
+``<<'DELIM'`` spelling, so `<<"EOF"` and `<<\\EOF` can never reach SAFE(0); since
+#1993 they additionally record a Marker, which arms the writer-owns-a-real-marker
+and multi-marker rules and lands a `gh … <<\\EOF` writer on MALFORMED(20) where it
+used to be UNSUPPORTED(10). That is a deliberate, test-pinned over-block: the
+documented payload-strip workaround is spelled `<<'EOF'`. Widening
+``classify_safe`` to admit other spellings is a separate change needing its own
+proof — do not do it as a side effect of body-semantics work.
+"""
 
 from __future__ import annotations
 
@@ -494,6 +553,105 @@ def collapse_body_continuations(body: str) -> str:
     return "".join(result)
 
 
+def trailing_continuation(line: str) -> str | None:
+    """Strip a bash ``\\<newline>`` continuation backslash, or ``None``.
+
+    A here-doc body line ends in a continuation exactly when it ends in an ODD
+    run of backslashes: each pair is one escaped literal backslash, so a leftover
+    single backslash is the one that escapes the following newline. Parity of the
+    TRAILING run is sufficient — any backslash earlier in the line is separated
+    from the run by a non-backslash byte, which ends that escape.
+    """
+    stripped = line.rstrip("\\")
+    if (len(line) - len(stripped)) % 2 == 0:
+        return None
+    return line[:-1]
+
+
+def terminator_line_index(command: str, marker: Marker) -> int | None:
+    """Index of the physical line that closes ``marker``, or ``None``.
+
+    THE single home of "where does this here-doc body end", consulted by the
+    closure check, the body scanner, the literal-body strip and the body
+    neutraliser so no two of them can ever disagree about the window (issue
+    #1993 R5a).
+
+    Bash removes ``\\<newline>`` continuations from an UNQUOTED here-doc body
+    BEFORE it matches the delimiter, so a trailing backslash on the last body
+    line JOINS that line to the delimiter line and the here-doc is NOT closed
+    there — the real body swallows the apparent terminator and keeps consuming
+    following lines, where a ``$(...)`` the classifier believed was ordinary
+    post-here-doc text is expanded and EXECUTED. Matching the delimiter per
+    PHYSICAL line therefore under-reads the body window for unquoted delimiters.
+    Measured ground truth: ``cat <<EOF`` / ``foo\\`` / ``EOF`` / ``bar`` prints
+    ``fooEOF\\nbar`` (never terminated), while the same shape with ``<<'EOF'``
+    prints ``foo\\`` and then fails on ``bar: command not found``.
+
+    A QUOTED (or backslash-quoted) delimiter makes the body fully literal —
+    backslash is DATA there, not an escape — so those markers keep the exact
+    per-physical-line match, which the same measurement proves correct.
+    """
+    lines = bash_lines(command)
+    marker_line = command.count("\n", 0, marker.start)
+    pending: list[str] = []
+    for index in range(marker_line + 1, len(lines)):
+        line = lines[index]
+        if not marker.quoted:
+            continued = trailing_continuation(line)
+            if continued is not None:
+                pending.append(continued)
+                continue
+        candidate = "".join(pending) + line
+        pending = []
+        if marker.strip_tabs:
+            candidate = candidate.lstrip("\t")
+        if candidate == marker.delimiter:
+            return index
+    return None
+
+
+def neutralize_heredoc_bodies(command: str, markers: list[Marker]) -> str:
+    """Blank every real here-doc body window, preserving offsets.
+
+    ``has_active_command_substitution`` runs ONE flat single/double-quote state
+    machine across the whole command — including here-doc bodies, where bash
+    applies NO quote processing at all. An odd apostrophe in an unquoted body
+    (``it's fine``) therefore opens a phantom single-quoted string in the flat
+    scanner that persists PAST the terminator, hiding a live ``$(...)`` on a
+    FOLLOWING command line that bash happily executes (issue #1993 R5b). The
+    trigger is precisely an odd ``'`` count: an even ``''``, an odd ``"``, a
+    ``#``, an ANSI-C ``$'a`` and a lone trailing backslash all leave the flat
+    state correct, which is what pins the defect to this one branch.
+
+    ``strip_provably_literal_body`` cannot fix this: it bails whenever the marker
+    is unquoted, so the poisoning body is exactly the one it never touches. So
+    blank the body window of EVERY marker bash really treats as a here-doc
+    redirection before the flat scan runs. Bytes are replaced with spaces and
+    newlines are preserved, so marker offsets and line numbering stay valid for
+    every later walker.
+
+    Blanking loses nothing: a substitution INSIDE an unquoted body is still
+    caught by ``unquoted_heredoc_body_has_substitution`` (scanned with correct
+    here-doc-body semantics), and a quoted body is genuinely inert to bash. A
+    marker that is not closed blanks to end of command — that command is
+    MALFORMED on the closure check regardless, and its trailing region is still
+    body-scanned. As everywhere else, a marker nested inside an open quoted
+    string is NOT a here-doc to bash and is skipped, so its "body" stays fully
+    visible to the flat scan (issue #1958 Finding 1).
+    """
+    lines = bash_lines(command)
+    blanked = list(lines)
+    for marker in markers:
+        if cross_line_quote_state(command, marker.start) != "plain":
+            continue
+        marker_line = command.count("\n", 0, marker.start)
+        end = terminator_line_index(command, marker)
+        stop = len(lines) if end is None else end
+        for index in range(marker_line + 1, stop):
+            blanked[index] = " " * len(lines[index])
+    return "\n".join(blanked)
+
+
 def body_line_has_substitution(line: str) -> bool:
     """True if an unquoted-heredoc-body line contains an active substitution.
 
@@ -553,22 +711,22 @@ def unquoted_heredoc_body_has_substitution(
         if cross_line_quote_state(command, marker.start) != "plain":
             continue
         marker_line = command.count("\n", 0, marker.start)
-        body_lines: list[str] = []
-        for index in range(marker_line + 1, len(lines)):
-            candidate = (
-                lines[index].lstrip("\t") if marker.strip_tabs else lines[index]
-            )
-            if candidate == marker.delimiter:
-                break
-            body_lines.append(lines[index])
+        end = terminator_line_index(command, marker)
+        stop = len(lines) if end is None else end
+        body_lines = lines[marker_line + 1 : stop]
         # Join the raw body window under bash's unquoted-here-doc ``\<newline>``
         # removal BEFORE scanning, so a ``$(`` a caller split across a line
         # continuation is seen as the one contiguous token bash executes. The
-        # terminator was matched per physical line above (bash matches the
-        # delimiter before continuation processing), so continuations are joined
-        # only WITHIN the body window, never across the delimiter. This does not
-        # rely on ``collapse_line_continuations`` — whose flat quote state a body
-        # apostrophe corrupts — which is the whole point of Finding R4.
+        # window itself comes from ``terminator_line_index``, which applies that
+        # SAME removal before matching the delimiter — because bash does (issue
+        # #1993 R5a). An earlier revision matched the terminator per physical
+        # line here on the belief that bash matches the delimiter before
+        # continuation processing; that is false for an unquoted delimiter, and
+        # it let a trailing backslash on the last body line swallow the
+        # terminator so this scan stopped short of the region bash still treats
+        # as body. This does not rely on ``collapse_line_continuations`` — whose
+        # flat quote state a body apostrophe corrupts — which is the whole point
+        # of Finding R4.
         body = collapse_body_continuations("\n".join(body_lines))
         if body_line_has_substitution(body):
             return True
@@ -595,16 +753,42 @@ def parse_marker(line: str, start: int, offset: int) -> Marker | None:
         delimiter = line[index:end]
         final = end + 1
         # Deliberate POSIX divergence, fail-safe: POSIX makes the body
-        # non-expanding when ANY part of the delimiter is quoted — including
-        # `<<\EOF` (invisible to this parser: backslash is not a quote char and
-        # the identifier regex rejects it, so no Marker is recorded and the
-        # body stays raw-visible to every guard) and partial forms like
-        # `<<EO'F'` (mis-tokenized as delimiter EO, so the terminator never
-        # matches and the command fails closed as MALFORMED). Only a delimiter
-        # this parser can PROVE was one full quote pair earns quoted=True, and
-        # trailing word characters after the closing quote (`<<'EOF'X` — real
-        # bash delimiter EOFX) keep it conservative too: the next character
-        # must end the token.
+        # non-expanding when ANY part of the delimiter is quoted. Partial forms
+        # like `<<EO'F'` stay unmodelled (mis-tokenized as delimiter EO, so the
+        # terminator never matches and the command fails closed as MALFORMED).
+        # Only a delimiter this parser can PROVE was one full quote pair earns
+        # quoted=True, and trailing word characters after the closing quote
+        # (`<<'EOF'X` — real bash delimiter EOFX) keep it conservative too: the
+        # next character must end the token.
+        quoted = final >= len(line) or line[final] in " \t;&|)<>#"
+    elif line[index] == "\\":
+        # `<<\DELIM` is a BACKSLASH-quoted delimiter: bash and POSIX make its
+        # body fully literal, exactly like `<<'DELIM'` (measured: `cat <<\EOF`
+        # with body `it's $(echo RAN)` prints that text verbatim, unexpanded).
+        # This spelling used to record NO Marker at all, on the rationale that an
+        # unmodelled body stays raw-visible to every content guard. That covers
+        # the body's own contents but NOT the body's ability to corrupt the flat
+        # scanner's quote state for text AFTER the terminator: an apostrophe in
+        # an invisible body still opened a phantom string that hid a live
+        # `$(...)` on a following line (issue #1993 R5c). Recording it as the
+        # quoted marker bash actually treats it as is both more faithful and
+        # what brings it under `neutralize_heredoc_bodies`. The same
+        # token-must-end discipline as the quote-pair branch applies, so exotic
+        # spellings (`<<\EOF'x'` — real bash delimiter EOFx) stay conservative.
+        # quoted=True here is a statement about BODY semantics only. Recording a
+        # Marker where there was none also arms the writer-owns-a-real-marker and
+        # multi-marker rules, so `gh issue create --body-file - <<\EOF` and
+        # `cat <<\A <<B` now fail closed at MALFORMED instead of passing through
+        # at UNSUPPORTED. Both are valid, harmless bash, so that is a real
+        # over-block — accepted and test-pinned, because `classify_safe` requires
+        # the literal `<<'DELIM'` spelling and `<<\EOF` can never reach SAFE
+        # anyway. The documented payload-strip workaround is `<<'EOF'`.
+        index += 1
+        match = re.match(r"[A-Za-z_][A-Za-z0-9_]*", line[index:])
+        if match is None:
+            return None
+        delimiter = match.group(0)
+        final = index + len(delimiter)
         quoted = final >= len(line) or line[final] in " \t;&|)<>#"
     else:
         match = re.match(r"[A-Za-z_][A-Za-z0-9_]*", line[index:])
@@ -698,21 +882,22 @@ def strip_provably_literal_body(command: str, markers: list[Marker]) -> str:
         return command
     lines = bash_lines(command)
     marker_line = command.count("\n", 0, marker.start)
-    for index in range(marker_line + 1, len(lines)):
-        candidate = lines[index].lstrip("\t") if marker.strip_tabs else lines[index]
-        if candidate == marker.delimiter:
-            return "\n".join(lines[: marker_line + 1] + lines[index:])
-    return command
+    end = terminator_line_index(command, marker)
+    if end is None:
+        return command
+    return "\n".join(lines[: marker_line + 1] + lines[end:])
 
 
 def marker_is_closed(command: str, marker: Marker) -> bool:
-    marker_line = command.count("\n", 0, marker.start)
-    lines = bash_lines(command)
-    for line in lines[marker_line + 1 :]:
-        candidate = line.lstrip("\t") if marker.strip_tabs else line
-        if candidate == marker.delimiter:
-            return True
-    return False
+    """True when bash really terminates this here-doc inside the command.
+
+    Delegates to ``terminator_line_index`` so the closure verdict and the body
+    window are decided by one rule. For an unquoted delimiter that rule removes
+    ``\\<newline>`` continuations first, so a trailing backslash on the last body
+    line correctly reads as NOT closed — which is what bash does, and what makes
+    the swallowed-terminator shape fail closed as MALFORMED (issue #1993 R5a).
+    """
+    return terminator_line_index(command, marker) is not None
 
 
 def main() -> int:
@@ -748,11 +933,18 @@ def main() -> int:
         return MALFORMED
 
     # Nested substitution plus a heredoc is executable shell syntax unless it
-    # matched the one exact quoted `--body "$(cat ...)"` form above. The body
-    # of a single provably-literal heredoc is excluded from this scan (its
-    # tokens are inert data); the text outside that window is still scanned.
+    # matched the one exact quoted `--body "$(cat ...)"` form above. Here-doc
+    # bodies are neutralised before the flat scan: bash applies NO quote
+    # processing inside a body, so leaving those bytes in a flat quote state
+    # machine let an odd body apostrophe poison the scanner PAST the terminator
+    # and hide a live substitution on a following command line (issue #1993
+    # R5b). Neutralising preserves offsets, so the narrower literal-body strip
+    # still applies on top; the text outside every body window is still scanned,
+    # and in-body substitutions are covered by the body-semantics scan below.
     if has_active_command_substitution(
-        strip_provably_literal_body(logical_command, markers)
+        strip_provably_literal_body(
+            neutralize_heredoc_bodies(logical_command, markers), markers
+        )
     ) or unquoted_heredoc_body_has_substitution(logical_command, markers):
         return MALFORMED
     if len(markers) > 1:

--- a/plugins/src/base/hooks/parity-safety-net.sh
+++ b/plugins/src/base/hooks/parity-safety-net.sh
@@ -54,7 +54,27 @@
 # would never expand — a single-quoted `echo '$(rm -rf /)'` or an escaped
 # `echo "\$(rm -rf /)"` — because the scan has no quote-context awareness. That
 # over-block stays inside this accepted class. Workaround: quote-break the string
-# or use the gh-writer heredoc form, whose payload is stripped before the guards run.
+# or use the gh-writer heredoc form, whose payload is stripped before the guards
+# run — spelled with a QUOTE-PAIR delimiter (`<<'EOF'`). That exact spelling is
+# what the SAFE path recognises; `<<"EOF"` and `<<\EOF` do not reach it, and
+# since #1993 a `gh … <<\EOF` writer fails closed instead (see parse_marker).
+#
+# Known accepted BYPASS class (the symmetric error direction, issue #1993): the
+# heredoc classifier in parity-safety-net-heredoc.py re-implements bash's
+# here-doc lexing in Python, and any divergence from real bash is a shape it
+# mis-classifies. Five rounds on #1958 and three more on #1993 (R5a swallowed
+# terminator, R5b body-apostrophe quote-state poisoning, R5c backslash-quoted
+# delimiter) established that enumerating those divergences is an open-ended
+# arms race, so the class is CLOSED as accepted rather than chased further. This
+# is survivable because of where a mis-classification lands: ONLY the narrow
+# gh-writer SAFE path strips payload text, and every other classifier exit hands
+# the RAW command to the guards below. A missed here-doc therefore degrades to
+# the content guards; it does not bypass them. Since #1982 taught those guards to
+# see through substitution wrappers, every destructive class this net exists to
+# stop is blocked on the raw text regardless of how the here-doc was read. The
+# net catches ACCIDENTAL catastrophic commands; it is not a wall against an
+# adversary who knows bash's lexer, and it was never the only thing standing
+# between an agent and arbitrary execution.
 #
 # Operators extend the built-in rules with a project-local rule file — one
 # extended-regex (ERE) per line, blank lines and `#` comments ignored — managed

--- a/plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -103,7 +103,44 @@ same reason the rm guard treats substitution-wrapping as verdict-neutral (issue
 #1982): an executable `echo "$(rm -rf /)"` is blocked, and so are inert twins the
 shell would never expand — a single-quoted `echo '$(rm -rf /)'` or an escaped
 `echo "\$(rm -rf /)"` — since the scan has no quote-context awareness. The same
-quote-break or heredoc workaround applies.
+quote-break or heredoc workaround applies. Spell that heredoc workaround with a
+**quote-pair** delimiter (`gh issue create --body-file - <<'EOF'`) — only that
+spelling reaches the payload-strip path. `<<"EOF"` and `<<\EOF` do not, and a
+`gh … <<\EOF` writer now fails closed instead.
+
+## What this does and does not defend against
+
+Read this before treating the safety net as a wall.
+
+**What it is for:** stopping *accidental* catastrophic commands — an agent (or a
+human) that reaches for `rm -rf /`, force-pushes `main`, drops a table, or writes
+to a raw device by mistake. Within that job the guards above are the floor and
+they are always on.
+
+**What it is not:** a security boundary against a deliberate adversary. Two
+structural reasons, both accepted rather than open bugs:
+
+- **It is a text scan, not a shell engine.** It has no quote-context awareness,
+  which produces the false positives described above and means an operation
+  spelled in a way the patterns do not anticipate is not matched.
+- **The here-doc classifier re-implements bash's lexer in Python** to decide
+  which payload text is inert data. Every divergence from real bash is a shape it
+  mis-classifies. Eight distinct divergences were found and fixed across issues
+  #1958 and #1993; the class is open-ended, so it is now closed as an accepted
+  limitation rather than chased indefinitely.
+
+**Why that is tolerable:** a here-doc mis-classification degrades to the content
+guards rather than bypassing them. Only the narrow `gh issue|pr` writer form ever
+strips payload text; every other path passes the **raw** command to the guards,
+and since issue #1982 those guards see through substitution wrappers. So a
+mis-read here-doc costs no guard coverage for any destructive class listed above.
+
+**The honest bottom line:** an agent that is actively trying to run something
+destructive has many paths that never involve a here-doc at all — the safety net
+does not claim to close them. Do not rely on it as the only control over what an
+agent may execute; treat it as the last line of defence against mistakes, and
+keep the real boundary (credentials, permissions, environment isolation) outside
+the agent.
 
 ## View the current rules
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -589,11 +589,11 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/install-pkgs.sh":
       "e9a13faba849a277410dde911ab102ee6f88ef915b33571bb1d4eef904172db5",
     "plugins/src/base/hooks/parity-safety-net-heredoc.py":
-      "4be511d0e325e1df09983feb33023c1feb3b492fc92c16cbb48a08c3aaa5f540",
+      "f21b1232ac82bd0e42d2ba43c68f4cc4546334fc885ba31747881f427097ef78",
     "plugins/src/base/hooks/parity-safety-net.agy.sh":
       "ce9bd2b4566ad9147e4ace56434cffbbe87edb4ccbb57549ab3fd9f4c671ced4",
     "plugins/src/base/hooks/parity-safety-net.sh":
-      "772202ddd42d626625ff719666afbbe83445d8bae1bc7c0fb5ffdcb402be83f8",
+      "062c69eea85157f1e941ec3626d8912aa9f182af6ccdbe19687588a6074db5ce",
     "plugins/src/base/hooks/setup-jira-cli.sh":
       "a675f6b17ce7f0d6b9fb7daeba6d2bc59bcb48ef79b034076ea73b2b1e72ee09",
     "plugins/src/base/hooks/shell-write-nudge.sh":
@@ -965,7 +965,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-parity-coderabbit/SKILL.md":
       "ae882837d43741293d1b639c4516331fa6124fa1f5da234a74ecb31c5d7e52cd",
     "plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md":
-      "ce2fae102752b37df94abfa5a5cb602c1dad06766c450c9fbb3acf20be51420e",
+      "8757ea8c83e9acaad1af59f7b46d5ac7efaba61da76f9df3fc94b258f9a16b2b",
     "plugins/src/base/skills/lisa-parity-sentry-sdk-setup/SKILL.md":
       "ed52b0273f6b535d26d561c80ae6c0bedb84c67fcf4321f688c05fe3ee3af575",
     "plugins/src/base/skills/lisa-parity-sentry-seer/SKILL.md":
@@ -7935,6 +7935,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts": true,
     "tests/unit/hooks/lint-on-edit.test.ts": true,
     "tests/unit/hooks/parity-safety-net-guards.test.ts": true,
+    "tests/unit/hooks/parity-safety-net-heredoc-body-quote-state.test.ts": true,
     "tests/unit/hooks/parity-safety-net-heredoc-continuation.test.ts": true,
     "tests/unit/hooks/parity-safety-net-heredoc-literal.test.ts": true,
     "tests/unit/hooks/parity-safety-net-heredoc.test.ts": true,

--- a/tests/unit/hooks/parity-safety-net-heredoc-body-quote-state.test.ts
+++ b/tests/unit/hooks/parity-safety-net-heredoc-body-quote-state.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Here-doc body bytes must not corrupt the flat quote scanner (issue #1993
+ * R5b/R5c).
+ *
+ * `has_active_command_substitution` runs ONE flat single/double-quote state
+ * machine across the whole command — including here-doc bodies, where bash
+ * applies NO quote processing at all. An ODD apostrophe in an unquoted body
+ * (`it's fine`) therefore opens a phantom single-quoted string in that scanner
+ * which persists PAST the terminator, hiding a live `$(...)` on a FOLLOWING
+ * command line that bash happily executes. `strip_provably_literal_body` could
+ * not save it: it bails whenever the delimiter is unquoted, so the poisoning
+ * body is exactly the one it never neutralized. R5c is the same defect reached
+ * through a delimiter spelling the parser did not model at all — `<<\EOF`,
+ * which bash treats as fully quoted (measured: its body prints verbatim,
+ * byte-identical to `<<'EOF'`), but for which no Marker was recorded, so no
+ * body window existed to neutralize.
+ *
+ * Every BYPASS row below was ALLOWED (parser 10) and created its sentinel
+ * end-to-end under real bash before the fix. The POISON CONTROL table is the
+ * load-bearing half: the trigger is PRECISELY an odd `'` count, so an even
+ * `''`, an odd `"`, a `#`, an ANSI-C `$'a` and a lone trailing backslash were
+ * all already BLOCKED and must STAY blocked. Those rows pin the root cause and
+ * stop a future fix from over-generalizing into "blank anything that looks like
+ * a body". The over-block guards prove ordinary apostrophe prose is still
+ * allowed.
+ *
+ * Severity note: these are defence-in-depth, not RCE. Every one lands on
+ * UNSUPPORTED, where the hook passes the RAW command to the content guards, so
+ * a wall miss removes zero guard coverage — the destructive-payload rows at the
+ * bottom prove `rm -rf /` in the same position is still blocked.
+ * @module tests/unit/hooks/parity-safety-net-heredoc-body-quote-state
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+const HOOK_PATH = path.resolve("plugins/lisa/hooks/parity-safety-net.sh");
+const EXIT_BLOCKED = 2;
+const EXIT_ALLOWED = 0;
+const HEREDOC_TERMINATOR = "EOF";
+const HEREDOC_WALL_REASON = "malformed or ambiguous heredoc";
+const UNQUOTED_CAT_HEREDOC = "cat <<EOF";
+// `<<\EOF` — a BACKSLASH-quoted delimiter. Bash makes this body fully literal,
+// exactly like `<<'EOF'`; the parser used to record no Marker for it at all.
+const BACKSLASH_QUOTED_HEREDOC = "cat <<\\EOF";
+const BACKSLASH = "\\";
+const BACKTICK = "`";
+const SUBSTITUTION = "$(touch heredoc-1993-body-quote-sentinel)";
+
+const runHook = (
+  command: string
+): { status: number | null; stderr: string } => {
+  const result = spawnSync("/bin/bash", [HOOK_PATH], {
+    input: JSON.stringify({
+      tool_name: "Bash",
+      tool_input: { command },
+    }),
+    encoding: "utf8",
+  });
+  return { status: result.status, stderr: result.stderr };
+};
+
+/**
+ * Build a here-doc with text placed AFTER the terminator — the position where a
+ * poisoned flat quote scanner hides a live substitution.
+ * @param header The here-doc header line, e.g. `cat <<EOF`.
+ * @param body The single body line, i.e. the candidate poison.
+ * @param tail Lines following the terminator, i.e. the smuggled payload.
+ * @returns The assembled multi-line command.
+ */
+const withTail = (header: string, body: string, ...tail: string[]): string =>
+  [header, body, HEREDOC_TERMINATOR, ...tail].join("\n");
+
+describe("an odd body apostrophe must not hide a substitution after the terminator (issue #1993 R5b)", () => {
+  it("blocks a $(touch) after a body that is a bare apostrophe (R5b C2min)", () => {
+    const result = runHook(withTail(UNQUOTED_CAT_HEREDOC, "'", SUBSTITUTION));
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+
+  it("blocks the ordinary agent shape: apostrophe prose then one more command (R5b real)", () => {
+    // The shape that makes this worth fixing at all — `cat <<EOF` writing a note
+    // containing an English apostrophe, then a following command line.
+    const result = runHook(
+      withTail(UNQUOTED_CAT_HEREDOC, "it's fine", `echo ${SUBSTITUTION}`)
+    );
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+
+  it("blocks a $(touch) after a partially-quoted body line (R5b full)", () => {
+    const result = runHook(
+      withTail(UNQUOTED_CAT_HEREDOC, "'foo", SUBSTITUTION)
+    );
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+
+  it("blocks a backtick substitution after apostrophe prose (R5b bt)", () => {
+    const result = runHook(
+      withTail(
+        UNQUOTED_CAT_HEREDOC,
+        "it's fine",
+        `${BACKTICK}touch heredoc-1993-R5bbt-sentinel${BACKTICK}`
+      )
+    );
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+
+  it("blocks with THREE apostrophes — any odd count poisons the scanner (R5b odd-3)", () => {
+    const result = runHook(
+      withTail(UNQUOTED_CAT_HEREDOC, "it's o'clock'", SUBSTITUTION)
+    );
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+
+  it("blocks an apostrophe combined with a body # comment marker (R5b sq+hash)", () => {
+    const result = runHook(
+      withTail(UNQUOTED_CAT_HEREDOC, "it's # note", SUBSTITUTION)
+    );
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+});
+
+describe("poison-family controls: the trigger is precisely an ODD apostrophe count (issue #1993 R5b)", () => {
+  // Each body below leaves the flat scanner's quote state CORRECT, so each was
+  // already BLOCKED before the fix. They must stay blocked: if one of these ever
+  // flips to ALLOWED, a body-neutralizing change has over-generalized and is
+  // hiding substitutions the flat scan was legitimately catching.
+  const controls: ReadonlyArray<readonly [string, string]> = [
+    ["a plain body with no quote bytes", "body"],
+    ["an EVEN apostrophe count", "it's fine'"],
+    ["an odd DOUBLE quote", 'say "hi'],
+    ["a lone # comment marker", "# note"],
+    ["an ANSI-C $'a token", "x $'a"],
+    ["an escaped backslash pair", `back${BACKSLASH}${BACKSLASH}slash`],
+  ];
+
+  for (const [label, body] of controls) {
+    it(`still blocks a following $(touch) behind ${label}`, () => {
+      const result = runHook(
+        withTail(UNQUOTED_CAT_HEREDOC, body, SUBSTITUTION)
+      );
+      expect(result.status).toBe(EXIT_BLOCKED);
+      expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+    });
+  }
+});
+
+describe("a backslash-quoted delimiter is a modelled quoted here-doc (issue #1993 R5c)", () => {
+  it("blocks a $(touch) after an apostrophe body under <<\\EOF (R5c)", () => {
+    const result = runHook(
+      withTail(BACKSLASH_QUOTED_HEREDOC, "it's", SUBSTITUTION)
+    );
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+
+  it("blocks a backtick after an apostrophe body under <<\\EOF (R5c bt)", () => {
+    const result = runHook(
+      withTail(
+        BACKSLASH_QUOTED_HEREDOC,
+        "it's",
+        `${BACKTICK}touch heredoc-1993-R5cbt-sentinel${BACKTICK}`
+      )
+    );
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+
+  it("still blocks the same shape with NO apostrophe (R5c control)", () => {
+    // Pins the trigger to the apostrophe, exactly as in the R5b table.
+    const result = runHook(
+      withTail(BACKSLASH_QUOTED_HEREDOC, "plain body", SUBSTITUTION)
+    );
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+});
+
+describe("R5c's accepted over-block: <<\\EOF is quoted for BODY semantics, not for the writer path", () => {
+  // Recording a Marker for `<<\EOF` (which R5c requires — no Marker meant no body
+  // window to neutralize) also arms the writer-owns-a-real-marker rule and the
+  // multi-marker rule. These three commands are valid, harmless bash that moved
+  // from UNSUPPORTED(10) to MALFORMED(20). That is a REAL over-block, accepted
+  // deliberately rather than silently: `classify_safe` demands the literal
+  // `<<'DELIM'` spelling, so `<<\EOF` could never reach the SAFE payload-strip
+  // path regardless. `Marker.quoted` therefore means "bash makes this body
+  // literal" and NOT "this is interchangeable with `<<'EOF'` everywhere" — the
+  // documented payload-strip workaround stays spelled `<<'EOF'`, pinned by the
+  // last test here. Widening `classify_safe` needs its own proof.
+  const overBlocked: ReadonlyArray<readonly [string, readonly string[]]> = [
+    [
+      "a gh issue writer using a backslash-quoted delimiter",
+      ["gh issue create --title t --body-file - <<\\EOF", "hello", "EOF"],
+    ],
+    [
+      "a gh pr comment writer using a backslash-quoted delimiter",
+      ["gh pr comment 1 --body-file - <<\\EOF", "hello", "EOF"],
+    ],
+    [
+      "two here-docs where the first delimiter is backslash-quoted",
+      ["cat <<\\A <<B", "x", "A", "y", "B"],
+    ],
+  ];
+
+  for (const [label, lines] of overBlocked) {
+    it(`fails closed on ${label} (accepted over-block)`, () => {
+      expect(runHook(lines.join("\n")).status).toBe(EXIT_BLOCKED);
+    });
+  }
+
+  it("keeps the documented <<'EOF' writer workaround working", () => {
+    // The counterpart that must NOT regress: the quote-pair spelling is the one
+    // `classify_safe` recognizes, and it still reaches the SAFE strip path.
+    const command = [
+      "gh issue create --title t --body-file - <<'EOF'",
+      "hello",
+      "EOF",
+    ].join("\n");
+    expect(runHook(command).status).toBe(EXIT_ALLOWED);
+  });
+});
+
+describe("body neutralization must not over-block ordinary payloads (issue #1993)", () => {
+  it("allows apostrophe prose with nothing after the terminator", () => {
+    const command = [
+      UNQUOTED_CAT_HEREDOC,
+      "it's fine",
+      HEREDOC_TERMINATOR,
+    ].join("\n");
+    expect(runHook(command).status).toBe(EXIT_ALLOWED);
+  });
+
+  it("allows apostrophe prose followed by an ordinary command", () => {
+    const result = runHook(
+      withTail(UNQUOTED_CAT_HEREDOC, "it's fine", "echo done")
+    );
+    expect(result.status).toBe(EXIT_ALLOWED);
+  });
+
+  it("allows a tab-stripped <<-EOF body containing an apostrophe", () => {
+    const command = ["cat <<-EOF", "\tit's fine", "\tEOF"].join("\n");
+    expect(runHook(command).status).toBe(EXIT_ALLOWED);
+  });
+
+  it("allows a literal $(...) inside a fully quoted <<'EOF' body", () => {
+    // The Finding-1 literal-payload win: a quoted body is genuinely inert to
+    // bash, and neutralizing bodies must not disturb that.
+    const command = [
+      `cat <<'${HEREDOC_TERMINATOR}'`,
+      SUBSTITUTION,
+      HEREDOC_TERMINATOR,
+    ].join("\n");
+    expect(runHook(command).status).toBe(EXIT_ALLOWED);
+  });
+
+  it("allows an unexpanded $HOME reference in an unquoted body", () => {
+    const command = [
+      UNQUOTED_CAT_HEREDOC,
+      "path is $HOME",
+      HEREDOC_TERMINATOR,
+    ].join("\n");
+    expect(runHook(command).status).toBe(EXIT_ALLOWED);
+  });
+});
+
+describe("the content guards remain the real backstop (issue #1993 severity)", () => {
+  // Neutralizing a body must never hide a DESTRUCTIVE payload from the content
+  // guards, which scan the raw command text. These are the rows that make a
+  // here-doc-wall miss defence-in-depth rather than an RCE.
+  const destructive: ReadonlyArray<readonly [string, string]> = [
+    ["rm -rf of a root path", "$(rm -rf /)"],
+    ["rm -rf of a home path", "$(rm -rf ~/)"],
+    ["destructive SQL", '$(psql -c "DROP TABLE users")'],
+  ];
+
+  for (const [label, payload] of destructive) {
+    it(`blocks ${label} placed after an apostrophe body`, () => {
+      const result = runHook(
+        withTail(UNQUOTED_CAT_HEREDOC, "it's fine", payload)
+      );
+      expect(result.status).toBe(EXIT_BLOCKED);
+    });
+  }
+});

--- a/tests/unit/hooks/parity-safety-net-heredoc-continuation.test.ts
+++ b/tests/unit/hooks/parity-safety-net-heredoc-continuation.test.ts
@@ -141,3 +141,158 @@ describe("unquoted-heredoc-body line-continuation split does not smuggle a live 
     ).toBe(EXIT_ALLOWED);
   });
 });
+
+// A trailing backslash on the LAST body line is a bash line continuation that
+// joins that line to the delimiter line, so the delimiter never matches and the
+// here-doc is NOT closed there — the real body swallows the apparent terminator
+// and keeps consuming following lines. Anything the classifier read as ordinary
+// post-here-doc text is therefore still body to bash, and a `$(...)` placed
+// there is EXPANDED. Ground truth measured directly against /bin/bash:
+//   `cat <<EOF` / `foo\` / `EOF` / `bar`      -> stdout `fooEOF\nbar` (never closed)
+//   `cat <<'EOF'` / `foo\` / `EOF` / `bar`    -> stdout `foo\`, then `bar: command not found`
+// So the per-physical-line delimiter match is CORRECT for a quoted delimiter and
+// WRONG only for an unquoted one, which is what makes the fix local: the window
+// resolver removes `\<newline>` before matching only when the delimiter is
+// unquoted. These shapes were ALLOWED (parser 10) and executed the sentinel
+// end-to-end under real bash before the fix.
+const afterTerminator = (body: string[], ...tail: string[]): string =>
+  [UNQUOTED_CAT_HEREDOC, ...body, HEREDOC_TERMINATOR, ...tail].join("\n");
+// A last body line whose trailing backslash continues INTO the delimiter line.
+const SWALLOWING_TAIL = `'foo${BACKSLASH}`;
+
+describe("a trailing-backslash continuation must not swallow the terminator (issue #1993 R5a)", () => {
+  it("blocks a $(touch) placed after the swallowed terminator (R5a X1)", () => {
+    const result = runHook(
+      afterTerminator(
+        [SWALLOWING_TAIL],
+        "$(touch heredoc-1993-R5a-X1-sentinel)"
+      )
+    );
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+
+  it("blocks a weaponized $(touch && id) after the swallowed terminator (R5a W)", () => {
+    const result = runHook(
+      afterTerminator(
+        [SWALLOWING_TAIL],
+        "$(touch heredoc-1993-R5aW-sentinel && id)"
+      )
+    );
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+
+  it("blocks a backtick substitution after the swallowed terminator (R5a bt)", () => {
+    const result = runHook(
+      afterTerminator(
+        [SWALLOWING_TAIL],
+        `${BACKTICK}touch heredoc-1993-R5abt-sentinel${BACKTICK}`
+      )
+    );
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+
+  it("blocks the realistic apostrophe-prose shape that ends in a line wrap (R5a P)", () => {
+    const result = runHook(
+      afterTerminator(
+        [`notes: it's the rollout plan${BACKSLASH}`],
+        "echo $(touch heredoc-1993-R5aP-sentinel)"
+      )
+    );
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+
+  it("still blocks the same shape with NO apostrophe (R5a C1 control)", () => {
+    // Isolates the trigger. Without the apostrophe the flat scanner is not
+    // poisoned and already saw the `$(`, so this was BLOCKED before the fix and
+    // must stay BLOCKED after it — the fix must not be what makes it pass.
+    const result = runHook(
+      afterTerminator(
+        [`foo${BACKSLASH}`],
+        "$(touch heredoc-1993-R5aC1-sentinel)"
+      )
+    );
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+
+  it("still blocks the same shape with BALANCED apostrophes (R5a C3 control)", () => {
+    // The second control from the reproduction: an even apostrophe count leaves
+    // the flat quote state correct. BLOCKED before and after.
+    const result = runHook(
+      afterTerminator(
+        [`'foo'${BACKSLASH}`],
+        "$(touch heredoc-1993-R5aC3-sentinel)"
+      )
+    );
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+
+  // The two rows below are the ONLY fixtures in this file that isolate fix A
+  // (continuation-aware terminator matching) from fix B (here-doc body
+  // neutralization). Every other R5a row places a BARE `$(` or backtick after
+  // the terminator, and B's blanking already exposes those to the flat scanner —
+  // so those rows stay BLOCKED even with A reverted and cannot pin it. Only a
+  // tail the flat scanner deliberately SKIPS can tell the two apart: text after
+  // a `#` comment marker, or after an opening `'` that it reads as a quote. With
+  // A reverted (B and C kept) both of these go ALLOWED and execute their
+  // sentinel under real bash; with A present both are BLOCKED, because the
+  // swallowed terminator makes the here-doc unterminated and the command fails
+  // closed before the flat scanner's blind spot can matter. Mutation-verified.
+  it("blocks a #-commented substitution after the swallowed terminator (R5a fix-A pin)", () => {
+    const result = runHook(
+      afterTerminator(
+        [SWALLOWING_TAIL],
+        "#$(touch heredoc-1993-R5a-hash-sentinel)"
+      )
+    );
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+
+  it("blocks an apostrophe-prefixed substitution after the swallowed terminator (R5a fix-A pin)", () => {
+    const result = runHook(
+      afterTerminator(
+        [SWALLOWING_TAIL],
+        `'$(touch heredoc-1993-R5a-sq-sentinel)`
+      )
+    );
+    expect(result.status).toBe(EXIT_BLOCKED);
+    expect(result.stderr).toContain(HEREDOC_WALL_REASON);
+  });
+
+  it("keeps a quoted-delimiter body with a mid-body line wrap allowed (R5a quoted-asymmetry guard)", () => {
+    // Bash does NOT remove `\<newline>` in a `<<'EOF'` body — backslash is DATA
+    // there — so that body is inert literal text and the window resolver must
+    // keep matching the delimiter per PHYSICAL line for quoted delimiters. This
+    // pins the quoted path against the R5a continuation removal leaking into it.
+    const command = [
+      `cat <<'${HEREDOC_TERMINATOR}'`,
+      `foo${BACKSLASH}`,
+      "bar",
+      HEREDOC_TERMINATOR,
+    ].join("\n");
+    expect(runHook(command).status).toBe(EXIT_ALLOWED);
+  });
+
+  it("pins a PRE-EXISTING false positive: quoted delimiter, trailing wrap on the LAST body line", () => {
+    // Measured BLOCKED on the parent commit and still BLOCKED here — this is NOT
+    // an R5a regression. Bash accepts this shape (`foo\` is literal data and the
+    // next line terminates), but the whole-command `collapse_line_continuations`
+    // joins `foo\` to the delimiter line before the here-doc logic ever runs, so
+    // the terminator is not found and the command fails closed. That collapser
+    // is outside the R5a fix (which governs the here-doc WINDOW resolver only);
+    // narrowing it is a separate change with its own bypass surface. Pinned so
+    // the false positive is visible and attributed rather than rediscovered.
+    const command = [
+      `cat <<'${HEREDOC_TERMINATOR}'`,
+      `foo${BACKSLASH}`,
+      HEREDOC_TERMINATOR,
+    ].join("\n");
+    expect(runHook(command).status).toBe(EXIT_BLOCKED);
+  });
+});

--- a/tests/unit/hooks/parity-safety-net-heredoc.test.ts
+++ b/tests/unit/hooks/parity-safety-net-heredoc.test.ts
@@ -152,13 +152,16 @@ describe("parity-safety-net heredoc grammar", () => {
   });
 
   describe("delimiter-quoting conservatism (issue #1958 F4)", () => {
-    // POSIX says ANY quoting of ANY part of a heredoc delimiter (including a
-    // backslash escape, `<<\EOF`) makes the body non-expanding. The parser
-    // cannot PROVE that for backslash or partially-quoted forms — parse_marker
-    // records no Marker for `<<\EOF` and mis-tokenizes `<<EO'F'` — so only a
-    // delimiter wrapped in one full single- or double-quote pair earns the
-    // literal-body exclusion. These pins make that deliberate fail-safe
-    // divergence from POSIX visible if it ever drifts.
+    // POSIX says ANY quoting of ANY part of a heredoc delimiter makes the body
+    // non-expanding. `<<\EOF` is now MODELLED as exactly that — a quoted
+    // delimiter (issue #1993 R5c) — because bash agrees, measured directly:
+    // `cat <<\EOF` with body `x = "`ls`"` prints that text VERBATIM (backticks
+    // never run), byte-identical to `<<'EOF'`, while unquoted `<<EOF` prints
+    // `x = ""` because it really did expand them. Leaving it unmodelled was not
+    // merely conservative: an apostrophe in the invisible body still poisoned
+    // the flat scanner's quote state and hid a live `$(...)` on a line AFTER
+    // the terminator. Partially-quoted forms like `<<EO'F'` remain unmodelled
+    // and fail closed. These pins keep `<<\EOF` in lockstep with `<<'EOF'`.
     it("allows a backslash-quoted delimiter with a harmless payload", () => {
       const command = [
         BACKSLASH_QUOTED_HEREDOC,
@@ -169,14 +172,19 @@ describe("parity-safety-net heredoc grammar", () => {
       expect(runHook(command).status).toBe(EXIT_ALLOWED);
     });
 
-    it("still fails closed on substitution tokens under a backslash-quoted delimiter", () => {
+    it("treats substitution tokens under a backslash-quoted delimiter as the literal data bash makes them", () => {
+      // Was BLOCKED while `<<\EOF` was unmodelled. Bash does NOT execute these
+      // backticks, so blocking was a false positive; `<<'EOF'` with the same
+      // body has always been allowed. The classifier returns UNSUPPORTED, which
+      // passes the RAW command to the content guards — the next test proves a
+      // destructive payload in this exact position is still caught.
       const command = [
         BACKSLASH_QUOTED_HEREDOC,
         'x = "`ls`"',
         HEREDOC_TERMINATOR,
       ].join("\n");
 
-      expect(runHook(command).status).toBe(EXIT_BLOCKED);
+      expect(runHook(command).status).toBe(EXIT_ALLOWED);
     });
 
     it("keeps destructive payloads behind a backslash-quoted delimiter visible to guards", () => {


### PR DESCRIPTION
## Summary

Closes #1993.

Closes the residual heredoc-classifier bypasses R5a and R5b, plus **R5c — a third member found during scoping**. All three share one root cause.

## Work item

Work-Item: CodySwannGT/lisa#1993

## Severity is downgraded, deliberately

**This is defence-in-depth hygiene, not an RCE fix, and nothing here claims otherwise.**

R5a/R5b/R5c all land on parser exit `10` (UNSUPPORTED), never `0` (SAFE). Only exit `0` rewrites the command handed to the content guards, and that needs the narrow `gh issue|pr` + single-quoted-heredoc grammar none of these reach. **A wall miss therefore removes zero content-guard coverage.**

Measured through the real hook after #1982 merged, behind each bypass: recursive delete of root, of home, of a top-level wildcard, of an absolute path outside the project, destructive SQL, and `dd` to a raw device — **all still BLOCKED**. What still passes is equally allowed with no heredoc present at all, so the marginal capability these grant over baseline is nil. The original CRITICAL rating was explicitly conditioned on the guard blindness #1982 removed.

## One root cause, three symptoms

The classifier re-implements bash's lexing, so every divergence is a payload it believes inert that bash actually expands. Two invariants, both **measured against real bash** rather than assumed:

1. The flat quote/comment state machine applies shell quote semantics to bytes **inside a heredoc body**, where bash applies none.
2. The terminator is matched **per physical line**, where bash matches it only after line-continuation removal — and *only for an unquoted delimiter*. With a quoted delimiter a trailing backslash is literal data and per-physical-line is correct.

That asymmetry is what makes the fixes local and provable rather than heuristic.

| | symptom |
|---|---|
| **R5a** | a trailing `\` on the last body line joins it to the terminator and **swallows** it, leaving following text as body |
| **R5b** | an odd apostrophe in an unquoted body poisons the scanner's quote state **past** the terminator |
| **R5c** | `<<\DELIM` recorded **no marker at all**, so its body was never neutralized |

All three now resolve the body window through **one shared helper**, so the closure check, body scanner, literal strip, and the new neutralizer cannot disagree about where a body ends. Bodies are blanked with spaces before the flat scan, preserving newlines so byte offsets and reported line numbers stay exact.

`<<\DELIM` is recorded as quoted because bash treats its body as fully literal — verified byte-identical to `<<'DELIM'` on every probe.

## Verification

- **Sweep: 122 → 1** of 399 generated shapes. The single residual contains no `<<` at all (process substitution) — documented baseline, not a wall bypass.
- **Zero over-block delta**, confirmed by name: OB-apostrophe-prose, OB-trailing-bs-mid, OB-quoted-literal, OB-tabs, OB-home-var, OB-apos-then-plain-cmd, OB-gh-writer. Finding-1, R1-ansic, R3-inline, R3-hash and R4-split all still BLOCK.
- The shared window resolver was exercised over **2,240 generated shapes**: zero window disagreements, zero offset drift, zero length change.
- Full suite **7699 passed / 448 files**; safety-net subset 340 (from 303 baseline).

### Fix A is now mutation-proven — it was not, and that mattered

Review found that reverting fix A alone left **all fifteen** existing continuation fixtures green. Two shapes it silently re-opens were then confirmed to **actually execute** under bash:

- body `'foo\`, terminator `EOF`, tail `#$(…)`
- body `'foo\`, terminator `EOF`, tail `'$(…)`

Every pre-existing R5a fixture put a bare `$(` or backtick after the terminator, which fix B's blanking already exposes — so only a tail the flat scanner deliberately *skips* can distinguish A from B. Both rows are now pinned, and the proof is two-level: at parser level they flip 20 → 10 with A reverted, and installing the mutant into the fanned hook fails **exactly 2 of 17** tests, precisely the new rows.

## Accepted trade-off, pinned rather than hidden

Recording a marker for `<<\DELIM` also arms the "writer owns a marker" and multi-marker rules, so three valid, harmless commands now fail closed:

`gh issue create … <<\EOF`, `gh pr comment … <<\EOF`, and `cat <<\A <<B`.

`classify_safe` deliberately still requires the `<<'DELIM'` spelling, so `<<\EOF` can never reach SAFE and falls into the writer rule instead. Since the gh-writer heredoc form is the *documented workaround* for the over-block class, one spelling of that escape hatch stopped working. Widening `classify_safe` would need its own proof and is out of scope, so this is **accepted and pinned by tests** — including a counterpart test asserting `<<'EOF'` still reaches SAFE, which must never regress. The documented workaround now names its spelling.

## Documented as an accepted limitation, with a stop condition

Three sites, three readers: the module docstring (authoritative scope + the recorded bash invariants), the hook header (a known-accepted-*bypass* paragraph symmetric to the existing false-positive one, naming the #1982 backstop), and the rules SKILL.md (which had **no** limitations section at all, so an operator read "always on" and inferred a wall).

The owner hard-bounded this class at round 5 of an arms race, and that judgement stands. What is adopted from it is the **stop condition**: this class is now closed as an accepted limitation, and the next member found is documented rather than fixed — unless someone first shows it defeats the *content guards*.

Honest caveat: R5c was found in one session purely by sweeping. **Each fix is bounded; the class is not.** That is exactly why the documentation is part of this change rather than a follow-up.

## Also included

A `postcss` floor in the override maps. A tailwind lint plugin in production dependencies pinned a nested copy affected by a source-map path-traversal advisory, failing the pre-push gate. Adding the floor the same way every other advisory in that file is handled collapses the nested copies onto the already-safe top-level version — rather than suppressing the finding with an audit ignore.

🤖 Generated with Claude Code
