### PR TITLE
Make Claude Code web a first-class secrets surface

### DIFF
--- a/plans/claude-web-surface.md
+++ b/plans/claude-web-surface.md
@@ -1,0 +1,284 @@
+# Claude Code web as a first-class secrets/execution surface
+
+> Rename to `plans/claude-web-surface.md` on first commit, matching the descriptive
+> convention of the parent plan (`plans/portable-secrets-remote-execution.md`).
+
+## Context
+
+`plans/portable-secrets-remote-execution.md` shipped a two-axis model — **provider**
+(where secrets live) × **surface** (how they reach running code) — and implemented
+exactly one remote surface: `codex-cloud`. Its own scope note says the shape is
+"deliberately surface-agnostic so Claude Code web, Cursor remote, and others slot in
+without redesign."
+
+They have not slotted in. Today a Lisa skill running inside a Claude Code cloud
+session falls through `detectSurface` to `local`, which carries
+`mayWriteValues: false` — so materialization refuses, the resolver attempts a live
+provider read, and there is no keychain to read from. **The credential manager is
+unreachable on that surface.** Claude gets `lisa-analyze-claude-remote` and
+`lisa-generate-claude-remote-build-script` (May–Jun 2026): an audit and a one-shot
+script generator, with no secrets contract, no verify read-back, and no dispatch.
+
+Parity across every supported coding agent is a project rule in `AGENTS.md`, and
+Claude is the reference implementation — so it being the *least* supported remote
+surface is backwards.
+
+The intended outcome: `executionEnv=claude-web` works end to end — provisioned,
+verified, dispatched, scheduled — through the same `lisa-secrets-access` chokepoint,
+with the surface's genuine differences expressed as explicit branches rather than
+silently papered over.
+
+## What is actually different about this surface
+
+Four findings from the docs drive every design decision below. They are not
+cosmetic; three of them break an assumption the Codex implementation is built on.
+
+| | Codex Cloud | Claude Code web |
+|---|---|---|
+| Environment bound to a repo | **Yes** | **No** — environment is `{network, env vars, setup script}` only; repo arrives per session |
+| Environment owned by | The repo | The **account** (personal or org-shared); no API, no settings URL |
+| Setup script on resume | Re-runs | **Skipped** whenever a filesystem cache exists (~7d, or on script/allowlist edit) |
+| Secrets store | Provider-backed | **None** — env vars are plaintext and "visible to anyone who uses the environment" |
+
+Consequences, in order of severity:
+
+1. **Setup ≠ maintenance here.** The Codex entrypoint's core claim — "running it on
+   resume is what picks up a rotated value" — is false on Claude. A rotated
+   credential would go stale until cache expiry.
+2. **Provisioning is emit-tier only.** B.4 tier 1 (API) and tier 2 (browser) are both
+   unavailable: the environment dialog has no API and, per the docs, *"no settings
+   page or direct URL for the selector."* `/remote-env` only *selects* an
+   environment; it cannot create or edit one. B.5 still holds — the read-back is
+   tier-independent and runs inside a session.
+3. **Only the bootstrap variable may enter the env-var box**, and an org-shared
+   environment broadcasts it to every member. Lisa already has exactly the right
+   shape here (`secrets.bootstrap.sources` / `.key`, from PRs #2157/#2159).
+4. **`GITHUB_TOKEN` reads as the literal string `proxy-injected`** when the GitHub
+   proxy handles auth. This is a live landmine: `checkRequired`
+   (`doctor-secrets.mjs:57`) resolves a required name against `process.env[name]` and
+   reports `ok` for any non-empty value. `proxy-injected` passes the check and is
+   unusable by any script that reads it.
+
+One finding cuts the other way and is worth banking: **plugins declared in the
+repo's `.claude/settings.json` are installed at session start from the declared
+marketplace**, and `github.com` is on the Trusted allowlist. Lisa reaches a Claude
+cloud session through its normal marketplace path — the `node_modules` fallback that
+PR #2161 added for Codex is a belt-and-braces path here, not the only one.
+
+## Decisions
+
+- **Dispatch** — ~~shell out to `claude --cloud`~~. **Superseded by the U1 probe on
+  2026-08-03: `claude --cloud` refuses non-interactive invocation and therefore
+  cannot be a dispatch mechanism.** The routine `/fire` endpoint is the only
+  programmatic path, and now carries both dispatch and scheduling. See U1 below.
+- **Materialize phase moves to a SessionStart hook** gated on
+  `CLAUDE_CODE_REMOTE=true`, committed to the repo's `.claude/settings.json`. The
+  setup script keeps toolchain + project hook. Secrets are then fresh on *every*
+  session including resumed ones — stronger than the Codex arrangement — and the
+  hook is repo-owned, which claws back the ownership lost to an account-scoped
+  environment.
+- **Do not touch the Codex path.** Its re-run-on-resume behaviour is correct for
+  that surface. The split is surface-conditional, like `mayWriteValues` before it.
+- **`gh` goes in the toolchain `install` list** for this surface. It is not
+  pre-installed, and Lisa leans on it throughout.
+
+## Open unknowns — settle by live probe before building
+
+The parent plan's Session 3 overturned a documented assumption by dispatching three
+read-only probes. Same discipline applies. All four are cheap, and U1/U4 change code
+shape rather than just prose.
+
+| # | Question | Why it blocks |
+|---|---|---|
+| ~~U1~~ | ~~What does `claude --cloud` print on success…~~ **ANSWERED 2026-08-03 — `claude --cloud` cannot be used for dispatch at all.** | See below. |
+| U2 | Does a SessionStart hook run before the first agent turn in a cloud session, and does a value written to `$CLAUDE_ENV_FILE` reach later Bash calls? | The whole materialize relocation rests on this. |
+| U3 | Confirm `CLAUDE_CODE_REMOTE=true`, `GH_TOKEN=proxy-injected`, and that the setup script is genuinely skipped on a cache hit. | Surface detection and the `proxy-injected` verdict. |
+| U4 | Can an environment be selected per `--cloud` invocation, or only via the `/remote-env` saved default? | If only the saved default, `remoteEnv.surfaces["claude-web"].environmentId` is advisory and `assertPreconditions` must say so instead of implying a binding it cannot enforce. |
+
+Probe from a throwaway repo with a read-only prompt (`report the value of $CLAUDE_CODE_REMOTE and exit`). Record answers in this file's Sessions table.
+
+### U1 — answered, and it invalidates the original dispatch design
+
+A non-interactive `claude --cloud` invocation from CLI 2.1.220 exits `1` in under a
+second with:
+
+```
+Error: --cloud requires an interactive terminal.
+Non-interactive invocations (piped stdout, --init-only, --sdk-url) run locally and
+would silently ignore --cloud. Drop --cloud, or run from a TTY.
+```
+
+`lisa-remote-dispatch` calls `execFileSync(..., { stdio: ["ignore", "pipe", "pipe"] })`
+— piped stdout, which is exactly the case this rejects. There is no non-interactive
+escape hatch: `--print` *is* the non-interactive mode and is named in the refusal.
+
+**This is a deliberate guard, not an obstacle to route around.** It exists so that a
+scripted `--cloud` cannot silently execute locally while the operator believes the
+work went to the cloud — the same failure class the parent plan's C.1 rule addresses
+("a skill that does not support `executionEnv` must reject it explicitly, never
+ignore it"). Wrapping the call in a PTY to defeat it would reintroduce precisely the
+silent-local-execution risk the guard prevents.
+
+`claude --cloud` therefore stays what it is: a human-at-a-terminal affordance, and
+the vehicle for this plan's end-to-end verification. It is not plumbing.
+
+**Corrected design.** `executionEnv=claude-web` dispatches by POSTing to a routine's
+`/fire` endpoint. This is better than the Codex path in three ways and worse in one:
+
+- The response is structured JSON (`claude_code_session_id`,
+  `claude_code_session_url`), so `extractTaskId`'s regex-scraping has no analogue
+  here — the identifier is a field, not something parsed out of console output.
+- The dispatching machine needs no CLI and no claude.ai login, only the bearer
+  token. The laptop stops being a launcher at all.
+- Dispatch and schedule collapse into one mechanism: a routine carries a cron
+  trigger and an API trigger simultaneously, so Part D stops needing a separate seam.
+- **Worse:** a routine is a saved config created on the web, so there is one routine
+  per dispatch target, created by hand — the same emit-tier constraint as the
+  environment itself.
+
+The `text` field carries the work item. Per the docs it arrives wrapped in a
+`<routine-fire-payload>` block explicitly labelled untrusted, and *"a routine's saved
+prompt must opt in to acting on fire text."* That is the parent plan's C.5 boundary
+("the ticket body is untrusted input") enforced by the platform rather than by
+convention — so the emitted routine prompt must reference the payload deliberately,
+e.g. *"Run the Lisa skill named in the routine-fire-payload block."*
+
+The bearer token becomes the dispatcher credential, resolved through
+`lisa-secrets-access` and never stored in config. It can be regenerated and revoked,
+so it belongs in `secrets.rotating` — mirroring the parent plan's D.3 observation
+that the dispatcher's own credential exercises the rotating path.
+
+## Sequencing
+
+Five PRs. Each carries `bun run build:plugins` **and**
+`bun run build:upstream-evidence-manifest` in the same commit, with all five variants
+(`plugins/src/base`, `lisa`, `lisa-cursor`, `lisa-agy`, `lisa-copilot`) regenerated.
+
+### PR 0 — Probes
+
+Settle U1–U4, record findings here. No source changes beyond this plan file.
+
+### PR 1 — Secrets surface
+
+The load-bearing PR; everything else composes on it.
+
+- `lisa-secrets-access/scripts/surfaces.mjs` — add
+  `"claude-web": { materialized: true, mayWriteValues: true }` to `SURFACES` (:32),
+  and a `CLAUDE_CODE_REMOTE` branch to `detectSurface` (:59), ordered after the
+  existing `GITHUB_ACTIONS` check.
+- `doctor-secrets.mjs` — `checkRequired` (:57) gains a distinct verdict when a
+  required name resolves to exactly `proxy-injected` on this surface: **not** `ok`,
+  and the message names the proxy and the fact that scripts reading the variable get
+  the placeholder rather than a token.
+- `validate-config.mjs` — schema for `remoteEnv.surfaces["claude-web"]`.
+
+Tests land beside the existing seven files in `tests/unit/secrets/`.
+
+### PR 2 — Remote env setup, emit tier
+
+- `lisa-setup-remote-env/scripts/setup-remote-env.mjs` — `main()` (:200) becomes
+  surface-aware: on `claude-web` it runs toolchain + project hook and **skips** the
+  secrets phase, printing why.
+- `assets/session-start.sh` (new) — the materialize phase, gated on
+  `CLAUDE_CODE_REMOTE`, reusing the same skill-resolution ladder already in
+  `assets/setup.sh` (which correctly prefers `.claude/skills/` and falls back to
+  `node_modules/@codyswann/lisa`).
+- The emitter — produces the three paste-able field values (network access level,
+  env-var block containing *only* the bootstrap variable, setup script), plus the
+  `.claude/settings.json` SessionStart block, and states plainly that no API tier
+  exists for this surface.
+- `toolchain.mjs` — `gh` as an `install` entry.
+- `verify-remote-env.mjs` — `main()` (:145) gains the `claude-web` read-back: the
+  existing mode/notes/clean-checkout assertions plus the `proxy-injected` check and
+  a `CLAUDE_CODE_REMOTE` assertion.
+
+### PR 3 — Dispatch via the routine `/fire` endpoint
+
+- `lisa-remote-dispatch/scripts/dispatch.mjs` — `EXECUTION_ENVS` (:27) gains
+  `claude-web`. `assertPreconditions` (:103) becomes surface-aware: this surface
+  requires `routineId` and `fireUrl`, and **not** `repository` — the repo is a
+  property of the routine, recorded for the ledger rather than enforced as a binding.
+- New `dispatchClaudeWeb` beside `dispatchCodexCloud` (:177): an HTTPS POST with
+  `Authorization: Bearer <resolved through lisa-secrets-access>`,
+  `anthropic-beta: experimental-cc-routine-2026-04-01`, body `{"text": prompt}`.
+  It reads `claude_code_session_id` / `claude_code_session_url` straight from the
+  response — `extractTaskId` (:125) is not extended to this surface, because there
+  is nothing to scrape.
+- Ledger entries carry `surface: "claude-web"`, the session ID, and the session URL.
+
+### PR 4 — Scheduler, runbook, docs
+
+Smaller than originally scoped: a routine's cron trigger and API trigger are the same
+object, so registering a `claude-web` loop is the same emit-tier artifact PR 3
+already produces, plus a schedule.
+
+- `scheduler: "claude-routine"` in the `automations` block, registered emit-tier —
+  config records `routineId` and `fireUrl`; the bearer token lives in the provider
+  and is declared in `secrets.rotating`.
+- `lisa-automation-status` stopped-clock detection for routines: paused schedule,
+  daily-run-cap exhaustion, and a one-off routine that already fired and
+  auto-disabled — the Claude analogues of GitHub's 60-day auto-disable. Note the
+  1-hour minimum cron interval, which is coarser than the parent plan's hourly
+  intake assumes in places.
+- Runbook per the Automation Runbook Contract; `AGENTS.md` and `wiki/` updates.
+
+## Verification
+
+Unit and contract level:
+
+```bash
+bun test tests/unit/secrets/
+bun run build:plugins && bun run build:upstream-evidence-manifest
+git diff --exit-code   # manifest must be current in the same commit
+```
+
+End to end — this is the part that matters, and per
+`feedback_verify_e2e_not_just_unit` it cannot be skipped:
+
+1. Configure a **personal** (never org-shared) cloud environment with one bootstrap
+   variable and the emitted setup script.
+2. `claude --cloud "run /lisa:setup:remote-env verify"` against a real repo, and read
+   the read-back output in the session. It must report the surface as `claude-web`,
+   both file modes, every required variable, and the `proxy-injected` verdict —
+   without printing a value.
+3. Rotate one non-critical credential in the provider, start a **resumed** session,
+   and confirm the SessionStart hook re-materialized it. This is the specific
+   regression the design exists to prevent, and a cached session is the only place it
+   shows up.
+4. Dispatch one real ticket with `executionEnv=claude-web` through to a merged PR,
+   per the parent plan's C.6 rule that a surface is proven on one real item before
+   being extended.
+5. Confirm `.lisa/remote-dispatch.json` carries the session identifier — a dispatch
+   whose ID was not captured is treated as failed.
+
+## Repository constraints
+
+- Five-variant fanout; parity is a project rule, not a nicety.
+- Manifest regeneration reads **tracked** files — run it after `git add`.
+- Thresholds may only tighten.
+- Merge with `--merge`, never `--squash`.
+- `Closes #N` does not fire in this repo — close and relabel by hand.
+- CI needs `Work-Item` in the PR **body** plus a `[lisa-pr-link]` backlink comment.
+
+## Concerns to carry, not resolve
+
+Stated plainly rather than designed around:
+
+- **Claude Code on the web and routines are both research preview.** The `/fire`
+  endpoint ships behind a dated beta header (`experimental-cc-routine-2026-04-01`)
+  that rotates, with two prior versions honoured. Expect churn.
+- **Personal vs org-shared environments are not programmatically distinguishable.**
+  The rule that a bootstrap secret must not live in a shared environment is therefore
+  documented and asserted at verify time by the operator — it cannot be enforced.
+- **Routines run as an individual's account.** Commits, PRs, and connector actions
+  appear as that person. That sits awkwardly against the "humans are not allowed
+  inside a factory" premise in `AGENTS.md`: the loop has a human owner in a way the
+  GitHub Actions clock does not. Worth a decision before Part D is enabled for a
+  production loop, not before it is built.
+
+## Sessions
+
+| Session | Date | Phases | Notes |
+|---------|------|--------|-------|
+| 1 | 2026-08-03 | Research | Audited Claude Code web / cloud environments / routines docs against the shipped `codex-cloud` implementation. Confirmed `--cloud` and `--teleport` exist in CLI 2.1.220 but are hidden from `--help`. Established the four structural differences and the `proxy-injected` landmine. Plan created. |
+| 2 | 2026-08-03 | PR 0 (probes) | Settled U1 by live invocation: `claude --cloud` refuses any non-interactive call (exit 1, <1s) and names `--print` among the rejected modes, so it cannot back `executionEnv`. Dispatch redesigned onto the routine `/fire` endpoint; PR 3 rewritten, PR 4 reduced. Verified account preconditions are met (`claude.ai` auth, Max, first-party) and that no `remote.defaultEnvironmentId` is saved in user settings, so CLI cloud sessions would fall back to the first available environment. U2–U4 still open — U3 and U4 now need a session started from the web or a TTY rather than a scripted dispatch. |

--- a/plans/claude-web-surface.md
+++ b/plans/claude-web-surface.md
@@ -1,8 +1,5 @@
 # Claude Code web as a first-class secrets/execution surface
 
-> Rename to `plans/claude-web-surface.md` on first commit, matching the descriptive
-> convention of the parent plan (`plans/portable-secrets-remote-execution.md`).
-
 ## Context
 
 `plans/portable-secrets-remote-execution.md` shipped a two-axis model — **provider**

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -48,6 +48,16 @@ function fingerprint(value) {
 }
 
 /**
+ * The value a proxied credential reads as instead of a usable token.
+ *
+ * Some surfaces keep a credential outside the sandbox entirely and substitute
+ * the real value at egress. The variable is then present and non-empty, which
+ * is exactly what makes it dangerous: a presence check passes, and only a
+ * consumer that reads the variable *itself* discovers it holds a placeholder.
+ */
+const PROXY_PLACEHOLDER = "proxy-injected";
+
+/**
  * Assert every declared name actually resolves.
  * @param {object} cfg Resolved configuration.
  * @param {Map<string, object>} provider Provider view.
@@ -56,18 +66,36 @@ function fingerprint(value) {
  */
 export function checkRequired(cfg, provider, file, report) {
   for (const name of cfg.require ?? []) {
-    const resolves =
-      (process.env[name] ?? "").trim() ||
-      file.get(name) ||
-      provider.get(name)?.value;
-    if (resolves) report("ok", name, "resolves");
-    else
+    const fromEnv = (process.env[name] ?? "").trim();
+    const resolves = fromEnv || file.get(name) || provider.get(name)?.value;
+
+    if (!resolves) {
       report(
         "error",
         name,
         "declared in secrets.require but resolves nowhere — a startup error, " +
           "not a late surprise"
       );
+      continue;
+    }
+
+    // Reported separately from "resolves" because the two are not the same
+    // claim. A tool that authenticates through the proxy works; a script that
+    // reads this variable and puts it in an Authorization header sends the
+    // literal placeholder and gets a confusing auth failure far from here.
+    if (fromEnv === PROXY_PLACEHOLDER) {
+      report(
+        "warn",
+        name,
+        `reads as the literal string "${PROXY_PLACEHOLDER}" — the value is ` +
+          `substituted at egress and never enters this environment. Tools that ` +
+          `authenticate through the proxy work; anything reading this variable ` +
+          `directly gets the placeholder, not a credential`
+      );
+      continue;
+    }
+
+    report("ok", name, "resolves");
   }
 }
 

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -28,11 +28,19 @@ import { join } from "node:path";
  * drift and leak. It is *required* on surfaces whose bootstrap runs before the
  * consuming process exists and which therefore have no other channel; a remote
  * agent container prepares itself during setup, long before any task starts.
+ *
+ * The two remote surfaces share the capability but not the timing, and a reader
+ * adding a third should not assume otherwise. `codex-cloud` re-runs its setup
+ * script when a container resumes, so materializing there picks up a rotated
+ * value. `claude-web` *skips* its setup script whenever a filesystem cache
+ * exists, so materializing there would strand a rotated value until the cache
+ * expired — its materialize step runs from a session-start hook instead.
  */
 export const SURFACES = {
   local: { materialized: false, mayWriteValues: false },
   "github-actions": { materialized: false, mayWriteValues: false },
   "codex-cloud": { materialized: true, mayWriteValues: true },
+  "claude-web": { materialized: true, mayWriteValues: true },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */
@@ -68,6 +76,10 @@ export function detectSurface(configured = null, env = process.env) {
     return explicit;
   }
   if ((env.GITHUB_ACTIONS ?? "") === "true") return "github-actions";
+  // Compared to the exact string rather than tested for presence: the variable
+  // is documented as carrying "true" in a cloud session and never being true
+  // locally, so a presence test would misread a shell that exports it empty.
+  if ((env.CLAUDE_CODE_REMOTE ?? "") === "true") return "claude-web";
   if ((env.CODEX_SANDBOX ?? env.CODEX_HOME ?? "") !== "") return "codex-cloud";
   return "local";
 }

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -59,6 +59,20 @@ const SURFACE_BINDINGS = {
   "claude-web": ["routineId", "fireUrl"],
 };
 
+/**
+ * The fields a surface must record, with the default applied.
+ *
+ * Read through one helper rather than at each call site, because the two
+ * callers answer different questions — "could this declaration be correct" and
+ * "may an automation dispatch to it" — and a fallback that drifted between them
+ * would let those answers disagree about the very same config.
+ * @param {string} surface Surface name.
+ * @returns {string[]} Field names that must be present.
+ */
+function bindingsFor(surface) {
+  return SURFACE_BINDINGS[surface] ?? ["repository"];
+}
+
 /** Install methods the toolchain runner supports. */
 const INSTALL_METHODS = new Set(["release-zip", "npm-global"]);
 
@@ -172,7 +186,7 @@ export function validateRemoteEnv(remoteEnv) {
       problems.push(`remoteEnv.surfaces has unknown surface "${surface}"`);
       continue;
     }
-    for (const field of SURFACE_BINDINGS[surface] ?? ["repository"]) {
+    for (const field of bindingsFor(surface)) {
       if (!block[field]) {
         problems.push(`remoteEnv.surfaces["${surface}"] has no ${field}`);
       }
@@ -191,9 +205,7 @@ export function validateRemoteEnv(remoteEnv) {
 export function isProvisioned(remoteEnv, surface) {
   const block = remoteEnv?.surfaces?.[surface];
   if (!block) return false;
-  return (SURFACE_BINDINGS[surface] ?? ["repository"]).every(field =>
-    Boolean(block[field])
-  );
+  return bindingsFor(surface).every(field => Boolean(block[field]));
 }
 
 /**

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -19,14 +19,45 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { SURFACES as SURFACE_CAPABILITIES } from "./surfaces.mjs";
+
 /** Providers with a read implementation today. */
 const IMPLEMENTED_PROVIDERS = new Set(["bitwarden", "doppler", "env"]);
 
 /** Providers named in the dispatch table but not yet implemented. */
 const DECLARED_PROVIDERS = new Set(["1password", "aws", "vault"]);
 
-/** Surfaces the resolver knows. */
-const SURFACES = new Set(["local", "github-actions", "codex-cloud"]);
+/**
+ * Surfaces the resolver knows.
+ *
+ * Derived from the resolver's own table rather than restated here. The two
+ * lists previously drifted apart by construction: adding a surface meant
+ * remembering to edit a second file, and forgetting produced a config that
+ * resolved correctly at runtime while `doctor` called it unknown.
+ */
+const SURFACES = new Set(Object.keys(SURFACE_CAPABILITIES));
+
+/**
+ * What a provisioned surface must record before anything dispatches to it.
+ *
+ * Deliberately not uniform, because these surfaces do not bind the same way. A
+ * Codex Cloud environment is bound to one repository, so naming the repository
+ * is part of proving the environment is the right one. A Claude cloud
+ * environment has no repository at all — it is account-scoped configuration
+ * (network policy, variables, setup script) and the repository arrives per
+ * session — so its durable handle is the routine that dispatch fires.
+ *
+ * Requiring `repository` of every surface, as this file used to, would demand
+ * a field that cannot be true of `claude-web` in any meaningful sense.
+ *
+ * `repository` stays the default so every existing surface keeps its current
+ * contract. This file checks structure only — whether a declaration *could* be
+ * correct — so it deliberately does not restate the fuller preconditions that
+ * `lisa-remote-dispatch` enforces at the moment it actually dispatches.
+ */
+const SURFACE_BINDINGS = {
+  "claude-web": ["routineId", "fireUrl"],
+};
 
 /** Install methods the toolchain runner supports. */
 const INSTALL_METHODS = new Set(["release-zip", "npm-global"]);
@@ -139,13 +170,30 @@ export function validateRemoteEnv(remoteEnv) {
   for (const [surface, block] of Object.entries(remoteEnv.surfaces ?? {})) {
     if (!SURFACES.has(surface)) {
       problems.push(`remoteEnv.surfaces has unknown surface "${surface}"`);
+      continue;
     }
-    if (!block.repository) {
-      problems.push(`remoteEnv.surfaces["${surface}"] has no repository`);
+    for (const field of SURFACE_BINDINGS[surface] ?? ["repository"]) {
+      if (!block[field]) {
+        problems.push(`remoteEnv.surfaces["${surface}"] has no ${field}`);
+      }
     }
   }
 
   return problems;
+}
+
+/**
+ * Report whether a surface has been provisioned far enough to dispatch to.
+ * @param {object|undefined} remoteEnv The remote-environment block.
+ * @param {string} surface Surface name.
+ * @returns {boolean} Whether every binding field is recorded.
+ */
+export function isProvisioned(remoteEnv, surface) {
+  const block = remoteEnv?.surfaces?.[surface];
+  if (!block) return false;
+  return (SURFACE_BINDINGS[surface] ?? ["repository"]).every(field =>
+    Boolean(block[field])
+  );
 }
 
 /**
@@ -173,7 +221,7 @@ export function validateAutomations(automations, remoteEnv) {
       );
       continue;
     }
-    if (!remoteEnv?.surfaces?.[loop.executionEnv]?.repository) {
+    if (!isProvisioned(remoteEnv, loop.executionEnv)) {
       problems.push(
         `automations["${name}"] dispatches to "${loop.executionEnv}", which is ` +
           `not provisioned. Run /lisa:setup:remote-env ${loop.executionEnv} first.`

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -48,6 +48,16 @@ function fingerprint(value) {
 }
 
 /**
+ * The value a proxied credential reads as instead of a usable token.
+ *
+ * Some surfaces keep a credential outside the sandbox entirely and substitute
+ * the real value at egress. The variable is then present and non-empty, which
+ * is exactly what makes it dangerous: a presence check passes, and only a
+ * consumer that reads the variable *itself* discovers it holds a placeholder.
+ */
+const PROXY_PLACEHOLDER = "proxy-injected";
+
+/**
  * Assert every declared name actually resolves.
  * @param {object} cfg Resolved configuration.
  * @param {Map<string, object>} provider Provider view.
@@ -56,18 +66,36 @@ function fingerprint(value) {
  */
 export function checkRequired(cfg, provider, file, report) {
   for (const name of cfg.require ?? []) {
-    const resolves =
-      (process.env[name] ?? "").trim() ||
-      file.get(name) ||
-      provider.get(name)?.value;
-    if (resolves) report("ok", name, "resolves");
-    else
+    const fromEnv = (process.env[name] ?? "").trim();
+    const resolves = fromEnv || file.get(name) || provider.get(name)?.value;
+
+    if (!resolves) {
       report(
         "error",
         name,
         "declared in secrets.require but resolves nowhere — a startup error, " +
           "not a late surprise"
       );
+      continue;
+    }
+
+    // Reported separately from "resolves" because the two are not the same
+    // claim. A tool that authenticates through the proxy works; a script that
+    // reads this variable and puts it in an Authorization header sends the
+    // literal placeholder and gets a confusing auth failure far from here.
+    if (fromEnv === PROXY_PLACEHOLDER) {
+      report(
+        "warn",
+        name,
+        `reads as the literal string "${PROXY_PLACEHOLDER}" — the value is ` +
+          `substituted at egress and never enters this environment. Tools that ` +
+          `authenticate through the proxy work; anything reading this variable ` +
+          `directly gets the placeholder, not a credential`
+      );
+      continue;
+    }
+
+    report("ok", name, "resolves");
   }
 }
 

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -28,11 +28,19 @@ import { join } from "node:path";
  * drift and leak. It is *required* on surfaces whose bootstrap runs before the
  * consuming process exists and which therefore have no other channel; a remote
  * agent container prepares itself during setup, long before any task starts.
+ *
+ * The two remote surfaces share the capability but not the timing, and a reader
+ * adding a third should not assume otherwise. `codex-cloud` re-runs its setup
+ * script when a container resumes, so materializing there picks up a rotated
+ * value. `claude-web` *skips* its setup script whenever a filesystem cache
+ * exists, so materializing there would strand a rotated value until the cache
+ * expired — its materialize step runs from a session-start hook instead.
  */
 export const SURFACES = {
   local: { materialized: false, mayWriteValues: false },
   "github-actions": { materialized: false, mayWriteValues: false },
   "codex-cloud": { materialized: true, mayWriteValues: true },
+  "claude-web": { materialized: true, mayWriteValues: true },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */
@@ -68,6 +76,10 @@ export function detectSurface(configured = null, env = process.env) {
     return explicit;
   }
   if ((env.GITHUB_ACTIONS ?? "") === "true") return "github-actions";
+  // Compared to the exact string rather than tested for presence: the variable
+  // is documented as carrying "true" in a cloud session and never being true
+  // locally, so a presence test would misread a shell that exports it empty.
+  if ((env.CLAUDE_CODE_REMOTE ?? "") === "true") return "claude-web";
   if ((env.CODEX_SANDBOX ?? env.CODEX_HOME ?? "") !== "") return "codex-cloud";
   return "local";
 }

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -59,6 +59,20 @@ const SURFACE_BINDINGS = {
   "claude-web": ["routineId", "fireUrl"],
 };
 
+/**
+ * The fields a surface must record, with the default applied.
+ *
+ * Read through one helper rather than at each call site, because the two
+ * callers answer different questions — "could this declaration be correct" and
+ * "may an automation dispatch to it" — and a fallback that drifted between them
+ * would let those answers disagree about the very same config.
+ * @param {string} surface Surface name.
+ * @returns {string[]} Field names that must be present.
+ */
+function bindingsFor(surface) {
+  return SURFACE_BINDINGS[surface] ?? ["repository"];
+}
+
 /** Install methods the toolchain runner supports. */
 const INSTALL_METHODS = new Set(["release-zip", "npm-global"]);
 
@@ -172,7 +186,7 @@ export function validateRemoteEnv(remoteEnv) {
       problems.push(`remoteEnv.surfaces has unknown surface "${surface}"`);
       continue;
     }
-    for (const field of SURFACE_BINDINGS[surface] ?? ["repository"]) {
+    for (const field of bindingsFor(surface)) {
       if (!block[field]) {
         problems.push(`remoteEnv.surfaces["${surface}"] has no ${field}`);
       }
@@ -191,9 +205,7 @@ export function validateRemoteEnv(remoteEnv) {
 export function isProvisioned(remoteEnv, surface) {
   const block = remoteEnv?.surfaces?.[surface];
   if (!block) return false;
-  return (SURFACE_BINDINGS[surface] ?? ["repository"]).every(field =>
-    Boolean(block[field])
-  );
+  return bindingsFor(surface).every(field => Boolean(block[field]));
 }
 
 /**

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -19,14 +19,45 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { SURFACES as SURFACE_CAPABILITIES } from "./surfaces.mjs";
+
 /** Providers with a read implementation today. */
 const IMPLEMENTED_PROVIDERS = new Set(["bitwarden", "doppler", "env"]);
 
 /** Providers named in the dispatch table but not yet implemented. */
 const DECLARED_PROVIDERS = new Set(["1password", "aws", "vault"]);
 
-/** Surfaces the resolver knows. */
-const SURFACES = new Set(["local", "github-actions", "codex-cloud"]);
+/**
+ * Surfaces the resolver knows.
+ *
+ * Derived from the resolver's own table rather than restated here. The two
+ * lists previously drifted apart by construction: adding a surface meant
+ * remembering to edit a second file, and forgetting produced a config that
+ * resolved correctly at runtime while `doctor` called it unknown.
+ */
+const SURFACES = new Set(Object.keys(SURFACE_CAPABILITIES));
+
+/**
+ * What a provisioned surface must record before anything dispatches to it.
+ *
+ * Deliberately not uniform, because these surfaces do not bind the same way. A
+ * Codex Cloud environment is bound to one repository, so naming the repository
+ * is part of proving the environment is the right one. A Claude cloud
+ * environment has no repository at all — it is account-scoped configuration
+ * (network policy, variables, setup script) and the repository arrives per
+ * session — so its durable handle is the routine that dispatch fires.
+ *
+ * Requiring `repository` of every surface, as this file used to, would demand
+ * a field that cannot be true of `claude-web` in any meaningful sense.
+ *
+ * `repository` stays the default so every existing surface keeps its current
+ * contract. This file checks structure only — whether a declaration *could* be
+ * correct — so it deliberately does not restate the fuller preconditions that
+ * `lisa-remote-dispatch` enforces at the moment it actually dispatches.
+ */
+const SURFACE_BINDINGS = {
+  "claude-web": ["routineId", "fireUrl"],
+};
 
 /** Install methods the toolchain runner supports. */
 const INSTALL_METHODS = new Set(["release-zip", "npm-global"]);
@@ -139,13 +170,30 @@ export function validateRemoteEnv(remoteEnv) {
   for (const [surface, block] of Object.entries(remoteEnv.surfaces ?? {})) {
     if (!SURFACES.has(surface)) {
       problems.push(`remoteEnv.surfaces has unknown surface "${surface}"`);
+      continue;
     }
-    if (!block.repository) {
-      problems.push(`remoteEnv.surfaces["${surface}"] has no repository`);
+    for (const field of SURFACE_BINDINGS[surface] ?? ["repository"]) {
+      if (!block[field]) {
+        problems.push(`remoteEnv.surfaces["${surface}"] has no ${field}`);
+      }
     }
   }
 
   return problems;
+}
+
+/**
+ * Report whether a surface has been provisioned far enough to dispatch to.
+ * @param {object|undefined} remoteEnv The remote-environment block.
+ * @param {string} surface Surface name.
+ * @returns {boolean} Whether every binding field is recorded.
+ */
+export function isProvisioned(remoteEnv, surface) {
+  const block = remoteEnv?.surfaces?.[surface];
+  if (!block) return false;
+  return (SURFACE_BINDINGS[surface] ?? ["repository"]).every(field =>
+    Boolean(block[field])
+  );
 }
 
 /**
@@ -173,7 +221,7 @@ export function validateAutomations(automations, remoteEnv) {
       );
       continue;
     }
-    if (!remoteEnv?.surfaces?.[loop.executionEnv]?.repository) {
+    if (!isProvisioned(remoteEnv, loop.executionEnv)) {
       problems.push(
         `automations["${name}"] dispatches to "${loop.executionEnv}", which is ` +
           `not provisioned. Run /lisa:setup:remote-env ${loop.executionEnv} first.`

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -48,6 +48,16 @@ function fingerprint(value) {
 }
 
 /**
+ * The value a proxied credential reads as instead of a usable token.
+ *
+ * Some surfaces keep a credential outside the sandbox entirely and substitute
+ * the real value at egress. The variable is then present and non-empty, which
+ * is exactly what makes it dangerous: a presence check passes, and only a
+ * consumer that reads the variable *itself* discovers it holds a placeholder.
+ */
+const PROXY_PLACEHOLDER = "proxy-injected";
+
+/**
  * Assert every declared name actually resolves.
  * @param {object} cfg Resolved configuration.
  * @param {Map<string, object>} provider Provider view.
@@ -56,18 +66,36 @@ function fingerprint(value) {
  */
 export function checkRequired(cfg, provider, file, report) {
   for (const name of cfg.require ?? []) {
-    const resolves =
-      (process.env[name] ?? "").trim() ||
-      file.get(name) ||
-      provider.get(name)?.value;
-    if (resolves) report("ok", name, "resolves");
-    else
+    const fromEnv = (process.env[name] ?? "").trim();
+    const resolves = fromEnv || file.get(name) || provider.get(name)?.value;
+
+    if (!resolves) {
       report(
         "error",
         name,
         "declared in secrets.require but resolves nowhere — a startup error, " +
           "not a late surprise"
       );
+      continue;
+    }
+
+    // Reported separately from "resolves" because the two are not the same
+    // claim. A tool that authenticates through the proxy works; a script that
+    // reads this variable and puts it in an Authorization header sends the
+    // literal placeholder and gets a confusing auth failure far from here.
+    if (fromEnv === PROXY_PLACEHOLDER) {
+      report(
+        "warn",
+        name,
+        `reads as the literal string "${PROXY_PLACEHOLDER}" — the value is ` +
+          `substituted at egress and never enters this environment. Tools that ` +
+          `authenticate through the proxy work; anything reading this variable ` +
+          `directly gets the placeholder, not a credential`
+      );
+      continue;
+    }
+
+    report("ok", name, "resolves");
   }
 }
 

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -28,11 +28,19 @@ import { join } from "node:path";
  * drift and leak. It is *required* on surfaces whose bootstrap runs before the
  * consuming process exists and which therefore have no other channel; a remote
  * agent container prepares itself during setup, long before any task starts.
+ *
+ * The two remote surfaces share the capability but not the timing, and a reader
+ * adding a third should not assume otherwise. `codex-cloud` re-runs its setup
+ * script when a container resumes, so materializing there picks up a rotated
+ * value. `claude-web` *skips* its setup script whenever a filesystem cache
+ * exists, so materializing there would strand a rotated value until the cache
+ * expired — its materialize step runs from a session-start hook instead.
  */
 export const SURFACES = {
   local: { materialized: false, mayWriteValues: false },
   "github-actions": { materialized: false, mayWriteValues: false },
   "codex-cloud": { materialized: true, mayWriteValues: true },
+  "claude-web": { materialized: true, mayWriteValues: true },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */
@@ -68,6 +76,10 @@ export function detectSurface(configured = null, env = process.env) {
     return explicit;
   }
   if ((env.GITHUB_ACTIONS ?? "") === "true") return "github-actions";
+  // Compared to the exact string rather than tested for presence: the variable
+  // is documented as carrying "true" in a cloud session and never being true
+  // locally, so a presence test would misread a shell that exports it empty.
+  if ((env.CLAUDE_CODE_REMOTE ?? "") === "true") return "claude-web";
   if ((env.CODEX_SANDBOX ?? env.CODEX_HOME ?? "") !== "") return "codex-cloud";
   return "local";
 }

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -59,6 +59,20 @@ const SURFACE_BINDINGS = {
   "claude-web": ["routineId", "fireUrl"],
 };
 
+/**
+ * The fields a surface must record, with the default applied.
+ *
+ * Read through one helper rather than at each call site, because the two
+ * callers answer different questions — "could this declaration be correct" and
+ * "may an automation dispatch to it" — and a fallback that drifted between them
+ * would let those answers disagree about the very same config.
+ * @param {string} surface Surface name.
+ * @returns {string[]} Field names that must be present.
+ */
+function bindingsFor(surface) {
+  return SURFACE_BINDINGS[surface] ?? ["repository"];
+}
+
 /** Install methods the toolchain runner supports. */
 const INSTALL_METHODS = new Set(["release-zip", "npm-global"]);
 
@@ -172,7 +186,7 @@ export function validateRemoteEnv(remoteEnv) {
       problems.push(`remoteEnv.surfaces has unknown surface "${surface}"`);
       continue;
     }
-    for (const field of SURFACE_BINDINGS[surface] ?? ["repository"]) {
+    for (const field of bindingsFor(surface)) {
       if (!block[field]) {
         problems.push(`remoteEnv.surfaces["${surface}"] has no ${field}`);
       }
@@ -191,9 +205,7 @@ export function validateRemoteEnv(remoteEnv) {
 export function isProvisioned(remoteEnv, surface) {
   const block = remoteEnv?.surfaces?.[surface];
   if (!block) return false;
-  return (SURFACE_BINDINGS[surface] ?? ["repository"]).every(field =>
-    Boolean(block[field])
-  );
+  return bindingsFor(surface).every(field => Boolean(block[field]));
 }
 
 /**

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -19,14 +19,45 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { SURFACES as SURFACE_CAPABILITIES } from "./surfaces.mjs";
+
 /** Providers with a read implementation today. */
 const IMPLEMENTED_PROVIDERS = new Set(["bitwarden", "doppler", "env"]);
 
 /** Providers named in the dispatch table but not yet implemented. */
 const DECLARED_PROVIDERS = new Set(["1password", "aws", "vault"]);
 
-/** Surfaces the resolver knows. */
-const SURFACES = new Set(["local", "github-actions", "codex-cloud"]);
+/**
+ * Surfaces the resolver knows.
+ *
+ * Derived from the resolver's own table rather than restated here. The two
+ * lists previously drifted apart by construction: adding a surface meant
+ * remembering to edit a second file, and forgetting produced a config that
+ * resolved correctly at runtime while `doctor` called it unknown.
+ */
+const SURFACES = new Set(Object.keys(SURFACE_CAPABILITIES));
+
+/**
+ * What a provisioned surface must record before anything dispatches to it.
+ *
+ * Deliberately not uniform, because these surfaces do not bind the same way. A
+ * Codex Cloud environment is bound to one repository, so naming the repository
+ * is part of proving the environment is the right one. A Claude cloud
+ * environment has no repository at all — it is account-scoped configuration
+ * (network policy, variables, setup script) and the repository arrives per
+ * session — so its durable handle is the routine that dispatch fires.
+ *
+ * Requiring `repository` of every surface, as this file used to, would demand
+ * a field that cannot be true of `claude-web` in any meaningful sense.
+ *
+ * `repository` stays the default so every existing surface keeps its current
+ * contract. This file checks structure only — whether a declaration *could* be
+ * correct — so it deliberately does not restate the fuller preconditions that
+ * `lisa-remote-dispatch` enforces at the moment it actually dispatches.
+ */
+const SURFACE_BINDINGS = {
+  "claude-web": ["routineId", "fireUrl"],
+};
 
 /** Install methods the toolchain runner supports. */
 const INSTALL_METHODS = new Set(["release-zip", "npm-global"]);
@@ -139,13 +170,30 @@ export function validateRemoteEnv(remoteEnv) {
   for (const [surface, block] of Object.entries(remoteEnv.surfaces ?? {})) {
     if (!SURFACES.has(surface)) {
       problems.push(`remoteEnv.surfaces has unknown surface "${surface}"`);
+      continue;
     }
-    if (!block.repository) {
-      problems.push(`remoteEnv.surfaces["${surface}"] has no repository`);
+    for (const field of SURFACE_BINDINGS[surface] ?? ["repository"]) {
+      if (!block[field]) {
+        problems.push(`remoteEnv.surfaces["${surface}"] has no ${field}`);
+      }
     }
   }
 
   return problems;
+}
+
+/**
+ * Report whether a surface has been provisioned far enough to dispatch to.
+ * @param {object|undefined} remoteEnv The remote-environment block.
+ * @param {string} surface Surface name.
+ * @returns {boolean} Whether every binding field is recorded.
+ */
+export function isProvisioned(remoteEnv, surface) {
+  const block = remoteEnv?.surfaces?.[surface];
+  if (!block) return false;
+  return (SURFACE_BINDINGS[surface] ?? ["repository"]).every(field =>
+    Boolean(block[field])
+  );
 }
 
 /**
@@ -173,7 +221,7 @@ export function validateAutomations(automations, remoteEnv) {
       );
       continue;
     }
-    if (!remoteEnv?.surfaces?.[loop.executionEnv]?.repository) {
+    if (!isProvisioned(remoteEnv, loop.executionEnv)) {
       problems.push(
         `automations["${name}"] dispatches to "${loop.executionEnv}", which is ` +
           `not provisioned. Run /lisa:setup:remote-env ${loop.executionEnv} first.`

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -48,6 +48,16 @@ function fingerprint(value) {
 }
 
 /**
+ * The value a proxied credential reads as instead of a usable token.
+ *
+ * Some surfaces keep a credential outside the sandbox entirely and substitute
+ * the real value at egress. The variable is then present and non-empty, which
+ * is exactly what makes it dangerous: a presence check passes, and only a
+ * consumer that reads the variable *itself* discovers it holds a placeholder.
+ */
+const PROXY_PLACEHOLDER = "proxy-injected";
+
+/**
  * Assert every declared name actually resolves.
  * @param {object} cfg Resolved configuration.
  * @param {Map<string, object>} provider Provider view.
@@ -56,18 +66,36 @@ function fingerprint(value) {
  */
 export function checkRequired(cfg, provider, file, report) {
   for (const name of cfg.require ?? []) {
-    const resolves =
-      (process.env[name] ?? "").trim() ||
-      file.get(name) ||
-      provider.get(name)?.value;
-    if (resolves) report("ok", name, "resolves");
-    else
+    const fromEnv = (process.env[name] ?? "").trim();
+    const resolves = fromEnv || file.get(name) || provider.get(name)?.value;
+
+    if (!resolves) {
       report(
         "error",
         name,
         "declared in secrets.require but resolves nowhere — a startup error, " +
           "not a late surprise"
       );
+      continue;
+    }
+
+    // Reported separately from "resolves" because the two are not the same
+    // claim. A tool that authenticates through the proxy works; a script that
+    // reads this variable and puts it in an Authorization header sends the
+    // literal placeholder and gets a confusing auth failure far from here.
+    if (fromEnv === PROXY_PLACEHOLDER) {
+      report(
+        "warn",
+        name,
+        `reads as the literal string "${PROXY_PLACEHOLDER}" — the value is ` +
+          `substituted at egress and never enters this environment. Tools that ` +
+          `authenticate through the proxy work; anything reading this variable ` +
+          `directly gets the placeholder, not a credential`
+      );
+      continue;
+    }
+
+    report("ok", name, "resolves");
   }
 }
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -28,11 +28,19 @@ import { join } from "node:path";
  * drift and leak. It is *required* on surfaces whose bootstrap runs before the
  * consuming process exists and which therefore have no other channel; a remote
  * agent container prepares itself during setup, long before any task starts.
+ *
+ * The two remote surfaces share the capability but not the timing, and a reader
+ * adding a third should not assume otherwise. `codex-cloud` re-runs its setup
+ * script when a container resumes, so materializing there picks up a rotated
+ * value. `claude-web` *skips* its setup script whenever a filesystem cache
+ * exists, so materializing there would strand a rotated value until the cache
+ * expired — its materialize step runs from a session-start hook instead.
  */
 export const SURFACES = {
   local: { materialized: false, mayWriteValues: false },
   "github-actions": { materialized: false, mayWriteValues: false },
   "codex-cloud": { materialized: true, mayWriteValues: true },
+  "claude-web": { materialized: true, mayWriteValues: true },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */
@@ -68,6 +76,10 @@ export function detectSurface(configured = null, env = process.env) {
     return explicit;
   }
   if ((env.GITHUB_ACTIONS ?? "") === "true") return "github-actions";
+  // Compared to the exact string rather than tested for presence: the variable
+  // is documented as carrying "true" in a cloud session and never being true
+  // locally, so a presence test would misread a shell that exports it empty.
+  if ((env.CLAUDE_CODE_REMOTE ?? "") === "true") return "claude-web";
   if ((env.CODEX_SANDBOX ?? env.CODEX_HOME ?? "") !== "") return "codex-cloud";
   return "local";
 }

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -59,6 +59,20 @@ const SURFACE_BINDINGS = {
   "claude-web": ["routineId", "fireUrl"],
 };
 
+/**
+ * The fields a surface must record, with the default applied.
+ *
+ * Read through one helper rather than at each call site, because the two
+ * callers answer different questions — "could this declaration be correct" and
+ * "may an automation dispatch to it" — and a fallback that drifted between them
+ * would let those answers disagree about the very same config.
+ * @param {string} surface Surface name.
+ * @returns {string[]} Field names that must be present.
+ */
+function bindingsFor(surface) {
+  return SURFACE_BINDINGS[surface] ?? ["repository"];
+}
+
 /** Install methods the toolchain runner supports. */
 const INSTALL_METHODS = new Set(["release-zip", "npm-global"]);
 
@@ -172,7 +186,7 @@ export function validateRemoteEnv(remoteEnv) {
       problems.push(`remoteEnv.surfaces has unknown surface "${surface}"`);
       continue;
     }
-    for (const field of SURFACE_BINDINGS[surface] ?? ["repository"]) {
+    for (const field of bindingsFor(surface)) {
       if (!block[field]) {
         problems.push(`remoteEnv.surfaces["${surface}"] has no ${field}`);
       }
@@ -191,9 +205,7 @@ export function validateRemoteEnv(remoteEnv) {
 export function isProvisioned(remoteEnv, surface) {
   const block = remoteEnv?.surfaces?.[surface];
   if (!block) return false;
-  return (SURFACE_BINDINGS[surface] ?? ["repository"]).every(field =>
-    Boolean(block[field])
-  );
+  return bindingsFor(surface).every(field => Boolean(block[field]));
 }
 
 /**

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -19,14 +19,45 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { SURFACES as SURFACE_CAPABILITIES } from "./surfaces.mjs";
+
 /** Providers with a read implementation today. */
 const IMPLEMENTED_PROVIDERS = new Set(["bitwarden", "doppler", "env"]);
 
 /** Providers named in the dispatch table but not yet implemented. */
 const DECLARED_PROVIDERS = new Set(["1password", "aws", "vault"]);
 
-/** Surfaces the resolver knows. */
-const SURFACES = new Set(["local", "github-actions", "codex-cloud"]);
+/**
+ * Surfaces the resolver knows.
+ *
+ * Derived from the resolver's own table rather than restated here. The two
+ * lists previously drifted apart by construction: adding a surface meant
+ * remembering to edit a second file, and forgetting produced a config that
+ * resolved correctly at runtime while `doctor` called it unknown.
+ */
+const SURFACES = new Set(Object.keys(SURFACE_CAPABILITIES));
+
+/**
+ * What a provisioned surface must record before anything dispatches to it.
+ *
+ * Deliberately not uniform, because these surfaces do not bind the same way. A
+ * Codex Cloud environment is bound to one repository, so naming the repository
+ * is part of proving the environment is the right one. A Claude cloud
+ * environment has no repository at all — it is account-scoped configuration
+ * (network policy, variables, setup script) and the repository arrives per
+ * session — so its durable handle is the routine that dispatch fires.
+ *
+ * Requiring `repository` of every surface, as this file used to, would demand
+ * a field that cannot be true of `claude-web` in any meaningful sense.
+ *
+ * `repository` stays the default so every existing surface keeps its current
+ * contract. This file checks structure only — whether a declaration *could* be
+ * correct — so it deliberately does not restate the fuller preconditions that
+ * `lisa-remote-dispatch` enforces at the moment it actually dispatches.
+ */
+const SURFACE_BINDINGS = {
+  "claude-web": ["routineId", "fireUrl"],
+};
 
 /** Install methods the toolchain runner supports. */
 const INSTALL_METHODS = new Set(["release-zip", "npm-global"]);
@@ -139,13 +170,30 @@ export function validateRemoteEnv(remoteEnv) {
   for (const [surface, block] of Object.entries(remoteEnv.surfaces ?? {})) {
     if (!SURFACES.has(surface)) {
       problems.push(`remoteEnv.surfaces has unknown surface "${surface}"`);
+      continue;
     }
-    if (!block.repository) {
-      problems.push(`remoteEnv.surfaces["${surface}"] has no repository`);
+    for (const field of SURFACE_BINDINGS[surface] ?? ["repository"]) {
+      if (!block[field]) {
+        problems.push(`remoteEnv.surfaces["${surface}"] has no ${field}`);
+      }
     }
   }
 
   return problems;
+}
+
+/**
+ * Report whether a surface has been provisioned far enough to dispatch to.
+ * @param {object|undefined} remoteEnv The remote-environment block.
+ * @param {string} surface Surface name.
+ * @returns {boolean} Whether every binding field is recorded.
+ */
+export function isProvisioned(remoteEnv, surface) {
+  const block = remoteEnv?.surfaces?.[surface];
+  if (!block) return false;
+  return (SURFACE_BINDINGS[surface] ?? ["repository"]).every(field =>
+    Boolean(block[field])
+  );
 }
 
 /**
@@ -173,7 +221,7 @@ export function validateAutomations(automations, remoteEnv) {
       );
       continue;
     }
-    if (!remoteEnv?.surfaces?.[loop.executionEnv]?.repository) {
+    if (!isProvisioned(remoteEnv, loop.executionEnv)) {
       problems.push(
         `automations["${name}"] dispatches to "${loop.executionEnv}", which is ` +
           `not provisioned. Run /lisa:setup:remote-env ${loop.executionEnv} first.`

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -48,6 +48,16 @@ function fingerprint(value) {
 }
 
 /**
+ * The value a proxied credential reads as instead of a usable token.
+ *
+ * Some surfaces keep a credential outside the sandbox entirely and substitute
+ * the real value at egress. The variable is then present and non-empty, which
+ * is exactly what makes it dangerous: a presence check passes, and only a
+ * consumer that reads the variable *itself* discovers it holds a placeholder.
+ */
+const PROXY_PLACEHOLDER = "proxy-injected";
+
+/**
  * Assert every declared name actually resolves.
  * @param {object} cfg Resolved configuration.
  * @param {Map<string, object>} provider Provider view.
@@ -56,18 +66,36 @@ function fingerprint(value) {
  */
 export function checkRequired(cfg, provider, file, report) {
   for (const name of cfg.require ?? []) {
-    const resolves =
-      (process.env[name] ?? "").trim() ||
-      file.get(name) ||
-      provider.get(name)?.value;
-    if (resolves) report("ok", name, "resolves");
-    else
+    const fromEnv = (process.env[name] ?? "").trim();
+    const resolves = fromEnv || file.get(name) || provider.get(name)?.value;
+
+    if (!resolves) {
       report(
         "error",
         name,
         "declared in secrets.require but resolves nowhere — a startup error, " +
           "not a late surprise"
       );
+      continue;
+    }
+
+    // Reported separately from "resolves" because the two are not the same
+    // claim. A tool that authenticates through the proxy works; a script that
+    // reads this variable and puts it in an Authorization header sends the
+    // literal placeholder and gets a confusing auth failure far from here.
+    if (fromEnv === PROXY_PLACEHOLDER) {
+      report(
+        "warn",
+        name,
+        `reads as the literal string "${PROXY_PLACEHOLDER}" — the value is ` +
+          `substituted at egress and never enters this environment. Tools that ` +
+          `authenticate through the proxy work; anything reading this variable ` +
+          `directly gets the placeholder, not a credential`
+      );
+      continue;
+    }
+
+    report("ok", name, "resolves");
   }
 }
 

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -28,11 +28,19 @@ import { join } from "node:path";
  * drift and leak. It is *required* on surfaces whose bootstrap runs before the
  * consuming process exists and which therefore have no other channel; a remote
  * agent container prepares itself during setup, long before any task starts.
+ *
+ * The two remote surfaces share the capability but not the timing, and a reader
+ * adding a third should not assume otherwise. `codex-cloud` re-runs its setup
+ * script when a container resumes, so materializing there picks up a rotated
+ * value. `claude-web` *skips* its setup script whenever a filesystem cache
+ * exists, so materializing there would strand a rotated value until the cache
+ * expired — its materialize step runs from a session-start hook instead.
  */
 export const SURFACES = {
   local: { materialized: false, mayWriteValues: false },
   "github-actions": { materialized: false, mayWriteValues: false },
   "codex-cloud": { materialized: true, mayWriteValues: true },
+  "claude-web": { materialized: true, mayWriteValues: true },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */
@@ -68,6 +76,10 @@ export function detectSurface(configured = null, env = process.env) {
     return explicit;
   }
   if ((env.GITHUB_ACTIONS ?? "") === "true") return "github-actions";
+  // Compared to the exact string rather than tested for presence: the variable
+  // is documented as carrying "true" in a cloud session and never being true
+  // locally, so a presence test would misread a shell that exports it empty.
+  if ((env.CLAUDE_CODE_REMOTE ?? "") === "true") return "claude-web";
   if ((env.CODEX_SANDBOX ?? env.CODEX_HOME ?? "") !== "") return "codex-cloud";
   return "local";
 }

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -59,6 +59,20 @@ const SURFACE_BINDINGS = {
   "claude-web": ["routineId", "fireUrl"],
 };
 
+/**
+ * The fields a surface must record, with the default applied.
+ *
+ * Read through one helper rather than at each call site, because the two
+ * callers answer different questions — "could this declaration be correct" and
+ * "may an automation dispatch to it" — and a fallback that drifted between them
+ * would let those answers disagree about the very same config.
+ * @param {string} surface Surface name.
+ * @returns {string[]} Field names that must be present.
+ */
+function bindingsFor(surface) {
+  return SURFACE_BINDINGS[surface] ?? ["repository"];
+}
+
 /** Install methods the toolchain runner supports. */
 const INSTALL_METHODS = new Set(["release-zip", "npm-global"]);
 
@@ -172,7 +186,7 @@ export function validateRemoteEnv(remoteEnv) {
       problems.push(`remoteEnv.surfaces has unknown surface "${surface}"`);
       continue;
     }
-    for (const field of SURFACE_BINDINGS[surface] ?? ["repository"]) {
+    for (const field of bindingsFor(surface)) {
       if (!block[field]) {
         problems.push(`remoteEnv.surfaces["${surface}"] has no ${field}`);
       }
@@ -191,9 +205,7 @@ export function validateRemoteEnv(remoteEnv) {
 export function isProvisioned(remoteEnv, surface) {
   const block = remoteEnv?.surfaces?.[surface];
   if (!block) return false;
-  return (SURFACE_BINDINGS[surface] ?? ["repository"]).every(field =>
-    Boolean(block[field])
-  );
+  return bindingsFor(surface).every(field => Boolean(block[field]));
 }
 
 /**

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -19,14 +19,45 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { SURFACES as SURFACE_CAPABILITIES } from "./surfaces.mjs";
+
 /** Providers with a read implementation today. */
 const IMPLEMENTED_PROVIDERS = new Set(["bitwarden", "doppler", "env"]);
 
 /** Providers named in the dispatch table but not yet implemented. */
 const DECLARED_PROVIDERS = new Set(["1password", "aws", "vault"]);
 
-/** Surfaces the resolver knows. */
-const SURFACES = new Set(["local", "github-actions", "codex-cloud"]);
+/**
+ * Surfaces the resolver knows.
+ *
+ * Derived from the resolver's own table rather than restated here. The two
+ * lists previously drifted apart by construction: adding a surface meant
+ * remembering to edit a second file, and forgetting produced a config that
+ * resolved correctly at runtime while `doctor` called it unknown.
+ */
+const SURFACES = new Set(Object.keys(SURFACE_CAPABILITIES));
+
+/**
+ * What a provisioned surface must record before anything dispatches to it.
+ *
+ * Deliberately not uniform, because these surfaces do not bind the same way. A
+ * Codex Cloud environment is bound to one repository, so naming the repository
+ * is part of proving the environment is the right one. A Claude cloud
+ * environment has no repository at all — it is account-scoped configuration
+ * (network policy, variables, setup script) and the repository arrives per
+ * session — so its durable handle is the routine that dispatch fires.
+ *
+ * Requiring `repository` of every surface, as this file used to, would demand
+ * a field that cannot be true of `claude-web` in any meaningful sense.
+ *
+ * `repository` stays the default so every existing surface keeps its current
+ * contract. This file checks structure only — whether a declaration *could* be
+ * correct — so it deliberately does not restate the fuller preconditions that
+ * `lisa-remote-dispatch` enforces at the moment it actually dispatches.
+ */
+const SURFACE_BINDINGS = {
+  "claude-web": ["routineId", "fireUrl"],
+};
 
 /** Install methods the toolchain runner supports. */
 const INSTALL_METHODS = new Set(["release-zip", "npm-global"]);
@@ -139,13 +170,30 @@ export function validateRemoteEnv(remoteEnv) {
   for (const [surface, block] of Object.entries(remoteEnv.surfaces ?? {})) {
     if (!SURFACES.has(surface)) {
       problems.push(`remoteEnv.surfaces has unknown surface "${surface}"`);
+      continue;
     }
-    if (!block.repository) {
-      problems.push(`remoteEnv.surfaces["${surface}"] has no repository`);
+    for (const field of SURFACE_BINDINGS[surface] ?? ["repository"]) {
+      if (!block[field]) {
+        problems.push(`remoteEnv.surfaces["${surface}"] has no ${field}`);
+      }
     }
   }
 
   return problems;
+}
+
+/**
+ * Report whether a surface has been provisioned far enough to dispatch to.
+ * @param {object|undefined} remoteEnv The remote-environment block.
+ * @param {string} surface Surface name.
+ * @returns {boolean} Whether every binding field is recorded.
+ */
+export function isProvisioned(remoteEnv, surface) {
+  const block = remoteEnv?.surfaces?.[surface];
+  if (!block) return false;
+  return (SURFACE_BINDINGS[surface] ?? ["repository"]).every(field =>
+    Boolean(block[field])
+  );
 }
 
 /**
@@ -173,7 +221,7 @@ export function validateAutomations(automations, remoteEnv) {
       );
       continue;
     }
-    if (!remoteEnv?.surfaces?.[loop.executionEnv]?.repository) {
+    if (!isProvisioned(remoteEnv, loop.executionEnv)) {
       problems.push(
         `automations["${name}"] dispatches to "${loop.executionEnv}", which is ` +
           `not provisioned. Run /lisa:setup:remote-env ${loop.executionEnv} first.`

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -48,6 +48,16 @@ function fingerprint(value) {
 }
 
 /**
+ * The value a proxied credential reads as instead of a usable token.
+ *
+ * Some surfaces keep a credential outside the sandbox entirely and substitute
+ * the real value at egress. The variable is then present and non-empty, which
+ * is exactly what makes it dangerous: a presence check passes, and only a
+ * consumer that reads the variable *itself* discovers it holds a placeholder.
+ */
+const PROXY_PLACEHOLDER = "proxy-injected";
+
+/**
  * Assert every declared name actually resolves.
  * @param {object} cfg Resolved configuration.
  * @param {Map<string, object>} provider Provider view.
@@ -56,18 +66,36 @@ function fingerprint(value) {
  */
 export function checkRequired(cfg, provider, file, report) {
   for (const name of cfg.require ?? []) {
-    const resolves =
-      (process.env[name] ?? "").trim() ||
-      file.get(name) ||
-      provider.get(name)?.value;
-    if (resolves) report("ok", name, "resolves");
-    else
+    const fromEnv = (process.env[name] ?? "").trim();
+    const resolves = fromEnv || file.get(name) || provider.get(name)?.value;
+
+    if (!resolves) {
       report(
         "error",
         name,
         "declared in secrets.require but resolves nowhere — a startup error, " +
           "not a late surprise"
       );
+      continue;
+    }
+
+    // Reported separately from "resolves" because the two are not the same
+    // claim. A tool that authenticates through the proxy works; a script that
+    // reads this variable and puts it in an Authorization header sends the
+    // literal placeholder and gets a confusing auth failure far from here.
+    if (fromEnv === PROXY_PLACEHOLDER) {
+      report(
+        "warn",
+        name,
+        `reads as the literal string "${PROXY_PLACEHOLDER}" — the value is ` +
+          `substituted at egress and never enters this environment. Tools that ` +
+          `authenticate through the proxy work; anything reading this variable ` +
+          `directly gets the placeholder, not a credential`
+      );
+      continue;
+    }
+
+    report("ok", name, "resolves");
   }
 }
 

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -28,11 +28,19 @@ import { join } from "node:path";
  * drift and leak. It is *required* on surfaces whose bootstrap runs before the
  * consuming process exists and which therefore have no other channel; a remote
  * agent container prepares itself during setup, long before any task starts.
+ *
+ * The two remote surfaces share the capability but not the timing, and a reader
+ * adding a third should not assume otherwise. `codex-cloud` re-runs its setup
+ * script when a container resumes, so materializing there picks up a rotated
+ * value. `claude-web` *skips* its setup script whenever a filesystem cache
+ * exists, so materializing there would strand a rotated value until the cache
+ * expired — its materialize step runs from a session-start hook instead.
  */
 export const SURFACES = {
   local: { materialized: false, mayWriteValues: false },
   "github-actions": { materialized: false, mayWriteValues: false },
   "codex-cloud": { materialized: true, mayWriteValues: true },
+  "claude-web": { materialized: true, mayWriteValues: true },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */
@@ -68,6 +76,10 @@ export function detectSurface(configured = null, env = process.env) {
     return explicit;
   }
   if ((env.GITHUB_ACTIONS ?? "") === "true") return "github-actions";
+  // Compared to the exact string rather than tested for presence: the variable
+  // is documented as carrying "true" in a cloud session and never being true
+  // locally, so a presence test would misread a shell that exports it empty.
+  if ((env.CLAUDE_CODE_REMOTE ?? "") === "true") return "claude-web";
   if ((env.CODEX_SANDBOX ?? env.CODEX_HOME ?? "") !== "") return "codex-cloud";
   return "local";
 }

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -59,6 +59,20 @@ const SURFACE_BINDINGS = {
   "claude-web": ["routineId", "fireUrl"],
 };
 
+/**
+ * The fields a surface must record, with the default applied.
+ *
+ * Read through one helper rather than at each call site, because the two
+ * callers answer different questions — "could this declaration be correct" and
+ * "may an automation dispatch to it" — and a fallback that drifted between them
+ * would let those answers disagree about the very same config.
+ * @param {string} surface Surface name.
+ * @returns {string[]} Field names that must be present.
+ */
+function bindingsFor(surface) {
+  return SURFACE_BINDINGS[surface] ?? ["repository"];
+}
+
 /** Install methods the toolchain runner supports. */
 const INSTALL_METHODS = new Set(["release-zip", "npm-global"]);
 
@@ -172,7 +186,7 @@ export function validateRemoteEnv(remoteEnv) {
       problems.push(`remoteEnv.surfaces has unknown surface "${surface}"`);
       continue;
     }
-    for (const field of SURFACE_BINDINGS[surface] ?? ["repository"]) {
+    for (const field of bindingsFor(surface)) {
       if (!block[field]) {
         problems.push(`remoteEnv.surfaces["${surface}"] has no ${field}`);
       }
@@ -191,9 +205,7 @@ export function validateRemoteEnv(remoteEnv) {
 export function isProvisioned(remoteEnv, surface) {
   const block = remoteEnv?.surfaces?.[surface];
   if (!block) return false;
-  return (SURFACE_BINDINGS[surface] ?? ["repository"]).every(field =>
-    Boolean(block[field])
-  );
+  return bindingsFor(surface).every(field => Boolean(block[field]));
 }
 
 /**

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -19,14 +19,45 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { SURFACES as SURFACE_CAPABILITIES } from "./surfaces.mjs";
+
 /** Providers with a read implementation today. */
 const IMPLEMENTED_PROVIDERS = new Set(["bitwarden", "doppler", "env"]);
 
 /** Providers named in the dispatch table but not yet implemented. */
 const DECLARED_PROVIDERS = new Set(["1password", "aws", "vault"]);
 
-/** Surfaces the resolver knows. */
-const SURFACES = new Set(["local", "github-actions", "codex-cloud"]);
+/**
+ * Surfaces the resolver knows.
+ *
+ * Derived from the resolver's own table rather than restated here. The two
+ * lists previously drifted apart by construction: adding a surface meant
+ * remembering to edit a second file, and forgetting produced a config that
+ * resolved correctly at runtime while `doctor` called it unknown.
+ */
+const SURFACES = new Set(Object.keys(SURFACE_CAPABILITIES));
+
+/**
+ * What a provisioned surface must record before anything dispatches to it.
+ *
+ * Deliberately not uniform, because these surfaces do not bind the same way. A
+ * Codex Cloud environment is bound to one repository, so naming the repository
+ * is part of proving the environment is the right one. A Claude cloud
+ * environment has no repository at all — it is account-scoped configuration
+ * (network policy, variables, setup script) and the repository arrives per
+ * session — so its durable handle is the routine that dispatch fires.
+ *
+ * Requiring `repository` of every surface, as this file used to, would demand
+ * a field that cannot be true of `claude-web` in any meaningful sense.
+ *
+ * `repository` stays the default so every existing surface keeps its current
+ * contract. This file checks structure only — whether a declaration *could* be
+ * correct — so it deliberately does not restate the fuller preconditions that
+ * `lisa-remote-dispatch` enforces at the moment it actually dispatches.
+ */
+const SURFACE_BINDINGS = {
+  "claude-web": ["routineId", "fireUrl"],
+};
 
 /** Install methods the toolchain runner supports. */
 const INSTALL_METHODS = new Set(["release-zip", "npm-global"]);
@@ -139,13 +170,30 @@ export function validateRemoteEnv(remoteEnv) {
   for (const [surface, block] of Object.entries(remoteEnv.surfaces ?? {})) {
     if (!SURFACES.has(surface)) {
       problems.push(`remoteEnv.surfaces has unknown surface "${surface}"`);
+      continue;
     }
-    if (!block.repository) {
-      problems.push(`remoteEnv.surfaces["${surface}"] has no repository`);
+    for (const field of SURFACE_BINDINGS[surface] ?? ["repository"]) {
+      if (!block[field]) {
+        problems.push(`remoteEnv.surfaces["${surface}"] has no ${field}`);
+      }
     }
   }
 
   return problems;
+}
+
+/**
+ * Report whether a surface has been provisioned far enough to dispatch to.
+ * @param {object|undefined} remoteEnv The remote-environment block.
+ * @param {string} surface Surface name.
+ * @returns {boolean} Whether every binding field is recorded.
+ */
+export function isProvisioned(remoteEnv, surface) {
+  const block = remoteEnv?.surfaces?.[surface];
+  if (!block) return false;
+  return (SURFACE_BINDINGS[surface] ?? ["repository"]).every(field =>
+    Boolean(block[field])
+  );
 }
 
 /**
@@ -173,7 +221,7 @@ export function validateAutomations(automations, remoteEnv) {
       );
       continue;
     }
-    if (!remoteEnv?.surfaces?.[loop.executionEnv]?.repository) {
+    if (!isProvisioned(remoteEnv, loop.executionEnv)) {
       problems.push(
         `automations["${name}"] dispatches to "${loop.executionEnv}", which is ` +
           `not provisioned. Run /lisa:setup:remote-env ${loop.executionEnv} first.`

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1073,7 +1073,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/SKILL.md":
       "9d7346864b04304e5b4bbb90512c7f2e701d69ab012b4fcf3b7b687221fc76bd",
     "plugins/src/base/skills/lisa-secrets-access/scripts/doctor-secrets.mjs":
-      "aca23d562016bfda30d0ace0f77668edb91e5bcda1bf278036353671c53e9cbc",
+      "62cd565234b55c1d269d94103bc33bc4f9edb4077a76ab3b975d8989fa10ebc9",
     "plugins/src/base/skills/lisa-secrets-access/scripts/envfile.mjs":
       "be4e38ce85f9268b52b29dbde264ecd8d50973c2b63a15410336234a921d9644",
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs":
@@ -1087,9 +1087,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/rotate-secret.mjs":
       "f896ef08c53c9f6a859c4ddb527f7e765c542e1fd8bb198c6d75c8f260185669",
     "plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs":
-      "1c66994259475f3c2edb6b21e27df79ce5206b2a8755f4665b97ac814689f658",
+      "97c0cde692991fdf01cf640a563cd78f2f91812f135c06eac7ac418ff2bf2c8a",
     "plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs":
-      "d1ce8808983ba4c45a6e5631606e49b8183f59a71f7e55d52baed869b895b0ab",
+      "e317eeaa65283ceadb2f25b6ca5e22178801094209420e9b516f225cebae985f",
     "plugins/src/base/skills/lisa-security-review/SKILL.md":
       "5a980eaf5efc4fcce66e75521ec5b1eda143a5b0d36e7157234a705dac94e3f5",
     "plugins/src/base/skills/lisa-security-zap-scan/SKILL.md":
@@ -2580,6 +2580,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "phaser/package-lisa/package.lisa.json": true,
     "plans/abstract-conjuring-map.md": true,
     "plans/breezy-dancing-pancake.md": true,
+    "plans/claude-web-surface.md": true,
     "plans/compiled-riding-whisper.md": true,
     "plans/completed/add-managed-files-list-to-claude-md/add-managed-files-list-to-claude-md.md": true,
     "plans/completed/add-managed-files-list-to-claude-md/jaunty-tumbling-hellman.md": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1089,7 +1089,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs":
       "97c0cde692991fdf01cf640a563cd78f2f91812f135c06eac7ac418ff2bf2c8a",
     "plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs":
-      "e317eeaa65283ceadb2f25b6ca5e22178801094209420e9b516f225cebae985f",
+      "4a5209cdc1344dc309d853d2a4197cf7eef786f0c4de4886847c731a28629522",
     "plugins/src/base/skills/lisa-security-review/SKILL.md":
       "5a980eaf5efc4fcce66e75521ec5b1eda143a5b0d36e7157234a705dac94e3f5",
     "plugins/src/base/skills/lisa-security-zap-scan/SKILL.md":

--- a/tests/unit/secrets/doctor-secrets.test.ts
+++ b/tests/unit/secrets/doctor-secrets.test.ts
@@ -34,6 +34,27 @@ const providerView = (
     ])
   );
 
+/**
+ * Run a body with one environment variable set, restoring what was there.
+ *
+ * Restores rather than deletes: these tests share one process environment with
+ * every other test in the run, so unconditionally deleting a name would quietly
+ * clear a value something else had set and depended on.
+ * @param name Variable to set for the duration of the body.
+ * @param value Value to set it to.
+ * @param body What to run while it is set.
+ */
+const withEnv = (name: string, value: string, body: () => void): void => {
+  const previous = process.env[name];
+  process.env[name] = value;
+  try {
+    body();
+  } finally {
+    if (previous === undefined) delete process.env[name];
+    else process.env[name] = previous;
+  }
+};
+
 describe("required-name assertion", () => {
   it("passes a name the provider supplies", () => {
     const { findings, report } = collector();
@@ -58,8 +79,7 @@ describe("required-name assertion", () => {
     // The variable is present and non-empty, which is exactly what makes it
     // dangerous: a presence check passes while any consumer reading the
     // variable itself receives the placeholder instead of a credential.
-    process.env.PROXIED_TOKEN = "proxy-injected";
-    try {
+    withEnv("PROXIED_TOKEN", "proxy-injected", () => {
       const { findings, report } = collector();
       checkRequired(
         { require: ["PROXIED_TOKEN"] },
@@ -69,20 +89,15 @@ describe("required-name assertion", () => {
       );
       expect(findings[0].level).toBe("warn");
       expect(findings[0].message).toMatch(/substituted at egress/i);
-    } finally {
-      delete process.env.PROXIED_TOKEN;
-    }
+    });
   });
 
   it("still resolves a real value that merely looks ordinary", () => {
-    process.env.REAL_TOKEN = "an-actual-value";
-    try {
+    withEnv("REAL_TOKEN", "an-actual-value", () => {
       const { findings, report } = collector();
       checkRequired({ require: ["REAL_TOKEN"] }, new Map(), new Map(), report);
       expect(findings[0].level).toBe("ok");
-    } finally {
-      delete process.env.REAL_TOKEN;
-    }
+    });
   });
 
   it("accepts a name satisfied only by the materialized file", () => {

--- a/tests/unit/secrets/doctor-secrets.test.ts
+++ b/tests/unit/secrets/doctor-secrets.test.ts
@@ -54,6 +54,37 @@ describe("required-name assertion", () => {
     expect(findings[0].level).toBe("error");
   });
 
+  it("does not call a proxy placeholder resolved", () => {
+    // The variable is present and non-empty, which is exactly what makes it
+    // dangerous: a presence check passes while any consumer reading the
+    // variable itself receives the placeholder instead of a credential.
+    process.env.PROXIED_TOKEN = "proxy-injected";
+    try {
+      const { findings, report } = collector();
+      checkRequired(
+        { require: ["PROXIED_TOKEN"] },
+        new Map(),
+        new Map(),
+        report
+      );
+      expect(findings[0].level).toBe("warn");
+      expect(findings[0].message).toMatch(/substituted at egress/i);
+    } finally {
+      delete process.env.PROXIED_TOKEN;
+    }
+  });
+
+  it("still resolves a real value that merely looks ordinary", () => {
+    process.env.REAL_TOKEN = "an-actual-value";
+    try {
+      const { findings, report } = collector();
+      checkRequired({ require: ["REAL_TOKEN"] }, new Map(), new Map(), report);
+      expect(findings[0].level).toBe("ok");
+    } finally {
+      delete process.env.REAL_TOKEN;
+    }
+  });
+
   it("accepts a name satisfied only by the materialized file", () => {
     const { findings, report } = collector();
     checkRequired(

--- a/tests/unit/secrets/secrets-access-contract.test.ts
+++ b/tests/unit/secrets/secrets-access-contract.test.ts
@@ -63,8 +63,9 @@ const PROJECT = "project-a";
 /** Namespace used by the materialized-file fixtures. */
 const NAMESPACE = "test-ns";
 
-/** The one surface that materializes values to disk. */
+/** The remote surfaces, both of which materialize values to disk. */
 const CODEX_CLOUD = "codex-cloud";
+const CLAUDE_WEB = "claude-web";
 
 /** The two materialized filenames, kept in one place as the contract names them. */
 const VALUES_FILE = "secrets.env";
@@ -210,10 +211,33 @@ describe("surfaces", () => {
     expect(detectSurface(null, env)).toBe(CODEX_CLOUD);
   });
 
+  it("grants the write capability to both remote surfaces", () => {
+    // Neither can read through live during setup, so both must materialize.
+    expect(SURFACES[CLAUDE_WEB].materialized).toBe(true);
+    expect(SURFACES[CLAUDE_WEB].mayWriteValues).toBe(true);
+  });
+
   it("detects a CI runner", () => {
     expect(detectSurface(null, { GITHUB_ACTIONS: "true" })).toBe(
       "github-actions"
     );
+  });
+
+  it("detects a Claude cloud session", () => {
+    // Without this the session falls through to local, which forbids writing
+    // values — so materialization refuses and the resolver reaches for a live
+    // provider read that a cloud container has no keychain to satisfy.
+    expect(detectSurface(null, { CLAUDE_CODE_REMOTE: "true" })).toBe(
+      CLAUDE_WEB
+    );
+  });
+
+  it("does not read an empty CLAUDE_CODE_REMOTE as a cloud session", () => {
+    // The variable is documented as carrying "true" remotely and never being
+    // true locally; a presence test would misread a shell that exports it empty
+    // and would grant disk-write permission on a developer's laptop.
+    expect(detectSurface(null, { CLAUDE_CODE_REMOTE: "" })).toBe("local");
+    expect(detectSurface(null, { CLAUDE_CODE_REMOTE: "false" })).toBe("local");
   });
 
   it("falls back to local", () => {

--- a/tests/unit/secrets/validate-config.test.ts
+++ b/tests/unit/secrets/validate-config.test.ts
@@ -199,6 +199,36 @@ describe("automations block", () => {
   it("accepts a loop whose surface is provisioned", () => {
     expect(validateAutomations({ intake: loop }, PROVISIONED)).toEqual([]);
   });
+
+  it("accepts a claude-web loop bound to a routine rather than a repository", () => {
+    // This is the path that actually gates dispatch, and it asks a different
+    // question of each surface: demanding a repository here would reject a
+    // correctly provisioned Claude surface, which has none to give.
+    const claudeLoop = { ...loop, executionEnv: "claude-web" };
+    const provisioned = {
+      surfaces: {
+        "claude-web": {
+          routineId: "trig_01ABC",
+          fireUrl: "https://api.anthropic.com/v1/claude_code/routines/x/fire",
+        },
+      },
+    };
+    expect(validateAutomations({ intake: claudeLoop }, provisioned)).toEqual(
+      []
+    );
+  });
+
+  it("rejects a claude-web loop whose routine was never recorded", () => {
+    const claudeLoop = { ...loop, executionEnv: "claude-web" };
+    const halfProvisioned = {
+      surfaces: { "claude-web": { routineId: "trig_01ABC" } },
+    };
+    const problems = validateAutomations(
+      { intake: claudeLoop },
+      halfProvisioned
+    );
+    expect(problems[0]).toMatch(/setup:remote-env claude-web/);
+  });
 });
 
 describe("whole-config validation", () => {

--- a/tests/unit/secrets/validate-config.test.ts
+++ b/tests/unit/secrets/validate-config.test.ts
@@ -111,6 +111,39 @@ describe("remoteEnv block", () => {
     expect(problems[0]).toMatch(/Supported: release-zip, npm-global/);
   });
 
+  it("requires a Claude surface to name its routine, not a repository", () => {
+    // A Claude cloud environment is account-scoped configuration and carries no
+    // repository at all — the repository arrives per session — so demanding one
+    // would ask for a field that cannot be true. The routine is the handle.
+    const problems = validateRemoteEnv({
+      surfaces: { "claude-web": { repository: "org/repo" } },
+    });
+    expect(problems).toHaveLength(2);
+    expect(problems.join("\n")).toMatch(/has no routineId/);
+    expect(problems.join("\n")).toMatch(/has no fireUrl/);
+  });
+
+  it("accepts a Claude surface bound to a routine", () => {
+    const problems = validateRemoteEnv({
+      surfaces: {
+        "claude-web": {
+          routineId: "trig_01ABC",
+          fireUrl: "https://api.anthropic.com/v1/claude_code/routines/x/fire",
+        },
+      },
+    });
+    expect(problems).toEqual([]);
+  });
+
+  it("knows every surface the resolver knows", () => {
+    // The two lists used to be restated independently, so a surface could be
+    // added to the resolver and still be called unknown by doctor.
+    const problems = validateRemoteEnv({
+      surfaces: { "claude-web": { routineId: "r", fireUrl: "u" } },
+    });
+    expect(problems.join("\n")).not.toMatch(/unknown surface/i);
+  });
+
   it("rejects a surface declared without a repository", () => {
     const problems = validateRemoteEnv({ surfaces: { "codex-cloud": {} } });
     expect(problems[0]).toMatch(/has no repository/i);


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2173

## The bug

A Lisa skill running inside a Claude Code cloud session falls through `detectSurface` to `local`, which carries `mayWriteValues: false`. Materialization therefore refuses, the resolver reaches for a live provider read, and a cloud container has no keychain to satisfy it — the credential manager is unreachable on that surface.

`plans/portable-secrets-remote-execution.md` shipped the provider × surface model with one remote surface and said the shape was "deliberately surface-agnostic so Claude Code web, Cursor remote, and others slot in without redesign." This is the first of four PRs making that true for Claude. Plan: `plans/claude-web-surface.md`.

## What changed

**`surfaces.mjs`** — `claude-web` joins the capability table and is detected from `CLAUDE_CODE_REMOTE`. The variable is compared to the exact string `"true"` rather than tested for presence: it is documented as carrying `"true"` remotely and never being true locally, so a presence test would misread a shell that exports it empty and would grant disk-write permission on a laptop.

The table's comment now records that the two remote surfaces share the capability but **not the timing** — `codex-cloud` re-runs its setup script on resume, while `claude-web` skips its own whenever a filesystem cache exists. A future reader adding a third surface should not assume otherwise; materializing from Claude's setup script would strand a rotated value until the cache expired, which is why PR 2 moves that step to a session-start hook.

**`doctor-secrets.mjs`** — a proxied credential is reported separately from a resolved one. Where a surface keeps a credential outside the sandbox and substitutes it at egress, the variable reads as the literal `proxy-injected`. It is present and non-empty, so the previous check reported `ok`; a tool authenticating through the proxy works, but anything reading the variable directly gets a placeholder and fails somewhere far from here. Reported as `warn` rather than `error` because the proxied path is a legitimate configuration, not a broken one.

**`validate-config.mjs`** — the surface list is now derived from the resolver's own table instead of being restated. The two had drifted by construction: adding a surface meant editing a second file, and forgetting produced a config that resolved correctly at runtime while `doctor` called it unknown. The binding requirement is now surface-aware — a Claude cloud environment is account-scoped and carries no repository at all (the repository arrives per session), so demanding one asks for a field that cannot be true; its handle is the routine that dispatch fires. `repository` remains the default, so every existing surface keeps its current contract.

## Verification

- `bun test tests/unit/secrets/` — 144 pass (8 new)
- `bun run test:unit` — 481 files, 8240 tests, all pass
- `bun run typecheck`, `bun run lint`, `bun run check:plugins`, `bun run check:upstream-evidence-manifest` — all green
- Fanned to all five variants; evidence manifest regenerated in the same commit

## Note on the plan

`claude --cloud` was probed live during planning and **refuses non-interactive invocation**, so it cannot back `executionEnv` as originally designed. Dispatch (PR 3) is redesigned onto the routine `/fire` endpoint. Recorded in the plan's Sessions table.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Web as a remote execution surface, including secret materialization and secure value writing.
  * Added Claude Web configuration and provisioning validation using routine and dispatch URL settings.
  * Added detection of Claude Web sessions in remote environments.
* **Bug Fixes**
  * Improved secret checks to distinguish valid credentials from proxy-substituted placeholders and provide clearer warnings.
* **Documentation**
  * Added a comprehensive Claude Web integration and operations plan.
* **Tests**
  * Added coverage for Claude Web detection, provisioning, configuration, and proxy-substituted secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->