### PR TITLE
fix(readiness): require artifact integrity proof

### DIFF
--- a/src/cli/doctor-readiness-promoted-artifact.ts
+++ b/src/cli/doctor-readiness-promoted-artifact.ts
@@ -14,6 +14,13 @@ const DOCKER_BUILD_PUSH_ACTION = "docker/build-push-action";
 const GITHUB_RELEASE_ACTION = "softprops/action-gh-release";
 const PYPI_PUBLISH_ACTION = "pypa/gh-action-pypi-publish";
 const UPLOAD_ARTIFACT_ACTION = "actions/upload-artifact";
+const ARTIFACT_INTEGRITY_COMMANDS: readonly RegExp[] = [
+  /\bgh\s+attestation\s+verify\b/i,
+  /\bcosign\s+verify\b/i,
+  /\bslsa-verifier\b/i,
+  /\bsha256sum\s+(?:--check|-c)\b/i,
+  /\bshasum\s+-a\s+256\s+(?:--check|-c)\b/i,
+];
 
 /**
  * Normalize an action reference to its owner/repo component.
@@ -149,6 +156,40 @@ export function hasArtifactNameMismatch(
 }
 
 /**
+ * Whether a named promotion verifies the downloaded artifact's identity before
+ * publication. A matching artifact name proves a useful link, but a digest or
+ * attestation check is the offline evidence that the bytes were not swapped.
+ * @param job - The publishing job
+ * @param publishStep - The step that ships
+ * @param ancestorJobs - Jobs in the publishing job's `needs:` closure
+ * @returns True when a named promotion lacks digest/attestation verification
+ */
+export function hasUnprovenArtifactIntegrity(
+  job: ParsedWorkflowJob,
+  publishStep: ParsedWorkflowStep,
+  ancestorJobs: readonly ParsedWorkflowJob[]
+): boolean {
+  const uploads = uploadedArtifactNames(ancestorJobs);
+  if (uploads.size === 0) {
+    return false;
+  }
+  const priorSteps = job.steps.slice(0, job.steps.indexOf(publishStep));
+  const matchingNamedDownload = priorSteps.some(step => {
+    if (!isPromotionAction(step.uses)) {
+      return false;
+    }
+    const downloadName = stepInput(step.inputs, "name");
+    return downloadName !== null && uploads.has(downloadName);
+  });
+  return (
+    matchingNamedDownload &&
+    !priorSteps.some(step =>
+      ARTIFACT_INTEGRITY_COMMANDS.some(command => command.test(step.run))
+    )
+  );
+}
+
+/**
  * The release job downloaded a named artifact different from anything a
  * validating ancestor uploaded, so the shipped bytes are not the tested bytes.
  * @param where - Evidence location label
@@ -160,6 +201,22 @@ export function artifactNameMismatch(where: string): ReleasePathOutcome {
     evidence:
       `${where} downloads a named artifact that no validating ancestor uploads, ` +
       "so the release path cannot prove the shipped artifact is the one CI tested",
+  };
+}
+
+/**
+ * A named artifact promotion exists, but no digest/attestation check proves the
+ * downloaded bytes are the same bytes the validating job uploaded.
+ * @param where - Evidence location label
+ * @returns The unresolved outcome
+ */
+export function unresolvedArtifactIntegrity(where: string): ReleasePathOutcome {
+  return {
+    kind: "unresolved",
+    reason:
+      `${where} promotes a named artifact from a validating job, but no ` +
+      "digest or attestation verification step before publication proves the " +
+      "downloaded bytes are the same bytes CI validated",
   };
 }
 

--- a/src/cli/doctor-readiness-promoted-artifact.ts
+++ b/src/cli/doctor-readiness-promoted-artifact.ts
@@ -174,18 +174,25 @@ export function hasUnprovenArtifactIntegrity(
     return false;
   }
   const priorSteps = job.steps.slice(0, job.steps.indexOf(publishStep));
-  const matchingNamedDownload = priorSteps.some(step => {
-    if (!isPromotionAction(step.uses)) {
-      return false;
-    }
-    const downloadName = stepInput(step.inputs, "name");
-    return downloadName !== null && uploads.has(downloadName);
-  });
+  const matchingNamedDownloadIndex = priorSteps.reduce(
+    (index, step, currentIndex) => {
+      if (!isPromotionAction(step.uses)) {
+        return index;
+      }
+      const downloadName = stepInput(step.inputs, "name");
+      return downloadName !== null && uploads.has(downloadName)
+        ? currentIndex
+        : index;
+    },
+    -1
+  );
   return (
-    matchingNamedDownload &&
-    !priorSteps.some(step =>
-      ARTIFACT_INTEGRITY_COMMANDS.some(command => command.test(step.run))
-    )
+    matchingNamedDownloadIndex >= 0 &&
+    !priorSteps
+      .slice(matchingNamedDownloadIndex + 1)
+      .some(step =>
+        ARTIFACT_INTEGRITY_COMMANDS.some(command => command.test(step.run))
+      )
   );
 }
 

--- a/src/cli/doctor-readiness-release-path.ts
+++ b/src/cli/doctor-readiness-release-path.ts
@@ -15,10 +15,12 @@ import {
 import {
   artifactNameMismatch,
   hasArtifactNameMismatch,
+  hasUnprovenArtifactIntegrity,
   isPublishAction,
   isPromotionAction,
   promotesValidatedArtifact,
   PROMOTION_ACTION,
+  unresolvedArtifactIntegrity,
   unresolvedPromotedArtifact,
 } from "./doctor-readiness-promoted-artifact.js";
 
@@ -345,6 +347,12 @@ export function assessReleasePaths(
       hasArtifactNameMismatch(job, publishStep, validatingAncestors)
     ) {
       return artifactNameMismatch(where);
+    }
+    if (
+      validated &&
+      hasUnprovenArtifactIntegrity(job, publishStep, validatingAncestors)
+    ) {
+      return unresolvedArtifactIntegrity(where);
     }
     if (validated) {
       return { kind: "clean" };

--- a/tests/unit/cli/doctor-readiness-delivery-promotion.test.ts
+++ b/tests/unit/cli/doctor-readiness-delivery-promotion.test.ts
@@ -19,11 +19,20 @@ import {
   RELEASE_NAME,
   RELEASE_YML,
   RUN_PUBLISH,
+  RUN_TEST,
   RUNS_ON,
   STEPS,
   TAGS,
+  TEST_JOB,
   writeWorkflow,
 } from "../../helpers/readiness-workflow-fixtures.js";
+
+const PINNED_UPLOAD_ARTIFACT =
+  "      - uses: actions/upload-artifact@0123456789abcdef0123456789abcdef01234567";
+const ARTIFACT_WITH = "        with:";
+const ARTIFACT_PATH_DIST = "          path: dist";
+const NEEDS_TEST = "    needs: [test]";
+const APP_PACKAGE_NAME = "          name: app-package";
 
 let tempDir: string | undefined;
 
@@ -101,20 +110,20 @@ describe("assessDeliveryAuthorityDimension — promoted artifact integrity", () 
       PUSH,
       TAGS,
       JOBS,
-      "  test:",
+      TEST_JOB,
       RUNS_ON,
       STEPS,
-      "      - run: npm test",
-      "      - uses: actions/upload-artifact@0123456789abcdef0123456789abcdef01234567",
-      "        with:",
+      RUN_TEST,
+      PINNED_UPLOAD_ARTIFACT,
+      ARTIFACT_WITH,
       "          name: tested-package",
-      "          path: dist",
+      ARTIFACT_PATH_DIST,
       PUBLISH_JOB,
-      "    needs: [test]",
+      NEEDS_TEST,
       RUNS_ON,
       STEPS,
       `      - uses: ${PINNED_DOWNLOAD_ARTIFACT}`,
-      "        with:",
+      ARTIFACT_WITH,
       "          name: untested-package",
       RUN_PUBLISH,
     ]);
@@ -136,24 +145,24 @@ describe("assessDeliveryAuthorityDimension — promoted artifact integrity", () 
       PUSH,
       TAGS,
       JOBS,
-      "  test:",
+      TEST_JOB,
       RUNS_ON,
       STEPS,
-      "      - run: npm test",
+      RUN_TEST,
       "  package:",
       RUNS_ON,
       STEPS,
-      "      - uses: actions/upload-artifact@0123456789abcdef0123456789abcdef01234567",
-      "        with:",
-      "          name: app-package",
-      "          path: dist",
+      PINNED_UPLOAD_ARTIFACT,
+      ARTIFACT_WITH,
+      APP_PACKAGE_NAME,
+      ARTIFACT_PATH_DIST,
       PUBLISH_JOB,
       "    needs: [test, package]",
       RUNS_ON,
       STEPS,
       `      - uses: ${PINNED_DOWNLOAD_ARTIFACT}`,
-      "        with:",
-      "          name: app-package",
+      ARTIFACT_WITH,
+      APP_PACKAGE_NAME,
       RUN_PUBLISH,
     ]);
 
@@ -164,5 +173,75 @@ describe("assessDeliveryAuthorityDimension — promoted artifact integrity", () 
     expect(String(asFindings(record.findings)[0].evidence)).toContain(
       "no validating ancestor uploads"
     );
+  });
+
+  // Test hardened to kill mutant M001 (Risk Factor: Release artifact integrity).
+  it("SKIPs when a matching named artifact lacks digest or attestation verification", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, RELEASE_YML, [
+      RELEASE_NAME,
+      ON,
+      PUSH,
+      TAGS,
+      JOBS,
+      TEST_JOB,
+      RUNS_ON,
+      STEPS,
+      RUN_TEST,
+      PINNED_UPLOAD_ARTIFACT,
+      ARTIFACT_WITH,
+      APP_PACKAGE_NAME,
+      ARTIFACT_PATH_DIST,
+      PUBLISH_JOB,
+      NEEDS_TEST,
+      RUNS_ON,
+      STEPS,
+      `      - uses: ${PINNED_DOWNLOAD_ARTIFACT}`,
+      ARTIFACT_WITH,
+      APP_PACKAGE_NAME,
+      RUN_PUBLISH,
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe("SKIP");
+    expect(assessReadiness([record]).blockers).toEqual([]);
+    expect(String(asFindings(record.findings)[0].reason)).toContain(
+      "no digest or attestation verification"
+    );
+  });
+
+  // Test hardened to kill mutant M002 (Risk Factor: Release artifact integrity).
+  it("PASSes a matching named artifact with attestation verification before publish", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, RELEASE_YML, [
+      RELEASE_NAME,
+      ON,
+      PUSH,
+      TAGS,
+      JOBS,
+      TEST_JOB,
+      RUNS_ON,
+      STEPS,
+      RUN_TEST,
+      PINNED_UPLOAD_ARTIFACT,
+      ARTIFACT_WITH,
+      APP_PACKAGE_NAME,
+      ARTIFACT_PATH_DIST,
+      PUBLISH_JOB,
+      NEEDS_TEST,
+      RUNS_ON,
+      STEPS,
+      `      - uses: ${PINNED_DOWNLOAD_ARTIFACT}`,
+      ARTIFACT_WITH,
+      APP_PACKAGE_NAME,
+      "      - run: gh attestation verify dist/app.tgz --repo acme/app",
+      RUN_PUBLISH,
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe("PASS");
+    expect(assessReadiness([record]).blockers).toEqual([]);
   });
 });

--- a/tests/unit/cli/doctor-readiness-delivery-promotion.test.ts
+++ b/tests/unit/cli/doctor-readiness-delivery-promotion.test.ts
@@ -244,4 +244,43 @@ describe("assessDeliveryAuthorityDimension — promoted artifact integrity", () 
     expect(record.status).toBe("PASS");
     expect(assessReadiness([record]).blockers).toEqual([]);
   });
+
+  // Test hardened to kill mutant M003 (Risk Factor: Release artifact integrity).
+  // An attestation check that runs BEFORE the artifact is downloaded cannot
+  // have verified the downloaded bytes, so it must not clear the finding.
+  it("SKIPs a matching named artifact with attestation verification only before the download", async () => {
+    const cwd = await getTempDir();
+    await writeWorkflow(cwd, RELEASE_YML, [
+      RELEASE_NAME,
+      ON,
+      PUSH,
+      TAGS,
+      JOBS,
+      TEST_JOB,
+      RUNS_ON,
+      STEPS,
+      RUN_TEST,
+      PINNED_UPLOAD_ARTIFACT,
+      ARTIFACT_WITH,
+      APP_PACKAGE_NAME,
+      ARTIFACT_PATH_DIST,
+      PUBLISH_JOB,
+      NEEDS_TEST,
+      RUNS_ON,
+      STEPS,
+      "      - run: gh attestation verify dist/app.tgz --repo acme/app",
+      `      - uses: ${PINNED_DOWNLOAD_ARTIFACT}`,
+      ARTIFACT_WITH,
+      APP_PACKAGE_NAME,
+      RUN_PUBLISH,
+    ]);
+
+    const record = await assessDeliveryAuthorityDimension(cwd);
+
+    expect(record.status).toBe("SKIP");
+    expect(assessReadiness([record]).blockers).toEqual([]);
+    expect(String(asFindings(record.findings)[0].reason)).toContain(
+      "no digest or attestation verification"
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Treat matching named artifact promotion as unestablished unless the release job verifies digest or attestation evidence before publishing.
- Keep mismatched named artifact promotion as a B2 failure, and keep verified named promotion as clean.
- Add focused B2 promotion regression coverage for missing and present artifact-integrity proof.

## Validation

- `bun test tests/unit/cli/doctor-readiness-delivery-promotion.test.ts`
- `bun run typecheck`
- `bunx eslint src/cli/doctor-readiness-promoted-artifact.ts src/cli/doctor-readiness-release-path.ts tests/unit/cli/doctor-readiness-delivery-promotion.test.ts`
- `bun test tests/unit/cli/doctor-readiness-delivery.test.ts tests/unit/cli/doctor-readiness-delivery-artifact.test.ts tests/unit/cli/doctor-readiness-delivery-action-pins.test.ts tests/unit/cli/doctor-readiness-delivery-promotion.test.ts tests/unit/cli/doctor-readiness-delivery-multiple-publish.test.ts tests/unit/cli/doctor-readiness-delivery-action-publish.test.ts tests/unit/cli/doctor-readiness-delivery-reusable-callers.test.ts tests/unit/cli/doctor-readiness-delivery-triggers.test.ts`
- `bun run format:check`
- `bun run lint`
- pre-push: `bun run typecheck`, production audit, `bun run lint:slow`, `bun run knip:check`, `bun run test:cov`, `bun run test:integration`, plugin parity

Work-Item: CodySwannGT/lisa#1903


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release readiness checks for promoted artifacts by flagging cases where digest/attestation verification is missing or runs in the wrong order relative to publication.
  * Added recognition of common offline artifact integrity verification commands, reducing missed detections.
* **Tests**
  * Expanded and strengthened integrity verification scenarios (skip/pass conditions based on attestation/digest timing).
  * Consolidated workflow test fixtures to keep artifact inputs consistent across cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->