### PR TITLE
The AWS bootstrap bundle belongs in the configured provider, not a named store

### DIFF
--- a/plugins/lisa-agy/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa-agy/scripts/remote-agent-aws-setup.sh
@@ -3,8 +3,14 @@
 # source copied into every generated Lisa agent plugin.
 #
 # Required secret:
-#   LISA_AWS_BOOTSTRAP_JSON  Complete SecretString emitted by cdkstarter's
-#                            remote-agent IAM kit.
+#   LISA_AWS_BOOTSTRAP_JSON  The complete remote-agent bootstrap bundle, as one
+#                            JSON value. cdkstarter's IAM kit emits it, but this
+#                            script neither knows nor cares which store it came
+#                            from — resolve it through lisa-secrets-access like
+#                            any other secret. Note that a project whose
+#                            provider is AWS Secrets Manager cannot keep it
+#                            there: reading it would need the very credential it
+#                            contains.
 # Optional plain variables:
 #   LISA_REMOTE_AGENT       claude | codex | cursor | copilot | agy | opencode
 #   LISA_AWS_DEFAULT_PROFILE  Defaults to dev, then the first available profile.

--- a/plugins/lisa-agy/skills/lisa-secrets-access/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/SKILL.md
@@ -198,6 +198,13 @@ Values never enter that process, so its output cannot leak one even if logged.
 | `aws` | `aws secretsmanager get-secret-value --secret-id <name>` | not implemented |
 | `vault` | `vault kv get -field=<name> <path>` | not implemented |
 
+**A provider cannot hold its own bootstrap.** With `provider: "aws"`, reading any
+secret needs AWS credentials — so the AWS bootstrap bundle
+(`LISA_AWS_BOOTSTRAP_JSON`, see `lisa-setup-remote-aws`) cannot live there:
+resolving it would require the very credential it contains. Keep that one in a
+different provider. The same applies to any provider whose own access key is a
+secret you would otherwise store inside it.
+
 Unimplemented providers fail with a message naming where to add them, rather than failing obscurely. Do not claim support that does not exist.
 
 Cache **in-process only**. Never write a resolved value to disk except through the materialization contract above.

--- a/plugins/lisa-agy/skills/lisa-setup-remote-aws/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-aws/SKILL.md
@@ -30,15 +30,40 @@ Install the vendor-neutral AWS bootstrap into the current repository.
    `.github/workflows/copilot-setup-steps.yml`; and it always writes
    `docs/remote-agent-aws.md`.
 4. Run `bash -n scripts/remote-agent-aws-setup.sh`.
-5. Never write or request the actual bootstrap SecretString in repository
-   files. Tell the operator to retrieve the `remote-agent-credentials` secret
-   from the shared AWS account and paste its complete SecretString into the
-   platform secret named `LISA_AWS_BOOTSTRAP_JSON`. The default cdkstarter
-   secret name is `remote-agent-credentials`; downstream infrastructure may
-   configure a different name. Pass that name with `--secret-name` so the
-   generated runbook contains the exact retrieval command.
+5. Never write or request the actual bootstrap bundle in repository files. Tell
+   the operator where to obtain it and where to put it — see **Where the bundle
+   lives** below. Pass `--secret-name` when the source names it something other
+   than `remote-agent-credentials`, so the generated runbook contains the exact
+   retrieval command.
 6. Report the external step that remains: configure that one secret in the
    remote environment and launch a smoke session.
+
+## Where the bundle lives
+
+`LISA_AWS_BOOTSTRAP_JSON` is **just another secret**, and it belongs wherever
+the project keeps its secrets — resolved through `lisa-secrets-access` like
+everything else. It is not tied to any one store.
+
+Whoever provisions the IAM user emits the bundle somewhere. `cdkstarter` writes
+it to AWS Secrets Manager as `remote-agent-credentials`, but that is where it is
+*emitted*, not where it must *live*. Copy it once into the project's configured
+provider and read it from there.
+
+**Do not keep it in two stores.** A bundle sitting in Secrets Manager *and* in
+the platform's secret store is two live copies of one credential: rotate the
+IAM key and whichever copy you forget keeps authenticating until it doesn't,
+with nothing to say which is current. That is the drift the single-store rule in
+`lisa-secrets-access` exists to prevent, and this credential is not exempt.
+
+**One provider cannot serve this particular secret.** If `secrets.provider` is
+`aws`, reading the bundle requires AWS credentials — and the bundle *is* the AWS
+credential. Anything else works: Bitwarden, 1Password, Doppler, Vault, or a
+platform secret store. Pick the one that is not the thing being bootstrapped.
+
+On a surface that materializes (see `lisa-secrets-access`), the bundle arrives
+in `secrets.env` with everything else, so the project hook can run this setup
+script after materialization with no extra plumbing. On a surface that reads
+through live, resolve it at the point of use.
 
 ## Contract
 

--- a/plugins/lisa-copilot/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa-copilot/scripts/remote-agent-aws-setup.sh
@@ -3,8 +3,14 @@
 # source copied into every generated Lisa agent plugin.
 #
 # Required secret:
-#   LISA_AWS_BOOTSTRAP_JSON  Complete SecretString emitted by cdkstarter's
-#                            remote-agent IAM kit.
+#   LISA_AWS_BOOTSTRAP_JSON  The complete remote-agent bootstrap bundle, as one
+#                            JSON value. cdkstarter's IAM kit emits it, but this
+#                            script neither knows nor cares which store it came
+#                            from — resolve it through lisa-secrets-access like
+#                            any other secret. Note that a project whose
+#                            provider is AWS Secrets Manager cannot keep it
+#                            there: reading it would need the very credential it
+#                            contains.
 # Optional plain variables:
 #   LISA_REMOTE_AGENT       claude | codex | cursor | copilot | agy | opencode
 #   LISA_AWS_DEFAULT_PROFILE  Defaults to dev, then the first available profile.

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/SKILL.md
@@ -198,6 +198,13 @@ Values never enter that process, so its output cannot leak one even if logged.
 | `aws` | `aws secretsmanager get-secret-value --secret-id <name>` | not implemented |
 | `vault` | `vault kv get -field=<name> <path>` | not implemented |
 
+**A provider cannot hold its own bootstrap.** With `provider: "aws"`, reading any
+secret needs AWS credentials — so the AWS bootstrap bundle
+(`LISA_AWS_BOOTSTRAP_JSON`, see `lisa-setup-remote-aws`) cannot live there:
+resolving it would require the very credential it contains. Keep that one in a
+different provider. The same applies to any provider whose own access key is a
+secret you would otherwise store inside it.
+
 Unimplemented providers fail with a message naming where to add them, rather than failing obscurely. Do not claim support that does not exist.
 
 Cache **in-process only**. Never write a resolved value to disk except through the materialization contract above.

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-aws/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-aws/SKILL.md
@@ -30,15 +30,40 @@ Install the vendor-neutral AWS bootstrap into the current repository.
    `.github/workflows/copilot-setup-steps.yml`; and it always writes
    `docs/remote-agent-aws.md`.
 4. Run `bash -n scripts/remote-agent-aws-setup.sh`.
-5. Never write or request the actual bootstrap SecretString in repository
-   files. Tell the operator to retrieve the `remote-agent-credentials` secret
-   from the shared AWS account and paste its complete SecretString into the
-   platform secret named `LISA_AWS_BOOTSTRAP_JSON`. The default cdkstarter
-   secret name is `remote-agent-credentials`; downstream infrastructure may
-   configure a different name. Pass that name with `--secret-name` so the
-   generated runbook contains the exact retrieval command.
+5. Never write or request the actual bootstrap bundle in repository files. Tell
+   the operator where to obtain it and where to put it — see **Where the bundle
+   lives** below. Pass `--secret-name` when the source names it something other
+   than `remote-agent-credentials`, so the generated runbook contains the exact
+   retrieval command.
 6. Report the external step that remains: configure that one secret in the
    remote environment and launch a smoke session.
+
+## Where the bundle lives
+
+`LISA_AWS_BOOTSTRAP_JSON` is **just another secret**, and it belongs wherever
+the project keeps its secrets — resolved through `lisa-secrets-access` like
+everything else. It is not tied to any one store.
+
+Whoever provisions the IAM user emits the bundle somewhere. `cdkstarter` writes
+it to AWS Secrets Manager as `remote-agent-credentials`, but that is where it is
+*emitted*, not where it must *live*. Copy it once into the project's configured
+provider and read it from there.
+
+**Do not keep it in two stores.** A bundle sitting in Secrets Manager *and* in
+the platform's secret store is two live copies of one credential: rotate the
+IAM key and whichever copy you forget keeps authenticating until it doesn't,
+with nothing to say which is current. That is the drift the single-store rule in
+`lisa-secrets-access` exists to prevent, and this credential is not exempt.
+
+**One provider cannot serve this particular secret.** If `secrets.provider` is
+`aws`, reading the bundle requires AWS credentials — and the bundle *is* the AWS
+credential. Anything else works: Bitwarden, 1Password, Doppler, Vault, or a
+platform secret store. Pick the one that is not the thing being bootstrapped.
+
+On a surface that materializes (see `lisa-secrets-access`), the bundle arrives
+in `secrets.env` with everything else, so the project hook can run this setup
+script after materialization with no extra plumbing. On a surface that reads
+through live, resolve it at the point of use.
 
 ## Contract
 

--- a/plugins/lisa-cursor/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa-cursor/scripts/remote-agent-aws-setup.sh
@@ -3,8 +3,14 @@
 # source copied into every generated Lisa agent plugin.
 #
 # Required secret:
-#   LISA_AWS_BOOTSTRAP_JSON  Complete SecretString emitted by cdkstarter's
-#                            remote-agent IAM kit.
+#   LISA_AWS_BOOTSTRAP_JSON  The complete remote-agent bootstrap bundle, as one
+#                            JSON value. cdkstarter's IAM kit emits it, but this
+#                            script neither knows nor cares which store it came
+#                            from — resolve it through lisa-secrets-access like
+#                            any other secret. Note that a project whose
+#                            provider is AWS Secrets Manager cannot keep it
+#                            there: reading it would need the very credential it
+#                            contains.
 # Optional plain variables:
 #   LISA_REMOTE_AGENT       claude | codex | cursor | copilot | agy | opencode
 #   LISA_AWS_DEFAULT_PROFILE  Defaults to dev, then the first available profile.

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/SKILL.md
@@ -198,6 +198,13 @@ Values never enter that process, so its output cannot leak one even if logged.
 | `aws` | `aws secretsmanager get-secret-value --secret-id <name>` | not implemented |
 | `vault` | `vault kv get -field=<name> <path>` | not implemented |
 
+**A provider cannot hold its own bootstrap.** With `provider: "aws"`, reading any
+secret needs AWS credentials — so the AWS bootstrap bundle
+(`LISA_AWS_BOOTSTRAP_JSON`, see `lisa-setup-remote-aws`) cannot live there:
+resolving it would require the very credential it contains. Keep that one in a
+different provider. The same applies to any provider whose own access key is a
+secret you would otherwise store inside it.
+
 Unimplemented providers fail with a message naming where to add them, rather than failing obscurely. Do not claim support that does not exist.
 
 Cache **in-process only**. Never write a resolved value to disk except through the materialization contract above.

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-aws/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-aws/SKILL.md
@@ -30,15 +30,40 @@ Install the vendor-neutral AWS bootstrap into the current repository.
    `.github/workflows/copilot-setup-steps.yml`; and it always writes
    `docs/remote-agent-aws.md`.
 4. Run `bash -n scripts/remote-agent-aws-setup.sh`.
-5. Never write or request the actual bootstrap SecretString in repository
-   files. Tell the operator to retrieve the `remote-agent-credentials` secret
-   from the shared AWS account and paste its complete SecretString into the
-   platform secret named `LISA_AWS_BOOTSTRAP_JSON`. The default cdkstarter
-   secret name is `remote-agent-credentials`; downstream infrastructure may
-   configure a different name. Pass that name with `--secret-name` so the
-   generated runbook contains the exact retrieval command.
+5. Never write or request the actual bootstrap bundle in repository files. Tell
+   the operator where to obtain it and where to put it — see **Where the bundle
+   lives** below. Pass `--secret-name` when the source names it something other
+   than `remote-agent-credentials`, so the generated runbook contains the exact
+   retrieval command.
 6. Report the external step that remains: configure that one secret in the
    remote environment and launch a smoke session.
+
+## Where the bundle lives
+
+`LISA_AWS_BOOTSTRAP_JSON` is **just another secret**, and it belongs wherever
+the project keeps its secrets — resolved through `lisa-secrets-access` like
+everything else. It is not tied to any one store.
+
+Whoever provisions the IAM user emits the bundle somewhere. `cdkstarter` writes
+it to AWS Secrets Manager as `remote-agent-credentials`, but that is where it is
+*emitted*, not where it must *live*. Copy it once into the project's configured
+provider and read it from there.
+
+**Do not keep it in two stores.** A bundle sitting in Secrets Manager *and* in
+the platform's secret store is two live copies of one credential: rotate the
+IAM key and whichever copy you forget keeps authenticating until it doesn't,
+with nothing to say which is current. That is the drift the single-store rule in
+`lisa-secrets-access` exists to prevent, and this credential is not exempt.
+
+**One provider cannot serve this particular secret.** If `secrets.provider` is
+`aws`, reading the bundle requires AWS credentials — and the bundle *is* the AWS
+credential. Anything else works: Bitwarden, 1Password, Doppler, Vault, or a
+platform secret store. Pick the one that is not the thing being bootstrapped.
+
+On a surface that materializes (see `lisa-secrets-access`), the bundle arrives
+in `secrets.env` with everything else, so the project hook can run this setup
+script after materialization with no extra plumbing. On a surface that reads
+through live, resolve it at the point of use.
 
 ## Contract
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/SKILL.md
@@ -198,6 +198,13 @@ Values never enter that process, so its output cannot leak one even if logged.
 | `aws` | `aws secretsmanager get-secret-value --secret-id <name>` | not implemented |
 | `vault` | `vault kv get -field=<name> <path>` | not implemented |
 
+**A provider cannot hold its own bootstrap.** With `provider: "aws"`, reading any
+secret needs AWS credentials — so the AWS bootstrap bundle
+(`LISA_AWS_BOOTSTRAP_JSON`, see `lisa-setup-remote-aws`) cannot live there:
+resolving it would require the very credential it contains. Keep that one in a
+different provider. The same applies to any provider whose own access key is a
+secret you would otherwise store inside it.
+
 Unimplemented providers fail with a message naming where to add them, rather than failing obscurely. Do not claim support that does not exist.
 
 Cache **in-process only**. Never write a resolved value to disk except through the materialization contract above.

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-aws/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-aws/SKILL.md
@@ -30,15 +30,40 @@ Install the vendor-neutral AWS bootstrap into the current repository.
    `.github/workflows/copilot-setup-steps.yml`; and it always writes
    `docs/remote-agent-aws.md`.
 4. Run `bash -n scripts/remote-agent-aws-setup.sh`.
-5. Never write or request the actual bootstrap SecretString in repository
-   files. Tell the operator to retrieve the `remote-agent-credentials` secret
-   from the shared AWS account and paste its complete SecretString into the
-   platform secret named `LISA_AWS_BOOTSTRAP_JSON`. The default cdkstarter
-   secret name is `remote-agent-credentials`; downstream infrastructure may
-   configure a different name. Pass that name with `--secret-name` so the
-   generated runbook contains the exact retrieval command.
+5. Never write or request the actual bootstrap bundle in repository files. Tell
+   the operator where to obtain it and where to put it — see **Where the bundle
+   lives** below. Pass `--secret-name` when the source names it something other
+   than `remote-agent-credentials`, so the generated runbook contains the exact
+   retrieval command.
 6. Report the external step that remains: configure that one secret in the
    remote environment and launch a smoke session.
+
+## Where the bundle lives
+
+`LISA_AWS_BOOTSTRAP_JSON` is **just another secret**, and it belongs wherever
+the project keeps its secrets — resolved through `lisa-secrets-access` like
+everything else. It is not tied to any one store.
+
+Whoever provisions the IAM user emits the bundle somewhere. `cdkstarter` writes
+it to AWS Secrets Manager as `remote-agent-credentials`, but that is where it is
+*emitted*, not where it must *live*. Copy it once into the project's configured
+provider and read it from there.
+
+**Do not keep it in two stores.** A bundle sitting in Secrets Manager *and* in
+the platform's secret store is two live copies of one credential: rotate the
+IAM key and whichever copy you forget keeps authenticating until it doesn't,
+with nothing to say which is current. That is the drift the single-store rule in
+`lisa-secrets-access` exists to prevent, and this credential is not exempt.
+
+**One provider cannot serve this particular secret.** If `secrets.provider` is
+`aws`, reading the bundle requires AWS credentials — and the bundle *is* the AWS
+credential. Anything else works: Bitwarden, 1Password, Doppler, Vault, or a
+platform secret store. Pick the one that is not the thing being bootstrapped.
+
+On a surface that materializes (see `lisa-secrets-access`), the bundle arrives
+in `secrets.env` with everything else, so the project hook can run this setup
+script after materialization with no extra plumbing. On a surface that reads
+through live, resolve it at the point of use.
 
 ## Contract
 

--- a/plugins/lisa/scripts/remote-agent-aws-setup.sh
+++ b/plugins/lisa/scripts/remote-agent-aws-setup.sh
@@ -3,8 +3,14 @@
 # source copied into every generated Lisa agent plugin.
 #
 # Required secret:
-#   LISA_AWS_BOOTSTRAP_JSON  Complete SecretString emitted by cdkstarter's
-#                            remote-agent IAM kit.
+#   LISA_AWS_BOOTSTRAP_JSON  The complete remote-agent bootstrap bundle, as one
+#                            JSON value. cdkstarter's IAM kit emits it, but this
+#                            script neither knows nor cares which store it came
+#                            from — resolve it through lisa-secrets-access like
+#                            any other secret. Note that a project whose
+#                            provider is AWS Secrets Manager cannot keep it
+#                            there: reading it would need the very credential it
+#                            contains.
 # Optional plain variables:
 #   LISA_REMOTE_AGENT       claude | codex | cursor | copilot | agy | opencode
 #   LISA_AWS_DEFAULT_PROFILE  Defaults to dev, then the first available profile.

--- a/plugins/lisa/skills/lisa-secrets-access/SKILL.md
+++ b/plugins/lisa/skills/lisa-secrets-access/SKILL.md
@@ -198,6 +198,13 @@ Values never enter that process, so its output cannot leak one even if logged.
 | `aws` | `aws secretsmanager get-secret-value --secret-id <name>` | not implemented |
 | `vault` | `vault kv get -field=<name> <path>` | not implemented |
 
+**A provider cannot hold its own bootstrap.** With `provider: "aws"`, reading any
+secret needs AWS credentials — so the AWS bootstrap bundle
+(`LISA_AWS_BOOTSTRAP_JSON`, see `lisa-setup-remote-aws`) cannot live there:
+resolving it would require the very credential it contains. Keep that one in a
+different provider. The same applies to any provider whose own access key is a
+secret you would otherwise store inside it.
+
 Unimplemented providers fail with a message naming where to add them, rather than failing obscurely. Do not claim support that does not exist.
 
 Cache **in-process only**. Never write a resolved value to disk except through the materialization contract above.

--- a/plugins/lisa/skills/lisa-setup-remote-aws/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-remote-aws/SKILL.md
@@ -30,15 +30,40 @@ Install the vendor-neutral AWS bootstrap into the current repository.
    `.github/workflows/copilot-setup-steps.yml`; and it always writes
    `docs/remote-agent-aws.md`.
 4. Run `bash -n scripts/remote-agent-aws-setup.sh`.
-5. Never write or request the actual bootstrap SecretString in repository
-   files. Tell the operator to retrieve the `remote-agent-credentials` secret
-   from the shared AWS account and paste its complete SecretString into the
-   platform secret named `LISA_AWS_BOOTSTRAP_JSON`. The default cdkstarter
-   secret name is `remote-agent-credentials`; downstream infrastructure may
-   configure a different name. Pass that name with `--secret-name` so the
-   generated runbook contains the exact retrieval command.
+5. Never write or request the actual bootstrap bundle in repository files. Tell
+   the operator where to obtain it and where to put it — see **Where the bundle
+   lives** below. Pass `--secret-name` when the source names it something other
+   than `remote-agent-credentials`, so the generated runbook contains the exact
+   retrieval command.
 6. Report the external step that remains: configure that one secret in the
    remote environment and launch a smoke session.
+
+## Where the bundle lives
+
+`LISA_AWS_BOOTSTRAP_JSON` is **just another secret**, and it belongs wherever
+the project keeps its secrets — resolved through `lisa-secrets-access` like
+everything else. It is not tied to any one store.
+
+Whoever provisions the IAM user emits the bundle somewhere. `cdkstarter` writes
+it to AWS Secrets Manager as `remote-agent-credentials`, but that is where it is
+*emitted*, not where it must *live*. Copy it once into the project's configured
+provider and read it from there.
+
+**Do not keep it in two stores.** A bundle sitting in Secrets Manager *and* in
+the platform's secret store is two live copies of one credential: rotate the
+IAM key and whichever copy you forget keeps authenticating until it doesn't,
+with nothing to say which is current. That is the drift the single-store rule in
+`lisa-secrets-access` exists to prevent, and this credential is not exempt.
+
+**One provider cannot serve this particular secret.** If `secrets.provider` is
+`aws`, reading the bundle requires AWS credentials — and the bundle *is* the AWS
+credential. Anything else works: Bitwarden, 1Password, Doppler, Vault, or a
+platform secret store. Pick the one that is not the thing being bootstrapped.
+
+On a surface that materializes (see `lisa-secrets-access`), the bundle arrives
+in `secrets.env` with everything else, so the project hook can run this setup
+script after materialization with no extra plumbing. On a surface that reads
+through live, resolve it at the point of use.
 
 ## Contract
 

--- a/plugins/src/base/scripts/remote-agent-aws-setup.sh
+++ b/plugins/src/base/scripts/remote-agent-aws-setup.sh
@@ -3,8 +3,14 @@
 # source copied into every generated Lisa agent plugin.
 #
 # Required secret:
-#   LISA_AWS_BOOTSTRAP_JSON  Complete SecretString emitted by cdkstarter's
-#                            remote-agent IAM kit.
+#   LISA_AWS_BOOTSTRAP_JSON  The complete remote-agent bootstrap bundle, as one
+#                            JSON value. cdkstarter's IAM kit emits it, but this
+#                            script neither knows nor cares which store it came
+#                            from — resolve it through lisa-secrets-access like
+#                            any other secret. Note that a project whose
+#                            provider is AWS Secrets Manager cannot keep it
+#                            there: reading it would need the very credential it
+#                            contains.
 # Optional plain variables:
 #   LISA_REMOTE_AGENT       claude | codex | cursor | copilot | agy | opencode
 #   LISA_AWS_DEFAULT_PROFILE  Defaults to dev, then the first available profile.

--- a/plugins/src/base/skills/lisa-secrets-access/SKILL.md
+++ b/plugins/src/base/skills/lisa-secrets-access/SKILL.md
@@ -198,6 +198,13 @@ Values never enter that process, so its output cannot leak one even if logged.
 | `aws` | `aws secretsmanager get-secret-value --secret-id <name>` | not implemented |
 | `vault` | `vault kv get -field=<name> <path>` | not implemented |
 
+**A provider cannot hold its own bootstrap.** With `provider: "aws"`, reading any
+secret needs AWS credentials — so the AWS bootstrap bundle
+(`LISA_AWS_BOOTSTRAP_JSON`, see `lisa-setup-remote-aws`) cannot live there:
+resolving it would require the very credential it contains. Keep that one in a
+different provider. The same applies to any provider whose own access key is a
+secret you would otherwise store inside it.
+
 Unimplemented providers fail with a message naming where to add them, rather than failing obscurely. Do not claim support that does not exist.
 
 Cache **in-process only**. Never write a resolved value to disk except through the materialization contract above.

--- a/plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md
@@ -30,15 +30,40 @@ Install the vendor-neutral AWS bootstrap into the current repository.
    `.github/workflows/copilot-setup-steps.yml`; and it always writes
    `docs/remote-agent-aws.md`.
 4. Run `bash -n scripts/remote-agent-aws-setup.sh`.
-5. Never write or request the actual bootstrap SecretString in repository
-   files. Tell the operator to retrieve the `remote-agent-credentials` secret
-   from the shared AWS account and paste its complete SecretString into the
-   platform secret named `LISA_AWS_BOOTSTRAP_JSON`. The default cdkstarter
-   secret name is `remote-agent-credentials`; downstream infrastructure may
-   configure a different name. Pass that name with `--secret-name` so the
-   generated runbook contains the exact retrieval command.
+5. Never write or request the actual bootstrap bundle in repository files. Tell
+   the operator where to obtain it and where to put it — see **Where the bundle
+   lives** below. Pass `--secret-name` when the source names it something other
+   than `remote-agent-credentials`, so the generated runbook contains the exact
+   retrieval command.
 6. Report the external step that remains: configure that one secret in the
    remote environment and launch a smoke session.
+
+## Where the bundle lives
+
+`LISA_AWS_BOOTSTRAP_JSON` is **just another secret**, and it belongs wherever
+the project keeps its secrets — resolved through `lisa-secrets-access` like
+everything else. It is not tied to any one store.
+
+Whoever provisions the IAM user emits the bundle somewhere. `cdkstarter` writes
+it to AWS Secrets Manager as `remote-agent-credentials`, but that is where it is
+*emitted*, not where it must *live*. Copy it once into the project's configured
+provider and read it from there.
+
+**Do not keep it in two stores.** A bundle sitting in Secrets Manager *and* in
+the platform's secret store is two live copies of one credential: rotate the
+IAM key and whichever copy you forget keeps authenticating until it doesn't,
+with nothing to say which is current. That is the drift the single-store rule in
+`lisa-secrets-access` exists to prevent, and this credential is not exempt.
+
+**One provider cannot serve this particular secret.** If `secrets.provider` is
+`aws`, reading the bundle requires AWS credentials — and the bundle *is* the AWS
+credential. Anything else works: Bitwarden, 1Password, Doppler, Vault, or a
+platform secret store. Pick the one that is not the thing being bootstrapped.
+
+On a surface that materializes (see `lisa-secrets-access`), the bundle arrives
+in `secrets.env` with everything else, so the project hook can run this setup
+script after materialization with no extra plumbing. On a surface that reads
+through live, resolve it at the point of use.
 
 ## Contract
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -799,7 +799,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/scripts/queue-status-prd-readers.mjs":
       "32b4366fc292062c869793aeaf5b006ff400df5da09ee510f862e15d59a77770",
     "plugins/src/base/scripts/remote-agent-aws-setup.sh":
-      "a0e35ed9222c78bce58097a761204f22d388296656c6f4b5043da547e4dad103",
+      "e3fc922d9b868e0f5a72c7a16a4c32e4a1b3f5278b7c8563648e4f05c49072c5",
     "plugins/src/base/skills/lisa-acceptance-criteria/SKILL.md":
       "b4289ec04de657f0eeefaed56939fa171c2f8a11086bd225db39130f4a609e95",
     "plugins/src/base/skills/lisa-agent-design-best-practices/SKILL.md":
@@ -1071,7 +1071,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-root-cause-analysis/SKILL.md":
       "3fa14217ca36b238ebb8203d18f10eaaf98a3647f949cdada6cb9f56ddf9ed50",
     "plugins/src/base/skills/lisa-secrets-access/SKILL.md":
-      "e7ccac9b7c8e9a9ad61f267de3b121c916b69a495da95eb280f390c33f8e04f6",
+      "9d7346864b04304e5b4bbb90512c7f2e701d69ab012b4fcf3b7b687221fc76bd",
     "plugins/src/base/skills/lisa-secrets-access/scripts/doctor-secrets.mjs":
       "aca23d562016bfda30d0ace0f77668edb91e5bcda1bf278036353671c53e9cbc",
     "plugins/src/base/skills/lisa-secrets-access/scripts/envfile.mjs":
@@ -1117,7 +1117,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-notion/SKILL.md":
       "f5a1e9290789fd1c33675168d30461fb24a11c98a433ef777c1f536bc2f905ef",
     "plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md":
-      "7a134f6ce7857152076c2a85e0777d88f1f22b0ecfe607dd2fc6f8a286547910",
+      "80fbf157f9c562c033886c25a99b37356602edd9e61cd2d492f339769ddcf97e",
     "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md":
       "cf0f54c4960c682c5135a5bc9db4701c2e95fec07faf4b041ede80b9cbc61072",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":


### PR DESCRIPTION
`lisa-setup-remote-aws` tells the operator to retrieve the bootstrap bundle from AWS Secrets Manager and paste it into the platform secret. That names one store as the source and leaves the credential in two places at once.

## Why that is wrong

**It contradicts the single-store rule Lisa itself ships.** A bundle in Secrets Manager *and* in the platform's secret store is two live copies of one credential. Rotate the IAM key and whichever copy you forget keeps authenticating until it doesn't, with nothing to say which is current — exactly the drift `lisa-secrets-access` exists to prevent.

**It is store-specific in a system that is deliberately not.** The provider axis already supports `bitwarden | 1password | aws | doppler | vault | env`. The bundle is just another secret; it belongs wherever the project keeps secrets, resolved through `lisa-secrets-access` like everything else.

**And it should not become Bitwarden-specific either.** The fix is provider-neutral guidance, not a swap of one hardcoded store for another.

## One real constraint worth documenting

A project whose `secrets.provider` is `aws` **cannot** keep this bundle there: reading it would require the very AWS credential it contains. That circularity is worth stating explicitly, since `aws` is otherwise a perfectly valid provider.

## Scope

Documentation only, no behaviour change — the setup script already reads `LISA_AWS_BOOTSTRAP_JSON` from the environment and has never cared where the value came from.

## What changed

Guidance now names no vendor. `cdkstarter` is described as where the bundle is *emitted*, not where it must live, and the bundle is resolved through `lisa-secrets-access` like any other secret.

The circularity caveat is documented in two places: the remote-aws skill, and the provider dispatch table in `lisa-secrets-access` — where someone actually chooses `provider: "aws"`.

The setup script header said the value was "the SecretString emitted by cdkstarter". It now says the script neither knows nor cares which store it came from, which is what the code has always done.

Work-Item: CodySwannGT/lisa#2158

🤖 Generated with Claude Code
