### PR TITLE
feat(rules): make every flow report whether the operator is needed

### DIFF
--- a/plugins/lisa-copilot/hooks/enforce-verification-gate.sh
+++ b/plugins/lisa-copilot/hooks/enforce-verification-gate.sh
@@ -132,6 +132,7 @@ STATE_DIR="${TMPDIR:-/tmp}/lisa-verification-gate"
 mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
 
 ARM_FLAG="${STATE_DIR}/${SESSION_ID}.armed"
+ARM_PLAN_FILE="${STATE_DIR}/${SESSION_ID}.plan"
 SUBAGENT_FLAG="${STATE_DIR}/${SESSION_ID}.subagent"
 COUNT_FILE="${STATE_DIR}/${SESSION_ID}.blocks"
 
@@ -149,6 +150,19 @@ arm_once() {
   [ -f "$ARM_FLAG" ] || touch "$ARM_FLAG" 2>/dev/null || true
 }
 
+record_current_plan() {
+  local plan="$1"
+  [ -n "$plan" ] || return 0
+  [ -f "$ARM_PLAN_FILE" ] && return 0
+  printf '%s\n' "$plan" > "$ARM_PLAN_FILE" 2>/dev/null || true
+}
+
+plan_from_prompt() {
+  printf '%s' "$1" |
+    sed -nE '1{s/^[[:space:]]*\/(lisa:implement|implement)[[:space:]]+([^[:space:]]+).*$/\2/p;}' |
+    tr '[:upper:]' '[:lower:]'
+}
+
 case "$HOOK_EVENT" in
   SubagentStart)
     touch "$SUBAGENT_FLAG" 2>/dev/null || true
@@ -162,6 +176,7 @@ case "$HOOK_EVENT" in
       case "$LEADING" in
         /lisa:implement*|/implement*)
           arm_once
+          record_current_plan "$(plan_from_prompt "$LEADING")"
           ;;
       esac
     fi
@@ -175,6 +190,8 @@ case "$HOOK_EVENT" in
       case "$SKILL_NAME" in
         lisa-implement|implement)
           arm_once
+          SKILL_ARGUMENTS=$(printf '%s' "$INPUT" | jq -r '.tool_input.arguments // .tool_input.input // empty' 2>/dev/null || true)
+          record_current_plan "$(printf '%s' "$SKILL_ARGUMENTS" | awk '{print tolower($1)}')"
           ;;
       esac
     fi
@@ -217,9 +234,16 @@ preserve_foreign_verdict() {
   [ -f "$VERDICT_FILE" ] || return 0
   command -v jq >/dev/null 2>&1 || return 0
 
-  local prior_plan archive
+  local prior_plan current_plan archive
   prior_plan=$(jq -r '.plan // empty' "$VERDICT_FILE" 2>/dev/null || true)
   [ -n "$prior_plan" ] || return 0
+  case "$prior_plan" in
+    *[!A-Za-z0-9._-]*)
+      return 0
+      ;;
+  esac
+  current_plan=$(cat "$ARM_PLAN_FILE" 2>/dev/null || true)
+  [ -z "$current_plan" ] || [ "$prior_plan" != "$current_plan" ] || return 0
 
   # Only archive a verdict written BEFORE this flow armed — anything newer
   # belongs to the current run.
@@ -413,7 +437,7 @@ verdict_is_terminal() {
 if verdict_is_terminal; then
   # Gate satisfied — disarm so a follow-up stop in the same session is not
   # re-gated against the now-consumed verdict, and allow the stop.
-  rm -f "$ARM_FLAG" "$COUNT_FILE" 2>/dev/null || true
+  rm -f "$ARM_FLAG" "$ARM_PLAN_FILE" "$COUNT_FILE" 2>/dev/null || true
   exit 0
 fi
 
@@ -426,7 +450,7 @@ COUNT=$((COUNT + 1))
 echo "$COUNT" > "$COUNT_FILE" 2>/dev/null || true
 
 if [ "$COUNT" -gt "$MAX_BLOCKS" ]; then
-  rm -f "$ARM_FLAG" "$COUNT_FILE" 2>/dev/null || true
+  rm -f "$ARM_FLAG" "$ARM_PLAN_FILE" "$COUNT_FILE" 2>/dev/null || true
   cat >&2 <<EOF
 Verification gate: still no passing verdict after ${MAX_BLOCKS} attempts.
 Releasing the stop gate to avoid an infinite loop. The /lisa:implement Verify

--- a/plugins/lisa-copilot/hooks/enforce-verification-gate.sh
+++ b/plugins/lisa-copilot/hooks/enforce-verification-gate.sh
@@ -205,6 +205,32 @@ fi
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 VERDICT_FILE="${PROJECT_DIR}/.lisa/verification-status.json"
 
+# A completed flow's verdict is a shipped record. The next flow in the same
+# worktree writes the SAME path and destroys it — losing the evidence that
+# proved the earlier work, and gating the new run against a verdict whose
+# `plan` names something else entirely. Preserve any verdict belonging to a
+# different plan before this run can overwrite it.
+#
+# Keyed on `.plan`, so re-running the same plan still overwrites in place and
+# no archive accumulates.
+preserve_foreign_verdict() {
+  [ -f "$VERDICT_FILE" ] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+
+  local prior_plan archive
+  prior_plan=$(jq -r '.plan // empty' "$VERDICT_FILE" 2>/dev/null || true)
+  [ -n "$prior_plan" ] || return 0
+
+  # Only archive a verdict written BEFORE this flow armed — anything newer
+  # belongs to the current run.
+  [ "$VERDICT_FILE" -ot "$ARM_FLAG" ] || return 0
+
+  archive="${PROJECT_DIR}/.lisa/verification-status.${prior_plan}.json"
+  [ -f "$archive" ] || cp -p "$VERDICT_FILE" "$archive" 2>/dev/null || true
+}
+
+preserve_foreign_verdict
+
 # Set by the v2 path when a claim/evidence violation is what closed the gate,
 # so the block message can state the real reason instead of the v1 fallback.
 V2_BLOCK_REASON=""

--- a/plugins/lisa-copilot/rules/eager/automation-runbook-contract.md
+++ b/plugins/lisa-copilot/rules/eager/automation-runbook-contract.md
@@ -15,6 +15,29 @@ Membership is **registration, not skill-existence**: a loop is under this contra
 registered as a scheduled automation, and registering a new one pulls it in automatically. There is
 no hardcoded roster of loops anywhere.
 
+### Interactive flows are members too
+
+The outcome vocabulary is **not cron-specific** — it answers "did this need me?", which an operator
+asks of an interactive run exactly as often as of a scheduled one. Every Lisa flow that terminates
+is a member: `lisa-implement`, `lisa-verify`, `lisa-plan`, `lisa-git-submit-pr`,
+`lisa-drive-pr-to-merge`, `lisa-research`, and any skill invoked as a slash command.
+
+For an interactive flow the record is the **final user-facing message**, not a JSONL row. It opens
+with the outcome and the operator action, before any narrative:
+
+```
+change-proved — nothing for you. PR #6393 open, auto-merge on, CI running.
+approval-requested — need a decision: ship the 135 Regular→Bold flips, or hold for design sign-off?
+recovery-required — need you: staging E2E gate red for congestion; rerun or admin-merge.
+```
+
+The operator must learn whether they are needed **from the first line**, without reading the report.
+Findings, evidence and caveats follow; they never replace the action line and never precede it.
+
+An interactive flow that ends in prose with the action buried — or absent — is the same contract
+violation as a silent cron exit. "I flagged X, I noticed Y, worth knowing Z" is narrative, not an
+outcome. If nothing is needed, say **"nothing for you"** in those words and stop.
+
 ## The six run outcomes
 
 Exactly one per run:

--- a/plugins/lisa-copilot/rules/eager/automation-runbook-contract.md
+++ b/plugins/lisa-copilot/rules/eager/automation-runbook-contract.md
@@ -22,8 +22,10 @@ asks of an interactive run exactly as often as of a scheduled one. Every Lisa fl
 is a member: `lisa-implement`, `lisa-verify`, `lisa-plan`, `lisa-git-submit-pr`,
 `lisa-drive-pr-to-merge`, `lisa-research`, and any skill invoked as a slash command.
 
-For an interactive flow the record is the **final user-facing message**, not a JSONL row. It opens
-with the outcome and the operator action, before any narrative:
+For an interactive flow the required run record is the **final user-facing message**, not a JSONL
+row written by `automation-run-record.mjs`. Interactive flows may also record local JSONL telemetry
+when a specific skill owns that surface, but this contract's mandatory record is the final answer.
+It opens with the outcome and the operator action, before any narrative:
 
 ```
 change-proved — nothing for you. PR #6393 open, auto-merge on, CI running.

--- a/plugins/lisa-copilot/rules/eager/settled-decisions.md
+++ b/plugins/lisa-copilot/rules/eager/settled-decisions.md
@@ -1,0 +1,55 @@
+# Settled Decisions (load-bearing)
+
+**Never ask the operator a question that a standing preference or your own gathered evidence has
+already answered.** Re-asking a settled decision is not caution — it hands back a choice the
+operator already made and makes them make it twice.
+
+## The test
+
+Before asking anything, check the three sources that may already hold the answer:
+
+1. **A standing preference** — something the operator has told you once and expects to hold:
+   recorded in project memory, `.lisa.config.json`, a project rule, `CLAUDE.md`/`AGENTS.md`, or
+   stated earlier in this conversation. "Every PR gets auto-merge and gets watched to merge" is a
+   standing preference; asking "want me to watch this PR?" violates it.
+2. **Evidence you already gathered** — if the research, measurement or code read you just performed
+   resolves the question, the question is answered. Report the decision and the evidence for it.
+3. **A convention with an obvious default** — where one option is clearly conventional and the other
+   needs a reason, take the conventional one and say so in one line.
+
+If any source answers it: **act, and state the decision in a clause.** Do not convert it into a
+question.
+
+## When asking IS right
+
+Ask when the answer would change the work *and* you genuinely cannot derive it:
+
+- The options lead to materially different deliverables and nothing in scope decides between them.
+- Proceeding on a wrong assumption would be unsafe, destructive, or waste substantial work.
+- The answer is a human judgement the artifacts do not contain — a product decision, a design
+  vocabulary that does not exist yet, a risk the operator owns.
+
+That kind of question is load-bearing and should be asked plainly, once, with a recommendation.
+
+## The failure mode this rule exists to stop
+
+Asking feels collaborative, so it gets over-applied — especially at the end of a report, where a
+trailing question reads as deference. It is not deference when the answer was already given; it is
+work handed back. Two specific tells:
+
+- **Half-applying an instruction.** Doing the first half of a standing preference automatically and
+  asking permission for the second half of the same preference.
+- **Asking after the research answered it.** Completing an investigation that points one direction
+  unambiguously, then presenting the conclusion as an open question.
+
+## Partial application is worse than either extreme
+
+If a standing preference covers a multi-step behavior, apply **all** of it. Applying part and asking
+about the rest produces the worst outcome: the operator is interrupted *and* the instruction was not
+honored.
+
+## Recording, not asking
+
+When you take a settled decision, make it auditable in one clause — "auto-merge on, per your standing
+preference", "scoped app-wide, because the Android finding decides it". That gives the operator the
+chance to correct it without requiring them to answer first.

--- a/plugins/lisa-copilot/rules/reference/settled-decisions.md
+++ b/plugins/lisa-copilot/rules/reference/settled-decisions.md
@@ -1,0 +1,29 @@
+# Settled Decisions
+
+Do not ask the operator to decide something that is already settled by standing preference, evidence you just gathered, or a conventional default. A question is appropriate only when the answer materially changes the work and the answer cannot be derived from available artifacts.
+
+## Decision Sources
+
+Check these sources before asking:
+
+1. Standing preferences recorded in memory, project config, project rules, instruction files, or earlier in the same conversation.
+2. Evidence already gathered during the current run. If research or code inspection resolves the choice, report the decision and cite the evidence.
+3. Conventional defaults where one option is clearly standard and the alternative needs a reason.
+
+If one of those sources answers the question, act on it and state the basis briefly.
+
+## When To Ask
+
+Ask only when the answer changes the deliverable and cannot be inferred. That includes product decisions, design vocabulary that does not exist yet, destructive or unsafe assumptions, or choices that would waste substantial work if guessed wrong.
+
+When asking, ask once, plainly, with a recommended option.
+
+## Common Violations
+
+Half-applying a standing instruction is a violation. If a preference covers a multi-step behavior, apply the whole behavior instead of doing one part and asking about the rest.
+
+Asking after the research answered the question is also a violation. When gathered evidence points one way unambiguously, treat it as a decision and make the reasoning auditable in the report.
+
+## Reporting
+
+Record settled decisions in a short clause, such as "auto-merge on, per standing preference" or "scoped app-wide, because the Android finding decides it." This gives the operator a chance to correct the decision without requiring an avoidable question first.

--- a/plugins/lisa-cursor/hooks/enforce-verification-gate.sh
+++ b/plugins/lisa-cursor/hooks/enforce-verification-gate.sh
@@ -132,6 +132,7 @@ STATE_DIR="${TMPDIR:-/tmp}/lisa-verification-gate"
 mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
 
 ARM_FLAG="${STATE_DIR}/${SESSION_ID}.armed"
+ARM_PLAN_FILE="${STATE_DIR}/${SESSION_ID}.plan"
 SUBAGENT_FLAG="${STATE_DIR}/${SESSION_ID}.subagent"
 COUNT_FILE="${STATE_DIR}/${SESSION_ID}.blocks"
 
@@ -149,6 +150,19 @@ arm_once() {
   [ -f "$ARM_FLAG" ] || touch "$ARM_FLAG" 2>/dev/null || true
 }
 
+record_current_plan() {
+  local plan="$1"
+  [ -n "$plan" ] || return 0
+  [ -f "$ARM_PLAN_FILE" ] && return 0
+  printf '%s\n' "$plan" > "$ARM_PLAN_FILE" 2>/dev/null || true
+}
+
+plan_from_prompt() {
+  printf '%s' "$1" |
+    sed -nE '1{s/^[[:space:]]*\/(lisa:implement|implement)[[:space:]]+([^[:space:]]+).*$/\2/p;}' |
+    tr '[:upper:]' '[:lower:]'
+}
+
 case "$HOOK_EVENT" in
   SubagentStart)
     touch "$SUBAGENT_FLAG" 2>/dev/null || true
@@ -162,6 +176,7 @@ case "$HOOK_EVENT" in
       case "$LEADING" in
         /lisa:implement*|/implement*)
           arm_once
+          record_current_plan "$(plan_from_prompt "$LEADING")"
           ;;
       esac
     fi
@@ -175,6 +190,8 @@ case "$HOOK_EVENT" in
       case "$SKILL_NAME" in
         lisa-implement|implement)
           arm_once
+          SKILL_ARGUMENTS=$(printf '%s' "$INPUT" | jq -r '.tool_input.arguments // .tool_input.input // empty' 2>/dev/null || true)
+          record_current_plan "$(printf '%s' "$SKILL_ARGUMENTS" | awk '{print tolower($1)}')"
           ;;
       esac
     fi
@@ -217,9 +234,16 @@ preserve_foreign_verdict() {
   [ -f "$VERDICT_FILE" ] || return 0
   command -v jq >/dev/null 2>&1 || return 0
 
-  local prior_plan archive
+  local prior_plan current_plan archive
   prior_plan=$(jq -r '.plan // empty' "$VERDICT_FILE" 2>/dev/null || true)
   [ -n "$prior_plan" ] || return 0
+  case "$prior_plan" in
+    *[!A-Za-z0-9._-]*)
+      return 0
+      ;;
+  esac
+  current_plan=$(cat "$ARM_PLAN_FILE" 2>/dev/null || true)
+  [ -z "$current_plan" ] || [ "$prior_plan" != "$current_plan" ] || return 0
 
   # Only archive a verdict written BEFORE this flow armed — anything newer
   # belongs to the current run.
@@ -413,7 +437,7 @@ verdict_is_terminal() {
 if verdict_is_terminal; then
   # Gate satisfied — disarm so a follow-up stop in the same session is not
   # re-gated against the now-consumed verdict, and allow the stop.
-  rm -f "$ARM_FLAG" "$COUNT_FILE" 2>/dev/null || true
+  rm -f "$ARM_FLAG" "$ARM_PLAN_FILE" "$COUNT_FILE" 2>/dev/null || true
   exit 0
 fi
 
@@ -426,7 +450,7 @@ COUNT=$((COUNT + 1))
 echo "$COUNT" > "$COUNT_FILE" 2>/dev/null || true
 
 if [ "$COUNT" -gt "$MAX_BLOCKS" ]; then
-  rm -f "$ARM_FLAG" "$COUNT_FILE" 2>/dev/null || true
+  rm -f "$ARM_FLAG" "$ARM_PLAN_FILE" "$COUNT_FILE" 2>/dev/null || true
   cat >&2 <<EOF
 Verification gate: still no passing verdict after ${MAX_BLOCKS} attempts.
 Releasing the stop gate to avoid an infinite loop. The /lisa:implement Verify

--- a/plugins/lisa-cursor/hooks/enforce-verification-gate.sh
+++ b/plugins/lisa-cursor/hooks/enforce-verification-gate.sh
@@ -205,6 +205,32 @@ fi
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 VERDICT_FILE="${PROJECT_DIR}/.lisa/verification-status.json"
 
+# A completed flow's verdict is a shipped record. The next flow in the same
+# worktree writes the SAME path and destroys it — losing the evidence that
+# proved the earlier work, and gating the new run against a verdict whose
+# `plan` names something else entirely. Preserve any verdict belonging to a
+# different plan before this run can overwrite it.
+#
+# Keyed on `.plan`, so re-running the same plan still overwrites in place and
+# no archive accumulates.
+preserve_foreign_verdict() {
+  [ -f "$VERDICT_FILE" ] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+
+  local prior_plan archive
+  prior_plan=$(jq -r '.plan // empty' "$VERDICT_FILE" 2>/dev/null || true)
+  [ -n "$prior_plan" ] || return 0
+
+  # Only archive a verdict written BEFORE this flow armed — anything newer
+  # belongs to the current run.
+  [ "$VERDICT_FILE" -ot "$ARM_FLAG" ] || return 0
+
+  archive="${PROJECT_DIR}/.lisa/verification-status.${prior_plan}.json"
+  [ -f "$archive" ] || cp -p "$VERDICT_FILE" "$archive" 2>/dev/null || true
+}
+
+preserve_foreign_verdict
+
 # Set by the v2 path when a claim/evidence violation is what closed the gate,
 # so the block message can state the real reason instead of the v1 fallback.
 V2_BLOCK_REASON=""

--- a/plugins/lisa-cursor/rules/automation-runbook-contract.mdc
+++ b/plugins/lisa-cursor/rules/automation-runbook-contract.mdc
@@ -20,6 +20,29 @@ Membership is **registration, not skill-existence**: a loop is under this contra
 registered as a scheduled automation, and registering a new one pulls it in automatically. There is
 no hardcoded roster of loops anywhere.
 
+### Interactive flows are members too
+
+The outcome vocabulary is **not cron-specific** — it answers "did this need me?", which an operator
+asks of an interactive run exactly as often as of a scheduled one. Every Lisa flow that terminates
+is a member: `lisa-implement`, `lisa-verify`, `lisa-plan`, `lisa-git-submit-pr`,
+`lisa-drive-pr-to-merge`, `lisa-research`, and any skill invoked as a slash command.
+
+For an interactive flow the record is the **final user-facing message**, not a JSONL row. It opens
+with the outcome and the operator action, before any narrative:
+
+```
+change-proved — nothing for you. PR #6393 open, auto-merge on, CI running.
+approval-requested — need a decision: ship the 135 Regular→Bold flips, or hold for design sign-off?
+recovery-required — need you: staging E2E gate red for congestion; rerun or admin-merge.
+```
+
+The operator must learn whether they are needed **from the first line**, without reading the report.
+Findings, evidence and caveats follow; they never replace the action line and never precede it.
+
+An interactive flow that ends in prose with the action buried — or absent — is the same contract
+violation as a silent cron exit. "I flagged X, I noticed Y, worth knowing Z" is narrative, not an
+outcome. If nothing is needed, say **"nothing for you"** in those words and stop.
+
 ## The six run outcomes
 
 Exactly one per run:

--- a/plugins/lisa-cursor/rules/automation-runbook-contract.mdc
+++ b/plugins/lisa-cursor/rules/automation-runbook-contract.mdc
@@ -27,8 +27,10 @@ asks of an interactive run exactly as often as of a scheduled one. Every Lisa fl
 is a member: `lisa-implement`, `lisa-verify`, `lisa-plan`, `lisa-git-submit-pr`,
 `lisa-drive-pr-to-merge`, `lisa-research`, and any skill invoked as a slash command.
 
-For an interactive flow the record is the **final user-facing message**, not a JSONL row. It opens
-with the outcome and the operator action, before any narrative:
+For an interactive flow the required run record is the **final user-facing message**, not a JSONL
+row written by `automation-run-record.mjs`. Interactive flows may also record local JSONL telemetry
+when a specific skill owns that surface, but this contract's mandatory record is the final answer.
+It opens with the outcome and the operator action, before any narrative:
 
 ```
 change-proved — nothing for you. PR #6393 open, auto-merge on, CI running.

--- a/plugins/lisa-cursor/rules/settled-decisions-reference.mdc
+++ b/plugins/lisa-cursor/rules/settled-decisions-reference.mdc
@@ -1,0 +1,34 @@
+---
+description: "Settled Decisions"
+alwaysApply: false
+---
+
+# Settled Decisions
+
+Do not ask the operator to decide something that is already settled by standing preference, evidence you just gathered, or a conventional default. A question is appropriate only when the answer materially changes the work and the answer cannot be derived from available artifacts.
+
+## Decision Sources
+
+Check these sources before asking:
+
+1. Standing preferences recorded in memory, project config, project rules, instruction files, or earlier in the same conversation.
+2. Evidence already gathered during the current run. If research or code inspection resolves the choice, report the decision and cite the evidence.
+3. Conventional defaults where one option is clearly standard and the alternative needs a reason.
+
+If one of those sources answers the question, act on it and state the basis briefly.
+
+## When To Ask
+
+Ask only when the answer changes the deliverable and cannot be inferred. That includes product decisions, design vocabulary that does not exist yet, destructive or unsafe assumptions, or choices that would waste substantial work if guessed wrong.
+
+When asking, ask once, plainly, with a recommended option.
+
+## Common Violations
+
+Half-applying a standing instruction is a violation. If a preference covers a multi-step behavior, apply the whole behavior instead of doing one part and asking about the rest.
+
+Asking after the research answered the question is also a violation. When gathered evidence points one way unambiguously, treat it as a decision and make the reasoning auditable in the report.
+
+## Reporting
+
+Record settled decisions in a short clause, such as "auto-merge on, per standing preference" or "scoped app-wide, because the Android finding decides it." This gives the operator a chance to correct the decision without requiring an avoidable question first.

--- a/plugins/lisa-cursor/rules/settled-decisions.mdc
+++ b/plugins/lisa-cursor/rules/settled-decisions.mdc
@@ -1,0 +1,60 @@
+---
+description: "Settled Decisions (load-bearing)"
+alwaysApply: true
+---
+
+# Settled Decisions (load-bearing)
+
+**Never ask the operator a question that a standing preference or your own gathered evidence has
+already answered.** Re-asking a settled decision is not caution — it hands back a choice the
+operator already made and makes them make it twice.
+
+## The test
+
+Before asking anything, check the three sources that may already hold the answer:
+
+1. **A standing preference** — something the operator has told you once and expects to hold:
+   recorded in project memory, `.lisa.config.json`, a project rule, `CLAUDE.md`/`AGENTS.md`, or
+   stated earlier in this conversation. "Every PR gets auto-merge and gets watched to merge" is a
+   standing preference; asking "want me to watch this PR?" violates it.
+2. **Evidence you already gathered** — if the research, measurement or code read you just performed
+   resolves the question, the question is answered. Report the decision and the evidence for it.
+3. **A convention with an obvious default** — where one option is clearly conventional and the other
+   needs a reason, take the conventional one and say so in one line.
+
+If any source answers it: **act, and state the decision in a clause.** Do not convert it into a
+question.
+
+## When asking IS right
+
+Ask when the answer would change the work *and* you genuinely cannot derive it:
+
+- The options lead to materially different deliverables and nothing in scope decides between them.
+- Proceeding on a wrong assumption would be unsafe, destructive, or waste substantial work.
+- The answer is a human judgement the artifacts do not contain — a product decision, a design
+  vocabulary that does not exist yet, a risk the operator owns.
+
+That kind of question is load-bearing and should be asked plainly, once, with a recommendation.
+
+## The failure mode this rule exists to stop
+
+Asking feels collaborative, so it gets over-applied — especially at the end of a report, where a
+trailing question reads as deference. It is not deference when the answer was already given; it is
+work handed back. Two specific tells:
+
+- **Half-applying an instruction.** Doing the first half of a standing preference automatically and
+  asking permission for the second half of the same preference.
+- **Asking after the research answered it.** Completing an investigation that points one direction
+  unambiguously, then presenting the conclusion as an open question.
+
+## Partial application is worse than either extreme
+
+If a standing preference covers a multi-step behavior, apply **all** of it. Applying part and asking
+about the rest produces the worst outcome: the operator is interrupted *and* the instruction was not
+honored.
+
+## Recording, not asking
+
+When you take a settled decision, make it auditable in one clause — "auto-merge on, per your standing
+preference", "scoped app-wide, because the Android finding decides it". That gives the operator the
+chance to correct it without requiring them to answer first.

--- a/plugins/lisa/hooks/enforce-verification-gate.sh
+++ b/plugins/lisa/hooks/enforce-verification-gate.sh
@@ -132,6 +132,7 @@ STATE_DIR="${TMPDIR:-/tmp}/lisa-verification-gate"
 mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
 
 ARM_FLAG="${STATE_DIR}/${SESSION_ID}.armed"
+ARM_PLAN_FILE="${STATE_DIR}/${SESSION_ID}.plan"
 SUBAGENT_FLAG="${STATE_DIR}/${SESSION_ID}.subagent"
 COUNT_FILE="${STATE_DIR}/${SESSION_ID}.blocks"
 
@@ -149,6 +150,19 @@ arm_once() {
   [ -f "$ARM_FLAG" ] || touch "$ARM_FLAG" 2>/dev/null || true
 }
 
+record_current_plan() {
+  local plan="$1"
+  [ -n "$plan" ] || return 0
+  [ -f "$ARM_PLAN_FILE" ] && return 0
+  printf '%s\n' "$plan" > "$ARM_PLAN_FILE" 2>/dev/null || true
+}
+
+plan_from_prompt() {
+  printf '%s' "$1" |
+    sed -nE '1{s/^[[:space:]]*\/(lisa:implement|implement)[[:space:]]+([^[:space:]]+).*$/\2/p;}' |
+    tr '[:upper:]' '[:lower:]'
+}
+
 case "$HOOK_EVENT" in
   SubagentStart)
     touch "$SUBAGENT_FLAG" 2>/dev/null || true
@@ -162,6 +176,7 @@ case "$HOOK_EVENT" in
       case "$LEADING" in
         /lisa:implement*|/implement*)
           arm_once
+          record_current_plan "$(plan_from_prompt "$LEADING")"
           ;;
       esac
     fi
@@ -175,6 +190,8 @@ case "$HOOK_EVENT" in
       case "$SKILL_NAME" in
         lisa-implement|implement)
           arm_once
+          SKILL_ARGUMENTS=$(printf '%s' "$INPUT" | jq -r '.tool_input.arguments // .tool_input.input // empty' 2>/dev/null || true)
+          record_current_plan "$(printf '%s' "$SKILL_ARGUMENTS" | awk '{print tolower($1)}')"
           ;;
       esac
     fi
@@ -217,9 +234,16 @@ preserve_foreign_verdict() {
   [ -f "$VERDICT_FILE" ] || return 0
   command -v jq >/dev/null 2>&1 || return 0
 
-  local prior_plan archive
+  local prior_plan current_plan archive
   prior_plan=$(jq -r '.plan // empty' "$VERDICT_FILE" 2>/dev/null || true)
   [ -n "$prior_plan" ] || return 0
+  case "$prior_plan" in
+    *[!A-Za-z0-9._-]*)
+      return 0
+      ;;
+  esac
+  current_plan=$(cat "$ARM_PLAN_FILE" 2>/dev/null || true)
+  [ -z "$current_plan" ] || [ "$prior_plan" != "$current_plan" ] || return 0
 
   # Only archive a verdict written BEFORE this flow armed — anything newer
   # belongs to the current run.
@@ -413,7 +437,7 @@ verdict_is_terminal() {
 if verdict_is_terminal; then
   # Gate satisfied — disarm so a follow-up stop in the same session is not
   # re-gated against the now-consumed verdict, and allow the stop.
-  rm -f "$ARM_FLAG" "$COUNT_FILE" 2>/dev/null || true
+  rm -f "$ARM_FLAG" "$ARM_PLAN_FILE" "$COUNT_FILE" 2>/dev/null || true
   exit 0
 fi
 
@@ -426,7 +450,7 @@ COUNT=$((COUNT + 1))
 echo "$COUNT" > "$COUNT_FILE" 2>/dev/null || true
 
 if [ "$COUNT" -gt "$MAX_BLOCKS" ]; then
-  rm -f "$ARM_FLAG" "$COUNT_FILE" 2>/dev/null || true
+  rm -f "$ARM_FLAG" "$ARM_PLAN_FILE" "$COUNT_FILE" 2>/dev/null || true
   cat >&2 <<EOF
 Verification gate: still no passing verdict after ${MAX_BLOCKS} attempts.
 Releasing the stop gate to avoid an infinite loop. The /lisa:implement Verify

--- a/plugins/lisa/hooks/enforce-verification-gate.sh
+++ b/plugins/lisa/hooks/enforce-verification-gate.sh
@@ -205,6 +205,32 @@ fi
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 VERDICT_FILE="${PROJECT_DIR}/.lisa/verification-status.json"
 
+# A completed flow's verdict is a shipped record. The next flow in the same
+# worktree writes the SAME path and destroys it — losing the evidence that
+# proved the earlier work, and gating the new run against a verdict whose
+# `plan` names something else entirely. Preserve any verdict belonging to a
+# different plan before this run can overwrite it.
+#
+# Keyed on `.plan`, so re-running the same plan still overwrites in place and
+# no archive accumulates.
+preserve_foreign_verdict() {
+  [ -f "$VERDICT_FILE" ] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+
+  local prior_plan archive
+  prior_plan=$(jq -r '.plan // empty' "$VERDICT_FILE" 2>/dev/null || true)
+  [ -n "$prior_plan" ] || return 0
+
+  # Only archive a verdict written BEFORE this flow armed — anything newer
+  # belongs to the current run.
+  [ "$VERDICT_FILE" -ot "$ARM_FLAG" ] || return 0
+
+  archive="${PROJECT_DIR}/.lisa/verification-status.${prior_plan}.json"
+  [ -f "$archive" ] || cp -p "$VERDICT_FILE" "$archive" 2>/dev/null || true
+}
+
+preserve_foreign_verdict
+
 # Set by the v2 path when a claim/evidence violation is what closed the gate,
 # so the block message can state the real reason instead of the v1 fallback.
 V2_BLOCK_REASON=""

--- a/plugins/lisa/rules/eager/automation-runbook-contract.md
+++ b/plugins/lisa/rules/eager/automation-runbook-contract.md
@@ -15,6 +15,29 @@ Membership is **registration, not skill-existence**: a loop is under this contra
 registered as a scheduled automation, and registering a new one pulls it in automatically. There is
 no hardcoded roster of loops anywhere.
 
+### Interactive flows are members too
+
+The outcome vocabulary is **not cron-specific** — it answers "did this need me?", which an operator
+asks of an interactive run exactly as often as of a scheduled one. Every Lisa flow that terminates
+is a member: `lisa-implement`, `lisa-verify`, `lisa-plan`, `lisa-git-submit-pr`,
+`lisa-drive-pr-to-merge`, `lisa-research`, and any skill invoked as a slash command.
+
+For an interactive flow the record is the **final user-facing message**, not a JSONL row. It opens
+with the outcome and the operator action, before any narrative:
+
+```
+change-proved — nothing for you. PR #6393 open, auto-merge on, CI running.
+approval-requested — need a decision: ship the 135 Regular→Bold flips, or hold for design sign-off?
+recovery-required — need you: staging E2E gate red for congestion; rerun or admin-merge.
+```
+
+The operator must learn whether they are needed **from the first line**, without reading the report.
+Findings, evidence and caveats follow; they never replace the action line and never precede it.
+
+An interactive flow that ends in prose with the action buried — or absent — is the same contract
+violation as a silent cron exit. "I flagged X, I noticed Y, worth knowing Z" is narrative, not an
+outcome. If nothing is needed, say **"nothing for you"** in those words and stop.
+
 ## The six run outcomes
 
 Exactly one per run:

--- a/plugins/lisa/rules/eager/automation-runbook-contract.md
+++ b/plugins/lisa/rules/eager/automation-runbook-contract.md
@@ -22,8 +22,10 @@ asks of an interactive run exactly as often as of a scheduled one. Every Lisa fl
 is a member: `lisa-implement`, `lisa-verify`, `lisa-plan`, `lisa-git-submit-pr`,
 `lisa-drive-pr-to-merge`, `lisa-research`, and any skill invoked as a slash command.
 
-For an interactive flow the record is the **final user-facing message**, not a JSONL row. It opens
-with the outcome and the operator action, before any narrative:
+For an interactive flow the required run record is the **final user-facing message**, not a JSONL
+row written by `automation-run-record.mjs`. Interactive flows may also record local JSONL telemetry
+when a specific skill owns that surface, but this contract's mandatory record is the final answer.
+It opens with the outcome and the operator action, before any narrative:
 
 ```
 change-proved — nothing for you. PR #6393 open, auto-merge on, CI running.

--- a/plugins/lisa/rules/eager/settled-decisions.md
+++ b/plugins/lisa/rules/eager/settled-decisions.md
@@ -1,0 +1,55 @@
+# Settled Decisions (load-bearing)
+
+**Never ask the operator a question that a standing preference or your own gathered evidence has
+already answered.** Re-asking a settled decision is not caution — it hands back a choice the
+operator already made and makes them make it twice.
+
+## The test
+
+Before asking anything, check the three sources that may already hold the answer:
+
+1. **A standing preference** — something the operator has told you once and expects to hold:
+   recorded in project memory, `.lisa.config.json`, a project rule, `CLAUDE.md`/`AGENTS.md`, or
+   stated earlier in this conversation. "Every PR gets auto-merge and gets watched to merge" is a
+   standing preference; asking "want me to watch this PR?" violates it.
+2. **Evidence you already gathered** — if the research, measurement or code read you just performed
+   resolves the question, the question is answered. Report the decision and the evidence for it.
+3. **A convention with an obvious default** — where one option is clearly conventional and the other
+   needs a reason, take the conventional one and say so in one line.
+
+If any source answers it: **act, and state the decision in a clause.** Do not convert it into a
+question.
+
+## When asking IS right
+
+Ask when the answer would change the work *and* you genuinely cannot derive it:
+
+- The options lead to materially different deliverables and nothing in scope decides between them.
+- Proceeding on a wrong assumption would be unsafe, destructive, or waste substantial work.
+- The answer is a human judgement the artifacts do not contain — a product decision, a design
+  vocabulary that does not exist yet, a risk the operator owns.
+
+That kind of question is load-bearing and should be asked plainly, once, with a recommendation.
+
+## The failure mode this rule exists to stop
+
+Asking feels collaborative, so it gets over-applied — especially at the end of a report, where a
+trailing question reads as deference. It is not deference when the answer was already given; it is
+work handed back. Two specific tells:
+
+- **Half-applying an instruction.** Doing the first half of a standing preference automatically and
+  asking permission for the second half of the same preference.
+- **Asking after the research answered it.** Completing an investigation that points one direction
+  unambiguously, then presenting the conclusion as an open question.
+
+## Partial application is worse than either extreme
+
+If a standing preference covers a multi-step behavior, apply **all** of it. Applying part and asking
+about the rest produces the worst outcome: the operator is interrupted *and* the instruction was not
+honored.
+
+## Recording, not asking
+
+When you take a settled decision, make it auditable in one clause — "auto-merge on, per your standing
+preference", "scoped app-wide, because the Android finding decides it". That gives the operator the
+chance to correct it without requiring them to answer first.

--- a/plugins/lisa/rules/reference/settled-decisions.md
+++ b/plugins/lisa/rules/reference/settled-decisions.md
@@ -1,0 +1,29 @@
+# Settled Decisions
+
+Do not ask the operator to decide something that is already settled by standing preference, evidence you just gathered, or a conventional default. A question is appropriate only when the answer materially changes the work and the answer cannot be derived from available artifacts.
+
+## Decision Sources
+
+Check these sources before asking:
+
+1. Standing preferences recorded in memory, project config, project rules, instruction files, or earlier in the same conversation.
+2. Evidence already gathered during the current run. If research or code inspection resolves the choice, report the decision and cite the evidence.
+3. Conventional defaults where one option is clearly standard and the alternative needs a reason.
+
+If one of those sources answers the question, act on it and state the basis briefly.
+
+## When To Ask
+
+Ask only when the answer changes the deliverable and cannot be inferred. That includes product decisions, design vocabulary that does not exist yet, destructive or unsafe assumptions, or choices that would waste substantial work if guessed wrong.
+
+When asking, ask once, plainly, with a recommended option.
+
+## Common Violations
+
+Half-applying a standing instruction is a violation. If a preference covers a multi-step behavior, apply the whole behavior instead of doing one part and asking about the rest.
+
+Asking after the research answered the question is also a violation. When gathered evidence points one way unambiguously, treat it as a decision and make the reasoning auditable in the report.
+
+## Reporting
+
+Record settled decisions in a short clause, such as "auto-merge on, per standing preference" or "scoped app-wide, because the Android finding decides it." This gives the operator a chance to correct the decision without requiring an avoidable question first.

--- a/plugins/src/base/hooks/enforce-verification-gate.sh
+++ b/plugins/src/base/hooks/enforce-verification-gate.sh
@@ -132,6 +132,7 @@ STATE_DIR="${TMPDIR:-/tmp}/lisa-verification-gate"
 mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
 
 ARM_FLAG="${STATE_DIR}/${SESSION_ID}.armed"
+ARM_PLAN_FILE="${STATE_DIR}/${SESSION_ID}.plan"
 SUBAGENT_FLAG="${STATE_DIR}/${SESSION_ID}.subagent"
 COUNT_FILE="${STATE_DIR}/${SESSION_ID}.blocks"
 
@@ -149,6 +150,19 @@ arm_once() {
   [ -f "$ARM_FLAG" ] || touch "$ARM_FLAG" 2>/dev/null || true
 }
 
+record_current_plan() {
+  local plan="$1"
+  [ -n "$plan" ] || return 0
+  [ -f "$ARM_PLAN_FILE" ] && return 0
+  printf '%s\n' "$plan" > "$ARM_PLAN_FILE" 2>/dev/null || true
+}
+
+plan_from_prompt() {
+  printf '%s' "$1" |
+    sed -nE '1{s/^[[:space:]]*\/(lisa:implement|implement)[[:space:]]+([^[:space:]]+).*$/\2/p;}' |
+    tr '[:upper:]' '[:lower:]'
+}
+
 case "$HOOK_EVENT" in
   SubagentStart)
     touch "$SUBAGENT_FLAG" 2>/dev/null || true
@@ -162,6 +176,7 @@ case "$HOOK_EVENT" in
       case "$LEADING" in
         /lisa:implement*|/implement*)
           arm_once
+          record_current_plan "$(plan_from_prompt "$LEADING")"
           ;;
       esac
     fi
@@ -175,6 +190,8 @@ case "$HOOK_EVENT" in
       case "$SKILL_NAME" in
         lisa-implement|implement)
           arm_once
+          SKILL_ARGUMENTS=$(printf '%s' "$INPUT" | jq -r '.tool_input.arguments // .tool_input.input // empty' 2>/dev/null || true)
+          record_current_plan "$(printf '%s' "$SKILL_ARGUMENTS" | awk '{print tolower($1)}')"
           ;;
       esac
     fi
@@ -217,9 +234,16 @@ preserve_foreign_verdict() {
   [ -f "$VERDICT_FILE" ] || return 0
   command -v jq >/dev/null 2>&1 || return 0
 
-  local prior_plan archive
+  local prior_plan current_plan archive
   prior_plan=$(jq -r '.plan // empty' "$VERDICT_FILE" 2>/dev/null || true)
   [ -n "$prior_plan" ] || return 0
+  case "$prior_plan" in
+    *[!A-Za-z0-9._-]*)
+      return 0
+      ;;
+  esac
+  current_plan=$(cat "$ARM_PLAN_FILE" 2>/dev/null || true)
+  [ -z "$current_plan" ] || [ "$prior_plan" != "$current_plan" ] || return 0
 
   # Only archive a verdict written BEFORE this flow armed — anything newer
   # belongs to the current run.
@@ -413,7 +437,7 @@ verdict_is_terminal() {
 if verdict_is_terminal; then
   # Gate satisfied — disarm so a follow-up stop in the same session is not
   # re-gated against the now-consumed verdict, and allow the stop.
-  rm -f "$ARM_FLAG" "$COUNT_FILE" 2>/dev/null || true
+  rm -f "$ARM_FLAG" "$ARM_PLAN_FILE" "$COUNT_FILE" 2>/dev/null || true
   exit 0
 fi
 
@@ -426,7 +450,7 @@ COUNT=$((COUNT + 1))
 echo "$COUNT" > "$COUNT_FILE" 2>/dev/null || true
 
 if [ "$COUNT" -gt "$MAX_BLOCKS" ]; then
-  rm -f "$ARM_FLAG" "$COUNT_FILE" 2>/dev/null || true
+  rm -f "$ARM_FLAG" "$ARM_PLAN_FILE" "$COUNT_FILE" 2>/dev/null || true
   cat >&2 <<EOF
 Verification gate: still no passing verdict after ${MAX_BLOCKS} attempts.
 Releasing the stop gate to avoid an infinite loop. The /lisa:implement Verify

--- a/plugins/src/base/hooks/enforce-verification-gate.sh
+++ b/plugins/src/base/hooks/enforce-verification-gate.sh
@@ -205,6 +205,32 @@ fi
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 VERDICT_FILE="${PROJECT_DIR}/.lisa/verification-status.json"
 
+# A completed flow's verdict is a shipped record. The next flow in the same
+# worktree writes the SAME path and destroys it — losing the evidence that
+# proved the earlier work, and gating the new run against a verdict whose
+# `plan` names something else entirely. Preserve any verdict belonging to a
+# different plan before this run can overwrite it.
+#
+# Keyed on `.plan`, so re-running the same plan still overwrites in place and
+# no archive accumulates.
+preserve_foreign_verdict() {
+  [ -f "$VERDICT_FILE" ] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+
+  local prior_plan archive
+  prior_plan=$(jq -r '.plan // empty' "$VERDICT_FILE" 2>/dev/null || true)
+  [ -n "$prior_plan" ] || return 0
+
+  # Only archive a verdict written BEFORE this flow armed — anything newer
+  # belongs to the current run.
+  [ "$VERDICT_FILE" -ot "$ARM_FLAG" ] || return 0
+
+  archive="${PROJECT_DIR}/.lisa/verification-status.${prior_plan}.json"
+  [ -f "$archive" ] || cp -p "$VERDICT_FILE" "$archive" 2>/dev/null || true
+}
+
+preserve_foreign_verdict
+
 # Set by the v2 path when a claim/evidence violation is what closed the gate,
 # so the block message can state the real reason instead of the v1 fallback.
 V2_BLOCK_REASON=""

--- a/plugins/src/base/rules/eager/automation-runbook-contract.md
+++ b/plugins/src/base/rules/eager/automation-runbook-contract.md
@@ -15,6 +15,29 @@ Membership is **registration, not skill-existence**: a loop is under this contra
 registered as a scheduled automation, and registering a new one pulls it in automatically. There is
 no hardcoded roster of loops anywhere.
 
+### Interactive flows are members too
+
+The outcome vocabulary is **not cron-specific** — it answers "did this need me?", which an operator
+asks of an interactive run exactly as often as of a scheduled one. Every Lisa flow that terminates
+is a member: `lisa-implement`, `lisa-verify`, `lisa-plan`, `lisa-git-submit-pr`,
+`lisa-drive-pr-to-merge`, `lisa-research`, and any skill invoked as a slash command.
+
+For an interactive flow the record is the **final user-facing message**, not a JSONL row. It opens
+with the outcome and the operator action, before any narrative:
+
+```
+change-proved — nothing for you. PR #6393 open, auto-merge on, CI running.
+approval-requested — need a decision: ship the 135 Regular→Bold flips, or hold for design sign-off?
+recovery-required — need you: staging E2E gate red for congestion; rerun or admin-merge.
+```
+
+The operator must learn whether they are needed **from the first line**, without reading the report.
+Findings, evidence and caveats follow; they never replace the action line and never precede it.
+
+An interactive flow that ends in prose with the action buried — or absent — is the same contract
+violation as a silent cron exit. "I flagged X, I noticed Y, worth knowing Z" is narrative, not an
+outcome. If nothing is needed, say **"nothing for you"** in those words and stop.
+
 ## The six run outcomes
 
 Exactly one per run:

--- a/plugins/src/base/rules/eager/automation-runbook-contract.md
+++ b/plugins/src/base/rules/eager/automation-runbook-contract.md
@@ -22,8 +22,10 @@ asks of an interactive run exactly as often as of a scheduled one. Every Lisa fl
 is a member: `lisa-implement`, `lisa-verify`, `lisa-plan`, `lisa-git-submit-pr`,
 `lisa-drive-pr-to-merge`, `lisa-research`, and any skill invoked as a slash command.
 
-For an interactive flow the record is the **final user-facing message**, not a JSONL row. It opens
-with the outcome and the operator action, before any narrative:
+For an interactive flow the required run record is the **final user-facing message**, not a JSONL
+row written by `automation-run-record.mjs`. Interactive flows may also record local JSONL telemetry
+when a specific skill owns that surface, but this contract's mandatory record is the final answer.
+It opens with the outcome and the operator action, before any narrative:
 
 ```
 change-proved — nothing for you. PR #6393 open, auto-merge on, CI running.

--- a/plugins/src/base/rules/eager/settled-decisions.md
+++ b/plugins/src/base/rules/eager/settled-decisions.md
@@ -1,0 +1,55 @@
+# Settled Decisions (load-bearing)
+
+**Never ask the operator a question that a standing preference or your own gathered evidence has
+already answered.** Re-asking a settled decision is not caution — it hands back a choice the
+operator already made and makes them make it twice.
+
+## The test
+
+Before asking anything, check the three sources that may already hold the answer:
+
+1. **A standing preference** — something the operator has told you once and expects to hold:
+   recorded in project memory, `.lisa.config.json`, a project rule, `CLAUDE.md`/`AGENTS.md`, or
+   stated earlier in this conversation. "Every PR gets auto-merge and gets watched to merge" is a
+   standing preference; asking "want me to watch this PR?" violates it.
+2. **Evidence you already gathered** — if the research, measurement or code read you just performed
+   resolves the question, the question is answered. Report the decision and the evidence for it.
+3. **A convention with an obvious default** — where one option is clearly conventional and the other
+   needs a reason, take the conventional one and say so in one line.
+
+If any source answers it: **act, and state the decision in a clause.** Do not convert it into a
+question.
+
+## When asking IS right
+
+Ask when the answer would change the work *and* you genuinely cannot derive it:
+
+- The options lead to materially different deliverables and nothing in scope decides between them.
+- Proceeding on a wrong assumption would be unsafe, destructive, or waste substantial work.
+- The answer is a human judgement the artifacts do not contain — a product decision, a design
+  vocabulary that does not exist yet, a risk the operator owns.
+
+That kind of question is load-bearing and should be asked plainly, once, with a recommendation.
+
+## The failure mode this rule exists to stop
+
+Asking feels collaborative, so it gets over-applied — especially at the end of a report, where a
+trailing question reads as deference. It is not deference when the answer was already given; it is
+work handed back. Two specific tells:
+
+- **Half-applying an instruction.** Doing the first half of a standing preference automatically and
+  asking permission for the second half of the same preference.
+- **Asking after the research answered it.** Completing an investigation that points one direction
+  unambiguously, then presenting the conclusion as an open question.
+
+## Partial application is worse than either extreme
+
+If a standing preference covers a multi-step behavior, apply **all** of it. Applying part and asking
+about the rest produces the worst outcome: the operator is interrupted *and* the instruction was not
+honored.
+
+## Recording, not asking
+
+When you take a settled decision, make it auditable in one clause — "auto-merge on, per your standing
+preference", "scoped app-wide, because the Android finding decides it". That gives the operator the
+chance to correct it without requiring them to answer first.

--- a/plugins/src/base/rules/reference/settled-decisions.md
+++ b/plugins/src/base/rules/reference/settled-decisions.md
@@ -1,0 +1,29 @@
+# Settled Decisions
+
+Do not ask the operator to decide something that is already settled by standing preference, evidence you just gathered, or a conventional default. A question is appropriate only when the answer materially changes the work and the answer cannot be derived from available artifacts.
+
+## Decision Sources
+
+Check these sources before asking:
+
+1. Standing preferences recorded in memory, project config, project rules, instruction files, or earlier in the same conversation.
+2. Evidence already gathered during the current run. If research or code inspection resolves the choice, report the decision and cite the evidence.
+3. Conventional defaults where one option is clearly standard and the alternative needs a reason.
+
+If one of those sources answers the question, act on it and state the basis briefly.
+
+## When To Ask
+
+Ask only when the answer changes the deliverable and cannot be inferred. That includes product decisions, design vocabulary that does not exist yet, destructive or unsafe assumptions, or choices that would waste substantial work if guessed wrong.
+
+When asking, ask once, plainly, with a recommended option.
+
+## Common Violations
+
+Half-applying a standing instruction is a violation. If a preference covers a multi-step behavior, apply the whole behavior instead of doing one part and asking about the rest.
+
+Asking after the research answered the question is also a violation. When gathered evidence points one way unambiguously, treat it as a decision and make the reasoning auditable in the report.
+
+## Reporting
+
+Record settled decisions in a short clause, such as "auto-merge on, per standing preference" or "scoped app-wide, because the Android finding decides it." This gives the operator a chance to correct the decision without requiring an avoidable question first.

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -583,7 +583,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/enforce-team-first.sh":
       "51d2e929ea6c04e7c7851be7849dd7d3e7cd0c211b4c8fb856e858a51ddeeb58",
     "plugins/src/base/hooks/enforce-verification-gate.sh":
-      "5c1bc7522643a9252c680fb5aafa71bc61c8e689476a3562809223c143ad540c",
+      "29885d07ff6da70f193ea0f0691d63f324deb79fbd7ede519596415875d94458",
     "plugins/src/base/hooks/inject-flow-context.sh":
       "f4ab07065762d592c0fc36be2e4918e767b293aaa4094b9d85d69010576c6dbf",
     "plugins/src/base/hooks/inject-rules.sh":
@@ -613,7 +613,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/track-plan-sessions.sh":
       "8bc47dcad3aed628df0c9efbe7b6f3df87635b94b0c54c71e0bd52eceace563a",
     "plugins/src/base/rules/eager/automation-runbook-contract.md":
-      "963fcdbfc65b1a1f983ddfacb5e76d18e562064d5b0681bdca7fcc2ddac00a45",
+      "3d082e2f9a980ccf1dd6b51cc7251dfb171a53f8dcc36c11b4d9fd1f3d89dec7",
     "plugins/src/base/rules/eager/base-rules.md":
       "d3a4bd518acf2c6f4e866042542f9155fdbf5b2fdad5747e1afd097bdef15351",
     "plugins/src/base/rules/eager/claim-archaeology.md":
@@ -742,6 +742,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "209920b49dfae89460ef5366d5f2213e47d32ed3c2e23ed0b50e8283c37ad57c",
     "plugins/src/base/rules/reference/security-audit-handling.md":
       "9633e11ac89af26444a272449f36fe03f26e61fab40ca16a0ab50464725f7d8c",
+    "plugins/src/base/rules/reference/settled-decisions.md":
+      "6c84f309a1f765eba1648d6ace836387bd96b924f245c16cf3629f501ef6bb18",
     "plugins/src/base/rules/reference/stale-state-claims.md":
       "6329e1a7629f9a12f10454c767842aecee4964df8b7bb4aebda9dde3c0959c2a",
     "plugins/src/base/rules/reference/tool-access-gate.md":
@@ -3420,6 +3422,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/rules/reference/rejection-detection.md": true,
     "plugins/lisa-copilot/rules/reference/repo-scope-split.md": true,
     "plugins/lisa-copilot/rules/reference/security-audit-handling.md": true,
+    "plugins/lisa-copilot/rules/reference/settled-decisions.md": true,
     "plugins/lisa-copilot/rules/reference/stale-state-claims.md": true,
     "plugins/lisa-copilot/rules/reference/tool-access-gate.md": true,
     "plugins/lisa-copilot/rules/reference/tracked-work.md": true,
@@ -3791,6 +3794,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/rules/repo-scope-split.mdc": true,
     "plugins/lisa-cursor/rules/security-audit-handling-reference.mdc": true,
     "plugins/lisa-cursor/rules/security-audit-handling.mdc": true,
+    "plugins/lisa-cursor/rules/settled-decisions-reference.mdc": true,
     "plugins/lisa-cursor/rules/settled-decisions.mdc": true,
     "plugins/lisa-cursor/rules/stale-state-claims-reference.mdc": true,
     "plugins/lisa-cursor/rules/stale-state-claims.mdc": true,
@@ -6232,6 +6236,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/rules/reference/rejection-detection.md": true,
     "plugins/lisa/rules/reference/repo-scope-split.md": true,
     "plugins/lisa/rules/reference/security-audit-handling.md": true,
+    "plugins/lisa/rules/reference/settled-decisions.md": true,
     "plugins/lisa/rules/reference/stale-state-claims.md": true,
     "plugins/lisa/rules/reference/tool-access-gate.md": true,
     "plugins/lisa/rules/reference/tracked-work.md": true,
@@ -6786,6 +6791,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/rules/reference/rejection-detection.md": true,
     "plugins/src/base/rules/reference/repo-scope-split.md": true,
     "plugins/src/base/rules/reference/security-audit-handling.md": true,
+    "plugins/src/base/rules/reference/settled-decisions.md": true,
     "plugins/src/base/rules/reference/stale-state-claims.md": true,
     "plugins/src/base/rules/reference/tool-access-gate.md": true,
     "plugins/src/base/rules/reference/tracked-work.md": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -583,7 +583,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/enforce-team-first.sh":
       "51d2e929ea6c04e7c7851be7849dd7d3e7cd0c211b4c8fb856e858a51ddeeb58",
     "plugins/src/base/hooks/enforce-verification-gate.sh":
-      "120cec1795ad4cb49ab67a54fb0c3552185338bb0b8dda0f19f70dc1dac288f9",
+      "5c1bc7522643a9252c680fb5aafa71bc61c8e689476a3562809223c143ad540c",
     "plugins/src/base/hooks/inject-flow-context.sh":
       "f4ab07065762d592c0fc36be2e4918e767b293aaa4094b9d85d69010576c6dbf",
     "plugins/src/base/hooks/inject-rules.sh":
@@ -613,7 +613,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/track-plan-sessions.sh":
       "8bc47dcad3aed628df0c9efbe7b6f3df87635b94b0c54c71e0bd52eceace563a",
     "plugins/src/base/rules/eager/automation-runbook-contract.md":
-      "b9b4f4d82b366959e90451a2b425ac116953ac074ab6a192dc3909ec8a2be1d6",
+      "963fcdbfc65b1a1f983ddfacb5e76d18e562064d5b0681bdca7fcc2ddac00a45",
     "plugins/src/base/rules/eager/base-rules.md":
       "d3a4bd518acf2c6f4e866042542f9155fdbf5b2fdad5747e1afd097bdef15351",
     "plugins/src/base/rules/eager/claim-archaeology.md":
@@ -668,6 +668,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "a1702d6d0e9d80abc118b7c32a97ba9a988b195d86363b2d7a35e71752d9bd2e",
     "plugins/src/base/rules/eager/security-audit-handling.md":
       "1f6effe92be66736a0c9fab634c5fdd6ad1e789865faa67bb783c67ddb4ad490",
+    "plugins/src/base/rules/eager/settled-decisions.md":
+      "f5339c81b8d29f628830e6147314cbb941b9d9e6d87c3834d8fe7adc4b46ef4c",
     "plugins/src/base/rules/eager/stale-state-claims.md":
       "faf5057f5910237b8d5048dbcccb73e0cd03762a8eefbeae43b5d0153104a85a",
     "plugins/src/base/rules/eager/tool-access-gate.md":
@@ -3381,6 +3383,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/rules/eager/rejection-detection.md": true,
     "plugins/lisa-copilot/rules/eager/repo-scope-split.md": true,
     "plugins/lisa-copilot/rules/eager/security-audit-handling.md": true,
+    "plugins/lisa-copilot/rules/eager/settled-decisions.md": true,
     "plugins/lisa-copilot/rules/eager/stale-state-claims.md": true,
     "plugins/lisa-copilot/rules/eager/tool-access-gate.md": true,
     "plugins/lisa-copilot/rules/eager/tracked-work.md": true,
@@ -3788,6 +3791,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/rules/repo-scope-split.mdc": true,
     "plugins/lisa-cursor/rules/security-audit-handling-reference.mdc": true,
     "plugins/lisa-cursor/rules/security-audit-handling.mdc": true,
+    "plugins/lisa-cursor/rules/settled-decisions.mdc": true,
     "plugins/lisa-cursor/rules/stale-state-claims-reference.mdc": true,
     "plugins/lisa-cursor/rules/stale-state-claims.mdc": true,
     "plugins/lisa-cursor/rules/tool-access-gate-reference.mdc": true,
@@ -6191,6 +6195,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/rules/eager/rejection-detection.md": true,
     "plugins/lisa/rules/eager/repo-scope-split.md": true,
     "plugins/lisa/rules/eager/security-audit-handling.md": true,
+    "plugins/lisa/rules/eager/settled-decisions.md": true,
     "plugins/lisa/rules/eager/stale-state-claims.md": true,
     "plugins/lisa/rules/eager/tool-access-gate.md": true,
     "plugins/lisa/rules/eager/tracked-work.md": true,
@@ -6744,6 +6749,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/rules/eager/rejection-detection.md": true,
     "plugins/src/base/rules/eager/repo-scope-split.md": true,
     "plugins/src/base/rules/eager/security-audit-handling.md": true,
+    "plugins/src/base/rules/eager/settled-decisions.md": true,
     "plugins/src/base/rules/eager/stale-state-claims.md": true,
     "plugins/src/base/rules/eager/tool-access-gate.md": true,
     "plugins/src/base/rules/eager/tracked-work.md": true,
@@ -8066,6 +8072,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/hooks/commit-msg.test.ts": true,
     "tests/unit/hooks/enforce-config-extensions.test.ts": true,
     "tests/unit/hooks/enforce-team-first.test.ts": true,
+    "tests/unit/hooks/enforce-verification-gate-preserve.test.ts": true,
     "tests/unit/hooks/enforce-verification-gate-v1.test.ts": true,
     "tests/unit/hooks/enforce-verification-gate-v2.test.ts": true,
     "tests/unit/hooks/enforcement-gates-e2e.test.ts": true,

--- a/tests/helpers/verification-gate-harness.ts
+++ b/tests/helpers/verification-gate-harness.ts
@@ -12,7 +12,15 @@
  * @module tests/helpers/verification-gate-harness
  */
 import { spawnSync } from "child_process";
-import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "fs";
 import { tmpdir } from "os";
 import path from "path";
 
@@ -57,6 +65,8 @@ export type GateScenario = {
   writeVerdict: (contents: string, options?: WriteVerdictOptions) => void;
   writeConfig: (enforceBoundaries: boolean) => void;
   writeEvidenceFile: (relativePath: string, contents: string) => void;
+  /** Reads a project-relative file, or null when it does not exist. */
+  readProjectFile: (relativePath: string) => string | null;
 };
 
 /**
@@ -146,6 +156,11 @@ export const createGateScenario = (
       const target = path.join(projectDir, relativePath);
       mkdirSync(path.dirname(target), { recursive: true });
       writeFileSync(target, contents);
+    },
+
+    readProjectFile: (relativePath: string): string | null => {
+      const target = path.join(projectDir, relativePath);
+      return existsSync(target) ? readFileSync(target, "utf8") : null;
     },
   };
 };

--- a/tests/unit/hooks/enforce-verification-gate-preserve.test.ts
+++ b/tests/unit/hooks/enforce-verification-gate-preserve.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Preservation of a foreign verdict by the enforce-verification-gate.sh Stop hook.
+ *
+ * `.lisa/verification-status.json` is a single path per repo, but a worktree
+ * outlives any one flow. When a second `/lisa:implement` runs there, the
+ * verification-specialist writes that same path — destroying the completed
+ * flow's verdict, which is the record of what its evidence proved.
+ *
+ * Observed: a shipped SE-5494 verdict (status `pass`, six evidence entries)
+ * was one write away from being lost to an unrelated SE-5780 run, and its
+ * stale mtime gated that run for four consecutive stop attempts while naming
+ * a criterion from the other ticket.
+ *
+ * The hook archives any verdict whose `plan` differs from the current run
+ * before it can be overwritten. Keyed on `.plan`, so re-running the SAME plan
+ * still overwrites in place and no archive accumulates.
+ * @module tests/unit/hooks/enforce-verification-gate-preserve
+ */
+import {
+  PASSING_CRITERION,
+  v1Verdict,
+} from "../../helpers/verification-gate-fixtures";
+import type { GateScenario } from "../../helpers/verification-gate-harness";
+import { createGateScenario } from "../../helpers/verification-gate-harness";
+
+let harness: GateScenario;
+
+beforeEach(() => {
+  harness = createGateScenario(process.env);
+});
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+/** The completed flow whose verdict must survive the next run. */
+const PRIOR_PLAN = "se-5494-player-preview-drawer";
+/** Where the hook is expected to archive it. */
+const PRIOR_ARCHIVE = `.lisa/verification-status.${PRIOR_PLAN}.json`;
+
+/**
+ * Builds a terminal verdict belonging to a named plan.
+ * @param plan Value for the verdict's `.plan` field, which keys the archive.
+ * @returns Serialized verdict JSON.
+ */
+const verdictForPlan = (plan: string): string =>
+  JSON.stringify({
+    ...JSON.parse(v1Verdict("pass", [PASSING_CRITERION])),
+    plan,
+  });
+
+describe("enforce-verification-gate.sh — foreign verdict preservation", () => {
+  it("archives a prior plan's verdict under a plan-scoped filename", () => {
+    harness.writeVerdict(verdictForPlan(PRIOR_PLAN), {
+      stale: true,
+    });
+
+    harness.armSession("s1");
+    harness.stop("s1");
+
+    const archived = harness.readProjectFile(PRIOR_ARCHIVE);
+
+    expect(archived).not.toBeNull();
+    expect(JSON.parse(archived as string).plan).toBe(PRIOR_PLAN);
+  });
+
+  it("preserves the archived verdict's claims, not just its status", () => {
+    harness.writeVerdict(verdictForPlan(PRIOR_PLAN), {
+      stale: true,
+    });
+
+    harness.armSession("s1");
+    harness.stop("s1");
+
+    const archived = JSON.parse(
+      harness.readProjectFile(PRIOR_ARCHIVE) as string
+    );
+
+    // The point of the archive is the evidence, not the verdict word.
+    expect(archived.criteria).toHaveLength(1);
+    expect(archived.status).toBe("pass");
+  });
+
+  it("does not archive when the verdict has no plan to key on", () => {
+    harness.writeVerdict(v1Verdict("pass", [PASSING_CRITERION]), {
+      stale: true,
+    });
+
+    harness.armSession("s1");
+    harness.stop("s1");
+
+    // Nothing to name the archive after — and nothing to distinguish it from
+    // the current run's own output, so leaving it alone is correct.
+    expect(
+      harness.readProjectFile(".lisa/verification-status.undefined.json")
+    ).toBeNull();
+  });
+
+  it("leaves a fresh verdict alone — it belongs to the current run", () => {
+    harness.armSession("s1");
+    harness.writeVerdict(verdictForPlan("se-5780-dpl-font-enforcement"));
+    harness.stop("s1");
+
+    // Written after arming, so it is this run's own verdict. Archiving it
+    // would litter the repo on every successful flow.
+    expect(
+      harness.readProjectFile(
+        ".lisa/verification-status.se-5780-dpl-font-enforcement.json"
+      )
+    ).toBeNull();
+  });
+
+  it("does not overwrite an archive that already exists", () => {
+    harness.writeVerdict(verdictForPlan(PRIOR_PLAN), {
+      stale: true,
+    });
+    harness.writeEvidenceFile(
+      PRIOR_ARCHIVE,
+      JSON.stringify({ plan: PRIOR_PLAN, sentinel: "original" })
+    );
+
+    harness.armSession("s1");
+    harness.stop("s1");
+
+    const archived = JSON.parse(
+      harness.readProjectFile(PRIOR_ARCHIVE) as string
+    );
+
+    // A second run must not clobber the first archive with a partial verdict.
+    expect(archived.sentinel).toBe("original");
+  });
+});

--- a/tests/unit/hooks/enforce-verification-gate-preserve.test.ts
+++ b/tests/unit/hooks/enforce-verification-gate-preserve.test.ts
@@ -81,6 +81,19 @@ describe("enforce-verification-gate.sh — foreign verdict preservation", () => 
     expect(archived.status).toBe("pass");
   });
 
+  it("does not archive when the prior verdict belongs to the current plan", () => {
+    harness.writeVerdict(verdictForPlan("bce-2"), {
+      stale: true,
+    });
+
+    harness.armSession("s1");
+    harness.stop("s1");
+
+    expect(
+      harness.readProjectFile(".lisa/verification-status.bce-2.json")
+    ).toBeNull();
+  });
+
   it("does not archive when the verdict has no plan to key on", () => {
     harness.writeVerdict(v1Verdict("pass", [PASSING_CRITERION]), {
       stale: true,
@@ -94,6 +107,20 @@ describe("enforce-verification-gate.sh — foreign verdict preservation", () => 
     expect(
       harness.readProjectFile(".lisa/verification-status.undefined.json")
     ).toBeNull();
+  });
+
+  it("does not construct an archive path from an unsafe plan name", () => {
+    harness.writeVerdict(verdictForPlan("../outside"), {
+      stale: true,
+    });
+
+    harness.armSession("s1");
+    harness.stop("s1");
+
+    expect(
+      harness.readProjectFile(".lisa/verification-status.../outside.json")
+    ).toBeNull();
+    expect(harness.readProjectFile("../outside.json")).toBeNull();
   });
 
   it("leaves a fresh verdict alone — it belongs to the current run", () => {


### PR DESCRIPTION
## Summary

Refs #2144

Work-Item: CodySwannGT/lisa#2144

- Extend the run-outcome contract to interactive Lisa flows so the first line states the outcome and operator action.
- Add the settled-decisions rule so agents apply standing preferences, gathered evidence, and conventional defaults instead of re-asking.
- Preserve stale verification verdicts only for foreign plans, skip same-plan reruns, and reject unsafe archive plan names.
- Add the settled-decisions reference bodies and regenerate plugin artifacts for Claude, Cursor, Antigravity, and Copilot parity.

## Verification

- `bun run check:rules-pairing`
- `bun test tests/unit/hooks/enforce-verification-gate-preserve.test.ts`
- `bun run check:plugins`
- Commit hook: secrets scan, lint-staged, work-item tracking, commitlint, and AI co-authorship passed.

## Notes

CodeRabbit requested the reference rule pairing, explicit interactive-flow record semantics, safe verdict archive names, and same-plan archive behavior. This update addresses those items source-first and regenerates the distributed plugin copies.