### PR TITLE
Raise the brace-expansion floor past GHSA-rgw5-rvv9-x895

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -109,7 +109,7 @@
   "overrides": {
     "@isaacs/brace-expansion": "^5.0.1",
     "axios": ">=1.15.2",
-    "brace-expansion": ">=5.0.8",
+    "brace-expansion": ">=5.0.9",
     "esbuild": ">=0.28.1",
     "flatted": "^3.4.2",
     "form-data": ">=4.0.6",
@@ -850,7 +850,7 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 

--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -98,7 +98,7 @@
     },
     "resolutions": {
       "@isaacs/brace-expansion": "^5.0.1",
-      "brace-expansion": ">=5.0.8",
+      "brace-expansion": ">=5.0.9",
       "eslint-plugin-react-hooks": "^7.0.0",
       "fast-xml-parser": "^5.10.1",
       "tar": ">=7.5.19",
@@ -106,7 +106,7 @@
     },
     "overrides": {
       "@isaacs/brace-expansion": "^5.0.1",
-      "brace-expansion": ">=5.0.8",
+      "brace-expansion": ">=5.0.9",
       "eslint-plugin-react-hooks": "^7.0.0",
       "fast-xml-parser": "^5.10.1",
       "zod-validation-error": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "postcss": ">=8.5.18",
     "undici": "^6.27.0",
     "form-data": ">=4.0.6",
-    "brace-expansion": ">=5.0.8"
+    "brace-expansion": ">=5.0.9"
   },
   "overrides": {
     "@isaacs/brace-expansion": "^5.0.1",
@@ -112,7 +112,7 @@
     "postcss": ">=8.5.18",
     "undici": "^6.27.0",
     "form-data": ">=4.0.6",
-    "brace-expansion": ">=5.0.8"
+    "brace-expansion": ">=5.0.9"
   },
   "name": "@codyswann/lisa",
   "version": "2.321.0",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -187,7 +187,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/merge/.oxlintrc.json":
       "2a0ea2191abd5b377aed4b525a4a97d3eefb1d9e41c845c02ee0daac75df6b1f",
     "expo/package-lisa/package.lisa.json":
-      "430a2e42be94f5eda106d8e89ec33d1927813fe66851575d5f3453a8f2b2ab98",
+      "c0d30ba53a179acb8720c4443b5f5fd6df092f735b9e3fbcea34f6b4995def0f",
     "harper-fabric/copy-contents/.prettierignore":
       "478c782f4c5611187e21584dfd5522e37fc636c5eb03394fea3db45321c6712c",
     "harper-fabric/copy-contents/gitignore":
@@ -2155,7 +2155,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/merge/.oxlintrc.json":
       "4debc093acfd263eb81ae15894073ebf098513204f45f40b83fb8fa5353fa1f8",
     "typescript/package-lisa/package.lisa.json":
-      "6a70ca152ac9daf5f1546cbaa876818b9a63360cf784870879d8d199fafe22d4",
+      "5d66792e54b1ed0ca1f2103e504f77a6afb8187660404ddba24936b049568934",
     "ui/README.md":
       "deeb35e767ea5dd2883268835ea3ad21cbad9fa63ec8d8ff5e200f0e2a7d2751",
     "ui/index.html":

--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -28,7 +28,7 @@
     },
     "resolutions": {
       "@isaacs/brace-expansion": "^5.0.1",
-      "brace-expansion": ">=5.0.8",
+      "brace-expansion": ">=5.0.9",
       "axios": ">=1.18.0",
       "esbuild": ">=0.28.1",
       "handlebars": ">=4.7.9",
@@ -42,7 +42,7 @@
     },
     "overrides": {
       "@isaacs/brace-expansion": "^5.0.1",
-      "brace-expansion": ">=5.0.8",
+      "brace-expansion": ">=5.0.9",
       "axios": ">=1.18.0",
       "esbuild": ">=0.28.1",
       "handlebars": ">=4.7.9",


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2182

GHSA-rgw5-rvv9-x895 is a high-severity denial of service in `brace-expansion` — unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation. Affected range is `>= 4.0.0, < 5.0.9`; the pinned floor was `>=5.0.8`, one release short, so the resolved build was vulnerable and the pre-push audit blocked every push.

Moved in all six declaration sites at once — `package.json` (force block and `overrides`), `typescript/package-lisa/package.lisa.json`, and `expo/package-lisa/package.lisa.json` — because a floor that holds here and not in the templates is worse than no floor: downstream projects would inherit the vulnerable range from the very files meant to protect them.

Verified: `bun pm ls` now resolves `brace-expansion@5.0.9`, and the pre-push audit passes.

Found while pushing unrelated work; it was blocking every push to this repository.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required `brace-expansion` version to 5.0.9 or later across supported package configurations.
  * Synchronized package metadata and verification records to keep installations consistent.
  * No changes to public APIs or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->