### PR TITLE
feat(ci): ship the work-item traceability backstop to the fleet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
     name: 🔍 Quality Checks
     permissions:
       contents: read
+      # The work_item_traceability job reads the tracker issue to verify the
+      # PR backlink. A reusable workflow can only DOWNGRADE the caller's grant,
+      # so without issues:read here that job cannot enforce anything.
+      issues: read
       pull-requests: read
     uses: ./.github/workflows/quality.yml
     with:
@@ -19,111 +23,6 @@ jobs:
       package_manager: 'bun'
       skip_jobs: ''
     secrets: inherit
-  # -----------------------------------------------------------------------------
-  # Server-side backstop for work-item traceability (#1978)
-  # -----------------------------------------------------------------------------
-  # The pre-push `validate-push` gate is client-side and fail-safe: since #1956
-  # it subtracts commits reachable from the remote default branch so a
-  # merge-sync does not drag the base branch's history into validation. #1956's
-  # security review proved that exclusion is locally bypassable — an agent owns
-  # its `.git`, so it can `update-ref refs/remotes/origin/<anything> <branch-tip>`
-  # and repoint the `refs/remotes/origin/HEAD` symref at it, which empties the
-  # branch-authored range and launders commits carrying a missing, mixed, or
-  # closed-issue Work-Item trailer past the hook.
-  #
-  # `validate-pr` is the designed backstop: it recomputes `rev-list base..head`
-  # from SHAs supplied by the GitHub event payload, with no exclusion logic and
-  # without ever reading a symref, so nothing in the pusher's repository can
-  # shrink the range. Impact of the bypass is bounded to traceability integrity
-  # (wrong/closed-issue attribution), not code execution — this job closes it
-  # anyway, because a client-side-only gate is not a gate.
-  #
-  # The gate fails safe by construction: an EMPTY range is a failure, not a
-  # pass. `validatePrData` throws "Pull request has no non-merge commit linked
-  # to a work item" when nothing survives, so the #1956 outcome that slips past
-  # the pre-push hook (range emptied to zero commits) is exactly the outcome
-  # that reddens here. There is no way to widen an exclusion into a green run.
-  #
-  # Not airtight, and deliberately so: this job inherits the validator's
-  # exemptions, so merge commits and `chore(release): x.y.z [skip ci]` subjects
-  # skip work-item validation entirely. It proves branch-authored commits are
-  # traceable — it does not prove every commit in the range was inspected.
-  work_item_traceability:
-    name: 🔗 Work-Item Traceability
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    # Only meaningful on pull_request: the range and the PR number both come
-    # from the event payload. workflow_dispatch runs report success.
-    if: ${{ github.event_name == 'pull_request' }}
-    # `gh pr view` needs pull-requests:read and `gh issue view` needs
-    # issues:read. The validator writes nothing — never grant more.
-    permissions:
-      contents: read
-      issues: read
-      pull-requests: read
-    steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v6
-        with:
-          # `rev-list base..head` needs both endpoints and everything between
-          # them. A shallow clone would make the range error out or silently
-          # under-report, which would void the gate. fetch-depth: 0 also brings
-          # every branch down as refs/remotes/origin/*, which the next step uses.
-          fetch-depth: 0
-          persist-credentials: false
-          # Check out the PR head itself, not the default synthetic
-          # refs/pull/N/merge: that ref does not exist while the PR has
-          # conflicts, and it can lag head.sha immediately after a push. Either
-          # would redden this job for a reason unrelated to traceability.
-          # Base resolution is unaffected — fetch-depth: 0 still fetches
-          # refs/remotes/origin/<base.ref> regardless of which ref is checked out.
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          package-manager-cache: false
-          # Read the pin from the canonical manifest (engines.node) rather than
-          # duplicating the literal — see the Duplicate Versions workflow.
-          node-version-file: 'package.json'
-
-      - name: 🔗 Resolve the branch-authored commit range
-        id: range
-        env:
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          # Default to the payload's base.sha. Prefer the base branch's CURRENT
-          # tip when it descends from it: a PR that merge-synced the base branch
-          # carries the base's own commits (whose trailers reference other, often
-          # closed, work items) inside base.sha..head, and those are not
-          # branch-authored. Starting the range at the tip drops them by plain
-          # set subtraction — no exclusion logic, nothing for a pusher to steer.
-          # The tip is whatever CI fetched from GitHub, NOT the agent-repointable
-          # local origin/HEAD symref that #1956's bypass abused.
-          base="$PR_BASE_SHA"
-          tip="$(git rev-parse -q --verify "refs/remotes/origin/${PR_BASE_REF}" || true)"
-          # The ancestry check keeps this monotonic: if the base branch was
-          # rewritten or the ref is missing, fall back to base.sha rather than
-          # widening the exclusion to an unrelated history.
-          if [ -n "$tip" ] && git merge-base --is-ancestor "$base" "$tip"; then
-            base="$tip"
-          fi
-          echo "base=$base" >> "$GITHUB_OUTPUT"
-          echo "Validating ${base}..${PR_HEAD_SHA}"
-
-      - name: 🔗 Validate Work-Item traceability
-        # Env-var form (equivalent to --base/--head/--pr-number) keeps event
-        # payload values out of the shell command entirely.
-        env:
-          GH_TOKEN: ${{ github.token }}
-          LISA_PR_BASE_SHA: ${{ steps.range.outputs.base }}
-          LISA_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          LISA_PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: node scripts/lisa-work-item.mjs validate-pr
-
   bin_smoke:
     name: Lisa CLI bin smoke
     runs-on: ubuntu-latest

--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -43,7 +43,7 @@ on:
         type: string
         default: 'test'
       skip_jobs:
-        description: 'Comma-separated list of jobs to skip (lint, security, test, mutation, code_quality, secret_scanning, sg_scan, learnings_budget, threshold_ratchet, license_compliance, zap_baseline)'
+        description: 'Comma-separated list of jobs to skip (lint, security, test, mutation, code_quality, secret_scanning, sg_scan, learnings_budget, threshold_ratchet, work_item_traceability, license_compliance, zap_baseline)'
         required: false
         type: string
         default: ''
@@ -61,6 +61,19 @@ on:
       GITGUARDIAN_API_KEY:
         required: false
       FOSSA_API_KEY:
+        required: false
+      # Work-item traceability reads the configured tracker to verify the PR's
+      # backlink. `tracker: github` needs nothing beyond github.token; jira and
+      # linear need their API credentials, and without them the job reports
+      # not-enforceable rather than a false traceability failure.
+      JIRA_API_TOKEN:
+        description: 'Atlassian/Jira API token (only when tracker is jira)'
+        required: false
+      JIRA_LOGIN:
+        description: 'Atlassian account email for the Jira API token (only when tracker is jira)'
+        required: false
+      LINEAR_API_KEY:
+        description: 'Linear API key (only when tracker is linear)'
         required: false
 
 permissions:
@@ -121,6 +134,93 @@ jobs:
             exit 1
           fi
           node scripts/check-threshold-ratchet.mjs --base "origin/$BASE_REF"
+
+  # ---------------------------------------------------------------------------
+  # Server-side backstop for work-item traceability (#1978, fleet rollout #2046)
+  # ---------------------------------------------------------------------------
+  # Rails counterpart of the quality.yml job — same validator, same rationale:
+  # the client-side lefthook gates (`validate-commit`, `validate-push`) are
+  # locally bypassable because an agent owns its `.git` and can repoint
+  # `refs/remotes/origin/HEAD` to empty the branch-authored range (#1956).
+  # `validate-pr` recomputes the range from event-payload SHAs and never reads a
+  # symref, so nothing local can shrink it. An EMPTY range is a failure.
+  work_item_traceability:
+    name: 🔗 Work-Item Traceability
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.event_name == 'pull_request' && !contains(format(',{0},', inputs.skip_jobs), ',work_item_traceability,') }}
+    # The validator writes nothing — never grant more. A reusable workflow can
+    # only DOWNGRADE the caller's grant, so a caller that does not grant
+    # issues:read leaves this job unable to read the tracker.
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # `rev-list base..head` needs both endpoints and everything between
+          # them; a shallow clone would void the gate.
+          fetch-depth: 0
+          persist-credentials: false
+          # The PR head itself, not refs/pull/N/merge: that ref does not exist
+          # while the PR has conflicts and can lag head.sha after a push.
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: 🔗 Resolve the branch-authored commit range
+        id: range
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Prefer the base branch's CURRENT tip when it descends from base.sha:
+          # a merge-synced PR carries the base's own commits (referencing other,
+          # often closed, work items) inside base.sha..head. Starting at the tip
+          # drops them by plain set subtraction — nothing for a pusher to steer.
+          base="$PR_BASE_SHA"
+          tip="$(git rev-parse -q --verify "refs/remotes/origin/${PR_BASE_REF}" || true)"
+          if [ -n "$tip" ] && git merge-base --is-ancestor "$base" "$tip"; then
+            base="$tip"
+          fi
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+          echo "Validating ${base}..${PR_HEAD_SHA}"
+
+      - name: 🔗 Validate Work-Item traceability
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LISA_PR_BASE_SHA: ${{ steps.range.outputs.base }}
+          LISA_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          LISA_PR_NUMBER: ${{ github.event.pull_request.number }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_LOGIN: ${{ secrets.JIRA_LOGIN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+        run: |
+          if [ ! -f scripts/lisa-work-item.mjs ]; then
+            echo "scripts/lisa-work-item.mjs not present — project not yet on the work-item template; skipping."
+            exit 0
+          fi
+          # A project mid-onboarding has no tracker configured yet; the
+          # validator hard-fails on a missing `tracker`, and a gate nobody can
+          # satisfy teaches people to ignore red checks.
+          if [ ! -f .lisa.config.json ] || \
+             ! node -e 'const c=require("./.lisa.config.json");process.exit(typeof c.tracker==="string"&&c.tracker?0:1)' 2>/dev/null; then
+            echo "No tracker configured in .lisa.config.json — work-item traceability is not enforceable here; skipping."
+            exit 0
+          fi
+          tracker="$(node -p 'require("./.lisa.config.json").tracker' 2>/dev/null | tr '[:upper:]' '[:lower:]')"
+          if [ "$tracker" = "jira" ] && { [ -z "${JIRA_API_TOKEN:-}" ] || [ -z "${JIRA_LOGIN:-}" ]; }; then
+            echo "::warning::tracker is jira but JIRA_API_TOKEN/JIRA_LOGIN are not mapped to this workflow — work-item traceability cannot verify the tracker backlink and is NOT enforced. Map both secrets in the caller's ci.yml to enable it."
+            exit 0
+          fi
+          if [ "$tracker" = "linear" ] && [ -z "${LINEAR_API_KEY:-}" ]; then
+            echo "::warning::tracker is linear but LINEAR_API_KEY is not mapped to this workflow — work-item traceability cannot verify the tracker backlink and is NOT enforced. Map the secret in the caller's ci.yml to enable it."
+            exit 0
+          fi
+          node scripts/lisa-work-item.mjs validate-pr
 
   security:
     name: Security

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -55,7 +55,7 @@ on:
         default: 'npm'
         type: string
       skip_jobs:
-        description: 'Jobs to skip (comma-separated: lint,lint_slow,typecheck,test,test:unit,test:mutation,test:integration,test:e2e,maestro_e2e,playwright_e2e,e2e_coverage,learnings_budget,threshold_ratchet,format,build,dead_code,sg_scan,npm_security_scan,zap_baseline,github_issue)'
+        description: 'Jobs to skip (comma-separated: lint,lint_slow,typecheck,test,test:unit,test:mutation,test:integration,test:e2e,maestro_e2e,playwright_e2e,e2e_coverage,learnings_budget,threshold_ratchet,work_item_traceability,format,build,dead_code,sg_scan,npm_security_scan,zap_baseline,github_issue)'
         required: false
         default: ''
         type: string
@@ -159,6 +159,20 @@ on:
         required: false
       MAESTRO_API_KEY:
         description: 'Maestro Cloud API key for mobile E2E testing'
+        required: false
+      # Work-item traceability reads the configured tracker to verify the
+      # PR's backlink. `tracker: github` needs nothing beyond the job's own
+      # github.token; jira and linear need their API credentials, and without
+      # them the job reports a credential failure rather than a real
+      # traceability failure — so a jira/linear repo MUST map these.
+      JIRA_API_TOKEN:
+        description: 'Atlassian/Jira API token (only when tracker is jira)'
+        required: false
+      JIRA_LOGIN:
+        description: 'Atlassian account email for the Jira API token (only when tracker is jira)'
+        required: false
+      LINEAR_API_KEY:
+        description: 'Linear API key (only when tracker is linear)'
         required: false
 
 # Cross-run serialization is opt-in via the `concurrency_group` input.
@@ -1475,6 +1489,136 @@ jobs:
             exit 1
           fi
           node scripts/check-threshold-ratchet.mjs --base "origin/$BASE_REF"
+
+  # ---------------------------------------------------------------------------
+  # Server-side backstop for work-item traceability (#1978, fleet rollout #2046)
+  # ---------------------------------------------------------------------------
+  # The client-side gates (commit-msg `validate-commit`, pre-push
+  # `validate-push`) are fail-safe but locally bypassable: an agent owns its
+  # `.git`, so it can repoint `refs/remotes/origin/HEAD` to empty the
+  # branch-authored range and launder commits carrying a missing, mixed, or
+  # closed-issue Work-Item trailer past the hook (#1956's security review).
+  # `validate-pr` recomputes `rev-list base..head` from SHAs in the GitHub event
+  # payload, with no exclusion logic and without ever reading a symref, so
+  # nothing in the pusher's repository can shrink the range. An EMPTY range is a
+  # failure, not a pass.
+  #
+  # This job lived only in Lisa's own ci.yml until #2046; every host repo had
+  # the bypassable client-side half and no backstop, which is the configuration
+  # #1978 called "not a gate" — and host repos are exactly where agents run
+  # unattended.
+  #
+  # Inherits the validator's exemptions: merge commits and
+  # `chore(release): x.y.z [skip ci]` subjects skip validation entirely.
+  work_item_traceability:
+    name: 🔗 Work-Item Traceability
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Only meaningful on pull_request: the range and the PR number both come
+    # from the event payload. Other events report success.
+    if: ${{ github.event_name == 'pull_request' && !contains(format(',{0},', inputs.skip_jobs), ',work_item_traceability,') }}
+    # `gh pr view` needs pull-requests:read and `gh issue view` needs
+    # issues:read. The validator writes nothing — never grant more. A reusable
+    # workflow can only DOWNGRADE the caller's grant, so a caller that does not
+    # grant issues:read leaves this job unable to read the tracker; the step
+    # below detects that and reports instead of failing falsely.
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # `rev-list base..head` needs both endpoints and everything between
+          # them. A shallow clone would make the range error out or silently
+          # under-report, which would void the gate. fetch-depth: 0 also brings
+          # every branch down as refs/remotes/origin/*, which the next step uses.
+          fetch-depth: 0
+          persist-credentials: false
+          # Check out the PR head itself, not the default synthetic
+          # refs/pull/N/merge: that ref does not exist while the PR has
+          # conflicts, and it can lag head.sha immediately after a push. Either
+          # would redden this job for a reason unrelated to traceability.
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version: ${{ inputs.node_version }}
+
+      - name: 🔗 Resolve the branch-authored commit range
+        id: range
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Default to the payload's base.sha. Prefer the base branch's CURRENT
+          # tip when it descends from it: a PR that merge-synced the base branch
+          # carries the base's own commits (whose trailers reference other, often
+          # closed, work items) inside base.sha..head, and those are not
+          # branch-authored. Starting the range at the tip drops them by plain
+          # set subtraction — no exclusion logic, nothing for a pusher to steer.
+          # The tip is whatever CI fetched from GitHub, NOT the agent-repointable
+          # local origin/HEAD symref that #1956's bypass abused.
+          base="$PR_BASE_SHA"
+          tip="$(git rev-parse -q --verify "refs/remotes/origin/${PR_BASE_REF}" || true)"
+          # The ancestry check keeps this monotonic: if the base branch was
+          # rewritten or the ref is missing, fall back to base.sha rather than
+          # widening the exclusion to an unrelated history.
+          if [ -n "$tip" ] && git merge-base --is-ancestor "$base" "$tip"; then
+            base="$tip"
+          fi
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+          echo "Validating ${base}..${PR_HEAD_SHA}"
+
+      - name: 🔗 Validate Work-Item traceability
+        # Env-var form (equivalent to --base/--head/--pr-number) keeps event
+        # payload values out of the shell command entirely.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LISA_PR_BASE_SHA: ${{ steps.range.outputs.base }}
+          LISA_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          LISA_PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Only the configured tracker's credentials are read. `tracker: github`
+          # needs none of these; jira and linear cannot verify their backlink
+          # without them, which the readiness check below reports as
+          # not-enforceable rather than as a traceability failure.
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_LOGIN: ${{ secrets.JIRA_LOGIN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+        run: |
+          if [ ! -f scripts/lisa-work-item.mjs ]; then
+            echo "scripts/lisa-work-item.mjs not present — project not yet on the work-item template; skipping."
+            exit 0
+          fi
+          # A project mid-onboarding has no tracker configured yet. The
+          # validator hard-fails on a missing `tracker`, which would redden
+          # every PR in a repo that has not adopted tracked work at all — a
+          # gate nobody can satisfy teaches people to ignore red checks.
+          if [ ! -f .lisa.config.json ] || \
+             ! node -e 'const c=require("./.lisa.config.json");process.exit(typeof c.tracker==="string"&&c.tracker?0:1)' 2>/dev/null; then
+            echo "No tracker configured in .lisa.config.json — work-item traceability is not enforceable here; skipping."
+            exit 0
+          fi
+          # Credential readiness: jira/linear cannot verify the PR backlink
+          # without their API credentials. Reporting a credential gap as a
+          # traceability failure would be a false red, so name the missing
+          # secret and skip. `tracker: github` needs only github.token.
+          tracker="$(node -p 'require("./.lisa.config.json").tracker' 2>/dev/null | tr '[:upper:]' '[:lower:]')"
+          if [ "$tracker" = "jira" ] && { [ -z "${JIRA_API_TOKEN:-}" ] || [ -z "${JIRA_LOGIN:-}" ]; }; then
+            echo "::warning::tracker is jira but JIRA_API_TOKEN/JIRA_LOGIN are not mapped to this workflow — work-item traceability cannot verify the tracker backlink and is NOT enforced. Map both secrets in the caller's ci.yml to enable it."
+            exit 0
+          fi
+          if [ "$tracker" = "linear" ] && [ -z "${LINEAR_API_KEY:-}" ]; then
+            echo "::warning::tracker is linear but LINEAR_API_KEY is not mapped to this workflow — work-item traceability cannot verify the tracker backlink and is NOT enforced. Map the secret in the caller's ci.yml to enable it."
+            exit 0
+          fi
+          node scripts/lisa-work-item.mjs validate-pr
 
   dead_code:
     name: 🗑️ Dead Code Detection

--- a/cdk/create-only/.github/workflows/ci.yml
+++ b/cdk/create-only/.github/workflows/ci.yml
@@ -133,6 +133,11 @@ jobs:
     # Reference to the quality checks workflow
     permissions:
       contents: read
+      # work_item_traceability reads the tracker issue to verify the PR
+      # backlink. A reusable workflow can only DOWNGRADE the caller's
+      # grant, so without issues:read that job cannot enforce anything.
+      issues: read
+      pull-requests: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'
@@ -143,3 +148,9 @@ jobs:
       GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
       MAESTRO_API_KEY: ${{ secrets.MAESTRO_API_KEY }}
+      # Only the configured tracker's credentials are used. tracker:
+      # github needs none of these; jira/linear cannot verify the PR
+      # backlink without them and report not-enforceable instead.
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      JIRA_LOGIN: ${{ secrets.JIRA_LOGIN }}
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}

--- a/expo/create-only/.github/workflows/ci.yml
+++ b/expo/create-only/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
     # Reference to the quality checks workflow
     permissions:
       contents: read
+      # work_item_traceability reads the tracker issue to verify the PR
+      # backlink. A reusable workflow can only DOWNGRADE the caller's
+      # grant, so without issues:read that job cannot enforce anything.
+      issues: read
+      pull-requests: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'
@@ -47,6 +52,12 @@ jobs:
       GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
       MAESTRO_API_KEY: ${{ secrets.MAESTRO_API_KEY }}
+      # Only the configured tracker's credentials are used. tracker:
+      # github needs none of these; jira/linear cannot verify the PR
+      # backlink without them and report not-enforceable instead.
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      JIRA_LOGIN: ${{ secrets.JIRA_LOGIN }}
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
   lighthouse:
     name: 💡 Lighthouse CI
     needs: [quality]

--- a/harper-fabric/copy-overwrite/.github/workflows/ci.yml
+++ b/harper-fabric/copy-overwrite/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
     name: 🔍 Quality Checks
     permissions:
       contents: read
+      # work_item_traceability reads the tracker issue to verify the PR
+      # backlink. A reusable workflow can only DOWNGRADE the caller's
+      # grant, so without issues:read that job cannot enforce anything.
+      issues: read
+      pull-requests: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'
@@ -23,3 +28,9 @@ jobs:
       GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
       MAESTRO_API_KEY: ${{ secrets.MAESTRO_API_KEY }}
+      # Only the configured tracker's credentials are used. tracker:
+      # github needs none of these; jira/linear cannot verify the PR
+      # backlink without them and report not-enforceable instead.
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      JIRA_LOGIN: ${{ secrets.JIRA_LOGIN }}
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}

--- a/nestjs/create-only/.github/workflows/ci.yml
+++ b/nestjs/create-only/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
     # Reference to the quality checks workflow
     permissions:
       contents: read
+      # work_item_traceability reads the tracker issue to verify the PR
+      # backlink. A reusable workflow can only DOWNGRADE the caller's
+      # grant, so without issues:read that job cannot enforce anything.
+      issues: read
+      pull-requests: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'
@@ -25,6 +30,12 @@ jobs:
       GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
       MAESTRO_API_KEY: ${{ secrets.MAESTRO_API_KEY }}
+      # Only the configured tracker's credentials are used. tracker:
+      # github needs none of these; jira/linear cannot verify the PR
+      # backlink without them and report not-enforceable instead.
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      JIRA_LOGIN: ${{ secrets.JIRA_LOGIN }}
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
 
   zap:
     name: 🕷️ ZAP Baseline Scan

--- a/phaser/copy-overwrite/.github/workflows/ci.yml
+++ b/phaser/copy-overwrite/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ jobs:
     name: 🔍 Quality Checks
     permissions:
       contents: read
+      # work_item_traceability reads the tracker issue to verify the PR
+      # backlink. A reusable workflow can only DOWNGRADE the caller's
+      # grant, so without issues:read that job cannot enforce anything.
+      issues: read
+      pull-requests: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'
@@ -29,3 +34,9 @@ jobs:
       GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
       MAESTRO_API_KEY: ${{ secrets.MAESTRO_API_KEY }}
+      # Only the configured tracker's credentials are used. tracker:
+      # github needs none of these; jira/linear cannot verify the PR
+      # backlink without them and report not-enforceable instead.
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      JIRA_LOGIN: ${{ secrets.JIRA_LOGIN }}
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}

--- a/rails/create-only/.github/workflows/ci.yml
+++ b/rails/create-only/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
       contents: read
       checks: write
       pull-requests: write
+      # work_item_traceability reads the tracker issue to verify the PR
+      # backlink. A reusable workflow can only DOWNGRADE the caller's
+      # grant, so without issues:read that job cannot enforce anything.
+      issues: read
     uses: CodySwannGT/lisa/.github/workflows/quality-rails.yml@main
     # Rails projects default to PostgreSQL. For a MySQL app, uncomment:
     # with:
@@ -27,3 +31,9 @@ jobs:
     secrets:
       GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+      # Only the configured tracker's credentials are used. tracker:
+      # github needs none of these; jira/linear cannot verify the PR
+      # backlink without them and report not-enforceable instead.
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      JIRA_LOGIN: ${{ secrets.JIRA_LOGIN }}
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}

--- a/rails/github-rulesets/quality-checks.json
+++ b/rails/github-rulesets/quality-checks.json
@@ -43,6 +43,10 @@
           {
             "context": "Quality Checks / Security",
             "integration_id": 15368
+          },
+          {
+            "context": "Quality Checks / 🔗 Work-Item Traceability",
+            "integration_id": 15368
           }
         ]
       }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -47,7 +47,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "cdk/copy-overwrite/vitest.config.ts":
       "ce14179d4ab31011bb012ee1669af7d86b5189bdf2934e0bd9dd666a30e3d01e",
     "cdk/create-only/.github/workflows/ci.yml":
-      "04cca8fbcb7a5c6da1aeb2b2d00d7a328d15618e4252f1d9dd495052d264d0f5",
+      "dc384ef9bd46af723cafd8d140f6d58d2630cfa8a7b07104254d8ecd4a556636",
     "cdk/create-only/.github/workflows/deploy.yml":
       "2746e78fb0fbe7b23b30bbcb0f83171e16f6804fd467b3d41d3c69970572af3f",
     "cdk/create-only/cdk.json":
@@ -147,7 +147,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/copy-overwrite/tsconfig.json":
       "c92e2c2c109e8794ee351f634361ef46297f5a0cd606aaf5c19911da836df307",
     "expo/create-only/.github/workflows/ci.yml":
-      "3ade267cca43e33c68e56b8c4f5d821ed03f642e5a11aa8b70b79e76ec41b96f",
+      "bf75c9d3b4f4a2cb24c2214d9fc27a9cb2247a6694b0cf02c40032b4d3e87cd9",
     "expo/create-only/.github/workflows/deploy.yml":
       "0978b1f4e19e1ff66bb8cdd037d36a3751d4e917db7ceb5bcf100fad36768516",
     "expo/create-only/.github/workflows/maestro-e2e.yml":
@@ -195,7 +195,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "harper-fabric/copy-overwrite/.github/dependabot.yml":
       "e28fde0d906478b3fb7d6b7fc16f7fc5a4a0a20d8160f547f2b4be97c90578b7",
     "harper-fabric/copy-overwrite/.github/workflows/ci.yml":
-      "6823d87b989f1fbeb2f471552a041f5c9476e67ece8f6ec7ba75e97738afe2f9",
+      "d8227671ebec99255c2adac8ef76ec29cdfa5b8f4c56fe376a37dab08accc0cc",
     "harper-fabric/copy-overwrite/ast-grep/rules/harper/no-early-return-in-search-loop.yml":
       "c25106e1d4ee3566c70824ba4ecbc2ee0345014008aedb4fac56d0be23029264",
     "harper-fabric/copy-overwrite/ast-grep/rules/harper/no-empty-conditions-with-sort.yml":
@@ -295,7 +295,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "nestjs/create-only/.github/k6/thresholds/strict.json":
       "e121ec72de4596b95c013a8c71f03653bcdf057cf7f8d1fec6f0e13c1381867f",
     "nestjs/create-only/.github/workflows/ci.yml":
-      "8db7de7f2e3eb2a1605539849a346b55281cfcd9951526f9d5a1757a210da3c6",
+      "0985668e6d0478f1993bed8ccd398601d8e73376afd8775e1269ae129418152e",
     "nestjs/create-only/.github/workflows/deploy.yml":
       "78abfa87639cb7506418dd34387963a0557614933d823e6fa0413395166b945b",
     "nestjs/create-only/.zap/baseline.conf":
@@ -339,7 +339,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "phaser/copy-contents/gitignore":
       "4b8d1a5817d35f64f5d4859f9184ebe2e1dc42e63f8e9269fff233e2ec258d6c",
     "phaser/copy-overwrite/.github/workflows/ci.yml":
-      "02b7fa8ceb9950b72d000fa1688177e747ef549d1b49d2cb4b1db97ec94a3a61",
+      "7b037b5961569a09e8407e6b9bf9a91377208f76bc309680870c2b56ff2f4813",
     "phaser/copy-overwrite/.husky/pre-push.verify":
       "fef6694c2fde6178f46c62936d2b19515adce4fc8ac694ea66d8342aa1474ee7",
     "phaser/copy-overwrite/ast-grep/rule-tests/.gitkeep":
@@ -1779,7 +1779,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/copy-overwrite/sgconfig.yml":
       "0ffe058c791d4d323f98104cf78c763bb0356d88739042060ceb86b6b1cb78d7",
     "rails/create-only/.github/workflows/ci.yml":
-      "599805266a47b5c0039145a11df225d4db6c59d35b2ecc582a44d55ab7f4b1f0",
+      "ad53014bdd6cf15bfadfaef7740b6094c3c7bd044f9d176c4938154da983529d",
     "rails/create-only/.github/workflows/claude-code-review-response.yml":
       "bfbe3127c4941c35886d324d439ae0302fbccd74a11cb4decf05a21195efa0e9",
     "rails/create-only/.github/workflows/claude-nightly-code-complexity.yml":
@@ -1823,7 +1823,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/deletions.json":
       "eeadf9a2b1677913199a235091a8d6190477f3e2a5fd598d62cf658cb59a8099",
     "rails/github-rulesets/quality-checks.json":
-      "ea42f2bb938881bc6ec129e7300a2b824313951031d4720f46e944c4dfe1a9da",
+      "0ec1c366589edbaa6b8f45f940cef3ada5ed7b1a956d98d3fa6034b0f78fbc7c",
     "rails/merge/.claude/settings.json":
       "9c49f8c7c453f8749c90def3e22d412c3345c533d24b30dc7745ffa052ad6fa1",
     "scripts/build-plugins.sh":
@@ -2029,7 +2029,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/create-only/.github/workflows/auto-update-pr-branches.yml":
       "cf185555bcbe8e9957333abcae2e0c20e00875f8d867f70134efbd2a5c974ee5",
     "typescript/create-only/.github/workflows/ci.yml":
-      "d8c7f65e408a21e344b3a518ddf088d5ada4b08eb24d6b2cfa38ec6755ca8b5a",
+      "dac98b7ab5a7397461e459b2553101bfdc6451d28b42f3b0115056b62cfb8b1d",
     "typescript/create-only/.github/workflows/claude-ci-auto-fix.yml":
       "a9155c10d0c28eba0f77ec5bc2a2d99b0eeb5d499218aac81948d3f27e6aa4fb",
     "typescript/create-only/.github/workflows/claude-code-review-response.yml":
@@ -2071,7 +2071,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/deletions.json":
       "fe5f44b7a02148eacc429782e948b1c4aee302d1d56524cc16adec5489bbc308",
     "typescript/github-rulesets/quality-checks.json":
-      "89b9e09267cdb65865728d0e873de9c1225b8ca796e67f06fa8b72ccf6d4515e",
+      "d92599b203071b99b8fac1422b8493d2546138961ef04ba98176bc400af60945",
     "typescript/merge/.claude/settings.json":
       "834e6456cae81f45073bbbb08bf731fef043efb30cae2658cb4a59f17e66d165",
     "typescript/merge/.oxlintrc.json":

--- a/tests/unit/hooks/work-item-wiring.test.ts
+++ b/tests/unit/hooks/work-item-wiring.test.ts
@@ -15,6 +15,9 @@ const read = (file: string): string => readFileSync(path.resolve(file), "utf8");
 const BASH = "/bin/bash";
 const GIT = "/usr/bin/git";
 
+/** The validator invocation the backstop job must actually run. */
+const VALIDATE_PR = "scripts/lisa-work-item.mjs validate-pr";
+
 /** Disposable repositories created by the CI-range cases, removed after them. */
 const roots: string[] = [];
 
@@ -124,19 +127,18 @@ describe("work-item Git enforcement wiring", () => {
    * `rev-list base..head` server-side with no exclusion and no symref, so it is
    * the designed backstop; it only backstops anything if CI actually runs it.
    */
-  describe("server-side validate-pr backstop in Lisa's own CI (#1978)", () => {
-    const ci = loadYaml(read(".github/workflows/ci.yml")) as CiWorkflow;
+  describe.each([
+    ".github/workflows/quality.yml",
+    ".github/workflows/quality-rails.yml",
+  ])("server-side validate-pr backstop in %s (#1978, #2046)", workflow => {
+    const ci = loadYaml(read(workflow)) as CiWorkflow;
     const job = ci.jobs?.["work_item_traceability"];
     const steps = job?.steps ?? [];
 
     it("runs validate-pr on pull requests only", () => {
       expect(job).toBeDefined();
       expect(job?.if).toContain("github.event_name == 'pull_request'");
-      expect(
-        steps.some(step =>
-          step.run?.includes("scripts/lisa-work-item.mjs validate-pr")
-        )
-      ).toBe(true);
+      expect(steps.some(step => step.run?.includes(VALIDATE_PR))).toBe(true);
     });
 
     it("checks out enough history for rev-list base..head to resolve", () => {
@@ -170,9 +172,7 @@ describe("work-item Git enforcement wiring", () => {
     });
 
     it("passes the server-supplied range and PR number through the env-var form", () => {
-      const validate = steps.find(step =>
-        step.run?.includes("scripts/lisa-work-item.mjs validate-pr")
-      );
+      const validate = steps.find(step => step.run?.includes(VALIDATE_PR));
       // Env-var form (not shell-interpolated argv) keeps event payload values
       // out of the `run:` string entirely.
       expect(validate?.env?.["LISA_PR_BASE_SHA"]).toBeTruthy();
@@ -291,6 +291,76 @@ describe("work-item Git enforcement wiring", () => {
         "pull-requests": "read",
       });
     });
+
+    it("stays skippable so a repo can adopt tracked work on its own schedule", () => {
+      // The reusable workflows are consumed @main, so this job goes live
+      // fleet-wide the moment it merges. Without a skip token a repo mid
+      // standards-adoption has no way to land anything.
+      expect(job?.if).toContain("work_item_traceability,");
+    });
+
+    it("reports instead of failing when the gate is not enforceable", () => {
+      const validate = steps.find(step => step.run?.includes(VALIDATE_PR));
+      // A repo with no tracker configured, or a jira/linear repo whose
+      // credentials were never mapped, cannot satisfy this gate at all. Failing
+      // there would be a red check nobody can fix, which teaches people to
+      // ignore red checks — so those paths exit 0 with an explanation.
+      expect(validate?.run).toContain("No tracker configured");
+      expect(validate?.run).toContain("JIRA_API_TOKEN");
+      expect(validate?.run).toContain("LINEAR_API_KEY");
+    });
+  });
+
+  /**
+   * #2046: the job only backstops a downstream repo if that repo's caller
+   * grants the scopes it needs. A reusable workflow can only DOWNGRADE the
+   * caller's grant, so a caller missing `issues: read` silently produces a job
+   * that cannot read the tracker.
+   */
+  it.each([
+    "typescript/create-only/.github/workflows/ci.yml",
+    "expo/create-only/.github/workflows/ci.yml",
+    "nestjs/create-only/.github/workflows/ci.yml",
+    "cdk/create-only/.github/workflows/ci.yml",
+    "rails/create-only/.github/workflows/ci.yml",
+    "harper-fabric/copy-overwrite/.github/workflows/ci.yml",
+    "phaser/copy-overwrite/.github/workflows/ci.yml",
+  ])("%s grants the caller scopes the backstop needs", template => {
+    const caller = loadYaml(read(template)) as CiWorkflow;
+    const job = Object.values(caller.jobs ?? {}).find(candidate =>
+      String((candidate as { uses?: string }).uses ?? "").includes("/quality")
+    );
+
+    expect(job?.permissions?.["issues"]).toBe("read");
+    expect(job?.permissions?.["pull-requests"]).toMatch(/read|write/u);
+  });
+
+  it.each([
+    [
+      "typescript/github-rulesets/quality-checks.json",
+      "🔍 Quality Checks / 🔗 Work-Item Traceability",
+    ],
+    [
+      "rails/github-rulesets/quality-checks.json",
+      "Quality Checks / 🔗 Work-Item Traceability",
+    ],
+  ])("%s requires the backstop context", (ruleset, context) => {
+    // A job that reports red but is not a REQUIRED context does not gate
+    // anything — auto-merge sails past it. That was the #2039 gap.
+    const parsed = JSON.parse(read(ruleset)) as {
+      rules: {
+        parameters?: {
+          required_status_checks?: { context: string }[];
+        };
+        type: string;
+      }[];
+    };
+    const contexts = parsed.rules
+      .filter(rule => rule.type === "required_status_checks")
+      .flatMap(rule => rule.parameters?.required_status_checks ?? [])
+      .map(check => check.context);
+
+    expect(contexts).toContain(context);
   });
 
   it("gives Rails the same gates and a single stdin consumer", () => {

--- a/typescript/create-only/.github/workflows/ci.yml
+++ b/typescript/create-only/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      # work_item_traceability reads the tracker issue to verify the PR
+      # backlink. A reusable workflow can only DOWNGRADE the caller's
+      # grant, so without issues:read that job cannot enforce anything.
+      issues: read
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     with:
       node_version: '22.21.1'
@@ -25,3 +29,9 @@ jobs:
       GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
       MAESTRO_API_KEY: ${{ secrets.MAESTRO_API_KEY }}
+      # Only the configured tracker's credentials are used. tracker:
+      # github needs none of these; jira/linear cannot verify the PR
+      # backlink without them and report not-enforceable instead.
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      JIRA_LOGIN: ${{ secrets.JIRA_LOGIN }}
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}

--- a/typescript/github-rulesets/quality-checks.json
+++ b/typescript/github-rulesets/quality-checks.json
@@ -59,6 +59,10 @@
           {
             "context": "🔍 Quality Checks / 🧪 Run Integration Tests",
             "integration_id": 15368
+          },
+          {
+            "context": "🔍 Quality Checks / 🔗 Work-Item Traceability",
+            "integration_id": 15368
           }
         ]
       }


### PR DESCRIPTION
## Summary

Ships the `🔗 Work-Item Traceability` backstop (`validate-pr`) to every downstream project by moving it from Lisa's own `ci.yml` into the reusable `quality.yml` and `quality-rails.yml`, and makes it an actually-gating required check.

**Why it matters.** Host projects already ship the client-side half — `commit-msg` → `validate-commit`, `pre-push` → `validate-push`, and the validator itself via `all/copy-overwrite/scripts/lisa-work-item.mjs` — and none of the server-side backstop. Per #1978 and #1956's security review, the client-side gate is locally bypassable: an agent owns its `.git`, so it can repoint `refs/remotes/origin/HEAD` to empty the branch-authored range and launder commits carrying a missing, mixed, or closed-issue `Work-Item:` trailer past the hook. That left every host repo in the configuration #1978 called "not a gate" — and host repos are exactly where agents run unattended.

**Why it also didn't gate on Lisa.** #2039 merged with this check red: a job that reports failure but isn't a *required context* doesn't block anything. Auto-merge sailed past it.

## What the validator checks

1. Every non-merge, non-release commit in the branch-authored range carries a `Work-Item:` trailer (an **empty range is a failure**, not a pass).
2. All those commits reference the **same** work item.
3. The **PR body** carries a matching `Work-Item:` line.
4. The tracker issue has a verified backlink to the PR (native reference or a comment containing the PR URL), and the issue itself is live.

Read-only throughout: `issues: read` + `pull-requests: read`.

## Making a fleet-wide rollout safe

The reusable workflows are consumed `@main`, so this goes live everywhere on merge — the same delivery path the threshold ratchet's CI layer used. Three properties keep that from being a fleet-wide outage:

- **Skippable** via `skip_jobs: work_item_traceability`, so a repo mid standards-adoption can still land work.
- **Not-enforceable states report and exit 0** rather than failing — no `tracker` configured in `.lisa.config.json`, or a jira/linear tracker whose credentials were never mapped. A red check nobody can satisfy just teaches people to ignore red checks.
- **Tracker credentials added to the secrets surface** (`JIRA_API_TOKEN`, `JIRA_LOGIN`, `LINEAR_API_KEY`) and mapped explicitly in every caller template — never `secrets: inherit`.

## Caller scope (the non-obvious part)

A reusable workflow can only **downgrade** the caller's grant, so the job silently can't read the tracker unless the caller grants the scope. Every caller template now grants `issues: read`, and five that never granted `pull-requests: read` at all — expo, nestjs, cdk, harper-fabric, phaser — now do. Without it `gh pr view` can't read the PR body that check 3 compares against.

## Files

- `.github/workflows/quality.yml`, `quality-rails.yml` — the job, the skip token, the secrets surface.
- `.github/workflows/ci.yml` — standalone job removed (now inherited from the reusable workflow); `issues: read` added to the caller.
- 7 caller templates — `issues: read`, `pull-requests: read` where missing, tracker secret mappings.
- `typescript/` + `rails/github-rulesets/quality-checks.json` — the new required context.
- `tests/unit/hooks/work-item-wiring.test.ts` — the existing backstop suite now runs against **both** reusable workflows, plus new coverage for caller grants, ruleset contexts, the skip token, and the not-enforceable paths.

## Verification

- `tests/unit/hooks/` + `tests/unit/scripts/`: **999 tests, 56 files, all passing**.
- All three workflow YAML files parse.
- Upstream evidence manifest rebuilt in the same commit.

## Follow-up (not in this PR)

Existing downstream repos have `ci.yml` as **create-only**, so they will not receive the caller-side `issues: read` grant or the secret mappings automatically. Until each repo updates its caller, the job runs but reports not-enforceable rather than gating. A migration to patch installed callers is the natural next step.

Closes #2046

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2046
