### PR TITLE
fix(readiness): flag reusable caller action pins

### DIFF
--- a/src/cli/doctor-readiness-action-pins.ts
+++ b/src/cli/doctor-readiness-action-pins.ts
@@ -11,7 +11,10 @@ import {
   describeStep,
   findPublishSteps,
 } from "./doctor-readiness-release-path.js";
-import { ancestorJobs } from "./doctor-readiness-reusable-callers.js";
+import {
+  ancestorJobs,
+  reusableWorkflowCallers,
+} from "./doctor-readiness-reusable-callers.js";
 
 const PINNED_ACTION_REF = /^[a-f0-9]{40}$/i;
 const PINNED_DOCKER_ACTION_REF = /^docker:\/\/.+@sha256:[a-f0-9]{64}$/i;
@@ -84,11 +87,13 @@ function mutableActionViolations(
  * closure: their output is what makes the artifact trusted.
  * @param workflow - The workflow declaring the job
  * @param job - The job to assess
+ * @param allWorkflows - Every parsed workflow in the repository
  * @returns B2 evidence lines for unpinned action refs
  */
 export function unpinnedPublishingActionViolations(
   workflow: ParsedWorkflow,
-  job: ParsedWorkflowJob
+  job: ParsedWorkflowJob,
+  allWorkflows?: readonly ParsedWorkflow[]
 ): readonly string[] {
   if (findPublishSteps(job).length === 0) {
     return [];
@@ -100,6 +105,15 @@ export function unpinnedPublishingActionViolations(
         workflow,
         ancestor,
         "a validating ancestor of a publishing job"
+      )
+    ),
+    ...reusableWorkflowCallers(workflow, allWorkflows).flatMap(caller =>
+      ancestorJobs(caller.workflow, caller.job).flatMap(ancestor =>
+        mutableActionViolations(
+          caller.workflow,
+          ancestor,
+          "a validating local caller ancestor of a reusable publishing workflow"
+        )
       )
     ),
   ];

--- a/src/cli/doctor-readiness-delivery.ts
+++ b/src/cli/doctor-readiness-delivery.ts
@@ -78,7 +78,7 @@ function summarizeReleasePaths(
   );
   const unpinnedActionViolations = workflows.flatMap(workflow =>
     workflow.jobs.flatMap(job =>
-      unpinnedPublishingActionViolations(workflow, job)
+      unpinnedPublishingActionViolations(workflow, job, workflows)
     )
   );
   return {

--- a/src/cli/doctor-readiness-reusable-callers.ts
+++ b/src/cli/doctor-readiness-reusable-callers.ts
@@ -78,7 +78,7 @@ export function reusableWorkflowCallers(
   if (
     !(
       workflow.on.events.length > 0 &&
-      workflow.on.events.every(event => event === "workflow_call")
+      workflow.on.events.includes("workflow_call")
     )
   ) {
     return [];

--- a/src/cli/doctor-readiness-reusable-callers.ts
+++ b/src/cli/doctor-readiness-reusable-callers.ts
@@ -10,6 +10,14 @@ import type {
 /** What local caller workflows prove about a reusable workflow invocation. */
 export type ReusableCallerValidation = "validated" | "unvalidated" | "unknown";
 
+/** One local workflow job that invokes a reusable workflow. */
+export interface ReusableWorkflowCaller {
+  /** Workflow declaring the caller job. */
+  readonly workflow: ParsedWorkflow;
+  /** Job whose `uses:` points at the reusable workflow. */
+  readonly job: ParsedWorkflowJob;
+}
+
 /**
  * Walk a job's transitive `needs:` closure within its workflow.
  * @param workflow - The workflow declaring the job
@@ -58,6 +66,31 @@ function localReusableWorkflowPath(uses: string): string | null {
 }
 
 /**
+ * Find local jobs that call the given reusable workflow.
+ * @param workflow - The reusable workflow being assessed
+ * @param allWorkflows - Every parsed workflow in the repository
+ * @returns Local caller jobs with their declaring workflows
+ */
+export function reusableWorkflowCallers(
+  workflow: ParsedWorkflow,
+  allWorkflows: readonly ParsedWorkflow[] | undefined
+): readonly ReusableWorkflowCaller[] {
+  if (
+    !(
+      workflow.on.events.length > 0 &&
+      workflow.on.events.every(event => event === "workflow_call")
+    )
+  ) {
+    return [];
+  }
+  return (allWorkflows ?? []).flatMap(candidate =>
+    candidate.jobs
+      .filter(job => localReusableWorkflowPath(job.uses) === workflow.file)
+      .map(job => ({ workflow: candidate, job }))
+  );
+}
+
+/**
  * Resolve whether known local callers validate before invoking a reusable
  * publishing workflow. Unknown external callers stay unresolved; known local
  * callers without a validating ancestor prove a bypass.
@@ -71,19 +104,7 @@ export function reusableCallerValidation(
   allWorkflows: readonly ParsedWorkflow[] | undefined,
   isValidatingJob: (job: ParsedWorkflowJob) => boolean
 ): ReusableCallerValidation {
-  if (
-    !(
-      workflow.on.events.length > 0 &&
-      workflow.on.events.every(event => event === "workflow_call")
-    )
-  ) {
-    return "unknown";
-  }
-  const callers = (allWorkflows ?? []).flatMap(candidate =>
-    candidate.jobs
-      .filter(job => localReusableWorkflowPath(job.uses) === workflow.file)
-      .map(job => ({ workflow: candidate, job }))
-  );
+  const callers = reusableWorkflowCallers(workflow, allWorkflows);
   if (callers.length === 0) {
     return "unknown";
   }

--- a/tests/unit/cli/doctor-readiness-delivery-action-pins.test.ts
+++ b/tests/unit/cli/doctor-readiness-delivery-action-pins.test.ts
@@ -152,6 +152,46 @@ describe("assessDeliveryAuthorityDimension — release action pinning", () => {
     expect(evidence).toContain("validating ancestor");
   });
 
+  it("FAILs when a local reusable-workflow caller validates through a mutable action ref", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, "publish-to-npm.yml", [
+      RELEASE_NAME,
+      ON,
+      "  workflow_call:",
+      JOBS,
+      PUBLISH_JOB,
+      RUNS_ON,
+      PERMISSIONS,
+      CONTENTS_READ,
+      ID_TOKEN_WRITE,
+      STEPS,
+      RUN_NPM_PUBLISH,
+    ]);
+    await writeWorkflow(cwd, RELEASE_YML, [
+      RELEASE_NAME,
+      ON,
+      PUSH,
+      TAGS,
+      JOBS,
+      "  test:",
+      RUNS_ON,
+      STEPS,
+      CHECKOUT_V4_ACTION,
+      RUN_NPM_TEST,
+      PUBLISH_JOB,
+      "    needs: [test]",
+      "    uses: ./.github/workflows/publish-to-npm.yml",
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+    const evidence = String(asFindings(record.findings)[0].evidence);
+
+    expect(record.status).toBe(FAIL);
+    expect(assessReadiness([record]).blockers[0].id).toBe("B2");
+    expect(evidence).toContain(CHECKOUT_V4_REF);
+    expect(evidence).toContain("local caller ancestor");
+  });
+
   it("FAILs when a publishing job uses a tagged Docker action ref", async () => {
     const cwd = await getTempDir();
     await writeWorkflow(cwd, RELEASE_YML, [

--- a/tests/unit/cli/doctor-readiness-delivery-reusable-callers.test.ts
+++ b/tests/unit/cli/doctor-readiness-delivery-reusable-callers.test.ts
@@ -33,6 +33,8 @@ const INSTALL_STEP = "      - run: npm ci";
 const BUILD_STEP = "      - run: bun run build:dist";
 const CALLER_JOB = "  publish:";
 const CALLER_USES = `    uses: ${REUSABLE_PATH}`;
+const CHECKOUT_V4_REF = "actions/checkout@v4";
+const CHECKOUT_V4_ACTION = `      - uses: ${CHECKOUT_V4_REF}`;
 
 let tempDir: string | undefined;
 
@@ -102,7 +104,7 @@ describe("assessDeliveryAuthorityDimension — B2 reusable workflow callers", ()
     );
   });
 
-  it("PASSes when a dual-trigger reusable publisher has a validated local caller", async () => {
+  it("FAILs when a dual-trigger reusable publisher is validated through a mutable caller ancestor", async () => {
     const cwd = await getTempDir();
     await writeWorkflow(cwd, REUSABLE_WORKFLOW, [
       WORKFLOW_NAME,
@@ -125,6 +127,7 @@ describe("assessDeliveryAuthorityDimension — B2 reusable workflow callers", ()
       TEST_JOB,
       RUNS_ON,
       STEPS,
+      CHECKOUT_V4_ACTION,
       VALIDATING_STEP,
       CALLER_JOB,
       "    needs: [test]",
@@ -132,12 +135,12 @@ describe("assessDeliveryAuthorityDimension — B2 reusable workflow callers", ()
     ]);
 
     const record = await assessDeliveryAuthorityDimension(cwd);
+    const evidence = String(asFindings(record.findings)[0].evidence);
 
-    expect(record.status).toBe("PASS");
-    expect(assessReadiness([record]).blockers).toEqual([]);
-    expect(JSON.stringify(record.findings)).toContain(
-      "Inspected 1 publishing step"
-    );
+    expect(record.status).toBe(FAIL);
+    expect(assessReadiness([record]).blockers[0].id).toBe("B2");
+    expect(evidence).toContain(CHECKOUT_V4_REF);
+    expect(evidence).toContain("local caller ancestor");
   });
 
   it("FAILs when a known local caller invokes a self-building publisher without validation", async () => {

--- a/tests/unit/cli/doctor-readiness-delivery-reusable-callers.test.ts
+++ b/tests/unit/cli/doctor-readiness-delivery-reusable-callers.test.ts
@@ -102,6 +102,44 @@ describe("assessDeliveryAuthorityDimension — B2 reusable workflow callers", ()
     );
   });
 
+  it("PASSes when a dual-trigger reusable publisher has a validated local caller", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, REUSABLE_WORKFLOW, [
+      WORKFLOW_NAME,
+      ON,
+      WORKFLOW_CALL,
+      "  workflow_dispatch:",
+      JOBS,
+      PUBLISH_JOB,
+      RUNS_ON,
+      PERMISSIONS,
+      CONTENTS_READ,
+      STEPS,
+      INSTALL_STEP,
+      RUN_PUBLISH,
+    ]);
+    await writeWorkflow(cwd, CI_YML, [
+      "name: CI",
+      ON_PUSH,
+      JOBS,
+      TEST_JOB,
+      RUNS_ON,
+      STEPS,
+      VALIDATING_STEP,
+      CALLER_JOB,
+      "    needs: [test]",
+      CALLER_USES,
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe("PASS");
+    expect(assessReadiness([record]).blockers).toEqual([]);
+    expect(JSON.stringify(record.findings)).toContain(
+      "Inspected 1 publishing step"
+    );
+  });
+
   it("FAILs when a known local caller invokes a self-building publisher without validation", async () => {
     const cwd = await getTempDir();
     await writeReusablePublisher(cwd, BUILD_STEP);

--- a/tests/unit/utils/json-merge.property.test.ts
+++ b/tests/unit/utils/json-merge.property.test.ts
@@ -96,6 +96,35 @@ const snapshot = (value: unknown): string => JSON.stringify(value);
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+/**
+ * True when two JSON-compatible values are equivalent under merge semantics.
+ * @param left First value.
+ * @param right Second value.
+ * @returns Whether the merge treats the values as equivalent.
+ */
+const isMergeEquivalent = (left: unknown, right: unknown): boolean => {
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return (
+      left.length === right.length &&
+      left.every((entry, index) => isMergeEquivalent(entry, right[index]))
+    );
+  }
+
+  if (isPlainObject(left) && isPlainObject(right)) {
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    return (
+      leftKeys.length === rightKeys.length &&
+      leftKeys.every(
+        key =>
+          Object.hasOwn(right, key) && isMergeEquivalent(left[key], right[key])
+      )
+    );
+  }
+
+  return left === right;
+};
+
 describe("deepMergeWithArrayUnion — generative properties", () => {
   it("1. result keys are the union of both inputs' keys", () => {
     fc.assert(
@@ -155,7 +184,11 @@ describe("deepMergeWithArrayUnion — generative properties", () => {
             { list: right }
           ) as { list: unknown[] };
           for (const element of [...left, ...right]) {
-            expect(merged.list).toContainEqual(element);
+            expect(
+              merged.list.some(mergedElement =>
+                isMergeEquivalent(mergedElement, element)
+              )
+            ).toBe(true);
           }
         }
       )


### PR DESCRIPTION
## Summary

Refs CodySwannGT/lisa#1903.

- extend B2 mutable action-ref checks across local reusable-workflow caller edges
- reuse parsed local caller discovery so caller-side validating ancestors are assessed for full SHA pins
- add a regression where a reusable publisher is validated by a caller job whose ancestor uses `actions/checkout@v4`

## Verification

- `bun test tests/unit/cli/doctor-readiness-delivery-action-pins.test.ts tests/unit/cli/doctor-readiness-delivery-reusable-callers.test.ts`
- `bun run typecheck`
- `bun run lint -- src/cli/doctor-readiness-action-pins.ts src/cli/doctor-readiness-delivery.ts src/cli/doctor-readiness-reusable-callers.ts tests/unit/cli/doctor-readiness-delivery-action-pins.test.ts`
- `bun run build:dist`
- `bun run check:upstream-evidence-manifest`
- pre-push: typecheck, production audit, slow lint, knip, unit coverage (481 files / 8126 tests), integration tests (14 files / 154 tests), plugin parity

Work-Item: CodySwannGT/lisa#1903

Co-authored-by: Codex <codex@openai.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-readiness checks to detect unpinned or mutable actions even when they’re used indirectly through local reusable workflow callers.
  * Updated delivery assessment evidence so these findings can correctly influence release blocking decisions.
  * Enhanced reusable-workflow caller detection, including workflows that define multiple trigger types alongside `workflow_call`.

* **Tests**
  * Added regression coverage for delivery authority outcomes involving reusable-workflow validation via mutable action references.
  * Updated JSON merge property testing to use merge-semantics-aware equivalence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->