### PR TITLE
fix(github-sync): correct the linkage claims left behind by the non-closing rule

### DIFF
--- a/plugins/lisa-agy/skills/lisa-git-submit-pr/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-git-submit-pr/SKILL.md
@@ -46,7 +46,8 @@ Add provider-appropriate linkage to the PR title and/or body without changing th
 
 - **GitHub Issues**:
   - If `work_item_ref` is a GitHub issue URL, `org/repo#<n>`, or `#<n>`, add a dedicated issue reference line to the PR body.
-  - Always use a non-closing reference such as `Refs #<n>` so GitHub links the PR in the issue's Development / linked pull requests surface without prematurely closing the issue before the post-merge deploy, remote verification, health check, and terminal `done` label.
+  - Always use a non-closing reference such as `Refs #<n>`, so the merge cannot close the issue before the post-merge deploy, remote verification, health check, and terminal `done` label.
+  - **A non-closing reference does not populate the issue's Development / linked pull requests surface, and no non-closing form does.** That surface *is* the closing-reference mechanism: a closing keyword populates the PR's `closingIssuesReferences`, while `Refs` yields only a `CrossReferencedEvent`. Measured on this repository — a `Refs`-only PR reports `closingIssuesReferences: 0`; a `Closes` PR reports 1. So the ticket-side backlink cannot be delegated to GitHub: the managed `[lisa-pr-link]` comment written by `lisa-github-sync` is the **required** backlink under this rule, not a fallback for when native linkage happens to be absent. Two-way linkage (`lisa-implement` step 7a) and the Work-Item Traceability check both depend on that comment, and a PR carrying a correct `Refs` line still fails the check without it.
   - For cross-repo issue refs, use the fully qualified non-closing form, for example `Refs CodySwannGT/lisa#614`.
 - **Linear**:
   - Ensure the Linear issue identifier appears in the branch name when the branch is created upstream by `lisa-implement`.

--- a/plugins/lisa-agy/skills/lisa-github-sync/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-github-sync/SKILL.md
@@ -56,11 +56,11 @@ Optional arguments include `pr_url=<url>` for the live pull request and `merge_s
 
 When `$ARGUMENTS` includes `pr_url=<url>` for `PR ready` or `PR merged`, ensure the GitHub Issue has a durable ticket -> PR link:
 
-1. Prefer GitHub's native development link by making sure the PR body contains `Refs #<n>` / `Closes #<n>` (or the fully qualified cross-repo form) and verify with `gh issue view <number> --json timelineItems` or an equivalent GitHub read that exposes the linked PR.
-2. If native linkage cannot be verified, post or update a single managed issue comment starting with `[lisa-pr-link]`. Include the PR URL, milestone (`pr-ready` or `pr-merged`), and merge SHA when available.
+1. Make sure the PR body contains `Refs #<n>` (or the fully qualified cross-repo form) — never a closing keyword, per the GitHub rule in `lisa-git-submit-pr`. Read the issue side with `gh api graphql` against `issue.timelineItems`, or `gh issue view <number> --json closedByPullRequestsReferences`. **Not** `gh issue view --json timelineItems`: `timelineItems` is not a supported field for that command, so the check silently returns nothing useful rather than failing loudly.
+2. Post or update a single managed issue comment starting with `[lisa-pr-link]`. Include the PR URL, milestone (`pr-ready` or `pr-merged`), and merge SHA when available. This is **unconditional**, not contingent on step 1 failing: under the non-closing rule GitHub never creates a native development link (that surface is the closing-reference mechanism), so this comment is the only ticket-side backlink there will be.
 3. Keep the fallback idempotent: search existing comments for `[lisa-pr-link]` and the PR URL; update/replace that managed comment where the provider allows updates, otherwise skip when the current body already matches. Do not append duplicate backlink comments on reruns.
 
-This fallback is required even though GitHub usually links PRs natively from PR body keywords; the issue must show the PR from at least one ticket-side surface.
+Native GitHub linkage cannot be verified under the non-closing rule because it is never created in the first place, so the managed comment is not a contingency here — it is the mechanism. The issue must show the PR from at least one ticket-side surface, and this is the only one available.
 
 ### Step 4: Suggest Status Transition
 

--- a/plugins/lisa-copilot/skills/lisa-git-submit-pr/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-git-submit-pr/SKILL.md
@@ -46,7 +46,8 @@ Add provider-appropriate linkage to the PR title and/or body without changing th
 
 - **GitHub Issues**:
   - If `work_item_ref` is a GitHub issue URL, `org/repo#<n>`, or `#<n>`, add a dedicated issue reference line to the PR body.
-  - Always use a non-closing reference such as `Refs #<n>` so GitHub links the PR in the issue's Development / linked pull requests surface without prematurely closing the issue before the post-merge deploy, remote verification, health check, and terminal `done` label.
+  - Always use a non-closing reference such as `Refs #<n>`, so the merge cannot close the issue before the post-merge deploy, remote verification, health check, and terminal `done` label.
+  - **A non-closing reference does not populate the issue's Development / linked pull requests surface, and no non-closing form does.** That surface *is* the closing-reference mechanism: a closing keyword populates the PR's `closingIssuesReferences`, while `Refs` yields only a `CrossReferencedEvent`. Measured on this repository — a `Refs`-only PR reports `closingIssuesReferences: 0`; a `Closes` PR reports 1. So the ticket-side backlink cannot be delegated to GitHub: the managed `[lisa-pr-link]` comment written by `lisa-github-sync` is the **required** backlink under this rule, not a fallback for when native linkage happens to be absent. Two-way linkage (`lisa-implement` step 7a) and the Work-Item Traceability check both depend on that comment, and a PR carrying a correct `Refs` line still fails the check without it.
   - For cross-repo issue refs, use the fully qualified non-closing form, for example `Refs CodySwannGT/lisa#614`.
 - **Linear**:
   - Ensure the Linear issue identifier appears in the branch name when the branch is created upstream by `lisa-implement`.

--- a/plugins/lisa-copilot/skills/lisa-github-sync/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-github-sync/SKILL.md
@@ -56,11 +56,11 @@ Optional arguments include `pr_url=<url>` for the live pull request and `merge_s
 
 When `$ARGUMENTS` includes `pr_url=<url>` for `PR ready` or `PR merged`, ensure the GitHub Issue has a durable ticket -> PR link:
 
-1. Prefer GitHub's native development link by making sure the PR body contains `Refs #<n>` / `Closes #<n>` (or the fully qualified cross-repo form) and verify with `gh issue view <number> --json timelineItems` or an equivalent GitHub read that exposes the linked PR.
-2. If native linkage cannot be verified, post or update a single managed issue comment starting with `[lisa-pr-link]`. Include the PR URL, milestone (`pr-ready` or `pr-merged`), and merge SHA when available.
+1. Make sure the PR body contains `Refs #<n>` (or the fully qualified cross-repo form) — never a closing keyword, per the GitHub rule in `lisa-git-submit-pr`. Read the issue side with `gh api graphql` against `issue.timelineItems`, or `gh issue view <number> --json closedByPullRequestsReferences`. **Not** `gh issue view --json timelineItems`: `timelineItems` is not a supported field for that command, so the check silently returns nothing useful rather than failing loudly.
+2. Post or update a single managed issue comment starting with `[lisa-pr-link]`. Include the PR URL, milestone (`pr-ready` or `pr-merged`), and merge SHA when available. This is **unconditional**, not contingent on step 1 failing: under the non-closing rule GitHub never creates a native development link (that surface is the closing-reference mechanism), so this comment is the only ticket-side backlink there will be.
 3. Keep the fallback idempotent: search existing comments for `[lisa-pr-link]` and the PR URL; update/replace that managed comment where the provider allows updates, otherwise skip when the current body already matches. Do not append duplicate backlink comments on reruns.
 
-This fallback is required even though GitHub usually links PRs natively from PR body keywords; the issue must show the PR from at least one ticket-side surface.
+Native GitHub linkage cannot be verified under the non-closing rule because it is never created in the first place, so the managed comment is not a contingency here — it is the mechanism. The issue must show the PR from at least one ticket-side surface, and this is the only one available.
 
 ### Step 4: Suggest Status Transition
 

--- a/plugins/lisa-cursor/skills/lisa-git-submit-pr/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-git-submit-pr/SKILL.md
@@ -46,7 +46,8 @@ Add provider-appropriate linkage to the PR title and/or body without changing th
 
 - **GitHub Issues**:
   - If `work_item_ref` is a GitHub issue URL, `org/repo#<n>`, or `#<n>`, add a dedicated issue reference line to the PR body.
-  - Always use a non-closing reference such as `Refs #<n>` so GitHub links the PR in the issue's Development / linked pull requests surface without prematurely closing the issue before the post-merge deploy, remote verification, health check, and terminal `done` label.
+  - Always use a non-closing reference such as `Refs #<n>`, so the merge cannot close the issue before the post-merge deploy, remote verification, health check, and terminal `done` label.
+  - **A non-closing reference does not populate the issue's Development / linked pull requests surface, and no non-closing form does.** That surface *is* the closing-reference mechanism: a closing keyword populates the PR's `closingIssuesReferences`, while `Refs` yields only a `CrossReferencedEvent`. Measured on this repository — a `Refs`-only PR reports `closingIssuesReferences: 0`; a `Closes` PR reports 1. So the ticket-side backlink cannot be delegated to GitHub: the managed `[lisa-pr-link]` comment written by `lisa-github-sync` is the **required** backlink under this rule, not a fallback for when native linkage happens to be absent. Two-way linkage (`lisa-implement` step 7a) and the Work-Item Traceability check both depend on that comment, and a PR carrying a correct `Refs` line still fails the check without it.
   - For cross-repo issue refs, use the fully qualified non-closing form, for example `Refs CodySwannGT/lisa#614`.
 - **Linear**:
   - Ensure the Linear issue identifier appears in the branch name when the branch is created upstream by `lisa-implement`.

--- a/plugins/lisa-cursor/skills/lisa-github-sync/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-github-sync/SKILL.md
@@ -56,11 +56,11 @@ Optional arguments include `pr_url=<url>` for the live pull request and `merge_s
 
 When `$ARGUMENTS` includes `pr_url=<url>` for `PR ready` or `PR merged`, ensure the GitHub Issue has a durable ticket -> PR link:
 
-1. Prefer GitHub's native development link by making sure the PR body contains `Refs #<n>` / `Closes #<n>` (or the fully qualified cross-repo form) and verify with `gh issue view <number> --json timelineItems` or an equivalent GitHub read that exposes the linked PR.
-2. If native linkage cannot be verified, post or update a single managed issue comment starting with `[lisa-pr-link]`. Include the PR URL, milestone (`pr-ready` or `pr-merged`), and merge SHA when available.
+1. Make sure the PR body contains `Refs #<n>` (or the fully qualified cross-repo form) — never a closing keyword, per the GitHub rule in `lisa-git-submit-pr`. Read the issue side with `gh api graphql` against `issue.timelineItems`, or `gh issue view <number> --json closedByPullRequestsReferences`. **Not** `gh issue view --json timelineItems`: `timelineItems` is not a supported field for that command, so the check silently returns nothing useful rather than failing loudly.
+2. Post or update a single managed issue comment starting with `[lisa-pr-link]`. Include the PR URL, milestone (`pr-ready` or `pr-merged`), and merge SHA when available. This is **unconditional**, not contingent on step 1 failing: under the non-closing rule GitHub never creates a native development link (that surface is the closing-reference mechanism), so this comment is the only ticket-side backlink there will be.
 3. Keep the fallback idempotent: search existing comments for `[lisa-pr-link]` and the PR URL; update/replace that managed comment where the provider allows updates, otherwise skip when the current body already matches. Do not append duplicate backlink comments on reruns.
 
-This fallback is required even though GitHub usually links PRs natively from PR body keywords; the issue must show the PR from at least one ticket-side surface.
+Native GitHub linkage cannot be verified under the non-closing rule because it is never created in the first place, so the managed comment is not a contingency here — it is the mechanism. The issue must show the PR from at least one ticket-side surface, and this is the only one available.
 
 ### Step 4: Suggest Status Transition
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-git-submit-pr/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-git-submit-pr/SKILL.md
@@ -46,7 +46,8 @@ Add provider-appropriate linkage to the PR title and/or body without changing th
 
 - **GitHub Issues**:
   - If `work_item_ref` is a GitHub issue URL, `org/repo#<n>`, or `#<n>`, add a dedicated issue reference line to the PR body.
-  - Always use a non-closing reference such as `Refs #<n>` so GitHub links the PR in the issue's Development / linked pull requests surface without prematurely closing the issue before the post-merge deploy, remote verification, health check, and terminal `done` label.
+  - Always use a non-closing reference such as `Refs #<n>`, so the merge cannot close the issue before the post-merge deploy, remote verification, health check, and terminal `done` label.
+  - **A non-closing reference does not populate the issue's Development / linked pull requests surface, and no non-closing form does.** That surface *is* the closing-reference mechanism: a closing keyword populates the PR's `closingIssuesReferences`, while `Refs` yields only a `CrossReferencedEvent`. Measured on this repository — a `Refs`-only PR reports `closingIssuesReferences: 0`; a `Closes` PR reports 1. So the ticket-side backlink cannot be delegated to GitHub: the managed `[lisa-pr-link]` comment written by `lisa-github-sync` is the **required** backlink under this rule, not a fallback for when native linkage happens to be absent. Two-way linkage (`lisa-implement` step 7a) and the Work-Item Traceability check both depend on that comment, and a PR carrying a correct `Refs` line still fails the check without it.
   - For cross-repo issue refs, use the fully qualified non-closing form, for example `Refs CodySwannGT/lisa#614`.
 - **Linear**:
   - Ensure the Linear issue identifier appears in the branch name when the branch is created upstream by `lisa-implement`.

--- a/plugins/lisa/.codex-plugin/skills/lisa-github-sync/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-github-sync/SKILL.md
@@ -56,11 +56,11 @@ Optional arguments include `pr_url=<url>` for the live pull request and `merge_s
 
 When `$ARGUMENTS` includes `pr_url=<url>` for `PR ready` or `PR merged`, ensure the GitHub Issue has a durable ticket -> PR link:
 
-1. Prefer GitHub's native development link by making sure the PR body contains `Refs #<n>` / `Closes #<n>` (or the fully qualified cross-repo form) and verify with `gh issue view <number> --json timelineItems` or an equivalent GitHub read that exposes the linked PR.
-2. If native linkage cannot be verified, post or update a single managed issue comment starting with `[lisa-pr-link]`. Include the PR URL, milestone (`pr-ready` or `pr-merged`), and merge SHA when available.
+1. Make sure the PR body contains `Refs #<n>` (or the fully qualified cross-repo form) — never a closing keyword, per the GitHub rule in `lisa-git-submit-pr`. Read the issue side with `gh api graphql` against `issue.timelineItems`, or `gh issue view <number> --json closedByPullRequestsReferences`. **Not** `gh issue view --json timelineItems`: `timelineItems` is not a supported field for that command, so the check silently returns nothing useful rather than failing loudly.
+2. Post or update a single managed issue comment starting with `[lisa-pr-link]`. Include the PR URL, milestone (`pr-ready` or `pr-merged`), and merge SHA when available. This is **unconditional**, not contingent on step 1 failing: under the non-closing rule GitHub never creates a native development link (that surface is the closing-reference mechanism), so this comment is the only ticket-side backlink there will be.
 3. Keep the fallback idempotent: search existing comments for `[lisa-pr-link]` and the PR URL; update/replace that managed comment where the provider allows updates, otherwise skip when the current body already matches. Do not append duplicate backlink comments on reruns.
 
-This fallback is required even though GitHub usually links PRs natively from PR body keywords; the issue must show the PR from at least one ticket-side surface.
+Native GitHub linkage cannot be verified under the non-closing rule because it is never created in the first place, so the managed comment is not a contingency here — it is the mechanism. The issue must show the PR from at least one ticket-side surface, and this is the only one available.
 
 ### Step 4: Suggest Status Transition
 

--- a/plugins/lisa/skills/lisa-git-submit-pr/SKILL.md
+++ b/plugins/lisa/skills/lisa-git-submit-pr/SKILL.md
@@ -46,7 +46,8 @@ Add provider-appropriate linkage to the PR title and/or body without changing th
 
 - **GitHub Issues**:
   - If `work_item_ref` is a GitHub issue URL, `org/repo#<n>`, or `#<n>`, add a dedicated issue reference line to the PR body.
-  - Always use a non-closing reference such as `Refs #<n>` so GitHub links the PR in the issue's Development / linked pull requests surface without prematurely closing the issue before the post-merge deploy, remote verification, health check, and terminal `done` label.
+  - Always use a non-closing reference such as `Refs #<n>`, so the merge cannot close the issue before the post-merge deploy, remote verification, health check, and terminal `done` label.
+  - **A non-closing reference does not populate the issue's Development / linked pull requests surface, and no non-closing form does.** That surface *is* the closing-reference mechanism: a closing keyword populates the PR's `closingIssuesReferences`, while `Refs` yields only a `CrossReferencedEvent`. Measured on this repository — a `Refs`-only PR reports `closingIssuesReferences: 0`; a `Closes` PR reports 1. So the ticket-side backlink cannot be delegated to GitHub: the managed `[lisa-pr-link]` comment written by `lisa-github-sync` is the **required** backlink under this rule, not a fallback for when native linkage happens to be absent. Two-way linkage (`lisa-implement` step 7a) and the Work-Item Traceability check both depend on that comment, and a PR carrying a correct `Refs` line still fails the check without it.
   - For cross-repo issue refs, use the fully qualified non-closing form, for example `Refs CodySwannGT/lisa#614`.
 - **Linear**:
   - Ensure the Linear issue identifier appears in the branch name when the branch is created upstream by `lisa-implement`.

--- a/plugins/lisa/skills/lisa-github-sync/SKILL.md
+++ b/plugins/lisa/skills/lisa-github-sync/SKILL.md
@@ -56,11 +56,11 @@ Optional arguments include `pr_url=<url>` for the live pull request and `merge_s
 
 When `$ARGUMENTS` includes `pr_url=<url>` for `PR ready` or `PR merged`, ensure the GitHub Issue has a durable ticket -> PR link:
 
-1. Prefer GitHub's native development link by making sure the PR body contains `Refs #<n>` / `Closes #<n>` (or the fully qualified cross-repo form) and verify with `gh issue view <number> --json timelineItems` or an equivalent GitHub read that exposes the linked PR.
-2. If native linkage cannot be verified, post or update a single managed issue comment starting with `[lisa-pr-link]`. Include the PR URL, milestone (`pr-ready` or `pr-merged`), and merge SHA when available.
+1. Make sure the PR body contains `Refs #<n>` (or the fully qualified cross-repo form) — never a closing keyword, per the GitHub rule in `lisa-git-submit-pr`. Read the issue side with `gh api graphql` against `issue.timelineItems`, or `gh issue view <number> --json closedByPullRequestsReferences`. **Not** `gh issue view --json timelineItems`: `timelineItems` is not a supported field for that command, so the check silently returns nothing useful rather than failing loudly.
+2. Post or update a single managed issue comment starting with `[lisa-pr-link]`. Include the PR URL, milestone (`pr-ready` or `pr-merged`), and merge SHA when available. This is **unconditional**, not contingent on step 1 failing: under the non-closing rule GitHub never creates a native development link (that surface is the closing-reference mechanism), so this comment is the only ticket-side backlink there will be.
 3. Keep the fallback idempotent: search existing comments for `[lisa-pr-link]` and the PR URL; update/replace that managed comment where the provider allows updates, otherwise skip when the current body already matches. Do not append duplicate backlink comments on reruns.
 
-This fallback is required even though GitHub usually links PRs natively from PR body keywords; the issue must show the PR from at least one ticket-side surface.
+Native GitHub linkage cannot be verified under the non-closing rule because it is never created in the first place, so the managed comment is not a contingency here — it is the mechanism. The issue must show the PR from at least one ticket-side surface, and this is the only one available.
 
 ### Step 4: Suggest Status Transition
 

--- a/plugins/src/base/skills/lisa-git-submit-pr/SKILL.md
+++ b/plugins/src/base/skills/lisa-git-submit-pr/SKILL.md
@@ -46,7 +46,8 @@ Add provider-appropriate linkage to the PR title and/or body without changing th
 
 - **GitHub Issues**:
   - If `work_item_ref` is a GitHub issue URL, `org/repo#<n>`, or `#<n>`, add a dedicated issue reference line to the PR body.
-  - Always use a non-closing reference such as `Refs #<n>` so GitHub links the PR in the issue's Development / linked pull requests surface without prematurely closing the issue before the post-merge deploy, remote verification, health check, and terminal `done` label.
+  - Always use a non-closing reference such as `Refs #<n>`, so the merge cannot close the issue before the post-merge deploy, remote verification, health check, and terminal `done` label.
+  - **A non-closing reference does not populate the issue's Development / linked pull requests surface, and no non-closing form does.** That surface *is* the closing-reference mechanism: a closing keyword populates the PR's `closingIssuesReferences`, while `Refs` yields only a `CrossReferencedEvent`. Measured on this repository — a `Refs`-only PR reports `closingIssuesReferences: 0`; a `Closes` PR reports 1. So the ticket-side backlink cannot be delegated to GitHub: the managed `[lisa-pr-link]` comment written by `lisa-github-sync` is the **required** backlink under this rule, not a fallback for when native linkage happens to be absent. Two-way linkage (`lisa-implement` step 7a) and the Work-Item Traceability check both depend on that comment, and a PR carrying a correct `Refs` line still fails the check without it.
   - For cross-repo issue refs, use the fully qualified non-closing form, for example `Refs CodySwannGT/lisa#614`.
 - **Linear**:
   - Ensure the Linear issue identifier appears in the branch name when the branch is created upstream by `lisa-implement`.

--- a/plugins/src/base/skills/lisa-github-sync/SKILL.md
+++ b/plugins/src/base/skills/lisa-github-sync/SKILL.md
@@ -56,11 +56,11 @@ Optional arguments include `pr_url=<url>` for the live pull request and `merge_s
 
 When `$ARGUMENTS` includes `pr_url=<url>` for `PR ready` or `PR merged`, ensure the GitHub Issue has a durable ticket -> PR link:
 
-1. Prefer GitHub's native development link by making sure the PR body contains `Refs #<n>` / `Closes #<n>` (or the fully qualified cross-repo form) and verify with `gh issue view <number> --json timelineItems` or an equivalent GitHub read that exposes the linked PR.
-2. If native linkage cannot be verified, post or update a single managed issue comment starting with `[lisa-pr-link]`. Include the PR URL, milestone (`pr-ready` or `pr-merged`), and merge SHA when available.
+1. Make sure the PR body contains `Refs #<n>` (or the fully qualified cross-repo form) — never a closing keyword, per the GitHub rule in `lisa-git-submit-pr`. Read the issue side with `gh api graphql` against `issue.timelineItems`, or `gh issue view <number> --json closedByPullRequestsReferences`. **Not** `gh issue view --json timelineItems`: `timelineItems` is not a supported field for that command, so the check silently returns nothing useful rather than failing loudly.
+2. Post or update a single managed issue comment starting with `[lisa-pr-link]`. Include the PR URL, milestone (`pr-ready` or `pr-merged`), and merge SHA when available. This is **unconditional**, not contingent on step 1 failing: under the non-closing rule GitHub never creates a native development link (that surface is the closing-reference mechanism), so this comment is the only ticket-side backlink there will be.
 3. Keep the fallback idempotent: search existing comments for `[lisa-pr-link]` and the PR URL; update/replace that managed comment where the provider allows updates, otherwise skip when the current body already matches. Do not append duplicate backlink comments on reruns.
 
-This fallback is required even though GitHub usually links PRs natively from PR body keywords; the issue must show the PR from at least one ticket-side surface.
+Native GitHub linkage cannot be verified under the non-closing rule because it is never created in the first place, so the managed comment is not a contingency here — it is the mechanism. The issue must show the PR from at least one ticket-side surface, and this is the only one available.
 
 ### Step 4: Suggest Status Transition
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -839,7 +839,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-git-prune/SKILL.md":
       "11fad06d109538f1a8ee4ef8043bb0e083672e3c9a7cb7ae8a7233c5411d6dd2",
     "plugins/src/base/skills/lisa-git-submit-pr/SKILL.md":
-      "f20b690e8212ee3891b79c3ebb38d89089aa8f7b0ed17e5ef3552f164c739083",
+      "7126076f246bf56c85ce83b4c8ff98c9888ab2a543fba527372e137c1340c129",
     "plugins/src/base/skills/lisa-github-add-journey/SKILL.md":
       "6b3bbe8ff85c7cb20412dcfcab3d7506a3efc67907cb749622c329fb4130baf4",
     "plugins/src/base/skills/lisa-github-build-intake/SKILL.md":
@@ -859,7 +859,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-github-read-issue/SKILL.md":
       "9cf01c2b23a7f82a02e6cd935669de04345720ef9e01a5daadfdebbea040bd99",
     "plugins/src/base/skills/lisa-github-sync/SKILL.md":
-      "c63c8bf7aeabc1ba5f6e5a3f982212e9903496c559ba035da303aa50fe4626e3",
+      "386256c1e721a2395d942f1bd5d544bdd0a14895390edab34d1d8a593dc2ada7",
     "plugins/src/base/skills/lisa-github-to-tracker/SKILL.md":
       "3b0e67ed50909d38249b9780052d97e66268990c8806aa271000c37716aafa06",
     "plugins/src/base/skills/lisa-github-validate-issue/SKILL.md":

--- a/tests/unit/strategies/two-way-pr-ticket-linking.test.ts
+++ b/tests/unit/strategies/two-way-pr-ticket-linking.test.ts
@@ -97,7 +97,9 @@ describe("two-way PR/ticket linking contract", () => {
  * prematurely, desyncing the env-keyed `status:*` label ladder. `git-submit-pr`
  * must gate magic words on the production/default branch, and `linear-sync` must
  * carry a post-merge reconciliation step that re-opens a natively-completed
- * Issue whose derived env is intermediate. All 5 ROOTS stay in parity.
+ * Issue whose derived env is intermediate. All 6 ROOTS stay in parity — the count
+ * said 5 while `ROOTS` already listed the Codex skill root, so the comment
+ * understated the cohort it documents.
  */
 describe("Linear native auto-close env gate contract", () => {
   describe.each(ROOTS)("%s/lisa-git-submit-pr Linear magic-word gate", root => {
@@ -121,7 +123,14 @@ describe("Linear native auto-close env gate contract", () => {
       expect(content).toMatch(/Always use a non-closing reference/);
       expect(content).toMatch(/Refs #<n>/);
       expect(content).toMatch(/terminal `done` label/);
-      expect(content).not.toMatch(/Closes #<n>/);
+      // The whole closing-keyword family, not just `Closes`. The contract is
+      // "GitHub never emits a closing keyword"; asserting one spelling let a
+      // regression to `Fixes #<n>` or `Resolves #<n>` pass the gate while
+      // reintroducing the exact defect — close at merge, ahead of the deploy and
+      // remote verification the work item is actually terminal on.
+      expect(content).not.toMatch(
+        /\b(clos(e|es|ed)|fix(es|ed)?|resolv(e|es|ed)) #<n>/i
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

`main` now prohibits GitHub closing keywords (#2109, landed independently). Three claims it left standing are false, and a fourth gap makes the new gate weaker than it reads. All four apply to `main`.

## 1. `Refs` does not create a native Development link

`lisa-git-submit-pr` claimed the non-closing reference works "so GitHub links the PR in the issue's Development / linked pull requests surface". It does not. That surface **is** the closing-reference mechanism.

| PR | Reference form | `closingIssuesReferences` |
| --- | --- | --- |
| #2110 | `Refs #2109` | **0** |
| #2108 | `Closes #2107` | 1 |

`Refs` produces only a `CrossReferencedEvent`. There is no non-closing form that yields the native link.

**Consequence:** the managed `[lisa-pr-link]` comment is the **required** ticket-side backlink under the non-closing rule — not a fallback for when native linkage is absent, because it is always absent. `github-sync` step 2 becomes unconditional, and the trailing "required even though GitHub usually links PRs natively" sentence is replaced, since GitHub no longer links natively at all.

Found the hard way: Work-Item Traceability failed PR #2110 despite a correctly-formed `Refs` line. **This PR carries the `[lisa-pr-link]` comment on #2112** — the mechanism it documents, dogfooded.

## 2. `github-sync` still offered a closing keyword

Step 1 said to ensure the PR body contains ``Refs #<n>` / `Closes #<n>``, directly contradicting the rule `git-submit-pr` states.

## 3. `gh issue view --json timelineItems` is not a supported field

The documented verification step returned nothing useful instead of failing loudly — the worst shape for a check. Replaced with `gh api graphql` against `issue.timelineItems`, or `--json closedByPullRequestsReferences`.

## 4. The prohibition asserted one spelling

`not.toMatch(/Closes #<n>/)` — a regression to `Fixes #<n>` or `Resolves #<n>` would pass the gate while reintroducing the exact defect. Now asserts the whole closing-keyword family, case-insensitively. The docblock also said "All 5 ROOTS" while `ROOTS` already listed six including the Codex skill root.

Items 3 and 4 came from CodeRabbit on #2110; they were findings against `main`, not against that branch, so they are landed here rather than dropped with it.

## Provenance

This replaces #2110, which became ~80% duplicate when `main` landed the same core fix mid-flight. Rebuilt clean off current `main` rather than resolving 14 conflicts for content already there.

## Verification

- Contract test: 72 passing across all six parity roots.
- Full suite: 479 files. Only failure was the upstream evidence manifest going stale on the skill edits — regenerated after staging.
- `lint`, `tsc --noEmit` clean. Fanout rebuilt via `build:plugins`.

Refs #2112
Work-Item: CodySwannGT/lisa#2112
