### PR TITLE
fix(remote-env): anchor Claude setup in checkout

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -109,7 +109,7 @@
   "overrides": {
     "@isaacs/brace-expansion": "^5.0.1",
     "axios": ">=1.15.2",
-    "brace-expansion": ">=5.0.8",
+    "brace-expansion": ">=5.0.9",
     "esbuild": ">=0.28.1",
     "flatted": "^3.4.2",
     "form-data": ">=4.0.6",
@@ -850,7 +850,7 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "postcss": ">=8.5.18",
     "undici": "^6.27.0",
     "form-data": ">=4.0.6",
-    "brace-expansion": ">=5.0.8"
+    "brace-expansion": ">=5.0.9"
   },
   "overrides": {
     "@isaacs/brace-expansion": "^5.0.1",
@@ -112,7 +112,7 @@
     "postcss": ">=8.5.18",
     "undici": "^6.27.0",
     "form-data": ">=4.0.6",
-    "brace-expansion": ">=5.0.8"
+    "brace-expansion": ">=5.0.9"
   },
   "name": "@codyswann/lisa",
   "version": "2.321.0",

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
@@ -161,6 +161,8 @@ It reads the project's own install command from its lockfile and the bootstrap n
 
 - **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
 - **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
+- **The setup field runs from `$HOME`, not from the checkout.** The emitted setup command starts with `cd <repo-name>` on purpose; without it the package install runs one directory above the clone and cannot find `package.json`.
+- **Trusted network access is not enough for provider CLIs.** Use Custom and include package registries, GitHub, cloud SDK hosts, and the bootstrap credential manager API.
 
 ### One environment per project, pinned locally
 

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/assets/setup.sh
@@ -13,6 +13,16 @@
 # and emphatically not in a vendor settings field.
 set -euo pipefail
 
+# Claude Code web runs the environment setup field from $HOME, while the
+# checkout lives at $HOME/<repo>. If this installed copy is invoked by absolute
+# path, move back to the repository root before resolving project-local files.
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+case "$script_dir" in
+  */scripts/lisa-remote-env)
+    cd "$script_dir/../.."
+    ;;
+esac
+
 # Node is the one thing that cannot be installed by the installer, since the
 # installer is written in it. Fail with an actionable message rather than a
 # "command not found" forty lines deep.

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -37,7 +37,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
@@ -337,11 +337,12 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
  * settings page, no direct URL, and no endpoint. Emit is not a degraded option
  * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
  * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null, install: string}} options Project details.
+ * @param {{bootstrapKey: string|null, install: string, repoDir?: string}} options Project details.
  * @returns {string} Text to show the operator.
  */
-export function emitClaudeWeb({ bootstrapKey, install }) {
+export function emitClaudeWeb({ bootstrapKey, install, repoDir = "lisa" }) {
   const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+  const setup = `cd ${shellQuote(repoDir)} && ${install} && bash scripts/lisa-remote-env/setup.sh`;
   return [
     "Provisioning tier: EMIT — and for this surface that is the only tier.",
     "  A Claude cloud environment is account-scoped configuration edited in the",
@@ -350,7 +351,8 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "",
     "Paste into the environment dialog",
     "---------------------------------",
-    "  Network access:  Trusted, or Custom plus any host your project needs",
+    "  Network access:  Custom plus your package registries, GitHub, cloud SDK",
+    "                   hosts, and the bootstrap credential manager API",
     "",
     "  Environment variables:",
     `    ${key}=<read this from your credential manager>`,
@@ -362,11 +364,13 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "    is why exactly one value needs to live here.",
     "",
     "  Setup script:",
-    `    ${install} && bash scripts/lisa-remote-env/setup.sh`,
+    `    ${setup}`,
     "",
-    "    The install must come first. On a fresh container node_modules is the",
-    "    only copy of the Lisa skills present, because Claude receives them as",
-    "    an installed plugin rather than as part of the clone.",
+    `    Claude runs this field from $HOME, while the checkout is $HOME/${repoDir}.`,
+    "    The `cd` must come first, and the install must run before the setup",
+    "    script. On a fresh container node_modules is the only copy of the Lisa",
+    "    skills present, because Claude receives them as an installed plugin",
+    "    rather than as part of the clone.",
     "",
     "Commit to the repository",
     "------------------------",
@@ -468,6 +472,35 @@ export function detectInstallCommand(cwd = process.cwd()) {
 }
 
 /**
+ * Name the directory Claude creates under $HOME when it clones this repository.
+ *
+ * Claude cloud runs the environment setup field from $HOME, not from the
+ * checkout. The setup line therefore has to `cd` into the clone before running
+ * the project install. Prefer the configured GitHub repo name because it is the
+ * thing Claude clones; fall back to the current directory for non-GitHub tests
+ * and local dry runs.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} Directory name to place after `cd`.
+ */
+export function detectRepositoryDirectory(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (existsSync(path)) {
+    const repo = JSON.parse(readFileSync(path, "utf8")).github?.repo;
+    if (repo && !repo.includes("/") && !repo.includes("\0")) return repo;
+  }
+  return basename(cwd);
+}
+
+/**
+ * Quote a value for POSIX shell usage.
+ * @param {string} value Raw value.
+ * @returns {string} Single-quoted shell literal.
+ */
+function shellQuote(value) {
+  return "'" + String(value).replaceAll("'", "'\\''") + "'";
+}
+
+/**
  * Read the bootstrap key name, which is the one value the operator must paste.
  * @param {string} [cwd] Repository root.
  * @returns {string|null} The configured key name, when there is one.
@@ -519,6 +552,7 @@ async function main() {
       emitClaudeWeb({
         bootstrapKey: readBootstrapKey(),
         install: detectInstallCommand(),
+        repoDir: detectRepositoryDirectory(),
       })
     );
     return;

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
@@ -161,6 +161,8 @@ It reads the project's own install command from its lockfile and the bootstrap n
 
 - **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
 - **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
+- **The setup field runs from `$HOME`, not from the checkout.** The emitted setup command starts with `cd <repo-name>` on purpose; without it the package install runs one directory above the clone and cannot find `package.json`.
+- **Trusted network access is not enough for provider CLIs.** Use Custom and include package registries, GitHub, cloud SDK hosts, and the bootstrap credential manager API.
 
 ### One environment per project, pinned locally
 

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/assets/setup.sh
@@ -13,6 +13,16 @@
 # and emphatically not in a vendor settings field.
 set -euo pipefail
 
+# Claude Code web runs the environment setup field from $HOME, while the
+# checkout lives at $HOME/<repo>. If this installed copy is invoked by absolute
+# path, move back to the repository root before resolving project-local files.
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+case "$script_dir" in
+  */scripts/lisa-remote-env)
+    cd "$script_dir/../.."
+    ;;
+esac
+
 # Node is the one thing that cannot be installed by the installer, since the
 # installer is written in it. Fail with an actionable message rather than a
 # "command not found" forty lines deep.

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -37,7 +37,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
@@ -337,11 +337,12 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
  * settings page, no direct URL, and no endpoint. Emit is not a degraded option
  * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
  * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null, install: string}} options Project details.
+ * @param {{bootstrapKey: string|null, install: string, repoDir?: string}} options Project details.
  * @returns {string} Text to show the operator.
  */
-export function emitClaudeWeb({ bootstrapKey, install }) {
+export function emitClaudeWeb({ bootstrapKey, install, repoDir = "lisa" }) {
   const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+  const setup = `cd ${shellQuote(repoDir)} && ${install} && bash scripts/lisa-remote-env/setup.sh`;
   return [
     "Provisioning tier: EMIT — and for this surface that is the only tier.",
     "  A Claude cloud environment is account-scoped configuration edited in the",
@@ -350,7 +351,8 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "",
     "Paste into the environment dialog",
     "---------------------------------",
-    "  Network access:  Trusted, or Custom plus any host your project needs",
+    "  Network access:  Custom plus your package registries, GitHub, cloud SDK",
+    "                   hosts, and the bootstrap credential manager API",
     "",
     "  Environment variables:",
     `    ${key}=<read this from your credential manager>`,
@@ -362,11 +364,13 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "    is why exactly one value needs to live here.",
     "",
     "  Setup script:",
-    `    ${install} && bash scripts/lisa-remote-env/setup.sh`,
+    `    ${setup}`,
     "",
-    "    The install must come first. On a fresh container node_modules is the",
-    "    only copy of the Lisa skills present, because Claude receives them as",
-    "    an installed plugin rather than as part of the clone.",
+    `    Claude runs this field from $HOME, while the checkout is $HOME/${repoDir}.`,
+    "    The `cd` must come first, and the install must run before the setup",
+    "    script. On a fresh container node_modules is the only copy of the Lisa",
+    "    skills present, because Claude receives them as an installed plugin",
+    "    rather than as part of the clone.",
     "",
     "Commit to the repository",
     "------------------------",
@@ -468,6 +472,35 @@ export function detectInstallCommand(cwd = process.cwd()) {
 }
 
 /**
+ * Name the directory Claude creates under $HOME when it clones this repository.
+ *
+ * Claude cloud runs the environment setup field from $HOME, not from the
+ * checkout. The setup line therefore has to `cd` into the clone before running
+ * the project install. Prefer the configured GitHub repo name because it is the
+ * thing Claude clones; fall back to the current directory for non-GitHub tests
+ * and local dry runs.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} Directory name to place after `cd`.
+ */
+export function detectRepositoryDirectory(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (existsSync(path)) {
+    const repo = JSON.parse(readFileSync(path, "utf8")).github?.repo;
+    if (repo && !repo.includes("/") && !repo.includes("\0")) return repo;
+  }
+  return basename(cwd);
+}
+
+/**
+ * Quote a value for POSIX shell usage.
+ * @param {string} value Raw value.
+ * @returns {string} Single-quoted shell literal.
+ */
+function shellQuote(value) {
+  return "'" + String(value).replaceAll("'", "'\\''") + "'";
+}
+
+/**
  * Read the bootstrap key name, which is the one value the operator must paste.
  * @param {string} [cwd] Repository root.
  * @returns {string|null} The configured key name, when there is one.
@@ -519,6 +552,7 @@ async function main() {
       emitClaudeWeb({
         bootstrapKey: readBootstrapKey(),
         install: detectInstallCommand(),
+        repoDir: detectRepositoryDirectory(),
       })
     );
     return;

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
@@ -161,6 +161,8 @@ It reads the project's own install command from its lockfile and the bootstrap n
 
 - **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
 - **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
+- **The setup field runs from `$HOME`, not from the checkout.** The emitted setup command starts with `cd <repo-name>` on purpose; without it the package install runs one directory above the clone and cannot find `package.json`.
+- **Trusted network access is not enough for provider CLIs.** Use Custom and include package registries, GitHub, cloud SDK hosts, and the bootstrap credential manager API.
 
 ### One environment per project, pinned locally
 

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/assets/setup.sh
@@ -13,6 +13,16 @@
 # and emphatically not in a vendor settings field.
 set -euo pipefail
 
+# Claude Code web runs the environment setup field from $HOME, while the
+# checkout lives at $HOME/<repo>. If this installed copy is invoked by absolute
+# path, move back to the repository root before resolving project-local files.
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+case "$script_dir" in
+  */scripts/lisa-remote-env)
+    cd "$script_dir/../.."
+    ;;
+esac
+
 # Node is the one thing that cannot be installed by the installer, since the
 # installer is written in it. Fail with an actionable message rather than a
 # "command not found" forty lines deep.

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -37,7 +37,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
@@ -337,11 +337,12 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
  * settings page, no direct URL, and no endpoint. Emit is not a degraded option
  * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
  * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null, install: string}} options Project details.
+ * @param {{bootstrapKey: string|null, install: string, repoDir?: string}} options Project details.
  * @returns {string} Text to show the operator.
  */
-export function emitClaudeWeb({ bootstrapKey, install }) {
+export function emitClaudeWeb({ bootstrapKey, install, repoDir = "lisa" }) {
   const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+  const setup = `cd ${shellQuote(repoDir)} && ${install} && bash scripts/lisa-remote-env/setup.sh`;
   return [
     "Provisioning tier: EMIT — and for this surface that is the only tier.",
     "  A Claude cloud environment is account-scoped configuration edited in the",
@@ -350,7 +351,8 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "",
     "Paste into the environment dialog",
     "---------------------------------",
-    "  Network access:  Trusted, or Custom plus any host your project needs",
+    "  Network access:  Custom plus your package registries, GitHub, cloud SDK",
+    "                   hosts, and the bootstrap credential manager API",
     "",
     "  Environment variables:",
     `    ${key}=<read this from your credential manager>`,
@@ -362,11 +364,13 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "    is why exactly one value needs to live here.",
     "",
     "  Setup script:",
-    `    ${install} && bash scripts/lisa-remote-env/setup.sh`,
+    `    ${setup}`,
     "",
-    "    The install must come first. On a fresh container node_modules is the",
-    "    only copy of the Lisa skills present, because Claude receives them as",
-    "    an installed plugin rather than as part of the clone.",
+    `    Claude runs this field from $HOME, while the checkout is $HOME/${repoDir}.`,
+    "    The `cd` must come first, and the install must run before the setup",
+    "    script. On a fresh container node_modules is the only copy of the Lisa",
+    "    skills present, because Claude receives them as an installed plugin",
+    "    rather than as part of the clone.",
     "",
     "Commit to the repository",
     "------------------------",
@@ -468,6 +472,35 @@ export function detectInstallCommand(cwd = process.cwd()) {
 }
 
 /**
+ * Name the directory Claude creates under $HOME when it clones this repository.
+ *
+ * Claude cloud runs the environment setup field from $HOME, not from the
+ * checkout. The setup line therefore has to `cd` into the clone before running
+ * the project install. Prefer the configured GitHub repo name because it is the
+ * thing Claude clones; fall back to the current directory for non-GitHub tests
+ * and local dry runs.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} Directory name to place after `cd`.
+ */
+export function detectRepositoryDirectory(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (existsSync(path)) {
+    const repo = JSON.parse(readFileSync(path, "utf8")).github?.repo;
+    if (repo && !repo.includes("/") && !repo.includes("\0")) return repo;
+  }
+  return basename(cwd);
+}
+
+/**
+ * Quote a value for POSIX shell usage.
+ * @param {string} value Raw value.
+ * @returns {string} Single-quoted shell literal.
+ */
+function shellQuote(value) {
+  return "'" + String(value).replaceAll("'", "'\\''") + "'";
+}
+
+/**
  * Read the bootstrap key name, which is the one value the operator must paste.
  * @param {string} [cwd] Repository root.
  * @returns {string|null} The configured key name, when there is one.
@@ -519,6 +552,7 @@ async function main() {
       emitClaudeWeb({
         bootstrapKey: readBootstrapKey(),
         install: detectInstallCommand(),
+        repoDir: detectRepositoryDirectory(),
       })
     );
     return;

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
@@ -161,6 +161,8 @@ It reads the project's own install command from its lockfile and the bootstrap n
 
 - **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
 - **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
+- **The setup field runs from `$HOME`, not from the checkout.** The emitted setup command starts with `cd <repo-name>` on purpose; without it the package install runs one directory above the clone and cannot find `package.json`.
+- **Trusted network access is not enough for provider CLIs.** Use Custom and include package registries, GitHub, cloud SDK hosts, and the bootstrap credential manager API.
 
 ### One environment per project, pinned locally
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/assets/setup.sh
@@ -13,6 +13,16 @@
 # and emphatically not in a vendor settings field.
 set -euo pipefail
 
+# Claude Code web runs the environment setup field from $HOME, while the
+# checkout lives at $HOME/<repo>. If this installed copy is invoked by absolute
+# path, move back to the repository root before resolving project-local files.
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+case "$script_dir" in
+  */scripts/lisa-remote-env)
+    cd "$script_dir/../.."
+    ;;
+esac
+
 # Node is the one thing that cannot be installed by the installer, since the
 # installer is written in it. Fail with an actionable message rather than a
 # "command not found" forty lines deep.

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -37,7 +37,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
@@ -337,11 +337,12 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
  * settings page, no direct URL, and no endpoint. Emit is not a degraded option
  * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
  * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null, install: string}} options Project details.
+ * @param {{bootstrapKey: string|null, install: string, repoDir?: string}} options Project details.
  * @returns {string} Text to show the operator.
  */
-export function emitClaudeWeb({ bootstrapKey, install }) {
+export function emitClaudeWeb({ bootstrapKey, install, repoDir = "lisa" }) {
   const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+  const setup = `cd ${shellQuote(repoDir)} && ${install} && bash scripts/lisa-remote-env/setup.sh`;
   return [
     "Provisioning tier: EMIT — and for this surface that is the only tier.",
     "  A Claude cloud environment is account-scoped configuration edited in the",
@@ -350,7 +351,8 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "",
     "Paste into the environment dialog",
     "---------------------------------",
-    "  Network access:  Trusted, or Custom plus any host your project needs",
+    "  Network access:  Custom plus your package registries, GitHub, cloud SDK",
+    "                   hosts, and the bootstrap credential manager API",
     "",
     "  Environment variables:",
     `    ${key}=<read this from your credential manager>`,
@@ -362,11 +364,13 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "    is why exactly one value needs to live here.",
     "",
     "  Setup script:",
-    `    ${install} && bash scripts/lisa-remote-env/setup.sh`,
+    `    ${setup}`,
     "",
-    "    The install must come first. On a fresh container node_modules is the",
-    "    only copy of the Lisa skills present, because Claude receives them as",
-    "    an installed plugin rather than as part of the clone.",
+    `    Claude runs this field from $HOME, while the checkout is $HOME/${repoDir}.`,
+    "    The `cd` must come first, and the install must run before the setup",
+    "    script. On a fresh container node_modules is the only copy of the Lisa",
+    "    skills present, because Claude receives them as an installed plugin",
+    "    rather than as part of the clone.",
     "",
     "Commit to the repository",
     "------------------------",
@@ -468,6 +472,35 @@ export function detectInstallCommand(cwd = process.cwd()) {
 }
 
 /**
+ * Name the directory Claude creates under $HOME when it clones this repository.
+ *
+ * Claude cloud runs the environment setup field from $HOME, not from the
+ * checkout. The setup line therefore has to `cd` into the clone before running
+ * the project install. Prefer the configured GitHub repo name because it is the
+ * thing Claude clones; fall back to the current directory for non-GitHub tests
+ * and local dry runs.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} Directory name to place after `cd`.
+ */
+export function detectRepositoryDirectory(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (existsSync(path)) {
+    const repo = JSON.parse(readFileSync(path, "utf8")).github?.repo;
+    if (repo && !repo.includes("/") && !repo.includes("\0")) return repo;
+  }
+  return basename(cwd);
+}
+
+/**
+ * Quote a value for POSIX shell usage.
+ * @param {string} value Raw value.
+ * @returns {string} Single-quoted shell literal.
+ */
+function shellQuote(value) {
+  return "'" + String(value).replaceAll("'", "'\\''") + "'";
+}
+
+/**
  * Read the bootstrap key name, which is the one value the operator must paste.
  * @param {string} [cwd] Repository root.
  * @returns {string|null} The configured key name, when there is one.
@@ -519,6 +552,7 @@ async function main() {
       emitClaudeWeb({
         bootstrapKey: readBootstrapKey(),
         install: detectInstallCommand(),
+        repoDir: detectRepositoryDirectory(),
       })
     );
     return;

--- a/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
@@ -161,6 +161,8 @@ It reads the project's own install command from its lockfile and the bootstrap n
 
 - **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
 - **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
+- **The setup field runs from `$HOME`, not from the checkout.** The emitted setup command starts with `cd <repo-name>` on purpose; without it the package install runs one directory above the clone and cannot find `package.json`.
+- **Trusted network access is not enough for provider CLIs.** Use Custom and include package registries, GitHub, cloud SDK hosts, and the bootstrap credential manager API.
 
 ### One environment per project, pinned locally
 

--- a/plugins/lisa/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa/skills/lisa-setup-remote-env/assets/setup.sh
@@ -13,6 +13,16 @@
 # and emphatically not in a vendor settings field.
 set -euo pipefail
 
+# Claude Code web runs the environment setup field from $HOME, while the
+# checkout lives at $HOME/<repo>. If this installed copy is invoked by absolute
+# path, move back to the repository root before resolving project-local files.
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+case "$script_dir" in
+  */scripts/lisa-remote-env)
+    cd "$script_dir/../.."
+    ;;
+esac
+
 # Node is the one thing that cannot be installed by the installer, since the
 # installer is written in it. Fail with an actionable message rather than a
 # "command not found" forty lines deep.

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -37,7 +37,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
@@ -337,11 +337,12 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
  * settings page, no direct URL, and no endpoint. Emit is not a degraded option
  * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
  * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null, install: string}} options Project details.
+ * @param {{bootstrapKey: string|null, install: string, repoDir?: string}} options Project details.
  * @returns {string} Text to show the operator.
  */
-export function emitClaudeWeb({ bootstrapKey, install }) {
+export function emitClaudeWeb({ bootstrapKey, install, repoDir = "lisa" }) {
   const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+  const setup = `cd ${shellQuote(repoDir)} && ${install} && bash scripts/lisa-remote-env/setup.sh`;
   return [
     "Provisioning tier: EMIT — and for this surface that is the only tier.",
     "  A Claude cloud environment is account-scoped configuration edited in the",
@@ -350,7 +351,8 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "",
     "Paste into the environment dialog",
     "---------------------------------",
-    "  Network access:  Trusted, or Custom plus any host your project needs",
+    "  Network access:  Custom plus your package registries, GitHub, cloud SDK",
+    "                   hosts, and the bootstrap credential manager API",
     "",
     "  Environment variables:",
     `    ${key}=<read this from your credential manager>`,
@@ -362,11 +364,13 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "    is why exactly one value needs to live here.",
     "",
     "  Setup script:",
-    `    ${install} && bash scripts/lisa-remote-env/setup.sh`,
+    `    ${setup}`,
     "",
-    "    The install must come first. On a fresh container node_modules is the",
-    "    only copy of the Lisa skills present, because Claude receives them as",
-    "    an installed plugin rather than as part of the clone.",
+    `    Claude runs this field from $HOME, while the checkout is $HOME/${repoDir}.`,
+    "    The `cd` must come first, and the install must run before the setup",
+    "    script. On a fresh container node_modules is the only copy of the Lisa",
+    "    skills present, because Claude receives them as an installed plugin",
+    "    rather than as part of the clone.",
     "",
     "Commit to the repository",
     "------------------------",
@@ -468,6 +472,35 @@ export function detectInstallCommand(cwd = process.cwd()) {
 }
 
 /**
+ * Name the directory Claude creates under $HOME when it clones this repository.
+ *
+ * Claude cloud runs the environment setup field from $HOME, not from the
+ * checkout. The setup line therefore has to `cd` into the clone before running
+ * the project install. Prefer the configured GitHub repo name because it is the
+ * thing Claude clones; fall back to the current directory for non-GitHub tests
+ * and local dry runs.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} Directory name to place after `cd`.
+ */
+export function detectRepositoryDirectory(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (existsSync(path)) {
+    const repo = JSON.parse(readFileSync(path, "utf8")).github?.repo;
+    if (repo && !repo.includes("/") && !repo.includes("\0")) return repo;
+  }
+  return basename(cwd);
+}
+
+/**
+ * Quote a value for POSIX shell usage.
+ * @param {string} value Raw value.
+ * @returns {string} Single-quoted shell literal.
+ */
+function shellQuote(value) {
+  return "'" + String(value).replaceAll("'", "'\\''") + "'";
+}
+
+/**
  * Read the bootstrap key name, which is the one value the operator must paste.
  * @param {string} [cwd] Repository root.
  * @returns {string|null} The configured key name, when there is one.
@@ -519,6 +552,7 @@ async function main() {
       emitClaudeWeb({
         bootstrapKey: readBootstrapKey(),
         install: detectInstallCommand(),
+        repoDir: detectRepositoryDirectory(),
       })
     );
     return;

--- a/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
@@ -161,6 +161,8 @@ It reads the project's own install command from its lockfile and the bootstrap n
 
 - **`gh` is not pre-installed.** If the project's flows shell out to it, add it to `remoteEnv.tools.install`, pinned and checksummed like anything else.
 - **A proxied credential reads as the literal string `proxy-injected`.** Tools that authenticate through the GitHub proxy work; a script that reads the variable directly gets the placeholder. The read-back asserts this rather than leaving it to be discovered against a live service.
+- **The setup field runs from `$HOME`, not from the checkout.** The emitted setup command starts with `cd <repo-name>` on purpose; without it the package install runs one directory above the clone and cannot find `package.json`.
+- **Trusted network access is not enough for provider CLIs.** Use Custom and include package registries, GitHub, cloud SDK hosts, and the bootstrap credential manager API.
 
 ### One environment per project, pinned locally
 

--- a/plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh
@@ -13,6 +13,16 @@
 # and emphatically not in a vendor settings field.
 set -euo pipefail
 
+# Claude Code web runs the environment setup field from $HOME, while the
+# checkout lives at $HOME/<repo>. If this installed copy is invoked by absolute
+# path, move back to the repository root before resolving project-local files.
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+case "$script_dir" in
+  */scripts/lisa-remote-env)
+    cd "$script_dir/../.."
+    ;;
+esac
+
 # Node is the one thing that cannot be installed by the installer, since the
 # installer is written in it. Fail with an actionable message rather than a
 # "command not found" forty lines deep.

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -37,7 +37,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
@@ -337,11 +337,12 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
  * settings page, no direct URL, and no endpoint. Emit is not a degraded option
  * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
  * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null, install: string}} options Project details.
+ * @param {{bootstrapKey: string|null, install: string, repoDir?: string}} options Project details.
  * @returns {string} Text to show the operator.
  */
-export function emitClaudeWeb({ bootstrapKey, install }) {
+export function emitClaudeWeb({ bootstrapKey, install, repoDir = "lisa" }) {
   const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+  const setup = `cd ${shellQuote(repoDir)} && ${install} && bash scripts/lisa-remote-env/setup.sh`;
   return [
     "Provisioning tier: EMIT — and for this surface that is the only tier.",
     "  A Claude cloud environment is account-scoped configuration edited in the",
@@ -350,7 +351,8 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "",
     "Paste into the environment dialog",
     "---------------------------------",
-    "  Network access:  Trusted, or Custom plus any host your project needs",
+    "  Network access:  Custom plus your package registries, GitHub, cloud SDK",
+    "                   hosts, and the bootstrap credential manager API",
     "",
     "  Environment variables:",
     `    ${key}=<read this from your credential manager>`,
@@ -362,11 +364,13 @@ export function emitClaudeWeb({ bootstrapKey, install }) {
     "    is why exactly one value needs to live here.",
     "",
     "  Setup script:",
-    `    ${install} && bash scripts/lisa-remote-env/setup.sh`,
+    `    ${setup}`,
     "",
-    "    The install must come first. On a fresh container node_modules is the",
-    "    only copy of the Lisa skills present, because Claude receives them as",
-    "    an installed plugin rather than as part of the clone.",
+    `    Claude runs this field from $HOME, while the checkout is $HOME/${repoDir}.`,
+    "    The `cd` must come first, and the install must run before the setup",
+    "    script. On a fresh container node_modules is the only copy of the Lisa",
+    "    skills present, because Claude receives them as an installed plugin",
+    "    rather than as part of the clone.",
     "",
     "Commit to the repository",
     "------------------------",
@@ -468,6 +472,35 @@ export function detectInstallCommand(cwd = process.cwd()) {
 }
 
 /**
+ * Name the directory Claude creates under $HOME when it clones this repository.
+ *
+ * Claude cloud runs the environment setup field from $HOME, not from the
+ * checkout. The setup line therefore has to `cd` into the clone before running
+ * the project install. Prefer the configured GitHub repo name because it is the
+ * thing Claude clones; fall back to the current directory for non-GitHub tests
+ * and local dry runs.
+ * @param {string} [cwd] Repository root.
+ * @returns {string} Directory name to place after `cd`.
+ */
+export function detectRepositoryDirectory(cwd = process.cwd()) {
+  const path = join(cwd, ".lisa.config.json");
+  if (existsSync(path)) {
+    const repo = JSON.parse(readFileSync(path, "utf8")).github?.repo;
+    if (repo && !repo.includes("/") && !repo.includes("\0")) return repo;
+  }
+  return basename(cwd);
+}
+
+/**
+ * Quote a value for POSIX shell usage.
+ * @param {string} value Raw value.
+ * @returns {string} Single-quoted shell literal.
+ */
+function shellQuote(value) {
+  return "'" + String(value).replaceAll("'", "'\\''") + "'";
+}
+
+/**
  * Read the bootstrap key name, which is the one value the operator must paste.
  * @param {string} [cwd] Repository root.
  * @returns {string|null} The configured key name, when there is one.
@@ -519,6 +552,7 @@ async function main() {
       emitClaudeWeb({
         bootstrapKey: readBootstrapKey(),
         install: detectInstallCommand(),
+        repoDir: detectRepositoryDirectory(),
       })
     );
     return;

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1119,13 +1119,13 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md":
       "80fbf157f9c562c033886c25a99b37356602edd9e61cd2d492f339769ddcf97e",
     "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md":
-      "21de7c108a5f372d76416dfd3e2d229053d0d23c84fe88e646719a97405bd1e9",
+      "313d1b96500950b566a3e22bc1620662a76635c89c6c90c2648d48e0497574b7",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh":
       "6e3871ec2f8d56b8ebb85376ebdd3956f3ed8fa4f7b278c2ed90ca9b8845897c",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
-      "a043074dd52e3f9b4b4a32bdd8b5eaa728160e5a0622a8a18388e6e26c7d25e3",
+      "f1b492196f41adcceb1c2a2ada048355e7f36735de3be0dfe028e472b452f28c",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "5e79d25368ddbc51ab2d9616a921b6eaea0e7fbee65de74a404b7b880f54fd9e",
+      "0ac27775b2a11cc7ab6368aba4df7466cbf8cf57fd5470a807e24547b36cc94f",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
       "ff66d33ba41a068d09be18f81ac68988238c2afa1d4e3733ae906b73eea74324",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":

--- a/tests/unit/secrets/remote-env-phases.test.ts
+++ b/tests/unit/secrets/remote-env-phases.test.ts
@@ -28,6 +28,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SURFACES } from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs";
 import {
   detectInstallCommand,
+  detectRepositoryDirectory,
   installAssets,
   pinEnvironment,
   probe,
@@ -131,6 +132,28 @@ describe("install command detection", () => {
     // A guessed package manager produces a container that fails on its very
     // first command, with an error that blames the project rather than the guess.
     expect(detectInstallCommand(root)).toBe("<your install command>");
+  });
+});
+
+describe("repository directory detection", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "lisa-repo-dir-"));
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it("uses the configured GitHub repo name", () => {
+    writeFileSync(
+      path.join(root, ".lisa.config.json"),
+      JSON.stringify({ github: { repo: "lisa" } })
+    );
+    expect(detectRepositoryDirectory(root)).toBe("lisa");
+  });
+
+  it("falls back to the checkout basename", () => {
+    expect(detectRepositoryDirectory(root)).toBe(path.basename(root));
   });
 });
 
@@ -270,6 +293,7 @@ describe("emitted Claude configuration", () => {
   const emitted = emitClaudeWeb({
     bootstrapKey: "BWS_ACCESS_TOKEN",
     install: "bun install",
+    repoDir: "lisa",
   });
 
   it("states that emit is the only tier for this surface", () => {
@@ -277,10 +301,16 @@ describe("emitted Claude configuration", () => {
     expect(emitted).toMatch(/no API/i);
   });
 
-  it("puts the install ahead of the setup script", () => {
+  it("enters the checkout before installing and running setup", () => {
     expect(emitted).toContain(
-      "bun install && bash scripts/lisa-remote-env/setup.sh"
+      "cd 'lisa' && bun install && bash scripts/lisa-remote-env/setup.sh"
     );
+  });
+
+  it("uses custom network access so the credential manager can be reached", () => {
+    expect(emitted).toContain("Network access:  Custom");
+    expect(emitted).toMatch(/credential manager API/i);
+    expect(emitted).not.toContain("Trusted, or Custom");
   });
 
   it("asks for the bootstrap and warns who else can read it", () => {
@@ -300,7 +330,11 @@ describe("emitted Claude configuration", () => {
   });
 
   it("says plainly when the bootstrap has not been configured", () => {
-    const missing = emitClaudeWeb({ bootstrapKey: null, install: "npm ci" });
+    const missing = emitClaudeWeb({
+      bootstrapKey: null,
+      install: "npm ci",
+      repoDir: "lisa",
+    });
     expect(missing).toMatch(/secrets\.bootstrap\.key is not configured/);
   });
 });

--- a/tests/unit/secrets/remote-env-skill-resolution.test.ts
+++ b/tests/unit/secrets/remote-env-skill-resolution.test.ts
@@ -98,6 +98,28 @@ function runEntrypoint(
   });
 }
 
+/**
+ * Install the entrypoint at its real repository path and invoke it from outside
+ * the checkout, the way Claude cloud runs an environment setup field.
+ * @param root Project directory
+ * @param cwd Directory to run from
+ * @param args Arguments forwarded to the entrypoint
+ * @returns The completed process
+ */
+function runInstalledEntrypointFrom(
+  root: string,
+  cwd: string,
+  args: readonly string[] = []
+): ReturnType<typeof spawnSync> {
+  const script = path.join(root, "scripts", "lisa-remote-env", "setup.sh");
+  mkdirSync(path.dirname(script), { recursive: true });
+  writeFileSync(script, readFileSync(ENTRYPOINT_PATH, "utf8"));
+  return spawnSync(BASH, [script, ...args], {
+    cwd,
+    encoding: "utf8",
+  });
+}
+
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
     rmSync(directory, { recursive: true, force: true });
@@ -134,6 +156,19 @@ describe("remote-env entrypoint skill resolution", () => {
     const result = runEntrypoint(root, ["--dry-run"]);
 
     expect(result.status).toBe(0);
+    expect(result.stdout).toContain("--dry-run");
+  });
+
+  it("re-anchors to the repository root when installed script runs from its parent", () => {
+    const parent = temporaryDirectory();
+    const root = path.join(parent, "lisa");
+    mkdirSync(root);
+    plantRunner(root, NODE_MODULES_RUNNER, `${NODE_MODULES_MARKER}:${root}`);
+
+    const result = runInstalledEntrypointFrom(root, parent, ["--dry-run"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`${NODE_MODULES_MARKER}:${root}`);
     expect(result.stdout).toContain("--dry-run");
   });
 


### PR DESCRIPTION
## Summary
- emit Claude web setup commands that first cd into the cloned repo before installing dependencies
- re-anchor the installed setup entrypoint when invoked from scripts/lisa-remote-env outside the checkout
- require Custom network guidance for provider CLI access

Fixes #2181

## Verification
- bun test tests/unit/secrets/remote-env-phases.test.ts tests/unit/secrets/remote-env-skill-resolution.test.ts
- bun test tests/unit/secrets/
- bun run build:dist
- bun run lint
- bun run build:plugins
- bun run build:upstream-evidence-manifest
- bun run check:plugins
- bun run check:upstream-evidence-manifest
- git push pre-push gate: tsc --noEmit, security audit, lint:slow, knip, vitest --coverage, integration tests, plugin parity

Work-Item: CodySwannGT/lisa#2181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved remote environment setup when launched from a different working directory or via an absolute path.
  - Setup commands now enter the repository directory before installing dependencies and running configuration.
  - Added safer repository directory detection and shell handling.

- **Documentation**
  - Expanded web setup guidance with required custom network access for package registries, GitHub, cloud SDKs, and credential services.

- **Tests**
  - Added coverage for repository detection, setup execution from alternate directories, network guidance, and command generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->