### PR TITLE
fix(readiness): surface opaque guardrail actions

### DIFF
--- a/src/cli/doctor-readiness-guardrails.ts
+++ b/src/cli/doctor-readiness-guardrails.ts
@@ -113,6 +113,28 @@ const PRODUCTION_MARKERS: readonly RegExp[] = [
 ];
 
 /**
+ * Action/reusable-workflow evidence that may hide consequential behavior behind
+ * an opaque implementation this offline scanner cannot inspect.
+ */
+const OPAQUE_CONSEQUENTIAL_ACTIONS: readonly RegExp[] = [
+  /\bterraform\b/,
+  /\bpulumi\b/,
+  /\bserverless\b/,
+  /\bdeploy\b/,
+  /\bdestroy\b/,
+  /\bmigrat(e|ion)\b/,
+];
+
+/** Inputs that make an opaque action/reusable workflow look consequential. */
+const OPAQUE_CONSEQUENTIAL_INPUTS: readonly RegExp[] = [
+  /\bdestroy\b/,
+  /\bremove\b/,
+  /\bdelete\b/,
+  /\bapply\b[^\n]*-auto-approve\b/,
+  /\bprod(uction)?\b/,
+];
+
+/**
  * Collapse only shell continuation newlines. Ordinary newlines remain command
  * boundaries so unrelated invocations cannot combine into one Terraform apply.
  * @param command - Shell command text
@@ -252,6 +274,74 @@ function servicesDeferral(
 }
 
 /**
+ * Whether an opaque action/reusable call has enough local text to be named as
+ * an unassessed consequential surface.
+ * @param id - The `uses:` target
+ * @param inputs - Serialized `with:`/`env:` text adjacent to the call
+ * @returns True when the call should be surfaced as unresolved
+ */
+function looksLikeOpaqueConsequentialCall(id: string, inputs: string): boolean {
+  const evidence = `${id}\n${inputs}`.toLowerCase();
+  return (
+    OPAQUE_CONSEQUENTIAL_ACTIONS.some(pattern => pattern.test(evidence)) &&
+    OPAQUE_CONSEQUENTIAL_INPUTS.some(pattern => pattern.test(evidence)) &&
+    !looksEphemeral(evidence)
+  );
+}
+
+/**
+ * State why a reusable workflow call may hide consequential behavior this file
+ * cannot inspect.
+ * @param workflow - The workflow declaring the job
+ * @param job - The reusable workflow job
+ * @returns A stated reason, or null when the call does not look consequential
+ */
+function reusableCallDeferral(
+  workflow: ParsedWorkflow,
+  job: ParsedWorkflowJob
+): string | null {
+  if (
+    job.uses === "" ||
+    !looksLikeOpaqueConsequentialCall(job.uses, job.inputs)
+  ) {
+    return null;
+  }
+  return (
+    `\`${workflow.file}\` job \`${job.id}\` calls reusable workflow ` +
+    `\`${job.uses}\` with consequential-looking inputs; this offline read ` +
+    "cannot inspect the called workflow implementation, so whether it runs an " +
+    "irreversible or expensive operation is not established either way"
+  );
+}
+
+/**
+ * State why an action step may hide consequential behavior this file cannot
+ * inspect.
+ * @param workflow - The workflow declaring the job
+ * @param job - The job declaring the action step
+ * @param step - The action step
+ * @returns A stated reason, or null when the action does not look consequential
+ */
+function actionStepDeferral(
+  workflow: ParsedWorkflow,
+  job: ParsedWorkflowJob,
+  step: ParsedWorkflowStep
+): string | null {
+  if (
+    step.uses === "" ||
+    !looksLikeOpaqueConsequentialCall(step.uses, step.inputs)
+  ) {
+    return null;
+  }
+  return (
+    `\`${workflow.file}\` job \`${job.id}\` uses action ` +
+    `\`${step.uses}\` with consequential-looking inputs; this offline read ` +
+    "cannot inspect the action implementation, so whether it runs an " +
+    "irreversible or expensive operation is not established either way"
+  );
+}
+
+/**
  * Build the rubric-shaped B4 finding from the operations it cites.
  * @param scan - The consequential-operation scan
  * @returns The B4 finding
@@ -345,6 +435,8 @@ export async function assessFeedbackGuardrailsDimension(
   const scan = scanCommands(workflows, isConsequential, {
     unresolvedWorkflow: lifecycleDeferral,
     unresolvedStep: servicesDeferral,
+    unresolvedJobCall: reusableCallDeferral,
+    unresolvedActionStep: actionStepDeferral,
   });
   const runbook = await hasCheckedInRunbook(root);
   if (scan.ungated.length === 0 || runbook) {

--- a/src/cli/doctor-readiness-operations.ts
+++ b/src/cli/doctor-readiness-operations.ts
@@ -72,6 +72,23 @@ export interface ScanOptions {
     job: ParsedWorkflowJob,
     step: ParsedWorkflowStep
   ) => string | null;
+  /**
+   * A job-level reusable workflow call reason the scan cannot settle offline,
+   * returning `null` when the call carries no relevant evidence.
+   */
+  readonly unresolvedJobCall?: (
+    workflow: ParsedWorkflow,
+    job: ParsedWorkflowJob
+  ) => string | null;
+  /**
+   * An action step reason the scan cannot settle offline, returning `null` when
+   * the action carries no relevant evidence.
+   */
+  readonly unresolvedActionStep?: (
+    workflow: ParsedWorkflow,
+    job: ParsedWorkflowJob,
+    step: ParsedWorkflowStep
+  ) => string | null;
 }
 
 /**
@@ -342,34 +359,50 @@ function classifyJob(
   matches: CommandPredicate,
   options: ScanOptions
 ): readonly ScanOutcome[] {
+  const unresolvedCalls = [
+    options.unresolvedJobCall?.(workflow, job),
+    ...job.steps.map(step =>
+      options.unresolvedActionStep?.(workflow, job, step)
+    ),
+  ].flatMap(reason =>
+    reason === undefined || reason === null
+      ? []
+      : [{ kind: "unresolved" as const, reason }]
+  );
   const hits = job.steps.filter(
     step => step.run !== "" && matches(step.run.toLowerCase(), job, step)
   );
   if (hits.length === 0) {
-    return [];
+    return unresolvedCalls;
   }
   if (!runsUnattended(workflow)) {
-    return [{ kind: "unresolved", reason: unresolvedReason(workflow, job) }];
+    return [
+      { kind: "unresolved", reason: unresolvedReason(workflow, job) },
+      ...unresolvedCalls,
+    ];
   }
   const deferred =
     options.unresolvedWorkflow?.(workflow) ?? options.unresolvedJob?.(job);
   if (deferred !== undefined && deferred !== null) {
-    return [{ kind: "unresolved", reason: deferred }];
+    return [{ kind: "unresolved", reason: deferred }, ...unresolvedCalls];
   }
   const jobGated = jobIsGated(job) || (options.exemptJob?.(job) ?? false);
-  return hits.map(step => {
-    const stepDeferred = options.unresolvedStep?.(workflow, job, step);
-    if (stepDeferred !== undefined && stepDeferred !== null) {
-      return { kind: "unresolved" as const, reason: stepDeferred };
-    }
-    return {
-      kind:
-        jobGated || stepIsGated(step)
-          ? ("gated" as const)
-          : ("ungated" as const),
-      command: { workflow: workflow.file, jobId: job.id, command: step.run },
-    };
-  });
+  return [
+    ...hits.map(step => {
+      const stepDeferred = options.unresolvedStep?.(workflow, job, step);
+      if (stepDeferred !== undefined && stepDeferred !== null) {
+        return { kind: "unresolved" as const, reason: stepDeferred };
+      }
+      return {
+        kind:
+          jobGated || stepIsGated(step)
+            ? ("gated" as const)
+            : ("ungated" as const),
+        command: { workflow: workflow.file, jobId: job.id, command: step.run },
+      };
+    }),
+    ...unresolvedCalls,
+  ];
 }
 
 /**

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7768,6 +7768,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/doctor-readiness-domain-negatives.test.ts": true,
     "tests/unit/cli/doctor-readiness-domain.test.ts": true,
     "tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts": true,
+    "tests/unit/cli/doctor-readiness-guardrails-opaque-actions.test.ts": true,
     "tests/unit/cli/doctor-readiness-guardrails-terraform.test.ts": true,
     "tests/unit/cli/doctor-readiness-guardrails.test.ts": true,
     "tests/unit/cli/doctor-readiness-journey.test.ts": true,

--- a/tests/unit/cli/doctor-readiness-guardrails-opaque-actions.test.ts
+++ b/tests/unit/cli/doctor-readiness-guardrails-opaque-actions.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Opaque action/reusable-workflow coverage for the feedback/guardrails
+ * readiness producer (B4, PRD #1739, #1896).
+ *
+ * These cases are deliberately unresolved observations. The offline scanner
+ * cannot inspect action internals or called workflow files, but it should not
+ * let consequential-looking authority disappear from the report.
+ * @module tests/unit/cli/doctor-readiness-guardrails-opaque-actions
+ */
+import { rm } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { assessFeedbackGuardrailsDimension } from "../../../src/cli/doctor-readiness-guardrails.js";
+import {
+  asFindings,
+  DEPLOY_YML,
+  JOBS,
+  makeScratchRepo,
+  ON_PUSH,
+  RUNS_ON,
+  SKIP,
+  STEPS,
+  writeWorkflow,
+} from "../../helpers/readiness-workflow-fixtures.js";
+
+/** The workflow `name:` line most fixtures in this suite write. */
+const DEPLOY_NAME_LINE = "name: Deploy";
+
+/** The infrastructure job header reused across fixtures. */
+const INFRA_JOB = "  infra:";
+
+/**
+ * Every finding in a record, asserted to name no blocker.
+ * @param findings - The record's raw findings
+ */
+function expectNoBlocker(findings: readonly unknown[]): void {
+  for (const finding of asFindings(findings)) {
+    expect(Object.hasOwn(finding, "blocker")).toBe(false);
+  }
+}
+
+let tempDir: string | undefined;
+
+/**
+ * Resolve a scratch repository for one test case.
+ * @returns Temporary directory path
+ */
+async function getTempDir(): Promise<string> {
+  tempDir ??= await makeScratchRepo("guardrails-opaque-actions");
+  return tempDir;
+}
+
+afterEach(async () => {
+  if (tempDir !== undefined) {
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+describe("assessFeedbackGuardrailsDimension — opaque consequential calls", () => {
+  it("surfaces action-driven destructive work as unresolved", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      DEPLOY_NAME_LINE,
+      ON_PUSH,
+      JOBS,
+      INFRA_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - uses: hashicorp/terraform-github-actions@v1",
+      "        with:",
+      "          tf_actions_subcommand: destroy",
+      "          tf_actions_working_dir: infra/prod",
+    ]);
+
+    const record = await assessFeedbackGuardrailsDimension(root);
+
+    expect(record.status).toBe(SKIP);
+    expectNoBlocker(record.findings);
+    expect(
+      asFindings(record.findings).some(finding =>
+        String(finding.observation).includes(
+          "hashicorp/terraform-github-actions@v1"
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("surfaces consequential reusable workflow calls as unresolved", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      DEPLOY_NAME_LINE,
+      ON_PUSH,
+      JOBS,
+      "  teardown:",
+      "    uses: ./.github/workflows/destroy-production.yml",
+      "    with:",
+      "      command: terraform destroy -auto-approve",
+      "      target: production",
+    ]);
+
+    const record = await assessFeedbackGuardrailsDimension(root);
+
+    expect(record.status).toBe(SKIP);
+    expectNoBlocker(record.findings);
+    expect(
+      asFindings(record.findings).some(finding =>
+        String(finding.observation).includes("destroy-production.yml")
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#1903

## Summary
- Add shared scanner hooks for unresolved opaque job/action calls.
- Surface B4 observations when action or reusable workflow `uses:` targets carry consequential-looking deployment/destruction inputs.
- Add focused tests for Terraform action-driven destroy and reusable production teardown calls.

## Verification
- bun test tests/unit/cli/doctor-readiness-guardrails.test.ts tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts tests/unit/cli/doctor-readiness-guardrails-opaque-actions.test.ts
- bun run typecheck
- bun run format:check
- bun run lint
- bun run check:upstream-evidence-manifest
- bun run build:dist
- bun test $(rg --files tests/unit/cli | rg 'doctor-readiness.*\\.test\\.ts$')
- pre-push: typecheck, production audit, slow lint, knip, full coverage, integration tests, plugin parity

[lisa-pr-link] https://github.com/CodySwannGT/lisa/issues/1903


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline readiness scans for reusable workflows and actions with potentially consequential inputs.
  * Added clearer “cannot inspect” findings when workflow or action behavior cannot be resolved offline.
  * Ensured unresolved findings are reported even when no direct command matches are found.
  * Prevented opaque consequential calls from being incorrectly treated as blocking issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->