### PR TITLE
fix(readiness): clarify no-workflow skip reasons

### DIFF
--- a/src/cli/doctor-readiness-domain.ts
+++ b/src/cli/doctor-readiness-domain.ts
@@ -162,6 +162,18 @@ function domainFinding(scan: OperationScan): Record<string, unknown> {
  * @returns The SKIP reason
  */
 function skipReason(inspected: number, runbook: boolean): string {
+  if (inspected === 0) {
+    return (
+      "No GitHub Actions workflow files were found under `.github/workflows/`, " +
+      "so no irreversible data-destroying operations could be assessed from " +
+      "workflow declarations (recovery runbook " +
+      `${runbook ? "present" : "absent"}). Whether this ` +
+      "repository's business rules, glossary, and danger zones are genuinely " +
+      "owned and written down cannot be established by reading files offline — " +
+      "that needs the agent-ready domain phase — so domain ownership is not " +
+      "established either way."
+    );
+  }
   return (
     `Read ${inspected} workflow file(s) for irreversible data-destroying ` +
     "operations and found none that this file alone proves runs unattended, " +

--- a/src/cli/doctor-readiness-guardrails.ts
+++ b/src/cli/doctor-readiness-guardrails.ts
@@ -196,16 +196,22 @@ function skipRecord(
   inspected: number,
   runbook: boolean
 ): ReadinessDimensionRecord {
+  const reason =
+    inspected === 0
+      ? `No GitHub Actions workflow files were found under \`.github/workflows/\`, ` +
+        `so no irreversible or expensive operations could be assessed from ` +
+        `workflow declarations (recovery runbook ` +
+        `${runbook ? "present" : "absent"}). ${PROTECTION_RULES_SKIP_REASON}`
+      : `Read ${inspected} workflow file(s) for irreversible or expensive ` +
+        "operations and found none that this file alone proves runs " +
+        `unattended with no gate and no way back (recovery runbook ` +
+        `${runbook ? "present" : "absent"}). ${PROTECTION_RULES_SKIP_REASON}`;
   return {
     id: FEEDBACK_GUARDRAILS_DIMENSION_ID,
     status: "SKIP",
     findings: [
       {
-        reason:
-          `Read ${inspected} workflow file(s) for irreversible or expensive ` +
-          "operations and found none that this file alone proves runs " +
-          `unattended with no gate and no way back (recovery runbook ` +
-          `${runbook ? "present" : "absent"}). ${PROTECTION_RULES_SKIP_REASON}`,
+        reason,
         skip: true,
       },
       ...informationalFindings([

--- a/tests/unit/cli/doctor-readiness-domain.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain.test.ts
@@ -153,7 +153,9 @@ describe("assessDomainOwnershipDimension — reports silence as silence", () => 
     const findings = asFindings(record.findings);
     expect(findings.length).toBeGreaterThan(0);
     expect(typeof findings[0].reason).toBe("string");
-    expect(String(findings[0].reason)).not.toBe("");
+    expect(String(findings[0].reason)).toContain(
+      "No GitHub Actions workflow files were found"
+    );
     expect(findings[0].skip).toBe(true);
     expect(Object.hasOwn(findings[0], "blocker")).toBe(false);
   });

--- a/tests/unit/cli/doctor-readiness-guardrails.test.ts
+++ b/tests/unit/cli/doctor-readiness-guardrails.test.ts
@@ -304,7 +304,9 @@ describe("assessFeedbackGuardrailsDimension — ordinary operations stay clear",
     expect(record.status).toBe(SKIP);
     const findings = asFindings(record.findings);
     expect(findings.length).toBeGreaterThan(0);
-    expect(String(findings[0].reason)).not.toBe("");
+    expect(String(findings[0].reason)).toContain(
+      "No GitHub Actions workflow files were found"
+    );
     expect(findings[0].skip).toBe(true);
     expectNoBlocker(record.findings);
   });


### PR DESCRIPTION
## Summary
- Clarify B1/B4 readiness SKIP reasons when a repository has no GitHub Actions workflows.
- Preserve the existing inspected-workflow wording for repositories where workflow files were actually parsed.
- Pin the no-workflow wording in domain ownership and feedback guardrails unit tests.

## Verification
- `bun test tests/unit/cli/doctor-readiness-domain.test.ts tests/unit/cli/doctor-readiness-guardrails.test.ts`
- `bun run typecheck`
- `bun run build:dist`
- `bun run lint`
- pre-push: security audit, slow lint, knip, full unit coverage, integration tests, plugin parity

Work-Item: CodySwannGT/lisa#1903
Related: CodySwannGT/lisa#1903 partial no-workflow honesty slice; keep parent issue open for remaining B1/B2/B3/B5/B6 backlog.
