### PR TITLE
fix: patch brace expansion release gate

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -108,7 +108,7 @@
   "overrides": {
     "@isaacs/brace-expansion": "^5.0.1",
     "axios": ">=1.15.2",
-    "brace-expansion": ">=5.0.6",
+    "brace-expansion": ">=5.0.8",
     "esbuild": ">=0.28.1",
     "flatted": "^3.4.2",
     "form-data": ">=4.0.6",
@@ -849,7 +849,7 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "postcss": ">=8.5.18",
     "undici": ">=6.27.0",
     "form-data": ">=4.0.6",
-    "brace-expansion": ">=5.0.6"
+    "brace-expansion": ">=5.0.8"
   },
   "overrides": {
     "@isaacs/brace-expansion": "^5.0.1",
@@ -112,7 +112,7 @@
     "postcss": ">=8.5.18",
     "undici": ">=6.27.0",
     "form-data": ">=4.0.6",
-    "brace-expansion": ">=5.0.6"
+    "brace-expansion": ">=5.0.8"
   },
   "name": "@codyswann/lisa",
   "version": "2.300.5",


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#1903

## Summary
- raises the `brace-expansion` resolution/override floor from `>=5.0.6` to `>=5.0.8`
- refreshes `bun.lock` so the production audit resolves the patched package
- unblocks the failed Release and Deploy run for the merged #1903 poisoned-pipeline slice

## Verification
- `bun audit --production --json` with the workflow ignore-list filter returns `[]` for unignored high/critical findings
- `bun run typecheck`
- `bun run build:dist`
- pre-push hook: typecheck, production security audit, slow lint, knip, unit coverage, integration tests, plugin parity

Reconciles release blocker for #1903.
