### PR TITLE
fix: reconnect Android emulator before Maestro

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -350,6 +350,15 @@ jobs:
           # trailing `\` as a flow path ("Flow path does not exist"). Keep
           # each command on ONE line.
           script: |
+            # android-emulator-runner can observe the AVD while it is still
+            # offline, leaving Maestro's dadb connection bound to that stale
+            # server state (mobile-dev-inc/Maestro#3451). Recreate adb only
+            # after the action's boot wait has completed, then prove the
+            # device is online before installing or starting Maestro.
+            adb kill-server
+            adb start-server
+            adb wait-for-device
+            adb shell getprop sys.boot_completed | grep -q 1
             adb install app-android.apk
             maestro test $MAESTRO_E2E_ARGS --format junit --output maestro-android-report.xml --debug-output maestro-debug ${{ inputs.flows_dir }}
 

--- a/tests/integration/maestro-native-workflow.test.ts
+++ b/tests/integration/maestro-native-workflow.test.ts
@@ -190,6 +190,18 @@ describe("maestro-native-e2e reusable workflow", () => {
     );
     expect(emulator).toBeDefined();
     const script = String(emulator?.with?.script ?? "");
+    const killAdb = script.indexOf("adb kill-server");
+    const startAdb = script.indexOf("adb start-server");
+    const waitForDevice = script.indexOf("adb wait-for-device");
+    const verifyBoot = script.indexOf(
+      "adb shell getprop sys.boot_completed | grep -q 1"
+    );
+    const installApp = script.indexOf("adb install app-android.apk");
+    expect(killAdb).toBeGreaterThanOrEqual(0);
+    expect(startAdb).toBeGreaterThan(killAdb);
+    expect(waitForDevice).toBeGreaterThan(startAdb);
+    expect(verifyBoot).toBeGreaterThan(waitForDevice);
+    expect(installApp).toBeGreaterThan(verifyBoot);
     expect(script).toContain("adb install app-android.apk");
     // android-emulator-runner runs each line as its own `sh -c`; a
     // backslash-continued maestro command breaks. The whole invocation —


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2091

Closes #2091

The reusable Android harness now recreates ADB after android-emulator-runner completes its boot wait, then waits for an online device and verifies sys.boot_completed before installing the APK or starting Maestro. This prevents Maestro 2.6.1 from binding dadb to the stale device-offline state observed in TunnlAI/frontend run 30215794552.

Verification:
- actionlint passed for maestro-native-e2e.yml
- focused workflow integration suite passed: 15 tests
- pre-push typecheck, security audit, slow lint, knip, 476 unit files with 8006 tests, and 14 integration files with 154 tests passed