### PR TITLE
fix: keep Android awake for Maestro

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -360,6 +360,15 @@ jobs:
             adb wait-for-device
             adb shell getprop sys.boot_completed | grep -q 1
             adb install app-android.apk
+            # Installing a large APK can outlast the emulator's screen timeout.
+            # Reassert the awake/unlocked state immediately before Maestro;
+            # otherwise every flow can fail its first assertion behind the
+            # keyguard even though the app and selectors are healthy.
+            adb shell settings put system screen_off_timeout 2147483647
+            adb shell svc power stayon true
+            adb shell input keyevent KEYCODE_WAKEUP
+            adb shell wm dismiss-keyguard
+            adb shell input keyevent 82
             maestro test $MAESTRO_E2E_ARGS --format junit --output maestro-android-report.xml --debug-output maestro-debug ${{ inputs.flows_dir }}
 
       - name: 📤 Upload Maestro debug output

--- a/tests/integration/maestro-native-workflow.test.ts
+++ b/tests/integration/maestro-native-workflow.test.ts
@@ -197,11 +197,27 @@ describe("maestro-native-e2e reusable workflow", () => {
       "adb shell getprop sys.boot_completed | grep -q 1"
     );
     const installApp = script.indexOf("adb install app-android.apk");
+    const preventSleep = script.indexOf(
+      "adb shell settings put system screen_off_timeout 2147483647"
+    );
+    const stayAwake = script.indexOf("adb shell svc power stayon true");
+    const wakeDevice = script.indexOf(
+      "adb shell input keyevent KEYCODE_WAKEUP"
+    );
+    const dismissKeyguard = script.indexOf("adb shell wm dismiss-keyguard");
+    const unlockDevice = script.indexOf("adb shell input keyevent 82");
+    const runMaestro = script.indexOf("maestro test");
     expect(killAdb).toBeGreaterThanOrEqual(0);
     expect(startAdb).toBeGreaterThan(killAdb);
     expect(waitForDevice).toBeGreaterThan(startAdb);
     expect(verifyBoot).toBeGreaterThan(waitForDevice);
     expect(installApp).toBeGreaterThan(verifyBoot);
+    expect(preventSleep).toBeGreaterThan(installApp);
+    expect(stayAwake).toBeGreaterThan(preventSleep);
+    expect(wakeDevice).toBeGreaterThan(stayAwake);
+    expect(dismissKeyguard).toBeGreaterThan(wakeDevice);
+    expect(unlockDevice).toBeGreaterThan(dismissKeyguard);
+    expect(runMaestro).toBeGreaterThan(unlockDevice);
     expect(script).toContain("adb install app-android.apk");
     // android-emulator-runner runs each line as its own `sh -c`; a
     // backslash-continued maestro command breaks. The whole invocation —


### PR DESCRIPTION
## Summary
- prevent the hosted Android emulator from sleeping during long APK installs
- wake and dismiss keyguard immediately before Maestro starts
- enforce install-to-unlock-to-test ordering with integration coverage

## Evidence
- TunnlAI/frontend run 30225030040 failed all 15 flows at their first readiness assertion after a 52-second APK install
- the exact hosted APK launches and exposes the expected test IDs locally
- the wake/unlock sequence was verified after deliberately sleeping the local Android emulator: Awake, keyguard not showing

## Local verification
- 8,082 unit tests passed with coverage
- 154 integration tests passed
- typecheck passed
- full lint and slow lint passed
- knip and security audit passed
- actionlint and formatting passed

Refs #2091

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android end-to-end test reliability by keeping the emulator awake and unlocked before UI tests run.
  * Prevented test failures caused by the emulator entering sleep or lock states.

* **Tests**
  * Added coverage to verify emulator wake, unlock, and readiness steps occur in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->