### PR TITLE
feat(ci): audit force-pinned security floors against the advisory database

### DIFF
--- a/.github/workflows/security-floors.yml
+++ b/.github/workflows/security-floors.yml
@@ -1,0 +1,58 @@
+name: 🔒 Security Floors
+
+# Checks that no version floor Lisa pins permits a release the GitHub advisory
+# database marks vulnerable.
+#
+# This exists because a stale floor in a `force` section is worse than no pin:
+# it OVERWRITES a downstream project that pinned correctly, moving it back onto
+# the vulnerable range on the next `lisa apply`. That happened — a project had
+# correctly set `brace-expansion: >=5.0.8` and apply rewrote it to `>=5.0.7`.
+#
+# The floors are compared against `first_patched_version` rather than against
+# whatever npm resolves. Resolution drifts as advisories land; the advisory
+# floor does not. Deriving floors from resolution produced the same defect
+# repeatedly (fast-uri, js-yaml, then brace-expansion/axios/@apollo-server,
+# then tar/systeminformation).
+#
+# Runs on a schedule as well as on PRs: an advisory can land against a pin
+# nobody touched, so change-triggered checking alone would miss it until the
+# next unrelated edit.
+#
+# NOTE: repo-specific to the Lisa monorepo, NOT a Lisa template — do not move
+# it under plugins/src or the create-only template sets. Deliberately separate
+# from ci.yml/quality.yml, which are Lisa-managed generated files.
+
+on:
+  pull_request:
+    paths:
+      - '*/package-lisa/package.lisa.json'
+      - 'scripts/check-security-floors.mjs'
+      - '.github/workflows/security-floors.yml'
+  schedule:
+    # Weekly. Advisories land independently of commits.
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  security-floors:
+    name: 🔒 Forced floors vs advisory database
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version: '22.21.1'
+      - name: Audit force-pinned security floors
+        env:
+          # The anonymous advisory limit is 60 requests/hour and these
+          # manifests declare ~190 packages. Without a token the run answers
+          # for the first 60 and reports the rest unchecked — the script now
+          # says so rather than calling them clean, and --strict fails on an
+          # inconclusive run for exactly that reason.
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/check-security-floors.mjs --strict | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/security-floors.yml
+++ b/.github/workflows/security-floors.yml
@@ -42,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           package-manager-cache: false

--- a/cdk/package-lisa/package.lisa.json
+++ b/cdk/package-lisa/package.lisa.json
@@ -49,8 +49,8 @@
   },
   "defaults": {
     "dependencies": {
-      "@aws-cdk/aws-amplify-alpha": "^2.259.0-alpha.0",
-      "aws-cdk-lib": "2.259.0"
+      "@aws-cdk/aws-amplify-alpha": "^2.260.0-alpha.0",
+      "aws-cdk-lib": "2.260.0"
     },
     "devDependencies": {
       "@codyswann/lisa": "^2.106.0"

--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -69,7 +69,7 @@
       "i18n-js": "^4.5.1",
       "patch-package": "^8.0.0",
       "react-hook-form": "^7.70.0",
-      "tar": ">=7.5.11",
+      "tar": ">=7.5.19",
       "text-encoding-polyfill": "^0.6.7",
       "usehooks-ts": "^3.1.1",
       "zod": "^4.3.5"
@@ -101,7 +101,7 @@
       "brace-expansion": ">=5.0.8",
       "eslint-plugin-react-hooks": "^7.0.0",
       "fast-xml-parser": "^5.10.1",
-      "tar": ">=7.5.11",
+      "tar": ">=7.5.19",
       "websocket-driver": ">=0.7.5"
     },
     "overrides": {
@@ -110,7 +110,7 @@
       "eslint-plugin-react-hooks": "^7.0.0",
       "fast-xml-parser": "^5.10.1",
       "zod-validation-error": "^4.0.0",
-      "tar": ">=7.5.11",
+      "tar": ">=7.5.19",
       "websocket-driver": ">=0.7.5"
     }
   },

--- a/scripts/check-security-floors.mjs
+++ b/scripts/check-security-floors.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+/**
+ * Verify no force-pinned version floor permits a known-vulnerable release.
+ *
+ * A floor in a `force` section does not merely fail to protect when it goes
+ * stale — it OVERWRITES whatever the downstream project had. A project that
+ * pinned correctly gets moved back onto the vulnerable range by `lisa apply`,
+ * silently, and the only signal is a suspicious line in a diff nobody is
+ * looking for. That is how `brace-expansion >=5.0.7` survived: it was written
+ * to match GHSA-3jxr-9vmj-r5cp, whose first_patched_version genuinely is
+ * 5.0.7, and GHSA-mh99-v99m-4gvg later moved the floor to 5.0.8.
+ *
+ * The floors are therefore checked against the advisory database rather than
+ * against what npm happens to resolve. Resolution drifts as new advisories
+ * land; `first_patched_version` does not. Deriving floors from resolution is
+ * the specific mistake this exists to catch — it produced the same defect
+ * three times (fast-uri, js-yaml, and the three fixed in #2168).
+ *
+ * Usage:
+ *   check-security-floors.mjs [--strict] [--json]
+ *
+ * Exits non-zero only with --strict, so the job can report before it gates.
+ * @module scripts/check-security-floors
+ */
+
+import { readFileSync } from "node:fs";
+import { globSync } from "node:fs";
+
+/** Sections whose entries are version constraints worth checking. */
+const CONSTRAINT_SECTIONS = [
+  "overrides",
+  "resolutions",
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+];
+
+/** Governance groups in a package.lisa.json. */
+const GOVERNANCE_GROUPS = ["force", "defaults", "merge"];
+
+/** Severities that gate. Medium and low are reported but never fail. */
+const GATING_SEVERITIES = new Set(["high", "critical"]);
+
+const ADVISORY_ENDPOINT = "https://api.github.com/advisories";
+
+/**
+ * Every version constraint declared across the template manifests.
+ * @returns {Map<string, Array<{file: string, path: string, spec: string}>>} By package name.
+ */
+function collectFloors() {
+  const found = new Map();
+  const files = globSync("*/package-lisa/package.lisa.json").filter(
+    file => !file.includes("node_modules") && !file.includes(".worktrees")
+  );
+  for (const file of files) {
+    let manifest;
+    try {
+      manifest = JSON.parse(readFileSync(file, "utf8"));
+    } catch (error) {
+      throw new Error(`${file} is not valid JSON: ${error.message}`);
+    }
+    for (const group of GOVERNANCE_GROUPS) {
+      const block = manifest[group];
+      if (!block || typeof block !== "object") continue;
+      for (const section of CONSTRAINT_SECTIONS) {
+        const entries = block[section];
+        if (!entries || typeof entries !== "object") continue;
+        for (const [name, spec] of Object.entries(entries)) {
+          // `$name` self-references defer to the project's own pin and carry
+          // no floor of their own; a literal like "workspace:*" likewise.
+          if (typeof spec !== "string" || !/\d/.test(spec)) continue;
+          if (spec.startsWith("$")) continue;
+          if (!found.has(name)) found.set(name, []);
+          found.get(name).push({ file, path: `${group}.${section}`, spec });
+        }
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Lowest version a spec permits, as a comparable tuple.
+ * @param {string} spec A range like ">=5.0.7", "^1.2.3", "~2.0.0".
+ * @returns {number[]|null} [major, minor, patch], or null if unparseable.
+ */
+export function lowestPermitted(spec) {
+  const match = /(\d+)\.(\d+)\.(\d+)/.exec(spec);
+  if (!match) return null;
+  return match.slice(1, 4).map(Number);
+}
+
+/**
+ * Compare two version tuples.
+ * @param {number[]} left First version.
+ * @param {number[]} right Second version.
+ * @returns {number} Negative, zero, or positive.
+ */
+function compare(left, right) {
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}
+
+/**
+ * Whether a version falls inside an advisory's vulnerable range.
+ * @param {number[]} version Candidate version.
+ * @param {string} range e.g. ">= 4.0.0, < 5.0.8".
+ * @returns {boolean} True when the version is vulnerable.
+ */
+export function withinRange(version, range) {
+  if (!range) return false;
+  let inside = true;
+  for (const clause of range.split(",")) {
+    const match = /(>=|<=|<|>|=)\s*(\d+)\.(\d+)\.(\d+)/.exec(clause.trim());
+    if (!match) continue;
+    const bound = match.slice(2, 5).map(Number);
+    const delta = compare(version, bound);
+    switch (match[1]) {
+      case ">=":
+        inside &&= delta >= 0;
+        break;
+      case ">":
+        inside &&= delta > 0;
+        break;
+      case "<=":
+        inside &&= delta <= 0;
+        break;
+      case "<":
+        inside &&= delta < 0;
+        break;
+      default:
+        inside &&= delta === 0;
+    }
+  }
+  return inside;
+}
+
+/**
+ * Advisories affecting one package.
+ *
+ * Distinguishes "no advisories" from "could not ask", because conflating them
+ * is how a check like this goes quietly blind. The anonymous advisory limit is
+ * 60 requests/hour and these manifests declare roughly 200 packages, so an
+ * unauthenticated run answers for the first 60 and silently reports the other
+ * 140 as clean unless the difference is tracked.
+ * @param {string} name npm package name.
+ * @returns {Promise<{advisories: Array}|{error: string}>} Result or reason.
+ */
+async function advisoriesFor(name) {
+  const url = `${ADVISORY_ENDPOINT}?ecosystem=npm&affects=${encodeURIComponent(name)}&per_page=100`;
+  const headers = { accept: "application/vnd.github+json" };
+  // Authenticated calls get 5000/hour instead of 60. CI supplies the token via
+  // the standard GITHUB_TOKEN; locally, `gh auth token` covers it.
+  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  if (token) headers.authorization = `Bearer ${token}`;
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    let response;
+    try {
+      response = await fetch(url, { headers });
+    } catch (error) {
+      return { error: `network: ${error.message}` };
+    }
+    if (response.ok) return { advisories: await response.json() };
+
+    const remaining = response.headers.get("x-ratelimit-remaining");
+    const limited =
+      response.status === 429 || (response.status === 403 && remaining === "0");
+    if (!limited) return { error: `HTTP ${response.status}` };
+
+    // Honour Retry-After when given, otherwise back off. A rate-limited run
+    // cannot demonstrate anything, so it is worth waiting rather than
+    // reporting a clean sheet that was never checked.
+    const retryAfter = Number(response.headers.get("retry-after"));
+    const waitSeconds =
+      Number.isFinite(retryAfter) && retryAfter > 0
+        ? Math.min(retryAfter, 30)
+        : 2 ** attempt;
+    await new Promise(resolve => setTimeout(resolve, waitSeconds * 1000));
+  }
+  return { error: "rate limited" };
+}
+
+/**
+ * Audit every collected floor.
+ * @returns {Promise<{problems: Array, unreachable: string[], checked: number}>} Findings.
+ */
+async function audit() {
+  const floors = collectFloors();
+  const problems = [];
+  const unreachable = [];
+  for (const [name, sites] of floors) {
+    const result = await advisoriesFor(name);
+    if (result.error) {
+      unreachable.push({ name, reason: result.error });
+      continue;
+    }
+    const { advisories } = result;
+    for (const advisory of advisories) {
+      if (!GATING_SEVERITIES.has(advisory.severity)) continue;
+      for (const vulnerability of advisory.vulnerabilities ?? []) {
+        if (vulnerability.package?.name !== name) continue;
+        for (const site of sites) {
+          const lowest = lowestPermitted(site.spec);
+          if (!lowest) continue;
+          if (!withinRange(lowest, vulnerability.vulnerable_version_range)) {
+            continue;
+          }
+          problems.push({
+            package: name,
+            ...site,
+            advisory: advisory.ghsa_id,
+            severity: advisory.severity,
+            vulnerableRange: vulnerability.vulnerable_version_range,
+            patched: vulnerability.first_patched_version,
+          });
+        }
+      }
+    }
+  }
+  return { problems, unreachable, checked: floors.size };
+}
+
+const strict = process.argv.includes("--strict");
+const asJson = process.argv.includes("--json");
+const { problems, unreachable, checked } = await audit();
+
+if (asJson) {
+  console.log(JSON.stringify({ problems, unreachable, checked }, null, 2));
+} else if (problems.length === 0) {
+  console.log(
+    `## Security floors\n\nNo force-pinned floor permits a high or critical vulnerable release. ${checked} package(s) checked.`
+  );
+} else {
+  console.log("## Security floors\n");
+  console.log(
+    "These pins permit a release the advisory database marks vulnerable. Because they sit in governance sections, a stale floor **overwrites** a downstream project that pinned correctly.\n"
+  );
+  console.log("| package | pinned | permits | advisory | patched | site |");
+  console.log("|---|---|---|---|---|---|");
+  for (const problem of problems) {
+    console.log(
+      `| \`${problem.package}\` | \`${problem.spec}\` | ${problem.vulnerableRange} | ${problem.advisory} (${problem.severity}) | **${problem.patched}** | ${problem.file} ${problem.path} |`
+    );
+  }
+  console.log(
+    "\nRaise each floor to the advisory's `first_patched_version`, then confirm the new value actually resolves on npm — a floor nothing satisfies is its own breakage."
+  );
+}
+
+if (unreachable.length > 0) {
+  const limited = unreachable.filter(entry =>
+    entry.reason.includes("rate limited")
+  );
+  console.log(
+    `\n> **Inconclusive for ${unreachable.length} of ${checked} package(s).** Their floors were NOT verified — this is not a clean result for them.`
+  );
+  if (limited.length > 0) {
+    console.log(
+      "> Cause is rate limiting. The anonymous advisory limit is 60 requests/hour; set `GITHUB_TOKEN` for 5000."
+    );
+  }
+  console.log(`> Affected: ${unreachable.map(entry => entry.name).join(", ")}`);
+}
+
+// Deliberately exit 0 without --strict. An advisory landing overnight would
+// otherwise fail a PR that changed nothing, and a check that cries wolf gets
+// disabled rather than fixed.
+//
+// Under --strict an inconclusive run also fails: it proves nothing, and
+// treating "could not check" as "checked and clean" is exactly the silent
+// degradation this script exists to prevent.
+if (strict && (problems.length > 0 || unreachable.length > 0)) {
+  process.exitCode = 1;
+}

--- a/scripts/check-security-floors.mjs
+++ b/scripts/check-security-floors.mjs
@@ -38,7 +38,7 @@ const CONSTRAINT_SECTIONS = [
 /** Governance groups in a package.lisa.json. */
 const GOVERNANCE_GROUPS = ["force", "defaults", "merge"];
 
-/** Severities that gate. Medium and low are reported but never fail. */
+/** Severities that gate. Medium and low advisories are ignored by this check. */
 const GATING_SEVERITIES = new Set(["high", "critical"]);
 
 const ADVISORY_ENDPOINT = "https://api.github.com/advisories";
@@ -223,55 +223,63 @@ async function audit() {
   return { problems, unreachable, checked: floors.size };
 }
 
-const strict = process.argv.includes("--strict");
-const asJson = process.argv.includes("--json");
-const { problems, unreachable, checked } = await audit();
+async function main() {
+  const strict = process.argv.includes("--strict");
+  const asJson = process.argv.includes("--json");
+  const { problems, unreachable, checked } = await audit();
 
-if (asJson) {
-  console.log(JSON.stringify({ problems, unreachable, checked }, null, 2));
-} else if (problems.length === 0) {
-  console.log(
-    `## Security floors\n\nNo force-pinned floor permits a high or critical vulnerable release. ${checked} package(s) checked.`
-  );
-} else {
-  console.log("## Security floors\n");
-  console.log(
-    "These pins permit a release the advisory database marks vulnerable. Because they sit in governance sections, a stale floor **overwrites** a downstream project that pinned correctly.\n"
-  );
-  console.log("| package | pinned | permits | advisory | patched | site |");
-  console.log("|---|---|---|---|---|---|");
-  for (const problem of problems) {
+  if (asJson) {
+    console.log(JSON.stringify({ problems, unreachable, checked }, null, 2));
+  } else if (problems.length === 0) {
     console.log(
-      `| \`${problem.package}\` | \`${problem.spec}\` | ${problem.vulnerableRange} | ${problem.advisory} (${problem.severity}) | **${problem.patched}** | ${problem.file} ${problem.path} |`
+      `## Security floors\n\nNo force-pinned floor permits a high or critical vulnerable release. ${checked} package(s) checked.`
+    );
+  } else {
+    console.log("## Security floors\n");
+    console.log(
+      "These pins permit a release the advisory database marks vulnerable. Because they sit in governance sections, a stale floor **overwrites** a downstream project that pinned correctly.\n"
+    );
+    console.log("| package | pinned | permits | advisory | patched | site |");
+    console.log("|---|---|---|---|---|---|");
+    for (const problem of problems) {
+      console.log(
+        `| \`${problem.package}\` | \`${problem.spec}\` | ${problem.vulnerableRange} | ${problem.advisory} (${problem.severity}) | **${problem.patched}** | ${problem.file} ${problem.path} |`
+      );
+    }
+    console.log(
+      "\nRaise each floor to the advisory's `first_patched_version`, then confirm the new value actually resolves on npm — a floor nothing satisfies is its own breakage."
     );
   }
-  console.log(
-    "\nRaise each floor to the advisory's `first_patched_version`, then confirm the new value actually resolves on npm — a floor nothing satisfies is its own breakage."
-  );
-}
 
-if (unreachable.length > 0) {
-  const limited = unreachable.filter(entry =>
-    entry.reason.includes("rate limited")
-  );
-  console.log(
-    `\n> **Inconclusive for ${unreachable.length} of ${checked} package(s).** Their floors were NOT verified — this is not a clean result for them.`
-  );
-  if (limited.length > 0) {
+  if (unreachable.length > 0) {
+    const limited = unreachable.filter(entry =>
+      entry.reason.includes("rate limited")
+    );
     console.log(
-      "> Cause is rate limiting. The anonymous advisory limit is 60 requests/hour; set `GITHUB_TOKEN` for 5000."
+      `\n> **Inconclusive for ${unreachable.length} of ${checked} package(s).** Their floors were NOT verified — this is not a clean result for them.`
+    );
+    if (limited.length > 0) {
+      console.log(
+        "> Cause is rate limiting. The anonymous advisory limit is 60 requests/hour; set `GITHUB_TOKEN` for 5000."
+      );
+    }
+    console.log(
+      `> Affected: ${unreachable.map(entry => entry.name).join(", ")}`
     );
   }
-  console.log(`> Affected: ${unreachable.map(entry => entry.name).join(", ")}`);
+
+  // Deliberately exit 0 without --strict. An advisory landing overnight would
+  // otherwise fail a PR that changed nothing, and a check that cries wolf gets
+  // disabled rather than fixed.
+  //
+  // Under --strict an inconclusive run also fails: it proves nothing, and
+  // treating "could not check" as "checked and clean" is exactly the silent
+  // degradation this script exists to prevent.
+  if (strict && (problems.length > 0 || unreachable.length > 0)) {
+    process.exitCode = 1;
+  }
 }
 
-// Deliberately exit 0 without --strict. An advisory landing overnight would
-// otherwise fail a PR that changed nothing, and a check that cries wolf gets
-// disabled rather than fixed.
-//
-// Under --strict an inconclusive run also fails: it proves nothing, and
-// treating "could not check" as "checked and clean" is exactly the silent
-// degradation this script exists to prevent.
-if (strict && (problems.length > 0 || unreachable.length > 0)) {
-  process.exitCode = 1;
+if (import.meta.main) {
+  await main();
 }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -65,7 +65,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "cdk/merge/.oxlintrc.json":
       "e74885a33fdb7b5d565e13ebd781a3dd2fd02409a2a059deed851645630a6985",
     "cdk/package-lisa/package.lisa.json":
-      "8ab146a3323f970c3a8aafb8d78d17e8b2c121bf24e2a7d4ba07a75485176869",
+      "6eb9a4cea78747750d6efadb7a142a349bc8572ed5e5d109f8b71d862ed4e45d",
     "eslint-plugin-code-organization/README.md":
       "7943820d0b301041f764d4b33adc3c8afbd5bf08f800989390233e78962a51de",
     "eslint-plugin-code-organization/__tests__/enforce-statement-order.test.js":
@@ -187,7 +187,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/merge/.oxlintrc.json":
       "2a0ea2191abd5b377aed4b525a4a97d3eefb1d9e41c845c02ee0daac75df6b1f",
     "expo/package-lisa/package.lisa.json":
-      "36ff218f50b41fc1a55d7477245e8554e241e6f42239dfa37083844a3c4183b7",
+      "430a2e42be94f5eda106d8e89ec33d1927813fe66851575d5f3453a8f2b2ab98",
     "harper-fabric/copy-contents/.prettierignore":
       "478c782f4c5611187e21584dfd5522e37fc636c5eb03394fea3db45321c6712c",
     "harper-fabric/copy-contents/gitignore":
@@ -1906,6 +1906,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "3a99cbff0e8ec5e7c944690eae003a6d51b51c85436d77bd37faea4d553728af",
     "scripts/check-rules-pairing.sh":
       "4d4a0d9e8d36794a22020f419c879d7336b1c5bfe883acdcc826d26764560c7a",
+    "scripts/check-security-floors.mjs":
+      "8db373947c934e0d7d262bb6983a9750a51dc28b1b568e694ba503ef44a80932",
     "scripts/claude-remote-setup.sh":
       "0e33accf8aa057c70497f01c38bef9f9f3801d649272f583578d89201b242655",
     "scripts/clean-dist.mjs":
@@ -2147,7 +2149,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/merge/.oxlintrc.json":
       "4debc093acfd263eb81ae15894073ebf098513204f45f40b83fb8fa5353fa1f8",
     "typescript/package-lisa/package.lisa.json":
-      "f8a793afd505fa3631c1f4b94a360f6873f46c184d0bae103580e92020b1e9d3",
+      "6a70ca152ac9daf5f1546cbaa876818b9a63360cf784870879d8d199fafe22d4",
     "ui/README.md":
       "deeb35e767ea5dd2883268835ea3ad21cbad9fa63ec8d8ff5e200f0e2a7d2751",
     "ui/index.html":
@@ -2277,6 +2279,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     ".github/workflows/reusable-claude-nightly-test-improvement.yml": true,
     ".github/workflows/reusable-claude-sync-down-branches.yml": true,
     ".github/workflows/reusable-claude.yml": true,
+    ".github/workflows/security-floors.yml": true,
     ".github/workflows/zap-baseline-expo.yml": true,
     ".github/workflows/zap-baseline-nestjs.yml": true,
     ".gitignore": true,
@@ -7577,6 +7580,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "scripts/check-learnings-budget.ts": true,
     "scripts/check-plugins-sync.sh": true,
     "scripts/check-rules-pairing.sh": true,
+    "scripts/check-security-floors.mjs": true,
     "scripts/claude-remote-setup.sh": true,
     "scripts/clean-dist.mjs": true,
     "scripts/cleanup-amplify-branches.sh": true,
@@ -8306,6 +8310,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/plugin-routing-validate.test.ts": true,
     "tests/unit/scripts/plugin-sync-scripts.test.ts": true,
     "tests/unit/scripts/plugin-sync-workflow.test.ts": true,
+    "tests/unit/scripts/security-floors.test.ts": true,
     "tests/unit/scripts/setup-jira-cli-config.test.ts": true,
     "tests/unit/scripts/threshold-ratchet-gates.test.ts": true,
     "tests/unit/scripts/threshold-ratchet-wiring.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1907,7 +1907,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/check-rules-pairing.sh":
       "4d4a0d9e8d36794a22020f419c879d7336b1c5bfe883acdcc826d26764560c7a",
     "scripts/check-security-floors.mjs":
-      "8db373947c934e0d7d262bb6983a9750a51dc28b1b568e694ba503ef44a80932",
+      "3d3c0d0ddff2d810bf3470ff88926566210a3373954761727bd4281c38fe8d8c",
     "scripts/claude-remote-setup.sh":
       "0e33accf8aa057c70497f01c38bef9f9f3801d649272f583578d89201b242655",
     "scripts/clean-dist.mjs":

--- a/tests/unit/config/postinstall-ci-guard.test.ts
+++ b/tests/unit/config/postinstall-ci-guard.test.ts
@@ -144,8 +144,8 @@ describe("package.lisa.json templates carry force-governed CVE floors", () => {
     const template = readTemplateJson(
       TYPESCRIPT_PACKAGE_TEMPLATE
     ) as OverridesShape;
-    expect(template.force?.overrides?.systeminformation).toBe(">=5.27.14");
-    expect(template.force?.resolutions?.systeminformation).toBe(">=5.27.14");
+    expect(template.force?.overrides?.systeminformation).toBe(">=5.31.7");
+    expect(template.force?.resolutions?.systeminformation).toBe(">=5.31.7");
   });
 
   it("typescript template keeps undici on the File-exporting v6 line", () => {

--- a/tests/unit/scripts/security-floors.test.ts
+++ b/tests/unit/scripts/security-floors.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the version-range comparison behind the security-floor audit.
+ *
+ * The network half is not tested here — it is a thin fetch wrapper, and pinning
+ * live advisory content would make the suite fail whenever a real advisory
+ * lands. What is worth pinning is the comparison, because a wrong answer here
+ * is silent: an off-by-one boundary reports a vulnerable floor as clean, which
+ * is the exact failure this script exists to prevent.
+ * @module tests/unit/scripts/security-floors
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  lowestPermitted,
+  withinRange,
+} from "../../../scripts/check-security-floors.mjs";
+
+describe("lowestPermitted", () => {
+  it("reads the floor out of a >= range", () => {
+    expect(lowestPermitted(">=5.0.7")).toEqual([5, 0, 7]);
+  });
+
+  it("reads the floor out of a caret range", () => {
+    expect(lowestPermitted("^4.3.0")).toEqual([4, 3, 0]);
+  });
+
+  it("reads the floor out of a tilde range", () => {
+    expect(lowestPermitted("~2.0.0")).toEqual([2, 0, 0]);
+  });
+
+  it("treats a bare version as its own floor", () => {
+    expect(lowestPermitted("2.259.0")).toEqual([2, 259, 0]);
+  });
+
+  it("returns null for a spec carrying no version", () => {
+    expect(lowestPermitted("workspace:*")).toBeNull();
+  });
+});
+
+describe("withinRange", () => {
+  /** The brace-expansion range that started all this. */
+  const BRACE_RANGE = ">= 4.0.0, < 5.0.8";
+  /** The aws-cdk-lib range, where lexical comparison gives a wrong answer. */
+  const CDK_RANGE = ">= 2.0.0, < 2.260.0";
+
+  // The real case: brace-expansion >=5.0.7 permits 5.0.7, which
+  // GHSA-mh99-v99m-4gvg marks vulnerable up to (not including) 5.0.8.
+  it("flags a floor that sits inside a two-sided range", () => {
+    expect(withinRange([5, 0, 7], BRACE_RANGE)).toBe(true);
+  });
+
+  it("clears a floor at the patched boundary", () => {
+    expect(withinRange([5, 0, 8], BRACE_RANGE)).toBe(false);
+  });
+
+  it("clears a floor below the vulnerable range", () => {
+    expect(withinRange([3, 0, 0], BRACE_RANGE)).toBe(false);
+  });
+
+  it("handles an inclusive upper bound", () => {
+    expect(withinRange([7, 5, 18], "<= 7.5.18")).toBe(true);
+    expect(withinRange([7, 5, 19], "<= 7.5.18")).toBe(false);
+  });
+
+  it("handles a bare upper bound with no lower bound", () => {
+    expect(withinRange([5, 30, 7], "< 5.30.8")).toBe(true);
+  });
+
+  it("handles an exact-version range", () => {
+    expect(withinRange([4, 0, 0], "= 4.0.0")).toBe(true);
+    expect(withinRange([4, 0, 1], "= 4.0.0")).toBe(false);
+  });
+
+  it("compares numerically rather than lexically", () => {
+    // "2.259.0" < "2.26.0" as strings; the opposite is true as versions, and
+    // getting this wrong would clear a genuinely vulnerable aws-cdk-lib pin.
+    expect(withinRange([2, 259, 0], CDK_RANGE)).toBe(true);
+    expect(withinRange([2, 26, 0], CDK_RANGE)).toBe(true);
+    expect(withinRange([2, 260, 0], CDK_RANGE)).toBe(false);
+  });
+
+  it("treats an empty range as no constraint rather than a match", () => {
+    expect(withinRange([1, 0, 0], "")).toBe(false);
+  });
+});

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -1875,9 +1875,9 @@ describe("PackageLisaStrategy", () => {
       }
       // Exact pins (not just "is defined") so an accidental version bump in
       // the template is caught by this regression test.
-      expect(template.defaults.dependencies["aws-cdk-lib"]).toBe("2.259.0");
+      expect(template.defaults.dependencies["aws-cdk-lib"]).toBe("2.260.0");
       expect(template.defaults.dependencies["@aws-cdk/aws-amplify-alpha"]).toBe(
-        "^2.259.0-alpha.0"
+        "^2.260.0-alpha.0"
       );
     });
 

--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -38,7 +38,7 @@
       "vite": ">=8.0.16",
       "ws": ">=8.21.0",
       "form-data": ">=4.0.6",
-      "systeminformation": ">=5.27.14"
+      "systeminformation": ">=5.31.7"
     },
     "overrides": {
       "@isaacs/brace-expansion": "^5.0.1",
@@ -52,7 +52,7 @@
       "vite": "^8.0.16",
       "ws": ">=8.21.0",
       "form-data": ">=4.0.6",
-      "systeminformation": ">=5.27.14"
+      "systeminformation": ">=5.31.7"
     }
   },
   "defaults": {


### PR DESCRIPTION
Follow-up to #2168, which raised three stale floors found by eye. This adds the check that finds them without eyes — and it immediately found **three more, one critical**.

| package | pinned | patched | advisory |
|---|---|---|---|
| `tar` | `>=7.5.11` | **7.5.19** | GHSA-23hp-3jrh-7fpw (**critical**) |
| `systeminformation` | `>=5.27.14` | **5.31.7** | GHSA-5xpp-75jx-m839 (high) |
| `aws-cdk-lib` | `2.259.0` | **2.260.0** | GHSA-vcrf-j523-4mrf (high) |

The `aws-cdk-lib` alpha companion moves with it — the two must stay on the same minor, a constraint an existing regression test already pins and which caught my incomplete first attempt.

## The blindness this also fixes

My first run reported only **one** of these three.

The advisory API allows **60 requests/hour anonymously**, and these manifests declare **189 packages**. So the run answered for 60 and silently treated the remaining 143 as clean. The `tar` critical was sitting in that silent set.

A check that examines a third of its inputs and reports success is worse than no check — it manufactures false confidence. So the script now:

- separates **"no advisories"** from **"could not ask"**
- retries rate limits with backoff, honouring `Retry-After`
- names every inconclusive package in its output
- under `--strict`, **fails on an inconclusive run** rather than reporting a clean sheet it never verified

CI passes `github.token`, which lifts the limit to 5000/hour. The current run: **189 checked, 0 inconclusive.**

## Why compare against advisories rather than resolution

Floors are compared against `first_patched_version`, never against what npm happens to resolve. Resolution drifts as new advisories land; the advisory floor doesn't.

Deriving floors from resolution is the original defect, now seen four times — `fast-uri`, `js-yaml`, then `brace-expansion`/`axios`/`@apollo/server`, then these three. `brace-expansion >=5.0.7` was *correct* against GHSA-3jxr-9vmj-r5cp, whose `first_patched_version` genuinely is 5.0.7; GHSA-mh99-v99m-4gvg later moved it to 5.0.8 and nothing re-checked.

## Design notes

- **Weekly cron as well as PR-triggered.** An advisory can land against a pin nobody touched; a purely change-triggered check wouldn't notice until some unrelated edit wandered past.
- **Exits 0 without `--strict`**, so the job can be observed before it gates.
- **Repo-specific workflow**, deliberately not a Lisa template, and separate from the generated `ci.yml`/`quality.yml`.

## Tests

Unit tests cover the version comparison, not the network wrapper. A wrong answer in the comparison is silent — an off-by-one at a range boundary reports a vulnerable floor as clean, which is precisely what this exists to prevent. Pinning live advisory content, by contrast, would break the suite whenever a real advisory landed.

Includes the numeric-vs-lexical case: `"2.259.0"` sorts *below* `"2.26.0"` as a string, and getting that backwards would clear a genuinely vulnerable `aws-cdk-lib` pin.

**8386 tests across 495 files** pass.

Work-Item: CodySwannGT/lisa#2169

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated security-floor auditing for dependency versions, with scheduled, pull request, and manual checks.
  * Improved reporting for security findings and inconclusive advisory checks.

* **Updates**
  * Updated CDK packages to version 2.260.0.
  * Raised minimum versions for `tar` and `systeminformation` to address security requirements.

* **Tests**
  * Added coverage for dependency version and vulnerability-range validation.
  * Updated regression checks for the new minimum versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->