### PR TITLE
fix(readiness): flag poisoned pull_request_target pipelines

### DIFF
--- a/src/cli/doctor-readiness-credentials.ts
+++ b/src/cli/doctor-readiness-credentials.ts
@@ -62,6 +62,18 @@ const OIDC_REPLACEABLE_KEYS = new Set([
 /** Matches a repository-token reference in either of its spellings. */
 const REPOSITORY_TOKEN = /\b(?:GITHUB_TOKEN|GH_TOKEN)\b|github\.token/;
 
+/** A checkout ref that replaces trusted base code with untrusted PR-head code. */
+const PULL_REQUEST_HEAD_REF =
+  /github\.event\.pull_request\.head\.(?:sha|ref)|github\.head_ref/;
+
+/** Commands that execute code from the checkout rather than only inspecting metadata. */
+const CHECKED_OUT_CODE_EXECUTION: readonly RegExp[] = [
+  /\b(?:npm|yarn|pnpm|bun|npx|bunx)\s+(?:install|ci|test|run|exec|x)\b/,
+  /\b(?:make|pytest|rspec|bundle|cargo|go|mvn|gradle)\s+(?:test|build|run|install)\b/,
+  /\b(?:bash|sh)\s+\.\//,
+  /(?:^|\s)\.\/(?:scripts\/)?[\w./-]+/,
+];
+
 /** One secret referenced by one deployment environment. */
 interface SecretEnvironmentPair {
   readonly secret: string;
@@ -120,6 +132,21 @@ function grantsOidc(permissions: WorkflowBlock): boolean {
     permissions !== null &&
     permissions["id-token"] === "write"
   );
+}
+
+/**
+ * Whether a permissions block grants write authority to the repository token.
+ * @param permissions - A job- or workflow-level permissions block
+ * @returns True when at least one declared scope is writable
+ */
+function grantsWriteAuthority(permissions: WorkflowBlock): boolean {
+  if (permissions === "write-all") {
+    return true;
+  }
+  if (typeof permissions !== "object" || permissions === null) {
+    return false;
+  }
+  return Object.values(permissions).some(value => value === "write");
 }
 
 /**
@@ -220,6 +247,97 @@ function staticKeyViolations(
 }
 
 /**
+ * Whether the job maps any secret material into the run.
+ * @param job - Parsed workflow job
+ * @param text - Flattened job text
+ * @returns True when secret authority is declared in YAML
+ */
+function hasDeclaredSecretAuthority(
+  job: ParsedWorkflowJob,
+  text: string
+): boolean {
+  return (
+    job.secrets !== null ||
+    text.includes("secrets.") ||
+    STATIC_CREDENTIAL_KEYS.some(key => text.includes(key))
+  );
+}
+
+/**
+ * Whether the job checks out attacker-controlled PR-head code.
+ * @param job - Parsed workflow job
+ * @returns True when actions/checkout is aimed at the PR head
+ */
+function checksOutPullRequestHead(job: ParsedWorkflowJob): boolean {
+  return job.steps.some(
+    step =>
+      step.uses.toLowerCase().split("@")[0] === "actions/checkout" &&
+      PULL_REQUEST_HEAD_REF.test(step.inputs)
+  );
+}
+
+/**
+ * Whether checked-out code runs after the PR-head checkout step.
+ * @param job - Parsed workflow job
+ * @returns True when a later shell step executes project code
+ */
+function runsCheckedOutCodeAfterPullRequestCheckout(
+  job: ParsedWorkflowJob
+): boolean {
+  const checkoutIndex = job.steps.findIndex(
+    step =>
+      step.uses.toLowerCase().split("@")[0] === "actions/checkout" &&
+      PULL_REQUEST_HEAD_REF.test(step.inputs)
+  );
+  return (
+    checkoutIndex >= 0 &&
+    job.steps
+      .slice(checkoutIndex + 1)
+      .some(step =>
+        CHECKED_OUT_CODE_EXECUTION.some(pattern => pattern.test(step.run))
+      )
+  );
+}
+
+/**
+ * Report CICD-SEC-4 poisoned-pipeline execution that runs untrusted PR code
+ * inside a privileged `pull_request_target` context.
+ * @param where - Evidence location label
+ * @param workflow - The workflow declaring the job
+ * @param job - The parsed job
+ * @param text - Flattened job text
+ * @returns Evidence lines (empty when the provable dangerous shape is absent)
+ */
+function poisonedPipelineViolations(
+  where: string,
+  workflow: ParsedWorkflow,
+  job: ParsedWorkflowJob,
+  text: string
+): readonly string[] {
+  if (!workflow.on.events.includes("pull_request_target")) {
+    return [];
+  }
+  if (
+    !checksOutPullRequestHead(job) ||
+    !runsCheckedOutCodeAfterPullRequestCheckout(job)
+  ) {
+    return [];
+  }
+  const authority =
+    grantsWriteAuthority(job.permissions) ||
+    grantsWriteAuthority(workflow.permissions) ||
+    hasDeclaredSecretAuthority(job, text);
+  if (!authority) {
+    return [];
+  }
+  return [
+    `${where} runs under \`pull_request_target\`, checks out ` +
+      "`github.event.pull_request.head` code, then executes that checked-out " +
+      "code while write permissions or secrets are declared in scope (CICD-SEC-4)",
+  ];
+}
+
+/**
  * Detect per-job credential over-authority inside one workflow.
  * @param workflow - The parsed workflow
  * @param job - The job to inspect
@@ -236,6 +354,7 @@ function jobCredentialViolations(
     ...inheritedSecretViolations(where, job),
     ...unscopedTokenViolations(where, workflow, job, text),
     ...staticKeyViolations(where, workflow, job, text),
+    ...poisonedPipelineViolations(where, workflow, job, text),
   ];
 }
 

--- a/tests/unit/cli/doctor-readiness-credentials-round2.test.ts
+++ b/tests/unit/cli/doctor-readiness-credentials-round2.test.ts
@@ -109,8 +109,8 @@ describe("assessDeliveryAuthorityDimension — B3 round-2 credentials", () => {
       ON_PUSH,
       JOBS,
       "  ship:",
-      "    permissions:",
-      "      contents: read",
+      PERMISSIONS,
+      CONTENTS_READ,
       "      id-token: write",
       STEPS,
       "      - uses: aws-actions/configure-aws-credentials@v4",
@@ -177,5 +177,56 @@ describe("assessDeliveryAuthorityDimension — B3 round-2 credentials", () => {
     );
     expect(finding?.evidence).toContain("NPM_TOKEN");
     expect(finding?.evidence).toContain("job `publish`");
+  });
+
+  it("FAILs with B3 on pull_request_target executing PR-head code with write authority", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, DEPLOY_YML, [
+      DEPLOY_NAME,
+      "on: [pull_request_target]",
+      JOBS,
+      "  privileged:",
+      PERMISSIONS,
+      "      contents: write",
+      STEPS,
+      "      - uses: actions/checkout@v4",
+      "        with:",
+      "          ref: ${{ github.event.pull_request.head.sha }}",
+      "      - run: npm test",
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    const finding = asFindings(record.findings).find(
+      candidate =>
+        candidate.blocker === "B3" &&
+        String(candidate.evidence).includes("CICD-SEC-4")
+    );
+    expect(finding?.evidence).toContain("pull_request_target");
+    expect(finding?.evidence).toContain("github.event.pull_request.head");
+  });
+
+  it("does not stand poisoned-pipeline B3 when pull_request_target only checks out trusted base code", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, DEPLOY_YML, [
+      DEPLOY_NAME,
+      "on: [pull_request_target]",
+      JOBS,
+      "  label:",
+      PERMISSIONS,
+      CONTENTS_READ,
+      "      pull-requests: write",
+      STEPS,
+      "      - uses: actions/checkout@v4",
+      "      - run: npm test",
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    const poisonedFinding = asFindings(record.findings).find(finding =>
+      String(finding.evidence).includes("CICD-SEC-4")
+    );
+    expect(poisonedFinding).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Detect CICD-SEC-4 poisoned-pipeline execution in the B3 credential-authority readiness producer.
- Fail only when `pull_request_target` checks out PR-head code, executes checked-out code, and declared write authority or secrets are in scope.
- Add regression coverage for the dangerous shape and for a trusted-base checkout boundary case.

## Verification

- `bun test tests/unit/cli/doctor-readiness-credentials-round2.test.ts tests/unit/cli/doctor-readiness-delivery.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build:dist`
- `bun run format:check`
- `bun run check:upstream-evidence-manifest`
- pre-push: typecheck, production security audit, slow lint, knip, full unit coverage, integration tests, plugin parity

Work-Item: CodySwannGT/lisa#1903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for potentially poisoned `pull_request_target` workflows that execute pull-request code with write or secret access.
  * Security assessments now report evidence for this unsafe pipeline configuration.

* **Bug Fixes**
  * Improved credential readiness checks to distinguish unsafe pull-request code execution from trusted base-code workflows.

* **Tests**
  * Added regression coverage for both vulnerable and safe `pull_request_target` scenarios.
  * Standardized permission fixtures in credential assessment tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->