### PR TITLE
fix(readiness): flag install-time dependency execution

### DIFF
--- a/src/cli/doctor-readiness-supply-chain-evidence.ts
+++ b/src/cli/doctor-readiness-supply-chain-evidence.ts
@@ -1,0 +1,234 @@
+/**
+ * Evidence builders for the dependencies/supply-chain readiness producer.
+ * @module cli/doctor-readiness-supply-chain-evidence
+ */
+import {
+  type DependencySpec,
+  isFloatingSpec,
+  LOCKFILES,
+} from "./doctor-readiness-supply-chain-scan.js";
+import type { WorkspaceMembers } from "./doctor-readiness-workspaces.js";
+
+/** Package lifecycle scripts that execute during dependency installation. */
+const INSTALL_TIME_SCRIPT_NAMES: ReadonlySet<string> = new Set([
+  "preinstall",
+  "install",
+  "postinstall",
+  "prepare",
+]);
+
+/** One package manifest B5 inspects. */
+export interface ManifestUnderAssessment {
+  readonly manifestPath: string;
+  readonly manifest: Record<string, unknown>;
+}
+
+/** Values already read from the repository for dependency-confidence evidence. */
+interface DependencyConfidenceInputs {
+  readonly auditGate: string | null;
+  readonly lockfile: string | null;
+  readonly lockfileInstallGate: string | null;
+  readonly specs: readonly DependencySpec[];
+  readonly workspaces: WorkspaceMembers;
+}
+
+/**
+ * Render a bounded list for operator-facing evidence.
+ * @param values - Values to render
+ * @returns A comma-separated list
+ */
+function renderList(values: readonly string[]): string {
+  const shown = values.slice(0, 5);
+  const overflow = values.length - shown.length;
+  return (
+    shown.map(value => `\`${value}\``).join(", ") +
+    (overflow > 0 ? `, and ${overflow} more` : "")
+  );
+}
+
+/**
+ * Build the evidence line for a manifest with no committed lockfile.
+ * @param specCount - How many specs the manifest declares
+ * @returns One evidence line
+ */
+function lockfileEvidence(specCount: number): string {
+  return (
+    `package manifest(s), starting with \`package.json\`, declare ${specCount} ` +
+    `dependency spec(s) but no lockfile is committed (looked for ` +
+    `${LOCKFILES.join(", ")}) — two installs can resolve to different trees, ` +
+    "so what was validated is not provably what gets installed"
+  );
+}
+
+/**
+ * Whether a floating-looking spec is really a local workspace link.
+ * @param spec - The declared spec
+ * @param workspaces - What resolving the workspace members established
+ * @returns True when the spec links to a workspace member
+ */
+function linksWorkspaceMember(
+  spec: DependencySpec,
+  workspaces: WorkspaceMembers
+): boolean {
+  if (!workspaces.declared) {
+    return false;
+  }
+  return (
+    workspaces.names.has(spec.name) ||
+    (workspaces.names.size === 0 && spec.spec.trim() === "*")
+  );
+}
+
+/**
+ * Build evidence when a manifest declares install-time lifecycle scripts.
+ * @param manifestPath - Repo-relative manifest path
+ * @param manifest - Parsed package manifest
+ * @returns Evidence line when install-time scripts exist
+ */
+function installTimeScriptEvidence(
+  manifestPath: string,
+  manifest: Record<string, unknown>
+): string | null {
+  const scripts = manifest.scripts;
+  if (
+    scripts === null ||
+    typeof scripts !== "object" ||
+    Array.isArray(scripts)
+  ) {
+    return null;
+  }
+  const scriptNames = Object.keys(scripts).filter(name =>
+    INSTALL_TIME_SCRIPT_NAMES.has(name)
+  );
+  if (scriptNames.length === 0) {
+    return null;
+  }
+  return (
+    `\`${manifestPath}\` declares install-time lifecycle script(s) ` +
+    `${renderList(scriptNames)}, so dependency installation executes project ` +
+    "code before the normal test/audit surface; B5 needs an explicit confidence " +
+    "decision for that install-time execution path"
+  );
+}
+
+/**
+ * Build evidence when Bun trusted dependencies are declared.
+ * @param manifestPath - Repo-relative manifest path
+ * @param manifest - Parsed package manifest
+ * @returns Evidence line when trusted dependencies are declared
+ */
+function trustedDependencyEvidence(
+  manifestPath: string,
+  manifest: Record<string, unknown>
+): string | null {
+  const trusted = manifest.trustedDependencies;
+  const names = Array.isArray(trusted)
+    ? trusted.filter((entry): entry is string => typeof entry === "string")
+    : [];
+  if (names.length === 0) {
+    return null;
+  }
+  return (
+    `\`${manifestPath}\` marks ${renderList(names)} as ` +
+    "`trustedDependencies`, allowing third-party install-time scripts to run; " +
+    "B5 needs a written confidence decision for each trusted package because " +
+    "a clean audit gate alone does not explain that execution authority"
+  );
+}
+
+/**
+ * Collect B5 evidence for install-time execution surfaces.
+ * @param manifests - Manifests under assessment
+ * @returns Evidence lines for install-time execution surfaces
+ */
+export function installTimeExecutionViolations(
+  manifests: readonly ManifestUnderAssessment[]
+): readonly string[] {
+  return manifests.flatMap(({ manifestPath, manifest }) =>
+    [
+      installTimeScriptEvidence(manifestPath, manifest),
+      trustedDependencyEvidence(manifestPath, manifest),
+    ].flatMap(evidence => (evidence === null ? [] : [evidence]))
+  );
+}
+
+/**
+ * Collect B5 violations from dependency specs, lockfiles, and audit gates.
+ * @param inputs - Values already read from the repository
+ * @param inputs.auditGate - Path to the dependency-audit gate, if found
+ * @param inputs.lockfile - Path to the committed lockfile, if found
+ * @param inputs.lockfileInstallGate - Path to the lockfile-enforcing install
+ * @param inputs.specs - Declared dependency specs
+ * @param inputs.workspaces - What resolving the workspace members established
+ * @returns Evidence lines for dependency-confidence violations
+ */
+export function dependencyConfidenceViolations({
+  auditGate,
+  lockfile,
+  lockfileInstallGate,
+  specs,
+  workspaces,
+}: DependencyConfidenceInputs): readonly string[] {
+  if (specs.length === 0) {
+    return [];
+  }
+  const floating = specs.filter(
+    spec => isFloatingSpec(spec.spec) && !linksWorkspaceMember(spec, workspaces)
+  );
+  return [
+    ...(lockfile === null ? [lockfileEvidence(specs.length)] : []),
+    ...(lockfile !== null && lockfileInstallGate === null
+      ? [
+          `lockfile \`${lockfile}\` is committed, but no CI or hook install ` +
+            "step was found that enforces it with `npm ci`, " +
+            "`bun install --frozen-lockfile`, `pnpm install --frozen-lockfile`, " +
+            "or `yarn install --immutable`; a workflow can silently rewrite " +
+            "or bypass the tree that was validated",
+        ]
+      : []),
+    ...floating.map(
+      spec =>
+        `\`${spec.manifestPath}\` \`${spec.block}.${spec.name}\` is ` +
+        `\`${spec.spec}\`, which resolves to whatever is newest at install ` +
+        "time rather than to a version anything was ever validated against"
+    ),
+    ...(auditGate === null
+      ? [
+          "no dependency-audit gate covering the JavaScript tree was found " +
+            "anywhere — no `npm`/`bun` audit step in `.github/workflows/*.yml`, " +
+            "none in a git hook, and no `dependabot.yml` npm entry or " +
+            "`renovate.json` — so a newly disclosed advisory in this tree " +
+            "would never be noticed by anything",
+        ]
+      : []),
+  ];
+}
+
+/**
+ * Collect non-blocking observations from dependency-confidence evidence.
+ * @param inputs - Values already read from the repository
+ * @param inputs.auditGate - Path to the dependency-audit gate, if found
+ * @param inputs.lockfile - Path to the committed lockfile, if found
+ * @param inputs.lockfileInstallGate - Path to the lockfile-enforcing install
+ * @param inputs.specs - Declared dependency specs
+ * @returns Evidence lines for clean dependency-confidence signals
+ */
+export function dependencyConfidenceObservations({
+  auditGate,
+  lockfile,
+  lockfileInstallGate,
+  specs,
+}: DependencyConfidenceInputs): readonly string[] {
+  if (specs.length === 0) {
+    return [];
+  }
+  return [
+    ...(lockfile === null ? [] : [`Lockfile in use: \`${lockfile}\`.`]),
+    ...(lockfileInstallGate === null
+      ? []
+      : [`Lockfile-enforcing install declared in \`${lockfileInstallGate}\`.`]),
+    ...(auditGate === null
+      ? []
+      : [`Dependency-audit gate declared in \`${auditGate}\`.`]),
+  ];
+}

--- a/src/cli/doctor-readiness-supply-chain.ts
+++ b/src/cli/doctor-readiness-supply-chain.ts
@@ -35,10 +35,14 @@ import {
   findAuditGate,
   findLockfile,
   findLockfileInstallGate,
-  isFloatingSpec,
-  LOCKFILES,
   readManifest,
 } from "./doctor-readiness-supply-chain-scan.js";
+import {
+  dependencyConfidenceObservations,
+  dependencyConfidenceViolations,
+  installTimeExecutionViolations,
+  type ManifestUnderAssessment,
+} from "./doctor-readiness-supply-chain-evidence.js";
 import {
   resolveWorkspaceMembers,
   type WorkspaceMembers,
@@ -54,155 +58,6 @@ const SUPPLY_CHAIN_BLOCKER_ID = "B5";
 
 /** Most evidence lines carried into a single finding, to keep it readable. */
 const MAX_EVIDENCE_LINES = 12;
-
-/** Package lifecycle scripts that execute during dependency installation. */
-const INSTALL_TIME_SCRIPT_NAMES: ReadonlySet<string> = new Set([
-  "preinstall",
-  "install",
-  "postinstall",
-  "prepare",
-]);
-
-/** One package manifest B5 inspects. */
-interface ManifestUnderAssessment {
-  readonly manifestPath: string;
-  readonly manifest: Record<string, unknown>;
-}
-
-/**
- * Render a bounded list for operator-facing evidence.
- * @param values - Values to render
- * @returns A comma-separated list
- */
-function renderList(values: readonly string[]): string {
-  const shown = values.slice(0, 5);
-  const overflow = values.length - shown.length;
-  return (
-    shown.map(value => `\`${value}\``).join(", ") +
-    (overflow > 0 ? `, and ${overflow} more` : "")
-  );
-}
-
-/**
- * Build the evidence line for a manifest with no committed lockfile.
- * @param specCount - How many specs the manifest declares
- * @returns One evidence line
- */
-function lockfileEvidence(specCount: number): string {
-  return (
-    `package manifest(s), starting with \`package.json\`, declare ${specCount} ` +
-    `dependency spec(s) but no lockfile is committed (looked for ` +
-    `${LOCKFILES.join(", ")}) — two installs can resolve to different trees, ` +
-    "so what was validated is not provably what gets installed"
-  );
-}
-
-/**
- * Whether a floating-looking spec is really a link to a package in this
- * repository. `"@acme/utils": "*"` against a workspace member resolves to the
- * local package, which is the workspace idiom rather than a floating install —
- * so faulting it would fail every correctly configured monorepo.
- *
- * When workspaces are declared but no member name could be resolved (an
- * unreadable child manifest, an unsupported glob), a bare `*` is exempted
- * anyway: the repository has told us it links locally, and absence of proof is
- * not proof of a violation.
- * @param spec - The declared spec
- * @param workspaces - What resolving the workspace members established
- * @returns True when the spec links to a workspace member
- */
-function linksWorkspaceMember(
-  spec: DependencySpec,
-  workspaces: WorkspaceMembers
-): boolean {
-  if (!workspaces.declared) {
-    return false;
-  }
-  return (
-    workspaces.names.has(spec.name) ||
-    (workspaces.names.size === 0 && spec.spec.trim() === "*")
-  );
-}
-
-/**
- * Lifecycle scripts that run while installing dependencies widen the
- * supply-chain surface: install no longer only resolves packages, it executes
- * repository-owned code. That is legitimate when intentional, but B5 should not
- * silently treat it as the same confidence model as a pure dependency install.
- * @param manifestPath - Repo-relative manifest path
- * @param manifest - Parsed package manifest
- * @returns Evidence line when install-time scripts exist
- */
-function installTimeScriptEvidence(
-  manifestPath: string,
-  manifest: Record<string, unknown>
-): string | null {
-  const scripts = manifest.scripts;
-  if (
-    scripts === null ||
-    typeof scripts !== "object" ||
-    Array.isArray(scripts)
-  ) {
-    return null;
-  }
-  const scriptNames = Object.keys(scripts).filter(name =>
-    INSTALL_TIME_SCRIPT_NAMES.has(name)
-  );
-  if (scriptNames.length === 0) {
-    return null;
-  }
-  return (
-    `\`${manifestPath}\` declares install-time lifecycle script(s) ` +
-    `${renderList(scriptNames)}, so dependency installation executes project ` +
-    "code before the normal test/audit surface; B5 needs an explicit confidence " +
-    "decision for that install-time execution path"
-  );
-}
-
-/**
- * Bun `trustedDependencies` opt third-party packages back into lifecycle script
- * execution. That is a real install-time authority surface and should be named
- * in B5 evidence instead of hidden behind an otherwise clean lockfile/audit
- * model.
- * @param manifestPath - Repo-relative manifest path
- * @param manifest - Parsed package manifest
- * @returns Evidence line when trusted dependencies are declared
- */
-function trustedDependencyEvidence(
-  manifestPath: string,
-  manifest: Record<string, unknown>
-): string | null {
-  const trusted = manifest.trustedDependencies;
-  const names = Array.isArray(trusted)
-    ? trusted.filter((entry): entry is string => typeof entry === "string")
-    : [];
-  if (names.length === 0) {
-    return null;
-  }
-  return (
-    `\`${manifestPath}\` marks ${renderList(names)} as ` +
-    "`trustedDependencies`, allowing third-party install-time scripts to run; " +
-    "B5 needs a written confidence decision for each trusted package because " +
-    "a clean audit gate alone does not explain that execution authority"
-  );
-}
-
-/**
- * Collect B5 evidence for install-time execution surfaces declared by package
- * manifests.
- * @param manifests - Manifests under assessment
- * @returns Evidence lines for install-time execution surfaces
- */
-function installTimeExecutionViolations(
-  manifests: readonly ManifestUnderAssessment[]
-): readonly string[] {
-  return manifests.flatMap(({ manifestPath, manifest }) =>
-    [
-      installTimeScriptEvidence(manifestPath, manifest),
-      trustedDependencyEvidence(manifestPath, manifest),
-    ].flatMap(evidence => (evidence === null ? [] : [evidence]))
-  );
-}
 
 /**
  * Assess a repository's dependency confidence model.
@@ -225,50 +80,21 @@ async function collectFindings(
   const lockfileInstallGate =
     lockfile === null ? null : await findLockfileInstallGate(root);
   const auditGate = await findAuditGate(root);
-  const floating = specs.filter(
-    spec => isFloatingSpec(spec.spec) && !linksWorkspaceMember(spec, workspaces)
-  );
+  const inputs = {
+    auditGate,
+    lockfile,
+    lockfileInstallGate,
+    specs,
+    workspaces,
+  };
   return {
     violations: [
-      ...(lockfile === null ? [lockfileEvidence(specs.length)] : []),
-      ...(lockfile !== null && lockfileInstallGate === null
-        ? [
-            `lockfile \`${lockfile}\` is committed, but no CI or hook install ` +
-              "step was found that enforces it with `npm ci`, " +
-              "`bun install --frozen-lockfile`, `pnpm install --frozen-lockfile`, " +
-              "or `yarn install --immutable`; a workflow can silently rewrite " +
-              "or bypass the tree that was validated",
-          ]
-        : []),
-      ...floating.map(
-        spec =>
-          `\`${spec.manifestPath}\` \`${spec.block}.${spec.name}\` is ` +
-          `\`${spec.spec}\`, ` +
-          "which resolves to whatever is newest at install time rather than to " +
-          "a version anything was ever validated against"
-      ),
-      ...(auditGate === null
-        ? [
-            "no dependency-audit gate covering the JavaScript tree was found " +
-              "anywhere — no `npm`/`bun` audit step in `.github/workflows/*.yml`, " +
-              "none in a git hook, and no `dependabot.yml` npm entry or " +
-              "`renovate.json` — so a newly disclosed advisory in this tree " +
-              "would never be noticed by anything",
-          ]
-        : []),
+      ...dependencyConfidenceViolations(inputs),
       ...installTimeExecutionViolations(manifests),
       ...(await auditExceptionViolations(root)),
     ],
     observations: [
-      ...(lockfile === null ? [] : [`Lockfile in use: \`${lockfile}\`.`]),
-      ...(lockfileInstallGate === null
-        ? []
-        : [
-            `Lockfile-enforcing install declared in \`${lockfileInstallGate}\`.`,
-          ]),
-      ...(auditGate === null
-        ? []
-        : [`Dependency-audit gate declared in \`${auditGate}\`.`]),
+      ...dependencyConfidenceObservations(inputs),
       ...(workspaces.declared ? [workspaceObservation(workspaces)] : []),
     ],
   };
@@ -413,7 +239,8 @@ export async function assessDependenciesSupplyChainDimension(
       collectSpecs(member.manifest, member.manifestPath)
     ),
   ];
-  if (specs.length === 0) {
+  const installTimeViolations = installTimeExecutionViolations(manifests);
+  if (specs.length === 0 && installTimeViolations.length === 0) {
     return skipRecord(
       "No resolved package manifest declares dependencies, so this repository " +
         "owns no third-party surface a confidence model could cover; " +

--- a/src/cli/doctor-readiness-supply-chain.ts
+++ b/src/cli/doctor-readiness-supply-chain.ts
@@ -55,6 +55,34 @@ const SUPPLY_CHAIN_BLOCKER_ID = "B5";
 /** Most evidence lines carried into a single finding, to keep it readable. */
 const MAX_EVIDENCE_LINES = 12;
 
+/** Package lifecycle scripts that execute during dependency installation. */
+const INSTALL_TIME_SCRIPT_NAMES: ReadonlySet<string> = new Set([
+  "preinstall",
+  "install",
+  "postinstall",
+  "prepare",
+]);
+
+/** One package manifest B5 inspects. */
+interface ManifestUnderAssessment {
+  readonly manifestPath: string;
+  readonly manifest: Record<string, unknown>;
+}
+
+/**
+ * Render a bounded list for operator-facing evidence.
+ * @param values - Values to render
+ * @returns A comma-separated list
+ */
+function renderList(values: readonly string[]): string {
+  const shown = values.slice(0, 5);
+  const overflow = values.length - shown.length;
+  return (
+    shown.map(value => `\`${value}\``).join(", ") +
+    (overflow > 0 ? `, and ${overflow} more` : "")
+  );
+}
+
 /**
  * Build the evidence line for a manifest with no committed lockfile.
  * @param specCount - How many specs the manifest declares
@@ -97,15 +125,97 @@ function linksWorkspaceMember(
 }
 
 /**
+ * Lifecycle scripts that run while installing dependencies widen the
+ * supply-chain surface: install no longer only resolves packages, it executes
+ * repository-owned code. That is legitimate when intentional, but B5 should not
+ * silently treat it as the same confidence model as a pure dependency install.
+ * @param manifestPath - Repo-relative manifest path
+ * @param manifest - Parsed package manifest
+ * @returns Evidence line when install-time scripts exist
+ */
+function installTimeScriptEvidence(
+  manifestPath: string,
+  manifest: Record<string, unknown>
+): string | null {
+  const scripts = manifest.scripts;
+  if (
+    scripts === null ||
+    typeof scripts !== "object" ||
+    Array.isArray(scripts)
+  ) {
+    return null;
+  }
+  const scriptNames = Object.keys(scripts).filter(name =>
+    INSTALL_TIME_SCRIPT_NAMES.has(name)
+  );
+  if (scriptNames.length === 0) {
+    return null;
+  }
+  return (
+    `\`${manifestPath}\` declares install-time lifecycle script(s) ` +
+    `${renderList(scriptNames)}, so dependency installation executes project ` +
+    "code before the normal test/audit surface; B5 needs an explicit confidence " +
+    "decision for that install-time execution path"
+  );
+}
+
+/**
+ * Bun `trustedDependencies` opt third-party packages back into lifecycle script
+ * execution. That is a real install-time authority surface and should be named
+ * in B5 evidence instead of hidden behind an otherwise clean lockfile/audit
+ * model.
+ * @param manifestPath - Repo-relative manifest path
+ * @param manifest - Parsed package manifest
+ * @returns Evidence line when trusted dependencies are declared
+ */
+function trustedDependencyEvidence(
+  manifestPath: string,
+  manifest: Record<string, unknown>
+): string | null {
+  const trusted = manifest.trustedDependencies;
+  const names = Array.isArray(trusted)
+    ? trusted.filter((entry): entry is string => typeof entry === "string")
+    : [];
+  if (names.length === 0) {
+    return null;
+  }
+  return (
+    `\`${manifestPath}\` marks ${renderList(names)} as ` +
+    "`trustedDependencies`, allowing third-party install-time scripts to run; " +
+    "B5 needs a written confidence decision for each trusted package because " +
+    "a clean audit gate alone does not explain that execution authority"
+  );
+}
+
+/**
+ * Collect B5 evidence for install-time execution surfaces declared by package
+ * manifests.
+ * @param manifests - Manifests under assessment
+ * @returns Evidence lines for install-time execution surfaces
+ */
+function installTimeExecutionViolations(
+  manifests: readonly ManifestUnderAssessment[]
+): readonly string[] {
+  return manifests.flatMap(({ manifestPath, manifest }) =>
+    [
+      installTimeScriptEvidence(manifestPath, manifest),
+      trustedDependencyEvidence(manifestPath, manifest),
+    ].flatMap(evidence => (evidence === null ? [] : [evidence]))
+  );
+}
+
+/**
  * Assess a repository's dependency confidence model.
  * @param root - Repository root
  * @param specs - Declared dependency specs
+ * @param manifests - Parsed package manifests under assessment
  * @param workspaces - What resolving the workspace members established
  * @returns Evidence lines for violations, and non-blocking observations
  */
 async function collectFindings(
   root: string,
   specs: readonly DependencySpec[],
+  manifests: readonly ManifestUnderAssessment[],
   workspaces: WorkspaceMembers
 ): Promise<{
   readonly violations: readonly string[];
@@ -146,6 +256,7 @@ async function collectFindings(
               "would never be noticed by anything",
           ]
         : []),
+      ...installTimeExecutionViolations(manifests),
       ...(await auditExceptionViolations(root)),
     ],
     observations: [
@@ -289,6 +400,13 @@ export async function assessDependenciesSupplyChainDimension(
     return skipRecord(outcome.reason);
   }
   const workspaces = await resolveWorkspaceMembers(root, outcome.manifest);
+  const manifests = [
+    { manifestPath: "package.json", manifest: outcome.manifest },
+    ...workspaces.members.map(member => ({
+      manifestPath: member.manifestPath,
+      manifest: member.manifest,
+    })),
+  ];
   const specs = [
     ...collectSpecs(outcome.manifest),
     ...workspaces.members.flatMap(member =>
@@ -305,6 +423,7 @@ export async function assessDependenciesSupplyChainDimension(
   const { violations, observations } = await collectFindings(
     root,
     specs,
+    manifests,
     workspaces
   );
   if (violations.length > 0) {

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7772,6 +7772,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/doctor-readiness-journey.test.ts": true,
     "tests/unit/cli/doctor-readiness-supply-chain-exceptions.test.ts": true,
     "tests/unit/cli/doctor-readiness-supply-chain-install-gate.test.ts": true,
+    "tests/unit/cli/doctor-readiness-supply-chain-install-scripts.test.ts": true,
     "tests/unit/cli/doctor-readiness-supply-chain-precision.test.ts": true,
     "tests/unit/cli/doctor-readiness-supply-chain-workspaces.test.ts": true,
     "tests/unit/cli/doctor-readiness-supply-chain.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7386,6 +7386,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/cli/doctor-readiness-operations.ts": true,
     "src/cli/doctor-readiness-release-path.ts": true,
     "src/cli/doctor-readiness-shared.ts": true,
+    "src/cli/doctor-readiness-supply-chain-evidence.ts": true,
     "src/cli/doctor-readiness-supply-chain-scan.ts": true,
     "src/cli/doctor-readiness-supply-chain.ts": true,
     "src/cli/doctor-readiness-types.ts": true,

--- a/tests/unit/cli/doctor-readiness-supply-chain-install-scripts.test.ts
+++ b/tests/unit/cli/doctor-readiness-supply-chain-install-scripts.test.ts
@@ -89,6 +89,28 @@ afterEach(async () => {
 });
 
 describe("assessDependenciesSupplyChainDimension — install-time execution", () => {
+  // Test hardened to kill mutant M001 (Risk Factor: Supply-chain / lifecycle-only install authority).
+  it("FAILs with B5 when lifecycle scripts are the only package surface", async () => {
+    const cwd = await getTempDir();
+    await writeRepoJson(cwd, PACKAGE_JSON, {
+      name: "scratch",
+      version: "1.0.0",
+      scripts: {
+        prepare: "node scripts/prepare.js",
+      },
+    });
+
+    const record = await assessDependenciesSupplyChainDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    const finding = asFindings(record.findings).find(
+      candidate => candidate.blocker === BLOCKER_ID
+    );
+    expect(finding?.evidence).toContain("prepare");
+    expect(finding?.evidence).toContain("install-time lifecycle");
+  });
+
+  // Test hardened to kill mutant M002 (Risk Factor: Supply-chain / package lifecycle execution).
   it("FAILs with B5 when dependency install runs package lifecycle code", async () => {
     const cwd = await getTempDir();
     await writeCleanRepo(cwd);
@@ -111,6 +133,7 @@ describe("assessDependenciesSupplyChainDimension — install-time execution", ()
     expect(finding?.evidence).not.toContain("`build`");
   });
 
+  // Test hardened to kill mutant M003 (Risk Factor: Supply-chain / trusted dependency execution).
   it("FAILs with B5 when trustedDependencies allow dependency lifecycle scripts", async () => {
     const cwd = await getTempDir();
     await writeCleanRepo(cwd);

--- a/tests/unit/cli/doctor-readiness-supply-chain-install-scripts.test.ts
+++ b/tests/unit/cli/doctor-readiness-supply-chain-install-scripts.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Install-time script coverage for the dependencies/supply-chain readiness
+ * producer (B5, PRD #1739, #1896).
+ * @module tests/unit/cli/doctor-readiness-supply-chain-install-scripts
+ */
+import { rm } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { assessDependenciesSupplyChainDimension } from "../../../src/cli/doctor-readiness-supply-chain.js";
+import {
+  asFindings,
+  FAIL,
+  makeScratchRepo,
+  writeRepoFile,
+  writeRepoJson,
+} from "../../helpers/readiness-workflow-fixtures.js";
+
+/** The ship blocker this producer can stand up. */
+const BLOCKER_ID = "B5";
+
+/** The root JavaScript manifest. */
+const PACKAGE_JSON = "package.json";
+
+/** A minimal lockfile body — only presence is read. */
+const LOCKFILE_BODY = '{"lockfileVersion": 1}\n';
+
+/** The update-bot config used as a dependency-audit gate. */
+const DEPENDABOT_PATH = ".github/dependabot.yml";
+
+/** The CI workflow path used by dependency-confidence fixtures. */
+const QUALITY_WORKFLOW_PATH = ".github/workflows/quality.yml";
+
+/** A manifest whose dependency specs are all pinned or ranged. */
+const PINNED_MANIFEST = {
+  name: "scratch",
+  version: "1.0.0",
+  dependencies: { "js-yaml": "^4.1.0" },
+};
+
+/** A dependabot config that covers the JavaScript dependency tree. */
+const DEPENDABOT_YML = [
+  "version: 2",
+  "updates:",
+  "  - package-ecosystem: npm",
+  '    directory: "/"',
+  "    schedule:",
+  "      interval: weekly",
+  "",
+].join("\n");
+
+let tempDir: string | undefined;
+
+/**
+ * Resolve a scratch repository for one test case.
+ * @returns Temporary directory path
+ */
+async function getTempDir(): Promise<string> {
+  tempDir ??= await makeScratchRepo("supply-chain-install-scripts");
+  return tempDir;
+}
+
+/**
+ * Write a repository that is clean before an install-time script surface is
+ * added.
+ * @param root - Repository root
+ */
+async function writeCleanRepo(root: string): Promise<void> {
+  await writeRepoJson(root, PACKAGE_JSON, PINNED_MANIFEST);
+  await writeRepoFile(root, "bun.lock", LOCKFILE_BODY);
+  await writeRepoFile(root, DEPENDABOT_PATH, DEPENDABOT_YML);
+  await writeRepoFile(
+    root,
+    QUALITY_WORKFLOW_PATH,
+    [
+      "name: Quality",
+      "jobs:",
+      "  test:",
+      "    steps:",
+      "      - run: bun install --frozen-lockfile",
+      "",
+    ].join("\n")
+  );
+}
+
+afterEach(async () => {
+  if (tempDir) {
+    await rm(tempDir, { force: true, recursive: true });
+    tempDir = undefined;
+  }
+});
+
+describe("assessDependenciesSupplyChainDimension — install-time execution", () => {
+  it("FAILs with B5 when dependency install runs package lifecycle code", async () => {
+    const cwd = await getTempDir();
+    await writeCleanRepo(cwd);
+    await writeRepoJson(cwd, PACKAGE_JSON, {
+      ...PINNED_MANIFEST,
+      scripts: {
+        build: "tsc",
+        postinstall: "node scripts/bootstrap.js",
+      },
+    });
+
+    const record = await assessDependenciesSupplyChainDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    const finding = asFindings(record.findings).find(
+      candidate => candidate.blocker === BLOCKER_ID
+    );
+    expect(finding?.evidence).toContain("postinstall");
+    expect(finding?.evidence).toContain("install-time lifecycle");
+    expect(finding?.evidence).not.toContain("`build`");
+  });
+
+  it("FAILs with B5 when trustedDependencies allow dependency lifecycle scripts", async () => {
+    const cwd = await getTempDir();
+    await writeCleanRepo(cwd);
+    await writeRepoJson(cwd, PACKAGE_JSON, {
+      ...PINNED_MANIFEST,
+      trustedDependencies: ["@sentry/cli", "@ast-grep/cli"],
+    });
+
+    const record = await assessDependenciesSupplyChainDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    const finding = asFindings(record.findings).find(
+      candidate => candidate.blocker === BLOCKER_ID
+    );
+    expect(finding?.evidence).toContain("trustedDependencies");
+    expect(finding?.evidence).toContain("@sentry/cli");
+    expect(finding?.evidence).toContain("third-party install-time scripts");
+  });
+});


### PR DESCRIPTION
## Summary
- adds B5 evidence for package install-time lifecycle scripts (`preinstall`, `install`, `postinstall`, `prepare`)
- adds B5 evidence for Bun `trustedDependencies`, which allow third-party install-time scripts
- adds focused install-time execution coverage and updates the upstream evidence manifest

## Verification
- bun test tests/unit/cli/doctor-readiness-supply-chain-install-scripts.test.ts tests/unit/cli/doctor-readiness-supply-chain.test.ts
- bun test tests/unit/cli/doctor-readiness-supply-chain.test.ts tests/unit/cli/doctor-readiness-supply-chain-install-scripts.test.ts tests/unit/cli/doctor-readiness-supply-chain-precision.test.ts tests/unit/cli/doctor-readiness-supply-chain-workspaces.test.ts tests/unit/cli/doctor-readiness-supply-chain-install-gate.test.ts tests/unit/cli/doctor-readiness-supply-chain-exceptions.test.ts
- bun run typecheck
- bun run lint -- src/cli/doctor-readiness-supply-chain.ts tests/unit/cli/doctor-readiness-supply-chain.test.ts tests/unit/cli/doctor-readiness-supply-chain-install-scripts.test.ts
- bun run build:dist
- bun run check:upstream-evidence-manifest
- pre-push gate: typecheck, production dependency audit, slow lint, knip, full coverage (7943 tests), integration tests (151 tests), plugin parity

Work-Item: CodySwannGT/lisa#1903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supply-chain readiness checks now include install-time execution risk signals (e.g., lifecycle scripts and trusted dependency settings) when evaluating project manifests, including workspace packages.
  * Evidence messages for blocker B5 now surface the specific install-time lifecycle findings alongside dependency-confidence results.
* **Bug Fixes**
  * Updated the “no assessable inputs” skip logic to require both missing dependency specs and no install-time violations before skipping.
* **Tests**
  * Added unit coverage for install-time lifecycle scripts and trusted dependency configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->