### PR TITLE
fix(readiness): redact persisted doc excerpts

### DIFF
--- a/src/cli/doctor-readiness-report-redaction.ts
+++ b/src/cli/doctor-readiness-report-redaction.ts
@@ -7,7 +7,7 @@ import { CONTEXT_ROUTING_DIMENSION_ID } from "./doctor-readiness-context.js";
 import type { ReadinessReport } from "./doctor-readiness.js";
 
 /** Evidence strings for B6 include source-doc excerpts; persist hashes instead. */
-const DOC_EXCERPT_PATTERN = /: "([^"]+)"/g;
+const DOC_EXCERPT_PATTERN = /: "([\s\S]*?)"(?=(?: \| `| \| \(\+\d|$))/g;
 
 /**
  * Remove source-document prose excerpts from the persisted report while keeping
@@ -59,16 +59,13 @@ function sanitizeContextFinding(value: unknown): unknown {
 }
 
 /**
- * Replace quoted documentation excerpts with a short stable digest.
+ * Replace quoted documentation excerpts with a stable digest.
  * @param text - Evidence text
  * @returns Evidence text without the raw excerpt
  */
 function redactDocExcerpts(text: string): string {
   return text.replace(DOC_EXCERPT_PATTERN, (_match, excerpt: string) => {
-    const digest = createHash("sha256")
-      .update(excerpt)
-      .digest("hex")
-      .slice(0, 12);
+    const digest = createHash("sha256").update(excerpt).digest("hex");
     return `: [doc excerpt redacted sha256:${digest}]`;
   });
 }

--- a/src/cli/doctor-readiness-report-redaction.ts
+++ b/src/cli/doctor-readiness-report-redaction.ts
@@ -1,0 +1,74 @@
+/**
+ * Persistence-only redaction for `.lisa/readiness.json`.
+ * @module cli/doctor-readiness-report-redaction
+ */
+import { createHash } from "node:crypto";
+import { CONTEXT_ROUTING_DIMENSION_ID } from "./doctor-readiness-context.js";
+import type { ReadinessReport } from "./doctor-readiness.js";
+
+/** Evidence strings for B6 include source-doc excerpts; persist hashes instead. */
+const DOC_EXCERPT_PATTERN = /: "([^"]+)"/g;
+
+/**
+ * Remove source-document prose excerpts from the persisted report while keeping
+ * the in-memory blocker decision untouched. The console detail already names
+ * the blocker; `.lisa/readiness.json` should not become a second committed copy
+ * of potentially sensitive docs text.
+ * @param report - Full readiness report computed for this run
+ * @returns Report safe to serialize to `.lisa/readiness.json`
+ */
+export function sanitizeReadinessReportForPersistence(
+  report: ReadinessReport
+): ReadinessReport {
+  return {
+    ...report,
+    blockers: report.blockers.map(blocker =>
+      blocker.id === "B6"
+        ? {
+            ...blocker,
+            evidence: redactDocExcerpts(blocker.evidence),
+          }
+        : blocker
+    ),
+    dimensions: report.dimensions.map(dimension =>
+      dimension.id === CONTEXT_ROUTING_DIMENSION_ID
+        ? {
+            ...dimension,
+            findings: dimension.findings.map(sanitizeContextFinding),
+          }
+        : dimension
+    ),
+  };
+}
+
+/**
+ * Redact B6 finding strings that can contain quoted documentation excerpts.
+ * @param value - One untyped finding
+ * @returns Finding with prose excerpts redacted, or the original value
+ */
+function sanitizeContextFinding(value: unknown): unknown {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      typeof entry === "string" ? redactDocExcerpts(entry) : entry,
+    ])
+  );
+}
+
+/**
+ * Replace quoted documentation excerpts with a short stable digest.
+ * @param text - Evidence text
+ * @returns Evidence text without the raw excerpt
+ */
+function redactDocExcerpts(text: string): string {
+  return text.replace(DOC_EXCERPT_PATTERN, (_match, excerpt: string) => {
+    const digest = createHash("sha256")
+      .update(excerpt)
+      .digest("hex")
+      .slice(0, 12);
+    return `: [doc excerpt redacted sha256:${digest}]`;
+  });
+}

--- a/src/cli/doctor-readiness.ts
+++ b/src/cli/doctor-readiness.ts
@@ -39,6 +39,7 @@ import {
   assessExecutionProofDimension,
   assessProportionalityDimension,
 } from "./doctor-readiness-journey.js";
+import { sanitizeReadinessReportForPersistence } from "./doctor-readiness-report-redaction.js";
 import type { ReadinessDimensionRecord } from "./doctor-readiness-types.js";
 import { getPackageVersion } from "./version.js";
 
@@ -144,7 +145,7 @@ export const READINESS_DIMENSION_IDS: readonly string[] =
   READINESS_DIMENSIONS.map(dimension => dimension.id);
 
 /** The persisted `.lisa/readiness.json` shape (schema_version 1). */
-interface ReadinessReport {
+export interface ReadinessReport {
   readonly schema_version: number;
   readonly generated_at: string;
   readonly lisa_version: string;
@@ -207,7 +208,10 @@ export async function checkRepositoryReadiness(
 
   const reportPath = resolveReadinessReportPath(targetPath);
   try {
-    await persistReadinessReport(reportPath, report);
+    await persistReadinessReport(
+      reportPath,
+      sanitizeReadinessReportForPersistence(report)
+    );
   } catch (error) {
     return {
       name: REPOSITORY_READINESS_CHECK_NAME,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7411,6 +7411,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/cli/doctor-readiness-journey.ts": true,
     "src/cli/doctor-readiness-operations.ts": true,
     "src/cli/doctor-readiness-release-path.ts": true,
+    "src/cli/doctor-readiness-report-redaction.ts": true,
     "src/cli/doctor-readiness-reusable-callers.ts": true,
     "src/cli/doctor-readiness-shared.ts": true,
     "src/cli/doctor-readiness-supply-chain-evidence.ts": true,

--- a/tests/unit/cli/doctor-readiness-context.test.ts
+++ b/tests/unit/cli/doctor-readiness-context.test.ts
@@ -227,4 +227,30 @@ describe("context-routing dimension identity", () => {
     );
     expect(dimension?.status).toBe(WARN);
   });
+
+  it("redacts B6 documentation excerpts from the persisted report", async () => {
+    const cwd = await getTempDir();
+    await writeRoutingArtifacts(cwd);
+    const sensitiveClaim =
+      "Every push is blocked by `.github/workflows/absent.yml` before " +
+      "customer Acme Private Rollout 713 can deploy.";
+    await writeRepoFile(cwd, "README.md", `# Scratch\n\n${sensitiveClaim}\n`);
+
+    await checkRepositoryReadiness(cwd);
+
+    const raw = await readFile(resolveReadinessReportPath(cwd), "utf8");
+    expect(raw).not.toContain(sensitiveClaim);
+    expect(raw).not.toContain("Acme Private Rollout 713");
+    expect(raw).toContain("[doc excerpt redacted sha256:");
+
+    const report = JSON.parse(raw) as {
+      readonly blockers: readonly {
+        readonly id: string;
+        readonly evidence: string;
+      }[];
+    };
+    const blocker = report.blockers.find(entry => entry.id === BLOCKER_ID);
+    expect(blocker?.evidence).not.toContain(sensitiveClaim);
+    expect(blocker?.evidence).toContain("[doc excerpt redacted sha256:");
+  });
 });

--- a/tests/unit/cli/doctor-readiness-context.test.ts
+++ b/tests/unit/cli/doctor-readiness-context.test.ts
@@ -231,26 +231,49 @@ describe("context-routing dimension identity", () => {
   it("redacts B6 documentation excerpts from the persisted report", async () => {
     const cwd = await getTempDir();
     await writeRoutingArtifacts(cwd);
+    const sensitiveCustomer = "Acme Private Rollout 713";
     const sensitiveClaim =
       "Every push is blocked by `.github/workflows/absent.yml` before " +
-      "customer Acme Private Rollout 713 can deploy.";
+      `the "Deploy" label for customer ${sensitiveCustomer} can deploy.`;
+    const expectedMarker =
+      "[doc excerpt redacted sha256:" +
+      "df458609e0672ebf3d634fac3f691cb123d5118f0003671f113477191c240dcc" +
+      "]";
     await writeRepoFile(cwd, "README.md", `# Scratch\n\n${sensitiveClaim}\n`);
 
     await checkRepositoryReadiness(cwd);
 
     const raw = await readFile(resolveReadinessReportPath(cwd), "utf8");
     expect(raw).not.toContain(sensitiveClaim);
-    expect(raw).not.toContain("Acme Private Rollout 713");
-    expect(raw).toContain("[doc excerpt redacted sha256:");
+    expect(raw).not.toContain('the "Deploy" label');
+    expect(raw).not.toContain(sensitiveCustomer);
+    expect(raw).toContain(expectedMarker);
 
     const report = JSON.parse(raw) as {
       readonly blockers: readonly {
         readonly id: string;
         readonly evidence: string;
       }[];
+      readonly dimensions: readonly {
+        readonly id: string;
+        readonly findings: readonly { readonly evidence?: string }[];
+      }[];
     };
     const blocker = report.blockers.find(entry => entry.id === BLOCKER_ID);
+    expect(blocker).toBeDefined();
     expect(blocker?.evidence).not.toContain(sensitiveClaim);
-    expect(blocker?.evidence).toContain("[doc excerpt redacted sha256:");
+    expect(blocker?.evidence).not.toContain(sensitiveCustomer);
+    expect(blocker?.evidence).toContain(expectedMarker);
+
+    const dimension = report.dimensions.find(
+      entry => entry.id === DIMENSION_ID
+    );
+    const finding = dimension?.findings.find(entry =>
+      entry.evidence?.includes(expectedMarker)
+    );
+    expect(finding).toBeDefined();
+    expect(finding?.evidence).not.toContain(sensitiveClaim);
+    expect(finding?.evidence).not.toContain(sensitiveCustomer);
+    expect(finding?.evidence).toContain(expectedMarker);
   });
 });


### PR DESCRIPTION
## Summary
- Redact B6 source-document excerpts before persisting `.lisa/readiness.json` while preserving blocker decisions in memory.
- Add a focused regression proving sensitive prose does not appear in persisted dimensions or blockers.
- Refresh the upstream evidence manifest for the new redaction helper.

## Verification
- bun test tests/unit/cli/doctor-readiness-context.test.ts tests/unit/cli/doctor-readiness.test.ts
- bun run typecheck
- bun run lint -- src/cli/doctor-readiness.ts src/cli/doctor-readiness-report-redaction.ts tests/unit/cli/doctor-readiness-context.test.ts
- bun run check:upstream-evidence-manifest
- bun run build:dist
- pre-push: typecheck, production audit, slow lint, knip, full coverage, integration tests, plugin parity

Work-Item: CodySwannGT/lisa#1903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Privacy**
  * Sensitive documentation excerpts are now redacted from persisted readiness reports.
  * Redacted content is replaced with a stable digest, preserving report usefulness without storing quoted details.

* **Bug Fixes**
  * Routing-context findings are sanitized before reports are saved.
  * In-memory blocker decisions remain unchanged while persisted reports protect sensitive evidence.

* **Tests**
  * Added coverage confirming sensitive claims and identifiers do not appear in saved readiness reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->