### PR TITLE
fix(readiness): require backup before data wipe

### DIFF
--- a/src/cli/doctor-readiness-domain.ts
+++ b/src/cli/doctor-readiness-domain.ts
@@ -144,15 +144,28 @@ function servicesDeferral(
 }
 
 /**
- * Whether a job takes its own copy before destroying anything — the way back,
- * sitting right beside the danger.
+ * Whether a job takes its own copy before this destructive step runs — the way
+ * back, sitting before the danger. A later backup-looking command cannot recover
+ * data that has already been deleted.
  * @param job - The parsed job
- * @returns True when any step in the job looks like a backup
+ * @param step - The destructive step being classified
+ * @returns True when an earlier step in the job looks like a backup
  */
-function jobTakesBackup(job: ParsedWorkflowJob): boolean {
-  return job.steps.some(step =>
-    RECOVERY_COMMANDS.some(pattern => pattern.test(step.run.toLowerCase()))
-  );
+function jobTakesBackupBeforeStep(
+  job: ParsedWorkflowJob,
+  step: ParsedWorkflowStep
+): boolean {
+  const stepIndex = job.steps.indexOf(step);
+  if (stepIndex <= 0) {
+    return false;
+  }
+  return job.steps
+    .slice(0, stepIndex)
+    .some(previousStep =>
+      RECOVERY_COMMANDS.some(pattern =>
+        pattern.test(previousStep.run.toLowerCase())
+      )
+    );
 }
 
 /**
@@ -278,7 +291,7 @@ export async function assessDomainOwnershipDimension(
   const workflows: readonly ParsedWorkflow[] =
     parsedWorkflows ?? (await parseRepositoryWorkflows(root));
   const scan = scanCommands(workflows, destroysData, {
-    exemptJob: jobTakesBackup,
+    exemptStep: jobTakesBackupBeforeStep,
     unresolvedStep: servicesDeferral,
   });
   // A checked-in runbook is a way back, so it clears the "no recovery" half of

--- a/src/cli/doctor-readiness-operations.ts
+++ b/src/cli/doctor-readiness-operations.ts
@@ -45,11 +45,14 @@ export interface OperationScan {
 /** Optional refinements a caller layers onto a scan. */
 export interface ScanOptions {
   /**
-   * A job-level exemption, evaluated when a match is found. B1 uses it for a
-   * job that takes its own backup first: the destructive command is real, but
-   * the way back is right there in the same job.
+   * A step-level exemption, evaluated after a matching step is found. B1 uses it
+   * for a destructive command that has a preceding backup in the same job; a
+   * backup that runs later is not a way back for the already-executed command.
    */
-  readonly exemptJob?: (job: ParsedWorkflowJob) => boolean;
+  readonly exemptStep?: (
+    job: ParsedWorkflowJob,
+    step: ParsedWorkflowStep
+  ) => boolean;
   /**
    * A workflow-level reason the match cannot be settled offline, returning
    * `null` when it can. Used for triggers that make the operation obviously
@@ -386,7 +389,7 @@ function classifyJob(
   if (deferred !== undefined && deferred !== null) {
     return [{ kind: "unresolved", reason: deferred }, ...unresolvedCalls];
   }
-  const jobGated = jobIsGated(job) || (options.exemptJob?.(job) ?? false);
+  const jobGated = jobIsGated(job);
   return [
     ...hits.map(step => {
       const stepDeferred = options.unresolvedStep?.(workflow, job, step);
@@ -395,7 +398,9 @@ function classifyJob(
       }
       return {
         kind:
-          jobGated || stepIsGated(step)
+          jobGated ||
+          (options.exemptStep?.(job, step) ?? false) ||
+          stepIsGated(step)
             ? ("gated" as const)
             : ("ungated" as const),
         command: { workflow: workflow.file, jobId: job.id, command: step.run },

--- a/tests/unit/cli/doctor-readiness-domain-negatives.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain-negatives.test.ts
@@ -119,6 +119,26 @@ describe("assessDomainOwnershipDimension — never manufactures RED from absence
     }
   });
 
+  it("stands B1 when the only backup runs after the destructive command", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      STEPS,
+      RUN_S3_WIPE,
+      "      - run: aws s3 sync s3://acme-backup s3://acme-prod-user-uploads",
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(
+      asFindings(record.findings).some(finding => finding.blocker === "B1")
+    ).toBe(true);
+  });
+
   it("does not stand B1 for a manually dispatched workflow", async () => {
     const root = await getTempDir();
     await writeWorkflow(root, CLEANUP_YML, [

--- a/tests/unit/cli/doctor-readiness-domain-negatives.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain-negatives.test.ts
@@ -119,6 +119,7 @@ describe("assessDomainOwnershipDimension — never manufactures RED from absence
     }
   });
 
+  // Test hardened to kill mutant M001 (Risk Factor: Data loss / recovery-order correctness).
   it("stands B1 when the only backup runs after the destructive command", async () => {
     const root = await getTempDir();
     await writeWorkflow(root, CLEANUP_YML, [


### PR DESCRIPTION
## Summary
- require B1 backup/recovery evidence to appear before the destructive data operation it clears
- keep the shared workflow scanner reusable with a per-step exemption hook
- add a regression where backup-after-wipe still stands B1

## Validation
- `bun test tests/unit/cli/doctor-readiness-domain-negatives.test.ts tests/unit/cli/doctor-readiness-guardrails.test.ts`
- `bun run typecheck`
- `bun run lint -- src/cli/doctor-readiness-operations.ts src/cli/doctor-readiness-domain.ts tests/unit/cli/doctor-readiness-domain-negatives.test.ts`
- pre-push: typecheck, production audit, slow lint, knip, unit coverage (481 files / 8,128 tests), integration tests (154 tests), plugin parity

Work-Item: CodySwannGT/lisa#1903


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved readiness assessments for destructive operations.
  - Recovery or backup steps now qualify only when they occur before the destructive action within the same job.
  - Backups performed afterward no longer incorrectly mark the operation as recoverable.
  - Findings now more accurately identify cases that lack a valid way to recover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->