### PR TITLE
fix(readiness): honor git default branch in delivery checks

### DIFF
--- a/src/cli/doctor-readiness-delivery.ts
+++ b/src/cli/doctor-readiness-delivery.ts
@@ -88,8 +88,94 @@ function summarizeReleasePaths(
 }
 
 /**
- * Read the local production branch hint Lisa writes into project config. This
- * stays offline and best-effort: unreadable or unusual config falls back to the
+ * Resolve the repository's local `.git` directory. Worktrees store this as a
+ * pointer file, while ordinary checkouts use a directory.
+ * @param root - Project root to inspect
+ * @returns The resolved git directory path, or null when it cannot be read
+ */
+async function localGitDir(root: string): Promise<string | null> {
+  const dotGit = path.join(root, ".git");
+  try {
+    const marker = await readFile(dotGit, "utf8");
+    const trimmed = marker.trim();
+    const prefix = "gitdir:";
+    if (!trimmed.toLowerCase().startsWith(prefix)) {
+      return null;
+    }
+    const target = trimmed.slice(prefix.length).trim();
+    return path.isAbsolute(target) ? target : path.resolve(root, target);
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EISDIR" ? dotGit : null;
+  }
+}
+
+/**
+ * Resolve where shared refs live for a gitdir. Linked worktrees keep refs in
+ * the common directory named by `commondir`; ordinary repositories do not.
+ * @param gitDir - The resolved `.git` or per-worktree gitdir
+ * @returns The directory that owns shared refs
+ */
+async function commonGitDir(gitDir: string): Promise<string> {
+  try {
+    const raw = await readFile(path.join(gitDir, "commondir"), "utf8");
+    const target = raw.trim();
+    return path.isAbsolute(target) ? target : path.resolve(gitDir, target);
+  } catch {
+    return gitDir;
+  }
+}
+
+/**
+ * Read the default branch cached by git's local `origin/HEAD` symbolic ref.
+ * This is best-effort and does not fetch; if the ref is absent, callers fall
+ * back to Lisa config and built-in branch names.
+ * @param root - Project root to inspect
+ * @returns The local remote-default branch name when available
+ */
+async function gitDefaultBranch(root: string): Promise<string | null> {
+  const gitDir = await localGitDir(root);
+  if (!gitDir) {
+    return null;
+  }
+  const refsGitDir = await commonGitDir(gitDir);
+  try {
+    const raw = await readFile(
+      path.join(refsGitDir, "refs", "remotes", "origin", "HEAD"),
+      "utf8"
+    );
+    const trimmed = raw.trim();
+    const prefix = "ref: refs/remotes/origin/";
+    return trimmed.startsWith(prefix) ? trimmed.slice(prefix.length) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read Lisa's configured production branch hint.
+ * @param root - Project root to inspect
+ * @returns A one-item branch list, or empty when no hint exists
+ */
+async function configDefaultBranches(root: string): Promise<readonly string[]> {
+  try {
+    const raw = await readFile(path.join(root, ".lisa.config.json"), "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (!isJsonObject(parsed) || !isJsonObject(parsed.deploy)) {
+      return [];
+    }
+    const deployBranches = parsed.deploy.branches;
+    return isJsonObject(deployBranches) &&
+      typeof deployBranches.production === "string"
+      ? [deployBranches.production]
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read local default-branch hints Lisa can establish offline. This stays
+ * best-effort: unreadable or unusual config/git metadata falls back to the
  * built-in `main`/`master` defaults in the release-path assessor.
  * @param root - Project root to inspect
  * @returns Configured default-like branch names
@@ -97,20 +183,10 @@ function summarizeReleasePaths(
 async function configuredDefaultBranches(
   root: string
 ): Promise<readonly string[]> {
-  try {
-    const raw = await readFile(path.join(root, ".lisa.config.json"), "utf8");
-    const parsed: unknown = JSON.parse(raw);
-    if (!isJsonObject(parsed) || !isJsonObject(parsed.deploy)) {
-      return [];
-    }
-    const branches = parsed.deploy.branches;
-    if (!isJsonObject(branches)) {
-      return [];
-    }
-    return typeof branches.production === "string" ? [branches.production] : [];
-  } catch {
-    return [];
-  }
+  const configBranches = await configDefaultBranches(root);
+  const gitBranch = await gitDefaultBranch(root);
+  const branches = gitBranch ? [...configBranches, gitBranch] : configBranches;
+  return [...new Set(branches.map(branch => branch.trim()).filter(Boolean))];
 }
 
 /**

--- a/tests/unit/cli/doctor-readiness-delivery-triggers.test.ts
+++ b/tests/unit/cli/doctor-readiness-delivery-triggers.test.ts
@@ -10,7 +10,8 @@
  * silence must not be read as a bypass.
  * @module tests/unit/cli/doctor-readiness-delivery-triggers
  */
-import { rm } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import * as path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { assessDeliveryAuthorityDimension } from "../../../src/cli/doctor-readiness-delivery.js";
 import { assessReadiness } from "../../../src/cli/doctor-readiness-blockers.js";
@@ -41,6 +42,8 @@ import {
 const RUN_CDK_DEPLOY = "      - run: cdk deploy";
 const WORKFLOW_RUN = "  workflow_run:";
 const WORKFLOWS_CI = "    workflows: [CI]";
+const TRUNK_BRANCH = "trunk";
+const DEFAULT_BRANCH_REASON = "default branch";
 
 let tempDir: string | undefined;
 
@@ -51,6 +54,49 @@ let tempDir: string | undefined;
 async function getTempDir(): Promise<string> {
   tempDir ??= await makeScratchRepo("triggers");
   return tempDir;
+}
+
+/**
+ * Seed the local git remote-default symbolic ref without invoking git.
+ * @param root - Scratch repository root
+ * @param branch - Remote default branch name
+ */
+async function writeOriginHead(root: string, branch: string): Promise<void> {
+  const refsDir = path.join(root, ".git", "refs", "remotes", "origin");
+  await mkdir(refsDir, { recursive: true });
+  await writeFile(
+    path.join(refsDir, "HEAD"),
+    `ref: refs/remotes/origin/${branch}\n`,
+    "utf8"
+  );
+}
+
+/**
+ * Seed git metadata as a linked worktree would: `.git` points at a per-worktree
+ * gitdir, and that gitdir's `commondir` points at the shared refs directory.
+ * @param root - Scratch repository root
+ * @param branch - Remote default branch name
+ */
+async function writeWorktreeOriginHead(
+  root: string,
+  branch: string
+): Promise<void> {
+  const commonDir = path.join(root, "common.git");
+  const worktreeGitDir = path.join(commonDir, "worktrees", "fixture");
+  const refsDir = path.join(commonDir, "refs", "remotes", "origin");
+  await mkdir(worktreeGitDir, { recursive: true });
+  await mkdir(refsDir, { recursive: true });
+  await writeFile(
+    path.join(root, ".git"),
+    `gitdir: ${worktreeGitDir}\n`,
+    "utf8"
+  );
+  await writeFile(path.join(worktreeGitDir, "commondir"), "../..\n", "utf8");
+  await writeFile(
+    path.join(refsDir, "HEAD"),
+    `ref: refs/remotes/origin/${branch}\n`,
+    "utf8"
+  );
 }
 
 afterEach(async () => {
@@ -166,7 +212,57 @@ describe("assessDeliveryAuthorityDimension — B2 never manufactures RED from ab
 
     expect(record.status).toBe(SKIP);
     expect(assessReadiness([record]).blockers).toEqual([]);
-    expect(JSON.stringify(record.findings)).toContain("default branch");
+    expect(JSON.stringify(record.findings)).toContain(DEFAULT_BRANCH_REASON);
+  });
+
+  it("uses git origin/HEAD when config does not name the default branch", async () => {
+    const cwd = await getTempDir();
+    await writeOriginHead(cwd, TRUNK_BRANCH);
+    await writeWorkflow(cwd, DEPLOY_YML, [
+      DEPLOY_NAME,
+      ON,
+      "  push:",
+      `    branches: [${TRUNK_BRANCH}]`,
+      JOBS,
+      SHIP_JOB,
+      RUNS_ON,
+      PERMISSIONS,
+      CONTENTS_READ,
+      STEPS,
+      RUN_BUILD,
+      RUN_CDK_DEPLOY,
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe(SKIP);
+    expect(assessReadiness([record]).blockers).toEqual([]);
+    expect(JSON.stringify(record.findings)).toContain(DEFAULT_BRANCH_REASON);
+  });
+
+  it("uses linked-worktree origin/HEAD from git commondir", async () => {
+    const cwd = await getTempDir();
+    await writeWorktreeOriginHead(cwd, TRUNK_BRANCH);
+    await writeWorkflow(cwd, DEPLOY_YML, [
+      DEPLOY_NAME,
+      ON,
+      "  push:",
+      `    branches: [${TRUNK_BRANCH}]`,
+      JOBS,
+      SHIP_JOB,
+      RUNS_ON,
+      PERMISSIONS,
+      CONTENTS_READ,
+      STEPS,
+      RUN_BUILD,
+      RUN_CDK_DEPLOY,
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe(SKIP);
+    expect(assessReadiness([record]).blockers).toEqual([]);
+    expect(JSON.stringify(record.findings)).toContain(DEFAULT_BRANCH_REASON);
   });
 
   it("SKIPs with a stated reason when workflows exist but nothing publishes", async () => {


### PR DESCRIPTION
## Summary
- Teach delivery-authority B2 default-branch detection to read the local git `origin/HEAD` symbolic ref in addition to Lisa production-branch config.
- Add a regression proving a `trunk` default-branch push deploy stays an evidence-backed SKIP instead of becoming a false B2 failure.

## Work item

Work-Item: CodySwannGT/lisa#1903

## Verification
- `bun test tests/unit/cli/doctor-readiness-delivery-triggers.test.ts`
- `bun run typecheck`
- `bun run lint -- src/cli/doctor-readiness-delivery.ts tests/unit/cli/doctor-readiness-delivery-triggers.test.ts`
- `bun run check:upstream-evidence-manifest`
- pre-push hook: typecheck, production security audit, slow lint, knip, full unit coverage, integration tests, plugin parity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default branch detection for delivery readiness checks.
  * Default branch information can now be detected from local Git metadata, including worktree repositories, when project configuration does not specify it.
  * Improved handling of branch hints from configuration and Git sources, including duplicate and whitespace cleanup.
* **Tests**
  * Added coverage for detecting the default branch through Git’s remote origin metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->