### PR TITLE
fix(readiness): inspect step env for destructive workflows

### DIFF
--- a/src/cli/doctor-readiness-domain.ts
+++ b/src/cli/doctor-readiness-domain.ts
@@ -96,12 +96,17 @@ const RECOVERY_COMMANDS: readonly RegExp[] = [
  * question outright.
  * @param command - The lower-cased `run` command
  * @param job - The job the command runs in
+ * @param step - The step the command runs in
  * @returns True when the command is an unambiguous data-destroying operation
  */
-function destroysData(command: string, job: ParsedWorkflowJob): boolean {
+function destroysData(
+  command: string,
+  job: ParsedWorkflowJob,
+  step: ParsedWorkflowStep
+): boolean {
   return (
     IRREVERSIBLE_DATA_OPS.some(pattern => pattern.test(command)) &&
-    !looksEphemeral(`${command}\n${job.env}`)
+    !looksEphemeral(`${command}\n${step.env}\n${job.env}`)
   );
 }
 

--- a/src/cli/doctor-readiness-guardrails.ts
+++ b/src/cli/doctor-readiness-guardrails.ts
@@ -95,7 +95,7 @@ const MIGRATION_COMMANDS: readonly RegExp[] = [
  * the two alike is the false positive that would discredit this whole check.
  */
 const PRODUCTION_MARKERS: readonly RegExp[] = [
-  /\b(rails_env|node_env|app_env|django_settings_module|environment)=[^\s]*prod/,
+  /\b(rails_env|node_env|app_env|django_settings_module|environment)\s*[:=]\s*[^\s]*prod/,
   /--env(ironment)?[= ]prod/,
   /\bprod(uction)?\.tfvars\b/,
 ];
@@ -110,16 +110,22 @@ const PRODUCTION_MARKERS: readonly RegExp[] = [
  * is read alongside the command, since the stage name usually lives there.
  * @param command - The lower-cased `run` command
  * @param job - The job the command runs in
+ * @param step - The step the command runs in
  * @returns True when the command is consequential on its face
  */
-function isConsequential(command: string, job: ParsedWorkflowJob): boolean {
-  if (looksEphemeral(`${command}\n${job.env}`)) {
+function isConsequential(
+  command: string,
+  job: ParsedWorkflowJob,
+  step: ParsedWorkflowStep
+): boolean {
+  const targetEvidence = `${command}\n${step.env}\n${job.env}`.toLowerCase();
+  if (looksEphemeral(targetEvidence)) {
     return false;
   }
   return (
     CONSEQUENTIAL_OPS.some(pattern => pattern.test(command)) ||
     (MIGRATION_COMMANDS.some(pattern => pattern.test(command)) &&
-      PRODUCTION_MARKERS.some(pattern => pattern.test(command)))
+      PRODUCTION_MARKERS.some(pattern => pattern.test(targetEvidence)))
   );
 }
 

--- a/src/cli/doctor-readiness-guardrails.ts
+++ b/src/cli/doctor-readiness-guardrails.ts
@@ -95,7 +95,7 @@ const MIGRATION_COMMANDS: readonly RegExp[] = [
  * the two alike is the false positive that would discredit this whole check.
  */
 const PRODUCTION_MARKERS: readonly RegExp[] = [
-  /\b(rails_env|node_env|app_env|django_settings_module|environment)\s*[:=]\s*[^\s]*prod/,
+  /\b(rails_env|node_env|app_env|django_settings_module|environment)\s*[:=]\s*["']?prod(?:uction)?["']?(?=\s|$)/,
   /--env(ironment)?[= ]prod/,
   /\bprod(uction)?\.tfvars\b/,
 ];

--- a/src/cli/doctor-readiness-operations.ts
+++ b/src/cli/doctor-readiness-operations.ts
@@ -243,7 +243,8 @@ export function commandTargetsOwnedService(
  */
 export type CommandPredicate = (
   command: string,
-  job: ParsedWorkflowJob
+  job: ParsedWorkflowJob,
+  step: ParsedWorkflowStep
 ) => boolean;
 
 /** One classified match, before the buckets are assembled. */
@@ -342,7 +343,7 @@ function classifyJob(
   options: ScanOptions
 ): readonly ScanOutcome[] {
   const hits = job.steps.filter(
-    step => step.run !== "" && matches(step.run.toLowerCase(), job)
+    step => step.run !== "" && matches(step.run.toLowerCase(), job, step)
   );
   if (hits.length === 0) {
     return [];

--- a/tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts
@@ -99,6 +99,28 @@ describe("assessDomainOwnershipDimension — ephemeral CI evidence outside the c
     }
   });
 
+  it("does not stand B1 when the step's own `env:` resolves the target to an ephemeral one", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      STEPS,
+      RUN_SCHEMA_RESET,
+      "        env:",
+      "          DATABASE_URL: postgres://postgres@127.0.0.1:5432/app",
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(SKIP);
+    for (const finding of asFindings(record.findings)) {
+      expect(Object.hasOwn(finding, "blocker")).toBe(false);
+    }
+  });
+
   it("does not stand B1 when the job runs against its own `services:` container", async () => {
     const root = await getTempDir();
     await writeWorkflow(root, CLEANUP_YML, [

--- a/tests/unit/cli/doctor-readiness-guardrails.test.ts
+++ b/tests/unit/cli/doctor-readiness-guardrails.test.ts
@@ -154,6 +154,30 @@ describe("assessFeedbackGuardrailsDimension — B4 stands only on a file-provabl
       )
     ).toBe(true);
   });
+
+  it("stands B4 when a production migration marker is declared in step env", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      DEPLOY_NAME_LINE,
+      ON_PUSH,
+      JOBS,
+      INFRA_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: bundle exec rails db:migrate",
+      "        env:",
+      "          RAILS_ENV: production",
+    ]);
+
+    const record = await assessFeedbackGuardrailsDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+  });
 });
 
 describe("assessFeedbackGuardrailsDimension — the gate half is reasoned-SKIPped", () => {

--- a/tests/unit/cli/doctor-readiness-guardrails.test.ts
+++ b/tests/unit/cli/doctor-readiness-guardrails.test.ts
@@ -259,6 +259,26 @@ describe("assessFeedbackGuardrailsDimension — ordinary operations stay clear",
     expectNoBlocker(record.findings);
   });
 
+  it("does not stand B4 when step env names a non-production environment", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      DEPLOY_NAME_LINE,
+      ON_PUSH,
+      JOBS,
+      INFRA_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: bundle exec rails db:migrate",
+      "        env:",
+      "          RAILS_ENV: nonprod",
+    ]);
+
+    const record = await assessFeedbackGuardrailsDimension(root);
+
+    expect(record.status).toBe(SKIP);
+    expectNoBlocker(record.findings);
+  });
+
   it("does not stand B4 when a checked-in runbook provides the way back", async () => {
     const root = await getTempDir();
     await writeRepoFile(


### PR DESCRIPTION
## Summary

- passes step-level context into the shared B1/B4 workflow operation scanner
- lets B1 use step `env:` when deciding whether a destructive target is ephemeral
- lets B4 recognize production migration markers declared in step `env:` YAML

## Verification

- bun test tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts tests/unit/cli/doctor-readiness-guardrails.test.ts
- bun run typecheck
- bun run build:dist
- bun run format:check
- bun run lint
- git push pre-push hook: typecheck, production audit, slow lint, knip, full coverage unit suite, integration tests, plugin parity

Work-Item: CodySwannGT/lisa#1903


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness checks to account for environment variables defined at the workflow-step level.
  * More reliably identifies ephemeral/local targets and avoids false blockers for safe operations.
  * Recognizes additional production environment formats, ensuring consequential production migrations continue to trigger warnings.

* **Tests**
  * Added coverage for step-level environment settings in domain and guardrail readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->