### PR TITLE
fix: normalize Android launcher before Maestro

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -368,7 +368,14 @@ jobs:
             adb shell svc power stayon true
             adb shell input keyevent KEYCODE_WAKEUP
             adb shell wm dismiss-keyguard
-            adb shell input keyevent 82
+            # KEYCODE_MENU (82) opens the Pixel launcher's customization
+            # popup once the keyguard is already dismissed. That popup can
+            # consume every subsequent Maestro launchApp command and make all
+            # flows fail their first assertion. HOME instead normalizes the
+            # post-unlock surface and closes any boot-time launcher popup.
+            adb shell input keyevent KEYCODE_HOME
+            adb shell dumpsys power | grep -q 'mWakefulness=Awake'
+            adb shell dumpsys window | grep -q 'isKeyguardShowing=false'
             maestro test $MAESTRO_E2E_ARGS --format junit --output maestro-android-report.xml --debug-output maestro-debug ${{ inputs.flows_dir }}
 
       - name: 📤 Upload Maestro debug output

--- a/tests/integration/maestro-native-workflow.test.ts
+++ b/tests/integration/maestro-native-workflow.test.ts
@@ -205,7 +205,15 @@ describe("maestro-native-e2e reusable workflow", () => {
       "adb shell input keyevent KEYCODE_WAKEUP"
     );
     const dismissKeyguard = script.indexOf("adb shell wm dismiss-keyguard");
-    const unlockDevice = script.indexOf("adb shell input keyevent 82");
+    const normalizeLauncher = script.indexOf(
+      "adb shell input keyevent KEYCODE_HOME"
+    );
+    const verifyAwake = script.indexOf(
+      "adb shell dumpsys power | grep -q 'mWakefulness=Awake'"
+    );
+    const verifyUnlocked = script.indexOf(
+      "adb shell dumpsys window | grep -q 'isKeyguardShowing=false'"
+    );
     const runMaestro = script.indexOf("maestro test");
     expect(killAdb).toBeGreaterThanOrEqual(0);
     expect(startAdb).toBeGreaterThan(killAdb);
@@ -216,8 +224,11 @@ describe("maestro-native-e2e reusable workflow", () => {
     expect(stayAwake).toBeGreaterThan(preventSleep);
     expect(wakeDevice).toBeGreaterThan(stayAwake);
     expect(dismissKeyguard).toBeGreaterThan(wakeDevice);
-    expect(unlockDevice).toBeGreaterThan(dismissKeyguard);
-    expect(runMaestro).toBeGreaterThan(unlockDevice);
+    expect(normalizeLauncher).toBeGreaterThan(dismissKeyguard);
+    expect(verifyAwake).toBeGreaterThan(normalizeLauncher);
+    expect(verifyUnlocked).toBeGreaterThan(verifyAwake);
+    expect(runMaestro).toBeGreaterThan(verifyUnlocked);
+    expect(script).not.toContain("adb shell input keyevent 82");
     expect(script).toContain("adb install app-android.apk");
     // android-emulator-runner runs each line as its own `sh -c`; a
     // backslash-continued maestro command breaks. The whole invocation —


### PR DESCRIPTION
## Summary
- replace the Android runner keycode 82 wake action, which opens the Pixel launcher customization popup, with explicit wake, dismiss-keyguard, and HOME normalization
- keep the emulator awake for the full Maestro suite
- fail early unless the device is awake and unlocked
- add workflow contract coverage preventing keycode 82 from returning

## Why
TunnlAI/frontend hosted Android run https://github.com/TunnlAI/frontend/actions/runs/30238150250 built and installed the exact app successfully, but all 15 flows failed at their first screen because the launcher customization popup intercepted `launchApp`. The same popup was reproduced locally with the runner sequence. The APK launches normally once the popup is dismissed.

## Validation
- 14 integration test files / 154 tests passed
- lint passed
- typecheck passed
- format passed
- slow lint passed
- workflow YAML parsed successfully
- full pre-push repository gate passed

Closes #2091