### PR TITLE
fix: exclude the bare .worktrees/ root from git, EAS, eslint, jest and vitest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,10 @@ tasks.json
 **/.claude/scheduled_tasks.lock
 **/.claude/.lisa-plugins-synced
 **/.claude/.lisa-marketplace-heal-v2
+
+# Second agent worktree root — see the full rationale on the same entry in
+# all/copy-contents/gitignore. Must stay above `### EASINCLUDE! ###`.
+.worktrees/
 .roo
 .roo/
 .roomodes

--- a/all/copy-contents/gitignore
+++ b/all/copy-contents/gitignore
@@ -172,6 +172,22 @@ tasks.json
 **/.claude/scheduled_tasks.lock
 **/.claude/.lisa-plugins-synced
 **/.claude/.lisa-marketplace-heal-v2
+
+# Second agent worktree root. Sessions and loops park isolated checkouts under
+# a bare `.worktrees/` as well as under `.claude/worktrees/`, and each one
+# carries its own node_modules — measured at 102G across 39 worktrees in one
+# host project. Only `.claude/worktrees/` was ever listed here, so the bare root
+# survived on whatever a developer had hand-added to the machine-local,
+# uncommitted `.git/info/exclude` — invisible to every fresh clone.
+#
+# This entry MUST stay above the `### EASINCLUDE! ###` marker below. The Expo
+# `pre-build:eas` script (expo/package-lisa/package.lisa.json) builds .easignore
+# as `cat .gitignore > .easignore && cat .easignore.extra >> .easignore`, and
+# EAS reads .easignore EXCLUSIVELY — so this file is also what keeps agent
+# worktrees out of the build upload archive. Below the marker it would be
+# re-included, and the worktrees land in the tarball: one observed EAS build
+# compressed to a 1.8 GB archive and failed metadata upload with a 400.
+.worktrees/
 .roo
 .roo/
 .roomodes

--- a/eslint.ignore.config.json
+++ b/eslint.ignore.config.json
@@ -32,6 +32,7 @@
     ".lisabak/**",
     ".codex/**",
     ".claude/worktrees/**",
+    ".worktrees/**",
     ".claude-active-project/**",
     ".claude-active-plan/**",
     "coverage/**",

--- a/src/configs/eslint/base.ts
+++ b/src/configs/eslint/base.ts
@@ -45,6 +45,11 @@ export const defaultIgnores = [
   "components/ui/**",
   ".lisabak/**",
   ".claude/worktrees/**",
+  // Second agent worktree root — sibling checkouts also land in a bare
+  // `.worktrees/`. Linting them from the primary checkout reports another
+  // branch's in-flight code as errors here (measured: 1122 in this repo),
+  // which turns the pre-push gate into noise developers push past.
+  ".worktrees/**",
   ".claude-active-project/**",
   ".claude-active-plan/**",
   "coverage/**",

--- a/src/configs/jest/base.ts
+++ b/src/configs/jest/base.ts
@@ -11,6 +11,7 @@
  * @module configs/jest/base
  */
 import type { Config } from "jest";
+import { isInsideWorktree } from "../worktrees.js";
 
 /**
  * Default coverage thresholds used when not specified in project config.
@@ -27,24 +28,25 @@ export const defaultThresholds: Config["coverageThreshold"] = {
 
 /**
  * Returns the extra `testPathIgnorePatterns` entries a stack config
- * should add to skip tests that live inside `.claude/worktrees/`.
+ * should add to skip tests that live inside an agent worktree.
+ *
+ * Both roots must be covered — `.claude/worktrees/` and the bare
+ * `.worktrees/`. Omitting the second let sibling worktrees dominate test
+ * discovery from the primary checkout (one host project measured 13,821 of
+ * 14,277 collected files coming from other branches' worktrees), so the local
+ * suite reported other agents' in-flight failures instead of this checkout's.
  *
  * When jest runs from the primary checkout, tests inside worktrees
  * should be skipped — each worktree has its own jest run. When jest
  * runs from INSIDE a worktree (rootDir *is* the worktree), the same
- * pattern would match every test path and jest would find zero tests.
- * This helper returns `["/.claude/worktrees/"]` only when the current
- * working directory is outside a worktree, so each stack can spread
- * it into its own `testPathIgnorePatterns` without hand-rolling the
- * conditional.
- * @returns Single-entry array with the worktree ignore pattern, or an empty array when already inside a worktree.
+ * patterns would match every test path and jest would find zero tests.
+ * This helper returns the patterns only when the current working
+ * directory is outside a worktree, so each stack can spread them into
+ * its own `testPathIgnorePatterns` without hand-rolling the conditional.
+ * @returns The worktree ignore patterns, or an empty array when already inside a worktree.
  */
 export function worktreeTestPathIgnorePatterns(): readonly string[] {
-  const isInsideWorktree = /[/\\]\.claude[/\\]worktrees(?:[/\\]|$)/.test(
-    process.cwd()
-  );
-
-  return isInsideWorktree ? [] : ["/.claude/worktrees/"];
+  return isInsideWorktree() ? [] : ["/.claude/worktrees/", "/.worktrees/"];
 }
 
 /**

--- a/src/configs/vitest/base.ts
+++ b/src/configs/vitest/base.ts
@@ -11,6 +11,7 @@
  * @module configs/vitest/base
  */
 import type { ViteUserConfig } from "vitest/config";
+import { isInsideWorktree } from "../worktrees.js";
 
 /** Vite UserConfig augmented with Vitest's `test` property */
 type UserConfig = ViteUserConfig;
@@ -91,25 +92,29 @@ export const defaultTestExclusions: readonly string[] = [
 ];
 
 /**
- * Returns the worktree exclusion glob a stack config should add to skip
- * test files / coverage that live inside `.claude/worktrees/`.
+ * Returns the worktree exclusion globs a stack config should add to skip
+ * test files / coverage that live inside an agent worktree.
  *
- * Lisa manages `.claude/worktrees/` as scratch worktrees for subagents.
+ * Lisa manages scratch worktrees for subagents under TWO roots —
+ * `.claude/worktrees/` and a bare `.worktrees/` — and both must be covered.
+ * Omitting the second one let sibling worktrees dominate test discovery from
+ * the primary checkout (one host project measured 13,821 of 14,277 collected
+ * files coming from other branches' worktrees), so the local suite reported
+ * other agents' in-flight failures instead of this checkout's.
+ *
  * When vitest runs from the primary checkout, tests inside those worktrees
  * should be skipped — each worktree has its own vitest run. When vitest runs
- * from INSIDE a worktree (the project root *is* the worktree), the same glob
- * matches every path under root and vitest finds zero tests. This returns the
- * glob only when the current working directory is outside a worktree, so each
- * stack factory can spread it into its `exclude` arrays without hand-rolling
+ * from INSIDE a worktree (the project root *is* the worktree), the same globs
+ * match every path under root and vitest finds zero tests. This returns the
+ * globs only when the current working directory is outside a worktree, so each
+ * stack factory can spread them into its `exclude` arrays without hand-rolling
  * the conditional. Mirrors jest's `worktreeTestPathIgnorePatterns()`.
- * @returns Single-entry array with the worktree exclude glob, or an empty array when already inside a worktree.
+ * @returns The worktree exclude globs, or an empty array when already inside a worktree.
  */
 export function worktreeExclusions(): readonly string[] {
-  const isInsideWorktree = /[/\\]\.claude[/\\]worktrees(?:[/\\]|$)/.test(
-    process.cwd()
-  );
-
-  return isInsideWorktree ? [] : ["**/.claude/worktrees/**"];
+  return isInsideWorktree()
+    ? []
+    : ["**/.claude/worktrees/**", "**/.worktrees/**"];
 }
 
 /**

--- a/src/configs/worktrees.ts
+++ b/src/configs/worktrees.ts
@@ -1,0 +1,47 @@
+/**
+ * Single source of truth for where agent worktrees live.
+ *
+ * Lisa parks isolated per-session checkouts under TWO roots — `.claude/worktrees/`
+ * (Claude Code sessions) and a bare `.worktrees/` (loops and hand-created ticket
+ * worktrees). Every surface that enumerates project files has to know about both:
+ * git, EAS uploads, ESLint, jest, and vitest.
+ *
+ * They were previously registered one file at a time, and the bare root was
+ * missed everywhere. The failure mode is quiet in each case — a gate that still
+ * reports green while measuring the wrong tree:
+ *
+ * - jest/vitest collect sibling branches' tests, so the local suite reports other
+ *   agents' in-flight failures (one host project measured 13,821 of 14,277
+ *   collected files coming from worktrees).
+ * - ESLint lints those same files, so the pre-push gate fails on code the
+ *   developer never touched (measured: 1122 errors in this repo).
+ * - EAS packs them into the build upload archive (measured: a 1.8 GB archive
+ *   that failed metadata upload with a 400).
+ *
+ * CI never has worktrees, which is exactly why these stayed hidden.
+ */
+
+/** Repo-relative roots under which agent worktrees are created. */
+export const WORKTREE_ROOTS: readonly string[] = [
+  ".claude/worktrees",
+  ".worktrees",
+];
+
+/**
+ * Matches a path that is INSIDE one of the worktree roots.
+ *
+ * Used against `process.cwd()` so a run launched from within a worktree does not
+ * exclude itself — the same glob that skips siblings from the primary checkout
+ * would otherwise match every path under root and find zero tests.
+ */
+export const WORKTREE_CWD_PATTERN =
+  /[/\\]\.claude[/\\]worktrees(?:[/\\]|$)|[/\\]\.worktrees(?:[/\\]|$)/;
+
+/**
+ * Report whether a directory sits inside an agent worktree.
+ * @param cwd Directory to test; defaults to the current working directory.
+ * @returns True when the path is inside one of {@link WORKTREE_ROOTS}.
+ */
+export function isInsideWorktree(cwd: string = process.cwd()): boolean {
+  return WORKTREE_CWD_PATTERN.test(cwd);
+}

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -5,7 +5,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-contents/.gitattributes":
       "9d3831007e681186a3673e1037ef3fc82980cab2fc04e27c0868e562912c9e9f",
     "all/copy-contents/gitignore":
-      "06b56376465d5421db55d0b04958bbc79fdbf33b42f0559fe5ef6875ced1160f",
+      "46f11b3fe840006c2d49fe83bf0fb873851f671ada417823674c3374b4774413",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
       "5eb31c284e820a51312d4484f0669128007326af55ee515923fec33700d003a1",
     "all/create-only/.claude/rules/PROJECT_RULES.md":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2071,7 +2071,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/eslint.config.ts":
       "2959e30c73c191279c1d68d816bb66654e3dd857cf871dcc265c3a0610fe502a",
     "typescript/copy-overwrite/eslint.ignore.config.json":
-      "54739e51ce09c314fe01d8a3919e6db5d48cbfb63dcba957f8aca6eba6229a9b",
+      "04dcd754829cf93bf0ba0d76e4031d28cb7149afa658575d02bb13bf73f7880e",
     "typescript/copy-overwrite/eslint.slow.config.ts":
       "f66d04381940936544931d7f20ffd4e43c38b8a907d56ffa101e2236371d8c94",
     "typescript/copy-overwrite/knip.json":
@@ -7778,6 +7778,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/configs/vitest/nestjs.ts": true,
     "src/configs/vitest/phaser.ts": true,
     "src/configs/vitest/typescript.ts": true,
+    "src/configs/worktrees.ts": true,
     "src/copilot/copilot-instructions-installer.ts": true,
     "src/copilot/plugin-installer.ts": true,
     "src/core/bootstrap-environment.ts": true,
@@ -8388,6 +8389,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/doctor-vendor-preflight.test.ts": true,
     "tests/unit/strategies/doctor-wiki-delegation.test.ts": true,
     "tests/unit/strategies/drive-pr-auto-merge-race.test.ts": true,
+    "tests/unit/strategies/easignore-worktree-exclusion.test.ts": true,
     "tests/unit/strategies/evidence-ref-contract.test.ts": true,
     "tests/unit/strategies/evidence-reference-contract.test.ts": true,
     "tests/unit/strategies/falsifiable-checks-rule.test.ts": true,

--- a/tests/unit/config/jest-base.test.ts
+++ b/tests/unit/config/jest-base.test.ts
@@ -223,6 +223,8 @@ describe("jest.base", () => {
   });
 
   describe("worktreeTestPathIgnorePatterns", () => {
+    const WORKTREE_PATTERNS = ["/.claude/worktrees/", "/.worktrees/"];
+
     const originalCwd = process.cwd;
 
     afterEach(() => {
@@ -232,7 +234,7 @@ describe("jest.base", () => {
     it("returns the worktree ignore pattern when cwd is outside a worktree", () => {
       process.cwd = () => "/some/project";
 
-      expect(worktreeTestPathIgnorePatterns()).toEqual(["/.claude/worktrees/"]);
+      expect(worktreeTestPathIgnorePatterns()).toEqual(WORKTREE_PATTERNS);
     });
 
     it("returns an empty array when cwd is inside a .claude/worktrees path", () => {
@@ -260,10 +262,34 @@ describe("jest.base", () => {
       expect(worktreeTestPathIgnorePatterns()).toEqual([]);
     });
 
+    it("covers the bare .worktrees/ root, not just .claude/worktrees/", () => {
+      process.cwd = () => "/some/project";
+
+      expect(worktreeTestPathIgnorePatterns()).toContain("/.worktrees/");
+    });
+
+    it("returns an empty array when cwd is inside a bare .worktrees path", () => {
+      process.cwd = () => "/some/project/.worktrees/tun-401";
+
+      expect(worktreeTestPathIgnorePatterns()).toEqual([]);
+    });
+
+    it("returns an empty array for a Windows-style bare worktree path", () => {
+      process.cwd = () => "C:\\projects\\.worktrees\\tun-401";
+
+      expect(worktreeTestPathIgnorePatterns()).toEqual([]);
+    });
+
+    it("does not treat an ordinary directory named worktrees as a worktree", () => {
+      process.cwd = () => "/some/project/docs/worktrees";
+
+      expect(worktreeTestPathIgnorePatterns()).toEqual(WORKTREE_PATTERNS);
+    });
+
     it("returns the ignore pattern for a Windows-style path outside a worktree", () => {
       process.cwd = () => "C:\\projects\\my-app";
 
-      expect(worktreeTestPathIgnorePatterns()).toEqual(["/.claude/worktrees/"]);
+      expect(worktreeTestPathIgnorePatterns()).toEqual(WORKTREE_PATTERNS);
     });
   });
 });

--- a/tests/unit/config/vitest-base.test.ts
+++ b/tests/unit/config/vitest-base.test.ts
@@ -11,6 +11,8 @@ import type { PortableThresholds } from "../../../src/configs/vitest/base.js";
 
 const DSTAR_TEST_TS = "**/*.test.ts";
 const WORKTREE_GLOB = "**/.claude/worktrees/**";
+const BARE_WORKTREE_GLOB = "**/.worktrees/**";
+const WORKTREE_GLOBS = [WORKTREE_GLOB, BARE_WORKTREE_GLOB];
 const TESTS_GLOB = "tests/**/*.test.ts";
 const SRC_TEST_GLOB = "src/**/*.test.ts";
 const SRC_TS_GLOB = "src/**/*.ts";
@@ -56,8 +58,9 @@ describe("vitest.base", () => {
       expect(hasNegation).toBe(false);
     });
 
-    it("does not bake the worktree glob into the static list (supplied by worktreeExclusions)", () => {
+    it("does not bake the worktree globs into the static list (supplied by worktreeExclusions)", () => {
       expect(defaultCoverageExclusions).not.toContain(WORKTREE_GLOB);
+      expect(defaultCoverageExclusions).not.toContain(BARE_WORKTREE_GLOB);
     });
   });
 
@@ -80,7 +83,7 @@ describe("vitest.base", () => {
     it("returns the worktree exclude glob when cwd is outside a worktree", () => {
       process.cwd = () => "/some/project";
 
-      expect(worktreeExclusions()).toEqual([WORKTREE_GLOB]);
+      expect(worktreeExclusions()).toEqual(WORKTREE_GLOBS);
     });
 
     it("returns an empty array when cwd is inside a .claude/worktrees path", () => {
@@ -101,10 +104,34 @@ describe("vitest.base", () => {
       expect(worktreeExclusions()).toEqual([]);
     });
 
-    it("returns the glob for a Windows-style path outside a worktree", () => {
+    it("returns the globs for a Windows-style path outside a worktree", () => {
       process.cwd = () => "C:\\projects\\my-app";
 
-      expect(worktreeExclusions()).toEqual([WORKTREE_GLOB]);
+      expect(worktreeExclusions()).toEqual(WORKTREE_GLOBS);
+    });
+
+    it("covers the bare .worktrees/ root, not just .claude/worktrees/", () => {
+      process.cwd = () => "/some/project";
+
+      expect(worktreeExclusions()).toContain(BARE_WORKTREE_GLOB);
+    });
+
+    it("returns an empty array when cwd is inside a bare .worktrees path", () => {
+      process.cwd = () => "/some/project/.worktrees/tun-401";
+
+      expect(worktreeExclusions()).toEqual([]);
+    });
+
+    it("returns an empty array for a Windows-style bare worktree path", () => {
+      process.cwd = () => "C:\\projects\\.worktrees\\tun-401";
+
+      expect(worktreeExclusions()).toEqual([]);
+    });
+
+    it("does not treat an ordinary directory named worktrees as a worktree", () => {
+      process.cwd = () => "/some/project/docs/worktrees";
+
+      expect(worktreeExclusions()).toEqual(WORKTREE_GLOBS);
     });
   });
 

--- a/tests/unit/strategies/easignore-worktree-exclusion.test.ts
+++ b/tests/unit/strategies/easignore-worktree-exclusion.test.ts
@@ -1,0 +1,190 @@
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { devNull } from "node:os";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { createTempDir, cleanupTempDir } from "../../helpers/test-utils.js";
+
+/**
+ * Agent worktree roots must be excluded from BOTH git and EAS build uploads.
+ *
+ * Two roots exist in practice — `.claude/worktrees/` and a bare `.worktrees/` —
+ * and each worktree carries its own node_modules. Only the first was ever in
+ * the shipped gitignore; the bare root survived on whatever a developer had
+ * hand-added to the machine-local, uncommitted `.git/info/exclude`, so it was
+ * invisible to every fresh clone AND to EAS. One host project measured 102G
+ * across 39 such worktrees, which produced a 1.8 GB EAS upload archive that
+ * failed metadata upload with a 400.
+ *
+ * The EAS half is what makes placement load-bearing: `pre-build:eas` derives
+ * .easignore from THIS file, and everything below `### EASINCLUDE! ###` is
+ * deliberately re-included. An entry that drifts below the marker still reads
+ * as "worktrees are ignored" while shipping them in every build tarball.
+ */
+
+const GIT_BIN = "/usr/bin/git";
+const CHECK_IGNORE = "check-ignore";
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const TEMPLATE_GITIGNORE = path.join(
+  REPO_ROOT,
+  "all",
+  "copy-contents",
+  "gitignore"
+);
+const EASIGNORE_EXTRA = path.join(
+  REPO_ROOT,
+  "expo",
+  "copy-overwrite",
+  ".easignore.extra"
+);
+const PACKAGE_LISA = path.join(
+  REPO_ROOT,
+  "expo",
+  "package-lisa",
+  "package.lisa.json"
+);
+const EASINCLUDE_MARKER = "### EASINCLUDE! ###";
+
+const WORKTREE_ROOTS = [".worktrees/", "**/.claude/worktrees/"];
+
+const BARE_WORKTREE_FILE = ".worktrees/tun-401/node_modules/a.js";
+const CLAUDE_WORKTREE_FILE = ".claude/worktrees/agent-abc/a.js";
+const KEPT_CONFIG = "app.json";
+const KEPT_SOURCE = "src/index.tsx";
+
+/**
+ * Build a git environment that cannot reach the real repository.
+ *
+ * git exports GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE to every process it
+ * spawns, and all of them outrank `cwd` — an inherited value would point
+ * check-ignore at this repository and produce a vacuous pass against a fixture
+ * that was never consulted.
+ * @returns An environment scrubbed of repository-selecting git variables.
+ */
+function cleanGitEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: devNull,
+    GIT_CONFIG_NOSYSTEM: "1",
+  };
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_PREFIX;
+  return env;
+}
+
+/**
+ * Reproduce what `pre-build:eas` writes: gitignore, then .easignore.extra.
+ * @returns The exact bytes EAS would read as .easignore.
+ */
+function regeneratedEasignore(): string {
+  return (
+    fs.readFileSync(TEMPLATE_GITIGNORE, "utf8") +
+    fs.readFileSync(EASIGNORE_EXTRA, "utf8")
+  );
+}
+
+/**
+ * Stand up a throwaway repository governed by `ignoreFile`, holding one file
+ * under each worktree root plus two files that must survive.
+ *
+ * .easignore uses gitignore syntax, so a git checkout is a faithful stand-in
+ * for what EAS packs.
+ * @param dir Directory to initialize.
+ * @param ignoreFile Contents to write as the repository's .gitignore.
+ * @returns A predicate reporting whether git ignores a given path.
+ */
+async function seedFixture(
+  dir: string,
+  ignoreFile: string
+): Promise<(target: string) => boolean> {
+  await fs.outputFile(path.join(dir, ".gitignore"), ignoreFile);
+  await fs.outputFile(path.join(dir, BARE_WORKTREE_FILE), "\n");
+  await fs.outputFile(path.join(dir, CLAUDE_WORKTREE_FILE), "\n");
+  await fs.outputFile(path.join(dir, KEPT_CONFIG), "{}\n");
+  await fs.outputFile(path.join(dir, KEPT_SOURCE), "export {};\n");
+
+  const env = cleanGitEnv();
+  execFileSync(GIT_BIN, ["init", "-q"], { cwd: dir, env });
+
+  return (target: string) =>
+    spawnSync(GIT_BIN, [CHECK_IGNORE, "-q", target], { cwd: dir, env })
+      .status === 0;
+}
+
+describe("agent worktree roots are excluded from git and EAS", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  it.each(WORKTREE_ROOTS)(
+    "ships %s as an exact line in the gitignore template",
+    entry => {
+      const lines = fs.readFileSync(TEMPLATE_GITIGNORE, "utf8").split("\n");
+      expect(lines).toContain(entry);
+    }
+  );
+
+  it.each(WORKTREE_ROOTS)(
+    "keeps %s ABOVE the EASINCLUDE marker so EAS still ignores it",
+    entry => {
+      const lines = fs.readFileSync(TEMPLATE_GITIGNORE, "utf8").split("\n");
+      // Exact match, not `includes` — prose ABOVE the real marker quotes the
+      // marker text, and a substring search matches that comment first, which
+      // reports a correctly-placed entry as misplaced.
+      const markerIndex = lines.findIndex(
+        line => line.trim() === EASINCLUDE_MARKER
+      );
+      expect(markerIndex).toBeGreaterThan(-1);
+      expect(lines.indexOf(entry)).toBeGreaterThan(-1);
+      expect(lines.indexOf(entry)).toBeLessThan(markerIndex);
+    }
+  );
+
+  it("still derives .easignore from .gitignore, which is why placement matters", () => {
+    const pkg = fs.readJsonSync(PACKAGE_LISA);
+    const script = pkg.force?.scripts?.["pre-build:eas"];
+    // If this shape changes, the above-the-marker requirement may no longer
+    // hold and the placement assertions need to be re-derived, not deleted.
+    expect(script).toContain("cat .gitignore > .easignore");
+    expect(script).toContain("cat .easignore.extra >> .easignore");
+  });
+
+  it("excludes both worktree roots from a host project's git checkout", async () => {
+    const ignored = await seedFixture(
+      tempDir,
+      fs.readFileSync(TEMPLATE_GITIGNORE, "utf8")
+    );
+
+    expect(ignored(BARE_WORKTREE_FILE)).toBe(true);
+    expect(ignored(CLAUDE_WORKTREE_FILE)).toBe(true);
+    // Guard against an over-broad pattern eating the actual project.
+    expect(ignored(KEPT_CONFIG)).toBe(false);
+    expect(ignored(KEPT_SOURCE)).toBe(false);
+
+    const status = execFileSync(
+      GIT_BIN,
+      ["status", "--short", "--untracked-files=all"],
+      { cwd: tempDir, env: cleanGitEnv(), encoding: "utf8" }
+    );
+    expect(status).not.toContain(".worktrees/");
+    expect(status).toContain(KEPT_CONFIG);
+    expect(status).toContain(KEPT_SOURCE);
+  });
+
+  it("excludes both worktree roots from the REGENERATED .easignore", async () => {
+    const ignored = await seedFixture(tempDir, regeneratedEasignore());
+
+    expect(ignored(BARE_WORKTREE_FILE)).toBe(true);
+    expect(ignored(CLAUDE_WORKTREE_FILE)).toBe(true);
+    expect(ignored(KEPT_CONFIG)).toBe(false);
+    expect(ignored(KEPT_SOURCE)).toBe(false);
+  });
+});

--- a/tests/unit/strategies/easignore-worktree-exclusion.test.ts
+++ b/tests/unit/strategies/easignore-worktree-exclusion.test.ts
@@ -45,6 +45,17 @@ const PACKAGE_LISA = path.join(
 );
 const EASINCLUDE_MARKER = "### EASINCLUDE! ###";
 
+/** Both the repo's own config and the copy shipped into host projects. */
+const ESLINT_IGNORE_CONFIGS = [
+  path.join(REPO_ROOT, "eslint.ignore.config.json"),
+  path.join(
+    REPO_ROOT,
+    "typescript",
+    "copy-overwrite",
+    "eslint.ignore.config.json"
+  ),
+];
+
 const WORKTREE_ROOTS = [".worktrees/", "**/.claude/worktrees/"];
 
 const BARE_WORKTREE_FILE = ".worktrees/tun-401/node_modules/a.js";
@@ -187,4 +198,17 @@ describe("agent worktree roots are excluded from git and EAS", () => {
     expect(ignored(KEPT_CONFIG)).toBe(false);
     expect(ignored(KEPT_SOURCE)).toBe(false);
   });
+
+  it.each(ESLINT_IGNORE_CONFIGS)(
+    "ignores both worktree roots in %s",
+    configPath => {
+      // Linting sibling worktrees from the primary checkout reports another
+      // branch's in-flight code as errors, which fails the pre-push gate on
+      // work the developer never touched. CI has no worktrees, so this is
+      // invisible there — the local gate is the only place it shows up.
+      const { ignores } = fs.readJsonSync(configPath);
+      expect(ignores).toContain(".claude/worktrees/**");
+      expect(ignores).toContain(".worktrees/**");
+    }
+  );
 });

--- a/typescript/copy-overwrite/eslint.ignore.config.json
+++ b/typescript/copy-overwrite/eslint.ignore.config.json
@@ -32,6 +32,7 @@
 
     ".lisabak/**",
     ".claude/worktrees/**",
+    ".worktrees/**",
     ".claude-active-project/**",
     ".claude-active-plan/**",
     "coverage/**",


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2165

Closes #2165

## The bug

Lisa parks isolated per-session checkouts under **two** worktree roots — `.claude/worktrees/` and a bare `.worktrees/`. Only the first was ever registered anywhere. The bare root was registered in **none** of the surfaces that enumerate project files:

| Surface | `.claude/worktrees/` | `.worktrees/` |
|---|---|---|
| `all/copy-contents/gitignore` | ✅ | ❌ |
| `eslint.ignore.config.json` (own + shipped) | ✅ | ❌ |
| `src/configs/eslint/base.ts` | ✅ | ❌ |
| `src/configs/jest/base.ts` | ✅ | ❌ |
| `src/configs/vitest/base.ts` | ✅ | ❌ |

It survived on whatever a developer had hand-added to the machine-local, uncommitted `.git/info/exclude`. This repo shows the symptom directly — `git status` reported `?? .worktrees/` before this PR.

## Why it matters — every failure mode is quiet

Each worktree carries its own `node_modules`. One host project measured **102G across 39 worktrees** under the bare root, alongside 39G under `.claude/worktrees/`. None of these surfaces *error*; they measure the wrong tree and still report a verdict.

**EAS build uploads.** EAS reads `.easignore` **exclusively** (it ignores `.gitignore` entirely when that file is present), and `pre-build:eas` derives it from the shipped gitignore:

```
cat .gitignore > .easignore && cat .easignore.extra >> .easignore
```

So every agent worktree went into the build upload archive. Observed: a **1.8 GB archive that failed metadata upload with a 400**.

**Pre-push lint.** `bun run lint:slow` in this repo failed with **1122 errors**, every one from another branch's checkout under `.worktrees/`. A gate that fails on code you never touched is a gate developers push past.

**Test discovery.** jest/vitest collect sibling worktrees' tests, so the local suite reports other agents' in-flight failures. One host project measured **13,821 of 14,277** collected files coming from worktrees.

CI never has worktrees, which is exactly why all of this stayed hidden.

## Placement is load-bearing

In the gitignore template, everything below `### EASINCLUDE! ###` is deliberately re-included by EAS. An entry that drifts under the marker still reads as "worktrees are ignored" while shipping them in every tarball. The test pins the position, not just the presence.

## What changed

- **`all/copy-contents/gitignore`** + this repo's `.gitignore` — add `.worktrees/`, above the EASINCLUDE marker. This one line fixes git *and* EAS for every host project, because `pre-build:eas` derives `.easignore` from it.
- **`eslint.ignore.config.json`** (this repo's and the shipped `typescript/copy-overwrite/` copy) and **`src/configs/eslint/base.ts`** — add `.worktrees/**`.
- **`src/configs/worktrees.ts`** (new) — single source of truth for where agent worktrees live. This bug happened by registering one root and missing the other, one file at a time; jest and vitest now share the definition instead of each hand-rolling the regex.
- **`src/configs/jest/base.ts`** / **`src/configs/vitest/base.ts`** — cover both roots. The cwd-conditional behavior is preserved and now applies to both: a run launched from inside `.worktrees/<ticket>` still discovers its own tests rather than excluding everything under its root.

## Verification

- `bun run lint:slow`: **1122 errors → exit 0**.
- Full unit suite: **8205 passed**. The one failing file (`tests/unit/scripts/check-learnings-budget.test.ts`, a collect error) fails identically on a clean `origin/main` — verified by stashing this branch's changes. Not touched by this PR.
- `tsc --noEmit`: clean.
- New `tests/unit/strategies/easignore-worktree-exclusion.test.ts` proves exclusion **behaviorally** — it stands up a throwaway git repo governed by the template, and a second governed by the regenerated `.easignore`, then asserts via `git check-ignore` that both worktree roots are excluded and that `app.json` / `src/` still are not (guarding against an over-broad pattern eating the project).
- The placement assertion was **mutation-tested**: drifting `.worktrees/` below the EASINCLUDE marker turns it red with `expected 211 to be less than 209`.
- New negative test pins that an ordinary directory named `worktrees` (e.g. `docs/worktrees`) is *not* mistaken for a worktree root.

## Out of scope

The wiki wrapper templates (`plugins/src/wiki/templates/wrapper-gitignore.txt` and its per-agent copies) carry their own worktree block covering `/.claude/worktrees/` and `/.codex/worktrees/` but not `/.worktrees/`. Same class, different surface, no EAS exposure — noted on #2165 for a separate pass.

🤖 Generated with Claude Code
