### PR TITLE
fix(hooks): run whole-project typecheck on push

### DIFF
--- a/.claude-pr/.husky/pre-commit
+++ b/.claude-pr/.husky/pre-commit
@@ -82,14 +82,6 @@ fi
 #   exit 1
 # fi
 
-# Run type check on entire project (can't be done incrementally)
-echo "🔍 Running type check..."
-$RUNNER typecheck
-if [ $? -ne 0 ]; then
-  echo "❌ Type check failed. Please fix TypeScript errors before committing."
-  exit 1
-fi
-
 # Run lint-staged for incremental lint and format checks
 echo "🚀 Running lint-staged..."
 $EXECUTOR lint-staged --config .lintstagedrc.json

--- a/.claude-pr/.husky/pre-push
+++ b/.claude-pr/.husky/pre-push
@@ -27,6 +27,16 @@ fi
 
 echo "📦 Using package manager: $PACKAGE_MANAGER"
 
+# Run the whole-project type check once before code leaves the machine. It is
+# intentionally not a pre-commit gate because TypeScript cannot check only the
+# staged files and rebuilding the full program makes small commits too slow.
+echo "🔍 Running type check..."
+$RUNNER typecheck
+if [ $? -ne 0 ]; then
+  echo "❌ Type check failed. Please fix TypeScript errors before pushing."
+  exit 1
+fi
+
 # Run security audit
 echo "🔒 Running security audit..."
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -82,14 +82,6 @@ fi
 #   exit 1
 # fi
 
-# Run type check on entire project (can't be done incrementally)
-echo "🔍 Running type check..."
-$RUNNER typecheck
-if [ $? -ne 0 ]; then
-  echo "❌ Type check failed. Please fix TypeScript errors before committing."
-  exit 1
-fi
-
 # Run lint-staged for incremental lint and format checks
 echo "🚀 Running lint-staged..."
 $EXECUTOR lint-staged --config .lintstagedrc.json

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -38,6 +38,16 @@ fi
 
 echo "📦 Using package manager: $PACKAGE_MANAGER"
 
+# Run the whole-project type check once before code leaves the machine. It is
+# intentionally not a pre-commit gate because TypeScript cannot check only the
+# staged files and rebuilding the full program makes small commits too slow.
+echo "🔍 Running type check..."
+$RUNNER typecheck
+if [ $? -ne 0 ]; then
+  echo "❌ Type check failed. Please fix TypeScript errors before pushing."
+  exit 1
+fi
+
 # Run security audit
 echo "🔒 Running security audit..."
 

--- a/bun.lock
+++ b/bun.lock
@@ -115,7 +115,7 @@
     "handlebars": ">=4.7.9",
     "lodash": ">=4.18.1",
     "multer": ">=2.2.0",
-    "postcss": ">=8.5.12",
+    "postcss": ">=8.5.18",
     "undici": ">=6.27.0",
     "vite": "^8.0.16",
     "ws": ">=8.21.0",
@@ -1587,7 +1587,7 @@
 
     "nano-spawn": ["nano-spawn@2.0.0", "", {}, "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw=="],
 
-    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
 
@@ -1695,7 +1695,7 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+    "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "postcss-import": ["postcss-import@15.1.0", "", { "dependencies": { "postcss-value-parser": "^4.0.0", "read-cache": "^1.0.0", "resolve": "^1.1.7" }, "peerDependencies": { "postcss": "^8.0.0" } }, "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew=="],
 

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "vite": "$vite",
     "ws": ">=8.21.0",
     "multer": ">=2.2.0",
-    "postcss": ">=8.5.12",
+    "postcss": ">=8.5.18",
     "undici": ">=6.27.0",
     "form-data": ">=4.0.6",
     "brace-expansion": ">=5.0.6"
@@ -109,7 +109,7 @@
     "vite": "$vite",
     "ws": ">=8.21.0",
     "multer": ">=2.2.0",
-    "postcss": ">=8.5.12",
+    "postcss": ">=8.5.18",
     "undici": ">=6.27.0",
     "form-data": ">=4.0.6",
     "brace-expansion": ">=5.0.6"

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7951,6 +7951,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/hooks/post-checkout.test.ts": true,
     "tests/unit/hooks/pre-push-git-environment.test.ts": true,
     "tests/unit/hooks/track-plan-sessions.test.ts": true,
+    "tests/unit/hooks/typecheck-hook-placement.test.ts": true,
     "tests/unit/hooks/verification-failure-mode-fixtures.test.ts": true,
     "tests/unit/hooks/work-item-wiring.test.ts": true,
     "tests/unit/hooks/worktree-create.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1961,9 +1961,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-contents/.husky/post-checkout":
       "f3abc4528e12d3ad2bc48b236d19f105e2817595c744156a558c62ae5551ccfb",
     "typescript/copy-contents/.husky/pre-commit":
-      "30fbbff4fc0f3a6188958ce49cf202ec072ea3fd5965acca7cd12923ed03412d",
+      "0a2274ae48d9cccad9bf32afdce757113776814dbc1fa1221b50c933e616ab3b",
     "typescript/copy-contents/.husky/pre-push":
-      "001b5c2a779cf242c8d49029651f92ebddebf4ab706d58269d46e2be88a9df5b",
+      "bb929b9fa108586e5591e80e5d3682d6540fc681543f1e02d7a626022bbffb15",
     "typescript/copy-contents/.husky/prepare-commit-msg":
       "58671fb61f6fcc1fc384a2d7295f16949faa58150a8213e0a39d3c70fad728b5",
     "typescript/copy-overwrite/.claude/hooks/worktree-create.sh":

--- a/tests/unit/hooks/pre-push-git-environment.test.ts
+++ b/tests/unit/hooks/pre-push-git-environment.test.ts
@@ -95,7 +95,7 @@ describe("pre-push Git environment isolation", () => {
       fixture.root
     );
     expect(await readFile(fixture.commandLog, "utf8")).toBe(
-      "run test:cov\nrun test:integration\n"
+      "run typecheck\nrun test:cov\nrun test:integration\n"
     );
   });
 

--- a/tests/unit/hooks/typecheck-hook-placement.test.ts
+++ b/tests/unit/hooks/typecheck-hook-placement.test.ts
@@ -1,0 +1,35 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const MANAGED_HOOK_PAIRS = [
+  [".husky/pre-commit", ".husky/pre-push"],
+  [
+    "typescript/copy-contents/.husky/pre-commit",
+    "typescript/copy-contents/.husky/pre-push",
+  ],
+  [".claude-pr/.husky/pre-commit", ".claude-pr/.husky/pre-push"],
+] as const;
+
+describe("whole-project TypeScript hook placement", () => {
+  it.each(MANAGED_HOOK_PAIRS)(
+    "keeps commits staged and runs typecheck before push gates: %s",
+    async (preCommitPath, prePushPath) => {
+      const preCommit = await readFile(path.resolve(preCommitPath), "utf8");
+      const prePush = await readFile(path.resolve(prePushPath), "utf8");
+
+      expect(preCommit).not.toContain("$RUNNER typecheck");
+      expect(preCommit).toContain("gitleaks protect --staged");
+      expect(preCommit).toContain("lint-staged --config");
+
+      const typecheckIndex = prePush.indexOf("$RUNNER typecheck");
+      expect(typecheckIndex).toBeGreaterThanOrEqual(0);
+      expect(typecheckIndex).toBeLessThan(
+        prePush.indexOf('echo "🔒 Running security audit..."')
+      );
+      expect(typecheckIndex).toBeLessThan(prePush.indexOf("$RUNNER test:cov"));
+      expect(prePush).toContain("TypeScript errors before pushing");
+    }
+  );
+});

--- a/typescript/copy-contents/.husky/pre-commit
+++ b/typescript/copy-contents/.husky/pre-commit
@@ -126,14 +126,6 @@ if [ -f "scripts/check-threshold-ratchet.mjs" ] && command -v node >/dev/null 2>
   fi
 fi
 
-# Run type check on entire project (can't be done incrementally)
-echo "🔍 Running type check..."
-$RUNNER typecheck
-if [ $? -ne 0 ]; then
-  echo "❌ Type check failed. Please fix TypeScript errors before committing."
-  exit 1
-fi
-
 # Run lint-staged for incremental lint and format checks
 echo "🚀 Running lint-staged..."
 $EXECUTOR lint-staged --config .lintstagedrc.json

--- a/typescript/copy-contents/.husky/pre-push
+++ b/typescript/copy-contents/.husky/pre-push
@@ -38,6 +38,16 @@ fi
 
 echo "📦 Using package manager: $PACKAGE_MANAGER"
 
+# Run the whole-project type check once before code leaves the machine. It is
+# intentionally not a pre-commit gate because TypeScript cannot check only the
+# staged files and rebuilding the full program makes small commits too slow.
+echo "🔍 Running type check..."
+$RUNNER typecheck
+if [ $? -ne 0 ]; then
+  echo "❌ Type check failed. Please fix TypeScript errors before pushing."
+  exit 1
+fi
+
 # Run security audit
 echo "🔒 Running security audit..."
 


### PR DESCRIPTION
## Summary

- move whole-project TypeScript checking from pre-commit to pre-push across every managed hook surface
- add regression coverage for hook placement and command ordering
- raise the PostCSS security floor past GHSA-r28c-9q8g-f849

## Local verification

- typecheck
- security audit
- slow lint
- knip
- 466 unit/coverage files, 7,922 tests
- 14 integration files, 148 tests
- plugin parity

Work-Item: CodySwannGT/lisa#2030

Closes #2030