### PR TITLE
fix(readiness): scope B1 ephemeral screening per invocation

### DIFF
--- a/src/cli/doctor-readiness-domain.ts
+++ b/src/cli/doctor-readiness-domain.ts
@@ -93,6 +93,31 @@ const RECOVERY_COMMANDS: readonly RegExp[] = [
   /\baws\s+s3\s+sync\b/,
 ];
 
+/** Separators that end one shell invocation for this conservative scan. */
+const SHELL_INVOCATION_SEPARATOR = /\n|;|&&|\|\|/;
+
+/**
+ * Collapse only shell continuation newlines. Ordinary newlines remain command
+ * boundaries so unrelated invocations cannot hide a destructive one.
+ * @param command - Shell command text
+ * @returns Command text with escaped newlines joined
+ */
+function normalizeShellContinuations(command: string): string {
+  return command.replace(/\\\r?\n\s*/g, " ");
+}
+
+/**
+ * Extract command fragments that contain an irreversible data operation.
+ * @param command - Lower-cased shell command text
+ * @returns Invocation fragments that include data destruction
+ */
+function destructiveInvocations(command: string): string[] {
+  return normalizeShellContinuations(command)
+    .split(SHELL_INVOCATION_SEPARATOR)
+    .map(part => part.trim())
+    .filter(part => IRREVERSIBLE_DATA_OPS.some(pattern => pattern.test(part)));
+}
+
 /**
  * Whether a command irreversibly destroys data that is not obviously throwaway.
  *
@@ -111,9 +136,8 @@ function destroysData(
   job: ParsedWorkflowJob,
   step: ParsedWorkflowStep
 ): boolean {
-  return (
-    IRREVERSIBLE_DATA_OPS.some(pattern => pattern.test(command)) &&
-    !looksEphemeral(`${command}\n${step.env}\n${job.env}`)
+  return destructiveInvocations(command).some(
+    invocation => !looksEphemeral(`${invocation}\n${step.env}\n${job.env}`)
   );
 }
 

--- a/src/cli/doctor-readiness-domain.ts
+++ b/src/cli/doctor-readiness-domain.ts
@@ -94,7 +94,7 @@ const RECOVERY_COMMANDS: readonly RegExp[] = [
 ];
 
 /** Separators that end one shell invocation for this conservative scan. */
-const SHELL_INVOCATION_SEPARATOR = /\n|;|&&|\|\|/;
+const SHELL_INVOCATION_SEPARATOR = /\n|&&|\|\||[;&|]/;
 
 /**
  * Collapse only shell continuation newlines. Ordinary newlines remain command

--- a/tests/unit/cli/doctor-readiness-domain.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain.test.ts
@@ -141,29 +141,51 @@ describe("assessDomainOwnershipDimension — B1 stands only on a provable path",
     ).toBe(true);
   });
 
-  it("stands B1 when an unrelated ephemeral line precedes a production wipe", async () => {
-    const root = await getTempDir();
-    await writeWorkflow(root, CLEANUP_YML, [
-      CLEANUP_NAME,
-      ON_PUSH,
-      JOBS,
-      WIPE_JOB,
-      RUNS_ON,
-      STEPS,
-      "      - run: |",
-      "          npm test",
-      "          aws s3 rm s3://acme-prod-user-uploads --recursive",
-    ]);
+  it.each([
+    [
+      "newline",
+      [
+        "          npm test",
+        "          aws s3 rm s3://acme-prod-user-uploads --recursive",
+      ],
+    ],
+    [
+      "background operator",
+      [
+        "          npm test & aws s3 rm s3://acme-prod-user-uploads --recursive",
+      ],
+    ],
+    [
+      "pipeline operator",
+      [
+        "          npm test | aws s3 rm s3://acme-prod-user-uploads --recursive",
+      ],
+    ],
+  ])(
+    "stands B1 when an unrelated ephemeral %s precedes a production wipe",
+    async (_label, lines) => {
+      const root = await getTempDir();
+      await writeWorkflow(root, CLEANUP_YML, [
+        CLEANUP_NAME,
+        ON_PUSH,
+        JOBS,
+        WIPE_JOB,
+        RUNS_ON,
+        STEPS,
+        "      - run: |",
+        ...lines,
+      ]);
 
-    const record = await assessDomainOwnershipDimension(root);
+      const record = await assessDomainOwnershipDimension(root);
 
-    expect(record.status).toBe(WARN);
-    expect(
-      asFindings(record.findings).some(
-        finding => finding.blocker === BLOCKER_ID
-      )
-    ).toBe(true);
-  });
+      expect(record.status).toBe(WARN);
+      expect(
+        asFindings(record.findings).some(
+          finding => finding.blocker === BLOCKER_ID
+        )
+      ).toBe(true);
+    }
+  );
 
   it.each([
     ["Rails database drop", "rails db:drop"],

--- a/tests/unit/cli/doctor-readiness-domain.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain.test.ts
@@ -141,6 +141,30 @@ describe("assessDomainOwnershipDimension — B1 stands only on a provable path",
     ).toBe(true);
   });
 
+  it("stands B1 when an unrelated ephemeral line precedes a production wipe", async () => {
+    const root = await getTempDir();
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: |",
+      "          npm test",
+      "          aws s3 rm s3://acme-prod-user-uploads --recursive",
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+  });
+
   it.each([
     ["Rails database drop", "rails db:drop"],
     ["Prisma forced reset", "prisma migrate reset --force"],


### PR DESCRIPTION
## Summary

Fixes one B1 readiness false-negative slice from #1903: an unrelated ephemeral command in the same multiline `run:` block no longer suppresses a later production data-destruction command.

## Changes

- Splits B1 destructive command assessment into shell invocation fragments before applying the ephemeral-target screen.
- Preserves escaped-line continuations so a continued destructive command is still assessed as one invocation.
- Adds regression coverage for `npm test` preceding a production `aws s3 rm ... --recursive` wipe in the same block.

## Verification

- `bun test tests/unit/cli/doctor-readiness-domain.test.ts tests/unit/cli/doctor-readiness-domain-negatives.test.ts`
- `bun test tests/unit/cli/doctor-readiness-guardrails.test.ts tests/unit/cli/doctor-readiness-guardrails-ephemeral.test.ts tests/unit/cli/doctor-readiness-guardrails-terraform.test.ts`
- `bun run lint -- src/cli/doctor-readiness-domain.ts tests/unit/cli/doctor-readiness-domain.test.ts`
- `bun run typecheck`
- `bun run build:dist`
- `bun run build:upstream-evidence-manifest`
- `bun run test:cov`
- `bun run lint`
- `bun run knip:check` (configuration hints only; exited 0)
- `bun run lint:slow`
- `bun run check:upstream-evidence-manifest`
- `bun run test:integration`
- `bun run check:plugins`
- `bun run format:check`
- `git diff --check`
- Pre-push hook passed: typecheck, production audit, slow lint, knip, unit coverage, integration tests, plugin parity

Work-Item: CodySwannGT/lisa#1903


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness scans to identify destructive data operations within multi-command shell steps.
  * Prevented unrelated ephemeral commands from masking production data-deletion risks.
  * Added coverage to ensure the B1 blocker is correctly reported for destructive production operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->