### PR TITLE
fix(readiness): inspect workspace dependency manifests

### DIFF
--- a/src/cli/doctor-readiness-supply-chain-scan.ts
+++ b/src/cli/doctor-readiness-supply-chain-scan.ts
@@ -280,6 +280,7 @@ export async function readManifest(root: string): Promise<ManifestOutcome> {
 
 /** One declared dependency spec, flattened out of the manifest blocks. */
 export interface DependencySpec {
+  readonly manifestPath: string;
   readonly block: string;
   readonly name: string;
   readonly spec: string;
@@ -291,12 +292,14 @@ export interface DependencySpec {
  * installs exactly as loosely as one at the top.
  * @param block - Block name, e.g. `dependencies`
  * @param value - The block's raw value
+ * @param manifestPath - Repo-relative manifest path the block came from
  * @param prefix - Accumulated name path for nested overrides
  * @returns Flattened specs
  */
 function flattenBlock(
   block: string,
   value: unknown,
+  manifestPath: string,
   prefix = ""
 ): readonly DependencySpec[] {
   if (!isRecord(value)) {
@@ -305,22 +308,24 @@ function flattenBlock(
   return Object.entries(value).flatMap(([name, spec]) => {
     const qualified = prefix === "" ? name : `${prefix}.${name}`;
     if (typeof spec === "string") {
-      return [{ block, name: qualified, spec }];
+      return [{ manifestPath, block, name: qualified, spec }];
     }
-    return flattenBlock(block, spec, qualified);
+    return flattenBlock(block, spec, manifestPath, qualified);
   });
 }
 
 /**
  * Flatten every versioned manifest block into one list of specs.
  * @param manifest - Parsed `package.json`
+ * @param manifestPath - Repo-relative manifest path the specs came from
  * @returns Every declared spec across the versioned blocks
  */
 export function collectSpecs(
-  manifest: Record<string, unknown>
+  manifest: Record<string, unknown>,
+  manifestPath = "package.json"
 ): readonly DependencySpec[] {
   return VERSIONED_BLOCKS.flatMap(block =>
-    flattenBlock(block, manifest[block])
+    flattenBlock(block, manifest[block], manifestPath)
   );
 }
 

--- a/src/cli/doctor-readiness-supply-chain.ts
+++ b/src/cli/doctor-readiness-supply-chain.ts
@@ -62,10 +62,10 @@ const MAX_EVIDENCE_LINES = 12;
  */
 function lockfileEvidence(specCount: number): string {
   return (
-    `\`package.json\` declares ${specCount} dependency spec(s) but no lockfile ` +
-    `is committed (looked for ${LOCKFILES.join(", ")}) — two installs can ` +
-    "resolve to different trees, so what was validated is not provably what " +
-    "gets installed"
+    `\`package.json\` and workspace package manifest(s) declare ${specCount} ` +
+    `dependency spec(s) but no lockfile is committed (looked for ` +
+    `${LOCKFILES.join(", ")}) — two installs can resolve to different trees, ` +
+    "so what was validated is not provably what gets installed"
   );
 }
 
@@ -132,7 +132,8 @@ async function collectFindings(
         : []),
       ...floating.map(
         spec =>
-          `\`package.json\` \`${spec.block}.${spec.name}\` is \`${spec.spec}\`, ` +
+          `\`${spec.manifestPath}\` \`${spec.block}.${spec.name}\` is ` +
+          `\`${spec.spec}\`, ` +
           "which resolves to whatever is newest at install time rather than to " +
           "a version anything was ever validated against"
       ),
@@ -220,6 +221,32 @@ function supplyChainFinding(
 }
 
 /**
+ * Count workspace manifests that contributed dependency specs.
+ * @param specs - The dependency specs under assessment
+ * @returns Number of non-root package manifests represented by the specs
+ */
+function workspaceManifestCount(specs: readonly DependencySpec[]): number {
+  return new Set(
+    specs
+      .map(spec => spec.manifestPath)
+      .filter(manifestPath => manifestPath !== "package.json")
+  ).size;
+}
+
+/**
+ * Describe the manifest scope B5 actually inspected.
+ * @param specs - The dependency specs under assessment
+ * @returns One clause for operator-facing evidence
+ */
+function describeManifestScope(specs: readonly DependencySpec[]): string {
+  const workspaceCount = workspaceManifestCount(specs);
+  return workspaceCount === 0
+    ? `the root \`package.json\``
+    : `the root \`package.json\` and ${workspaceCount} workspace child ` +
+        `manifest(s)`;
+}
+
+/**
  * Describe what the spec check established, without overstating the bare-`*`
  * workspace fallback as a resolved link.
  * @param workspaces - What resolving the workspace members established
@@ -261,15 +288,20 @@ export async function assessDependenciesSupplyChainDimension(
   if (outcome.kind === "unassessable") {
     return skipRecord(outcome.reason);
   }
-  const specs = collectSpecs(outcome.manifest);
+  const workspaces = await resolveWorkspaceMembers(root, outcome.manifest);
+  const specs = [
+    ...collectSpecs(outcome.manifest),
+    ...workspaces.members.flatMap(member =>
+      collectSpecs(member.manifest, member.manifestPath)
+    ),
+  ];
   if (specs.length === 0) {
     return skipRecord(
-      "`package.json` declares no dependencies, so this repository owns no " +
-        "third-party surface a confidence model could cover; supply-chain " +
-        "confidence is not established either way"
+      "No resolved package manifest declares dependencies, so this repository " +
+        "owns no third-party surface a confidence model could cover; " +
+        "supply-chain confidence is not established either way"
     );
   }
-  const workspaces = await resolveWorkspaceMembers(root, outcome.manifest);
   const { violations, observations } = await collectFindings(
     root,
     specs,
@@ -291,12 +323,12 @@ export async function assessDependenciesSupplyChainDimension(
     findings: [
       {
         evidence:
-          `Inspected ${specs.length} dependency spec(s) in the root ` +
-          `\`package.json\`: ${describeSpecCleanliness(workspaces)}, a ` +
+          `Inspected ${specs.length} dependency spec(s) in ` +
+          `${describeManifestScope(specs)}: ` +
+          `${describeSpecCleanliness(workspaces)}, a ` +
           "lockfile is committed, a dependency-audit gate covering the " +
           "JavaScript tree is declared, and every active audit exception " +
-          "carries a written decision. Workspace child manifests are not " +
-          "walked, so this speaks only to the root manifest.",
+          "carries a written decision.",
         checked: [SUPPLY_CHAIN_BLOCKER_ID],
       },
       ...informationalFindings(observations),

--- a/src/cli/doctor-readiness-supply-chain.ts
+++ b/src/cli/doctor-readiness-supply-chain.ts
@@ -62,7 +62,7 @@ const MAX_EVIDENCE_LINES = 12;
  */
 function lockfileEvidence(specCount: number): string {
   return (
-    `\`package.json\` and workspace package manifest(s) declare ${specCount} ` +
+    `package manifest(s), starting with \`package.json\`, declare ${specCount} ` +
     `dependency spec(s) but no lockfile is committed (looked for ` +
     `${LOCKFILES.join(", ")}) — two installs can resolve to different trees, ` +
     "so what was validated is not provably what gets installed"

--- a/src/cli/doctor-readiness-workspaces.ts
+++ b/src/cli/doctor-readiness-workspaces.ts
@@ -28,6 +28,18 @@ export interface WorkspaceMembers {
   readonly declared: boolean;
   /** Names of the local packages the workspaces resolve to. */
   readonly names: ReadonlySet<string>;
+  /** Parsed package manifests resolved from workspace children. */
+  readonly members: readonly WorkspaceMember[];
+}
+
+/** One workspace child manifest that could be parsed offline. */
+export interface WorkspaceMember {
+  /** Repo-relative path to the child package manifest. */
+  readonly manifestPath: string;
+  /** Child package name when the manifest declares one. */
+  readonly name: string | null;
+  /** Parsed child package manifest. */
+  readonly manifest: Record<string, unknown>;
 }
 
 /**
@@ -78,25 +90,34 @@ export async function resolveWorkspaceMembers(
   const directories = (
     await Promise.all(globs.map(async glob => await expandGlob(root, glob)))
   ).flat();
-  const names = (
+  const members = (
     await Promise.all(
       directories.map(async directory => {
-        const source = await readFileOrNull(root, `${directory}/package.json`);
+        const manifestPath = `${directory}/package.json`;
+        const source = await readFileOrNull(root, manifestPath);
         if (source === null) {
           return [];
         }
         try {
           const parsed: unknown = JSON.parse(source);
-          return isRecord(parsed) && typeof parsed.name === "string"
-            ? [parsed.name]
-            : [];
+          if (!isRecord(parsed)) {
+            return [];
+          }
+          const name = typeof parsed.name === "string" ? parsed.name : null;
+          return [{ manifestPath, name, manifest: parsed }];
         } catch {
           return [];
         }
       })
     )
   ).flat();
-  return { declared: globs.length > 0, names: new Set(names) };
+  return {
+    declared: globs.length > 0,
+    names: new Set(
+      members.flatMap(member => (member.name === null ? [] : [member.name]))
+    ),
+    members,
+  };
 }
 
 /**

--- a/src/cli/doctor-readiness-workspaces.ts
+++ b/src/cli/doctor-readiness-workspaces.ts
@@ -90,9 +90,10 @@ export async function resolveWorkspaceMembers(
   const directories = (
     await Promise.all(globs.map(async glob => await expandGlob(root, glob)))
   ).flat();
+  const uniqueDirectories = [...new Set(directories)];
   const members = (
     await Promise.all(
-      directories.map(async directory => {
+      uniqueDirectories.map(async directory => {
         const manifestPath = `${directory}/package.json`;
         const source = await readFileOrNull(root, manifestPath);
         if (source === null) {

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7772,6 +7772,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/doctor-readiness-supply-chain-exceptions.test.ts": true,
     "tests/unit/cli/doctor-readiness-supply-chain-install-gate.test.ts": true,
     "tests/unit/cli/doctor-readiness-supply-chain-precision.test.ts": true,
+    "tests/unit/cli/doctor-readiness-supply-chain-workspaces.test.ts": true,
     "tests/unit/cli/doctor-readiness-supply-chain.test.ts": true,
     "tests/unit/cli/doctor-readiness-workflows.test.ts": true,
     "tests/unit/cli/doctor-readiness.test.ts": true,

--- a/tests/unit/cli/doctor-readiness-supply-chain-workspaces.test.ts
+++ b/tests/unit/cli/doctor-readiness-supply-chain-workspaces.test.ts
@@ -145,4 +145,55 @@ describe("assessDependenciesSupplyChainDimension — workspace child manifests",
       "1 workspace child manifest"
     );
   });
+
+  it("deduplicates workspace manifests resolved through overlapping globs", async () => {
+    const cwd = await getTempDir();
+    await writeConfidenceGates(cwd);
+    await writeRepoJson(cwd, PACKAGE_JSON, {
+      name: MONOREPO_NAME,
+      version: "1.0.0",
+      workspaces: [WORKSPACE_GLOB, "packages/utils"],
+      dependencies: { [WORKSPACE_PACKAGE_NAME]: "*" },
+    });
+    await writeRepoJson(cwd, WORKSPACE_MANIFEST, {
+      name: WORKSPACE_PACKAGE_NAME,
+      version: "1.0.0",
+      dependencies: { "left-pad": "*" },
+    });
+
+    const record = await assessDependenciesSupplyChainDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    const finding = asFindings(record.findings).find(
+      candidate => candidate.blocker === BLOCKER_ID
+    );
+    expect(
+      Array.from(
+        finding?.evidence.matchAll(new RegExp(WORKSPACE_MANIFEST, "g")) ?? []
+      )
+    ).toHaveLength(1);
+  });
+
+  it("counts an overlapping workspace manifest once in PASS evidence", async () => {
+    const cwd = await getTempDir();
+    await writeConfidenceGates(cwd);
+    await writeRepoJson(cwd, PACKAGE_JSON, {
+      name: MONOREPO_NAME,
+      version: "1.0.0",
+      workspaces: [WORKSPACE_GLOB, "packages/utils"],
+      dependencies: { [WORKSPACE_PACKAGE_NAME]: "*" },
+    });
+    await writeRepoJson(cwd, WORKSPACE_MANIFEST, {
+      name: WORKSPACE_PACKAGE_NAME,
+      version: "1.0.0",
+      dependencies: { "left-pad": "1.3.0" },
+    });
+
+    const record = await assessDependenciesSupplyChainDimension(cwd);
+
+    expect(record.status).toBe(PASS);
+    const evidence = asFindings(record.findings)[0].evidence;
+    expect(evidence).toContain("2 dependency spec(s)");
+    expect(evidence).toContain("1 workspace child manifest");
+  });
 });

--- a/tests/unit/cli/doctor-readiness-supply-chain-workspaces.test.ts
+++ b/tests/unit/cli/doctor-readiness-supply-chain-workspaces.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Workspace-child manifest coverage for the dependencies/supply-chain readiness
+ * producer (B5, PRD #1739, #1896).
+ *
+ * The root manifest can be clean while workspace package manifests carry the
+ * actual dependency surface. These regressions pin that B5 walks those child
+ * manifests without breaking the normal local-workspace-link exemption.
+ * @module tests/unit/cli/doctor-readiness-supply-chain-workspaces
+ */
+import { rm } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { assessDependenciesSupplyChainDimension } from "../../../src/cli/doctor-readiness-supply-chain.js";
+import { assessReadiness } from "../../../src/cli/doctor-readiness-blockers.js";
+import {
+  asFindings,
+  FAIL,
+  makeScratchRepo,
+  PASS,
+  writeRepoFile,
+  writeRepoJson,
+} from "../../helpers/readiness-workflow-fixtures.js";
+
+/** The ship blocker this producer can stand up. */
+const BLOCKER_ID = "B5";
+
+/** The manifest every fixture writes. */
+const PACKAGE_JSON = "package.json";
+
+/** The workspace child manifest path the tests inspect. */
+const WORKSPACE_MANIFEST = "packages/utils/package.json";
+
+/** The monorepo fixture's root package name. */
+const MONOREPO_NAME = "scratch-monorepo";
+
+/** The workspace package name used by the fixtures. */
+const WORKSPACE_PACKAGE_NAME = "@acme/utils";
+
+/** The workspace glob the monorepo fixtures declare. */
+const WORKSPACE_GLOB = "packages/*";
+
+/** The lockfile most fixtures commit. */
+const BUN_LOCK = "bun.lock";
+
+/** A minimal lockfile body; presence is what the check reads. */
+const LOCKFILE_BODY = '{"lockfileVersion": 1}\n';
+
+/** The update-bot config most fixtures use as their audit gate. */
+const DEPENDABOT_PATH = ".github/dependabot.yml";
+
+/** The CI workflow path used by dependency-confidence fixtures. */
+const QUALITY_WORKFLOW_PATH = ".github/workflows/quality.yml";
+
+/** Minimal CI install step that proves the committed lockfile is honored. */
+const LOCKFILE_INSTALL_WORKFLOW =
+  "jobs:\n  test:\n    steps:\n      - run: npm ci\n";
+
+/** A dependabot config that watches the JavaScript dependency tree. */
+const DEPENDABOT_YML = [
+  "version: 2",
+  "updates:",
+  "  - package-ecosystem: npm",
+  '    directory: "/"',
+  "    schedule:",
+  "      interval: weekly",
+  "",
+].join("\n");
+
+let tempDir: string | undefined;
+
+/**
+ * Resolve a scratch repository for one test case.
+ * @returns Temporary directory path
+ */
+async function getTempDir(): Promise<string> {
+  tempDir ??= await makeScratchRepo("supply-chain-workspaces");
+  return tempDir;
+}
+
+/**
+ * Write the shared clean B5 confidence gates.
+ * @param root - Repository root
+ */
+async function writeConfidenceGates(root: string): Promise<void> {
+  await writeRepoFile(root, BUN_LOCK, LOCKFILE_BODY);
+  await writeRepoFile(root, DEPENDABOT_PATH, DEPENDABOT_YML);
+  await writeRepoFile(root, QUALITY_WORKFLOW_PATH, LOCKFILE_INSTALL_WORKFLOW);
+}
+
+/**
+ * Write a workspace root whose local child is linked with the `*` workspace idiom.
+ * @param root - Repository root
+ */
+async function writeWorkspaceRoot(root: string): Promise<void> {
+  await writeRepoJson(root, PACKAGE_JSON, {
+    name: MONOREPO_NAME,
+    version: "1.0.0",
+    workspaces: [WORKSPACE_GLOB],
+    dependencies: { [WORKSPACE_PACKAGE_NAME]: "*" },
+  });
+}
+
+afterEach(async () => {
+  if (tempDir) {
+    await rm(tempDir, { force: true, recursive: true });
+    tempDir = undefined;
+  }
+});
+
+describe("assessDependenciesSupplyChainDimension — workspace child manifests", () => {
+  it("FAILs when a workspace child manifest declares a floating dependency", async () => {
+    const cwd = await getTempDir();
+    await writeConfidenceGates(cwd);
+    await writeWorkspaceRoot(cwd);
+    await writeRepoJson(cwd, WORKSPACE_MANIFEST, {
+      name: WORKSPACE_PACKAGE_NAME,
+      version: "1.0.0",
+      dependencies: { "left-pad": "*" },
+    });
+
+    const record = await assessDependenciesSupplyChainDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    const finding = asFindings(record.findings).find(
+      candidate => candidate.blocker === BLOCKER_ID
+    );
+    expect(finding?.evidence).toContain(WORKSPACE_MANIFEST);
+    expect(finding?.evidence).toContain("left-pad");
+  });
+
+  it("PASSes and says so when workspace child dependencies are pinned", async () => {
+    const cwd = await getTempDir();
+    await writeConfidenceGates(cwd);
+    await writeWorkspaceRoot(cwd);
+    await writeRepoJson(cwd, WORKSPACE_MANIFEST, {
+      name: WORKSPACE_PACKAGE_NAME,
+      version: "1.0.0",
+      dependencies: { "left-pad": "1.3.0" },
+    });
+
+    const record = await assessDependenciesSupplyChainDimension(cwd);
+
+    expect(record.status).toBe(PASS);
+    expect(assessReadiness([record]).blockers).toEqual([]);
+    expect(asFindings(record.findings)[0].evidence).toContain(
+      "1 workspace child manifest"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Extend B5 dependency-confidence scanning to include resolved workspace child `package.json` manifests.
- Preserve the existing workspace-link exemption while reporting floating specs from child manifests with their exact manifest path.
- Add focused workspace-manifest regressions and refresh the upstream evidence manifest.

## Verification

- `bun test tests/unit/cli/doctor-readiness-supply-chain.test.ts tests/unit/cli/doctor-readiness-supply-chain-precision.test.ts tests/unit/cli/doctor-readiness-supply-chain-workspaces.test.ts tests/unit/cli/doctor-readiness-supply-chain-install-gate.test.ts tests/unit/cli/doctor-readiness-supply-chain-exceptions.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build:dist`
- `bun run format:check`
- `bun run knip:check`
- `bun run check:upstream-evidence-manifest`
- Pre-push: `tsc --noEmit`, production dependency audit, slow lint, `knip`, full unit coverage (7,927 tests), integration tests (151 tests), plugin parity

Work-Item: CodySwannGT/lisa#1903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Supply-chain readiness checks now inspect dependency declarations in workspace child manifests as well as the root manifest.
  * Findings identify the specific manifest containing each dependency issue.
  * Readiness results now describe the manifests included in the assessment.

* **Bug Fixes**
  * Improved detection and reporting of floating dependency versions in workspaces.

* **Tests**
  * Added coverage for failing and passing workspace dependency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->