### PR TITLE
test(readiness): cover B2 action publish bypasses

### DIFF
--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7761,6 +7761,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/doctor-readiness-context-precision.test.ts": true,
     "tests/unit/cli/doctor-readiness-context.test.ts": true,
     "tests/unit/cli/doctor-readiness-credentials-round2.test.ts": true,
+    "tests/unit/cli/doctor-readiness-delivery-action-publish.test.ts": true,
     "tests/unit/cli/doctor-readiness-delivery-artifact.test.ts": true,
     "tests/unit/cli/doctor-readiness-delivery-multiple-publish.test.ts": true,
     "tests/unit/cli/doctor-readiness-delivery-triggers.test.ts": true,

--- a/tests/unit/cli/doctor-readiness-delivery-action-publish.test.ts
+++ b/tests/unit/cli/doctor-readiness-delivery-action-publish.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression coverage for B2 action-based publish steps from #1903.
+ * @module tests/unit/cli/doctor-readiness-delivery-action-publish
+ */
+import { rm } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { assessReadiness } from "../../../src/cli/doctor-readiness-blockers.js";
+import { assessDeliveryAuthorityDimension } from "../../../src/cli/doctor-readiness-delivery.js";
+import {
+  asFindings,
+  FAIL,
+  JOBS,
+  makeScratchRepo,
+  ON,
+  PUBLISH_JOB,
+  PUSH,
+  RELEASE_NAME,
+  RELEASE_YML,
+  RUN_PACK,
+  RUNS_ON,
+  STEPS,
+  TAGS,
+  writeWorkflow,
+} from "../../helpers/readiness-workflow-fixtures.js";
+
+let tempDir: string | undefined;
+
+/**
+ * Resolve a scratch repository for one test case.
+ * @returns Temporary directory path
+ */
+async function getTempDir(): Promise<string> {
+  tempDir ??= await makeScratchRepo("action-publish");
+  return tempDir;
+}
+
+afterEach(async () => {
+  if (tempDir) {
+    await rm(tempDir, { force: true, recursive: true });
+    tempDir = undefined;
+  }
+});
+
+describe("assessDeliveryAuthorityDimension — B2 action publish steps", () => {
+  it("FAILs when PyPI publish action ships a locally built artifact", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, RELEASE_YML, [
+      RELEASE_NAME,
+      ON,
+      PUSH,
+      TAGS,
+      JOBS,
+      PUBLISH_JOB,
+      RUNS_ON,
+      STEPS,
+      RUN_PACK,
+      "      - uses: pypa/gh-action-pypi-publish@release/v1",
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    expect(assessReadiness([record]).blockers[0].id).toBe("B2");
+    expect(String(asFindings(record.findings)[0].evidence)).toContain(
+      "pypa/gh-action-pypi-publish@release/v1"
+    );
+  });
+
+  it("FAILs when GitHub release action ships a locally built artifact", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, RELEASE_YML, [
+      RELEASE_NAME,
+      ON,
+      PUSH,
+      TAGS,
+      JOBS,
+      PUBLISH_JOB,
+      RUNS_ON,
+      STEPS,
+      RUN_PACK,
+      "      - uses: softprops/action-gh-release@v2",
+      "        with:",
+      "          files: dist/*.tgz",
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    expect(assessReadiness([record]).blockers[0].id).toBe("B2");
+    expect(String(asFindings(record.findings)[0].evidence)).toContain(
+      "softprops/action-gh-release@v2"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add focused B2 regression coverage for action-based publish steps from #1903.
- Pin PyPI and GitHub release actions shipping locally built artifacts as B2 failures.
- Refresh the upstream evidence manifest for the new test file.

## Verification

- bun test tests/unit/cli/doctor-readiness-delivery-action-publish.test.ts tests/unit/cli/doctor-readiness-delivery-artifact.test.ts
- bun run typecheck
- bun run lint
- bunx prettier --check tests/unit/cli/doctor-readiness-delivery-action-publish.test.ts tests/unit/cli/doctor-readiness-delivery-artifact.test.ts
- bun run check:upstream-evidence-manifest
- pre-push gate: typecheck, production audit, slow lint, knip, full unit coverage, integration tests, plugin parity

Work-Item: CodySwannGT/lisa#1903