### PR TITLE
Install the scripts a remote environment invokes, and stop misreading present tools as missing

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,5 +44,18 @@
       }
     }
   },
-  "plansDirectory": "./plans"
+  "plansDirectory": "./plans",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/lisa-remote-env/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.lisa.config.json
+++ b/.lisa.config.json
@@ -143,5 +143,30 @@
       "p95LatencyMs": 1000,
       "faultRatePct": 5
     }
+  },
+  "secrets": {
+    "provider": "bitwarden",
+    "bootstrap": {
+      "sources": ["env", "keychain"],
+      "key": "BWS_ACCESS_TOKEN_lisa"
+    }
+  },
+  "remoteEnv": {
+    "tools": {
+      "require": [
+        { "name": "node", "minVersion": "20" },
+        { "name": "curl" },
+        { "name": "unzip" }
+      ],
+      "install": [
+        {
+          "name": "bws",
+          "version": "2.1.0",
+          "install": "release-zip",
+          "url": "https://github.com/bitwarden/sdk-sm/releases/download/bws-v2.1.0/bws-x86_64-unknown-linux-gnu-2.1.0.zip",
+          "sha256": "ba8233c3a4aee5d43e3c73bbd04d99e9bc5aba13bbbfd06d89b073abe732b860"
+        }
+      ]
+    }
   }
 }

--- a/plans/claude-web-surface.md
+++ b/plans/claude-web-surface.md
@@ -90,7 +90,7 @@ shape rather than just prose.
 | ~~U1~~ | ~~What does `claude --cloud` print on success…~~ **ANSWERED 2026-08-03 — `claude --cloud` cannot be used for dispatch at all.** | See below. |
 | U2 | Does a SessionStart hook run before the first agent turn in a cloud session, and does a value written to `$CLAUDE_ENV_FILE` reach later Bash calls? | The whole materialize relocation rests on this. |
 | U3 | Confirm `CLAUDE_CODE_REMOTE=true`, `GH_TOKEN=proxy-injected`, and that the setup script is genuinely skipped on a cache hit. | Surface detection and the `proxy-injected` verdict. |
-| U4 | Can an environment be selected per `--cloud` invocation, or only via the `/remote-env` saved default? | If only the saved default, `remoteEnv.surfaces["claude-web"].environmentId` is advisory and `assertPreconditions` must say so instead of implying a binding it cannot enforce. |
+| ~~U4~~ | ~~Can an environment be selected per `--cloud` invocation…~~ **ANSWERED 2026-08-03: no flag, but a settings key.** | See below. |
 
 Probe from a throwaway repo with a read-only prompt (`report the value of $CLAUDE_CODE_REMOTE and exit`). Record answers in this file's Sessions table.
 
@@ -144,6 +144,33 @@ The bearer token becomes the dispatcher credential, resolved through
 `lisa-secrets-access` and never stored in config. It can be regenerated and revoked,
 so it belongs in `secrets.rotating` — mirroring the parent plan's D.3 observation
 that the dispatcher's own credential exercises the rotating path.
+
+### U4 — answered: no flag, but the choice is a settings key
+
+CLI 2.1.220 has no per-invocation environment option. `--environment` appears in
+the binary but is Bun runtime noise — Claude Code ships as a Bun-compiled
+executable, and Commander rejects the flag exactly as it rejects a nonsense one:
+
+```
+--definitelynotaflag   -> error: unknown option '--definitelynotaflag'
+--environment          -> error: unknown option '--environment'
+```
+
+The selection is nonetheless expressible per invocation, because `/remote-env` is
+only a picker that writes `remote.defaultEnvironmentId` into user settings, and
+`--settings` accepts inline JSON:
+
+```sh
+claude --cloud --settings '{"remote":{"defaultEnvironmentId":"<id>"}}' '<prompt>'
+```
+
+Two consequences for this plan. First, nothing here is load-bearing for dispatch —
+U1 already moved that onto the routine `/fire` endpoint, and this affects only the
+interactive and verification paths. Second, `remoteEnv.surfaces["claude-web"]`
+should **not** carry an `environmentId` as though it were a binding: the durable
+handle is the routine, and an environment recorded in config would imply an
+enforcement this surface cannot provide. A repo's project settings outrank
+`--settings` for the same key, which is a further reason not to write it there.
 
 ## Sequencing
 
@@ -278,4 +305,5 @@ Stated plainly rather than designed around:
 | Session | Date | Phases | Notes |
 |---------|------|--------|-------|
 | 1 | 2026-08-03 | Research | Audited Claude Code web / cloud environments / routines docs against the shipped `codex-cloud` implementation. Confirmed `--cloud` and `--teleport` exist in CLI 2.1.220 but are hidden from `--help`. Established the four structural differences and the `proxy-injected` landmine. Plan created. |
+| 3 | 2026-08-03 | PR 2 follow-up | Setting the surface up for real against a live Bitwarden project surfaced two defects unit tests could not: nothing ever installed `scripts/lisa-remote-env/` despite four references naming it (affects Codex identically), and the toolchain probe read any non-zero exit as a missing tool, so `require: unzip` failed on machines that had it — Info-ZIP's `unzip`, shipped by macOS and Ubuntu alike, exits 10 on `--version`. Settled U4: no per-invocation environment flag, but `--settings` can inject `remote.defaultEnvironmentId`. Verified the full chain end to end — keychain bootstrap, `bws` auth, materialization at 0700/0600 into a throwaway config root. |
 | 2 | 2026-08-03 | PR 0 (probes) | Settled U1 by live invocation: `claude --cloud` refuses any non-interactive call (exit 1, <1s) and names `--print` among the rejected modes, so it cannot back `executionEnv`. Dispatch redesigned onto the routine `/fire` endpoint; PR 3 rewritten, PR 4 reduced. Verified account preconditions are met (`claude.ai` auth, Max, first-party) and that no `remote.defaultEnvironmentId` is saved in user settings, so CLI cloud sessions would fall back to the first available environment. U2–U4 still open — U3 and U4 now need a session started from the web or a TTY rather than a scripted dispatch. |

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
@@ -162,6 +162,18 @@ It reads the project's own install command from its lockfile and the bootstrap n
 - **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
 - **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
 
+### One environment per project, pinned locally
+
+An environment is **not** bound to a repository — the repository arrives per session, and one environment is technically reusable across all of them. Give each project its own anyway, because an environment's *contents* are project-shaped: its setup script is a repository-relative path and its bootstrap is scoped to that project's secrets. Pointing one project's session at another's environment runs a setup script that may not exist there, and a setup script that exits non-zero means the session never starts.
+
+`/remote-env` writes `remote.defaultEnvironmentId` into **user** settings, which is one value for the whole machine — wrong as soon as a developer has two projects. Pin it per project instead:
+
+```sh
+node scripts/setup-remote-env.mjs --install --pin-env=<environment-id>
+```
+
+That writes `.claude/settings.local.json`, which outranks user settings and is gitignored — correct on both counts, since an environment belongs to one developer's account and is meaningless in someone else's checkout. Existing keys in that file are merged, not replaced; it commonly holds permission grants worth keeping.
+
 **Only the bootstrap belongs in the environment-variable box.** Values there are stored as plain text and are readable by anyone who uses the environment — on an organization-shared environment, that is every member of the organization. Everything else is materialized by the session-start hook. There is no dedicated secrets store on this surface, and personal versus shared environments cannot be told apart programmatically, so this one is a rule the operator upholds rather than something the tooling can enforce.
 
 ## Verification is tier-independent

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -293,6 +293,43 @@ const SESSION_START_BLOCK = `{
 }`;
 
 /**
+ * Pin which cloud environment this project's sessions use.
+ *
+ * `/remote-env` writes `remote.defaultEnvironmentId` into *user* settings, which
+ * is one value for the whole machine. That is wrong as soon as a developer has
+ * more than one project, because an environment's contents are project-shaped:
+ * its setup script is a repository-relative path and its bootstrap is scoped to
+ * that project's secrets. Pointing one project's session at another's
+ * environment runs a setup script that may not exist there, and a non-zero setup
+ * script means the session never starts.
+ *
+ * Written to `.claude/settings.local.json` for two reasons. It outranks user
+ * settings, so the per-project choice wins over the machine-wide default; and it
+ * is gitignored, which is correct because an environment belongs to one
+ * developer's account and is meaningless in someone else's checkout.
+ *
+ * Merged rather than replaced — that file commonly holds permission grants a
+ * developer has accumulated, and clobbering them to write one key would be a
+ * poor trade.
+ * @param {string} environmentId Cloud environment identifier.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} The settings path written.
+ */
+export function pinEnvironment(environmentId, cwd = process.cwd()) {
+  const path = join(cwd, ".claude", "settings.local.json");
+  mkdirSync(dirname(path), { recursive: true });
+  const existing = existsSync(path)
+    ? JSON.parse(readFileSync(path, "utf8"))
+    : {};
+  const merged = {
+    ...existing,
+    remote: { ...(existing.remote ?? {}), defaultEnvironmentId: environmentId },
+  };
+  writeFileSync(path, `${JSON.stringify(merged, null, 2)}\n`);
+  return path;
+}
+
+/**
  * Produce the configuration a human pastes to provision a Claude cloud surface.
  *
  * This surface has no API tier and no console tier to fall back to: a Claude
@@ -451,6 +488,18 @@ async function main() {
     console.log(`Installing remote-environment scripts into ${INSTALL_DIR}/`);
     for (const { name, action } of installAssets()) {
       console.log(`  ${action.padEnd(8)} ${join(INSTALL_DIR, name)}`);
+    }
+
+    const pin = process.argv
+      .find(arg => arg.startsWith("--pin-env="))
+      ?.slice("--pin-env=".length);
+    if (pin) {
+      console.log(`\nPinned this project to environment ${pin}`);
+      console.log(`  written  ${pinEnvironment(pin)}`);
+      console.log(
+        "  That file is gitignored and outranks the machine-wide default, so\n" +
+          "  every project can name its own environment."
+      );
     }
     console.log(
       "\nCommit these. They are repository files by design — a container that " +

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -35,6 +35,7 @@ import {
   mkdirSync,
   readFileSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -89,18 +90,35 @@ export function readRemoteEnvConfig(cwd = process.cwd()) {
 
 /**
  * Probe what a tool reports for its version, treating absence as not present.
+ *
+ * "Not installed" and "dislikes `--version`" are different answers, and only a
+ * failure to *spawn* means the first. Info-ZIP's `unzip` — the build shipped by
+ * both macOS and Ubuntu — parses `--version` one letter at a time, warns that
+ * `-n` and `-o` conflict, and exits 10. Reading that as absence made `require`
+ * fail on a machine that had the tool, which is precisely the false alarm the
+ * check exists to avoid raising.
+ *
+ * Version text is still recovered from a failed invocation where there is any,
+ * because a tool that refuses the flag often prints its banner anyway — which
+ * is how `unzip` still reports 6.00 despite exiting non-zero.
+ *
+ * The runner is injectable so both branches can be exercised without depending
+ * on which quirky binaries happen to exist on the machine running the tests.
  * @param {string} name Executable name.
+ * @param {Function} [exec] Command runner, for tests.
  * @returns {{version: string|null, present: boolean}} Probe result.
  */
-function probe(name) {
+export function probe(name, exec = execFileSync) {
   try {
-    const out = execFileSync(name, ["--version"], {
+    const out = exec(name, ["--version"], {
       encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
+      stdio: ["ignore", "pipe", "pipe"],
     });
     return { present: true, version: extractVersion(out) };
-  } catch {
-    return { present: false, version: null };
+  } catch (err) {
+    if (err.code === "ENOENT") return { present: false, version: null };
+    const output = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+    return { present: true, version: extractVersion(output) };
   }
 }
 
@@ -210,6 +228,46 @@ function runHook(hook, dryRun) {
 
 /** Phases this runner can execute, in the order they must happen. */
 const PHASES = ["toolchain", "secrets", "hook"];
+
+/** Where a host project keeps the scripts its remote environment invokes. */
+export const INSTALL_DIR = join("scripts", "lisa-remote-env");
+
+/** Assets a host project needs on disk before any remote session can start. */
+const INSTALLABLE = ["setup.sh", "session-start.sh"];
+
+/**
+ * Copy this skill's assets into the host project that will run them.
+ *
+ * These live in the skill, but the paths that reference them are *repository*
+ * paths: a vendor's setup field says `bash scripts/lisa-remote-env/setup.sh`,
+ * and a session-start hook is only committed if it is a real file in the repo.
+ * Nothing put them there, so every reference resolved to a path that did not
+ * exist — the environment came up, ran a missing script, exited non-zero, and
+ * the session failed to start with no indication that a setup step was skipped.
+ *
+ * Copied rather than symlinked or generated: the file must survive in a fresh
+ * clone on a container that has never seen the plugin, which is the whole
+ * reason the entrypoint is thin enough to copy in the first place.
+ * @param {string} [cwd] Repository root.
+ * @returns {Array<{name: string, action: string}>} What was written.
+ */
+export function installAssets(cwd = process.cwd()) {
+  const destination = join(cwd, INSTALL_DIR);
+  mkdirSync(destination, { recursive: true, mode: 0o755 });
+  return INSTALLABLE.map(name => {
+    const source = resolve(HERE, "..", "assets", name);
+    if (!existsSync(source)) {
+      throw new Error(`asset ${name} is missing from this skill install`);
+    }
+    const target = join(destination, name);
+    const desired = readFileSync(source, "utf8");
+    const unchanged =
+      existsSync(target) && readFileSync(target, "utf8") === desired;
+    if (!unchanged) writeFileSync(target, desired, { mode: 0o755 });
+    chmodSync(target, 0o755);
+    return { name, action: unchanged ? "current" : "written" };
+  });
+}
 
 /**
  * The settings block that wires the session-start hook into a repository.
@@ -388,6 +446,18 @@ async function main() {
   const emit = process.argv
     .find(arg => arg.startsWith("--emit="))
     ?.slice("--emit=".length);
+
+  if (process.argv.includes("--install")) {
+    console.log(`Installing remote-environment scripts into ${INSTALL_DIR}/`);
+    for (const { name, action } of installAssets()) {
+      console.log(`  ${action.padEnd(8)} ${join(INSTALL_DIR, name)}`);
+    }
+    console.log(
+      "\nCommit these. They are repository files by design — a container that " +
+        "has\njust cloned the repo has never seen the plugin they came from."
+    );
+    return;
+  }
 
   if (emit) {
     if (emit !== "claude-web") {

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
@@ -162,6 +162,18 @@ It reads the project's own install command from its lockfile and the bootstrap n
 - **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
 - **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
 
+### One environment per project, pinned locally
+
+An environment is **not** bound to a repository — the repository arrives per session, and one environment is technically reusable across all of them. Give each project its own anyway, because an environment's *contents* are project-shaped: its setup script is a repository-relative path and its bootstrap is scoped to that project's secrets. Pointing one project's session at another's environment runs a setup script that may not exist there, and a setup script that exits non-zero means the session never starts.
+
+`/remote-env` writes `remote.defaultEnvironmentId` into **user** settings, which is one value for the whole machine — wrong as soon as a developer has two projects. Pin it per project instead:
+
+```sh
+node scripts/setup-remote-env.mjs --install --pin-env=<environment-id>
+```
+
+That writes `.claude/settings.local.json`, which outranks user settings and is gitignored — correct on both counts, since an environment belongs to one developer's account and is meaningless in someone else's checkout. Existing keys in that file are merged, not replaced; it commonly holds permission grants worth keeping.
+
 **Only the bootstrap belongs in the environment-variable box.** Values there are stored as plain text and are readable by anyone who uses the environment — on an organization-shared environment, that is every member of the organization. Everything else is materialized by the session-start hook. There is no dedicated secrets store on this surface, and personal versus shared environments cannot be told apart programmatically, so this one is a rule the operator upholds rather than something the tooling can enforce.
 
 ## Verification is tier-independent

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -293,6 +293,43 @@ const SESSION_START_BLOCK = `{
 }`;
 
 /**
+ * Pin which cloud environment this project's sessions use.
+ *
+ * `/remote-env` writes `remote.defaultEnvironmentId` into *user* settings, which
+ * is one value for the whole machine. That is wrong as soon as a developer has
+ * more than one project, because an environment's contents are project-shaped:
+ * its setup script is a repository-relative path and its bootstrap is scoped to
+ * that project's secrets. Pointing one project's session at another's
+ * environment runs a setup script that may not exist there, and a non-zero setup
+ * script means the session never starts.
+ *
+ * Written to `.claude/settings.local.json` for two reasons. It outranks user
+ * settings, so the per-project choice wins over the machine-wide default; and it
+ * is gitignored, which is correct because an environment belongs to one
+ * developer's account and is meaningless in someone else's checkout.
+ *
+ * Merged rather than replaced — that file commonly holds permission grants a
+ * developer has accumulated, and clobbering them to write one key would be a
+ * poor trade.
+ * @param {string} environmentId Cloud environment identifier.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} The settings path written.
+ */
+export function pinEnvironment(environmentId, cwd = process.cwd()) {
+  const path = join(cwd, ".claude", "settings.local.json");
+  mkdirSync(dirname(path), { recursive: true });
+  const existing = existsSync(path)
+    ? JSON.parse(readFileSync(path, "utf8"))
+    : {};
+  const merged = {
+    ...existing,
+    remote: { ...(existing.remote ?? {}), defaultEnvironmentId: environmentId },
+  };
+  writeFileSync(path, `${JSON.stringify(merged, null, 2)}\n`);
+  return path;
+}
+
+/**
  * Produce the configuration a human pastes to provision a Claude cloud surface.
  *
  * This surface has no API tier and no console tier to fall back to: a Claude
@@ -451,6 +488,18 @@ async function main() {
     console.log(`Installing remote-environment scripts into ${INSTALL_DIR}/`);
     for (const { name, action } of installAssets()) {
       console.log(`  ${action.padEnd(8)} ${join(INSTALL_DIR, name)}`);
+    }
+
+    const pin = process.argv
+      .find(arg => arg.startsWith("--pin-env="))
+      ?.slice("--pin-env=".length);
+    if (pin) {
+      console.log(`\nPinned this project to environment ${pin}`);
+      console.log(`  written  ${pinEnvironment(pin)}`);
+      console.log(
+        "  That file is gitignored and outranks the machine-wide default, so\n" +
+          "  every project can name its own environment."
+      );
     }
     console.log(
       "\nCommit these. They are repository files by design — a container that " +

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -35,6 +35,7 @@ import {
   mkdirSync,
   readFileSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -89,18 +90,35 @@ export function readRemoteEnvConfig(cwd = process.cwd()) {
 
 /**
  * Probe what a tool reports for its version, treating absence as not present.
+ *
+ * "Not installed" and "dislikes `--version`" are different answers, and only a
+ * failure to *spawn* means the first. Info-ZIP's `unzip` — the build shipped by
+ * both macOS and Ubuntu — parses `--version` one letter at a time, warns that
+ * `-n` and `-o` conflict, and exits 10. Reading that as absence made `require`
+ * fail on a machine that had the tool, which is precisely the false alarm the
+ * check exists to avoid raising.
+ *
+ * Version text is still recovered from a failed invocation where there is any,
+ * because a tool that refuses the flag often prints its banner anyway — which
+ * is how `unzip` still reports 6.00 despite exiting non-zero.
+ *
+ * The runner is injectable so both branches can be exercised without depending
+ * on which quirky binaries happen to exist on the machine running the tests.
  * @param {string} name Executable name.
+ * @param {Function} [exec] Command runner, for tests.
  * @returns {{version: string|null, present: boolean}} Probe result.
  */
-function probe(name) {
+export function probe(name, exec = execFileSync) {
   try {
-    const out = execFileSync(name, ["--version"], {
+    const out = exec(name, ["--version"], {
       encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
+      stdio: ["ignore", "pipe", "pipe"],
     });
     return { present: true, version: extractVersion(out) };
-  } catch {
-    return { present: false, version: null };
+  } catch (err) {
+    if (err.code === "ENOENT") return { present: false, version: null };
+    const output = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+    return { present: true, version: extractVersion(output) };
   }
 }
 
@@ -210,6 +228,46 @@ function runHook(hook, dryRun) {
 
 /** Phases this runner can execute, in the order they must happen. */
 const PHASES = ["toolchain", "secrets", "hook"];
+
+/** Where a host project keeps the scripts its remote environment invokes. */
+export const INSTALL_DIR = join("scripts", "lisa-remote-env");
+
+/** Assets a host project needs on disk before any remote session can start. */
+const INSTALLABLE = ["setup.sh", "session-start.sh"];
+
+/**
+ * Copy this skill's assets into the host project that will run them.
+ *
+ * These live in the skill, but the paths that reference them are *repository*
+ * paths: a vendor's setup field says `bash scripts/lisa-remote-env/setup.sh`,
+ * and a session-start hook is only committed if it is a real file in the repo.
+ * Nothing put them there, so every reference resolved to a path that did not
+ * exist — the environment came up, ran a missing script, exited non-zero, and
+ * the session failed to start with no indication that a setup step was skipped.
+ *
+ * Copied rather than symlinked or generated: the file must survive in a fresh
+ * clone on a container that has never seen the plugin, which is the whole
+ * reason the entrypoint is thin enough to copy in the first place.
+ * @param {string} [cwd] Repository root.
+ * @returns {Array<{name: string, action: string}>} What was written.
+ */
+export function installAssets(cwd = process.cwd()) {
+  const destination = join(cwd, INSTALL_DIR);
+  mkdirSync(destination, { recursive: true, mode: 0o755 });
+  return INSTALLABLE.map(name => {
+    const source = resolve(HERE, "..", "assets", name);
+    if (!existsSync(source)) {
+      throw new Error(`asset ${name} is missing from this skill install`);
+    }
+    const target = join(destination, name);
+    const desired = readFileSync(source, "utf8");
+    const unchanged =
+      existsSync(target) && readFileSync(target, "utf8") === desired;
+    if (!unchanged) writeFileSync(target, desired, { mode: 0o755 });
+    chmodSync(target, 0o755);
+    return { name, action: unchanged ? "current" : "written" };
+  });
+}
 
 /**
  * The settings block that wires the session-start hook into a repository.
@@ -388,6 +446,18 @@ async function main() {
   const emit = process.argv
     .find(arg => arg.startsWith("--emit="))
     ?.slice("--emit=".length);
+
+  if (process.argv.includes("--install")) {
+    console.log(`Installing remote-environment scripts into ${INSTALL_DIR}/`);
+    for (const { name, action } of installAssets()) {
+      console.log(`  ${action.padEnd(8)} ${join(INSTALL_DIR, name)}`);
+    }
+    console.log(
+      "\nCommit these. They are repository files by design — a container that " +
+        "has\njust cloned the repo has never seen the plugin they came from."
+    );
+    return;
+  }
 
   if (emit) {
     if (emit !== "claude-web") {

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
@@ -162,6 +162,18 @@ It reads the project's own install command from its lockfile and the bootstrap n
 - **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
 - **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
 
+### One environment per project, pinned locally
+
+An environment is **not** bound to a repository — the repository arrives per session, and one environment is technically reusable across all of them. Give each project its own anyway, because an environment's *contents* are project-shaped: its setup script is a repository-relative path and its bootstrap is scoped to that project's secrets. Pointing one project's session at another's environment runs a setup script that may not exist there, and a setup script that exits non-zero means the session never starts.
+
+`/remote-env` writes `remote.defaultEnvironmentId` into **user** settings, which is one value for the whole machine — wrong as soon as a developer has two projects. Pin it per project instead:
+
+```sh
+node scripts/setup-remote-env.mjs --install --pin-env=<environment-id>
+```
+
+That writes `.claude/settings.local.json`, which outranks user settings and is gitignored — correct on both counts, since an environment belongs to one developer's account and is meaningless in someone else's checkout. Existing keys in that file are merged, not replaced; it commonly holds permission grants worth keeping.
+
 **Only the bootstrap belongs in the environment-variable box.** Values there are stored as plain text and are readable by anyone who uses the environment — on an organization-shared environment, that is every member of the organization. Everything else is materialized by the session-start hook. There is no dedicated secrets store on this surface, and personal versus shared environments cannot be told apart programmatically, so this one is a rule the operator upholds rather than something the tooling can enforce.
 
 ## Verification is tier-independent

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -293,6 +293,43 @@ const SESSION_START_BLOCK = `{
 }`;
 
 /**
+ * Pin which cloud environment this project's sessions use.
+ *
+ * `/remote-env` writes `remote.defaultEnvironmentId` into *user* settings, which
+ * is one value for the whole machine. That is wrong as soon as a developer has
+ * more than one project, because an environment's contents are project-shaped:
+ * its setup script is a repository-relative path and its bootstrap is scoped to
+ * that project's secrets. Pointing one project's session at another's
+ * environment runs a setup script that may not exist there, and a non-zero setup
+ * script means the session never starts.
+ *
+ * Written to `.claude/settings.local.json` for two reasons. It outranks user
+ * settings, so the per-project choice wins over the machine-wide default; and it
+ * is gitignored, which is correct because an environment belongs to one
+ * developer's account and is meaningless in someone else's checkout.
+ *
+ * Merged rather than replaced — that file commonly holds permission grants a
+ * developer has accumulated, and clobbering them to write one key would be a
+ * poor trade.
+ * @param {string} environmentId Cloud environment identifier.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} The settings path written.
+ */
+export function pinEnvironment(environmentId, cwd = process.cwd()) {
+  const path = join(cwd, ".claude", "settings.local.json");
+  mkdirSync(dirname(path), { recursive: true });
+  const existing = existsSync(path)
+    ? JSON.parse(readFileSync(path, "utf8"))
+    : {};
+  const merged = {
+    ...existing,
+    remote: { ...(existing.remote ?? {}), defaultEnvironmentId: environmentId },
+  };
+  writeFileSync(path, `${JSON.stringify(merged, null, 2)}\n`);
+  return path;
+}
+
+/**
  * Produce the configuration a human pastes to provision a Claude cloud surface.
  *
  * This surface has no API tier and no console tier to fall back to: a Claude
@@ -451,6 +488,18 @@ async function main() {
     console.log(`Installing remote-environment scripts into ${INSTALL_DIR}/`);
     for (const { name, action } of installAssets()) {
       console.log(`  ${action.padEnd(8)} ${join(INSTALL_DIR, name)}`);
+    }
+
+    const pin = process.argv
+      .find(arg => arg.startsWith("--pin-env="))
+      ?.slice("--pin-env=".length);
+    if (pin) {
+      console.log(`\nPinned this project to environment ${pin}`);
+      console.log(`  written  ${pinEnvironment(pin)}`);
+      console.log(
+        "  That file is gitignored and outranks the machine-wide default, so\n" +
+          "  every project can name its own environment."
+      );
     }
     console.log(
       "\nCommit these. They are repository files by design — a container that " +

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -35,6 +35,7 @@ import {
   mkdirSync,
   readFileSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -89,18 +90,35 @@ export function readRemoteEnvConfig(cwd = process.cwd()) {
 
 /**
  * Probe what a tool reports for its version, treating absence as not present.
+ *
+ * "Not installed" and "dislikes `--version`" are different answers, and only a
+ * failure to *spawn* means the first. Info-ZIP's `unzip` — the build shipped by
+ * both macOS and Ubuntu — parses `--version` one letter at a time, warns that
+ * `-n` and `-o` conflict, and exits 10. Reading that as absence made `require`
+ * fail on a machine that had the tool, which is precisely the false alarm the
+ * check exists to avoid raising.
+ *
+ * Version text is still recovered from a failed invocation where there is any,
+ * because a tool that refuses the flag often prints its banner anyway — which
+ * is how `unzip` still reports 6.00 despite exiting non-zero.
+ *
+ * The runner is injectable so both branches can be exercised without depending
+ * on which quirky binaries happen to exist on the machine running the tests.
  * @param {string} name Executable name.
+ * @param {Function} [exec] Command runner, for tests.
  * @returns {{version: string|null, present: boolean}} Probe result.
  */
-function probe(name) {
+export function probe(name, exec = execFileSync) {
   try {
-    const out = execFileSync(name, ["--version"], {
+    const out = exec(name, ["--version"], {
       encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
+      stdio: ["ignore", "pipe", "pipe"],
     });
     return { present: true, version: extractVersion(out) };
-  } catch {
-    return { present: false, version: null };
+  } catch (err) {
+    if (err.code === "ENOENT") return { present: false, version: null };
+    const output = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+    return { present: true, version: extractVersion(output) };
   }
 }
 
@@ -210,6 +228,46 @@ function runHook(hook, dryRun) {
 
 /** Phases this runner can execute, in the order they must happen. */
 const PHASES = ["toolchain", "secrets", "hook"];
+
+/** Where a host project keeps the scripts its remote environment invokes. */
+export const INSTALL_DIR = join("scripts", "lisa-remote-env");
+
+/** Assets a host project needs on disk before any remote session can start. */
+const INSTALLABLE = ["setup.sh", "session-start.sh"];
+
+/**
+ * Copy this skill's assets into the host project that will run them.
+ *
+ * These live in the skill, but the paths that reference them are *repository*
+ * paths: a vendor's setup field says `bash scripts/lisa-remote-env/setup.sh`,
+ * and a session-start hook is only committed if it is a real file in the repo.
+ * Nothing put them there, so every reference resolved to a path that did not
+ * exist — the environment came up, ran a missing script, exited non-zero, and
+ * the session failed to start with no indication that a setup step was skipped.
+ *
+ * Copied rather than symlinked or generated: the file must survive in a fresh
+ * clone on a container that has never seen the plugin, which is the whole
+ * reason the entrypoint is thin enough to copy in the first place.
+ * @param {string} [cwd] Repository root.
+ * @returns {Array<{name: string, action: string}>} What was written.
+ */
+export function installAssets(cwd = process.cwd()) {
+  const destination = join(cwd, INSTALL_DIR);
+  mkdirSync(destination, { recursive: true, mode: 0o755 });
+  return INSTALLABLE.map(name => {
+    const source = resolve(HERE, "..", "assets", name);
+    if (!existsSync(source)) {
+      throw new Error(`asset ${name} is missing from this skill install`);
+    }
+    const target = join(destination, name);
+    const desired = readFileSync(source, "utf8");
+    const unchanged =
+      existsSync(target) && readFileSync(target, "utf8") === desired;
+    if (!unchanged) writeFileSync(target, desired, { mode: 0o755 });
+    chmodSync(target, 0o755);
+    return { name, action: unchanged ? "current" : "written" };
+  });
+}
 
 /**
  * The settings block that wires the session-start hook into a repository.
@@ -388,6 +446,18 @@ async function main() {
   const emit = process.argv
     .find(arg => arg.startsWith("--emit="))
     ?.slice("--emit=".length);
+
+  if (process.argv.includes("--install")) {
+    console.log(`Installing remote-environment scripts into ${INSTALL_DIR}/`);
+    for (const { name, action } of installAssets()) {
+      console.log(`  ${action.padEnd(8)} ${join(INSTALL_DIR, name)}`);
+    }
+    console.log(
+      "\nCommit these. They are repository files by design — a container that " +
+        "has\njust cloned the repo has never seen the plugin they came from."
+    );
+    return;
+  }
 
   if (emit) {
     if (emit !== "claude-web") {

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
@@ -162,6 +162,18 @@ It reads the project's own install command from its lockfile and the bootstrap n
 - **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
 - **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
 
+### One environment per project, pinned locally
+
+An environment is **not** bound to a repository — the repository arrives per session, and one environment is technically reusable across all of them. Give each project its own anyway, because an environment's *contents* are project-shaped: its setup script is a repository-relative path and its bootstrap is scoped to that project's secrets. Pointing one project's session at another's environment runs a setup script that may not exist there, and a setup script that exits non-zero means the session never starts.
+
+`/remote-env` writes `remote.defaultEnvironmentId` into **user** settings, which is one value for the whole machine — wrong as soon as a developer has two projects. Pin it per project instead:
+
+```sh
+node scripts/setup-remote-env.mjs --install --pin-env=<environment-id>
+```
+
+That writes `.claude/settings.local.json`, which outranks user settings and is gitignored — correct on both counts, since an environment belongs to one developer's account and is meaningless in someone else's checkout. Existing keys in that file are merged, not replaced; it commonly holds permission grants worth keeping.
+
 **Only the bootstrap belongs in the environment-variable box.** Values there are stored as plain text and are readable by anyone who uses the environment — on an organization-shared environment, that is every member of the organization. Everything else is materialized by the session-start hook. There is no dedicated secrets store on this surface, and personal versus shared environments cannot be told apart programmatically, so this one is a rule the operator upholds rather than something the tooling can enforce.
 
 ## Verification is tier-independent

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -293,6 +293,43 @@ const SESSION_START_BLOCK = `{
 }`;
 
 /**
+ * Pin which cloud environment this project's sessions use.
+ *
+ * `/remote-env` writes `remote.defaultEnvironmentId` into *user* settings, which
+ * is one value for the whole machine. That is wrong as soon as a developer has
+ * more than one project, because an environment's contents are project-shaped:
+ * its setup script is a repository-relative path and its bootstrap is scoped to
+ * that project's secrets. Pointing one project's session at another's
+ * environment runs a setup script that may not exist there, and a non-zero setup
+ * script means the session never starts.
+ *
+ * Written to `.claude/settings.local.json` for two reasons. It outranks user
+ * settings, so the per-project choice wins over the machine-wide default; and it
+ * is gitignored, which is correct because an environment belongs to one
+ * developer's account and is meaningless in someone else's checkout.
+ *
+ * Merged rather than replaced — that file commonly holds permission grants a
+ * developer has accumulated, and clobbering them to write one key would be a
+ * poor trade.
+ * @param {string} environmentId Cloud environment identifier.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} The settings path written.
+ */
+export function pinEnvironment(environmentId, cwd = process.cwd()) {
+  const path = join(cwd, ".claude", "settings.local.json");
+  mkdirSync(dirname(path), { recursive: true });
+  const existing = existsSync(path)
+    ? JSON.parse(readFileSync(path, "utf8"))
+    : {};
+  const merged = {
+    ...existing,
+    remote: { ...(existing.remote ?? {}), defaultEnvironmentId: environmentId },
+  };
+  writeFileSync(path, `${JSON.stringify(merged, null, 2)}\n`);
+  return path;
+}
+
+/**
  * Produce the configuration a human pastes to provision a Claude cloud surface.
  *
  * This surface has no API tier and no console tier to fall back to: a Claude
@@ -451,6 +488,18 @@ async function main() {
     console.log(`Installing remote-environment scripts into ${INSTALL_DIR}/`);
     for (const { name, action } of installAssets()) {
       console.log(`  ${action.padEnd(8)} ${join(INSTALL_DIR, name)}`);
+    }
+
+    const pin = process.argv
+      .find(arg => arg.startsWith("--pin-env="))
+      ?.slice("--pin-env=".length);
+    if (pin) {
+      console.log(`\nPinned this project to environment ${pin}`);
+      console.log(`  written  ${pinEnvironment(pin)}`);
+      console.log(
+        "  That file is gitignored and outranks the machine-wide default, so\n" +
+          "  every project can name its own environment."
+      );
     }
     console.log(
       "\nCommit these. They are repository files by design — a container that " +

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -35,6 +35,7 @@ import {
   mkdirSync,
   readFileSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -89,18 +90,35 @@ export function readRemoteEnvConfig(cwd = process.cwd()) {
 
 /**
  * Probe what a tool reports for its version, treating absence as not present.
+ *
+ * "Not installed" and "dislikes `--version`" are different answers, and only a
+ * failure to *spawn* means the first. Info-ZIP's `unzip` — the build shipped by
+ * both macOS and Ubuntu — parses `--version` one letter at a time, warns that
+ * `-n` and `-o` conflict, and exits 10. Reading that as absence made `require`
+ * fail on a machine that had the tool, which is precisely the false alarm the
+ * check exists to avoid raising.
+ *
+ * Version text is still recovered from a failed invocation where there is any,
+ * because a tool that refuses the flag often prints its banner anyway — which
+ * is how `unzip` still reports 6.00 despite exiting non-zero.
+ *
+ * The runner is injectable so both branches can be exercised without depending
+ * on which quirky binaries happen to exist on the machine running the tests.
  * @param {string} name Executable name.
+ * @param {Function} [exec] Command runner, for tests.
  * @returns {{version: string|null, present: boolean}} Probe result.
  */
-function probe(name) {
+export function probe(name, exec = execFileSync) {
   try {
-    const out = execFileSync(name, ["--version"], {
+    const out = exec(name, ["--version"], {
       encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
+      stdio: ["ignore", "pipe", "pipe"],
     });
     return { present: true, version: extractVersion(out) };
-  } catch {
-    return { present: false, version: null };
+  } catch (err) {
+    if (err.code === "ENOENT") return { present: false, version: null };
+    const output = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+    return { present: true, version: extractVersion(output) };
   }
 }
 
@@ -210,6 +228,46 @@ function runHook(hook, dryRun) {
 
 /** Phases this runner can execute, in the order they must happen. */
 const PHASES = ["toolchain", "secrets", "hook"];
+
+/** Where a host project keeps the scripts its remote environment invokes. */
+export const INSTALL_DIR = join("scripts", "lisa-remote-env");
+
+/** Assets a host project needs on disk before any remote session can start. */
+const INSTALLABLE = ["setup.sh", "session-start.sh"];
+
+/**
+ * Copy this skill's assets into the host project that will run them.
+ *
+ * These live in the skill, but the paths that reference them are *repository*
+ * paths: a vendor's setup field says `bash scripts/lisa-remote-env/setup.sh`,
+ * and a session-start hook is only committed if it is a real file in the repo.
+ * Nothing put them there, so every reference resolved to a path that did not
+ * exist — the environment came up, ran a missing script, exited non-zero, and
+ * the session failed to start with no indication that a setup step was skipped.
+ *
+ * Copied rather than symlinked or generated: the file must survive in a fresh
+ * clone on a container that has never seen the plugin, which is the whole
+ * reason the entrypoint is thin enough to copy in the first place.
+ * @param {string} [cwd] Repository root.
+ * @returns {Array<{name: string, action: string}>} What was written.
+ */
+export function installAssets(cwd = process.cwd()) {
+  const destination = join(cwd, INSTALL_DIR);
+  mkdirSync(destination, { recursive: true, mode: 0o755 });
+  return INSTALLABLE.map(name => {
+    const source = resolve(HERE, "..", "assets", name);
+    if (!existsSync(source)) {
+      throw new Error(`asset ${name} is missing from this skill install`);
+    }
+    const target = join(destination, name);
+    const desired = readFileSync(source, "utf8");
+    const unchanged =
+      existsSync(target) && readFileSync(target, "utf8") === desired;
+    if (!unchanged) writeFileSync(target, desired, { mode: 0o755 });
+    chmodSync(target, 0o755);
+    return { name, action: unchanged ? "current" : "written" };
+  });
+}
 
 /**
  * The settings block that wires the session-start hook into a repository.
@@ -388,6 +446,18 @@ async function main() {
   const emit = process.argv
     .find(arg => arg.startsWith("--emit="))
     ?.slice("--emit=".length);
+
+  if (process.argv.includes("--install")) {
+    console.log(`Installing remote-environment scripts into ${INSTALL_DIR}/`);
+    for (const { name, action } of installAssets()) {
+      console.log(`  ${action.padEnd(8)} ${join(INSTALL_DIR, name)}`);
+    }
+    console.log(
+      "\nCommit these. They are repository files by design — a container that " +
+        "has\njust cloned the repo has never seen the plugin they came from."
+    );
+    return;
+  }
 
   if (emit) {
     if (emit !== "claude-web") {

--- a/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
@@ -162,6 +162,18 @@ It reads the project's own install command from its lockfile and the bootstrap n
 - **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
 - **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
 
+### One environment per project, pinned locally
+
+An environment is **not** bound to a repository — the repository arrives per session, and one environment is technically reusable across all of them. Give each project its own anyway, because an environment's *contents* are project-shaped: its setup script is a repository-relative path and its bootstrap is scoped to that project's secrets. Pointing one project's session at another's environment runs a setup script that may not exist there, and a setup script that exits non-zero means the session never starts.
+
+`/remote-env` writes `remote.defaultEnvironmentId` into **user** settings, which is one value for the whole machine — wrong as soon as a developer has two projects. Pin it per project instead:
+
+```sh
+node scripts/setup-remote-env.mjs --install --pin-env=<environment-id>
+```
+
+That writes `.claude/settings.local.json`, which outranks user settings and is gitignored — correct on both counts, since an environment belongs to one developer's account and is meaningless in someone else's checkout. Existing keys in that file are merged, not replaced; it commonly holds permission grants worth keeping.
+
 **Only the bootstrap belongs in the environment-variable box.** Values there are stored as plain text and are readable by anyone who uses the environment — on an organization-shared environment, that is every member of the organization. Everything else is materialized by the session-start hook. There is no dedicated secrets store on this surface, and personal versus shared environments cannot be told apart programmatically, so this one is a rule the operator upholds rather than something the tooling can enforce.
 
 ## Verification is tier-independent

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -293,6 +293,43 @@ const SESSION_START_BLOCK = `{
 }`;
 
 /**
+ * Pin which cloud environment this project's sessions use.
+ *
+ * `/remote-env` writes `remote.defaultEnvironmentId` into *user* settings, which
+ * is one value for the whole machine. That is wrong as soon as a developer has
+ * more than one project, because an environment's contents are project-shaped:
+ * its setup script is a repository-relative path and its bootstrap is scoped to
+ * that project's secrets. Pointing one project's session at another's
+ * environment runs a setup script that may not exist there, and a non-zero setup
+ * script means the session never starts.
+ *
+ * Written to `.claude/settings.local.json` for two reasons. It outranks user
+ * settings, so the per-project choice wins over the machine-wide default; and it
+ * is gitignored, which is correct because an environment belongs to one
+ * developer's account and is meaningless in someone else's checkout.
+ *
+ * Merged rather than replaced — that file commonly holds permission grants a
+ * developer has accumulated, and clobbering them to write one key would be a
+ * poor trade.
+ * @param {string} environmentId Cloud environment identifier.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} The settings path written.
+ */
+export function pinEnvironment(environmentId, cwd = process.cwd()) {
+  const path = join(cwd, ".claude", "settings.local.json");
+  mkdirSync(dirname(path), { recursive: true });
+  const existing = existsSync(path)
+    ? JSON.parse(readFileSync(path, "utf8"))
+    : {};
+  const merged = {
+    ...existing,
+    remote: { ...(existing.remote ?? {}), defaultEnvironmentId: environmentId },
+  };
+  writeFileSync(path, `${JSON.stringify(merged, null, 2)}\n`);
+  return path;
+}
+
+/**
  * Produce the configuration a human pastes to provision a Claude cloud surface.
  *
  * This surface has no API tier and no console tier to fall back to: a Claude
@@ -451,6 +488,18 @@ async function main() {
     console.log(`Installing remote-environment scripts into ${INSTALL_DIR}/`);
     for (const { name, action } of installAssets()) {
       console.log(`  ${action.padEnd(8)} ${join(INSTALL_DIR, name)}`);
+    }
+
+    const pin = process.argv
+      .find(arg => arg.startsWith("--pin-env="))
+      ?.slice("--pin-env=".length);
+    if (pin) {
+      console.log(`\nPinned this project to environment ${pin}`);
+      console.log(`  written  ${pinEnvironment(pin)}`);
+      console.log(
+        "  That file is gitignored and outranks the machine-wide default, so\n" +
+          "  every project can name its own environment."
+      );
     }
     console.log(
       "\nCommit these. They are repository files by design — a container that " +

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -35,6 +35,7 @@ import {
   mkdirSync,
   readFileSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -89,18 +90,35 @@ export function readRemoteEnvConfig(cwd = process.cwd()) {
 
 /**
  * Probe what a tool reports for its version, treating absence as not present.
+ *
+ * "Not installed" and "dislikes `--version`" are different answers, and only a
+ * failure to *spawn* means the first. Info-ZIP's `unzip` — the build shipped by
+ * both macOS and Ubuntu — parses `--version` one letter at a time, warns that
+ * `-n` and `-o` conflict, and exits 10. Reading that as absence made `require`
+ * fail on a machine that had the tool, which is precisely the false alarm the
+ * check exists to avoid raising.
+ *
+ * Version text is still recovered from a failed invocation where there is any,
+ * because a tool that refuses the flag often prints its banner anyway — which
+ * is how `unzip` still reports 6.00 despite exiting non-zero.
+ *
+ * The runner is injectable so both branches can be exercised without depending
+ * on which quirky binaries happen to exist on the machine running the tests.
  * @param {string} name Executable name.
+ * @param {Function} [exec] Command runner, for tests.
  * @returns {{version: string|null, present: boolean}} Probe result.
  */
-function probe(name) {
+export function probe(name, exec = execFileSync) {
   try {
-    const out = execFileSync(name, ["--version"], {
+    const out = exec(name, ["--version"], {
       encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
+      stdio: ["ignore", "pipe", "pipe"],
     });
     return { present: true, version: extractVersion(out) };
-  } catch {
-    return { present: false, version: null };
+  } catch (err) {
+    if (err.code === "ENOENT") return { present: false, version: null };
+    const output = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+    return { present: true, version: extractVersion(output) };
   }
 }
 
@@ -210,6 +228,46 @@ function runHook(hook, dryRun) {
 
 /** Phases this runner can execute, in the order they must happen. */
 const PHASES = ["toolchain", "secrets", "hook"];
+
+/** Where a host project keeps the scripts its remote environment invokes. */
+export const INSTALL_DIR = join("scripts", "lisa-remote-env");
+
+/** Assets a host project needs on disk before any remote session can start. */
+const INSTALLABLE = ["setup.sh", "session-start.sh"];
+
+/**
+ * Copy this skill's assets into the host project that will run them.
+ *
+ * These live in the skill, but the paths that reference them are *repository*
+ * paths: a vendor's setup field says `bash scripts/lisa-remote-env/setup.sh`,
+ * and a session-start hook is only committed if it is a real file in the repo.
+ * Nothing put them there, so every reference resolved to a path that did not
+ * exist — the environment came up, ran a missing script, exited non-zero, and
+ * the session failed to start with no indication that a setup step was skipped.
+ *
+ * Copied rather than symlinked or generated: the file must survive in a fresh
+ * clone on a container that has never seen the plugin, which is the whole
+ * reason the entrypoint is thin enough to copy in the first place.
+ * @param {string} [cwd] Repository root.
+ * @returns {Array<{name: string, action: string}>} What was written.
+ */
+export function installAssets(cwd = process.cwd()) {
+  const destination = join(cwd, INSTALL_DIR);
+  mkdirSync(destination, { recursive: true, mode: 0o755 });
+  return INSTALLABLE.map(name => {
+    const source = resolve(HERE, "..", "assets", name);
+    if (!existsSync(source)) {
+      throw new Error(`asset ${name} is missing from this skill install`);
+    }
+    const target = join(destination, name);
+    const desired = readFileSync(source, "utf8");
+    const unchanged =
+      existsSync(target) && readFileSync(target, "utf8") === desired;
+    if (!unchanged) writeFileSync(target, desired, { mode: 0o755 });
+    chmodSync(target, 0o755);
+    return { name, action: unchanged ? "current" : "written" };
+  });
+}
 
 /**
  * The settings block that wires the session-start hook into a repository.
@@ -388,6 +446,18 @@ async function main() {
   const emit = process.argv
     .find(arg => arg.startsWith("--emit="))
     ?.slice("--emit=".length);
+
+  if (process.argv.includes("--install")) {
+    console.log(`Installing remote-environment scripts into ${INSTALL_DIR}/`);
+    for (const { name, action } of installAssets()) {
+      console.log(`  ${action.padEnd(8)} ${join(INSTALL_DIR, name)}`);
+    }
+    console.log(
+      "\nCommit these. They are repository files by design — a container that " +
+        "has\njust cloned the repo has never seen the plugin they came from."
+    );
+    return;
+  }
 
   if (emit) {
     if (emit !== "claude-web") {

--- a/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
@@ -162,6 +162,18 @@ It reads the project's own install command from its lockfile and the bootstrap n
 - **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
 - **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
 
+### One environment per project, pinned locally
+
+An environment is **not** bound to a repository — the repository arrives per session, and one environment is technically reusable across all of them. Give each project its own anyway, because an environment's *contents* are project-shaped: its setup script is a repository-relative path and its bootstrap is scoped to that project's secrets. Pointing one project's session at another's environment runs a setup script that may not exist there, and a setup script that exits non-zero means the session never starts.
+
+`/remote-env` writes `remote.defaultEnvironmentId` into **user** settings, which is one value for the whole machine — wrong as soon as a developer has two projects. Pin it per project instead:
+
+```sh
+node scripts/setup-remote-env.mjs --install --pin-env=<environment-id>
+```
+
+That writes `.claude/settings.local.json`, which outranks user settings and is gitignored — correct on both counts, since an environment belongs to one developer's account and is meaningless in someone else's checkout. Existing keys in that file are merged, not replaced; it commonly holds permission grants worth keeping.
+
 **Only the bootstrap belongs in the environment-variable box.** Values there are stored as plain text and are readable by anyone who uses the environment — on an organization-shared environment, that is every member of the organization. Everything else is materialized by the session-start hook. There is no dedicated secrets store on this surface, and personal versus shared environments cannot be told apart programmatically, so this one is a rule the operator upholds rather than something the tooling can enforce.
 
 ## Verification is tier-independent

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -293,6 +293,43 @@ const SESSION_START_BLOCK = `{
 }`;
 
 /**
+ * Pin which cloud environment this project's sessions use.
+ *
+ * `/remote-env` writes `remote.defaultEnvironmentId` into *user* settings, which
+ * is one value for the whole machine. That is wrong as soon as a developer has
+ * more than one project, because an environment's contents are project-shaped:
+ * its setup script is a repository-relative path and its bootstrap is scoped to
+ * that project's secrets. Pointing one project's session at another's
+ * environment runs a setup script that may not exist there, and a non-zero setup
+ * script means the session never starts.
+ *
+ * Written to `.claude/settings.local.json` for two reasons. It outranks user
+ * settings, so the per-project choice wins over the machine-wide default; and it
+ * is gitignored, which is correct because an environment belongs to one
+ * developer's account and is meaningless in someone else's checkout.
+ *
+ * Merged rather than replaced — that file commonly holds permission grants a
+ * developer has accumulated, and clobbering them to write one key would be a
+ * poor trade.
+ * @param {string} environmentId Cloud environment identifier.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} The settings path written.
+ */
+export function pinEnvironment(environmentId, cwd = process.cwd()) {
+  const path = join(cwd, ".claude", "settings.local.json");
+  mkdirSync(dirname(path), { recursive: true });
+  const existing = existsSync(path)
+    ? JSON.parse(readFileSync(path, "utf8"))
+    : {};
+  const merged = {
+    ...existing,
+    remote: { ...(existing.remote ?? {}), defaultEnvironmentId: environmentId },
+  };
+  writeFileSync(path, `${JSON.stringify(merged, null, 2)}\n`);
+  return path;
+}
+
+/**
  * Produce the configuration a human pastes to provision a Claude cloud surface.
  *
  * This surface has no API tier and no console tier to fall back to: a Claude
@@ -451,6 +488,18 @@ async function main() {
     console.log(`Installing remote-environment scripts into ${INSTALL_DIR}/`);
     for (const { name, action } of installAssets()) {
       console.log(`  ${action.padEnd(8)} ${join(INSTALL_DIR, name)}`);
+    }
+
+    const pin = process.argv
+      .find(arg => arg.startsWith("--pin-env="))
+      ?.slice("--pin-env=".length);
+    if (pin) {
+      console.log(`\nPinned this project to environment ${pin}`);
+      console.log(`  written  ${pinEnvironment(pin)}`);
+      console.log(
+        "  That file is gitignored and outranks the machine-wide default, so\n" +
+          "  every project can name its own environment."
+      );
     }
     console.log(
       "\nCommit these. They are repository files by design — a container that " +

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -35,6 +35,7 @@ import {
   mkdirSync,
   readFileSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -89,18 +90,35 @@ export function readRemoteEnvConfig(cwd = process.cwd()) {
 
 /**
  * Probe what a tool reports for its version, treating absence as not present.
+ *
+ * "Not installed" and "dislikes `--version`" are different answers, and only a
+ * failure to *spawn* means the first. Info-ZIP's `unzip` — the build shipped by
+ * both macOS and Ubuntu — parses `--version` one letter at a time, warns that
+ * `-n` and `-o` conflict, and exits 10. Reading that as absence made `require`
+ * fail on a machine that had the tool, which is precisely the false alarm the
+ * check exists to avoid raising.
+ *
+ * Version text is still recovered from a failed invocation where there is any,
+ * because a tool that refuses the flag often prints its banner anyway — which
+ * is how `unzip` still reports 6.00 despite exiting non-zero.
+ *
+ * The runner is injectable so both branches can be exercised without depending
+ * on which quirky binaries happen to exist on the machine running the tests.
  * @param {string} name Executable name.
+ * @param {Function} [exec] Command runner, for tests.
  * @returns {{version: string|null, present: boolean}} Probe result.
  */
-function probe(name) {
+export function probe(name, exec = execFileSync) {
   try {
-    const out = execFileSync(name, ["--version"], {
+    const out = exec(name, ["--version"], {
       encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
+      stdio: ["ignore", "pipe", "pipe"],
     });
     return { present: true, version: extractVersion(out) };
-  } catch {
-    return { present: false, version: null };
+  } catch (err) {
+    if (err.code === "ENOENT") return { present: false, version: null };
+    const output = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+    return { present: true, version: extractVersion(output) };
   }
 }
 
@@ -210,6 +228,46 @@ function runHook(hook, dryRun) {
 
 /** Phases this runner can execute, in the order they must happen. */
 const PHASES = ["toolchain", "secrets", "hook"];
+
+/** Where a host project keeps the scripts its remote environment invokes. */
+export const INSTALL_DIR = join("scripts", "lisa-remote-env");
+
+/** Assets a host project needs on disk before any remote session can start. */
+const INSTALLABLE = ["setup.sh", "session-start.sh"];
+
+/**
+ * Copy this skill's assets into the host project that will run them.
+ *
+ * These live in the skill, but the paths that reference them are *repository*
+ * paths: a vendor's setup field says `bash scripts/lisa-remote-env/setup.sh`,
+ * and a session-start hook is only committed if it is a real file in the repo.
+ * Nothing put them there, so every reference resolved to a path that did not
+ * exist — the environment came up, ran a missing script, exited non-zero, and
+ * the session failed to start with no indication that a setup step was skipped.
+ *
+ * Copied rather than symlinked or generated: the file must survive in a fresh
+ * clone on a container that has never seen the plugin, which is the whole
+ * reason the entrypoint is thin enough to copy in the first place.
+ * @param {string} [cwd] Repository root.
+ * @returns {Array<{name: string, action: string}>} What was written.
+ */
+export function installAssets(cwd = process.cwd()) {
+  const destination = join(cwd, INSTALL_DIR);
+  mkdirSync(destination, { recursive: true, mode: 0o755 });
+  return INSTALLABLE.map(name => {
+    const source = resolve(HERE, "..", "assets", name);
+    if (!existsSync(source)) {
+      throw new Error(`asset ${name} is missing from this skill install`);
+    }
+    const target = join(destination, name);
+    const desired = readFileSync(source, "utf8");
+    const unchanged =
+      existsSync(target) && readFileSync(target, "utf8") === desired;
+    if (!unchanged) writeFileSync(target, desired, { mode: 0o755 });
+    chmodSync(target, 0o755);
+    return { name, action: unchanged ? "current" : "written" };
+  });
+}
 
 /**
  * The settings block that wires the session-start hook into a repository.
@@ -388,6 +446,18 @@ async function main() {
   const emit = process.argv
     .find(arg => arg.startsWith("--emit="))
     ?.slice("--emit=".length);
+
+  if (process.argv.includes("--install")) {
+    console.log(`Installing remote-environment scripts into ${INSTALL_DIR}/`);
+    for (const { name, action } of installAssets()) {
+      console.log(`  ${action.padEnd(8)} ${join(INSTALL_DIR, name)}`);
+    }
+    console.log(
+      "\nCommit these. They are repository files by design — a container that " +
+        "has\njust cloned the repo has never seen the plugin they came from."
+    );
+    return;
+  }
 
   if (emit) {
     if (emit !== "claude-web") {

--- a/scripts/lisa-remote-env/session-start.sh
+++ b/scripts/lisa-remote-env/session-start.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Session-start entrypoint for surfaces that materialize secrets per session
+# rather than during environment setup.
+#
+# Wired into the repository's `.claude/settings.json` as a SessionStart hook,
+# so it is part of the clone and runs on every session — including a session
+# resumed onto a cached environment, which is the case that matters.
+#
+# Why this exists at all: a cloud environment's setup script is skipped whenever
+# a filesystem cache exists. Materializing there would write the values once and
+# never refresh them, so a rotated credential would stay stale until the cache
+# expired days later. This hook runs every session, so the copy on disk is
+# always the provider's current view.
+#
+# It is deliberately a guard and a delegation, not a second implementation. The
+# skill-resolution ladder is subtle enough that two copies would drift, so the
+# real work stays in setup.sh and this file only decides whether to call it.
+set -euo pipefail
+
+# Exit before doing anything on a machine that is not a remote session. The hook
+# is committed to the repository, so it also fires on every local session; the
+# materialize step would correctly refuse there, but failing on a developer's
+# laptop every time they start a session is noise, not a signal.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+here="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+exec bash "${here}/setup.sh" --phase=secrets "$@"

--- a/scripts/lisa-remote-env/setup.sh
+++ b/scripts/lisa-remote-env/setup.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Remote environment entrypoint. Installed by /lisa:setup:remote-env; the remote
+# environment's setup AND maintenance fields both call this exact path.
+#
+# They are the same script on purpose. A container may be built fresh or resumed
+# from cache, and everything below is idempotent and version-aware — so running
+# it twice is correct, and running it on resume is what picks up a rotated
+# value, an edited note, or a changed version pin.
+#
+# This file is deliberately thin. It resolves an interpreter and hands off; the
+# reviewed, tested, versioned logic lives in the Lisa skill rather than here,
+# and emphatically not in a vendor settings field.
+set -euo pipefail
+
+# Node is the one thing that cannot be installed by the installer, since the
+# installer is written in it. Fail with an actionable message rather than a
+# "command not found" forty lines deep.
+if ! command -v node >/dev/null 2>&1; then
+  echo "node is required to prepare this environment but is not present." >&2
+  echo "It cannot be installed by the toolchain step, because that step runs" >&2
+  echo "on node. Pin a base image that provides it." >&2
+  exit 1
+fi
+
+# Where the skill lives depends on how this project's harness receives it, and
+# the two delivery models differ in a way that matters here.
+#
+# OpenCode and Antigravity get skills written INTO the checkout by `lisa apply`,
+# so a clone already carries them. Claude and Codex receive them as an installed
+# plugin, which lives in the user's home directory and is emphatically NOT part
+# of a clone. A fresh remote container is the second case every time: it clones
+# the repository and has never run a plugin install.
+#
+# So the agent directories are searched first — they are the cheapest hit and
+# need nothing installed — and the npm package is the fallback that makes the
+# plugin-delivered harnesses work at all. Lisa is a dependency of every project
+# it is applied to, so `node_modules` carries the same skill at the version that
+# project pins, which is the version its setup should run.
+runner=""
+for candidate in \
+  ".claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  ".agents/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  "node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
+  if [ -f "$candidate" ]; then
+    runner="$candidate"
+    break
+  fi
+done
+
+if [ -z "$runner" ]; then
+  echo "Cannot find the lisa-setup-remote-env skill." >&2
+  echo >&2
+  echo "Searched the agent skill directories and node_modules. On a remote" >&2
+  echo "container the usual cause is that dependencies have not been installed" >&2
+  echo "yet: Claude and Codex receive Lisa skills as an installed plugin, which" >&2
+  echo "is not part of a clone, so node_modules is the only copy present." >&2
+  echo >&2
+  echo "Install dependencies before this script runs. The environment's setup" >&2
+  echo "command should be the install and this script together, for example:" >&2
+  echo "  bun install && bash scripts/lisa-remote-env/setup.sh" >&2
+  echo >&2
+  echo "If dependencies are installed, run 'lisa apply' so the skills are" >&2
+  echo "present, then re-run setup." >&2
+  exit 1
+fi
+
+exec node "$runner" "$@"

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1125,7 +1125,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "a043074dd52e3f9b4b4a32bdd8b5eaa728160e5a0622a8a18388e6e26c7d25e3",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "d63a47cbf5ca4875c2d0e173943dd36a4c95db5b5ff994e1267d00b251277b57",
+      "2fc05e4cc3128bb8753e6f51edd921728ab1cf502c7d53178e86ea75c38e0f55",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
       "ff66d33ba41a068d09be18f81ac68988238c2afa1d4e3733ae906b73eea74324",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
@@ -1978,6 +1978,10 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "dc2f1c9d718aa34ba57161120d9319b5f78fe6b0b496d8e3c77226a08795aa36",
     "scripts/lisa-github-rulesets.sh":
       "920a43ba268421b6fe55096062bd85850468bee9389f6006ad7c671010e7cccb",
+    "scripts/lisa-remote-env/session-start.sh":
+      "6e3871ec2f8d56b8ebb85376ebdd3956f3ed8fa4f7b278c2ed90ca9b8845897c",
+    "scripts/lisa-remote-env/setup.sh":
+      "a043074dd52e3f9b4b4a32bdd8b5eaa728160e5a0622a8a18388e6e26c7d25e3",
     "scripts/lisa-update-local.sh":
       "c811f9e10dbcb38499a9791c1ae9051460b347051d04a1d2046925bab9a53c96",
     "scripts/lisa-work-item.mjs":
@@ -7624,6 +7628,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "scripts/lisa-github-repo-settings.sh": true,
     "scripts/lisa-github-repo-setup.sh": true,
     "scripts/lisa-github-rulesets.sh": true,
+    "scripts/lisa-remote-env/session-start.sh": true,
+    "scripts/lisa-remote-env/setup.sh": true,
     "scripts/lisa-update-local.sh": true,
     "scripts/lisa-work-item.mjs": true,
     "scripts/migrate-deploy-order.sh": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1119,13 +1119,13 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md":
       "80fbf157f9c562c033886c25a99b37356602edd9e61cd2d492f339769ddcf97e",
     "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md":
-      "91c5d4dbc513b642e9da304425501ca6802f28c8059135e8ccc6ca0200060ee9",
+      "21de7c108a5f372d76416dfd3e2d229053d0d23c84fe88e646719a97405bd1e9",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh":
       "6e3871ec2f8d56b8ebb85376ebdd3956f3ed8fa4f7b278c2ed90ca9b8845897c",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "a043074dd52e3f9b4b4a32bdd8b5eaa728160e5a0622a8a18388e6e26c7d25e3",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "2fc05e4cc3128bb8753e6f51edd921728ab1cf502c7d53178e86ea75c38e0f55",
+      "5e79d25368ddbc51ab2d9616a921b6eaea0e7fbee65de74a404b7b880f54fd9e",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
       "ff66d33ba41a068d09be18f81ac68988238c2afa1d4e3733ae906b73eea74324",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":

--- a/tests/unit/secrets/remote-env-phases.test.ts
+++ b/tests/unit/secrets/remote-env-phases.test.ts
@@ -13,7 +13,9 @@
  */
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -27,6 +29,7 @@ import { SURFACES } from "../../../plugins/src/base/skills/lisa-secrets-access/s
 import {
   detectInstallCommand,
   installAssets,
+  pinEnvironment,
   probe,
   emitClaudeWeb,
   selectPhases,
@@ -167,6 +170,55 @@ describe("asset installation", () => {
     writeFileSync(target, "#!/usr/bin/env bash\nexit 0\n");
     const written = installAssets(root);
     expect(written.find(w => w.name === SETUP)?.action).toBe("written");
+  });
+});
+
+describe("environment pinning", () => {
+  const LOCAL_SETTINGS = path.join(".claude", "settings.local.json");
+  let root: string;
+
+  const readSettings = (): Record<string, never> =>
+    JSON.parse(readFileSync(path.join(root, LOCAL_SETTINGS), "utf8"));
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "lisa-pin-"));
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it("writes the id where it outranks the machine-wide default", () => {
+    // `/remote-env` stores one value for the whole machine, which is wrong the
+    // moment a developer has two projects: an environment's setup script is a
+    // repository-relative path, so the wrong one fails to start a session.
+    expect(pinEnvironment("env_abc123", root)).toContain(LOCAL_SETTINGS);
+    expect(readSettings()).toEqual({
+      remote: { defaultEnvironmentId: "env_abc123" },
+    });
+  });
+
+  it("preserves settings the developer already accumulated", () => {
+    mkdirSync(path.join(root, ".claude"), { recursive: true });
+    writeFileSync(
+      path.join(root, LOCAL_SETTINGS),
+      JSON.stringify({ permissions: { allow: ["Bash(ls:*)"] } })
+    );
+    pinEnvironment("env_xyz", root);
+    expect(readSettings()).toEqual({
+      permissions: { allow: ["Bash(ls:*)"] },
+      remote: { defaultEnvironmentId: "env_xyz" },
+    });
+  });
+
+  it("replaces only the environment id, leaving sibling remote keys", () => {
+    mkdirSync(path.join(root, ".claude"), { recursive: true });
+    writeFileSync(
+      path.join(root, LOCAL_SETTINGS),
+      JSON.stringify({ remote: { defaultEnvironmentId: "old", other: 1 } })
+    );
+    pinEnvironment("new", root);
+    expect(readSettings()).toEqual({
+      remote: { defaultEnvironmentId: "new", other: 1 },
+    });
   });
 });
 

--- a/tests/unit/secrets/remote-env-phases.test.ts
+++ b/tests/unit/secrets/remote-env-phases.test.ts
@@ -11,7 +11,13 @@
  * file starts a container, reaches a provider, or writes a value to disk.
  * @module tests/unit/secrets/remote-env-phases
  */
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -20,6 +26,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SURFACES } from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs";
 import {
   detectInstallCommand,
+  installAssets,
+  probe,
   emitClaudeWeb,
   selectPhases,
 } from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs";
@@ -120,6 +128,89 @@ describe("install command detection", () => {
     // A guessed package manager produces a container that fails on its very
     // first command, with an error that blames the project rather than the guess.
     expect(detectInstallCommand(root)).toBe("<your install command>");
+  });
+});
+
+describe("asset installation", () => {
+  const SETUP = "setup.sh";
+  const SESSION_START = "session-start.sh";
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "lisa-assets-"));
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it("puts both scripts in the repository, executable", () => {
+    // Nothing used to do this. Every reference to scripts/lisa-remote-env/
+    // resolved to a path that did not exist, so the environment came up, ran a
+    // missing script, exited non-zero, and the session failed to start.
+    const written = installAssets(root);
+    const names = written.map(w => w.name).sort((a, b) => a.localeCompare(b));
+    expect(names).toEqual([SESSION_START, SETUP]);
+    for (const name of [SETUP, SESSION_START]) {
+      const target = path.join(root, "scripts", "lisa-remote-env", name);
+      expect(existsSync(target)).toBe(true);
+      expect(statSync(target).mode & 0o111).toBeGreaterThan(0);
+    }
+  });
+
+  it("reports an unchanged file as current rather than rewriting it", () => {
+    installAssets(root);
+    expect(installAssets(root).every(w => w.action === "current")).toBe(true);
+  });
+
+  it("restores a file that was edited in the repository", () => {
+    installAssets(root);
+    const target = path.join(root, "scripts", "lisa-remote-env", SETUP);
+    writeFileSync(target, "#!/usr/bin/env bash\nexit 0\n");
+    const written = installAssets(root);
+    expect(written.find(w => w.name === SETUP)?.action).toBe("written");
+  });
+});
+
+describe("tool presence probe", () => {
+  /**
+   * A runner that fails the way a real binary does.
+   * @param code Spawn error code — `ENOENT` only when the binary is absent.
+   * @param stdout What the tool printed before failing.
+   * @param stderr What the tool complained about.
+   * @returns A runner that throws that failure.
+   */
+  const failsWith =
+    (code: string | undefined, stdout: string, stderr: string) => () => {
+      throw Object.assign(new Error("command failed"), {
+        code,
+        stdout,
+        stderr,
+      });
+    };
+
+  it("treats a non-zero exit as present, not missing", () => {
+    // Info-ZIP's unzip — shipped by both macOS and Ubuntu — parses `--version`
+    // one letter at a time, warns that -n and -o conflict, and exits 10.
+    // Reading that as absence made `require` fail on a machine that had it.
+    const result = probe(
+      "unzip",
+      failsWith(
+        undefined,
+        "UnZip 6.00 of 20 April 2009, by Info-ZIP.",
+        "caution: both -n and -o specified; ignoring -o"
+      )
+    );
+    expect(result.present).toBe(true);
+    expect(result.version).toBe("6.00");
+  });
+
+  it("treats a failure to spawn as genuinely missing", () => {
+    const result = probe("nope", failsWith("ENOENT", "", ""));
+    expect(result).toEqual({ present: false, version: null });
+  });
+
+  it("reads the version from a clean run", () => {
+    const result = probe("node", () => "v22.22.0\n");
+    expect(result).toEqual({ present: true, version: "22.22.0" });
   });
 });
 


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2175

Follows #2176. Two bugs found while actually setting this up against a real Bitwarden project, plus Lisa's own configuration as the first host.

## Bug 1 — nothing installed the scripts the environment invokes

Four places name `scripts/lisa-remote-env/setup.sh`: the vendor setup field, the emitted config, the generated automation workflow, and the skill's own prose. **Nothing ever created it.** `lisa apply` doesn't install it, no script copies it, and the SKILL.md never told the agent to write it either — despite carrying `Write` in `allowed-tools`.

So every reference resolved to a path that did not exist. An environment would come up, run a missing script, exit non-zero, and fail to start a session with no indication that a setup step had been skipped. This affects the **Codex** path identically; it never surfaced because the implementation this was promoted from had those scripts written into that repository by hand.

`--install` now copies the assets into the host project and reports whether each was written or already current. Copied rather than symlinked or generated: the file has to survive in a fresh clone on a container that has never seen the plugin it came from, which is the whole reason the entrypoint is thin enough to copy.

## Bug 2 — a non-zero exit was read as a missing tool

Info-ZIP's `unzip` — the build shipped by **both macOS and Ubuntu** — parses `--version` one letter at a time, warns that `-n` and `-o` conflict, and exits 10. The probe treated any non-zero exit as absence, so `require: unzip` failed on machines that had it.

That is precisely the false alarm the check exists to avoid raising: `require` is meant to catch a vendor silently changing the base image, and instead it fired on an unchanged one. Only a failure to *spawn* means absent now; a tool that dislikes the flag is still present, and its version is recovered from the banner it printed before complaining (`unzip` reports 6.00 this way).

Found by running the toolchain step for real rather than against synthetic rows.

## Lisa as its own first host

`.lisa.config.json` gains a `secrets` block (bitwarden, tenant-suffixed bootstrap key) and a `remoteEnv` toolchain with a pinned, checksummed `bws` 2.1.0. `.claude/settings.json` gains the `SessionStart` hook. `scripts/lisa-remote-env/` is committed.

## Verification

Beyond the unit suite, this was proven against the real provider end to end:

- bootstrap resolves from the macOS keychain via the exact lookup `providers.mjs` performs
- `bws` authenticates with it and reads the project
- the secrets phase materializes into a throwaway config root at the right modes — dir `0700`, both files `0600` — and the notes file carries keys with no values
- the toolchain phase reports `node`, `curl`, `unzip` present and `bws` at its pin
- with the surface detected as `claude-web`, the default phases correctly **defer** secrets to the session-start hook and say why
- the session-start guard exits 0 outside a cloud session

482 files / 8269 tests pass; typecheck, lint, plugin sync and evidence manifest all green.

No real secret was left on disk — the materialize test used a temporary config root, which was removed.

🤖 Generated with Claude Code
