### PR TITLE
fix(readiness): require lockfile-enforced installs

### DIFF
--- a/src/cli/doctor-readiness-supply-chain-scan.ts
+++ b/src/cli/doctor-readiness-supply-chain-scan.ts
@@ -160,6 +160,13 @@ const AUDIT_GATE_PATTERN =
   /\b(npm|bun|yarn|pnpm)\s+audit\b|audit-ci|osv-scanner|dependency-review-action|\bsnyk\b|\btrivy\b|\bgrype\b/i;
 
 /**
+ * Install commands that prove CI will honor the committed lockfile instead of
+ * silently updating it or accepting a different dependency tree.
+ */
+const LOCKFILE_INSTALL_PATTERN =
+  /\bnpm\s+ci\b|\b(?:bun|pnpm)\s+install\b[^\n\r]*(?:--frozen-lockfile|--immutable)\b|\byarn\s+install\b[^\n\r]*(?:--frozen-lockfile|--immutable)\b/i;
+
+/**
  * An update bot covering the JavaScript dependency tree. A `dependabot.yml`
  * that only watches `github-actions` never looks at `package.json`, so its mere
  * presence is not a confidence model for the dependencies.
@@ -363,6 +370,30 @@ export async function findAuditGate(root: string): Promise<string | null> {
   for (const file of scanned) {
     const source = await readFileOrNull(root, file);
     if (source !== null && AUDIT_GATE_PATTERN.test(source)) {
+      return file.split(path.sep).join("/");
+    }
+  }
+  return null;
+}
+
+/**
+ * Find where the repository installs dependencies in a way that must honor the
+ * committed lockfile.
+ * @param root - Repository root
+ * @returns The repo-relative path of the first enforcing install gate found, or null
+ */
+export async function findLockfileInstallGate(
+  root: string
+): Promise<string | null> {
+  const scanned = [
+    ...(
+      await Promise.all(GATE_DIRECTORIES.map(dir => listDirectory(root, dir)))
+    ).flat(),
+    ...GATE_FILES,
+  ];
+  for (const file of scanned) {
+    const source = await readFileOrNull(root, file);
+    if (source !== null && LOCKFILE_INSTALL_PATTERN.test(source)) {
       return file.split(path.sep).join("/");
     }
   }

--- a/src/cli/doctor-readiness-supply-chain-scan.ts
+++ b/src/cli/doctor-readiness-supply-chain-scan.ts
@@ -159,12 +159,18 @@ export function isFloatingSpec(spec: string): boolean {
 const AUDIT_GATE_PATTERN =
   /\b(npm|bun|yarn|pnpm)\s+audit\b|audit-ci|osv-scanner|dependency-review-action|\bsnyk\b|\btrivy\b|\bgrype\b/i;
 
-/**
- * Install commands that prove CI will honor the committed lockfile instead of
- * silently updating it or accepting a different dependency tree.
- */
-const LOCKFILE_INSTALL_PATTERN =
-  /\bnpm\s+ci\b|\b(?:bun|pnpm)\s+install\b[^\n\r]*(?:--frozen-lockfile|--immutable)\b|\byarn\s+install\b[^\n\r]*(?:--frozen-lockfile|--immutable)\b/i;
+/** Package managers whose install command can enforce a committed lockfile. */
+const FROZEN_INSTALL_MANAGERS: ReadonlySet<string> = new Set([
+  "bun",
+  "pnpm",
+  "yarn",
+]);
+
+/** Install flags that prove the committed lockfile is enforced. */
+const LOCKFILE_INSTALL_FLAGS: ReadonlySet<string> = new Set([
+  "--frozen-lockfile",
+  "--immutable",
+]);
 
 /**
  * An update bot covering the JavaScript dependency tree. A `dependabot.yml`
@@ -349,6 +355,84 @@ function coversJavaScriptTree(botFile: string, source: string): boolean {
 }
 
 /**
+ * Remove one layer of YAML quoting from a command scalar.
+ * @param value - Potentially quoted YAML scalar text
+ * @returns The command text without balanced outer quotes
+ */
+function unquoteCommand(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length < 2) {
+    return trimmed;
+  }
+  const first = trimmed.at(0);
+  const last = trimmed.at(-1);
+  return (first === '"' && last === '"') || (first === "'" && last === "'")
+    ? trimmed.slice(1, -1)
+    : trimmed;
+}
+
+/**
+ * Strip a leading YAML list marker from a possibly indented step line.
+ * @param trimmed - A source line after outer whitespace was removed
+ * @returns The line without a leading `- ` marker
+ */
+function stripYamlListMarker(trimmed: string): string {
+  return trimmed.startsWith("- ") ? trimmed.slice(2).trimStart() : trimmed;
+}
+
+/**
+ * Extract a command-shaped line from CI/hook text. This intentionally accepts
+ * direct hook commands and GitHub Actions `run:` scalars, while rejecting
+ * comments and quoted mentions such as `run: echo "npm ci"`.
+ * @param line - One source line
+ * @returns The executable command candidate, or null
+ */
+function executableCommandCandidate(line: string): string | null {
+  const trimmed = line.trim();
+  if (trimmed === "" || trimmed.startsWith("#")) {
+    return null;
+  }
+  const commandish = stripYamlListMarker(trimmed);
+  if (commandish.toLowerCase().startsWith("run:")) {
+    const command = unquoteCommand(commandish.slice("run:".length));
+    return command === "|" || command === ">" ? null : command;
+  }
+  return commandish;
+}
+
+/**
+ * Whether a command starts with a package-manager install that enforces the
+ * committed lockfile.
+ * @param command - Candidate executable command
+ * @returns True when the command enforces the committed lockfile
+ */
+function isLockfileInstallCommand(command: string): boolean {
+  const tokens = command.trim().toLowerCase().split(/\s+/);
+  const [manager, subcommand] = tokens;
+  if (manager === "npm" && subcommand === "ci") {
+    return true;
+  }
+  return (
+    manager !== undefined &&
+    FROZEN_INSTALL_MANAGERS.has(manager) &&
+    subcommand === "install" &&
+    tokens.some(token => LOCKFILE_INSTALL_FLAGS.has(token))
+  );
+}
+
+/**
+ * Whether CI/hook text contains a real lockfile-enforcing install command.
+ * @param source - File text
+ * @returns True when an executable command enforces the committed lockfile
+ */
+function hasLockfileInstallCommand(source: string): boolean {
+  return source.split(/\r?\n/).some(line => {
+    const command = executableCommandCandidate(line);
+    return command !== null && isLockfileInstallCommand(command);
+  });
+}
+
+/**
  * Find where the repository audits its dependency tree: a CI job, a git hook, a
  * lefthook declaration, or an update bot.
  * @param root - Repository root
@@ -393,7 +477,7 @@ export async function findLockfileInstallGate(
   ];
   for (const file of scanned) {
     const source = await readFileOrNull(root, file);
-    if (source !== null && LOCKFILE_INSTALL_PATTERN.test(source)) {
+    if (source !== null && hasLockfileInstallCommand(source)) {
       return file.split(path.sep).join("/");
     }
   }

--- a/src/cli/doctor-readiness-supply-chain.ts
+++ b/src/cli/doctor-readiness-supply-chain.ts
@@ -34,6 +34,7 @@ import {
   type DependencySpec,
   findAuditGate,
   findLockfile,
+  findLockfileInstallGate,
   isFloatingSpec,
   LOCKFILES,
   readManifest,
@@ -111,6 +112,8 @@ async function collectFindings(
   readonly observations: readonly string[];
 }> {
   const lockfile = await findLockfile(root);
+  const lockfileInstallGate =
+    lockfile === null ? null : await findLockfileInstallGate(root);
   const auditGate = await findAuditGate(root);
   const floating = specs.filter(
     spec => isFloatingSpec(spec.spec) && !linksWorkspaceMember(spec, workspaces)
@@ -118,6 +121,15 @@ async function collectFindings(
   return {
     violations: [
       ...(lockfile === null ? [lockfileEvidence(specs.length)] : []),
+      ...(lockfile !== null && lockfileInstallGate === null
+        ? [
+            `lockfile \`${lockfile}\` is committed, but no CI or hook install ` +
+              "step was found that enforces it with `npm ci`, " +
+              "`bun install --frozen-lockfile`, `pnpm install --frozen-lockfile`, " +
+              "or `yarn install --immutable`; a workflow can silently rewrite " +
+              "or bypass the tree that was validated",
+          ]
+        : []),
       ...floating.map(
         spec =>
           `\`package.json\` \`${spec.block}.${spec.name}\` is \`${spec.spec}\`, ` +
@@ -137,6 +149,11 @@ async function collectFindings(
     ],
     observations: [
       ...(lockfile === null ? [] : [`Lockfile in use: \`${lockfile}\`.`]),
+      ...(lockfileInstallGate === null
+        ? []
+        : [
+            `Lockfile-enforcing install declared in \`${lockfileInstallGate}\`.`,
+          ]),
       ...(auditGate === null
         ? []
         : [`Dependency-audit gate declared in \`${auditGate}\`.`]),

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7770,6 +7770,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/doctor-readiness-guardrails.test.ts": true,
     "tests/unit/cli/doctor-readiness-journey.test.ts": true,
     "tests/unit/cli/doctor-readiness-supply-chain-exceptions.test.ts": true,
+    "tests/unit/cli/doctor-readiness-supply-chain-install-gate.test.ts": true,
     "tests/unit/cli/doctor-readiness-supply-chain-precision.test.ts": true,
     "tests/unit/cli/doctor-readiness-supply-chain.test.ts": true,
     "tests/unit/cli/doctor-readiness-workflows.test.ts": true,

--- a/tests/unit/cli/doctor-readiness-supply-chain-exceptions.test.ts
+++ b/tests/unit/cli/doctor-readiness-supply-chain-exceptions.test.ts
@@ -49,6 +49,13 @@ const WORKSPACE_GLOB = "packages/*";
 /** The update-bot config most fixtures use as their audit gate. */
 const DEPENDABOT_PATH = ".github/dependabot.yml";
 
+/** The CI workflow path used by dependency-confidence fixtures. */
+const QUALITY_WORKFLOW_PATH = ".github/workflows/quality.yml";
+
+/** Minimal CI install step that proves the committed lockfile is honored. */
+const LOCKFILE_INSTALL_WORKFLOW =
+  "jobs:\n  test:\n    steps:\n      - run: npm ci\n";
+
 /** A manifest whose dependency specs are all exactly pinned or caret-ranged. */
 const PINNED_MANIFEST = {
   name: "scratch",
@@ -88,6 +95,7 @@ async function writeCleanRepo(root: string): Promise<void> {
   await writeRepoJson(root, PACKAGE_JSON, PINNED_MANIFEST);
   await writeRepoFile(root, BUN_LOCK, LOCKFILE_BODY);
   await writeRepoFile(root, DEPENDABOT_PATH, DEPENDABOT_YML);
+  await writeRepoFile(root, QUALITY_WORKFLOW_PATH, LOCKFILE_INSTALL_WORKFLOW);
 }
 
 afterEach(async () => {
@@ -156,6 +164,7 @@ describe("assessDependenciesSupplyChainDimension — evidence states what it act
     const cwd = await getTempDir();
     await writeRepoFile(cwd, BUN_LOCK, LOCKFILE_BODY);
     await writeRepoFile(cwd, DEPENDABOT_PATH, DEPENDABOT_YML);
+    await writeRepoFile(cwd, QUALITY_WORKFLOW_PATH, LOCKFILE_INSTALL_WORKFLOW);
     await writeRepoJson(cwd, PACKAGE_JSON, {
       name: MONOREPO_NAME,
       version: "1.0.0",

--- a/tests/unit/cli/doctor-readiness-supply-chain-install-gate.test.ts
+++ b/tests/unit/cli/doctor-readiness-supply-chain-install-gate.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Lockfile install-gate regression coverage for the dependencies/supply-chain
+ * readiness producer (B5, PRD #1739, #1896).
+ * @module tests/unit/cli/doctor-readiness-supply-chain-install-gate
+ */
+import { rm } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { assessDependenciesSupplyChainDimension } from "../../../src/cli/doctor-readiness-supply-chain.js";
+import {
+  asFindings,
+  FAIL,
+  makeScratchRepo,
+  writeRepoFile,
+  writeRepoJson,
+} from "../../helpers/readiness-workflow-fixtures.js";
+
+const BLOCKER_ID = "B5";
+const PACKAGE_JSON = "package.json";
+const BUN_LOCK = "bun.lock";
+const LOCKFILE_BODY = '{"lockfileVersion": 1}\n';
+const DEPENDABOT_PATH = ".github/dependabot.yml";
+const QUALITY_WORKFLOW_PATH = ".github/workflows/quality.yml";
+const UNENFORCED_INSTALL = "      - run: npm install";
+const MISSING_ENFORCEMENT_EVIDENCE = "no CI or hook install";
+
+const PINNED_MANIFEST = {
+  name: "scratch",
+  version: "1.0.0",
+  dependencies: { "js-yaml": "^4.1.0" },
+};
+
+const DEPENDABOT_YML = [
+  "version: 2",
+  "updates:",
+  "  - package-ecosystem: npm",
+  '    directory: "/"',
+  "    schedule:",
+  "      interval: weekly",
+  "",
+].join("\n");
+
+let tempDir: string | undefined;
+
+/**
+ * Render a minimal GitHub Actions workflow with caller-supplied step lines.
+ * @param steps - Step declarations already indented under `steps:`
+ * @returns Workflow YAML text
+ */
+function qualityWorkflow(...steps: readonly string[]): string {
+  return ["jobs:", "  test:", "    steps:", ...steps, ""].join("\n");
+}
+
+/**
+ * Resolve a scratch repository for one test case.
+ * @returns Temporary directory path
+ */
+async function getTempDir(): Promise<string> {
+  tempDir ??= await makeScratchRepo("supply-chain-install-gate");
+  return tempDir;
+}
+
+/**
+ * Write the manifest, lockfile, and audit gate shared by install-gate tests.
+ * @param root - Repository root
+ */
+async function writeBaseRepo(root: string): Promise<void> {
+  await writeRepoJson(root, PACKAGE_JSON, PINNED_MANIFEST);
+  await writeRepoFile(root, BUN_LOCK, LOCKFILE_BODY);
+  await writeRepoFile(root, DEPENDABOT_PATH, DEPENDABOT_YML);
+}
+
+/**
+ * Assert that B5 stands because no executable lockfile install gate was found.
+ * @param root - Repository root
+ */
+async function expectMissingInstallGate(root: string): Promise<void> {
+  const record = await assessDependenciesSupplyChainDimension(root);
+  const finding = asFindings(record.findings).find(
+    candidate => candidate.blocker === BLOCKER_ID
+  );
+
+  expect(record.status).toBe(FAIL);
+  expect(finding?.evidence).toContain(MISSING_ENFORCEMENT_EVIDENCE);
+}
+
+afterEach(async () => {
+  if (tempDir) {
+    await rm(tempDir, { force: true, recursive: true });
+    tempDir = undefined;
+  }
+});
+
+describe("assessDependenciesSupplyChainDimension — lockfile install gates", () => {
+  it("FAILs with B5 when lockfile install enforcement is only commented", async () => {
+    const cwd = await getTempDir();
+    await writeBaseRepo(cwd);
+    await writeRepoFile(
+      cwd,
+      QUALITY_WORKFLOW_PATH,
+      qualityWorkflow(UNENFORCED_INSTALL, "      # npm ci")
+    );
+
+    await expectMissingInstallGate(cwd);
+  });
+
+  it("FAILs with B5 when lockfile install enforcement is only echoed", async () => {
+    const cwd = await getTempDir();
+    await writeBaseRepo(cwd);
+    await writeRepoFile(
+      cwd,
+      QUALITY_WORKFLOW_PATH,
+      qualityWorkflow(UNENFORCED_INSTALL, '      - run: echo "npm ci"')
+    );
+
+    await expectMissingInstallGate(cwd);
+  });
+});

--- a/tests/unit/cli/doctor-readiness-supply-chain-precision.test.ts
+++ b/tests/unit/cli/doctor-readiness-supply-chain-precision.test.ts
@@ -45,6 +45,13 @@ const WORKSPACE_GLOB = "packages/*";
 /** The update-bot config most fixtures use as their audit gate. */
 const DEPENDABOT_PATH = ".github/dependabot.yml";
 
+/** The CI workflow path used by dependency-confidence fixtures. */
+const QUALITY_WORKFLOW_PATH = ".github/workflows/quality.yml";
+
+/** Minimal CI install step that proves the committed lockfile is honored. */
+const LOCKFILE_INSTALL_WORKFLOW =
+  "jobs:\n  test:\n    steps:\n      - run: npm ci\n";
+
 /** A manifest whose dependency specs are all exactly pinned or caret-ranged. */
 const PINNED_MANIFEST = {
   name: "scratch",
@@ -84,6 +91,7 @@ async function writeCleanRepo(root: string): Promise<void> {
   await writeRepoJson(root, PACKAGE_JSON, PINNED_MANIFEST);
   await writeRepoFile(root, BUN_LOCK, LOCKFILE_BODY);
   await writeRepoFile(root, DEPENDABOT_PATH, DEPENDABOT_YML);
+  await writeRepoFile(root, QUALITY_WORKFLOW_PATH, LOCKFILE_INSTALL_WORKFLOW);
 }
 
 afterEach(async () => {
@@ -97,6 +105,7 @@ describe("assessDependenciesSupplyChainDimension — configurations that must NO
     const cwd = await getTempDir();
     await writeRepoFile(cwd, BUN_LOCK, LOCKFILE_BODY);
     await writeRepoFile(cwd, DEPENDABOT_PATH, DEPENDABOT_YML);
+    await writeRepoFile(cwd, QUALITY_WORKFLOW_PATH, LOCKFILE_INSTALL_WORKFLOW);
     await writeRepoJson(cwd, PACKAGE_JSON, {
       name: MONOREPO_NAME,
       version: "1.0.0",
@@ -120,6 +129,7 @@ describe("assessDependenciesSupplyChainDimension — configurations that must NO
     const cwd = await getTempDir();
     await writeRepoFile(cwd, BUN_LOCK, LOCKFILE_BODY);
     await writeRepoFile(cwd, DEPENDABOT_PATH, DEPENDABOT_YML);
+    await writeRepoFile(cwd, QUALITY_WORKFLOW_PATH, LOCKFILE_INSTALL_WORKFLOW);
     await writeRepoJson(cwd, PACKAGE_JSON, {
       name: MONOREPO_NAME,
       version: "1.0.0",

--- a/tests/unit/cli/doctor-readiness-supply-chain.test.ts
+++ b/tests/unit/cli/doctor-readiness-supply-chain.test.ts
@@ -300,6 +300,15 @@ describe("assessDependenciesSupplyChainDimension — clean and unassessable repo
 
     expect(record.status).toBe(PASS);
     expect(assessReadiness([record]).blockers).toEqual([]);
+    expect(
+      asFindings(record.findings).some(
+        finding =>
+          typeof finding.observation === "string" &&
+          finding.observation.includes(
+            "Lockfile-enforcing install declared in `.github/workflows/quality.yml`."
+          )
+      )
+    ).toBe(true);
   });
 
   it("accepts an audit gate declared only in a git hook", async () => {

--- a/tests/unit/cli/doctor-readiness-supply-chain.test.ts
+++ b/tests/unit/cli/doctor-readiness-supply-chain.test.ts
@@ -52,6 +52,9 @@ const LOCKFILE_BODY = '{"lockfileVersion": 1}\n';
 /** The update-bot config most fixtures use as their audit gate. */
 const DEPENDABOT_PATH = ".github/dependabot.yml";
 
+/** The CI workflow path used by dependency-confidence fixtures. */
+const QUALITY_WORKFLOW_PATH = ".github/workflows/quality.yml";
+
 /** A manifest whose dependency specs are all exactly pinned or caret-ranged. */
 const PINNED_MANIFEST = {
   name: "scratch",
@@ -70,6 +73,22 @@ const DEPENDABOT_YML = [
   "      interval: weekly",
   "",
 ].join("\n");
+
+/**
+ * Render a minimal GitHub Actions workflow with caller-supplied step lines.
+ * @param steps - Step declarations already indented under `steps:`
+ * @returns Workflow YAML text
+ */
+function qualityWorkflow(...steps: readonly string[]): string {
+  return ["name: Quality", "jobs:", "  test:", "    steps:", ...steps, ""].join(
+    "\n"
+  );
+}
+
+/** Minimal CI install step that proves the committed lockfile is honored. */
+const LOCKFILE_INSTALL_WORKFLOW = qualityWorkflow(
+  "      - run: bun install --frozen-lockfile"
+);
 
 let tempDir: string | undefined;
 
@@ -91,6 +110,7 @@ async function writeCleanRepo(root: string): Promise<void> {
   await writeRepoJson(root, PACKAGE_JSON, PINNED_MANIFEST);
   await writeRepoFile(root, BUN_LOCK, LOCKFILE_BODY);
   await writeRepoFile(root, DEPENDABOT_PATH, DEPENDABOT_YML);
+  await writeRepoFile(root, QUALITY_WORKFLOW_PATH, LOCKFILE_INSTALL_WORKFLOW);
 }
 
 afterEach(async () => {
@@ -197,6 +217,30 @@ describe("assessDependenciesSupplyChainDimension — B5 violations", () => {
     expect(finding?.evidence).toContain("audit");
   });
 
+  it("FAILs with B5 when CI installs without enforcing the committed lockfile", async () => {
+    const cwd = await getTempDir();
+    await writeRepoJson(cwd, PACKAGE_JSON, PINNED_MANIFEST);
+    await writeRepoFile(cwd, BUN_LOCK, LOCKFILE_BODY);
+    await writeRepoFile(cwd, DEPENDABOT_PATH, DEPENDABOT_YML);
+    await writeRepoFile(
+      cwd,
+      QUALITY_WORKFLOW_PATH,
+      qualityWorkflow(
+        "      - run: npm install",
+        "      - run: npm audit --audit-level=high"
+      )
+    );
+
+    const record = await assessDependenciesSupplyChainDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    const finding = asFindings(record.findings).find(
+      candidate => candidate.blocker === BLOCKER_ID
+    );
+    expect(finding?.evidence).toContain("no CI or hook install");
+    expect(finding?.evidence).toContain("npm ci");
+  });
+
   it("FAILs with B5 when an audit exclusion carries no decision record", async () => {
     const cwd = await getTempDir();
     await writeCleanRepo(cwd);
@@ -245,15 +289,11 @@ describe("assessDependenciesSupplyChainDimension — clean and unassessable repo
     await writeRepoFile(cwd, "package-lock.json", '{"lockfileVersion": 3}\n');
     await writeRepoFile(
       cwd,
-      ".github/workflows/quality.yml",
-      [
-        "name: Quality",
-        "jobs:",
-        "  scan:",
-        "    steps:",
-        "      - run: npm audit --audit-level=high",
-        "",
-      ].join("\n")
+      QUALITY_WORKFLOW_PATH,
+      qualityWorkflow(
+        "      - run: npm ci",
+        "      - run: npm audit --audit-level=high"
+      )
     );
 
     const record = await assessDependenciesSupplyChainDimension(cwd);
@@ -269,7 +309,7 @@ describe("assessDependenciesSupplyChainDimension — clean and unassessable repo
     await writeRepoFile(
       cwd,
       ".husky/pre-push",
-      "#!/bin/sh\nnpm audit --audit-level=moderate\n"
+      "#!/bin/sh\npnpm install --frozen-lockfile\nnpm audit --audit-level=moderate\n"
     );
 
     const record = await assessDependenciesSupplyChainDimension(cwd);


### PR DESCRIPTION
## Summary

- Require a CI/hook install gate that honors committed lockfiles for B5 supply-chain readiness.
- Report `npm install`/missing enforcement as B5 evidence instead of treating lockfile presence alone as confidence.
- Add regression coverage for failing non-enforcing installs and passing `npm ci` / frozen-lockfile paths.

## Validation

- `bun test tests/unit/cli/doctor-readiness-supply-chain.test.ts tests/unit/cli/doctor-readiness-supply-chain-precision.test.ts tests/unit/cli/doctor-readiness-supply-chain-exceptions.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx prettier --check src/cli/doctor-readiness-supply-chain-scan.ts src/cli/doctor-readiness-supply-chain.ts tests/unit/cli/doctor-readiness-supply-chain.test.ts tests/unit/cli/doctor-readiness-supply-chain-precision.test.ts tests/unit/cli/doctor-readiness-supply-chain-exceptions.test.ts`
- `bun run build:dist`
- Pre-push: production dependency audit, slow lint, knip, full unit coverage (7,917 tests; 85.38% statements / 77.13% branches), integration tests (148 tests), plugin parity

Work-Item: CodySwannGT/lisa#1903

Refs #1903


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supply-chain readiness checks now confirm that CI or repository hooks enforce the committed lockfile during dependency installation.
  * Supports detection of lockfile-enforcing installs such as `npm ci`, frozen Bun/pnpm installs, and immutable Yarn installs.
* **Bug Fixes**
  * Reports a readiness failure when a lockfile exists but no lockfile-enforcing install step is found.
  * Evidence can now point to the lockfile-enforcing installation gate when present.
* **Tests**
  * Added/expanded unit test coverage for CI and hook scenarios, including new workflow fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->