### PR TITLE
feat(rules): add stale-state-claims — "not yet" expires, the note does not

### DIFF
--- a/plugins/lisa-copilot/rules/eager/empirical-inquiry.md
+++ b/plugins/lisa-copilot/rules/eager/empirical-inquiry.md
@@ -16,6 +16,7 @@ Do not reason your way to a confident-sounding answer from documentation, prior 
 - Presenting a guess, recollection, or doc summary as established fact when it was cheap to verify and you did not.
 - "Should work" / "probably" / "the docs say" as the basis for a load-bearing decision an experiment could have settled.
 - Skipping the probe because the answer "seems obvious" — those are exactly the ones that quietly drift from reality.
+- Treating a recorded "not yet" / "pending" / "blocked" / "human-gated" note as current state. It is a claim about the day it was written; probe the live state before planning around it, escalating it, or reporting it as a blocker (`stale-state-claims`).
 
 This is the inquiry counterpart to the `verification` rule (which proves completed work behaves correctly). Both reject "it looks correct" as evidence.
 

--- a/plugins/lisa-copilot/rules/eager/stale-state-claims.md
+++ b/plugins/lisa-copilot/rules/eager/stale-state-claims.md
@@ -1,0 +1,26 @@
+# Stale State Claims — "Not Yet" Expires, the Note Does Not (load-bearing)
+
+A comment, docstring, config annotation, or work-item note that records a **temporary** state — "not yet", "pending", "waiting on X", "human-gated", "will flip once Y ships" — was accurate the day it was written and is believed long after it stopped being true. Nobody revisits prose when the condition clears.
+
+It then misdirects with full authority: work gets skipped as blocked when nothing blocks it, re-planned as undone when it already shipped, or escalated to a person who made that exact decision weeks ago.
+
+This is the sibling of `falsifiable-checks`. That rule is about **instruments that cannot fail**; this one is about **assertions of state that have expired**. Both read as authoritative and neither announces its own decay.
+
+## The four ways a recorded state outlives its truth
+
+Each has been observed; each was believed long after it went false:
+
+1. **Expired blocker note** — prose asserting a not-yet condition that has since cleared. An endpoint left unset under a comment saying its routing was "not yet promoted" had been serving live for days; an agent planned work to enable what was already enabled.
+2. **Stale gate marker** — a "pending human approval / not provisioned yet" annotation whose precondition is satisfied. One held for twelve days after the thing it waited on existed, and the decision was escalated to a person surprised to be asked.
+3. **Prediction buried by closure** — a warning recorded in a comment on an item that then closes. Closure deletes the warning: one correctly predicted a defect, the item closed 25 minutes later, and the defect sat unnoticed for eight days while a dependent item was parked waiting on it.
+4. **Silent waiting gate** — a queue or approval state with no surfacing mechanism, which holds work for exactly as long as nobody happens to look. One held a security-relevant fix undeployed for two days.
+
+## Mandatory
+
+- **A recorded blocker is a claim about the past — check the present before acting on it.** Before planning around it, escalating it, or reporting it as a blocker, probe the live state (`empirical-inquiry`). One command is cheap; inheriting a false premise is not.
+- **Whoever clears the condition deletes the claim.** Removing the block is not done until the note describing it is gone. A cleared gate whose comment survives is the next reader's false premise, and you are the last person who knows it is false.
+- **Prefer expiry-resistant forms.** State what **is** true rather than what is pending. Where a temporal claim is unavoidable, anchor it to something that fails when it goes stale — a check, a linked work item — never to prose nobody re-reads.
+- **A prediction on a closing item becomes tracked work or is retracted.** If the warning is real it is a work item with an explicit blocking link (`tracked-work`); if it is not real, retract it. Prose on a closed item is neither, and the one-way lifecycle means only `claim-archaeology` can recover it.
+- **A gate that can hold work silently is a defect in the gate.** Any waiting state needs a surfacing mechanism — notification, dashboard, scheduled sweep. Fix the gate; do not resolve to look more often.
+
+Full prose, worked examples, and the rewrite patterns: [reference/stale-state-claims.md](../reference/stale-state-claims.md).

--- a/plugins/lisa-copilot/rules/reference/falsifiable-checks.md
+++ b/plugins/lisa-copilot/rules/reference/falsifiable-checks.md
@@ -89,3 +89,4 @@ Concretely:
 - **`verification`** — proves the software behaves as a user needs. This rule proves the proof is real. Codified regression tests added under `codify-verification` are subject to this rule: a codified spec that cannot fail is not a regression gate.
 - **`empirical-inquiry`** — settles an uncertain fact with the cheapest probe. A probe is a check, so it inherits the falsification requirement, including deliberate bite controls (cases that MUST report a problem) when the probe's job is to detect problems.
 - **`claim-evidence-mapping`** — an unfalsified gate cannot back a claim.
+- **`stale-state-claims`** — the sibling failure from the opposite direction: an assertion of state that *could* fail but is never re-evaluated, because nothing re-runs prose. Binding a temporal claim to a check is the recommended fix there, which puts that check under this rule.

--- a/plugins/lisa-copilot/rules/reference/stale-state-claims.md
+++ b/plugins/lisa-copilot/rules/reference/stale-state-claims.md
@@ -1,0 +1,88 @@
+# Stale State Claims — Reference
+
+Eager head: [eager/stale-state-claims.md](../eager/stale-state-claims.md).
+
+## Why this rule exists
+
+Most bad documentation is *wrong*. This kind was **right** — and that is what makes it dangerous. A note saying "not wired up yet" earned its credibility honestly, so the next reader has no reason to doubt it. There is no defect to find, no test that goes red, no reviewer who objects. The claim simply keeps being read after the world moved.
+
+The cost is not confusion, it is confident misdirection in a specific direction: **toward doing nothing**. An expired blocker never causes someone to break production. It causes work to be skipped, re-planned, or escalated — outcomes that look like caution and are indistinguishable from good judgment at the moment they happen.
+
+The `falsifiable-checks` rule covers instruments that cannot fail. This one covers assertions that *could* fail but are never re-evaluated, because nothing re-runs prose. Both produce the same end state — a confident answer with no live evidence behind it — from opposite directions.
+
+## The four failure modes, in detail
+
+### 1. Expired blocker note
+
+A comment, docstring, config value, or README line records that something is not available yet. The condition clears. The note does not.
+
+Observed: a deployment stage's endpoint was left unset with an adjacent comment explaining that its routing had "not yet been promoted." The routing had been live for days. An agent read the comment, believed it, and planned work to enable a capability that was already enabled — then reported the capability as pending.
+
+Countermeasures:
+- Treat any not-yet claim as a **hypothesis with an expiry you cannot see**. Resolve it with one live probe (a request, a query, a status read) before it enters a plan, a status report, or an escalation.
+- Cite the probe, not the comment: "verified live at <time>" is evidence; "the comment says" is hearsay about the past.
+- When you are the one who promotes/enables/provisions the thing, the note describing its absence is part of the change. Grep for it.
+
+### 2. Stale gate marker
+
+A config entry, flag, or checklist item is annotated as awaiting a human decision or an unfulfilled prerequisite. The prerequisite arrives, or the decision gets made elsewhere. The marker persists and keeps routing work to a gate that is no longer closed.
+
+Observed: an entry marked human-gated because no client had been provisioned. The client had existed for twelve days. The gate was honored anyway and the question escalated to a person who had already decided it and was surprised to be asked.
+
+This mode is corrosive twice over: it wastes the human's attention, and it teaches the agent that gates are noise — which is exactly the wrong lesson to carry into a gate that is still real.
+
+Countermeasures:
+- Before honoring a gate, verify the condition that justifies it still holds. A gate whose stated reason is falsifiable and false is not a gate.
+- Record gates as **conditions**, not as verdicts: "gated until <checkable condition>" can be evaluated; "human-gated" cannot.
+- When escalating, state the evidence that the gate is still live. If you cannot, you are escalating a comment.
+
+### 3. Prediction buried by closure
+
+Someone records a correct warning — "this will fail until X is fixed", "this leaves Y broken" — as a comment on a work item, and the item then closes. Closure is a filter: closed items are not read. The prediction is deleted in every practical sense while feeling like it was recorded.
+
+Observed: a comment correctly predicted a defect. The item closed 25 minutes later with no follow-up filed. The defect sat unnoticed for **eight days**, blocking a dependent item that was itself parked waiting for it — two items, both stalled, and the explanation was already written down in a place nobody would look.
+
+Countermeasures:
+- A prediction is either **real work or a retraction**. If real, it is a tracked leaf with an explicit blocking link to what it blocks (`tracked-work`), created **before** the parent item closes. If not real, say so in the same thread so the next reader is not left holding an unresolved warning.
+- Never let closing be the last action on an item that carries an open prediction. Check the comment thread as part of closing.
+- Blocking links are the mechanism that makes the parked dependent item legible. A prediction with no link is invisible from the side that is actually waiting.
+
+### 4. Silent waiting gate
+
+An approval, queue, or review state holds work and emits nothing. Its duration is therefore set by how often somebody happens to look, which is not a property of the work's urgency.
+
+Observed: a deploy approval gate held a security-relevant fix undeployed for two days. Nothing was broken, nobody was wrong, and nothing surfaced that the gate was waiting.
+
+Countermeasures:
+- Every waiting state needs a surfacing mechanism proportional to what it can hold: notification, dashboard row, scheduled sweep, or an automatic expiry.
+- **Fix the gate, not your habits.** "Remember to check" is not a mechanism; it is the same failure with a person's name on it.
+- When you add a gate, state how long it may silently hold work and what surfaces it. If the answer is "indefinitely" and "nothing", the gate is not finished.
+
+## Expiry-resistant forms
+
+Prefer, in order:
+
+1. **State what is true.** "Serves from <path>" outlives "not yet serving from <path>", because it stays wrong-detectably wrong instead of quietly-stale.
+2. **Bind the claim to a check.** A test, guard, or assertion that fails when the temporal claim goes false converts a silent expiry into a red build. (That check is itself subject to `falsifiable-checks` — a guard that cannot fail re-creates the problem it was added to solve.)
+3. **Bind the claim to a work item.** "Blocked by <ref>" is resolvable by anyone; "waiting on the migration" is resolvable only by whoever wrote it.
+4. **Timestamp and scope it.** If prose is genuinely the only option, write "as of <date>" and name the condition that ends it. A dated claim at least advertises its own age.
+
+Avoid: bare "not yet", "TODO once", "temporarily", "for now", "pending" with no owner, condition, date, or link. Each is a claim that can only be falsified by someone who already knows the truth — which is the one person who does not need to read it.
+
+## How to apply
+
+1. Reading a note that asserts a pending/blocked/not-yet state: **do not act on it yet.**
+2. Identify the cheapest live probe that settles the underlying fact.
+3. Run it. Report the observation, not the note.
+4. If the note is stale, **delete or correct it in the same change** — leaving it is handing the next reader the trap you just escaped.
+5. If the note is accurate, upgrade it while you are there: attach the condition, the link, or the check that will make it self-expiring.
+
+And when you are the one clearing a condition: sweep for the notes that described it. The change is not complete while the repository still asserts the old state.
+
+## Interaction with other rules
+
+- **`falsifiable-checks`** — the sibling failure. That rule prevents an instrument that cannot fail; this one prevents an assertion that never gets re-evaluated. A check bound to a temporal claim (form 2 above) sits under both rules at once.
+- **`empirical-inquiry`** — supplies the discipline this rule depends on: settle the fact with the cheapest probe rather than reasoning from what is written down. A stale note is exactly the "confident-sounding answer from a prior assumption" that rule forbids.
+- **`verification`** — a status derived from a comment is not runtime evidence. Reporting "still blocked" on the strength of a note is the same error as reporting "works" on the strength of the code looking correct.
+- **`tracked-work`** — the destination for any prediction that survives its item's closure: one live leaf, explicit blocking link, carried on the branch and PR.
+- **`claim-archaeology`** — the recovery path once mode 3 has already happened. Lifecycles are one-way, so a warning lost to closure resurfaces only as a fresh item whose ancestry has to be reconstructed. Archaeology is the cleanup; this rule is the prevention.

--- a/plugins/lisa-cursor/rules/empirical-inquiry.mdc
+++ b/plugins/lisa-cursor/rules/empirical-inquiry.mdc
@@ -21,6 +21,7 @@ Do not reason your way to a confident-sounding answer from documentation, prior 
 - Presenting a guess, recollection, or doc summary as established fact when it was cheap to verify and you did not.
 - "Should work" / "probably" / "the docs say" as the basis for a load-bearing decision an experiment could have settled.
 - Skipping the probe because the answer "seems obvious" — those are exactly the ones that quietly drift from reality.
+- Treating a recorded "not yet" / "pending" / "blocked" / "human-gated" note as current state. It is a claim about the day it was written; probe the live state before planning around it, escalating it, or reporting it as a blocker (`stale-state-claims`).
 
 This is the inquiry counterpart to the `verification` rule (which proves completed work behaves correctly). Both reject "it looks correct" as evidence.
 

--- a/plugins/lisa-cursor/rules/falsifiable-checks-reference.mdc
+++ b/plugins/lisa-cursor/rules/falsifiable-checks-reference.mdc
@@ -94,3 +94,4 @@ Concretely:
 - **`verification`** — proves the software behaves as a user needs. This rule proves the proof is real. Codified regression tests added under `codify-verification` are subject to this rule: a codified spec that cannot fail is not a regression gate.
 - **`empirical-inquiry`** — settles an uncertain fact with the cheapest probe. A probe is a check, so it inherits the falsification requirement, including deliberate bite controls (cases that MUST report a problem) when the probe's job is to detect problems.
 - **`claim-evidence-mapping`** — an unfalsified gate cannot back a claim.
+- **`stale-state-claims`** — the sibling failure from the opposite direction: an assertion of state that *could* fail but is never re-evaluated, because nothing re-runs prose. Binding a temporal claim to a check is the recommended fix there, which puts that check under this rule.

--- a/plugins/lisa-cursor/rules/stale-state-claims-reference.mdc
+++ b/plugins/lisa-cursor/rules/stale-state-claims-reference.mdc
@@ -1,0 +1,93 @@
+---
+description: "Stale State Claims — Reference"
+alwaysApply: false
+---
+
+# Stale State Claims — Reference
+
+Eager head: [eager/stale-state-claims.md](stale-state-claims.mdc).
+
+## Why this rule exists
+
+Most bad documentation is *wrong*. This kind was **right** — and that is what makes it dangerous. A note saying "not wired up yet" earned its credibility honestly, so the next reader has no reason to doubt it. There is no defect to find, no test that goes red, no reviewer who objects. The claim simply keeps being read after the world moved.
+
+The cost is not confusion, it is confident misdirection in a specific direction: **toward doing nothing**. An expired blocker never causes someone to break production. It causes work to be skipped, re-planned, or escalated — outcomes that look like caution and are indistinguishable from good judgment at the moment they happen.
+
+The `falsifiable-checks` rule covers instruments that cannot fail. This one covers assertions that *could* fail but are never re-evaluated, because nothing re-runs prose. Both produce the same end state — a confident answer with no live evidence behind it — from opposite directions.
+
+## The four failure modes, in detail
+
+### 1. Expired blocker note
+
+A comment, docstring, config value, or README line records that something is not available yet. The condition clears. The note does not.
+
+Observed: a deployment stage's endpoint was left unset with an adjacent comment explaining that its routing had "not yet been promoted." The routing had been live for days. An agent read the comment, believed it, and planned work to enable a capability that was already enabled — then reported the capability as pending.
+
+Countermeasures:
+- Treat any not-yet claim as a **hypothesis with an expiry you cannot see**. Resolve it with one live probe (a request, a query, a status read) before it enters a plan, a status report, or an escalation.
+- Cite the probe, not the comment: "verified live at <time>" is evidence; "the comment says" is hearsay about the past.
+- When you are the one who promotes/enables/provisions the thing, the note describing its absence is part of the change. Grep for it.
+
+### 2. Stale gate marker
+
+A config entry, flag, or checklist item is annotated as awaiting a human decision or an unfulfilled prerequisite. The prerequisite arrives, or the decision gets made elsewhere. The marker persists and keeps routing work to a gate that is no longer closed.
+
+Observed: an entry marked human-gated because no client had been provisioned. The client had existed for twelve days. The gate was honored anyway and the question escalated to a person who had already decided it and was surprised to be asked.
+
+This mode is corrosive twice over: it wastes the human's attention, and it teaches the agent that gates are noise — which is exactly the wrong lesson to carry into a gate that is still real.
+
+Countermeasures:
+- Before honoring a gate, verify the condition that justifies it still holds. A gate whose stated reason is falsifiable and false is not a gate.
+- Record gates as **conditions**, not as verdicts: "gated until <checkable condition>" can be evaluated; "human-gated" cannot.
+- When escalating, state the evidence that the gate is still live. If you cannot, you are escalating a comment.
+
+### 3. Prediction buried by closure
+
+Someone records a correct warning — "this will fail until X is fixed", "this leaves Y broken" — as a comment on a work item, and the item then closes. Closure is a filter: closed items are not read. The prediction is deleted in every practical sense while feeling like it was recorded.
+
+Observed: a comment correctly predicted a defect. The item closed 25 minutes later with no follow-up filed. The defect sat unnoticed for **eight days**, blocking a dependent item that was itself parked waiting for it — two items, both stalled, and the explanation was already written down in a place nobody would look.
+
+Countermeasures:
+- A prediction is either **real work or a retraction**. If real, it is a tracked leaf with an explicit blocking link to what it blocks (`tracked-work`), created **before** the parent item closes. If not real, say so in the same thread so the next reader is not left holding an unresolved warning.
+- Never let closing be the last action on an item that carries an open prediction. Check the comment thread as part of closing.
+- Blocking links are the mechanism that makes the parked dependent item legible. A prediction with no link is invisible from the side that is actually waiting.
+
+### 4. Silent waiting gate
+
+An approval, queue, or review state holds work and emits nothing. Its duration is therefore set by how often somebody happens to look, which is not a property of the work's urgency.
+
+Observed: a deploy approval gate held a security-relevant fix undeployed for two days. Nothing was broken, nobody was wrong, and nothing surfaced that the gate was waiting.
+
+Countermeasures:
+- Every waiting state needs a surfacing mechanism proportional to what it can hold: notification, dashboard row, scheduled sweep, or an automatic expiry.
+- **Fix the gate, not your habits.** "Remember to check" is not a mechanism; it is the same failure with a person's name on it.
+- When you add a gate, state how long it may silently hold work and what surfaces it. If the answer is "indefinitely" and "nothing", the gate is not finished.
+
+## Expiry-resistant forms
+
+Prefer, in order:
+
+1. **State what is true.** "Serves from <path>" outlives "not yet serving from <path>", because it stays wrong-detectably wrong instead of quietly-stale.
+2. **Bind the claim to a check.** A test, guard, or assertion that fails when the temporal claim goes false converts a silent expiry into a red build. (That check is itself subject to `falsifiable-checks` — a guard that cannot fail re-creates the problem it was added to solve.)
+3. **Bind the claim to a work item.** "Blocked by <ref>" is resolvable by anyone; "waiting on the migration" is resolvable only by whoever wrote it.
+4. **Timestamp and scope it.** If prose is genuinely the only option, write "as of <date>" and name the condition that ends it. A dated claim at least advertises its own age.
+
+Avoid: bare "not yet", "TODO once", "temporarily", "for now", "pending" with no owner, condition, date, or link. Each is a claim that can only be falsified by someone who already knows the truth — which is the one person who does not need to read it.
+
+## How to apply
+
+1. Reading a note that asserts a pending/blocked/not-yet state: **do not act on it yet.**
+2. Identify the cheapest live probe that settles the underlying fact.
+3. Run it. Report the observation, not the note.
+4. If the note is stale, **delete or correct it in the same change** — leaving it is handing the next reader the trap you just escaped.
+5. If the note is accurate, upgrade it while you are there: attach the condition, the link, or the check that will make it self-expiring.
+
+And when you are the one clearing a condition: sweep for the notes that described it. The change is not complete while the repository still asserts the old state.
+
+## Interaction with other rules
+
+- **`falsifiable-checks`** — the sibling failure. That rule prevents an instrument that cannot fail; this one prevents an assertion that never gets re-evaluated. A check bound to a temporal claim (form 2 above) sits under both rules at once.
+- **`empirical-inquiry`** — supplies the discipline this rule depends on: settle the fact with the cheapest probe rather than reasoning from what is written down. A stale note is exactly the "confident-sounding answer from a prior assumption" that rule forbids.
+- **`verification`** — a status derived from a comment is not runtime evidence. Reporting "still blocked" on the strength of a note is the same error as reporting "works" on the strength of the code looking correct.
+- **`tracked-work`** — the destination for any prediction that survives its item's closure: one live leaf, explicit blocking link, carried on the branch and PR.
+- **`claim-archaeology`** — the recovery path once mode 3 has already happened. Lifecycles are one-way, so a warning lost to closure resurfaces only as a fresh item whose ancestry has to be reconstructed. Archaeology is the cleanup; this rule is the prevention.

--- a/plugins/lisa-cursor/rules/stale-state-claims.mdc
+++ b/plugins/lisa-cursor/rules/stale-state-claims.mdc
@@ -1,0 +1,31 @@
+---
+description: "Stale State Claims — \"Not Yet\" Expires, the Note Does Not (load-bearing)"
+alwaysApply: true
+---
+
+# Stale State Claims — "Not Yet" Expires, the Note Does Not (load-bearing)
+
+A comment, docstring, config annotation, or work-item note that records a **temporary** state — "not yet", "pending", "waiting on X", "human-gated", "will flip once Y ships" — was accurate the day it was written and is believed long after it stopped being true. Nobody revisits prose when the condition clears.
+
+It then misdirects with full authority: work gets skipped as blocked when nothing blocks it, re-planned as undone when it already shipped, or escalated to a person who made that exact decision weeks ago.
+
+This is the sibling of `falsifiable-checks`. That rule is about **instruments that cannot fail**; this one is about **assertions of state that have expired**. Both read as authoritative and neither announces its own decay.
+
+## The four ways a recorded state outlives its truth
+
+Each has been observed; each was believed long after it went false:
+
+1. **Expired blocker note** — prose asserting a not-yet condition that has since cleared. An endpoint left unset under a comment saying its routing was "not yet promoted" had been serving live for days; an agent planned work to enable what was already enabled.
+2. **Stale gate marker** — a "pending human approval / not provisioned yet" annotation whose precondition is satisfied. One held for twelve days after the thing it waited on existed, and the decision was escalated to a person surprised to be asked.
+3. **Prediction buried by closure** — a warning recorded in a comment on an item that then closes. Closure deletes the warning: one correctly predicted a defect, the item closed 25 minutes later, and the defect sat unnoticed for eight days while a dependent item was parked waiting on it.
+4. **Silent waiting gate** — a queue or approval state with no surfacing mechanism, which holds work for exactly as long as nobody happens to look. One held a security-relevant fix undeployed for two days.
+
+## Mandatory
+
+- **A recorded blocker is a claim about the past — check the present before acting on it.** Before planning around it, escalating it, or reporting it as a blocker, probe the live state (`empirical-inquiry`). One command is cheap; inheriting a false premise is not.
+- **Whoever clears the condition deletes the claim.** Removing the block is not done until the note describing it is gone. A cleared gate whose comment survives is the next reader's false premise, and you are the last person who knows it is false.
+- **Prefer expiry-resistant forms.** State what **is** true rather than what is pending. Where a temporal claim is unavoidable, anchor it to something that fails when it goes stale — a check, a linked work item — never to prose nobody re-reads.
+- **A prediction on a closing item becomes tracked work or is retracted.** If the warning is real it is a work item with an explicit blocking link (`tracked-work`); if it is not real, retract it. Prose on a closed item is neither, and the one-way lifecycle means only `claim-archaeology` can recover it.
+- **A gate that can hold work silently is a defect in the gate.** Any waiting state needs a surfacing mechanism — notification, dashboard, scheduled sweep. Fix the gate; do not resolve to look more often.
+
+Full prose, worked examples, and the rewrite patterns: [reference/stale-state-claims.md](stale-state-claims-reference.mdc).

--- a/plugins/lisa/rules/eager/empirical-inquiry.md
+++ b/plugins/lisa/rules/eager/empirical-inquiry.md
@@ -16,6 +16,7 @@ Do not reason your way to a confident-sounding answer from documentation, prior 
 - Presenting a guess, recollection, or doc summary as established fact when it was cheap to verify and you did not.
 - "Should work" / "probably" / "the docs say" as the basis for a load-bearing decision an experiment could have settled.
 - Skipping the probe because the answer "seems obvious" — those are exactly the ones that quietly drift from reality.
+- Treating a recorded "not yet" / "pending" / "blocked" / "human-gated" note as current state. It is a claim about the day it was written; probe the live state before planning around it, escalating it, or reporting it as a blocker (`stale-state-claims`).
 
 This is the inquiry counterpart to the `verification` rule (which proves completed work behaves correctly). Both reject "it looks correct" as evidence.
 

--- a/plugins/lisa/rules/eager/stale-state-claims.md
+++ b/plugins/lisa/rules/eager/stale-state-claims.md
@@ -1,0 +1,26 @@
+# Stale State Claims — "Not Yet" Expires, the Note Does Not (load-bearing)
+
+A comment, docstring, config annotation, or work-item note that records a **temporary** state — "not yet", "pending", "waiting on X", "human-gated", "will flip once Y ships" — was accurate the day it was written and is believed long after it stopped being true. Nobody revisits prose when the condition clears.
+
+It then misdirects with full authority: work gets skipped as blocked when nothing blocks it, re-planned as undone when it already shipped, or escalated to a person who made that exact decision weeks ago.
+
+This is the sibling of `falsifiable-checks`. That rule is about **instruments that cannot fail**; this one is about **assertions of state that have expired**. Both read as authoritative and neither announces its own decay.
+
+## The four ways a recorded state outlives its truth
+
+Each has been observed; each was believed long after it went false:
+
+1. **Expired blocker note** — prose asserting a not-yet condition that has since cleared. An endpoint left unset under a comment saying its routing was "not yet promoted" had been serving live for days; an agent planned work to enable what was already enabled.
+2. **Stale gate marker** — a "pending human approval / not provisioned yet" annotation whose precondition is satisfied. One held for twelve days after the thing it waited on existed, and the decision was escalated to a person surprised to be asked.
+3. **Prediction buried by closure** — a warning recorded in a comment on an item that then closes. Closure deletes the warning: one correctly predicted a defect, the item closed 25 minutes later, and the defect sat unnoticed for eight days while a dependent item was parked waiting on it.
+4. **Silent waiting gate** — a queue or approval state with no surfacing mechanism, which holds work for exactly as long as nobody happens to look. One held a security-relevant fix undeployed for two days.
+
+## Mandatory
+
+- **A recorded blocker is a claim about the past — check the present before acting on it.** Before planning around it, escalating it, or reporting it as a blocker, probe the live state (`empirical-inquiry`). One command is cheap; inheriting a false premise is not.
+- **Whoever clears the condition deletes the claim.** Removing the block is not done until the note describing it is gone. A cleared gate whose comment survives is the next reader's false premise, and you are the last person who knows it is false.
+- **Prefer expiry-resistant forms.** State what **is** true rather than what is pending. Where a temporal claim is unavoidable, anchor it to something that fails when it goes stale — a check, a linked work item — never to prose nobody re-reads.
+- **A prediction on a closing item becomes tracked work or is retracted.** If the warning is real it is a work item with an explicit blocking link (`tracked-work`); if it is not real, retract it. Prose on a closed item is neither, and the one-way lifecycle means only `claim-archaeology` can recover it.
+- **A gate that can hold work silently is a defect in the gate.** Any waiting state needs a surfacing mechanism — notification, dashboard, scheduled sweep. Fix the gate; do not resolve to look more often.
+
+Full prose, worked examples, and the rewrite patterns: [reference/stale-state-claims.md](../reference/stale-state-claims.md).

--- a/plugins/lisa/rules/reference/falsifiable-checks.md
+++ b/plugins/lisa/rules/reference/falsifiable-checks.md
@@ -89,3 +89,4 @@ Concretely:
 - **`verification`** — proves the software behaves as a user needs. This rule proves the proof is real. Codified regression tests added under `codify-verification` are subject to this rule: a codified spec that cannot fail is not a regression gate.
 - **`empirical-inquiry`** — settles an uncertain fact with the cheapest probe. A probe is a check, so it inherits the falsification requirement, including deliberate bite controls (cases that MUST report a problem) when the probe's job is to detect problems.
 - **`claim-evidence-mapping`** — an unfalsified gate cannot back a claim.
+- **`stale-state-claims`** — the sibling failure from the opposite direction: an assertion of state that *could* fail but is never re-evaluated, because nothing re-runs prose. Binding a temporal claim to a check is the recommended fix there, which puts that check under this rule.

--- a/plugins/lisa/rules/reference/stale-state-claims.md
+++ b/plugins/lisa/rules/reference/stale-state-claims.md
@@ -1,0 +1,88 @@
+# Stale State Claims — Reference
+
+Eager head: [eager/stale-state-claims.md](../eager/stale-state-claims.md).
+
+## Why this rule exists
+
+Most bad documentation is *wrong*. This kind was **right** — and that is what makes it dangerous. A note saying "not wired up yet" earned its credibility honestly, so the next reader has no reason to doubt it. There is no defect to find, no test that goes red, no reviewer who objects. The claim simply keeps being read after the world moved.
+
+The cost is not confusion, it is confident misdirection in a specific direction: **toward doing nothing**. An expired blocker never causes someone to break production. It causes work to be skipped, re-planned, or escalated — outcomes that look like caution and are indistinguishable from good judgment at the moment they happen.
+
+The `falsifiable-checks` rule covers instruments that cannot fail. This one covers assertions that *could* fail but are never re-evaluated, because nothing re-runs prose. Both produce the same end state — a confident answer with no live evidence behind it — from opposite directions.
+
+## The four failure modes, in detail
+
+### 1. Expired blocker note
+
+A comment, docstring, config value, or README line records that something is not available yet. The condition clears. The note does not.
+
+Observed: a deployment stage's endpoint was left unset with an adjacent comment explaining that its routing had "not yet been promoted." The routing had been live for days. An agent read the comment, believed it, and planned work to enable a capability that was already enabled — then reported the capability as pending.
+
+Countermeasures:
+- Treat any not-yet claim as a **hypothesis with an expiry you cannot see**. Resolve it with one live probe (a request, a query, a status read) before it enters a plan, a status report, or an escalation.
+- Cite the probe, not the comment: "verified live at <time>" is evidence; "the comment says" is hearsay about the past.
+- When you are the one who promotes/enables/provisions the thing, the note describing its absence is part of the change. Grep for it.
+
+### 2. Stale gate marker
+
+A config entry, flag, or checklist item is annotated as awaiting a human decision or an unfulfilled prerequisite. The prerequisite arrives, or the decision gets made elsewhere. The marker persists and keeps routing work to a gate that is no longer closed.
+
+Observed: an entry marked human-gated because no client had been provisioned. The client had existed for twelve days. The gate was honored anyway and the question escalated to a person who had already decided it and was surprised to be asked.
+
+This mode is corrosive twice over: it wastes the human's attention, and it teaches the agent that gates are noise — which is exactly the wrong lesson to carry into a gate that is still real.
+
+Countermeasures:
+- Before honoring a gate, verify the condition that justifies it still holds. A gate whose stated reason is falsifiable and false is not a gate.
+- Record gates as **conditions**, not as verdicts: "gated until <checkable condition>" can be evaluated; "human-gated" cannot.
+- When escalating, state the evidence that the gate is still live. If you cannot, you are escalating a comment.
+
+### 3. Prediction buried by closure
+
+Someone records a correct warning — "this will fail until X is fixed", "this leaves Y broken" — as a comment on a work item, and the item then closes. Closure is a filter: closed items are not read. The prediction is deleted in every practical sense while feeling like it was recorded.
+
+Observed: a comment correctly predicted a defect. The item closed 25 minutes later with no follow-up filed. The defect sat unnoticed for **eight days**, blocking a dependent item that was itself parked waiting for it — two items, both stalled, and the explanation was already written down in a place nobody would look.
+
+Countermeasures:
+- A prediction is either **real work or a retraction**. If real, it is a tracked leaf with an explicit blocking link to what it blocks (`tracked-work`), created **before** the parent item closes. If not real, say so in the same thread so the next reader is not left holding an unresolved warning.
+- Never let closing be the last action on an item that carries an open prediction. Check the comment thread as part of closing.
+- Blocking links are the mechanism that makes the parked dependent item legible. A prediction with no link is invisible from the side that is actually waiting.
+
+### 4. Silent waiting gate
+
+An approval, queue, or review state holds work and emits nothing. Its duration is therefore set by how often somebody happens to look, which is not a property of the work's urgency.
+
+Observed: a deploy approval gate held a security-relevant fix undeployed for two days. Nothing was broken, nobody was wrong, and nothing surfaced that the gate was waiting.
+
+Countermeasures:
+- Every waiting state needs a surfacing mechanism proportional to what it can hold: notification, dashboard row, scheduled sweep, or an automatic expiry.
+- **Fix the gate, not your habits.** "Remember to check" is not a mechanism; it is the same failure with a person's name on it.
+- When you add a gate, state how long it may silently hold work and what surfaces it. If the answer is "indefinitely" and "nothing", the gate is not finished.
+
+## Expiry-resistant forms
+
+Prefer, in order:
+
+1. **State what is true.** "Serves from <path>" outlives "not yet serving from <path>", because it stays wrong-detectably wrong instead of quietly-stale.
+2. **Bind the claim to a check.** A test, guard, or assertion that fails when the temporal claim goes false converts a silent expiry into a red build. (That check is itself subject to `falsifiable-checks` — a guard that cannot fail re-creates the problem it was added to solve.)
+3. **Bind the claim to a work item.** "Blocked by <ref>" is resolvable by anyone; "waiting on the migration" is resolvable only by whoever wrote it.
+4. **Timestamp and scope it.** If prose is genuinely the only option, write "as of <date>" and name the condition that ends it. A dated claim at least advertises its own age.
+
+Avoid: bare "not yet", "TODO once", "temporarily", "for now", "pending" with no owner, condition, date, or link. Each is a claim that can only be falsified by someone who already knows the truth — which is the one person who does not need to read it.
+
+## How to apply
+
+1. Reading a note that asserts a pending/blocked/not-yet state: **do not act on it yet.**
+2. Identify the cheapest live probe that settles the underlying fact.
+3. Run it. Report the observation, not the note.
+4. If the note is stale, **delete or correct it in the same change** — leaving it is handing the next reader the trap you just escaped.
+5. If the note is accurate, upgrade it while you are there: attach the condition, the link, or the check that will make it self-expiring.
+
+And when you are the one clearing a condition: sweep for the notes that described it. The change is not complete while the repository still asserts the old state.
+
+## Interaction with other rules
+
+- **`falsifiable-checks`** — the sibling failure. That rule prevents an instrument that cannot fail; this one prevents an assertion that never gets re-evaluated. A check bound to a temporal claim (form 2 above) sits under both rules at once.
+- **`empirical-inquiry`** — supplies the discipline this rule depends on: settle the fact with the cheapest probe rather than reasoning from what is written down. A stale note is exactly the "confident-sounding answer from a prior assumption" that rule forbids.
+- **`verification`** — a status derived from a comment is not runtime evidence. Reporting "still blocked" on the strength of a note is the same error as reporting "works" on the strength of the code looking correct.
+- **`tracked-work`** — the destination for any prediction that survives its item's closure: one live leaf, explicit blocking link, carried on the branch and PR.
+- **`claim-archaeology`** — the recovery path once mode 3 has already happened. Lifecycles are one-way, so a warning lost to closure resurfaces only as a fresh item whose ancestry has to be reconstructed. Archaeology is the cleanup; this rule is the prevention.

--- a/plugins/src/base/rules/eager/empirical-inquiry.md
+++ b/plugins/src/base/rules/eager/empirical-inquiry.md
@@ -16,6 +16,7 @@ Do not reason your way to a confident-sounding answer from documentation, prior 
 - Presenting a guess, recollection, or doc summary as established fact when it was cheap to verify and you did not.
 - "Should work" / "probably" / "the docs say" as the basis for a load-bearing decision an experiment could have settled.
 - Skipping the probe because the answer "seems obvious" — those are exactly the ones that quietly drift from reality.
+- Treating a recorded "not yet" / "pending" / "blocked" / "human-gated" note as current state. It is a claim about the day it was written; probe the live state before planning around it, escalating it, or reporting it as a blocker (`stale-state-claims`).
 
 This is the inquiry counterpart to the `verification` rule (which proves completed work behaves correctly). Both reject "it looks correct" as evidence.
 

--- a/plugins/src/base/rules/eager/stale-state-claims.md
+++ b/plugins/src/base/rules/eager/stale-state-claims.md
@@ -1,0 +1,26 @@
+# Stale State Claims — "Not Yet" Expires, the Note Does Not (load-bearing)
+
+A comment, docstring, config annotation, or work-item note that records a **temporary** state — "not yet", "pending", "waiting on X", "human-gated", "will flip once Y ships" — was accurate the day it was written and is believed long after it stopped being true. Nobody revisits prose when the condition clears.
+
+It then misdirects with full authority: work gets skipped as blocked when nothing blocks it, re-planned as undone when it already shipped, or escalated to a person who made that exact decision weeks ago.
+
+This is the sibling of `falsifiable-checks`. That rule is about **instruments that cannot fail**; this one is about **assertions of state that have expired**. Both read as authoritative and neither announces its own decay.
+
+## The four ways a recorded state outlives its truth
+
+Each has been observed; each was believed long after it went false:
+
+1. **Expired blocker note** — prose asserting a not-yet condition that has since cleared. An endpoint left unset under a comment saying its routing was "not yet promoted" had been serving live for days; an agent planned work to enable what was already enabled.
+2. **Stale gate marker** — a "pending human approval / not provisioned yet" annotation whose precondition is satisfied. One held for twelve days after the thing it waited on existed, and the decision was escalated to a person surprised to be asked.
+3. **Prediction buried by closure** — a warning recorded in a comment on an item that then closes. Closure deletes the warning: one correctly predicted a defect, the item closed 25 minutes later, and the defect sat unnoticed for eight days while a dependent item was parked waiting on it.
+4. **Silent waiting gate** — a queue or approval state with no surfacing mechanism, which holds work for exactly as long as nobody happens to look. One held a security-relevant fix undeployed for two days.
+
+## Mandatory
+
+- **A recorded blocker is a claim about the past — check the present before acting on it.** Before planning around it, escalating it, or reporting it as a blocker, probe the live state (`empirical-inquiry`). One command is cheap; inheriting a false premise is not.
+- **Whoever clears the condition deletes the claim.** Removing the block is not done until the note describing it is gone. A cleared gate whose comment survives is the next reader's false premise, and you are the last person who knows it is false.
+- **Prefer expiry-resistant forms.** State what **is** true rather than what is pending. Where a temporal claim is unavoidable, anchor it to something that fails when it goes stale — a check, a linked work item — never to prose nobody re-reads.
+- **A prediction on a closing item becomes tracked work or is retracted.** If the warning is real it is a work item with an explicit blocking link (`tracked-work`); if it is not real, retract it. Prose on a closed item is neither, and the one-way lifecycle means only `claim-archaeology` can recover it.
+- **A gate that can hold work silently is a defect in the gate.** Any waiting state needs a surfacing mechanism — notification, dashboard, scheduled sweep. Fix the gate; do not resolve to look more often.
+
+Full prose, worked examples, and the rewrite patterns: [reference/stale-state-claims.md](../reference/stale-state-claims.md).

--- a/plugins/src/base/rules/reference/falsifiable-checks.md
+++ b/plugins/src/base/rules/reference/falsifiable-checks.md
@@ -89,3 +89,4 @@ Concretely:
 - **`verification`** — proves the software behaves as a user needs. This rule proves the proof is real. Codified regression tests added under `codify-verification` are subject to this rule: a codified spec that cannot fail is not a regression gate.
 - **`empirical-inquiry`** — settles an uncertain fact with the cheapest probe. A probe is a check, so it inherits the falsification requirement, including deliberate bite controls (cases that MUST report a problem) when the probe's job is to detect problems.
 - **`claim-evidence-mapping`** — an unfalsified gate cannot back a claim.
+- **`stale-state-claims`** — the sibling failure from the opposite direction: an assertion of state that *could* fail but is never re-evaluated, because nothing re-runs prose. Binding a temporal claim to a check is the recommended fix there, which puts that check under this rule.

--- a/plugins/src/base/rules/reference/stale-state-claims.md
+++ b/plugins/src/base/rules/reference/stale-state-claims.md
@@ -1,0 +1,88 @@
+# Stale State Claims — Reference
+
+Eager head: [eager/stale-state-claims.md](../eager/stale-state-claims.md).
+
+## Why this rule exists
+
+Most bad documentation is *wrong*. This kind was **right** — and that is what makes it dangerous. A note saying "not wired up yet" earned its credibility honestly, so the next reader has no reason to doubt it. There is no defect to find, no test that goes red, no reviewer who objects. The claim simply keeps being read after the world moved.
+
+The cost is not confusion, it is confident misdirection in a specific direction: **toward doing nothing**. An expired blocker never causes someone to break production. It causes work to be skipped, re-planned, or escalated — outcomes that look like caution and are indistinguishable from good judgment at the moment they happen.
+
+The `falsifiable-checks` rule covers instruments that cannot fail. This one covers assertions that *could* fail but are never re-evaluated, because nothing re-runs prose. Both produce the same end state — a confident answer with no live evidence behind it — from opposite directions.
+
+## The four failure modes, in detail
+
+### 1. Expired blocker note
+
+A comment, docstring, config value, or README line records that something is not available yet. The condition clears. The note does not.
+
+Observed: a deployment stage's endpoint was left unset with an adjacent comment explaining that its routing had "not yet been promoted." The routing had been live for days. An agent read the comment, believed it, and planned work to enable a capability that was already enabled — then reported the capability as pending.
+
+Countermeasures:
+- Treat any not-yet claim as a **hypothesis with an expiry you cannot see**. Resolve it with one live probe (a request, a query, a status read) before it enters a plan, a status report, or an escalation.
+- Cite the probe, not the comment: "verified live at <time>" is evidence; "the comment says" is hearsay about the past.
+- When you are the one who promotes/enables/provisions the thing, the note describing its absence is part of the change. Grep for it.
+
+### 2. Stale gate marker
+
+A config entry, flag, or checklist item is annotated as awaiting a human decision or an unfulfilled prerequisite. The prerequisite arrives, or the decision gets made elsewhere. The marker persists and keeps routing work to a gate that is no longer closed.
+
+Observed: an entry marked human-gated because no client had been provisioned. The client had existed for twelve days. The gate was honored anyway and the question escalated to a person who had already decided it and was surprised to be asked.
+
+This mode is corrosive twice over: it wastes the human's attention, and it teaches the agent that gates are noise — which is exactly the wrong lesson to carry into a gate that is still real.
+
+Countermeasures:
+- Before honoring a gate, verify the condition that justifies it still holds. A gate whose stated reason is falsifiable and false is not a gate.
+- Record gates as **conditions**, not as verdicts: "gated until <checkable condition>" can be evaluated; "human-gated" cannot.
+- When escalating, state the evidence that the gate is still live. If you cannot, you are escalating a comment.
+
+### 3. Prediction buried by closure
+
+Someone records a correct warning — "this will fail until X is fixed", "this leaves Y broken" — as a comment on a work item, and the item then closes. Closure is a filter: closed items are not read. The prediction is deleted in every practical sense while feeling like it was recorded.
+
+Observed: a comment correctly predicted a defect. The item closed 25 minutes later with no follow-up filed. The defect sat unnoticed for **eight days**, blocking a dependent item that was itself parked waiting for it — two items, both stalled, and the explanation was already written down in a place nobody would look.
+
+Countermeasures:
+- A prediction is either **real work or a retraction**. If real, it is a tracked leaf with an explicit blocking link to what it blocks (`tracked-work`), created **before** the parent item closes. If not real, say so in the same thread so the next reader is not left holding an unresolved warning.
+- Never let closing be the last action on an item that carries an open prediction. Check the comment thread as part of closing.
+- Blocking links are the mechanism that makes the parked dependent item legible. A prediction with no link is invisible from the side that is actually waiting.
+
+### 4. Silent waiting gate
+
+An approval, queue, or review state holds work and emits nothing. Its duration is therefore set by how often somebody happens to look, which is not a property of the work's urgency.
+
+Observed: a deploy approval gate held a security-relevant fix undeployed for two days. Nothing was broken, nobody was wrong, and nothing surfaced that the gate was waiting.
+
+Countermeasures:
+- Every waiting state needs a surfacing mechanism proportional to what it can hold: notification, dashboard row, scheduled sweep, or an automatic expiry.
+- **Fix the gate, not your habits.** "Remember to check" is not a mechanism; it is the same failure with a person's name on it.
+- When you add a gate, state how long it may silently hold work and what surfaces it. If the answer is "indefinitely" and "nothing", the gate is not finished.
+
+## Expiry-resistant forms
+
+Prefer, in order:
+
+1. **State what is true.** "Serves from <path>" outlives "not yet serving from <path>", because it stays wrong-detectably wrong instead of quietly-stale.
+2. **Bind the claim to a check.** A test, guard, or assertion that fails when the temporal claim goes false converts a silent expiry into a red build. (That check is itself subject to `falsifiable-checks` — a guard that cannot fail re-creates the problem it was added to solve.)
+3. **Bind the claim to a work item.** "Blocked by <ref>" is resolvable by anyone; "waiting on the migration" is resolvable only by whoever wrote it.
+4. **Timestamp and scope it.** If prose is genuinely the only option, write "as of <date>" and name the condition that ends it. A dated claim at least advertises its own age.
+
+Avoid: bare "not yet", "TODO once", "temporarily", "for now", "pending" with no owner, condition, date, or link. Each is a claim that can only be falsified by someone who already knows the truth — which is the one person who does not need to read it.
+
+## How to apply
+
+1. Reading a note that asserts a pending/blocked/not-yet state: **do not act on it yet.**
+2. Identify the cheapest live probe that settles the underlying fact.
+3. Run it. Report the observation, not the note.
+4. If the note is stale, **delete or correct it in the same change** — leaving it is handing the next reader the trap you just escaped.
+5. If the note is accurate, upgrade it while you are there: attach the condition, the link, or the check that will make it self-expiring.
+
+And when you are the one clearing a condition: sweep for the notes that described it. The change is not complete while the repository still asserts the old state.
+
+## Interaction with other rules
+
+- **`falsifiable-checks`** — the sibling failure. That rule prevents an instrument that cannot fail; this one prevents an assertion that never gets re-evaluated. A check bound to a temporal claim (form 2 above) sits under both rules at once.
+- **`empirical-inquiry`** — supplies the discipline this rule depends on: settle the fact with the cheapest probe rather than reasoning from what is written down. A stale note is exactly the "confident-sounding answer from a prior assumption" that rule forbids.
+- **`verification`** — a status derived from a comment is not runtime evidence. Reporting "still blocked" on the strength of a note is the same error as reporting "works" on the strength of the code looking correct.
+- **`tracked-work`** — the destination for any prediction that survives its item's closure: one live leaf, explicit blocking link, carried on the branch and PR.
+- **`claim-archaeology`** — the recovery path once mode 3 has already happened. Lifecycles are one-way, so a warning lost to closure resurfaces only as a fresh item whose ancestry has to be reconstructed. Archaeology is the cleanup; this rule is the prevention.

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -635,7 +635,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/eager/documentation-source-paths.md":
       "3a7c2a6264654a3cc44dd326441ba211a39c1c267033cc189c1c635adb84b52b",
     "plugins/src/base/rules/eager/empirical-inquiry.md":
-      "60d77a67cc0d3b6a0aad0ab8fe6de5dff0127b2a6c63fa46b021b7a711eb07d6",
+      "e638352e2426110eb831a2c4c7dbbd302f578009cdc5bc69258bddf3677c2f44",
     "plugins/src/base/rules/eager/factory-model.md":
       "dee39b4276926ee27a2614bf26b985fd33bb3d115313fa6e2893de12da13ed7c",
     "plugins/src/base/rules/eager/falsifiable-checks.md":
@@ -668,6 +668,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "a1702d6d0e9d80abc118b7c32a97ba9a988b195d86363b2d7a35e71752d9bd2e",
     "plugins/src/base/rules/eager/security-audit-handling.md":
       "1f6effe92be66736a0c9fab634c5fdd6ad1e789865faa67bb783c67ddb4ad490",
+    "plugins/src/base/rules/eager/stale-state-claims.md":
+      "faf5057f5910237b8d5048dbcccb73e0cd03762a8eefbeae43b5d0153104a85a",
     "plugins/src/base/rules/eager/tool-access-gate.md":
       "a5413a43ec353f768586e0a1cde3836db025cb5d8b80821020602995e71aa296",
     "plugins/src/base/rules/eager/tracked-work.md":
@@ -709,7 +711,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/reference/factory-model.md":
       "b28a2ea4df7c33390111667a2807d9003cf8c9a14829f6fb0dbc929b05bfed3a",
     "plugins/src/base/rules/reference/falsifiable-checks.md":
-      "e17b6700f3e5999059b030e5a66ac6250b93364efe8e6dcfb465e76e1edc571a",
+      "89015d3c21b38de5f6d871ef6d97f64820d0068cf93c5c3ab58927f65741944f",
     "plugins/src/base/rules/reference/history-audit.md":
       "20a46390f71fadda499c61193d430c3d53df49b55a4cefa50a112f82fa4b05ef",
     "plugins/src/base/rules/reference/integration-access-layer.md":
@@ -738,6 +740,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "209920b49dfae89460ef5366d5f2213e47d32ed3c2e23ed0b50e8283c37ad57c",
     "plugins/src/base/rules/reference/security-audit-handling.md":
       "9633e11ac89af26444a272449f36fe03f26e61fab40ca16a0ab50464725f7d8c",
+    "plugins/src/base/rules/reference/stale-state-claims.md":
+      "6329e1a7629f9a12f10454c767842aecee4964df8b7bb4aebda9dde3c0959c2a",
     "plugins/src/base/rules/reference/tool-access-gate.md":
       "70fcd6cd92dc003a40886b1bef02540e6401f5b70ba97308d42bbbddc0206eab",
     "plugins/src/base/rules/reference/tracked-work.md":
@@ -3377,6 +3381,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/rules/eager/rejection-detection.md": true,
     "plugins/lisa-copilot/rules/eager/repo-scope-split.md": true,
     "plugins/lisa-copilot/rules/eager/security-audit-handling.md": true,
+    "plugins/lisa-copilot/rules/eager/stale-state-claims.md": true,
     "plugins/lisa-copilot/rules/eager/tool-access-gate.md": true,
     "plugins/lisa-copilot/rules/eager/tracked-work.md": true,
     "plugins/lisa-copilot/rules/eager/upstream-to-lisa.md": true,
@@ -3412,6 +3417,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/rules/reference/rejection-detection.md": true,
     "plugins/lisa-copilot/rules/reference/repo-scope-split.md": true,
     "plugins/lisa-copilot/rules/reference/security-audit-handling.md": true,
+    "plugins/lisa-copilot/rules/reference/stale-state-claims.md": true,
     "plugins/lisa-copilot/rules/reference/tool-access-gate.md": true,
     "plugins/lisa-copilot/rules/reference/tracked-work.md": true,
     "plugins/lisa-copilot/rules/reference/upstream-to-lisa.md": true,
@@ -3782,6 +3788,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/rules/repo-scope-split.mdc": true,
     "plugins/lisa-cursor/rules/security-audit-handling-reference.mdc": true,
     "plugins/lisa-cursor/rules/security-audit-handling.mdc": true,
+    "plugins/lisa-cursor/rules/stale-state-claims-reference.mdc": true,
+    "plugins/lisa-cursor/rules/stale-state-claims.mdc": true,
     "plugins/lisa-cursor/rules/tool-access-gate-reference.mdc": true,
     "plugins/lisa-cursor/rules/tool-access-gate.mdc": true,
     "plugins/lisa-cursor/rules/tracked-work-reference.mdc": true,
@@ -6183,6 +6191,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/rules/eager/rejection-detection.md": true,
     "plugins/lisa/rules/eager/repo-scope-split.md": true,
     "plugins/lisa/rules/eager/security-audit-handling.md": true,
+    "plugins/lisa/rules/eager/stale-state-claims.md": true,
     "plugins/lisa/rules/eager/tool-access-gate.md": true,
     "plugins/lisa/rules/eager/tracked-work.md": true,
     "plugins/lisa/rules/eager/upstream-to-lisa.md": true,
@@ -6218,6 +6227,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/rules/reference/rejection-detection.md": true,
     "plugins/lisa/rules/reference/repo-scope-split.md": true,
     "plugins/lisa/rules/reference/security-audit-handling.md": true,
+    "plugins/lisa/rules/reference/stale-state-claims.md": true,
     "plugins/lisa/rules/reference/tool-access-gate.md": true,
     "plugins/lisa/rules/reference/tracked-work.md": true,
     "plugins/lisa/rules/reference/upstream-to-lisa.md": true,
@@ -6734,6 +6744,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/rules/eager/rejection-detection.md": true,
     "plugins/src/base/rules/eager/repo-scope-split.md": true,
     "plugins/src/base/rules/eager/security-audit-handling.md": true,
+    "plugins/src/base/rules/eager/stale-state-claims.md": true,
     "plugins/src/base/rules/eager/tool-access-gate.md": true,
     "plugins/src/base/rules/eager/tracked-work.md": true,
     "plugins/src/base/rules/eager/upstream-to-lisa.md": true,
@@ -6769,6 +6780,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/rules/reference/rejection-detection.md": true,
     "plugins/src/base/rules/reference/repo-scope-split.md": true,
     "plugins/src/base/rules/reference/security-audit-handling.md": true,
+    "plugins/src/base/rules/reference/stale-state-claims.md": true,
     "plugins/src/base/rules/reference/tool-access-gate.md": true,
     "plugins/src/base/rules/reference/tracked-work.md": true,
     "plugins/src/base/rules/reference/upstream-to-lisa.md": true,
@@ -8287,6 +8299,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/setup-github-project-verification.test.ts": true,
     "tests/unit/strategies/setup-linear-prd-verified-label.test.ts": true,
     "tests/unit/strategies/setup-notion-prd-verified-status.test.ts": true,
+    "tests/unit/strategies/stale-state-claims-rule.test.ts": true,
     "tests/unit/strategies/tagged-merge.test.ts": true,
     "tests/unit/strategies/tracked-work-contract.test.ts": true,
     "tests/unit/strategies/two-way-pr-ticket-linking.test.ts": true,

--- a/tests/unit/strategies/stale-state-claims-rule.test.ts
+++ b/tests/unit/strategies/stale-state-claims-rule.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Contract coverage for the stale-state-claims rule.
+ *
+ * The rule exists because a note recording a temporary state ("not yet",
+ * "pending", "human-gated") was ACCURATE when written, so nothing ever marks it
+ * false. It keeps being believed, and it misdirects in one specific direction —
+ * toward doing nothing: work skipped as blocked, re-planned as undone, or
+ * escalated to a human who already decided.
+ *
+ * These assertions pin the parts an agent must not lose: the closed four-mode
+ * vocabulary (each is a distinct mechanism with a distinct countermeasure), the
+ * delete-the-claim-when-you-clear-the-condition obligation (without it the rule
+ * is advice to be careful rather than an owner for the cleanup), the
+ * prediction-becomes-tracked-work escape from closure, and the cross-references
+ * that keep it a sibling of `falsifiable-checks` instead of a restatement.
+ *
+ * The confidentiality assertion is load-bearing rather than cosmetic: eager
+ * rules ship to every Lisa consumer, and the observed instances behind this rule
+ * came from one project's live infrastructure. Tracker refs and hostnames are
+ * the two forms that leak by copy-paste.
+ *
+ * Both roots are checked because `plugins/lisa` is generated from
+ * `plugins/src/base`: asserting one side only would let source-or-artifact drift
+ * through, which is the failure `check-plugins-sync` exists to catch.
+ * @module tests/unit/strategies/stale-state-claims-rule
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+
+/**
+ * The four observed ways a recorded state outlives its truth. Each is a distinct
+ * mechanism with a distinct countermeasure — this is a closed set, and losing an
+ * entry re-opens that blind spot.
+ */
+const FAILURE_MODES = [
+  "Expired blocker note",
+  "Stale gate marker",
+  "Prediction buried by closure",
+  "Silent waiting gate",
+] as const;
+
+const read = (root: string, rel: string): string =>
+  readFileSync(path.resolve(root, rel), "utf8");
+
+describe("stale-state-claims rule contract", () => {
+  describe.each(ROOTS)("%s", root => {
+    const eager = read(root, "rules/eager/stale-state-claims.md");
+    const reference = read(root, "rules/reference/stale-state-claims.md");
+
+    it("ships as a paired rule with a non-trivial body on both sides", () => {
+      expect(eager.length).toBeGreaterThan(500);
+      expect(reference.length).toBeGreaterThan(2000);
+    });
+
+    it("eager head breadcrumbs to the reference body verbatim", () => {
+      expect(eager).toContain(
+        "Full prose, worked examples, and the rewrite patterns: [reference/stale-state-claims.md](../reference/stale-state-claims.md)."
+      );
+    });
+
+    it("states the core rule: a recorded blocker is a claim about the past", () => {
+      expect(eager).toMatch(/claim about the past/i);
+      // The load-bearing instruction, not just the observation.
+      expect(eager).toMatch(/check the present before acting on it/i);
+    });
+
+    it("enumerates all four failure modes in the eager head", () => {
+      for (const mode of FAILURE_MODES) {
+        expect(eager).toContain(mode);
+      }
+    });
+
+    it("expands every failure mode in the reference body", () => {
+      for (const mode of FAILURE_MODES) {
+        expect(reference).toContain(mode);
+      }
+      // Each mode needs its observed instance, or it reads as hypothetical and
+      // gets skipped.
+      expect(reference).toMatch(/Observed:/);
+    });
+
+    it("assigns ownership of the cleanup to whoever clears the condition", () => {
+      // Without an owner the note survives every time, because the only person
+      // who knows it is false is the one who just made it false.
+      expect(eager).toMatch(/clears the condition deletes the claim/i);
+      expect(reference).toMatch(/sweep for the notes that described it/i);
+    });
+
+    it("requires expiry-resistant forms over pending prose", () => {
+      expect(eager).toMatch(/expiry-resistant/i);
+      expect(eager).toMatch(/fails when it goes stale/i);
+      expect(reference).toMatch(/Bind the claim to a check/);
+      expect(reference).toMatch(/Bind the claim to a work item/);
+    });
+
+    it("routes a prediction on a closing item to tracked work or retraction", () => {
+      expect(eager).toMatch(/becomes tracked work or is retracted/i);
+      expect(eager).toMatch(/blocking link/i);
+      expect(reference).toMatch(/before.{0,20}the parent item closes/i);
+    });
+
+    it("treats a gate that holds work silently as a defect in the gate", () => {
+      expect(eager).toMatch(/defect in the gate/i);
+      expect(eager).toMatch(/surfacing mechanism/i);
+      // "Remember to check" is the same failure with a person's name on it.
+      expect(reference).toMatch(/Fix the gate, not your habits/);
+    });
+
+    it("cross-references the sibling rules instead of restating them", () => {
+      expect(eager).toContain("falsifiable-checks");
+      expect(eager).toContain("empirical-inquiry");
+      expect(eager).toContain("tracked-work");
+      expect(eager).toContain("claim-archaeology");
+      expect(reference).toMatch(/## Interaction with other rules/);
+    });
+
+    it("carries no originating-project identifiers", () => {
+      // Eager rules ship to every consumer. Tracker refs and hostnames are the
+      // two forms that survive a copy-paste from the project that produced the
+      // observation.
+      for (const doc of [eager, reference]) {
+        expect(doc).not.toMatch(/\b[A-Z]{2,6}-\d{1,6}\b/);
+        expect(doc).not.toMatch(/https?:\/\//);
+        expect(doc).not.toMatch(/\b[a-z0-9-]+\.(com|net|org|io|dev)\b/);
+      }
+    });
+  });
+
+  describe.each(ROOTS)("%s sibling rule cross-references", root => {
+    it("empirical-inquiry forbids treating a recorded note as current state", () => {
+      const empirical = read(root, "rules/eager/empirical-inquiry.md");
+      expect(empirical).toMatch(/stale-state-claims/);
+      expect(empirical).toMatch(/human-gated/);
+    });
+
+    it("falsifiable-checks names it as the opposite-direction sibling", () => {
+      const falsifiable = read(root, "rules/reference/falsifiable-checks.md");
+      expect(falsifiable).toMatch(/stale-state-claims/);
+      expect(falsifiable).toMatch(/nothing re-runs prose/);
+    });
+  });
+});


### PR DESCRIPTION
Closes #2141

Work-Item: CodySwannGT/lisa#2141

## What

New paired eager/reference rule **`stale-state-claims`** — the sibling of `falsifiable-checks` from the opposite direction.

`falsifiable-checks` covers **instruments that cannot fail**. This covers **assertions of state that could fail but are never re-evaluated**, because nothing re-runs prose. Both end at the same place: a confident answer with no live evidence behind it.

## Why

A note recording a temporary state — "not yet", "pending", "waiting on X", "human-gated", "will flip once Y ships" — was **accurate the day it was written**. That is what makes it dangerous. There is no defect to find, no test that goes red, no reviewer who objects. It simply keeps being read after the world moved.

And it misdirects in one specific direction: **toward doing nothing**. Work gets skipped as blocked when nothing blocks it, re-planned as undone when it already shipped, or escalated to a person who made that decision weeks ago. Each of those looks like caution at the moment it happens, which is why nobody catches it.

## The four observed modes

| Mode | Observed |
| --- | --- |
| **Expired blocker note** | An endpoint left unset under a comment saying its routing was "not yet promoted." It had been serving live for days; an agent planned work to enable what was already enabled. |
| **Stale gate marker** | A "human-gated, nothing provisioned yet" annotation held twelve days past the day the thing it waited on existed. The decision was escalated to a person surprised to be asked. |
| **Prediction buried by closure** | A comment correctly predicted a defect. The item closed 25 minutes later, no follow-up was filed, and the defect sat unnoticed for eight days while a dependent item was parked waiting for it. |
| **Silent waiting gate** | An approval gate held a security-relevant fix undeployed for two days because nothing surfaced that it was waiting. |

## The five mandatory disciplines

1. **A recorded blocker is a claim about the past — check the present before acting on it.**
2. **Whoever clears the condition deletes the claim.** This is the load-bearing one. Without a named owner the note survives every time, because the only person who knows it is false is the one who just made it false.
3. **Prefer expiry-resistant forms.** Bind a temporal claim to a check or a work item, never to prose nobody re-reads.
4. **A prediction on a closing item becomes tracked work or is retracted.** Closure is a filter; prose on a closed item is deleted in every practical sense.
5. **A gate that can hold work silently is a defect in the gate.** "Remember to check" is the same failure with a person's name on it.

## Cross-references, not duplication

Per the one-canonical-slug convention, the rule cites rather than restates `falsifiable-checks`, `empirical-inquiry`, `verification`, `tracked-work`, and `claim-archaeology`. Two existing rules gain a pointer back:

- `eager/empirical-inquiry.md` — forbids treating a recorded pending/blocked/human-gated note as current state.
- `reference/falsifiable-checks.md` — names the opposite-direction sibling in its interactions list.

## Confidentiality

Eager rules ship to every Lisa consumer. Every observed instance is generalized — no client, repo, file path, hostname, or tracker id appears anywhere in the added rule text. The contract test enforces this mechanically (tracker-ref, URL, and hostname patterns) so it cannot rot back in.

## Falsification

Per `falsifiable-checks`, the contract test was broken four ways before landing. Each produced **exactly one** failing test, naming the assertion and the root:

| Deliberate break | Failing assertion |
| --- | --- |
| Dropped `Silent waiting gate` from the closed vocabulary | `enumerates all four failure modes in the eager head` |
| Removed the "whoever clears the condition deletes the claim" clause | `assigns ownership of the cleanup to whoever clears the condition` |
| Removed the `stale-state-claims` line from `empirical-inquiry` | `empirical-inquiry forbids treating a recorded note as current state` |
| Injected a tracker ref into an observed instance | `carries no originating-project identifiers` |

Restored: 26/26 green.

## Reviewer replay steps

```bash
bunx vitest run tests/unit/strategies/stale-state-claims-rule.test.ts   # 26 passed
bun run check:rules-pairing                                             # eager/reference pair resolves
bun run check:plugins                                                   # artifacts in sync with plugins/src
bun run check:upstream-evidence-manifest                                # manifest current
```

To reproduce the falsification, delete `Silent waiting gate` from `plugins/src/base/rules/eager/stale-state-claims.md`, re-run the test, and confirm exactly one failure naming the failure-mode assertion.

## Verification

- `bun run test:unit` — 470 test files / 8053 tests pass
- `tsc --noEmit` — clean
- `prettier --check .` — clean
- `oxlint` + `eslint` on the new test — 0 errors, 0 warnings
- `bun run check:rules-pairing` — green
- `bun run build:plugins` — run; `bun run check:plugins` confirms artifacts in sync
- `bun run build:upstream-evidence-manifest` — regenerated; `--check` green

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for identifying and correcting stale blockers, approval gates, predictions, and waiting states.
  * Added live-state verification requirements before planning, escalation, or blocker reporting.
  * Added tracked-work and expiry-resistant documentation practices for temporary claims.

* **Documentation**
  * Expanded rule references and connections to empirical inquiry and falsifiable checks.

* **Tests**
  * Added coverage validating the new guidance across supported plugin variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
