### PR TITLE
feat(prd): requirement-atom definition of ready (29148/EARS/fit criteria)

### DIFF
--- a/plugins/lisa-agy/skills/lisa-confluence-to-tracker/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-confluence-to-tracker/SKILL.md
@@ -224,6 +224,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa-agy/skills/lisa-confluence-write-prd/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-confluence-write-prd/SKILL.md
@@ -99,6 +99,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - All access via `lisa-atlassian-access`; never call Atlassian directly.
 - State is the parent page, not a label — never attempt Confluence label writes (they 401 on scoped
   tokens; see `config-resolution`).

--- a/plugins/lisa-agy/skills/lisa-github-to-tracker/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-github-to-tracker/SKILL.md
@@ -211,6 +211,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Notion / Confluence / Linear pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa-agy/skills/lisa-github-write-prd/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-github-write-prd/SKILL.md
@@ -146,6 +146,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - Exactly one PRD lifecycle label at all times (leaf-only does not apply — PRDs are not build leaves).
 - Match dedupe by marker, never by title.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/lisa-agy/skills/lisa-linear-to-tracker/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-linear-to-tracker/SKILL.md
@@ -208,6 +208,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Linear or Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa-agy/skills/lisa-linear-write-prd/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-linear-write-prd/SKILL.md
@@ -86,6 +86,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - Exactly one PRD lifecycle project-label at all times.
 - Match dedupe by marker, never by project name.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/lisa-agy/skills/lisa-notion-to-tracker/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-notion-to-tracker/SKILL.md
@@ -190,6 +190,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa-agy/skills/lisa-notion-write-prd/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-notion-write-prd/SKILL.md
@@ -100,6 +100,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - All access via `lisa-notion-access`; never touch the Notion API/MCP directly.
 - Match dedupe by marker, never by title.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/lisa-agy/skills/lisa-research/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-research/SKILL.md
@@ -56,7 +56,9 @@ A PRD **created in the configured PRD source** (per the intent-routing rule's Re
 definition) structured as: problem statement, high-level solution description, links (if needed),
 user stories (each with its own functional/non-functional requirements and, only for stories with
 new UI/visual work, a design-file pointer), overall acceptance criteria, open questions, and the
-"Recommended Tooling for Plan Phase" section. The final
+"Recommended Tooling for Plan Phase" section. Requirements MUST conform to the
+`prd-definition-of-ready` rule: identified atoms (`R1`, `R2`, …), one behavior each in an
+EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. The final
 flow step invokes `lisa-prd-source-write`, which creates the PRD in the configured `source` (Notion
 page in the PRD database, Confluence page under the lifecycle parent, GitHub issue, or Linear
 project) in the `draft` role by default or `ready` when `prd_ready=true`. **The PRD lives in the

--- a/plugins/lisa-copilot/rules/eager/prd-definition-of-ready.md
+++ b/plugins/lisa-copilot/rules/eager/prd-definition-of-ready.md
@@ -1,0 +1,32 @@
+# PRD Definition of Ready (requirement atoms)
+
+**A requirements document is ready when a planner can decompose it mechanically and a verifier can check the result against it.** Both properties come from the shape of the requirements, not the prose around them. Modeled on ISO/IEC/IEEE 29148's requirement quality characteristics and the EARS sentence patterns; the fit criterion is Volere's.
+
+## The atom
+
+Every requirement is an **identified atom**:
+
+- **Identified** — carries an id (`R1`, `R2`, …). Ids are per-generation; the verbatim text is the durable anchor (same convention as the `*-to-tracker` Requirement Register).
+- **Singular** — one behavior per atom. "The system shall X and Y when Z" is two atoms.
+- **Unambiguous** — no vagueness lexicon: *as appropriate, user-friendly, fast, robust, handle gracefully, etc., and/or, optimize, seamless, intuitive, support* (unbounded). Each is a word no test can check.
+- **Verifiable** — carries a **fit criterion**: the measurable test of satisfaction ("p95 upload completes < 4s for files ≤ 25 MB"). A requirement no test could check is a wish.
+- **Pattern-shaped (SHOULD)** — one of the EARS patterns, which decompose into Gherkin mechanically:
+  - Ubiquitous: *The `<system>` shall `<response>`*
+  - Event-driven: *When `<trigger>`, the `<system>` shall `<response>`*
+  - State-driven: *While `<state>`, the `<system>` shall `<response>`*
+  - Unwanted behavior: *If `<condition>`, then the `<system>` shall `<response>`*
+  - Optional feature: *Where `<feature>` is present, the `<system>` shall `<response>`*
+
+## The document
+
+Beyond the atoms, a ready PRD carries: problem statement · solution outline · user stories grouping their atoms · an explicit **non-functional checklist** (walk the ISO 25010 axes — performance, security, reliability, usability, compatibility, maintainability — and either state the requirement as an atom or state "no requirement"; silence is not a decision) · out of scope · open questions (the honest home for what is NOT ready).
+
+## Enforcement points
+
+- **Write time** — `lisa-research` authors to this shape; `*-write-prd` skills carry it as a body rule.
+- **Intake time (the universal gate)** — `*-to-tracker` Phase 1.45 validates every register atom, because human-authored PRDs never pass through the write path. Failures are product clarifications quoting the atom verbatim with candidate rewrites.
+- **Verify time** — `verify-prd` / spec-conformance consume the atoms; fit criteria become the conformance checks.
+
+Downstream, ticket gate S16 quotes these atoms verbatim and `prd-ticket-coverage` audits atom→ticket coverage — both degrade when "one requirement" is secretly three welded together.
+
+Full rationale, the vagueness lexicon, and worked rewrites: [the reference body of this rule](../reference/prd-definition-of-ready.md).

--- a/plugins/lisa-copilot/rules/reference/prd-definition-of-ready.md
+++ b/plugins/lisa-copilot/rules/reference/prd-definition-of-ready.md
@@ -1,0 +1,81 @@
+# PRD Definition of Ready — Reference
+
+The eager head carries the atom definition and enforcement points; this
+reference carries the rationale, the full vagueness lexicon, and worked
+rewrites. The companion rule `work-item-definition-of-ready` governs the next
+stage down (tickets); this rule governs what the Plan factory decomposes from.
+
+## Why requirement shape is the whole game
+
+The pipeline consumes requirements three times, and each consumer needs a
+different property that only shaped atoms provide:
+
+1. **Plan decomposes** — an EARS-shaped atom (*When X, the system shall Y*)
+   maps to a Gherkin scenario (*When X / Then Y*) nearly mechanically. Prose
+   paragraphs force the planner to invent the split, which is where scope
+   quietly drifts between the PRD and the backlog.
+2. **Tickets trace** — gate S16 quotes the requirement verbatim on every leaf.
+   A verbatim quote of a paragraph containing three requirements is an
+   ambiguous trace: which of the three does this ticket satisfy?
+3. **Verification checks conformance** — spec-conformance and `verify-prd`
+   read the PRD back against the shipped result. A fit criterion is a
+   conformance check waiting to run; an adjective is not.
+
+The standards being distilled: **ISO/IEC/IEEE 29148** (successor to IEEE 830)
+supplies the per-requirement quality characteristics — necessary, appropriate,
+unambiguous, complete, singular, feasible, verifiable, correct — and the
+practice of banning untestable phrasing. **EARS** (Mavin et al.) supplies the
+five sentence patterns. **Volere** supplies the fit criterion. **ISO 25010**
+supplies the non-functional axes for the completeness walk. None of these are
+imported wholesale; this rule takes exactly the parts a machine planner and a
+machine verifier consume.
+
+## The vagueness lexicon
+
+Presence of these (and their kin) in a requirement atom FAILs it as
+unverifiable — each is a phrase no test can check:
+
+> as appropriate · as needed · if necessary · user-friendly · intuitive ·
+> seamless · robust · flexible · fast · quickly · efficient · optimize ·
+> minimize / maximize (unbounded) · handle gracefully · support (unbounded) ·
+> etc. · and/or · TBD inside an atom (TBD belongs in Open Questions)
+
+The lexicon is a floor, not a ceiling — validators should flag any phrasing
+they cannot turn into a check.
+
+## Worked rewrites
+
+| Before (fails) | After (passes) |
+|---|---|
+| "Uploads should be fast and handle errors gracefully." | R4: *When a user uploads a file ≤ 25 MB, the system shall complete the upload within 4s at p95.* Fit: perf-trace on staging. R5: *If an upload fails, then the system shall show a retryable error naming the cause.* Fit: screenshot of the error state per failure class. |
+| "The dashboard should be user-friendly and support filtering, sorting, etc." | R7: *The dashboard shall filter by status, owner, and date range.* R8: *The dashboard shall sort by any visible column.* Fit: each verb exercised in an E2E journey. ("etc." is deleted — unnamed features are unbuilt features.) |
+| "Optimize the pipeline." | R2: *The nightly pipeline shall complete within 30 minutes for a 10k-item batch* (baseline: 47m measured 2026-07-01). Fit: pipeline duration metric. — note this is Improvement-shaped: baseline + target, per `work-item-definition-of-ready`. |
+
+## Singularity repair
+
+When an atom contains multiple behaviors, the register splits it (`R4` →
+`R4a`, `R4b`) — **mechanically when the split preserves meaning**, as a
+product clarification when it does not. The split is recorded in the dry-run
+report; it is never silent, because the PRD author's numbering is part of the
+traceability contract.
+
+## The non-functional walk
+
+A PRD is complete only when the ISO 25010 axes were each considered:
+performance, security, reliability, usability, compatibility,
+maintainability/operability. The required artifact is one line per axis —
+either an atom or an explicit "no requirement." The point is not ceremony; it
+is that **silence and "no requirement" are different facts**, and only one of
+them is a decision a verifier can hold the product to.
+
+## Relationship to the lifecycle
+
+- **Write** — `lisa-research` authors atoms; `*-write-prd` carries the body
+  rule. Factory-authored PRDs are born conforming.
+- **Intake** — `*-to-tracker` Phase 1.45 is the universal gate (human-authored
+  PRDs arrive here without passing any write path). Failures quote the atom
+  verbatim, name the defect, and offer 1–3 candidate rewrites — the
+  EARS-shaped rewrite is the default recommendation. Routed like every other
+  intake failure: PRD to `blocked`, product-readable comments.
+- **Verify** — fit criteria become the spec-conformance checks; the
+  requirement register ids appear in the PRD backlink and the coverage audit.

--- a/plugins/lisa-copilot/skills/lisa-confluence-to-tracker/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-confluence-to-tracker/SKILL.md
@@ -224,6 +224,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa-copilot/skills/lisa-confluence-write-prd/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-confluence-write-prd/SKILL.md
@@ -99,6 +99,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - All access via `lisa-atlassian-access`; never call Atlassian directly.
 - State is the parent page, not a label — never attempt Confluence label writes (they 401 on scoped
   tokens; see `config-resolution`).

--- a/plugins/lisa-copilot/skills/lisa-github-to-tracker/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-github-to-tracker/SKILL.md
@@ -211,6 +211,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Notion / Confluence / Linear pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa-copilot/skills/lisa-github-write-prd/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-github-write-prd/SKILL.md
@@ -146,6 +146,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - Exactly one PRD lifecycle label at all times (leaf-only does not apply — PRDs are not build leaves).
 - Match dedupe by marker, never by title.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/lisa-copilot/skills/lisa-linear-to-tracker/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-linear-to-tracker/SKILL.md
@@ -208,6 +208,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Linear or Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa-copilot/skills/lisa-linear-write-prd/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-linear-write-prd/SKILL.md
@@ -86,6 +86,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - Exactly one PRD lifecycle project-label at all times.
 - Match dedupe by marker, never by project name.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/lisa-copilot/skills/lisa-notion-to-tracker/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-notion-to-tracker/SKILL.md
@@ -190,6 +190,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa-copilot/skills/lisa-notion-write-prd/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-notion-write-prd/SKILL.md
@@ -100,6 +100,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - All access via `lisa-notion-access`; never touch the Notion API/MCP directly.
 - Match dedupe by marker, never by title.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/lisa-copilot/skills/lisa-research/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-research/SKILL.md
@@ -56,7 +56,9 @@ A PRD **created in the configured PRD source** (per the intent-routing rule's Re
 definition) structured as: problem statement, high-level solution description, links (if needed),
 user stories (each with its own functional/non-functional requirements and, only for stories with
 new UI/visual work, a design-file pointer), overall acceptance criteria, open questions, and the
-"Recommended Tooling for Plan Phase" section. The final
+"Recommended Tooling for Plan Phase" section. Requirements MUST conform to the
+`prd-definition-of-ready` rule: identified atoms (`R1`, `R2`, …), one behavior each in an
+EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. The final
 flow step invokes `lisa-prd-source-write`, which creates the PRD in the configured `source` (Notion
 page in the PRD database, Confluence page under the lifecycle parent, GitHub issue, or Linear
 project) in the `draft` role by default or `ready` when `prd_ready=true`. **The PRD lives in the

--- a/plugins/lisa-cursor/rules/prd-definition-of-ready-reference.mdc
+++ b/plugins/lisa-cursor/rules/prd-definition-of-ready-reference.mdc
@@ -1,0 +1,86 @@
+---
+description: "PRD Definition of Ready — Reference"
+alwaysApply: false
+---
+
+# PRD Definition of Ready — Reference
+
+The eager head carries the atom definition and enforcement points; this
+reference carries the rationale, the full vagueness lexicon, and worked
+rewrites. The companion rule `work-item-definition-of-ready` governs the next
+stage down (tickets); this rule governs what the Plan factory decomposes from.
+
+## Why requirement shape is the whole game
+
+The pipeline consumes requirements three times, and each consumer needs a
+different property that only shaped atoms provide:
+
+1. **Plan decomposes** — an EARS-shaped atom (*When X, the system shall Y*)
+   maps to a Gherkin scenario (*When X / Then Y*) nearly mechanically. Prose
+   paragraphs force the planner to invent the split, which is where scope
+   quietly drifts between the PRD and the backlog.
+2. **Tickets trace** — gate S16 quotes the requirement verbatim on every leaf.
+   A verbatim quote of a paragraph containing three requirements is an
+   ambiguous trace: which of the three does this ticket satisfy?
+3. **Verification checks conformance** — spec-conformance and `verify-prd`
+   read the PRD back against the shipped result. A fit criterion is a
+   conformance check waiting to run; an adjective is not.
+
+The standards being distilled: **ISO/IEC/IEEE 29148** (successor to IEEE 830)
+supplies the per-requirement quality characteristics — necessary, appropriate,
+unambiguous, complete, singular, feasible, verifiable, correct — and the
+practice of banning untestable phrasing. **EARS** (Mavin et al.) supplies the
+five sentence patterns. **Volere** supplies the fit criterion. **ISO 25010**
+supplies the non-functional axes for the completeness walk. None of these are
+imported wholesale; this rule takes exactly the parts a machine planner and a
+machine verifier consume.
+
+## The vagueness lexicon
+
+Presence of these (and their kin) in a requirement atom FAILs it as
+unverifiable — each is a phrase no test can check:
+
+> as appropriate · as needed · if necessary · user-friendly · intuitive ·
+> seamless · robust · flexible · fast · quickly · efficient · optimize ·
+> minimize / maximize (unbounded) · handle gracefully · support (unbounded) ·
+> etc. · and/or · TBD inside an atom (TBD belongs in Open Questions)
+
+The lexicon is a floor, not a ceiling — validators should flag any phrasing
+they cannot turn into a check.
+
+## Worked rewrites
+
+| Before (fails) | After (passes) |
+|---|---|
+| "Uploads should be fast and handle errors gracefully." | R4: *When a user uploads a file ≤ 25 MB, the system shall complete the upload within 4s at p95.* Fit: perf-trace on staging. R5: *If an upload fails, then the system shall show a retryable error naming the cause.* Fit: screenshot of the error state per failure class. |
+| "The dashboard should be user-friendly and support filtering, sorting, etc." | R7: *The dashboard shall filter by status, owner, and date range.* R8: *The dashboard shall sort by any visible column.* Fit: each verb exercised in an E2E journey. ("etc." is deleted — unnamed features are unbuilt features.) |
+| "Optimize the pipeline." | R2: *The nightly pipeline shall complete within 30 minutes for a 10k-item batch* (baseline: 47m measured 2026-07-01). Fit: pipeline duration metric. — note this is Improvement-shaped: baseline + target, per `work-item-definition-of-ready`. |
+
+## Singularity repair
+
+When an atom contains multiple behaviors, the register splits it (`R4` →
+`R4a`, `R4b`) — **mechanically when the split preserves meaning**, as a
+product clarification when it does not. The split is recorded in the dry-run
+report; it is never silent, because the PRD author's numbering is part of the
+traceability contract.
+
+## The non-functional walk
+
+A PRD is complete only when the ISO 25010 axes were each considered:
+performance, security, reliability, usability, compatibility,
+maintainability/operability. The required artifact is one line per axis —
+either an atom or an explicit "no requirement." The point is not ceremony; it
+is that **silence and "no requirement" are different facts**, and only one of
+them is a decision a verifier can hold the product to.
+
+## Relationship to the lifecycle
+
+- **Write** — `lisa-research` authors atoms; `*-write-prd` carries the body
+  rule. Factory-authored PRDs are born conforming.
+- **Intake** — `*-to-tracker` Phase 1.45 is the universal gate (human-authored
+  PRDs arrive here without passing any write path). Failures quote the atom
+  verbatim, name the defect, and offer 1–3 candidate rewrites — the
+  EARS-shaped rewrite is the default recommendation. Routed like every other
+  intake failure: PRD to `blocked`, product-readable comments.
+- **Verify** — fit criteria become the spec-conformance checks; the
+  requirement register ids appear in the PRD backlink and the coverage audit.

--- a/plugins/lisa-cursor/rules/prd-definition-of-ready.mdc
+++ b/plugins/lisa-cursor/rules/prd-definition-of-ready.mdc
@@ -1,0 +1,37 @@
+---
+description: "PRD Definition of Ready (requirement atoms)"
+alwaysApply: true
+---
+
+# PRD Definition of Ready (requirement atoms)
+
+**A requirements document is ready when a planner can decompose it mechanically and a verifier can check the result against it.** Both properties come from the shape of the requirements, not the prose around them. Modeled on ISO/IEC/IEEE 29148's requirement quality characteristics and the EARS sentence patterns; the fit criterion is Volere's.
+
+## The atom
+
+Every requirement is an **identified atom**:
+
+- **Identified** — carries an id (`R1`, `R2`, …). Ids are per-generation; the verbatim text is the durable anchor (same convention as the `*-to-tracker` Requirement Register).
+- **Singular** — one behavior per atom. "The system shall X and Y when Z" is two atoms.
+- **Unambiguous** — no vagueness lexicon: *as appropriate, user-friendly, fast, robust, handle gracefully, etc., and/or, optimize, seamless, intuitive, support* (unbounded). Each is a word no test can check.
+- **Verifiable** — carries a **fit criterion**: the measurable test of satisfaction ("p95 upload completes < 4s for files ≤ 25 MB"). A requirement no test could check is a wish.
+- **Pattern-shaped (SHOULD)** — one of the EARS patterns, which decompose into Gherkin mechanically:
+  - Ubiquitous: *The `<system>` shall `<response>`*
+  - Event-driven: *When `<trigger>`, the `<system>` shall `<response>`*
+  - State-driven: *While `<state>`, the `<system>` shall `<response>`*
+  - Unwanted behavior: *If `<condition>`, then the `<system>` shall `<response>`*
+  - Optional feature: *Where `<feature>` is present, the `<system>` shall `<response>`*
+
+## The document
+
+Beyond the atoms, a ready PRD carries: problem statement · solution outline · user stories grouping their atoms · an explicit **non-functional checklist** (walk the ISO 25010 axes — performance, security, reliability, usability, compatibility, maintainability — and either state the requirement as an atom or state "no requirement"; silence is not a decision) · out of scope · open questions (the honest home for what is NOT ready).
+
+## Enforcement points
+
+- **Write time** — `lisa-research` authors to this shape; `*-write-prd` skills carry it as a body rule.
+- **Intake time (the universal gate)** — `*-to-tracker` Phase 1.45 validates every register atom, because human-authored PRDs never pass through the write path. Failures are product clarifications quoting the atom verbatim with candidate rewrites.
+- **Verify time** — `verify-prd` / spec-conformance consume the atoms; fit criteria become the conformance checks.
+
+Downstream, ticket gate S16 quotes these atoms verbatim and `prd-ticket-coverage` audits atom→ticket coverage — both degrade when "one requirement" is secretly three welded together.
+
+Full rationale, the vagueness lexicon, and worked rewrites: [the reference body of this rule](prd-definition-of-ready-reference.mdc).

--- a/plugins/lisa-cursor/skills/lisa-confluence-to-tracker/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-confluence-to-tracker/SKILL.md
@@ -224,6 +224,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa-cursor/skills/lisa-confluence-write-prd/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-confluence-write-prd/SKILL.md
@@ -99,6 +99,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - All access via `lisa-atlassian-access`; never call Atlassian directly.
 - State is the parent page, not a label — never attempt Confluence label writes (they 401 on scoped
   tokens; see `config-resolution`).

--- a/plugins/lisa-cursor/skills/lisa-github-to-tracker/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-github-to-tracker/SKILL.md
@@ -211,6 +211,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Notion / Confluence / Linear pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa-cursor/skills/lisa-github-write-prd/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-github-write-prd/SKILL.md
@@ -146,6 +146,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - Exactly one PRD lifecycle label at all times (leaf-only does not apply — PRDs are not build leaves).
 - Match dedupe by marker, never by title.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/lisa-cursor/skills/lisa-linear-to-tracker/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-linear-to-tracker/SKILL.md
@@ -208,6 +208,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Linear or Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa-cursor/skills/lisa-linear-write-prd/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-linear-write-prd/SKILL.md
@@ -86,6 +86,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - Exactly one PRD lifecycle project-label at all times.
 - Match dedupe by marker, never by project name.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/lisa-cursor/skills/lisa-notion-to-tracker/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-notion-to-tracker/SKILL.md
@@ -190,6 +190,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa-cursor/skills/lisa-notion-write-prd/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-notion-write-prd/SKILL.md
@@ -100,6 +100,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - All access via `lisa-notion-access`; never touch the Notion API/MCP directly.
 - Match dedupe by marker, never by title.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/lisa-cursor/skills/lisa-research/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-research/SKILL.md
@@ -56,7 +56,9 @@ A PRD **created in the configured PRD source** (per the intent-routing rule's Re
 definition) structured as: problem statement, high-level solution description, links (if needed),
 user stories (each with its own functional/non-functional requirements and, only for stories with
 new UI/visual work, a design-file pointer), overall acceptance criteria, open questions, and the
-"Recommended Tooling for Plan Phase" section. The final
+"Recommended Tooling for Plan Phase" section. Requirements MUST conform to the
+`prd-definition-of-ready` rule: identified atoms (`R1`, `R2`, …), one behavior each in an
+EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. The final
 flow step invokes `lisa-prd-source-write`, which creates the PRD in the configured `source` (Notion
 page in the PRD database, Confluence page under the lifecycle parent, GitHub issue, or Linear
 project) in the `draft` role by default or `ready` when `prd_ready=true`. **The PRD lives in the

--- a/plugins/lisa/.codex-plugin/skills/lisa-confluence-to-tracker/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-confluence-to-tracker/SKILL.md
@@ -218,6 +218,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa/.codex-plugin/skills/lisa-confluence-write-prd/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-confluence-write-prd/SKILL.md
@@ -99,6 +99,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - All access via `lisa-atlassian-access`; never call Atlassian directly.
 - State is the parent page, not a label — never attempt Confluence label writes (they 401 on scoped
   tokens; see `config-resolution`).

--- a/plugins/lisa/.codex-plugin/skills/lisa-github-to-tracker/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-github-to-tracker/SKILL.md
@@ -203,6 +203,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Notion / Confluence / Linear pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa/.codex-plugin/skills/lisa-github-write-prd/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-github-write-prd/SKILL.md
@@ -146,6 +146,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - Exactly one PRD lifecycle label at all times (leaf-only does not apply — PRDs are not build leaves).
 - Match dedupe by marker, never by title.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/lisa/.codex-plugin/skills/lisa-linear-to-tracker/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-linear-to-tracker/SKILL.md
@@ -203,6 +203,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Linear or Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa/.codex-plugin/skills/lisa-linear-write-prd/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-linear-write-prd/SKILL.md
@@ -86,6 +86,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - Exactly one PRD lifecycle project-label at all times.
 - Match dedupe by marker, never by project name.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/lisa/.codex-plugin/skills/lisa-notion-to-tracker/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-notion-to-tracker/SKILL.md
@@ -184,6 +184,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa/.codex-plugin/skills/lisa-notion-write-prd/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-notion-write-prd/SKILL.md
@@ -100,6 +100,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - All access via `lisa-notion-access`; never touch the Notion API/MCP directly.
 - Match dedupe by marker, never by title.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/lisa/.codex-plugin/skills/lisa-research/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-research/SKILL.md
@@ -56,7 +56,9 @@ A PRD **created in the configured PRD source** (per the intent-routing rule's Re
 definition) structured as: problem statement, high-level solution description, links (if needed),
 user stories (each with its own functional/non-functional requirements and, only for stories with
 new UI/visual work, a design-file pointer), overall acceptance criteria, open questions, and the
-"Recommended Tooling for Plan Phase" section. The final
+"Recommended Tooling for Plan Phase" section. Requirements MUST conform to the
+`prd-definition-of-ready` rule: identified atoms (`R1`, `R2`, …), one behavior each in an
+EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. The final
 flow step invokes `lisa-prd-source-write`, which creates the PRD in the configured `source` (Notion
 page in the PRD database, Confluence page under the lifecycle parent, GitHub issue, or Linear
 project) in the `draft` role by default or `ready` when `prd_ready=true`. **The PRD lives in the

--- a/plugins/lisa/rules/eager/prd-definition-of-ready.md
+++ b/plugins/lisa/rules/eager/prd-definition-of-ready.md
@@ -1,0 +1,32 @@
+# PRD Definition of Ready (requirement atoms)
+
+**A requirements document is ready when a planner can decompose it mechanically and a verifier can check the result against it.** Both properties come from the shape of the requirements, not the prose around them. Modeled on ISO/IEC/IEEE 29148's requirement quality characteristics and the EARS sentence patterns; the fit criterion is Volere's.
+
+## The atom
+
+Every requirement is an **identified atom**:
+
+- **Identified** — carries an id (`R1`, `R2`, …). Ids are per-generation; the verbatim text is the durable anchor (same convention as the `*-to-tracker` Requirement Register).
+- **Singular** — one behavior per atom. "The system shall X and Y when Z" is two atoms.
+- **Unambiguous** — no vagueness lexicon: *as appropriate, user-friendly, fast, robust, handle gracefully, etc., and/or, optimize, seamless, intuitive, support* (unbounded). Each is a word no test can check.
+- **Verifiable** — carries a **fit criterion**: the measurable test of satisfaction ("p95 upload completes < 4s for files ≤ 25 MB"). A requirement no test could check is a wish.
+- **Pattern-shaped (SHOULD)** — one of the EARS patterns, which decompose into Gherkin mechanically:
+  - Ubiquitous: *The `<system>` shall `<response>`*
+  - Event-driven: *When `<trigger>`, the `<system>` shall `<response>`*
+  - State-driven: *While `<state>`, the `<system>` shall `<response>`*
+  - Unwanted behavior: *If `<condition>`, then the `<system>` shall `<response>`*
+  - Optional feature: *Where `<feature>` is present, the `<system>` shall `<response>`*
+
+## The document
+
+Beyond the atoms, a ready PRD carries: problem statement · solution outline · user stories grouping their atoms · an explicit **non-functional checklist** (walk the ISO 25010 axes — performance, security, reliability, usability, compatibility, maintainability — and either state the requirement as an atom or state "no requirement"; silence is not a decision) · out of scope · open questions (the honest home for what is NOT ready).
+
+## Enforcement points
+
+- **Write time** — `lisa-research` authors to this shape; `*-write-prd` skills carry it as a body rule.
+- **Intake time (the universal gate)** — `*-to-tracker` Phase 1.45 validates every register atom, because human-authored PRDs never pass through the write path. Failures are product clarifications quoting the atom verbatim with candidate rewrites.
+- **Verify time** — `verify-prd` / spec-conformance consume the atoms; fit criteria become the conformance checks.
+
+Downstream, ticket gate S16 quotes these atoms verbatim and `prd-ticket-coverage` audits atom→ticket coverage — both degrade when "one requirement" is secretly three welded together.
+
+Full rationale, the vagueness lexicon, and worked rewrites: [the reference body of this rule](../reference/prd-definition-of-ready.md).

--- a/plugins/lisa/rules/reference/prd-definition-of-ready.md
+++ b/plugins/lisa/rules/reference/prd-definition-of-ready.md
@@ -1,0 +1,81 @@
+# PRD Definition of Ready — Reference
+
+The eager head carries the atom definition and enforcement points; this
+reference carries the rationale, the full vagueness lexicon, and worked
+rewrites. The companion rule `work-item-definition-of-ready` governs the next
+stage down (tickets); this rule governs what the Plan factory decomposes from.
+
+## Why requirement shape is the whole game
+
+The pipeline consumes requirements three times, and each consumer needs a
+different property that only shaped atoms provide:
+
+1. **Plan decomposes** — an EARS-shaped atom (*When X, the system shall Y*)
+   maps to a Gherkin scenario (*When X / Then Y*) nearly mechanically. Prose
+   paragraphs force the planner to invent the split, which is where scope
+   quietly drifts between the PRD and the backlog.
+2. **Tickets trace** — gate S16 quotes the requirement verbatim on every leaf.
+   A verbatim quote of a paragraph containing three requirements is an
+   ambiguous trace: which of the three does this ticket satisfy?
+3. **Verification checks conformance** — spec-conformance and `verify-prd`
+   read the PRD back against the shipped result. A fit criterion is a
+   conformance check waiting to run; an adjective is not.
+
+The standards being distilled: **ISO/IEC/IEEE 29148** (successor to IEEE 830)
+supplies the per-requirement quality characteristics — necessary, appropriate,
+unambiguous, complete, singular, feasible, verifiable, correct — and the
+practice of banning untestable phrasing. **EARS** (Mavin et al.) supplies the
+five sentence patterns. **Volere** supplies the fit criterion. **ISO 25010**
+supplies the non-functional axes for the completeness walk. None of these are
+imported wholesale; this rule takes exactly the parts a machine planner and a
+machine verifier consume.
+
+## The vagueness lexicon
+
+Presence of these (and their kin) in a requirement atom FAILs it as
+unverifiable — each is a phrase no test can check:
+
+> as appropriate · as needed · if necessary · user-friendly · intuitive ·
+> seamless · robust · flexible · fast · quickly · efficient · optimize ·
+> minimize / maximize (unbounded) · handle gracefully · support (unbounded) ·
+> etc. · and/or · TBD inside an atom (TBD belongs in Open Questions)
+
+The lexicon is a floor, not a ceiling — validators should flag any phrasing
+they cannot turn into a check.
+
+## Worked rewrites
+
+| Before (fails) | After (passes) |
+|---|---|
+| "Uploads should be fast and handle errors gracefully." | R4: *When a user uploads a file ≤ 25 MB, the system shall complete the upload within 4s at p95.* Fit: perf-trace on staging. R5: *If an upload fails, then the system shall show a retryable error naming the cause.* Fit: screenshot of the error state per failure class. |
+| "The dashboard should be user-friendly and support filtering, sorting, etc." | R7: *The dashboard shall filter by status, owner, and date range.* R8: *The dashboard shall sort by any visible column.* Fit: each verb exercised in an E2E journey. ("etc." is deleted — unnamed features are unbuilt features.) |
+| "Optimize the pipeline." | R2: *The nightly pipeline shall complete within 30 minutes for a 10k-item batch* (baseline: 47m measured 2026-07-01). Fit: pipeline duration metric. — note this is Improvement-shaped: baseline + target, per `work-item-definition-of-ready`. |
+
+## Singularity repair
+
+When an atom contains multiple behaviors, the register splits it (`R4` →
+`R4a`, `R4b`) — **mechanically when the split preserves meaning**, as a
+product clarification when it does not. The split is recorded in the dry-run
+report; it is never silent, because the PRD author's numbering is part of the
+traceability contract.
+
+## The non-functional walk
+
+A PRD is complete only when the ISO 25010 axes were each considered:
+performance, security, reliability, usability, compatibility,
+maintainability/operability. The required artifact is one line per axis —
+either an atom or an explicit "no requirement." The point is not ceremony; it
+is that **silence and "no requirement" are different facts**, and only one of
+them is a decision a verifier can hold the product to.
+
+## Relationship to the lifecycle
+
+- **Write** — `lisa-research` authors atoms; `*-write-prd` carries the body
+  rule. Factory-authored PRDs are born conforming.
+- **Intake** — `*-to-tracker` Phase 1.45 is the universal gate (human-authored
+  PRDs arrive here without passing any write path). Failures quote the atom
+  verbatim, name the defect, and offer 1–3 candidate rewrites — the
+  EARS-shaped rewrite is the default recommendation. Routed like every other
+  intake failure: PRD to `blocked`, product-readable comments.
+- **Verify** — fit criteria become the spec-conformance checks; the
+  requirement register ids appear in the PRD backlink and the coverage audit.

--- a/plugins/lisa/skills/lisa-confluence-to-tracker/SKILL.md
+++ b/plugins/lisa/skills/lisa-confluence-to-tracker/SKILL.md
@@ -224,6 +224,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa/skills/lisa-confluence-write-prd/SKILL.md
+++ b/plugins/lisa/skills/lisa-confluence-write-prd/SKILL.md
@@ -99,6 +99,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - All access via `lisa-atlassian-access`; never call Atlassian directly.
 - State is the parent page, not a label — never attempt Confluence label writes (they 401 on scoped
   tokens; see `config-resolution`).

--- a/plugins/lisa/skills/lisa-github-to-tracker/SKILL.md
+++ b/plugins/lisa/skills/lisa-github-to-tracker/SKILL.md
@@ -211,6 +211,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Notion / Confluence / Linear pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa/skills/lisa-github-write-prd/SKILL.md
+++ b/plugins/lisa/skills/lisa-github-write-prd/SKILL.md
@@ -146,6 +146,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - Exactly one PRD lifecycle label at all times (leaf-only does not apply — PRDs are not build leaves).
 - Match dedupe by marker, never by title.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/lisa/skills/lisa-linear-to-tracker/SKILL.md
+++ b/plugins/lisa/skills/lisa-linear-to-tracker/SKILL.md
@@ -208,6 +208,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Linear or Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa/skills/lisa-linear-write-prd/SKILL.md
+++ b/plugins/lisa/skills/lisa-linear-write-prd/SKILL.md
@@ -86,6 +86,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - Exactly one PRD lifecycle project-label at all times.
 - Match dedupe by marker, never by project name.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/lisa/skills/lisa-notion-to-tracker/SKILL.md
+++ b/plugins/lisa/skills/lisa-notion-to-tracker/SKILL.md
@@ -190,6 +190,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/lisa/skills/lisa-notion-write-prd/SKILL.md
+++ b/plugins/lisa/skills/lisa-notion-write-prd/SKILL.md
@@ -100,6 +100,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - All access via `lisa-notion-access`; never touch the Notion API/MCP directly.
 - Match dedupe by marker, never by title.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/lisa/skills/lisa-research/SKILL.md
+++ b/plugins/lisa/skills/lisa-research/SKILL.md
@@ -56,7 +56,9 @@ A PRD **created in the configured PRD source** (per the intent-routing rule's Re
 definition) structured as: problem statement, high-level solution description, links (if needed),
 user stories (each with its own functional/non-functional requirements and, only for stories with
 new UI/visual work, a design-file pointer), overall acceptance criteria, open questions, and the
-"Recommended Tooling for Plan Phase" section. The final
+"Recommended Tooling for Plan Phase" section. Requirements MUST conform to the
+`prd-definition-of-ready` rule: identified atoms (`R1`, `R2`, …), one behavior each in an
+EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. The final
 flow step invokes `lisa-prd-source-write`, which creates the PRD in the configured `source` (Notion
 page in the PRD database, Confluence page under the lifecycle parent, GitHub issue, or Linear
 project) in the `draft` role by default or `ready` when `prd_ready=true`. **The PRD lives in the

--- a/plugins/src/base/rules/eager/prd-definition-of-ready.md
+++ b/plugins/src/base/rules/eager/prd-definition-of-ready.md
@@ -1,0 +1,32 @@
+# PRD Definition of Ready (requirement atoms)
+
+**A requirements document is ready when a planner can decompose it mechanically and a verifier can check the result against it.** Both properties come from the shape of the requirements, not the prose around them. Modeled on ISO/IEC/IEEE 29148's requirement quality characteristics and the EARS sentence patterns; the fit criterion is Volere's.
+
+## The atom
+
+Every requirement is an **identified atom**:
+
+- **Identified** — carries an id (`R1`, `R2`, …). Ids are per-generation; the verbatim text is the durable anchor (same convention as the `*-to-tracker` Requirement Register).
+- **Singular** — one behavior per atom. "The system shall X and Y when Z" is two atoms.
+- **Unambiguous** — no vagueness lexicon: *as appropriate, user-friendly, fast, robust, handle gracefully, etc., and/or, optimize, seamless, intuitive, support* (unbounded). Each is a word no test can check.
+- **Verifiable** — carries a **fit criterion**: the measurable test of satisfaction ("p95 upload completes < 4s for files ≤ 25 MB"). A requirement no test could check is a wish.
+- **Pattern-shaped (SHOULD)** — one of the EARS patterns, which decompose into Gherkin mechanically:
+  - Ubiquitous: *The `<system>` shall `<response>`*
+  - Event-driven: *When `<trigger>`, the `<system>` shall `<response>`*
+  - State-driven: *While `<state>`, the `<system>` shall `<response>`*
+  - Unwanted behavior: *If `<condition>`, then the `<system>` shall `<response>`*
+  - Optional feature: *Where `<feature>` is present, the `<system>` shall `<response>`*
+
+## The document
+
+Beyond the atoms, a ready PRD carries: problem statement · solution outline · user stories grouping their atoms · an explicit **non-functional checklist** (walk the ISO 25010 axes — performance, security, reliability, usability, compatibility, maintainability — and either state the requirement as an atom or state "no requirement"; silence is not a decision) · out of scope · open questions (the honest home for what is NOT ready).
+
+## Enforcement points
+
+- **Write time** — `lisa-research` authors to this shape; `*-write-prd` skills carry it as a body rule.
+- **Intake time (the universal gate)** — `*-to-tracker` Phase 1.45 validates every register atom, because human-authored PRDs never pass through the write path. Failures are product clarifications quoting the atom verbatim with candidate rewrites.
+- **Verify time** — `verify-prd` / spec-conformance consume the atoms; fit criteria become the conformance checks.
+
+Downstream, ticket gate S16 quotes these atoms verbatim and `prd-ticket-coverage` audits atom→ticket coverage — both degrade when "one requirement" is secretly three welded together.
+
+Full rationale, the vagueness lexicon, and worked rewrites: [the reference body of this rule](../reference/prd-definition-of-ready.md).

--- a/plugins/src/base/rules/reference/prd-definition-of-ready.md
+++ b/plugins/src/base/rules/reference/prd-definition-of-ready.md
@@ -1,0 +1,81 @@
+# PRD Definition of Ready — Reference
+
+The eager head carries the atom definition and enforcement points; this
+reference carries the rationale, the full vagueness lexicon, and worked
+rewrites. The companion rule `work-item-definition-of-ready` governs the next
+stage down (tickets); this rule governs what the Plan factory decomposes from.
+
+## Why requirement shape is the whole game
+
+The pipeline consumes requirements three times, and each consumer needs a
+different property that only shaped atoms provide:
+
+1. **Plan decomposes** — an EARS-shaped atom (*When X, the system shall Y*)
+   maps to a Gherkin scenario (*When X / Then Y*) nearly mechanically. Prose
+   paragraphs force the planner to invent the split, which is where scope
+   quietly drifts between the PRD and the backlog.
+2. **Tickets trace** — gate S16 quotes the requirement verbatim on every leaf.
+   A verbatim quote of a paragraph containing three requirements is an
+   ambiguous trace: which of the three does this ticket satisfy?
+3. **Verification checks conformance** — spec-conformance and `verify-prd`
+   read the PRD back against the shipped result. A fit criterion is a
+   conformance check waiting to run; an adjective is not.
+
+The standards being distilled: **ISO/IEC/IEEE 29148** (successor to IEEE 830)
+supplies the per-requirement quality characteristics — necessary, appropriate,
+unambiguous, complete, singular, feasible, verifiable, correct — and the
+practice of banning untestable phrasing. **EARS** (Mavin et al.) supplies the
+five sentence patterns. **Volere** supplies the fit criterion. **ISO 25010**
+supplies the non-functional axes for the completeness walk. None of these are
+imported wholesale; this rule takes exactly the parts a machine planner and a
+machine verifier consume.
+
+## The vagueness lexicon
+
+Presence of these (and their kin) in a requirement atom FAILs it as
+unverifiable — each is a phrase no test can check:
+
+> as appropriate · as needed · if necessary · user-friendly · intuitive ·
+> seamless · robust · flexible · fast · quickly · efficient · optimize ·
+> minimize / maximize (unbounded) · handle gracefully · support (unbounded) ·
+> etc. · and/or · TBD inside an atom (TBD belongs in Open Questions)
+
+The lexicon is a floor, not a ceiling — validators should flag any phrasing
+they cannot turn into a check.
+
+## Worked rewrites
+
+| Before (fails) | After (passes) |
+|---|---|
+| "Uploads should be fast and handle errors gracefully." | R4: *When a user uploads a file ≤ 25 MB, the system shall complete the upload within 4s at p95.* Fit: perf-trace on staging. R5: *If an upload fails, then the system shall show a retryable error naming the cause.* Fit: screenshot of the error state per failure class. |
+| "The dashboard should be user-friendly and support filtering, sorting, etc." | R7: *The dashboard shall filter by status, owner, and date range.* R8: *The dashboard shall sort by any visible column.* Fit: each verb exercised in an E2E journey. ("etc." is deleted — unnamed features are unbuilt features.) |
+| "Optimize the pipeline." | R2: *The nightly pipeline shall complete within 30 minutes for a 10k-item batch* (baseline: 47m measured 2026-07-01). Fit: pipeline duration metric. — note this is Improvement-shaped: baseline + target, per `work-item-definition-of-ready`. |
+
+## Singularity repair
+
+When an atom contains multiple behaviors, the register splits it (`R4` →
+`R4a`, `R4b`) — **mechanically when the split preserves meaning**, as a
+product clarification when it does not. The split is recorded in the dry-run
+report; it is never silent, because the PRD author's numbering is part of the
+traceability contract.
+
+## The non-functional walk
+
+A PRD is complete only when the ISO 25010 axes were each considered:
+performance, security, reliability, usability, compatibility,
+maintainability/operability. The required artifact is one line per axis —
+either an atom or an explicit "no requirement." The point is not ceremony; it
+is that **silence and "no requirement" are different facts**, and only one of
+them is a decision a verifier can hold the product to.
+
+## Relationship to the lifecycle
+
+- **Write** — `lisa-research` authors atoms; `*-write-prd` carries the body
+  rule. Factory-authored PRDs are born conforming.
+- **Intake** — `*-to-tracker` Phase 1.45 is the universal gate (human-authored
+  PRDs arrive here without passing any write path). Failures quote the atom
+  verbatim, name the defect, and offer 1–3 candidate rewrites — the
+  EARS-shaped rewrite is the default recommendation. Routed like every other
+  intake failure: PRD to `blocked`, product-readable comments.
+- **Verify** — fit criteria become the spec-conformance checks; the
+  requirement register ids appear in the PRD backlink and the coverage audit.

--- a/plugins/src/base/skills/lisa-confluence-to-tracker/SKILL.md
+++ b/plugins/src/base/skills/lisa-confluence-to-tracker/SKILL.md
@@ -224,6 +224,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/src/base/skills/lisa-confluence-write-prd/SKILL.md
+++ b/plugins/src/base/skills/lisa-confluence-write-prd/SKILL.md
@@ -99,6 +99,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - All access via `lisa-atlassian-access`; never call Atlassian directly.
 - State is the parent page, not a label — never attempt Confluence label writes (they 401 on scoped
   tokens; see `config-resolution`).

--- a/plugins/src/base/skills/lisa-github-to-tracker/SKILL.md
+++ b/plugins/src/base/skills/lisa-github-to-tracker/SKILL.md
@@ -211,6 +211,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Notion / Confluence / Linear pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/src/base/skills/lisa-github-write-prd/SKILL.md
+++ b/plugins/src/base/skills/lisa-github-write-prd/SKILL.md
@@ -146,6 +146,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - Exactly one PRD lifecycle label at all times (leaf-only does not apply — PRDs are not build leaves).
 - Match dedupe by marker, never by title.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/src/base/skills/lisa-linear-to-tracker/SKILL.md
+++ b/plugins/src/base/skills/lisa-linear-to-tracker/SKILL.md
@@ -208,6 +208,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, peer Linear or Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/src/base/skills/lisa-linear-write-prd/SKILL.md
+++ b/plugins/src/base/skills/lisa-linear-write-prd/SKILL.md
@@ -86,6 +86,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - Exactly one PRD lifecycle project-label at all times.
 - Match dedupe by marker, never by project name.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/src/base/skills/lisa-notion-to-tracker/SKILL.md
+++ b/plugins/src/base/skills/lisa-notion-to-tracker/SKILL.md
@@ -190,6 +190,30 @@ The register feeds three consumers: the `## Source Requirement` section on
 every created ticket (Phases 3–5), the dry-run report (above), and the
 requirement tokens in the PRD back-link (Phase 7).
 
+### Phase 1.45: Requirement Quality Gates (prd-definition-of-ready)
+
+Validate every Phase 1.4 register entry against the `prd-definition-of-ready` rule before
+planning proceeds. Per atom:
+
+- **Singular** — one behavior per entry. An entry welding multiple shall/when clauses together is
+  split in the register (R4 → R4a/R4b) when the split is mechanical and meaning-preserving; when
+  the split would change meaning, it is a product question, not a repair.
+- **Unambiguous** — FAIL on the vagueness lexicon ("as appropriate", "user-friendly", "fast",
+  "handle gracefully", "etc.", "and/or", unbounded "optimize"/"support"): phrasing no test can
+  check. The full lexicon lives in the rule's reference body.
+- **Verifiable** — a fit criterion (the measurable test of satisfaction) is present or
+  mechanically derivable from the text; a requirement no test could check is not admitted as a
+  requirement.
+- **Pattern shape (SHOULD)** — an EARS pattern (ubiquitous / When / While / If-then / Where) or an
+  equivalent single-behavior sentence; conforming shapes decompose into Gherkin mechanically.
+
+Failures here are **requirement-level product clarifications**, not internal errors: report each in
+the dry-run report as a `product-clarity` item quoting the atom verbatim, naming the defect, and
+offering 1–3 candidate rewrites (an EARS-shaped rewrite is the default recommendation). In intake
+flows these route to the PRD's `blocked` role with comments, exactly like ticket-validator
+failures. Mechanical splits and derived fit criteria are repaired in-register and recorded in the
+report — never silently.
+
 ### Phase 1.5: Extract Source Artifacts
 
 PRDs typically reference external design, UX, and data artifacts (Figma files, Lovable prototypes, Loom walkthroughs, screenshots, example payloads, Confluence pages). These MUST be preserved onto the resulting tickets — otherwise developers picking up a ticket lose the source of truth. This is the failure mode this step exists to prevent.

--- a/plugins/src/base/skills/lisa-notion-write-prd/SKILL.md
+++ b/plugins/src/base/skills/lisa-notion-write-prd/SKILL.md
@@ -100,6 +100,8 @@ outcome: created | reused
 
 ## Rules
 
+- The PRD body's requirements MUST conform to `prd-definition-of-ready`: identified atoms (`R1`, `R2`, …), one behavior each in an EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. This governs factory-authored bodies; human-authored PRDs are validated at intake instead (`*-to-tracker` Phase 1.45).
+
 - All access via `lisa-notion-access`; never touch the Notion API/MCP directly.
 - Match dedupe by marker, never by title.
 - Preserve an existing canonical `## Lisa Usage` section on update; never append a second usage

--- a/plugins/src/base/skills/lisa-research/SKILL.md
+++ b/plugins/src/base/skills/lisa-research/SKILL.md
@@ -56,7 +56,9 @@ A PRD **created in the configured PRD source** (per the intent-routing rule's Re
 definition) structured as: problem statement, high-level solution description, links (if needed),
 user stories (each with its own functional/non-functional requirements and, only for stories with
 new UI/visual work, a design-file pointer), overall acceptance criteria, open questions, and the
-"Recommended Tooling for Plan Phase" section. The final
+"Recommended Tooling for Plan Phase" section. Requirements MUST conform to the
+`prd-definition-of-ready` rule: identified atoms (`R1`, `R2`, …), one behavior each in an
+EARS-pattern shape, each with a measurable fit criterion, plus the non-functional checklist. The final
 flow step invokes `lisa-prd-source-write`, which creates the PRD in the configured `source` (Notion
 page in the PRD database, Confluence page under the lifecycle parent, GitHub issue, or Linear
 project) in the `draft` role by default or `ready` when `prd_ready=true`. **The PRD lives in the

--- a/spec/tasc-0.1-draft.md
+++ b/spec/tasc-0.1-draft.md
@@ -387,7 +387,11 @@ focus (non-authoritative guidance).
 - **AC8.4 Intake validation.** Work MUST be admitted to implementation only through
   an adversarial intake gate that rejects ambiguity and verifies the system has
   provable access to the tooling the work requires; rejections MUST be raised to a
-  human legibly (AC2.1).
+  human legibly (AC2.1). Requirements admitted from a requirements document MUST be
+  singular, identified, unambiguous, verifiable atoms, each carrying a fit
+  criterion — a measurable test of satisfaction — with untestable phrasing rejected
+  at the gate. (Non-normative: ISO/IEC/IEEE 29148's quality characteristics define
+  the bar; the EARS patterns are a conforming syntax.)
 - **AC8.5 Deployment protection.** Production deployment MUST be gated by a
   protected mechanism the deploying agent cannot self-approve (server-side
   environment protection and/or CHC approval). Progressive delivery SHOULD bound

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -646,6 +646,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "270a7b071c0dfabd2c80417e6a63ab462a9ac630dc3d1ae36c68a2fbf6235578",
     "plugins/src/base/rules/eager/observability-audit.md":
       "eef7f612937db85e2fb685f262a651ac0fea195fb79363224281f057dc1a6ef7",
+    "plugins/src/base/rules/eager/prd-definition-of-ready.md":
+      "5d30476344425f78961ed1412b06edd5e7cde478c81e1b945860b55aecf56e1f",
     "plugins/src/base/rules/eager/prd-lifecycle-rollup.md":
       "b5c58148a0ed78989e21bc7789ecf1d5448077879be01ee342ddb46d8f105a1e",
     "plugins/src/base/rules/eager/pre-flight-autofill.md":
@@ -712,6 +714,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "3d6d531fdca61a348fa1dd1bdb4c28fe66c85fb955238ef668a78cce4a36a7a1",
     "plugins/src/base/rules/reference/observability-audit.md":
       "98cf4c849baf0801bd2c46a90e7a072196649d506fbda577cc5c4019d2194551",
+    "plugins/src/base/rules/reference/prd-definition-of-ready.md":
+      "041a8f3c9b703b3921acc30fe92acfb9e2ab43da04cf019c102ebca98b2f4ba3",
     "plugins/src/base/rules/reference/prd-lifecycle-rollup.md":
       "f539e7b43918e173dd7491a139be078815d26098f992cd7fc86cd05878c90b9b",
     "plugins/src/base/rules/reference/pre-flight-autofill.md":
@@ -801,9 +805,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-confluence-prd-intake/SKILL.md":
       "a6a099abeb32940d44da7e9a6a62c3519f64efa85294c4b996789fa4fba97461",
     "plugins/src/base/skills/lisa-confluence-to-tracker/SKILL.md":
-      "71ab183ba9f14b83d2e940f4b5ec0e2282b75e30d9d452689d330b5345132bba",
+      "a52cf7c4361e43884574f2e8e273ddf8a90b707902c182efb2646b1787e10d8d",
     "plugins/src/base/skills/lisa-confluence-write-prd/SKILL.md":
-      "548c7f7da38372e3b39bc051d5f09417f5008c880caddb59bc6a8b6e05b0aa7b",
+      "29fce0dce5f3d1b9cbe8705c8fc002e5885675e1807cf948b166aef88ddfd73a",
     "plugins/src/base/skills/lisa-cross-pollinate/SKILL.md":
       "d1d33a149cab2de0d0b4c7ddc6bb2f67f43a097e5f551f642b1cb076747a5a05",
     "plugins/src/base/skills/lisa-debrief-apply/SKILL.md":
@@ -849,7 +853,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-github-sync/SKILL.md":
       "c63c8bf7aeabc1ba5f6e5a3f982212e9903496c559ba035da303aa50fe4626e3",
     "plugins/src/base/skills/lisa-github-to-tracker/SKILL.md":
-      "ab2d38a49ff0444c6f7981269a8e63350bef6e7fd9a9759a489e573493b7ed4b",
+      "3b0e67ed50909d38249b9780052d97e66268990c8806aa271000c37716aafa06",
     "plugins/src/base/skills/lisa-github-validate-issue/SKILL.md":
       "bc285142bc2b83ef7e4be785308573c6102ef7460159c9b9fa1da1bded941ad0",
     "plugins/src/base/skills/lisa-github-verify/SKILL.md":
@@ -857,7 +861,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-github-write-issue/SKILL.md":
       "ee54b3d14cc5dd3a68a8c36590102dd02f49334c9493ad52fa8c7f35157073b1",
     "plugins/src/base/skills/lisa-github-write-prd/SKILL.md":
-      "bc919c52e2f42129d41a3f40279d2def99486ec58bed2dab51ca7166b427a947",
+      "262f8a1bcfad4c5dd4456cfaaf1b71abf9697a0da588966e58ff491acd3c17e8",
     "plugins/src/base/skills/lisa-health/SKILL.md":
       "dfdb08a863e78bff42671793dcec29cfae0654db18ebf66a4aa77aeb56ddb775",
     "plugins/src/base/skills/lisa-implement/SKILL.md":
@@ -937,7 +941,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-linear-sync/SKILL.md":
       "85fbf548b9d7972912fde717d1d6ca82c0350ad82f6d779d08c831b23b90ebd3",
     "plugins/src/base/skills/lisa-linear-to-tracker/SKILL.md":
-      "6a096c6818c6a6b3938ed3b52f6e9be8416de3b61b0b5e23fabf0ae32a9756d8",
+      "13612749caa946ff1c318e26dbf40f0b87be682d8a40383ee7e143ac78baa5d3",
     "plugins/src/base/skills/lisa-linear-validate-issue/SKILL.md":
       "da58b538723bd846060f7b0a1374aec13b8436ce6fd8ff8911e2d8d3449f68a9",
     "plugins/src/base/skills/lisa-linear-verify/SKILL.md":
@@ -945,7 +949,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-linear-write-issue/SKILL.md":
       "467092235285874cf21a75b2ad1fb13fddcb35253b09b1ffb9308c614ecadaa7",
     "plugins/src/base/skills/lisa-linear-write-prd/SKILL.md":
-      "d8499f92cfb683955fb3e0100c9ea6f267bd6b3ee457312af5e10c0192952401",
+      "ad4289b5530d65d3b61b27da54db8cd7f8e9133f97326d8961f853f364c5b457",
     "plugins/src/base/skills/lisa-monitor/SKILL.md":
       "e441767176da88484b8034df9589cb33240d5d895339ee96926917a52a103423",
     "plugins/src/base/skills/lisa-nightly-add-test-coverage/SKILL.md":
@@ -959,9 +963,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-notion-prd-intake/SKILL.md":
       "cf9be0a2173782696e2c1d2fcbc2fc2ae29c0eefa3815ae951f5afef7d029c94",
     "plugins/src/base/skills/lisa-notion-to-tracker/SKILL.md":
-      "64da7698e1244b684541d33abf0090b9af19d780a431c26fd1f4b1c388b50319",
+      "0535fe6fc76c7c20aee2617a7b4e4b33aee82e57aea7dded17469d9ee0de5eea",
     "plugins/src/base/skills/lisa-notion-write-prd/SKILL.md":
-      "53251bf1acab622d360a74cfff2ef41b4487ea77eddb4d9eb5c58693176b654b",
+      "d470ed077aa58e53f770c171c8409fa65a3411e15212333fd196237cdfdbf73e",
     "plugins/src/base/skills/lisa-parity-code-review/SKILL.md":
       "5805254747c4ed9081fd514236f06e078be86d41694bf74b480bf7592cd58c1f",
     "plugins/src/base/skills/lisa-parity-code-simplifier/SKILL.md":
@@ -1027,7 +1031,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-reproduce-bug/SKILL.md":
       "6304c848c64a00be230337d9e40770c3a09aa59c6241733e32060d0cce9a4f9b",
     "plugins/src/base/skills/lisa-research/SKILL.md":
-      "8af0479e6ba1a04398487eb9542dd9c5518d65d78cb0173e0b770f191dc362d3",
+      "19de7c5910b117c4b3b1bb7ae42cf9c8b6ff2a376b2e21961526bc7ebde18e85",
     "plugins/src/base/skills/lisa-review-implementation/SKILL.md":
       "42134253cca50e384f36eaa085c0a1e6b8772e9f3e912a8d1231f1cd69199858",
     "plugins/src/base/skills/lisa-review-local/SKILL.md":
@@ -2085,7 +2089,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "ui/README.md":
       "deeb35e767ea5dd2883268835ea3ad21cbad9fa63ec8d8ff5e200f0e2a7d2751",
     "ui/index.html":
-      "ee615cb23b2073cef9d390acad64861583bae4a444e4148989026c7d252880fc",
+      "5dba7cf366d5d44fae3ac68bf65d63e931046cbce0f382e91eb85fa44d8d151d",
   });
 
 /** Exact paths tracked by the public Lisa repository at generation time. */
@@ -3340,6 +3344,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/rules/eager/intent-routing.md": true,
     "plugins/lisa-copilot/rules/eager/leaf-only-lifecycle.md": true,
     "plugins/lisa-copilot/rules/eager/observability-audit.md": true,
+    "plugins/lisa-copilot/rules/eager/prd-definition-of-ready.md": true,
     "plugins/lisa-copilot/rules/eager/prd-lifecycle-rollup.md": true,
     "plugins/lisa-copilot/rules/eager/pre-flight-autofill.md": true,
     "plugins/lisa-copilot/rules/eager/project-learnings.md": true,
@@ -3373,6 +3378,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/rules/reference/intent-routing.md": true,
     "plugins/lisa-copilot/rules/reference/leaf-only-lifecycle.md": true,
     "plugins/lisa-copilot/rules/reference/observability-audit.md": true,
+    "plugins/lisa-copilot/rules/reference/prd-definition-of-ready.md": true,
     "plugins/lisa-copilot/rules/reference/prd-lifecycle-rollup.md": true,
     "plugins/lisa-copilot/rules/reference/pre-flight-autofill.md": true,
     "plugins/lisa-copilot/rules/reference/project-learnings.md": true,
@@ -3725,6 +3731,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/rules/leaf-only-lifecycle.mdc": true,
     "plugins/lisa-cursor/rules/observability-audit-reference.mdc": true,
     "plugins/lisa-cursor/rules/observability-audit.mdc": true,
+    "plugins/lisa-cursor/rules/prd-definition-of-ready-reference.mdc": true,
+    "plugins/lisa-cursor/rules/prd-definition-of-ready.mdc": true,
     "plugins/lisa-cursor/rules/prd-lifecycle-rollup-reference.mdc": true,
     "plugins/lisa-cursor/rules/prd-lifecycle-rollup.mdc": true,
     "plugins/lisa-cursor/rules/pre-flight-autofill-reference.mdc": true,
@@ -6117,6 +6125,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/rules/eager/intent-routing.md": true,
     "plugins/lisa/rules/eager/leaf-only-lifecycle.md": true,
     "plugins/lisa/rules/eager/observability-audit.md": true,
+    "plugins/lisa/rules/eager/prd-definition-of-ready.md": true,
     "plugins/lisa/rules/eager/prd-lifecycle-rollup.md": true,
     "plugins/lisa/rules/eager/pre-flight-autofill.md": true,
     "plugins/lisa/rules/eager/project-learnings.md": true,
@@ -6150,6 +6159,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/rules/reference/intent-routing.md": true,
     "plugins/lisa/rules/reference/leaf-only-lifecycle.md": true,
     "plugins/lisa/rules/reference/observability-audit.md": true,
+    "plugins/lisa/rules/reference/prd-definition-of-ready.md": true,
     "plugins/lisa/rules/reference/prd-lifecycle-rollup.md": true,
     "plugins/lisa/rules/reference/pre-flight-autofill.md": true,
     "plugins/lisa/rules/reference/project-learnings.md": true,
@@ -6654,6 +6664,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/rules/eager/intent-routing.md": true,
     "plugins/src/base/rules/eager/leaf-only-lifecycle.md": true,
     "plugins/src/base/rules/eager/observability-audit.md": true,
+    "plugins/src/base/rules/eager/prd-definition-of-ready.md": true,
     "plugins/src/base/rules/eager/prd-lifecycle-rollup.md": true,
     "plugins/src/base/rules/eager/pre-flight-autofill.md": true,
     "plugins/src/base/rules/eager/project-learnings.md": true,
@@ -6687,6 +6698,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/rules/reference/intent-routing.md": true,
     "plugins/src/base/rules/reference/leaf-only-lifecycle.md": true,
     "plugins/src/base/rules/reference/observability-audit.md": true,
+    "plugins/src/base/rules/reference/prd-definition-of-ready.md": true,
     "plugins/src/base/rules/reference/prd-lifecycle-rollup.md": true,
     "plugins/src/base/rules/reference/pre-flight-autofill.md": true,
     "plugins/src/base/rules/reference/project-learnings.md": true,

--- a/ui/index.html
+++ b/ui/index.html
@@ -5352,6 +5352,17 @@
                       "None",
                     ],
                   },
+                  {
+                    q: "Are requirements written as testable atoms?",
+                    help: "TASC AC8.4. Identified requirement atoms — one behavior each, patterned syntax (EARS: When X, the system shall Y), each with a measurable fit criterion — are what let a planner decompose mechanically and a verifier check conformance. A paragraph welding three requirements together degrades tracing, coverage and verification all at once.",
+                    kind: "select",
+                    value: "Identified atoms — patterned + fit criteria",
+                    options: [
+                      "Identified atoms — patterned + fit criteria",
+                      "Structured prose",
+                      "Free-form documents",
+                    ],
+                  },
                 ],
               },
               {

--- a/wiki/concepts/tasc-specification.md
+++ b/wiki/concepts/tasc-specification.md
@@ -23,7 +23,7 @@ provisional pending trademark diligence.
   the agent threat model, sensor integrity and learning promotion (mistakes captured, judged, and promoted upstream into enforcement — AC4.5), enforcement integrity (server-side
   authority, staff parity, the threshold ratchet), identity & credentials,
   operations & recovery (incl. autonomy-rate measurement), change management
-  (incl. "the agent program is code" and "model change is system change", plus type-keyed work-item readiness with the stateless-pickup check — AC8.6), and
+  (incl. "the agent program is code" and "model change is system change", plus type-keyed work-item readiness with the stateless-pickup check — AC8.6, and requirement-atom intake validation with fit criteria under AC8.4), and
   supply chain (model vendors as subservice organizations).
 - **Supplemental categories**: SI (Software Integrity — mandatory for
   production software, unlike SOC 2's optional Processing Integrity), DP (Data


### PR DESCRIPTION
Closes CodySwannGT/lisa#2067

Work-Item: CodySwannGT/lisa#2067

## What

The PRD-side counterpart to #2066's work-item DoR: **a requirements document is ready when a planner can decompose it mechanically and a verifier can check the result against it** — and both properties come from the shape of the requirements, not the prose around them.

## Shared rule (new)

`prd-definition-of-ready` (eager + reference): every requirement is an **identified atom** (`R1`, `R2`, …) that is **singular** (one behavior), **unambiguous** (vagueness lexicon banned — *user-friendly, fast, handle gracefully, etc., and/or* …), and **verifiable** via a Volere-style **fit criterion**; SHOULD be shaped as an **EARS pattern** (*When X, the system shall Y*) so it decomposes into Gherkin nearly mechanically. The document walks the ISO 25010 non-functional axes — "no requirement" is a decision, silence is not. Distills **ISO/IEC/IEEE 29148** (successor to IEEE 830); the reference body carries the full lexicon and worked rewrites.

## Enforcement at both ends

- **Write time** — `lisa-research` authors to the shape; the four `*-write-prd` skills carry it as a body rule. Factory-authored PRDs are born conforming.
- **Intake time (the universal gate)** — new **Phase 1.45** in the four `*-to-tracker` skills validates every Phase 1.4 Requirement Register atom. This is where the bar binds, because human-authored PRDs never pass the write path. Failures are `product-clarity` items quoting the atom verbatim with 1–3 candidate rewrites (EARS-shaped by default), routed to `blocked` + comments like every other intake failure. Mechanical singularity splits (R4 → R4a/R4b) are repaired in-register and recorded — never silent.

Downstream, ticket gate S16's verbatim quotes and `prd-ticket-coverage`'s audit now consume defined atoms instead of conventionally-formatted paragraphs — both were quietly degrading when "one requirement" was three welded together.

## Spec + questionnaire

- **TASC AC8.4 extended**: admitted requirements MUST be singular, identified, unambiguous, verifiable atoms with fit criteria; untestable phrasing rejected at the gate (29148 cited non-normatively, EARS as a conforming syntax — the spec stays vendor-neutral).
- **Readiness intake**: new Work-intake row — *"Are requirements written as testable atoms?"* (77 questions).

## Test plan

- `check-rules-pairing.sh`, `check-plugins-sync` (fanout regenerated from source), manifest `--check` — green
- Full pre-push suite passed
- `lisa ui` → Readiness → Work intake shows the new row

🤖 Generated with Claude Code
