### PR TITLE
fix(hooks): allow the Skill call that loads a lifecycle skill

### DIFF
--- a/plugins/lisa/hooks/enforce-team-first.sh
+++ b/plugins/lisa/hooks/enforce-team-first.sh
@@ -51,8 +51,14 @@ TEAM_FLAG="${STATE_DIR}/${SESSION_ID}.team"
 # Best-effort cleanup of stale state files. Errors are ignored.
 find "$STATE_DIR" -maxdepth 1 -type f -mmin +1440 -delete 2>/dev/null || true
 
+# Lifecycle skills are named with either separator depending on the call path:
+# the Skill tool invokes plugin skills as `lisa:implement` (plugin:skill), while
+# the skill's own slug is `lisa-implement`. Normalize `:` to `-` before matching
+# so BOTH forms resolve — matching only the hyphen form made the "skill load is
+# always allowed" branch below dead code for every real plugin-skill call, which
+# blocked the very Skill call that loads the orchestration preamble.
 is_lifecycle_skill() {
-  case "$1" in
+  case "${1//:/-}" in
     lisa-research|lisa-plan|lisa-implement|lisa-intake|lisa-debrief) return 0 ;;
     *) return 1 ;;
   esac
@@ -200,7 +206,15 @@ If you are running Lisa in a non-Claude harness, this Claude enforcement hook
 should not be installed; follow the runtime-aware orchestration preamble in the
 skill instead.
 
-Re-read the orchestration preamble in /${ACTIVE_SKILL} and start by spawning the
-bounded input-resolver with the \`Agent\` tool.
+Start by spawning the bounded input-resolver with the \`Agent\` tool.
+
+THEN CALL \`Skill\` FOR /${ACTIVE_SKILL} AGAIN. This block is a precondition, not a
+substitute for the skill — nothing in this message replaces its contents. If you
+proceed straight from the input-resolver into the work, you will improvise a
+lifecycle that only resembles the real one: the skill's own steps (auto-merge on
+the PR, driving it to merged, usage accounting, two-way tracker linkage,
+non-closing work-item refs, remote verification, config-bound status
+transitions) are nowhere in this text and will be silently skipped. That failure
+is invisible in the output — the work still looks finished.
 EOF
 exit 2

--- a/plugins/src/base/hooks/enforce-team-first.sh
+++ b/plugins/src/base/hooks/enforce-team-first.sh
@@ -51,8 +51,14 @@ TEAM_FLAG="${STATE_DIR}/${SESSION_ID}.team"
 # Best-effort cleanup of stale state files. Errors are ignored.
 find "$STATE_DIR" -maxdepth 1 -type f -mmin +1440 -delete 2>/dev/null || true
 
+# Lifecycle skills are named with either separator depending on the call path:
+# the Skill tool invokes plugin skills as `lisa:implement` (plugin:skill), while
+# the skill's own slug is `lisa-implement`. Normalize `:` to `-` before matching
+# so BOTH forms resolve — matching only the hyphen form made the "skill load is
+# always allowed" branch below dead code for every real plugin-skill call, which
+# blocked the very Skill call that loads the orchestration preamble.
 is_lifecycle_skill() {
-  case "$1" in
+  case "${1//:/-}" in
     lisa-research|lisa-plan|lisa-implement|lisa-intake|lisa-debrief) return 0 ;;
     *) return 1 ;;
   esac
@@ -200,7 +206,15 @@ If you are running Lisa in a non-Claude harness, this Claude enforcement hook
 should not be installed; follow the runtime-aware orchestration preamble in the
 skill instead.
 
-Re-read the orchestration preamble in /${ACTIVE_SKILL} and start by spawning the
-bounded input-resolver with the \`Agent\` tool.
+Start by spawning the bounded input-resolver with the \`Agent\` tool.
+
+THEN CALL \`Skill\` FOR /${ACTIVE_SKILL} AGAIN. This block is a precondition, not a
+substitute for the skill — nothing in this message replaces its contents. If you
+proceed straight from the input-resolver into the work, you will improvise a
+lifecycle that only resembles the real one: the skill's own steps (auto-merge on
+the PR, driving it to merged, usage accounting, two-way tracker linkage,
+non-closing work-item refs, remote verification, config-bound status
+transitions) are nowhere in this text and will be silently skipped. That failure
+is invisible in the output — the work still looks finished.
 EOF
 exit 2

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -583,7 +583,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/debug-hook.sh":
       "50124ffc72d7914553b0ed259882f2202643cdccf238380675ac1ff6d8d27d05",
     "plugins/src/base/hooks/enforce-team-first.sh":
-      "51d2e929ea6c04e7c7851be7849dd7d3e7cd0c211b4c8fb856e858a51ddeeb58",
+      "104922ba5912b797bf9ce15881dcef76916ea1782ac1e669151265b7db9fb263",
     "plugins/src/base/hooks/enforce-verification-gate.sh":
       "29885d07ff6da70f193ea0f0691d63f324deb79fbd7ede519596415875d94458",
     "plugins/src/base/hooks/inject-flow-context.sh":

--- a/tests/unit/hooks/enforce-team-first.test.ts
+++ b/tests/unit/hooks/enforce-team-first.test.ts
@@ -109,6 +109,40 @@ describe("enforce-team-first.sh", () => {
       preToolUse(LISA_GIT_COMMIT, "Skill", { skill: LISA_GIT_COMMIT });
       expect(existsSync(flagPath(LISA_GIT_COMMIT, "skill"))).toBe(false);
     });
+
+    // Regression: the Skill tool invokes PLUGIN skills as `lisa:implement`
+    // (plugin:skill), not as the `lisa-implement` slug. Matching only the
+    // hyphen form made the "skill load itself is allowed" branch dead code for
+    // every real invocation, so the hook blocked the one call that loads the
+    // orchestration preamble. An agent that hit this could satisfy the gate by
+    // spawning the input-resolver and then proceed to improvise the entire
+    // lifecycle, never having read the skill — a silent failure that looks
+    // exactly like success.
+    it.each([
+      ["lisa:implement", "colon (plugin:skill — what the Skill tool sends)"],
+      ["lisa-implement", "hyphen (skill slug)"],
+    ])("allows and arms the Skill load for %s — %s", skillName => {
+      const sid = `skill-arm-${skillName}`;
+      const { status } = preToolUse(sid, "Skill", { skill: skillName });
+      expect(status).toBe(EXIT_ALLOWED);
+      expect(existsSync(flagPath(sid, "skill"))).toBe(true);
+    });
+
+    // The colon form must survive the arming path too: a user typing
+    // /lisa:implement arms the flag with the colon spelling, so a later Skill
+    // call has to resolve against that same session without being blocked.
+    it("allows the Skill load even after UserPromptSubmit already armed", () => {
+      const sid = "armed-then-skill";
+      armSession(sid, IMPLEMENT_PROMPT);
+      const { status } = preToolUse(sid, "Skill", { skill: "lisa:implement" });
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("still does not arm for the single-agent debrief:apply variant", () => {
+      const sid = "debrief-apply";
+      preToolUse(sid, "Skill", { skill: "lisa:debrief:apply" });
+      expect(existsSync(flagPath(sid, "skill"))).toBe(false);
+    });
   });
 
   describe("blocks bypass tools when armed and team not yet created", () => {
@@ -147,6 +181,11 @@ describe("enforce-team-first.sh", () => {
       // against the implicit-team "one fat agent" collapse.
       expect(stderr).toContain("input-resolver");
       expect(stderr).toContain("Roster Decision");
+      // The block is a PRECONDITION, not a substitute for the skill. Without an
+      // explicit instruction to retry the Skill call, an agent reads the hook
+      // text as having replaced the skill and improvises the lifecycle from it.
+      expect(stderr).toContain("AGAIN");
+      expect(stderr).toContain("precondition, not a");
     });
   });
 


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2163

## The bug

`enforce-team-first.sh` **blocks the very call it means to allow.**

The allow-branch is already in the hook, with the comment `# The skill load itself is allowed; enforcement begins on the next call.` It just never fires, because `is_lifecycle_skill()` matches only the hyphenated slug:

```sh
case "$1" in
  lisa-research|lisa-plan|lisa-implement|lisa-intake|lisa-debrief) return 0 ;;
```

The `Skill` tool invokes **plugin** skills as `plugin:skill` — `lisa:implement`, with a colon. So the guard returns 1, execution falls through, `Skill` is in the `should_block` set, and the load is rejected with exit 2. That branch has been dead code for every real plugin-skill invocation.

The hook's own `UserPromptSubmit` path confirms the colon form is canonical: it strips the leading `/` and writes `lisa:implement` into the skill flag.

### Reproduction on `main` (5134e43d6)

```console
$ printf '{"hook_event_name":"PreToolUse","session_id":"p1","tool_name":"Skill","tool_input":{"skill":"lisa:implement"}}' \
    | bash plugins/lisa/hooks/enforce-team-first.sh >/dev/null 2>&1; echo "exit=$?"
exit=2      # BLOCKED — the call that loads the skill

$ printf '{"hook_event_name":"PreToolUse","session_id":"p2","tool_name":"Skill","tool_input":{"skill":"lisa-implement"}}' \
    | bash plugins/lisa/hooks/enforce-team-first.sh >/dev/null 2>&1; echo "exit=$?"
exit=0      # allowed
```

## Why it matters more than a blocked call

Blocked, the agent does exactly what the message says: spawns the bounded input-resolver. Then it proceeds into the work — **never having read the skill** — and improvises a lifecycle from the hook's error text.

Observed in a live `/lisa:implement` run. Silently skipped, all of it living only in the unread skill body:

| Step | What was skipped |
| --- | --- |
| 7 | open the PR **with auto-merge on** |
| 8 | drive to merged via `drive-pr-to-merge` — *"the single source of truth… do not re-implement them"*; hand-rolled instead |
| 4 | `lisa-usage-accounting` — no `## Lisa Usage` entry |
| 7a / 9 | two-way tracker linkage via `lisa-tracker-sync`; one ticket ended with no PR attachment at all |
| 1–2 | environment / base-branch resolution with provenance from `deploy.branches` |
| 99 | **non-closing work-item refs** — *"so merge cannot front-run the deploy, remote verification, health check, and terminal `done` label"*. A parent ticket auto-closed on a child PR merge: exactly the failure that rule prevents |
| 12–13 | remote verification verdict, post-deploy health check |
| — | config-bound status transitions |

**The failure is invisible in the output.** That run produced green PRs, genuine red-then-green TDD, and mutation-verified gates. Nothing signalled that half the contract never executed. It surfaced only because a human noticed the agent had stopped enabling auto-merge — a habit change, not an error.

## The fix

**1. Normalize the separator** so both spellings resolve and the intended allow-branch fires:

```sh
case "${1//:/-}" in
```

`lisa:debrief:apply` normalizes to `lisa-debrief-apply`, which still correctly fails to match `lisa-debrief` — the single-agent variant stays excluded, and there is a test pinning that.

**2. Rewrite the closing line of the block message.** It previously read *"Re-read the orchestration preamble in /lisa:implement"* — which presupposes the preamble was already read, while the hook has just blocked the only call that reads it, and never says to retry. It now says to call `Skill` again, states that the block is a **precondition, not a substitute**, and names the concrete steps that get skipped otherwise.

This second part matters independently of the root cause: `Skill` stays in the `should_block` set for non-lifecycle skill calls made while armed.

## Tests

`tests/unit/hooks/enforce-team-first.test.ts` previously had `arms via Skill tool with skill=lisa-implement` — only the hyphen form, the one that works. That gap is why this survived.

Added: the arming test parameterized over **both** spellings, an armed-then-`Skill` sequence (the real slash-command path), `debrief:apply` still excluded, and an assertion that the block message carries the retry instruction.

### Mutation-verified — both halves

| Mutation | Result |
| --- | --- |
| revert `${1//:/-}` → `$1` | **2 fail** — exactly the two colon tests |
| remove the retry instruction | **1 fail** — exactly the block-message test |
| neither (as shipped) | 40 pass, 0 fail |

## Gates

| Gate | Result |
| --- | --- |
| `bun run typecheck` | clean |
| `bun run lint` | 0 warnings, 0 errors |
| `bun run test:cov` | 493 files, 8356 tests passed |
| hook suite | 40 passed |

`src/core/upstream-evidence-manifest.ts` is in the diff because the hook is a tracked public source — regenerated via `bun run build:upstream-evidence-manifest`, not hand-edited. Both `plugins/src/base/` (source) and `plugins/lisa/` (generated) copies are updated via `bun run build:plugins`; the build touched only this hook, no unrelated churn.

🤖 Generated with Claude Code
