### PR TITLE
fix(doctor): detect terraform auto approve env args

### DIFF
--- a/src/cli/doctor-readiness-guardrails.ts
+++ b/src/cli/doctor-readiness-guardrails.ts
@@ -76,14 +76,17 @@ const CONSEQUENTIAL_OPS: readonly RegExp[] = [
 ];
 
 /** A Terraform apply command, consequential only when auto-approval is present. */
-const TERRAFORM_APPLY = /\bterraform\s+(\S+\s+)*apply\b/;
+const TERRAFORM_APPLY = /\bterraform(?:\s+\S+)*\s+apply\b/;
 
 /** Terraform's non-interactive approval flag. */
 const TERRAFORM_AUTO_APPROVE = /(^|\s)-auto-approve\b/;
 
 /** Terraform env vars that inject CLI args into every command. */
 const TERRAFORM_ARGS_AUTO_APPROVE =
-  /\b(tf_cli_args|tf_args)\s*[:=][^\n]*-auto-approve\b/;
+  /\b(tf_cli_args(?:_apply)?|tf_args)\s*[:=][^\n]*-auto-approve\b/;
+
+/** Separators that end one shell invocation for this conservative scan. */
+const SHELL_INVOCATION_SEPARATOR = /\n|;|&&|\|\|/;
 
 /**
  * Commands that apply schema migrations, in the ecosystems Lisa templates. The
@@ -110,6 +113,48 @@ const PRODUCTION_MARKERS: readonly RegExp[] = [
 ];
 
 /**
+ * Collapse only shell continuation newlines. Ordinary newlines remain command
+ * boundaries so unrelated invocations cannot combine into one Terraform apply.
+ * @param command - Shell command text
+ * @returns Command text with escaped newlines joined
+ */
+function normalizeShellContinuations(command: string): string {
+  return command.replace(/\\\r?\n\s*/g, " ");
+}
+
+/**
+ * Extract shell invocations that contain `terraform apply`.
+ * @param command - Shell command text
+ * @returns Invocation fragments that include Terraform apply
+ */
+function terraformApplyInvocations(command: string): string[] {
+  return normalizeShellContinuations(command)
+    .split(SHELL_INVOCATION_SEPARATOR)
+    .map(part => part.trim())
+    .filter(part => TERRAFORM_APPLY.test(part));
+}
+
+/**
+ * Check whether a Terraform apply invocation targets a saved plan file.
+ * @param invocation - Single shell invocation
+ * @returns True when `apply` has a positional plan-file argument
+ */
+function appliesSavedTerraformPlan(invocation: string): boolean {
+  const tokens = invocation.split(/\s+/).filter(Boolean);
+  const terraformIndex = tokens.findIndex(token => token === "terraform");
+  if (terraformIndex === -1) {
+    return false;
+  }
+  const applyIndex = tokens.indexOf("apply", terraformIndex + 1);
+  if (applyIndex === -1) {
+    return false;
+  }
+  return tokens
+    .slice(applyIndex + 1)
+    .some(token => token !== "\\" && !token.startsWith("-"));
+}
+
+/**
  * Whether a command is an irreversible or expensive operation.
  *
  * The ephemeral screen is the same one B1 uses, widened to the per-pull-request
@@ -131,9 +176,14 @@ function isConsequential(
   if (looksEphemeral(targetEvidence)) {
     return false;
   }
+  const terraformApplyInvocationsToAssess = terraformApplyInvocations(command);
   const terraformAutoApprovedApply =
-    TERRAFORM_APPLY.test(command) &&
-    (TERRAFORM_AUTO_APPROVE.test(command) ||
+    terraformApplyInvocationsToAssess.some(
+      invocation =>
+        TERRAFORM_AUTO_APPROVE.test(invocation) ||
+        appliesSavedTerraformPlan(invocation)
+    ) ||
+    (terraformApplyInvocationsToAssess.length > 0 &&
       TERRAFORM_ARGS_AUTO_APPROVE.test(targetEvidence));
   return (
     terraformAutoApprovedApply ||

--- a/src/cli/doctor-readiness-guardrails.ts
+++ b/src/cli/doctor-readiness-guardrails.ts
@@ -68,13 +68,22 @@ const PROTECTION_RULES_SKIP_REASON =
  * blocker that fires on normal delivery is a blocker nobody will believe.
  */
 const CONSEQUENTIAL_OPS: readonly RegExp[] = [
-  /\bterraform\s+(\S+\s+)*apply\b[^\n]*-auto-approve\b/,
   /\bterraform\s+(\S+\s+)*destroy\b/,
   /\bcdk\s+destroy\b/,
   /\bpulumi\s+destroy\b/,
   /\bpulumi\s+up\b[^\n]*--yes\b/,
   /\bserverless\s+remove\b/,
 ];
+
+/** A Terraform apply command, consequential only when auto-approval is present. */
+const TERRAFORM_APPLY = /\bterraform\s+(\S+\s+)*apply\b/;
+
+/** Terraform's non-interactive approval flag. */
+const TERRAFORM_AUTO_APPROVE = /(^|\s)-auto-approve\b/;
+
+/** Terraform env vars that inject CLI args into every command. */
+const TERRAFORM_ARGS_AUTO_APPROVE =
+  /\b(tf_cli_args|tf_args)\s*[:=][^\n]*-auto-approve\b/;
 
 /**
  * Commands that apply schema migrations, in the ecosystems Lisa templates. The
@@ -122,7 +131,12 @@ function isConsequential(
   if (looksEphemeral(targetEvidence)) {
     return false;
   }
+  const terraformAutoApprovedApply =
+    TERRAFORM_APPLY.test(command) &&
+    (TERRAFORM_AUTO_APPROVE.test(command) ||
+      TERRAFORM_ARGS_AUTO_APPROVE.test(targetEvidence));
   return (
+    terraformAutoApprovedApply ||
     CONSEQUENTIAL_OPS.some(pattern => pattern.test(command)) ||
     (MIGRATION_COMMANDS.some(pattern => pattern.test(command)) &&
       PRODUCTION_MARKERS.some(pattern => pattern.test(targetEvidence)))

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7767,6 +7767,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/doctor-readiness-domain-negatives.test.ts": true,
     "tests/unit/cli/doctor-readiness-domain.test.ts": true,
     "tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts": true,
+    "tests/unit/cli/doctor-readiness-guardrails-terraform.test.ts": true,
     "tests/unit/cli/doctor-readiness-guardrails.test.ts": true,
     "tests/unit/cli/doctor-readiness-journey.test.ts": true,
     "tests/unit/cli/doctor-readiness-supply-chain-exceptions.test.ts": true,

--- a/tests/unit/cli/doctor-readiness-guardrails-terraform.test.ts
+++ b/tests/unit/cli/doctor-readiness-guardrails-terraform.test.ts
@@ -21,6 +21,9 @@ import {
 /** The B4 ship blocker. */
 const BLOCKER_ID = "B4";
 
+/** Single-line interactive Terraform apply step. */
+const TERRAFORM_APPLY_STEP = "      - run: terraform apply";
+
 /** Shared deploy workflow fixture lines. */
 const BASE_WORKFLOW = [
   "name: Deploy",
@@ -60,6 +63,17 @@ async function expectB4(root: string): Promise<void> {
   ).toBe(true);
 }
 
+/**
+ * Assert that B4 is absent for the workflow just written.
+ * @param root - Scratch repository path
+ */
+async function expectNoB4(root: string): Promise<void> {
+  const record = await assessFeedbackGuardrailsDimension(root);
+  expect(
+    asFindings(record.findings).some(finding => finding.blocker === BLOCKER_ID)
+  ).toBe(false);
+}
+
 describe("assessFeedbackGuardrailsDimension — Terraform auto-approval", () => {
   it("stands B4 when auto-approval appears on a later shell line", async () => {
     const root = await getTempDir();
@@ -67,11 +81,24 @@ describe("assessFeedbackGuardrailsDimension — Terraform auto-approval", () => 
       ...BASE_WORKFLOW,
       STEPS,
       "      - run: |",
-      "          terraform apply",
+      "          terraform apply \\",
       "            -auto-approve",
     ]);
 
     await expectB4(root);
+  });
+
+  it("does not combine unrelated shell lines into Terraform auto-approval", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      ...BASE_WORKFLOW,
+      STEPS,
+      "      - run: |",
+      "          terraform apply",
+      "          echo -auto-approve",
+    ]);
+
+    await expectNoB4(root);
   });
 
   it("stands B4 when job env supplies Terraform auto-approval", async () => {
@@ -81,7 +108,20 @@ describe("assessFeedbackGuardrailsDimension — Terraform auto-approval", () => 
       "    env:",
       "      TF_CLI_ARGS: -auto-approve",
       STEPS,
-      "      - run: terraform apply",
+      TERRAFORM_APPLY_STEP,
+    ]);
+
+    await expectB4(root);
+  });
+
+  it("stands B4 when apply-specific env supplies Terraform auto-approval", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      ...BASE_WORKFLOW,
+      "    env:",
+      "      TF_CLI_ARGS_apply: -auto-approve",
+      STEPS,
+      TERRAFORM_APPLY_STEP,
     ]);
 
     await expectB4(root);
@@ -92,11 +132,33 @@ describe("assessFeedbackGuardrailsDimension — Terraform auto-approval", () => 
     await writeWorkflow(root, DEPLOY_YML, [
       ...BASE_WORKFLOW,
       STEPS,
-      "      - run: terraform apply",
+      TERRAFORM_APPLY_STEP,
       "        env:",
       "          TF_ARGS: -auto-approve",
     ]);
 
     await expectB4(root);
+  });
+
+  it("stands B4 when Terraform applies a saved plan file", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      ...BASE_WORKFLOW,
+      STEPS,
+      "      - run: terraform apply -input=false terraform.tfplan",
+    ]);
+
+    await expectB4(root);
+  });
+
+  it("does not stand B4 for an interactive Terraform apply", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      ...BASE_WORKFLOW,
+      STEPS,
+      TERRAFORM_APPLY_STEP,
+    ]);
+
+    await expectNoB4(root);
   });
 });

--- a/tests/unit/cli/doctor-readiness-guardrails-terraform.test.ts
+++ b/tests/unit/cli/doctor-readiness-guardrails-terraform.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Terraform argument coverage for the feedback/guardrails readiness producer
+ * (B4, PRD #1739, #1896).
+ * @module tests/unit/cli/doctor-readiness-guardrails-terraform
+ */
+import { rm } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { assessFeedbackGuardrailsDimension } from "../../../src/cli/doctor-readiness-guardrails.js";
+import {
+  asFindings,
+  DEPLOY_YML,
+  JOBS,
+  makeScratchRepo,
+  ON_PUSH,
+  RUNS_ON,
+  STEPS,
+  WARN,
+  writeWorkflow,
+} from "../../helpers/readiness-workflow-fixtures.js";
+
+/** The B4 ship blocker. */
+const BLOCKER_ID = "B4";
+
+/** Shared deploy workflow fixture lines. */
+const BASE_WORKFLOW = [
+  "name: Deploy",
+  ON_PUSH,
+  JOBS,
+  "  infra:",
+  RUNS_ON,
+] as const;
+
+let tempDir: string | undefined;
+
+/**
+ * Resolve a scratch repository for one test case.
+ * @returns Temporary directory path
+ */
+async function getTempDir(): Promise<string> {
+  tempDir ??= await makeScratchRepo("guardrails-terraform");
+  return tempDir;
+}
+
+afterEach(async () => {
+  if (tempDir !== undefined) {
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+/**
+ * Assert that B4 stands for the workflow just written.
+ * @param root - Scratch repository path
+ */
+async function expectB4(root: string): Promise<void> {
+  const record = await assessFeedbackGuardrailsDimension(root);
+  expect(record.status).toBe(WARN);
+  expect(
+    asFindings(record.findings).some(finding => finding.blocker === BLOCKER_ID)
+  ).toBe(true);
+}
+
+describe("assessFeedbackGuardrailsDimension — Terraform auto-approval", () => {
+  it("stands B4 when auto-approval appears on a later shell line", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      ...BASE_WORKFLOW,
+      STEPS,
+      "      - run: |",
+      "          terraform apply",
+      "            -auto-approve",
+    ]);
+
+    await expectB4(root);
+  });
+
+  it("stands B4 when job env supplies Terraform auto-approval", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      ...BASE_WORKFLOW,
+      "    env:",
+      "      TF_CLI_ARGS: -auto-approve",
+      STEPS,
+      "      - run: terraform apply",
+    ]);
+
+    await expectB4(root);
+  });
+
+  it("stands B4 when step env supplies Terraform auto-approval", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      ...BASE_WORKFLOW,
+      STEPS,
+      "      - run: terraform apply",
+      "        env:",
+      "          TF_ARGS: -auto-approve",
+    ]);
+
+    await expectB4(root);
+  });
+});


### PR DESCRIPTION
## Summary
- Detect B4 Terraform `apply` auto-approval when `-auto-approve` is on a later shell line.
- Detect B4 Terraform auto-approval supplied through `TF_CLI_ARGS` or `TF_ARGS` at job or step scope.
- Add a focused guardrails Terraform regression suite and refresh the upstream evidence manifest.

Refs CodySwannGT/lisa#1903

## Verification
- `bunx vitest run tests/unit/cli/doctor-readiness-guardrails.test.ts tests/unit/cli/doctor-readiness-guardrails-terraform.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build:dist`
- `bun run check:upstream-evidence-manifest`
- `bunx vitest run tests/unit/cli/doctor-readiness-guardrails-terraform.test.ts tests/unit/scripts/upstream-evidence-manifest.test.ts`
- pre-push: typecheck, production dependency audit, slow lint, knip, full coverage, integration tests, plugin parity

Work-Item: CodySwannGT/lisa#1903


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safeguards for Terraform deployments using automatic approval flags.
  * The system now detects auto-approval settings in commands and relevant workflow environment variables, ensuring potentially consequential operations receive appropriate warnings.

* **Tests**
  * Added coverage for Terraform auto-approval detection across command, job-level, and step-level configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->