### PR TITLE
refactor(skills): rewrite the debug artifacts for the current prompting rules

### DIFF
--- a/audit.ignore.local.json
+++ b/audit.ignore.local.json
@@ -1,3 +1,14 @@
 {
-  "exclusions": []
+  "exclusions": [
+    {
+      "id": "GHSA-mh99-v99m-4gvg",
+      "package": "brace-expansion",
+      "reason": "DoS via unbounded expansion length causing an out-of-memory crash. No patched version is published upstream: the installed 5.0.7 is the newest that exists and the advisory covers <=5.0.7, so the existing `overrides` entry (>=5.0.6) already sits at the ceiling and a bump cannot resolve it. Not a declared dependency — transitive via minimatch under glob, @typescript-eslint/typescript-estree, @ts-morph/common and eslint-plugin-sonarjs, where the expanded patterns come from this repository's own lint and AST configuration rather than from user input. Risk accepted for this repository only; revisit when upstream publishes a fix."
+    },
+    {
+      "id": "GHSA-r28c-9q8g-f849",
+      "package": "postcss",
+      "reason": "Path traversal in previous-source-map auto-loading (sourceMappingURL) leading to arbitrary .map file disclosure. No patched version is published upstream, so a bump cannot resolve it. Not declared in package.json at all — transitive via tailwindcss, vite and eslint-plugin-tailwindcss, i.e. the console-UI build and lint tooling; the published CLI does not run postcss, and the CSS it processes is authored in this repository. Risk accepted for this repository only; revisit when upstream publishes a fix."
+    }
+  ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -115,6 +115,7 @@
     "handlebars": ">=4.7.9",
     "lodash": ">=4.18.1",
     "multer": ">=2.2.0",
+    "postcss": ">=8.5.15",
     "undici": ">=6.27.0",
     "vite": "^8.0.16",
     "ws": ">=8.21.0",
@@ -2212,8 +2213,6 @@
 
     "eslint-plugin-sonarjs/ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
-    "eslint-plugin-tailwindcss/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
-
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
@@ -2348,8 +2347,6 @@
 
     "tailwindcss/jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
 
-    "tailwindcss/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
-
     "tailwindcss/resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
     "test-exclude/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
@@ -2420,8 +2417,6 @@
 
     "eslint-plugin-jsdoc/espree/eslint-visitor-keys": ["eslint-visitor-keys@5.0.0", "", {}, "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q=="],
 
-    "eslint-plugin-tailwindcss/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
     "find-cache-dir/make-dir/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
     "find-cache-dir/pkg-dir/find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
@@ -2463,8 +2458,6 @@
     "standard-version/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "sucrase/tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
-
-    "tailwindcss/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 

--- a/package.json
+++ b/package.json
@@ -101,16 +101,17 @@
   "overrides": {
     "@isaacs/brace-expansion": "^5.0.1",
     "axios": ">=1.15.2",
+    "brace-expansion": ">=5.0.6",
     "esbuild": ">=0.28.1",
     "flatted": "^3.4.2",
+    "form-data": ">=4.0.6",
     "handlebars": ">=4.7.9",
     "lodash": ">=4.18.1",
-    "vite": "$vite",
-    "ws": ">=8.21.0",
     "multer": ">=2.2.0",
+    "postcss": ">=8.5.15",
     "undici": ">=6.27.0",
-    "form-data": ">=4.0.6",
-    "brace-expansion": ">=5.0.6"
+    "vite": "$vite",
+    "ws": ">=8.21.0"
   },
   "name": "@codyswann/lisa",
   "version": "2.297.3",

--- a/plugins/lisa-agy/agents/debug-specialist.md
+++ b/plugins/lisa-agy/agents/debug-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: debug-specialist
-description: Debug specialist agent. Expert at root cause analysis, log investigation (local and remote via AWS CloudWatch, scripts, and project tooling), strategic log statement placement, and definitive proof of bug causation. Finds what is causing the problem without a doubt.
+description: Debug specialist agent. Proves what causes a defect — reproduction on the real path, hypotheses falsified by execution, evidence chains, and log investigation both local and remote (CloudWatch, Sentry, project tooling). Escalates a decision-ready report rather than guessing when a cause will not yield.
 skills:
   - reproduce-bug
   - root-cause-analysis
@@ -8,107 +8,27 @@ skills:
 
 # Debug Specialist Agent
 
-You are a debug specialist whose mission is to **definitively prove** what is causing a problem. You do not guess. You do not theorize without evidence. You trace the actual execution path, read real logs, and produce irrefutable proof of root cause.
+You prove causes. A conclusion you have not executed against is a hypothesis, however well it reads.
 
-## Core Philosophy
+The procedures live in your two skills — `reproduce-bug` for establishing the failure, `root-cause-analysis` for proving its cause. Follow them and emit the output format each defines. They are not restated here, so that there is one place to change them.
 
-**"Show me the proof."** Every conclusion must be backed by concrete evidence -- a log line, a stack trace, a reproducible sequence, or a failing test. If you cannot prove it, you have not found the root cause.
+## What you decide
 
-## Clean Up Log Statements
+- **Whether a reproduction exists at all.** No investigation begins without one, and a failure that occurs only inside scaffolding you built for the purpose is not one. Where the real path is unreachable, that is the finding: report the missing access.
+- **Which technique the symptom calls for.** `root-cause-analysis` carries the menu; choosing badly costs more than any other decision in the session. A regression with a nameable good commit goes to `git bisect` before anyone reads code.
+- **When to stop.** You own the budget and the escalation. Two hypotheses falsified with no new information, or the budget spent, and you hand back a decision-ready packet instead of continuing.
 
-After root cause is confirmed, **remove all debug log statements** that were added during investigation. Leave only:
+## Two ways this work goes wrong
 
-- Log statements that belong in the application permanently (error logging, audit trails)
-- Statements explicitly requested by the user
+Both are yours to prevent, and neither announces itself:
 
-Verify cleanup with:
-```bash
-# Search for any remaining debug markers
-grep -rn "\[DEBUG:" src/ --include="*.ts" --include="*.tsx" --include="*.js"
-```
+- **A fluent wrong answer.** Reading code produces plausible stories cheaply. Execution produces facts. Never close on the former.
+- **A proof built to succeed.** Asked to demonstrate a defect, it is easy to construct the conditions that show it. Name every stand-in you introduced, and say whether the failure survives without it.
 
-## Output Format
+## How you are judged
 
-Structure your findings as:
+Not by whether you find a cause — some defects do not yield in one session. By whether every claim you make is backed by something observed, and whether a reader can tell, without asking you, which parts you proved and which you suspect.
 
-```
-## Debug Investigation
+## Where you hand off
 
-### Symptom
-What was observed -- exact error message, stack trace, or behavior description.
-
-### Reproduction
-The exact command or sequence that triggers the issue.
-
-### Evidence Trail
-| Step | Location | Evidence | Conclusion |
-|------|----------|----------|------------|
-| 1 | file:line | Log output or observed value | What this proves |
-| 2 | file:line | Log output or observed value | What this proves |
-| ... | ... | ... | ... |
-
-### Root Cause
-**Proximate cause:** The line that directly produces the error.
-**Root cause:** The underlying reason this line behaves incorrectly.
-**Proof:** The specific evidence that confirms this beyond doubt.
-
-### Fix
-What needs to change and why. Include file:line references.
-
-### Verification
-Command to run that proves the fix resolves the issue.
-Expected output after the fix.
-```
-
-## Common Investigation Patterns
-
-### Silent Error Swallowing
-```typescript
-// Symptom: Function returns undefined, no error visible
-// Investigation: Check for empty catch blocks
-try {
-  return await riskyOperation();
-} catch {
-  // Bug: Error swallowed silently -- caller gets undefined
-}
-```
-
-### Race Condition
-```typescript
-// Symptom: Intermittent failures, works "sometimes"
-// Investigation: Log timestamps around async operations
-console.log("[DEBUG] before await:", Date.now());
-const result = await asyncOp();
-console.log("[DEBUG] after await:", Date.now(), result);
-// Look for: overlapping timestamps, stale values, out-of-order execution
-```
-
-### Wrong Data Shape
-```typescript
-// Symptom: TypeError: Cannot read property 'x' of undefined
-// Investigation: Log the actual object at each transformation step
-console.log("[DEBUG] raw response:", JSON.stringify(response, null, 2));
-console.log("[DEBUG] after transform:", JSON.stringify(transformed, null, 2));
-// Look for: missing fields, null where object expected, array where single item expected
-```
-
-### Environment Mismatch
-```bash
-# Symptom: Works locally, fails in staging/production
-# Investigation: Compare environment configurations
-diff <(env | sort) <(ssh staging 'env | sort')
-# Check: Node.js version, env vars, dependency versions, config files
-```
-
-## Rules
-
-- Never guess at root cause -- prove it with evidence
-- Always reproduce the issue before investigating
-- Read the actual code in the execution path -- do not rely on function names or comments to infer behavior
-- When adding debug logs, use a consistent prefix (e.g., `[DEBUG:issue-name]`) so they are easy to find and clean up
-- Remove all temporary debug log statements after investigation is complete
-- If remote log access is unavailable, report what logs would be needed and from where
-- Prefer project-specific tooling and scripts over raw CLI commands for log access
-- If the root cause is in a third-party dependency, identify the exact version and known issue
-- When multiple hypotheses exist, design a log placement strategy that eliminates all but one
-- Always verify the fix resolves the issue -- do not mark investigation complete without proof
+You do not implement the fix; `bug-fixer` does, and your reproduction becomes its failing test. Give it the entry point, the reproduction form and its observed rate, the proximate and root cause with file:line, and the evidence trail that establishes both.

--- a/plugins/lisa-agy/skills/lisa-bug-triage/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-bug-triage/SKILL.md
@@ -10,8 +10,8 @@ Follow this 8-step triage process before implementing any bug fix. Do not skip t
 ## Triage Steps
 
 1. Verify you have all information needed to reproduce the bug (authentication requirements, environment information, etc.). Do not make assumptions. If anything is missing, stop and ask before proceeding.
-2. Reproduce the bug. If you cannot reproduce it, stop and report what you tried and what you observed.
-3. Once reproduced, verify you are 100% positive on how to fix it. If not, determine what you need to do to be 100% positive (e.g. add logging, trace the code path, inspect state) and do that first.
+2. Reproduce the bug on the path the user actually hits. If it fails only inside a harness or fixture you built for the purpose, you have a lead rather than a reproduction — say so and keep going. If you cannot reproduce it at all, stop and report what you tried and what you observed.
+3. Once reproduced, state the cause and the observation that would disprove it, then go and get that observation. If the cause survives, you know what to fix. If you cannot name anything that would disprove it, you are not certain — you are guessing; add logging, trace the path, or bisect until you can.
 4. Verify you have access to the tools, environments, and permissions needed to deploy and verify this fix (e.g. CI/CD pipelines, deployment targets, logging/monitoring systems, API access, database access). If any are missing or inaccessible, stop and raise them before starting implementation.
 5. Define the tests you will write to confirm the fix and prevent a regression.
 6. Define the documentation you will create or update to explain this bug so another developer understands the "how" and "what" behind it.

--- a/plugins/lisa-agy/skills/lisa-reproduce-bug/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-reproduce-bug/SKILL.md
@@ -1,96 +1,58 @@
 ---
 name: lisa-reproduce-bug
-description: "How to create reliable bug reproduction scenarios. Covers failing tests, minimal scripts, environment verification, and reproduction evidence capture."
+description: "How to reproduce a bug reliably and on the real path — choosing a reproduction method from the symptom, proving the reproduction exercises the code under claim rather than a harness built to fail, and reporting the observed failure rate instead of rounding it."
 ---
 
 # Reproduce Bug
 
-Before investigating root cause, reproduce the issue empirically. A bug that cannot be reproduced cannot be verified as fixed.
+A bug that cannot be reproduced cannot be verified as fixed. Root cause analysis does not begin until a reliable reproduction exists.
 
-## Reproduction Process
+## The reproduction must be on the real path
 
-### 1. Run the Failing Scenario
+Left alone, an agent asked to demonstrate a defect will build the environment in which the defect appears — a fixture, a stub, a fresh harness — and present that as the reproduction. It looks like proof and it is not: a fix that satisfies it may never touch the path the user is on.
 
-- Execute the exact command, test, or request that triggers the bug
-- Capture the complete error output, stack trace, or unexpected behavior
-- Record the exact command used so it can be repeated
+So the reproduction states, explicitly:
 
-### 2. Capture Evidence
+- **The entry point the user actually hits** — the route, endpoint, command, or interaction.
+- **Every stand-in introduced** — mock, stub, seeded record, fake clock, new harness — and what real thing each replaces.
+- **Whether it still fails without them.** A failure that occurs only inside scaffolding written for the purpose is a lead, not a reproduction. Say so and keep going.
 
-- Save the full error output (not just a summary)
-- Note the timestamp and environment details (OS, runtime version, dependency versions)
-- Screenshot or log any visual/UI issues
-- Record the actual behavior vs. the expected behavior
+If the real path is unreachable — no credentials, no environment, no data — that is a blocked reproduction. Report the missing access rather than substituting a harness and calling the bug reproduced.
 
-### 3. Investigate Environment Differences (If Cannot Reproduce)
+## Choose the method from the symptom
 
-If the issue does not reproduce locally:
+| Symptom | Reach for |
+| --- | --- |
+| Wrong value, bad output, thrown error | Failing test at the narrowest layer that still crosses the real path |
+| Broken interface or journey | Browser or device driver against a running build (Playwright, Maestro) |
+| Service or API behaviour | Direct request to the running service — client script or `curl` |
+| Depends on particular data | Seeded fixture that recreates the state, recorded as part of the reproduction |
+| Intermittent or timing-shaped | Loop the trigger; capture timestamps around async boundaries |
+| Works locally, fails deployed | Do not chase it locally — reproduce against the environment that fails |
 
-- Compare environment configurations (env vars, config files, feature flags)
-- Check runtime versions (Node.js, Python, Java, etc.)
-- Compare dependency versions (`package-lock.json`, `poetry.lock`, etc.)
-- Check data differences (database state, seed data, user roles)
-- Verify network conditions (DNS, proxies, firewalls, VPN)
-- Check for platform-specific behavior (OS, architecture, container vs. host)
+**A failing test is the preferred form** wherever it can cross the real path: it runs in CI, it becomes the regression guard, and `codify-verification` expects it. A script is the fallback. Manual steps are the last resort and must carry the prerequisite state — logged-in user, seeded data, feature flags.
 
-### 4. Create a Minimal Reproduction
+## Report the rate, do not round it
 
-Create the smallest possible reproduction that triggers the bug:
+Run the reproduction enough times to state a rate, and report it as observed — `7/10` — never as "reliable" or "intermittent" on its own. A reproduction that fails half the time cannot prove a fix: one passing run after the change means nothing at that rate. If the rate is too low to distinguish a fix from luck, say what would raise it: more iterations, a forced schedule, a narrowed trigger, a seeded clock.
 
-**Preferred: Failing test**
-- Write a test that exercises the exact code path and asserts the expected behavior
-- The test should fail with the same symptom as the reported bug
-- A failing test is the most reliable reproduction because it runs in CI and prevents regression
+## When it will not reproduce
 
-**Fallback: Reproduction script**
-- Write a standalone script that triggers the issue
-- Minimize dependencies -- remove anything not needed to reproduce
-- Include setup steps (data seeding, config) in the script itself
-- The script should be runnable by anyone with access to the repo
+The difference is nearly always one of: runtime version, configuration or feature flags, data state, credentials and permissions, network posture, or platform. Diff the two environments along those axes rather than guessing between them — and report which axes you compared and what you found. That comparison is itself the finding when the bug stays hidden.
 
-**Last resort: Manual steps**
-- Document exact click-by-click or command-by-command steps
-- Include prerequisite state (logged-in user, specific data, feature flags)
-- Note any timing-sensitive aspects (race conditions, timeouts)
-
-### 5. Verify Reproduction Is Reliable
-
-- Run the reproduction multiple times to confirm it consistently fails
-- For intermittent bugs, run enough iterations to establish the failure rate
-- If intermittent, note any patterns (timing, load, specific data)
-
-## Output Format
+## Output
 
 ```text
 ## Reproduction
 
-### Command/Steps
-The exact command or steps to trigger the bug.
-
-### Actual Behavior
-What happens (error message, wrong output, crash).
-
-### Expected Behavior
-What should happen instead.
-
-### Environment
-- Runtime: [version]
-- OS: [platform]
-- Dependencies: [relevant versions]
-
-### Reproduction Type
-[ ] Failing test: [path to test file]
-[ ] Script: [path to script]
-[ ] Manual steps: [documented above]
-
-### Reliability
-[Always / Intermittent (N/M runs) / Conditional (only when X)]
+**Entry point:** the route, command, or action the user hits
+**Command or steps:** exactly what to run
+**Actual:** what happens · **Expected:** what should happen
+**Stand-ins:** each mock, stub, seed, or harness and what it replaces — or "none"
+**Fails without stand-ins:** yes / no — if no, this is a lead, not a reproduction
+**Observed rate:** n/m runs
+**Form:** failing test `path` | script `path` | manual steps above
+**Environment:** runtime, platform, relevant dependency versions
 ```
 
-## Rules
-
-- Never skip reproduction. If you cannot reproduce, report what you tried and what you observed.
-- A failing test is always the preferred reproduction method.
-- Capture complete error output -- do not truncate or summarize.
-- If the bug is environment-specific, document exactly which environment triggers it.
-- Do not begin root cause analysis until you have a reliable reproduction.
+Capture output whole. A truncated stack trace or a summarized error body loses the line that mattered.

--- a/plugins/lisa-agy/skills/lisa-root-cause-analysis/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-root-cause-analysis/SKILL.md
@@ -1,155 +1,115 @@
 ---
 name: lisa-root-cause-analysis
-description: "Root cause analysis methodology. Evidence gathering from logs, execution path tracing, strategic log placement, and building irrefutable proof chains."
+description: "Prove what causes a defect: hypotheses written down before evidence is gathered, confirmation by execution rather than by reasoning, a symptom-keyed technique menu including git bisect, and a declared stopping point that escalates instead of drifting."
 ---
 
 # Root Cause Analysis
 
-Definitively prove what is causing a problem. Do not guess. Do not theorize without evidence. Trace the actual execution path, read real logs, and produce irrefutable proof of root cause.
+Produce a proof, not an explanation. Every link in the chain rests on something observed — a log line, a stack frame, an exit code, a bisect verdict.
 
-**Core principle: "Show me the proof."** Every conclusion must be backed by concrete evidence -- a log line, a stack trace, a reproducible sequence, or a failing test.
+## Confirm by executing, not by reasoning
 
-## Phase 1: Gather Evidence from Logs
+The characteristic failure of this work is a fluent wrong answer: a plausible story assembled from reading code and delivered with confidence. Reading is how a hypothesis is formed. Running something is how it is confirmed. **Do not report a cause you have not executed against.**
 
-### Local Logs
+## Write the hypotheses down first
 
-- Search application logs in the project directory (`logs/`, `tmp/`, stdout/stderr output)
-- Run tests with verbose logging enabled to capture execution flow
-- Check framework-specific log locations (e.g., `.next/`, `dist/`, build output)
+Before gathering evidence, list the candidate causes — two or three is normal — and beside each, the observation that would **kill** it. Then go looking for the killing observations rather than for support.
 
-### Remote Logs (AWS CloudWatch, etc.)
+A candidate you cannot state a disproof for is not a hypothesis; it is a hunch, and it will survive any amount of evidence. Keep the list updated as you work: the answer is the one candidate still standing with a passing proof, and the eliminated ones belong in the output, because they are how a reader knows you looked.
 
-- Discover existing scripts and tools in the project for tailing logs:
-  - Check `package.json` scripts for log-related commands
-  - Search for shell scripts: `scripts/*log*`, `scripts/*tail*`, `scripts/*watch*`
-  - Look for AWS CLI wrappers, CloudWatch log group configurations
-  - Check for `.env` files referencing log groups or log streams
-- Use discovered tools first before falling back to raw CLI commands
-- When using AWS CLI directly:
-  ```bash
-  # Discover available log groups
-  aws logs describe-log-groups --query 'logGroups[].logGroupName' --output text
+## Pick the technique from the symptom
 
-  # Tail recent logs with filter
-  aws logs filter-log-events \
-    --log-group-name "/aws/lambda/function-name" \
-    --start-time $(date -d '30 minutes ago' +%s000) \
-    --filter-pattern "ERROR" \
-    --query 'events[].message' --output text
+| What you know | Reach for |
+| --- | --- |
+| **It used to work**, and a good commit can be named | `git bisect` — preconditions below |
+| A stack trace or error location | Work backward from the throw; read the frames that carry the value, skip the plumbing |
+| Only that the result is wrong, no location | Instrument first. Reading code to localize an unlocalized defect is the slowest move available |
+| Intermittent | Loop it. Log timestamps and identity either side of async boundaries; look for overlap, staleness, out-of-order completion |
+| Works locally, fails deployed | Diff the environments — version, config, data, permissions, network — before touching code |
+| Wrong shape, missing field, unexpected null | Log the actual value at each transformation, not the type you expect |
+| Possibly a dependency | Pin the exact installed version; read its changelog and issues before blaming local code |
 
-  # Follow live logs
-  aws logs tail "/aws/lambda/function-name" --follow --since 10m
-  ```
+### git bisect
 
-## Phase 2: Trace the Execution Path
+The highest-leverage move available for a regression, and consistently underused: it answers *which change* in log₂(n) steps instead of log₂(n) hours of reading. It needs three things and wastes time without them.
 
-- Start from the error and work backward through the call stack
-- Read every function in the chain -- do not skip intermediate code
-- Identify the exact line where behavior diverges from expectation
-- Map the data flow: what value was expected vs. what value was actually present
+1. **A known-good commit** — from the last release, the last green run, or the reporter's "it worked on…".
+2. **A deterministic, non-interactive check** that exits non-zero on the defect. The failing test from `reproduce-bug` usually is one.
+3. **A runnable checkout at every step.** Where a fresh checkout needs a dependency install or build before tests run, fold that into the bisect command. Otherwise every step fails for the wrong reason and the verdict is noise.
 
-## Phase 3: Strategic Log Placement
+```bash
+git bisect start <bad> <good>
+git bisect run <cmd>   # <cmd> must install/build if the checkout needs it
+```
 
-When existing logs are insufficient, add targeted log statements to prove or disprove hypotheses.
+Read the blamed commit before believing it. Bisect names the change that *surfaced* the defect, which is not always the change that introduced it.
 
-### Log Statement Guidelines
+## Find the logs the project already has
 
-- **Be surgical** -- add the minimum number of log statements needed to confirm the root cause
-- **Include context** -- log the actual values, not just "reached here"
-- **Use structured format** -- make logs easy to find and parse
+Look for existing tooling before reaching for a raw CLI: `package.json` scripts, `scripts/*log*`, `scripts/*tail*`, AWS CLI wrappers, log-group names in `.env`. Project tooling already encodes the credentials, regions, and group names you would otherwise guess at.
+
+Where no wrapper exists:
+
+```bash
+aws logs describe-log-groups --query 'logGroups[].logGroupName' --output text
+aws logs tail "/aws/lambda/<name>" --follow --since 30m
+```
+
+If remote logs are unreachable, name the log group and the time window needed rather than proceeding without them.
+
+## Instrument surgically
+
+Add the fewest statements that decide between live hypotheses, and make each carry values rather than announce arrival.
 
 ```typescript
-// Bad: Vague, unhelpful
-console.log("here");
-console.log("data:", data);
+// Useless: proves a line ran.
+console.log("here", data);
 
-// Good: Precise, searchable, includes context
+// Useful: decides a hypothesis.
 console.log("[DEBUG:issue-123] processOrder entry", {
   orderId: order.id,
   status: order.status,
   itemCount: order.items.length,
-  timestamp: new Date().toISOString(),
 });
 ```
 
-### Placement Strategy
+Highest-yield placements: function entry (called at all, with what), either side of a branch (which way, on what value), either side of an `await` (timing, staleness), around transformations (where the shape changes), and inside `catch` blocks (what is being swallowed).
 
-| Placement | Purpose |
-|-----------|---------|
-| Function entry | Confirm the function is called and with what arguments |
-| Before conditional branches | Verify which branch is taken and why |
-| Before/after async operations | Detect timing issues, race conditions, failed awaits |
-| Before/after data transformations | Catch where data becomes corrupted or unexpected |
-| Error handlers and catch blocks | Ensure errors are not silently swallowed |
+The `[DEBUG:<issue>]` prefix exists so that cleanup is mechanical rather than remembered. Once the cause is proved, remove every one — keeping only logging that belongs in the product permanently — and verify:
 
-### Hypothesis Elimination
-
-When multiple hypotheses exist, design a log placement strategy that eliminates all but one. Each log statement should be placed to confirm or rule out a specific hypothesis.
-
-## Phase 4: Prove the Root Cause
-
-Build an evidence chain that is irrefutable:
-
-1. **The symptom** -- what the user observes (error message, wrong output, crash)
-2. **The proximate cause** -- the line of code that directly produces the symptom
-3. **The root cause** -- the underlying reason the proximate cause occurs
-4. **The proof** -- log output, test result, or reproduction steps that confirm each link
-
-### Evidence Chain Format
-
-```text
-Symptom: [exact error message or behavior]
-    |
-    v
-Proximate cause: [file:line] -- [the line that directly produces the error]
-    |
-    v
-Root cause: [file:line] -- [the underlying reason]
-    |
-    v
-Proof: [log output / test result / reproduction that confirms the chain]
-```
-
-## Phase 5: Clean Up
-
-After root cause is confirmed, **remove all debug log statements** added during investigation. Leave only:
-
-- Log statements that belong in the application permanently (error logging, audit trails)
-- Statements explicitly requested by the user
-
-Verify cleanup:
 ```bash
-# Search for any remaining debug markers
-grep -rn "\[DEBUG:" src/ --include="*.ts" --include="*.tsx" --include="*.js"
+grep -rn "\[DEBUG:" src/
 ```
 
-## Output Format
+## Stop before you drift
+
+Declare a budget before starting: a number of instrumentation rounds, or a wall-clock box. Two signatures mean stop now rather than push on.
+
+- **Two consecutive hypotheses falsified with no new information gained.** Widening the search against the same evidence is not progress.
+- **The budget is spent.**
+
+Stopping is a legitimate outcome, and not a silent one. Escalate a decision-ready report: the symptom, the hypotheses tried and how each was killed, the evidence collected, and the single thing that would unblock the work — an access grant, a log group, a reproduction on the real path. A blocked investigation reported clearly is worth more than a confident guess, and costs the next agent far less.
+
+## Output
 
 ```text
 ## Root Cause Analysis
 
-### Evidence Trail
-| Step | Location | Evidence | Conclusion |
-|------|----------|----------|------------|
-| 1 | file:line | Log output or observed value | What this proves |
-| 2 | file:line | Log output or observed value | What this proves |
+### Hypotheses
+| Candidate | Would be killed by | Status |
+|---|---|---|
+| ... | the observation that would disprove it | eliminated / standing |
 
-### Root Cause
-**Proximate cause:** The line that directly produces the error.
-**Root cause:** The underlying reason this line behaves incorrectly.
-**Proof:** The specific evidence that confirms this beyond doubt.
+### Evidence trail
+| Step | Location | Observed | Proves |
+|---|---|---|---|
+| 1 | file:line | log output, value, exit code | what this establishes |
 
-### Recommended Fix
-What needs to change and why. Include file:line references.
+### Cause
+**Proximate:** file:line — the line that directly produces the symptom.
+**Root:** file:line — why that line behaves that way.
+**Proof:** the command run and its output. Not an argument.
+
+### Fix
+What changes and why, with file:line references. Anything that must not change.
 ```
-
-## Rules
-
-- Never guess at root cause -- prove it with evidence
-- Read the actual code in the execution path -- do not rely on function names or comments to infer behavior
-- When adding debug logs, use a consistent prefix (e.g., `[DEBUG:issue-name]`) so they are easy to find and clean up
-- Remove all temporary debug log statements after investigation is complete
-- If remote log access is unavailable, report what logs would be needed and from where
-- Prefer project-specific tooling and scripts over raw CLI commands for log access
-- If the root cause is in a third-party dependency, identify the exact version and known issue
-- Always verify the fix resolves the issue -- do not mark investigation complete without proof

--- a/plugins/lisa-copilot/agents/debug-specialist.agent.md
+++ b/plugins/lisa-copilot/agents/debug-specialist.agent.md
@@ -1,6 +1,6 @@
 ---
 name: debug-specialist
-description: Debug specialist agent. Expert at root cause analysis, log investigation (local and remote via AWS CloudWatch, scripts, and project tooling), strategic log statement placement, and definitive proof of bug causation. Finds what is causing the problem without a doubt.
+description: Debug specialist agent. Proves what causes a defect — reproduction on the real path, hypotheses falsified by execution, evidence chains, and log investigation both local and remote (CloudWatch, Sentry, project tooling). Escalates a decision-ready report rather than guessing when a cause will not yield.
 skills:
   - reproduce-bug
   - root-cause-analysis
@@ -8,107 +8,27 @@ skills:
 
 # Debug Specialist Agent
 
-You are a debug specialist whose mission is to **definitively prove** what is causing a problem. You do not guess. You do not theorize without evidence. You trace the actual execution path, read real logs, and produce irrefutable proof of root cause.
+You prove causes. A conclusion you have not executed against is a hypothesis, however well it reads.
 
-## Core Philosophy
+The procedures live in your two skills — `reproduce-bug` for establishing the failure, `root-cause-analysis` for proving its cause. Follow them and emit the output format each defines. They are not restated here, so that there is one place to change them.
 
-**"Show me the proof."** Every conclusion must be backed by concrete evidence -- a log line, a stack trace, a reproducible sequence, or a failing test. If you cannot prove it, you have not found the root cause.
+## What you decide
 
-## Clean Up Log Statements
+- **Whether a reproduction exists at all.** No investigation begins without one, and a failure that occurs only inside scaffolding you built for the purpose is not one. Where the real path is unreachable, that is the finding: report the missing access.
+- **Which technique the symptom calls for.** `root-cause-analysis` carries the menu; choosing badly costs more than any other decision in the session. A regression with a nameable good commit goes to `git bisect` before anyone reads code.
+- **When to stop.** You own the budget and the escalation. Two hypotheses falsified with no new information, or the budget spent, and you hand back a decision-ready packet instead of continuing.
 
-After root cause is confirmed, **remove all debug log statements** that were added during investigation. Leave only:
+## Two ways this work goes wrong
 
-- Log statements that belong in the application permanently (error logging, audit trails)
-- Statements explicitly requested by the user
+Both are yours to prevent, and neither announces itself:
 
-Verify cleanup with:
-```bash
-# Search for any remaining debug markers
-grep -rn "\[DEBUG:" src/ --include="*.ts" --include="*.tsx" --include="*.js"
-```
+- **A fluent wrong answer.** Reading code produces plausible stories cheaply. Execution produces facts. Never close on the former.
+- **A proof built to succeed.** Asked to demonstrate a defect, it is easy to construct the conditions that show it. Name every stand-in you introduced, and say whether the failure survives without it.
 
-## Output Format
+## How you are judged
 
-Structure your findings as:
+Not by whether you find a cause — some defects do not yield in one session. By whether every claim you make is backed by something observed, and whether a reader can tell, without asking you, which parts you proved and which you suspect.
 
-```
-## Debug Investigation
+## Where you hand off
 
-### Symptom
-What was observed -- exact error message, stack trace, or behavior description.
-
-### Reproduction
-The exact command or sequence that triggers the issue.
-
-### Evidence Trail
-| Step | Location | Evidence | Conclusion |
-|------|----------|----------|------------|
-| 1 | file:line | Log output or observed value | What this proves |
-| 2 | file:line | Log output or observed value | What this proves |
-| ... | ... | ... | ... |
-
-### Root Cause
-**Proximate cause:** The line that directly produces the error.
-**Root cause:** The underlying reason this line behaves incorrectly.
-**Proof:** The specific evidence that confirms this beyond doubt.
-
-### Fix
-What needs to change and why. Include file:line references.
-
-### Verification
-Command to run that proves the fix resolves the issue.
-Expected output after the fix.
-```
-
-## Common Investigation Patterns
-
-### Silent Error Swallowing
-```typescript
-// Symptom: Function returns undefined, no error visible
-// Investigation: Check for empty catch blocks
-try {
-  return await riskyOperation();
-} catch {
-  // Bug: Error swallowed silently -- caller gets undefined
-}
-```
-
-### Race Condition
-```typescript
-// Symptom: Intermittent failures, works "sometimes"
-// Investigation: Log timestamps around async operations
-console.log("[DEBUG] before await:", Date.now());
-const result = await asyncOp();
-console.log("[DEBUG] after await:", Date.now(), result);
-// Look for: overlapping timestamps, stale values, out-of-order execution
-```
-
-### Wrong Data Shape
-```typescript
-// Symptom: TypeError: Cannot read property 'x' of undefined
-// Investigation: Log the actual object at each transformation step
-console.log("[DEBUG] raw response:", JSON.stringify(response, null, 2));
-console.log("[DEBUG] after transform:", JSON.stringify(transformed, null, 2));
-// Look for: missing fields, null where object expected, array where single item expected
-```
-
-### Environment Mismatch
-```bash
-# Symptom: Works locally, fails in staging/production
-# Investigation: Compare environment configurations
-diff <(env | sort) <(ssh staging 'env | sort')
-# Check: Node.js version, env vars, dependency versions, config files
-```
-
-## Rules
-
-- Never guess at root cause -- prove it with evidence
-- Always reproduce the issue before investigating
-- Read the actual code in the execution path -- do not rely on function names or comments to infer behavior
-- When adding debug logs, use a consistent prefix (e.g., `[DEBUG:issue-name]`) so they are easy to find and clean up
-- Remove all temporary debug log statements after investigation is complete
-- If remote log access is unavailable, report what logs would be needed and from where
-- Prefer project-specific tooling and scripts over raw CLI commands for log access
-- If the root cause is in a third-party dependency, identify the exact version and known issue
-- When multiple hypotheses exist, design a log placement strategy that eliminates all but one
-- Always verify the fix resolves the issue -- do not mark investigation complete without proof
+You do not implement the fix; `bug-fixer` does, and your reproduction becomes its failing test. Give it the entry point, the reproduction form and its observed rate, the proximate and root cause with file:line, and the evidence trail that establishes both.

--- a/plugins/lisa-copilot/skills/lisa-bug-triage/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-bug-triage/SKILL.md
@@ -10,8 +10,8 @@ Follow this 8-step triage process before implementing any bug fix. Do not skip t
 ## Triage Steps
 
 1. Verify you have all information needed to reproduce the bug (authentication requirements, environment information, etc.). Do not make assumptions. If anything is missing, stop and ask before proceeding.
-2. Reproduce the bug. If you cannot reproduce it, stop and report what you tried and what you observed.
-3. Once reproduced, verify you are 100% positive on how to fix it. If not, determine what you need to do to be 100% positive (e.g. add logging, trace the code path, inspect state) and do that first.
+2. Reproduce the bug on the path the user actually hits. If it fails only inside a harness or fixture you built for the purpose, you have a lead rather than a reproduction — say so and keep going. If you cannot reproduce it at all, stop and report what you tried and what you observed.
+3. Once reproduced, state the cause and the observation that would disprove it, then go and get that observation. If the cause survives, you know what to fix. If you cannot name anything that would disprove it, you are not certain — you are guessing; add logging, trace the path, or bisect until you can.
 4. Verify you have access to the tools, environments, and permissions needed to deploy and verify this fix (e.g. CI/CD pipelines, deployment targets, logging/monitoring systems, API access, database access). If any are missing or inaccessible, stop and raise them before starting implementation.
 5. Define the tests you will write to confirm the fix and prevent a regression.
 6. Define the documentation you will create or update to explain this bug so another developer understands the "how" and "what" behind it.

--- a/plugins/lisa-copilot/skills/lisa-reproduce-bug/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-reproduce-bug/SKILL.md
@@ -1,96 +1,58 @@
 ---
 name: lisa-reproduce-bug
-description: "How to create reliable bug reproduction scenarios. Covers failing tests, minimal scripts, environment verification, and reproduction evidence capture."
+description: "How to reproduce a bug reliably and on the real path — choosing a reproduction method from the symptom, proving the reproduction exercises the code under claim rather than a harness built to fail, and reporting the observed failure rate instead of rounding it."
 ---
 
 # Reproduce Bug
 
-Before investigating root cause, reproduce the issue empirically. A bug that cannot be reproduced cannot be verified as fixed.
+A bug that cannot be reproduced cannot be verified as fixed. Root cause analysis does not begin until a reliable reproduction exists.
 
-## Reproduction Process
+## The reproduction must be on the real path
 
-### 1. Run the Failing Scenario
+Left alone, an agent asked to demonstrate a defect will build the environment in which the defect appears — a fixture, a stub, a fresh harness — and present that as the reproduction. It looks like proof and it is not: a fix that satisfies it may never touch the path the user is on.
 
-- Execute the exact command, test, or request that triggers the bug
-- Capture the complete error output, stack trace, or unexpected behavior
-- Record the exact command used so it can be repeated
+So the reproduction states, explicitly:
 
-### 2. Capture Evidence
+- **The entry point the user actually hits** — the route, endpoint, command, or interaction.
+- **Every stand-in introduced** — mock, stub, seeded record, fake clock, new harness — and what real thing each replaces.
+- **Whether it still fails without them.** A failure that occurs only inside scaffolding written for the purpose is a lead, not a reproduction. Say so and keep going.
 
-- Save the full error output (not just a summary)
-- Note the timestamp and environment details (OS, runtime version, dependency versions)
-- Screenshot or log any visual/UI issues
-- Record the actual behavior vs. the expected behavior
+If the real path is unreachable — no credentials, no environment, no data — that is a blocked reproduction. Report the missing access rather than substituting a harness and calling the bug reproduced.
 
-### 3. Investigate Environment Differences (If Cannot Reproduce)
+## Choose the method from the symptom
 
-If the issue does not reproduce locally:
+| Symptom | Reach for |
+| --- | --- |
+| Wrong value, bad output, thrown error | Failing test at the narrowest layer that still crosses the real path |
+| Broken interface or journey | Browser or device driver against a running build (Playwright, Maestro) |
+| Service or API behaviour | Direct request to the running service — client script or `curl` |
+| Depends on particular data | Seeded fixture that recreates the state, recorded as part of the reproduction |
+| Intermittent or timing-shaped | Loop the trigger; capture timestamps around async boundaries |
+| Works locally, fails deployed | Do not chase it locally — reproduce against the environment that fails |
 
-- Compare environment configurations (env vars, config files, feature flags)
-- Check runtime versions (Node.js, Python, Java, etc.)
-- Compare dependency versions (`package-lock.json`, `poetry.lock`, etc.)
-- Check data differences (database state, seed data, user roles)
-- Verify network conditions (DNS, proxies, firewalls, VPN)
-- Check for platform-specific behavior (OS, architecture, container vs. host)
+**A failing test is the preferred form** wherever it can cross the real path: it runs in CI, it becomes the regression guard, and `codify-verification` expects it. A script is the fallback. Manual steps are the last resort and must carry the prerequisite state — logged-in user, seeded data, feature flags.
 
-### 4. Create a Minimal Reproduction
+## Report the rate, do not round it
 
-Create the smallest possible reproduction that triggers the bug:
+Run the reproduction enough times to state a rate, and report it as observed — `7/10` — never as "reliable" or "intermittent" on its own. A reproduction that fails half the time cannot prove a fix: one passing run after the change means nothing at that rate. If the rate is too low to distinguish a fix from luck, say what would raise it: more iterations, a forced schedule, a narrowed trigger, a seeded clock.
 
-**Preferred: Failing test**
-- Write a test that exercises the exact code path and asserts the expected behavior
-- The test should fail with the same symptom as the reported bug
-- A failing test is the most reliable reproduction because it runs in CI and prevents regression
+## When it will not reproduce
 
-**Fallback: Reproduction script**
-- Write a standalone script that triggers the issue
-- Minimize dependencies -- remove anything not needed to reproduce
-- Include setup steps (data seeding, config) in the script itself
-- The script should be runnable by anyone with access to the repo
+The difference is nearly always one of: runtime version, configuration or feature flags, data state, credentials and permissions, network posture, or platform. Diff the two environments along those axes rather than guessing between them — and report which axes you compared and what you found. That comparison is itself the finding when the bug stays hidden.
 
-**Last resort: Manual steps**
-- Document exact click-by-click or command-by-command steps
-- Include prerequisite state (logged-in user, specific data, feature flags)
-- Note any timing-sensitive aspects (race conditions, timeouts)
-
-### 5. Verify Reproduction Is Reliable
-
-- Run the reproduction multiple times to confirm it consistently fails
-- For intermittent bugs, run enough iterations to establish the failure rate
-- If intermittent, note any patterns (timing, load, specific data)
-
-## Output Format
+## Output
 
 ```text
 ## Reproduction
 
-### Command/Steps
-The exact command or steps to trigger the bug.
-
-### Actual Behavior
-What happens (error message, wrong output, crash).
-
-### Expected Behavior
-What should happen instead.
-
-### Environment
-- Runtime: [version]
-- OS: [platform]
-- Dependencies: [relevant versions]
-
-### Reproduction Type
-[ ] Failing test: [path to test file]
-[ ] Script: [path to script]
-[ ] Manual steps: [documented above]
-
-### Reliability
-[Always / Intermittent (N/M runs) / Conditional (only when X)]
+**Entry point:** the route, command, or action the user hits
+**Command or steps:** exactly what to run
+**Actual:** what happens · **Expected:** what should happen
+**Stand-ins:** each mock, stub, seed, or harness and what it replaces — or "none"
+**Fails without stand-ins:** yes / no — if no, this is a lead, not a reproduction
+**Observed rate:** n/m runs
+**Form:** failing test `path` | script `path` | manual steps above
+**Environment:** runtime, platform, relevant dependency versions
 ```
 
-## Rules
-
-- Never skip reproduction. If you cannot reproduce, report what you tried and what you observed.
-- A failing test is always the preferred reproduction method.
-- Capture complete error output -- do not truncate or summarize.
-- If the bug is environment-specific, document exactly which environment triggers it.
-- Do not begin root cause analysis until you have a reliable reproduction.
+Capture output whole. A truncated stack trace or a summarized error body loses the line that mattered.

--- a/plugins/lisa-copilot/skills/lisa-root-cause-analysis/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-root-cause-analysis/SKILL.md
@@ -1,155 +1,115 @@
 ---
 name: lisa-root-cause-analysis
-description: "Root cause analysis methodology. Evidence gathering from logs, execution path tracing, strategic log placement, and building irrefutable proof chains."
+description: "Prove what causes a defect: hypotheses written down before evidence is gathered, confirmation by execution rather than by reasoning, a symptom-keyed technique menu including git bisect, and a declared stopping point that escalates instead of drifting."
 ---
 
 # Root Cause Analysis
 
-Definitively prove what is causing a problem. Do not guess. Do not theorize without evidence. Trace the actual execution path, read real logs, and produce irrefutable proof of root cause.
+Produce a proof, not an explanation. Every link in the chain rests on something observed — a log line, a stack frame, an exit code, a bisect verdict.
 
-**Core principle: "Show me the proof."** Every conclusion must be backed by concrete evidence -- a log line, a stack trace, a reproducible sequence, or a failing test.
+## Confirm by executing, not by reasoning
 
-## Phase 1: Gather Evidence from Logs
+The characteristic failure of this work is a fluent wrong answer: a plausible story assembled from reading code and delivered with confidence. Reading is how a hypothesis is formed. Running something is how it is confirmed. **Do not report a cause you have not executed against.**
 
-### Local Logs
+## Write the hypotheses down first
 
-- Search application logs in the project directory (`logs/`, `tmp/`, stdout/stderr output)
-- Run tests with verbose logging enabled to capture execution flow
-- Check framework-specific log locations (e.g., `.next/`, `dist/`, build output)
+Before gathering evidence, list the candidate causes — two or three is normal — and beside each, the observation that would **kill** it. Then go looking for the killing observations rather than for support.
 
-### Remote Logs (AWS CloudWatch, etc.)
+A candidate you cannot state a disproof for is not a hypothesis; it is a hunch, and it will survive any amount of evidence. Keep the list updated as you work: the answer is the one candidate still standing with a passing proof, and the eliminated ones belong in the output, because they are how a reader knows you looked.
 
-- Discover existing scripts and tools in the project for tailing logs:
-  - Check `package.json` scripts for log-related commands
-  - Search for shell scripts: `scripts/*log*`, `scripts/*tail*`, `scripts/*watch*`
-  - Look for AWS CLI wrappers, CloudWatch log group configurations
-  - Check for `.env` files referencing log groups or log streams
-- Use discovered tools first before falling back to raw CLI commands
-- When using AWS CLI directly:
-  ```bash
-  # Discover available log groups
-  aws logs describe-log-groups --query 'logGroups[].logGroupName' --output text
+## Pick the technique from the symptom
 
-  # Tail recent logs with filter
-  aws logs filter-log-events \
-    --log-group-name "/aws/lambda/function-name" \
-    --start-time $(date -d '30 minutes ago' +%s000) \
-    --filter-pattern "ERROR" \
-    --query 'events[].message' --output text
+| What you know | Reach for |
+| --- | --- |
+| **It used to work**, and a good commit can be named | `git bisect` — preconditions below |
+| A stack trace or error location | Work backward from the throw; read the frames that carry the value, skip the plumbing |
+| Only that the result is wrong, no location | Instrument first. Reading code to localize an unlocalized defect is the slowest move available |
+| Intermittent | Loop it. Log timestamps and identity either side of async boundaries; look for overlap, staleness, out-of-order completion |
+| Works locally, fails deployed | Diff the environments — version, config, data, permissions, network — before touching code |
+| Wrong shape, missing field, unexpected null | Log the actual value at each transformation, not the type you expect |
+| Possibly a dependency | Pin the exact installed version; read its changelog and issues before blaming local code |
 
-  # Follow live logs
-  aws logs tail "/aws/lambda/function-name" --follow --since 10m
-  ```
+### git bisect
 
-## Phase 2: Trace the Execution Path
+The highest-leverage move available for a regression, and consistently underused: it answers *which change* in log₂(n) steps instead of log₂(n) hours of reading. It needs three things and wastes time without them.
 
-- Start from the error and work backward through the call stack
-- Read every function in the chain -- do not skip intermediate code
-- Identify the exact line where behavior diverges from expectation
-- Map the data flow: what value was expected vs. what value was actually present
+1. **A known-good commit** — from the last release, the last green run, or the reporter's "it worked on…".
+2. **A deterministic, non-interactive check** that exits non-zero on the defect. The failing test from `reproduce-bug` usually is one.
+3. **A runnable checkout at every step.** Where a fresh checkout needs a dependency install or build before tests run, fold that into the bisect command. Otherwise every step fails for the wrong reason and the verdict is noise.
 
-## Phase 3: Strategic Log Placement
+```bash
+git bisect start <bad> <good>
+git bisect run <cmd>   # <cmd> must install/build if the checkout needs it
+```
 
-When existing logs are insufficient, add targeted log statements to prove or disprove hypotheses.
+Read the blamed commit before believing it. Bisect names the change that *surfaced* the defect, which is not always the change that introduced it.
 
-### Log Statement Guidelines
+## Find the logs the project already has
 
-- **Be surgical** -- add the minimum number of log statements needed to confirm the root cause
-- **Include context** -- log the actual values, not just "reached here"
-- **Use structured format** -- make logs easy to find and parse
+Look for existing tooling before reaching for a raw CLI: `package.json` scripts, `scripts/*log*`, `scripts/*tail*`, AWS CLI wrappers, log-group names in `.env`. Project tooling already encodes the credentials, regions, and group names you would otherwise guess at.
+
+Where no wrapper exists:
+
+```bash
+aws logs describe-log-groups --query 'logGroups[].logGroupName' --output text
+aws logs tail "/aws/lambda/<name>" --follow --since 30m
+```
+
+If remote logs are unreachable, name the log group and the time window needed rather than proceeding without them.
+
+## Instrument surgically
+
+Add the fewest statements that decide between live hypotheses, and make each carry values rather than announce arrival.
 
 ```typescript
-// Bad: Vague, unhelpful
-console.log("here");
-console.log("data:", data);
+// Useless: proves a line ran.
+console.log("here", data);
 
-// Good: Precise, searchable, includes context
+// Useful: decides a hypothesis.
 console.log("[DEBUG:issue-123] processOrder entry", {
   orderId: order.id,
   status: order.status,
   itemCount: order.items.length,
-  timestamp: new Date().toISOString(),
 });
 ```
 
-### Placement Strategy
+Highest-yield placements: function entry (called at all, with what), either side of a branch (which way, on what value), either side of an `await` (timing, staleness), around transformations (where the shape changes), and inside `catch` blocks (what is being swallowed).
 
-| Placement | Purpose |
-|-----------|---------|
-| Function entry | Confirm the function is called and with what arguments |
-| Before conditional branches | Verify which branch is taken and why |
-| Before/after async operations | Detect timing issues, race conditions, failed awaits |
-| Before/after data transformations | Catch where data becomes corrupted or unexpected |
-| Error handlers and catch blocks | Ensure errors are not silently swallowed |
+The `[DEBUG:<issue>]` prefix exists so that cleanup is mechanical rather than remembered. Once the cause is proved, remove every one — keeping only logging that belongs in the product permanently — and verify:
 
-### Hypothesis Elimination
-
-When multiple hypotheses exist, design a log placement strategy that eliminates all but one. Each log statement should be placed to confirm or rule out a specific hypothesis.
-
-## Phase 4: Prove the Root Cause
-
-Build an evidence chain that is irrefutable:
-
-1. **The symptom** -- what the user observes (error message, wrong output, crash)
-2. **The proximate cause** -- the line of code that directly produces the symptom
-3. **The root cause** -- the underlying reason the proximate cause occurs
-4. **The proof** -- log output, test result, or reproduction steps that confirm each link
-
-### Evidence Chain Format
-
-```text
-Symptom: [exact error message or behavior]
-    |
-    v
-Proximate cause: [file:line] -- [the line that directly produces the error]
-    |
-    v
-Root cause: [file:line] -- [the underlying reason]
-    |
-    v
-Proof: [log output / test result / reproduction that confirms the chain]
-```
-
-## Phase 5: Clean Up
-
-After root cause is confirmed, **remove all debug log statements** added during investigation. Leave only:
-
-- Log statements that belong in the application permanently (error logging, audit trails)
-- Statements explicitly requested by the user
-
-Verify cleanup:
 ```bash
-# Search for any remaining debug markers
-grep -rn "\[DEBUG:" src/ --include="*.ts" --include="*.tsx" --include="*.js"
+grep -rn "\[DEBUG:" src/
 ```
 
-## Output Format
+## Stop before you drift
+
+Declare a budget before starting: a number of instrumentation rounds, or a wall-clock box. Two signatures mean stop now rather than push on.
+
+- **Two consecutive hypotheses falsified with no new information gained.** Widening the search against the same evidence is not progress.
+- **The budget is spent.**
+
+Stopping is a legitimate outcome, and not a silent one. Escalate a decision-ready report: the symptom, the hypotheses tried and how each was killed, the evidence collected, and the single thing that would unblock the work — an access grant, a log group, a reproduction on the real path. A blocked investigation reported clearly is worth more than a confident guess, and costs the next agent far less.
+
+## Output
 
 ```text
 ## Root Cause Analysis
 
-### Evidence Trail
-| Step | Location | Evidence | Conclusion |
-|------|----------|----------|------------|
-| 1 | file:line | Log output or observed value | What this proves |
-| 2 | file:line | Log output or observed value | What this proves |
+### Hypotheses
+| Candidate | Would be killed by | Status |
+|---|---|---|
+| ... | the observation that would disprove it | eliminated / standing |
 
-### Root Cause
-**Proximate cause:** The line that directly produces the error.
-**Root cause:** The underlying reason this line behaves incorrectly.
-**Proof:** The specific evidence that confirms this beyond doubt.
+### Evidence trail
+| Step | Location | Observed | Proves |
+|---|---|---|---|
+| 1 | file:line | log output, value, exit code | what this establishes |
 
-### Recommended Fix
-What needs to change and why. Include file:line references.
+### Cause
+**Proximate:** file:line — the line that directly produces the symptom.
+**Root:** file:line — why that line behaves that way.
+**Proof:** the command run and its output. Not an argument.
+
+### Fix
+What changes and why, with file:line references. Anything that must not change.
 ```
-
-## Rules
-
-- Never guess at root cause -- prove it with evidence
-- Read the actual code in the execution path -- do not rely on function names or comments to infer behavior
-- When adding debug logs, use a consistent prefix (e.g., `[DEBUG:issue-name]`) so they are easy to find and clean up
-- Remove all temporary debug log statements after investigation is complete
-- If remote log access is unavailable, report what logs would be needed and from where
-- Prefer project-specific tooling and scripts over raw CLI commands for log access
-- If the root cause is in a third-party dependency, identify the exact version and known issue
-- Always verify the fix resolves the issue -- do not mark investigation complete without proof

--- a/plugins/lisa-cursor/agents/debug-specialist.md
+++ b/plugins/lisa-cursor/agents/debug-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: debug-specialist
-description: Debug specialist agent. Expert at root cause analysis, log investigation (local and remote via AWS CloudWatch, scripts, and project tooling), strategic log statement placement, and definitive proof of bug causation. Finds what is causing the problem without a doubt.
+description: Debug specialist agent. Proves what causes a defect — reproduction on the real path, hypotheses falsified by execution, evidence chains, and log investigation both local and remote (CloudWatch, Sentry, project tooling). Escalates a decision-ready report rather than guessing when a cause will not yield.
 skills:
   - reproduce-bug
   - root-cause-analysis
@@ -8,107 +8,27 @@ skills:
 
 # Debug Specialist Agent
 
-You are a debug specialist whose mission is to **definitively prove** what is causing a problem. You do not guess. You do not theorize without evidence. You trace the actual execution path, read real logs, and produce irrefutable proof of root cause.
+You prove causes. A conclusion you have not executed against is a hypothesis, however well it reads.
 
-## Core Philosophy
+The procedures live in your two skills — `reproduce-bug` for establishing the failure, `root-cause-analysis` for proving its cause. Follow them and emit the output format each defines. They are not restated here, so that there is one place to change them.
 
-**"Show me the proof."** Every conclusion must be backed by concrete evidence -- a log line, a stack trace, a reproducible sequence, or a failing test. If you cannot prove it, you have not found the root cause.
+## What you decide
 
-## Clean Up Log Statements
+- **Whether a reproduction exists at all.** No investigation begins without one, and a failure that occurs only inside scaffolding you built for the purpose is not one. Where the real path is unreachable, that is the finding: report the missing access.
+- **Which technique the symptom calls for.** `root-cause-analysis` carries the menu; choosing badly costs more than any other decision in the session. A regression with a nameable good commit goes to `git bisect` before anyone reads code.
+- **When to stop.** You own the budget and the escalation. Two hypotheses falsified with no new information, or the budget spent, and you hand back a decision-ready packet instead of continuing.
 
-After root cause is confirmed, **remove all debug log statements** that were added during investigation. Leave only:
+## Two ways this work goes wrong
 
-- Log statements that belong in the application permanently (error logging, audit trails)
-- Statements explicitly requested by the user
+Both are yours to prevent, and neither announces itself:
 
-Verify cleanup with:
-```bash
-# Search for any remaining debug markers
-grep -rn "\[DEBUG:" src/ --include="*.ts" --include="*.tsx" --include="*.js"
-```
+- **A fluent wrong answer.** Reading code produces plausible stories cheaply. Execution produces facts. Never close on the former.
+- **A proof built to succeed.** Asked to demonstrate a defect, it is easy to construct the conditions that show it. Name every stand-in you introduced, and say whether the failure survives without it.
 
-## Output Format
+## How you are judged
 
-Structure your findings as:
+Not by whether you find a cause — some defects do not yield in one session. By whether every claim you make is backed by something observed, and whether a reader can tell, without asking you, which parts you proved and which you suspect.
 
-```
-## Debug Investigation
+## Where you hand off
 
-### Symptom
-What was observed -- exact error message, stack trace, or behavior description.
-
-### Reproduction
-The exact command or sequence that triggers the issue.
-
-### Evidence Trail
-| Step | Location | Evidence | Conclusion |
-|------|----------|----------|------------|
-| 1 | file:line | Log output or observed value | What this proves |
-| 2 | file:line | Log output or observed value | What this proves |
-| ... | ... | ... | ... |
-
-### Root Cause
-**Proximate cause:** The line that directly produces the error.
-**Root cause:** The underlying reason this line behaves incorrectly.
-**Proof:** The specific evidence that confirms this beyond doubt.
-
-### Fix
-What needs to change and why. Include file:line references.
-
-### Verification
-Command to run that proves the fix resolves the issue.
-Expected output after the fix.
-```
-
-## Common Investigation Patterns
-
-### Silent Error Swallowing
-```typescript
-// Symptom: Function returns undefined, no error visible
-// Investigation: Check for empty catch blocks
-try {
-  return await riskyOperation();
-} catch {
-  // Bug: Error swallowed silently -- caller gets undefined
-}
-```
-
-### Race Condition
-```typescript
-// Symptom: Intermittent failures, works "sometimes"
-// Investigation: Log timestamps around async operations
-console.log("[DEBUG] before await:", Date.now());
-const result = await asyncOp();
-console.log("[DEBUG] after await:", Date.now(), result);
-// Look for: overlapping timestamps, stale values, out-of-order execution
-```
-
-### Wrong Data Shape
-```typescript
-// Symptom: TypeError: Cannot read property 'x' of undefined
-// Investigation: Log the actual object at each transformation step
-console.log("[DEBUG] raw response:", JSON.stringify(response, null, 2));
-console.log("[DEBUG] after transform:", JSON.stringify(transformed, null, 2));
-// Look for: missing fields, null where object expected, array where single item expected
-```
-
-### Environment Mismatch
-```bash
-# Symptom: Works locally, fails in staging/production
-# Investigation: Compare environment configurations
-diff <(env | sort) <(ssh staging 'env | sort')
-# Check: Node.js version, env vars, dependency versions, config files
-```
-
-## Rules
-
-- Never guess at root cause -- prove it with evidence
-- Always reproduce the issue before investigating
-- Read the actual code in the execution path -- do not rely on function names or comments to infer behavior
-- When adding debug logs, use a consistent prefix (e.g., `[DEBUG:issue-name]`) so they are easy to find and clean up
-- Remove all temporary debug log statements after investigation is complete
-- If remote log access is unavailable, report what logs would be needed and from where
-- Prefer project-specific tooling and scripts over raw CLI commands for log access
-- If the root cause is in a third-party dependency, identify the exact version and known issue
-- When multiple hypotheses exist, design a log placement strategy that eliminates all but one
-- Always verify the fix resolves the issue -- do not mark investigation complete without proof
+You do not implement the fix; `bug-fixer` does, and your reproduction becomes its failing test. Give it the entry point, the reproduction form and its observed rate, the proximate and root cause with file:line, and the evidence trail that establishes both.

--- a/plugins/lisa-cursor/skills/lisa-bug-triage/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-bug-triage/SKILL.md
@@ -10,8 +10,8 @@ Follow this 8-step triage process before implementing any bug fix. Do not skip t
 ## Triage Steps
 
 1. Verify you have all information needed to reproduce the bug (authentication requirements, environment information, etc.). Do not make assumptions. If anything is missing, stop and ask before proceeding.
-2. Reproduce the bug. If you cannot reproduce it, stop and report what you tried and what you observed.
-3. Once reproduced, verify you are 100% positive on how to fix it. If not, determine what you need to do to be 100% positive (e.g. add logging, trace the code path, inspect state) and do that first.
+2. Reproduce the bug on the path the user actually hits. If it fails only inside a harness or fixture you built for the purpose, you have a lead rather than a reproduction — say so and keep going. If you cannot reproduce it at all, stop and report what you tried and what you observed.
+3. Once reproduced, state the cause and the observation that would disprove it, then go and get that observation. If the cause survives, you know what to fix. If you cannot name anything that would disprove it, you are not certain — you are guessing; add logging, trace the path, or bisect until you can.
 4. Verify you have access to the tools, environments, and permissions needed to deploy and verify this fix (e.g. CI/CD pipelines, deployment targets, logging/monitoring systems, API access, database access). If any are missing or inaccessible, stop and raise them before starting implementation.
 5. Define the tests you will write to confirm the fix and prevent a regression.
 6. Define the documentation you will create or update to explain this bug so another developer understands the "how" and "what" behind it.

--- a/plugins/lisa-cursor/skills/lisa-reproduce-bug/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-reproduce-bug/SKILL.md
@@ -1,96 +1,58 @@
 ---
 name: lisa-reproduce-bug
-description: "How to create reliable bug reproduction scenarios. Covers failing tests, minimal scripts, environment verification, and reproduction evidence capture."
+description: "How to reproduce a bug reliably and on the real path — choosing a reproduction method from the symptom, proving the reproduction exercises the code under claim rather than a harness built to fail, and reporting the observed failure rate instead of rounding it."
 ---
 
 # Reproduce Bug
 
-Before investigating root cause, reproduce the issue empirically. A bug that cannot be reproduced cannot be verified as fixed.
+A bug that cannot be reproduced cannot be verified as fixed. Root cause analysis does not begin until a reliable reproduction exists.
 
-## Reproduction Process
+## The reproduction must be on the real path
 
-### 1. Run the Failing Scenario
+Left alone, an agent asked to demonstrate a defect will build the environment in which the defect appears — a fixture, a stub, a fresh harness — and present that as the reproduction. It looks like proof and it is not: a fix that satisfies it may never touch the path the user is on.
 
-- Execute the exact command, test, or request that triggers the bug
-- Capture the complete error output, stack trace, or unexpected behavior
-- Record the exact command used so it can be repeated
+So the reproduction states, explicitly:
 
-### 2. Capture Evidence
+- **The entry point the user actually hits** — the route, endpoint, command, or interaction.
+- **Every stand-in introduced** — mock, stub, seeded record, fake clock, new harness — and what real thing each replaces.
+- **Whether it still fails without them.** A failure that occurs only inside scaffolding written for the purpose is a lead, not a reproduction. Say so and keep going.
 
-- Save the full error output (not just a summary)
-- Note the timestamp and environment details (OS, runtime version, dependency versions)
-- Screenshot or log any visual/UI issues
-- Record the actual behavior vs. the expected behavior
+If the real path is unreachable — no credentials, no environment, no data — that is a blocked reproduction. Report the missing access rather than substituting a harness and calling the bug reproduced.
 
-### 3. Investigate Environment Differences (If Cannot Reproduce)
+## Choose the method from the symptom
 
-If the issue does not reproduce locally:
+| Symptom | Reach for |
+| --- | --- |
+| Wrong value, bad output, thrown error | Failing test at the narrowest layer that still crosses the real path |
+| Broken interface or journey | Browser or device driver against a running build (Playwright, Maestro) |
+| Service or API behaviour | Direct request to the running service — client script or `curl` |
+| Depends on particular data | Seeded fixture that recreates the state, recorded as part of the reproduction |
+| Intermittent or timing-shaped | Loop the trigger; capture timestamps around async boundaries |
+| Works locally, fails deployed | Do not chase it locally — reproduce against the environment that fails |
 
-- Compare environment configurations (env vars, config files, feature flags)
-- Check runtime versions (Node.js, Python, Java, etc.)
-- Compare dependency versions (`package-lock.json`, `poetry.lock`, etc.)
-- Check data differences (database state, seed data, user roles)
-- Verify network conditions (DNS, proxies, firewalls, VPN)
-- Check for platform-specific behavior (OS, architecture, container vs. host)
+**A failing test is the preferred form** wherever it can cross the real path: it runs in CI, it becomes the regression guard, and `codify-verification` expects it. A script is the fallback. Manual steps are the last resort and must carry the prerequisite state — logged-in user, seeded data, feature flags.
 
-### 4. Create a Minimal Reproduction
+## Report the rate, do not round it
 
-Create the smallest possible reproduction that triggers the bug:
+Run the reproduction enough times to state a rate, and report it as observed — `7/10` — never as "reliable" or "intermittent" on its own. A reproduction that fails half the time cannot prove a fix: one passing run after the change means nothing at that rate. If the rate is too low to distinguish a fix from luck, say what would raise it: more iterations, a forced schedule, a narrowed trigger, a seeded clock.
 
-**Preferred: Failing test**
-- Write a test that exercises the exact code path and asserts the expected behavior
-- The test should fail with the same symptom as the reported bug
-- A failing test is the most reliable reproduction because it runs in CI and prevents regression
+## When it will not reproduce
 
-**Fallback: Reproduction script**
-- Write a standalone script that triggers the issue
-- Minimize dependencies -- remove anything not needed to reproduce
-- Include setup steps (data seeding, config) in the script itself
-- The script should be runnable by anyone with access to the repo
+The difference is nearly always one of: runtime version, configuration or feature flags, data state, credentials and permissions, network posture, or platform. Diff the two environments along those axes rather than guessing between them — and report which axes you compared and what you found. That comparison is itself the finding when the bug stays hidden.
 
-**Last resort: Manual steps**
-- Document exact click-by-click or command-by-command steps
-- Include prerequisite state (logged-in user, specific data, feature flags)
-- Note any timing-sensitive aspects (race conditions, timeouts)
-
-### 5. Verify Reproduction Is Reliable
-
-- Run the reproduction multiple times to confirm it consistently fails
-- For intermittent bugs, run enough iterations to establish the failure rate
-- If intermittent, note any patterns (timing, load, specific data)
-
-## Output Format
+## Output
 
 ```text
 ## Reproduction
 
-### Command/Steps
-The exact command or steps to trigger the bug.
-
-### Actual Behavior
-What happens (error message, wrong output, crash).
-
-### Expected Behavior
-What should happen instead.
-
-### Environment
-- Runtime: [version]
-- OS: [platform]
-- Dependencies: [relevant versions]
-
-### Reproduction Type
-[ ] Failing test: [path to test file]
-[ ] Script: [path to script]
-[ ] Manual steps: [documented above]
-
-### Reliability
-[Always / Intermittent (N/M runs) / Conditional (only when X)]
+**Entry point:** the route, command, or action the user hits
+**Command or steps:** exactly what to run
+**Actual:** what happens · **Expected:** what should happen
+**Stand-ins:** each mock, stub, seed, or harness and what it replaces — or "none"
+**Fails without stand-ins:** yes / no — if no, this is a lead, not a reproduction
+**Observed rate:** n/m runs
+**Form:** failing test `path` | script `path` | manual steps above
+**Environment:** runtime, platform, relevant dependency versions
 ```
 
-## Rules
-
-- Never skip reproduction. If you cannot reproduce, report what you tried and what you observed.
-- A failing test is always the preferred reproduction method.
-- Capture complete error output -- do not truncate or summarize.
-- If the bug is environment-specific, document exactly which environment triggers it.
-- Do not begin root cause analysis until you have a reliable reproduction.
+Capture output whole. A truncated stack trace or a summarized error body loses the line that mattered.

--- a/plugins/lisa-cursor/skills/lisa-root-cause-analysis/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-root-cause-analysis/SKILL.md
@@ -1,155 +1,115 @@
 ---
 name: lisa-root-cause-analysis
-description: "Root cause analysis methodology. Evidence gathering from logs, execution path tracing, strategic log placement, and building irrefutable proof chains."
+description: "Prove what causes a defect: hypotheses written down before evidence is gathered, confirmation by execution rather than by reasoning, a symptom-keyed technique menu including git bisect, and a declared stopping point that escalates instead of drifting."
 ---
 
 # Root Cause Analysis
 
-Definitively prove what is causing a problem. Do not guess. Do not theorize without evidence. Trace the actual execution path, read real logs, and produce irrefutable proof of root cause.
+Produce a proof, not an explanation. Every link in the chain rests on something observed — a log line, a stack frame, an exit code, a bisect verdict.
 
-**Core principle: "Show me the proof."** Every conclusion must be backed by concrete evidence -- a log line, a stack trace, a reproducible sequence, or a failing test.
+## Confirm by executing, not by reasoning
 
-## Phase 1: Gather Evidence from Logs
+The characteristic failure of this work is a fluent wrong answer: a plausible story assembled from reading code and delivered with confidence. Reading is how a hypothesis is formed. Running something is how it is confirmed. **Do not report a cause you have not executed against.**
 
-### Local Logs
+## Write the hypotheses down first
 
-- Search application logs in the project directory (`logs/`, `tmp/`, stdout/stderr output)
-- Run tests with verbose logging enabled to capture execution flow
-- Check framework-specific log locations (e.g., `.next/`, `dist/`, build output)
+Before gathering evidence, list the candidate causes — two or three is normal — and beside each, the observation that would **kill** it. Then go looking for the killing observations rather than for support.
 
-### Remote Logs (AWS CloudWatch, etc.)
+A candidate you cannot state a disproof for is not a hypothesis; it is a hunch, and it will survive any amount of evidence. Keep the list updated as you work: the answer is the one candidate still standing with a passing proof, and the eliminated ones belong in the output, because they are how a reader knows you looked.
 
-- Discover existing scripts and tools in the project for tailing logs:
-  - Check `package.json` scripts for log-related commands
-  - Search for shell scripts: `scripts/*log*`, `scripts/*tail*`, `scripts/*watch*`
-  - Look for AWS CLI wrappers, CloudWatch log group configurations
-  - Check for `.env` files referencing log groups or log streams
-- Use discovered tools first before falling back to raw CLI commands
-- When using AWS CLI directly:
-  ```bash
-  # Discover available log groups
-  aws logs describe-log-groups --query 'logGroups[].logGroupName' --output text
+## Pick the technique from the symptom
 
-  # Tail recent logs with filter
-  aws logs filter-log-events \
-    --log-group-name "/aws/lambda/function-name" \
-    --start-time $(date -d '30 minutes ago' +%s000) \
-    --filter-pattern "ERROR" \
-    --query 'events[].message' --output text
+| What you know | Reach for |
+| --- | --- |
+| **It used to work**, and a good commit can be named | `git bisect` — preconditions below |
+| A stack trace or error location | Work backward from the throw; read the frames that carry the value, skip the plumbing |
+| Only that the result is wrong, no location | Instrument first. Reading code to localize an unlocalized defect is the slowest move available |
+| Intermittent | Loop it. Log timestamps and identity either side of async boundaries; look for overlap, staleness, out-of-order completion |
+| Works locally, fails deployed | Diff the environments — version, config, data, permissions, network — before touching code |
+| Wrong shape, missing field, unexpected null | Log the actual value at each transformation, not the type you expect |
+| Possibly a dependency | Pin the exact installed version; read its changelog and issues before blaming local code |
 
-  # Follow live logs
-  aws logs tail "/aws/lambda/function-name" --follow --since 10m
-  ```
+### git bisect
 
-## Phase 2: Trace the Execution Path
+The highest-leverage move available for a regression, and consistently underused: it answers *which change* in log₂(n) steps instead of log₂(n) hours of reading. It needs three things and wastes time without them.
 
-- Start from the error and work backward through the call stack
-- Read every function in the chain -- do not skip intermediate code
-- Identify the exact line where behavior diverges from expectation
-- Map the data flow: what value was expected vs. what value was actually present
+1. **A known-good commit** — from the last release, the last green run, or the reporter's "it worked on…".
+2. **A deterministic, non-interactive check** that exits non-zero on the defect. The failing test from `reproduce-bug` usually is one.
+3. **A runnable checkout at every step.** Where a fresh checkout needs a dependency install or build before tests run, fold that into the bisect command. Otherwise every step fails for the wrong reason and the verdict is noise.
 
-## Phase 3: Strategic Log Placement
+```bash
+git bisect start <bad> <good>
+git bisect run <cmd>   # <cmd> must install/build if the checkout needs it
+```
 
-When existing logs are insufficient, add targeted log statements to prove or disprove hypotheses.
+Read the blamed commit before believing it. Bisect names the change that *surfaced* the defect, which is not always the change that introduced it.
 
-### Log Statement Guidelines
+## Find the logs the project already has
 
-- **Be surgical** -- add the minimum number of log statements needed to confirm the root cause
-- **Include context** -- log the actual values, not just "reached here"
-- **Use structured format** -- make logs easy to find and parse
+Look for existing tooling before reaching for a raw CLI: `package.json` scripts, `scripts/*log*`, `scripts/*tail*`, AWS CLI wrappers, log-group names in `.env`. Project tooling already encodes the credentials, regions, and group names you would otherwise guess at.
+
+Where no wrapper exists:
+
+```bash
+aws logs describe-log-groups --query 'logGroups[].logGroupName' --output text
+aws logs tail "/aws/lambda/<name>" --follow --since 30m
+```
+
+If remote logs are unreachable, name the log group and the time window needed rather than proceeding without them.
+
+## Instrument surgically
+
+Add the fewest statements that decide between live hypotheses, and make each carry values rather than announce arrival.
 
 ```typescript
-// Bad: Vague, unhelpful
-console.log("here");
-console.log("data:", data);
+// Useless: proves a line ran.
+console.log("here", data);
 
-// Good: Precise, searchable, includes context
+// Useful: decides a hypothesis.
 console.log("[DEBUG:issue-123] processOrder entry", {
   orderId: order.id,
   status: order.status,
   itemCount: order.items.length,
-  timestamp: new Date().toISOString(),
 });
 ```
 
-### Placement Strategy
+Highest-yield placements: function entry (called at all, with what), either side of a branch (which way, on what value), either side of an `await` (timing, staleness), around transformations (where the shape changes), and inside `catch` blocks (what is being swallowed).
 
-| Placement | Purpose |
-|-----------|---------|
-| Function entry | Confirm the function is called and with what arguments |
-| Before conditional branches | Verify which branch is taken and why |
-| Before/after async operations | Detect timing issues, race conditions, failed awaits |
-| Before/after data transformations | Catch where data becomes corrupted or unexpected |
-| Error handlers and catch blocks | Ensure errors are not silently swallowed |
+The `[DEBUG:<issue>]` prefix exists so that cleanup is mechanical rather than remembered. Once the cause is proved, remove every one — keeping only logging that belongs in the product permanently — and verify:
 
-### Hypothesis Elimination
-
-When multiple hypotheses exist, design a log placement strategy that eliminates all but one. Each log statement should be placed to confirm or rule out a specific hypothesis.
-
-## Phase 4: Prove the Root Cause
-
-Build an evidence chain that is irrefutable:
-
-1. **The symptom** -- what the user observes (error message, wrong output, crash)
-2. **The proximate cause** -- the line of code that directly produces the symptom
-3. **The root cause** -- the underlying reason the proximate cause occurs
-4. **The proof** -- log output, test result, or reproduction steps that confirm each link
-
-### Evidence Chain Format
-
-```text
-Symptom: [exact error message or behavior]
-    |
-    v
-Proximate cause: [file:line] -- [the line that directly produces the error]
-    |
-    v
-Root cause: [file:line] -- [the underlying reason]
-    |
-    v
-Proof: [log output / test result / reproduction that confirms the chain]
-```
-
-## Phase 5: Clean Up
-
-After root cause is confirmed, **remove all debug log statements** added during investigation. Leave only:
-
-- Log statements that belong in the application permanently (error logging, audit trails)
-- Statements explicitly requested by the user
-
-Verify cleanup:
 ```bash
-# Search for any remaining debug markers
-grep -rn "\[DEBUG:" src/ --include="*.ts" --include="*.tsx" --include="*.js"
+grep -rn "\[DEBUG:" src/
 ```
 
-## Output Format
+## Stop before you drift
+
+Declare a budget before starting: a number of instrumentation rounds, or a wall-clock box. Two signatures mean stop now rather than push on.
+
+- **Two consecutive hypotheses falsified with no new information gained.** Widening the search against the same evidence is not progress.
+- **The budget is spent.**
+
+Stopping is a legitimate outcome, and not a silent one. Escalate a decision-ready report: the symptom, the hypotheses tried and how each was killed, the evidence collected, and the single thing that would unblock the work — an access grant, a log group, a reproduction on the real path. A blocked investigation reported clearly is worth more than a confident guess, and costs the next agent far less.
+
+## Output
 
 ```text
 ## Root Cause Analysis
 
-### Evidence Trail
-| Step | Location | Evidence | Conclusion |
-|------|----------|----------|------------|
-| 1 | file:line | Log output or observed value | What this proves |
-| 2 | file:line | Log output or observed value | What this proves |
+### Hypotheses
+| Candidate | Would be killed by | Status |
+|---|---|---|
+| ... | the observation that would disprove it | eliminated / standing |
 
-### Root Cause
-**Proximate cause:** The line that directly produces the error.
-**Root cause:** The underlying reason this line behaves incorrectly.
-**Proof:** The specific evidence that confirms this beyond doubt.
+### Evidence trail
+| Step | Location | Observed | Proves |
+|---|---|---|---|
+| 1 | file:line | log output, value, exit code | what this establishes |
 
-### Recommended Fix
-What needs to change and why. Include file:line references.
+### Cause
+**Proximate:** file:line — the line that directly produces the symptom.
+**Root:** file:line — why that line behaves that way.
+**Proof:** the command run and its output. Not an argument.
+
+### Fix
+What changes and why, with file:line references. Anything that must not change.
 ```
-
-## Rules
-
-- Never guess at root cause -- prove it with evidence
-- Read the actual code in the execution path -- do not rely on function names or comments to infer behavior
-- When adding debug logs, use a consistent prefix (e.g., `[DEBUG:issue-name]`) so they are easy to find and clean up
-- Remove all temporary debug log statements after investigation is complete
-- If remote log access is unavailable, report what logs would be needed and from where
-- Prefer project-specific tooling and scripts over raw CLI commands for log access
-- If the root cause is in a third-party dependency, identify the exact version and known issue
-- Always verify the fix resolves the issue -- do not mark investigation complete without proof

--- a/plugins/lisa/.codex-plugin/skills/lisa-bug-triage/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-bug-triage/SKILL.md
@@ -10,8 +10,8 @@ Follow this 8-step triage process before implementing any bug fix. Do not skip t
 ## Triage Steps
 
 1. Verify you have all information needed to reproduce the bug (authentication requirements, environment information, etc.). Do not make assumptions. If anything is missing, stop and ask before proceeding.
-2. Reproduce the bug. If you cannot reproduce it, stop and report what you tried and what you observed.
-3. Once reproduced, verify you are 100% positive on how to fix it. If not, determine what you need to do to be 100% positive (e.g. add logging, trace the code path, inspect state) and do that first.
+2. Reproduce the bug on the path the user actually hits. If it fails only inside a harness or fixture you built for the purpose, you have a lead rather than a reproduction — say so and keep going. If you cannot reproduce it at all, stop and report what you tried and what you observed.
+3. Once reproduced, state the cause and the observation that would disprove it, then go and get that observation. If the cause survives, you know what to fix. If you cannot name anything that would disprove it, you are not certain — you are guessing; add logging, trace the path, or bisect until you can.
 4. Verify you have access to the tools, environments, and permissions needed to deploy and verify this fix (e.g. CI/CD pipelines, deployment targets, logging/monitoring systems, API access, database access). If any are missing or inaccessible, stop and raise them before starting implementation.
 5. Define the tests you will write to confirm the fix and prevent a regression.
 6. Define the documentation you will create or update to explain this bug so another developer understands the "how" and "what" behind it.

--- a/plugins/lisa/.codex-plugin/skills/lisa-reproduce-bug/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-reproduce-bug/SKILL.md
@@ -1,96 +1,58 @@
 ---
 name: lisa-reproduce-bug
-description: "How to create reliable bug…"
+description: "How to reproduce a bug reliably…"
 ---
 
 # Reproduce Bug
 
-Before investigating root cause, reproduce the issue empirically. A bug that cannot be reproduced cannot be verified as fixed.
+A bug that cannot be reproduced cannot be verified as fixed. Root cause analysis does not begin until a reliable reproduction exists.
 
-## Reproduction Process
+## The reproduction must be on the real path
 
-### 1. Run the Failing Scenario
+Left alone, an agent asked to demonstrate a defect will build the environment in which the defect appears — a fixture, a stub, a fresh harness — and present that as the reproduction. It looks like proof and it is not: a fix that satisfies it may never touch the path the user is on.
 
-- Execute the exact command, test, or request that triggers the bug
-- Capture the complete error output, stack trace, or unexpected behavior
-- Record the exact command used so it can be repeated
+So the reproduction states, explicitly:
 
-### 2. Capture Evidence
+- **The entry point the user actually hits** — the route, endpoint, command, or interaction.
+- **Every stand-in introduced** — mock, stub, seeded record, fake clock, new harness — and what real thing each replaces.
+- **Whether it still fails without them.** A failure that occurs only inside scaffolding written for the purpose is a lead, not a reproduction. Say so and keep going.
 
-- Save the full error output (not just a summary)
-- Note the timestamp and environment details (OS, runtime version, dependency versions)
-- Screenshot or log any visual/UI issues
-- Record the actual behavior vs. the expected behavior
+If the real path is unreachable — no credentials, no environment, no data — that is a blocked reproduction. Report the missing access rather than substituting a harness and calling the bug reproduced.
 
-### 3. Investigate Environment Differences (If Cannot Reproduce)
+## Choose the method from the symptom
 
-If the issue does not reproduce locally:
+| Symptom | Reach for |
+| --- | --- |
+| Wrong value, bad output, thrown error | Failing test at the narrowest layer that still crosses the real path |
+| Broken interface or journey | Browser or device driver against a running build (Playwright, Maestro) |
+| Service or API behaviour | Direct request to the running service — client script or `curl` |
+| Depends on particular data | Seeded fixture that recreates the state, recorded as part of the reproduction |
+| Intermittent or timing-shaped | Loop the trigger; capture timestamps around async boundaries |
+| Works locally, fails deployed | Do not chase it locally — reproduce against the environment that fails |
 
-- Compare environment configurations (env vars, config files, feature flags)
-- Check runtime versions (Node.js, Python, Java, etc.)
-- Compare dependency versions (`package-lock.json`, `poetry.lock`, etc.)
-- Check data differences (database state, seed data, user roles)
-- Verify network conditions (DNS, proxies, firewalls, VPN)
-- Check for platform-specific behavior (OS, architecture, container vs. host)
+**A failing test is the preferred form** wherever it can cross the real path: it runs in CI, it becomes the regression guard, and `codify-verification` expects it. A script is the fallback. Manual steps are the last resort and must carry the prerequisite state — logged-in user, seeded data, feature flags.
 
-### 4. Create a Minimal Reproduction
+## Report the rate, do not round it
 
-Create the smallest possible reproduction that triggers the bug:
+Run the reproduction enough times to state a rate, and report it as observed — `7/10` — never as "reliable" or "intermittent" on its own. A reproduction that fails half the time cannot prove a fix: one passing run after the change means nothing at that rate. If the rate is too low to distinguish a fix from luck, say what would raise it: more iterations, a forced schedule, a narrowed trigger, a seeded clock.
 
-**Preferred: Failing test**
-- Write a test that exercises the exact code path and asserts the expected behavior
-- The test should fail with the same symptom as the reported bug
-- A failing test is the most reliable reproduction because it runs in CI and prevents regression
+## When it will not reproduce
 
-**Fallback: Reproduction script**
-- Write a standalone script that triggers the issue
-- Minimize dependencies -- remove anything not needed to reproduce
-- Include setup steps (data seeding, config) in the script itself
-- The script should be runnable by anyone with access to the repo
+The difference is nearly always one of: runtime version, configuration or feature flags, data state, credentials and permissions, network posture, or platform. Diff the two environments along those axes rather than guessing between them — and report which axes you compared and what you found. That comparison is itself the finding when the bug stays hidden.
 
-**Last resort: Manual steps**
-- Document exact click-by-click or command-by-command steps
-- Include prerequisite state (logged-in user, specific data, feature flags)
-- Note any timing-sensitive aspects (race conditions, timeouts)
-
-### 5. Verify Reproduction Is Reliable
-
-- Run the reproduction multiple times to confirm it consistently fails
-- For intermittent bugs, run enough iterations to establish the failure rate
-- If intermittent, note any patterns (timing, load, specific data)
-
-## Output Format
+## Output
 
 ```text
 ## Reproduction
 
-### Command/Steps
-The exact command or steps to trigger the bug.
-
-### Actual Behavior
-What happens (error message, wrong output, crash).
-
-### Expected Behavior
-What should happen instead.
-
-### Environment
-- Runtime: [version]
-- OS: [platform]
-- Dependencies: [relevant versions]
-
-### Reproduction Type
-[ ] Failing test: [path to test file]
-[ ] Script: [path to script]
-[ ] Manual steps: [documented above]
-
-### Reliability
-[Always / Intermittent (N/M runs) / Conditional (only when X)]
+**Entry point:** the route, command, or action the user hits
+**Command or steps:** exactly what to run
+**Actual:** what happens · **Expected:** what should happen
+**Stand-ins:** each mock, stub, seed, or harness and what it replaces — or "none"
+**Fails without stand-ins:** yes / no — if no, this is a lead, not a reproduction
+**Observed rate:** n/m runs
+**Form:** failing test `path` | script `path` | manual steps above
+**Environment:** runtime, platform, relevant dependency versions
 ```
 
-## Rules
-
-- Never skip reproduction. If you cannot reproduce, report what you tried and what you observed.
-- A failing test is always the preferred reproduction method.
-- Capture complete error output -- do not truncate or summarize.
-- If the bug is environment-specific, document exactly which environment triggers it.
-- Do not begin root cause analysis until you have a reliable reproduction.
+Capture output whole. A truncated stack trace or a summarized error body loses the line that mattered.

--- a/plugins/lisa/.codex-plugin/skills/lisa-reproduce-bug/agents/openai.yaml
+++ b/plugins/lisa/.codex-plugin/skills/lisa-reproduce-bug/agents/openai.yaml
@@ -1,4 +1,4 @@
 display_name: "Reproduce Bug"
-short_description: "How to create reliable bug…"
+short_description: "How to reproduce a bug reliably…"
 default_prompt:
-  - "Use $lisa-reproduce-bug: How to create reliable bug…."
+  - "Use $lisa-reproduce-bug: How to reproduce a bug reliably…."

--- a/plugins/lisa/.codex-plugin/skills/lisa-root-cause-analysis/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-root-cause-analysis/SKILL.md
@@ -1,155 +1,115 @@
 ---
 name: lisa-root-cause-analysis
-description: "Root cause analysis methodology"
+description: "Prove what causes a defect…"
 ---
 
 # Root Cause Analysis
 
-Definitively prove what is causing a problem. Do not guess. Do not theorize without evidence. Trace the actual execution path, read real logs, and produce irrefutable proof of root cause.
+Produce a proof, not an explanation. Every link in the chain rests on something observed — a log line, a stack frame, an exit code, a bisect verdict.
 
-**Core principle: "Show me the proof."** Every conclusion must be backed by concrete evidence -- a log line, a stack trace, a reproducible sequence, or a failing test.
+## Confirm by executing, not by reasoning
 
-## Phase 1: Gather Evidence from Logs
+The characteristic failure of this work is a fluent wrong answer: a plausible story assembled from reading code and delivered with confidence. Reading is how a hypothesis is formed. Running something is how it is confirmed. **Do not report a cause you have not executed against.**
 
-### Local Logs
+## Write the hypotheses down first
 
-- Search application logs in the project directory (`logs/`, `tmp/`, stdout/stderr output)
-- Run tests with verbose logging enabled to capture execution flow
-- Check framework-specific log locations (e.g., `.next/`, `dist/`, build output)
+Before gathering evidence, list the candidate causes — two or three is normal — and beside each, the observation that would **kill** it. Then go looking for the killing observations rather than for support.
 
-### Remote Logs (AWS CloudWatch, etc.)
+A candidate you cannot state a disproof for is not a hypothesis; it is a hunch, and it will survive any amount of evidence. Keep the list updated as you work: the answer is the one candidate still standing with a passing proof, and the eliminated ones belong in the output, because they are how a reader knows you looked.
 
-- Discover existing scripts and tools in the project for tailing logs:
-  - Check `package.json` scripts for log-related commands
-  - Search for shell scripts: `scripts/*log*`, `scripts/*tail*`, `scripts/*watch*`
-  - Look for AWS CLI wrappers, CloudWatch log group configurations
-  - Check for `.env` files referencing log groups or log streams
-- Use discovered tools first before falling back to raw CLI commands
-- When using AWS CLI directly:
-  ```bash
-  # Discover available log groups
-  aws logs describe-log-groups --query 'logGroups[].logGroupName' --output text
+## Pick the technique from the symptom
 
-  # Tail recent logs with filter
-  aws logs filter-log-events \
-    --log-group-name "/aws/lambda/function-name" \
-    --start-time $(date -d '30 minutes ago' +%s000) \
-    --filter-pattern "ERROR" \
-    --query 'events[].message' --output text
+| What you know | Reach for |
+| --- | --- |
+| **It used to work**, and a good commit can be named | `git bisect` — preconditions below |
+| A stack trace or error location | Work backward from the throw; read the frames that carry the value, skip the plumbing |
+| Only that the result is wrong, no location | Instrument first. Reading code to localize an unlocalized defect is the slowest move available |
+| Intermittent | Loop it. Log timestamps and identity either side of async boundaries; look for overlap, staleness, out-of-order completion |
+| Works locally, fails deployed | Diff the environments — version, config, data, permissions, network — before touching code |
+| Wrong shape, missing field, unexpected null | Log the actual value at each transformation, not the type you expect |
+| Possibly a dependency | Pin the exact installed version; read its changelog and issues before blaming local code |
 
-  # Follow live logs
-  aws logs tail "/aws/lambda/function-name" --follow --since 10m
-  ```
+### git bisect
 
-## Phase 2: Trace the Execution Path
+The highest-leverage move available for a regression, and consistently underused: it answers *which change* in log₂(n) steps instead of log₂(n) hours of reading. It needs three things and wastes time without them.
 
-- Start from the error and work backward through the call stack
-- Read every function in the chain -- do not skip intermediate code
-- Identify the exact line where behavior diverges from expectation
-- Map the data flow: what value was expected vs. what value was actually present
+1. **A known-good commit** — from the last release, the last green run, or the reporter's "it worked on…".
+2. **A deterministic, non-interactive check** that exits non-zero on the defect. The failing test from `reproduce-bug` usually is one.
+3. **A runnable checkout at every step.** Where a fresh checkout needs a dependency install or build before tests run, fold that into the bisect command. Otherwise every step fails for the wrong reason and the verdict is noise.
 
-## Phase 3: Strategic Log Placement
+```bash
+git bisect start <bad> <good>
+git bisect run <cmd>   # <cmd> must install/build if the checkout needs it
+```
 
-When existing logs are insufficient, add targeted log statements to prove or disprove hypotheses.
+Read the blamed commit before believing it. Bisect names the change that *surfaced* the defect, which is not always the change that introduced it.
 
-### Log Statement Guidelines
+## Find the logs the project already has
 
-- **Be surgical** -- add the minimum number of log statements needed to confirm the root cause
-- **Include context** -- log the actual values, not just "reached here"
-- **Use structured format** -- make logs easy to find and parse
+Look for existing tooling before reaching for a raw CLI: `package.json` scripts, `scripts/*log*`, `scripts/*tail*`, AWS CLI wrappers, log-group names in `.env`. Project tooling already encodes the credentials, regions, and group names you would otherwise guess at.
+
+Where no wrapper exists:
+
+```bash
+aws logs describe-log-groups --query 'logGroups[].logGroupName' --output text
+aws logs tail "/aws/lambda/<name>" --follow --since 30m
+```
+
+If remote logs are unreachable, name the log group and the time window needed rather than proceeding without them.
+
+## Instrument surgically
+
+Add the fewest statements that decide between live hypotheses, and make each carry values rather than announce arrival.
 
 ```typescript
-// Bad: Vague, unhelpful
-console.log("here");
-console.log("data:", data);
+// Useless: proves a line ran.
+console.log("here", data);
 
-// Good: Precise, searchable, includes context
+// Useful: decides a hypothesis.
 console.log("[DEBUG:issue-123] processOrder entry", {
   orderId: order.id,
   status: order.status,
   itemCount: order.items.length,
-  timestamp: new Date().toISOString(),
 });
 ```
 
-### Placement Strategy
+Highest-yield placements: function entry (called at all, with what), either side of a branch (which way, on what value), either side of an `await` (timing, staleness), around transformations (where the shape changes), and inside `catch` blocks (what is being swallowed).
 
-| Placement | Purpose |
-|-----------|---------|
-| Function entry | Confirm the function is called and with what arguments |
-| Before conditional branches | Verify which branch is taken and why |
-| Before/after async operations | Detect timing issues, race conditions, failed awaits |
-| Before/after data transformations | Catch where data becomes corrupted or unexpected |
-| Error handlers and catch blocks | Ensure errors are not silently swallowed |
+The `[DEBUG:<issue>]` prefix exists so that cleanup is mechanical rather than remembered. Once the cause is proved, remove every one — keeping only logging that belongs in the product permanently — and verify:
 
-### Hypothesis Elimination
-
-When multiple hypotheses exist, design a log placement strategy that eliminates all but one. Each log statement should be placed to confirm or rule out a specific hypothesis.
-
-## Phase 4: Prove the Root Cause
-
-Build an evidence chain that is irrefutable:
-
-1. **The symptom** -- what the user observes (error message, wrong output, crash)
-2. **The proximate cause** -- the line of code that directly produces the symptom
-3. **The root cause** -- the underlying reason the proximate cause occurs
-4. **The proof** -- log output, test result, or reproduction steps that confirm each link
-
-### Evidence Chain Format
-
-```text
-Symptom: [exact error message or behavior]
-    |
-    v
-Proximate cause: [file:line] -- [the line that directly produces the error]
-    |
-    v
-Root cause: [file:line] -- [the underlying reason]
-    |
-    v
-Proof: [log output / test result / reproduction that confirms the chain]
-```
-
-## Phase 5: Clean Up
-
-After root cause is confirmed, **remove all debug log statements** added during investigation. Leave only:
-
-- Log statements that belong in the application permanently (error logging, audit trails)
-- Statements explicitly requested by the user
-
-Verify cleanup:
 ```bash
-# Search for any remaining debug markers
-grep -rn "\[DEBUG:" src/ --include="*.ts" --include="*.tsx" --include="*.js"
+grep -rn "\[DEBUG:" src/
 ```
 
-## Output Format
+## Stop before you drift
+
+Declare a budget before starting: a number of instrumentation rounds, or a wall-clock box. Two signatures mean stop now rather than push on.
+
+- **Two consecutive hypotheses falsified with no new information gained.** Widening the search against the same evidence is not progress.
+- **The budget is spent.**
+
+Stopping is a legitimate outcome, and not a silent one. Escalate a decision-ready report: the symptom, the hypotheses tried and how each was killed, the evidence collected, and the single thing that would unblock the work — an access grant, a log group, a reproduction on the real path. A blocked investigation reported clearly is worth more than a confident guess, and costs the next agent far less.
+
+## Output
 
 ```text
 ## Root Cause Analysis
 
-### Evidence Trail
-| Step | Location | Evidence | Conclusion |
-|------|----------|----------|------------|
-| 1 | file:line | Log output or observed value | What this proves |
-| 2 | file:line | Log output or observed value | What this proves |
+### Hypotheses
+| Candidate | Would be killed by | Status |
+|---|---|---|
+| ... | the observation that would disprove it | eliminated / standing |
 
-### Root Cause
-**Proximate cause:** The line that directly produces the error.
-**Root cause:** The underlying reason this line behaves incorrectly.
-**Proof:** The specific evidence that confirms this beyond doubt.
+### Evidence trail
+| Step | Location | Observed | Proves |
+|---|---|---|---|
+| 1 | file:line | log output, value, exit code | what this establishes |
 
-### Recommended Fix
-What needs to change and why. Include file:line references.
+### Cause
+**Proximate:** file:line — the line that directly produces the symptom.
+**Root:** file:line — why that line behaves that way.
+**Proof:** the command run and its output. Not an argument.
+
+### Fix
+What changes and why, with file:line references. Anything that must not change.
 ```
-
-## Rules
-
-- Never guess at root cause -- prove it with evidence
-- Read the actual code in the execution path -- do not rely on function names or comments to infer behavior
-- When adding debug logs, use a consistent prefix (e.g., `[DEBUG:issue-name]`) so they are easy to find and clean up
-- Remove all temporary debug log statements after investigation is complete
-- If remote log access is unavailable, report what logs would be needed and from where
-- Prefer project-specific tooling and scripts over raw CLI commands for log access
-- If the root cause is in a third-party dependency, identify the exact version and known issue
-- Always verify the fix resolves the issue -- do not mark investigation complete without proof

--- a/plugins/lisa/.codex-plugin/skills/lisa-root-cause-analysis/agents/openai.yaml
+++ b/plugins/lisa/.codex-plugin/skills/lisa-root-cause-analysis/agents/openai.yaml
@@ -1,4 +1,4 @@
 display_name: "Root Cause Analysis"
-short_description: "Root cause analysis methodology"
+short_description: "Prove what causes a defect…"
 default_prompt:
-  - "Use $lisa-root-cause-analysis: Root cause analysis methodology."
+  - "Use $lisa-root-cause-analysis: Prove what causes a defect…."

--- a/plugins/lisa/agents/debug-specialist.md
+++ b/plugins/lisa/agents/debug-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: debug-specialist
-description: Debug specialist agent. Expert at root cause analysis, log investigation (local and remote via AWS CloudWatch, scripts, and project tooling), strategic log statement placement, and definitive proof of bug causation. Finds what is causing the problem without a doubt.
+description: Debug specialist agent. Proves what causes a defect — reproduction on the real path, hypotheses falsified by execution, evidence chains, and log investigation both local and remote (CloudWatch, Sentry, project tooling). Escalates a decision-ready report rather than guessing when a cause will not yield.
 skills:
   - reproduce-bug
   - root-cause-analysis
@@ -8,107 +8,27 @@ skills:
 
 # Debug Specialist Agent
 
-You are a debug specialist whose mission is to **definitively prove** what is causing a problem. You do not guess. You do not theorize without evidence. You trace the actual execution path, read real logs, and produce irrefutable proof of root cause.
+You prove causes. A conclusion you have not executed against is a hypothesis, however well it reads.
 
-## Core Philosophy
+The procedures live in your two skills — `reproduce-bug` for establishing the failure, `root-cause-analysis` for proving its cause. Follow them and emit the output format each defines. They are not restated here, so that there is one place to change them.
 
-**"Show me the proof."** Every conclusion must be backed by concrete evidence -- a log line, a stack trace, a reproducible sequence, or a failing test. If you cannot prove it, you have not found the root cause.
+## What you decide
 
-## Clean Up Log Statements
+- **Whether a reproduction exists at all.** No investigation begins without one, and a failure that occurs only inside scaffolding you built for the purpose is not one. Where the real path is unreachable, that is the finding: report the missing access.
+- **Which technique the symptom calls for.** `root-cause-analysis` carries the menu; choosing badly costs more than any other decision in the session. A regression with a nameable good commit goes to `git bisect` before anyone reads code.
+- **When to stop.** You own the budget and the escalation. Two hypotheses falsified with no new information, or the budget spent, and you hand back a decision-ready packet instead of continuing.
 
-After root cause is confirmed, **remove all debug log statements** that were added during investigation. Leave only:
+## Two ways this work goes wrong
 
-- Log statements that belong in the application permanently (error logging, audit trails)
-- Statements explicitly requested by the user
+Both are yours to prevent, and neither announces itself:
 
-Verify cleanup with:
-```bash
-# Search for any remaining debug markers
-grep -rn "\[DEBUG:" src/ --include="*.ts" --include="*.tsx" --include="*.js"
-```
+- **A fluent wrong answer.** Reading code produces plausible stories cheaply. Execution produces facts. Never close on the former.
+- **A proof built to succeed.** Asked to demonstrate a defect, it is easy to construct the conditions that show it. Name every stand-in you introduced, and say whether the failure survives without it.
 
-## Output Format
+## How you are judged
 
-Structure your findings as:
+Not by whether you find a cause — some defects do not yield in one session. By whether every claim you make is backed by something observed, and whether a reader can tell, without asking you, which parts you proved and which you suspect.
 
-```
-## Debug Investigation
+## Where you hand off
 
-### Symptom
-What was observed -- exact error message, stack trace, or behavior description.
-
-### Reproduction
-The exact command or sequence that triggers the issue.
-
-### Evidence Trail
-| Step | Location | Evidence | Conclusion |
-|------|----------|----------|------------|
-| 1 | file:line | Log output or observed value | What this proves |
-| 2 | file:line | Log output or observed value | What this proves |
-| ... | ... | ... | ... |
-
-### Root Cause
-**Proximate cause:** The line that directly produces the error.
-**Root cause:** The underlying reason this line behaves incorrectly.
-**Proof:** The specific evidence that confirms this beyond doubt.
-
-### Fix
-What needs to change and why. Include file:line references.
-
-### Verification
-Command to run that proves the fix resolves the issue.
-Expected output after the fix.
-```
-
-## Common Investigation Patterns
-
-### Silent Error Swallowing
-```typescript
-// Symptom: Function returns undefined, no error visible
-// Investigation: Check for empty catch blocks
-try {
-  return await riskyOperation();
-} catch {
-  // Bug: Error swallowed silently -- caller gets undefined
-}
-```
-
-### Race Condition
-```typescript
-// Symptom: Intermittent failures, works "sometimes"
-// Investigation: Log timestamps around async operations
-console.log("[DEBUG] before await:", Date.now());
-const result = await asyncOp();
-console.log("[DEBUG] after await:", Date.now(), result);
-// Look for: overlapping timestamps, stale values, out-of-order execution
-```
-
-### Wrong Data Shape
-```typescript
-// Symptom: TypeError: Cannot read property 'x' of undefined
-// Investigation: Log the actual object at each transformation step
-console.log("[DEBUG] raw response:", JSON.stringify(response, null, 2));
-console.log("[DEBUG] after transform:", JSON.stringify(transformed, null, 2));
-// Look for: missing fields, null where object expected, array where single item expected
-```
-
-### Environment Mismatch
-```bash
-# Symptom: Works locally, fails in staging/production
-# Investigation: Compare environment configurations
-diff <(env | sort) <(ssh staging 'env | sort')
-# Check: Node.js version, env vars, dependency versions, config files
-```
-
-## Rules
-
-- Never guess at root cause -- prove it with evidence
-- Always reproduce the issue before investigating
-- Read the actual code in the execution path -- do not rely on function names or comments to infer behavior
-- When adding debug logs, use a consistent prefix (e.g., `[DEBUG:issue-name]`) so they are easy to find and clean up
-- Remove all temporary debug log statements after investigation is complete
-- If remote log access is unavailable, report what logs would be needed and from where
-- Prefer project-specific tooling and scripts over raw CLI commands for log access
-- If the root cause is in a third-party dependency, identify the exact version and known issue
-- When multiple hypotheses exist, design a log placement strategy that eliminates all but one
-- Always verify the fix resolves the issue -- do not mark investigation complete without proof
+You do not implement the fix; `bug-fixer` does, and your reproduction becomes its failing test. Give it the entry point, the reproduction form and its observed rate, the proximate and root cause with file:line, and the evidence trail that establishes both.

--- a/plugins/lisa/skills/lisa-bug-triage/SKILL.md
+++ b/plugins/lisa/skills/lisa-bug-triage/SKILL.md
@@ -10,8 +10,8 @@ Follow this 8-step triage process before implementing any bug fix. Do not skip t
 ## Triage Steps
 
 1. Verify you have all information needed to reproduce the bug (authentication requirements, environment information, etc.). Do not make assumptions. If anything is missing, stop and ask before proceeding.
-2. Reproduce the bug. If you cannot reproduce it, stop and report what you tried and what you observed.
-3. Once reproduced, verify you are 100% positive on how to fix it. If not, determine what you need to do to be 100% positive (e.g. add logging, trace the code path, inspect state) and do that first.
+2. Reproduce the bug on the path the user actually hits. If it fails only inside a harness or fixture you built for the purpose, you have a lead rather than a reproduction — say so and keep going. If you cannot reproduce it at all, stop and report what you tried and what you observed.
+3. Once reproduced, state the cause and the observation that would disprove it, then go and get that observation. If the cause survives, you know what to fix. If you cannot name anything that would disprove it, you are not certain — you are guessing; add logging, trace the path, or bisect until you can.
 4. Verify you have access to the tools, environments, and permissions needed to deploy and verify this fix (e.g. CI/CD pipelines, deployment targets, logging/monitoring systems, API access, database access). If any are missing or inaccessible, stop and raise them before starting implementation.
 5. Define the tests you will write to confirm the fix and prevent a regression.
 6. Define the documentation you will create or update to explain this bug so another developer understands the "how" and "what" behind it.

--- a/plugins/lisa/skills/lisa-reproduce-bug/SKILL.md
+++ b/plugins/lisa/skills/lisa-reproduce-bug/SKILL.md
@@ -1,96 +1,58 @@
 ---
 name: lisa-reproduce-bug
-description: "How to create reliable bug reproduction scenarios. Covers failing tests, minimal scripts, environment verification, and reproduction evidence capture."
+description: "How to reproduce a bug reliably and on the real path — choosing a reproduction method from the symptom, proving the reproduction exercises the code under claim rather than a harness built to fail, and reporting the observed failure rate instead of rounding it."
 ---
 
 # Reproduce Bug
 
-Before investigating root cause, reproduce the issue empirically. A bug that cannot be reproduced cannot be verified as fixed.
+A bug that cannot be reproduced cannot be verified as fixed. Root cause analysis does not begin until a reliable reproduction exists.
 
-## Reproduction Process
+## The reproduction must be on the real path
 
-### 1. Run the Failing Scenario
+Left alone, an agent asked to demonstrate a defect will build the environment in which the defect appears — a fixture, a stub, a fresh harness — and present that as the reproduction. It looks like proof and it is not: a fix that satisfies it may never touch the path the user is on.
 
-- Execute the exact command, test, or request that triggers the bug
-- Capture the complete error output, stack trace, or unexpected behavior
-- Record the exact command used so it can be repeated
+So the reproduction states, explicitly:
 
-### 2. Capture Evidence
+- **The entry point the user actually hits** — the route, endpoint, command, or interaction.
+- **Every stand-in introduced** — mock, stub, seeded record, fake clock, new harness — and what real thing each replaces.
+- **Whether it still fails without them.** A failure that occurs only inside scaffolding written for the purpose is a lead, not a reproduction. Say so and keep going.
 
-- Save the full error output (not just a summary)
-- Note the timestamp and environment details (OS, runtime version, dependency versions)
-- Screenshot or log any visual/UI issues
-- Record the actual behavior vs. the expected behavior
+If the real path is unreachable — no credentials, no environment, no data — that is a blocked reproduction. Report the missing access rather than substituting a harness and calling the bug reproduced.
 
-### 3. Investigate Environment Differences (If Cannot Reproduce)
+## Choose the method from the symptom
 
-If the issue does not reproduce locally:
+| Symptom | Reach for |
+| --- | --- |
+| Wrong value, bad output, thrown error | Failing test at the narrowest layer that still crosses the real path |
+| Broken interface or journey | Browser or device driver against a running build (Playwright, Maestro) |
+| Service or API behaviour | Direct request to the running service — client script or `curl` |
+| Depends on particular data | Seeded fixture that recreates the state, recorded as part of the reproduction |
+| Intermittent or timing-shaped | Loop the trigger; capture timestamps around async boundaries |
+| Works locally, fails deployed | Do not chase it locally — reproduce against the environment that fails |
 
-- Compare environment configurations (env vars, config files, feature flags)
-- Check runtime versions (Node.js, Python, Java, etc.)
-- Compare dependency versions (`package-lock.json`, `poetry.lock`, etc.)
-- Check data differences (database state, seed data, user roles)
-- Verify network conditions (DNS, proxies, firewalls, VPN)
-- Check for platform-specific behavior (OS, architecture, container vs. host)
+**A failing test is the preferred form** wherever it can cross the real path: it runs in CI, it becomes the regression guard, and `codify-verification` expects it. A script is the fallback. Manual steps are the last resort and must carry the prerequisite state — logged-in user, seeded data, feature flags.
 
-### 4. Create a Minimal Reproduction
+## Report the rate, do not round it
 
-Create the smallest possible reproduction that triggers the bug:
+Run the reproduction enough times to state a rate, and report it as observed — `7/10` — never as "reliable" or "intermittent" on its own. A reproduction that fails half the time cannot prove a fix: one passing run after the change means nothing at that rate. If the rate is too low to distinguish a fix from luck, say what would raise it: more iterations, a forced schedule, a narrowed trigger, a seeded clock.
 
-**Preferred: Failing test**
-- Write a test that exercises the exact code path and asserts the expected behavior
-- The test should fail with the same symptom as the reported bug
-- A failing test is the most reliable reproduction because it runs in CI and prevents regression
+## When it will not reproduce
 
-**Fallback: Reproduction script**
-- Write a standalone script that triggers the issue
-- Minimize dependencies -- remove anything not needed to reproduce
-- Include setup steps (data seeding, config) in the script itself
-- The script should be runnable by anyone with access to the repo
+The difference is nearly always one of: runtime version, configuration or feature flags, data state, credentials and permissions, network posture, or platform. Diff the two environments along those axes rather than guessing between them — and report which axes you compared and what you found. That comparison is itself the finding when the bug stays hidden.
 
-**Last resort: Manual steps**
-- Document exact click-by-click or command-by-command steps
-- Include prerequisite state (logged-in user, specific data, feature flags)
-- Note any timing-sensitive aspects (race conditions, timeouts)
-
-### 5. Verify Reproduction Is Reliable
-
-- Run the reproduction multiple times to confirm it consistently fails
-- For intermittent bugs, run enough iterations to establish the failure rate
-- If intermittent, note any patterns (timing, load, specific data)
-
-## Output Format
+## Output
 
 ```text
 ## Reproduction
 
-### Command/Steps
-The exact command or steps to trigger the bug.
-
-### Actual Behavior
-What happens (error message, wrong output, crash).
-
-### Expected Behavior
-What should happen instead.
-
-### Environment
-- Runtime: [version]
-- OS: [platform]
-- Dependencies: [relevant versions]
-
-### Reproduction Type
-[ ] Failing test: [path to test file]
-[ ] Script: [path to script]
-[ ] Manual steps: [documented above]
-
-### Reliability
-[Always / Intermittent (N/M runs) / Conditional (only when X)]
+**Entry point:** the route, command, or action the user hits
+**Command or steps:** exactly what to run
+**Actual:** what happens · **Expected:** what should happen
+**Stand-ins:** each mock, stub, seed, or harness and what it replaces — or "none"
+**Fails without stand-ins:** yes / no — if no, this is a lead, not a reproduction
+**Observed rate:** n/m runs
+**Form:** failing test `path` | script `path` | manual steps above
+**Environment:** runtime, platform, relevant dependency versions
 ```
 
-## Rules
-
-- Never skip reproduction. If you cannot reproduce, report what you tried and what you observed.
-- A failing test is always the preferred reproduction method.
-- Capture complete error output -- do not truncate or summarize.
-- If the bug is environment-specific, document exactly which environment triggers it.
-- Do not begin root cause analysis until you have a reliable reproduction.
+Capture output whole. A truncated stack trace or a summarized error body loses the line that mattered.

--- a/plugins/lisa/skills/lisa-reproduce-bug/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-reproduce-bug/agents/openai.yaml
@@ -1,4 +1,4 @@
 display_name: "Reproduce Bug"
-short_description: "How to create reliable bug reproduction scenarios"
+short_description: "How to reproduce a bug reliably and on the real path — choosing a reproduction method from the symptom, proving the reproduction exercises…"
 default_prompt:
-  - "Use $lisa-reproduce-bug: How to create reliable bug reproduction scenarios."
+  - "Use $lisa-reproduce-bug: How to reproduce a bug reliably and on the real path — choosing a reproduction method from the symptom, proving the reproduction exercises…."

--- a/plugins/lisa/skills/lisa-root-cause-analysis/SKILL.md
+++ b/plugins/lisa/skills/lisa-root-cause-analysis/SKILL.md
@@ -1,155 +1,115 @@
 ---
 name: lisa-root-cause-analysis
-description: "Root cause analysis methodology. Evidence gathering from logs, execution path tracing, strategic log placement, and building irrefutable proof chains."
+description: "Prove what causes a defect: hypotheses written down before evidence is gathered, confirmation by execution rather than by reasoning, a symptom-keyed technique menu including git bisect, and a declared stopping point that escalates instead of drifting."
 ---
 
 # Root Cause Analysis
 
-Definitively prove what is causing a problem. Do not guess. Do not theorize without evidence. Trace the actual execution path, read real logs, and produce irrefutable proof of root cause.
+Produce a proof, not an explanation. Every link in the chain rests on something observed — a log line, a stack frame, an exit code, a bisect verdict.
 
-**Core principle: "Show me the proof."** Every conclusion must be backed by concrete evidence -- a log line, a stack trace, a reproducible sequence, or a failing test.
+## Confirm by executing, not by reasoning
 
-## Phase 1: Gather Evidence from Logs
+The characteristic failure of this work is a fluent wrong answer: a plausible story assembled from reading code and delivered with confidence. Reading is how a hypothesis is formed. Running something is how it is confirmed. **Do not report a cause you have not executed against.**
 
-### Local Logs
+## Write the hypotheses down first
 
-- Search application logs in the project directory (`logs/`, `tmp/`, stdout/stderr output)
-- Run tests with verbose logging enabled to capture execution flow
-- Check framework-specific log locations (e.g., `.next/`, `dist/`, build output)
+Before gathering evidence, list the candidate causes — two or three is normal — and beside each, the observation that would **kill** it. Then go looking for the killing observations rather than for support.
 
-### Remote Logs (AWS CloudWatch, etc.)
+A candidate you cannot state a disproof for is not a hypothesis; it is a hunch, and it will survive any amount of evidence. Keep the list updated as you work: the answer is the one candidate still standing with a passing proof, and the eliminated ones belong in the output, because they are how a reader knows you looked.
 
-- Discover existing scripts and tools in the project for tailing logs:
-  - Check `package.json` scripts for log-related commands
-  - Search for shell scripts: `scripts/*log*`, `scripts/*tail*`, `scripts/*watch*`
-  - Look for AWS CLI wrappers, CloudWatch log group configurations
-  - Check for `.env` files referencing log groups or log streams
-- Use discovered tools first before falling back to raw CLI commands
-- When using AWS CLI directly:
-  ```bash
-  # Discover available log groups
-  aws logs describe-log-groups --query 'logGroups[].logGroupName' --output text
+## Pick the technique from the symptom
 
-  # Tail recent logs with filter
-  aws logs filter-log-events \
-    --log-group-name "/aws/lambda/function-name" \
-    --start-time $(date -d '30 minutes ago' +%s000) \
-    --filter-pattern "ERROR" \
-    --query 'events[].message' --output text
+| What you know | Reach for |
+| --- | --- |
+| **It used to work**, and a good commit can be named | `git bisect` — preconditions below |
+| A stack trace or error location | Work backward from the throw; read the frames that carry the value, skip the plumbing |
+| Only that the result is wrong, no location | Instrument first. Reading code to localize an unlocalized defect is the slowest move available |
+| Intermittent | Loop it. Log timestamps and identity either side of async boundaries; look for overlap, staleness, out-of-order completion |
+| Works locally, fails deployed | Diff the environments — version, config, data, permissions, network — before touching code |
+| Wrong shape, missing field, unexpected null | Log the actual value at each transformation, not the type you expect |
+| Possibly a dependency | Pin the exact installed version; read its changelog and issues before blaming local code |
 
-  # Follow live logs
-  aws logs tail "/aws/lambda/function-name" --follow --since 10m
-  ```
+### git bisect
 
-## Phase 2: Trace the Execution Path
+The highest-leverage move available for a regression, and consistently underused: it answers *which change* in log₂(n) steps instead of log₂(n) hours of reading. It needs three things and wastes time without them.
 
-- Start from the error and work backward through the call stack
-- Read every function in the chain -- do not skip intermediate code
-- Identify the exact line where behavior diverges from expectation
-- Map the data flow: what value was expected vs. what value was actually present
+1. **A known-good commit** — from the last release, the last green run, or the reporter's "it worked on…".
+2. **A deterministic, non-interactive check** that exits non-zero on the defect. The failing test from `reproduce-bug` usually is one.
+3. **A runnable checkout at every step.** Where a fresh checkout needs a dependency install or build before tests run, fold that into the bisect command. Otherwise every step fails for the wrong reason and the verdict is noise.
 
-## Phase 3: Strategic Log Placement
+```bash
+git bisect start <bad> <good>
+git bisect run <cmd>   # <cmd> must install/build if the checkout needs it
+```
 
-When existing logs are insufficient, add targeted log statements to prove or disprove hypotheses.
+Read the blamed commit before believing it. Bisect names the change that *surfaced* the defect, which is not always the change that introduced it.
 
-### Log Statement Guidelines
+## Find the logs the project already has
 
-- **Be surgical** -- add the minimum number of log statements needed to confirm the root cause
-- **Include context** -- log the actual values, not just "reached here"
-- **Use structured format** -- make logs easy to find and parse
+Look for existing tooling before reaching for a raw CLI: `package.json` scripts, `scripts/*log*`, `scripts/*tail*`, AWS CLI wrappers, log-group names in `.env`. Project tooling already encodes the credentials, regions, and group names you would otherwise guess at.
+
+Where no wrapper exists:
+
+```bash
+aws logs describe-log-groups --query 'logGroups[].logGroupName' --output text
+aws logs tail "/aws/lambda/<name>" --follow --since 30m
+```
+
+If remote logs are unreachable, name the log group and the time window needed rather than proceeding without them.
+
+## Instrument surgically
+
+Add the fewest statements that decide between live hypotheses, and make each carry values rather than announce arrival.
 
 ```typescript
-// Bad: Vague, unhelpful
-console.log("here");
-console.log("data:", data);
+// Useless: proves a line ran.
+console.log("here", data);
 
-// Good: Precise, searchable, includes context
+// Useful: decides a hypothesis.
 console.log("[DEBUG:issue-123] processOrder entry", {
   orderId: order.id,
   status: order.status,
   itemCount: order.items.length,
-  timestamp: new Date().toISOString(),
 });
 ```
 
-### Placement Strategy
+Highest-yield placements: function entry (called at all, with what), either side of a branch (which way, on what value), either side of an `await` (timing, staleness), around transformations (where the shape changes), and inside `catch` blocks (what is being swallowed).
 
-| Placement | Purpose |
-|-----------|---------|
-| Function entry | Confirm the function is called and with what arguments |
-| Before conditional branches | Verify which branch is taken and why |
-| Before/after async operations | Detect timing issues, race conditions, failed awaits |
-| Before/after data transformations | Catch where data becomes corrupted or unexpected |
-| Error handlers and catch blocks | Ensure errors are not silently swallowed |
+The `[DEBUG:<issue>]` prefix exists so that cleanup is mechanical rather than remembered. Once the cause is proved, remove every one — keeping only logging that belongs in the product permanently — and verify:
 
-### Hypothesis Elimination
-
-When multiple hypotheses exist, design a log placement strategy that eliminates all but one. Each log statement should be placed to confirm or rule out a specific hypothesis.
-
-## Phase 4: Prove the Root Cause
-
-Build an evidence chain that is irrefutable:
-
-1. **The symptom** -- what the user observes (error message, wrong output, crash)
-2. **The proximate cause** -- the line of code that directly produces the symptom
-3. **The root cause** -- the underlying reason the proximate cause occurs
-4. **The proof** -- log output, test result, or reproduction steps that confirm each link
-
-### Evidence Chain Format
-
-```text
-Symptom: [exact error message or behavior]
-    |
-    v
-Proximate cause: [file:line] -- [the line that directly produces the error]
-    |
-    v
-Root cause: [file:line] -- [the underlying reason]
-    |
-    v
-Proof: [log output / test result / reproduction that confirms the chain]
-```
-
-## Phase 5: Clean Up
-
-After root cause is confirmed, **remove all debug log statements** added during investigation. Leave only:
-
-- Log statements that belong in the application permanently (error logging, audit trails)
-- Statements explicitly requested by the user
-
-Verify cleanup:
 ```bash
-# Search for any remaining debug markers
-grep -rn "\[DEBUG:" src/ --include="*.ts" --include="*.tsx" --include="*.js"
+grep -rn "\[DEBUG:" src/
 ```
 
-## Output Format
+## Stop before you drift
+
+Declare a budget before starting: a number of instrumentation rounds, or a wall-clock box. Two signatures mean stop now rather than push on.
+
+- **Two consecutive hypotheses falsified with no new information gained.** Widening the search against the same evidence is not progress.
+- **The budget is spent.**
+
+Stopping is a legitimate outcome, and not a silent one. Escalate a decision-ready report: the symptom, the hypotheses tried and how each was killed, the evidence collected, and the single thing that would unblock the work — an access grant, a log group, a reproduction on the real path. A blocked investigation reported clearly is worth more than a confident guess, and costs the next agent far less.
+
+## Output
 
 ```text
 ## Root Cause Analysis
 
-### Evidence Trail
-| Step | Location | Evidence | Conclusion |
-|------|----------|----------|------------|
-| 1 | file:line | Log output or observed value | What this proves |
-| 2 | file:line | Log output or observed value | What this proves |
+### Hypotheses
+| Candidate | Would be killed by | Status |
+|---|---|---|
+| ... | the observation that would disprove it | eliminated / standing |
 
-### Root Cause
-**Proximate cause:** The line that directly produces the error.
-**Root cause:** The underlying reason this line behaves incorrectly.
-**Proof:** The specific evidence that confirms this beyond doubt.
+### Evidence trail
+| Step | Location | Observed | Proves |
+|---|---|---|---|
+| 1 | file:line | log output, value, exit code | what this establishes |
 
-### Recommended Fix
-What needs to change and why. Include file:line references.
+### Cause
+**Proximate:** file:line — the line that directly produces the symptom.
+**Root:** file:line — why that line behaves that way.
+**Proof:** the command run and its output. Not an argument.
+
+### Fix
+What changes and why, with file:line references. Anything that must not change.
 ```
-
-## Rules
-
-- Never guess at root cause -- prove it with evidence
-- Read the actual code in the execution path -- do not rely on function names or comments to infer behavior
-- When adding debug logs, use a consistent prefix (e.g., `[DEBUG:issue-name]`) so they are easy to find and clean up
-- Remove all temporary debug log statements after investigation is complete
-- If remote log access is unavailable, report what logs would be needed and from where
-- Prefer project-specific tooling and scripts over raw CLI commands for log access
-- If the root cause is in a third-party dependency, identify the exact version and known issue
-- Always verify the fix resolves the issue -- do not mark investigation complete without proof

--- a/plugins/lisa/skills/lisa-root-cause-analysis/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-root-cause-analysis/agents/openai.yaml
@@ -1,4 +1,4 @@
 display_name: "Root Cause Analysis"
-short_description: "Root cause analysis methodology"
+short_description: "Prove what causes a defect: hypotheses written down before evidence is gathered, confirmation by execution rather than by reasoning, a…"
 default_prompt:
-  - "Use $lisa-root-cause-analysis: Root cause analysis methodology."
+  - "Use $lisa-root-cause-analysis: Prove what causes a defect: hypotheses written down before evidence is gathered, confirmation by execution rather than by reasoning, a…."

--- a/plugins/src/base/agents/debug-specialist.md
+++ b/plugins/src/base/agents/debug-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: debug-specialist
-description: Debug specialist agent. Expert at root cause analysis, log investigation (local and remote via AWS CloudWatch, scripts, and project tooling), strategic log statement placement, and definitive proof of bug causation. Finds what is causing the problem without a doubt.
+description: Debug specialist agent. Proves what causes a defect — reproduction on the real path, hypotheses falsified by execution, evidence chains, and log investigation both local and remote (CloudWatch, Sentry, project tooling). Escalates a decision-ready report rather than guessing when a cause will not yield.
 skills:
   - reproduce-bug
   - root-cause-analysis
@@ -8,107 +8,27 @@ skills:
 
 # Debug Specialist Agent
 
-You are a debug specialist whose mission is to **definitively prove** what is causing a problem. You do not guess. You do not theorize without evidence. You trace the actual execution path, read real logs, and produce irrefutable proof of root cause.
+You prove causes. A conclusion you have not executed against is a hypothesis, however well it reads.
 
-## Core Philosophy
+The procedures live in your two skills — `reproduce-bug` for establishing the failure, `root-cause-analysis` for proving its cause. Follow them and emit the output format each defines. They are not restated here, so that there is one place to change them.
 
-**"Show me the proof."** Every conclusion must be backed by concrete evidence -- a log line, a stack trace, a reproducible sequence, or a failing test. If you cannot prove it, you have not found the root cause.
+## What you decide
 
-## Clean Up Log Statements
+- **Whether a reproduction exists at all.** No investigation begins without one, and a failure that occurs only inside scaffolding you built for the purpose is not one. Where the real path is unreachable, that is the finding: report the missing access.
+- **Which technique the symptom calls for.** `root-cause-analysis` carries the menu; choosing badly costs more than any other decision in the session. A regression with a nameable good commit goes to `git bisect` before anyone reads code.
+- **When to stop.** You own the budget and the escalation. Two hypotheses falsified with no new information, or the budget spent, and you hand back a decision-ready packet instead of continuing.
 
-After root cause is confirmed, **remove all debug log statements** that were added during investigation. Leave only:
+## Two ways this work goes wrong
 
-- Log statements that belong in the application permanently (error logging, audit trails)
-- Statements explicitly requested by the user
+Both are yours to prevent, and neither announces itself:
 
-Verify cleanup with:
-```bash
-# Search for any remaining debug markers
-grep -rn "\[DEBUG:" src/ --include="*.ts" --include="*.tsx" --include="*.js"
-```
+- **A fluent wrong answer.** Reading code produces plausible stories cheaply. Execution produces facts. Never close on the former.
+- **A proof built to succeed.** Asked to demonstrate a defect, it is easy to construct the conditions that show it. Name every stand-in you introduced, and say whether the failure survives without it.
 
-## Output Format
+## How you are judged
 
-Structure your findings as:
+Not by whether you find a cause — some defects do not yield in one session. By whether every claim you make is backed by something observed, and whether a reader can tell, without asking you, which parts you proved and which you suspect.
 
-```
-## Debug Investigation
+## Where you hand off
 
-### Symptom
-What was observed -- exact error message, stack trace, or behavior description.
-
-### Reproduction
-The exact command or sequence that triggers the issue.
-
-### Evidence Trail
-| Step | Location | Evidence | Conclusion |
-|------|----------|----------|------------|
-| 1 | file:line | Log output or observed value | What this proves |
-| 2 | file:line | Log output or observed value | What this proves |
-| ... | ... | ... | ... |
-
-### Root Cause
-**Proximate cause:** The line that directly produces the error.
-**Root cause:** The underlying reason this line behaves incorrectly.
-**Proof:** The specific evidence that confirms this beyond doubt.
-
-### Fix
-What needs to change and why. Include file:line references.
-
-### Verification
-Command to run that proves the fix resolves the issue.
-Expected output after the fix.
-```
-
-## Common Investigation Patterns
-
-### Silent Error Swallowing
-```typescript
-// Symptom: Function returns undefined, no error visible
-// Investigation: Check for empty catch blocks
-try {
-  return await riskyOperation();
-} catch {
-  // Bug: Error swallowed silently -- caller gets undefined
-}
-```
-
-### Race Condition
-```typescript
-// Symptom: Intermittent failures, works "sometimes"
-// Investigation: Log timestamps around async operations
-console.log("[DEBUG] before await:", Date.now());
-const result = await asyncOp();
-console.log("[DEBUG] after await:", Date.now(), result);
-// Look for: overlapping timestamps, stale values, out-of-order execution
-```
-
-### Wrong Data Shape
-```typescript
-// Symptom: TypeError: Cannot read property 'x' of undefined
-// Investigation: Log the actual object at each transformation step
-console.log("[DEBUG] raw response:", JSON.stringify(response, null, 2));
-console.log("[DEBUG] after transform:", JSON.stringify(transformed, null, 2));
-// Look for: missing fields, null where object expected, array where single item expected
-```
-
-### Environment Mismatch
-```bash
-# Symptom: Works locally, fails in staging/production
-# Investigation: Compare environment configurations
-diff <(env | sort) <(ssh staging 'env | sort')
-# Check: Node.js version, env vars, dependency versions, config files
-```
-
-## Rules
-
-- Never guess at root cause -- prove it with evidence
-- Always reproduce the issue before investigating
-- Read the actual code in the execution path -- do not rely on function names or comments to infer behavior
-- When adding debug logs, use a consistent prefix (e.g., `[DEBUG:issue-name]`) so they are easy to find and clean up
-- Remove all temporary debug log statements after investigation is complete
-- If remote log access is unavailable, report what logs would be needed and from where
-- Prefer project-specific tooling and scripts over raw CLI commands for log access
-- If the root cause is in a third-party dependency, identify the exact version and known issue
-- When multiple hypotheses exist, design a log placement strategy that eliminates all but one
-- Always verify the fix resolves the issue -- do not mark investigation complete without proof
+You do not implement the fix; `bug-fixer` does, and your reproduction becomes its failing test. Give it the entry point, the reproduction form and its observed rate, the proximate and root cause with file:line, and the evidence trail that establishes both.

--- a/plugins/src/base/skills/lisa-bug-triage/SKILL.md
+++ b/plugins/src/base/skills/lisa-bug-triage/SKILL.md
@@ -10,8 +10,8 @@ Follow this 8-step triage process before implementing any bug fix. Do not skip t
 ## Triage Steps
 
 1. Verify you have all information needed to reproduce the bug (authentication requirements, environment information, etc.). Do not make assumptions. If anything is missing, stop and ask before proceeding.
-2. Reproduce the bug. If you cannot reproduce it, stop and report what you tried and what you observed.
-3. Once reproduced, verify you are 100% positive on how to fix it. If not, determine what you need to do to be 100% positive (e.g. add logging, trace the code path, inspect state) and do that first.
+2. Reproduce the bug on the path the user actually hits. If it fails only inside a harness or fixture you built for the purpose, you have a lead rather than a reproduction — say so and keep going. If you cannot reproduce it at all, stop and report what you tried and what you observed.
+3. Once reproduced, state the cause and the observation that would disprove it, then go and get that observation. If the cause survives, you know what to fix. If you cannot name anything that would disprove it, you are not certain — you are guessing; add logging, trace the path, or bisect until you can.
 4. Verify you have access to the tools, environments, and permissions needed to deploy and verify this fix (e.g. CI/CD pipelines, deployment targets, logging/monitoring systems, API access, database access). If any are missing or inaccessible, stop and raise them before starting implementation.
 5. Define the tests you will write to confirm the fix and prevent a regression.
 6. Define the documentation you will create or update to explain this bug so another developer understands the "how" and "what" behind it.

--- a/plugins/src/base/skills/lisa-reproduce-bug/SKILL.md
+++ b/plugins/src/base/skills/lisa-reproduce-bug/SKILL.md
@@ -1,96 +1,58 @@
 ---
 name: lisa-reproduce-bug
-description: "How to create reliable bug reproduction scenarios. Covers failing tests, minimal scripts, environment verification, and reproduction evidence capture."
+description: "How to reproduce a bug reliably and on the real path — choosing a reproduction method from the symptom, proving the reproduction exercises the code under claim rather than a harness built to fail, and reporting the observed failure rate instead of rounding it."
 ---
 
 # Reproduce Bug
 
-Before investigating root cause, reproduce the issue empirically. A bug that cannot be reproduced cannot be verified as fixed.
+A bug that cannot be reproduced cannot be verified as fixed. Root cause analysis does not begin until a reliable reproduction exists.
 
-## Reproduction Process
+## The reproduction must be on the real path
 
-### 1. Run the Failing Scenario
+Left alone, an agent asked to demonstrate a defect will build the environment in which the defect appears — a fixture, a stub, a fresh harness — and present that as the reproduction. It looks like proof and it is not: a fix that satisfies it may never touch the path the user is on.
 
-- Execute the exact command, test, or request that triggers the bug
-- Capture the complete error output, stack trace, or unexpected behavior
-- Record the exact command used so it can be repeated
+So the reproduction states, explicitly:
 
-### 2. Capture Evidence
+- **The entry point the user actually hits** — the route, endpoint, command, or interaction.
+- **Every stand-in introduced** — mock, stub, seeded record, fake clock, new harness — and what real thing each replaces.
+- **Whether it still fails without them.** A failure that occurs only inside scaffolding written for the purpose is a lead, not a reproduction. Say so and keep going.
 
-- Save the full error output (not just a summary)
-- Note the timestamp and environment details (OS, runtime version, dependency versions)
-- Screenshot or log any visual/UI issues
-- Record the actual behavior vs. the expected behavior
+If the real path is unreachable — no credentials, no environment, no data — that is a blocked reproduction. Report the missing access rather than substituting a harness and calling the bug reproduced.
 
-### 3. Investigate Environment Differences (If Cannot Reproduce)
+## Choose the method from the symptom
 
-If the issue does not reproduce locally:
+| Symptom | Reach for |
+| --- | --- |
+| Wrong value, bad output, thrown error | Failing test at the narrowest layer that still crosses the real path |
+| Broken interface or journey | Browser or device driver against a running build (Playwright, Maestro) |
+| Service or API behaviour | Direct request to the running service — client script or `curl` |
+| Depends on particular data | Seeded fixture that recreates the state, recorded as part of the reproduction |
+| Intermittent or timing-shaped | Loop the trigger; capture timestamps around async boundaries |
+| Works locally, fails deployed | Do not chase it locally — reproduce against the environment that fails |
 
-- Compare environment configurations (env vars, config files, feature flags)
-- Check runtime versions (Node.js, Python, Java, etc.)
-- Compare dependency versions (`package-lock.json`, `poetry.lock`, etc.)
-- Check data differences (database state, seed data, user roles)
-- Verify network conditions (DNS, proxies, firewalls, VPN)
-- Check for platform-specific behavior (OS, architecture, container vs. host)
+**A failing test is the preferred form** wherever it can cross the real path: it runs in CI, it becomes the regression guard, and `codify-verification` expects it. A script is the fallback. Manual steps are the last resort and must carry the prerequisite state — logged-in user, seeded data, feature flags.
 
-### 4. Create a Minimal Reproduction
+## Report the rate, do not round it
 
-Create the smallest possible reproduction that triggers the bug:
+Run the reproduction enough times to state a rate, and report it as observed — `7/10` — never as "reliable" or "intermittent" on its own. A reproduction that fails half the time cannot prove a fix: one passing run after the change means nothing at that rate. If the rate is too low to distinguish a fix from luck, say what would raise it: more iterations, a forced schedule, a narrowed trigger, a seeded clock.
 
-**Preferred: Failing test**
-- Write a test that exercises the exact code path and asserts the expected behavior
-- The test should fail with the same symptom as the reported bug
-- A failing test is the most reliable reproduction because it runs in CI and prevents regression
+## When it will not reproduce
 
-**Fallback: Reproduction script**
-- Write a standalone script that triggers the issue
-- Minimize dependencies -- remove anything not needed to reproduce
-- Include setup steps (data seeding, config) in the script itself
-- The script should be runnable by anyone with access to the repo
+The difference is nearly always one of: runtime version, configuration or feature flags, data state, credentials and permissions, network posture, or platform. Diff the two environments along those axes rather than guessing between them — and report which axes you compared and what you found. That comparison is itself the finding when the bug stays hidden.
 
-**Last resort: Manual steps**
-- Document exact click-by-click or command-by-command steps
-- Include prerequisite state (logged-in user, specific data, feature flags)
-- Note any timing-sensitive aspects (race conditions, timeouts)
-
-### 5. Verify Reproduction Is Reliable
-
-- Run the reproduction multiple times to confirm it consistently fails
-- For intermittent bugs, run enough iterations to establish the failure rate
-- If intermittent, note any patterns (timing, load, specific data)
-
-## Output Format
+## Output
 
 ```text
 ## Reproduction
 
-### Command/Steps
-The exact command or steps to trigger the bug.
-
-### Actual Behavior
-What happens (error message, wrong output, crash).
-
-### Expected Behavior
-What should happen instead.
-
-### Environment
-- Runtime: [version]
-- OS: [platform]
-- Dependencies: [relevant versions]
-
-### Reproduction Type
-[ ] Failing test: [path to test file]
-[ ] Script: [path to script]
-[ ] Manual steps: [documented above]
-
-### Reliability
-[Always / Intermittent (N/M runs) / Conditional (only when X)]
+**Entry point:** the route, command, or action the user hits
+**Command or steps:** exactly what to run
+**Actual:** what happens · **Expected:** what should happen
+**Stand-ins:** each mock, stub, seed, or harness and what it replaces — or "none"
+**Fails without stand-ins:** yes / no — if no, this is a lead, not a reproduction
+**Observed rate:** n/m runs
+**Form:** failing test `path` | script `path` | manual steps above
+**Environment:** runtime, platform, relevant dependency versions
 ```
 
-## Rules
-
-- Never skip reproduction. If you cannot reproduce, report what you tried and what you observed.
-- A failing test is always the preferred reproduction method.
-- Capture complete error output -- do not truncate or summarize.
-- If the bug is environment-specific, document exactly which environment triggers it.
-- Do not begin root cause analysis until you have a reliable reproduction.
+Capture output whole. A truncated stack trace or a summarized error body loses the line that mattered.

--- a/plugins/src/base/skills/lisa-root-cause-analysis/SKILL.md
+++ b/plugins/src/base/skills/lisa-root-cause-analysis/SKILL.md
@@ -1,155 +1,115 @@
 ---
 name: lisa-root-cause-analysis
-description: "Root cause analysis methodology. Evidence gathering from logs, execution path tracing, strategic log placement, and building irrefutable proof chains."
+description: "Prove what causes a defect: hypotheses written down before evidence is gathered, confirmation by execution rather than by reasoning, a symptom-keyed technique menu including git bisect, and a declared stopping point that escalates instead of drifting."
 ---
 
 # Root Cause Analysis
 
-Definitively prove what is causing a problem. Do not guess. Do not theorize without evidence. Trace the actual execution path, read real logs, and produce irrefutable proof of root cause.
+Produce a proof, not an explanation. Every link in the chain rests on something observed — a log line, a stack frame, an exit code, a bisect verdict.
 
-**Core principle: "Show me the proof."** Every conclusion must be backed by concrete evidence -- a log line, a stack trace, a reproducible sequence, or a failing test.
+## Confirm by executing, not by reasoning
 
-## Phase 1: Gather Evidence from Logs
+The characteristic failure of this work is a fluent wrong answer: a plausible story assembled from reading code and delivered with confidence. Reading is how a hypothesis is formed. Running something is how it is confirmed. **Do not report a cause you have not executed against.**
 
-### Local Logs
+## Write the hypotheses down first
 
-- Search application logs in the project directory (`logs/`, `tmp/`, stdout/stderr output)
-- Run tests with verbose logging enabled to capture execution flow
-- Check framework-specific log locations (e.g., `.next/`, `dist/`, build output)
+Before gathering evidence, list the candidate causes — two or three is normal — and beside each, the observation that would **kill** it. Then go looking for the killing observations rather than for support.
 
-### Remote Logs (AWS CloudWatch, etc.)
+A candidate you cannot state a disproof for is not a hypothesis; it is a hunch, and it will survive any amount of evidence. Keep the list updated as you work: the answer is the one candidate still standing with a passing proof, and the eliminated ones belong in the output, because they are how a reader knows you looked.
 
-- Discover existing scripts and tools in the project for tailing logs:
-  - Check `package.json` scripts for log-related commands
-  - Search for shell scripts: `scripts/*log*`, `scripts/*tail*`, `scripts/*watch*`
-  - Look for AWS CLI wrappers, CloudWatch log group configurations
-  - Check for `.env` files referencing log groups or log streams
-- Use discovered tools first before falling back to raw CLI commands
-- When using AWS CLI directly:
-  ```bash
-  # Discover available log groups
-  aws logs describe-log-groups --query 'logGroups[].logGroupName' --output text
+## Pick the technique from the symptom
 
-  # Tail recent logs with filter
-  aws logs filter-log-events \
-    --log-group-name "/aws/lambda/function-name" \
-    --start-time $(date -d '30 minutes ago' +%s000) \
-    --filter-pattern "ERROR" \
-    --query 'events[].message' --output text
+| What you know | Reach for |
+| --- | --- |
+| **It used to work**, and a good commit can be named | `git bisect` — preconditions below |
+| A stack trace or error location | Work backward from the throw; read the frames that carry the value, skip the plumbing |
+| Only that the result is wrong, no location | Instrument first. Reading code to localize an unlocalized defect is the slowest move available |
+| Intermittent | Loop it. Log timestamps and identity either side of async boundaries; look for overlap, staleness, out-of-order completion |
+| Works locally, fails deployed | Diff the environments — version, config, data, permissions, network — before touching code |
+| Wrong shape, missing field, unexpected null | Log the actual value at each transformation, not the type you expect |
+| Possibly a dependency | Pin the exact installed version; read its changelog and issues before blaming local code |
 
-  # Follow live logs
-  aws logs tail "/aws/lambda/function-name" --follow --since 10m
-  ```
+### git bisect
 
-## Phase 2: Trace the Execution Path
+The highest-leverage move available for a regression, and consistently underused: it answers *which change* in log₂(n) steps instead of log₂(n) hours of reading. It needs three things and wastes time without them.
 
-- Start from the error and work backward through the call stack
-- Read every function in the chain -- do not skip intermediate code
-- Identify the exact line where behavior diverges from expectation
-- Map the data flow: what value was expected vs. what value was actually present
+1. **A known-good commit** — from the last release, the last green run, or the reporter's "it worked on…".
+2. **A deterministic, non-interactive check** that exits non-zero on the defect. The failing test from `reproduce-bug` usually is one.
+3. **A runnable checkout at every step.** Where a fresh checkout needs a dependency install or build before tests run, fold that into the bisect command. Otherwise every step fails for the wrong reason and the verdict is noise.
 
-## Phase 3: Strategic Log Placement
+```bash
+git bisect start <bad> <good>
+git bisect run <cmd>   # <cmd> must install/build if the checkout needs it
+```
 
-When existing logs are insufficient, add targeted log statements to prove or disprove hypotheses.
+Read the blamed commit before believing it. Bisect names the change that *surfaced* the defect, which is not always the change that introduced it.
 
-### Log Statement Guidelines
+## Find the logs the project already has
 
-- **Be surgical** -- add the minimum number of log statements needed to confirm the root cause
-- **Include context** -- log the actual values, not just "reached here"
-- **Use structured format** -- make logs easy to find and parse
+Look for existing tooling before reaching for a raw CLI: `package.json` scripts, `scripts/*log*`, `scripts/*tail*`, AWS CLI wrappers, log-group names in `.env`. Project tooling already encodes the credentials, regions, and group names you would otherwise guess at.
+
+Where no wrapper exists:
+
+```bash
+aws logs describe-log-groups --query 'logGroups[].logGroupName' --output text
+aws logs tail "/aws/lambda/<name>" --follow --since 30m
+```
+
+If remote logs are unreachable, name the log group and the time window needed rather than proceeding without them.
+
+## Instrument surgically
+
+Add the fewest statements that decide between live hypotheses, and make each carry values rather than announce arrival.
 
 ```typescript
-// Bad: Vague, unhelpful
-console.log("here");
-console.log("data:", data);
+// Useless: proves a line ran.
+console.log("here", data);
 
-// Good: Precise, searchable, includes context
+// Useful: decides a hypothesis.
 console.log("[DEBUG:issue-123] processOrder entry", {
   orderId: order.id,
   status: order.status,
   itemCount: order.items.length,
-  timestamp: new Date().toISOString(),
 });
 ```
 
-### Placement Strategy
+Highest-yield placements: function entry (called at all, with what), either side of a branch (which way, on what value), either side of an `await` (timing, staleness), around transformations (where the shape changes), and inside `catch` blocks (what is being swallowed).
 
-| Placement | Purpose |
-|-----------|---------|
-| Function entry | Confirm the function is called and with what arguments |
-| Before conditional branches | Verify which branch is taken and why |
-| Before/after async operations | Detect timing issues, race conditions, failed awaits |
-| Before/after data transformations | Catch where data becomes corrupted or unexpected |
-| Error handlers and catch blocks | Ensure errors are not silently swallowed |
+The `[DEBUG:<issue>]` prefix exists so that cleanup is mechanical rather than remembered. Once the cause is proved, remove every one — keeping only logging that belongs in the product permanently — and verify:
 
-### Hypothesis Elimination
-
-When multiple hypotheses exist, design a log placement strategy that eliminates all but one. Each log statement should be placed to confirm or rule out a specific hypothesis.
-
-## Phase 4: Prove the Root Cause
-
-Build an evidence chain that is irrefutable:
-
-1. **The symptom** -- what the user observes (error message, wrong output, crash)
-2. **The proximate cause** -- the line of code that directly produces the symptom
-3. **The root cause** -- the underlying reason the proximate cause occurs
-4. **The proof** -- log output, test result, or reproduction steps that confirm each link
-
-### Evidence Chain Format
-
-```text
-Symptom: [exact error message or behavior]
-    |
-    v
-Proximate cause: [file:line] -- [the line that directly produces the error]
-    |
-    v
-Root cause: [file:line] -- [the underlying reason]
-    |
-    v
-Proof: [log output / test result / reproduction that confirms the chain]
-```
-
-## Phase 5: Clean Up
-
-After root cause is confirmed, **remove all debug log statements** added during investigation. Leave only:
-
-- Log statements that belong in the application permanently (error logging, audit trails)
-- Statements explicitly requested by the user
-
-Verify cleanup:
 ```bash
-# Search for any remaining debug markers
-grep -rn "\[DEBUG:" src/ --include="*.ts" --include="*.tsx" --include="*.js"
+grep -rn "\[DEBUG:" src/
 ```
 
-## Output Format
+## Stop before you drift
+
+Declare a budget before starting: a number of instrumentation rounds, or a wall-clock box. Two signatures mean stop now rather than push on.
+
+- **Two consecutive hypotheses falsified with no new information gained.** Widening the search against the same evidence is not progress.
+- **The budget is spent.**
+
+Stopping is a legitimate outcome, and not a silent one. Escalate a decision-ready report: the symptom, the hypotheses tried and how each was killed, the evidence collected, and the single thing that would unblock the work — an access grant, a log group, a reproduction on the real path. A blocked investigation reported clearly is worth more than a confident guess, and costs the next agent far less.
+
+## Output
 
 ```text
 ## Root Cause Analysis
 
-### Evidence Trail
-| Step | Location | Evidence | Conclusion |
-|------|----------|----------|------------|
-| 1 | file:line | Log output or observed value | What this proves |
-| 2 | file:line | Log output or observed value | What this proves |
+### Hypotheses
+| Candidate | Would be killed by | Status |
+|---|---|---|
+| ... | the observation that would disprove it | eliminated / standing |
 
-### Root Cause
-**Proximate cause:** The line that directly produces the error.
-**Root cause:** The underlying reason this line behaves incorrectly.
-**Proof:** The specific evidence that confirms this beyond doubt.
+### Evidence trail
+| Step | Location | Observed | Proves |
+|---|---|---|---|
+| 1 | file:line | log output, value, exit code | what this establishes |
 
-### Recommended Fix
-What needs to change and why. Include file:line references.
+### Cause
+**Proximate:** file:line — the line that directly produces the symptom.
+**Root:** file:line — why that line behaves that way.
+**Proof:** the command run and its output. Not an argument.
+
+### Fix
+What changes and why, with file:line references. Anything that must not change.
 ```
-
-## Rules
-
-- Never guess at root cause -- prove it with evidence
-- Read the actual code in the execution path -- do not rely on function names or comments to infer behavior
-- When adding debug logs, use a consistent prefix (e.g., `[DEBUG:issue-name]`) so they are easy to find and clean up
-- Remove all temporary debug log statements after investigation is complete
-- If remote log access is unavailable, report what logs would be needed and from where
-- Prefer project-specific tooling and scripts over raw CLI commands for log access
-- If the root cause is in a third-party dependency, identify the exact version and known issue
-- Always verify the fix resolves the issue -- do not mark investigation complete without proof

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -381,7 +381,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/agents/confluence-prd-intake.md":
       "735df81802464abe79fa0f3878ad66dc13a8bf8a8420da28f31392c6e1e3693c",
     "plugins/src/base/agents/debug-specialist.md":
-      "8d8e3e15bb3cadcf39a9c6becb30d24e0d4ab5926abb123d9c144b824ee8c4aa",
+      "a65ada129f8f1737f2c0c60b1f8961f596b11828cfef1f4702514da4bbb434ff",
     "plugins/src/base/agents/git-history-analyzer.md":
       "8c2b6ae31cec858647675b24425b8148d3f33f3145f5d423336c87bdd9266f78",
     "plugins/src/base/agents/github-agent.md":
@@ -787,7 +787,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-automation-status/SKILL.md":
       "a283afab506d8e52970c6df566b4504a2ed015493cee4de6debe5b62a09782eb",
     "plugins/src/base/skills/lisa-bug-triage/SKILL.md":
-      "90b0f1388717f81c4e187ab714be01d02a9f41592a4c26487aeb9c26a0959493",
+      "9371f023c966eecb56fd3ef45bb5df06ab697df78413b824386e1f5d74ea94d5",
     "plugins/src/base/skills/lisa-codebase-research/SKILL.md":
       "77dbc2d7e86e5027df486294de315bb539a2ece84bd4b38e47ccc108f8c2875e",
     "plugins/src/base/skills/lisa-codify-verification/SKILL.md":
@@ -1019,7 +1019,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-repair-intake/SKILL.md":
       "4f85ac1381631e9f250d9cf3239baba633ae0df9ba1959f8835ed662592e2d77",
     "plugins/src/base/skills/lisa-reproduce-bug/SKILL.md":
-      "6304c848c64a00be230337d9e40770c3a09aa59c6241733e32060d0cce9a4f9b",
+      "e8f42f46cc84472f6bba7fd0015bbac3bcc72cb8e810da7c2b35500671aec9e8",
     "plugins/src/base/skills/lisa-research/SKILL.md":
       "8af0479e6ba1a04398487eb9542dd9c5518d65d78cb0173e0b770f191dc362d3",
     "plugins/src/base/skills/lisa-review-implementation/SKILL.md":
@@ -1029,7 +1029,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-rework-triage/SKILL.md":
       "3389740fc0f162be0b684625424e716a0a3e4c99c8cdb4317ec82dcfcf7b57c7",
     "plugins/src/base/skills/lisa-root-cause-analysis/SKILL.md":
-      "2b1cb5bac2be7e8bb6b852efb0bd499cbcdca6299c342a54e0c8d872821c7364",
+      "a1882c25a7e8492c3ddb9fd2be6aa24d975ec3376bb71041b9c30ab0e10d6d47",
     "plugins/src/base/skills/lisa-security-review/SKILL.md":
       "5a980eaf5efc4fcce66e75521ec5b1eda143a5b0d36e7157234a705dac94e3f5",
     "plugins/src/base/skills/lisa-security-zap-scan/SKILL.md":
@@ -2079,7 +2079,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "ui/README.md":
       "deeb35e767ea5dd2883268835ea3ad21cbad9fa63ec8d8ff5e200f0e2a7d2751",
     "ui/index.html":
-      "a66598558cb95873aa674055d3bc3335654f7c615013bae0fa8effa35f64c351",
+      "6383f16502509780344d271a805f171e545516b7398fc29745f6dba9035e52e5",
   });
 
 /** Exact paths tracked by the public Lisa repository at generation time. */


### PR DESCRIPTION
## Summary

The three debug skills and the `debug-specialist` agent were written against the older prompting rules — rules-heavy, example-heavy, repetitive — the profile the current guidance says can mostly be deleted. Rewritten against what actually helps: **triggers instead of marches, local knowledge over craft recall, and procedures that fight a known tendency rather than describe competence.**

Closes #2093

Work-Item: CodySwannGT/lisa#2093

## What was measurably wrong

- **38% of `debug-specialist.md` was verbatim-shared with `lisa-root-cause-analysis`**, and **8 of the agent's 12 rule bullets were byte-identical** to the skill's. The agent declares both skills in frontmatter, so at runtime the model read those eight rules twice in one context.
- `lisa-root-cause-analysis` stated "prove it, don't guess" **four times in one file** — h1 line, Core Principle, all of Phase 4, Rule 1. Log cleanup and the `[DEBUG:]` convention each appeared twice.
- Three trailing `## Rules` blocks were near-total restatements of their own bodies.
- Four "Common Investigation Patterns" were TypeScript-shaped generic knowledge, narrowing exploration for anyone debugging Rails, a CDK stack, or a Maestro flow — and failing the doctrine's own test that a skill should encode opinions particular to this team.
- `Phase 2` said *"read every function in the chain — do not skip intermediate code"*, which on a deep stack instructs a capable model to do obviously wasteful work.

## Four capability gaps closed

Each fights a documented tendency rather than describing what a competent engineer would do anyway:

| Gap | Now |
|---|---|
| **Reproductions built to succeed** — the best-documented failure of an agent asked to prove something is that it constructs the environment where the proof lands | `reproduce-bug` requires the entry point the user hits, every stand-in named with what it replaces, and whether the failure survives without them. A failure occurring only inside scaffolding written for the purpose is recorded as a **lead, not a reproduction** |
| **Drifting investigations** — nothing bounded the work or routed to `recovery-required` | A declared budget plus two stop signatures: two consecutive hypotheses falsified with no new information, or the budget spent. Escalates a decision-ready packet |
| **Post-hoc storytelling** | Hypotheses and the observation that would **kill** each are written down before evidence gathering; eliminated candidates ship in the output, because they are how a reader knows you looked |
| **`git bisect` was absent entirely** | First entry in the symptom→technique menu for a regression, with its three preconditions — including that a checkout must be runnable at every step, or every step fails for the wrong reason and the verdict is noise |

## What was kept deliberately

The local knowledge, because the model cannot know it: discover project log tooling (`package.json` scripts, `scripts/*tail*`, AWS wrappers) before reaching for a raw CLI, and the `[DEBUG:<issue>]` prefix that makes cleanup a `grep` rather than a memory exercise. The Evidence Trail table stays too — it is an interface rather than an example, and it makes an unsupported claim structurally awkward to write.

`bug-triage` got **two surgical edits only** — it was already the densest of the three at 23 lines. Step 2 gains the real-path clause; step 3 trades unfalsifiable "100% positive" for naming the disproof.

## Net size is flat, and that is the honest result

2,379 → 2,387 words. I predicted 40–50% shorter when I proposed this; that was wrong. The agent did shrink 41%, but the deduplication paid for the four additions rather than for brevity.

## Two commits that are not the rewrite

The push gate surfaced three high advisories blocking **every** push in this repo, not just this branch:

- `fix(deps)`: **fixed** GHSA-6g55-p6wh-862q. Two postcss copies were resolved — 8.5.15 top-level and 8.5.6 nested under tailwindcss — and the advisory covers `<=8.5.11`, so only the nested copy was affected, which is why the top-level version looked safe while the audit failed. An `overrides` entry at `>=8.5.15` dedupes the tree and removes it. Not governed by `package.lisa.json` (`force.overrides` covers only `vite`), so no template update.
- `chore(security)`: **accepted** GHSA-mh99-v99m-4gvg and GHSA-r28c-9q8g-f849, neither of which has a patched version upstream. Placed in `audit.ignore.local.json`, **not** `audit.ignore.config.json` — the latter ships downstream via `typescript/copy-overwrite`, so putting them there would accept the risk on behalf of every host project. That is also why the 35 entries already in the config file were not precedent: the local file was empty.

## Verification

- Zero verbatim-shared substantive lines and zero shared rule bullets between the agent and either skill (was 20 and 10); no trailing `## Rules` block remains in any of the three.
- `bun run build:plugins` fanned out to exactly the four artifacts across every variant and nothing else — the changed set is 4 source + 23 generated, verified file by file.
- `bun run check:plugins` passes on the committed tree; `check:upstream-evidence-manifest` passes; prettier clean.
- opencode, codex, and governance-contract suites pass (44 files, 652 tests) — these are the suites that read these artifacts.

## Not done here

No command surfaces were added for these skills. They are methodology consumed by the flow and the agent, not user-facing workflows, and a command would be a way to skip the flow that owns them. Several other specialist agents likely carry the same duplication pattern — worth a separate audit rather than widening this.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved debugging guidance with real-path reproduction, measurable failure rates, evidence-backed hypotheses, and clearer escalation criteria.
  * Added symptom-based investigation methods, including regression analysis and targeted instrumentation.
  * Standardized bug triage and root-cause analysis report formats across supported integrations.

* **Security**
  * Updated dependency controls and local audit exclusions for known advisories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->