### PR TITLE
fix(readiness): flag production secret migrations

### DIFF
--- a/src/cli/doctor-readiness-guardrails.ts
+++ b/src/cli/doctor-readiness-guardrails.ts
@@ -109,7 +109,7 @@ const MIGRATION_COMMANDS: readonly RegExp[] = [
 const PRODUCTION_MARKERS: readonly RegExp[] = [
   /\b(rails_env|node_env|app_env|django_settings_module|environment)\s*[:=]\s*["']?prod(?:uction)?["']?(?=\s|$)/,
   /--env(ironment)?[= ]prod/,
-  /\b(?:database_url|db_url|url)\s*[:=]\s*\$\{\{\s*secrets\.[a-z0-9_]*(?:prod|production)[a-z0-9_]*\s*\}\}/,
+  /\b(?:database_url|db_url|url)\s*[:=]\s*\$\{\{\s*secrets\.(?:[a-z0-9]+_)*(?:prod|production)(?:_[a-z0-9]+)*\s*\}\}/,
   /\bprod(uction)?\.tfvars\b/,
 ];
 

--- a/src/cli/doctor-readiness-guardrails.ts
+++ b/src/cli/doctor-readiness-guardrails.ts
@@ -109,6 +109,7 @@ const MIGRATION_COMMANDS: readonly RegExp[] = [
 const PRODUCTION_MARKERS: readonly RegExp[] = [
   /\b(rails_env|node_env|app_env|django_settings_module|environment)\s*[:=]\s*["']?prod(?:uction)?["']?(?=\s|$)/,
   /--env(ironment)?[= ]prod/,
+  /\b(?:database_url|db_url|url)\s*[:=]\s*\$\{\{\s*secrets\.[a-z0-9_]*(?:prod|production)[a-z0-9_]*\s*\}\}/,
   /\bprod(uction)?\.tfvars\b/,
 ];
 

--- a/tests/unit/cli/doctor-readiness-guardrails.test.ts
+++ b/tests/unit/cli/doctor-readiness-guardrails.test.ts
@@ -178,6 +178,30 @@ describe("assessFeedbackGuardrailsDimension — B4 stands only on a file-provabl
       )
     ).toBe(true);
   });
+
+  it("stands B4 when a migration targets a production database secret", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, DEPLOY_YML, [
+      DEPLOY_NAME_LINE,
+      ON_PUSH,
+      JOBS,
+      INFRA_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: npx prisma migrate deploy",
+      "        env:",
+      "          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}",
+    ]);
+
+    const record = await assessFeedbackGuardrailsDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+  });
 });
 
 describe("assessFeedbackGuardrailsDimension — the gate half is reasoned-SKIPped", () => {

--- a/tests/unit/cli/doctor-readiness-guardrails.test.ts
+++ b/tests/unit/cli/doctor-readiness-guardrails.test.ts
@@ -283,7 +283,7 @@ describe("assessFeedbackGuardrailsDimension — ordinary operations stay clear",
     expectNoBlocker(record.findings);
   });
 
-  it("does not stand B4 when step env names a non-production environment", async () => {
+  it("does not stand B4 when step env names non-production evidence", async () => {
     const root = await getTempDir();
     await writeWorkflow(root, DEPLOY_YML, [
       DEPLOY_NAME_LINE,
@@ -292,9 +292,11 @@ describe("assessFeedbackGuardrailsDimension — ordinary operations stay clear",
       INFRA_JOB,
       RUNS_ON,
       STEPS,
-      "      - run: bundle exec rails db:migrate",
+      "      - run: npx prisma migrate deploy",
       "        env:",
       "          RAILS_ENV: nonprod",
+      "          DATABASE_URL: ${{ secrets.NONPROD_DATABASE_URL }}",
+      "          DB_URL: ${{ secrets.PRODUCT_DATABASE_URL }}",
     ]);
 
     const record = await assessFeedbackGuardrailsDimension(root);


### PR DESCRIPTION
## Summary

- Treat production database secret mappings like `DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}` as production evidence for B4 migration guardrail detection.
- Add regression coverage for an ungated `prisma migrate deploy` that targets a production database secret.

## Verification

- `bun test tests/unit/cli/doctor-readiness-guardrails.test.ts`
- `bun test tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts tests/unit/cli/doctor-readiness-guardrails-terraform.test.ts tests/unit/cli/doctor-readiness-domain.test.ts tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts tests/unit/cli/doctor-readiness-domain-negatives.test.ts`
- `bun run typecheck`
- `bun run lint -- src/cli/doctor-readiness-guardrails.ts tests/unit/cli/doctor-readiness-guardrails.test.ts`
- pre-push gate: typecheck, production audit, slow lint, knip, full unit coverage, integration tests, plugin parity

Work-Item: CodySwannGT/lisa#1903

[lisa-issue-link] https://github.com/CodySwannGT/lisa/issues/1903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production-targeting detection for database URLs that reference production secrets.
  * Readiness checks now correctly flag migration steps using production database credentials as warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->