### PR TITLE
chore(ci): drop dead issues:read from expo/nestjs deploy templates

### DIFF
--- a/expo/create-only/.github/workflows/deploy.yml
+++ b/expo/create-only/.github/workflows/deploy.yml
@@ -92,7 +92,6 @@ jobs:
     needs: [determine_environment]
     permissions:
       contents: write
-      issues: read
       pull-requests: read
     with:
       environment: ${{ needs.determine_environment.outputs.environment }}

--- a/nestjs/create-only/.github/workflows/deploy.yml
+++ b/nestjs/create-only/.github/workflows/deploy.yml
@@ -85,7 +85,6 @@ jobs:
     needs: [determine_environment]
     permissions:
       contents: write
-      issues: read
       pull-requests: read
     with:
       environment: ${{ needs.determine_environment.outputs.environment }}

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -149,7 +149,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/create-only/.github/workflows/ci.yml":
       "bf75c9d3b4f4a2cb24c2214d9fc27a9cb2247a6694b0cf02c40032b4d3e87cd9",
     "expo/create-only/.github/workflows/deploy.yml":
-      "49a1ae719c1a917f7fee2fc9ef405397308d01b56d75d94a7d03e3dfadd4dce7",
+      "0978b1f4e19e1ff66bb8cdd037d36a3751d4e917db7ceb5bcf100fad36768516",
     "expo/create-only/.github/workflows/maestro-e2e.yml":
       "444367a8cefaa81b484bc6eff5923c34177e10f6a67cbf1befec00c9d0d1d36b",
     "expo/create-only/.zap/baseline.conf":
@@ -297,7 +297,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "nestjs/create-only/.github/workflows/ci.yml":
       "0985668e6d0478f1993bed8ccd398601d8e73376afd8775e1269ae129418152e",
     "nestjs/create-only/.github/workflows/deploy.yml":
-      "d1b91b1de805c58602764f9041e3c9755682509d8d1de5c2ee1f0ada96665dca",
+      "78abfa87639cb7506418dd34387963a0557614933d823e6fa0413395166b945b",
     "nestjs/create-only/.zap/baseline.conf":
       "a7cd559b014555ef2efe7a6ce129384ec376ce4d66d5bc3ae9e2f3f883172c4d",
     "nestjs/create-only/scripts/zap-baseline.sh":

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -808,9 +808,10 @@ describe("release and deploy workflows", () => {
     expect(nestjsDeployWorkflow.jobs?.verify_vpn.permissions).toEqual({
       contents: "read",
     });
+    // No issues scope: release.yml requests none, and a host granting a scope
+    // its callee never asks for is dead weight, not defense in depth.
     expect(nestjsDeployWorkflow.jobs?.release.permissions).toEqual({
       contents: "write",
-      issues: "read",
       "pull-requests": "read",
     });
   });
@@ -835,7 +836,6 @@ describe("release and deploy workflows", () => {
   it("grants reusable Expo release and deploy jobs the permissions they request", () => {
     expect(expoDeployWorkflow.jobs?.release.permissions).toEqual({
       contents: "write",
-      issues: "read",
       "pull-requests": "read",
     });
     expect(expoDeployWorkflow.jobs?.determine_environment.permissions).toEqual({


### PR DESCRIPTION
## Summary

#2051 granted `issues: read` on the `release` job of the expo and nestjs host `deploy.yml` templates, to satisfy the escalation #2050 had introduced in `release.yml`. #2053 removed that escalation instead, so these grants now have nothing to satisfy.

## Verified dead before removing

- `release.yml` has exactly one `uses:` job — `quality` → `quality.yml` — and **no job in it requests an `issues` scope** (confirmed by parsing the workflow, not by reading it).
- `quality.yml`'s `work_item_traceability` job has declared no permissions of its own since #2050; it inherits.
- The `issues: write` requests in this chain belong to `create-issue-on-failure.yml` / `create-github-issue-on-failure.yml`, which the deploy `release` job does not call. No other job in either template carries an `issues` grant, so nothing on that path is touched.

## Kept

`contents: write` and `pull-requests: read` stay — `release.yml` genuinely needs the first for tagging and the second for `quality.yml`'s own request. Only the scope nothing asks for is removed.

The two contract assertions are updated to match, with the reasoning inline so the grants don't get re-added as phantom defense in depth.

## Verification

- `tests/integration/quality-workflow.test.ts`: 45 passing.
- `typecheck` and `eslint` clean (one pre-existing jsdoc warning, untouched by this change).
- Evidence manifest rebuilt in the same commit.

Closes #2054

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2054


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Reduced release workflow permissions by removing unnecessary read access to issues while retaining required repository and pull request permissions.

* **Tests**
  * Updated workflow validation to confirm the narrower permission scope for Expo and NestJS releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->