### PR TITLE
fix: allow coverage jobs to start service containers

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -144,6 +144,16 @@ on:
         required: false
         default: false
         type: boolean
+      coverage_services:
+        description: 'Optional JSON service-container spec for the coverage job. Empty string preserves prior behavior. Accepts an object map or array with image plus optional name, ports, env, options, and healthTimeoutSeconds.'
+        required: false
+        default: ''
+        type: string
+      coverage_env:
+        description: 'Optional JSON object of extra environment variables scoped to the coverage job before test:cov. Empty string preserves prior behavior.'
+        required: false
+        default: ''
+        type: string
     secrets:
       SONAR_TOKEN:
         description: 'SonarCloud token for SAST analysis'
@@ -715,6 +725,86 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
         working-directory: ${{ inputs.working_directory || '.' }}
+
+      - name: 🧰 Start coverage service containers
+        if: steps.check_script.outputs.exists == 'true' && inputs.coverage_services != ''
+        env:
+          COVERAGE_SERVICES: ${{ inputs.coverage_services }}
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+          const spec = JSON.parse(process.env.COVERAGE_SERVICES || "[]");
+          const services = Array.isArray(spec)
+            ? spec
+            : Object.entries(spec).map(([name, value]) => ({ name, ...value }));
+          const quote = value => `'${String(value).replace(/'/g, `'\\''`)}'`;
+          const lines = ["set -euo pipefail"];
+          const validateName = name => {
+            if (!/^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,62}$/.test(name)) {
+              throw new Error(`Invalid coverage service name: ${name}`);
+            }
+          };
+          for (const [index, service] of services.entries()) {
+            if (!service || typeof service !== "object") {
+              throw new Error(`coverage_services[${index}] must be an object`);
+            }
+            if (!service.image || typeof service.image !== "string") {
+              throw new Error(`coverage_services[${index}].image is required`);
+            }
+            const name = service.name || `lisa-coverage-service-${index + 1}`;
+            validateName(name);
+            lines.push(`docker rm -f ${quote(name)} >/dev/null 2>&1 || true`);
+            const args = ["run", "--detach", "--name", name];
+            for (const [key, value] of Object.entries(service.env || {})) {
+              args.push("--env", `${key}=${value}`);
+            }
+            for (const port of service.ports || []) {
+              args.push("--publish", port);
+            }
+            const optionText =
+              typeof service.options === "string" ? service.options.trim() : "";
+            if (Array.isArray(service.options)) {
+              args.push(...service.options);
+            }
+            const optionSuffix = optionText ? ` ${optionText}` : "";
+            lines.push(
+              `docker ${args.map(quote).join(" ")}${optionSuffix} ${quote(service.image)}`
+            );
+            const timeout = Number(service.healthTimeoutSeconds ?? 60);
+            lines.push(`if docker inspect --format='{{if .Config.Healthcheck}}yes{{end}}' ${quote(name)} | grep -q yes; then`);
+            lines.push(`  deadline=$((SECONDS + ${Number.isFinite(timeout) ? Math.max(1, timeout) : 60}))`);
+            lines.push("  until [ \"$(docker inspect --format='{{.State.Health.Status}}' " + quote(name) + ")\" = healthy ]; do");
+            lines.push("    if [ \"$SECONDS\" -ge \"$deadline\" ]; then docker logs " + quote(name) + "; exit 1; fi");
+            lines.push("    sleep 2");
+            lines.push("  done");
+            lines.push("fi");
+          }
+          fs.writeFileSync("/tmp/lisa-start-coverage-services.sh", `${lines.join("\n")}\n`);
+          NODE
+          bash /tmp/lisa-start-coverage-services.sh
+
+      - name: 🧪 Apply coverage environment
+        if: steps.check_script.outputs.exists == 'true' && inputs.coverage_env != ''
+        env:
+          COVERAGE_ENV: ${{ inputs.coverage_env }}
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+          const env = JSON.parse(process.env.COVERAGE_ENV || "{}");
+          if (!env || Array.isArray(env) || typeof env !== "object") {
+            throw new Error("coverage_env must be a JSON object");
+          }
+          const lines = [];
+          for (const [key, value] of Object.entries(env)) {
+            if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+              throw new Error(`Invalid coverage_env key: ${key}`);
+            }
+            lines.push(`${key}<<LISA_COVERAGE_ENV`);
+            lines.push(String(value));
+            lines.push("LISA_COVERAGE_ENV");
+          }
+          fs.appendFileSync(process.env.GITHUB_ENV, `${lines.join("\n")}\n`);
+          NODE
 
       - name: 🧪 Run unit tests with coverage
         if: steps.check_script.outputs.exists == 'true'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -761,16 +761,16 @@ jobs:
             for (const port of service.ports || []) {
               args.push("--publish", port);
             }
-            const optionText =
-              typeof service.options === "string" ? service.options.trim() : "";
+            if (service.options !== undefined && !Array.isArray(service.options)) {
+              throw new Error(`coverage_services[${index}].options must be an array of docker flags`);
+            }
             if (Array.isArray(service.options)) {
               args.push(...service.options);
             }
-            const optionSuffix = optionText ? ` ${optionText}` : "";
             lines.push(
-              `docker ${args.map(quote).join(" ")}${optionSuffix} ${quote(service.image)}`
+              `docker ${args.map(quote).join(" ")} ${quote(service.image)}`
             );
-            const timeout = Number(service.healthTimeoutSeconds ?? 60);
+            const timeout = Math.trunc(Number(service.healthTimeoutSeconds ?? 60));
             lines.push(`if docker inspect --format='{{if .Config.Healthcheck}}yes{{end}}' ${quote(name)} | grep -q yes; then`);
             lines.push(`  deadline=$((SECONDS + ${Number.isFinite(timeout) ? Math.max(1, timeout) : 60}))`);
             lines.push("  until [ \"$(docker inspect --format='{{.State.Health.Status}}' " + quote(name) + ")\" = healthy ]; do");
@@ -789,6 +789,7 @@ jobs:
           COVERAGE_ENV: ${{ inputs.coverage_env }}
         run: |
           node <<'NODE'
+          const { randomUUID } = require("node:crypto");
           const fs = require("node:fs");
           const env = JSON.parse(process.env.COVERAGE_ENV || "{}");
           if (!env || Array.isArray(env) || typeof env !== "object") {
@@ -799,9 +800,10 @@ jobs:
             if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
               throw new Error(`Invalid coverage_env key: ${key}`);
             }
-            lines.push(`${key}<<LISA_COVERAGE_ENV`);
-            lines.push(String(value));
-            lines.push("LISA_COVERAGE_ENV");
+            const delimiter = `LISA_COVERAGE_ENV_${randomUUID().replace(/-/g, "")}`;
+            lines.push(`${key}<<${delimiter}`);
+            lines.push(typeof value === "object" && value !== null ? JSON.stringify(value) : String(value));
+            lines.push(delimiter);
           }
           fs.appendFileSync(process.env.GITHUB_ENV, `${lines.join("\n")}\n`);
           NODE

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -371,6 +371,65 @@ describe("quality.yml reusable workflow", () => {
     });
   });
 
+  describe("coverage job service inputs", () => {
+    it("declares inert coverage service and env inputs", () => {
+      const inputs = workflow.on.workflow_call?.inputs ?? {};
+
+      expect(inputs.coverage_services).toEqual({
+        description:
+          "Optional JSON service-container spec for the coverage job. Empty string preserves prior behavior. Accepts an object map or array with image plus optional name, ports, env, options, and healthTimeoutSeconds.",
+        required: false,
+        default: "",
+        type: "string",
+      });
+      expect(inputs.coverage_env).toEqual({
+        description:
+          "Optional JSON object of extra environment variables scoped to the coverage job before test:cov. Empty string preserves prior behavior.",
+        required: false,
+        default: "",
+        type: "string",
+      });
+    });
+
+    it("starts optional service containers and applies env before coverage", () => {
+      const steps = workflow.jobs.test_unit.steps ?? [];
+      const checkIndex = steps.findIndex(step => step.id === "check_script");
+      const serviceIndex = steps.findIndex(
+        step => step.name === "🧰 Start coverage service containers"
+      );
+      const envIndex = steps.findIndex(
+        step => step.name === "🧪 Apply coverage environment"
+      );
+      const coverageIndex = steps.findIndex(
+        step => step.name === "🧪 Run unit tests with coverage"
+      );
+
+      expect(checkIndex).toBeGreaterThanOrEqual(0);
+      expect(serviceIndex).toBeGreaterThan(checkIndex);
+      expect(envIndex).toBeGreaterThan(serviceIndex);
+      expect(coverageIndex).toBeGreaterThan(envIndex);
+
+      const serviceStep = steps[serviceIndex];
+      expect(serviceStep?.if).toBe(
+        "steps.check_script.outputs.exists == 'true' && inputs.coverage_services != ''"
+      );
+      expect(serviceStep?.env?.COVERAGE_SERVICES).toBe(
+        "${{ inputs.coverage_services }}"
+      );
+      expect(serviceStep?.run).toContain("docker rm -f");
+      expect(serviceStep?.run).toContain("docker inspect");
+
+      const envStep = steps[envIndex];
+      expect(envStep?.if).toBe(
+        "steps.check_script.outputs.exists == 'true' && inputs.coverage_env != ''"
+      );
+      expect(envStep?.env?.COVERAGE_ENV).toBe("${{ inputs.coverage_env }}");
+      expect(envStep?.run).toContain(
+        "fs.appendFileSync(process.env.GITHUB_ENV"
+      );
+    });
+  });
+
   describe("e2e route coverage dependencies", () => {
     it("installs host dependencies after detection and before route analysis", () => {
       const steps = workflow.jobs.e2e_coverage.steps ?? [];

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -418,12 +418,25 @@ describe("quality.yml reusable workflow", () => {
       );
       expect(serviceStep?.run).toContain("docker rm -f");
       expect(serviceStep?.run).toContain("docker inspect");
+      expect(serviceStep?.run).toContain(
+        "options must be an array of docker flags"
+      );
+      expect(serviceStep?.run).toContain(
+        "Math.trunc(Number(service.healthTimeoutSeconds ?? 60))"
+      );
+      expect(serviceStep?.run).not.toContain("optionSuffix");
 
       const envStep = steps[envIndex];
       expect(envStep?.if).toBe(
         "steps.check_script.outputs.exists == 'true' && inputs.coverage_env != ''"
       );
       expect(envStep?.env?.COVERAGE_ENV).toBe("${{ inputs.coverage_env }}");
+      expect(envStep?.run).toContain(
+        'const { randomUUID } = require("node:crypto");'
+      );
+      expect(envStep?.run).toContain("randomUUID().replace");
+      expect(envStep?.run).toContain("JSON.stringify(value)");
+      expect(envStep?.run).not.toContain('lines.push("LISA_COVERAGE_ENV")');
       expect(envStep?.run).toContain(
         "fs.appendFileSync(process.env.GITHUB_ENV"
       );


### PR DESCRIPTION
## Summary
- Adds inert-by-default `coverage_services` and `coverage_env` inputs to `.github/workflows/quality.yml`.
- Starts requested coverage service containers before `test:cov`, waits for Docker health checks when present, and applies coverage-only environment variables via `$GITHUB_ENV`.
- Adds workflow-contract tests that lock the input defaults and setup order.

## Verification
- `bun test tests/integration/quality-workflow.test.ts`
- `bun run typecheck`
- `bun run check:workflow-inputs`
- `bun run check:upstream-evidence-manifest`
- `bunx prettier --check .github/workflows/quality.yml tests/integration/quality-workflow.test.ts`
- `bunx eslint tests/integration/quality-workflow.test.ts --quiet`
- `actionlint -no-color -shellcheck= .github/workflows/quality.yml`
- downstream-shaped probe with a gated Postgres integration spec:
  - baseline: `1` skipped test, `0%` lines, `0%` statements
  - with service/env: `0` skipped tests, `80%` lines, `72.72%` statements
- pre-push hook passed: typecheck, production audit, slow lint, knip, coverage (`8001` tests), integration (`154` tests), plugin parity

Work-Item: CodySwannGT/lisa#2027


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration for coverage service containers in reusable quality workflows.
  * Added support for coverage-specific environment variables, including service endpoints and credentials.
  * Coverage services now wait for health checks before unit tests run.

* **Tests**
  * Added validation for the new coverage inputs and workflow step sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->