### PR TITLE
fix(readiness): flag pnpm trusted build scripts

### DIFF
--- a/src/cli/doctor-readiness-supply-chain-evidence.ts
+++ b/src/cli/doctor-readiness-supply-chain-evidence.ts
@@ -111,26 +111,49 @@ function installTimeScriptEvidence(
   );
 }
 
+/** Package-manager fields that explicitly allow dependency build scripts. */
+const BUILD_SCRIPT_ALLOWLIST_FIELDS: readonly string[] = [
+  "trustedDependencies",
+  "onlyBuiltDependencies",
+];
+
 /**
- * Build evidence when Bun trusted dependencies are declared.
+ * Read string values from a package-manager build-script allowlist.
+ * @param value - Candidate manifest field
+ * @returns Declared package names
+ */
+function stringArray(value: unknown): readonly string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+/**
+ * Build evidence when package managers are configured to trust dependency build scripts.
  * @param manifestPath - Repo-relative manifest path
  * @param manifest - Parsed package manifest
- * @returns Evidence line when trusted dependencies are declared
+ * @returns Evidence line when trusted dependency build scripts are declared
  */
 function trustedDependencyEvidence(
   manifestPath: string,
   manifest: Record<string, unknown>
 ): string | null {
-  const trusted = manifest.trustedDependencies;
-  const names = Array.isArray(trusted)
-    ? trusted.filter((entry): entry is string => typeof entry === "string")
-    : [];
+  const pnpm = manifest.pnpm;
+  const names = [
+    ...BUILD_SCRIPT_ALLOWLIST_FIELDS.flatMap(field =>
+      stringArray(manifest[field])
+    ),
+    ...(pnpm !== null && typeof pnpm === "object" && !Array.isArray(pnpm)
+      ? stringArray((pnpm as Record<string, unknown>).onlyBuiltDependencies)
+      : []),
+  ];
   if (names.length === 0) {
     return null;
   }
   return (
-    `\`${manifestPath}\` marks ${renderList(names)} as ` +
-    "`trustedDependencies`, allowing third-party install-time scripts to run; " +
+    `\`${manifestPath}\` marks ${renderList([...new Set(names)])} as ` +
+    "trusted dependency build script(s) through `trustedDependencies` or " +
+    "`onlyBuiltDependencies`, allowing third-party install-time scripts to run; " +
     "B5 needs a written confidence decision for each trusted package because " +
     "a clean audit gate alone does not explain that execution authority"
   );

--- a/tests/unit/cli/doctor-readiness-supply-chain-install-scripts.test.ts
+++ b/tests/unit/cli/doctor-readiness-supply-chain-install-scripts.test.ts
@@ -152,4 +152,43 @@ describe("assessDependenciesSupplyChainDimension — install-time execution", ()
     expect(finding?.evidence).toContain("@sentry/cli");
     expect(finding?.evidence).toContain("third-party install-time scripts");
   });
+
+  it("FAILs with B5 when pnpm onlyBuiltDependencies allows dependency build scripts", async () => {
+    const cwd = await getTempDir();
+    await writeCleanRepo(cwd);
+    await writeRepoJson(cwd, PACKAGE_JSON, {
+      ...PINNED_MANIFEST,
+      onlyBuiltDependencies: ["esbuild"],
+    });
+
+    const record = await assessDependenciesSupplyChainDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    const finding = asFindings(record.findings).find(
+      candidate => candidate.blocker === BLOCKER_ID
+    );
+    expect(finding?.evidence).toContain("trusted dependency build script");
+    expect(finding?.evidence).toContain("esbuild");
+    expect(finding?.evidence).toContain("third-party install-time scripts");
+  });
+
+  it("FAILs with B5 when pnpm nested onlyBuiltDependencies allows dependency build scripts", async () => {
+    const cwd = await getTempDir();
+    await writeCleanRepo(cwd);
+    await writeRepoJson(cwd, PACKAGE_JSON, {
+      ...PINNED_MANIFEST,
+      pnpm: {
+        onlyBuiltDependencies: ["@parcel/watcher"],
+      },
+    });
+
+    const record = await assessDependenciesSupplyChainDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    const finding = asFindings(record.findings).find(
+      candidate => candidate.blocker === BLOCKER_ID
+    );
+    expect(finding?.evidence).toContain("@parcel/watcher");
+    expect(finding?.evidence).toContain("trusted dependency build script");
+  });
 });


### PR DESCRIPTION
## Summary

- Extend B5 install-time execution evidence from Bun `trustedDependencies` to pnpm `onlyBuiltDependencies` allowlists.
- Cover both top-level `onlyBuiltDependencies` and nested `pnpm.onlyBuiltDependencies` manifest shapes.

## Verification

- `bun test tests/unit/cli/doctor-readiness-supply-chain-install-scripts.test.ts tests/unit/cli/doctor-readiness-supply-chain-workspaces.test.ts`
- `bun run build:dist`
- `bun run typecheck`
- `bun run lint`
- pre-push gate: typecheck, production audit, slow lint, knip, full unit coverage, integration tests, plugin parity

Work-Item: CodySwannGT/lisa#1903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved supply-chain readiness checks to recognize trusted dependency declarations across supported package-manager manifest formats.
  * Added support for pnpm’s `onlyBuiltDependencies` settings, including nested configuration.
  * Reports now clearly identify trusted dependencies with install-time scripts and avoid empty evidence results.

* **Tests**
  * Added coverage for top-level and nested pnpm trusted dependency configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->