### PR TITLE
feat(spec): absorb published governance invariants into TASC

### DIFF
--- a/spec/tasc-0.1-draft.md
+++ b/spec/tasc-0.1-draft.md
@@ -239,9 +239,10 @@ focus (non-authoritative guidance).
   requirement → originating intent or signal. At Level 2+, at least one hop
   (change → work item) MUST be enforced mechanically at commit or merge time.
   The chain SHOULD extend to generation lineage — the producing procedure and
-  prompt version (AC8.2) and the pinned model version (AC8.3) — so a defect is
-  traceable to the instruction and runtime that produced it, not only to the
-  intent it served.
+  prompt version (AC8.2) and the pinned model version (AC8.3), recorded per
+  change — so a defect is traceable to the instruction and runtime that
+  produced it, not only to the intent it served. At Level 3, generation
+  lineage is MUST.
   *Focus: enforced work-item references; requirement backlinks; the chain survives
   refactors via history.*
 - **AC1.3 Segregation of duties.** The agent that authored a change MUST NOT be the

--- a/spec/tasc-0.1-draft.md
+++ b/spec/tasc-0.1-draft.md
@@ -63,6 +63,11 @@ The criteria embody a small number of normative principles, referenced throughou
   a non-technical operator.
 - **P7 — Monotonic quality.** Quality thresholds may only tighten in the ordinary
   course. Loosening a threshold is an exceptional, isolated, reviewed change.
+- **P8 — Author-agnostic enforcement.** No artifact is trusted by default,
+  whatever authored it. The same gates, with the same configurations, apply to
+  human-authored and agent-authored work alike: the pipeline evaluates the
+  artifact against the standard, never the author against a reputation. A
+  bypass that exists for one class of author exists for every attacker.
 
 ### 3. Scope and applicability
 
@@ -233,6 +238,10 @@ focus (non-authoritative guidance).
   machine-followable chain MUST exist: line → change → change request → work item →
   requirement → originating intent or signal. At Level 2+, at least one hop
   (change → work item) MUST be enforced mechanically at commit or merge time.
+  The chain SHOULD extend to generation lineage — the producing procedure and
+  prompt version (AC8.2) and the pinned model version (AC8.3) — so a defect is
+  traceable to the instruction and runtime that produced it, not only to the
+  intent it served.
   *Focus: enforced work-item references; requirement backlinks; the chain survives
   refactors via history.*
 - **AC1.3 Segregation of duties.** The agent that authored a change MUST NOT be the
@@ -375,7 +384,10 @@ focus (non-authoritative guidance).
   — validated intake, implementation, independent review (AC1.3), and the pre-merge
   integrity gates (SI1–SI4, as applicable) — with gates per AC5, followed by
   post-deployment verification (SI5). Review findings MUST be resolved, not merely
-  produced, before merge.
+  produced, before merge. When a gate rejects agent-produced work, remediation
+  SHOULD be regeneration from the specification rather than manual patching of
+  the artifact: a hand-patched artifact has mixed provenance that AC1.2 cannot
+  cleanly attribute.
 - **AC8.2 The agent program is code.** Prompts, skills, procedures, and workflow
   definitions MUST be version-controlled and MUST pass the same change gates as
   code. Production work MUST be driven by vetted procedures; free-form prompting
@@ -426,6 +438,10 @@ focus (non-authoritative guidance).
 - **AC9.5 Hosted runtimes.** Vendor-hosted agent runtimes MUST be assessed for
   sandbox properties, network posture, secret storage, and scheduler semantics
   before production use.
+- **AC9.6 Artifact provenance.** Released artifacts SHOULD carry a software
+  bill of materials and cryptographic provenance (signing or attestation) so a
+  consumer can verify what was built, from what inputs, by what pipeline. At
+  Level 3 the provenance chain MUST be machine-verifiable end to end.
 
 ### SI — Software Integrity *(supplemental; applies to all production software output — analogous to Processing Integrity)*
 
@@ -452,6 +468,13 @@ focus (non-authoritative guidance).
   indistinguishability: with authorship hidden, a reviewer (or classifier) should
   not reliably identify which agent or person wrote a change; distinguishing
   features found are candidate rules.
+- **SI8 Load and SLO conformance.** Where the software exposes a service
+  surface, changes MUST be validated under load before release: the system
+  meets its declared Service Level Objectives for latency and throughput, and
+  the change introduces no scaling regression (stress, spike, or soak testing
+  selected by the declared risk of the change). SLOs are entity-declared but
+  MUST be stated, and are subject to the ratchet (AC5.4). Inapplicability is
+  earned (P3) only by the absence of a service surface.
 
 ### DP — Data Protection *(supplemental; applies where sensitive or regulated data is in scope — analogous to Confidentiality/Privacy)*
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2089,7 +2089,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "ui/README.md":
       "deeb35e767ea5dd2883268835ea3ad21cbad9fa63ec8d8ff5e200f0e2a7d2751",
     "ui/index.html":
-      "5dba7cf366d5d44fae3ac68bf65d63e931046cbce0f382e91eb85fa44d8d151d",
+      "3df83a665f9c45a53d602f16632a7502a92ba068022cd1ac47d1685d31fcea28",
   });
 
 /** Exact paths tracked by the public Lisa repository at generation time. */

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2089,7 +2089,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "ui/README.md":
       "deeb35e767ea5dd2883268835ea3ad21cbad9fa63ec8d8ff5e200f0e2a7d2751",
     "ui/index.html":
-      "3df83a665f9c45a53d602f16632a7502a92ba068022cd1ac47d1685d31fcea28",
+      "6383f16502509780344d271a805f171e545516b7398fc29745f6dba9035e52e5",
   });
 
 /** Exact paths tracked by the public Lisa repository at generation time. */

--- a/ui/index.html
+++ b/ui/index.html
@@ -5366,7 +5366,7 @@
                 ],
               },
               {
-                label: "Correctness gates (SI1–SI3 · AC5.4)",
+                label: "Correctness gates (SI1–SI3 · SI8 · AC5.4)",
                 items: [
                   {
                     q: "Is unit behaviour proven on every change?",
@@ -5418,6 +5418,27 @@
                     kind: "select",
                     options: ["Yes — gates merges", "Yes — nightly only", "No"],
                     value: "Yes — nightly only",
+                  },
+                  {
+                    q: "Is the system load-tested against SLOs before release?",
+                    help: "TASC SI8. Functional correctness without performance is insufficient — an endpoint returning correct data in 30 seconds fails a 200ms SLO. Stress, spike, or soak per the risk of the change; no service surface is a valid answer.",
+                    kind: "select",
+                    value: "No service surface in this project",
+                    options: [
+                      "SLO conformance gates release",
+                      "Load-tested occasionally",
+                      "Not load-tested",
+                      "No service surface in this project",
+                    ],
+                    via: [
+                      "k6",
+                      "Gatling",
+                      "Locust",
+                      "Artillery",
+                      "In-house",
+                      "None",
+                    ],
+                    viaValue: "None",
                   },
                   {
                     q: "Can a quality threshold be quietly lowered?",
@@ -5485,6 +5506,24 @@
                       "checkov",
                       "tfsec",
                       "Terrascan",
+                      "None",
+                    ],
+                  },
+                  {
+                    q: "Do you produce an SBOM and sign released artifacts?",
+                    help: "TASC AC9.6. A software bill of materials plus cryptographic provenance lets a consumer verify what was built, from what inputs, by what pipeline — the supply-chain answer a procurement review increasingly demands.",
+                    kind: "select",
+                    options: [
+                      "SBOM + signed provenance",
+                      "SBOM only",
+                      "Neither",
+                    ],
+                    via: [
+                      "Syft / CycloneDX",
+                      "Sigstore / cosign",
+                      "SLSA provenance",
+                      "npm provenance",
+                      "In-house",
                       "None",
                     ],
                   },
@@ -5781,6 +5820,17 @@
                     ],
                   },
                   {
+                    q: "When a gate rejects agent output, what happens?",
+                    help: "TASC AC8.1. The published ideal is regenerate-from-spec — a hand-patched artifact has mixed provenance nobody can cleanly attribute. Agents iterating on their own output is the common middle ground; humans quietly patching agent work is the provenance leak.",
+                    kind: "select",
+                    value: "The agent patches its own output",
+                    options: [
+                      "Regenerated from the spec",
+                      "The agent patches its own output",
+                      "A human patches it by hand",
+                    ],
+                  },
+                  {
                     q: "Are your quality gates unskippable server-side?",
                     help: "A gate a worker can bypass with --no-verify is advisory. Only branch/push protection cannot be skipped — and an autonomous agent is exactly the worker that will route around a skippable one.",
                     kind: "select",
@@ -6057,6 +6107,16 @@
                       "Full chain, enforced at commit time",
                       "Partial — commits reference tickets",
                       "git blame is the end of the trail",
+                    ],
+                  },
+                  {
+                    q: "Can you trace an artifact to the prompt and model that produced it?",
+                    help: "TASC AC1.2 generation lineage — the audit question beyond 'why was this written': which instruction and which model wrote it. Transcripts that exist but aren't linked to the change answer this only partially.",
+                    kind: "select",
+                    options: [
+                      "Lineage recorded per change",
+                      "Transcripts exist, unlinked",
+                      "No",
                     ],
                   },
                   {

--- a/ui/index.html
+++ b/ui/index.html
@@ -5422,8 +5422,10 @@
                   {
                     q: "Is the system load-tested against SLOs before release?",
                     help: "TASC SI8. Functional correctness without performance is insufficient — an endpoint returning correct data in 30 seconds fails a 200ms SLO. Stress, spike, or soak per the risk of the change; no service surface is a valid answer.",
+                    // No prefill: per P3, "no service surface" must be derived
+                    // from a verified system fact, never self-declared — a wired
+                    // version answers this from stack detection.
                     kind: "select",
-                    value: "No service surface in this project",
                     options: [
                       "SLO conformance gates release",
                       "Load-tested occasionally",
@@ -5438,7 +5440,6 @@
                       "In-house",
                       "None",
                     ],
-                    viaValue: "None",
                   },
                   {
                     q: "Can a quality threshold be quietly lowered?",

--- a/wiki/concepts/tasc-specification.md
+++ b/wiki/concepts/tasc-specification.md
@@ -40,7 +40,7 @@ provisional pending trademark diligence.
   protected deploy approval, escalation response) each carry a response-time
   SLA — the human is a dependency with an SLA.
 
-## The Seven Principles
+## The Eight Principles
 
 1. **Exercised evidence** — a control is proven by firing, not by existing.
 2. **Unknown is never conforming** — evidence expires; stale degrades to
@@ -53,6 +53,8 @@ provisional pending trademark diligence.
    non-technical operators.
 7. **Monotonic quality** — thresholds only tighten; loosening is an isolated,
    reviewed exception.
+8. **Author-agnostic enforcement** — the same gates for human- and
+   agent-authored work; the pipeline judges the artifact, never the author.
 
 ## Relationship To Lisa
 


### PR DESCRIPTION
Closes CodySwannGT/lisa#2071

Work-Item: CodySwannGT/lisa#2071

## What

Aligns TASC with the published seven-governance-invariants / black-box-governance framework (the publishing repo research positions), so the spec and the published articles cross-cite instead of contradicting.

- **P8 Author-agnostic enforcement** — zero-trust for artifacts: same gates, same configs, whatever authored it
- **SI8 Load & SLO conformance** — the Scalable/Performant invariants; earned-N/A only without a service surface; SLOs ratchet (AC5.4)
- **AC1.2 → generation lineage** — the chain SHOULD reach producing prompt/procedure version + pinned model version
- **AC9.6 Artifact provenance** — SBOM + signing/attestation; machine-verifiable at Level 3
- **AC8.1 → reject-and-regenerate (SHOULD)** — hand-patched artifacts have mixed provenance

Questionnaire: 4 new rows (81 total), incl. the honestly pre-answered rejection-handling row ("the agent patches its own output" — a real divergence from the published ideal, shown rather than hidden).

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added author-agnostic enforcement as a core design principle.
  * Expanded traceability requirements to include prompts, procedures, and model versions.
  * Added requirements for SBOMs, cryptographic provenance, and machine-verifiable integrity.
  * Added load and service-level validation requirements before release.
  * Updated readiness questionnaires to capture these security, performance, and governance checks.

* **Documentation**
  * Updated the specification from seven to eight principles.
  * Clarified remediation guidance to favor regeneration when validation gates reject generated work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->