### PR TITLE
fix: tighten B1 service deferral scope

### DIFF
--- a/src/cli/doctor-readiness-domain.ts
+++ b/src/cli/doctor-readiness-domain.ts
@@ -40,6 +40,7 @@ import {
   type ParsedWorkflow,
   type ParsedWorkflowJob,
   parseRepositoryWorkflows,
+  type ParsedWorkflowStep,
 } from "./doctor-readiness-workflows.js";
 
 /** The domain-ownership readiness dimension id (readiness-rubric, RRR-1). */
@@ -104,15 +105,55 @@ function destroysData(command: string, job: ParsedWorkflowJob): boolean {
 }
 
 /**
- * State why a job that boots its own `services:` containers cannot be settled.
- * A job that starts its own database is operating on state it created moments
- * earlier, so destroying it is not data loss — but proving *which* store the
- * command targets is beyond an offline read, so this is deferred, not cleared.
+ * Whether the command plausibly targets one of the job's own `services:`
+ * containers. A service only defers the step it can explain; an unrelated
+ * container in the same job must not hide a durable destructive target.
  * @param job - The job to consider
- * @returns A stated reason, or null when the job starts no services
+ * @param step - The destructive step being classified
+ * @returns True when the command plausibly points at a job-local service
  */
-function servicesDeferral(job: ParsedWorkflowJob): string | null {
+function commandTargetsOwnedService(
+  job: ParsedWorkflowJob,
+  step: ParsedWorkflowStep
+): boolean {
   if (job.services.length === 0) {
+    return false;
+  }
+  const command = `${step.run}\n${job.env}`.toLowerCase();
+  return job.services.some(service => {
+    const normalized = service.toLowerCase();
+    return (
+      command.includes(normalized) ||
+      (/(postgres|postgresql|database|db)/.test(normalized) &&
+        /\b(psql|postgres|database_url|drop\s+(schema|database|table))\b/.test(
+          command
+        )) ||
+      (/(mysql|mariadb|database|db)/.test(normalized) &&
+        /\b(mysql|database_url|drop\s+(schema|database|table))\b/.test(
+          command
+        )) ||
+      (/redis/.test(normalized) && /\bredis-cli\b/.test(command)) ||
+      (/mongo/.test(normalized) && /\b(mongo|mongosh)\b/.test(command))
+    );
+  });
+}
+
+/**
+ * State why a service-targeted command cannot be settled. A job that starts its
+ * own database is operating on state it created moments earlier, so destroying
+ * it is not data loss — but proving that the command targets that service is
+ * still beyond an offline read, so this is deferred, not cleared.
+ * @param _workflow - The workflow declaring the job; unused for this deferral
+ * @param job - The job to consider
+ * @param step - The destructive step being classified
+ * @returns A stated reason, or null when the service does not explain the step
+ */
+function servicesDeferral(
+  _workflow: ParsedWorkflow,
+  job: ParsedWorkflowJob,
+  step: ParsedWorkflowStep
+): string | null {
+  if (!commandTargetsOwnedService(job, step)) {
     return null;
   }
   return (
@@ -248,7 +289,7 @@ export async function assessDomainOwnershipDimension(
     parsedWorkflows ?? (await parseRepositoryWorkflows(root));
   const scan = scanCommands(workflows, destroysData, {
     exemptJob: jobTakesBackup,
-    unresolvedJob: servicesDeferral,
+    unresolvedStep: servicesDeferral,
   });
   // A checked-in runbook is a way back, so it clears the "no recovery" half of
   // B1 for the whole repository — the blocker asks for BOTH halves at once.

--- a/src/cli/doctor-readiness-domain.ts
+++ b/src/cli/doctor-readiness-domain.ts
@@ -124,11 +124,11 @@ function commandTargetsOwnedService(
     const normalized = service.toLowerCase();
     return (
       command.includes(normalized) ||
-      (/(postgres|postgresql|database|db)/.test(normalized) &&
+      (/\b(postgres|postgresql|database|db)\b/.test(normalized) &&
         /\b(psql|postgres|database_url|drop\s+(schema|database|table))\b/.test(
           command
         )) ||
-      (/(mysql|mariadb|database|db)/.test(normalized) &&
+      (/\b(mysql|mariadb|database|db)\b/.test(normalized) &&
         /\b(mysql|database_url|drop\s+(schema|database|table))\b/.test(
           command
         )) ||

--- a/src/cli/doctor-readiness-domain.ts
+++ b/src/cli/doctor-readiness-domain.ts
@@ -85,6 +85,33 @@ const RECOVERY_COMMANDS: readonly RegExp[] = [
   /\baws\s+s3\s+sync\b/,
 ];
 
+/** Local endpoints that corroborate a command targets job-owned CI state. */
+const LOCAL_SERVICE_TARGETS: readonly RegExp[] = [
+  /\blocalhost\b/,
+  /\b127\.0\.0\.1\b/,
+];
+
+/**
+ * Escape a literal string for use inside a regular expression.
+ * @param value - Literal value to escape
+ * @returns Regex-safe literal
+ */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Whether a command/env blob names the concrete service hostname.
+ * @param command - Lower-cased command and environment text
+ * @param service - Lower-cased service id
+ * @returns True when the service appears as its own host/token
+ */
+function namesServiceHost(command: string, service: string): boolean {
+  return new RegExp(
+    `(^|[\\s:/@="'(,])${escapeRegExp(service)}($|[\\s:/;),'"?])`
+  ).test(command);
+}
+
 /**
  * Whether a command irreversibly destroys data that is not obviously throwaway.
  *
@@ -120,22 +147,12 @@ function commandTargetsOwnedService(
     return false;
   }
   const command = `${step.run}\n${job.env}`.toLowerCase();
-  return job.services.some(service => {
-    const normalized = service.toLowerCase();
-    return (
-      command.includes(normalized) ||
-      (/\b(postgres|postgresql|database|db)\b/.test(normalized) &&
-        /\b(psql|postgres|database_url|drop\s+(schema|database|table))\b/.test(
-          command
-        )) ||
-      (/\b(mysql|mariadb|database|db)\b/.test(normalized) &&
-        /\b(mysql|database_url|drop\s+(schema|database|table))\b/.test(
-          command
-        )) ||
-      (/redis/.test(normalized) && /\bredis-cli\b/.test(command)) ||
-      (/mongo/.test(normalized) && /\b(mongo|mongosh)\b/.test(command))
-    );
-  });
+  return (
+    LOCAL_SERVICE_TARGETS.some(pattern => pattern.test(command)) ||
+    job.services.some(service =>
+      namesServiceHost(command, service.toLowerCase())
+    )
+  );
 }
 
 /**

--- a/src/cli/doctor-readiness-operations.ts
+++ b/src/cli/doctor-readiness-operations.ts
@@ -62,6 +62,16 @@ export interface ScanOptions {
    * when it can. Used for a job that boots its own `services:` containers.
    */
   readonly unresolvedJob?: (job: ParsedWorkflowJob) => string | null;
+  /**
+   * A step-level reason the match cannot be settled offline, returning `null`
+   * when it can. Used when the same job-level evidence only applies to some
+   * matching commands.
+   */
+  readonly unresolvedStep?: (
+    workflow: ParsedWorkflow,
+    job: ParsedWorkflowJob,
+    step: ParsedWorkflowStep
+  ) => string | null;
 }
 
 /**
@@ -215,11 +225,19 @@ function classifyJob(
     return [{ kind: "unresolved", reason: deferred }];
   }
   const jobGated = jobIsGated(job) || (options.exemptJob?.(job) ?? false);
-  return hits.map(step => ({
-    kind:
-      jobGated || stepIsGated(step) ? ("gated" as const) : ("ungated" as const),
-    command: { workflow: workflow.file, jobId: job.id, command: step.run },
-  }));
+  return hits.map(step => {
+    const stepDeferred = options.unresolvedStep?.(workflow, job, step);
+    if (stepDeferred !== undefined && stepDeferred !== null) {
+      return { kind: "unresolved" as const, reason: stepDeferred };
+    }
+    return {
+      kind:
+        jobGated || stepIsGated(step)
+          ? ("gated" as const)
+          : ("ungated" as const),
+      command: { workflow: workflow.file, jobId: job.id, command: step.run },
+    };
+  });
 }
 
 /**

--- a/tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts
@@ -145,6 +145,39 @@ describe("assessDomainOwnershipDimension — ephemeral CI evidence outside the c
     ).toBe(false);
   });
 
+  it("stands B1 when the job's only service is a different database technology that merely names-collides on `db`", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      "    services:",
+      "      dynamodb-local:",
+      "        image: amazon/dynamodb-local",
+      STEPS,
+      '      - run: psql "$PROD_DATABASE_URL" -c "DROP TABLE users"',
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    // `dynamodb-local` is a NoSQL service; `psql`/`DROP TABLE` can never target
+    // it. The service name merely containing the substring `db` must not
+    // excuse the command as plausibly local.
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+    expect(
+      asFindings(record.findings).some(finding =>
+        String(finding.reason).includes("services:")
+      )
+    ).toBe(false);
+  });
+
   it("does not stand B1 for the AWS CLI's own `--dryrun` rehearsal spelling", async () => {
     const root = await getTempDir();
     await writeWorkflow(root, CLEANUP_YML, [

--- a/tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts
@@ -115,6 +115,36 @@ describe("assessDomainOwnershipDimension — ephemeral CI evidence outside the c
     }
   });
 
+  it("stands B1 when a job service is unrelated to the durable destructive target", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      "    services:",
+      "      redis:",
+      "        image: redis:7",
+      STEPS,
+      RUN_S3_WIPE,
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+    expect(
+      asFindings(record.findings).some(finding =>
+        String(finding.reason).includes("services:")
+      )
+    ).toBe(false);
+  });
+
   it("does not stand B1 for the AWS CLI's own `--dryrun` rehearsal spelling", async () => {
     const root = await getTempDir();
     await writeWorkflow(root, CLEANUP_YML, [

--- a/tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts
@@ -8,7 +8,8 @@
  * 1. **The evidence that a target is throwaway is routinely outside the
  *    command.** `psql "$DATABASE_URL" -c "DROP SCHEMA public CASCADE"` reads as
  *    production destruction until you see the job's `env:` block pointing at
- *    `127.0.0.1`, or the `services:` container the job booted moments earlier.
+ *    `127.0.0.1`, or the concrete service hostname the job booted moments
+ *    earlier.
  * 2. **An empty runbook directory is not a recovery procedure.** Treating one
  *    as a way back would make `mkdir docs/runbooks` a one-command switch for
  *    turning this blocker off repository-wide.
@@ -103,6 +104,8 @@ describe("assessDomainOwnershipDimension — ephemeral CI evidence outside the c
       "    services:",
       "      postgres:",
       "        image: postgres:16",
+      "    env:",
+      "      DATABASE_URL: postgres://postgres@postgres:5432/app",
       STEPS,
       RUN_SCHEMA_RESET,
     ]);
@@ -128,6 +131,38 @@ describe("assessDomainOwnershipDimension — ephemeral CI evidence outside the c
       "        image: redis:7",
       STEPS,
       RUN_S3_WIPE,
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+    expect(
+      asFindings(record.findings).some(finding =>
+        String(finding.reason).includes("services:")
+      )
+    ).toBe(false);
+  });
+
+  it("stands B1 when a database command does not prove it targets the local service", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      "    services:",
+      "      postgres:",
+      "        image: postgres:16",
+      "    env:",
+      "      DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}",
+      STEPS,
+      RUN_SCHEMA_RESET,
     ]);
 
     const record = await assessDomainOwnershipDimension(root);


### PR DESCRIPTION
## Summary

- make B1 services-container uncertainty step-specific instead of job-wide
- keep local database service cases conservative while allowing unrelated durable destructive targets to stand B1
- add a regression for an unrelated Redis service plus a production S3 wipe

## Work Item

Work-Item: CodySwannGT/lisa#1903

## Verification

- bun test tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts tests/unit/cli/doctor-readiness-domain.test.ts tests/unit/cli/doctor-readiness-domain-negatives.test.ts
- bun run typecheck
- bun run build:dist
- bun run lint
- bun run format:check
- bun run lint:slow
- bun run check:plugins
- bun run knip:check
- bun run test
- bun run test:integration
- .husky/pre-push


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline readiness assessments by making deferral logic step-aware when workflows run destructive operations.
  * More accurately identifies blocker B1 when destructive commands target job-local durable services, while ignoring unrelated service container evidence.
  * Updates findings to use clearer step-level “cannot settle offline” classification and avoids misleading service-related reasons.

* **Tests**
  * Added unit coverage to confirm unrelated service containers do not suppress B1 and that findings do not include service-related explanation text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->