### PR TITLE
Materialize secrets per session where the setup script is cached

### DIFF
--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -29,18 +29,35 @@ import { join } from "node:path";
  * consuming process exists and which therefore have no other channel; a remote
  * agent container prepares itself during setup, long before any task starts.
  *
- * The two remote surfaces share the capability but not the timing, and a reader
- * adding a third should not assume otherwise. `codex-cloud` re-runs its setup
- * script when a container resumes, so materializing there picks up a rotated
- * value. `claude-web` *skips* its setup script whenever a filesystem cache
- * exists, so materializing there would strand a rotated value until the cache
- * expired — its materialize step runs from a session-start hook instead.
+ * `materializeAt` — *when* the write happens, for surfaces that do one. The two
+ * remote surfaces share the capability but not the timing, and a reader adding a
+ * third should not assume otherwise. `codex-cloud` re-runs its setup script when
+ * a container resumes, so materializing during setup picks up a rotated value.
+ * `claude-web` *skips* its setup script whenever a filesystem cache exists, so
+ * materializing there would strand a rotated value until the cache expired —
+ * it materializes from a session-start hook instead, which runs every session.
+ *
+ * Stated as a capability rather than inferred from the surface name, so the
+ * setup runner selects its phases from the table instead of branching on which
+ * vendor it happens to be talking to.
  */
 export const SURFACES = {
-  local: { materialized: false, mayWriteValues: false },
-  "github-actions": { materialized: false, mayWriteValues: false },
-  "codex-cloud": { materialized: true, mayWriteValues: true },
-  "claude-web": { materialized: true, mayWriteValues: true },
+  local: { materialized: false, mayWriteValues: false, materializeAt: null },
+  "github-actions": {
+    materialized: false,
+    mayWriteValues: false,
+    materializeAt: null,
+  },
+  "codex-cloud": {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "setup",
+  },
+  "claude-web": {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "session-start",
+  },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
@@ -39,6 +39,20 @@ Omitting the install does not degrade gracefully. The entrypoint exits before th
 
 Order matters. The toolchain comes first because the secrets step needs the provider CLI it installs. The hook comes last because it is the only part that may assume everything else is ready.
 
+### Which phases run depends on the surface
+
+Not every surface runs all three here, and the reason is worth understanding before changing it.
+
+A surface that **re-runs this script when a container resumes** — Codex Cloud — should materialize during setup. Re-running is exactly what picks up a rotated value, an edited note, or a changed version pin.
+
+A surface that **skips this script whenever a filesystem cache exists** — Claude Code web — must not. Materializing here would write the values once and then never refresh them, so a credential rotated on Tuesday would still be serving Monday's value until the cache expired days later. Those surfaces materialize from a session-start hook instead, which runs every session including a resumed one:
+
+```sh
+bash scripts/lisa-remote-env/session-start.sh   # guard; delegates to --phase=secrets
+```
+
+The selection comes from the surface's `materializeAt` capability in `lisa-secrets-access`, not from its name, so adding a surface does not mean editing a branch. The hook is committed to the repository, so it also fires on a developer's machine — it exits `0` immediately there rather than failing, because a correct local session must not look broken.
+
 ## Toolchain manifest — two entry kinds
 
 ```json
@@ -131,6 +145,25 @@ Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
                    maintenance both run before task secrets exist>
 ```
 
+### Claude Code web is emit-only, and that is not a fallback
+
+**For Claude Code web there is no tier 1 or tier 2 to fall back from.** A cloud environment is account-scoped configuration — network access level, environment variables, setup script — edited only in the environment selector at claude.ai/code, which has no settings page, no direct URL, and no API. `/remote-env` selects an environment; it cannot create or edit one.
+
+Note what this surface's environment is *not*: it carries no repository. The repository arrives per session, so an environment is reusable across every project, and there is nothing to bind. Its durable handle is the routine that dispatch fires, which is why `remoteEnv.surfaces["claude-web"]` records `routineId` and `fireUrl` rather than a repository.
+
+Generate the exact text to paste:
+
+```sh
+node scripts/setup-remote-env.mjs --emit=claude-web
+```
+
+It reads the project's own install command from its lockfile and the bootstrap name from `secrets.bootstrap.key`, then emits the environment fields, the `.claude/settings.json` hook block, and the two base-image surprises worth knowing before they cost an afternoon:
+
+- **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
+- **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
+
+**Only the bootstrap belongs in the environment-variable box.** Values there are stored as plain text and are readable by anyone who uses the environment — on an organization-shared environment, that is every member of the organization. Everything else is materialized by the session-start hook. There is no dedicated secrets store on this surface, and personal versus shared environments cannot be told apart programmatically, so this one is a rule the operator upholds rather than something the tooling can enforce.
+
 ## Verification is tier-independent
 
 **Whatever tier provisioned it, the same read-back proves it.** Trust comes from the verify, not the mechanism — which is what makes emit-tier as trustworthy as API-tier.
@@ -139,7 +172,9 @@ Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
 scripts/verify-remote-env.mjs [SECRETS_DIR]
 ```
 
-Asserts, without printing a value: each declared tool at its pinned or minimum version, the detected surface, the secrets directory at mode `0700`, both files at mode `0600`, and a clean checkout.
+Asserts, without printing a value: each declared tool at its pinned or minimum version, the detected surface, the secrets directory at mode `0700`, both files at mode `0600`, a clean checkout, and that every name in `secrets.require` resolves to a real credential rather than a proxy placeholder.
+
+That last one exists because presence is a weaker claim than usability. A credential the surface keeps outside the sandbox and substitutes at egress is present and non-empty, so a presence check passes — and a script that reads the variable and puts it in a header sends the placeholder and fails against the service, with an error pointing anywhere but at the environment.
 
 **Never verify against vendor UI state.** On 2026-08-01 a Codex environments table reported zero tasks for an environment that had demonstrably completed one, because the task records carried a null environment identifier and the `--env` filter was correspondingly unreliable. Reconcile through durable identifiers only.
 
@@ -147,7 +182,7 @@ Asserts, without printing a value: each declared tool at its pinned or minimum v
 
 Checked when setup runs, not at 3am:
 
-- the environment exists and is bound to **this** repository as its default checkout;
+- the environment exists, and on a surface that binds one, is bound to **this** repository as its default checkout — Claude cloud environments bind no repository at all, so there is nothing to check there;
 - the bootstrap credential resolves;
 - either a checkout-local Lisa skill is present, or the project dependency install has made the pinned `@codyswann/lisa` package available under `node_modules`.
 
@@ -156,6 +191,8 @@ Fail with a message naming what is missing. Never provision-and-hope.
 ## Bootstrap credential placement
 
 On Codex Cloud the bootstrap must be an **environment variable, not a task secret**: setup runs on a new container and maintenance runs on cache resume, both before task secrets exist. The tradeoff is that the variable remains visible during the task, so compensate by keeping the machine account narrowly scoped and instructing the task never to inspect or use it.
+
+On Claude Code web the same placement applies for the same reason, with the exposure widened rather than narrowed: there is no secrets store, values are stored as plain text, and anyone who uses the environment can read them. On an organization-shared environment that is every member. Keep the bootstrap in a **personal** environment, scope the machine account to the minimum, and treat every other credential as something the session-start hook materializes rather than something a human pastes.
 
 ## Related
 

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/assets/session-start.sh
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/assets/session-start.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Session-start entrypoint for surfaces that materialize secrets per session
+# rather than during environment setup.
+#
+# Wired into the repository's `.claude/settings.json` as a SessionStart hook,
+# so it is part of the clone and runs on every session — including a session
+# resumed onto a cached environment, which is the case that matters.
+#
+# Why this exists at all: a cloud environment's setup script is skipped whenever
+# a filesystem cache exists. Materializing there would write the values once and
+# never refresh them, so a rotated credential would stay stale until the cache
+# expired days later. This hook runs every session, so the copy on disk is
+# always the provider's current view.
+#
+# It is deliberately a guard and a delegation, not a second implementation. The
+# skill-resolution ladder is subtle enough that two copies would drift, so the
+# real work stays in setup.sh and this file only decides whether to call it.
+set -euo pipefail
+
+# Exit before doing anything on a machine that is not a remote session. The hook
+# is committed to the repository, so it also fires on every local session; the
+# materialize step would correctly refuse there, but failing on a developer's
+# laptop every time they start a session is noise, not a signal.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+here="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+exec bash "${here}/setup.sh" --phase=secrets "$@"

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -300,7 +300,7 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "-------------",
     "  Start a session and run the read-back. Whatever provisioned an",
     "  environment, the same verify is what makes it trustworthy:",
-    "    node scripts/verify-remote-env.mjs",
+    "    node node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs",
   ].join("\n");
 }
 

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -5,15 +5,26 @@
  * This is the script a remote environment's setup **and** maintenance fields
  * call. They are the same script on purpose. A container may be built fresh or
  * resumed from cache, and every step here is idempotent and version-aware, so
- * running it twice is correct and running it on resume is what picks up a
- * rotated value, an edited note, or a changed version pin.
+ * running it twice is correct.
  *
  * Order matters. The toolchain comes first because the secrets step needs the
  * provider CLI that the toolchain installs. The project hook comes last because
  * it is the only part that may assume everything else is ready.
  *
+ * **Which phases run depends on the surface, and the reason is not cosmetic.**
+ * On a surface that re-runs this script when a container resumes, materializing
+ * here is what picks up a rotated value. On a surface that *skips* it whenever a
+ * filesystem cache exists, materializing here would write the value once and
+ * then never refresh it — a rotated credential would stay stale until the cache
+ * expired. Those surfaces materialize from a session-start hook instead, which
+ * runs every session including resumed ones, and `--phase=secrets` is how that
+ * hook re-enters this file.
+ *
+ * The selection comes from the surface's `materializeAt` capability rather than
+ * from its name, so adding a surface does not mean editing a branch here.
+ *
  * Usage:
- *   setup-remote-env.mjs [--dry-run]
+ *   setup-remote-env.mjs [--dry-run] [--phase=toolchain|secrets|hook]
  * @module setup-remote-env
  */
 
@@ -26,7 +37,7 @@ import {
   rmSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
 
@@ -197,31 +208,252 @@ function runHook(hook, dryRun) {
   execFileSync("bash", [path], { stdio: "inherit" });
 }
 
-function main() {
-  const dryRun = process.argv.includes("--dry-run");
-  const cfg = readRemoteEnvConfig();
+/** Phases this runner can execute, in the order they must happen. */
+const PHASES = ["toolchain", "secrets", "hook"];
 
-  console.log("Toolchain:");
-  applyToolchain(cfg.tools, dryRun);
+/**
+ * The settings block that wires the session-start hook into a repository.
+ *
+ * Emitted rather than written, because `.claude/settings.json` belongs to the
+ * project: it may already carry hooks, and merging someone else's file from
+ * here is how a careless tool destroys a configuration it did not understand.
+ */
+const SESSION_START_BLOCK = `{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \\"$CLAUDE_PROJECT_DIR\\"/scripts/lisa-remote-env/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}`;
 
-  console.log("\nSecrets:");
-  const materialize = siblingScript(
-    "lisa-secrets-access",
-    "materialize-secrets.mjs"
+/**
+ * Produce the configuration a human pastes to provision a Claude cloud surface.
+ *
+ * This surface has no API tier and no console tier to fall back to: a Claude
+ * cloud environment is configured only in the environment dialog, which has no
+ * settings page, no direct URL, and no endpoint. Emit is not a degraded option
+ * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
+ * what makes the result trustworthy, exactly as it would be at any other tier.
+ * @param {{bootstrapKey: string|null, install: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitClaudeWeb({ bootstrapKey, install }) {
+  const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+  return [
+    "Provisioning tier: EMIT — and for this surface that is the only tier.",
+    "  A Claude cloud environment is account-scoped configuration edited in the",
+    "  environment selector at claude.ai/code. There is no settings page, no",
+    "  direct URL and no API, so nothing here can provision it for you.",
+    "",
+    "Paste into the environment dialog",
+    "---------------------------------",
+    "  Network access:  Trusted, or Custom plus any host your project needs",
+    "",
+    "  Environment variables:",
+    `    ${key}=<read this from your credential manager>`,
+    "",
+    "    Only the bootstrap belongs in this box. Values here are stored as",
+    "    plain text and are readable by anyone who uses the environment — on an",
+    "    organization-shared environment that is every member of the org. Every",
+    "    other credential is materialized by the session-start hook below, which",
+    "    is why exactly one value needs to live here.",
+    "",
+    "  Setup script:",
+    `    ${install} && bash scripts/lisa-remote-env/setup.sh`,
+    "",
+    "    The install must come first. On a fresh container node_modules is the",
+    "    only copy of the Lisa skills present, because Claude receives them as",
+    "    an installed plugin rather than as part of the clone.",
+    "",
+    "Commit to the repository",
+    "------------------------",
+    "  scripts/lisa-remote-env/session-start.sh   (from this skill's assets)",
+    "",
+    "  .claude/settings.json — merge this into any hooks already there:",
+    SESSION_START_BLOCK.split("\n")
+      .map(line => `    ${line}`)
+      .join("\n"),
+    "",
+    "    The setup script is skipped whenever a cached environment exists, so",
+    "    secrets are materialized from this hook instead. It runs every session,",
+    "    including a resumed one, which is what keeps a rotated value current.",
+    "",
+    "Worth knowing about this base image",
+    "-----------------------------------",
+    "  The GitHub CLI is not pre-installed. If this project's flows shell out to",
+    "  `gh`, add it to remoteEnv.tools.install with a pinned version and",
+    "  checksum, the same as any other tool.",
+    "",
+    "  A credential handled by the GitHub proxy reads as the literal string",
+    '  "proxy-injected" inside the session. Tools that authenticate through the',
+    "  proxy work; a script that reads the variable itself gets the placeholder.",
+    "",
+    "Then prove it",
+    "-------------",
+    "  Start a session and run the read-back. Whatever provisioned an",
+    "  environment, the same verify is what makes it trustworthy:",
+    "    node scripts/verify-remote-env.mjs",
+  ].join("\n");
+}
+
+/**
+ * Decide which phases this invocation runs.
+ *
+ * An explicit `--phase` always wins, because that is how a session-start hook
+ * asks for the one phase it owns. Otherwise every phase runs except a secrets
+ * step that belongs to a different moment on this surface — running it here
+ * would produce a copy that the surface never refreshes.
+ * @param {string|undefined} requested Value of `--phase`, when given.
+ * @param {string|null} materializeAt When this surface materializes.
+ * @returns {string[]} Phases to run, in order.
+ */
+export function selectPhases(requested, materializeAt) {
+  if (requested) {
+    if (!PHASES.includes(requested)) {
+      throw new Error(
+        `unknown --phase "${requested}". Known: ${PHASES.join(", ")}.`
+      );
+    }
+    if (requested === "secrets" && materializeAt !== "session-start") {
+      // Not an error: the hook is committed to the repository and runs on every
+      // surface the project is ever checked out on. Refusing loudly would make
+      // a correct local session look broken every time it started.
+      return [];
+    }
+    return [requested];
+  }
+  return PHASES.filter(
+    phase => phase !== "secrets" || materializeAt === "setup"
   );
-  execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
-    stdio: "inherit",
-  });
+}
 
-  runHook(cfg.hook, dryRun);
+/**
+ * Read the surface the resolver detects, without duplicating its rules.
+ *
+ * Imported rather than shelled out to, because the answer is a pure function of
+ * the environment and a subprocess would buy nothing. The path is converted to
+ * a file URL first: a bare absolute path is not a portable module specifier.
+ * @returns {Promise<{surface: string, materializeAt: string|null}>} Detected surface.
+ */
+async function detectSurface() {
+  const script = siblingScript("lisa-secrets-access", "surfaces.mjs");
+  const mod = await import(pathToFileURL(script).href);
+  const surface = mod.detectSurface();
+  return { surface, materializeAt: mod.SURFACES[surface].materializeAt };
+}
+
+/**
+ * Name the project's own install command rather than inventing one.
+ *
+ * The emitted setup line must begin with whatever this project already uses; a
+ * guessed package manager produces a container that fails on its first command.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} The install command to place before the setup script.
+ */
+export function detectInstallCommand(cwd = process.cwd()) {
+  const lockfiles = [
+    ["bun.lockb", "bun install"],
+    ["bun.lock", "bun install"],
+    ["pnpm-lock.yaml", "pnpm install --frozen-lockfile"],
+    ["yarn.lock", "yarn install --immutable"],
+    ["package-lock.json", "npm ci"],
+  ];
+  for (const [file, command] of lockfiles) {
+    if (existsSync(join(cwd, file))) return command;
+  }
+  return "<your install command>";
+}
+
+/**
+ * Read the bootstrap key name, which is the one value the operator must paste.
+ * @param {string} [cwd] Repository root.
+ * @returns {string|null} The configured key name, when there is one.
+ */
+function readBootstrapKey(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8")).secrets?.bootstrap?.key ?? null;
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const emit = process.argv
+    .find(arg => arg.startsWith("--emit="))
+    ?.slice("--emit=".length);
+
+  if (emit) {
+    if (emit !== "claude-web") {
+      throw new Error(
+        `no emit template for surface "${emit}".\n` +
+          `Emitting is implemented for claude-web, which has no other tier.`
+      );
+    }
+    console.log(
+      emitClaudeWeb({
+        bootstrapKey: readBootstrapKey(),
+        install: detectInstallCommand(),
+      })
+    );
+    return;
+  }
+
+  const requested = process.argv
+    .find(arg => arg.startsWith("--phase="))
+    ?.slice("--phase=".length);
+  const cfg = readRemoteEnvConfig();
+  const { surface, materializeAt } = await detectSurface();
+  const phases = selectPhases(requested, materializeAt);
+
+  if (!phases.length) {
+    console.log(
+      `Nothing to do: surface "${surface}" does not materialize from a ` +
+        `session-start hook.`
+    );
+    return;
+  }
+
+  if (phases.includes("toolchain")) {
+    console.log("Toolchain:");
+    applyToolchain(cfg.tools, dryRun);
+  }
+
+  if (phases.includes("secrets")) {
+    console.log("\nSecrets:");
+    const materialize = siblingScript(
+      "lisa-secrets-access",
+      "materialize-secrets.mjs"
+    );
+    execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
+      stdio: "inherit",
+    });
+  } else if (!requested) {
+    console.log(
+      `\nSecrets: materialized from a session-start hook on "${surface}", ` +
+        `not here.\n` +
+        `  This script is skipped whenever a cached environment exists, so a ` +
+        `value written\n  here would go stale the moment it was rotated. The ` +
+        `hook runs every session.`
+    );
+  }
+
+  if (phases.includes("hook")) runHook(cfg.hook, dryRun);
   console.log(`\nRemote environment ${dryRun ? "plan complete" : "ready"}.`);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  try {
-    main();
-  } catch (err) {
+  // Awaited rather than called bare: main is async, so a synchronous try/catch
+  // would let a rejected promise escape as an unhandled rejection and exit 0 —
+  // reporting a prepared environment that was never prepared.
+  main().catch(err => {
     console.error(err.message);
     process.exit(1);
-  }
+  });
 }

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -22,7 +22,8 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
 
 import { readRemoteEnvConfig } from "./setup-remote-env.mjs";
 import { extractVersion } from "./toolchain.mjs";
@@ -120,6 +121,43 @@ function verifyToolchain(tools) {
 }
 
 /**
+ * Assert that a declared credential is genuinely readable, not a proxy stand-in.
+ *
+ * A surface may keep a credential outside the sandbox entirely and substitute
+ * the real value at egress. The variable is then present and non-empty, so a
+ * presence check passes — and a script that reads the variable and puts it in a
+ * header sends the placeholder and fails somewhere far from here, with an error
+ * that points at the service rather than at the environment.
+ *
+ * Reported without printing any value: the placeholder is compared, and a real
+ * credential is only ever reported as present.
+ *
+ * Takes its reporter as an argument rather than writing to this module's
+ * results array, so the rule can be exercised against a synthetic environment
+ * without a container and without leaking findings between runs.
+ * @param {string[]} required Declared credential names.
+ * @param {Record<string, string|undefined>} env Environment to inspect.
+ * @param {(ok: boolean, label: string, detail: string) => void} report Collector.
+ */
+export function verifyNotProxied(required, env, report) {
+  for (const name of required) {
+    const value = (env[name] ?? "").trim();
+    if (!value) {
+      report(false, `credential ${name}`, "declared but not present");
+      continue;
+    }
+    report(
+      value !== "proxy-injected",
+      `credential ${name}`,
+      value === "proxy-injected"
+        ? 'reads as "proxy-injected" — substituted at egress, so anything ' +
+            "reading this variable directly receives the placeholder"
+        : "present"
+    );
+  }
+}
+
+/**
  * Assert the working tree is clean.
  *
  * A remote environment that starts dirty will carry unrelated changes into
@@ -142,11 +180,23 @@ function verifyCleanCheckout() {
   }
 }
 
+/**
+ * Read the credential names the project declares it needs.
+ * @param {string} [cwd] Repository root.
+ * @returns {string[]} Declared names, or none when unconfigured.
+ */
+function readRequired(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (!existsSync(path)) return [];
+  return JSON.parse(readFileSync(path, "utf8")).secrets?.require ?? [];
+}
+
 function main() {
   const cfg = readRemoteEnvConfig();
   const secretsDir = process.argv[2];
 
   verifyToolchain(cfg.tools);
+  verifyNotProxied(readRequired(), process.env, check);
 
   const surface = node([
     new URL(

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -188,7 +188,12 @@ function verifyCleanCheckout() {
 function readRequired(cwd = process.cwd()) {
   const path = join(cwd, ".lisa.config.json");
   if (!existsSync(path)) return [];
-  return JSON.parse(readFileSync(path, "utf8")).secrets?.require ?? [];
+  const required = JSON.parse(readFileSync(path, "utf8")).secrets?.require;
+  if (required == null) return [];
+  if (!Array.isArray(required)) {
+    throw new Error("secrets.require must be an array when present");
+  }
+  return required;
 }
 
 function main() {

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -29,18 +29,35 @@ import { join } from "node:path";
  * consuming process exists and which therefore have no other channel; a remote
  * agent container prepares itself during setup, long before any task starts.
  *
- * The two remote surfaces share the capability but not the timing, and a reader
- * adding a third should not assume otherwise. `codex-cloud` re-runs its setup
- * script when a container resumes, so materializing there picks up a rotated
- * value. `claude-web` *skips* its setup script whenever a filesystem cache
- * exists, so materializing there would strand a rotated value until the cache
- * expired — its materialize step runs from a session-start hook instead.
+ * `materializeAt` — *when* the write happens, for surfaces that do one. The two
+ * remote surfaces share the capability but not the timing, and a reader adding a
+ * third should not assume otherwise. `codex-cloud` re-runs its setup script when
+ * a container resumes, so materializing during setup picks up a rotated value.
+ * `claude-web` *skips* its setup script whenever a filesystem cache exists, so
+ * materializing there would strand a rotated value until the cache expired —
+ * it materializes from a session-start hook instead, which runs every session.
+ *
+ * Stated as a capability rather than inferred from the surface name, so the
+ * setup runner selects its phases from the table instead of branching on which
+ * vendor it happens to be talking to.
  */
 export const SURFACES = {
-  local: { materialized: false, mayWriteValues: false },
-  "github-actions": { materialized: false, mayWriteValues: false },
-  "codex-cloud": { materialized: true, mayWriteValues: true },
-  "claude-web": { materialized: true, mayWriteValues: true },
+  local: { materialized: false, mayWriteValues: false, materializeAt: null },
+  "github-actions": {
+    materialized: false,
+    mayWriteValues: false,
+    materializeAt: null,
+  },
+  "codex-cloud": {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "setup",
+  },
+  "claude-web": {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "session-start",
+  },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
@@ -39,6 +39,20 @@ Omitting the install does not degrade gracefully. The entrypoint exits before th
 
 Order matters. The toolchain comes first because the secrets step needs the provider CLI it installs. The hook comes last because it is the only part that may assume everything else is ready.
 
+### Which phases run depends on the surface
+
+Not every surface runs all three here, and the reason is worth understanding before changing it.
+
+A surface that **re-runs this script when a container resumes** — Codex Cloud — should materialize during setup. Re-running is exactly what picks up a rotated value, an edited note, or a changed version pin.
+
+A surface that **skips this script whenever a filesystem cache exists** — Claude Code web — must not. Materializing here would write the values once and then never refresh them, so a credential rotated on Tuesday would still be serving Monday's value until the cache expired days later. Those surfaces materialize from a session-start hook instead, which runs every session including a resumed one:
+
+```sh
+bash scripts/lisa-remote-env/session-start.sh   # guard; delegates to --phase=secrets
+```
+
+The selection comes from the surface's `materializeAt` capability in `lisa-secrets-access`, not from its name, so adding a surface does not mean editing a branch. The hook is committed to the repository, so it also fires on a developer's machine — it exits `0` immediately there rather than failing, because a correct local session must not look broken.
+
 ## Toolchain manifest — two entry kinds
 
 ```json
@@ -131,6 +145,25 @@ Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
                    maintenance both run before task secrets exist>
 ```
 
+### Claude Code web is emit-only, and that is not a fallback
+
+**For Claude Code web there is no tier 1 or tier 2 to fall back from.** A cloud environment is account-scoped configuration — network access level, environment variables, setup script — edited only in the environment selector at claude.ai/code, which has no settings page, no direct URL, and no API. `/remote-env` selects an environment; it cannot create or edit one.
+
+Note what this surface's environment is *not*: it carries no repository. The repository arrives per session, so an environment is reusable across every project, and there is nothing to bind. Its durable handle is the routine that dispatch fires, which is why `remoteEnv.surfaces["claude-web"]` records `routineId` and `fireUrl` rather than a repository.
+
+Generate the exact text to paste:
+
+```sh
+node scripts/setup-remote-env.mjs --emit=claude-web
+```
+
+It reads the project's own install command from its lockfile and the bootstrap name from `secrets.bootstrap.key`, then emits the environment fields, the `.claude/settings.json` hook block, and the two base-image surprises worth knowing before they cost an afternoon:
+
+- **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
+- **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
+
+**Only the bootstrap belongs in the environment-variable box.** Values there are stored as plain text and are readable by anyone who uses the environment — on an organization-shared environment, that is every member of the organization. Everything else is materialized by the session-start hook. There is no dedicated secrets store on this surface, and personal versus shared environments cannot be told apart programmatically, so this one is a rule the operator upholds rather than something the tooling can enforce.
+
 ## Verification is tier-independent
 
 **Whatever tier provisioned it, the same read-back proves it.** Trust comes from the verify, not the mechanism — which is what makes emit-tier as trustworthy as API-tier.
@@ -139,7 +172,9 @@ Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
 scripts/verify-remote-env.mjs [SECRETS_DIR]
 ```
 
-Asserts, without printing a value: each declared tool at its pinned or minimum version, the detected surface, the secrets directory at mode `0700`, both files at mode `0600`, and a clean checkout.
+Asserts, without printing a value: each declared tool at its pinned or minimum version, the detected surface, the secrets directory at mode `0700`, both files at mode `0600`, a clean checkout, and that every name in `secrets.require` resolves to a real credential rather than a proxy placeholder.
+
+That last one exists because presence is a weaker claim than usability. A credential the surface keeps outside the sandbox and substitutes at egress is present and non-empty, so a presence check passes — and a script that reads the variable and puts it in a header sends the placeholder and fails against the service, with an error pointing anywhere but at the environment.
 
 **Never verify against vendor UI state.** On 2026-08-01 a Codex environments table reported zero tasks for an environment that had demonstrably completed one, because the task records carried a null environment identifier and the `--env` filter was correspondingly unreliable. Reconcile through durable identifiers only.
 
@@ -147,7 +182,7 @@ Asserts, without printing a value: each declared tool at its pinned or minimum v
 
 Checked when setup runs, not at 3am:
 
-- the environment exists and is bound to **this** repository as its default checkout;
+- the environment exists, and on a surface that binds one, is bound to **this** repository as its default checkout — Claude cloud environments bind no repository at all, so there is nothing to check there;
 - the bootstrap credential resolves;
 - either a checkout-local Lisa skill is present, or the project dependency install has made the pinned `@codyswann/lisa` package available under `node_modules`.
 
@@ -156,6 +191,8 @@ Fail with a message naming what is missing. Never provision-and-hope.
 ## Bootstrap credential placement
 
 On Codex Cloud the bootstrap must be an **environment variable, not a task secret**: setup runs on a new container and maintenance runs on cache resume, both before task secrets exist. The tradeoff is that the variable remains visible during the task, so compensate by keeping the machine account narrowly scoped and instructing the task never to inspect or use it.
+
+On Claude Code web the same placement applies for the same reason, with the exposure widened rather than narrowed: there is no secrets store, values are stored as plain text, and anyone who uses the environment can read them. On an organization-shared environment that is every member. Keep the bootstrap in a **personal** environment, scope the machine account to the minimum, and treat every other credential as something the session-start hook materializes rather than something a human pastes.
 
 ## Related
 

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/assets/session-start.sh
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/assets/session-start.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Session-start entrypoint for surfaces that materialize secrets per session
+# rather than during environment setup.
+#
+# Wired into the repository's `.claude/settings.json` as a SessionStart hook,
+# so it is part of the clone and runs on every session — including a session
+# resumed onto a cached environment, which is the case that matters.
+#
+# Why this exists at all: a cloud environment's setup script is skipped whenever
+# a filesystem cache exists. Materializing there would write the values once and
+# never refresh them, so a rotated credential would stay stale until the cache
+# expired days later. This hook runs every session, so the copy on disk is
+# always the provider's current view.
+#
+# It is deliberately a guard and a delegation, not a second implementation. The
+# skill-resolution ladder is subtle enough that two copies would drift, so the
+# real work stays in setup.sh and this file only decides whether to call it.
+set -euo pipefail
+
+# Exit before doing anything on a machine that is not a remote session. The hook
+# is committed to the repository, so it also fires on every local session; the
+# materialize step would correctly refuse there, but failing on a developer's
+# laptop every time they start a session is noise, not a signal.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+here="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+exec bash "${here}/setup.sh" --phase=secrets "$@"

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -300,7 +300,7 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "-------------",
     "  Start a session and run the read-back. Whatever provisioned an",
     "  environment, the same verify is what makes it trustworthy:",
-    "    node scripts/verify-remote-env.mjs",
+    "    node node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs",
   ].join("\n");
 }
 

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -5,15 +5,26 @@
  * This is the script a remote environment's setup **and** maintenance fields
  * call. They are the same script on purpose. A container may be built fresh or
  * resumed from cache, and every step here is idempotent and version-aware, so
- * running it twice is correct and running it on resume is what picks up a
- * rotated value, an edited note, or a changed version pin.
+ * running it twice is correct.
  *
  * Order matters. The toolchain comes first because the secrets step needs the
  * provider CLI that the toolchain installs. The project hook comes last because
  * it is the only part that may assume everything else is ready.
  *
+ * **Which phases run depends on the surface, and the reason is not cosmetic.**
+ * On a surface that re-runs this script when a container resumes, materializing
+ * here is what picks up a rotated value. On a surface that *skips* it whenever a
+ * filesystem cache exists, materializing here would write the value once and
+ * then never refresh it — a rotated credential would stay stale until the cache
+ * expired. Those surfaces materialize from a session-start hook instead, which
+ * runs every session including resumed ones, and `--phase=secrets` is how that
+ * hook re-enters this file.
+ *
+ * The selection comes from the surface's `materializeAt` capability rather than
+ * from its name, so adding a surface does not mean editing a branch here.
+ *
  * Usage:
- *   setup-remote-env.mjs [--dry-run]
+ *   setup-remote-env.mjs [--dry-run] [--phase=toolchain|secrets|hook]
  * @module setup-remote-env
  */
 
@@ -26,7 +37,7 @@ import {
   rmSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
 
@@ -197,31 +208,252 @@ function runHook(hook, dryRun) {
   execFileSync("bash", [path], { stdio: "inherit" });
 }
 
-function main() {
-  const dryRun = process.argv.includes("--dry-run");
-  const cfg = readRemoteEnvConfig();
+/** Phases this runner can execute, in the order they must happen. */
+const PHASES = ["toolchain", "secrets", "hook"];
 
-  console.log("Toolchain:");
-  applyToolchain(cfg.tools, dryRun);
+/**
+ * The settings block that wires the session-start hook into a repository.
+ *
+ * Emitted rather than written, because `.claude/settings.json` belongs to the
+ * project: it may already carry hooks, and merging someone else's file from
+ * here is how a careless tool destroys a configuration it did not understand.
+ */
+const SESSION_START_BLOCK = `{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \\"$CLAUDE_PROJECT_DIR\\"/scripts/lisa-remote-env/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}`;
 
-  console.log("\nSecrets:");
-  const materialize = siblingScript(
-    "lisa-secrets-access",
-    "materialize-secrets.mjs"
+/**
+ * Produce the configuration a human pastes to provision a Claude cloud surface.
+ *
+ * This surface has no API tier and no console tier to fall back to: a Claude
+ * cloud environment is configured only in the environment dialog, which has no
+ * settings page, no direct URL, and no endpoint. Emit is not a degraded option
+ * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
+ * what makes the result trustworthy, exactly as it would be at any other tier.
+ * @param {{bootstrapKey: string|null, install: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitClaudeWeb({ bootstrapKey, install }) {
+  const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+  return [
+    "Provisioning tier: EMIT — and for this surface that is the only tier.",
+    "  A Claude cloud environment is account-scoped configuration edited in the",
+    "  environment selector at claude.ai/code. There is no settings page, no",
+    "  direct URL and no API, so nothing here can provision it for you.",
+    "",
+    "Paste into the environment dialog",
+    "---------------------------------",
+    "  Network access:  Trusted, or Custom plus any host your project needs",
+    "",
+    "  Environment variables:",
+    `    ${key}=<read this from your credential manager>`,
+    "",
+    "    Only the bootstrap belongs in this box. Values here are stored as",
+    "    plain text and are readable by anyone who uses the environment — on an",
+    "    organization-shared environment that is every member of the org. Every",
+    "    other credential is materialized by the session-start hook below, which",
+    "    is why exactly one value needs to live here.",
+    "",
+    "  Setup script:",
+    `    ${install} && bash scripts/lisa-remote-env/setup.sh`,
+    "",
+    "    The install must come first. On a fresh container node_modules is the",
+    "    only copy of the Lisa skills present, because Claude receives them as",
+    "    an installed plugin rather than as part of the clone.",
+    "",
+    "Commit to the repository",
+    "------------------------",
+    "  scripts/lisa-remote-env/session-start.sh   (from this skill's assets)",
+    "",
+    "  .claude/settings.json — merge this into any hooks already there:",
+    SESSION_START_BLOCK.split("\n")
+      .map(line => `    ${line}`)
+      .join("\n"),
+    "",
+    "    The setup script is skipped whenever a cached environment exists, so",
+    "    secrets are materialized from this hook instead. It runs every session,",
+    "    including a resumed one, which is what keeps a rotated value current.",
+    "",
+    "Worth knowing about this base image",
+    "-----------------------------------",
+    "  The GitHub CLI is not pre-installed. If this project's flows shell out to",
+    "  `gh`, add it to remoteEnv.tools.install with a pinned version and",
+    "  checksum, the same as any other tool.",
+    "",
+    "  A credential handled by the GitHub proxy reads as the literal string",
+    '  "proxy-injected" inside the session. Tools that authenticate through the',
+    "  proxy work; a script that reads the variable itself gets the placeholder.",
+    "",
+    "Then prove it",
+    "-------------",
+    "  Start a session and run the read-back. Whatever provisioned an",
+    "  environment, the same verify is what makes it trustworthy:",
+    "    node scripts/verify-remote-env.mjs",
+  ].join("\n");
+}
+
+/**
+ * Decide which phases this invocation runs.
+ *
+ * An explicit `--phase` always wins, because that is how a session-start hook
+ * asks for the one phase it owns. Otherwise every phase runs except a secrets
+ * step that belongs to a different moment on this surface — running it here
+ * would produce a copy that the surface never refreshes.
+ * @param {string|undefined} requested Value of `--phase`, when given.
+ * @param {string|null} materializeAt When this surface materializes.
+ * @returns {string[]} Phases to run, in order.
+ */
+export function selectPhases(requested, materializeAt) {
+  if (requested) {
+    if (!PHASES.includes(requested)) {
+      throw new Error(
+        `unknown --phase "${requested}". Known: ${PHASES.join(", ")}.`
+      );
+    }
+    if (requested === "secrets" && materializeAt !== "session-start") {
+      // Not an error: the hook is committed to the repository and runs on every
+      // surface the project is ever checked out on. Refusing loudly would make
+      // a correct local session look broken every time it started.
+      return [];
+    }
+    return [requested];
+  }
+  return PHASES.filter(
+    phase => phase !== "secrets" || materializeAt === "setup"
   );
-  execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
-    stdio: "inherit",
-  });
+}
 
-  runHook(cfg.hook, dryRun);
+/**
+ * Read the surface the resolver detects, without duplicating its rules.
+ *
+ * Imported rather than shelled out to, because the answer is a pure function of
+ * the environment and a subprocess would buy nothing. The path is converted to
+ * a file URL first: a bare absolute path is not a portable module specifier.
+ * @returns {Promise<{surface: string, materializeAt: string|null}>} Detected surface.
+ */
+async function detectSurface() {
+  const script = siblingScript("lisa-secrets-access", "surfaces.mjs");
+  const mod = await import(pathToFileURL(script).href);
+  const surface = mod.detectSurface();
+  return { surface, materializeAt: mod.SURFACES[surface].materializeAt };
+}
+
+/**
+ * Name the project's own install command rather than inventing one.
+ *
+ * The emitted setup line must begin with whatever this project already uses; a
+ * guessed package manager produces a container that fails on its first command.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} The install command to place before the setup script.
+ */
+export function detectInstallCommand(cwd = process.cwd()) {
+  const lockfiles = [
+    ["bun.lockb", "bun install"],
+    ["bun.lock", "bun install"],
+    ["pnpm-lock.yaml", "pnpm install --frozen-lockfile"],
+    ["yarn.lock", "yarn install --immutable"],
+    ["package-lock.json", "npm ci"],
+  ];
+  for (const [file, command] of lockfiles) {
+    if (existsSync(join(cwd, file))) return command;
+  }
+  return "<your install command>";
+}
+
+/**
+ * Read the bootstrap key name, which is the one value the operator must paste.
+ * @param {string} [cwd] Repository root.
+ * @returns {string|null} The configured key name, when there is one.
+ */
+function readBootstrapKey(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8")).secrets?.bootstrap?.key ?? null;
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const emit = process.argv
+    .find(arg => arg.startsWith("--emit="))
+    ?.slice("--emit=".length);
+
+  if (emit) {
+    if (emit !== "claude-web") {
+      throw new Error(
+        `no emit template for surface "${emit}".\n` +
+          `Emitting is implemented for claude-web, which has no other tier.`
+      );
+    }
+    console.log(
+      emitClaudeWeb({
+        bootstrapKey: readBootstrapKey(),
+        install: detectInstallCommand(),
+      })
+    );
+    return;
+  }
+
+  const requested = process.argv
+    .find(arg => arg.startsWith("--phase="))
+    ?.slice("--phase=".length);
+  const cfg = readRemoteEnvConfig();
+  const { surface, materializeAt } = await detectSurface();
+  const phases = selectPhases(requested, materializeAt);
+
+  if (!phases.length) {
+    console.log(
+      `Nothing to do: surface "${surface}" does not materialize from a ` +
+        `session-start hook.`
+    );
+    return;
+  }
+
+  if (phases.includes("toolchain")) {
+    console.log("Toolchain:");
+    applyToolchain(cfg.tools, dryRun);
+  }
+
+  if (phases.includes("secrets")) {
+    console.log("\nSecrets:");
+    const materialize = siblingScript(
+      "lisa-secrets-access",
+      "materialize-secrets.mjs"
+    );
+    execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
+      stdio: "inherit",
+    });
+  } else if (!requested) {
+    console.log(
+      `\nSecrets: materialized from a session-start hook on "${surface}", ` +
+        `not here.\n` +
+        `  This script is skipped whenever a cached environment exists, so a ` +
+        `value written\n  here would go stale the moment it was rotated. The ` +
+        `hook runs every session.`
+    );
+  }
+
+  if (phases.includes("hook")) runHook(cfg.hook, dryRun);
   console.log(`\nRemote environment ${dryRun ? "plan complete" : "ready"}.`);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  try {
-    main();
-  } catch (err) {
+  // Awaited rather than called bare: main is async, so a synchronous try/catch
+  // would let a rejected promise escape as an unhandled rejection and exit 0 —
+  // reporting a prepared environment that was never prepared.
+  main().catch(err => {
     console.error(err.message);
     process.exit(1);
-  }
+  });
 }

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -22,7 +22,8 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
 
 import { readRemoteEnvConfig } from "./setup-remote-env.mjs";
 import { extractVersion } from "./toolchain.mjs";
@@ -120,6 +121,43 @@ function verifyToolchain(tools) {
 }
 
 /**
+ * Assert that a declared credential is genuinely readable, not a proxy stand-in.
+ *
+ * A surface may keep a credential outside the sandbox entirely and substitute
+ * the real value at egress. The variable is then present and non-empty, so a
+ * presence check passes — and a script that reads the variable and puts it in a
+ * header sends the placeholder and fails somewhere far from here, with an error
+ * that points at the service rather than at the environment.
+ *
+ * Reported without printing any value: the placeholder is compared, and a real
+ * credential is only ever reported as present.
+ *
+ * Takes its reporter as an argument rather than writing to this module's
+ * results array, so the rule can be exercised against a synthetic environment
+ * without a container and without leaking findings between runs.
+ * @param {string[]} required Declared credential names.
+ * @param {Record<string, string|undefined>} env Environment to inspect.
+ * @param {(ok: boolean, label: string, detail: string) => void} report Collector.
+ */
+export function verifyNotProxied(required, env, report) {
+  for (const name of required) {
+    const value = (env[name] ?? "").trim();
+    if (!value) {
+      report(false, `credential ${name}`, "declared but not present");
+      continue;
+    }
+    report(
+      value !== "proxy-injected",
+      `credential ${name}`,
+      value === "proxy-injected"
+        ? 'reads as "proxy-injected" — substituted at egress, so anything ' +
+            "reading this variable directly receives the placeholder"
+        : "present"
+    );
+  }
+}
+
+/**
  * Assert the working tree is clean.
  *
  * A remote environment that starts dirty will carry unrelated changes into
@@ -142,11 +180,23 @@ function verifyCleanCheckout() {
   }
 }
 
+/**
+ * Read the credential names the project declares it needs.
+ * @param {string} [cwd] Repository root.
+ * @returns {string[]} Declared names, or none when unconfigured.
+ */
+function readRequired(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (!existsSync(path)) return [];
+  return JSON.parse(readFileSync(path, "utf8")).secrets?.require ?? [];
+}
+
 function main() {
   const cfg = readRemoteEnvConfig();
   const secretsDir = process.argv[2];
 
   verifyToolchain(cfg.tools);
+  verifyNotProxied(readRequired(), process.env, check);
 
   const surface = node([
     new URL(

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -188,7 +188,12 @@ function verifyCleanCheckout() {
 function readRequired(cwd = process.cwd()) {
   const path = join(cwd, ".lisa.config.json");
   if (!existsSync(path)) return [];
-  return JSON.parse(readFileSync(path, "utf8")).secrets?.require ?? [];
+  const required = JSON.parse(readFileSync(path, "utf8")).secrets?.require;
+  if (required == null) return [];
+  if (!Array.isArray(required)) {
+    throw new Error("secrets.require must be an array when present");
+  }
+  return required;
 }
 
 function main() {

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -29,18 +29,35 @@ import { join } from "node:path";
  * consuming process exists and which therefore have no other channel; a remote
  * agent container prepares itself during setup, long before any task starts.
  *
- * The two remote surfaces share the capability but not the timing, and a reader
- * adding a third should not assume otherwise. `codex-cloud` re-runs its setup
- * script when a container resumes, so materializing there picks up a rotated
- * value. `claude-web` *skips* its setup script whenever a filesystem cache
- * exists, so materializing there would strand a rotated value until the cache
- * expired — its materialize step runs from a session-start hook instead.
+ * `materializeAt` — *when* the write happens, for surfaces that do one. The two
+ * remote surfaces share the capability but not the timing, and a reader adding a
+ * third should not assume otherwise. `codex-cloud` re-runs its setup script when
+ * a container resumes, so materializing during setup picks up a rotated value.
+ * `claude-web` *skips* its setup script whenever a filesystem cache exists, so
+ * materializing there would strand a rotated value until the cache expired —
+ * it materializes from a session-start hook instead, which runs every session.
+ *
+ * Stated as a capability rather than inferred from the surface name, so the
+ * setup runner selects its phases from the table instead of branching on which
+ * vendor it happens to be talking to.
  */
 export const SURFACES = {
-  local: { materialized: false, mayWriteValues: false },
-  "github-actions": { materialized: false, mayWriteValues: false },
-  "codex-cloud": { materialized: true, mayWriteValues: true },
-  "claude-web": { materialized: true, mayWriteValues: true },
+  local: { materialized: false, mayWriteValues: false, materializeAt: null },
+  "github-actions": {
+    materialized: false,
+    mayWriteValues: false,
+    materializeAt: null,
+  },
+  "codex-cloud": {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "setup",
+  },
+  "claude-web": {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "session-start",
+  },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
@@ -39,6 +39,20 @@ Omitting the install does not degrade gracefully. The entrypoint exits before th
 
 Order matters. The toolchain comes first because the secrets step needs the provider CLI it installs. The hook comes last because it is the only part that may assume everything else is ready.
 
+### Which phases run depends on the surface
+
+Not every surface runs all three here, and the reason is worth understanding before changing it.
+
+A surface that **re-runs this script when a container resumes** — Codex Cloud — should materialize during setup. Re-running is exactly what picks up a rotated value, an edited note, or a changed version pin.
+
+A surface that **skips this script whenever a filesystem cache exists** — Claude Code web — must not. Materializing here would write the values once and then never refresh them, so a credential rotated on Tuesday would still be serving Monday's value until the cache expired days later. Those surfaces materialize from a session-start hook instead, which runs every session including a resumed one:
+
+```sh
+bash scripts/lisa-remote-env/session-start.sh   # guard; delegates to --phase=secrets
+```
+
+The selection comes from the surface's `materializeAt` capability in `lisa-secrets-access`, not from its name, so adding a surface does not mean editing a branch. The hook is committed to the repository, so it also fires on a developer's machine — it exits `0` immediately there rather than failing, because a correct local session must not look broken.
+
 ## Toolchain manifest — two entry kinds
 
 ```json
@@ -131,6 +145,25 @@ Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
                    maintenance both run before task secrets exist>
 ```
 
+### Claude Code web is emit-only, and that is not a fallback
+
+**For Claude Code web there is no tier 1 or tier 2 to fall back from.** A cloud environment is account-scoped configuration — network access level, environment variables, setup script — edited only in the environment selector at claude.ai/code, which has no settings page, no direct URL, and no API. `/remote-env` selects an environment; it cannot create or edit one.
+
+Note what this surface's environment is *not*: it carries no repository. The repository arrives per session, so an environment is reusable across every project, and there is nothing to bind. Its durable handle is the routine that dispatch fires, which is why `remoteEnv.surfaces["claude-web"]` records `routineId` and `fireUrl` rather than a repository.
+
+Generate the exact text to paste:
+
+```sh
+node scripts/setup-remote-env.mjs --emit=claude-web
+```
+
+It reads the project's own install command from its lockfile and the bootstrap name from `secrets.bootstrap.key`, then emits the environment fields, the `.claude/settings.json` hook block, and the two base-image surprises worth knowing before they cost an afternoon:
+
+- **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
+- **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
+
+**Only the bootstrap belongs in the environment-variable box.** Values there are stored as plain text and are readable by anyone who uses the environment — on an organization-shared environment, that is every member of the organization. Everything else is materialized by the session-start hook. There is no dedicated secrets store on this surface, and personal versus shared environments cannot be told apart programmatically, so this one is a rule the operator upholds rather than something the tooling can enforce.
+
 ## Verification is tier-independent
 
 **Whatever tier provisioned it, the same read-back proves it.** Trust comes from the verify, not the mechanism — which is what makes emit-tier as trustworthy as API-tier.
@@ -139,7 +172,9 @@ Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
 scripts/verify-remote-env.mjs [SECRETS_DIR]
 ```
 
-Asserts, without printing a value: each declared tool at its pinned or minimum version, the detected surface, the secrets directory at mode `0700`, both files at mode `0600`, and a clean checkout.
+Asserts, without printing a value: each declared tool at its pinned or minimum version, the detected surface, the secrets directory at mode `0700`, both files at mode `0600`, a clean checkout, and that every name in `secrets.require` resolves to a real credential rather than a proxy placeholder.
+
+That last one exists because presence is a weaker claim than usability. A credential the surface keeps outside the sandbox and substitutes at egress is present and non-empty, so a presence check passes — and a script that reads the variable and puts it in a header sends the placeholder and fails against the service, with an error pointing anywhere but at the environment.
 
 **Never verify against vendor UI state.** On 2026-08-01 a Codex environments table reported zero tasks for an environment that had demonstrably completed one, because the task records carried a null environment identifier and the `--env` filter was correspondingly unreliable. Reconcile through durable identifiers only.
 
@@ -147,7 +182,7 @@ Asserts, without printing a value: each declared tool at its pinned or minimum v
 
 Checked when setup runs, not at 3am:
 
-- the environment exists and is bound to **this** repository as its default checkout;
+- the environment exists, and on a surface that binds one, is bound to **this** repository as its default checkout — Claude cloud environments bind no repository at all, so there is nothing to check there;
 - the bootstrap credential resolves;
 - either a checkout-local Lisa skill is present, or the project dependency install has made the pinned `@codyswann/lisa` package available under `node_modules`.
 
@@ -156,6 +191,8 @@ Fail with a message naming what is missing. Never provision-and-hope.
 ## Bootstrap credential placement
 
 On Codex Cloud the bootstrap must be an **environment variable, not a task secret**: setup runs on a new container and maintenance runs on cache resume, both before task secrets exist. The tradeoff is that the variable remains visible during the task, so compensate by keeping the machine account narrowly scoped and instructing the task never to inspect or use it.
+
+On Claude Code web the same placement applies for the same reason, with the exposure widened rather than narrowed: there is no secrets store, values are stored as plain text, and anyone who uses the environment can read them. On an organization-shared environment that is every member. Keep the bootstrap in a **personal** environment, scope the machine account to the minimum, and treat every other credential as something the session-start hook materializes rather than something a human pastes.
 
 ## Related
 

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/assets/session-start.sh
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/assets/session-start.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Session-start entrypoint for surfaces that materialize secrets per session
+# rather than during environment setup.
+#
+# Wired into the repository's `.claude/settings.json` as a SessionStart hook,
+# so it is part of the clone and runs on every session — including a session
+# resumed onto a cached environment, which is the case that matters.
+#
+# Why this exists at all: a cloud environment's setup script is skipped whenever
+# a filesystem cache exists. Materializing there would write the values once and
+# never refresh them, so a rotated credential would stay stale until the cache
+# expired days later. This hook runs every session, so the copy on disk is
+# always the provider's current view.
+#
+# It is deliberately a guard and a delegation, not a second implementation. The
+# skill-resolution ladder is subtle enough that two copies would drift, so the
+# real work stays in setup.sh and this file only decides whether to call it.
+set -euo pipefail
+
+# Exit before doing anything on a machine that is not a remote session. The hook
+# is committed to the repository, so it also fires on every local session; the
+# materialize step would correctly refuse there, but failing on a developer's
+# laptop every time they start a session is noise, not a signal.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+here="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+exec bash "${here}/setup.sh" --phase=secrets "$@"

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -300,7 +300,7 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "-------------",
     "  Start a session and run the read-back. Whatever provisioned an",
     "  environment, the same verify is what makes it trustworthy:",
-    "    node scripts/verify-remote-env.mjs",
+    "    node node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs",
   ].join("\n");
 }
 

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -5,15 +5,26 @@
  * This is the script a remote environment's setup **and** maintenance fields
  * call. They are the same script on purpose. A container may be built fresh or
  * resumed from cache, and every step here is idempotent and version-aware, so
- * running it twice is correct and running it on resume is what picks up a
- * rotated value, an edited note, or a changed version pin.
+ * running it twice is correct.
  *
  * Order matters. The toolchain comes first because the secrets step needs the
  * provider CLI that the toolchain installs. The project hook comes last because
  * it is the only part that may assume everything else is ready.
  *
+ * **Which phases run depends on the surface, and the reason is not cosmetic.**
+ * On a surface that re-runs this script when a container resumes, materializing
+ * here is what picks up a rotated value. On a surface that *skips* it whenever a
+ * filesystem cache exists, materializing here would write the value once and
+ * then never refresh it — a rotated credential would stay stale until the cache
+ * expired. Those surfaces materialize from a session-start hook instead, which
+ * runs every session including resumed ones, and `--phase=secrets` is how that
+ * hook re-enters this file.
+ *
+ * The selection comes from the surface's `materializeAt` capability rather than
+ * from its name, so adding a surface does not mean editing a branch here.
+ *
  * Usage:
- *   setup-remote-env.mjs [--dry-run]
+ *   setup-remote-env.mjs [--dry-run] [--phase=toolchain|secrets|hook]
  * @module setup-remote-env
  */
 
@@ -26,7 +37,7 @@ import {
   rmSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
 
@@ -197,31 +208,252 @@ function runHook(hook, dryRun) {
   execFileSync("bash", [path], { stdio: "inherit" });
 }
 
-function main() {
-  const dryRun = process.argv.includes("--dry-run");
-  const cfg = readRemoteEnvConfig();
+/** Phases this runner can execute, in the order they must happen. */
+const PHASES = ["toolchain", "secrets", "hook"];
 
-  console.log("Toolchain:");
-  applyToolchain(cfg.tools, dryRun);
+/**
+ * The settings block that wires the session-start hook into a repository.
+ *
+ * Emitted rather than written, because `.claude/settings.json` belongs to the
+ * project: it may already carry hooks, and merging someone else's file from
+ * here is how a careless tool destroys a configuration it did not understand.
+ */
+const SESSION_START_BLOCK = `{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \\"$CLAUDE_PROJECT_DIR\\"/scripts/lisa-remote-env/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}`;
 
-  console.log("\nSecrets:");
-  const materialize = siblingScript(
-    "lisa-secrets-access",
-    "materialize-secrets.mjs"
+/**
+ * Produce the configuration a human pastes to provision a Claude cloud surface.
+ *
+ * This surface has no API tier and no console tier to fall back to: a Claude
+ * cloud environment is configured only in the environment dialog, which has no
+ * settings page, no direct URL, and no endpoint. Emit is not a degraded option
+ * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
+ * what makes the result trustworthy, exactly as it would be at any other tier.
+ * @param {{bootstrapKey: string|null, install: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitClaudeWeb({ bootstrapKey, install }) {
+  const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+  return [
+    "Provisioning tier: EMIT — and for this surface that is the only tier.",
+    "  A Claude cloud environment is account-scoped configuration edited in the",
+    "  environment selector at claude.ai/code. There is no settings page, no",
+    "  direct URL and no API, so nothing here can provision it for you.",
+    "",
+    "Paste into the environment dialog",
+    "---------------------------------",
+    "  Network access:  Trusted, or Custom plus any host your project needs",
+    "",
+    "  Environment variables:",
+    `    ${key}=<read this from your credential manager>`,
+    "",
+    "    Only the bootstrap belongs in this box. Values here are stored as",
+    "    plain text and are readable by anyone who uses the environment — on an",
+    "    organization-shared environment that is every member of the org. Every",
+    "    other credential is materialized by the session-start hook below, which",
+    "    is why exactly one value needs to live here.",
+    "",
+    "  Setup script:",
+    `    ${install} && bash scripts/lisa-remote-env/setup.sh`,
+    "",
+    "    The install must come first. On a fresh container node_modules is the",
+    "    only copy of the Lisa skills present, because Claude receives them as",
+    "    an installed plugin rather than as part of the clone.",
+    "",
+    "Commit to the repository",
+    "------------------------",
+    "  scripts/lisa-remote-env/session-start.sh   (from this skill's assets)",
+    "",
+    "  .claude/settings.json — merge this into any hooks already there:",
+    SESSION_START_BLOCK.split("\n")
+      .map(line => `    ${line}`)
+      .join("\n"),
+    "",
+    "    The setup script is skipped whenever a cached environment exists, so",
+    "    secrets are materialized from this hook instead. It runs every session,",
+    "    including a resumed one, which is what keeps a rotated value current.",
+    "",
+    "Worth knowing about this base image",
+    "-----------------------------------",
+    "  The GitHub CLI is not pre-installed. If this project's flows shell out to",
+    "  `gh`, add it to remoteEnv.tools.install with a pinned version and",
+    "  checksum, the same as any other tool.",
+    "",
+    "  A credential handled by the GitHub proxy reads as the literal string",
+    '  "proxy-injected" inside the session. Tools that authenticate through the',
+    "  proxy work; a script that reads the variable itself gets the placeholder.",
+    "",
+    "Then prove it",
+    "-------------",
+    "  Start a session and run the read-back. Whatever provisioned an",
+    "  environment, the same verify is what makes it trustworthy:",
+    "    node scripts/verify-remote-env.mjs",
+  ].join("\n");
+}
+
+/**
+ * Decide which phases this invocation runs.
+ *
+ * An explicit `--phase` always wins, because that is how a session-start hook
+ * asks for the one phase it owns. Otherwise every phase runs except a secrets
+ * step that belongs to a different moment on this surface — running it here
+ * would produce a copy that the surface never refreshes.
+ * @param {string|undefined} requested Value of `--phase`, when given.
+ * @param {string|null} materializeAt When this surface materializes.
+ * @returns {string[]} Phases to run, in order.
+ */
+export function selectPhases(requested, materializeAt) {
+  if (requested) {
+    if (!PHASES.includes(requested)) {
+      throw new Error(
+        `unknown --phase "${requested}". Known: ${PHASES.join(", ")}.`
+      );
+    }
+    if (requested === "secrets" && materializeAt !== "session-start") {
+      // Not an error: the hook is committed to the repository and runs on every
+      // surface the project is ever checked out on. Refusing loudly would make
+      // a correct local session look broken every time it started.
+      return [];
+    }
+    return [requested];
+  }
+  return PHASES.filter(
+    phase => phase !== "secrets" || materializeAt === "setup"
   );
-  execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
-    stdio: "inherit",
-  });
+}
 
-  runHook(cfg.hook, dryRun);
+/**
+ * Read the surface the resolver detects, without duplicating its rules.
+ *
+ * Imported rather than shelled out to, because the answer is a pure function of
+ * the environment and a subprocess would buy nothing. The path is converted to
+ * a file URL first: a bare absolute path is not a portable module specifier.
+ * @returns {Promise<{surface: string, materializeAt: string|null}>} Detected surface.
+ */
+async function detectSurface() {
+  const script = siblingScript("lisa-secrets-access", "surfaces.mjs");
+  const mod = await import(pathToFileURL(script).href);
+  const surface = mod.detectSurface();
+  return { surface, materializeAt: mod.SURFACES[surface].materializeAt };
+}
+
+/**
+ * Name the project's own install command rather than inventing one.
+ *
+ * The emitted setup line must begin with whatever this project already uses; a
+ * guessed package manager produces a container that fails on its first command.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} The install command to place before the setup script.
+ */
+export function detectInstallCommand(cwd = process.cwd()) {
+  const lockfiles = [
+    ["bun.lockb", "bun install"],
+    ["bun.lock", "bun install"],
+    ["pnpm-lock.yaml", "pnpm install --frozen-lockfile"],
+    ["yarn.lock", "yarn install --immutable"],
+    ["package-lock.json", "npm ci"],
+  ];
+  for (const [file, command] of lockfiles) {
+    if (existsSync(join(cwd, file))) return command;
+  }
+  return "<your install command>";
+}
+
+/**
+ * Read the bootstrap key name, which is the one value the operator must paste.
+ * @param {string} [cwd] Repository root.
+ * @returns {string|null} The configured key name, when there is one.
+ */
+function readBootstrapKey(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8")).secrets?.bootstrap?.key ?? null;
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const emit = process.argv
+    .find(arg => arg.startsWith("--emit="))
+    ?.slice("--emit=".length);
+
+  if (emit) {
+    if (emit !== "claude-web") {
+      throw new Error(
+        `no emit template for surface "${emit}".\n` +
+          `Emitting is implemented for claude-web, which has no other tier.`
+      );
+    }
+    console.log(
+      emitClaudeWeb({
+        bootstrapKey: readBootstrapKey(),
+        install: detectInstallCommand(),
+      })
+    );
+    return;
+  }
+
+  const requested = process.argv
+    .find(arg => arg.startsWith("--phase="))
+    ?.slice("--phase=".length);
+  const cfg = readRemoteEnvConfig();
+  const { surface, materializeAt } = await detectSurface();
+  const phases = selectPhases(requested, materializeAt);
+
+  if (!phases.length) {
+    console.log(
+      `Nothing to do: surface "${surface}" does not materialize from a ` +
+        `session-start hook.`
+    );
+    return;
+  }
+
+  if (phases.includes("toolchain")) {
+    console.log("Toolchain:");
+    applyToolchain(cfg.tools, dryRun);
+  }
+
+  if (phases.includes("secrets")) {
+    console.log("\nSecrets:");
+    const materialize = siblingScript(
+      "lisa-secrets-access",
+      "materialize-secrets.mjs"
+    );
+    execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
+      stdio: "inherit",
+    });
+  } else if (!requested) {
+    console.log(
+      `\nSecrets: materialized from a session-start hook on "${surface}", ` +
+        `not here.\n` +
+        `  This script is skipped whenever a cached environment exists, so a ` +
+        `value written\n  here would go stale the moment it was rotated. The ` +
+        `hook runs every session.`
+    );
+  }
+
+  if (phases.includes("hook")) runHook(cfg.hook, dryRun);
   console.log(`\nRemote environment ${dryRun ? "plan complete" : "ready"}.`);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  try {
-    main();
-  } catch (err) {
+  // Awaited rather than called bare: main is async, so a synchronous try/catch
+  // would let a rejected promise escape as an unhandled rejection and exit 0 —
+  // reporting a prepared environment that was never prepared.
+  main().catch(err => {
     console.error(err.message);
     process.exit(1);
-  }
+  });
 }

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -22,7 +22,8 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
 
 import { readRemoteEnvConfig } from "./setup-remote-env.mjs";
 import { extractVersion } from "./toolchain.mjs";
@@ -120,6 +121,43 @@ function verifyToolchain(tools) {
 }
 
 /**
+ * Assert that a declared credential is genuinely readable, not a proxy stand-in.
+ *
+ * A surface may keep a credential outside the sandbox entirely and substitute
+ * the real value at egress. The variable is then present and non-empty, so a
+ * presence check passes — and a script that reads the variable and puts it in a
+ * header sends the placeholder and fails somewhere far from here, with an error
+ * that points at the service rather than at the environment.
+ *
+ * Reported without printing any value: the placeholder is compared, and a real
+ * credential is only ever reported as present.
+ *
+ * Takes its reporter as an argument rather than writing to this module's
+ * results array, so the rule can be exercised against a synthetic environment
+ * without a container and without leaking findings between runs.
+ * @param {string[]} required Declared credential names.
+ * @param {Record<string, string|undefined>} env Environment to inspect.
+ * @param {(ok: boolean, label: string, detail: string) => void} report Collector.
+ */
+export function verifyNotProxied(required, env, report) {
+  for (const name of required) {
+    const value = (env[name] ?? "").trim();
+    if (!value) {
+      report(false, `credential ${name}`, "declared but not present");
+      continue;
+    }
+    report(
+      value !== "proxy-injected",
+      `credential ${name}`,
+      value === "proxy-injected"
+        ? 'reads as "proxy-injected" — substituted at egress, so anything ' +
+            "reading this variable directly receives the placeholder"
+        : "present"
+    );
+  }
+}
+
+/**
  * Assert the working tree is clean.
  *
  * A remote environment that starts dirty will carry unrelated changes into
@@ -142,11 +180,23 @@ function verifyCleanCheckout() {
   }
 }
 
+/**
+ * Read the credential names the project declares it needs.
+ * @param {string} [cwd] Repository root.
+ * @returns {string[]} Declared names, or none when unconfigured.
+ */
+function readRequired(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (!existsSync(path)) return [];
+  return JSON.parse(readFileSync(path, "utf8")).secrets?.require ?? [];
+}
+
 function main() {
   const cfg = readRemoteEnvConfig();
   const secretsDir = process.argv[2];
 
   verifyToolchain(cfg.tools);
+  verifyNotProxied(readRequired(), process.env, check);
 
   const surface = node([
     new URL(

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -188,7 +188,12 @@ function verifyCleanCheckout() {
 function readRequired(cwd = process.cwd()) {
   const path = join(cwd, ".lisa.config.json");
   if (!existsSync(path)) return [];
-  return JSON.parse(readFileSync(path, "utf8")).secrets?.require ?? [];
+  const required = JSON.parse(readFileSync(path, "utf8")).secrets?.require;
+  if (required == null) return [];
+  if (!Array.isArray(required)) {
+    throw new Error("secrets.require must be an array when present");
+  }
+  return required;
 }
 
 function main() {

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -29,18 +29,35 @@ import { join } from "node:path";
  * consuming process exists and which therefore have no other channel; a remote
  * agent container prepares itself during setup, long before any task starts.
  *
- * The two remote surfaces share the capability but not the timing, and a reader
- * adding a third should not assume otherwise. `codex-cloud` re-runs its setup
- * script when a container resumes, so materializing there picks up a rotated
- * value. `claude-web` *skips* its setup script whenever a filesystem cache
- * exists, so materializing there would strand a rotated value until the cache
- * expired — its materialize step runs from a session-start hook instead.
+ * `materializeAt` — *when* the write happens, for surfaces that do one. The two
+ * remote surfaces share the capability but not the timing, and a reader adding a
+ * third should not assume otherwise. `codex-cloud` re-runs its setup script when
+ * a container resumes, so materializing during setup picks up a rotated value.
+ * `claude-web` *skips* its setup script whenever a filesystem cache exists, so
+ * materializing there would strand a rotated value until the cache expired —
+ * it materializes from a session-start hook instead, which runs every session.
+ *
+ * Stated as a capability rather than inferred from the surface name, so the
+ * setup runner selects its phases from the table instead of branching on which
+ * vendor it happens to be talking to.
  */
 export const SURFACES = {
-  local: { materialized: false, mayWriteValues: false },
-  "github-actions": { materialized: false, mayWriteValues: false },
-  "codex-cloud": { materialized: true, mayWriteValues: true },
-  "claude-web": { materialized: true, mayWriteValues: true },
+  local: { materialized: false, mayWriteValues: false, materializeAt: null },
+  "github-actions": {
+    materialized: false,
+    mayWriteValues: false,
+    materializeAt: null,
+  },
+  "codex-cloud": {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "setup",
+  },
+  "claude-web": {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "session-start",
+  },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
@@ -39,6 +39,20 @@ Omitting the install does not degrade gracefully. The entrypoint exits before th
 
 Order matters. The toolchain comes first because the secrets step needs the provider CLI it installs. The hook comes last because it is the only part that may assume everything else is ready.
 
+### Which phases run depends on the surface
+
+Not every surface runs all three here, and the reason is worth understanding before changing it.
+
+A surface that **re-runs this script when a container resumes** — Codex Cloud — should materialize during setup. Re-running is exactly what picks up a rotated value, an edited note, or a changed version pin.
+
+A surface that **skips this script whenever a filesystem cache exists** — Claude Code web — must not. Materializing here would write the values once and then never refresh them, so a credential rotated on Tuesday would still be serving Monday's value until the cache expired days later. Those surfaces materialize from a session-start hook instead, which runs every session including a resumed one:
+
+```sh
+bash scripts/lisa-remote-env/session-start.sh   # guard; delegates to --phase=secrets
+```
+
+The selection comes from the surface's `materializeAt` capability in `lisa-secrets-access`, not from its name, so adding a surface does not mean editing a branch. The hook is committed to the repository, so it also fires on a developer's machine — it exits `0` immediately there rather than failing, because a correct local session must not look broken.
+
 ## Toolchain manifest — two entry kinds
 
 ```json
@@ -131,6 +145,25 @@ Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
                    maintenance both run before task secrets exist>
 ```
 
+### Claude Code web is emit-only, and that is not a fallback
+
+**For Claude Code web there is no tier 1 or tier 2 to fall back from.** A cloud environment is account-scoped configuration — network access level, environment variables, setup script — edited only in the environment selector at claude.ai/code, which has no settings page, no direct URL, and no API. `/remote-env` selects an environment; it cannot create or edit one.
+
+Note what this surface's environment is *not*: it carries no repository. The repository arrives per session, so an environment is reusable across every project, and there is nothing to bind. Its durable handle is the routine that dispatch fires, which is why `remoteEnv.surfaces["claude-web"]` records `routineId` and `fireUrl` rather than a repository.
+
+Generate the exact text to paste:
+
+```sh
+node scripts/setup-remote-env.mjs --emit=claude-web
+```
+
+It reads the project's own install command from its lockfile and the bootstrap name from `secrets.bootstrap.key`, then emits the environment fields, the `.claude/settings.json` hook block, and the two base-image surprises worth knowing before they cost an afternoon:
+
+- **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
+- **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
+
+**Only the bootstrap belongs in the environment-variable box.** Values there are stored as plain text and are readable by anyone who uses the environment — on an organization-shared environment, that is every member of the organization. Everything else is materialized by the session-start hook. There is no dedicated secrets store on this surface, and personal versus shared environments cannot be told apart programmatically, so this one is a rule the operator upholds rather than something the tooling can enforce.
+
 ## Verification is tier-independent
 
 **Whatever tier provisioned it, the same read-back proves it.** Trust comes from the verify, not the mechanism — which is what makes emit-tier as trustworthy as API-tier.
@@ -139,7 +172,9 @@ Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
 scripts/verify-remote-env.mjs [SECRETS_DIR]
 ```
 
-Asserts, without printing a value: each declared tool at its pinned or minimum version, the detected surface, the secrets directory at mode `0700`, both files at mode `0600`, and a clean checkout.
+Asserts, without printing a value: each declared tool at its pinned or minimum version, the detected surface, the secrets directory at mode `0700`, both files at mode `0600`, a clean checkout, and that every name in `secrets.require` resolves to a real credential rather than a proxy placeholder.
+
+That last one exists because presence is a weaker claim than usability. A credential the surface keeps outside the sandbox and substitutes at egress is present and non-empty, so a presence check passes — and a script that reads the variable and puts it in a header sends the placeholder and fails against the service, with an error pointing anywhere but at the environment.
 
 **Never verify against vendor UI state.** On 2026-08-01 a Codex environments table reported zero tasks for an environment that had demonstrably completed one, because the task records carried a null environment identifier and the `--env` filter was correspondingly unreliable. Reconcile through durable identifiers only.
 
@@ -147,7 +182,7 @@ Asserts, without printing a value: each declared tool at its pinned or minimum v
 
 Checked when setup runs, not at 3am:
 
-- the environment exists and is bound to **this** repository as its default checkout;
+- the environment exists, and on a surface that binds one, is bound to **this** repository as its default checkout — Claude cloud environments bind no repository at all, so there is nothing to check there;
 - the bootstrap credential resolves;
 - either a checkout-local Lisa skill is present, or the project dependency install has made the pinned `@codyswann/lisa` package available under `node_modules`.
 
@@ -156,6 +191,8 @@ Fail with a message naming what is missing. Never provision-and-hope.
 ## Bootstrap credential placement
 
 On Codex Cloud the bootstrap must be an **environment variable, not a task secret**: setup runs on a new container and maintenance runs on cache resume, both before task secrets exist. The tradeoff is that the variable remains visible during the task, so compensate by keeping the machine account narrowly scoped and instructing the task never to inspect or use it.
+
+On Claude Code web the same placement applies for the same reason, with the exposure widened rather than narrowed: there is no secrets store, values are stored as plain text, and anyone who uses the environment can read them. On an organization-shared environment that is every member. Keep the bootstrap in a **personal** environment, scope the machine account to the minimum, and treat every other credential as something the session-start hook materializes rather than something a human pastes.
 
 ## Related
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/assets/session-start.sh
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/assets/session-start.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Session-start entrypoint for surfaces that materialize secrets per session
+# rather than during environment setup.
+#
+# Wired into the repository's `.claude/settings.json` as a SessionStart hook,
+# so it is part of the clone and runs on every session — including a session
+# resumed onto a cached environment, which is the case that matters.
+#
+# Why this exists at all: a cloud environment's setup script is skipped whenever
+# a filesystem cache exists. Materializing there would write the values once and
+# never refresh them, so a rotated credential would stay stale until the cache
+# expired days later. This hook runs every session, so the copy on disk is
+# always the provider's current view.
+#
+# It is deliberately a guard and a delegation, not a second implementation. The
+# skill-resolution ladder is subtle enough that two copies would drift, so the
+# real work stays in setup.sh and this file only decides whether to call it.
+set -euo pipefail
+
+# Exit before doing anything on a machine that is not a remote session. The hook
+# is committed to the repository, so it also fires on every local session; the
+# materialize step would correctly refuse there, but failing on a developer's
+# laptop every time they start a session is noise, not a signal.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+here="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+exec bash "${here}/setup.sh" --phase=secrets "$@"

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -300,7 +300,7 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "-------------",
     "  Start a session and run the read-back. Whatever provisioned an",
     "  environment, the same verify is what makes it trustworthy:",
-    "    node scripts/verify-remote-env.mjs",
+    "    node node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs",
   ].join("\n");
 }
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -5,15 +5,26 @@
  * This is the script a remote environment's setup **and** maintenance fields
  * call. They are the same script on purpose. A container may be built fresh or
  * resumed from cache, and every step here is idempotent and version-aware, so
- * running it twice is correct and running it on resume is what picks up a
- * rotated value, an edited note, or a changed version pin.
+ * running it twice is correct.
  *
  * Order matters. The toolchain comes first because the secrets step needs the
  * provider CLI that the toolchain installs. The project hook comes last because
  * it is the only part that may assume everything else is ready.
  *
+ * **Which phases run depends on the surface, and the reason is not cosmetic.**
+ * On a surface that re-runs this script when a container resumes, materializing
+ * here is what picks up a rotated value. On a surface that *skips* it whenever a
+ * filesystem cache exists, materializing here would write the value once and
+ * then never refresh it — a rotated credential would stay stale until the cache
+ * expired. Those surfaces materialize from a session-start hook instead, which
+ * runs every session including resumed ones, and `--phase=secrets` is how that
+ * hook re-enters this file.
+ *
+ * The selection comes from the surface's `materializeAt` capability rather than
+ * from its name, so adding a surface does not mean editing a branch here.
+ *
  * Usage:
- *   setup-remote-env.mjs [--dry-run]
+ *   setup-remote-env.mjs [--dry-run] [--phase=toolchain|secrets|hook]
  * @module setup-remote-env
  */
 
@@ -26,7 +37,7 @@ import {
   rmSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
 
@@ -197,31 +208,252 @@ function runHook(hook, dryRun) {
   execFileSync("bash", [path], { stdio: "inherit" });
 }
 
-function main() {
-  const dryRun = process.argv.includes("--dry-run");
-  const cfg = readRemoteEnvConfig();
+/** Phases this runner can execute, in the order they must happen. */
+const PHASES = ["toolchain", "secrets", "hook"];
 
-  console.log("Toolchain:");
-  applyToolchain(cfg.tools, dryRun);
+/**
+ * The settings block that wires the session-start hook into a repository.
+ *
+ * Emitted rather than written, because `.claude/settings.json` belongs to the
+ * project: it may already carry hooks, and merging someone else's file from
+ * here is how a careless tool destroys a configuration it did not understand.
+ */
+const SESSION_START_BLOCK = `{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \\"$CLAUDE_PROJECT_DIR\\"/scripts/lisa-remote-env/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}`;
 
-  console.log("\nSecrets:");
-  const materialize = siblingScript(
-    "lisa-secrets-access",
-    "materialize-secrets.mjs"
+/**
+ * Produce the configuration a human pastes to provision a Claude cloud surface.
+ *
+ * This surface has no API tier and no console tier to fall back to: a Claude
+ * cloud environment is configured only in the environment dialog, which has no
+ * settings page, no direct URL, and no endpoint. Emit is not a degraded option
+ * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
+ * what makes the result trustworthy, exactly as it would be at any other tier.
+ * @param {{bootstrapKey: string|null, install: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitClaudeWeb({ bootstrapKey, install }) {
+  const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+  return [
+    "Provisioning tier: EMIT — and for this surface that is the only tier.",
+    "  A Claude cloud environment is account-scoped configuration edited in the",
+    "  environment selector at claude.ai/code. There is no settings page, no",
+    "  direct URL and no API, so nothing here can provision it for you.",
+    "",
+    "Paste into the environment dialog",
+    "---------------------------------",
+    "  Network access:  Trusted, or Custom plus any host your project needs",
+    "",
+    "  Environment variables:",
+    `    ${key}=<read this from your credential manager>`,
+    "",
+    "    Only the bootstrap belongs in this box. Values here are stored as",
+    "    plain text and are readable by anyone who uses the environment — on an",
+    "    organization-shared environment that is every member of the org. Every",
+    "    other credential is materialized by the session-start hook below, which",
+    "    is why exactly one value needs to live here.",
+    "",
+    "  Setup script:",
+    `    ${install} && bash scripts/lisa-remote-env/setup.sh`,
+    "",
+    "    The install must come first. On a fresh container node_modules is the",
+    "    only copy of the Lisa skills present, because Claude receives them as",
+    "    an installed plugin rather than as part of the clone.",
+    "",
+    "Commit to the repository",
+    "------------------------",
+    "  scripts/lisa-remote-env/session-start.sh   (from this skill's assets)",
+    "",
+    "  .claude/settings.json — merge this into any hooks already there:",
+    SESSION_START_BLOCK.split("\n")
+      .map(line => `    ${line}`)
+      .join("\n"),
+    "",
+    "    The setup script is skipped whenever a cached environment exists, so",
+    "    secrets are materialized from this hook instead. It runs every session,",
+    "    including a resumed one, which is what keeps a rotated value current.",
+    "",
+    "Worth knowing about this base image",
+    "-----------------------------------",
+    "  The GitHub CLI is not pre-installed. If this project's flows shell out to",
+    "  `gh`, add it to remoteEnv.tools.install with a pinned version and",
+    "  checksum, the same as any other tool.",
+    "",
+    "  A credential handled by the GitHub proxy reads as the literal string",
+    '  "proxy-injected" inside the session. Tools that authenticate through the',
+    "  proxy work; a script that reads the variable itself gets the placeholder.",
+    "",
+    "Then prove it",
+    "-------------",
+    "  Start a session and run the read-back. Whatever provisioned an",
+    "  environment, the same verify is what makes it trustworthy:",
+    "    node scripts/verify-remote-env.mjs",
+  ].join("\n");
+}
+
+/**
+ * Decide which phases this invocation runs.
+ *
+ * An explicit `--phase` always wins, because that is how a session-start hook
+ * asks for the one phase it owns. Otherwise every phase runs except a secrets
+ * step that belongs to a different moment on this surface — running it here
+ * would produce a copy that the surface never refreshes.
+ * @param {string|undefined} requested Value of `--phase`, when given.
+ * @param {string|null} materializeAt When this surface materializes.
+ * @returns {string[]} Phases to run, in order.
+ */
+export function selectPhases(requested, materializeAt) {
+  if (requested) {
+    if (!PHASES.includes(requested)) {
+      throw new Error(
+        `unknown --phase "${requested}". Known: ${PHASES.join(", ")}.`
+      );
+    }
+    if (requested === "secrets" && materializeAt !== "session-start") {
+      // Not an error: the hook is committed to the repository and runs on every
+      // surface the project is ever checked out on. Refusing loudly would make
+      // a correct local session look broken every time it started.
+      return [];
+    }
+    return [requested];
+  }
+  return PHASES.filter(
+    phase => phase !== "secrets" || materializeAt === "setup"
   );
-  execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
-    stdio: "inherit",
-  });
+}
 
-  runHook(cfg.hook, dryRun);
+/**
+ * Read the surface the resolver detects, without duplicating its rules.
+ *
+ * Imported rather than shelled out to, because the answer is a pure function of
+ * the environment and a subprocess would buy nothing. The path is converted to
+ * a file URL first: a bare absolute path is not a portable module specifier.
+ * @returns {Promise<{surface: string, materializeAt: string|null}>} Detected surface.
+ */
+async function detectSurface() {
+  const script = siblingScript("lisa-secrets-access", "surfaces.mjs");
+  const mod = await import(pathToFileURL(script).href);
+  const surface = mod.detectSurface();
+  return { surface, materializeAt: mod.SURFACES[surface].materializeAt };
+}
+
+/**
+ * Name the project's own install command rather than inventing one.
+ *
+ * The emitted setup line must begin with whatever this project already uses; a
+ * guessed package manager produces a container that fails on its first command.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} The install command to place before the setup script.
+ */
+export function detectInstallCommand(cwd = process.cwd()) {
+  const lockfiles = [
+    ["bun.lockb", "bun install"],
+    ["bun.lock", "bun install"],
+    ["pnpm-lock.yaml", "pnpm install --frozen-lockfile"],
+    ["yarn.lock", "yarn install --immutable"],
+    ["package-lock.json", "npm ci"],
+  ];
+  for (const [file, command] of lockfiles) {
+    if (existsSync(join(cwd, file))) return command;
+  }
+  return "<your install command>";
+}
+
+/**
+ * Read the bootstrap key name, which is the one value the operator must paste.
+ * @param {string} [cwd] Repository root.
+ * @returns {string|null} The configured key name, when there is one.
+ */
+function readBootstrapKey(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8")).secrets?.bootstrap?.key ?? null;
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const emit = process.argv
+    .find(arg => arg.startsWith("--emit="))
+    ?.slice("--emit=".length);
+
+  if (emit) {
+    if (emit !== "claude-web") {
+      throw new Error(
+        `no emit template for surface "${emit}".\n` +
+          `Emitting is implemented for claude-web, which has no other tier.`
+      );
+    }
+    console.log(
+      emitClaudeWeb({
+        bootstrapKey: readBootstrapKey(),
+        install: detectInstallCommand(),
+      })
+    );
+    return;
+  }
+
+  const requested = process.argv
+    .find(arg => arg.startsWith("--phase="))
+    ?.slice("--phase=".length);
+  const cfg = readRemoteEnvConfig();
+  const { surface, materializeAt } = await detectSurface();
+  const phases = selectPhases(requested, materializeAt);
+
+  if (!phases.length) {
+    console.log(
+      `Nothing to do: surface "${surface}" does not materialize from a ` +
+        `session-start hook.`
+    );
+    return;
+  }
+
+  if (phases.includes("toolchain")) {
+    console.log("Toolchain:");
+    applyToolchain(cfg.tools, dryRun);
+  }
+
+  if (phases.includes("secrets")) {
+    console.log("\nSecrets:");
+    const materialize = siblingScript(
+      "lisa-secrets-access",
+      "materialize-secrets.mjs"
+    );
+    execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
+      stdio: "inherit",
+    });
+  } else if (!requested) {
+    console.log(
+      `\nSecrets: materialized from a session-start hook on "${surface}", ` +
+        `not here.\n` +
+        `  This script is skipped whenever a cached environment exists, so a ` +
+        `value written\n  here would go stale the moment it was rotated. The ` +
+        `hook runs every session.`
+    );
+  }
+
+  if (phases.includes("hook")) runHook(cfg.hook, dryRun);
   console.log(`\nRemote environment ${dryRun ? "plan complete" : "ready"}.`);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  try {
-    main();
-  } catch (err) {
+  // Awaited rather than called bare: main is async, so a synchronous try/catch
+  // would let a rejected promise escape as an unhandled rejection and exit 0 —
+  // reporting a prepared environment that was never prepared.
+  main().catch(err => {
     console.error(err.message);
     process.exit(1);
-  }
+  });
 }

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -22,7 +22,8 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
 
 import { readRemoteEnvConfig } from "./setup-remote-env.mjs";
 import { extractVersion } from "./toolchain.mjs";
@@ -120,6 +121,43 @@ function verifyToolchain(tools) {
 }
 
 /**
+ * Assert that a declared credential is genuinely readable, not a proxy stand-in.
+ *
+ * A surface may keep a credential outside the sandbox entirely and substitute
+ * the real value at egress. The variable is then present and non-empty, so a
+ * presence check passes — and a script that reads the variable and puts it in a
+ * header sends the placeholder and fails somewhere far from here, with an error
+ * that points at the service rather than at the environment.
+ *
+ * Reported without printing any value: the placeholder is compared, and a real
+ * credential is only ever reported as present.
+ *
+ * Takes its reporter as an argument rather than writing to this module's
+ * results array, so the rule can be exercised against a synthetic environment
+ * without a container and without leaking findings between runs.
+ * @param {string[]} required Declared credential names.
+ * @param {Record<string, string|undefined>} env Environment to inspect.
+ * @param {(ok: boolean, label: string, detail: string) => void} report Collector.
+ */
+export function verifyNotProxied(required, env, report) {
+  for (const name of required) {
+    const value = (env[name] ?? "").trim();
+    if (!value) {
+      report(false, `credential ${name}`, "declared but not present");
+      continue;
+    }
+    report(
+      value !== "proxy-injected",
+      `credential ${name}`,
+      value === "proxy-injected"
+        ? 'reads as "proxy-injected" — substituted at egress, so anything ' +
+            "reading this variable directly receives the placeholder"
+        : "present"
+    );
+  }
+}
+
+/**
  * Assert the working tree is clean.
  *
  * A remote environment that starts dirty will carry unrelated changes into
@@ -142,11 +180,23 @@ function verifyCleanCheckout() {
   }
 }
 
+/**
+ * Read the credential names the project declares it needs.
+ * @param {string} [cwd] Repository root.
+ * @returns {string[]} Declared names, or none when unconfigured.
+ */
+function readRequired(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (!existsSync(path)) return [];
+  return JSON.parse(readFileSync(path, "utf8")).secrets?.require ?? [];
+}
+
 function main() {
   const cfg = readRemoteEnvConfig();
   const secretsDir = process.argv[2];
 
   verifyToolchain(cfg.tools);
+  verifyNotProxied(readRequired(), process.env, check);
 
   const surface = node([
     new URL(

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -188,7 +188,12 @@ function verifyCleanCheckout() {
 function readRequired(cwd = process.cwd()) {
   const path = join(cwd, ".lisa.config.json");
   if (!existsSync(path)) return [];
-  return JSON.parse(readFileSync(path, "utf8")).secrets?.require ?? [];
+  const required = JSON.parse(readFileSync(path, "utf8")).secrets?.require;
+  if (required == null) return [];
+  if (!Array.isArray(required)) {
+    throw new Error("secrets.require must be an array when present");
+  }
+  return required;
 }
 
 function main() {

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -29,18 +29,35 @@ import { join } from "node:path";
  * consuming process exists and which therefore have no other channel; a remote
  * agent container prepares itself during setup, long before any task starts.
  *
- * The two remote surfaces share the capability but not the timing, and a reader
- * adding a third should not assume otherwise. `codex-cloud` re-runs its setup
- * script when a container resumes, so materializing there picks up a rotated
- * value. `claude-web` *skips* its setup script whenever a filesystem cache
- * exists, so materializing there would strand a rotated value until the cache
- * expired — its materialize step runs from a session-start hook instead.
+ * `materializeAt` — *when* the write happens, for surfaces that do one. The two
+ * remote surfaces share the capability but not the timing, and a reader adding a
+ * third should not assume otherwise. `codex-cloud` re-runs its setup script when
+ * a container resumes, so materializing during setup picks up a rotated value.
+ * `claude-web` *skips* its setup script whenever a filesystem cache exists, so
+ * materializing there would strand a rotated value until the cache expired —
+ * it materializes from a session-start hook instead, which runs every session.
+ *
+ * Stated as a capability rather than inferred from the surface name, so the
+ * setup runner selects its phases from the table instead of branching on which
+ * vendor it happens to be talking to.
  */
 export const SURFACES = {
-  local: { materialized: false, mayWriteValues: false },
-  "github-actions": { materialized: false, mayWriteValues: false },
-  "codex-cloud": { materialized: true, mayWriteValues: true },
-  "claude-web": { materialized: true, mayWriteValues: true },
+  local: { materialized: false, mayWriteValues: false, materializeAt: null },
+  "github-actions": {
+    materialized: false,
+    mayWriteValues: false,
+    materializeAt: null,
+  },
+  "codex-cloud": {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "setup",
+  },
+  "claude-web": {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "session-start",
+  },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */

--- a/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
@@ -39,6 +39,20 @@ Omitting the install does not degrade gracefully. The entrypoint exits before th
 
 Order matters. The toolchain comes first because the secrets step needs the provider CLI it installs. The hook comes last because it is the only part that may assume everything else is ready.
 
+### Which phases run depends on the surface
+
+Not every surface runs all three here, and the reason is worth understanding before changing it.
+
+A surface that **re-runs this script when a container resumes** — Codex Cloud — should materialize during setup. Re-running is exactly what picks up a rotated value, an edited note, or a changed version pin.
+
+A surface that **skips this script whenever a filesystem cache exists** — Claude Code web — must not. Materializing here would write the values once and then never refresh them, so a credential rotated on Tuesday would still be serving Monday's value until the cache expired days later. Those surfaces materialize from a session-start hook instead, which runs every session including a resumed one:
+
+```sh
+bash scripts/lisa-remote-env/session-start.sh   # guard; delegates to --phase=secrets
+```
+
+The selection comes from the surface's `materializeAt` capability in `lisa-secrets-access`, not from its name, so adding a surface does not mean editing a branch. The hook is committed to the repository, so it also fires on a developer's machine — it exits `0` immediately there rather than failing, because a correct local session must not look broken.
+
 ## Toolchain manifest — two entry kinds
 
 ```json
@@ -131,6 +145,25 @@ Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
                    maintenance both run before task secrets exist>
 ```
 
+### Claude Code web is emit-only, and that is not a fallback
+
+**For Claude Code web there is no tier 1 or tier 2 to fall back from.** A cloud environment is account-scoped configuration — network access level, environment variables, setup script — edited only in the environment selector at claude.ai/code, which has no settings page, no direct URL, and no API. `/remote-env` selects an environment; it cannot create or edit one.
+
+Note what this surface's environment is *not*: it carries no repository. The repository arrives per session, so an environment is reusable across every project, and there is nothing to bind. Its durable handle is the routine that dispatch fires, which is why `remoteEnv.surfaces["claude-web"]` records `routineId` and `fireUrl` rather than a repository.
+
+Generate the exact text to paste:
+
+```sh
+node scripts/setup-remote-env.mjs --emit=claude-web
+```
+
+It reads the project's own install command from its lockfile and the bootstrap name from `secrets.bootstrap.key`, then emits the environment fields, the `.claude/settings.json` hook block, and the two base-image surprises worth knowing before they cost an afternoon:
+
+- **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
+- **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
+
+**Only the bootstrap belongs in the environment-variable box.** Values there are stored as plain text and are readable by anyone who uses the environment — on an organization-shared environment, that is every member of the organization. Everything else is materialized by the session-start hook. There is no dedicated secrets store on this surface, and personal versus shared environments cannot be told apart programmatically, so this one is a rule the operator upholds rather than something the tooling can enforce.
+
 ## Verification is tier-independent
 
 **Whatever tier provisioned it, the same read-back proves it.** Trust comes from the verify, not the mechanism — which is what makes emit-tier as trustworthy as API-tier.
@@ -139,7 +172,9 @@ Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
 scripts/verify-remote-env.mjs [SECRETS_DIR]
 ```
 
-Asserts, without printing a value: each declared tool at its pinned or minimum version, the detected surface, the secrets directory at mode `0700`, both files at mode `0600`, and a clean checkout.
+Asserts, without printing a value: each declared tool at its pinned or minimum version, the detected surface, the secrets directory at mode `0700`, both files at mode `0600`, a clean checkout, and that every name in `secrets.require` resolves to a real credential rather than a proxy placeholder.
+
+That last one exists because presence is a weaker claim than usability. A credential the surface keeps outside the sandbox and substitutes at egress is present and non-empty, so a presence check passes — and a script that reads the variable and puts it in a header sends the placeholder and fails against the service, with an error pointing anywhere but at the environment.
 
 **Never verify against vendor UI state.** On 2026-08-01 a Codex environments table reported zero tasks for an environment that had demonstrably completed one, because the task records carried a null environment identifier and the `--env` filter was correspondingly unreliable. Reconcile through durable identifiers only.
 
@@ -147,7 +182,7 @@ Asserts, without printing a value: each declared tool at its pinned or minimum v
 
 Checked when setup runs, not at 3am:
 
-- the environment exists and is bound to **this** repository as its default checkout;
+- the environment exists, and on a surface that binds one, is bound to **this** repository as its default checkout — Claude cloud environments bind no repository at all, so there is nothing to check there;
 - the bootstrap credential resolves;
 - either a checkout-local Lisa skill is present, or the project dependency install has made the pinned `@codyswann/lisa` package available under `node_modules`.
 
@@ -156,6 +191,8 @@ Fail with a message naming what is missing. Never provision-and-hope.
 ## Bootstrap credential placement
 
 On Codex Cloud the bootstrap must be an **environment variable, not a task secret**: setup runs on a new container and maintenance runs on cache resume, both before task secrets exist. The tradeoff is that the variable remains visible during the task, so compensate by keeping the machine account narrowly scoped and instructing the task never to inspect or use it.
+
+On Claude Code web the same placement applies for the same reason, with the exposure widened rather than narrowed: there is no secrets store, values are stored as plain text, and anyone who uses the environment can read them. On an organization-shared environment that is every member. Keep the bootstrap in a **personal** environment, scope the machine account to the minimum, and treat every other credential as something the session-start hook materializes rather than something a human pastes.
 
 ## Related
 

--- a/plugins/lisa/skills/lisa-setup-remote-env/assets/session-start.sh
+++ b/plugins/lisa/skills/lisa-setup-remote-env/assets/session-start.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Session-start entrypoint for surfaces that materialize secrets per session
+# rather than during environment setup.
+#
+# Wired into the repository's `.claude/settings.json` as a SessionStart hook,
+# so it is part of the clone and runs on every session — including a session
+# resumed onto a cached environment, which is the case that matters.
+#
+# Why this exists at all: a cloud environment's setup script is skipped whenever
+# a filesystem cache exists. Materializing there would write the values once and
+# never refresh them, so a rotated credential would stay stale until the cache
+# expired days later. This hook runs every session, so the copy on disk is
+# always the provider's current view.
+#
+# It is deliberately a guard and a delegation, not a second implementation. The
+# skill-resolution ladder is subtle enough that two copies would drift, so the
+# real work stays in setup.sh and this file only decides whether to call it.
+set -euo pipefail
+
+# Exit before doing anything on a machine that is not a remote session. The hook
+# is committed to the repository, so it also fires on every local session; the
+# materialize step would correctly refuse there, but failing on a developer's
+# laptop every time they start a session is noise, not a signal.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+here="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+exec bash "${here}/setup.sh" --phase=secrets "$@"

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -300,7 +300,7 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "-------------",
     "  Start a session and run the read-back. Whatever provisioned an",
     "  environment, the same verify is what makes it trustworthy:",
-    "    node scripts/verify-remote-env.mjs",
+    "    node node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs",
   ].join("\n");
 }
 

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -5,15 +5,26 @@
  * This is the script a remote environment's setup **and** maintenance fields
  * call. They are the same script on purpose. A container may be built fresh or
  * resumed from cache, and every step here is idempotent and version-aware, so
- * running it twice is correct and running it on resume is what picks up a
- * rotated value, an edited note, or a changed version pin.
+ * running it twice is correct.
  *
  * Order matters. The toolchain comes first because the secrets step needs the
  * provider CLI that the toolchain installs. The project hook comes last because
  * it is the only part that may assume everything else is ready.
  *
+ * **Which phases run depends on the surface, and the reason is not cosmetic.**
+ * On a surface that re-runs this script when a container resumes, materializing
+ * here is what picks up a rotated value. On a surface that *skips* it whenever a
+ * filesystem cache exists, materializing here would write the value once and
+ * then never refresh it — a rotated credential would stay stale until the cache
+ * expired. Those surfaces materialize from a session-start hook instead, which
+ * runs every session including resumed ones, and `--phase=secrets` is how that
+ * hook re-enters this file.
+ *
+ * The selection comes from the surface's `materializeAt` capability rather than
+ * from its name, so adding a surface does not mean editing a branch here.
+ *
  * Usage:
- *   setup-remote-env.mjs [--dry-run]
+ *   setup-remote-env.mjs [--dry-run] [--phase=toolchain|secrets|hook]
  * @module setup-remote-env
  */
 
@@ -26,7 +37,7 @@ import {
   rmSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
 
@@ -197,31 +208,252 @@ function runHook(hook, dryRun) {
   execFileSync("bash", [path], { stdio: "inherit" });
 }
 
-function main() {
-  const dryRun = process.argv.includes("--dry-run");
-  const cfg = readRemoteEnvConfig();
+/** Phases this runner can execute, in the order they must happen. */
+const PHASES = ["toolchain", "secrets", "hook"];
 
-  console.log("Toolchain:");
-  applyToolchain(cfg.tools, dryRun);
+/**
+ * The settings block that wires the session-start hook into a repository.
+ *
+ * Emitted rather than written, because `.claude/settings.json` belongs to the
+ * project: it may already carry hooks, and merging someone else's file from
+ * here is how a careless tool destroys a configuration it did not understand.
+ */
+const SESSION_START_BLOCK = `{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \\"$CLAUDE_PROJECT_DIR\\"/scripts/lisa-remote-env/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}`;
 
-  console.log("\nSecrets:");
-  const materialize = siblingScript(
-    "lisa-secrets-access",
-    "materialize-secrets.mjs"
+/**
+ * Produce the configuration a human pastes to provision a Claude cloud surface.
+ *
+ * This surface has no API tier and no console tier to fall back to: a Claude
+ * cloud environment is configured only in the environment dialog, which has no
+ * settings page, no direct URL, and no endpoint. Emit is not a degraded option
+ * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
+ * what makes the result trustworthy, exactly as it would be at any other tier.
+ * @param {{bootstrapKey: string|null, install: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitClaudeWeb({ bootstrapKey, install }) {
+  const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+  return [
+    "Provisioning tier: EMIT — and for this surface that is the only tier.",
+    "  A Claude cloud environment is account-scoped configuration edited in the",
+    "  environment selector at claude.ai/code. There is no settings page, no",
+    "  direct URL and no API, so nothing here can provision it for you.",
+    "",
+    "Paste into the environment dialog",
+    "---------------------------------",
+    "  Network access:  Trusted, or Custom plus any host your project needs",
+    "",
+    "  Environment variables:",
+    `    ${key}=<read this from your credential manager>`,
+    "",
+    "    Only the bootstrap belongs in this box. Values here are stored as",
+    "    plain text and are readable by anyone who uses the environment — on an",
+    "    organization-shared environment that is every member of the org. Every",
+    "    other credential is materialized by the session-start hook below, which",
+    "    is why exactly one value needs to live here.",
+    "",
+    "  Setup script:",
+    `    ${install} && bash scripts/lisa-remote-env/setup.sh`,
+    "",
+    "    The install must come first. On a fresh container node_modules is the",
+    "    only copy of the Lisa skills present, because Claude receives them as",
+    "    an installed plugin rather than as part of the clone.",
+    "",
+    "Commit to the repository",
+    "------------------------",
+    "  scripts/lisa-remote-env/session-start.sh   (from this skill's assets)",
+    "",
+    "  .claude/settings.json — merge this into any hooks already there:",
+    SESSION_START_BLOCK.split("\n")
+      .map(line => `    ${line}`)
+      .join("\n"),
+    "",
+    "    The setup script is skipped whenever a cached environment exists, so",
+    "    secrets are materialized from this hook instead. It runs every session,",
+    "    including a resumed one, which is what keeps a rotated value current.",
+    "",
+    "Worth knowing about this base image",
+    "-----------------------------------",
+    "  The GitHub CLI is not pre-installed. If this project's flows shell out to",
+    "  `gh`, add it to remoteEnv.tools.install with a pinned version and",
+    "  checksum, the same as any other tool.",
+    "",
+    "  A credential handled by the GitHub proxy reads as the literal string",
+    '  "proxy-injected" inside the session. Tools that authenticate through the',
+    "  proxy work; a script that reads the variable itself gets the placeholder.",
+    "",
+    "Then prove it",
+    "-------------",
+    "  Start a session and run the read-back. Whatever provisioned an",
+    "  environment, the same verify is what makes it trustworthy:",
+    "    node scripts/verify-remote-env.mjs",
+  ].join("\n");
+}
+
+/**
+ * Decide which phases this invocation runs.
+ *
+ * An explicit `--phase` always wins, because that is how a session-start hook
+ * asks for the one phase it owns. Otherwise every phase runs except a secrets
+ * step that belongs to a different moment on this surface — running it here
+ * would produce a copy that the surface never refreshes.
+ * @param {string|undefined} requested Value of `--phase`, when given.
+ * @param {string|null} materializeAt When this surface materializes.
+ * @returns {string[]} Phases to run, in order.
+ */
+export function selectPhases(requested, materializeAt) {
+  if (requested) {
+    if (!PHASES.includes(requested)) {
+      throw new Error(
+        `unknown --phase "${requested}". Known: ${PHASES.join(", ")}.`
+      );
+    }
+    if (requested === "secrets" && materializeAt !== "session-start") {
+      // Not an error: the hook is committed to the repository and runs on every
+      // surface the project is ever checked out on. Refusing loudly would make
+      // a correct local session look broken every time it started.
+      return [];
+    }
+    return [requested];
+  }
+  return PHASES.filter(
+    phase => phase !== "secrets" || materializeAt === "setup"
   );
-  execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
-    stdio: "inherit",
-  });
+}
 
-  runHook(cfg.hook, dryRun);
+/**
+ * Read the surface the resolver detects, without duplicating its rules.
+ *
+ * Imported rather than shelled out to, because the answer is a pure function of
+ * the environment and a subprocess would buy nothing. The path is converted to
+ * a file URL first: a bare absolute path is not a portable module specifier.
+ * @returns {Promise<{surface: string, materializeAt: string|null}>} Detected surface.
+ */
+async function detectSurface() {
+  const script = siblingScript("lisa-secrets-access", "surfaces.mjs");
+  const mod = await import(pathToFileURL(script).href);
+  const surface = mod.detectSurface();
+  return { surface, materializeAt: mod.SURFACES[surface].materializeAt };
+}
+
+/**
+ * Name the project's own install command rather than inventing one.
+ *
+ * The emitted setup line must begin with whatever this project already uses; a
+ * guessed package manager produces a container that fails on its first command.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} The install command to place before the setup script.
+ */
+export function detectInstallCommand(cwd = process.cwd()) {
+  const lockfiles = [
+    ["bun.lockb", "bun install"],
+    ["bun.lock", "bun install"],
+    ["pnpm-lock.yaml", "pnpm install --frozen-lockfile"],
+    ["yarn.lock", "yarn install --immutable"],
+    ["package-lock.json", "npm ci"],
+  ];
+  for (const [file, command] of lockfiles) {
+    if (existsSync(join(cwd, file))) return command;
+  }
+  return "<your install command>";
+}
+
+/**
+ * Read the bootstrap key name, which is the one value the operator must paste.
+ * @param {string} [cwd] Repository root.
+ * @returns {string|null} The configured key name, when there is one.
+ */
+function readBootstrapKey(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8")).secrets?.bootstrap?.key ?? null;
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const emit = process.argv
+    .find(arg => arg.startsWith("--emit="))
+    ?.slice("--emit=".length);
+
+  if (emit) {
+    if (emit !== "claude-web") {
+      throw new Error(
+        `no emit template for surface "${emit}".\n` +
+          `Emitting is implemented for claude-web, which has no other tier.`
+      );
+    }
+    console.log(
+      emitClaudeWeb({
+        bootstrapKey: readBootstrapKey(),
+        install: detectInstallCommand(),
+      })
+    );
+    return;
+  }
+
+  const requested = process.argv
+    .find(arg => arg.startsWith("--phase="))
+    ?.slice("--phase=".length);
+  const cfg = readRemoteEnvConfig();
+  const { surface, materializeAt } = await detectSurface();
+  const phases = selectPhases(requested, materializeAt);
+
+  if (!phases.length) {
+    console.log(
+      `Nothing to do: surface "${surface}" does not materialize from a ` +
+        `session-start hook.`
+    );
+    return;
+  }
+
+  if (phases.includes("toolchain")) {
+    console.log("Toolchain:");
+    applyToolchain(cfg.tools, dryRun);
+  }
+
+  if (phases.includes("secrets")) {
+    console.log("\nSecrets:");
+    const materialize = siblingScript(
+      "lisa-secrets-access",
+      "materialize-secrets.mjs"
+    );
+    execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
+      stdio: "inherit",
+    });
+  } else if (!requested) {
+    console.log(
+      `\nSecrets: materialized from a session-start hook on "${surface}", ` +
+        `not here.\n` +
+        `  This script is skipped whenever a cached environment exists, so a ` +
+        `value written\n  here would go stale the moment it was rotated. The ` +
+        `hook runs every session.`
+    );
+  }
+
+  if (phases.includes("hook")) runHook(cfg.hook, dryRun);
   console.log(`\nRemote environment ${dryRun ? "plan complete" : "ready"}.`);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  try {
-    main();
-  } catch (err) {
+  // Awaited rather than called bare: main is async, so a synchronous try/catch
+  // would let a rejected promise escape as an unhandled rejection and exit 0 —
+  // reporting a prepared environment that was never prepared.
+  main().catch(err => {
     console.error(err.message);
     process.exit(1);
-  }
+  });
 }

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -22,7 +22,8 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
 
 import { readRemoteEnvConfig } from "./setup-remote-env.mjs";
 import { extractVersion } from "./toolchain.mjs";
@@ -120,6 +121,43 @@ function verifyToolchain(tools) {
 }
 
 /**
+ * Assert that a declared credential is genuinely readable, not a proxy stand-in.
+ *
+ * A surface may keep a credential outside the sandbox entirely and substitute
+ * the real value at egress. The variable is then present and non-empty, so a
+ * presence check passes — and a script that reads the variable and puts it in a
+ * header sends the placeholder and fails somewhere far from here, with an error
+ * that points at the service rather than at the environment.
+ *
+ * Reported without printing any value: the placeholder is compared, and a real
+ * credential is only ever reported as present.
+ *
+ * Takes its reporter as an argument rather than writing to this module's
+ * results array, so the rule can be exercised against a synthetic environment
+ * without a container and without leaking findings between runs.
+ * @param {string[]} required Declared credential names.
+ * @param {Record<string, string|undefined>} env Environment to inspect.
+ * @param {(ok: boolean, label: string, detail: string) => void} report Collector.
+ */
+export function verifyNotProxied(required, env, report) {
+  for (const name of required) {
+    const value = (env[name] ?? "").trim();
+    if (!value) {
+      report(false, `credential ${name}`, "declared but not present");
+      continue;
+    }
+    report(
+      value !== "proxy-injected",
+      `credential ${name}`,
+      value === "proxy-injected"
+        ? 'reads as "proxy-injected" — substituted at egress, so anything ' +
+            "reading this variable directly receives the placeholder"
+        : "present"
+    );
+  }
+}
+
+/**
  * Assert the working tree is clean.
  *
  * A remote environment that starts dirty will carry unrelated changes into
@@ -142,11 +180,23 @@ function verifyCleanCheckout() {
   }
 }
 
+/**
+ * Read the credential names the project declares it needs.
+ * @param {string} [cwd] Repository root.
+ * @returns {string[]} Declared names, or none when unconfigured.
+ */
+function readRequired(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (!existsSync(path)) return [];
+  return JSON.parse(readFileSync(path, "utf8")).secrets?.require ?? [];
+}
+
 function main() {
   const cfg = readRemoteEnvConfig();
   const secretsDir = process.argv[2];
 
   verifyToolchain(cfg.tools);
+  verifyNotProxied(readRequired(), process.env, check);
 
   const surface = node([
     new URL(

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -188,7 +188,12 @@ function verifyCleanCheckout() {
 function readRequired(cwd = process.cwd()) {
   const path = join(cwd, ".lisa.config.json");
   if (!existsSync(path)) return [];
-  return JSON.parse(readFileSync(path, "utf8")).secrets?.require ?? [];
+  const required = JSON.parse(readFileSync(path, "utf8")).secrets?.require;
+  if (required == null) return [];
+  if (!Array.isArray(required)) {
+    throw new Error("secrets.require must be an array when present");
+  }
+  return required;
 }
 
 function main() {

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -29,18 +29,35 @@ import { join } from "node:path";
  * consuming process exists and which therefore have no other channel; a remote
  * agent container prepares itself during setup, long before any task starts.
  *
- * The two remote surfaces share the capability but not the timing, and a reader
- * adding a third should not assume otherwise. `codex-cloud` re-runs its setup
- * script when a container resumes, so materializing there picks up a rotated
- * value. `claude-web` *skips* its setup script whenever a filesystem cache
- * exists, so materializing there would strand a rotated value until the cache
- * expired — its materialize step runs from a session-start hook instead.
+ * `materializeAt` — *when* the write happens, for surfaces that do one. The two
+ * remote surfaces share the capability but not the timing, and a reader adding a
+ * third should not assume otherwise. `codex-cloud` re-runs its setup script when
+ * a container resumes, so materializing during setup picks up a rotated value.
+ * `claude-web` *skips* its setup script whenever a filesystem cache exists, so
+ * materializing there would strand a rotated value until the cache expired —
+ * it materializes from a session-start hook instead, which runs every session.
+ *
+ * Stated as a capability rather than inferred from the surface name, so the
+ * setup runner selects its phases from the table instead of branching on which
+ * vendor it happens to be talking to.
  */
 export const SURFACES = {
-  local: { materialized: false, mayWriteValues: false },
-  "github-actions": { materialized: false, mayWriteValues: false },
-  "codex-cloud": { materialized: true, mayWriteValues: true },
-  "claude-web": { materialized: true, mayWriteValues: true },
+  local: { materialized: false, mayWriteValues: false, materializeAt: null },
+  "github-actions": {
+    materialized: false,
+    mayWriteValues: false,
+    materializeAt: null,
+  },
+  "codex-cloud": {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "setup",
+  },
+  "claude-web": {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "session-start",
+  },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */

--- a/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
@@ -39,6 +39,20 @@ Omitting the install does not degrade gracefully. The entrypoint exits before th
 
 Order matters. The toolchain comes first because the secrets step needs the provider CLI it installs. The hook comes last because it is the only part that may assume everything else is ready.
 
+### Which phases run depends on the surface
+
+Not every surface runs all three here, and the reason is worth understanding before changing it.
+
+A surface that **re-runs this script when a container resumes** — Codex Cloud — should materialize during setup. Re-running is exactly what picks up a rotated value, an edited note, or a changed version pin.
+
+A surface that **skips this script whenever a filesystem cache exists** — Claude Code web — must not. Materializing here would write the values once and then never refresh them, so a credential rotated on Tuesday would still be serving Monday's value until the cache expired days later. Those surfaces materialize from a session-start hook instead, which runs every session including a resumed one:
+
+```sh
+bash scripts/lisa-remote-env/session-start.sh   # guard; delegates to --phase=secrets
+```
+
+The selection comes from the surface's `materializeAt` capability in `lisa-secrets-access`, not from its name, so adding a surface does not mean editing a branch. The hook is committed to the repository, so it also fires on a developer's machine — it exits `0` immediately there rather than failing, because a correct local session must not look broken.
+
 ## Toolchain manifest — two entry kinds
 
 ```json
@@ -131,6 +145,25 @@ Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
                    maintenance both run before task secrets exist>
 ```
 
+### Claude Code web is emit-only, and that is not a fallback
+
+**For Claude Code web there is no tier 1 or tier 2 to fall back from.** A cloud environment is account-scoped configuration — network access level, environment variables, setup script — edited only in the environment selector at claude.ai/code, which has no settings page, no direct URL, and no API. `/remote-env` selects an environment; it cannot create or edit one.
+
+Note what this surface's environment is *not*: it carries no repository. The repository arrives per session, so an environment is reusable across every project, and there is nothing to bind. Its durable handle is the routine that dispatch fires, which is why `remoteEnv.surfaces["claude-web"]` records `routineId` and `fireUrl` rather than a repository.
+
+Generate the exact text to paste:
+
+```sh
+node scripts/setup-remote-env.mjs --emit=claude-web
+```
+
+It reads the project's own install command from its lockfile and the bootstrap name from `secrets.bootstrap.key`, then emits the environment fields, the `.claude/settings.json` hook block, and the two base-image surprises worth knowing before they cost an afternoon:
+
+- **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
+- **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
+
+**Only the bootstrap belongs in the environment-variable box.** Values there are stored as plain text and are readable by anyone who uses the environment — on an organization-shared environment, that is every member of the organization. Everything else is materialized by the session-start hook. There is no dedicated secrets store on this surface, and personal versus shared environments cannot be told apart programmatically, so this one is a rule the operator upholds rather than something the tooling can enforce.
+
 ## Verification is tier-independent
 
 **Whatever tier provisioned it, the same read-back proves it.** Trust comes from the verify, not the mechanism — which is what makes emit-tier as trustworthy as API-tier.
@@ -139,7 +172,9 @@ Environment vars:  LISA_SECRETS_SURFACE=codex-cloud
 scripts/verify-remote-env.mjs [SECRETS_DIR]
 ```
 
-Asserts, without printing a value: each declared tool at its pinned or minimum version, the detected surface, the secrets directory at mode `0700`, both files at mode `0600`, and a clean checkout.
+Asserts, without printing a value: each declared tool at its pinned or minimum version, the detected surface, the secrets directory at mode `0700`, both files at mode `0600`, a clean checkout, and that every name in `secrets.require` resolves to a real credential rather than a proxy placeholder.
+
+That last one exists because presence is a weaker claim than usability. A credential the surface keeps outside the sandbox and substitutes at egress is present and non-empty, so a presence check passes — and a script that reads the variable and puts it in a header sends the placeholder and fails against the service, with an error pointing anywhere but at the environment.
 
 **Never verify against vendor UI state.** On 2026-08-01 a Codex environments table reported zero tasks for an environment that had demonstrably completed one, because the task records carried a null environment identifier and the `--env` filter was correspondingly unreliable. Reconcile through durable identifiers only.
 
@@ -147,7 +182,7 @@ Asserts, without printing a value: each declared tool at its pinned or minimum v
 
 Checked when setup runs, not at 3am:
 
-- the environment exists and is bound to **this** repository as its default checkout;
+- the environment exists, and on a surface that binds one, is bound to **this** repository as its default checkout — Claude cloud environments bind no repository at all, so there is nothing to check there;
 - the bootstrap credential resolves;
 - either a checkout-local Lisa skill is present, or the project dependency install has made the pinned `@codyswann/lisa` package available under `node_modules`.
 
@@ -156,6 +191,8 @@ Fail with a message naming what is missing. Never provision-and-hope.
 ## Bootstrap credential placement
 
 On Codex Cloud the bootstrap must be an **environment variable, not a task secret**: setup runs on a new container and maintenance runs on cache resume, both before task secrets exist. The tradeoff is that the variable remains visible during the task, so compensate by keeping the machine account narrowly scoped and instructing the task never to inspect or use it.
+
+On Claude Code web the same placement applies for the same reason, with the exposure widened rather than narrowed: there is no secrets store, values are stored as plain text, and anyone who uses the environment can read them. On an organization-shared environment that is every member. Keep the bootstrap in a **personal** environment, scope the machine account to the minimum, and treat every other credential as something the session-start hook materializes rather than something a human pastes.
 
 ## Related
 

--- a/plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh
+++ b/plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Session-start entrypoint for surfaces that materialize secrets per session
+# rather than during environment setup.
+#
+# Wired into the repository's `.claude/settings.json` as a SessionStart hook,
+# so it is part of the clone and runs on every session — including a session
+# resumed onto a cached environment, which is the case that matters.
+#
+# Why this exists at all: a cloud environment's setup script is skipped whenever
+# a filesystem cache exists. Materializing there would write the values once and
+# never refresh them, so a rotated credential would stay stale until the cache
+# expired days later. This hook runs every session, so the copy on disk is
+# always the provider's current view.
+#
+# It is deliberately a guard and a delegation, not a second implementation. The
+# skill-resolution ladder is subtle enough that two copies would drift, so the
+# real work stays in setup.sh and this file only decides whether to call it.
+set -euo pipefail
+
+# Exit before doing anything on a machine that is not a remote session. The hook
+# is committed to the repository, so it also fires on every local session; the
+# materialize step would correctly refuse there, but failing on a developer's
+# laptop every time they start a session is noise, not a signal.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+here="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+exec bash "${here}/setup.sh" --phase=secrets "$@"

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -300,7 +300,7 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "-------------",
     "  Start a session and run the read-back. Whatever provisioned an",
     "  environment, the same verify is what makes it trustworthy:",
-    "    node scripts/verify-remote-env.mjs",
+    "    node node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs",
   ].join("\n");
 }
 

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -5,15 +5,26 @@
  * This is the script a remote environment's setup **and** maintenance fields
  * call. They are the same script on purpose. A container may be built fresh or
  * resumed from cache, and every step here is idempotent and version-aware, so
- * running it twice is correct and running it on resume is what picks up a
- * rotated value, an edited note, or a changed version pin.
+ * running it twice is correct.
  *
  * Order matters. The toolchain comes first because the secrets step needs the
  * provider CLI that the toolchain installs. The project hook comes last because
  * it is the only part that may assume everything else is ready.
  *
+ * **Which phases run depends on the surface, and the reason is not cosmetic.**
+ * On a surface that re-runs this script when a container resumes, materializing
+ * here is what picks up a rotated value. On a surface that *skips* it whenever a
+ * filesystem cache exists, materializing here would write the value once and
+ * then never refresh it — a rotated credential would stay stale until the cache
+ * expired. Those surfaces materialize from a session-start hook instead, which
+ * runs every session including resumed ones, and `--phase=secrets` is how that
+ * hook re-enters this file.
+ *
+ * The selection comes from the surface's `materializeAt` capability rather than
+ * from its name, so adding a surface does not mean editing a branch here.
+ *
  * Usage:
- *   setup-remote-env.mjs [--dry-run]
+ *   setup-remote-env.mjs [--dry-run] [--phase=toolchain|secrets|hook]
  * @module setup-remote-env
  */
 
@@ -26,7 +37,7 @@ import {
   rmSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
 
@@ -197,31 +208,252 @@ function runHook(hook, dryRun) {
   execFileSync("bash", [path], { stdio: "inherit" });
 }
 
-function main() {
-  const dryRun = process.argv.includes("--dry-run");
-  const cfg = readRemoteEnvConfig();
+/** Phases this runner can execute, in the order they must happen. */
+const PHASES = ["toolchain", "secrets", "hook"];
 
-  console.log("Toolchain:");
-  applyToolchain(cfg.tools, dryRun);
+/**
+ * The settings block that wires the session-start hook into a repository.
+ *
+ * Emitted rather than written, because `.claude/settings.json` belongs to the
+ * project: it may already carry hooks, and merging someone else's file from
+ * here is how a careless tool destroys a configuration it did not understand.
+ */
+const SESSION_START_BLOCK = `{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \\"$CLAUDE_PROJECT_DIR\\"/scripts/lisa-remote-env/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}`;
 
-  console.log("\nSecrets:");
-  const materialize = siblingScript(
-    "lisa-secrets-access",
-    "materialize-secrets.mjs"
+/**
+ * Produce the configuration a human pastes to provision a Claude cloud surface.
+ *
+ * This surface has no API tier and no console tier to fall back to: a Claude
+ * cloud environment is configured only in the environment dialog, which has no
+ * settings page, no direct URL, and no endpoint. Emit is not a degraded option
+ * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
+ * what makes the result trustworthy, exactly as it would be at any other tier.
+ * @param {{bootstrapKey: string|null, install: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitClaudeWeb({ bootstrapKey, install }) {
+  const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+  return [
+    "Provisioning tier: EMIT — and for this surface that is the only tier.",
+    "  A Claude cloud environment is account-scoped configuration edited in the",
+    "  environment selector at claude.ai/code. There is no settings page, no",
+    "  direct URL and no API, so nothing here can provision it for you.",
+    "",
+    "Paste into the environment dialog",
+    "---------------------------------",
+    "  Network access:  Trusted, or Custom plus any host your project needs",
+    "",
+    "  Environment variables:",
+    `    ${key}=<read this from your credential manager>`,
+    "",
+    "    Only the bootstrap belongs in this box. Values here are stored as",
+    "    plain text and are readable by anyone who uses the environment — on an",
+    "    organization-shared environment that is every member of the org. Every",
+    "    other credential is materialized by the session-start hook below, which",
+    "    is why exactly one value needs to live here.",
+    "",
+    "  Setup script:",
+    `    ${install} && bash scripts/lisa-remote-env/setup.sh`,
+    "",
+    "    The install must come first. On a fresh container node_modules is the",
+    "    only copy of the Lisa skills present, because Claude receives them as",
+    "    an installed plugin rather than as part of the clone.",
+    "",
+    "Commit to the repository",
+    "------------------------",
+    "  scripts/lisa-remote-env/session-start.sh   (from this skill's assets)",
+    "",
+    "  .claude/settings.json — merge this into any hooks already there:",
+    SESSION_START_BLOCK.split("\n")
+      .map(line => `    ${line}`)
+      .join("\n"),
+    "",
+    "    The setup script is skipped whenever a cached environment exists, so",
+    "    secrets are materialized from this hook instead. It runs every session,",
+    "    including a resumed one, which is what keeps a rotated value current.",
+    "",
+    "Worth knowing about this base image",
+    "-----------------------------------",
+    "  The GitHub CLI is not pre-installed. If this project's flows shell out to",
+    "  `gh`, add it to remoteEnv.tools.install with a pinned version and",
+    "  checksum, the same as any other tool.",
+    "",
+    "  A credential handled by the GitHub proxy reads as the literal string",
+    '  "proxy-injected" inside the session. Tools that authenticate through the',
+    "  proxy work; a script that reads the variable itself gets the placeholder.",
+    "",
+    "Then prove it",
+    "-------------",
+    "  Start a session and run the read-back. Whatever provisioned an",
+    "  environment, the same verify is what makes it trustworthy:",
+    "    node scripts/verify-remote-env.mjs",
+  ].join("\n");
+}
+
+/**
+ * Decide which phases this invocation runs.
+ *
+ * An explicit `--phase` always wins, because that is how a session-start hook
+ * asks for the one phase it owns. Otherwise every phase runs except a secrets
+ * step that belongs to a different moment on this surface — running it here
+ * would produce a copy that the surface never refreshes.
+ * @param {string|undefined} requested Value of `--phase`, when given.
+ * @param {string|null} materializeAt When this surface materializes.
+ * @returns {string[]} Phases to run, in order.
+ */
+export function selectPhases(requested, materializeAt) {
+  if (requested) {
+    if (!PHASES.includes(requested)) {
+      throw new Error(
+        `unknown --phase "${requested}". Known: ${PHASES.join(", ")}.`
+      );
+    }
+    if (requested === "secrets" && materializeAt !== "session-start") {
+      // Not an error: the hook is committed to the repository and runs on every
+      // surface the project is ever checked out on. Refusing loudly would make
+      // a correct local session look broken every time it started.
+      return [];
+    }
+    return [requested];
+  }
+  return PHASES.filter(
+    phase => phase !== "secrets" || materializeAt === "setup"
   );
-  execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
-    stdio: "inherit",
-  });
+}
 
-  runHook(cfg.hook, dryRun);
+/**
+ * Read the surface the resolver detects, without duplicating its rules.
+ *
+ * Imported rather than shelled out to, because the answer is a pure function of
+ * the environment and a subprocess would buy nothing. The path is converted to
+ * a file URL first: a bare absolute path is not a portable module specifier.
+ * @returns {Promise<{surface: string, materializeAt: string|null}>} Detected surface.
+ */
+async function detectSurface() {
+  const script = siblingScript("lisa-secrets-access", "surfaces.mjs");
+  const mod = await import(pathToFileURL(script).href);
+  const surface = mod.detectSurface();
+  return { surface, materializeAt: mod.SURFACES[surface].materializeAt };
+}
+
+/**
+ * Name the project's own install command rather than inventing one.
+ *
+ * The emitted setup line must begin with whatever this project already uses; a
+ * guessed package manager produces a container that fails on its first command.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} The install command to place before the setup script.
+ */
+export function detectInstallCommand(cwd = process.cwd()) {
+  const lockfiles = [
+    ["bun.lockb", "bun install"],
+    ["bun.lock", "bun install"],
+    ["pnpm-lock.yaml", "pnpm install --frozen-lockfile"],
+    ["yarn.lock", "yarn install --immutable"],
+    ["package-lock.json", "npm ci"],
+  ];
+  for (const [file, command] of lockfiles) {
+    if (existsSync(join(cwd, file))) return command;
+  }
+  return "<your install command>";
+}
+
+/**
+ * Read the bootstrap key name, which is the one value the operator must paste.
+ * @param {string} [cwd] Repository root.
+ * @returns {string|null} The configured key name, when there is one.
+ */
+function readBootstrapKey(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8")).secrets?.bootstrap?.key ?? null;
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const emit = process.argv
+    .find(arg => arg.startsWith("--emit="))
+    ?.slice("--emit=".length);
+
+  if (emit) {
+    if (emit !== "claude-web") {
+      throw new Error(
+        `no emit template for surface "${emit}".\n` +
+          `Emitting is implemented for claude-web, which has no other tier.`
+      );
+    }
+    console.log(
+      emitClaudeWeb({
+        bootstrapKey: readBootstrapKey(),
+        install: detectInstallCommand(),
+      })
+    );
+    return;
+  }
+
+  const requested = process.argv
+    .find(arg => arg.startsWith("--phase="))
+    ?.slice("--phase=".length);
+  const cfg = readRemoteEnvConfig();
+  const { surface, materializeAt } = await detectSurface();
+  const phases = selectPhases(requested, materializeAt);
+
+  if (!phases.length) {
+    console.log(
+      `Nothing to do: surface "${surface}" does not materialize from a ` +
+        `session-start hook.`
+    );
+    return;
+  }
+
+  if (phases.includes("toolchain")) {
+    console.log("Toolchain:");
+    applyToolchain(cfg.tools, dryRun);
+  }
+
+  if (phases.includes("secrets")) {
+    console.log("\nSecrets:");
+    const materialize = siblingScript(
+      "lisa-secrets-access",
+      "materialize-secrets.mjs"
+    );
+    execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
+      stdio: "inherit",
+    });
+  } else if (!requested) {
+    console.log(
+      `\nSecrets: materialized from a session-start hook on "${surface}", ` +
+        `not here.\n` +
+        `  This script is skipped whenever a cached environment exists, so a ` +
+        `value written\n  here would go stale the moment it was rotated. The ` +
+        `hook runs every session.`
+    );
+  }
+
+  if (phases.includes("hook")) runHook(cfg.hook, dryRun);
   console.log(`\nRemote environment ${dryRun ? "plan complete" : "ready"}.`);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  try {
-    main();
-  } catch (err) {
+  // Awaited rather than called bare: main is async, so a synchronous try/catch
+  // would let a rejected promise escape as an unhandled rejection and exit 0 —
+  // reporting a prepared environment that was never prepared.
+  main().catch(err => {
     console.error(err.message);
     process.exit(1);
-  }
+  });
 }

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -22,7 +22,8 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
 
 import { readRemoteEnvConfig } from "./setup-remote-env.mjs";
 import { extractVersion } from "./toolchain.mjs";
@@ -120,6 +121,43 @@ function verifyToolchain(tools) {
 }
 
 /**
+ * Assert that a declared credential is genuinely readable, not a proxy stand-in.
+ *
+ * A surface may keep a credential outside the sandbox entirely and substitute
+ * the real value at egress. The variable is then present and non-empty, so a
+ * presence check passes — and a script that reads the variable and puts it in a
+ * header sends the placeholder and fails somewhere far from here, with an error
+ * that points at the service rather than at the environment.
+ *
+ * Reported without printing any value: the placeholder is compared, and a real
+ * credential is only ever reported as present.
+ *
+ * Takes its reporter as an argument rather than writing to this module's
+ * results array, so the rule can be exercised against a synthetic environment
+ * without a container and without leaking findings between runs.
+ * @param {string[]} required Declared credential names.
+ * @param {Record<string, string|undefined>} env Environment to inspect.
+ * @param {(ok: boolean, label: string, detail: string) => void} report Collector.
+ */
+export function verifyNotProxied(required, env, report) {
+  for (const name of required) {
+    const value = (env[name] ?? "").trim();
+    if (!value) {
+      report(false, `credential ${name}`, "declared but not present");
+      continue;
+    }
+    report(
+      value !== "proxy-injected",
+      `credential ${name}`,
+      value === "proxy-injected"
+        ? 'reads as "proxy-injected" — substituted at egress, so anything ' +
+            "reading this variable directly receives the placeholder"
+        : "present"
+    );
+  }
+}
+
+/**
  * Assert the working tree is clean.
  *
  * A remote environment that starts dirty will carry unrelated changes into
@@ -142,11 +180,23 @@ function verifyCleanCheckout() {
   }
 }
 
+/**
+ * Read the credential names the project declares it needs.
+ * @param {string} [cwd] Repository root.
+ * @returns {string[]} Declared names, or none when unconfigured.
+ */
+function readRequired(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (!existsSync(path)) return [];
+  return JSON.parse(readFileSync(path, "utf8")).secrets?.require ?? [];
+}
+
 function main() {
   const cfg = readRemoteEnvConfig();
   const secretsDir = process.argv[2];
 
   verifyToolchain(cfg.tools);
+  verifyNotProxied(readRequired(), process.env, check);
 
   const surface = node([
     new URL(

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -188,7 +188,12 @@ function verifyCleanCheckout() {
 function readRequired(cwd = process.cwd()) {
   const path = join(cwd, ".lisa.config.json");
   if (!existsSync(path)) return [];
-  return JSON.parse(readFileSync(path, "utf8")).secrets?.require ?? [];
+  const required = JSON.parse(readFileSync(path, "utf8")).secrets?.require;
+  if (required == null) return [];
+  if (!Array.isArray(required)) {
+    throw new Error("secrets.require must be an array when present");
+  }
+  return required;
 }
 
 function main() {

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1087,7 +1087,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/rotate-secret.mjs":
       "f896ef08c53c9f6a859c4ddb527f7e765c542e1fd8bb198c6d75c8f260185669",
     "plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs":
-      "97c0cde692991fdf01cf640a563cd78f2f91812f135c06eac7ac418ff2bf2c8a",
+      "da3fdf62b88f77c6c2ae09f5352797818813fccb0dafe551c801b58f25de2711",
     "plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs":
       "e317eeaa65283ceadb2f25b6ca5e22178801094209420e9b516f225cebae985f",
     "plugins/src/base/skills/lisa-security-review/SKILL.md":
@@ -1119,15 +1119,17 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md":
       "80fbf157f9c562c033886c25a99b37356602edd9e61cd2d492f339769ddcf97e",
     "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md":
-      "d3ecfe4ffbb7c6df241f2b3f7252c4b24e907ccf87fb3da7db95fadbaa45c054",
+      "91c5d4dbc513b642e9da304425501ca6802f28c8059135e8ccc6ca0200060ee9",
+    "plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh":
+      "6e3871ec2f8d56b8ebb85376ebdd3956f3ed8fa4f7b278c2ed90ca9b8845897c",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "a043074dd52e3f9b4b4a32bdd8b5eaa728160e5a0622a8a18388e6e26c7d25e3",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "1e3f57c34edd65129a157f7418524594ca92b5472978bf5be1641981f4f1afbe",
+      "4ae3531444e8873697c5c238a93b5942c3a8b4070444187ba7b94db3ea177a40",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
       "ff66d33ba41a068d09be18f81ac68988238c2afa1d4e3733ae906b73eea74324",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
-      "5c025cd06d3d9f01649b75d03859126e347ba62e8230447580a0ae5297240697",
+      "7577d2e4a2eea68e4494600be0acc3e705187eeb50aed79ebec294542abdee50",
     "plugins/src/base/skills/lisa-setup-sonar/SKILL.md":
       "53fbd8acce4b5e47e88195a7b90d5be424fa6ef7ad872f52c50467c690664c3b",
     "plugins/src/base/skills/lisa-sonarcloud-access/SKILL.md":
@@ -3257,6 +3259,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-agy/skills/lisa-setup-notion/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-setup-remote-aws/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md": true,
+    "plugins/lisa-agy/skills/lisa-setup-remote-env/assets/session-start.sh": true,
     "plugins/lisa-agy/skills/lisa-setup-remote-env/assets/setup.sh": true,
     "plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs": true,
     "plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/toolchain.mjs": true,
@@ -3671,6 +3674,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/skills/lisa-setup-notion/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-setup-remote-aws/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md": true,
+    "plugins/lisa-copilot/skills/lisa-setup-remote-env/assets/session-start.sh": true,
     "plugins/lisa-copilot/skills/lisa-setup-remote-env/assets/setup.sh": true,
     "plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs": true,
     "plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/toolchain.mjs": true,
@@ -4071,6 +4075,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/skills/lisa-setup-notion/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-setup-remote-aws/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md": true,
+    "plugins/lisa-cursor/skills/lisa-setup-remote-env/assets/session-start.sh": true,
     "plugins/lisa-cursor/skills/lisa-setup-remote-env/assets/setup.sh": true,
     "plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs": true,
     "plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/toolchain.mjs": true,
@@ -6103,6 +6108,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/.codex-plugin/skills/lisa-setup-remote-aws/agents/openai.yaml": true,
     "plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md": true,
     "plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/agents/openai.yaml": true,
+    "plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/assets/session-start.sh": true,
     "plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/assets/setup.sh": true,
     "plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs": true,
     "plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/toolchain.mjs": true,
@@ -6679,6 +6685,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/skills/lisa-setup-remote-aws/agents/openai.yaml": true,
     "plugins/lisa/skills/lisa-setup-remote-env/SKILL.md": true,
     "plugins/lisa/skills/lisa-setup-remote-env/agents/openai.yaml": true,
+    "plugins/lisa/skills/lisa-setup-remote-env/assets/session-start.sh": true,
     "plugins/lisa/skills/lisa-setup-remote-env/assets/setup.sh": true,
     "plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs": true,
     "plugins/lisa/skills/lisa-setup-remote-env/scripts/toolchain.mjs": true,
@@ -7118,6 +7125,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/skills/lisa-setup-notion/SKILL.md": true,
     "plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md": true,
     "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md": true,
+    "plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh": true,
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh": true,
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs": true,
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs": true,
@@ -8322,6 +8330,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/bootstrap-key-naming.test.ts": true,
     "tests/unit/secrets/doctor-secrets.test.ts": true,
     "tests/unit/secrets/remote-dispatch.test.ts": true,
+    "tests/unit/secrets/remote-env-phases.test.ts": true,
     "tests/unit/secrets/remote-env-skill-resolution.test.ts": true,
     "tests/unit/secrets/remote-env-toolchain.test.ts": true,
     "tests/unit/secrets/secrets-access-contract.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1125,11 +1125,11 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "a043074dd52e3f9b4b4a32bdd8b5eaa728160e5a0622a8a18388e6e26c7d25e3",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "0fe8b00b18aace2b23e989d68ddb5f055688f4c956b811767d30028cd57fffb4",
+      "d63a47cbf5ca4875c2d0e173943dd36a4c95db5b5ff994e1267d00b251277b57",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
       "ff66d33ba41a068d09be18f81ac68988238c2afa1d4e3733ae906b73eea74324",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
-      "7577d2e4a2eea68e4494600be0acc3e705187eeb50aed79ebec294542abdee50",
+      "82bc2a27a0a5afb2ff413a88365c619fd7f0eaada5de3ccabf2000938f0607a4",
     "plugins/src/base/skills/lisa-setup-sonar/SKILL.md":
       "53fbd8acce4b5e47e88195a7b90d5be424fa6ef7ad872f52c50467c690664c3b",
     "plugins/src/base/skills/lisa-sonarcloud-access/SKILL.md":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1125,7 +1125,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "a043074dd52e3f9b4b4a32bdd8b5eaa728160e5a0622a8a18388e6e26c7d25e3",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "4ae3531444e8873697c5c238a93b5942c3a8b4070444187ba7b94db3ea177a40",
+      "0fe8b00b18aace2b23e989d68ddb5f055688f4c956b811767d30028cd57fffb4",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
       "ff66d33ba41a068d09be18f81ac68988238c2afa1d4e3733ae906b73eea74324",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":

--- a/tests/unit/secrets/remote-env-phases.test.ts
+++ b/tests/unit/secrets/remote-env-phases.test.ts
@@ -31,6 +31,7 @@ type Finding = { ok: boolean; label: string; detail: string };
 /** The two moments a surface can materialize at, as the capability names them. */
 const AT_SETUP = "setup";
 const AT_SESSION_START = "session-start";
+const BUN_INSTALL = "bun install";
 
 /**
  * Collect findings without touching the module's own results array.
@@ -105,7 +106,8 @@ describe("install command detection", () => {
   afterEach(() => rmSync(root, { recursive: true, force: true }));
 
   it.each([
-    ["bun.lock", "bun install"],
+    ["bun.lock", BUN_INSTALL],
+    ["bun.lockb", BUN_INSTALL],
     ["pnpm-lock.yaml", "pnpm install --frozen-lockfile"],
     ["yarn.lock", "yarn install --immutable"],
     ["package-lock.json", "npm ci"],

--- a/tests/unit/secrets/remote-env-phases.test.ts
+++ b/tests/unit/secrets/remote-env-phases.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Contract tests for phase selection, emitted config, and the proxy read-back.
+ *
+ * The rule these protect is the one that is easy to get wrong twice: *when* a
+ * surface materializes is not the same question as *whether* it may. A surface
+ * whose setup script is skipped on a cache hit must materialize somewhere that
+ * runs every session, or a rotated credential silently stays stale until the
+ * cache expires days later.
+ *
+ * Every case here is a pure function against synthetic input. Nothing in this
+ * file starts a container, reaches a provider, or writes a value to disk.
+ * @module tests/unit/secrets/remote-env-phases
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { SURFACES } from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs";
+import {
+  detectInstallCommand,
+  emitClaudeWeb,
+  selectPhases,
+} from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs";
+import { verifyNotProxied } from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs";
+
+/** A finding as the verify read-back records it. */
+type Finding = { ok: boolean; label: string; detail: string };
+
+/** The two moments a surface can materialize at, as the capability names them. */
+const AT_SETUP = "setup";
+const AT_SESSION_START = "session-start";
+
+/**
+ * Collect findings without touching the module's own results array.
+ * @returns A collector holding its own findings and a matching reporter.
+ */
+const collect = (): {
+  findings: Finding[];
+  report: (ok: boolean, label: string, detail: string) => void;
+} => {
+  const findings: Finding[] = [];
+  return {
+    findings,
+    report: (ok, label, detail) => findings.push({ ok, label, detail }),
+  };
+};
+
+describe("materialize timing", () => {
+  it("records when each surface materializes, not merely whether", () => {
+    // Both remote surfaces may write; only one of them may write during setup.
+    expect(SURFACES["codex-cloud"].materializeAt).toBe(AT_SETUP);
+    expect(SURFACES["claude-web"].materializeAt).toBe(AT_SESSION_START);
+    expect(SURFACES.local.materializeAt).toBe(null);
+    expect(SURFACES["github-actions"].materializeAt).toBe(null);
+  });
+});
+
+describe("phase selection", () => {
+  it("runs every phase on a surface that materializes during setup", () => {
+    expect(selectPhases(undefined, AT_SETUP)).toEqual([
+      "toolchain",
+      "secrets",
+      "hook",
+    ]);
+  });
+
+  it("omits secrets on a surface that materializes per session", () => {
+    // Writing here would produce a copy the surface never refreshes, because
+    // this script is skipped whenever a cached environment exists.
+    expect(selectPhases(undefined, AT_SESSION_START)).toEqual([
+      "toolchain",
+      "hook",
+    ]);
+  });
+
+  it("omits secrets on a surface that never materializes at all", () => {
+    expect(selectPhases(undefined, null)).toEqual(["toolchain", "hook"]);
+  });
+
+  it("runs only the requested phase when a hook asks for one", () => {
+    expect(selectPhases("secrets", AT_SESSION_START)).toEqual(["secrets"]);
+  });
+
+  it("no-ops rather than failing when the session-start hook fires locally", () => {
+    // The hook is committed to the repository, so it also runs on a developer's
+    // machine. Failing there would make every correct local session look broken.
+    expect(selectPhases("secrets", null)).toEqual([]);
+    expect(selectPhases("secrets", AT_SETUP)).toEqual([]);
+  });
+
+  it("rejects a phase name it does not know", () => {
+    expect(() => selectPhases("secrts", AT_SETUP)).toThrow(/unknown --phase/i);
+  });
+});
+
+describe("install command detection", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "lisa-install-"));
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it.each([
+    ["bun.lock", "bun install"],
+    ["pnpm-lock.yaml", "pnpm install --frozen-lockfile"],
+    ["yarn.lock", "yarn install --immutable"],
+    ["package-lock.json", "npm ci"],
+  ])("reads %s as %s", (lockfile, expected) => {
+    writeFileSync(path.join(root, lockfile), "");
+    expect(detectInstallCommand(root)).toBe(expected);
+  });
+
+  it("refuses to guess when no lockfile identifies the manager", () => {
+    // A guessed package manager produces a container that fails on its very
+    // first command, with an error that blames the project rather than the guess.
+    expect(detectInstallCommand(root)).toBe("<your install command>");
+  });
+});
+
+describe("emitted Claude configuration", () => {
+  const emitted = emitClaudeWeb({
+    bootstrapKey: "BWS_ACCESS_TOKEN",
+    install: "bun install",
+  });
+
+  it("states that emit is the only tier for this surface", () => {
+    expect(emitted).toMatch(/no settings page, no/i);
+    expect(emitted).toMatch(/no API/i);
+  });
+
+  it("puts the install ahead of the setup script", () => {
+    expect(emitted).toContain(
+      "bun install && bash scripts/lisa-remote-env/setup.sh"
+    );
+  });
+
+  it("asks for the bootstrap and warns who else can read it", () => {
+    expect(emitted).toContain("BWS_ACCESS_TOKEN=");
+    expect(emitted).toMatch(/readable by anyone who uses the environment/i);
+    expect(emitted).toMatch(/organization-shared/i);
+  });
+
+  it("wires the session-start hook and says why it exists", () => {
+    expect(emitted).toContain("session-start.sh");
+    expect(emitted).toMatch(/skipped whenever a cached environment exists/i);
+  });
+
+  it("names the base-image surprises rather than leaving them to be discovered", () => {
+    expect(emitted).toMatch(/GitHub CLI is not pre-installed/i);
+    expect(emitted).toContain("proxy-injected");
+  });
+
+  it("says plainly when the bootstrap has not been configured", () => {
+    const missing = emitClaudeWeb({ bootstrapKey: null, install: "npm ci" });
+    expect(missing).toMatch(/secrets\.bootstrap\.key is not configured/);
+  });
+});
+
+describe("proxy read-back", () => {
+  it("fails a credential that is only a proxy stand-in", () => {
+    // Present and non-empty, so a presence check passes — while any consumer
+    // reading the variable receives the placeholder instead of a credential.
+    const { findings, report } = collect();
+    verifyNotProxied(
+      ["GITHUB_TOKEN"],
+      { GITHUB_TOKEN: "proxy-injected" },
+      report
+    );
+    expect(findings[0].ok).toBe(false);
+    expect(findings[0].detail).toMatch(/substituted at egress/i);
+  });
+
+  it("passes a real credential without printing it", () => {
+    const { findings, report } = collect();
+    verifyNotProxied(["API_KEY"], { API_KEY: "sk-live-do-not-print" }, report);
+    expect(findings[0].ok).toBe(true);
+    expect(JSON.stringify(findings)).not.toContain("sk-live-do-not-print");
+  });
+
+  it("fails a declared credential that is absent", () => {
+    const { findings, report } = collect();
+    verifyNotProxied(["MISSING"], {}, report);
+    expect(findings[0].ok).toBe(false);
+    expect(findings[0].detail).toMatch(/not present/i);
+  });
+});


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2175

Follows #2174, now merged.

## The bug

`lisa-setup-remote-env` assumes its entrypoint runs again whenever a container resumes. That assumption is load-bearing: it is what makes "setup and maintenance are the same script" true, and it is what picks up a rotated value.

It does not hold on Claude Code web, which **skips the setup script whenever a filesystem cache exists** — roughly seven days, or until the script or the network allowlist changes. Materializing secrets there would write the values once and never refresh them, so a credential rotated on Tuesday would still be serving Monday's value days later, with nothing failing loudly to say so.

## What changed

**Phases are now selectable, and driven by a capability.** `materializeAt` joins the surface table: `codex-cloud` materializes during setup, where re-running is exactly what refreshes it; `claude-web` materializes from a session-start hook. The runner picks its phases from that capability rather than branching on a vendor name, so adding a surface stays a single table entry — which is the property the surface table exists to have.

**`assets/session-start.sh` is a guard and a delegation, not a second implementation.** The skill-resolution ladder is subtle enough (agent directories first, `node_modules/@codyswann/lisa` as the fallback that makes plugin-delivered harnesses work at all) that a second copy would drift. So the new asset decides only *whether* to run, then re-enters the existing entrypoint with `--phase=secrets`.

It exits `0` immediately outside a cloud session. The hook is committed to the repository, so it fires on every local session too; materialize would correctly refuse there, but failing on a developer's laptop every time they start a session is noise, not a signal.

**Emit is the only provisioning tier here, and the skill now says so.** A Claude cloud environment is account-scoped configuration edited in a dialog with no settings page, no direct URL, and no API; `/remote-env` selects an environment but cannot create or edit one. `--emit=claude-web` produces the fields to paste, reading the install command from the project's lockfile and the bootstrap name from `secrets.bootstrap.key`. Since emit is the only tier, the tier-independent read-back is what earns trust — which is the design working as intended, not a compromise.

The emitted text also names the two base-image surprises before they cost an afternoon: `gh` is not pre-installed, and a proxied credential reads as the literal `proxy-injected`.

**The read-back asserts a credential is readable, not merely present.** `proxy-injected` is present and non-empty, so a presence check passes while any consumer reading the variable receives a placeholder. Reported through a caller-supplied collector, matching the pattern `doctor-secrets.mjs` already uses so the rule is testable without a container.

## Verification

- `bun run test:unit` — 482 files, 8263 tests, all pass (21 new)
- Typecheck, lint, plugin sync, evidence manifest — all green
- Smoke-tested each new path: `--emit=claude-web` renders and detects `bun install` from the lockfile; `--phase=secrets` no-ops with exit 0 on a local surface; the guard exits 0 outside a cloud session; and with the surface faked, the default phases correctly defer secrets and explain why

## Not in scope

Dispatch and scheduling — the remaining two PRs.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Claude Web remote-environment setup instructions, including installation, session-start configuration, bootstrap guidance, and verification.
  * Added phase-aware setup for toolchain, secrets, and hooks across supported environments.
  * Secrets now refresh at session start where needed, helping prevent stale cached credentials.

* **Bug Fixes**
  * Improved credential verification to detect missing, unusable, or proxy-injected values without exposing secrets.

* **Documentation**
  * Added environment-specific setup, security, and repository-binding guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->