### PR TITLE
fix(readiness): flag kubectl namespace shorthand deletes

### DIFF
--- a/src/cli/doctor-readiness-domain.ts
+++ b/src/cli/doctor-readiness-domain.ts
@@ -70,7 +70,7 @@ const IRREVERSIBLE_DATA_OPS: readonly RegExp[] = [
   /\brails\s+db:(drop|reset)\b/,
   /\bprisma\s+migrate\s+reset\b[^\n]*--force\b/,
   /\bredis-cli\b[^\n]*\bflushall\b/i,
-  /\bkubectl\s+delete\s+(namespace|pvc|persistentvolumeclaims?)\b/,
+  /\bkubectl\s+delete\s+(namespace|ns|pvc|persistentvolumeclaims?)\b/,
   /\bgcloud\s+sql\s+instances\s+delete\b/,
   /\baz\s+group\s+delete\b/,
   /\b(mongo|mongosh)\b[^\n]*\bdropdatabase\s*\(/i,

--- a/tests/unit/cli/doctor-readiness-domain.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain.test.ts
@@ -192,6 +192,8 @@ describe("assessDomainOwnershipDimension — B1 stands only on a provable path",
     ["Prisma forced reset", "prisma migrate reset --force"],
     ["Redis flushall", "redis-cli -u $REDIS_URL FLUSHALL"],
     ["Kubernetes namespace delete", "kubectl delete namespace prod"],
+    // Test hardened to kill mutant M001 (Risk Factor: Data loss / Kubernetes namespace shorthand coverage).
+    ["Kubernetes namespace shorthand delete", "kubectl delete ns prod"],
     ["Kubernetes persistent-volume-claim delete", "kubectl delete pvc data"],
     [
       "Kubernetes full persistent-volume-claim delete",


### PR DESCRIPTION
## Summary

- Treat `kubectl delete ns ...` as the Kubernetes namespace shorthand form of the existing B1 irreversible data-destruction signal.
- Add the positive domain-readiness regression alongside the existing namespace, PVC, cloud, Mongo, and SQL command coverage.

## Verification

- `bun test tests/unit/cli/doctor-readiness-domain.test.ts tests/unit/cli/doctor-readiness-domain-negatives.test.ts tests/unit/cli/doctor-readiness-domain-ephemeral.test.ts`
- `bun run lint -- src/cli/doctor-readiness-domain.ts tests/unit/cli/doctor-readiness-domain.test.ts`
- `bun run typecheck`
- `bun run build:dist`
- `bun run check:upstream-evidence-manifest`
- `bun run check:plugins`
- pre-push: typecheck, production audit, slow lint, knip, unit coverage, integration tests, plugin parity

Refs CodySwannGT/lisa#1903

Work-Item: CodySwannGT/lisa#1903
Co-authored-by: Codex <codex@openai.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness checks to detect destructive Kubernetes namespace deletion commands.
  * Commands using the `ns` shorthand are now correctly flagged as potentially irreversible operations.

* **Tests**
  * Added coverage to verify namespace deletion commands trigger the appropriate safety blocker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->