### PR TITLE
Flag mutable validation actions in readiness

### DIFF
--- a/src/cli/doctor-readiness-action-pins.ts
+++ b/src/cli/doctor-readiness-action-pins.ts
@@ -5,11 +5,13 @@
 import type {
   ParsedWorkflow,
   ParsedWorkflowJob,
+  ParsedWorkflowStep,
 } from "./doctor-readiness-workflows.js";
 import {
   describeStep,
   findPublishSteps,
 } from "./doctor-readiness-release-path.js";
+import { ancestorJobs } from "./doctor-readiness-reusable-callers.js";
 
 const PINNED_ACTION_REF = /^[a-f0-9]{40}$/i;
 const PINNED_DOCKER_ACTION_REF = /^docker:\/\/.+@sha256:[a-f0-9]{64}$/i;
@@ -33,9 +35,53 @@ function isMutableActionRef(uses: string): boolean {
 }
 
 /**
- * Report mutable action references in jobs that publish release artifacts.
+ * Report mutable action references in a release-path job.
+ * @param workflow - The workflow declaring the job
+ * @param job - The job to assess
+ * @param step - The action step to report
+ * @param role - Why this job is release-path relevant
+ * @returns One B2 evidence line
+ */
+function mutableActionEvidence(
+  workflow: ParsedWorkflow,
+  job: ParsedWorkflowJob,
+  step: ParsedWorkflowStep,
+  role: string
+): string {
+  return (
+    `${workflow.file} job \`${job.id}\` step \`${describeStep(step)}\` ` +
+    `uses mutable action reference \`${step.uses}\` in ${role}; pin it to a ` +
+    "full commit SHA so the release path cannot change without a reviewed " +
+    "workflow diff"
+  );
+}
+
+/**
+ * Report mutable action references in one job.
+ * @param workflow - The workflow declaring the job
+ * @param job - The job to assess
+ * @param role - Why this job is release-path relevant
+ * @returns B2 evidence lines for unpinned action refs
+ */
+function mutableActionViolations(
+  workflow: ParsedWorkflow,
+  job: ParsedWorkflowJob,
+  role: string
+): readonly string[] {
+  return job.steps.flatMap(step =>
+    isMutableActionRef(step.uses)
+      ? [mutableActionEvidence(workflow, job, step, role)]
+      : []
+  );
+}
+
+/**
+ * Report mutable action references in jobs that publish release artifacts or
+ * provide the validation those publishing jobs rely on.
  * A release job has deployment authority, so an action tag such as `@v4` or
- * `@main` is supply-chain authority handed to whoever can move that ref.
+ * `@main` is supply-chain authority handed to whoever can move that ref. The
+ * same is true for the validating ancestors in the publishing job's `needs:`
+ * closure: their output is what makes the artifact trusted.
  * @param workflow - The workflow declaring the job
  * @param job - The job to assess
  * @returns B2 evidence lines for unpinned action refs
@@ -47,14 +93,14 @@ export function unpinnedPublishingActionViolations(
   if (findPublishSteps(job).length === 0) {
     return [];
   }
-  return job.steps.flatMap(step =>
-    isMutableActionRef(step.uses)
-      ? [
-          `${workflow.file} job \`${job.id}\` step \`${describeStep(step)}\` ` +
-            `uses mutable action reference \`${step.uses}\` in a publishing ` +
-            "job; pin it to a full commit SHA so the release path cannot change " +
-            "without a reviewed workflow diff",
-        ]
-      : []
-  );
+  return [
+    ...mutableActionViolations(workflow, job, "a publishing job"),
+    ...ancestorJobs(workflow, job).flatMap(ancestor =>
+      mutableActionViolations(
+        workflow,
+        ancestor,
+        "a validating ancestor of a publishing job"
+      )
+    ),
+  ];
 }

--- a/tests/unit/cli/doctor-readiness-delivery-action-pins.test.ts
+++ b/tests/unit/cli/doctor-readiness-delivery-action-pins.test.ts
@@ -29,6 +29,9 @@ import {
 const RUN_NPM_TEST = "      - run: npm test";
 const ID_TOKEN_WRITE = "      id-token: write";
 const RUN_NPM_PUBLISH = "      - run: npm publish --provenance";
+const NEEDS_TEST = "    needs: [test]";
+const CHECKOUT_V4_REF = "actions/checkout@v4";
+const CHECKOUT_V4_ACTION = `      - uses: ${CHECKOUT_V4_REF}`;
 const PINNED_DOCKER_IMAGE =
   "docker://ghcr.io/acme/releaser@sha256:" +
   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
@@ -65,7 +68,7 @@ describe("assessDeliveryAuthorityDimension — release action pinning", () => {
       STEPS,
       RUN_NPM_TEST,
       PUBLISH_JOB,
-      "    needs: [test]",
+      NEEDS_TEST,
       RUNS_ON,
       PERMISSIONS,
       CONTENTS_READ,
@@ -100,7 +103,7 @@ describe("assessDeliveryAuthorityDimension — release action pinning", () => {
       STEPS,
       RUN_NPM_TEST,
       PUBLISH_JOB,
-      "    needs: [test]",
+      NEEDS_TEST,
       RUNS_ON,
       PERMISSIONS,
       CONTENTS_READ,
@@ -114,6 +117,39 @@ describe("assessDeliveryAuthorityDimension — release action pinning", () => {
 
     expect(record.status).toBe(PASS);
     expect(assessReadiness([record]).blockers).toEqual([]);
+  });
+
+  it("FAILs when a validating ancestor uses a mutable action ref", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, RELEASE_YML, [
+      RELEASE_NAME,
+      ON,
+      PUSH,
+      TAGS,
+      JOBS,
+      "  test:",
+      RUNS_ON,
+      STEPS,
+      CHECKOUT_V4_ACTION,
+      RUN_NPM_TEST,
+      PUBLISH_JOB,
+      NEEDS_TEST,
+      RUNS_ON,
+      PERMISSIONS,
+      CONTENTS_READ,
+      ID_TOKEN_WRITE,
+      STEPS,
+      `      - uses: ${PINNED_DOWNLOAD_ARTIFACT}`,
+      RUN_NPM_PUBLISH,
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+    const evidence = String(asFindings(record.findings)[0].evidence);
+
+    expect(record.status).toBe(FAIL);
+    expect(assessReadiness([record]).blockers[0].id).toBe("B2");
+    expect(evidence).toContain(CHECKOUT_V4_REF);
+    expect(evidence).toContain("validating ancestor");
   });
 
   it("FAILs when a publishing job uses a tagged Docker action ref", async () => {
@@ -178,15 +214,13 @@ describe("assessDeliveryAuthorityDimension — release action pinning", () => {
       "  quality:",
       RUNS_ON,
       STEPS,
-      "      - uses: actions/checkout@v4",
+      CHECKOUT_V4_ACTION,
       RUN_NPM_TEST,
     ]);
 
     const record = await assessDeliveryAuthorityDimension(cwd);
 
     expect(record.status).not.toBe(FAIL);
-    expect(JSON.stringify(record.findings)).not.toContain(
-      "actions/checkout@v4"
-    );
+    expect(JSON.stringify(record.findings)).not.toContain(CHECKOUT_V4_REF);
   });
 });


### PR DESCRIPTION
## Summary
- Extend the B2 mutable-action check from publishing jobs to the validating `needs:` ancestors that publishing jobs rely on.
- Add a regression for a release path whose validating ancestor uses `actions/checkout@v4`.

## Verification
- `bun test tests/unit/cli/doctor-readiness-delivery-action-pins.test.ts`
- `bun run lint -- src/cli/doctor-readiness-action-pins.ts tests/unit/cli/doctor-readiness-delivery-action-pins.test.ts`
- `bun run typecheck`
- `bun run build:dist`
- `bun test tests/unit/cli/doctor-readiness-delivery-artifact.test.ts tests/unit/cli/doctor-readiness-delivery-reusable-callers.test.ts tests/unit/cli/doctor-readiness-delivery-triggers.test.ts tests/unit/cli/doctor-readiness-credentials-round2.test.ts tests/unit/cli/doctor-readiness-delivery-action-pins.test.ts`
- `bun run build:upstream-evidence-manifest -- --check`
- pre-push: typecheck, production audit, slow lint, knip, full unit coverage (8,123 tests), integration tests (154 tests), plugin parity

Refs #1903
Work-Item: CodySwannGT/lisa#1903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Readiness checks now detect unpinned third-party GitHub Actions in validating ancestor jobs, not just publishing jobs.
  * Reports now include clearer evidence identifying the mutable action reference and its validating ancestor.
  * Non-publishing jobs continue to be excluded from these findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->