### PR TITLE
fix(readiness): flag full pvc deletions

### DIFF
--- a/src/cli/doctor-readiness-domain.ts
+++ b/src/cli/doctor-readiness-domain.ts
@@ -70,7 +70,7 @@ const IRREVERSIBLE_DATA_OPS: readonly RegExp[] = [
   /\brails\s+db:(drop|reset)\b/,
   /\bprisma\s+migrate\s+reset\b[^\n]*--force\b/,
   /\bredis-cli\b[^\n]*\bflushall\b/i,
-  /\bkubectl\s+delete\s+(namespace|pvc)\b/,
+  /\bkubectl\s+delete\s+(namespace|pvc|persistentvolumeclaims?)\b/,
   /\bgcloud\s+sql\s+instances\s+delete\b/,
   /\baz\s+group\s+delete\b/,
   /\b(mongo|mongosh)\b[^\n]*\bdropdatabase\s*\(/i,

--- a/tests/unit/cli/doctor-readiness-domain.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain.test.ts
@@ -198,6 +198,10 @@ describe("assessDomainOwnershipDimension — B1 stands only on a provable path",
       "kubectl delete persistentvolumeclaim uploads-data",
     ],
     [
+      "Kubernetes plural persistent-volume-claims delete",
+      "kubectl delete persistentvolumeclaims uploads-data",
+    ],
+    [
       "Google Cloud SQL instance delete",
       "gcloud sql instances delete app-prod",
     ],

--- a/tests/unit/cli/doctor-readiness-domain.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain.test.ts
@@ -194,6 +194,10 @@ describe("assessDomainOwnershipDimension — B1 stands only on a provable path",
     ["Kubernetes namespace delete", "kubectl delete namespace prod"],
     ["Kubernetes persistent-volume-claim delete", "kubectl delete pvc data"],
     [
+      "Kubernetes full persistent-volume-claim delete",
+      "kubectl delete persistentvolumeclaim uploads-data",
+    ],
+    [
       "Google Cloud SQL instance delete",
       "gcloud sql instances delete app-prod",
     ],


### PR DESCRIPTION
Refs #1903

## Summary
- Extend B1 irreversible data operation matching to recognize full Kubernetes `persistentvolumeclaim`/`persistentvolumeclaims` resource names, not only the `pvc` shorthand.
- Add focused regression coverage proving `kubectl delete persistentvolumeclaim ...` stands B1.

## Verification
- `bun test tests/unit/cli/doctor-readiness-domain.test.ts`
- `bun run lint -- src/cli/doctor-readiness-domain.ts tests/unit/cli/doctor-readiness-domain.test.ts`
- `bun run typecheck`
- pre-push: typecheck, production audit, slow lint, knip, full unit coverage (481 files / 8,132 tests), integration tests (154 tests), plugin parity

Work-Item: CodySwannGT/lisa#1903
Co-authored-by: Codex <codex@openai.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved destructive-operation detection for Kubernetes commands that delete persistent volume claims.
  * Full `persistentvolumeclaim` and `persistentvolumeclaims` resource names are now recognized alongside the `pvc` shorthand.
* **Tests**
  * Added coverage confirming persistent volume claim deletion commands trigger the appropriate readiness blocker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->