### PR TITLE
fix(readiness): scan B1 wrapper scripts

### DIFF
--- a/src/cli/doctor-readiness-domain.ts
+++ b/src/cli/doctor-readiness-domain.ts
@@ -26,8 +26,6 @@
  *    files; claiming PASS would be the same overstatement B6 exists to catch.
  * @module cli/doctor-readiness-domain
  */
-import { readFile } from "node:fs/promises";
-import * as path from "node:path";
 import {
   commandTargetsOwnedService,
   describeCommands,
@@ -37,6 +35,7 @@ import {
   scanCommands,
   type ScannedCommand,
 } from "./doctor-readiness-operations.js";
+import { expandLocalScriptCommands } from "./doctor-readiness-local-scripts.js";
 import { informationalFindings } from "./doctor-readiness-shared.js";
 import type { ReadinessDimensionRecord } from "./doctor-readiness-types.js";
 import {
@@ -61,13 +60,6 @@ const DOMAIN_OWNERSHIP_OFFLINE_TAIL =
   "genuinely owned and written down cannot be established by reading files " +
   "offline — that needs the agent-ready domain phase — so domain ownership is " +
   "not established either way.";
-
-/** Most bytes read from one local wrapper script during offline expansion. */
-const MAX_LOCAL_SCRIPT_BYTES = 16_384;
-
-/** Repo-local shell script invocations that a workflow can hide danger behind. */
-const LOCAL_SCRIPT_INVOCATION =
-  /(?:^|[\s;&|])(?:(?:bash|sh|source|\.)\s+)?((?:\.\/)?[\w./-]+\.sh)\b/g;
 
 /**
  * Commands that irreversibly destroy stored data. Every entry is a whole
@@ -125,109 +117,6 @@ function destructiveInvocations(command: string): string[] {
     .split(SHELL_INVOCATION_SEPARATOR)
     .map(part => part.trim())
     .filter(part => IRREVERSIBLE_DATA_OPS.some(pattern => pattern.test(part)));
-}
-
-/**
- * Extract repo-relative shell scripts named directly by a workflow run step.
- * @param command - Workflow step command
- * @returns Unique repo-relative script paths
- */
-function localScriptPaths(command: string): readonly string[] {
-  return [
-    ...new Set(
-      [...command.matchAll(LOCAL_SCRIPT_INVOCATION)].flatMap(match => {
-        const candidate = match[1];
-        if (candidate === undefined || candidate.includes("..")) {
-          return [];
-        }
-        return [candidate.replace(/^\.\//u, "")];
-      })
-    ),
-  ];
-}
-
-/**
- * Read one bounded repo-local script for offline command expansion.
- * @param root - Repository root
- * @param relativePath - Repo-relative script path
- * @returns Script content, or null when it cannot be safely read
- */
-async function readLocalScript(
-  root: string,
-  relativePath: string
-): Promise<string | null> {
-  const rootPath = path.resolve(root);
-  const target = path.resolve(rootPath, relativePath);
-  if (!target.startsWith(`${rootPath}${path.sep}`)) {
-    return null;
-  }
-  try {
-    const content = await readFile(target, "utf8");
-    return content.length > MAX_LOCAL_SCRIPT_BYTES ? null : content;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Append any bounded local script bodies referenced by a workflow step.
- * @param root - Repository root
- * @param step - Parsed workflow step
- * @returns Step with script bodies appended to `run`, when present
- */
-async function expandLocalScriptStep(
-  root: string,
-  step: ParsedWorkflowStep
-): Promise<ParsedWorkflowStep> {
-  const scripts = await Promise.all(
-    localScriptPaths(step.run).map(
-      async script => await readLocalScript(root, script)
-    )
-  );
-  const scriptBodies = scripts.filter(
-    (content): content is string => content !== null
-  );
-  return scriptBodies.length === 0
-    ? step
-    : { ...step, run: [step.run, ...scriptBodies].join("\n") };
-}
-
-/**
- * Expand directly invoked local shell scripts in one parsed job.
- * @param root - Repository root
- * @param job - Parsed workflow job
- * @returns Job with script-expanded steps
- */
-async function expandLocalScriptJob(
-  root: string,
-  job: ParsedWorkflowJob
-): Promise<ParsedWorkflowJob> {
-  return {
-    ...job,
-    steps: await Promise.all(
-      job.steps.map(async step => await expandLocalScriptStep(root, step))
-    ),
-  };
-}
-
-/**
- * Inline directly invoked local shell scripts into the parsed workflow commands.
- * @param root - Repository root
- * @param workflows - Parsed workflow files
- * @returns Workflows with bounded script content appended to matching steps
- */
-async function expandLocalScriptCommands(
-  root: string,
-  workflows: readonly ParsedWorkflow[]
-): Promise<readonly ParsedWorkflow[]> {
-  return await Promise.all(
-    workflows.map(async workflow => ({
-      ...workflow,
-      jobs: await Promise.all(
-        workflow.jobs.map(async job => await expandLocalScriptJob(root, job))
-      ),
-    }))
-  );
 }
 
 /**

--- a/src/cli/doctor-readiness-domain.ts
+++ b/src/cli/doctor-readiness-domain.ts
@@ -26,6 +26,8 @@
  *    files; claiming PASS would be the same overstatement B6 exists to catch.
  * @module cli/doctor-readiness-domain
  */
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
 import {
   commandTargetsOwnedService,
   describeCommands,
@@ -59,6 +61,13 @@ const DOMAIN_OWNERSHIP_OFFLINE_TAIL =
   "genuinely owned and written down cannot be established by reading files " +
   "offline — that needs the agent-ready domain phase — so domain ownership is " +
   "not established either way.";
+
+/** Most bytes read from one local wrapper script during offline expansion. */
+const MAX_LOCAL_SCRIPT_BYTES = 16_384;
+
+/** Repo-local shell script invocations that a workflow can hide danger behind. */
+const LOCAL_SCRIPT_INVOCATION =
+  /(?:^|[\s;&|])(?:(?:bash|sh|source|\.)\s+)?((?:\.\/)?[\w./-]+\.sh)\b/g;
 
 /**
  * Commands that irreversibly destroy stored data. Every entry is a whole
@@ -116,6 +125,109 @@ function destructiveInvocations(command: string): string[] {
     .split(SHELL_INVOCATION_SEPARATOR)
     .map(part => part.trim())
     .filter(part => IRREVERSIBLE_DATA_OPS.some(pattern => pattern.test(part)));
+}
+
+/**
+ * Extract repo-relative shell scripts named directly by a workflow run step.
+ * @param command - Workflow step command
+ * @returns Unique repo-relative script paths
+ */
+function localScriptPaths(command: string): readonly string[] {
+  return [
+    ...new Set(
+      [...command.matchAll(LOCAL_SCRIPT_INVOCATION)].flatMap(match => {
+        const candidate = match[1];
+        if (candidate === undefined || candidate.includes("..")) {
+          return [];
+        }
+        return [candidate.replace(/^\.\//u, "")];
+      })
+    ),
+  ];
+}
+
+/**
+ * Read one bounded repo-local script for offline command expansion.
+ * @param root - Repository root
+ * @param relativePath - Repo-relative script path
+ * @returns Script content, or null when it cannot be safely read
+ */
+async function readLocalScript(
+  root: string,
+  relativePath: string
+): Promise<string | null> {
+  const rootPath = path.resolve(root);
+  const target = path.resolve(rootPath, relativePath);
+  if (!target.startsWith(`${rootPath}${path.sep}`)) {
+    return null;
+  }
+  try {
+    const content = await readFile(target, "utf8");
+    return content.length > MAX_LOCAL_SCRIPT_BYTES ? null : content;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Append any bounded local script bodies referenced by a workflow step.
+ * @param root - Repository root
+ * @param step - Parsed workflow step
+ * @returns Step with script bodies appended to `run`, when present
+ */
+async function expandLocalScriptStep(
+  root: string,
+  step: ParsedWorkflowStep
+): Promise<ParsedWorkflowStep> {
+  const scripts = await Promise.all(
+    localScriptPaths(step.run).map(
+      async script => await readLocalScript(root, script)
+    )
+  );
+  const scriptBodies = scripts.filter(
+    (content): content is string => content !== null
+  );
+  return scriptBodies.length === 0
+    ? step
+    : { ...step, run: [step.run, ...scriptBodies].join("\n") };
+}
+
+/**
+ * Expand directly invoked local shell scripts in one parsed job.
+ * @param root - Repository root
+ * @param job - Parsed workflow job
+ * @returns Job with script-expanded steps
+ */
+async function expandLocalScriptJob(
+  root: string,
+  job: ParsedWorkflowJob
+): Promise<ParsedWorkflowJob> {
+  return {
+    ...job,
+    steps: await Promise.all(
+      job.steps.map(async step => await expandLocalScriptStep(root, step))
+    ),
+  };
+}
+
+/**
+ * Inline directly invoked local shell scripts into the parsed workflow commands.
+ * @param root - Repository root
+ * @param workflows - Parsed workflow files
+ * @returns Workflows with bounded script content appended to matching steps
+ */
+async function expandLocalScriptCommands(
+  root: string,
+  workflows: readonly ParsedWorkflow[]
+): Promise<readonly ParsedWorkflow[]> {
+  return await Promise.all(
+    workflows.map(async workflow => ({
+      ...workflow,
+      jobs: await Promise.all(
+        workflow.jobs.map(async job => await expandLocalScriptJob(root, job))
+      ),
+    }))
+  );
 }
 
 /**
@@ -312,8 +424,9 @@ export async function assessDomainOwnershipDimension(
   root: string,
   parsedWorkflows?: readonly ParsedWorkflow[]
 ): Promise<ReadinessDimensionRecord> {
-  const workflows: readonly ParsedWorkflow[] =
+  const parsed: readonly ParsedWorkflow[] =
     parsedWorkflows ?? (await parseRepositoryWorkflows(root));
+  const workflows = await expandLocalScriptCommands(root, parsed);
   const scan = scanCommands(workflows, destroysData, {
     exemptStep: jobTakesBackupBeforeStep,
     unresolvedStep: servicesDeferral,

--- a/src/cli/doctor-readiness-local-scripts.ts
+++ b/src/cli/doctor-readiness-local-scripts.ts
@@ -1,0 +1,156 @@
+/**
+ * Bounded expansion of repo-local shell wrappers referenced by workflow run
+ * steps.
+ * @module cli/doctor-readiness-local-scripts
+ */
+import { open, realpath } from "node:fs/promises";
+import * as path from "node:path";
+import type {
+  ParsedWorkflow,
+  ParsedWorkflowJob,
+  ParsedWorkflowStep,
+} from "./doctor-readiness-workflows.js";
+
+/** Most bytes read from one local wrapper script during offline expansion. */
+const MAX_LOCAL_SCRIPT_BYTES = 16_384;
+
+/** Separators that end one shell invocation for this conservative scan. */
+const SHELL_INVOCATION_SEPARATOR = /\n|&&|\|\||[;&|]/;
+
+/** Shell commands that execute another shell script path. */
+const SHELL_SCRIPT_RUNNERS = new Set(["bash", "sh", "source", "."]);
+
+/**
+ * Extract repo-relative shell scripts named directly by a workflow run step.
+ * @param command - Workflow step command
+ * @returns Unique repo-relative script paths
+ */
+function localScriptPaths(command: string): readonly string[] {
+  return [
+    ...new Set(
+      command
+        .split(SHELL_INVOCATION_SEPARATOR)
+        .flatMap(invocation => {
+          const words = invocation.trim().split(/\s+/u);
+          if (words.length === 0 || words[0]?.startsWith("#")) {
+            return [];
+          }
+          const usesRunner = SHELL_SCRIPT_RUNNERS.has(words[0] ?? "");
+          const candidate = usesRunner ? words[1] : words[0];
+          if (
+            candidate === undefined ||
+            !candidate.endsWith(".sh") ||
+            candidate.includes("..")
+          ) {
+            return [];
+          }
+          if (
+            !usesRunner &&
+            !candidate.includes("/") &&
+            !candidate.startsWith("./")
+          ) {
+            return [];
+          }
+          return [candidate.replace(/^\.\//u, "")];
+        })
+        .filter(candidate => !candidate.startsWith("-"))
+    ),
+  ];
+}
+
+/**
+ * Read one bounded repo-local script for offline command expansion.
+ * @param root - Repository root
+ * @param relativePath - Repo-relative script path
+ * @returns Script content, or null when it cannot be safely read
+ */
+async function readLocalScript(
+  root: string,
+  relativePath: string
+): Promise<string | null> {
+  try {
+    const rootPath = await realpath(root);
+    const target = await realpath(path.resolve(rootPath, relativePath));
+    if (!target.startsWith(`${rootPath}${path.sep}`)) {
+      return null;
+    }
+    const file = await open(target, "r");
+    try {
+      const buffer = Buffer.alloc(MAX_LOCAL_SCRIPT_BYTES + 1);
+      const { bytesRead } = await file.read(
+        buffer,
+        0,
+        MAX_LOCAL_SCRIPT_BYTES + 1,
+        0
+      );
+      return bytesRead > MAX_LOCAL_SCRIPT_BYTES
+        ? null
+        : buffer.subarray(0, bytesRead).toString("utf8");
+    } finally {
+      await file.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Append any bounded local script bodies referenced by a workflow step.
+ * @param root - Repository root
+ * @param step - Parsed workflow step
+ * @returns Step with script bodies appended to `run`, when present
+ */
+async function expandLocalScriptStep(
+  root: string,
+  step: ParsedWorkflowStep
+): Promise<ParsedWorkflowStep> {
+  const scripts = await Promise.all(
+    localScriptPaths(step.run).map(
+      async script => await readLocalScript(root, script)
+    )
+  );
+  const scriptBodies = scripts.filter(
+    (content): content is string => content !== null
+  );
+  return scriptBodies.length === 0
+    ? step
+    : { ...step, run: [step.run, ...scriptBodies].join("\n") };
+}
+
+/**
+ * Expand directly invoked local shell scripts in one parsed job.
+ * @param root - Repository root
+ * @param job - Parsed workflow job
+ * @returns Job with script-expanded steps
+ */
+async function expandLocalScriptJob(
+  root: string,
+  job: ParsedWorkflowJob
+): Promise<ParsedWorkflowJob> {
+  return {
+    ...job,
+    steps: await Promise.all(
+      job.steps.map(async step => await expandLocalScriptStep(root, step))
+    ),
+  };
+}
+
+/**
+ * Inline directly invoked local shell scripts into the parsed workflow commands.
+ * @param root - Repository root
+ * @param workflows - Parsed workflow files
+ * @returns Workflows with bounded script content appended to matching steps
+ */
+export async function expandLocalScriptCommands(
+  root: string,
+  workflows: readonly ParsedWorkflow[]
+): Promise<readonly ParsedWorkflow[]> {
+  return await Promise.all(
+    workflows.map(async workflow => ({
+      ...workflow,
+      jobs: await Promise.all(
+        workflow.jobs.map(async job => await expandLocalScriptJob(root, job))
+      ),
+    }))
+  );
+}

--- a/src/cli/doctor-readiness-local-scripts.ts
+++ b/src/cli/doctor-readiness-local-scripts.ts
@@ -14,11 +14,91 @@ import type {
 /** Most bytes read from one local wrapper script during offline expansion. */
 const MAX_LOCAL_SCRIPT_BYTES = 16_384;
 
+/** Most wrapper scripts expanded across one readiness scan. */
+const MAX_LOCAL_SCRIPT_EXPANSIONS = 64;
+
 /** Separators that end one shell invocation for this conservative scan. */
 const SHELL_INVOCATION_SEPARATOR = /\n|&&|\|\||[;&|]/;
 
 /** Shell commands that execute another shell script path. */
 const SHELL_SCRIPT_RUNNERS = new Set(["bash", "sh", "source", "."]);
+
+/** Shell runners that accept option flags before the script path. */
+const OPTIONED_SHELL_RUNNERS = new Set(["bash", "sh"]);
+
+/** Prefix assignments that set env only for the following shell invocation. */
+const SHELL_ENV_ASSIGNMENT = /^[A-Za-z_]\w*=.*$/u;
+
+/** Shared budget carried through one workflow expansion scan. */
+interface ExpansionContext {
+  readonly remainingScripts: number;
+}
+
+/** Expansion result plus the remaining aggregate script budget. */
+interface ExpansionResult<T> {
+  readonly value: T;
+  readonly remainingScripts: number;
+}
+
+/**
+ * Whether a word is a shell-runner option rather than the script path.
+ * @param word - Shell token
+ * @returns True when the token should be skipped after bash/sh
+ */
+function isShellRunnerOption(word: string): boolean {
+  return word.startsWith("-") && word !== "-";
+}
+
+/**
+ * Find the first non-assignment token in one shell invocation.
+ * @param words - Whitespace-split shell invocation
+ * @param index - Current scan index
+ * @returns Index of the command token
+ */
+function firstCommandIndex(words: readonly string[], index = 0): number {
+  return SHELL_ENV_ASSIGNMENT.test(words[index] ?? "")
+    ? firstCommandIndex(words, index + 1)
+    : index;
+}
+
+/**
+ * Find the first non-option script argument after a shell runner.
+ * @param words - Whitespace-split shell invocation
+ * @param index - Current scan index
+ * @returns Index of the script argument
+ */
+function firstShellScriptIndex(
+  words: readonly string[],
+  index: number
+): number {
+  return isShellRunnerOption(words[index] ?? "")
+    ? firstShellScriptIndex(words, index + 1)
+    : index;
+}
+
+/**
+ * Locate the word in one invocation that names the script to expand.
+ * @param words - Whitespace-split shell invocation
+ * @returns Script word and whether a shell runner selected it
+ */
+function scriptCandidate(
+  words: readonly string[]
+): { candidate: string; usesRunner: boolean } | null {
+  const index = firstCommandIndex(words);
+  const command = words[index];
+  if (command === undefined) {
+    return null;
+  }
+  const usesRunner = SHELL_SCRIPT_RUNNERS.has(command);
+  if (!usesRunner) {
+    return { candidate: command, usesRunner };
+  }
+  const candidateIndex = OPTIONED_SHELL_RUNNERS.has(command)
+    ? firstShellScriptIndex(words, index + 1)
+    : index + 1;
+  const candidate = words[candidateIndex];
+  return candidate === undefined ? null : { candidate, usesRunner };
+}
 
 /**
  * Extract repo-relative shell scripts named directly by a workflow run step.
@@ -35,8 +115,11 @@ function localScriptPaths(command: string): readonly string[] {
           if (words.length === 0 || words[0]?.startsWith("#")) {
             return [];
           }
-          const usesRunner = SHELL_SCRIPT_RUNNERS.has(words[0] ?? "");
-          const candidate = usesRunner ? words[1] : words[0];
+          const parsed = scriptCandidate(words);
+          if (parsed === null) {
+            return [];
+          }
+          const candidate = parsed?.candidate;
           if (
             candidate === undefined ||
             !candidate.endsWith(".sh") ||
@@ -45,7 +128,7 @@ function localScriptPaths(command: string): readonly string[] {
             return [];
           }
           if (
-            !usesRunner &&
+            !parsed.usesRunner &&
             !candidate.includes("/") &&
             !candidate.startsWith("./")
           ) {
@@ -98,40 +181,101 @@ async function readLocalScript(
  * Append any bounded local script bodies referenced by a workflow step.
  * @param root - Repository root
  * @param step - Parsed workflow step
+ * @param context - Shared expansion budget
  * @returns Step with script bodies appended to `run`, when present
  */
 async function expandLocalScriptStep(
   root: string,
-  step: ParsedWorkflowStep
-): Promise<ParsedWorkflowStep> {
-  const scripts = await Promise.all(
-    localScriptPaths(step.run).map(
-      async script => await readLocalScript(root, script)
-    )
+  step: ParsedWorkflowStep,
+  context: ExpansionContext
+): Promise<ExpansionResult<ParsedWorkflowStep>> {
+  const expanded = await expandLocalScriptBodies(
+    root,
+    localScriptPaths(step.run),
+    context.remainingScripts
   );
-  const scriptBodies = scripts.filter(
-    (content): content is string => content !== null
+  return {
+    remainingScripts: expanded.remainingScripts,
+    value:
+      expanded.value.length === 0
+        ? step
+        : { ...step, run: [step.run, ...expanded.value].join("\n") },
+  };
+}
+
+/**
+ * Read script bodies sequentially under the aggregate expansion budget.
+ * @param root - Repository root
+ * @param scripts - Candidate script paths
+ * @param remainingScripts - Remaining aggregate expansion budget
+ * @returns Expanded script bodies and updated budget
+ */
+async function expandLocalScriptBodies(
+  root: string,
+  scripts: readonly string[],
+  remainingScripts: number
+): Promise<ExpansionResult<readonly string[]>> {
+  const [script, ...rest] = scripts;
+  if (script === undefined || remainingScripts <= 0) {
+    return { value: [], remainingScripts };
+  }
+  const content = await readLocalScript(root, script);
+  const expanded = await expandLocalScriptBodies(
+    root,
+    rest,
+    remainingScripts - 1
   );
-  return scriptBodies.length === 0
-    ? step
-    : { ...step, run: [step.run, ...scriptBodies].join("\n") };
+  return {
+    remainingScripts: expanded.remainingScripts,
+    value: content === null ? expanded.value : [content, ...expanded.value],
+  };
 }
 
 /**
  * Expand directly invoked local shell scripts in one parsed job.
  * @param root - Repository root
  * @param job - Parsed workflow job
+ * @param context - Shared expansion budget
  * @returns Job with script-expanded steps
  */
 async function expandLocalScriptJob(
   root: string,
-  job: ParsedWorkflowJob
-): Promise<ParsedWorkflowJob> {
+  job: ParsedWorkflowJob,
+  context: ExpansionContext
+): Promise<ExpansionResult<ParsedWorkflowJob>> {
+  const expanded = await expandLocalScriptSteps(root, job.steps, context);
   return {
-    ...job,
-    steps: await Promise.all(
-      job.steps.map(async step => await expandLocalScriptStep(root, step))
-    ),
+    remainingScripts: expanded.remainingScripts,
+    value: {
+      ...job,
+      steps: expanded.value,
+    },
+  };
+}
+
+/**
+ * Expand local scripts across a job's steps under the shared budget.
+ * @param root - Repository root
+ * @param steps - Parsed workflow steps
+ * @param context - Shared expansion budget
+ * @returns Expanded steps and updated budget
+ */
+async function expandLocalScriptSteps(
+  root: string,
+  steps: readonly ParsedWorkflowStep[],
+  context: ExpansionContext
+): Promise<ExpansionResult<readonly ParsedWorkflowStep[]>> {
+  const [step, ...rest] = steps;
+  if (step === undefined) {
+    return { value: [], remainingScripts: context.remainingScripts };
+  }
+  const expandedStep = await expandLocalScriptStep(root, step, context);
+  const expandedRest = await expandLocalScriptSteps(root, rest, {
+    remainingScripts: expandedStep.remainingScripts,
+  });
+  return {
+    remainingScripts: expandedRest.remainingScripts,
+    value: [expandedStep.value, ...expandedRest.value],
   };
 }
 
@@ -145,12 +289,70 @@ export async function expandLocalScriptCommands(
   root: string,
   workflows: readonly ParsedWorkflow[]
 ): Promise<readonly ParsedWorkflow[]> {
-  return await Promise.all(
-    workflows.map(async workflow => ({
-      ...workflow,
-      jobs: await Promise.all(
-        workflow.jobs.map(async job => await expandLocalScriptJob(root, job))
-      ),
-    }))
+  const expanded = await expandLocalScriptWorkflows(root, workflows, {
+    remainingScripts: MAX_LOCAL_SCRIPT_EXPANSIONS,
+  });
+  return expanded.value;
+}
+
+/**
+ * Expand local scripts across workflows under the shared budget.
+ * @param root - Repository root
+ * @param workflows - Parsed workflow files
+ * @param context - Shared expansion budget
+ * @returns Expanded workflows and updated budget
+ */
+async function expandLocalScriptWorkflows(
+  root: string,
+  workflows: readonly ParsedWorkflow[],
+  context: ExpansionContext
+): Promise<ExpansionResult<readonly ParsedWorkflow[]>> {
+  const [workflow, ...rest] = workflows;
+  if (workflow === undefined) {
+    return { value: [], remainingScripts: context.remainingScripts };
+  }
+  const expandedJobs = await expandLocalScriptJobs(
+    root,
+    workflow.jobs,
+    context
   );
+  const expandedRest = await expandLocalScriptWorkflows(root, rest, {
+    remainingScripts: expandedJobs.remainingScripts,
+  });
+  return {
+    remainingScripts: expandedRest.remainingScripts,
+    value: [
+      {
+        ...workflow,
+        jobs: expandedJobs.value,
+      },
+      ...expandedRest.value,
+    ],
+  };
+}
+
+/**
+ * Expand local scripts across workflow jobs under the shared budget.
+ * @param root - Repository root
+ * @param jobs - Parsed workflow jobs
+ * @param context - Shared expansion budget
+ * @returns Expanded jobs and updated budget
+ */
+async function expandLocalScriptJobs(
+  root: string,
+  jobs: readonly ParsedWorkflowJob[],
+  context: ExpansionContext
+): Promise<ExpansionResult<readonly ParsedWorkflowJob[]>> {
+  const [job, ...rest] = jobs;
+  if (job === undefined) {
+    return { value: [], remainingScripts: context.remainingScripts };
+  }
+  const expandedJob = await expandLocalScriptJob(root, job, context);
+  const expandedRest = await expandLocalScriptJobs(root, rest, {
+    remainingScripts: expandedJob.remainingScripts,
+  });
+  return {
+    remainingScripts: expandedRest.remainingScripts,
+    value: [expandedJob.value, ...expandedRest.value],
+  };
 }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7851,6 +7851,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/doctor-readiness-guardrails-wrappers.test.ts": true,
     "tests/unit/cli/doctor-readiness-guardrails.test.ts": true,
     "tests/unit/cli/doctor-readiness-journey.test.ts": true,
+    "tests/unit/cli/doctor-readiness-local-scripts.test.ts": true,
     "tests/unit/cli/doctor-readiness-supply-chain-exceptions.test.ts": true,
     "tests/unit/cli/doctor-readiness-supply-chain-go.test.ts": true,
     "tests/unit/cli/doctor-readiness-supply-chain-install-gate.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7446,6 +7446,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/cli/doctor-readiness-guardrails.ts": true,
     "src/cli/doctor-readiness-journey-freshness.ts": true,
     "src/cli/doctor-readiness-journey.ts": true,
+    "src/cli/doctor-readiness-local-scripts.ts": true,
     "src/cli/doctor-readiness-operations.ts": true,
     "src/cli/doctor-readiness-promoted-artifact.ts": true,
     "src/cli/doctor-readiness-release-path.ts": true,

--- a/tests/unit/cli/doctor-readiness-domain.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain.test.ts
@@ -53,12 +53,6 @@ const WIPE_JOB = "  wipe:";
 const RUN_S3_WIPE =
   "      - run: aws s3 rm s3://acme-prod-user-uploads --recursive";
 
-/** A repo-local wrapper script used by B1 script-expansion fixtures. */
-const TEARDOWN_SCRIPT = "scripts/teardown-prod.sh";
-
-/** A destructive SQL command used by B1 script-expansion fixtures. */
-const DROP_TABLE_COMMAND = 'psql "$DATABASE_URL" -c "DROP TABLE users"';
-
 let tempDir: string | undefined;
 
 /**
@@ -226,111 +220,6 @@ describe("assessDomainOwnershipDimension — B1 stands only on a provable path",
       RUNS_ON,
       STEPS,
       `      - run: ${command}`,
-    ]);
-
-    const record = await assessDomainOwnershipDimension(root);
-
-    expect(record.status).toBe(WARN);
-    expect(
-      asFindings(record.findings).some(
-        finding => finding.blocker === BLOCKER_ID
-      )
-    ).toBe(true);
-  });
-
-  // Test hardened to kill mutant M001 (Risk Factor: Data loss / wrapper script visibility).
-  it("stands B1 when a workflow hides the destructive command inside a local script", async () => {
-    const root = await getTempDir();
-    await writeRepoFile(
-      root,
-      TEARDOWN_SCRIPT,
-      ["#!/usr/bin/env bash", "set -euo pipefail", DROP_TABLE_COMMAND].join(
-        "\n"
-      )
-    );
-    await writeWorkflow(root, CLEANUP_YML, [
-      CLEANUP_NAME,
-      ON_PUSH,
-      JOBS,
-      WIPE_JOB,
-      RUNS_ON,
-      STEPS,
-      "      - run: ./scripts/teardown-prod.sh",
-    ]);
-
-    const record = await assessDomainOwnershipDimension(root);
-
-    expect(record.status).toBe(WARN);
-    expect(
-      asFindings(record.findings).some(
-        finding => finding.blocker === BLOCKER_ID
-      )
-    ).toBe(true);
-  });
-
-  it("ignores oversized local wrapper scripts instead of decoding them", async () => {
-    const root = await getTempDir();
-    await writeRepoFile(
-      root,
-      TEARDOWN_SCRIPT,
-      `${"a".repeat(16_385)}\nDROP TABLE users`
-    );
-    await writeWorkflow(root, CLEANUP_YML, [
-      CLEANUP_NAME,
-      ON_PUSH,
-      JOBS,
-      WIPE_JOB,
-      RUNS_ON,
-      STEPS,
-      "      - run: ./scripts/teardown-prod.sh",
-    ]);
-
-    const record = await assessDomainOwnershipDimension(root);
-
-    expect(record.status).toBe(SKIP);
-    expect(
-      asFindings(record.findings).some(
-        finding => finding.blocker === BLOCKER_ID
-      )
-    ).toBe(false);
-  });
-
-  it("does not expand local script paths that are only echoed or commented", async () => {
-    const root = await getTempDir();
-    await writeRepoFile(root, TEARDOWN_SCRIPT, DROP_TABLE_COMMAND);
-    await writeWorkflow(root, CLEANUP_YML, [
-      CLEANUP_NAME,
-      ON_PUSH,
-      JOBS,
-      WIPE_JOB,
-      RUNS_ON,
-      STEPS,
-      "      - run: |",
-      "          echo ./scripts/teardown-prod.sh",
-      "          # ./scripts/teardown-prod.sh",
-    ]);
-
-    const record = await assessDomainOwnershipDimension(root);
-
-    expect(record.status).toBe(SKIP);
-    expect(
-      asFindings(record.findings).some(
-        finding => finding.blocker === BLOCKER_ID
-      )
-    ).toBe(false);
-  });
-
-  it("expands top-level scripts when an explicit shell runner invokes them", async () => {
-    const root = await getTempDir();
-    await writeRepoFile(root, "teardown-prod.sh", DROP_TABLE_COMMAND);
-    await writeWorkflow(root, CLEANUP_YML, [
-      CLEANUP_NAME,
-      ON_PUSH,
-      JOBS,
-      WIPE_JOB,
-      RUNS_ON,
-      STEPS,
-      "      - run: bash teardown-prod.sh",
     ]);
 
     const record = await assessDomainOwnershipDimension(root);

--- a/tests/unit/cli/doctor-readiness-domain.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain.test.ts
@@ -53,6 +53,12 @@ const WIPE_JOB = "  wipe:";
 const RUN_S3_WIPE =
   "      - run: aws s3 rm s3://acme-prod-user-uploads --recursive";
 
+/** A repo-local wrapper script used by B1 script-expansion fixtures. */
+const TEARDOWN_SCRIPT = "scripts/teardown-prod.sh";
+
+/** A destructive SQL command used by B1 script-expansion fixtures. */
+const DROP_TABLE_COMMAND = 'psql "$DATABASE_URL" -c "DROP TABLE users"';
+
 let tempDir: string | undefined;
 
 /**
@@ -237,12 +243,10 @@ describe("assessDomainOwnershipDimension — B1 stands only on a provable path",
     const root = await getTempDir();
     await writeRepoFile(
       root,
-      "scripts/teardown-prod.sh",
-      [
-        "#!/usr/bin/env bash",
-        "set -euo pipefail",
-        'psql "$DATABASE_URL" -c "DROP TABLE users"',
-      ].join("\n")
+      TEARDOWN_SCRIPT,
+      ["#!/usr/bin/env bash", "set -euo pipefail", DROP_TABLE_COMMAND].join(
+        "\n"
+      )
     );
     await writeWorkflow(root, CLEANUP_YML, [
       CLEANUP_NAME,
@@ -252,6 +256,81 @@ describe("assessDomainOwnershipDimension — B1 stands only on a provable path",
       RUNS_ON,
       STEPS,
       "      - run: ./scripts/teardown-prod.sh",
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+  });
+
+  it("ignores oversized local wrapper scripts instead of decoding them", async () => {
+    const root = await getTempDir();
+    await writeRepoFile(
+      root,
+      TEARDOWN_SCRIPT,
+      `${"a".repeat(16_385)}\nDROP TABLE users`
+    );
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: ./scripts/teardown-prod.sh",
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(SKIP);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(false);
+  });
+
+  it("does not expand local script paths that are only echoed or commented", async () => {
+    const root = await getTempDir();
+    await writeRepoFile(root, TEARDOWN_SCRIPT, DROP_TABLE_COMMAND);
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: |",
+      "          echo ./scripts/teardown-prod.sh",
+      "          # ./scripts/teardown-prod.sh",
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(SKIP);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(false);
+  });
+
+  it("expands top-level scripts when an explicit shell runner invokes them", async () => {
+    const root = await getTempDir();
+    await writeRepoFile(root, "teardown-prod.sh", DROP_TABLE_COMMAND);
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: bash teardown-prod.sh",
     ]);
 
     const record = await assessDomainOwnershipDimension(root);

--- a/tests/unit/cli/doctor-readiness-domain.test.ts
+++ b/tests/unit/cli/doctor-readiness-domain.test.ts
@@ -231,6 +231,38 @@ describe("assessDomainOwnershipDimension — B1 stands only on a provable path",
       )
     ).toBe(true);
   });
+
+  // Test hardened to kill mutant M001 (Risk Factor: Data loss / wrapper script visibility).
+  it("stands B1 when a workflow hides the destructive command inside a local script", async () => {
+    const root = await getTempDir();
+    await writeRepoFile(
+      root,
+      "scripts/teardown-prod.sh",
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'psql "$DATABASE_URL" -c "DROP TABLE users"',
+      ].join("\n")
+    );
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: ./scripts/teardown-prod.sh",
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+  });
 });
 
 describe("assessDomainOwnershipDimension — reports silence as silence", () => {

--- a/tests/unit/cli/doctor-readiness-local-scripts.test.ts
+++ b/tests/unit/cli/doctor-readiness-local-scripts.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Unit coverage for bounded local wrapper-script expansion in the B1
+ * domain-ownership readiness producer.
+ * @module tests/unit/cli/doctor-readiness-local-scripts
+ */
+import { rm } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { assessDomainOwnershipDimension } from "../../../src/cli/doctor-readiness-domain.js";
+import {
+  asFindings,
+  JOBS,
+  makeScratchRepo,
+  ON_PUSH,
+  RUNS_ON,
+  SKIP,
+  STEPS,
+  WARN,
+  writeRepoFile,
+  writeWorkflow,
+} from "../../helpers/readiness-workflow-fixtures.js";
+
+/** The ship blocker this producer can stand up. */
+const BLOCKER_ID = "B1";
+
+/** The workflow file every fixture in this suite writes. */
+const CLEANUP_YML = "cleanup.yml";
+
+/** The workflow `name:` line every fixture in this suite writes. */
+const CLEANUP_NAME = "name: Cleanup";
+
+/** A destructive job header reused across fixtures. */
+const WIPE_JOB = "  wipe:";
+
+/** A repo-local wrapper script used by B1 script-expansion fixtures. */
+const TEARDOWN_SCRIPT = "scripts/teardown-prod.sh";
+
+/** A destructive SQL command used by B1 script-expansion fixtures. */
+const DROP_TABLE_COMMAND = 'psql "$DATABASE_URL" -c "DROP TABLE users"';
+
+let tempDir: string | undefined;
+
+/**
+ * Resolve a scratch repository for one test case.
+ * @returns Temporary directory path
+ */
+async function getTempDir(): Promise<string> {
+  tempDir ??= await makeScratchRepo("local-scripts");
+  return tempDir;
+}
+
+afterEach(async () => {
+  if (tempDir !== undefined) {
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+describe("assessDomainOwnershipDimension — local wrapper script expansion", () => {
+  // Test hardened to kill mutant M001 (Risk Factor: Data loss / wrapper script visibility).
+  it("stands B1 when a workflow hides the destructive command inside a local script", async () => {
+    const root = await getTempDir();
+    await writeRepoFile(
+      root,
+      TEARDOWN_SCRIPT,
+      ["#!/usr/bin/env bash", "set -euo pipefail", DROP_TABLE_COMMAND].join(
+        "\n"
+      )
+    );
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: ./scripts/teardown-prod.sh",
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+  });
+
+  // Test hardened to kill mutant M002 (Risk Factor: Availability / oversized wrapper script allocation).
+  it("ignores oversized local wrapper scripts instead of decoding them", async () => {
+    const root = await getTempDir();
+    await writeRepoFile(
+      root,
+      TEARDOWN_SCRIPT,
+      `${"a".repeat(16_385)}\nDROP TABLE users`
+    );
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: ./scripts/teardown-prod.sh",
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(SKIP);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(false);
+  });
+
+  // Test hardened to kill mutant M003 (Risk Factor: Data loss / non-invoked wrapper false positive).
+  it("does not expand local script paths that are only echoed or commented", async () => {
+    const root = await getTempDir();
+    await writeRepoFile(root, TEARDOWN_SCRIPT, DROP_TABLE_COMMAND);
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: |",
+      "          echo ./scripts/teardown-prod.sh",
+      "          # ./scripts/teardown-prod.sh",
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(SKIP);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(false);
+  });
+
+  // Test hardened to kill mutant M004 (Risk Factor: Data loss / explicit shell runner visibility).
+  it("expands top-level scripts when an explicit shell runner invokes them", async () => {
+    const root = await getTempDir();
+    await writeRepoFile(root, "teardown-prod.sh", DROP_TABLE_COMMAND);
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: bash teardown-prod.sh",
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+  });
+
+  // Test hardened to kill mutant M005 (Risk Factor: Data loss / env-prefixed wrapper visibility).
+  it("expands local scripts after environment assignment prefixes", async () => {
+    const root = await getTempDir();
+    await writeRepoFile(root, TEARDOWN_SCRIPT, DROP_TABLE_COMMAND);
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: DATABASE_URL=postgres://prod ./scripts/teardown-prod.sh",
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+  });
+
+  // Test hardened to kill mutant M006 (Risk Factor: Data loss / shell runner option visibility).
+  it("expands local scripts after shell runner options", async () => {
+    const root = await getTempDir();
+    await writeRepoFile(root, TEARDOWN_SCRIPT, DROP_TABLE_COMMAND);
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: bash -e ./scripts/teardown-prod.sh",
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(WARN);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(true);
+  });
+
+  // Test hardened to kill mutant M007 (Risk Factor: Availability / aggregate wrapper expansion budget).
+  it("caps aggregate local wrapper expansion across one scan", async () => {
+    const root = await getTempDir();
+    const indices = Array.from({ length: 65 }, (_value, index) => index);
+    await Promise.all(
+      indices.map(async index => {
+        const script = `scripts/wrapper-${index}.sh`;
+        await writeRepoFile(
+          root,
+          script,
+          index === 64 ? DROP_TABLE_COMMAND : "echo safe"
+        );
+      })
+    );
+    await writeWorkflow(root, CLEANUP_YML, [
+      CLEANUP_NAME,
+      ON_PUSH,
+      JOBS,
+      WIPE_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: |",
+      ...indices.map(index => `          ./scripts/wrapper-${index}.sh`),
+    ]);
+
+    const record = await assessDomainOwnershipDimension(root);
+
+    expect(record.status).toBe(SKIP);
+    expect(
+      asFindings(record.findings).some(
+        finding => finding.blocker === BLOCKER_ID
+      )
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Hardens B1 wrapper-script expansion to scan only actual local shell invocations, including explicit shell runners and direct repo-local script execution.
- Rejects oversized wrapper scripts before UTF-8 decoding and validates script containment with realpath before reading.
- Adds regression coverage for oversized scripts, echoed/commented script paths, and explicit shell runner invocation.

## Verification

- `bun test tests/unit/cli/doctor-readiness-domain.test.ts`
- `bun run lint -- src/cli/doctor-readiness-domain.ts src/cli/doctor-readiness-local-scripts.ts tests/unit/cli/doctor-readiness-domain.test.ts`
- `bun run typecheck`
- pre-push: typecheck, production audit, slow lint, knip, full unit coverage, integration tests, plugin parity

Refs #1903

Work-Item: CodySwannGT/lisa#1903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline readiness analysis to detect destructive commands when workflows invoke repository-local `.sh` wrapper scripts.
  * Added safer local-script expansion with validation (e.g., only allowed `.sh` paths under the repo root) and bounded reads to avoid unsafe/oversized script handling.
* **Tests**
  * Expanded coverage for workflow-invoked local scripts, including cases where destructive commands should be detected, as well as cases where expansion is skipped for oversized, echoed/commented, or only top-level explicitly invoked scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->