### PR TITLE
fix(readiness): match promoted artifact names

### DIFF
--- a/src/cli/doctor-readiness-promoted-artifact.ts
+++ b/src/cli/doctor-readiness-promoted-artifact.ts
@@ -10,6 +10,45 @@ import type { ReleasePathOutcome } from "./doctor-readiness-release-path.js";
 
 /** The GitHub Actions promotion step Lisa recognizes for CI-built artifacts. */
 export const PROMOTION_ACTION = "actions/download-artifact";
+const DOCKER_BUILD_PUSH_ACTION = "docker/build-push-action";
+const GITHUB_RELEASE_ACTION = "softprops/action-gh-release";
+const PYPI_PUBLISH_ACTION = "pypa/gh-action-pypi-publish";
+const UPLOAD_ARTIFACT_ACTION = "actions/upload-artifact";
+
+/**
+ * Normalize an action reference to its owner/repo component.
+ * @param uses - Raw `uses:` value
+ * @returns Lowercase action id without an `@ref`
+ */
+function actionId(uses: string): string {
+  return (uses.split("@")[0] ?? "").trim().toLowerCase();
+}
+
+/**
+ * Whether a serialized `with:` block sets a boolean option to true.
+ * @param inputs - Flattened step inputs
+ * @param name - Input name to read
+ * @returns True when the option is explicitly true
+ */
+function hasTrueInput(inputs: string, name: string): boolean {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(^|\\n)${escaped}:\\s*['"]?true['"]?(\\s|$)`, "i").test(
+    inputs
+  );
+}
+
+/**
+ * Whether an action step publishes something externally.
+ * @param step - The step to classify
+ * @returns True when the action is a known publishing action
+ */
+export function isPublishAction(step: ParsedWorkflowStep): boolean {
+  const id = actionId(step.uses);
+  if (id === DOCKER_BUILD_PUSH_ACTION) {
+    return hasTrueInput(step.inputs, "push");
+  }
+  return id === PYPI_PUBLISH_ACTION || id === GITHUB_RELEASE_ACTION;
+}
 
 /**
  * Whether an action reference is the trusted artifact-promotion action.
@@ -17,23 +56,111 @@ export const PROMOTION_ACTION = "actions/download-artifact";
  * @returns True when the action id is exactly actions/download-artifact
  */
 export function isPromotionAction(uses: string): boolean {
-  const actionId = uses.split("@")[0]?.trim();
-  return actionId === PROMOTION_ACTION;
+  return actionId(uses) === PROMOTION_ACTION;
+}
+
+/**
+ * Whether an action reference uploads an artifact produced by CI.
+ * @param uses - Raw action reference
+ * @returns True when the action id is exactly actions/upload-artifact
+ */
+function isUploadAction(uses: string): boolean {
+  return actionId(uses) === UPLOAD_ARTIFACT_ACTION;
+}
+
+/**
+ * Read a scalar step input from the parser's flattened `with:` text.
+ * @param inputs - Flattened step inputs
+ * @param name - Input name to read
+ * @returns The input value, or null when absent
+ */
+function stepInput(inputs: string, name: string): string | null {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`(^|\\n)${escaped}:\\s*(.+)(\\n|$)`).exec(inputs);
+  const value = match?.[2]?.trim();
+  if (value === undefined || value === "") {
+    return null;
+  }
+  return value.replace(/^['"]|['"]$/g, "");
+}
+
+/**
+ * List artifact names uploaded by jobs whose outputs have already been validated.
+ * @param validatingAncestorJobs - Validating jobs in the publishing job's `needs:` closure
+ * @returns Uploaded artifact names
+ */
+function uploadedArtifactNames(
+  validatingAncestorJobs: readonly ParsedWorkflowJob[]
+): Set<string> {
+  return new Set(
+    validatingAncestorJobs.flatMap(job =>
+      job.steps
+        .filter(step => isUploadAction(step.uses))
+        .map(step => stepInput(step.inputs, "name"))
+        .filter((name): name is string => name !== null)
+    )
+  );
 }
 
 /**
  * Whether the job promotes an artifact produced by another job.
  * @param job - The publishing job
  * @param publishStep - The step that ships
+ * @param ancestorJobs - Jobs in the publishing job's `needs:` closure
  * @returns True when a download-artifact step is present before publication
  */
 export function promotesValidatedArtifact(
   job: ParsedWorkflowJob,
-  publishStep: ParsedWorkflowStep
+  publishStep: ParsedWorkflowStep,
+  ancestorJobs: readonly ParsedWorkflowJob[] = []
 ): boolean {
-  return job.steps
-    .slice(0, job.steps.indexOf(publishStep))
-    .some(step => isPromotionAction(step.uses));
+  const uploads = uploadedArtifactNames(ancestorJobs);
+  return job.steps.slice(0, job.steps.indexOf(publishStep)).some(step => {
+    if (!isPromotionAction(step.uses)) {
+      return false;
+    }
+    const downloadName = stepInput(step.inputs, "name");
+    return (
+      downloadName === null || uploads.size === 0 || uploads.has(downloadName)
+    );
+  });
+}
+
+/**
+ * Whether a named artifact download disagrees with named ancestor uploads.
+ * @param job - The publishing job
+ * @param publishStep - The step that ships
+ * @param ancestorJobs - Jobs in the publishing job's `needs:` closure
+ * @returns True when the downloaded artifact name is not uploaded by any ancestor
+ */
+export function hasArtifactNameMismatch(
+  job: ParsedWorkflowJob,
+  publishStep: ParsedWorkflowStep,
+  ancestorJobs: readonly ParsedWorkflowJob[]
+): boolean {
+  const uploads = uploadedArtifactNames(ancestorJobs);
+  return job.steps.slice(0, job.steps.indexOf(publishStep)).some(step => {
+    if (!isPromotionAction(step.uses)) {
+      return false;
+    }
+    const downloadName = stepInput(step.inputs, "name");
+    return downloadName !== null && !uploads.has(downloadName);
+  });
+}
+
+/**
+ * The release job downloaded a named artifact different from anything a
+ * validating ancestor uploaded, so the shipped bytes are not the tested bytes.
+ * @param where - Evidence location label
+ * @returns The violation outcome
+ */
+export function artifactNameMismatch(where: string): ReleasePathOutcome {
+  return {
+    kind: "violation",
+    evidence:
+      `${where} downloads a named artifact that no validating ancestor uploads, ` +
+      "so the release path cannot prove the shipped artifact is the one CI tested",
+  };
 }
 
 /**

--- a/src/cli/doctor-readiness-release-path.ts
+++ b/src/cli/doctor-readiness-release-path.ts
@@ -9,10 +9,13 @@ import type {
   ParsedWorkflowStep,
 } from "./doctor-readiness-workflows.js";
 import {
-  ancestorJobs,
+  ancestorJobs as ancestors,
   reusableCallerValidation,
 } from "./doctor-readiness-reusable-callers.js";
 import {
+  artifactNameMismatch,
+  hasArtifactNameMismatch,
+  isPublishAction,
   isPromotionAction,
   promotesValidatedArtifact,
   PROMOTION_ACTION,
@@ -21,18 +24,10 @@ import {
 
 export { PROMOTION_ACTION } from "./doctor-readiness-promoted-artifact.js";
 
-const PUBLISH_VERBS = [
-  "npm publish",
-  "docker push",
-  "gh release upload",
-  "aws s3 sync",
-  "cdk deploy",
-  "eas submit",
-];
+const PUBLISH_VERB =
+  /(npm publish|docker push|gh release upload|aws s3 sync|cdk deploy|eas submit)/;
 
 const DOCKER_BUILD_PUSH_ACTION = "docker/build-push-action";
-const PYPI_PUBLISH_ACTION = "pypa/gh-action-pypi-publish";
-const GITHUB_RELEASE_ACTION = "softprops/action-gh-release";
 
 /** Commands that actually run a test suite. */
 const VALIDATING_COMMANDS: readonly RegExp[] = [
@@ -146,32 +141,6 @@ function actionId(uses: string): string {
 }
 
 /**
- * Whether a serialized `with:` block sets a boolean option to true.
- * @param inputs - Flattened step inputs
- * @param name - Input name to read
- * @returns True when the option is explicitly true
- */
-function hasTrueInput(inputs: string, name: string): boolean {
-  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`(^|\\n)${escaped}:\\s*['"]?true['"]?(\\s|$)`, "i").test(
-    inputs
-  );
-}
-
-/**
- * Whether an action step publishes something externally.
- * @param step - The step to classify
- * @returns True when the action is a known publishing action
- */
-function isPublishAction(step: ParsedWorkflowStep): boolean {
-  const id = actionId(step.uses);
-  if (id === DOCKER_BUILD_PUSH_ACTION) {
-    return hasTrueInput(step.inputs, "push");
-  }
-  return id === PYPI_PUBLISH_ACTION || id === GITHUB_RELEASE_ACTION;
-}
-
-/**
  * Whether a step actually puts an artifact in front of users. A `--dry-run`
  * invocation names a publish verb but ships nothing, so faulting its release
  * path would be a finding about something that cannot reach anyone.
@@ -180,8 +149,7 @@ function isPublishAction(step: ParsedWorkflowStep): boolean {
  */
 function isPublishStep(step: ParsedWorkflowStep): boolean {
   return (
-    (PUBLISH_VERBS.some(verb => step.run.includes(verb)) &&
-      !DRY_RUN_FLAG.test(step.run)) ||
+    (PUBLISH_VERB.test(step.run) && !DRY_RUN_FLAG.test(step.run)) ||
     isPublishAction(step)
   );
 }
@@ -234,7 +202,7 @@ function validationPrecedesPublish(
   ) {
     return true;
   }
-  if (ancestorJobs(workflow, job).some(isValidatingJob)) {
+  if (ancestors(workflow, job).some(isValidatingJob)) {
     return true;
   }
   return job.steps
@@ -358,6 +326,9 @@ export function assessReleasePaths(
 ): readonly ReleasePathOutcome[] {
   return findPublishSteps(job).map(publishStep => {
     const where = `${workflow.file} job \`${job.id}\` step \`${describeStep(publishStep)}\``;
+    const validatingAncestors = ancestors(workflow, job).filter(
+      isValidatingJob
+    );
     const validated = validationPrecedesPublish(
       workflow,
       job,
@@ -369,10 +340,16 @@ export function assessReleasePaths(
         ? rebuildPastValidation(where)
         : unvalidatedSelfBuild(where, workflow, defaultBranches, allWorkflows);
     }
+    if (
+      validated &&
+      hasArtifactNameMismatch(job, publishStep, validatingAncestors)
+    ) {
+      return artifactNameMismatch(where);
+    }
     if (validated) {
       return { kind: "clean" };
     }
-    if (promotesValidatedArtifact(job, publishStep))
+    if (promotesValidatedArtifact(job, publishStep, validatingAncestors))
       return unresolvedPromotedArtifact(where);
     // Neither built here nor promoted from CI, and nothing validating precedes it:
     // the link between what ships and what was validated is simply not observable

--- a/tests/unit/cli/doctor-readiness-delivery-promotion.test.ts
+++ b/tests/unit/cli/doctor-readiness-delivery-promotion.test.ts
@@ -92,4 +92,77 @@ describe("assessDeliveryAuthorityDimension — promoted artifact integrity", () 
       "builds its own artifact and ships it"
     );
   });
+
+  it("FAILs when release downloads a different named artifact than CI uploaded", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, RELEASE_YML, [
+      RELEASE_NAME,
+      ON,
+      PUSH,
+      TAGS,
+      JOBS,
+      "  test:",
+      RUNS_ON,
+      STEPS,
+      "      - run: npm test",
+      "      - uses: actions/upload-artifact@0123456789abcdef0123456789abcdef01234567",
+      "        with:",
+      "          name: tested-package",
+      "          path: dist",
+      PUBLISH_JOB,
+      "    needs: [test]",
+      RUNS_ON,
+      STEPS,
+      `      - uses: ${PINNED_DOWNLOAD_ARTIFACT}`,
+      "        with:",
+      "          name: untested-package",
+      RUN_PUBLISH,
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    expect(assessReadiness([record]).blockers[0]?.id).toBe("B2");
+    expect(String(asFindings(record.findings)[0].evidence)).toContain(
+      "no validating ancestor uploads"
+    );
+  });
+
+  it("FAILs when only a non-validating ancestor uploaded the downloaded artifact", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, RELEASE_YML, [
+      RELEASE_NAME,
+      ON,
+      PUSH,
+      TAGS,
+      JOBS,
+      "  test:",
+      RUNS_ON,
+      STEPS,
+      "      - run: npm test",
+      "  package:",
+      RUNS_ON,
+      STEPS,
+      "      - uses: actions/upload-artifact@0123456789abcdef0123456789abcdef01234567",
+      "        with:",
+      "          name: app-package",
+      "          path: dist",
+      PUBLISH_JOB,
+      "    needs: [test, package]",
+      RUNS_ON,
+      STEPS,
+      `      - uses: ${PINNED_DOWNLOAD_ARTIFACT}`,
+      "        with:",
+      "          name: app-package",
+      RUN_PUBLISH,
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe(FAIL);
+    expect(assessReadiness([record]).blockers[0]?.id).toBe("B2");
+    expect(String(asFindings(record.findings)[0].evidence)).toContain(
+      "no validating ancestor uploads"
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- tighten B2 promoted-artifact handling so named `actions/download-artifact` steps must match named uploads from validating ancestor jobs when those names are declared
- report a B2 violation when a release job downloads a different named artifact than CI uploaded
- add regression coverage for mismatched artifact names in the delivery promotion suite

Work-Item: CodySwannGT/lisa#1903

## Test plan
- `bun test tests/unit/cli/doctor-readiness-delivery-promotion.test.ts tests/unit/cli/doctor-readiness-delivery-artifact.test.ts`
- `bun run typecheck`
- `bun run lint -- src/cli/doctor-readiness-promoted-artifact.ts src/cli/doctor-readiness-release-path.ts tests/unit/cli/doctor-readiness-delivery-promotion.test.ts`
- pre-push: typecheck, production dependency audit, slow lint, knip, unit coverage, integration tests, plugin parity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release readiness checks to verify that downloaded artifacts match artifacts uploaded by validated CI jobs.
  * Release workflows now flag mismatched or unvalidated artifacts before publication.
  * Improved detection of publishing steps across supported command formats.

* **Tests**
  * Added regression coverage confirming mismatched artifacts block release readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->