### PR TITLE
fix(readiness): scope B4 service deferrals

### DIFF
--- a/src/cli/doctor-readiness-domain.ts
+++ b/src/cli/doctor-readiness-domain.ts
@@ -27,6 +27,7 @@
  * @module cli/doctor-readiness-domain
  */
 import {
+  commandTargetsOwnedService,
   describeCommands,
   hasCheckedInRunbook,
   looksEphemeral,
@@ -85,33 +86,6 @@ const RECOVERY_COMMANDS: readonly RegExp[] = [
   /\baws\s+s3\s+sync\b/,
 ];
 
-/** Local endpoints that corroborate a command targets job-owned CI state. */
-const LOCAL_SERVICE_TARGETS: readonly RegExp[] = [
-  /\blocalhost\b/,
-  /\b127\.0\.0\.1\b/,
-];
-
-/**
- * Escape a literal string for use inside a regular expression.
- * @param value - Literal value to escape
- * @returns Regex-safe literal
- */
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-/**
- * Whether a command/env blob names the concrete service hostname.
- * @param command - Lower-cased command and environment text
- * @param service - Lower-cased service id
- * @returns True when the service appears as its own host/token
- */
-function namesServiceHost(command: string, service: string): boolean {
-  return new RegExp(
-    `(^|[\\s:/@="'(,])${escapeRegExp(service)}($|[\\s:/;),'"?])`
-  ).test(command);
-}
-
 /**
  * Whether a command irreversibly destroys data that is not obviously throwaway.
  *
@@ -128,30 +102,6 @@ function destroysData(command: string, job: ParsedWorkflowJob): boolean {
   return (
     IRREVERSIBLE_DATA_OPS.some(pattern => pattern.test(command)) &&
     !looksEphemeral(`${command}\n${job.env}`)
-  );
-}
-
-/**
- * Whether the command plausibly targets one of the job's own `services:`
- * containers. A service only defers the step it can explain; an unrelated
- * container in the same job must not hide a durable destructive target.
- * @param job - The job to consider
- * @param step - The destructive step being classified
- * @returns True when the command plausibly points at a job-local service
- */
-function commandTargetsOwnedService(
-  job: ParsedWorkflowJob,
-  step: ParsedWorkflowStep
-): boolean {
-  if (job.services.length === 0) {
-    return false;
-  }
-  const command = `${step.run}\n${job.env}`.toLowerCase();
-  return (
-    LOCAL_SERVICE_TARGETS.some(pattern => pattern.test(command)) ||
-    job.services.some(service =>
-      namesServiceHost(command, service.toLowerCase())
-    )
   );
 }
 

--- a/src/cli/doctor-readiness-guardrails.ts
+++ b/src/cli/doctor-readiness-guardrails.ts
@@ -23,6 +23,7 @@
  * @module cli/doctor-readiness-guardrails
  */
 import {
+  commandTargetsOwnedService,
   describeCommands,
   hasCheckedInRunbook,
   looksEphemeral,
@@ -34,6 +35,7 @@ import type { ReadinessDimensionRecord } from "./doctor-readiness-types.js";
 import {
   type ParsedWorkflow,
   type ParsedWorkflowJob,
+  type ParsedWorkflowStep,
   parseRepositoryWorkflows,
 } from "./doctor-readiness-workflows.js";
 
@@ -155,6 +157,31 @@ function lifecycleDeferral(workflow: ParsedWorkflow): string | null {
 }
 
 /**
+ * State why a service-targeted consequential operation cannot be settled. A job
+ * may run against service containers it created for that same CI run, but an
+ * unrelated service must not excuse a durable infrastructure operation.
+ * @param _workflow - The workflow declaring the job; unused for this deferral
+ * @param job - The job to consider
+ * @param step - The consequential step being classified
+ * @returns A stated reason, or null when the service does not explain the step
+ */
+function servicesDeferral(
+  _workflow: ParsedWorkflow,
+  job: ParsedWorkflowJob,
+  step: ParsedWorkflowStep
+): string | null {
+  if (!commandTargetsOwnedService(job, step)) {
+    return null;
+  }
+  return (
+    `Job \`${job.id}\` runs a consequential operation while starting its own ` +
+    `\`services:\` container(s) (${job.services.join(", ")}), which are created ` +
+    "and thrown away inside the run, so whether the operation targets a durable " +
+    "environment is not established either way"
+  );
+}
+
+/**
  * Build the rubric-shaped B4 finding from the operations it cites.
  * @param scan - The consequential-operation scan
  * @returns The B4 finding
@@ -247,6 +274,7 @@ export async function assessFeedbackGuardrailsDimension(
     parsedWorkflows ?? (await parseRepositoryWorkflows(root));
   const scan = scanCommands(workflows, isConsequential, {
     unresolvedWorkflow: lifecycleDeferral,
+    unresolvedStep: servicesDeferral,
   });
   const runbook = await hasCheckedInRunbook(root);
   if (scan.ungated.length === 0 || runbook) {

--- a/src/cli/doctor-readiness-operations.ts
+++ b/src/cli/doctor-readiness-operations.ts
@@ -104,6 +104,57 @@ export function looksEphemeral(text: string): boolean {
   return EPHEMERAL_TARGETS.some(pattern => pattern.test(normalized));
 }
 
+/** Local endpoints that corroborate a command targets job-owned CI state. */
+const LOCAL_SERVICE_TARGETS: readonly RegExp[] = [
+  /\blocalhost\b/,
+  /\b127\.0\.0\.1\b/,
+];
+
+/**
+ * Escape a literal string for use inside a regular expression.
+ * @param value - Literal value to escape
+ * @returns Regex-safe literal
+ */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Whether a command/env blob names the concrete service hostname.
+ * @param command - Lower-cased command and environment text
+ * @param service - Lower-cased service id
+ * @returns True when the service appears as its own host/token
+ */
+function namesServiceHost(command: string, service: string): boolean {
+  return new RegExp(
+    `(^|[\\s:/@="'(,])${escapeRegExp(service)}($|[\\s:/;),'"?])`
+  ).test(command);
+}
+
+/**
+ * Whether the command plausibly targets one of the job's own `services:`
+ * containers. A service only defers the step it can explain; an unrelated
+ * container in the same job must not hide a durable target.
+ * @param job - The job to consider
+ * @param step - The step being classified
+ * @returns True when the command plausibly points at a job-local service
+ */
+export function commandTargetsOwnedService(
+  job: ParsedWorkflowJob,
+  step: ParsedWorkflowStep
+): boolean {
+  if (job.services.length === 0) {
+    return false;
+  }
+  const command = `${step.run}\n${job.env}`.toLowerCase();
+  return (
+    LOCAL_SERVICE_TARGETS.some(pattern => pattern.test(command)) ||
+    job.services.some(service =>
+      namesServiceHost(command, service.toLowerCase())
+    )
+  );
+}
+
 /**
  * Whether one command is the kind of operation a producer is looking for. The
  * job travels with the command because the evidence that settles the question

--- a/src/cli/doctor-readiness-operations.ts
+++ b/src/cli/doctor-readiness-operations.ts
@@ -110,13 +110,91 @@ const LOCAL_SERVICE_TARGETS: readonly RegExp[] = [
   /\b127\.0\.0\.1\b/,
 ];
 
+/** Keys whose values are allowed to establish host-level service evidence. */
+const SERVICE_HOST_KEYS = new Set([
+  "addr",
+  "address",
+  "database_url",
+  "db_url",
+  "endpoint",
+  "host",
+  "hostname",
+  "jdbc_url",
+  "redis_url",
+  "url",
+]);
+
+/** Hostname separators accepted inside URLs and connection strings. */
+const HOST_BOUNDARY_CHARS = new Set([
+  "",
+  ":",
+  "/",
+  "?",
+  "#",
+  "&",
+  ")",
+  "'",
+  '"',
+]);
+
+/** Hostname prefixes accepted inside URLs and connection strings. */
+const HOST_PREFIX_CHARS = new Set(["/", "@"]);
+
 /**
- * Escape a literal string for use inside a regular expression.
- * @param value - Literal value to escape
- * @returns Regex-safe literal
+ * Whether the value has a URL or user-info host reference to a service.
+ * @param value - Lower-cased command or environment text
+ * @param service - Lower-cased service id
+ * @param offset - Current search offset, used by the recursive scan
+ * @returns True when the service appears in URL/user-host position
  */
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+function hasConnectionHost(
+  value: string,
+  service: string,
+  offset = value.indexOf(service)
+): boolean {
+  if (offset === -1) {
+    return false;
+  }
+  const previous = value[offset - 1] ?? "";
+  const next = value[offset + service.length] ?? "";
+  return (
+    (HOST_PREFIX_CHARS.has(previous) && HOST_BOUNDARY_CHARS.has(next)) ||
+    hasConnectionHost(
+      value,
+      service,
+      value.indexOf(service, offset + service.length)
+    )
+  );
+}
+
+/**
+ * Whether a line such as `HOST=postgres` or `DATABASE_URL: postgres://...`
+ * provides host-target evidence.
+ * @param line - Lower-cased serialized command/env line
+ * @param service - Lower-cased service id
+ * @returns True when the line has a host-like key and service host value
+ */
+function lineNamesServiceHost(line: string, service: string): boolean {
+  const trimmed = line.trim();
+  const colonIndex = trimmed.indexOf(":");
+  const equalsIndex = trimmed.indexOf("=");
+  const separatorIndexes = [colonIndex, equalsIndex].filter(
+    index => index !== -1
+  );
+  const separatorIndex = Math.min(...separatorIndexes);
+  if (!Number.isFinite(separatorIndex)) {
+    return false;
+  }
+  const rawKey = trimmed.slice(0, separatorIndex).trim();
+  const rawValue = trimmed.slice(separatorIndex + 1).trim();
+  const key = rawKey.replace(/[^a-z0-9]+/gu, "_");
+  const value = rawValue.trim();
+  return (
+    SERVICE_HOST_KEYS.has(key) &&
+    (value === service ||
+      value.startsWith(`${service}:`) ||
+      hasConnectionHost(value, service))
+  );
 }
 
 /**
@@ -126,9 +204,11 @@ function escapeRegExp(value: string): string {
  * @returns True when the service appears as its own host/token
  */
 function namesServiceHost(command: string, service: string): boolean {
-  return new RegExp(
-    `(^|[\\s:/@="'(,])${escapeRegExp(service)}($|[\\s:/;),'"?])`
-  ).test(command);
+  const lines = command.split(/\r?\n/u);
+  return lines.some(
+    line =>
+      hasConnectionHost(line, service) || lineNamesServiceHost(line, service)
+  );
 }
 
 /**
@@ -146,7 +226,7 @@ export function commandTargetsOwnedService(
   if (job.services.length === 0) {
     return false;
   }
-  const command = `${step.run}\n${job.env}`.toLowerCase();
+  const command = `${step.run}\n${step.env}\n${job.env}`.toLowerCase();
   return (
     LOCAL_SERVICE_TARGETS.some(pattern => pattern.test(command)) ||
     job.services.some(service =>

--- a/src/cli/doctor-readiness-workflows.ts
+++ b/src/cli/doctor-readiness-workflows.ts
@@ -51,6 +51,8 @@ export interface ParsedWorkflowStep {
   readonly run: string;
   /** The action the step uses, or `""` for a `run` step. */
   readonly uses: string;
+  /** Raw serialized step-level `env` text, used for target evidence. */
+  readonly env: string;
   /** Raw serialized `env` + `with` text, used for credential evidence. */
   readonly inputs: string;
   /**
@@ -225,6 +227,7 @@ function parseSteps(value: unknown): readonly ParsedWorkflowStep[] {
     name: typeof step.name === "string" ? step.name : "",
     run: typeof step.run === "string" ? step.run.trim() : "",
     uses: typeof step.uses === "string" ? step.uses.trim() : "",
+    env: serializeBlock(step.env).join("\n"),
     inputs: serializeStepInputs(step as Record<string, unknown>),
     ifCondition: asCondition(step.if),
   }));

--- a/tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts
@@ -43,6 +43,13 @@ const CLEANUP_NAME = "name: Cleanup";
 /** A destructive job header reused across fixtures. */
 const WIPE_JOB = "  wipe:";
 
+/** A local Postgres service declaration reused across service-target fixtures. */
+const POSTGRES_SERVICE = [
+  "    services:",
+  "      postgres:",
+  "        image: postgres:16",
+];
+
 /** An irreversible bucket-emptying command against a production bucket. */
 const RUN_S3_WIPE =
   "      - run: aws s3 rm s3://acme-prod-user-uploads --recursive";
@@ -101,9 +108,7 @@ describe("assessDomainOwnershipDimension — ephemeral CI evidence outside the c
       JOBS,
       WIPE_JOB,
       RUNS_ON,
-      "    services:",
-      "      postgres:",
-      "        image: postgres:16",
+      ...POSTGRES_SERVICE,
       "    env:",
       "      DATABASE_URL: postgres://postgres@postgres:5432/app",
       STEPS,
@@ -156,13 +161,39 @@ describe("assessDomainOwnershipDimension — ephemeral CI evidence outside the c
       JOBS,
       WIPE_JOB,
       RUNS_ON,
-      "    services:",
-      "      postgres:",
-      "        image: postgres:16",
+      ...POSTGRES_SERVICE,
       "    env:",
       "      DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}",
       STEPS,
       RUN_SCHEMA_RESET,
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+    expect(
+      asFindings(record.findings).some(finding =>
+        String(finding.reason).includes("services:")
+      )
+    ).toBe(false);
+  });
+
+  it("stands B1 when a service name only appears as a generic assignment value", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      ...POSTGRES_SERVICE,
+      STEPS,
+      '      - run: psql "$PROD_DATABASE_URL" --set database=postgres -c "DROP TABLE users"',
     ]);
 
     const record = await assessDomainOwnershipDimension(root);

--- a/tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts
+++ b/tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts
@@ -47,6 +47,13 @@ const RUN_TERRAFORM_APPLY = "      - run: terraform apply -auto-approve";
 const RUN_TERRAFORM_DESTROY =
   "      - run: terraform destroy -auto-approve -var-file=prod.tfvars";
 
+/** A local Postgres service declaration reused across service-target fixtures. */
+const POSTGRES_SERVICE = [
+  "    services:",
+  "      postgres:",
+  "        image: postgres:16",
+];
+
 /**
  * Every finding in a record, asserted to name no blocker.
  * @param findings - The record's raw findings
@@ -189,9 +196,7 @@ describe("assessFeedbackGuardrailsDimension — ephemeral environments stay clea
       JOBS,
       INFRA_JOB,
       RUNS_ON,
-      "    services:",
-      "      postgres:",
-      "        image: postgres:16",
+      ...POSTGRES_SERVICE,
       "    env:",
       "      DATABASE_URL: postgres://postgres@postgres:5432/app",
       STEPS,
@@ -237,6 +242,60 @@ describe("assessFeedbackGuardrailsDimension — ephemeral environments stay clea
         String(finding.observation).includes("services:")
       )
     ).toBe(false);
+  });
+
+  it("stands B4 when a service name only appears as a generic terraform variable value", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      DEPLOY_NAME_LINE,
+      ON_PUSH,
+      JOBS,
+      INFRA_JOB,
+      RUNS_ON,
+      ...POSTGRES_SERVICE,
+      STEPS,
+      "      - run: terraform destroy -auto-approve -var database=postgres",
+    ]);
+
+    const record = await assessFeedbackGuardrailsDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+    expect(
+      asFindings(record.findings).some(finding =>
+        String(finding.observation).includes("services:")
+      )
+    ).toBe(false);
+  });
+
+  it("does not stand B4 when a step `env:` URL targets the job's own service", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      DEPLOY_NAME_LINE,
+      ON_PUSH,
+      JOBS,
+      INFRA_JOB,
+      RUNS_ON,
+      ...POSTGRES_SERVICE,
+      STEPS,
+      "      - run: RAILS_ENV=production bundle exec rails db:migrate",
+      "        env:",
+      "          DATABASE_URL: postgres://postgres@postgres:5432/app",
+    ]);
+
+    const record = await assessFeedbackGuardrailsDimension(root);
+
+    expect(record.status).toBe(SKIP);
+    expectNoBlocker(record.findings);
+    expect(
+      asFindings(record.findings).some(finding =>
+        String(finding.observation).includes("services:")
+      )
+    ).toBe(true);
   });
 
   it("does not stand B4 for an integration job applying test tfvars", async () => {

--- a/tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts
+++ b/tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts
@@ -43,6 +43,10 @@ const INFRA_JOB = "  infra:";
 /** An irreversible infrastructure apply with the human confirmation removed. */
 const RUN_TERRAFORM_APPLY = "      - run: terraform apply -auto-approve";
 
+/** A production terraform destroy that should remain visible to B4. */
+const RUN_TERRAFORM_DESTROY =
+  "      - run: terraform destroy -auto-approve -var-file=prod.tfvars";
+
 /**
  * Every finding in a record, asserted to name no blocker.
  * @param findings - The record's raw findings
@@ -175,6 +179,64 @@ describe("assessFeedbackGuardrailsDimension — ephemeral environments stay clea
         finding => finding.blocker === BLOCKER_ID
       )
     ).toBe(true);
+  });
+
+  it("does not stand B4 when a migration targets the job's own `services:` container", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      DEPLOY_NAME_LINE,
+      ON_PUSH,
+      JOBS,
+      INFRA_JOB,
+      RUNS_ON,
+      "    services:",
+      "      postgres:",
+      "        image: postgres:16",
+      "    env:",
+      "      DATABASE_URL: postgres://postgres@postgres:5432/app",
+      STEPS,
+      "      - run: RAILS_ENV=production bundle exec rails db:migrate",
+    ]);
+
+    const record = await assessFeedbackGuardrailsDimension(root);
+
+    expect(record.status).toBe(SKIP);
+    expectNoBlocker(record.findings);
+    expect(
+      asFindings(record.findings).some(finding =>
+        String(finding.observation).includes("services:")
+      )
+    ).toBe(true);
+  });
+
+  it("stands B4 when a job service is unrelated to a durable infrastructure target", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      DEPLOY_NAME_LINE,
+      ON_PUSH,
+      JOBS,
+      INFRA_JOB,
+      RUNS_ON,
+      "    services:",
+      "      redis:",
+      "        image: redis:7",
+      STEPS,
+      RUN_TERRAFORM_DESTROY,
+    ]);
+
+    const record = await assessFeedbackGuardrailsDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+    expect(
+      asFindings(record.findings).some(finding =>
+        String(finding.observation).includes("services:")
+      )
+    ).toBe(false);
   });
 
   it("does not stand B4 for an integration job applying test tfvars", async () => {

--- a/tests/unit/cli/doctor-readiness-workflows.test.ts
+++ b/tests/unit/cli/doctor-readiness-workflows.test.ts
@@ -101,7 +101,14 @@ describe("parseRepositoryWorkflows", () => {
     const test = workflow.jobs[0];
     expect(test.needs).toEqual([]);
     expect(test.steps).toEqual([
-      { ifCondition: "", inputs: "", name: "", run: "npm run test", uses: "" },
+      {
+        env: "",
+        ifCondition: "",
+        inputs: "",
+        name: "",
+        run: "npm run test",
+        uses: "",
+      },
     ]);
 
     const publish = workflow.jobs[1];
@@ -114,6 +121,7 @@ describe("parseRepositoryWorkflows", () => {
     expect(publish.secrets).toBe("inherit");
     expect(publish.steps).toEqual([
       {
+        env: "",
         ifCondition: "",
         inputs: "",
         name: "",
@@ -121,6 +129,7 @@ describe("parseRepositoryWorkflows", () => {
         uses: "actions/download-artifact@v4",
       },
       {
+        env: "",
         ifCondition: "",
         inputs: "",
         name: "",


### PR DESCRIPTION
## Summary
- share the owned-service target predicate between B1 and B4 readiness scanning
- defer B4 only when the consequential step plausibly targets the job's own services container
- keep unrelated services from hiding durable infrastructure operations

## Verification
- bun test tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts
- bun run typecheck
- bun run build:dist
- bun run lint
- bun run check:upstream-evidence-manifest
- bun run check:plugins
- pre-push: production dependency audit, slow lint, knip, full unit coverage, integration tests, plugin parity

Work-Item: CodySwannGT/lisa#1903

[lisa-pr-link] https://github.com/CodySwannGT/lisa/pull/2021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness guardrails for ephemeral environments by recognizing destructive commands and env URLs that target job-owned `services`.
  * Adds clearer deferral behavior when a destructive step can’t be resolved offline, with an updated rationale.
  * Prevents unrelated job service names from incorrectly suppressing durable infrastructure warnings.
* **Tests**
  * Expanded unit test coverage for `services`-targeting scenarios, including blocker status and diagnostic observation details.
  * Updated workflow parsing expectations to include captured step-level `env` evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->