### PR TITLE
fix(ratchet): stop watching audit ignore lists

### DIFF
--- a/plugins/lisa-copilot/hooks/threshold-ratchet-compare.mjs
+++ b/plugins/lisa-copilot/hooks/threshold-ratchet-compare.mjs
@@ -8,7 +8,6 @@
  */
 import {
   extractAllowEntries,
-  extractExemptionEntries,
   extractK6Constraints,
   extractNumericLeaves,
   extractRubocopThresholds,
@@ -20,7 +19,7 @@ import {
 
 /** Finding type: a numeric bound or boolean gate moved the weakening way. */
 const TYPE_WEAKENED = "weakened";
-/** Finding type: an exemption entry was added (Tier 3). */
+/** Finding type: a gate-shrinking exemption was added (Tier 3). */
 const TYPE_EXEMPTION_ADDED = "exemption-added";
 /** Family kind for .lisa.config.json (the thresholdRatchet.allow carrier). */
 const KIND_ALLOW_LIST = "allow-list";
@@ -161,29 +160,6 @@ function compareK6(relPath, base, current) {
 }
 
 /**
- * Compare an exemption-list pair (audit ignore files): report added entries.
- * @param {string} relPath Repo-relative path
- * @param {unknown} base Parsed baseline list
- * @param {unknown} current Parsed current list
- * @returns {Finding[]} One finding per newly added ignore entry
- */
-function compareExemptions(relPath, base, current) {
-  const baseEntries = extractExemptionEntries(base);
-  const findings = [];
-  for (const entry of extractExemptionEntries(current)) {
-    if (!baseEntries.has(entry)) {
-      findings.push({
-        file: relPath,
-        key: entry,
-        type: TYPE_EXEMPTION_ADDED,
-        message: `${relPath}: new security-audit ignore entry "${entry}" — ignoring a finding weakens the gate and needs a human's sign-off.`,
-      });
-    }
-  }
-  return findings;
-}
-
-/**
  * Compare .lisa.config.json allow lists: report added exception entries so a
  * change can never grant itself an exception.
  * @param {string} relPath Repo-relative path
@@ -258,8 +234,6 @@ export function compareFile(relPath, baselineText, currentText) {
       return compareStryker(relPath, base, current);
     case "k6":
       return compareK6(relPath, base, current);
-    case "exemption-list":
-      return compareExemptions(relPath, base, current);
     case KIND_ALLOW_LIST:
       return compareAllowList(relPath, base, current);
     default:

--- a/plugins/lisa-copilot/hooks/threshold-ratchet-families.mjs
+++ b/plugins/lisa-copilot/hooks/threshold-ratchet-families.mjs
@@ -49,11 +49,6 @@ export const FAMILIES = [
     kind: "k6",
   },
   {
-    id: "audit-ignore",
-    match: /(^|\/)audit\.ignore\.(config|local)\.json$/,
-    kind: "exemption-list",
-  },
-  {
     id: "lisa-config",
     match: /(^|\/)\.lisa\.config\.json$/,
     kind: "allow-list",
@@ -249,35 +244,6 @@ export function extractK6Constraints(conf) {
     }
   }
   return { numeric, booleans };
-}
-
-/**
- * Flatten an exemption file (audit ignore list) into a set of entry tokens.
- * Arrays contribute their string items; objects contribute their keys.
- * @param {unknown} conf Parsed JSON
- * @returns {Set<string>} One token per exemption entry
- */
-export function extractExemptionEntries(conf) {
-  const out = new Set();
-  if (Array.isArray(conf)) {
-    for (const item of conf) {
-      if (typeof item === "string") out.add(item);
-      else if (item && typeof item === "object") out.add(JSON.stringify(item));
-    }
-  } else if (conf && typeof conf === "object") {
-    for (const [key, value] of Object.entries(conf)) {
-      if (Array.isArray(value)) {
-        for (const item of value) {
-          out.add(
-            `${key}:${typeof item === "string" ? item : JSON.stringify(item)}`
-          );
-        }
-      } else {
-        out.add(key);
-      }
-    }
-  }
-  return out;
 }
 
 /**

--- a/plugins/lisa-copilot/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa-copilot/hooks/threshold-ratchet.mjs
@@ -12,8 +12,11 @@
  * Tier 1 — designed tunables: vitest/jest/simplecov/e2e thresholds
  * (minimums) and eslint/rubocop thresholds (maximums). Tier 2 — stryker's
  * break score and k6 expression bounds. Tier 3 — exemption additions
- * (audit-ignore entries, stryker mutate exclusions, thresholdRatchet.allow
- * entries) which weaken a gate without touching a number.
+ * (stryker mutate exclusions, thresholdRatchet.allow entries) which weaken
+ * a gate without touching a number. Audit ignore lists are deliberately NOT
+ * watched: the security-audit-handling ladder authorizes agents to add
+ * documented entries autonomously, and doctor readiness (B5) audits that
+ * every entry carries a written decision.
  *
  * Human override: `.lisa.config.json` → `thresholdRatchet.allow` entries
  * ({ file, key, reason }). Honored ONLY from the baseline side (HEAD /

--- a/plugins/lisa-copilot/hooks/threshold-ratchet.sh
+++ b/plugins/lisa-copilot/hooks/threshold-ratchet.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # PostToolUse hook for Edit|Write|NotebookEdit|Bash: the threshold ratchet.
 # Quality thresholds (coverage minimums, complexity maximums, mutation break
-# score, e2e route floors, k6 bounds, audit-ignore lists) may tighten but never
+# score, e2e route floors, k6 bounds) may tighten but never
 # weaken. The deterministic comparator lives in threshold-ratchet.mjs and is
 # shared with the pre-commit (husky/lefthook --staged) and CI (--base) layers,
 # so this hook is fast feedback — not the only line of defense.

--- a/plugins/lisa-cursor/hooks/threshold-ratchet-compare.mjs
+++ b/plugins/lisa-cursor/hooks/threshold-ratchet-compare.mjs
@@ -8,7 +8,6 @@
  */
 import {
   extractAllowEntries,
-  extractExemptionEntries,
   extractK6Constraints,
   extractNumericLeaves,
   extractRubocopThresholds,
@@ -20,7 +19,7 @@ import {
 
 /** Finding type: a numeric bound or boolean gate moved the weakening way. */
 const TYPE_WEAKENED = "weakened";
-/** Finding type: an exemption entry was added (Tier 3). */
+/** Finding type: a gate-shrinking exemption was added (Tier 3). */
 const TYPE_EXEMPTION_ADDED = "exemption-added";
 /** Family kind for .lisa.config.json (the thresholdRatchet.allow carrier). */
 const KIND_ALLOW_LIST = "allow-list";
@@ -161,29 +160,6 @@ function compareK6(relPath, base, current) {
 }
 
 /**
- * Compare an exemption-list pair (audit ignore files): report added entries.
- * @param {string} relPath Repo-relative path
- * @param {unknown} base Parsed baseline list
- * @param {unknown} current Parsed current list
- * @returns {Finding[]} One finding per newly added ignore entry
- */
-function compareExemptions(relPath, base, current) {
-  const baseEntries = extractExemptionEntries(base);
-  const findings = [];
-  for (const entry of extractExemptionEntries(current)) {
-    if (!baseEntries.has(entry)) {
-      findings.push({
-        file: relPath,
-        key: entry,
-        type: TYPE_EXEMPTION_ADDED,
-        message: `${relPath}: new security-audit ignore entry "${entry}" — ignoring a finding weakens the gate and needs a human's sign-off.`,
-      });
-    }
-  }
-  return findings;
-}
-
-/**
  * Compare .lisa.config.json allow lists: report added exception entries so a
  * change can never grant itself an exception.
  * @param {string} relPath Repo-relative path
@@ -258,8 +234,6 @@ export function compareFile(relPath, baselineText, currentText) {
       return compareStryker(relPath, base, current);
     case "k6":
       return compareK6(relPath, base, current);
-    case "exemption-list":
-      return compareExemptions(relPath, base, current);
     case KIND_ALLOW_LIST:
       return compareAllowList(relPath, base, current);
     default:

--- a/plugins/lisa-cursor/hooks/threshold-ratchet-families.mjs
+++ b/plugins/lisa-cursor/hooks/threshold-ratchet-families.mjs
@@ -49,11 +49,6 @@ export const FAMILIES = [
     kind: "k6",
   },
   {
-    id: "audit-ignore",
-    match: /(^|\/)audit\.ignore\.(config|local)\.json$/,
-    kind: "exemption-list",
-  },
-  {
     id: "lisa-config",
     match: /(^|\/)\.lisa\.config\.json$/,
     kind: "allow-list",
@@ -249,35 +244,6 @@ export function extractK6Constraints(conf) {
     }
   }
   return { numeric, booleans };
-}
-
-/**
- * Flatten an exemption file (audit ignore list) into a set of entry tokens.
- * Arrays contribute their string items; objects contribute their keys.
- * @param {unknown} conf Parsed JSON
- * @returns {Set<string>} One token per exemption entry
- */
-export function extractExemptionEntries(conf) {
-  const out = new Set();
-  if (Array.isArray(conf)) {
-    for (const item of conf) {
-      if (typeof item === "string") out.add(item);
-      else if (item && typeof item === "object") out.add(JSON.stringify(item));
-    }
-  } else if (conf && typeof conf === "object") {
-    for (const [key, value] of Object.entries(conf)) {
-      if (Array.isArray(value)) {
-        for (const item of value) {
-          out.add(
-            `${key}:${typeof item === "string" ? item : JSON.stringify(item)}`
-          );
-        }
-      } else {
-        out.add(key);
-      }
-    }
-  }
-  return out;
 }
 
 /**

--- a/plugins/lisa-cursor/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa-cursor/hooks/threshold-ratchet.mjs
@@ -12,8 +12,11 @@
  * Tier 1 — designed tunables: vitest/jest/simplecov/e2e thresholds
  * (minimums) and eslint/rubocop thresholds (maximums). Tier 2 — stryker's
  * break score and k6 expression bounds. Tier 3 — exemption additions
- * (audit-ignore entries, stryker mutate exclusions, thresholdRatchet.allow
- * entries) which weaken a gate without touching a number.
+ * (stryker mutate exclusions, thresholdRatchet.allow entries) which weaken
+ * a gate without touching a number. Audit ignore lists are deliberately NOT
+ * watched: the security-audit-handling ladder authorizes agents to add
+ * documented entries autonomously, and doctor readiness (B5) audits that
+ * every entry carries a written decision.
  *
  * Human override: `.lisa.config.json` → `thresholdRatchet.allow` entries
  * ({ file, key, reason }). Honored ONLY from the baseline side (HEAD /

--- a/plugins/lisa-cursor/hooks/threshold-ratchet.sh
+++ b/plugins/lisa-cursor/hooks/threshold-ratchet.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # PostToolUse hook for Edit|Write|NotebookEdit|Bash: the threshold ratchet.
 # Quality thresholds (coverage minimums, complexity maximums, mutation break
-# score, e2e route floors, k6 bounds, audit-ignore lists) may tighten but never
+# score, e2e route floors, k6 bounds) may tighten but never
 # weaken. The deterministic comparator lives in threshold-ratchet.mjs and is
 # shared with the pre-commit (husky/lefthook --staged) and CI (--base) layers,
 # so this hook is fast feedback — not the only line of defense.

--- a/plugins/lisa/hooks/threshold-ratchet-compare.mjs
+++ b/plugins/lisa/hooks/threshold-ratchet-compare.mjs
@@ -8,7 +8,6 @@
  */
 import {
   extractAllowEntries,
-  extractExemptionEntries,
   extractK6Constraints,
   extractNumericLeaves,
   extractRubocopThresholds,
@@ -20,7 +19,7 @@ import {
 
 /** Finding type: a numeric bound or boolean gate moved the weakening way. */
 const TYPE_WEAKENED = "weakened";
-/** Finding type: an exemption entry was added (Tier 3). */
+/** Finding type: a gate-shrinking exemption was added (Tier 3). */
 const TYPE_EXEMPTION_ADDED = "exemption-added";
 /** Family kind for .lisa.config.json (the thresholdRatchet.allow carrier). */
 const KIND_ALLOW_LIST = "allow-list";
@@ -161,29 +160,6 @@ function compareK6(relPath, base, current) {
 }
 
 /**
- * Compare an exemption-list pair (audit ignore files): report added entries.
- * @param {string} relPath Repo-relative path
- * @param {unknown} base Parsed baseline list
- * @param {unknown} current Parsed current list
- * @returns {Finding[]} One finding per newly added ignore entry
- */
-function compareExemptions(relPath, base, current) {
-  const baseEntries = extractExemptionEntries(base);
-  const findings = [];
-  for (const entry of extractExemptionEntries(current)) {
-    if (!baseEntries.has(entry)) {
-      findings.push({
-        file: relPath,
-        key: entry,
-        type: TYPE_EXEMPTION_ADDED,
-        message: `${relPath}: new security-audit ignore entry "${entry}" — ignoring a finding weakens the gate and needs a human's sign-off.`,
-      });
-    }
-  }
-  return findings;
-}
-
-/**
  * Compare .lisa.config.json allow lists: report added exception entries so a
  * change can never grant itself an exception.
  * @param {string} relPath Repo-relative path
@@ -258,8 +234,6 @@ export function compareFile(relPath, baselineText, currentText) {
       return compareStryker(relPath, base, current);
     case "k6":
       return compareK6(relPath, base, current);
-    case "exemption-list":
-      return compareExemptions(relPath, base, current);
     case KIND_ALLOW_LIST:
       return compareAllowList(relPath, base, current);
     default:

--- a/plugins/lisa/hooks/threshold-ratchet-families.mjs
+++ b/plugins/lisa/hooks/threshold-ratchet-families.mjs
@@ -49,11 +49,6 @@ export const FAMILIES = [
     kind: "k6",
   },
   {
-    id: "audit-ignore",
-    match: /(^|\/)audit\.ignore\.(config|local)\.json$/,
-    kind: "exemption-list",
-  },
-  {
     id: "lisa-config",
     match: /(^|\/)\.lisa\.config\.json$/,
     kind: "allow-list",
@@ -249,35 +244,6 @@ export function extractK6Constraints(conf) {
     }
   }
   return { numeric, booleans };
-}
-
-/**
- * Flatten an exemption file (audit ignore list) into a set of entry tokens.
- * Arrays contribute their string items; objects contribute their keys.
- * @param {unknown} conf Parsed JSON
- * @returns {Set<string>} One token per exemption entry
- */
-export function extractExemptionEntries(conf) {
-  const out = new Set();
-  if (Array.isArray(conf)) {
-    for (const item of conf) {
-      if (typeof item === "string") out.add(item);
-      else if (item && typeof item === "object") out.add(JSON.stringify(item));
-    }
-  } else if (conf && typeof conf === "object") {
-    for (const [key, value] of Object.entries(conf)) {
-      if (Array.isArray(value)) {
-        for (const item of value) {
-          out.add(
-            `${key}:${typeof item === "string" ? item : JSON.stringify(item)}`
-          );
-        }
-      } else {
-        out.add(key);
-      }
-    }
-  }
-  return out;
 }
 
 /**

--- a/plugins/lisa/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa/hooks/threshold-ratchet.mjs
@@ -12,8 +12,11 @@
  * Tier 1 — designed tunables: vitest/jest/simplecov/e2e thresholds
  * (minimums) and eslint/rubocop thresholds (maximums). Tier 2 — stryker's
  * break score and k6 expression bounds. Tier 3 — exemption additions
- * (audit-ignore entries, stryker mutate exclusions, thresholdRatchet.allow
- * entries) which weaken a gate without touching a number.
+ * (stryker mutate exclusions, thresholdRatchet.allow entries) which weaken
+ * a gate without touching a number. Audit ignore lists are deliberately NOT
+ * watched: the security-audit-handling ladder authorizes agents to add
+ * documented entries autonomously, and doctor readiness (B5) audits that
+ * every entry carries a written decision.
  *
  * Human override: `.lisa.config.json` → `thresholdRatchet.allow` entries
  * ({ file, key, reason }). Honored ONLY from the baseline side (HEAD /

--- a/plugins/lisa/hooks/threshold-ratchet.sh
+++ b/plugins/lisa/hooks/threshold-ratchet.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # PostToolUse hook for Edit|Write|NotebookEdit|Bash: the threshold ratchet.
 # Quality thresholds (coverage minimums, complexity maximums, mutation break
-# score, e2e route floors, k6 bounds, audit-ignore lists) may tighten but never
+# score, e2e route floors, k6 bounds) may tighten but never
 # weaken. The deterministic comparator lives in threshold-ratchet.mjs and is
 # shared with the pre-commit (husky/lefthook --staged) and CI (--base) layers,
 # so this hook is fast feedback — not the only line of defense.

--- a/plugins/src/base/hooks/threshold-ratchet-compare.mjs
+++ b/plugins/src/base/hooks/threshold-ratchet-compare.mjs
@@ -8,7 +8,6 @@
  */
 import {
   extractAllowEntries,
-  extractExemptionEntries,
   extractK6Constraints,
   extractNumericLeaves,
   extractRubocopThresholds,
@@ -20,7 +19,7 @@ import {
 
 /** Finding type: a numeric bound or boolean gate moved the weakening way. */
 const TYPE_WEAKENED = "weakened";
-/** Finding type: an exemption entry was added (Tier 3). */
+/** Finding type: a gate-shrinking exemption was added (Tier 3). */
 const TYPE_EXEMPTION_ADDED = "exemption-added";
 /** Family kind for .lisa.config.json (the thresholdRatchet.allow carrier). */
 const KIND_ALLOW_LIST = "allow-list";
@@ -161,29 +160,6 @@ function compareK6(relPath, base, current) {
 }
 
 /**
- * Compare an exemption-list pair (audit ignore files): report added entries.
- * @param {string} relPath Repo-relative path
- * @param {unknown} base Parsed baseline list
- * @param {unknown} current Parsed current list
- * @returns {Finding[]} One finding per newly added ignore entry
- */
-function compareExemptions(relPath, base, current) {
-  const baseEntries = extractExemptionEntries(base);
-  const findings = [];
-  for (const entry of extractExemptionEntries(current)) {
-    if (!baseEntries.has(entry)) {
-      findings.push({
-        file: relPath,
-        key: entry,
-        type: TYPE_EXEMPTION_ADDED,
-        message: `${relPath}: new security-audit ignore entry "${entry}" — ignoring a finding weakens the gate and needs a human's sign-off.`,
-      });
-    }
-  }
-  return findings;
-}
-
-/**
  * Compare .lisa.config.json allow lists: report added exception entries so a
  * change can never grant itself an exception.
  * @param {string} relPath Repo-relative path
@@ -258,8 +234,6 @@ export function compareFile(relPath, baselineText, currentText) {
       return compareStryker(relPath, base, current);
     case "k6":
       return compareK6(relPath, base, current);
-    case "exemption-list":
-      return compareExemptions(relPath, base, current);
     case KIND_ALLOW_LIST:
       return compareAllowList(relPath, base, current);
     default:

--- a/plugins/src/base/hooks/threshold-ratchet-families.mjs
+++ b/plugins/src/base/hooks/threshold-ratchet-families.mjs
@@ -49,11 +49,6 @@ export const FAMILIES = [
     kind: "k6",
   },
   {
-    id: "audit-ignore",
-    match: /(^|\/)audit\.ignore\.(config|local)\.json$/,
-    kind: "exemption-list",
-  },
-  {
     id: "lisa-config",
     match: /(^|\/)\.lisa\.config\.json$/,
     kind: "allow-list",
@@ -249,35 +244,6 @@ export function extractK6Constraints(conf) {
     }
   }
   return { numeric, booleans };
-}
-
-/**
- * Flatten an exemption file (audit ignore list) into a set of entry tokens.
- * Arrays contribute their string items; objects contribute their keys.
- * @param {unknown} conf Parsed JSON
- * @returns {Set<string>} One token per exemption entry
- */
-export function extractExemptionEntries(conf) {
-  const out = new Set();
-  if (Array.isArray(conf)) {
-    for (const item of conf) {
-      if (typeof item === "string") out.add(item);
-      else if (item && typeof item === "object") out.add(JSON.stringify(item));
-    }
-  } else if (conf && typeof conf === "object") {
-    for (const [key, value] of Object.entries(conf)) {
-      if (Array.isArray(value)) {
-        for (const item of value) {
-          out.add(
-            `${key}:${typeof item === "string" ? item : JSON.stringify(item)}`
-          );
-        }
-      } else {
-        out.add(key);
-      }
-    }
-  }
-  return out;
 }
 
 /**

--- a/plugins/src/base/hooks/threshold-ratchet.mjs
+++ b/plugins/src/base/hooks/threshold-ratchet.mjs
@@ -12,8 +12,11 @@
  * Tier 1 — designed tunables: vitest/jest/simplecov/e2e thresholds
  * (minimums) and eslint/rubocop thresholds (maximums). Tier 2 — stryker's
  * break score and k6 expression bounds. Tier 3 — exemption additions
- * (audit-ignore entries, stryker mutate exclusions, thresholdRatchet.allow
- * entries) which weaken a gate without touching a number.
+ * (stryker mutate exclusions, thresholdRatchet.allow entries) which weaken
+ * a gate without touching a number. Audit ignore lists are deliberately NOT
+ * watched: the security-audit-handling ladder authorizes agents to add
+ * documented entries autonomously, and doctor readiness (B5) audits that
+ * every entry carries a written decision.
  *
  * Human override: `.lisa.config.json` → `thresholdRatchet.allow` entries
  * ({ file, key, reason }). Honored ONLY from the baseline side (HEAD /

--- a/plugins/src/base/hooks/threshold-ratchet.sh
+++ b/plugins/src/base/hooks/threshold-ratchet.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # PostToolUse hook for Edit|Write|NotebookEdit|Bash: the threshold ratchet.
 # Quality thresholds (coverage minimums, complexity maximums, mutation break
-# score, e2e route floors, k6 bounds, audit-ignore lists) may tighten but never
+# score, e2e route floors, k6 bounds) may tighten but never
 # weaken. The deterministic comparator lives in threshold-ratchet.mjs and is
 # shared with the pre-commit (husky/lefthook --staged) and CI (--base) layers,
 # so this hook is fast feedback — not the only line of defense.

--- a/rails/copy-overwrite/scripts/check-threshold-ratchet.mjs
+++ b/rails/copy-overwrite/scripts/check-threshold-ratchet.mjs
@@ -12,8 +12,11 @@
  * Tier 1 — designed tunables: vitest/jest/simplecov/e2e thresholds
  * (minimums) and eslint/rubocop thresholds (maximums). Tier 2 — stryker's
  * break score and k6 expression bounds. Tier 3 — exemption additions
- * (audit-ignore entries, stryker mutate exclusions, thresholdRatchet.allow
- * entries) which weaken a gate without touching a number.
+ * (stryker mutate exclusions, thresholdRatchet.allow entries) which weaken
+ * a gate without touching a number. Audit ignore lists are deliberately NOT
+ * watched: the security-audit-handling ladder authorizes agents to add
+ * documented entries autonomously, and doctor readiness (B5) audits that
+ * every entry carries a written decision.
  *
  * Human override: `.lisa.config.json` → `thresholdRatchet.allow` entries
  * ({ file, key, reason }). Honored ONLY from the baseline side (HEAD /

--- a/rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs
+++ b/rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs
@@ -8,7 +8,6 @@
  */
 import {
   extractAllowEntries,
-  extractExemptionEntries,
   extractK6Constraints,
   extractNumericLeaves,
   extractRubocopThresholds,
@@ -20,7 +19,7 @@ import {
 
 /** Finding type: a numeric bound or boolean gate moved the weakening way. */
 const TYPE_WEAKENED = "weakened";
-/** Finding type: an exemption entry was added (Tier 3). */
+/** Finding type: a gate-shrinking exemption was added (Tier 3). */
 const TYPE_EXEMPTION_ADDED = "exemption-added";
 /** Family kind for .lisa.config.json (the thresholdRatchet.allow carrier). */
 const KIND_ALLOW_LIST = "allow-list";
@@ -161,29 +160,6 @@ function compareK6(relPath, base, current) {
 }
 
 /**
- * Compare an exemption-list pair (audit ignore files): report added entries.
- * @param {string} relPath Repo-relative path
- * @param {unknown} base Parsed baseline list
- * @param {unknown} current Parsed current list
- * @returns {Finding[]} One finding per newly added ignore entry
- */
-function compareExemptions(relPath, base, current) {
-  const baseEntries = extractExemptionEntries(base);
-  const findings = [];
-  for (const entry of extractExemptionEntries(current)) {
-    if (!baseEntries.has(entry)) {
-      findings.push({
-        file: relPath,
-        key: entry,
-        type: TYPE_EXEMPTION_ADDED,
-        message: `${relPath}: new security-audit ignore entry "${entry}" — ignoring a finding weakens the gate and needs a human's sign-off.`,
-      });
-    }
-  }
-  return findings;
-}
-
-/**
  * Compare .lisa.config.json allow lists: report added exception entries so a
  * change can never grant itself an exception.
  * @param {string} relPath Repo-relative path
@@ -258,8 +234,6 @@ export function compareFile(relPath, baselineText, currentText) {
       return compareStryker(relPath, base, current);
     case "k6":
       return compareK6(relPath, base, current);
-    case "exemption-list":
-      return compareExemptions(relPath, base, current);
     case KIND_ALLOW_LIST:
       return compareAllowList(relPath, base, current);
     default:

--- a/rails/copy-overwrite/scripts/threshold-ratchet-families.mjs
+++ b/rails/copy-overwrite/scripts/threshold-ratchet-families.mjs
@@ -49,11 +49,6 @@ export const FAMILIES = [
     kind: "k6",
   },
   {
-    id: "audit-ignore",
-    match: /(^|\/)audit\.ignore\.(config|local)\.json$/,
-    kind: "exemption-list",
-  },
-  {
     id: "lisa-config",
     match: /(^|\/)\.lisa\.config\.json$/,
     kind: "allow-list",
@@ -249,35 +244,6 @@ export function extractK6Constraints(conf) {
     }
   }
   return { numeric, booleans };
-}
-
-/**
- * Flatten an exemption file (audit ignore list) into a set of entry tokens.
- * Arrays contribute their string items; objects contribute their keys.
- * @param {unknown} conf Parsed JSON
- * @returns {Set<string>} One token per exemption entry
- */
-export function extractExemptionEntries(conf) {
-  const out = new Set();
-  if (Array.isArray(conf)) {
-    for (const item of conf) {
-      if (typeof item === "string") out.add(item);
-      else if (item && typeof item === "object") out.add(JSON.stringify(item));
-    }
-  } else if (conf && typeof conf === "object") {
-    for (const [key, value] of Object.entries(conf)) {
-      if (Array.isArray(value)) {
-        for (const item of value) {
-          out.add(
-            `${key}:${typeof item === "string" ? item : JSON.stringify(item)}`
-          );
-        }
-      } else {
-        out.add(key);
-      }
-    }
-  }
-  return out;
 }
 
 /**

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -599,13 +599,13 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/shell-write-nudge.sh":
       "69839af423f8792b1e52c71097316c3264425553031627c0a2f9409a9d5becd0",
     "plugins/src/base/hooks/threshold-ratchet-compare.mjs":
-      "8bc4b379d7057b2fecf9cb35820c39efad0a65df7df49073786f996cc2a74810",
+      "4535a145c5c5cbee13bdf970bc91d390a264043604e607288cdd6bf28de56192",
     "plugins/src/base/hooks/threshold-ratchet-families.mjs":
-      "fee19c88c89eed5a2949dea42c4a4c794f04aabf0e36c71cdda70ffaaf2b17c9",
+      "db14245ed89b483912af287bdee917a7a921dc21bb29b49be37fc799c05c413f",
     "plugins/src/base/hooks/threshold-ratchet.mjs":
-      "6da00221189ed0f8a2938f15e02bcc2633d44f5f05489979fbb94202bc45a6d4",
+      "04f660131bf50864239eb09cbf4d9555e53921254f6ab45ff2b85c173e160901",
     "plugins/src/base/hooks/threshold-ratchet.sh":
-      "6186849d72eb98a73fc574e6c8e3773288e2aeadc7a30e07b21b9ab51de6e9f5",
+      "b86f4d0b554e44fd119ad8a8920cd0ba6c9dbe779f7ee219d381cf0629453990",
     "plugins/src/base/hooks/ticket-sync-reminder.sh":
       "212f80bcdfd9e3ec2254987c5a7186d1d2d38065b330ddcdc631f76df7c4a6c0",
     "plugins/src/base/hooks/track-plan-sessions.sh":
@@ -1769,13 +1769,13 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/copy-overwrite/lefthook.yml":
       "28bb382b9171a04fb92ebafc1f1522b8639f5edc4fcffcc6940e7fba3460fb4e",
     "rails/copy-overwrite/scripts/check-threshold-ratchet.mjs":
-      "6da00221189ed0f8a2938f15e02bcc2633d44f5f05489979fbb94202bc45a6d4",
+      "04f660131bf50864239eb09cbf4d9555e53921254f6ab45ff2b85c173e160901",
     "rails/copy-overwrite/scripts/lisa-clean-git-env.sh":
       "e7121a0ee9e1bf7c01cd2ab55f563dd6d9ab75990739bb6ddf571a513efa10e9",
     "rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs":
-      "8bc4b379d7057b2fecf9cb35820c39efad0a65df7df49073786f996cc2a74810",
+      "4535a145c5c5cbee13bdf970bc91d390a264043604e607288cdd6bf28de56192",
     "rails/copy-overwrite/scripts/threshold-ratchet-families.mjs":
-      "fee19c88c89eed5a2949dea42c4a4c794f04aabf0e36c71cdda70ffaaf2b17c9",
+      "db14245ed89b483912af287bdee917a7a921dc21bb29b49be37fc799c05c413f",
     "rails/copy-overwrite/sgconfig.yml":
       "0ffe058c791d4d323f98104cf78c763bb0356d88739042060ceb86b6b1cb78d7",
     "rails/create-only/.github/workflows/ci.yml":
@@ -2007,15 +2007,15 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/knip.json":
       "6eb93d705a2d645332fbae1dd42cf2d48f85978ebc265451a53790912f277d12",
     "typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs":
-      "6da00221189ed0f8a2938f15e02bcc2633d44f5f05489979fbb94202bc45a6d4",
+      "04f660131bf50864239eb09cbf4d9555e53921254f6ab45ff2b85c173e160901",
     "typescript/copy-overwrite/scripts/check-verification-coverage.mjs":
       "3c1d27d0668fc66a18cb014f2b607878f0a88c178a773fbe964b8e46b19e86d6",
     "typescript/copy-overwrite/scripts/lisa-mutation.mjs":
       "7d8d24dea151ef2178807046e97aea7ebfadd9c88eb50347feb7bb4bb190227d",
     "typescript/copy-overwrite/scripts/threshold-ratchet-compare.mjs":
-      "8bc4b379d7057b2fecf9cb35820c39efad0a65df7df49073786f996cc2a74810",
+      "4535a145c5c5cbee13bdf970bc91d390a264043604e607288cdd6bf28de56192",
     "typescript/copy-overwrite/scripts/threshold-ratchet-families.mjs":
-      "fee19c88c89eed5a2949dea42c4a4c794f04aabf0e36c71cdda70ffaaf2b17c9",
+      "db14245ed89b483912af287bdee917a7a921dc21bb29b49be37fc799c05c413f",
     "typescript/copy-overwrite/sgconfig.yml":
       "0ffe058c791d4d323f98104cf78c763bb0356d88739042060ceb86b6b1cb78d7",
     "typescript/copy-overwrite/tsconfig.eslint.json":

--- a/tests/unit/scripts/threshold-ratchet-gates.test.ts
+++ b/tests/unit/scripts/threshold-ratchet-gates.test.ts
@@ -1,8 +1,8 @@
 /**
  * Tests for the threshold ratchet, part 2: Tier 2 gate configs (stryker
- * break score, k6 bounds), Tier 3 exemption additions (audit ignores,
- * mutate exclusions, allow-list self-service), the baseline-side allow
- * list. Tier 1 comparator behavior lives in threshold-ratchet.test.ts;
+ * break score, k6 bounds), Tier 3 exemption additions (mutate exclusions,
+ * allow-list self-service), the baseline-side allow list, and the
+ * deliberately-unwatched audit ignore lists. Tier 1 comparator behavior lives in threshold-ratchet.test.ts;
  * enforcement-layer wiring lives in threshold-ratchet-wiring.test.ts.
  */
 import { beforeAll, describe, expect, it } from "vitest";
@@ -191,26 +191,18 @@ describe("threshold-ratchet tiers 2 and 3", () => {
   });
 
   describe("audit ignore lists", () => {
-    it("flags a newly ignored advisory", () => {
+    it("does not watch audit ignore files", () => {
       const base = JSON.stringify({ "GHSA-aaaa": "known, patched upstream" });
       const current = JSON.stringify({
         "GHSA-aaaa": "known, patched upstream",
-        "GHSA-bbbb": "new ignore",
+        "GHSA-bbbb": "new documented ignore",
       });
-      const findings = compareFile("audit.ignore.local.json", base, current);
-      expect(findings).toHaveLength(1);
-      expect(findings[0]).toMatchObject({
-        key: "GHSA-bbbb",
-        type: TYPE_EXEMPTION,
-      });
-    });
-
-    it("allows removing an ignore (tightening)", () => {
-      const base = JSON.stringify({ "GHSA-aaaa": "x", "GHSA-bbbb": "y" });
-      const current = JSON.stringify({ "GHSA-aaaa": "x" });
       expect(
-        compareFile("audit.ignore.config.json", base, current)
+        compareFile("audit.ignore.local.json", base, current)
       ).toHaveLength(0);
+      expect(compareFile("audit.ignore.config.json", base, null)).toHaveLength(
+        0
+      );
     });
   });
 

--- a/tests/unit/scripts/threshold-ratchet.test.ts
+++ b/tests/unit/scripts/threshold-ratchet.test.ts
@@ -63,12 +63,16 @@ describe("threshold-ratchet tier 1", () => {
       expect(familyFor(RUBOCOP_FILE)?.id).toBe("rubocop");
       expect(familyFor("stryker.conf.json")?.id).toBe("stryker");
       expect(familyFor(".github/k6/thresholds/normal.json")?.id).toBe("k6");
-      expect(familyFor("audit.ignore.local.json")?.id).toBe("audit-ignore");
       expect(familyFor(".lisa.config.json")?.id).toBe("lisa-config");
     });
 
     it("ignores unrelated files", () => {
       expect(familyFor("package.json")).toBeUndefined();
+      // Audit ignore lists are deliberately unwatched: the
+      // security-audit-handling ladder authorizes documented additions, and
+      // doctor readiness (B5) audits that each entry carries a decision.
+      expect(familyFor("audit.ignore.local.json")).toBeUndefined();
+      expect(familyFor("audit.ignore.config.json")).toBeUndefined();
       expect(familyFor("src/thresholds.json.ts")).toBeUndefined();
       expect(familyFor("docs/e2e.thresholds.json.md")).toBeUndefined();
     });

--- a/typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs
+++ b/typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs
@@ -12,8 +12,11 @@
  * Tier 1 — designed tunables: vitest/jest/simplecov/e2e thresholds
  * (minimums) and eslint/rubocop thresholds (maximums). Tier 2 — stryker's
  * break score and k6 expression bounds. Tier 3 — exemption additions
- * (audit-ignore entries, stryker mutate exclusions, thresholdRatchet.allow
- * entries) which weaken a gate without touching a number.
+ * (stryker mutate exclusions, thresholdRatchet.allow entries) which weaken
+ * a gate without touching a number. Audit ignore lists are deliberately NOT
+ * watched: the security-audit-handling ladder authorizes agents to add
+ * documented entries autonomously, and doctor readiness (B5) audits that
+ * every entry carries a written decision.
  *
  * Human override: `.lisa.config.json` → `thresholdRatchet.allow` entries
  * ({ file, key, reason }). Honored ONLY from the baseline side (HEAD /

--- a/typescript/copy-overwrite/scripts/threshold-ratchet-compare.mjs
+++ b/typescript/copy-overwrite/scripts/threshold-ratchet-compare.mjs
@@ -8,7 +8,6 @@
  */
 import {
   extractAllowEntries,
-  extractExemptionEntries,
   extractK6Constraints,
   extractNumericLeaves,
   extractRubocopThresholds,
@@ -20,7 +19,7 @@ import {
 
 /** Finding type: a numeric bound or boolean gate moved the weakening way. */
 const TYPE_WEAKENED = "weakened";
-/** Finding type: an exemption entry was added (Tier 3). */
+/** Finding type: a gate-shrinking exemption was added (Tier 3). */
 const TYPE_EXEMPTION_ADDED = "exemption-added";
 /** Family kind for .lisa.config.json (the thresholdRatchet.allow carrier). */
 const KIND_ALLOW_LIST = "allow-list";
@@ -161,29 +160,6 @@ function compareK6(relPath, base, current) {
 }
 
 /**
- * Compare an exemption-list pair (audit ignore files): report added entries.
- * @param {string} relPath Repo-relative path
- * @param {unknown} base Parsed baseline list
- * @param {unknown} current Parsed current list
- * @returns {Finding[]} One finding per newly added ignore entry
- */
-function compareExemptions(relPath, base, current) {
-  const baseEntries = extractExemptionEntries(base);
-  const findings = [];
-  for (const entry of extractExemptionEntries(current)) {
-    if (!baseEntries.has(entry)) {
-      findings.push({
-        file: relPath,
-        key: entry,
-        type: TYPE_EXEMPTION_ADDED,
-        message: `${relPath}: new security-audit ignore entry "${entry}" — ignoring a finding weakens the gate and needs a human's sign-off.`,
-      });
-    }
-  }
-  return findings;
-}
-
-/**
  * Compare .lisa.config.json allow lists: report added exception entries so a
  * change can never grant itself an exception.
  * @param {string} relPath Repo-relative path
@@ -258,8 +234,6 @@ export function compareFile(relPath, baselineText, currentText) {
       return compareStryker(relPath, base, current);
     case "k6":
       return compareK6(relPath, base, current);
-    case "exemption-list":
-      return compareExemptions(relPath, base, current);
     case KIND_ALLOW_LIST:
       return compareAllowList(relPath, base, current);
     default:

--- a/typescript/copy-overwrite/scripts/threshold-ratchet-families.mjs
+++ b/typescript/copy-overwrite/scripts/threshold-ratchet-families.mjs
@@ -49,11 +49,6 @@ export const FAMILIES = [
     kind: "k6",
   },
   {
-    id: "audit-ignore",
-    match: /(^|\/)audit\.ignore\.(config|local)\.json$/,
-    kind: "exemption-list",
-  },
-  {
     id: "lisa-config",
     match: /(^|\/)\.lisa\.config\.json$/,
     kind: "allow-list",
@@ -249,35 +244,6 @@ export function extractK6Constraints(conf) {
     }
   }
   return { numeric, booleans };
-}
-
-/**
- * Flatten an exemption file (audit ignore list) into a set of entry tokens.
- * Arrays contribute their string items; objects contribute their keys.
- * @param {unknown} conf Parsed JSON
- * @returns {Set<string>} One token per exemption entry
- */
-export function extractExemptionEntries(conf) {
-  const out = new Set();
-  if (Array.isArray(conf)) {
-    for (const item of conf) {
-      if (typeof item === "string") out.add(item);
-      else if (item && typeof item === "object") out.add(JSON.stringify(item));
-    }
-  } else if (conf && typeof conf === "object") {
-    for (const [key, value] of Object.entries(conf)) {
-      if (Array.isArray(value)) {
-        for (const item of value) {
-          out.add(
-            `${key}:${typeof item === "string" ? item : JSON.stringify(item)}`
-          );
-        }
-      } else {
-        out.add(key);
-      }
-    }
-  }
-  return out;
 }
 
 /**


### PR DESCRIPTION
## Summary

Removes the `audit-ignore` family from the threshold ratchet. The family contradicted the load-bearing `security-audit-handling` decision ladder: step 5 authorizes agents to **autonomously** add a documented exclusion to `audit.ignore.local.json` when an advisory has no viable upgrade/override and a recorded impact evaluation shows it does not affect the project — and the ratchet then blocked exactly that addition at all three layers (agent-time hook, pre-commit, CI). The only escape was a baseline-side `thresholdRatchet.allow` entry merged in a separate prior PR, which defeated the autonomous ladder and stranded downstream projects on unpatchable transitive CVEs.

## Why this is safe

Audit ignore lists remain guarded by controls better shaped for them:
- **security-audit-handling rule**: every entry must carry a `reason` recording the impact evaluation; ignoring before genuinely attempting upgrade/override is forbidden.
- **Doctor readiness B5** (supply-chain dimension): independently audits `audit.ignore.config.json` / `audit.ignore.local.json` / `.nsprc` and flags any entry lacking a written decision.

Unlike coverage floors, audit ignores are enumerable, individually documented, and continuously surfaced by readiness — growth of a documented list is the ladder working, not silent gate erosion.

## Changes

- `plugins/src/base/hooks/threshold-ratchet-families.mjs`: drop the `audit-ignore` family and the now-unused `extractExemptionEntries`.
- `plugins/src/base/hooks/threshold-ratchet-compare.mjs`: drop `compareExemptions` and the `exemption-list` dispatch case (`exemption-added` finding type stays — stryker mutate-scope findings still use it).
- Header comments in `threshold-ratchet.mjs` / `threshold-ratchet.sh` document that audit ignore lists are deliberately unwatched and why.
- All fanned-out copies regenerated via `scripts/build-plugins.sh` (plugins/lisa, lisa-cursor, lisa-copilot, typescript + rails `copy-overwrite/scripts`).
- Tests updated: `familyFor("audit.ignore.*")` pinned to `undefined`; gates suite asserts additions and even file deletion produce no findings.
- Upstream evidence manifest rebuilt in the same commit.

## Verification

- `vitest run` on all three threshold-ratchet suites: 41/41 pass.
- `rg` sweep confirms no remaining `audit-ignore` references in ratchet code; only the tests reference `audit.ignore.*` (as deliberately-unwatched assertions).

Closes #2037

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2037
