### PR TITLE
fix(ci): match skipped quality jobs by token

### DIFF
--- a/.github/GITHUB_ACTIONS.md
+++ b/.github/GITHUB_ACTIONS.md
@@ -107,7 +107,9 @@ Comprehensive quality validation with 20+ configurable jobs. Called by other wor
 ```
 lint, typecheck, test, test:unit, test:integration, test:e2e,
 maestro_e2e, playwright_e2e, format, build, npm_security_scan,
-sonarcloud, snyk, secret_scanning, license_compliance
+sonarcloud, snyk, secret_scanning, license_compliance, zap_baseline,
+e2e_coverage, test:mutation, learnings_budget, threshold_ratchet,
+dead_code, sg_scan
 ```
 
 `skip_jobs` entries are exact comma-delimited job ids. For example,

--- a/.github/GITHUB_ACTIONS.md
+++ b/.github/GITHUB_ACTIONS.md
@@ -65,7 +65,7 @@ Runs on every pull request to validate code quality:
 # In ci.yml, modify these inputs:
 node_version: '22.21.1'
 package_manager: 'bun'
-skip_jobs: 'test,test:integration,test:e2e'  # Comma-separated list
+skip_jobs: 'test:e2e,zap_baseline,playwright_e2e'  # Exact comma-separated job ids
 ```
 
 ### Release and Deploy (`deploy.yml`)
@@ -109,6 +109,15 @@ lint, typecheck, test, test:unit, test:integration, test:e2e,
 maestro_e2e, playwright_e2e, format, build, npm_security_scan,
 sonarcloud, snyk, secret_scanning, license_compliance
 ```
+
+`skip_jobs` entries are exact comma-delimited job ids. For example,
+`test:e2e` skips only the E2E job; it does not skip `test`, `test:unit`, or
+`test:integration`.
+
+Migration note: NestJS and Expo CI templates now default to
+`test:e2e,zap_baseline,playwright_e2e`, so unit and integration jobs run on
+promotion PRs as well as ordinary feature PRs. Projects that intentionally
+disable those jobs must list `test` or `test:integration` explicitly.
 
 ### Release (`release.yml`)
 

--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -72,7 +72,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    if: ${{ !contains(inputs.skip_jobs, 'lint') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',lint,') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -94,7 +94,7 @@ jobs:
     name: 📐 Threshold Ratchet
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: ${{ !contains(inputs.skip_jobs, 'threshold_ratchet') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',threshold_ratchet,') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -125,7 +125,7 @@ jobs:
   security:
     name: Security
     runs-on: ubuntu-latest
-    if: ${{ !contains(inputs.skip_jobs, 'security') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',security,') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -144,7 +144,7 @@ jobs:
   test-postgres:
     name: Test (PostgreSQL)
     runs-on: ubuntu-latest
-    if: ${{ !contains(inputs.skip_jobs, 'test') && inputs.database_type == 'postgres' }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',test,') && inputs.database_type == 'postgres' }}
     services:
       postgres:
         image: postgres:16
@@ -180,7 +180,7 @@ jobs:
   test-mysql:
     name: Test (MySQL)
     runs-on: ubuntu-latest
-    if: ${{ !contains(inputs.skip_jobs, 'test') && inputs.database_type == 'mysql' }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',test,') && inputs.database_type == 'mysql' }}
     services:
       mysql:
         image: mysql:8.0
@@ -223,7 +223,7 @@ jobs:
     # Diff-only mutation gate. Self-skips instantly when disabled
     # (mutation.gate.yml: enabled: false). PostgreSQL-based; MySQL projects can
     # adapt the service block or skip via skip_jobs: mutation.
-    if: ${{ !contains(inputs.skip_jobs, 'mutation') && inputs.database_type == 'postgres' }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',mutation,') && inputs.database_type == 'postgres' }}
     services:
       postgres:
         image: postgres:16
@@ -269,7 +269,7 @@ jobs:
   code-quality:
     name: Code Quality
     runs-on: ubuntu-latest
-    if: ${{ !contains(inputs.skip_jobs, 'code_quality') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',code_quality,') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -292,7 +292,7 @@ jobs:
     name: 🔐 GitGuardian Secret Detection
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ !contains(inputs.skip_jobs, 'secret_scanning') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',secret_scanning,') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -348,7 +348,7 @@ jobs:
     name: 🔎 AST Grep Scan
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ !contains(inputs.skip_jobs, 'sg_scan') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',sg_scan,') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -412,7 +412,7 @@ jobs:
     # inherited checks:write / pull-requests:write.
     permissions:
       contents: read
-    if: ${{ !contains(inputs.skip_jobs, 'learnings_budget') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',learnings_budget,') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -442,7 +442,7 @@ jobs:
     name: 📜 FOSSA License Check
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ !contains(inputs.skip_jobs, 'license_compliance') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',license_compliance,') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -476,7 +476,7 @@ jobs:
     name: 🕷️ OWASP ZAP Baseline
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ !contains(inputs.skip_jobs, 'zap_baseline') && inputs.zap_target_url != '' }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',zap_baseline,') && inputs.zap_target_url != '' }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -319,7 +319,7 @@ jobs:
     name: 🧹 Lint
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: ${{ !contains(inputs.skip_jobs, 'lint') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',lint,') }}
 
     steps:
       - name: 📥 Checkout repository
@@ -375,7 +375,7 @@ jobs:
     name: 🐢 Slow Lint Rules
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ !contains(inputs.skip_jobs, 'lint_slow') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',lint_slow,') }}
 
     steps:
       - name: 📥 Checkout repository
@@ -416,7 +416,7 @@ jobs:
     name: 🔍 Type Check
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: ${{ !contains(inputs.skip_jobs, 'typecheck') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',typecheck,') }}
 
     steps:
       - name: 📥 Checkout repository
@@ -457,7 +457,7 @@ jobs:
     name: 🧪 Run Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ !contains(inputs.skip_jobs, 'test') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',test,') }}
 
     steps:
       - name: 📥 Checkout repository
@@ -537,7 +537,7 @@ jobs:
     # at least one Playwright spec / Maestro flow, thresholds from
     # e2e.thresholds.json (default 80% per runner). Auto-enabled by the
     # presence of the Lisa-managed script (expo projects); a no-op elsewhere.
-    if: ${{ !contains(inputs.skip_jobs, 'e2e_coverage') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',e2e_coverage,') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -600,7 +600,7 @@ jobs:
     # the build when the file grows past budget. The check reads the learnings
     # file resolved from .lisa.config.json; a project that has never recorded a
     # learning has no file and passes silently.
-    if: ${{ !contains(inputs.skip_jobs, 'learnings_budget') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',learnings_budget,') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -657,7 +657,7 @@ jobs:
     name: 🧪 Run Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    if: ${{ !contains(inputs.skip_jobs, 'test:unit') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',test:unit,') }}
 
     steps:
       - name: 📥 Checkout repository
@@ -724,7 +724,7 @@ jobs:
     name: 🧬 Mutation Testing Gate
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    if: ${{ !contains(inputs.skip_jobs, 'test:mutation') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',test:mutation,') }}
 
     steps:
       - name: 📥 Checkout repository
@@ -792,7 +792,7 @@ jobs:
     name: 🧪 Run Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ !contains(inputs.skip_jobs, 'test:integration') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',test:integration,') }}
 
     steps:
       - name: 📥 Checkout repository
@@ -859,7 +859,7 @@ jobs:
     name: 🧪 Run E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    if: ${{ !contains(inputs.skip_jobs, 'test:e2e') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',test:e2e,') }}
 
     steps:
       - name: 📥 Checkout repository
@@ -945,7 +945,7 @@ jobs:
     name: 📱 Maestro Cloud E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ !contains(inputs.skip_jobs, 'maestro_e2e') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',maestro_e2e,') }}
 
     steps:
       - name: 📥 Checkout repository
@@ -1032,7 +1032,7 @@ jobs:
     runs-on: ubuntu-latest
     # Pure shell arithmetic — no checkout, no API. Needs no token at all.
     permissions: {}
-    if: ${{ !contains(inputs.skip_jobs, 'playwright_e2e') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',playwright_e2e,') }}
     outputs:
       shards: ${{ steps.matrix.outputs.shards }}
     steps:
@@ -1061,7 +1061,7 @@ jobs:
     # retries). Raise back down once downstream projects address their
     # backend-side root causes.
     timeout-minutes: 60
-    if: ${{ !contains(inputs.skip_jobs, 'playwright_e2e') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',playwright_e2e,') }}
     strategy:
       fail-fast: false
       matrix:
@@ -1213,7 +1213,7 @@ jobs:
     needs: playwright_e2e
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ always() && !contains(inputs.skip_jobs, 'playwright_e2e') }}
+    if: ${{ always() && !contains(format(',{0},', inputs.skip_jobs), ',playwright_e2e,') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -1315,7 +1315,7 @@ jobs:
     name: 📐 Check Formatting
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ !contains(inputs.skip_jobs, 'format') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',format,') }}
 
     steps:
       - name: 📥 Checkout repository
@@ -1356,7 +1356,7 @@ jobs:
     name: 🏗️ Build
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ !contains(inputs.skip_jobs, 'build') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',build,') }}
 
     steps:
       - name: 📥 Checkout repository
@@ -1447,7 +1447,7 @@ jobs:
     name: 📐 Threshold Ratchet
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: ${{ !contains(inputs.skip_jobs, 'threshold_ratchet') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',threshold_ratchet,') }}
 
     steps:
       - name: 📥 Checkout repository
@@ -1480,7 +1480,7 @@ jobs:
     name: 🗑️ Dead Code Detection
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ !contains(inputs.skip_jobs, 'dead_code') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',dead_code,') }}
 
     steps:
       - name: 📥 Checkout repository
@@ -1527,7 +1527,7 @@ jobs:
     name: 🔎 AST Grep Scan
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ !contains(inputs.skip_jobs, 'sg_scan') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',sg_scan,') }}
 
     steps:
       - name: 📥 Checkout repository
@@ -1607,7 +1607,7 @@ jobs:
     name: 🔒 Security Scan
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: ${{ !contains(inputs.skip_jobs, 'npm_security_scan') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',npm_security_scan,') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -1794,7 +1794,7 @@ jobs:
     name: 🔍 SonarCloud SAST
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ !contains(inputs.skip_jobs, 'sonarcloud') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',sonarcloud,') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -1884,7 +1884,7 @@ jobs:
     name: 🛡️ Snyk Dependency Scan
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ !contains(inputs.skip_jobs, 'snyk') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',snyk,') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -1955,7 +1955,7 @@ jobs:
     name: 🔐 GitGuardian Secret Detection
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ !contains(inputs.skip_jobs, 'secret_scanning') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',secret_scanning,') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -2012,7 +2012,7 @@ jobs:
     name: 📜 FOSSA License Check
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ !contains(inputs.skip_jobs, 'license_compliance') }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',license_compliance,') }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -2050,7 +2050,7 @@ jobs:
     name: 🕷️ OWASP ZAP Baseline
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ !contains(inputs.skip_jobs, 'zap_baseline') && inputs.zap_target_url != '' }}
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',zap_baseline,') && inputs.zap_target_url != '' }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6

--- a/bun.lock
+++ b/bun.lock
@@ -115,7 +115,7 @@
     "handlebars": ">=4.7.9",
     "lodash": ">=4.18.1",
     "multer": ">=2.2.0",
-    "postcss": ">=8.5.12",
+    "postcss": ">=8.5.18",
     "undici": ">=6.27.0",
     "vite": "^8.0.16",
     "ws": ">=8.21.0",
@@ -1587,7 +1587,7 @@
 
     "nano-spawn": ["nano-spawn@2.0.0", "", {}, "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw=="],
 
-    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
 
@@ -1695,7 +1695,7 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+    "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "postcss-import": ["postcss-import@15.1.0", "", { "dependencies": { "postcss-value-parser": "^4.0.0", "read-cache": "^1.0.0", "resolve": "^1.1.7" }, "peerDependencies": { "postcss": "^8.0.0" } }, "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew=="],
 

--- a/expo/create-only/.github/workflows/ci.yml
+++ b/expo/create-only/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     with:
       node_version: '22.21.1'
       package_manager: 'bun'
-      skip_jobs: 'test,test:integration,test:e2e'
+      skip_jobs: 'test:e2e,zap_baseline,playwright_e2e'
       # Forward SE-4551 / SE-4552 inputs. `|| fromJSON('...')` falls back to
       # the unchanged defaults when the workflow is triggered by pull_request
       # (which doesn't supply workflow_dispatch inputs), keeping behavior

--- a/nestjs/create-only/.github/workflows/ci.yml
+++ b/nestjs/create-only/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       node_version: '22.21.1'
       package_manager: 'bun'
-      skip_jobs: 'test,test:integration,test:e2e'
+      skip_jobs: 'test:e2e,zap_baseline,playwright_e2e'
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "vite": "$vite",
     "ws": ">=8.21.0",
     "multer": ">=2.2.0",
-    "postcss": ">=8.5.12",
+    "postcss": ">=8.5.18",
     "undici": ">=6.27.0",
     "form-data": ">=4.0.6",
     "brace-expansion": ">=5.0.6"
@@ -109,7 +109,7 @@
     "vite": "$vite",
     "ws": ">=8.21.0",
     "multer": ">=2.2.0",
-    "postcss": ">=8.5.12",
+    "postcss": ">=8.5.18",
     "undici": ">=6.27.0",
     "form-data": ">=4.0.6",
     "brace-expansion": ">=5.0.6"

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -147,7 +147,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/copy-overwrite/tsconfig.json":
       "c92e2c2c109e8794ee351f634361ef46297f5a0cd606aaf5c19911da836df307",
     "expo/create-only/.github/workflows/ci.yml":
-      "ba73a3d8c9195b6823525a396aef50809bbb3cab5cbdd24ce9ccf6e5efaf3d35",
+      "3ade267cca43e33c68e56b8c4f5d821ed03f642e5a11aa8b70b79e76ec41b96f",
     "expo/create-only/.github/workflows/deploy.yml":
       "0978b1f4e19e1ff66bb8cdd037d36a3751d4e917db7ceb5bcf100fad36768516",
     "expo/create-only/.github/workflows/maestro-e2e.yml":
@@ -295,7 +295,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "nestjs/create-only/.github/k6/thresholds/strict.json":
       "e121ec72de4596b95c013a8c71f03653bcdf057cf7f8d1fec6f0e13c1381867f",
     "nestjs/create-only/.github/workflows/ci.yml":
-      "1cbe153a37e61cef21b0af8d7b2d41e6b59adbf8a4c289475439852896a531fc",
+      "8db7de7f2e3eb2a1605539849a346b55281cfcd9951526f9d5a1757a210da3c6",
     "nestjs/create-only/.github/workflows/deploy.yml":
       "78abfa87639cb7506418dd34387963a0557614933d823e6fa0413395166b945b",
     "nestjs/create-only/.zap/baseline.conf":

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -12,8 +12,10 @@ const GITHUB_WORKFLOWS_PARTS = [".github", "workflows"] as const;
 const CREATE_ONLY_DIR = "create-only";
 const WORKFLOWS_DIR = path.join(REPO_ROOT, ...GITHUB_WORKFLOWS_PARTS);
 const DEPLOY_WORKFLOW_FILE = "deploy.yml";
-const QUALITY_YML = path.join(WORKFLOWS_DIR, "quality.yml");
-const QUALITY_RAILS_YML = path.join(WORKFLOWS_DIR, "quality-rails.yml");
+const QUALITY_WORKFLOW_FILE = "quality.yml";
+const QUALITY_RAILS_WORKFLOW_FILE = "quality-rails.yml";
+const QUALITY_YML = path.join(WORKFLOWS_DIR, QUALITY_WORKFLOW_FILE);
+const QUALITY_RAILS_YML = path.join(WORKFLOWS_DIR, QUALITY_RAILS_WORKFLOW_FILE);
 const RELEASE_YML = path.join(WORKFLOWS_DIR, "release.yml");
 const DEPLOY_YML = path.join(WORKFLOWS_DIR, DEPLOY_WORKFLOW_FILE);
 const NESTJS_DEPLOY_YML = path.join(
@@ -86,6 +88,7 @@ interface WorkflowJob {
   permissions?: Record<string, unknown>;
   strategy?: { matrix?: Record<string, unknown>; "fail-fast"?: boolean };
   steps?: WorkflowStep[];
+  with?: Record<string, unknown>;
 }
 
 /** Root shape of the parsed `quality.yml` reusable workflow. */
@@ -137,6 +140,7 @@ function needsList(job: WorkflowJob | undefined): string[] {
 
 describe("quality.yml reusable workflow", () => {
   let workflow: QualityWorkflow;
+  let railsWorkflow: QualityWorkflow;
   let qualityRaw: string;
   let qualityRailsRaw: string;
 
@@ -144,22 +148,31 @@ describe("quality.yml reusable workflow", () => {
     qualityRaw = fs.readFileSync(QUALITY_YML, "utf8");
     qualityRailsRaw = fs.readFileSync(QUALITY_RAILS_YML, "utf8");
     workflow = yaml.load(qualityRaw) as QualityWorkflow;
+    railsWorkflow = yaml.load(qualityRailsRaw) as QualityWorkflow;
   });
 
   describe("skip_jobs token matching", () => {
+    // Test hardened to kill mutant M001 (Risk Factor: CI gate correctness / exact skip token matching).
     it("matches every skipped job as an exact comma-delimited token", () => {
       expect(qualityRaw).not.toContain("contains(inputs.skip_jobs");
       expect(qualityRailsRaw).not.toContain("contains(inputs.skip_jobs");
-      for (const [jobName, job] of Object.entries(workflow.jobs)) {
-        if (!job.if?.includes("skip_jobs")) {
-          continue;
+      for (const [workflowName, parsedWorkflow] of [
+        [QUALITY_WORKFLOW_FILE, workflow],
+        [QUALITY_RAILS_WORKFLOW_FILE, railsWorkflow],
+      ] as const) {
+        for (const [jobName, job] of Object.entries(parsedWorkflow.jobs)) {
+          if (!job.if?.includes("skip_jobs")) {
+            continue;
+          }
+          expect(
+            job.if,
+            `${workflowName} ${jobName} should use token matching`
+          ).toContain("contains(format(',{0},', inputs.skip_jobs), ',");
         }
-        expect(job.if, `${jobName} should use token matching`).toContain(
-          "contains(format(',{0},', inputs.skip_jobs), ',"
-        );
       }
     });
 
+    // Test hardened to kill mutant M002 (Risk Factor: CI gate correctness / substring skip collision).
     it("does not let test:e2e skip the plain test job", () => {
       expect(workflow.jobs.test?.if).toBe(
         "${{ !contains(format(',{0},', inputs.skip_jobs), ',test,') }}"
@@ -171,12 +184,12 @@ describe("quality.yml reusable workflow", () => {
   });
 
   describe("template skip_jobs defaults", () => {
+    // Test hardened to kill mutant M003 (Risk Factor: Release confidence / promotion branch test coverage).
     it("keeps promotion-branch test jobs enabled in JS templates", () => {
       for (const file of [NESTJS_CI_YML, EXPO_CI_YML]) {
-        const ci = fs.readFileSync(file, "utf8");
-        expect(ci).not.toContain("skip_jobs: 'test,test:integration,test:e2e'");
-        expect(ci).toContain(
-          "skip_jobs: 'test:e2e,zap_baseline,playwright_e2e'"
+        const ci = yaml.load(fs.readFileSync(file, "utf8")) as QualityWorkflow;
+        expect(ci.jobs.quality?.with?.skip_jobs).toBe(
+          "test:e2e,zap_baseline,playwright_e2e"
         );
       }
     });

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -8,7 +8,9 @@ import { fileURLToPath } from "node:url";
 // portable across worktrees and CI working directories.
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
-const WORKFLOWS_DIR = path.join(REPO_ROOT, ".github", "workflows");
+const GITHUB_WORKFLOWS_PARTS = [".github", "workflows"] as const;
+const CREATE_ONLY_DIR = "create-only";
+const WORKFLOWS_DIR = path.join(REPO_ROOT, ...GITHUB_WORKFLOWS_PARTS);
 const DEPLOY_WORKFLOW_FILE = "deploy.yml";
 const QUALITY_YML = path.join(WORKFLOWS_DIR, "quality.yml");
 const QUALITY_RAILS_YML = path.join(WORKFLOWS_DIR, "quality-rails.yml");
@@ -17,18 +19,30 @@ const DEPLOY_YML = path.join(WORKFLOWS_DIR, DEPLOY_WORKFLOW_FILE);
 const NESTJS_DEPLOY_YML = path.join(
   REPO_ROOT,
   "nestjs",
-  "create-only",
-  ".github",
-  "workflows",
+  CREATE_ONLY_DIR,
+  ...GITHUB_WORKFLOWS_PARTS,
   DEPLOY_WORKFLOW_FILE
+);
+const NESTJS_CI_YML = path.join(
+  REPO_ROOT,
+  "nestjs",
+  CREATE_ONLY_DIR,
+  ...GITHUB_WORKFLOWS_PARTS,
+  "ci.yml"
 );
 const EXPO_DEPLOY_YML = path.join(
   REPO_ROOT,
   "expo",
-  "create-only",
-  ".github",
-  "workflows",
+  CREATE_ONLY_DIR,
+  ...GITHUB_WORKFLOWS_PARTS,
   DEPLOY_WORKFLOW_FILE
+);
+const EXPO_CI_YML = path.join(
+  REPO_ROOT,
+  "expo",
+  CREATE_ONLY_DIR,
+  ...GITHUB_WORKFLOWS_PARTS,
+  "ci.yml"
 );
 const EAS_BUILD_YML = path.join(WORKFLOWS_DIR, "build.yml");
 const CREATE_ISSUE_ON_FAILURE_YML = path.join(
@@ -123,10 +137,49 @@ function needsList(job: WorkflowJob | undefined): string[] {
 
 describe("quality.yml reusable workflow", () => {
   let workflow: QualityWorkflow;
+  let qualityRaw: string;
+  let qualityRailsRaw: string;
 
   beforeAll(() => {
-    const raw = fs.readFileSync(QUALITY_YML, "utf8");
-    workflow = yaml.load(raw) as QualityWorkflow;
+    qualityRaw = fs.readFileSync(QUALITY_YML, "utf8");
+    qualityRailsRaw = fs.readFileSync(QUALITY_RAILS_YML, "utf8");
+    workflow = yaml.load(qualityRaw) as QualityWorkflow;
+  });
+
+  describe("skip_jobs token matching", () => {
+    it("matches every skipped job as an exact comma-delimited token", () => {
+      expect(qualityRaw).not.toContain("contains(inputs.skip_jobs");
+      expect(qualityRailsRaw).not.toContain("contains(inputs.skip_jobs");
+      for (const [jobName, job] of Object.entries(workflow.jobs)) {
+        if (!job.if?.includes("skip_jobs")) {
+          continue;
+        }
+        expect(job.if, `${jobName} should use token matching`).toContain(
+          "contains(format(',{0},', inputs.skip_jobs), ',"
+        );
+      }
+    });
+
+    it("does not let test:e2e skip the plain test job", () => {
+      expect(workflow.jobs.test?.if).toBe(
+        "${{ !contains(format(',{0},', inputs.skip_jobs), ',test,') }}"
+      );
+      expect(workflow.jobs.test_e2e?.if).toBe(
+        "${{ !contains(format(',{0},', inputs.skip_jobs), ',test:e2e,') }}"
+      );
+    });
+  });
+
+  describe("template skip_jobs defaults", () => {
+    it("keeps promotion-branch test jobs enabled in JS templates", () => {
+      for (const file of [NESTJS_CI_YML, EXPO_CI_YML]) {
+        const ci = fs.readFileSync(file, "utf8");
+        expect(ci).not.toContain("skip_jobs: 'test,test:integration,test:e2e'");
+        expect(ci).toContain(
+          "skip_jobs: 'test:e2e,zap_baseline,playwright_e2e'"
+        );
+      }
+    });
   });
 
   describe("SE-4551 + SE-4552 new inputs", () => {

--- a/tests/unit/scripts/e2e-coverage.test.ts
+++ b/tests/unit/scripts/e2e-coverage.test.ts
@@ -338,7 +338,9 @@ describe("check-e2e-coverage", () => {
       const workflow = read(".github/workflows/quality.yml");
       expect(workflow).toContain("e2e_coverage:");
       expect(workflow).toContain("check-e2e-coverage.mjs");
-      expect(workflow).toContain("!contains(inputs.skip_jobs, 'e2e_coverage')");
+      expect(workflow).toContain(
+        "!contains(format(',{0},', inputs.skip_jobs), ',e2e_coverage,')"
+      );
     });
 
     it("registers the thresholds artifact in the sync registry", () => {


### PR DESCRIPTION
## Summary
- Match `skip_jobs` entries in `quality.yml` and `quality-rails.yml` as exact comma-delimited tokens.
- Update NestJS and Expo CI template defaults so unit and integration tests run by default while slow/browser jobs stay skipped.
- Add workflow/template regression coverage and refresh upstream evidence hashes.

## Verification
- `bun test tests/integration/quality-workflow.test.ts`
- `bun test tests/unit/scripts/e2e-coverage.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build:upstream-evidence-manifest`
- pre-push: production audit, slow lint, knip, full unit coverage, integration tests, plugin parity

Work-Item: CodySwannGT/lisa#2028
Closes CodySwannGT/lisa#2028


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI job skipping to match exact job names, preventing similarly named jobs from being skipped accidentally.
  * Updated quality and security workflow behavior for more reliable job selection.

* **Documentation**
  * Clarified `skip_jobs` formatting and behavior, including updated template defaults.

* **Tests**
  * Added coverage verifying exact job matching and promotion-branch test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->