### PR TITLE
fix(deps): raise three stale force-pinned security floors

### DIFF
--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -98,7 +98,7 @@
     },
     "resolutions": {
       "@isaacs/brace-expansion": "^5.0.1",
-      "brace-expansion": ">=5.0.7",
+      "brace-expansion": ">=5.0.8",
       "eslint-plugin-react-hooks": "^7.0.0",
       "fast-xml-parser": "^5.10.1",
       "tar": ">=7.5.11",
@@ -106,7 +106,7 @@
     },
     "overrides": {
       "@isaacs/brace-expansion": "^5.0.1",
-      "brace-expansion": ">=5.0.7",
+      "brace-expansion": ">=5.0.8",
       "eslint-plugin-react-hooks": "^7.0.0",
       "fast-xml-parser": "^5.10.1",
       "zod-validation-error": "^4.0.0",

--- a/nestjs/package-lisa/package.lisa.json
+++ b/nestjs/package-lisa/package.lisa.json
@@ -49,7 +49,7 @@
       "lint:fix": "oxlint --fix && eslint . --fix"
     },
     "dependencies": {
-      "@apollo/server": "^5.2.0",
+      "@apollo/server": "^5.4.0",
       "@as-integrations/express5": "^1.1.2",
       "@aws-sdk/client-apigatewaymanagementapi": "^3.967.0",
       "@aws-sdk/client-cognito-identity-provider": "^3.969.0",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -187,7 +187,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/merge/.oxlintrc.json":
       "2a0ea2191abd5b377aed4b525a4a97d3eefb1d9e41c845c02ee0daac75df6b1f",
     "expo/package-lisa/package.lisa.json":
-      "c0b971d10d40215ea0c0fa1bf1635322ed20ede330306e47e028bae8af03444d",
+      "36ff218f50b41fc1a55d7477245e8554e241e6f42239dfa37083844a3c4183b7",
     "harper-fabric/copy-contents/.prettierignore":
       "478c782f4c5611187e21584dfd5522e37fc636c5eb03394fea3db45321c6712c",
     "harper-fabric/copy-contents/gitignore":
@@ -315,7 +315,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "nestjs/merge/.oxlintrc.json":
       "3743a1e2bcfc879f5250f35206f413b10815f34e20b1d0afce67824579813b5d",
     "nestjs/package-lisa/package.lisa.json":
-      "2ef6fdb6751fcbfbb09d834104159111e4efef0938eca2c11e44539805c005e6",
+      "f54fbe079e12caa89f1b768a851e71cd1c30e37918ca309c50add4379102381d",
     "npm-package/create-only/.github/workflows/publish-to-npm.yml":
       "c21af3c31626abfe4dcbfdd42917f7e01753045a1ba6eba87b014e7f8c18db10",
     "npm-package/package-lisa/package.lisa.json":
@@ -2147,7 +2147,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/merge/.oxlintrc.json":
       "4debc093acfd263eb81ae15894073ebf098513204f45f40b83fb8fa5353fa1f8",
     "typescript/package-lisa/package.lisa.json":
-      "783e2a0a8d7463f4b32a68dae480f051b1814aa404fcbe10c713468d51727568",
+      "f8a793afd505fa3631c1f4b94a360f6873f46c184d0bae103580e92020b1e9d3",
     "ui/README.md":
       "deeb35e767ea5dd2883268835ea3ad21cbad9fa63ec8d8ff5e200f0e2a7d2751",
     "ui/index.html":

--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -28,8 +28,8 @@
     },
     "resolutions": {
       "@isaacs/brace-expansion": "^5.0.1",
-      "brace-expansion": ">=5.0.7",
-      "axios": ">=1.15.2",
+      "brace-expansion": ">=5.0.8",
+      "axios": ">=1.18.0",
       "esbuild": ">=0.28.1",
       "handlebars": ">=4.7.9",
       "lodash": ">=4.18.1",
@@ -42,8 +42,8 @@
     },
     "overrides": {
       "@isaacs/brace-expansion": "^5.0.1",
-      "brace-expansion": ">=5.0.7",
-      "axios": ">=1.15.2",
+      "brace-expansion": ">=5.0.8",
+      "axios": ">=1.18.0",
       "esbuild": ">=0.28.1",
       "handlebars": ">=4.7.9",
       "lodash": ">=4.18.1",


### PR DESCRIPTION
Three `force`-pinned floors permit versions the advisory database marks vulnerable. Because they're in `force`, they don't merely fail to protect — **they overwrite a project that pinned correctly** and move it back onto the vulnerable range.

| package | forced | permits | advisory | patched |
|---|---|---|---|---|
| `brace-expansion` | `>=5.0.7` | 5.0.7 | GHSA-mh99-v99m-4gvg (high) | **5.0.8** |
| `axios` | `>=1.15.2` | 1.15.2–1.17.x | GHSA-gcfj-64vw-6mp9 (high) + 6 more | **1.18.0** |
| `@apollo/server` | `^5.2.0` | 5.2.x–5.3.x | GHSA-mp6q-xf9x-fwf7 (high) | **5.4.0** |

## How it surfaced

Not by reading the file — by watching it do damage. `TunnlAI/infrastructure` had correctly pinned `brace-expansion: >=5.0.8`. Running `lisa apply` rewrote it **down** to `>=5.0.7`:

```diff
-    "brace-expansion": ">=5.0.8",
+    "brace-expansion": ">=5.0.7",
```

Caught only because that apply happened to be under review. Every other project on these templates has been silently taking the same downgrade.

## Root cause

Each floor was correct when written and was overtaken by a later advisory. `>=5.0.7` matched GHSA-3jxr-9vmj-r5cp precisely — whose `first_patched_version` *is* 5.0.7. GHSA-mh99-v99m-4gvg then moved it to 5.0.8 and the pin was never revisited.

This is the same root cause as the `fast-uri` and `js-yaml` floors corrected earlier: **the floor was derived from what resolved cleanly at the time, rather than from the advisory's own `first_patched_version`.** Resolution drifts as advisories land; the advisory floor doesn't.

## Verification

Every value here comes from `first_patched_version`, and each was checked to actually resolve on npm — a floor nothing satisfies is its own kind of breakage:

```
brace-expansion@>=5.0.8  -> 5.0.9
axios@>=1.18.0           -> 1.19.0
@apollo/server@^5.4.0    -> 5.5.1
```

An audit of **every** force-pinned floor against the live GitHub advisory API now reports none permitting a high or critical vulnerable version, where it previously reported nine across these three packages.

**8373 tests across 494 files** pass.

## Suggested follow-up

That audit is a few dozen lines and could run in CI, so the next stale floor is caught mechanically rather than by someone noticing a suspicious diff. Not included here to keep this reviewable as a security fix — happy to add it separately.

Work-Item: CodySwannGT/lisa#2167

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package compatibility constraints across Expo, NestJS, and TypeScript integrations.
  * Improved minimum supported versions for key supporting libraries.
  * Refreshed integrity records for the updated package configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->