### PR TITLE
Record verified finding: -c model= does not govern a Codex Cloud task's model

### DIFF
--- a/plans/portable-secrets-remote-execution.md
+++ b/plans/portable-secrets-remote-execution.md
@@ -446,13 +446,29 @@ but gates 5, because the dispatcher itself holds a rotating credential.
    exposes only `exec | status | list | apply | diff`. B.4 tier 1 is unavailable for this surface, so
    setup starts at the console/emit tiers and says so rather than claiming an API that does not exist.
 2. **Does Codex Cloud cap concurrent tasks per account?** Still open. Bounds useful fan-out; a quota
-   question, not a dollar question. Needs a live account to answer.
-3. **Does `-c model=` propagate into the Cloud task,** or does the environment's own setting win?
-   Still open. The flag documents itself as overriding the *dispatching* machine's
-   `~/.codex/config.toml`. One real dispatch settles it; deferred rather than burn quota probing.
+   question, not a dollar question. Needs a live account under load to answer.
+3. ~~**Does `-c model=` propagate into the Cloud task?**~~ **Answered 2026-08-01 by live dispatch:
+   `-c model=` does not govern the Cloud task's model.**
 
-Neither remaining unknown blocks anything shipped: both concern tuning a dispatch, not whether one
-works.
+   Dispatched `-c model="not-a-real-model-probe-xyz"` to a real environment. The CLI accepted it
+   without local validation and submitted the task, which then ran to `READY` successfully. Had the
+   invalid value governed remote execution, the task could not have run.
+
+   State this as an observation, not a mechanism: it is not established whether the override fails
+   to propagate or propagates and is ignored. Both produce the same operational rule — **do not use
+   `-c model=` to select a Cloud task's model.** Set it on the environment instead.
+
+   Two further observations from the same probes:
+
+   - `codex cloud exec` prints **only the task URL** on success — no separate identifier line. Any
+     dispatcher must extract the identifier from that URL, which `lisa-remote-dispatch` does.
+   - `codex cloud status` surfaces status, environment label, and diff summary — **not the agent's
+     text reply**. A read-only "report X" task therefore cannot be read back through the CLI. This
+     reinforces the existing rule: reconcile through durable artifacts (PR, diff, external object),
+     never through agent chatter.
+
+The one remaining unknown does not block anything shipped: it concerns tuning fan-out volume, not
+whether a dispatch works.
 
 ## Repository constraints
 
@@ -468,4 +484,5 @@ works.
 | Session | Date | Phases | Notes |
 |---------|------|--------|-------|
 | 1 | 2026-08-01 | Research | Audited the proven gunnertech implementation (frontend PRs #119–#169, wiki PRs #250–#253) and Lisa's existing `lisa-secrets-access` (PR #2127); confirmed `codex cloud exec` is fire-and-forget (3–4s) and has no `--model` flag; plan created |
+| 3 | 2026-08-01 | Verify | Live-dispatched three read-only probes to a real Codex Cloud environment (`files=0` on all three, nothing touched). Settled unknown 3: `-c model=` does not govern the Cloud task's model. Also proved the shipped `lisa-remote-dispatch` end to end against that environment — precondition check, real CLI invocation, task-ID capture from live output, durable ledger write, exit without polling |
 | 2 | 2026-08-01 | A, A.6, B, C, D, E | Implemented all parts. Verified unknown 1 (no Codex provisioning API). Part A: surfaces/ladder/materialization + rotation with write-scope preflight and provider-held advisory lease. Part B: `lisa-setup-remote-env` with `require`/`install` manifest. Part C: `lisa-remote-dispatch` + `executionEnv` on `lisa-implement`. Part D: `scheduler: "github-actions"` workflow generator + stopped-clock detection. Part E: routed `lisa-atlassian-access` and `lisa-notion-access` through the chokepoint, added `doctor-secrets` and `validate-config`. 123 new tests; full suite green at 477 files / 8185 tests. Two unknowns deferred (concurrency cap, `-c model=` propagation) — both tuning questions, neither blocking |

--- a/plugins/lisa-agy/skills/lisa-remote-dispatch/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-remote-dispatch/SKILL.md
@@ -55,6 +55,11 @@ It does **not** poll, wait, or hold anything open. The operator's machine is a l
 
 **A dispatch with no captured task identifier is a failed dispatch**, even when the command exited zero. The identifier is the only durable handle on work that outlives this process; an untracked remote task is worse than none, because nothing can reconcile it and a retry would duplicate it.
 
+Two things about the CLI surface, both verified live on 2026-08-01:
+
+- `codex cloud exec` prints **only the task URL** on success — there is no separate identifier line to parse. The identifier must be extracted from that URL.
+- `codex cloud status` returns status, environment label, and a diff summary — **not the agent's text reply**. So a task cannot report a result back through the CLI, only through an artifact. Reconcile through durable objects (the PR, the diff, the external record), never through what the agent said.
+
 ## Surface options
 
 ```json
@@ -75,7 +80,9 @@ It does **not** poll, wait, or hold anything open. The operator's machine is a l
 
 **`branch` is always passed explicitly.** `codex cloud exec` defaults to the *current* branch, and a dispatcher's incidental checkout state must never decide where work runs.
 
-**`model` goes through `-c`,** because the subcommand has no `--model` flag; the CLI's own help documents `-c model="..."`. Model is vendor-specific while `executionEnv` is routing, so it is scoped under the surface rather than hung off the top level. Resolution order: per-invocation override → project config → environment default.
+**`model` goes through `-c`,** because the subcommand has no `--model` flag; the CLI's own help documents `-c model="..."`. Model is vendor-specific while `executionEnv` is routing, so it is scoped under the surface rather than hung off the top level.
+
+**But do not rely on it to select a Codex Cloud task's model.** Verified by live dispatch on 2026-08-01: `-c model="not-a-real-model-probe-xyz"` was accepted without local validation, submitted, and the task then ran to `READY` successfully. Had the invalid value governed remote execution, the task could not have run. Whether the override fails to propagate or propagates and is ignored is not established — the operational rule is the same either way. **Set the model on the environment itself; treat this field as a hint the surface may disregard.**
 
 Do not invent an abstract tier (`fast` / `deep`) mapped per vendor. That produces confidently wrong mappings when a second surface arrives with an unrelated model lineup. A raw string scoped to the surface that owns it is honest.
 

--- a/plugins/lisa-copilot/skills/lisa-remote-dispatch/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-remote-dispatch/SKILL.md
@@ -55,6 +55,11 @@ It does **not** poll, wait, or hold anything open. The operator's machine is a l
 
 **A dispatch with no captured task identifier is a failed dispatch**, even when the command exited zero. The identifier is the only durable handle on work that outlives this process; an untracked remote task is worse than none, because nothing can reconcile it and a retry would duplicate it.
 
+Two things about the CLI surface, both verified live on 2026-08-01:
+
+- `codex cloud exec` prints **only the task URL** on success — there is no separate identifier line to parse. The identifier must be extracted from that URL.
+- `codex cloud status` returns status, environment label, and a diff summary — **not the agent's text reply**. So a task cannot report a result back through the CLI, only through an artifact. Reconcile through durable objects (the PR, the diff, the external record), never through what the agent said.
+
 ## Surface options
 
 ```json
@@ -75,7 +80,9 @@ It does **not** poll, wait, or hold anything open. The operator's machine is a l
 
 **`branch` is always passed explicitly.** `codex cloud exec` defaults to the *current* branch, and a dispatcher's incidental checkout state must never decide where work runs.
 
-**`model` goes through `-c`,** because the subcommand has no `--model` flag; the CLI's own help documents `-c model="..."`. Model is vendor-specific while `executionEnv` is routing, so it is scoped under the surface rather than hung off the top level. Resolution order: per-invocation override → project config → environment default.
+**`model` goes through `-c`,** because the subcommand has no `--model` flag; the CLI's own help documents `-c model="..."`. Model is vendor-specific while `executionEnv` is routing, so it is scoped under the surface rather than hung off the top level.
+
+**But do not rely on it to select a Codex Cloud task's model.** Verified by live dispatch on 2026-08-01: `-c model="not-a-real-model-probe-xyz"` was accepted without local validation, submitted, and the task then ran to `READY` successfully. Had the invalid value governed remote execution, the task could not have run. Whether the override fails to propagate or propagates and is ignored is not established — the operational rule is the same either way. **Set the model on the environment itself; treat this field as a hint the surface may disregard.**
 
 Do not invent an abstract tier (`fast` / `deep`) mapped per vendor. That produces confidently wrong mappings when a second surface arrives with an unrelated model lineup. A raw string scoped to the surface that owns it is honest.
 

--- a/plugins/lisa-cursor/skills/lisa-remote-dispatch/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-remote-dispatch/SKILL.md
@@ -55,6 +55,11 @@ It does **not** poll, wait, or hold anything open. The operator's machine is a l
 
 **A dispatch with no captured task identifier is a failed dispatch**, even when the command exited zero. The identifier is the only durable handle on work that outlives this process; an untracked remote task is worse than none, because nothing can reconcile it and a retry would duplicate it.
 
+Two things about the CLI surface, both verified live on 2026-08-01:
+
+- `codex cloud exec` prints **only the task URL** on success — there is no separate identifier line to parse. The identifier must be extracted from that URL.
+- `codex cloud status` returns status, environment label, and a diff summary — **not the agent's text reply**. So a task cannot report a result back through the CLI, only through an artifact. Reconcile through durable objects (the PR, the diff, the external record), never through what the agent said.
+
 ## Surface options
 
 ```json
@@ -75,7 +80,9 @@ It does **not** poll, wait, or hold anything open. The operator's machine is a l
 
 **`branch` is always passed explicitly.** `codex cloud exec` defaults to the *current* branch, and a dispatcher's incidental checkout state must never decide where work runs.
 
-**`model` goes through `-c`,** because the subcommand has no `--model` flag; the CLI's own help documents `-c model="..."`. Model is vendor-specific while `executionEnv` is routing, so it is scoped under the surface rather than hung off the top level. Resolution order: per-invocation override → project config → environment default.
+**`model` goes through `-c`,** because the subcommand has no `--model` flag; the CLI's own help documents `-c model="..."`. Model is vendor-specific while `executionEnv` is routing, so it is scoped under the surface rather than hung off the top level.
+
+**But do not rely on it to select a Codex Cloud task's model.** Verified by live dispatch on 2026-08-01: `-c model="not-a-real-model-probe-xyz"` was accepted without local validation, submitted, and the task then ran to `READY` successfully. Had the invalid value governed remote execution, the task could not have run. Whether the override fails to propagate or propagates and is ignored is not established — the operational rule is the same either way. **Set the model on the environment itself; treat this field as a hint the surface may disregard.**
 
 Do not invent an abstract tier (`fast` / `deep`) mapped per vendor. That produces confidently wrong mappings when a second surface arrives with an unrelated model lineup. A raw string scoped to the surface that owns it is honest.
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-remote-dispatch/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-remote-dispatch/SKILL.md
@@ -55,6 +55,11 @@ It does **not** poll, wait, or hold anything open. The operator's machine is a l
 
 **A dispatch with no captured task identifier is a failed dispatch**, even when the command exited zero. The identifier is the only durable handle on work that outlives this process; an untracked remote task is worse than none, because nothing can reconcile it and a retry would duplicate it.
 
+Two things about the CLI surface, both verified live on 2026-08-01:
+
+- `codex cloud exec` prints **only the task URL** on success — there is no separate identifier line to parse. The identifier must be extracted from that URL.
+- `codex cloud status` returns status, environment label, and a diff summary — **not the agent's text reply**. So a task cannot report a result back through the CLI, only through an artifact. Reconcile through durable objects (the PR, the diff, the external record), never through what the agent said.
+
 ## Surface options
 
 ```json
@@ -75,7 +80,9 @@ It does **not** poll, wait, or hold anything open. The operator's machine is a l
 
 **`branch` is always passed explicitly.** `codex cloud exec` defaults to the *current* branch, and a dispatcher's incidental checkout state must never decide where work runs.
 
-**`model` goes through `-c`,** because the subcommand has no `--model` flag; the CLI's own help documents `-c model="..."`. Model is vendor-specific while `executionEnv` is routing, so it is scoped under the surface rather than hung off the top level. Resolution order: per-invocation override → project config → environment default.
+**`model` goes through `-c`,** because the subcommand has no `--model` flag; the CLI's own help documents `-c model="..."`. Model is vendor-specific while `executionEnv` is routing, so it is scoped under the surface rather than hung off the top level.
+
+**But do not rely on it to select a Codex Cloud task's model.** Verified by live dispatch on 2026-08-01: `-c model="not-a-real-model-probe-xyz"` was accepted without local validation, submitted, and the task then ran to `READY` successfully. Had the invalid value governed remote execution, the task could not have run. Whether the override fails to propagate or propagates and is ignored is not established — the operational rule is the same either way. **Set the model on the environment itself; treat this field as a hint the surface may disregard.**
 
 Do not invent an abstract tier (`fast` / `deep`) mapped per vendor. That produces confidently wrong mappings when a second surface arrives with an unrelated model lineup. A raw string scoped to the surface that owns it is honest.
 

--- a/plugins/lisa/skills/lisa-remote-dispatch/SKILL.md
+++ b/plugins/lisa/skills/lisa-remote-dispatch/SKILL.md
@@ -55,6 +55,11 @@ It does **not** poll, wait, or hold anything open. The operator's machine is a l
 
 **A dispatch with no captured task identifier is a failed dispatch**, even when the command exited zero. The identifier is the only durable handle on work that outlives this process; an untracked remote task is worse than none, because nothing can reconcile it and a retry would duplicate it.
 
+Two things about the CLI surface, both verified live on 2026-08-01:
+
+- `codex cloud exec` prints **only the task URL** on success — there is no separate identifier line to parse. The identifier must be extracted from that URL.
+- `codex cloud status` returns status, environment label, and a diff summary — **not the agent's text reply**. So a task cannot report a result back through the CLI, only through an artifact. Reconcile through durable objects (the PR, the diff, the external record), never through what the agent said.
+
 ## Surface options
 
 ```json
@@ -75,7 +80,9 @@ It does **not** poll, wait, or hold anything open. The operator's machine is a l
 
 **`branch` is always passed explicitly.** `codex cloud exec` defaults to the *current* branch, and a dispatcher's incidental checkout state must never decide where work runs.
 
-**`model` goes through `-c`,** because the subcommand has no `--model` flag; the CLI's own help documents `-c model="..."`. Model is vendor-specific while `executionEnv` is routing, so it is scoped under the surface rather than hung off the top level. Resolution order: per-invocation override → project config → environment default.
+**`model` goes through `-c`,** because the subcommand has no `--model` flag; the CLI's own help documents `-c model="..."`. Model is vendor-specific while `executionEnv` is routing, so it is scoped under the surface rather than hung off the top level.
+
+**But do not rely on it to select a Codex Cloud task's model.** Verified by live dispatch on 2026-08-01: `-c model="not-a-real-model-probe-xyz"` was accepted without local validation, submitted, and the task then ran to `READY` successfully. Had the invalid value governed remote execution, the task could not have run. Whether the override fails to propagate or propagates and is ignored is not established — the operational rule is the same either way. **Set the model on the environment itself; treat this field as a hint the surface may disregard.**
 
 Do not invent an abstract tier (`fast` / `deep`) mapped per vendor. That produces confidently wrong mappings when a second surface arrives with an unrelated model lineup. A raw string scoped to the surface that owns it is honest.
 

--- a/plugins/src/base/skills/lisa-remote-dispatch/SKILL.md
+++ b/plugins/src/base/skills/lisa-remote-dispatch/SKILL.md
@@ -55,6 +55,11 @@ It does **not** poll, wait, or hold anything open. The operator's machine is a l
 
 **A dispatch with no captured task identifier is a failed dispatch**, even when the command exited zero. The identifier is the only durable handle on work that outlives this process; an untracked remote task is worse than none, because nothing can reconcile it and a retry would duplicate it.
 
+Two things about the CLI surface, both verified live on 2026-08-01:
+
+- `codex cloud exec` prints **only the task URL** on success — there is no separate identifier line to parse. The identifier must be extracted from that URL.
+- `codex cloud status` returns status, environment label, and a diff summary — **not the agent's text reply**. So a task cannot report a result back through the CLI, only through an artifact. Reconcile through durable objects (the PR, the diff, the external record), never through what the agent said.
+
 ## Surface options
 
 ```json
@@ -75,7 +80,9 @@ It does **not** poll, wait, or hold anything open. The operator's machine is a l
 
 **`branch` is always passed explicitly.** `codex cloud exec` defaults to the *current* branch, and a dispatcher's incidental checkout state must never decide where work runs.
 
-**`model` goes through `-c`,** because the subcommand has no `--model` flag; the CLI's own help documents `-c model="..."`. Model is vendor-specific while `executionEnv` is routing, so it is scoped under the surface rather than hung off the top level. Resolution order: per-invocation override → project config → environment default.
+**`model` goes through `-c`,** because the subcommand has no `--model` flag; the CLI's own help documents `-c model="..."`. Model is vendor-specific while `executionEnv` is routing, so it is scoped under the surface rather than hung off the top level.
+
+**But do not rely on it to select a Codex Cloud task's model.** Verified by live dispatch on 2026-08-01: `-c model="not-a-real-model-probe-xyz"` was accepted without local validation, submitted, and the task then ran to `READY` successfully. Had the invalid value governed remote execution, the task could not have run. Whether the override fails to propagate or propagates and is ignored is not established — the operational rule is the same either way. **Set the model on the environment itself; treat this field as a hint the surface may disregard.**
 
 Do not invent an abstract tier (`fast` / `deep`) mapped per vendor. That produces confidently wrong mappings when a second surface arrives with an unrelated model lineup. A raw string scoped to the surface that owns it is honest.
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1053,7 +1053,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-queue-status/SKILL.md":
       "87c6d34d0511d4afd812d1af3fee80fa3b7aa47db8449760b12f2699fedc1d78",
     "plugins/src/base/skills/lisa-remote-dispatch/SKILL.md":
-      "a33e5069e5aee78cdc7010b7d3b0e50c202f064a74b9ac09babaf2ce657cd28f",
+      "2cc999d2c3b61b10aabb849e0833fd58edb444c5013c05108dd58e5d7d60c4ba",
     "plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs":
       "3bf6c019de34a53a1c84b131ffeb9702441e8c1c7c1794f522f97c0de5ee5ce4",
     "plugins/src/base/skills/lisa-repair-intake/SKILL.md":


### PR DESCRIPTION
Follow-up to #2151, which shipped `executionEnv` dispatch with one open question: does `-c model=` propagate into a Codex Cloud task, or does the environment's own setting win?

## Answered by live dispatch

`-c model=` **does not govern the Cloud task's model.**

Dispatched `-c model="not-a-real-model-probe-xyz"` to a real Codex Cloud environment. The CLI accepted it without local validation, submitted the task, and the task ran to `READY` successfully. Had the invalid value governed remote execution, the task could not have run.

Recorded as an **observation, not a mechanism**: it is not established whether the override fails to propagate or propagates and is ignored. Both produce the same operational rule — set the model on the environment, and treat the dispatcher field as a hint the surface may disregard.

## Two further CLI facts from the same probes

Both are things a dispatcher has to build around:

- `codex cloud exec` prints **only the task URL** on success — no separate identifier line — so the id must be extracted from that URL.
- `codex cloud status` returns status, environment label, and a diff summary, but **not the agent's text reply**. A task cannot report a result back through the CLI at all. Reconcile through durable artifacts (PR, diff, external object), never through what the agent said.

## Safety

All three probes were read-only and changed nothing — `files=0` on every one, no branch, no PR.

## Scope

Documentation only: updates `lisa-remote-dispatch/SKILL.md` and the plan's open-unknowns section. No behaviour change — the `model` field already passes through `-c`, which remains correct for any surface that does honour it.

The remaining unknown (whether Codex Cloud caps concurrent tasks per account) still needs a live account under load and is unaffected by this.

Work-Item: CodySwannGT/lisa#2152

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified remote task execution behavior, including task URL output, identifier extraction, status limitations, and durable-artifact reconciliation.
  * Updated model configuration guidance to note that command-line model overrides may be ignored during remote execution.
  * Added verified probe results and an end-to-end dispatch verification record.
* **Maintenance**
  * Updated the pinned evidence reference for the remote-dispatch documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->