### PR TITLE
Separate where the bootstrap lives from what the provider CLI calls it

### DIFF
--- a/plugins/lisa-agy/skills/lisa-secrets-access/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/SKILL.md
@@ -82,6 +82,18 @@ ${XDG_CONFIG_HOME:-$HOME/.config}/<secrets.namespace>/     # dir 0700
 
 **`bootstrap`** — how to obtain the one credential that unlocks the rest. `sources` is ordered, environment first. This is the **only** credential permitted in a keychain; it is a bootstrap, not a cache.
 
+`bootstrap.key` answers exactly one question: **where do we find it** — the environment variable name and keychain service to look under. It is *not* the name the provider CLI reads. That name is fixed by the vendor (`bws` reads `BWS_ACCESS_TOKEN` and nothing else) and lives in `PROVIDER_BOOTSTRAP_ENV` in `providers.mjs`, which translates one into the other before invoking the CLI.
+
+Keeping these separate is what makes **one workstation serve several tenants**. Give each its own name and each project points at its own:
+
+```json
+"bootstrap": { "sources": ["env", "keychain"], "key": "BWS_ACCESS_TOKEN_acme" }
+```
+
+Conflating them worked only while every project used the default, where the two coincide. The first project to slug its key handed the CLI a variable it had never heard of, and every read and rotation failed with `Missing access token`. If you add a provider, add its canonical variable to that table — do not reach for `bootstrap.key`.
+
+On the GitHub Actions surface the repository secret and the exported environment variable both carry the **configured** name, and the generated workflow templates it. Translating to the CLI's own variable stays in `providers.mjs`.
+
 **`require`** — optional. Omit it and every secret the provider grants is available, which is correct when the provider already scopes access per project. Present, it narrows to exactly those names **and asserts them**: a listed name that does not resolve is a startup error, not a late surprise.
 
 **`narrow`** — may only *narrow* the provider's own grant. There is deliberately no way to widen access from config; that boundary belongs to the provider.

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/providers.mjs
@@ -29,6 +29,48 @@ export const ENV_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
 export const LEASE_KEY = "LISA_ROTATION_LEASES";
 
 /**
+ * The environment variable each provider's CLI reads its own bootstrap from.
+ *
+ * This is deliberately *not* configurable, and separating it from
+ * `bootstrap.key` is the whole point. Two different questions were previously
+ * answered by one value:
+ *
+ * - **Where do we find the bootstrap?** A keychain service or environment
+ *   variable name. That must be configurable, because one workstation serves
+ *   several tenants and each needs its own token stored under its own name.
+ * - **What does the provider CLI call it?** Fixed by the vendor. `bws` reads
+ *   `BWS_ACCESS_TOKEN` and nothing else.
+ *
+ * Conflating them worked only while every project used the default name, where
+ * the two happen to coincide. The moment a project set
+ * `bootstrap.key: "BWS_ACCESS_TOKEN_<tenant>"` the CLI was handed a variable it
+ * has never heard of and failed with "Missing access token".
+ */
+const PROVIDER_BOOTSTRAP_ENV = {
+  bitwarden: "BWS_ACCESS_TOKEN",
+  doppler: "DOPPLER_TOKEN",
+};
+
+/**
+ * Build the child environment for a provider CLI, injecting the bootstrap under
+ * the name that CLI actually reads.
+ *
+ * Both the read path and the rotation write path need this, and they previously
+ * carried separate copies of the same line — which is how they would eventually
+ * have drifted. One helper, one place to be wrong.
+ * @param {object} cfg Resolved configuration.
+ * @returns {NodeJS.ProcessEnv} Environment for the child process.
+ */
+export function providerEnv(cfg) {
+  const env = { ...process.env };
+  const canonical = PROVIDER_BOOTSTRAP_ENV[cfg.provider];
+  if (!canonical) return env;
+  const token = bootstrapToken(cfg.bootstrap);
+  if (token) env[canonical] = token;
+  return env;
+}
+
+/**
  * Obtain the one credential that unlocks the provider.
  *
  * Walks `sources` in order, environment first, so a CI run where the pipeline
@@ -83,9 +125,7 @@ function fromKeychain(key) {
  * @returns {Array<{key: string, value: string, note: string, projectId: string|null}>} Rows.
  */
 export function fetchRaw(cfg) {
-  const env = { ...process.env };
-  const token = bootstrapToken(cfg.bootstrap);
-  if (cfg.bootstrap.key && token) env[cfg.bootstrap.key] = token;
+  const env = providerEnv(cfg);
 
   if (cfg.provider === "env") {
     return Object.entries(process.env)
@@ -225,9 +265,7 @@ export function rawByKey(cfg, key) {
  * @param {string} value Replacement value.
  */
 export function writeSecret(cfg, id, value) {
-  const env = { ...process.env };
-  const token = bootstrapToken(cfg.bootstrap);
-  if (cfg.bootstrap.key && token) env[cfg.bootstrap.key] = token;
+  const env = providerEnv(cfg);
 
   if (cfg.provider === "bitwarden") {
     run("bws", ["secret", "edit", id, "--value", value], env);

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/providers.mjs
@@ -67,6 +67,14 @@ export function providerEnv(cfg) {
   if (!canonical) return env;
   const token = bootstrapToken(cfg.bootstrap);
   if (token) env[canonical] = token;
+  // Drop the tenant-scoped name once its value has been placed under the one
+  // the CLI reads. Inheriting it would leave two variables holding the same
+  // bootstrap in the child, which is how a tool that probes for a
+  // similarly-named credential binds to the wrong tenant on a workstation
+  // serving several. The child needs exactly one.
+  if (cfg.bootstrap.key && cfg.bootstrap.key !== canonical) {
+    delete env[cfg.bootstrap.key];
+  }
   return env;
 }
 

--- a/plugins/lisa-agy/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -44,6 +44,10 @@ export function readAutomation(name, cwd = process.cwd()) {
   return {
     ...loop,
     repository: cfg.remoteEnv?.surfaces?.[loop.executionEnv]?.repository,
+    // Where this project keeps its bootstrap. A workstation serving several
+    // tenants gives each its own name, so the generated workflow must template
+    // it rather than assume the default.
+    bootstrapKey: cfg.secrets?.bootstrap?.key ?? "BWS_ACCESS_TOKEN",
   };
 }
 
@@ -70,6 +74,11 @@ export function readAutomation(name, cwd = process.cwd()) {
  */
 export function renderWorkflow(name, loop) {
   if (!loop.schedule) throw new Error(`automations["${name}"] has no schedule`);
+  // The repository secret and the environment variable carry the same name, so
+  // the value the workflow exports is the one `bootstrap.key` tells the resolver
+  // to look for. Translating it to the provider CLI's own variable is
+  // providers.mjs's job, not this workflow's.
+  const bootstrap = loop.bootstrapKey ?? "BWS_ACCESS_TOKEN";
   if (!loop.repository) {
     throw new Error(
       `automations["${name}"] targets executionEnv "${loop.executionEnv}", ` +
@@ -118,22 +127,22 @@ jobs:
       # seconds rather than after a toolchain download.
       - name: Check the bootstrap credential is configured
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          test -n "\${BWS_ACCESS_TOKEN}" || {
-            echo "BWS_ACCESS_TOKEN is not configured for this repository" >&2
+          test -n "\${${bootstrap}}" || {
+            echo "${bootstrap} is not configured for this repository" >&2
             exit 1
           }
 
       - name: Prepare the toolchain and secrets
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: bash scripts/lisa-remote-env/setup.sh
 
       - name: Run one ${name} cycle
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
           node .claude/skills/lisa-remote-dispatch/scripts/dispatch.mjs \\
@@ -145,7 +154,7 @@ jobs:
       - name: Persist any credential rotation
         if: \${{ always() }}
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
           node .claude/skills/lisa-secrets-access/scripts/rotate-secret.mjs leases

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/SKILL.md
@@ -82,6 +82,18 @@ ${XDG_CONFIG_HOME:-$HOME/.config}/<secrets.namespace>/     # dir 0700
 
 **`bootstrap`** — how to obtain the one credential that unlocks the rest. `sources` is ordered, environment first. This is the **only** credential permitted in a keychain; it is a bootstrap, not a cache.
 
+`bootstrap.key` answers exactly one question: **where do we find it** — the environment variable name and keychain service to look under. It is *not* the name the provider CLI reads. That name is fixed by the vendor (`bws` reads `BWS_ACCESS_TOKEN` and nothing else) and lives in `PROVIDER_BOOTSTRAP_ENV` in `providers.mjs`, which translates one into the other before invoking the CLI.
+
+Keeping these separate is what makes **one workstation serve several tenants**. Give each its own name and each project points at its own:
+
+```json
+"bootstrap": { "sources": ["env", "keychain"], "key": "BWS_ACCESS_TOKEN_acme" }
+```
+
+Conflating them worked only while every project used the default, where the two coincide. The first project to slug its key handed the CLI a variable it had never heard of, and every read and rotation failed with `Missing access token`. If you add a provider, add its canonical variable to that table — do not reach for `bootstrap.key`.
+
+On the GitHub Actions surface the repository secret and the exported environment variable both carry the **configured** name, and the generated workflow templates it. Translating to the CLI's own variable stays in `providers.mjs`.
+
 **`require`** — optional. Omit it and every secret the provider grants is available, which is correct when the provider already scopes access per project. Present, it narrows to exactly those names **and asserts them**: a listed name that does not resolve is a startup error, not a late surprise.
 
 **`narrow`** — may only *narrow* the provider's own grant. There is deliberately no way to widen access from config; that boundary belongs to the provider.

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/providers.mjs
@@ -29,6 +29,48 @@ export const ENV_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
 export const LEASE_KEY = "LISA_ROTATION_LEASES";
 
 /**
+ * The environment variable each provider's CLI reads its own bootstrap from.
+ *
+ * This is deliberately *not* configurable, and separating it from
+ * `bootstrap.key` is the whole point. Two different questions were previously
+ * answered by one value:
+ *
+ * - **Where do we find the bootstrap?** A keychain service or environment
+ *   variable name. That must be configurable, because one workstation serves
+ *   several tenants and each needs its own token stored under its own name.
+ * - **What does the provider CLI call it?** Fixed by the vendor. `bws` reads
+ *   `BWS_ACCESS_TOKEN` and nothing else.
+ *
+ * Conflating them worked only while every project used the default name, where
+ * the two happen to coincide. The moment a project set
+ * `bootstrap.key: "BWS_ACCESS_TOKEN_<tenant>"` the CLI was handed a variable it
+ * has never heard of and failed with "Missing access token".
+ */
+const PROVIDER_BOOTSTRAP_ENV = {
+  bitwarden: "BWS_ACCESS_TOKEN",
+  doppler: "DOPPLER_TOKEN",
+};
+
+/**
+ * Build the child environment for a provider CLI, injecting the bootstrap under
+ * the name that CLI actually reads.
+ *
+ * Both the read path and the rotation write path need this, and they previously
+ * carried separate copies of the same line — which is how they would eventually
+ * have drifted. One helper, one place to be wrong.
+ * @param {object} cfg Resolved configuration.
+ * @returns {NodeJS.ProcessEnv} Environment for the child process.
+ */
+export function providerEnv(cfg) {
+  const env = { ...process.env };
+  const canonical = PROVIDER_BOOTSTRAP_ENV[cfg.provider];
+  if (!canonical) return env;
+  const token = bootstrapToken(cfg.bootstrap);
+  if (token) env[canonical] = token;
+  return env;
+}
+
+/**
  * Obtain the one credential that unlocks the provider.
  *
  * Walks `sources` in order, environment first, so a CI run where the pipeline
@@ -83,9 +125,7 @@ function fromKeychain(key) {
  * @returns {Array<{key: string, value: string, note: string, projectId: string|null}>} Rows.
  */
 export function fetchRaw(cfg) {
-  const env = { ...process.env };
-  const token = bootstrapToken(cfg.bootstrap);
-  if (cfg.bootstrap.key && token) env[cfg.bootstrap.key] = token;
+  const env = providerEnv(cfg);
 
   if (cfg.provider === "env") {
     return Object.entries(process.env)
@@ -225,9 +265,7 @@ export function rawByKey(cfg, key) {
  * @param {string} value Replacement value.
  */
 export function writeSecret(cfg, id, value) {
-  const env = { ...process.env };
-  const token = bootstrapToken(cfg.bootstrap);
-  if (cfg.bootstrap.key && token) env[cfg.bootstrap.key] = token;
+  const env = providerEnv(cfg);
 
   if (cfg.provider === "bitwarden") {
     run("bws", ["secret", "edit", id, "--value", value], env);

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/providers.mjs
@@ -67,6 +67,14 @@ export function providerEnv(cfg) {
   if (!canonical) return env;
   const token = bootstrapToken(cfg.bootstrap);
   if (token) env[canonical] = token;
+  // Drop the tenant-scoped name once its value has been placed under the one
+  // the CLI reads. Inheriting it would leave two variables holding the same
+  // bootstrap in the child, which is how a tool that probes for a
+  // similarly-named credential binds to the wrong tenant on a workstation
+  // serving several. The child needs exactly one.
+  if (cfg.bootstrap.key && cfg.bootstrap.key !== canonical) {
+    delete env[cfg.bootstrap.key];
+  }
   return env;
 }
 

--- a/plugins/lisa-copilot/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -44,6 +44,10 @@ export function readAutomation(name, cwd = process.cwd()) {
   return {
     ...loop,
     repository: cfg.remoteEnv?.surfaces?.[loop.executionEnv]?.repository,
+    // Where this project keeps its bootstrap. A workstation serving several
+    // tenants gives each its own name, so the generated workflow must template
+    // it rather than assume the default.
+    bootstrapKey: cfg.secrets?.bootstrap?.key ?? "BWS_ACCESS_TOKEN",
   };
 }
 
@@ -70,6 +74,11 @@ export function readAutomation(name, cwd = process.cwd()) {
  */
 export function renderWorkflow(name, loop) {
   if (!loop.schedule) throw new Error(`automations["${name}"] has no schedule`);
+  // The repository secret and the environment variable carry the same name, so
+  // the value the workflow exports is the one `bootstrap.key` tells the resolver
+  // to look for. Translating it to the provider CLI's own variable is
+  // providers.mjs's job, not this workflow's.
+  const bootstrap = loop.bootstrapKey ?? "BWS_ACCESS_TOKEN";
   if (!loop.repository) {
     throw new Error(
       `automations["${name}"] targets executionEnv "${loop.executionEnv}", ` +
@@ -118,22 +127,22 @@ jobs:
       # seconds rather than after a toolchain download.
       - name: Check the bootstrap credential is configured
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          test -n "\${BWS_ACCESS_TOKEN}" || {
-            echo "BWS_ACCESS_TOKEN is not configured for this repository" >&2
+          test -n "\${${bootstrap}}" || {
+            echo "${bootstrap} is not configured for this repository" >&2
             exit 1
           }
 
       - name: Prepare the toolchain and secrets
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: bash scripts/lisa-remote-env/setup.sh
 
       - name: Run one ${name} cycle
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
           node .claude/skills/lisa-remote-dispatch/scripts/dispatch.mjs \\
@@ -145,7 +154,7 @@ jobs:
       - name: Persist any credential rotation
         if: \${{ always() }}
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
           node .claude/skills/lisa-secrets-access/scripts/rotate-secret.mjs leases

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/SKILL.md
@@ -82,6 +82,18 @@ ${XDG_CONFIG_HOME:-$HOME/.config}/<secrets.namespace>/     # dir 0700
 
 **`bootstrap`** — how to obtain the one credential that unlocks the rest. `sources` is ordered, environment first. This is the **only** credential permitted in a keychain; it is a bootstrap, not a cache.
 
+`bootstrap.key` answers exactly one question: **where do we find it** — the environment variable name and keychain service to look under. It is *not* the name the provider CLI reads. That name is fixed by the vendor (`bws` reads `BWS_ACCESS_TOKEN` and nothing else) and lives in `PROVIDER_BOOTSTRAP_ENV` in `providers.mjs`, which translates one into the other before invoking the CLI.
+
+Keeping these separate is what makes **one workstation serve several tenants**. Give each its own name and each project points at its own:
+
+```json
+"bootstrap": { "sources": ["env", "keychain"], "key": "BWS_ACCESS_TOKEN_acme" }
+```
+
+Conflating them worked only while every project used the default, where the two coincide. The first project to slug its key handed the CLI a variable it had never heard of, and every read and rotation failed with `Missing access token`. If you add a provider, add its canonical variable to that table — do not reach for `bootstrap.key`.
+
+On the GitHub Actions surface the repository secret and the exported environment variable both carry the **configured** name, and the generated workflow templates it. Translating to the CLI's own variable stays in `providers.mjs`.
+
 **`require`** — optional. Omit it and every secret the provider grants is available, which is correct when the provider already scopes access per project. Present, it narrows to exactly those names **and asserts them**: a listed name that does not resolve is a startup error, not a late surprise.
 
 **`narrow`** — may only *narrow* the provider's own grant. There is deliberately no way to widen access from config; that boundary belongs to the provider.

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/providers.mjs
@@ -29,6 +29,48 @@ export const ENV_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
 export const LEASE_KEY = "LISA_ROTATION_LEASES";
 
 /**
+ * The environment variable each provider's CLI reads its own bootstrap from.
+ *
+ * This is deliberately *not* configurable, and separating it from
+ * `bootstrap.key` is the whole point. Two different questions were previously
+ * answered by one value:
+ *
+ * - **Where do we find the bootstrap?** A keychain service or environment
+ *   variable name. That must be configurable, because one workstation serves
+ *   several tenants and each needs its own token stored under its own name.
+ * - **What does the provider CLI call it?** Fixed by the vendor. `bws` reads
+ *   `BWS_ACCESS_TOKEN` and nothing else.
+ *
+ * Conflating them worked only while every project used the default name, where
+ * the two happen to coincide. The moment a project set
+ * `bootstrap.key: "BWS_ACCESS_TOKEN_<tenant>"` the CLI was handed a variable it
+ * has never heard of and failed with "Missing access token".
+ */
+const PROVIDER_BOOTSTRAP_ENV = {
+  bitwarden: "BWS_ACCESS_TOKEN",
+  doppler: "DOPPLER_TOKEN",
+};
+
+/**
+ * Build the child environment for a provider CLI, injecting the bootstrap under
+ * the name that CLI actually reads.
+ *
+ * Both the read path and the rotation write path need this, and they previously
+ * carried separate copies of the same line — which is how they would eventually
+ * have drifted. One helper, one place to be wrong.
+ * @param {object} cfg Resolved configuration.
+ * @returns {NodeJS.ProcessEnv} Environment for the child process.
+ */
+export function providerEnv(cfg) {
+  const env = { ...process.env };
+  const canonical = PROVIDER_BOOTSTRAP_ENV[cfg.provider];
+  if (!canonical) return env;
+  const token = bootstrapToken(cfg.bootstrap);
+  if (token) env[canonical] = token;
+  return env;
+}
+
+/**
  * Obtain the one credential that unlocks the provider.
  *
  * Walks `sources` in order, environment first, so a CI run where the pipeline
@@ -83,9 +125,7 @@ function fromKeychain(key) {
  * @returns {Array<{key: string, value: string, note: string, projectId: string|null}>} Rows.
  */
 export function fetchRaw(cfg) {
-  const env = { ...process.env };
-  const token = bootstrapToken(cfg.bootstrap);
-  if (cfg.bootstrap.key && token) env[cfg.bootstrap.key] = token;
+  const env = providerEnv(cfg);
 
   if (cfg.provider === "env") {
     return Object.entries(process.env)
@@ -225,9 +265,7 @@ export function rawByKey(cfg, key) {
  * @param {string} value Replacement value.
  */
 export function writeSecret(cfg, id, value) {
-  const env = { ...process.env };
-  const token = bootstrapToken(cfg.bootstrap);
-  if (cfg.bootstrap.key && token) env[cfg.bootstrap.key] = token;
+  const env = providerEnv(cfg);
 
   if (cfg.provider === "bitwarden") {
     run("bws", ["secret", "edit", id, "--value", value], env);

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/providers.mjs
@@ -67,6 +67,14 @@ export function providerEnv(cfg) {
   if (!canonical) return env;
   const token = bootstrapToken(cfg.bootstrap);
   if (token) env[canonical] = token;
+  // Drop the tenant-scoped name once its value has been placed under the one
+  // the CLI reads. Inheriting it would leave two variables holding the same
+  // bootstrap in the child, which is how a tool that probes for a
+  // similarly-named credential binds to the wrong tenant on a workstation
+  // serving several. The child needs exactly one.
+  if (cfg.bootstrap.key && cfg.bootstrap.key !== canonical) {
+    delete env[cfg.bootstrap.key];
+  }
   return env;
 }
 

--- a/plugins/lisa-cursor/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -44,6 +44,10 @@ export function readAutomation(name, cwd = process.cwd()) {
   return {
     ...loop,
     repository: cfg.remoteEnv?.surfaces?.[loop.executionEnv]?.repository,
+    // Where this project keeps its bootstrap. A workstation serving several
+    // tenants gives each its own name, so the generated workflow must template
+    // it rather than assume the default.
+    bootstrapKey: cfg.secrets?.bootstrap?.key ?? "BWS_ACCESS_TOKEN",
   };
 }
 
@@ -70,6 +74,11 @@ export function readAutomation(name, cwd = process.cwd()) {
  */
 export function renderWorkflow(name, loop) {
   if (!loop.schedule) throw new Error(`automations["${name}"] has no schedule`);
+  // The repository secret and the environment variable carry the same name, so
+  // the value the workflow exports is the one `bootstrap.key` tells the resolver
+  // to look for. Translating it to the provider CLI's own variable is
+  // providers.mjs's job, not this workflow's.
+  const bootstrap = loop.bootstrapKey ?? "BWS_ACCESS_TOKEN";
   if (!loop.repository) {
     throw new Error(
       `automations["${name}"] targets executionEnv "${loop.executionEnv}", ` +
@@ -118,22 +127,22 @@ jobs:
       # seconds rather than after a toolchain download.
       - name: Check the bootstrap credential is configured
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          test -n "\${BWS_ACCESS_TOKEN}" || {
-            echo "BWS_ACCESS_TOKEN is not configured for this repository" >&2
+          test -n "\${${bootstrap}}" || {
+            echo "${bootstrap} is not configured for this repository" >&2
             exit 1
           }
 
       - name: Prepare the toolchain and secrets
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: bash scripts/lisa-remote-env/setup.sh
 
       - name: Run one ${name} cycle
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
           node .claude/skills/lisa-remote-dispatch/scripts/dispatch.mjs \\
@@ -145,7 +154,7 @@ jobs:
       - name: Persist any credential rotation
         if: \${{ always() }}
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
           node .claude/skills/lisa-secrets-access/scripts/rotate-secret.mjs leases

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/SKILL.md
@@ -82,6 +82,18 @@ ${XDG_CONFIG_HOME:-$HOME/.config}/<secrets.namespace>/     # dir 0700
 
 **`bootstrap`** — how to obtain the one credential that unlocks the rest. `sources` is ordered, environment first. This is the **only** credential permitted in a keychain; it is a bootstrap, not a cache.
 
+`bootstrap.key` answers exactly one question: **where do we find it** — the environment variable name and keychain service to look under. It is *not* the name the provider CLI reads. That name is fixed by the vendor (`bws` reads `BWS_ACCESS_TOKEN` and nothing else) and lives in `PROVIDER_BOOTSTRAP_ENV` in `providers.mjs`, which translates one into the other before invoking the CLI.
+
+Keeping these separate is what makes **one workstation serve several tenants**. Give each its own name and each project points at its own:
+
+```json
+"bootstrap": { "sources": ["env", "keychain"], "key": "BWS_ACCESS_TOKEN_acme" }
+```
+
+Conflating them worked only while every project used the default, where the two coincide. The first project to slug its key handed the CLI a variable it had never heard of, and every read and rotation failed with `Missing access token`. If you add a provider, add its canonical variable to that table — do not reach for `bootstrap.key`.
+
+On the GitHub Actions surface the repository secret and the exported environment variable both carry the **configured** name, and the generated workflow templates it. Translating to the CLI's own variable stays in `providers.mjs`.
+
 **`require`** — optional. Omit it and every secret the provider grants is available, which is correct when the provider already scopes access per project. Present, it narrows to exactly those names **and asserts them**: a listed name that does not resolve is a startup error, not a late surprise.
 
 **`narrow`** — may only *narrow* the provider's own grant. There is deliberately no way to widen access from config; that boundary belongs to the provider.

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/providers.mjs
@@ -29,6 +29,48 @@ export const ENV_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
 export const LEASE_KEY = "LISA_ROTATION_LEASES";
 
 /**
+ * The environment variable each provider's CLI reads its own bootstrap from.
+ *
+ * This is deliberately *not* configurable, and separating it from
+ * `bootstrap.key` is the whole point. Two different questions were previously
+ * answered by one value:
+ *
+ * - **Where do we find the bootstrap?** A keychain service or environment
+ *   variable name. That must be configurable, because one workstation serves
+ *   several tenants and each needs its own token stored under its own name.
+ * - **What does the provider CLI call it?** Fixed by the vendor. `bws` reads
+ *   `BWS_ACCESS_TOKEN` and nothing else.
+ *
+ * Conflating them worked only while every project used the default name, where
+ * the two happen to coincide. The moment a project set
+ * `bootstrap.key: "BWS_ACCESS_TOKEN_<tenant>"` the CLI was handed a variable it
+ * has never heard of and failed with "Missing access token".
+ */
+const PROVIDER_BOOTSTRAP_ENV = {
+  bitwarden: "BWS_ACCESS_TOKEN",
+  doppler: "DOPPLER_TOKEN",
+};
+
+/**
+ * Build the child environment for a provider CLI, injecting the bootstrap under
+ * the name that CLI actually reads.
+ *
+ * Both the read path and the rotation write path need this, and they previously
+ * carried separate copies of the same line — which is how they would eventually
+ * have drifted. One helper, one place to be wrong.
+ * @param {object} cfg Resolved configuration.
+ * @returns {NodeJS.ProcessEnv} Environment for the child process.
+ */
+export function providerEnv(cfg) {
+  const env = { ...process.env };
+  const canonical = PROVIDER_BOOTSTRAP_ENV[cfg.provider];
+  if (!canonical) return env;
+  const token = bootstrapToken(cfg.bootstrap);
+  if (token) env[canonical] = token;
+  return env;
+}
+
+/**
  * Obtain the one credential that unlocks the provider.
  *
  * Walks `sources` in order, environment first, so a CI run where the pipeline
@@ -83,9 +125,7 @@ function fromKeychain(key) {
  * @returns {Array<{key: string, value: string, note: string, projectId: string|null}>} Rows.
  */
 export function fetchRaw(cfg) {
-  const env = { ...process.env };
-  const token = bootstrapToken(cfg.bootstrap);
-  if (cfg.bootstrap.key && token) env[cfg.bootstrap.key] = token;
+  const env = providerEnv(cfg);
 
   if (cfg.provider === "env") {
     return Object.entries(process.env)
@@ -225,9 +265,7 @@ export function rawByKey(cfg, key) {
  * @param {string} value Replacement value.
  */
 export function writeSecret(cfg, id, value) {
-  const env = { ...process.env };
-  const token = bootstrapToken(cfg.bootstrap);
-  if (cfg.bootstrap.key && token) env[cfg.bootstrap.key] = token;
+  const env = providerEnv(cfg);
 
   if (cfg.provider === "bitwarden") {
     run("bws", ["secret", "edit", id, "--value", value], env);

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/providers.mjs
@@ -67,6 +67,14 @@ export function providerEnv(cfg) {
   if (!canonical) return env;
   const token = bootstrapToken(cfg.bootstrap);
   if (token) env[canonical] = token;
+  // Drop the tenant-scoped name once its value has been placed under the one
+  // the CLI reads. Inheriting it would leave two variables holding the same
+  // bootstrap in the child, which is how a tool that probes for a
+  // similarly-named credential binds to the wrong tenant on a workstation
+  // serving several. The child needs exactly one.
+  if (cfg.bootstrap.key && cfg.bootstrap.key !== canonical) {
+    delete env[cfg.bootstrap.key];
+  }
   return env;
 }
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -44,6 +44,10 @@ export function readAutomation(name, cwd = process.cwd()) {
   return {
     ...loop,
     repository: cfg.remoteEnv?.surfaces?.[loop.executionEnv]?.repository,
+    // Where this project keeps its bootstrap. A workstation serving several
+    // tenants gives each its own name, so the generated workflow must template
+    // it rather than assume the default.
+    bootstrapKey: cfg.secrets?.bootstrap?.key ?? "BWS_ACCESS_TOKEN",
   };
 }
 
@@ -70,6 +74,11 @@ export function readAutomation(name, cwd = process.cwd()) {
  */
 export function renderWorkflow(name, loop) {
   if (!loop.schedule) throw new Error(`automations["${name}"] has no schedule`);
+  // The repository secret and the environment variable carry the same name, so
+  // the value the workflow exports is the one `bootstrap.key` tells the resolver
+  // to look for. Translating it to the provider CLI's own variable is
+  // providers.mjs's job, not this workflow's.
+  const bootstrap = loop.bootstrapKey ?? "BWS_ACCESS_TOKEN";
   if (!loop.repository) {
     throw new Error(
       `automations["${name}"] targets executionEnv "${loop.executionEnv}", ` +
@@ -118,22 +127,22 @@ jobs:
       # seconds rather than after a toolchain download.
       - name: Check the bootstrap credential is configured
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          test -n "\${BWS_ACCESS_TOKEN}" || {
-            echo "BWS_ACCESS_TOKEN is not configured for this repository" >&2
+          test -n "\${${bootstrap}}" || {
+            echo "${bootstrap} is not configured for this repository" >&2
             exit 1
           }
 
       - name: Prepare the toolchain and secrets
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: bash scripts/lisa-remote-env/setup.sh
 
       - name: Run one ${name} cycle
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
           node .claude/skills/lisa-remote-dispatch/scripts/dispatch.mjs \\
@@ -145,7 +154,7 @@ jobs:
       - name: Persist any credential rotation
         if: \${{ always() }}
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
           node .claude/skills/lisa-secrets-access/scripts/rotate-secret.mjs leases

--- a/plugins/lisa/skills/lisa-secrets-access/SKILL.md
+++ b/plugins/lisa/skills/lisa-secrets-access/SKILL.md
@@ -82,6 +82,18 @@ ${XDG_CONFIG_HOME:-$HOME/.config}/<secrets.namespace>/     # dir 0700
 
 **`bootstrap`** — how to obtain the one credential that unlocks the rest. `sources` is ordered, environment first. This is the **only** credential permitted in a keychain; it is a bootstrap, not a cache.
 
+`bootstrap.key` answers exactly one question: **where do we find it** — the environment variable name and keychain service to look under. It is *not* the name the provider CLI reads. That name is fixed by the vendor (`bws` reads `BWS_ACCESS_TOKEN` and nothing else) and lives in `PROVIDER_BOOTSTRAP_ENV` in `providers.mjs`, which translates one into the other before invoking the CLI.
+
+Keeping these separate is what makes **one workstation serve several tenants**. Give each its own name and each project points at its own:
+
+```json
+"bootstrap": { "sources": ["env", "keychain"], "key": "BWS_ACCESS_TOKEN_acme" }
+```
+
+Conflating them worked only while every project used the default, where the two coincide. The first project to slug its key handed the CLI a variable it had never heard of, and every read and rotation failed with `Missing access token`. If you add a provider, add its canonical variable to that table — do not reach for `bootstrap.key`.
+
+On the GitHub Actions surface the repository secret and the exported environment variable both carry the **configured** name, and the generated workflow templates it. Translating to the CLI's own variable stays in `providers.mjs`.
+
 **`require`** — optional. Omit it and every secret the provider grants is available, which is correct when the provider already scopes access per project. Present, it narrows to exactly those names **and asserts them**: a listed name that does not resolve is a startup error, not a late surprise.
 
 **`narrow`** — may only *narrow* the provider's own grant. There is deliberately no way to widen access from config; that boundary belongs to the provider.

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/providers.mjs
@@ -29,6 +29,48 @@ export const ENV_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
 export const LEASE_KEY = "LISA_ROTATION_LEASES";
 
 /**
+ * The environment variable each provider's CLI reads its own bootstrap from.
+ *
+ * This is deliberately *not* configurable, and separating it from
+ * `bootstrap.key` is the whole point. Two different questions were previously
+ * answered by one value:
+ *
+ * - **Where do we find the bootstrap?** A keychain service or environment
+ *   variable name. That must be configurable, because one workstation serves
+ *   several tenants and each needs its own token stored under its own name.
+ * - **What does the provider CLI call it?** Fixed by the vendor. `bws` reads
+ *   `BWS_ACCESS_TOKEN` and nothing else.
+ *
+ * Conflating them worked only while every project used the default name, where
+ * the two happen to coincide. The moment a project set
+ * `bootstrap.key: "BWS_ACCESS_TOKEN_<tenant>"` the CLI was handed a variable it
+ * has never heard of and failed with "Missing access token".
+ */
+const PROVIDER_BOOTSTRAP_ENV = {
+  bitwarden: "BWS_ACCESS_TOKEN",
+  doppler: "DOPPLER_TOKEN",
+};
+
+/**
+ * Build the child environment for a provider CLI, injecting the bootstrap under
+ * the name that CLI actually reads.
+ *
+ * Both the read path and the rotation write path need this, and they previously
+ * carried separate copies of the same line — which is how they would eventually
+ * have drifted. One helper, one place to be wrong.
+ * @param {object} cfg Resolved configuration.
+ * @returns {NodeJS.ProcessEnv} Environment for the child process.
+ */
+export function providerEnv(cfg) {
+  const env = { ...process.env };
+  const canonical = PROVIDER_BOOTSTRAP_ENV[cfg.provider];
+  if (!canonical) return env;
+  const token = bootstrapToken(cfg.bootstrap);
+  if (token) env[canonical] = token;
+  return env;
+}
+
+/**
  * Obtain the one credential that unlocks the provider.
  *
  * Walks `sources` in order, environment first, so a CI run where the pipeline
@@ -83,9 +125,7 @@ function fromKeychain(key) {
  * @returns {Array<{key: string, value: string, note: string, projectId: string|null}>} Rows.
  */
 export function fetchRaw(cfg) {
-  const env = { ...process.env };
-  const token = bootstrapToken(cfg.bootstrap);
-  if (cfg.bootstrap.key && token) env[cfg.bootstrap.key] = token;
+  const env = providerEnv(cfg);
 
   if (cfg.provider === "env") {
     return Object.entries(process.env)
@@ -225,9 +265,7 @@ export function rawByKey(cfg, key) {
  * @param {string} value Replacement value.
  */
 export function writeSecret(cfg, id, value) {
-  const env = { ...process.env };
-  const token = bootstrapToken(cfg.bootstrap);
-  if (cfg.bootstrap.key && token) env[cfg.bootstrap.key] = token;
+  const env = providerEnv(cfg);
 
   if (cfg.provider === "bitwarden") {
     run("bws", ["secret", "edit", id, "--value", value], env);

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/providers.mjs
@@ -67,6 +67,14 @@ export function providerEnv(cfg) {
   if (!canonical) return env;
   const token = bootstrapToken(cfg.bootstrap);
   if (token) env[canonical] = token;
+  // Drop the tenant-scoped name once its value has been placed under the one
+  // the CLI reads. Inheriting it would leave two variables holding the same
+  // bootstrap in the child, which is how a tool that probes for a
+  // similarly-named credential binds to the wrong tenant on a workstation
+  // serving several. The child needs exactly one.
+  if (cfg.bootstrap.key && cfg.bootstrap.key !== canonical) {
+    delete env[cfg.bootstrap.key];
+  }
   return env;
 }
 

--- a/plugins/lisa/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/lisa/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -44,6 +44,10 @@ export function readAutomation(name, cwd = process.cwd()) {
   return {
     ...loop,
     repository: cfg.remoteEnv?.surfaces?.[loop.executionEnv]?.repository,
+    // Where this project keeps its bootstrap. A workstation serving several
+    // tenants gives each its own name, so the generated workflow must template
+    // it rather than assume the default.
+    bootstrapKey: cfg.secrets?.bootstrap?.key ?? "BWS_ACCESS_TOKEN",
   };
 }
 
@@ -70,6 +74,11 @@ export function readAutomation(name, cwd = process.cwd()) {
  */
 export function renderWorkflow(name, loop) {
   if (!loop.schedule) throw new Error(`automations["${name}"] has no schedule`);
+  // The repository secret and the environment variable carry the same name, so
+  // the value the workflow exports is the one `bootstrap.key` tells the resolver
+  // to look for. Translating it to the provider CLI's own variable is
+  // providers.mjs's job, not this workflow's.
+  const bootstrap = loop.bootstrapKey ?? "BWS_ACCESS_TOKEN";
   if (!loop.repository) {
     throw new Error(
       `automations["${name}"] targets executionEnv "${loop.executionEnv}", ` +
@@ -118,22 +127,22 @@ jobs:
       # seconds rather than after a toolchain download.
       - name: Check the bootstrap credential is configured
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          test -n "\${BWS_ACCESS_TOKEN}" || {
-            echo "BWS_ACCESS_TOKEN is not configured for this repository" >&2
+          test -n "\${${bootstrap}}" || {
+            echo "${bootstrap} is not configured for this repository" >&2
             exit 1
           }
 
       - name: Prepare the toolchain and secrets
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: bash scripts/lisa-remote-env/setup.sh
 
       - name: Run one ${name} cycle
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
           node .claude/skills/lisa-remote-dispatch/scripts/dispatch.mjs \\
@@ -145,7 +154,7 @@ jobs:
       - name: Persist any credential rotation
         if: \${{ always() }}
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
           node .claude/skills/lisa-secrets-access/scripts/rotate-secret.mjs leases

--- a/plugins/src/base/skills/lisa-secrets-access/SKILL.md
+++ b/plugins/src/base/skills/lisa-secrets-access/SKILL.md
@@ -82,6 +82,18 @@ ${XDG_CONFIG_HOME:-$HOME/.config}/<secrets.namespace>/     # dir 0700
 
 **`bootstrap`** — how to obtain the one credential that unlocks the rest. `sources` is ordered, environment first. This is the **only** credential permitted in a keychain; it is a bootstrap, not a cache.
 
+`bootstrap.key` answers exactly one question: **where do we find it** — the environment variable name and keychain service to look under. It is *not* the name the provider CLI reads. That name is fixed by the vendor (`bws` reads `BWS_ACCESS_TOKEN` and nothing else) and lives in `PROVIDER_BOOTSTRAP_ENV` in `providers.mjs`, which translates one into the other before invoking the CLI.
+
+Keeping these separate is what makes **one workstation serve several tenants**. Give each its own name and each project points at its own:
+
+```json
+"bootstrap": { "sources": ["env", "keychain"], "key": "BWS_ACCESS_TOKEN_acme" }
+```
+
+Conflating them worked only while every project used the default, where the two coincide. The first project to slug its key handed the CLI a variable it had never heard of, and every read and rotation failed with `Missing access token`. If you add a provider, add its canonical variable to that table — do not reach for `bootstrap.key`.
+
+On the GitHub Actions surface the repository secret and the exported environment variable both carry the **configured** name, and the generated workflow templates it. Translating to the CLI's own variable stays in `providers.mjs`.
+
 **`require`** — optional. Omit it and every secret the provider grants is available, which is correct when the provider already scopes access per project. Present, it narrows to exactly those names **and asserts them**: a listed name that does not resolve is a startup error, not a late surprise.
 
 **`narrow`** — may only *narrow* the provider's own grant. There is deliberately no way to widen access from config; that boundary belongs to the provider.

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs
@@ -29,6 +29,48 @@ export const ENV_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
 export const LEASE_KEY = "LISA_ROTATION_LEASES";
 
 /**
+ * The environment variable each provider's CLI reads its own bootstrap from.
+ *
+ * This is deliberately *not* configurable, and separating it from
+ * `bootstrap.key` is the whole point. Two different questions were previously
+ * answered by one value:
+ *
+ * - **Where do we find the bootstrap?** A keychain service or environment
+ *   variable name. That must be configurable, because one workstation serves
+ *   several tenants and each needs its own token stored under its own name.
+ * - **What does the provider CLI call it?** Fixed by the vendor. `bws` reads
+ *   `BWS_ACCESS_TOKEN` and nothing else.
+ *
+ * Conflating them worked only while every project used the default name, where
+ * the two happen to coincide. The moment a project set
+ * `bootstrap.key: "BWS_ACCESS_TOKEN_<tenant>"` the CLI was handed a variable it
+ * has never heard of and failed with "Missing access token".
+ */
+const PROVIDER_BOOTSTRAP_ENV = {
+  bitwarden: "BWS_ACCESS_TOKEN",
+  doppler: "DOPPLER_TOKEN",
+};
+
+/**
+ * Build the child environment for a provider CLI, injecting the bootstrap under
+ * the name that CLI actually reads.
+ *
+ * Both the read path and the rotation write path need this, and they previously
+ * carried separate copies of the same line — which is how they would eventually
+ * have drifted. One helper, one place to be wrong.
+ * @param {object} cfg Resolved configuration.
+ * @returns {NodeJS.ProcessEnv} Environment for the child process.
+ */
+export function providerEnv(cfg) {
+  const env = { ...process.env };
+  const canonical = PROVIDER_BOOTSTRAP_ENV[cfg.provider];
+  if (!canonical) return env;
+  const token = bootstrapToken(cfg.bootstrap);
+  if (token) env[canonical] = token;
+  return env;
+}
+
+/**
  * Obtain the one credential that unlocks the provider.
  *
  * Walks `sources` in order, environment first, so a CI run where the pipeline
@@ -83,9 +125,7 @@ function fromKeychain(key) {
  * @returns {Array<{key: string, value: string, note: string, projectId: string|null}>} Rows.
  */
 export function fetchRaw(cfg) {
-  const env = { ...process.env };
-  const token = bootstrapToken(cfg.bootstrap);
-  if (cfg.bootstrap.key && token) env[cfg.bootstrap.key] = token;
+  const env = providerEnv(cfg);
 
   if (cfg.provider === "env") {
     return Object.entries(process.env)
@@ -225,9 +265,7 @@ export function rawByKey(cfg, key) {
  * @param {string} value Replacement value.
  */
 export function writeSecret(cfg, id, value) {
-  const env = { ...process.env };
-  const token = bootstrapToken(cfg.bootstrap);
-  if (cfg.bootstrap.key && token) env[cfg.bootstrap.key] = token;
+  const env = providerEnv(cfg);
 
   if (cfg.provider === "bitwarden") {
     run("bws", ["secret", "edit", id, "--value", value], env);

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs
@@ -67,6 +67,14 @@ export function providerEnv(cfg) {
   if (!canonical) return env;
   const token = bootstrapToken(cfg.bootstrap);
   if (token) env[canonical] = token;
+  // Drop the tenant-scoped name once its value has been placed under the one
+  // the CLI reads. Inheriting it would leave two variables holding the same
+  // bootstrap in the child, which is how a tool that probes for a
+  // similarly-named credential binds to the wrong tenant on a workstation
+  // serving several. The child needs exactly one.
+  if (cfg.bootstrap.key && cfg.bootstrap.key !== canonical) {
+    delete env[cfg.bootstrap.key];
+  }
   return env;
 }
 

--- a/plugins/src/base/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/src/base/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -44,6 +44,10 @@ export function readAutomation(name, cwd = process.cwd()) {
   return {
     ...loop,
     repository: cfg.remoteEnv?.surfaces?.[loop.executionEnv]?.repository,
+    // Where this project keeps its bootstrap. A workstation serving several
+    // tenants gives each its own name, so the generated workflow must template
+    // it rather than assume the default.
+    bootstrapKey: cfg.secrets?.bootstrap?.key ?? "BWS_ACCESS_TOKEN",
   };
 }
 
@@ -70,6 +74,11 @@ export function readAutomation(name, cwd = process.cwd()) {
  */
 export function renderWorkflow(name, loop) {
   if (!loop.schedule) throw new Error(`automations["${name}"] has no schedule`);
+  // The repository secret and the environment variable carry the same name, so
+  // the value the workflow exports is the one `bootstrap.key` tells the resolver
+  // to look for. Translating it to the provider CLI's own variable is
+  // providers.mjs's job, not this workflow's.
+  const bootstrap = loop.bootstrapKey ?? "BWS_ACCESS_TOKEN";
   if (!loop.repository) {
     throw new Error(
       `automations["${name}"] targets executionEnv "${loop.executionEnv}", ` +
@@ -118,22 +127,22 @@ jobs:
       # seconds rather than after a toolchain download.
       - name: Check the bootstrap credential is configured
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          test -n "\${BWS_ACCESS_TOKEN}" || {
-            echo "BWS_ACCESS_TOKEN is not configured for this repository" >&2
+          test -n "\${${bootstrap}}" || {
+            echo "${bootstrap} is not configured for this repository" >&2
             exit 1
           }
 
       - name: Prepare the toolchain and secrets
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: bash scripts/lisa-remote-env/setup.sh
 
       - name: Run one ${name} cycle
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
           node .claude/skills/lisa-remote-dispatch/scripts/dispatch.mjs \\
@@ -145,7 +154,7 @@ jobs:
       - name: Persist any credential rotation
         if: \${{ always() }}
         env:
-          BWS_ACCESS_TOKEN: \${{ secrets.BWS_ACCESS_TOKEN }}
+          ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
           node .claude/skills/lisa-secrets-access/scripts/rotate-secret.mjs leases

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1071,7 +1071,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-root-cause-analysis/SKILL.md":
       "3fa14217ca36b238ebb8203d18f10eaaf98a3647f949cdada6cb9f56ddf9ed50",
     "plugins/src/base/skills/lisa-secrets-access/SKILL.md":
-      "caf105ba5f6c368f60a62421d2ce6d10f6d9e0848e24979edfa8994ac997b9e7",
+      "e7ccac9b7c8e9a9ad61f267de3b121c916b69a495da95eb280f390c33f8e04f6",
     "plugins/src/base/skills/lisa-secrets-access/scripts/doctor-secrets.mjs":
       "aca23d562016bfda30d0ace0f77668edb91e5bcda1bf278036353671c53e9cbc",
     "plugins/src/base/skills/lisa-secrets-access/scripts/envfile.mjs":
@@ -1079,7 +1079,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs":
       "4b4448cd680a8fe7b1f51bad840c2655f898e9bc08ca06c385cd1d21dca3c3d4",
     "plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs":
-      "98b6a21168b40c060a5b9936a67821319aa80f68ddfc4e7d99718df1229aaf73",
+      "83268080e7e5d7ff3726cd245bb4dd38832246360b99c4083e2046644d11430a",
     "plugins/src/base/skills/lisa-secrets-access/scripts/read-secret-note.mjs":
       "1471d2108058f3059e242f9c71208c99fdbc212bde32de34b798eaa9a27ffbcc",
     "plugins/src/base/skills/lisa-secrets-access/scripts/resolve-secret.mjs":
@@ -1101,7 +1101,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-automations/SKILL.md":
       "3ad004148a54571a50df90f23abec71e8510ef3ea3562ac812f8e2e11beb157a",
     "plugins/src/base/skills/lisa-setup-automations/scripts/generate-workflow.mjs":
-      "5dbc1c1af852b0c0bd56364c22d9a8ade2637f1c8e8c024c25f2861f1f48856f",
+      "dd1a0999156bbbaf864fc0f1d85206db5ea2ada172ccac2ee11091303e06ff4d",
     "plugins/src/base/skills/lisa-setup-confluence/SKILL.md":
       "e92d762dbdaeae671c3e52dfe8e10d40a10b606b5e050589181a3898649faedc",
     "plugins/src/base/skills/lisa-setup-github-repo/SKILL.md":
@@ -8312,6 +8312,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/upstream-evidence-manifest.test.ts": true,
     "tests/unit/scripts/verification-coverage.test.ts": true,
     "tests/unit/secrets/automation-workflow.test.ts": true,
+    "tests/unit/secrets/bootstrap-key-naming.test.ts": true,
     "tests/unit/secrets/doctor-secrets.test.ts": true,
     "tests/unit/secrets/remote-dispatch.test.ts": true,
     "tests/unit/secrets/remote-env-toolchain.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1079,7 +1079,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs":
       "4b4448cd680a8fe7b1f51bad840c2655f898e9bc08ca06c385cd1d21dca3c3d4",
     "plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs":
-      "83268080e7e5d7ff3726cd245bb4dd38832246360b99c4083e2046644d11430a",
+      "be748382c81440c1807d6d4101b0ee97c467f30e3976dc1561bc61c01fcb2e99",
     "plugins/src/base/skills/lisa-secrets-access/scripts/read-secret-note.mjs":
       "1471d2108058f3059e242f9c71208c99fdbc212bde32de34b798eaa9a27ffbcc",
     "plugins/src/base/skills/lisa-secrets-access/scripts/resolve-secret.mjs":

--- a/tests/unit/secrets/bootstrap-key-naming.test.ts
+++ b/tests/unit/secrets/bootstrap-key-naming.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression tests for the two questions `bootstrap.key` used to conflate.
+ *
+ * "Where do we find the bootstrap?" must be configurable — one workstation
+ * serves several tenants and each needs its own token under its own name.
+ * "What does the provider CLI call it?" is fixed by the vendor: `bws` reads
+ * `BWS_ACCESS_TOKEN` and nothing else.
+ *
+ * Answering both with one value worked only while every project used the
+ * default name, where the two coincide. The first project to set
+ * `bootstrap.key: "BWS_ACCESS_TOKEN_<tenant>"` handed the CLI a variable it had
+ * never heard of, and every read and rotation failed with "Missing access
+ * token".
+ * @module tests/unit/secrets/bootstrap-key-naming
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { providerEnv } from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs";
+import { renderWorkflow } from "../../../plugins/src/base/skills/lisa-setup-automations/scripts/generate-workflow.mjs";
+
+/** A tenant-scoped bootstrap name, the case that exposed the bug. */
+const SLUGGED = "BWS_ACCESS_TOKEN_tenant";
+
+/** A distinctive value, so a test can tell a real resolution from an error. */
+const TENANT_TOKEN = "tenant-token";
+
+/** The only name the Bitwarden CLI reads. */
+const CANONICAL = "BWS_ACCESS_TOKEN";
+
+const cfgWith = (key: string): Record<string, unknown> => ({
+  provider: "bitwarden",
+  bootstrap: { sources: ["env"], key },
+});
+
+afterEach(() => {
+  delete process.env[SLUGGED];
+  delete process.env[CANONICAL];
+});
+
+describe("provider environment", () => {
+  it("injects a slugged bootstrap under the CLI's canonical name", () => {
+    // The bug: it injected under the slugged name, which bws never reads.
+    process.env[SLUGGED] = TENANT_TOKEN;
+    const env = providerEnv(cfgWith(SLUGGED));
+    expect(env[CANONICAL]).toBe(TENANT_TOKEN);
+  });
+
+  it("still works when the configured name is already the canonical one", () => {
+    process.env[CANONICAL] = "default-token";
+    expect(providerEnv(cfgWith(CANONICAL))[CANONICAL]).toBe("default-token");
+  });
+
+  it("maps doppler to its own CLI variable, not Bitwarden's", () => {
+    process.env.DOPPLER_SLUG = "doppler-token";
+    const env = providerEnv({
+      provider: "doppler",
+      bootstrap: { sources: ["env"], key: "DOPPLER_SLUG" },
+    });
+    expect(env.DOPPLER_TOKEN).toBe("doppler-token");
+    expect(env[CANONICAL]).toBeUndefined();
+    delete process.env.DOPPLER_SLUG;
+  });
+
+  it("injects nothing for a provider that needs no bootstrap", () => {
+    const env = providerEnv({
+      provider: "env",
+      bootstrap: { sources: [], key: null },
+    });
+    expect(env[CANONICAL]).toBeUndefined();
+  });
+
+  it("does not leak the tenant-scoped name into the child environment", () => {
+    // Only the canonical name should be added. Passing both would let a
+    // consumer bind to the wrong one and mask this class of bug again.
+    process.env[SLUGGED] = TENANT_TOKEN;
+    const before = { ...process.env };
+    const env = providerEnv(cfgWith(SLUGGED));
+    const added = Object.keys(env).filter(k => !(k in before));
+    expect(added).toEqual([CANONICAL]);
+  });
+});
+
+describe("generated workflow", () => {
+  const loop = {
+    schedule: "17 * * * *",
+    executionEnv: "codex-cloud",
+    repository: "org/repo",
+    enabled: true,
+  };
+
+  it("templates a tenant-scoped bootstrap through every reference", () => {
+    const yaml = renderWorkflow("intake", { ...loop, bootstrapKey: SLUGGED });
+    expect(yaml).toContain(`${SLUGGED}: \${{ secrets.${SLUGGED} }}`);
+    expect(yaml).toContain(`${SLUGGED} is not configured`);
+    // The hardcoded default must not survive anywhere in the rendered file.
+    expect(yaml).not.toContain(`secrets.${CANONICAL} }}`);
+  });
+
+  it("falls back to the canonical name when none is configured", () => {
+    const yaml = renderWorkflow("intake", loop);
+    expect(yaml).toContain(`${CANONICAL}: \${{ secrets.${CANONICAL} }}`);
+  });
+
+  it("asserts and exports the same name, so the resolver finds what CI set", () => {
+    const yaml = renderWorkflow("intake", { ...loop, bootstrapKey: SLUGGED });
+    expect(yaml).toContain(`test -n "\${${SLUGGED}}"`);
+  });
+});

--- a/tests/unit/secrets/bootstrap-key-naming.test.ts
+++ b/tests/unit/secrets/bootstrap-key-naming.test.ts
@@ -13,7 +13,7 @@
  * token".
  * @module tests/unit/secrets/bootstrap-key-naming
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { providerEnv } from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs";
 import { renderWorkflow } from "../../../plugins/src/base/skills/lisa-setup-automations/scripts/generate-workflow.mjs";
@@ -24,6 +24,9 @@ const SLUGGED = "BWS_ACCESS_TOKEN_tenant";
 /** A distinctive value, so a test can tell a real resolution from an error. */
 const TENANT_TOKEN = "tenant-token";
 
+/** Value used where the configured name is already the canonical one. */
+const DEFAULT_TOKEN = "default-token";
+
 /** The only name the Bitwarden CLI reads. */
 const CANONICAL = "BWS_ACCESS_TOKEN";
 
@@ -32,9 +35,24 @@ const cfgWith = (key: string): Record<string, unknown> => ({
   bootstrap: { sources: ["env"], key },
 });
 
+/**
+ * Variables these tests set, snapshotted so the suite restores whatever the
+ * runner had. Deleting unconditionally would destroy a legitimately-set
+ * BWS_ACCESS_TOKEN in CI and leak that damage into later tests.
+ */
+const MANAGED = [SLUGGED, CANONICAL, "DOPPLER_SLUG"] as const;
+let original: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  original = Object.fromEntries(MANAGED.map(k => [k, process.env[k]]));
+  for (const key of MANAGED) delete process.env[key];
+});
+
 afterEach(() => {
-  delete process.env[SLUGGED];
-  delete process.env[CANONICAL];
+  for (const key of MANAGED) {
+    if (original[key] === undefined) delete process.env[key];
+    else process.env[key] = original[key];
+  }
 });
 
 describe("provider environment", () => {
@@ -46,8 +64,8 @@ describe("provider environment", () => {
   });
 
   it("still works when the configured name is already the canonical one", () => {
-    process.env[CANONICAL] = "default-token";
-    expect(providerEnv(cfgWith(CANONICAL))[CANONICAL]).toBe("default-token");
+    process.env[CANONICAL] = DEFAULT_TOKEN;
+    expect(providerEnv(cfgWith(CANONICAL))[CANONICAL]).toBe(DEFAULT_TOKEN);
   });
 
   it("maps doppler to its own CLI variable, not Bitwarden's", () => {
@@ -70,13 +88,23 @@ describe("provider environment", () => {
   });
 
   it("does not leak the tenant-scoped name into the child environment", () => {
-    // Only the canonical name should be added. Passing both would let a
-    // consumer bind to the wrong one and mask this class of bug again.
+    // The child must hold exactly one bootstrap variable. Two would let a tool
+    // probing for a similarly-named credential bind to the wrong tenant on a
+    // workstation serving several — the bug this whole change exists to fix,
+    // reintroduced one layer down.
     process.env[SLUGGED] = TENANT_TOKEN;
     const before = { ...process.env };
     const env = providerEnv(cfgWith(SLUGGED));
-    const added = Object.keys(env).filter(k => !(k in before));
-    expect(added).toEqual([CANONICAL]);
+
+    expect(env[CANONICAL]).toBe(TENANT_TOKEN);
+    expect(env[SLUGGED]).toBeUndefined();
+    expect(Object.keys(env).filter(k => !(k in before))).toEqual([CANONICAL]);
+  });
+
+  it("keeps the canonical name when it is also the configured one", () => {
+    // The removal must not delete the very variable it just set.
+    process.env[CANONICAL] = DEFAULT_TOKEN;
+    expect(providerEnv(cfgWith(CANONICAL))[CANONICAL]).toBe(DEFAULT_TOKEN);
   });
 });
 
@@ -89,11 +117,20 @@ describe("generated workflow", () => {
   };
 
   it("templates a tenant-scoped bootstrap through every reference", () => {
+    // Counting matters. The workflow exports the bootstrap in four steps —
+    // assert, setup, dispatch, rotation-persist — and a mutant that leaves the
+    // canonical name in any ONE of them would pass a mere `toContain`, then
+    // fail at 3am on the step nobody checked.
     const yaml = renderWorkflow("intake", { ...loop, bootstrapKey: SLUGGED });
-    expect(yaml).toContain(`${SLUGGED}: \${{ secrets.${SLUGGED} }}`);
+    const mapping = `${SLUGGED}: \${{ secrets.${SLUGGED} }}`;
+    const occurrences = yaml.split(mapping).length - 1;
+
+    expect(occurrences).toBe(4);
     expect(yaml).toContain(`${SLUGGED} is not configured`);
-    // The hardcoded default must not survive anywhere in the rendered file.
+    expect(yaml).toContain(`test -n "\${${SLUGGED}}"`);
+    // The default must not survive anywhere, in any form.
     expect(yaml).not.toContain(`secrets.${CANONICAL} }}`);
+    expect(yaml).not.toContain(`${CANONICAL}:`);
   });
 
   it("falls back to the canonical name when none is configured", () => {


### PR DESCRIPTION
Found on first real multi-tenant use of the secrets standard shipped in #2151.

## The bug

`bootstrap.key` conflates two different questions:

- **Where do we find the bootstrap?** A keychain service / environment variable name. Must be configurable — one workstation serves several clients and each needs its own token under its own name.
- **What does the provider CLI call it?** Fixed by the vendor. `bws` reads `BWS_ACCESS_TOKEN` and nothing else.

`fetchRaw` and `writeSecret` both did `env[cfg.bootstrap.key] = token`, injecting the bootstrap under the *configured* name. That worked only while every project used the default, where the two coincide.

The moment a project sets `bootstrap.key: "BWS_ACCESS_TOKEN_<tenant>"` — exactly what the multi-tenant case requires — the CLI is handed a variable it has never heard of:

```
Error:
   0: Missing access token
```

Every read and every rotation fails. The feature is broken for precisely the case it was added to serve.

## Second surface

`generate-workflow.mjs` hardcoded `BWS_ACCESS_TOKEN` in 5 places, so a slugged project also got a GitHub Actions workflow asserting and exporting the wrong variable name.

## Fix

- `PROVIDER_BOOTSTRAP_ENV` maps provider → the variable its CLI reads. Not configurable.
- One `providerEnv(cfg)` helper builds the child environment, used by both the read and write paths. They previously carried duplicate copies of the same wrong line, which is how they would have drifted.
- Only the canonical name is injected — passing both would let a consumer bind to the wrong one and mask this class of bug again.
- The workflow generator templates `secrets.bootstrap.key`, defaulting to the canonical name.

## Verified

Two tenants now resolve from one workstation against their own tokens, simultaneously, with no keychain collision.

8 regression tests, including one asserting that *only* the canonical name is added to the child environment.

Work-Item: CodySwannGT/lisa#2156

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom bootstrap secret names, including tenant- or repository-specific configurations.
  * Generated automation workflows now consistently use the configured bootstrap secret name, with a default for existing setups.
  * Provider integrations translate custom names to the environment variables required by each secrets provider.

* **Documentation**
  * Clarified bootstrap naming, provider-specific behavior, and GitHub Actions propagation.

* **Bug Fixes**
  * Prevented custom bootstrap names from breaking secret reads, writes, and automated credential rotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->