### PR TITLE
fix(ci): stop work_item_traceability escalating caller permissions

### DIFF
--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -149,13 +149,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.event_name == 'pull_request' && !contains(format(',{0},', inputs.skip_jobs), ',work_item_traceability,') }}
-    # The validator writes nothing — never grant more. A reusable workflow can
-    # only DOWNGRADE the caller's grant, so a caller that does not grant
-    # issues:read leaves this job unable to read the tracker.
-    permissions:
-      contents: read
-      issues: read
-      pull-requests: read
+    # DELIBERATELY no `permissions:` block — see the quality.yml counterpart.
+    # Requesting a scope the caller never held is a startup_failure for the
+    # ENTIRE run, and these workflows are consumed @main by repos whose ci.yml
+    # is create-only and can never self-heal.
 
     steps:
       - name: 📥 Checkout repository
@@ -218,6 +215,17 @@ jobs:
           fi
           if [ "$tracker" = "linear" ] && [ -z "${LINEAR_API_KEY:-}" ]; then
             echo "::warning::tracker is linear but LINEAR_API_KEY is not mapped to this workflow — work-item traceability cannot verify the tracker backlink and is NOT enforced. Map the secret in the caller's ci.yml to enable it."
+            exit 0
+          fi
+          # Token-scope readiness (github tracker): the inherited caller token
+          # may lack issues:read, in which case the validator cannot read the
+          # tracker issue at all. That is a caller-configuration gap, not a
+          # traceability failure, so name it and skip rather than blocking a PR
+          # nobody can unblock. Repos whose ci.yml grants issues:read enforce
+          # for real.
+          if [ "$tracker" = "github" ] && \
+             ! gh api "repos/${GITHUB_REPOSITORY}/issues?per_page=1" >/dev/null 2>&1; then
+            echo "::warning::The caller workflow does not grant issues:read, so the tracker issue cannot be read and work-item traceability is NOT enforced. Add 'issues: read' to the quality job's permissions in this repo's .github/workflows/ci.yml to enable it."
             exit 0
           fi
           node scripts/lisa-work-item.mjs validate-pr

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1517,15 +1517,15 @@ jobs:
     # Only meaningful on pull_request: the range and the PR number both come
     # from the event payload. Other events report success.
     if: ${{ github.event_name == 'pull_request' && !contains(format(',{0},', inputs.skip_jobs), ',work_item_traceability,') }}
-    # `gh pr view` needs pull-requests:read and `gh issue view` needs
-    # issues:read. The validator writes nothing — never grant more. A reusable
-    # workflow can only DOWNGRADE the caller's grant, so a caller that does not
-    # grant issues:read leaves this job unable to read the tracker; the step
-    # below detects that and reports instead of failing falsely.
-    permissions:
-      contents: read
-      issues: read
-      pull-requests: read
+    # DELIBERATELY no `permissions:` block. This job needs pull-requests:read
+    # (`gh pr view`) and issues:read (`gh issue view`), but a called workflow
+    # may only DOWNGRADE the caller's grant: requesting a scope the caller never
+    # held is a startup_failure for the ENTIRE run, not a skipped job. These
+    # workflows are consumed @main by repos whose ci.yml is create-only and can
+    # never self-heal, so an escalation here would break every one of them —
+    # including on push paths where this job does not even run. Inheriting the
+    # caller's token instead keeps the blast radius inside this job, and the
+    # readiness probe below turns a missing scope into a report, not a red X.
 
     steps:
       - name: 📥 Checkout repository
@@ -1616,6 +1616,17 @@ jobs:
           fi
           if [ "$tracker" = "linear" ] && [ -z "${LINEAR_API_KEY:-}" ]; then
             echo "::warning::tracker is linear but LINEAR_API_KEY is not mapped to this workflow — work-item traceability cannot verify the tracker backlink and is NOT enforced. Map the secret in the caller's ci.yml to enable it."
+            exit 0
+          fi
+          # Token-scope readiness (github tracker): the inherited caller token
+          # may lack issues:read, in which case the validator cannot read the
+          # tracker issue at all. That is a caller-configuration gap, not a
+          # traceability failure, so name it and skip rather than blocking a PR
+          # nobody can unblock. Repos whose ci.yml grants issues:read enforce
+          # for real.
+          if [ "$tracker" = "github" ] && \
+             ! gh api "repos/${GITHUB_REPOSITORY}/issues?per_page=1" >/dev/null 2>&1; then
+            echo "::warning::The caller workflow does not grant issues:read, so the tracker issue cannot be read and work-item traceability is NOT enforced. Add 'issues: read' to the quality job's permissions in this repo's .github/workflows/ci.yml to enable it."
             exit 0
           fi
           node scripts/lisa-work-item.mjs validate-pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,6 +358,12 @@ jobs:
     needs: [release_init, release_schedule]
     permissions:
       contents: read
+      # A called workflow may only DOWNGRADE the caller's grant, and requesting
+      # a scope the caller never held is a startup_failure for the whole run —
+      # not a skipped job. quality.yml's work_item_traceability job requests
+      # issues:read, so every caller must grant it even when that job will not
+      # run (it is pull_request-only, and this path is a push).
+      issues: read
       pull-requests: read
     uses: ./.github/workflows/quality.yml
     with:

--- a/tests/unit/hooks/work-item-wiring.test.ts
+++ b/tests/unit/hooks/work-item-wiring.test.ts
@@ -282,14 +282,23 @@ describe("work-item Git enforcement wiring", () => {
       });
     });
 
-    it("grants the tracker reads the validator performs, and nothing more", () => {
-      // `gh pr view` needs pull-requests:read and `gh issue view` needs
-      // issues:read; the job writes nothing anywhere.
-      expect(job?.permissions).toEqual({
-        contents: "read",
-        issues: "read",
-        "pull-requests": "read",
-      });
+    it("never escalates permissions above the caller's grant", () => {
+      // Regression guard for the #2046 startup_failure. A called workflow may
+      // only DOWNGRADE the caller's grant: requesting a scope the caller never
+      // held fails the ENTIRE run at startup, not just this job — and it does
+      // so even on push paths where this job never runs. These workflows are
+      // consumed @main by repos whose ci.yml is create-only and can never
+      // self-heal, so an escalation here breaks the whole fleet at once.
+      // Inheriting keeps the blast radius inside this job.
+      expect(job?.permissions).toBeUndefined();
+    });
+
+    it("reports rather than blocks when the inherited token cannot read the tracker", () => {
+      const validate = steps.find(step => step.run?.includes(VALIDATE_PR));
+      // Without issues:read the validator cannot read the issue at all. That
+      // is a caller-configuration gap, not a traceability failure — blocking
+      // there would wedge every PR in a repo nobody can unwedge.
+      expect(validate?.run).toContain("issues:read");
     });
 
     it("stays skippable so a repo can adopt tracked work on its own schedule", () => {


### PR DESCRIPTION
## Impact — this is live right now

#2047 gave the `work_item_traceability` job a `permissions:` block requesting `issues: read`. A **called** workflow may only DOWNGRADE the caller's grant: requesting a scope the caller never held is a **`startup_failure` for the entire run**, not a skipped job — and it fires even on paths where the job would never execute (it is `pull_request`-only).

Both reusable workflows are consumed `@main`, and downstream `ci.yml` is create-only, so every installed repo whose caller lacks `issues: read` broke simultaneously and cannot self-heal.

**Observed:**
- Lisa's `Release and Deploy` for merge commit `b3af12c60` → `startup_failure` via `deploy.yml` → `release.yml` → `quality.yml` (release.yml's caller granted only contents + pull-requests). That is why #2047 is merged but **unreleased** — v2.300.13 was cut from the preceding commit.
- `CodySwannGT/railsstarter`'s installed caller grants `contents: read` + `pull-requests: write`, no `issues: read` — same failure on its next PR.

## Fix

- **Remove the `permissions:` block** from the job in both `quality.yml` and `quality-rails.yml`. It now inherits the caller's token, so the blast radius stays inside the job instead of failing the run at startup.
- **Token-scope readiness probe**: when the tracker is `github` and the inherited token cannot list issues, the job warns and exits 0 — matching how the existing missing-tracker and missing-credential paths already behave. A gate nobody can satisfy teaches people to ignore red checks.
- **`release.yml`'s quality caller gains `issues: read`**, so Lisa's own release path enforces for real rather than reporting not-enforceable.

## Regression guard

The wiring suite now asserts the job declares **no** `permissions:` block, in both workflows — the inverse of what it asserted before, with the reasoning recorded inline so nobody re-adds it.

## Verification

- `tests/unit/hooks/work-item-wiring.test.ts`: 37 passing.
- Parsed all three workflows and confirmed `work_item_traceability.permissions` is `undefined` in each.
- Upstream evidence manifest rebuilt in the same commit.

Closes #2049

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2049