### PR TITLE
fix(readiness): flag production wrapper guardrails

### DIFF
--- a/src/cli/doctor-readiness-guardrails.ts
+++ b/src/cli/doctor-readiness-guardrails.ts
@@ -134,6 +134,14 @@ const OPAQUE_CONSEQUENTIAL_INPUTS: readonly RegExp[] = [
   /\bprod(uction)?\b/,
 ];
 
+/** Local wrapper names that are explicit enough to count as consequential. */
+const LOCAL_CONSEQUENTIAL_WRAPPERS: readonly RegExp[] = [
+  /(?:^|\s)(?:\.\/|bash\s+|sh\s+)(?:scripts\/)?[a-z0-9._/-]*(?:destroy|delete|remove|teardown|migrate|reset)[a-z0-9._/-]*(?:prod|production)[a-z0-9._/-]*/,
+  /(?:^|\s)(?:\.\/|bash\s+|sh\s+)(?:scripts\/)?[a-z0-9._/-]*(?:prod|production)[a-z0-9._/-]*(?:destroy|delete|remove|teardown|migrate|reset)[a-z0-9._/-]*/,
+  /\b(?:npm|yarn|pnpm|bun)\s+run\s+[a-z0-9:_-]*(?:destroy|delete|remove|teardown|migrate|reset)[a-z0-9:_-]*(?:prod|production)[a-z0-9:_-]*/,
+  /\b(?:npm|yarn|pnpm|bun)\s+run\s+[a-z0-9:_-]*(?:prod|production)[a-z0-9:_-]*(?:destroy|delete|remove|teardown|migrate|reset)[a-z0-9:_-]*/,
+];
+
 /**
  * Collapse only shell continuation newlines. Ordinary newlines remain command
  * boundaries so unrelated invocations cannot combine into one Terraform apply.
@@ -210,6 +218,7 @@ function isConsequential(
   return (
     terraformAutoApprovedApply ||
     CONSEQUENTIAL_OPS.some(pattern => pattern.test(command)) ||
+    LOCAL_CONSEQUENTIAL_WRAPPERS.some(pattern => pattern.test(command)) ||
     (MIGRATION_COMMANDS.some(pattern => pattern.test(command)) &&
       PRODUCTION_MARKERS.some(pattern => pattern.test(targetEvidence)))
   );

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7802,6 +7802,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts": true,
     "tests/unit/cli/doctor-readiness-guardrails-opaque-actions.test.ts": true,
     "tests/unit/cli/doctor-readiness-guardrails-terraform.test.ts": true,
+    "tests/unit/cli/doctor-readiness-guardrails-wrappers.test.ts": true,
     "tests/unit/cli/doctor-readiness-guardrails.test.ts": true,
     "tests/unit/cli/doctor-readiness-journey.test.ts": true,
     "tests/unit/cli/doctor-readiness-supply-chain-exceptions.test.ts": true,

--- a/tests/unit/cli/doctor-readiness-guardrails-wrappers.test.ts
+++ b/tests/unit/cli/doctor-readiness-guardrails-wrappers.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Local wrapper command coverage for the feedback/guardrails readiness producer
+ * (B4, PRD #1739, #1896).
+ * @module tests/unit/cli/doctor-readiness-guardrails-wrappers
+ */
+import { rm } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { assessFeedbackGuardrailsDimension } from "../../../src/cli/doctor-readiness-guardrails.js";
+import {
+  asFindings,
+  DEPLOY_YML,
+  JOBS,
+  makeScratchRepo,
+  ON_PUSH,
+  RUNS_ON,
+  SKIP,
+  STEPS,
+  WARN,
+  writeWorkflow,
+} from "../../helpers/readiness-workflow-fixtures.js";
+
+/** The ship blocker this producer can stand up. */
+const BLOCKER_ID = "B4";
+
+/** Shared workflow name line for wrapper fixtures. */
+const DEPLOY_NAME_LINE = "name: Deploy";
+
+/** Shared infrastructure job header for wrapper fixtures. */
+const INFRA_JOB = "  infra:";
+
+let tempDir: string | undefined;
+
+/**
+ * Resolve a scratch repository for one test case.
+ * @returns Temporary repository path
+ */
+async function getTempDir(): Promise<string> {
+  tempDir ??= await makeScratchRepo("guardrails-wrappers");
+  return tempDir;
+}
+
+/**
+ * Assert that a command stands B4 and appears in evidence.
+ * @param command - Shell command line to place in the workflow
+ */
+async function expectB4ForCommand(command: string): Promise<void> {
+  const root = await getTempDir();
+  await writeWorkflow(root, DEPLOY_YML, [
+    DEPLOY_NAME_LINE,
+    ON_PUSH,
+    JOBS,
+    INFRA_JOB,
+    RUNS_ON,
+    STEPS,
+    `      - run: ${command}`,
+  ]);
+
+  const record = await assessFeedbackGuardrailsDimension(root);
+  const blocking = asFindings(record.findings).find(
+    finding => finding.blocker === BLOCKER_ID
+  );
+
+  expect(record.status).toBe(WARN);
+  expect(blocking?.evidence).toContain(command);
+}
+
+afterEach(async () => {
+  if (tempDir !== undefined) {
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+describe("assessFeedbackGuardrailsDimension — local wrapper commands", () => {
+  it("stands B4 for an explicitly production local destroy wrapper", async () => {
+    await expectB4ForCommand("./scripts/destroy-prod.sh");
+  });
+
+  it("stands B4 for an explicitly production package-script wrapper", async () => {
+    await expectB4ForCommand("npm run db:reset:prod");
+  });
+
+  it("does not stand B4 for a wrapper that targets test state", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      "name: Test teardown",
+      ON_PUSH,
+      JOBS,
+      INFRA_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: ./scripts/destroy-prod-test-fixture.sh",
+    ]);
+
+    const record = await assessFeedbackGuardrailsDimension(root);
+
+    expect(record.status).toBe(SKIP);
+    for (const finding of asFindings(record.findings)) {
+      expect(Object.hasOwn(finding, "blocker")).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- flag clearly production-named local wrapper commands as B4 consequential operations
- cover local script and package-script wrappers while preserving test-target suppression
- refresh the upstream evidence manifest for the new test file

## Verification
- bun run typecheck
- bun test tests/unit/cli/doctor-readiness-guardrails-wrappers.test.ts tests/unit/cli/doctor-readiness-guardrails.test.ts tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts
- bun run lint -- src/cli/doctor-readiness-guardrails.ts tests/unit/cli/doctor-readiness-guardrails-wrappers.test.ts src/core/upstream-evidence-manifest.ts
- bun run format:check -- src/cli/doctor-readiness-guardrails.ts tests/unit/cli/doctor-readiness-guardrails.test.ts tests/unit/cli/doctor-readiness-guardrails-wrappers.test.ts
- bun run check:upstream-evidence-manifest
- pre-push: typecheck, production audit, slow lint, knip, unit coverage, integration tests, plugin parity

Work-Item: CodySwannGT/lisa#1903