### PR TITLE
fix(readiness): scan B4 wrapper scripts

### DIFF
--- a/src/cli/doctor-readiness-guardrails.ts
+++ b/src/cli/doctor-readiness-guardrails.ts
@@ -30,7 +30,7 @@ import {
   type OperationScan,
   scanCommands,
 } from "./doctor-readiness-operations.js";
-import { expandLocalScriptCommands } from "./doctor-readiness-local-scripts.js";
+import { expandLocalScriptCommandsWithDiagnostics } from "./doctor-readiness-local-scripts.js";
 import { informationalFindings } from "./doctor-readiness-shared.js";
 import type { ReadinessDimensionRecord } from "./doctor-readiness-types.js";
 import {
@@ -443,13 +443,18 @@ export async function assessFeedbackGuardrailsDimension(
 ): Promise<ReadinessDimensionRecord> {
   const parsed: readonly ParsedWorkflow[] =
     parsedWorkflows ?? (await parseRepositoryWorkflows(root));
-  const workflows = await expandLocalScriptCommands(root, parsed);
-  const scan = scanCommands(workflows, isConsequential, {
+  const expanded = await expandLocalScriptCommandsWithDiagnostics(root, parsed);
+  const workflows = expanded.value;
+  const scanned = scanCommands(workflows, isConsequential, {
     unresolvedWorkflow: lifecycleDeferral,
     unresolvedStep: servicesDeferral,
     unresolvedJobCall: reusableCallDeferral,
     unresolvedActionStep: actionStepDeferral,
   });
+  const scan: OperationScan = {
+    ...scanned,
+    unresolved: [...scanned.unresolved, ...expanded.unresolved],
+  };
   const runbook = await hasCheckedInRunbook(root);
   if (scan.ungated.length === 0 || runbook) {
     return skipRecord(

--- a/src/cli/doctor-readiness-guardrails.ts
+++ b/src/cli/doctor-readiness-guardrails.ts
@@ -30,6 +30,7 @@ import {
   type OperationScan,
   scanCommands,
 } from "./doctor-readiness-operations.js";
+import { expandLocalScriptCommands } from "./doctor-readiness-local-scripts.js";
 import { informationalFindings } from "./doctor-readiness-shared.js";
 import type { ReadinessDimensionRecord } from "./doctor-readiness-types.js";
 import {
@@ -440,8 +441,9 @@ export async function assessFeedbackGuardrailsDimension(
   root: string,
   parsedWorkflows?: readonly ParsedWorkflow[]
 ): Promise<ReadinessDimensionRecord> {
-  const workflows: readonly ParsedWorkflow[] =
+  const parsed: readonly ParsedWorkflow[] =
     parsedWorkflows ?? (await parseRepositoryWorkflows(root));
+  const workflows = await expandLocalScriptCommands(root, parsed);
   const scan = scanCommands(workflows, isConsequential, {
     unresolvedWorkflow: lifecycleDeferral,
     unresolvedStep: servicesDeferral,

--- a/src/cli/doctor-readiness-local-scripts.ts
+++ b/src/cli/doctor-readiness-local-scripts.ts
@@ -29,15 +29,18 @@ const OPTIONED_SHELL_RUNNERS = new Set(["bash", "sh"]);
 /** Prefix assignments that set env only for the following shell invocation. */
 const SHELL_ENV_ASSIGNMENT = /^[A-Za-z_]\w*=.*$/u;
 
-/** Shared budget carried through one workflow expansion scan. */
-interface ExpansionContext {
-  readonly remainingScripts: number;
-}
-
 /** Expansion result plus the remaining aggregate script budget. */
 interface ExpansionResult<T> {
   readonly value: T;
   readonly remainingScripts: number;
+  readonly unresolved: readonly string[];
+}
+
+/** Result of reading local script bodies from one workflow step. */
+interface BodyExpansion {
+  readonly value: readonly string[];
+  readonly remainingScripts: number;
+  readonly skippedScripts: readonly string[];
 }
 
 /**
@@ -180,22 +183,32 @@ async function readLocalScript(
 /**
  * Append any bounded local script bodies referenced by a workflow step.
  * @param root - Repository root
+ * @param job - Parsed workflow job
  * @param step - Parsed workflow step
- * @param context - Shared expansion budget
+ * @param remainingScripts - Remaining aggregate expansion budget
  * @returns Step with script bodies appended to `run`, when present
  */
 async function expandLocalScriptStep(
   root: string,
+  job: ParsedWorkflowJob,
   step: ParsedWorkflowStep,
-  context: ExpansionContext
+  remainingScripts: number
 ): Promise<ExpansionResult<ParsedWorkflowStep>> {
   const expanded = await expandLocalScriptBodies(
     root,
     localScriptPaths(step.run),
-    context.remainingScripts
+    remainingScripts
+  );
+  const unresolved = expanded.skippedScripts.map(
+    script =>
+      `\`${job.workflow}\` job \`${job.id}\` step \`${step.name}\` invokes ` +
+      "local " +
+      `script \`${script}\`, but the bounded wrapper expansion budget was ` +
+      "exhausted before that script could be inspected"
   );
   return {
     remainingScripts: expanded.remainingScripts,
+    unresolved,
     value:
       expanded.value.length === 0
         ? step
@@ -214,10 +227,13 @@ async function expandLocalScriptBodies(
   root: string,
   scripts: readonly string[],
   remainingScripts: number
-): Promise<ExpansionResult<readonly string[]>> {
+): Promise<BodyExpansion> {
   const [script, ...rest] = scripts;
-  if (script === undefined || remainingScripts <= 0) {
-    return { value: [], remainingScripts };
+  if (script === undefined) {
+    return { value: [], remainingScripts, skippedScripts: [] };
+  }
+  if (remainingScripts <= 0) {
+    return { value: [], remainingScripts, skippedScripts: scripts };
   }
   const content = await readLocalScript(root, script);
   const expanded = await expandLocalScriptBodies(
@@ -227,6 +243,7 @@ async function expandLocalScriptBodies(
   );
   return {
     remainingScripts: expanded.remainingScripts,
+    skippedScripts: expanded.skippedScripts,
     value: content === null ? expanded.value : [content, ...expanded.value],
   };
 }
@@ -235,17 +252,23 @@ async function expandLocalScriptBodies(
  * Expand directly invoked local shell scripts in one parsed job.
  * @param root - Repository root
  * @param job - Parsed workflow job
- * @param context - Shared expansion budget
+ * @param remainingScripts - Remaining aggregate expansion budget
  * @returns Job with script-expanded steps
  */
 async function expandLocalScriptJob(
   root: string,
   job: ParsedWorkflowJob,
-  context: ExpansionContext
+  remainingScripts: number
 ): Promise<ExpansionResult<ParsedWorkflowJob>> {
-  const expanded = await expandLocalScriptSteps(root, job.steps, context);
+  const expanded = await expandLocalScriptSteps(
+    root,
+    job,
+    job.steps,
+    remainingScripts
+  );
   return {
     remainingScripts: expanded.remainingScripts,
+    unresolved: expanded.unresolved,
     value: {
       ...job,
       steps: expanded.value,
@@ -256,25 +279,36 @@ async function expandLocalScriptJob(
 /**
  * Expand local scripts across a job's steps under the shared budget.
  * @param root - Repository root
+ * @param job - Parsed workflow job
  * @param steps - Parsed workflow steps
- * @param context - Shared expansion budget
+ * @param remainingScripts - Remaining aggregate expansion budget
  * @returns Expanded steps and updated budget
  */
 async function expandLocalScriptSteps(
   root: string,
+  job: ParsedWorkflowJob,
   steps: readonly ParsedWorkflowStep[],
-  context: ExpansionContext
+  remainingScripts: number
 ): Promise<ExpansionResult<readonly ParsedWorkflowStep[]>> {
   const [step, ...rest] = steps;
   if (step === undefined) {
-    return { value: [], remainingScripts: context.remainingScripts };
+    return { value: [], remainingScripts, unresolved: [] };
   }
-  const expandedStep = await expandLocalScriptStep(root, step, context);
-  const expandedRest = await expandLocalScriptSteps(root, rest, {
-    remainingScripts: expandedStep.remainingScripts,
-  });
+  const expandedStep = await expandLocalScriptStep(
+    root,
+    job,
+    step,
+    remainingScripts
+  );
+  const expandedRest = await expandLocalScriptSteps(
+    root,
+    job,
+    rest,
+    expandedStep.remainingScripts
+  );
   return {
     remainingScripts: expandedRest.remainingScripts,
+    unresolved: [...expandedStep.unresolved, ...expandedRest.unresolved],
     value: [expandedStep.value, ...expandedRest.value],
   };
 }
@@ -289,38 +323,59 @@ export async function expandLocalScriptCommands(
   root: string,
   workflows: readonly ParsedWorkflow[]
 ): Promise<readonly ParsedWorkflow[]> {
-  const expanded = await expandLocalScriptWorkflows(root, workflows, {
-    remainingScripts: MAX_LOCAL_SCRIPT_EXPANSIONS,
-  });
+  const expanded = await expandLocalScriptCommandsWithDiagnostics(
+    root,
+    workflows
+  );
   return expanded.value;
+}
+
+/**
+ * Inline local scripts and report wrapper calls that bounded expansion skipped.
+ * @param root - Repository root
+ * @param workflows - Parsed workflow files
+ * @returns Expanded workflows plus unresolved skipped-wrapper observations
+ */
+export async function expandLocalScriptCommandsWithDiagnostics(
+  root: string,
+  workflows: readonly ParsedWorkflow[]
+): Promise<ExpansionResult<readonly ParsedWorkflow[]>> {
+  return await expandLocalScriptWorkflows(
+    root,
+    workflows,
+    MAX_LOCAL_SCRIPT_EXPANSIONS
+  );
 }
 
 /**
  * Expand local scripts across workflows under the shared budget.
  * @param root - Repository root
  * @param workflows - Parsed workflow files
- * @param context - Shared expansion budget
+ * @param remainingScripts - Remaining aggregate expansion budget
  * @returns Expanded workflows and updated budget
  */
 async function expandLocalScriptWorkflows(
   root: string,
   workflows: readonly ParsedWorkflow[],
-  context: ExpansionContext
+  remainingScripts: number
 ): Promise<ExpansionResult<readonly ParsedWorkflow[]>> {
   const [workflow, ...rest] = workflows;
   if (workflow === undefined) {
-    return { value: [], remainingScripts: context.remainingScripts };
+    return { value: [], remainingScripts, unresolved: [] };
   }
   const expandedJobs = await expandLocalScriptJobs(
     root,
     workflow.jobs,
-    context
+    remainingScripts
   );
-  const expandedRest = await expandLocalScriptWorkflows(root, rest, {
-    remainingScripts: expandedJobs.remainingScripts,
-  });
+  const expandedRest = await expandLocalScriptWorkflows(
+    root,
+    rest,
+    expandedJobs.remainingScripts
+  );
   return {
     remainingScripts: expandedRest.remainingScripts,
+    unresolved: [...expandedJobs.unresolved, ...expandedRest.unresolved],
     value: [
       {
         ...workflow,
@@ -335,24 +390,27 @@ async function expandLocalScriptWorkflows(
  * Expand local scripts across workflow jobs under the shared budget.
  * @param root - Repository root
  * @param jobs - Parsed workflow jobs
- * @param context - Shared expansion budget
+ * @param remainingScripts - Remaining aggregate expansion budget
  * @returns Expanded jobs and updated budget
  */
 async function expandLocalScriptJobs(
   root: string,
   jobs: readonly ParsedWorkflowJob[],
-  context: ExpansionContext
+  remainingScripts: number
 ): Promise<ExpansionResult<readonly ParsedWorkflowJob[]>> {
   const [job, ...rest] = jobs;
   if (job === undefined) {
-    return { value: [], remainingScripts: context.remainingScripts };
+    return { value: [], remainingScripts, unresolved: [] };
   }
-  const expandedJob = await expandLocalScriptJob(root, job, context);
-  const expandedRest = await expandLocalScriptJobs(root, rest, {
-    remainingScripts: expandedJob.remainingScripts,
-  });
+  const expandedJob = await expandLocalScriptJob(root, job, remainingScripts);
+  const expandedRest = await expandLocalScriptJobs(
+    root,
+    rest,
+    expandedJob.remainingScripts
+  );
   return {
     remainingScripts: expandedRest.remainingScripts,
+    unresolved: [...expandedJob.unresolved, ...expandedRest.unresolved],
     value: [expandedJob.value, ...expandedRest.value],
   };
 }

--- a/tests/unit/cli/doctor-readiness-guardrails-wrappers.test.ts
+++ b/tests/unit/cli/doctor-readiness-guardrails-wrappers.test.ts
@@ -16,6 +16,7 @@ import {
   SKIP,
   STEPS,
   WARN,
+  writeRepoFile,
   writeWorkflow,
 } from "../../helpers/readiness-workflow-fixtures.js";
 
@@ -27,6 +28,9 @@ const DEPLOY_NAME_LINE = "name: Deploy";
 
 /** Shared infrastructure job header for wrapper fixtures. */
 const INFRA_JOB = "  infra:";
+
+/** Neutral script name whose contents carry the consequential operation. */
+const DEPLOY_SCRIPT = "scripts/deploy.sh";
 
 let tempDir: string | undefined;
 
@@ -72,6 +76,37 @@ afterEach(async () => {
 });
 
 describe("assessFeedbackGuardrailsDimension — local wrapper commands", () => {
+  // Test hardened to kill mutant M001 (Risk Factor: Ungated production deploy / neutral wrapper visibility).
+  it("stands B4 when a neutral local script hides an auto-approved Terraform apply", async () => {
+    const root = await getTempDir();
+    await writeRepoFile(
+      root,
+      DEPLOY_SCRIPT,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "terraform apply -auto-approve prod.tfplan",
+      ].join("\n")
+    );
+    await writeWorkflow(root, DEPLOY_YML, [
+      DEPLOY_NAME_LINE,
+      ON_PUSH,
+      JOBS,
+      INFRA_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: ./scripts/deploy.sh",
+    ]);
+
+    const record = await assessFeedbackGuardrailsDimension(root);
+    const blocking = asFindings(record.findings).find(
+      finding => finding.blocker === BLOCKER_ID
+    );
+
+    expect(record.status).toBe(WARN);
+    expect(blocking?.evidence).toContain("terraform apply -auto-approve");
+  });
+
   it("stands B4 for an explicitly production local destroy wrapper", async () => {
     await expectB4ForCommand("./scripts/destroy-prod.sh");
   });

--- a/tests/unit/cli/doctor-readiness-guardrails-wrappers.test.ts
+++ b/tests/unit/cli/doctor-readiness-guardrails-wrappers.test.ts
@@ -134,4 +134,46 @@ describe("assessFeedbackGuardrailsDimension — local wrapper commands", () => {
       expect(Object.hasOwn(finding, "blocker")).toBe(false);
     }
   });
+
+  it("reports local wrapper scripts skipped after the expansion budget is exhausted", async () => {
+    const root = await getTempDir();
+    const wrapperScripts = Array.from(
+      { length: 65 },
+      (_, index) => `scripts/wrapper-${index + 1}.sh`
+    );
+    await Promise.all(
+      wrapperScripts.map(async script => {
+        await writeRepoFile(root, script, "echo checked");
+      })
+    );
+    await writeRepoFile(
+      root,
+      wrapperScripts[64],
+      "terraform apply -auto-approve prod.tfplan"
+    );
+    await writeWorkflow(root, DEPLOY_YML, [
+      DEPLOY_NAME_LINE,
+      ON_PUSH,
+      JOBS,
+      INFRA_JOB,
+      RUNS_ON,
+      STEPS,
+      "      - run: |",
+      ...wrapperScripts.map(script => `          ./${script}`),
+    ]);
+
+    const record = await assessFeedbackGuardrailsDimension(root);
+    const findings = asFindings(record.findings);
+
+    expect(record.status).toBe(SKIP);
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        blocking: false,
+        observation: expect.stringContaining("scripts/wrapper-65.sh"),
+      })
+    );
+    for (const finding of findings) {
+      expect(Object.hasOwn(finding, "blocker")).toBe(false);
+    }
+  });
 });


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#1903

## Summary
- Reuse the bounded local shell-script expansion helper in the B4 feedback/guardrails readiness producer before consequential-operation scanning.
- Add a regression where a neutral `./scripts/deploy.sh` wrapper hides `terraform apply -auto-approve`, so B4 now stands on the script contents instead of only obvious wrapper names.

## Validation
- `bun test tests/unit/cli/doctor-readiness-guardrails-wrappers.test.ts`
- `bun test tests/unit/cli/doctor-readiness-local-scripts.test.ts tests/unit/cli/doctor-readiness-guardrails-wrappers.test.ts tests/unit/cli/doctor-readiness-guardrails.test.ts`
- `bun run typecheck`
- `bunx eslint src/cli/doctor-readiness-guardrails.ts tests/unit/cli/doctor-readiness-guardrails-wrappers.test.ts`
- Pre-push: typecheck, production audit, slow lint, knip, full unit coverage (482 files / 8,144 tests), integration tests (154 tests), plugin parity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness checks to detect consequential operations hidden inside locally executed scripts, including cases invoked through wrapper scripts.
  * Readiness diagnostics now better report script expansion issues, including scenarios where expansion is skipped after an exhaustion limit.
* **Tests**
  * Added coverage to verify that neutral local scripts triggering auto-approved Terraform apply produce the expected readiness warning evidence.
  * Added coverage to confirm behavior when local script expansion budget is exhausted (skipping with no findings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->