### PR TITLE
test(governance): enforce the agent/skill layer boundaries

### DIFF
--- a/plugins/lisa-agy/skills/lisa-agent-design-best-practices/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-agent-design-best-practices/SKILL.md
@@ -94,7 +94,30 @@ Grant only the tools necessary for the agent's domain. This enforces focus and p
 | Implementer | `Read, Write, Edit, Bash, Grep, Glob` | Needs to modify code |
 | Planner | `Read, Grep, Glob` | Research only, no execution |
 
-Read-only agents cannot implement code. Do not assign implementation tasks to agents without `Write` and `Edit` tools.
+Do not assign implementation tasks to agents without `Write` and `Edit`.
+
+#### `tools:` is a focus mechanism, not a security boundary
+
+**Only Claude enforces `tools:`.** Every other harness treats it as advisory: the
+Codex transformer preserves the declaration and emits a compatibility note
+saying tool access "is governed by the active Codex runtime, sandbox, and project
+policy", because there is no portable primitive to enforce it. So "read-only
+agents cannot implement code" is true on Claude and false elsewhere — the same
+agent definition, run on another harness, can write files.
+
+Treat the field accordingly:
+
+- **Do** use it to keep an agent in its lane, to make its intent legible to a
+  reader, and to reduce accidental scope creep on the harness that honours it.
+- **Do not** rely on it to contain a compromised or prompt-injected agent, to
+  keep credentials out of reach, or to satisfy any control that has to hold
+  under attack. A boundary one runtime ignores is a suggestion everywhere.
+
+The controls that actually hold are outside the agent definition: the execution
+sandbox, network egress restriction, the credential scope the agent authenticates
+with, and — because an agent can ask a peer to act for it — which other agents it
+can reach. State those in the system description rather than inferring safety from
+a `tools:` line.
 
 ### 6. No Hardcoded Interaction Patterns
 

--- a/plugins/lisa-copilot/skills/lisa-agent-design-best-practices/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-agent-design-best-practices/SKILL.md
@@ -94,7 +94,30 @@ Grant only the tools necessary for the agent's domain. This enforces focus and p
 | Implementer | `Read, Write, Edit, Bash, Grep, Glob` | Needs to modify code |
 | Planner | `Read, Grep, Glob` | Research only, no execution |
 
-Read-only agents cannot implement code. Do not assign implementation tasks to agents without `Write` and `Edit` tools.
+Do not assign implementation tasks to agents without `Write` and `Edit`.
+
+#### `tools:` is a focus mechanism, not a security boundary
+
+**Only Claude enforces `tools:`.** Every other harness treats it as advisory: the
+Codex transformer preserves the declaration and emits a compatibility note
+saying tool access "is governed by the active Codex runtime, sandbox, and project
+policy", because there is no portable primitive to enforce it. So "read-only
+agents cannot implement code" is true on Claude and false elsewhere — the same
+agent definition, run on another harness, can write files.
+
+Treat the field accordingly:
+
+- **Do** use it to keep an agent in its lane, to make its intent legible to a
+  reader, and to reduce accidental scope creep on the harness that honours it.
+- **Do not** rely on it to contain a compromised or prompt-injected agent, to
+  keep credentials out of reach, or to satisfy any control that has to hold
+  under attack. A boundary one runtime ignores is a suggestion everywhere.
+
+The controls that actually hold are outside the agent definition: the execution
+sandbox, network egress restriction, the credential scope the agent authenticates
+with, and — because an agent can ask a peer to act for it — which other agents it
+can reach. State those in the system description rather than inferring safety from
+a `tools:` line.
 
 ### 6. No Hardcoded Interaction Patterns
 

--- a/plugins/lisa-cursor/skills/lisa-agent-design-best-practices/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-agent-design-best-practices/SKILL.md
@@ -94,7 +94,30 @@ Grant only the tools necessary for the agent's domain. This enforces focus and p
 | Implementer | `Read, Write, Edit, Bash, Grep, Glob` | Needs to modify code |
 | Planner | `Read, Grep, Glob` | Research only, no execution |
 
-Read-only agents cannot implement code. Do not assign implementation tasks to agents without `Write` and `Edit` tools.
+Do not assign implementation tasks to agents without `Write` and `Edit`.
+
+#### `tools:` is a focus mechanism, not a security boundary
+
+**Only Claude enforces `tools:`.** Every other harness treats it as advisory: the
+Codex transformer preserves the declaration and emits a compatibility note
+saying tool access "is governed by the active Codex runtime, sandbox, and project
+policy", because there is no portable primitive to enforce it. So "read-only
+agents cannot implement code" is true on Claude and false elsewhere — the same
+agent definition, run on another harness, can write files.
+
+Treat the field accordingly:
+
+- **Do** use it to keep an agent in its lane, to make its intent legible to a
+  reader, and to reduce accidental scope creep on the harness that honours it.
+- **Do not** rely on it to contain a compromised or prompt-injected agent, to
+  keep credentials out of reach, or to satisfy any control that has to hold
+  under attack. A boundary one runtime ignores is a suggestion everywhere.
+
+The controls that actually hold are outside the agent definition: the execution
+sandbox, network egress restriction, the credential scope the agent authenticates
+with, and — because an agent can ask a peer to act for it — which other agents it
+can reach. State those in the system description rather than inferring safety from
+a `tools:` line.
 
 ### 6. No Hardcoded Interaction Patterns
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-agent-design-best-practices/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-agent-design-best-practices/SKILL.md
@@ -94,7 +94,30 @@ Grant only the tools necessary for the agent's domain. This enforces focus and p
 | Implementer | `Read, Write, Edit, Bash, Grep, Glob` | Needs to modify code |
 | Planner | `Read, Grep, Glob` | Research only, no execution |
 
-Read-only agents cannot implement code. Do not assign implementation tasks to agents without `Write` and `Edit` tools.
+Do not assign implementation tasks to agents without `Write` and `Edit`.
+
+#### `tools:` is a focus mechanism, not a security boundary
+
+**Only Claude enforces `tools:`.** Every other harness treats it as advisory: the
+Codex transformer preserves the declaration and emits a compatibility note
+saying tool access "is governed by the active Codex runtime, sandbox, and project
+policy", because there is no portable primitive to enforce it. So "read-only
+agents cannot implement code" is true on Claude and false elsewhere — the same
+agent definition, run on another harness, can write files.
+
+Treat the field accordingly:
+
+- **Do** use it to keep an agent in its lane, to make its intent legible to a
+  reader, and to reduce accidental scope creep on the harness that honours it.
+- **Do not** rely on it to contain a compromised or prompt-injected agent, to
+  keep credentials out of reach, or to satisfy any control that has to hold
+  under attack. A boundary one runtime ignores is a suggestion everywhere.
+
+The controls that actually hold are outside the agent definition: the execution
+sandbox, network egress restriction, the credential scope the agent authenticates
+with, and — because an agent can ask a peer to act for it — which other agents it
+can reach. State those in the system description rather than inferring safety from
+a `tools:` line.
 
 ### 6. No Hardcoded Interaction Patterns
 

--- a/plugins/lisa/skills/lisa-agent-design-best-practices/SKILL.md
+++ b/plugins/lisa/skills/lisa-agent-design-best-practices/SKILL.md
@@ -94,7 +94,30 @@ Grant only the tools necessary for the agent's domain. This enforces focus and p
 | Implementer | `Read, Write, Edit, Bash, Grep, Glob` | Needs to modify code |
 | Planner | `Read, Grep, Glob` | Research only, no execution |
 
-Read-only agents cannot implement code. Do not assign implementation tasks to agents without `Write` and `Edit` tools.
+Do not assign implementation tasks to agents without `Write` and `Edit`.
+
+#### `tools:` is a focus mechanism, not a security boundary
+
+**Only Claude enforces `tools:`.** Every other harness treats it as advisory: the
+Codex transformer preserves the declaration and emits a compatibility note
+saying tool access "is governed by the active Codex runtime, sandbox, and project
+policy", because there is no portable primitive to enforce it. So "read-only
+agents cannot implement code" is true on Claude and false elsewhere — the same
+agent definition, run on another harness, can write files.
+
+Treat the field accordingly:
+
+- **Do** use it to keep an agent in its lane, to make its intent legible to a
+  reader, and to reduce accidental scope creep on the harness that honours it.
+- **Do not** rely on it to contain a compromised or prompt-injected agent, to
+  keep credentials out of reach, or to satisfy any control that has to hold
+  under attack. A boundary one runtime ignores is a suggestion everywhere.
+
+The controls that actually hold are outside the agent definition: the execution
+sandbox, network egress restriction, the credential scope the agent authenticates
+with, and — because an agent can ask a peer to act for it — which other agents it
+can reach. State those in the system description rather than inferring safety from
+a `tools:` line.
 
 ### 6. No Hardcoded Interaction Patterns
 

--- a/plugins/src/base/skills/lisa-agent-design-best-practices/SKILL.md
+++ b/plugins/src/base/skills/lisa-agent-design-best-practices/SKILL.md
@@ -94,7 +94,30 @@ Grant only the tools necessary for the agent's domain. This enforces focus and p
 | Implementer | `Read, Write, Edit, Bash, Grep, Glob` | Needs to modify code |
 | Planner | `Read, Grep, Glob` | Research only, no execution |
 
-Read-only agents cannot implement code. Do not assign implementation tasks to agents without `Write` and `Edit` tools.
+Do not assign implementation tasks to agents without `Write` and `Edit`.
+
+#### `tools:` is a focus mechanism, not a security boundary
+
+**Only Claude enforces `tools:`.** Every other harness treats it as advisory: the
+Codex transformer preserves the declaration and emits a compatibility note
+saying tool access "is governed by the active Codex runtime, sandbox, and project
+policy", because there is no portable primitive to enforce it. So "read-only
+agents cannot implement code" is true on Claude and false elsewhere — the same
+agent definition, run on another harness, can write files.
+
+Treat the field accordingly:
+
+- **Do** use it to keep an agent in its lane, to make its intent legible to a
+  reader, and to reduce accidental scope creep on the harness that honours it.
+- **Do not** rely on it to contain a compromised or prompt-injected agent, to
+  keep credentials out of reach, or to satisfy any control that has to hold
+  under attack. A boundary one runtime ignores is a suggestion everywhere.
+
+The controls that actually hold are outside the agent definition: the execution
+sandbox, network egress restriction, the credential scope the agent authenticates
+with, and — because an agent can ask a peer to act for it — which other agents it
+can reach. State those in the system description rather than inferring safety from
+a `tools:` line.
 
 ### 6. No Hardcoded Interaction Patterns
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -783,7 +783,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-acceptance-criteria/SKILL.md":
       "b4289ec04de657f0eeefaed56939fa171c2f8a11086bd225db39130f4a609e95",
     "plugins/src/base/skills/lisa-agent-design-best-practices/SKILL.md":
-      "5c7414198d5c747d2cda554c85784164afb2f6fe04fd28fb4d7674857dfd4801",
+      "2c487df59f54682d744e71f78a2bccccf9e3a6510705b4ff6be7edfa4be2d43b",
     "plugins/src/base/skills/lisa-agent-ready/SKILL.md":
       "13f2e0f50287a04ed9a036ef1c547563b5f6f6325b2b35f6746d46a5ed4d15df",
     "plugins/src/base/skills/lisa-analyze-claude-remote/SKILL.md":
@@ -8064,6 +8064,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/standards/test-evidence.test.ts": true,
     "tests/unit/strategies/agent-ready-ingest-boundary.test.ts": true,
     "tests/unit/strategies/agent-ready-readiness-consumption.test.ts": true,
+    "tests/unit/strategies/agent-skill-layer-contract.test.ts": true,
     "tests/unit/strategies/artifact-identity-contract.test.ts": true,
     "tests/unit/strategies/atlassian-access-acli-profile.test.ts": true,
     "tests/unit/strategies/atlassian-access-changelog.test.ts": true,

--- a/tests/unit/strategies/agent-skill-layer-contract.test.ts
+++ b/tests/unit/strategies/agent-skill-layer-contract.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Contract coverage for the four-layer split: command -> skill -> routing rule
+ * -> agent -> skill.
+ *
+ * The architecture is sound and, until now, entirely unenforced — which is how
+ * seven agents drifted to between 73% and 92% verbatim duplication of the very
+ * skills they declare, with up to nineteen byte-identical rule bullets each
+ * (#2093, #2096). Nothing detected it because nothing looked. A layer boundary
+ * that only prose defends is followed almost always, and almost always means
+ * broken constantly once enough people edit.
+ *
+ * So this suite pins the three invariants that make the layers real:
+ *
+ * 1. An agent does not restate the skills it declares. The skill owns the
+ *    procedure, the output format and the rules; the agent owns identity,
+ *    judgement and handoff. Both load into one context when the agent declares
+ *    the skill in frontmatter, so a duplicated contract is read twice and the
+ *    two copies drift silently.
+ * 2. Every agent the routing rule composes actually exists. `intent-routing`
+ *    is the single place flow composition lives, it is prose, and a mistyped
+ *    agent name there fails at runtime rather than at build.
+ * 3. Every skill a skill invokes actually exists. Skill-to-skill edges are
+ *    undeclared — there is no frontmatter equivalent of an agent's `skills:` —
+ *    so a renamed or deleted skill leaves a dangling invocation.
+ *
+ * Plus one honesty check: `tools:` is enforced only on Claude, and the doctrine
+ * has to keep saying so, because a field that looks like a sandbox and is not
+ * one is worse than no field at all.
+ *
+ * There is no exemption list, because no agent needs one. The single
+ * intentional duplication in the tree — the `Security (proven)` /
+ * `Security (unproven)` bucket headings that `security-specialist` and
+ * `lisa-security-review` must both render so they cannot drift — is pinned by
+ * `security-two-bucket-contract.test.ts` and never reaches this check, since
+ * headings are excluded below. Should a future contract genuinely require a
+ * shared sentence, add the allowlist together with the test that pins it, so the
+ * exemption and its justification cannot be separated.
+ *
+ * Scoped to `plugins/src`, which is the source of truth. The generated per-agent
+ * copies are verified against it by `bun run check:plugins`, so asserting them
+ * here would duplicate that gate rather than add coverage.
+ * @module tests/unit/strategies/agent-skill-layer-contract
+ */
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SRC = path.resolve("plugins/src");
+const ROUTING = path.join(SRC, "base/rules/reference/intent-routing.md");
+
+/**
+ * Template placeholders that look like skill references but name nothing.
+ * `lisa-my-skill` is the worked example inside the skill-creator guidance.
+ */
+const PLACEHOLDER_SKILLS = new Set(["lisa-my-skill"]);
+
+/**
+ * Every stack directory under `plugins/src` that can carry agents or skills.
+ * @returns Directory names such as `base`, `expo`, `phaser`.
+ */
+const stacks = (): readonly string[] =>
+  readdirSync(SRC, { withFileTypes: true })
+    .filter(e => e.isDirectory())
+    .map(e => e.name);
+
+/**
+ * Absolute paths of every agent definition in the source tree.
+ * @returns One path per `plugins/src/<stack>/agents/*.md`.
+ */
+const agentFiles = (): readonly string[] =>
+  stacks().flatMap(stack => {
+    const dir = path.join(SRC, stack, "agents");
+    return existsSync(dir)
+      ? readdirSync(dir)
+          .filter(f => f.endsWith(".md"))
+          .map(f => path.join(dir, f))
+      : [];
+  });
+
+/**
+ * Every skill directory name in the source tree, prefixed or not.
+ * @returns Directory names such as `lisa-reproduce-bug` and `ops-run-local`.
+ */
+const skillNames = (): ReadonlySet<string> => {
+  const found = new Set<string>();
+  for (const stack of stacks()) {
+    const dir = path.join(SRC, stack, "skills");
+    if (!existsSync(dir)) continue;
+    for (const entry of readdirSync(dir)) {
+      if (existsSync(path.join(dir, entry, "SKILL.md"))) found.add(entry);
+    }
+  }
+  return found;
+};
+
+/**
+ * Absolute paths of every `SKILL.md` in the source tree.
+ * @returns One path per skill directory that actually carries a `SKILL.md`.
+ */
+const skillFiles = (): readonly string[] =>
+  stacks().flatMap(stack => {
+    const dir = path.join(SRC, stack, "skills");
+    return existsSync(dir)
+      ? readdirSync(dir)
+          .map(entry => path.join(dir, entry, "SKILL.md"))
+          .filter(existsSync)
+      : [];
+  });
+
+/**
+ * Strips YAML frontmatter so only the rendered body is compared.
+ * @param text The full file contents.
+ * @returns The body with any leading frontmatter block removed.
+ */
+const body = (text: string): string => text.replace(/^---[\s\S]*?^---/mu, "");
+
+/**
+ * The lines a duplication check should judge: substantive prose and rule
+ * bullets, normalized for whitespace.
+ *
+ * Markdown headings are excluded. A shared `### 1. Confirm Quality Gates` is a
+ * structural coincidence between an agent and its skill, not a restated rule,
+ * and counting it would force an exemption that teaches nothing.
+ * @param text The full file contents.
+ * @returns Normalized prose and bullet lines of at least 25 characters.
+ */
+const substantiveLines = (text: string): readonly string[] =>
+  body(text)
+    .split("\n")
+    .map(line => line.replace(/\s+/gu, " ").trim())
+    .filter(line => line.length >= 25 && !line.startsWith("#"));
+
+/**
+ * The skills an agent declares in its frontmatter, unprefixed.
+ * @param text The full agent file contents.
+ * @returns Declared skill names, empty when the agent declares none.
+ */
+const declaredSkills = (text: string): readonly string[] => {
+  const front = /^---([\s\S]*?)^---/mu.exec(text);
+  if (front === null) return [];
+  const block = /^skills:\s*\n((?:[ \t]*-[ \t]*\S.*\n)+)/mu.exec(
+    front[1] ?? ""
+  );
+  if (block === null) return [];
+  return (block[1] ?? "")
+    .trim()
+    .split("\n")
+    .map(line => line.replace(/^[ \t]*-[ \t]*/u, "").trim())
+    .filter(name => name.length > 0);
+};
+
+/**
+ * Resolves a declared skill name to its `SKILL.md`, or null when absent.
+ *
+ * Two naming conventions coexist and both are legitimate: base skills carry the
+ * `lisa-` prefix (`reproduce-bug` -> `lisa-reproduce-bug`) while stack skills
+ * frequently do not (`ops-run-local`, `phaser-i18n`). A resolver that knew only
+ * the prefixed form silently resolved nothing for every stack agent, which is
+ * how the sweep that found #2096 reported zero overlap for expo, rails and all
+ * of phaser: it compared each against an empty pool. Try both forms, and let
+ * the "declares only skills that exist" assertion catch a genuinely absent one.
+ * @param name The unprefixed skill name from an agent's frontmatter.
+ * @returns Absolute path to the resolved `SKILL.md`, or null when absent.
+ */
+const resolveSkill = (name: string): string | null => {
+  for (const stack of stacks()) {
+    for (const dir of [`lisa-${name}`, name]) {
+      const candidate = path.join(SRC, stack, "skills", dir, "SKILL.md");
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return null;
+};
+
+/**
+ * Skill names a skill's prose actually invokes, as opposed to merely mentions.
+ *
+ * The looser shape — any `/lisa-*` token — matches paths, config keys and script
+ * names (`.lisa-config`, `lisa-github-repo-setup.sh`), so it reported fourteen
+ * phantom references on its first run. Requiring the word "skill" adjacent to
+ * the name keeps only genuine invocations.
+ * @param text The full `SKILL.md` contents.
+ * @returns Invoked skill names, excluding documented template placeholders.
+ */
+const invokedSkills = (text: string): readonly string[] => {
+  const patterns = [
+    /(?:invoke|use|call|run|via|through)\s+(?:the\s+)?`?\/?(lisa-[a-z0-9-]+)`?\s+skill/giu,
+    /`?\/(lisa-[a-z0-9-]+)`?\s+skill\b/giu,
+  ];
+  return patterns
+    .flatMap(pattern =>
+      [...text.matchAll(pattern)].map(match => match[1] ?? "")
+    )
+    .filter(name => name.length > 0 && !PLACEHOLDER_SKILLS.has(name));
+};
+
+describe("agent/skill layer contract", () => {
+  describe("an agent does not restate the skills it declares", () => {
+    const agents = agentFiles().filter(
+      file => declaredSkills(readFileSync(file, "utf8")).length > 0
+    );
+
+    it("finds agents that declare skills, so the check is not vacuous", () => {
+      expect(agents.length).toBeGreaterThan(10);
+    });
+
+    it.each(agents.map(file => [path.basename(file), file] as const))(
+      "%s shares no substantive line with its declared skills",
+      (_name, file) => {
+        const text = readFileSync(file, "utf8");
+        const pool = new Set(
+          declaredSkills(text).flatMap(skill => {
+            const resolved = resolveSkill(skill);
+            return resolved === null
+              ? []
+              : [...substantiveLines(readFileSync(resolved, "utf8"))];
+          })
+        );
+        const shared = substantiveLines(text).filter(line => pool.has(line));
+        expect(shared).toEqual([]);
+      }
+    );
+
+    it.each(agents.map(file => [path.basename(file), file] as const))(
+      "%s declares only skills that exist",
+      (_name, file) => {
+        const declared = declaredSkills(readFileSync(file, "utf8"));
+        const unresolved = declared.filter(
+          skill => resolveSkill(skill) === null
+        );
+        expect(unresolved).toEqual([]);
+      }
+    );
+  });
+
+  describe("the routing rule composes agents that exist", () => {
+    const known = new Set(agentFiles().map(file => path.basename(file, ".md")));
+    const referenced = [
+      ...new Set(
+        [
+          ...readFileSync(ROUTING, "utf8").matchAll(
+            /`([a-z][a-z0-9-]*(?:-specialist|-agent|-fixer|-analyzer|-judge|-synthesizer|-evaluator|builder|learner))`/gu
+          ),
+        ].map(match => match[1] ?? "")
+      ),
+    ].filter(name => name.length > 0);
+
+    it("names agents in the routing rule, so the check is not vacuous", () => {
+      expect(referenced.length).toBeGreaterThan(10);
+    });
+
+    it("resolves every agent the routing rule names", () => {
+      expect(referenced.filter(name => !known.has(name))).toEqual([]);
+    });
+  });
+
+  describe("a skill only invokes skills that exist", () => {
+    const known = skillNames();
+    const found = new Map(
+      skillFiles().flatMap(file =>
+        invokedSkills(readFileSync(file, "utf8")).map(
+          name => [name, path.basename(path.dirname(file))] as const
+        )
+      )
+    );
+
+    it("finds skill-to-skill invocations, so the check is not vacuous", () => {
+      expect(found.size).toBeGreaterThan(5);
+    });
+
+    it("resolves every skill a skill invokes", () => {
+      const dangling = [...found.entries()]
+        .filter(([name]) => !known.has(name))
+        .map(([name, from]) => `${name} (from ${from})`);
+      expect(dangling).toEqual([]);
+    });
+  });
+
+  describe("`tools:` is documented as advisory rather than enforced", () => {
+    const doctrine = readFileSync(
+      path.join(SRC, "base/skills/lisa-agent-design-best-practices/SKILL.md"),
+      "utf8"
+    );
+
+    it("says only Claude enforces the field", () => {
+      expect(doctrine).toMatch(/only claude enforces `tools:`/iu);
+    });
+
+    it("forbids treating it as a containment control", () => {
+      expect(doctrine).toMatch(/not a security boundary/iu);
+      expect(doctrine).toMatch(/compromised or prompt-injected/iu);
+    });
+
+    it("names where the real controls live", () => {
+      for (const control of [/sandbox/iu, /egress/iu, /credential scope/iu]) {
+        expect(doctrine).toMatch(control);
+      }
+    });
+
+    it("keeps the Codex transformer emitting the compatibility note", () => {
+      const transformer = readFileSync(
+        path.resolve("src/codex/agent-transformer.ts"),
+        "utf8"
+      );
+      expect(transformer).toContain("Claude allowed tools:");
+      expect(transformer).toContain("Claude Agent Compatibility");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The four-layer split — command → skill → routing rule → agent → skill — is sound and, until now, entirely unenforced. That is how seven agents drifted to between 73% and 92% verbatim duplication of the skills they declare, with up to nineteen byte-identical rule bullets each (#2093, #2096). Nothing detected it because nothing looked.

A layer boundary defended only by prose is followed almost always, and almost always means broken constantly once enough people edit. This adds the three checks that make the boundaries real, plus one honesty fix about `tools:`.

## The three invariants

1. **An agent does not restate the skills it declares.** The skill owns the procedure, output format and rules; the agent owns identity, judgement and handoff. Both load into one context when the agent declares the skill in frontmatter, so a duplicated contract is read twice and the copies drift silently. Also asserts every declared skill resolves — which is what keeps the overlap check from going vacuous.
2. **Every agent the routing rule composes exists.** `intent-routing` is the single place flow composition lives, it is prose, and a mistyped agent name there fails at runtime rather than at build.
3. **Every skill a skill invokes exists.** Skill-to-skill edges are undeclared — there is no frontmatter equivalent of an agent's `skills:` — so a renamed skill leaves a dangling invocation.

Each `describe` also carries a not-vacuous assertion, because a check that silently matches nothing is worse than no check.

## The `tools:` gap

`tools:` cannot be enforced portably — no harness here exposes an enforcement primitive, and the Codex transformer preserves the declaration only as a compatibility note. So "read-only agents cannot implement code" is true on Claude and **false everywhere else**: the same agent definition on another harness can write files.

That cannot be fixed by code, so it is fixed by saying so. `lisa-agent-design-best-practices` §5 now states that only Claude enforces the field, that it must not be relied on to contain a compromised or prompt-injected agent, and that the controls which actually hold are the sandbox, egress restriction, credential scope, and which peers an agent can reach. The suite pins that text and pins the Codex compatibility note, so the gap can never be silently dropped — which is what `AGENTS.md` requires when a behaviour cannot be represented on some agent.

## Out of scope

- Enforcing `tools:` anywhere. There is no primitive to enforce it with; this documents and tests the limitation instead.
- The generated per-agent plugin copies. `bun run check:plugins` already verifies them against `plugins/src`, so asserting them here would duplicate that gate.

## Acceptance criteria

```gherkin
Feature: The layer boundaries are enforced, not merely described

  Scenario: An agent restating its skill fails the build
    Given an agent body sharing a substantive line with a skill it declares
    Then the layer contract suite fails and names the agent

  Scenario: A dangling agent reference in the routing rule fails the build
    Given intent-routing naming an agent with no definition
    Then the suite fails and names it

  Scenario: A dangling skill invocation fails the build
    Given a SKILL.md invoking a skill that does not exist
    Then the suite fails and names both the skill and its caller

  Scenario: No check can pass by matching nothing
    Then each group asserts it found the population it judges

  Scenario: tools: is never presented as containment
    Then the doctrine states only Claude enforces it and names the real controls
```

## Validation journey

1. Run the suite; all groups pass on current `main`.
2. Confirm every one of the 31 declaring agents is measured against a non-empty skill pool — no vacuous passes.
3. `bun run lint`, `tsc --noEmit`, prettier clean.
4. `build:plugins` fans the doctrine change out; `check:plugins` and `check:upstream-evidence-manifest` pass.
5. Full suite with coverage passes.

Closes #2098

Work-Item: CodySwannGT/lisa#2098

## Two things writing the checks taught me

Both are now encoded in the test with the reasoning attached:

**The naive reference pattern reported fourteen phantom skills.** Matching any `/lisa-*` token catches paths, config keys and script names — `.lisa-config`, `lisa-github-repo-setup.sh`, `lisa-wiki`. Requiring the adjacent word "skill" leaves only genuine invocations, and the documented `lisa-my-skill` template placeholder is exempted by name.

**Resolving declared skills only as `lisa-<name>` silently resolved nothing for every stack agent.** Expo, rails and phaser skills are unprefixed — `ops-run-local`, `phaser-i18n`. Which means **the sweep that produced #2096 reported zero overlap for expo, rails and all 21 phaser agents by comparing each against an empty pool.** Those figures were vacuous, and I reported them as clean. The resolver now tries both forms, all 31 declaring agents measure against a non-empty pool, and they are genuinely clean this time — the "declares only skills that exist" assertion is what keeps it that way, since an unresolvable skill now fails loudly instead of quietly emptying the comparison.

That is the argument for these tests in one paragraph: the measurement I trusted was wrong in a direction that looked like success.

## Verification

- 71 assertions pass on current `main`; every group carries a not-vacuous check.
- All 31 declaring agents measured against a non-empty skill pool.
- `bun run lint`, `tsc --noEmit`, prettier clean.
- `build:plugins` fanned the doctrine change to every variant; `check:plugins` passes.
- Manifest regenerated and `--check` passes — it went stale a third time today because a newly *tracked* file needs an entry, and the manifest was generated before staging. Worth a note in the contributing guidance; the ordering is not obvious.
- Full suite with coverage: 477 files, 8,077 tests.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that `tools:` settings primarily guide agent focus and are not a portable security boundary.
  - Added guidance explaining that enforcement may vary by runtime and that security should rely on sandboxing, network restrictions, credential scope, and agent reachability.
  - Updated the guidance consistently across supported agent integrations.

- **Tests**
  - Added automated checks to validate agent and skill references, routing rules, documentation consistency, and compatibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->