### PR TITLE
fix(remote-env): resolve the skill from node_modules on a fresh container

### DIFF
--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
@@ -10,16 +10,26 @@ Prepare a remote surface so a host project can execute there. Today that means *
 
 ## What lives where
 
-The remote environment's own configuration fields stay **two one-line calls into the repository**. Nothing is pasted into a vendor UI.
+The remote environment's own configuration fields stay **one line into the repository, preceded by the project's dependency install**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       bash scripts/lisa-remote-env/setup.sh
-maintenance: bash scripts/lisa-remote-env/setup.sh
+setup:       <install> && bash scripts/lisa-remote-env/setup.sh
+maintenance: <install> && bash scripts/lisa-remote-env/setup.sh
 ```
 
-They are the same script. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
+`<install>` is whatever the project already uses — `bun install`, `npm ci`, `pnpm install`. Substitute it; do not invent one.
+
+They are the same command. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
 
 The complete logic is repository-owned so it is reviewed, versioned, tested, and reusable. A large inline installer in a settings field is none of those things.
+
+### Why the install has to come first
+
+**A clone does not contain the skills on the harnesses that matter here.** OpenCode and Antigravity have them written into the checkout by `lisa apply`. Claude and Codex receive them as an *installed plugin*, which lives in the user's home directory — so a container that has just cloned the repository has never seen it.
+
+`node_modules/@codyswann/lisa` is therefore the only copy present on a fresh container, and it is a good one: it is the version that project pins, which is the version its setup should run. The entrypoint searches the agent directories first and falls back to it.
+
+Omitting the install does not degrade gracefully. The entrypoint exits before the toolchain, secrets, and hook phases have done anything, so the environment looks provisioned and fails on first dispatch.
 
 ## The three phases
 
@@ -110,8 +120,11 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      bash scripts/lisa-remote-env/setup.sh
-Maintenance:       bash scripts/lisa-remote-env/setup.sh
+Setup script:      <install> && bash scripts/lisa-remote-env/setup.sh
+Maintenance:       <install> && bash scripts/lisa-remote-env/setup.sh
+                   (<install> is the project's own: bun install, npm ci, ...
+                   It must precede the script — on a fresh container
+                   node_modules is the only copy of the skills present.)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
                    BWS_ACCESS_TOKEN=<from the provider; an environment
                    variable, not a task secret — setup and cache-resume

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
@@ -149,7 +149,7 @@ Checked when setup runs, not at 3am:
 
 - the environment exists and is bound to **this** repository as its default checkout;
 - the bootstrap credential resolves;
-- Lisa has been applied to the repository, so its skills are present in that checkout.
+- either a checkout-local Lisa skill is present, or the project dependency install has made the pinned `@codyswann/lisa` package available under `node_modules`.
 
 Fail with a message naming what is missing. Never provision-and-hope.
 

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/assets/setup.sh
@@ -23,13 +23,26 @@ if ! command -v node >/dev/null 2>&1; then
   exit 1
 fi
 
-# The skill ships under whichever agent directory this project uses. Search
-# rather than hardcode, so one entrypoint serves every supported harness.
+# Where the skill lives depends on how this project's harness receives it, and
+# the two delivery models differ in a way that matters here.
+#
+# OpenCode and Antigravity get skills written INTO the checkout by `lisa apply`,
+# so a clone already carries them. Claude and Codex receive them as an installed
+# plugin, which lives in the user's home directory and is emphatically NOT part
+# of a clone. A fresh remote container is the second case every time: it clones
+# the repository and has never run a plugin install.
+#
+# So the agent directories are searched first — they are the cheapest hit and
+# need nothing installed — and the npm package is the fallback that makes the
+# plugin-delivered harnesses work at all. Lisa is a dependency of every project
+# it is applied to, so `node_modules` carries the same skill at the version that
+# project pins, which is the version its setup should run.
 runner=""
 for candidate in \
   ".claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".agents/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
-  ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
+  ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  "node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
   if [ -f "$candidate" ]; then
     runner="$candidate"
     break
@@ -37,8 +50,19 @@ for candidate in \
 done
 
 if [ -z "$runner" ]; then
-  echo "Cannot find the lisa-setup-remote-env skill in this checkout." >&2
-  echo "Run 'lisa apply' so the skills are present, then re-run setup." >&2
+  echo "Cannot find the lisa-setup-remote-env skill." >&2
+  echo >&2
+  echo "Searched the agent skill directories and node_modules. On a remote" >&2
+  echo "container the usual cause is that dependencies have not been installed" >&2
+  echo "yet: Claude and Codex receive Lisa skills as an installed plugin, which" >&2
+  echo "is not part of a clone, so node_modules is the only copy present." >&2
+  echo >&2
+  echo "Install dependencies before this script runs. The environment's setup" >&2
+  echo "command should be the install and this script together, for example:" >&2
+  echo "  bun install && bash scripts/lisa-remote-env/setup.sh" >&2
+  echo >&2
+  echo "If dependencies are installed, run 'lisa apply' so the skills are" >&2
+  echo "present, then re-run setup." >&2
   exit 1
 fi
 

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
@@ -10,16 +10,26 @@ Prepare a remote surface so a host project can execute there. Today that means *
 
 ## What lives where
 
-The remote environment's own configuration fields stay **two one-line calls into the repository**. Nothing is pasted into a vendor UI.
+The remote environment's own configuration fields stay **one line into the repository, preceded by the project's dependency install**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       bash scripts/lisa-remote-env/setup.sh
-maintenance: bash scripts/lisa-remote-env/setup.sh
+setup:       <install> && bash scripts/lisa-remote-env/setup.sh
+maintenance: <install> && bash scripts/lisa-remote-env/setup.sh
 ```
 
-They are the same script. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
+`<install>` is whatever the project already uses — `bun install`, `npm ci`, `pnpm install`. Substitute it; do not invent one.
+
+They are the same command. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
 
 The complete logic is repository-owned so it is reviewed, versioned, tested, and reusable. A large inline installer in a settings field is none of those things.
+
+### Why the install has to come first
+
+**A clone does not contain the skills on the harnesses that matter here.** OpenCode and Antigravity have them written into the checkout by `lisa apply`. Claude and Codex receive them as an *installed plugin*, which lives in the user's home directory — so a container that has just cloned the repository has never seen it.
+
+`node_modules/@codyswann/lisa` is therefore the only copy present on a fresh container, and it is a good one: it is the version that project pins, which is the version its setup should run. The entrypoint searches the agent directories first and falls back to it.
+
+Omitting the install does not degrade gracefully. The entrypoint exits before the toolchain, secrets, and hook phases have done anything, so the environment looks provisioned and fails on first dispatch.
 
 ## The three phases
 
@@ -110,8 +120,11 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      bash scripts/lisa-remote-env/setup.sh
-Maintenance:       bash scripts/lisa-remote-env/setup.sh
+Setup script:      <install> && bash scripts/lisa-remote-env/setup.sh
+Maintenance:       <install> && bash scripts/lisa-remote-env/setup.sh
+                   (<install> is the project's own: bun install, npm ci, ...
+                   It must precede the script — on a fresh container
+                   node_modules is the only copy of the skills present.)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
                    BWS_ACCESS_TOKEN=<from the provider; an environment
                    variable, not a task secret — setup and cache-resume

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
@@ -149,7 +149,7 @@ Checked when setup runs, not at 3am:
 
 - the environment exists and is bound to **this** repository as its default checkout;
 - the bootstrap credential resolves;
-- Lisa has been applied to the repository, so its skills are present in that checkout.
+- either a checkout-local Lisa skill is present, or the project dependency install has made the pinned `@codyswann/lisa` package available under `node_modules`.
 
 Fail with a message naming what is missing. Never provision-and-hope.
 

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/assets/setup.sh
@@ -23,13 +23,26 @@ if ! command -v node >/dev/null 2>&1; then
   exit 1
 fi
 
-# The skill ships under whichever agent directory this project uses. Search
-# rather than hardcode, so one entrypoint serves every supported harness.
+# Where the skill lives depends on how this project's harness receives it, and
+# the two delivery models differ in a way that matters here.
+#
+# OpenCode and Antigravity get skills written INTO the checkout by `lisa apply`,
+# so a clone already carries them. Claude and Codex receive them as an installed
+# plugin, which lives in the user's home directory and is emphatically NOT part
+# of a clone. A fresh remote container is the second case every time: it clones
+# the repository and has never run a plugin install.
+#
+# So the agent directories are searched first — they are the cheapest hit and
+# need nothing installed — and the npm package is the fallback that makes the
+# plugin-delivered harnesses work at all. Lisa is a dependency of every project
+# it is applied to, so `node_modules` carries the same skill at the version that
+# project pins, which is the version its setup should run.
 runner=""
 for candidate in \
   ".claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".agents/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
-  ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
+  ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  "node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
   if [ -f "$candidate" ]; then
     runner="$candidate"
     break
@@ -37,8 +50,19 @@ for candidate in \
 done
 
 if [ -z "$runner" ]; then
-  echo "Cannot find the lisa-setup-remote-env skill in this checkout." >&2
-  echo "Run 'lisa apply' so the skills are present, then re-run setup." >&2
+  echo "Cannot find the lisa-setup-remote-env skill." >&2
+  echo >&2
+  echo "Searched the agent skill directories and node_modules. On a remote" >&2
+  echo "container the usual cause is that dependencies have not been installed" >&2
+  echo "yet: Claude and Codex receive Lisa skills as an installed plugin, which" >&2
+  echo "is not part of a clone, so node_modules is the only copy present." >&2
+  echo >&2
+  echo "Install dependencies before this script runs. The environment's setup" >&2
+  echo "command should be the install and this script together, for example:" >&2
+  echo "  bun install && bash scripts/lisa-remote-env/setup.sh" >&2
+  echo >&2
+  echo "If dependencies are installed, run 'lisa apply' so the skills are" >&2
+  echo "present, then re-run setup." >&2
   exit 1
 fi
 

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
@@ -10,16 +10,26 @@ Prepare a remote surface so a host project can execute there. Today that means *
 
 ## What lives where
 
-The remote environment's own configuration fields stay **two one-line calls into the repository**. Nothing is pasted into a vendor UI.
+The remote environment's own configuration fields stay **one line into the repository, preceded by the project's dependency install**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       bash scripts/lisa-remote-env/setup.sh
-maintenance: bash scripts/lisa-remote-env/setup.sh
+setup:       <install> && bash scripts/lisa-remote-env/setup.sh
+maintenance: <install> && bash scripts/lisa-remote-env/setup.sh
 ```
 
-They are the same script. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
+`<install>` is whatever the project already uses — `bun install`, `npm ci`, `pnpm install`. Substitute it; do not invent one.
+
+They are the same command. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
 
 The complete logic is repository-owned so it is reviewed, versioned, tested, and reusable. A large inline installer in a settings field is none of those things.
+
+### Why the install has to come first
+
+**A clone does not contain the skills on the harnesses that matter here.** OpenCode and Antigravity have them written into the checkout by `lisa apply`. Claude and Codex receive them as an *installed plugin*, which lives in the user's home directory — so a container that has just cloned the repository has never seen it.
+
+`node_modules/@codyswann/lisa` is therefore the only copy present on a fresh container, and it is a good one: it is the version that project pins, which is the version its setup should run. The entrypoint searches the agent directories first and falls back to it.
+
+Omitting the install does not degrade gracefully. The entrypoint exits before the toolchain, secrets, and hook phases have done anything, so the environment looks provisioned and fails on first dispatch.
 
 ## The three phases
 
@@ -110,8 +120,11 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      bash scripts/lisa-remote-env/setup.sh
-Maintenance:       bash scripts/lisa-remote-env/setup.sh
+Setup script:      <install> && bash scripts/lisa-remote-env/setup.sh
+Maintenance:       <install> && bash scripts/lisa-remote-env/setup.sh
+                   (<install> is the project's own: bun install, npm ci, ...
+                   It must precede the script — on a fresh container
+                   node_modules is the only copy of the skills present.)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
                    BWS_ACCESS_TOKEN=<from the provider; an environment
                    variable, not a task secret — setup and cache-resume

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
@@ -149,7 +149,7 @@ Checked when setup runs, not at 3am:
 
 - the environment exists and is bound to **this** repository as its default checkout;
 - the bootstrap credential resolves;
-- Lisa has been applied to the repository, so its skills are present in that checkout.
+- either a checkout-local Lisa skill is present, or the project dependency install has made the pinned `@codyswann/lisa` package available under `node_modules`.
 
 Fail with a message naming what is missing. Never provision-and-hope.
 

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/assets/setup.sh
@@ -23,13 +23,26 @@ if ! command -v node >/dev/null 2>&1; then
   exit 1
 fi
 
-# The skill ships under whichever agent directory this project uses. Search
-# rather than hardcode, so one entrypoint serves every supported harness.
+# Where the skill lives depends on how this project's harness receives it, and
+# the two delivery models differ in a way that matters here.
+#
+# OpenCode and Antigravity get skills written INTO the checkout by `lisa apply`,
+# so a clone already carries them. Claude and Codex receive them as an installed
+# plugin, which lives in the user's home directory and is emphatically NOT part
+# of a clone. A fresh remote container is the second case every time: it clones
+# the repository and has never run a plugin install.
+#
+# So the agent directories are searched first — they are the cheapest hit and
+# need nothing installed — and the npm package is the fallback that makes the
+# plugin-delivered harnesses work at all. Lisa is a dependency of every project
+# it is applied to, so `node_modules` carries the same skill at the version that
+# project pins, which is the version its setup should run.
 runner=""
 for candidate in \
   ".claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".agents/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
-  ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
+  ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  "node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
   if [ -f "$candidate" ]; then
     runner="$candidate"
     break
@@ -37,8 +50,19 @@ for candidate in \
 done
 
 if [ -z "$runner" ]; then
-  echo "Cannot find the lisa-setup-remote-env skill in this checkout." >&2
-  echo "Run 'lisa apply' so the skills are present, then re-run setup." >&2
+  echo "Cannot find the lisa-setup-remote-env skill." >&2
+  echo >&2
+  echo "Searched the agent skill directories and node_modules. On a remote" >&2
+  echo "container the usual cause is that dependencies have not been installed" >&2
+  echo "yet: Claude and Codex receive Lisa skills as an installed plugin, which" >&2
+  echo "is not part of a clone, so node_modules is the only copy present." >&2
+  echo >&2
+  echo "Install dependencies before this script runs. The environment's setup" >&2
+  echo "command should be the install and this script together, for example:" >&2
+  echo "  bun install && bash scripts/lisa-remote-env/setup.sh" >&2
+  echo >&2
+  echo "If dependencies are installed, run 'lisa apply' so the skills are" >&2
+  echo "present, then re-run setup." >&2
   exit 1
 fi
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
@@ -10,16 +10,26 @@ Prepare a remote surface so a host project can execute there. Today that means *
 
 ## What lives where
 
-The remote environment's own configuration fields stay **two one-line calls into the repository**. Nothing is pasted into a vendor UI.
+The remote environment's own configuration fields stay **one line into the repository, preceded by the project's dependency install**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       bash scripts/lisa-remote-env/setup.sh
-maintenance: bash scripts/lisa-remote-env/setup.sh
+setup:       <install> && bash scripts/lisa-remote-env/setup.sh
+maintenance: <install> && bash scripts/lisa-remote-env/setup.sh
 ```
 
-They are the same script. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
+`<install>` is whatever the project already uses — `bun install`, `npm ci`, `pnpm install`. Substitute it; do not invent one.
+
+They are the same command. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
 
 The complete logic is repository-owned so it is reviewed, versioned, tested, and reusable. A large inline installer in a settings field is none of those things.
+
+### Why the install has to come first
+
+**A clone does not contain the skills on the harnesses that matter here.** OpenCode and Antigravity have them written into the checkout by `lisa apply`. Claude and Codex receive them as an *installed plugin*, which lives in the user's home directory — so a container that has just cloned the repository has never seen it.
+
+`node_modules/@codyswann/lisa` is therefore the only copy present on a fresh container, and it is a good one: it is the version that project pins, which is the version its setup should run. The entrypoint searches the agent directories first and falls back to it.
+
+Omitting the install does not degrade gracefully. The entrypoint exits before the toolchain, secrets, and hook phases have done anything, so the environment looks provisioned and fails on first dispatch.
 
 ## The three phases
 
@@ -110,8 +120,11 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      bash scripts/lisa-remote-env/setup.sh
-Maintenance:       bash scripts/lisa-remote-env/setup.sh
+Setup script:      <install> && bash scripts/lisa-remote-env/setup.sh
+Maintenance:       <install> && bash scripts/lisa-remote-env/setup.sh
+                   (<install> is the project's own: bun install, npm ci, ...
+                   It must precede the script — on a fresh container
+                   node_modules is the only copy of the skills present.)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
                    BWS_ACCESS_TOKEN=<from the provider; an environment
                    variable, not a task secret — setup and cache-resume

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
@@ -149,7 +149,7 @@ Checked when setup runs, not at 3am:
 
 - the environment exists and is bound to **this** repository as its default checkout;
 - the bootstrap credential resolves;
-- Lisa has been applied to the repository, so its skills are present in that checkout.
+- either a checkout-local Lisa skill is present, or the project dependency install has made the pinned `@codyswann/lisa` package available under `node_modules`.
 
 Fail with a message naming what is missing. Never provision-and-hope.
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/assets/setup.sh
@@ -23,13 +23,26 @@ if ! command -v node >/dev/null 2>&1; then
   exit 1
 fi
 
-# The skill ships under whichever agent directory this project uses. Search
-# rather than hardcode, so one entrypoint serves every supported harness.
+# Where the skill lives depends on how this project's harness receives it, and
+# the two delivery models differ in a way that matters here.
+#
+# OpenCode and Antigravity get skills written INTO the checkout by `lisa apply`,
+# so a clone already carries them. Claude and Codex receive them as an installed
+# plugin, which lives in the user's home directory and is emphatically NOT part
+# of a clone. A fresh remote container is the second case every time: it clones
+# the repository and has never run a plugin install.
+#
+# So the agent directories are searched first — they are the cheapest hit and
+# need nothing installed — and the npm package is the fallback that makes the
+# plugin-delivered harnesses work at all. Lisa is a dependency of every project
+# it is applied to, so `node_modules` carries the same skill at the version that
+# project pins, which is the version its setup should run.
 runner=""
 for candidate in \
   ".claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".agents/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
-  ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
+  ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  "node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
   if [ -f "$candidate" ]; then
     runner="$candidate"
     break
@@ -37,8 +50,19 @@ for candidate in \
 done
 
 if [ -z "$runner" ]; then
-  echo "Cannot find the lisa-setup-remote-env skill in this checkout." >&2
-  echo "Run 'lisa apply' so the skills are present, then re-run setup." >&2
+  echo "Cannot find the lisa-setup-remote-env skill." >&2
+  echo >&2
+  echo "Searched the agent skill directories and node_modules. On a remote" >&2
+  echo "container the usual cause is that dependencies have not been installed" >&2
+  echo "yet: Claude and Codex receive Lisa skills as an installed plugin, which" >&2
+  echo "is not part of a clone, so node_modules is the only copy present." >&2
+  echo >&2
+  echo "Install dependencies before this script runs. The environment's setup" >&2
+  echo "command should be the install and this script together, for example:" >&2
+  echo "  bun install && bash scripts/lisa-remote-env/setup.sh" >&2
+  echo >&2
+  echo "If dependencies are installed, run 'lisa apply' so the skills are" >&2
+  echo "present, then re-run setup." >&2
   exit 1
 fi
 

--- a/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
@@ -10,16 +10,26 @@ Prepare a remote surface so a host project can execute there. Today that means *
 
 ## What lives where
 
-The remote environment's own configuration fields stay **two one-line calls into the repository**. Nothing is pasted into a vendor UI.
+The remote environment's own configuration fields stay **one line into the repository, preceded by the project's dependency install**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       bash scripts/lisa-remote-env/setup.sh
-maintenance: bash scripts/lisa-remote-env/setup.sh
+setup:       <install> && bash scripts/lisa-remote-env/setup.sh
+maintenance: <install> && bash scripts/lisa-remote-env/setup.sh
 ```
 
-They are the same script. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
+`<install>` is whatever the project already uses — `bun install`, `npm ci`, `pnpm install`. Substitute it; do not invent one.
+
+They are the same command. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
 
 The complete logic is repository-owned so it is reviewed, versioned, tested, and reusable. A large inline installer in a settings field is none of those things.
+
+### Why the install has to come first
+
+**A clone does not contain the skills on the harnesses that matter here.** OpenCode and Antigravity have them written into the checkout by `lisa apply`. Claude and Codex receive them as an *installed plugin*, which lives in the user's home directory — so a container that has just cloned the repository has never seen it.
+
+`node_modules/@codyswann/lisa` is therefore the only copy present on a fresh container, and it is a good one: it is the version that project pins, which is the version its setup should run. The entrypoint searches the agent directories first and falls back to it.
+
+Omitting the install does not degrade gracefully. The entrypoint exits before the toolchain, secrets, and hook phases have done anything, so the environment looks provisioned and fails on first dispatch.
 
 ## The three phases
 
@@ -110,8 +120,11 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      bash scripts/lisa-remote-env/setup.sh
-Maintenance:       bash scripts/lisa-remote-env/setup.sh
+Setup script:      <install> && bash scripts/lisa-remote-env/setup.sh
+Maintenance:       <install> && bash scripts/lisa-remote-env/setup.sh
+                   (<install> is the project's own: bun install, npm ci, ...
+                   It must precede the script — on a fresh container
+                   node_modules is the only copy of the skills present.)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
                    BWS_ACCESS_TOKEN=<from the provider; an environment
                    variable, not a task secret — setup and cache-resume

--- a/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
@@ -149,7 +149,7 @@ Checked when setup runs, not at 3am:
 
 - the environment exists and is bound to **this** repository as its default checkout;
 - the bootstrap credential resolves;
-- Lisa has been applied to the repository, so its skills are present in that checkout.
+- either a checkout-local Lisa skill is present, or the project dependency install has made the pinned `@codyswann/lisa` package available under `node_modules`.
 
 Fail with a message naming what is missing. Never provision-and-hope.
 

--- a/plugins/lisa/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa/skills/lisa-setup-remote-env/assets/setup.sh
@@ -23,13 +23,26 @@ if ! command -v node >/dev/null 2>&1; then
   exit 1
 fi
 
-# The skill ships under whichever agent directory this project uses. Search
-# rather than hardcode, so one entrypoint serves every supported harness.
+# Where the skill lives depends on how this project's harness receives it, and
+# the two delivery models differ in a way that matters here.
+#
+# OpenCode and Antigravity get skills written INTO the checkout by `lisa apply`,
+# so a clone already carries them. Claude and Codex receive them as an installed
+# plugin, which lives in the user's home directory and is emphatically NOT part
+# of a clone. A fresh remote container is the second case every time: it clones
+# the repository and has never run a plugin install.
+#
+# So the agent directories are searched first — they are the cheapest hit and
+# need nothing installed — and the npm package is the fallback that makes the
+# plugin-delivered harnesses work at all. Lisa is a dependency of every project
+# it is applied to, so `node_modules` carries the same skill at the version that
+# project pins, which is the version its setup should run.
 runner=""
 for candidate in \
   ".claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".agents/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
-  ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
+  ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  "node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
   if [ -f "$candidate" ]; then
     runner="$candidate"
     break
@@ -37,8 +50,19 @@ for candidate in \
 done
 
 if [ -z "$runner" ]; then
-  echo "Cannot find the lisa-setup-remote-env skill in this checkout." >&2
-  echo "Run 'lisa apply' so the skills are present, then re-run setup." >&2
+  echo "Cannot find the lisa-setup-remote-env skill." >&2
+  echo >&2
+  echo "Searched the agent skill directories and node_modules. On a remote" >&2
+  echo "container the usual cause is that dependencies have not been installed" >&2
+  echo "yet: Claude and Codex receive Lisa skills as an installed plugin, which" >&2
+  echo "is not part of a clone, so node_modules is the only copy present." >&2
+  echo >&2
+  echo "Install dependencies before this script runs. The environment's setup" >&2
+  echo "command should be the install and this script together, for example:" >&2
+  echo "  bun install && bash scripts/lisa-remote-env/setup.sh" >&2
+  echo >&2
+  echo "If dependencies are installed, run 'lisa apply' so the skills are" >&2
+  echo "present, then re-run setup." >&2
   exit 1
 fi
 

--- a/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
@@ -10,16 +10,26 @@ Prepare a remote surface so a host project can execute there. Today that means *
 
 ## What lives where
 
-The remote environment's own configuration fields stay **two one-line calls into the repository**. Nothing is pasted into a vendor UI.
+The remote environment's own configuration fields stay **one line into the repository, preceded by the project's dependency install**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       bash scripts/lisa-remote-env/setup.sh
-maintenance: bash scripts/lisa-remote-env/setup.sh
+setup:       <install> && bash scripts/lisa-remote-env/setup.sh
+maintenance: <install> && bash scripts/lisa-remote-env/setup.sh
 ```
 
-They are the same script. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
+`<install>` is whatever the project already uses — `bun install`, `npm ci`, `pnpm install`. Substitute it; do not invent one.
+
+They are the same command. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
 
 The complete logic is repository-owned so it is reviewed, versioned, tested, and reusable. A large inline installer in a settings field is none of those things.
+
+### Why the install has to come first
+
+**A clone does not contain the skills on the harnesses that matter here.** OpenCode and Antigravity have them written into the checkout by `lisa apply`. Claude and Codex receive them as an *installed plugin*, which lives in the user's home directory — so a container that has just cloned the repository has never seen it.
+
+`node_modules/@codyswann/lisa` is therefore the only copy present on a fresh container, and it is a good one: it is the version that project pins, which is the version its setup should run. The entrypoint searches the agent directories first and falls back to it.
+
+Omitting the install does not degrade gracefully. The entrypoint exits before the toolchain, secrets, and hook phases have done anything, so the environment looks provisioned and fails on first dispatch.
 
 ## The three phases
 
@@ -110,8 +120,11 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      bash scripts/lisa-remote-env/setup.sh
-Maintenance:       bash scripts/lisa-remote-env/setup.sh
+Setup script:      <install> && bash scripts/lisa-remote-env/setup.sh
+Maintenance:       <install> && bash scripts/lisa-remote-env/setup.sh
+                   (<install> is the project's own: bun install, npm ci, ...
+                   It must precede the script — on a fresh container
+                   node_modules is the only copy of the skills present.)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
                    BWS_ACCESS_TOKEN=<from the provider; an environment
                    variable, not a task secret — setup and cache-resume

--- a/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
@@ -149,7 +149,7 @@ Checked when setup runs, not at 3am:
 
 - the environment exists and is bound to **this** repository as its default checkout;
 - the bootstrap credential resolves;
-- Lisa has been applied to the repository, so its skills are present in that checkout.
+- either a checkout-local Lisa skill is present, or the project dependency install has made the pinned `@codyswann/lisa` package available under `node_modules`.
 
 Fail with a message naming what is missing. Never provision-and-hope.
 

--- a/plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh
@@ -23,13 +23,26 @@ if ! command -v node >/dev/null 2>&1; then
   exit 1
 fi
 
-# The skill ships under whichever agent directory this project uses. Search
-# rather than hardcode, so one entrypoint serves every supported harness.
+# Where the skill lives depends on how this project's harness receives it, and
+# the two delivery models differ in a way that matters here.
+#
+# OpenCode and Antigravity get skills written INTO the checkout by `lisa apply`,
+# so a clone already carries them. Claude and Codex receive them as an installed
+# plugin, which lives in the user's home directory and is emphatically NOT part
+# of a clone. A fresh remote container is the second case every time: it clones
+# the repository and has never run a plugin install.
+#
+# So the agent directories are searched first — they are the cheapest hit and
+# need nothing installed — and the npm package is the fallback that makes the
+# plugin-delivered harnesses work at all. Lisa is a dependency of every project
+# it is applied to, so `node_modules` carries the same skill at the version that
+# project pins, which is the version its setup should run.
 runner=""
 for candidate in \
   ".claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".agents/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
-  ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
+  ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  "node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
   if [ -f "$candidate" ]; then
     runner="$candidate"
     break
@@ -37,8 +50,19 @@ for candidate in \
 done
 
 if [ -z "$runner" ]; then
-  echo "Cannot find the lisa-setup-remote-env skill in this checkout." >&2
-  echo "Run 'lisa apply' so the skills are present, then re-run setup." >&2
+  echo "Cannot find the lisa-setup-remote-env skill." >&2
+  echo >&2
+  echo "Searched the agent skill directories and node_modules. On a remote" >&2
+  echo "container the usual cause is that dependencies have not been installed" >&2
+  echo "yet: Claude and Codex receive Lisa skills as an installed plugin, which" >&2
+  echo "is not part of a clone, so node_modules is the only copy present." >&2
+  echo >&2
+  echo "Install dependencies before this script runs. The environment's setup" >&2
+  echo "command should be the install and this script together, for example:" >&2
+  echo "  bun install && bash scripts/lisa-remote-env/setup.sh" >&2
+  echo >&2
+  echo "If dependencies are installed, run 'lisa apply' so the skills are" >&2
+  echo "present, then re-run setup." >&2
   exit 1
 fi
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1119,9 +1119,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md":
       "80fbf157f9c562c033886c25a99b37356602edd9e61cd2d492f339769ddcf97e",
     "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md":
-      "cf0f54c4960c682c5135a5bc9db4701c2e95fec07faf4b041ede80b9cbc61072",
+      "3cab27540aa280598dec7b8f2df2f6dacd81d094b157b580d4efac1e76f5c574",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
-      "cf60c686b6861c33910f8175015dab2b4e33505af900a85c592d6ca061a8f7c4",
+      "a043074dd52e3f9b4b4a32bdd8b5eaa728160e5a0622a8a18388e6e26c7d25e3",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
       "1e3f57c34edd65129a157f7418524594ca92b5472978bf5be1641981f4f1afbe",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
@@ -8315,6 +8315,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/bootstrap-key-naming.test.ts": true,
     "tests/unit/secrets/doctor-secrets.test.ts": true,
     "tests/unit/secrets/remote-dispatch.test.ts": true,
+    "tests/unit/secrets/remote-env-skill-resolution.test.ts": true,
     "tests/unit/secrets/remote-env-toolchain.test.ts": true,
     "tests/unit/secrets/secrets-access-contract.test.ts": true,
     "tests/unit/secrets/validate-config.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1119,7 +1119,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md":
       "80fbf157f9c562c033886c25a99b37356602edd9e61cd2d492f339769ddcf97e",
     "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md":
-      "3cab27540aa280598dec7b8f2df2f6dacd81d094b157b580d4efac1e76f5c574",
+      "d3ecfe4ffbb7c6df241f2b3f7252c4b24e907ccf87fb3da7db95fadbaa45c054",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "a043074dd52e3f9b4b4a32bdd8b5eaa728160e5a0622a8a18388e6e26c7d25e3",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":

--- a/tests/unit/secrets/remote-env-skill-resolution.test.ts
+++ b/tests/unit/secrets/remote-env-skill-resolution.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Regression tests for how the remote-env entrypoint locates its skill.
+ *
+ * The entrypoint originally searched only the three agent skill directories,
+ * on the assumption that a checkout carries the skills. That holds for OpenCode
+ * and Antigravity, where `lisa apply` writes them into the repository, and is
+ * false for Claude and Codex, which receive them as an installed plugin living
+ * in the user's home directory.
+ *
+ * A remote container is always the second case: it clones the repository and
+ * has never run a plugin install. So every Claude or Codex project hit "Cannot
+ * find the lisa-setup-remote-env skill in this checkout" on its first container
+ * and provisioned an environment that failed on first dispatch.
+ *
+ * `node_modules/@codyswann/lisa` is the copy that is present, at the version
+ * the project pins. These tests pin both that it is searched and that the
+ * agent directories still win when they exist.
+ * @module tests/unit/secrets/remote-env-skill-resolution
+ */
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const ENTRYPOINT_PATH =
+  "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh";
+
+/**
+ * Absolute, so the interpreter cannot be resolved through a writable PATH
+ * entry. These tests deliberately do not shim PATH, so there is no reason to
+ * take the lookup.
+ */
+const BASH = "/bin/bash";
+
+/** Where the npm package carries the skill on a fresh container. */
+const NODE_MODULES_RUNNER =
+  "node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs";
+
+/** The in-checkout location that must keep taking precedence. */
+const CLAUDE_RUNNER =
+  ".claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs";
+
+/** Distinct markers, so a test can tell which runner actually executed. */
+const NODE_MODULES_MARKER = "ran-from-node-modules";
+const CLAUDE_MARKER = "ran-from-claude-skills";
+
+const temporaryDirectories: string[] = [];
+
+/**
+ * Create and register a disposable project directory.
+ * @returns Absolute path to the disposable directory
+ */
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "lisa-remote-env-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+/**
+ * Plant a stub runner that announces itself and echoes its arguments.
+ * @param root Project directory
+ * @param relativePath Runner location relative to root
+ * @param marker Text the stub prints on stdout
+ */
+function plantRunner(root: string, relativePath: string, marker: string): void {
+  const absolute = path.join(root, relativePath);
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(
+    absolute,
+    `console.log(${JSON.stringify(marker)});\n` +
+      `console.log(process.argv.slice(2).join(" "));\n`
+  );
+}
+
+/**
+ * Run the entrypoint in a project directory.
+ * @param root Project directory
+ * @param args Arguments forwarded to the entrypoint
+ * @returns The completed process
+ */
+function runEntrypoint(
+  root: string,
+  args: readonly string[] = []
+): ReturnType<typeof spawnSync> {
+  const script = path.join(root, "setup.sh");
+  writeFileSync(script, readFileSync(ENTRYPOINT_PATH, "utf8"));
+  return spawnSync(BASH, [script, ...args], {
+    cwd: root,
+    encoding: "utf8",
+  });
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("remote-env entrypoint skill resolution", () => {
+  it("resolves the runner from node_modules when no agent directory carries it", () => {
+    const root = temporaryDirectory();
+    plantRunner(root, NODE_MODULES_RUNNER, NODE_MODULES_MARKER);
+
+    const result = runEntrypoint(root);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(NODE_MODULES_MARKER);
+  });
+
+  it("prefers an agent skill directory over node_modules", () => {
+    const root = temporaryDirectory();
+    plantRunner(root, NODE_MODULES_RUNNER, NODE_MODULES_MARKER);
+    plantRunner(root, CLAUDE_RUNNER, CLAUDE_MARKER);
+
+    const result = runEntrypoint(root);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(CLAUDE_MARKER);
+    expect(result.stdout).not.toContain(NODE_MODULES_MARKER);
+  });
+
+  it("forwards its arguments to the resolved runner", () => {
+    const root = temporaryDirectory();
+    plantRunner(root, NODE_MODULES_RUNNER, NODE_MODULES_MARKER);
+
+    const result = runEntrypoint(root, ["--dry-run"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("--dry-run");
+  });
+
+  it("names the missing dependency install when nothing resolves", () => {
+    const root = temporaryDirectory();
+
+    const result = runEntrypoint(root);
+
+    expect(result.status).toBe(1);
+    // The operator's actual next action, not just the symptom. A bare "run
+    // lisa apply" sent them to fix a checkout that was never the problem.
+    expect(result.stderr).toContain("bash scripts/lisa-remote-env/setup.sh");
+    expect(result.stderr).toContain("node_modules");
+  });
+});


### PR DESCRIPTION
The remote-env entrypoint cannot find the skill that holds its logic, on the two harnesses where it matters most.

## The bug

`assets/setup.sh` is a thin stub. It searches for the real logic and hands off:

```
.claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
.agents/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
.codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
```

All three are **inside the checkout**. That assumes a clone carries the skills — true for OpenCode and Antigravity, where `lisa apply` writes them in; **false for Claude and Codex**, which receive them as an installed plugin in the user's home directory.

A remote container is always the second case. It clones the repository and has never run a plugin install.

## Impact

Every Claude or Codex project running `/lisa:setup:remote-env` gets an environment that provisions cleanly and fails on its first container:

```
Cannot find the lisa-setup-remote-env skill in this checkout.
Run 'lisa apply' so the skills are present, then re-run setup.
```

The advice is a dead end — the checkout was never the problem, and `lisa apply` will not put the skill there on these harnesses. The stub exits before the toolchain, secrets, and hook phases, so nothing installs and no secrets materialize.

Observed on `TunnlAI/frontend`, `TunnlAI/backend`, `TunnlAI/infrastructure` at Lisa 2.317.3: absent from all three searched directories, present only at `node_modules/@codyswann/lisa/plugins/lisa/skills/`.

## The fix

`node_modules` is searched last, after the agent directories:

```diff
   ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  "node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
```

Lisa is a dependency of every project it is applied to, so `node_modules` carries the skill **at the version that project pins** — the version its setup should run. The agent directories stay first: cheapest hit, nothing to install.

This makes the dependency install a precondition, so `SKILL.md` now emits it as part of both commands, parameterized on the project's own installer rather than hardcoding one:

```
setup:       <install> && bash scripts/lisa-remote-env/setup.sh
maintenance: <install> && bash scripts/lisa-remote-env/setup.sh
```

The failure message names it too, instead of sending operators to `lisa apply`.

## Verification

Four tests, run against the **previous** entrypoint first: 3 fail, 1 passes. The one that passes is the precedence case — correct, since that behavior is unchanged and a test that flipped would mean I'd broken it.

| | old | new |
|---|---|---|
| resolves from `node_modules` when no agent dir carries it | ✗ | ✓ |
| prefers an agent skill directory over `node_modules` | ✓ | ✓ |
| forwards arguments to the resolved runner | ✗ | ✓ |
| failure message names the dependency install | ✗ | ✓ |

Also: **8352 tests across 493 files** pass, `tsc` exit 0, eslint exit 0, `shellcheck` clean, `check:plugins` in sync, and the fix is present in all six fanned-out variants including `.codex-plugin`.

## Out of scope

`.opencode/skills/lisa/` in those three repos holds 257 skill directories last written at Lisa **2.210.0**, never refreshed by the 2.317.3 upgrade. So the in-checkout delivery model is carrying a stale snapshot too. Distinct problem, not touched here — worth its own issue.

Work-Item: CodySwannGT/lisa#2160

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote environment setup now installs project dependencies before running setup or maintenance commands.
  * Setup automatically locates the bundled Lisa runner when agent-specific skills are unavailable.
  * Improved guidance explains required installation steps and recovery options when setup cannot find a runner.

* **Bug Fixes**
  * Fixed remote setup failures in fresh environments where the runner was only available after dependency installation.

* **Tests**
  * Added coverage for runner fallback, skill precedence, argument forwarding, and missing-dependency errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->