### PR TITLE
fix(secrets): let a rotating credential be excluded from a surface

### DIFF
--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -19,7 +19,7 @@
 
 import { createHash } from "node:crypto";
 
-import { fetchAll } from "./providers.mjs";
+import { fetchAll, fetchRotatable } from "./providers.mjs";
 import { readMaterialized } from "./resolve-secret.mjs";
 import { readConfig } from "./surfaces.mjs";
 
@@ -220,7 +220,7 @@ function main() {
   checkRequired(cfg, provider, file, report);
   checkNaming(provider, report);
   checkNotes(provider, report);
-  checkRotating(cfg, provider, report);
+  checkRotating(cfg, fetchRotatable(cfg), report);
   checkTwoStores(provider, file, report);
 
   const order = { error: 0, warn: 1, ok: 2 };

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/providers.mjs
@@ -244,6 +244,51 @@ export function fetchAll(cfg) {
 }
 
 /**
+ * The provider view the rotation path sees: `excludeKeys` waived for declared
+ * rotating names only.
+ *
+ * `excludeKeys` exists to keep a credential off a **surface's disk**. Applying it
+ * to the rotation path conflated that with hiding the record from the provider,
+ * which made `rotating` and `excludeKeys` mutually exclusive for the same name —
+ * a credential you cannot see is one you cannot write back to, so `doctor`
+ * correctly errored. That is exactly backwards for a consumable credential: the
+ * kind you least want materialized onto an untrusted surface is the kind that
+ * most needs a proven write path.
+ *
+ * The waiver is deliberately narrow. It applies only to names listed in
+ * `secrets.rotating`, which is config and therefore reviewed — the same
+ * declared-never-inferred rule the write path already enforces. Project
+ * narrowing still applies untouched, because that is the provider's own grant
+ * boundary and this must never widen it. Nothing here materializes anything;
+ * `fetchAll` remains the only view that feeds a surface.
+ * @param {object} cfg Resolved configuration.
+ * @returns {Map<string, {value: string, note: string, id: string|null}>} Selected secrets by name.
+ */
+export function fetchRotatable(cfg) {
+  return normalizeRows(fetchRaw(cfg), rotationNarrow(cfg));
+}
+
+/**
+ * The narrowing the rotation view applies: project grants intact, `excludeKeys`
+ * waived for declared rotating names only.
+ *
+ * Split out from {@link fetchRotatable} so the decision is testable without a
+ * provider, matching how the toolchain planner separates planning from
+ * execution.
+ * @param {object} cfg Resolved configuration.
+ * @returns {{projectIds: string[], excludeKeys: string[]}} Narrowing controls.
+ */
+export function rotationNarrow(cfg) {
+  const rotating = new Set(cfg.rotating ?? []);
+  return {
+    projectIds: cfg.narrow?.projectIds ?? [],
+    excludeKeys: (cfg.narrow?.excludeKeys ?? []).filter(
+      key => !rotating.has(key)
+    ),
+  };
+}
+
+/**
  * Find one raw row by exact key, bypassing the exposure boundary.
  *
  * Only the rotation path uses this, and only to reach the lease record, which

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/providers.mjs
@@ -244,23 +244,16 @@ export function fetchAll(cfg) {
 }
 
 /**
- * The provider view the rotation path sees: `excludeKeys` waived for declared
- * rotating names only.
+ * The provider view the rotation path reads.
  *
- * `excludeKeys` exists to keep a credential off a **surface's disk**. Applying it
- * to the rotation path conflated that with hiding the record from the provider,
- * which made `rotating` and `excludeKeys` mutually exclusive for the same name —
- * a credential you cannot see is one you cannot write back to, so `doctor`
- * correctly errored. That is exactly backwards for a consumable credential: the
- * kind you least want materialized onto an untrusted surface is the kind that
- * most needs a proven write path.
+ * `excludeKeys` keeps a credential off a **surface's disk**. Applying it here
+ * too hid the provider record, making `rotating` and `excludeKeys` mutually
+ * exclusive — and a credential you cannot see is one you cannot write back to.
+ * That is backwards for a consumable credential: the kind you least want
+ * materialized is the kind that most needs a proven write path.
  *
- * The waiver is deliberately narrow. It applies only to names listed in
- * `secrets.rotating`, which is config and therefore reviewed — the same
- * declared-never-inferred rule the write path already enforces. Project
- * narrowing still applies untouched, because that is the provider's own grant
- * boundary and this must never widen it. Nothing here materializes anything;
- * `fetchAll` remains the only view that feeds a surface.
+ * Nothing here materializes anything. `fetchAll` remains the only view feeding
+ * a surface, so an excluded rotating credential still never reaches disk.
  * @param {object} cfg Resolved configuration.
  * @returns {Map<string, {value: string, note: string, id: string|null}>} Selected secrets by name.
  */
@@ -269,12 +262,13 @@ export function fetchRotatable(cfg) {
 }
 
 /**
- * The narrowing the rotation view applies: project grants intact, `excludeKeys`
- * waived for declared rotating names only.
+ * Narrowing for the rotation view: project grants intact, `excludeKeys` waived
+ * for declared rotating names only.
  *
- * Split out from {@link fetchRotatable} so the decision is testable without a
- * provider, matching how the toolchain planner separates planning from
- * execution.
+ * The waiver reaches only names in `secrets.rotating` — config, and therefore
+ * reviewed, the same declared-never-inferred rule the write path enforces.
+ * Project narrowing is the provider's own boundary and is never widened. Split
+ * from {@link fetchRotatable} so the decision is testable without a provider.
  * @param {object} cfg Resolved configuration.
  * @returns {{projectIds: string[], excludeKeys: string[]}} Narrowing controls.
  */

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/rotate-secret.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/rotate-secret.mjs
@@ -30,7 +30,12 @@
 import { readFileSync } from "node:fs";
 import { hostname } from "node:os";
 
-import { LEASE_KEY, fetchAll, rawByKey, writeSecret } from "./providers.mjs";
+import {
+  LEASE_KEY,
+  fetchRotatable,
+  rawByKey,
+  writeSecret,
+} from "./providers.mjs";
 import { readConfig } from "./surfaces.mjs";
 
 /** How long a lease is honoured before it is treated as abandoned. */
@@ -63,7 +68,10 @@ function assertRotating(name, cfg) {
  * @returns {{value: string, id: string}} The current entry.
  */
 function entryFor(name, cfg) {
-  const hit = fetchAll(cfg).get(name);
+  // Rotation view, not the materialization view: a name may be excluded from
+  // every surface and still need its replacement persisted. assertRotating has
+  // already proved this name is declared in config.
+  const hit = fetchRotatable(cfg).get(name);
   if (!hit) throw new Error(`${name} is not available to this account`);
   if (!hit.id) {
     throw new Error(

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -19,7 +19,7 @@
 
 import { createHash } from "node:crypto";
 
-import { fetchAll } from "./providers.mjs";
+import { fetchAll, fetchRotatable } from "./providers.mjs";
 import { readMaterialized } from "./resolve-secret.mjs";
 import { readConfig } from "./surfaces.mjs";
 
@@ -220,7 +220,7 @@ function main() {
   checkRequired(cfg, provider, file, report);
   checkNaming(provider, report);
   checkNotes(provider, report);
-  checkRotating(cfg, provider, report);
+  checkRotating(cfg, fetchRotatable(cfg), report);
   checkTwoStores(provider, file, report);
 
   const order = { error: 0, warn: 1, ok: 2 };

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/providers.mjs
@@ -244,6 +244,51 @@ export function fetchAll(cfg) {
 }
 
 /**
+ * The provider view the rotation path sees: `excludeKeys` waived for declared
+ * rotating names only.
+ *
+ * `excludeKeys` exists to keep a credential off a **surface's disk**. Applying it
+ * to the rotation path conflated that with hiding the record from the provider,
+ * which made `rotating` and `excludeKeys` mutually exclusive for the same name —
+ * a credential you cannot see is one you cannot write back to, so `doctor`
+ * correctly errored. That is exactly backwards for a consumable credential: the
+ * kind you least want materialized onto an untrusted surface is the kind that
+ * most needs a proven write path.
+ *
+ * The waiver is deliberately narrow. It applies only to names listed in
+ * `secrets.rotating`, which is config and therefore reviewed — the same
+ * declared-never-inferred rule the write path already enforces. Project
+ * narrowing still applies untouched, because that is the provider's own grant
+ * boundary and this must never widen it. Nothing here materializes anything;
+ * `fetchAll` remains the only view that feeds a surface.
+ * @param {object} cfg Resolved configuration.
+ * @returns {Map<string, {value: string, note: string, id: string|null}>} Selected secrets by name.
+ */
+export function fetchRotatable(cfg) {
+  return normalizeRows(fetchRaw(cfg), rotationNarrow(cfg));
+}
+
+/**
+ * The narrowing the rotation view applies: project grants intact, `excludeKeys`
+ * waived for declared rotating names only.
+ *
+ * Split out from {@link fetchRotatable} so the decision is testable without a
+ * provider, matching how the toolchain planner separates planning from
+ * execution.
+ * @param {object} cfg Resolved configuration.
+ * @returns {{projectIds: string[], excludeKeys: string[]}} Narrowing controls.
+ */
+export function rotationNarrow(cfg) {
+  const rotating = new Set(cfg.rotating ?? []);
+  return {
+    projectIds: cfg.narrow?.projectIds ?? [],
+    excludeKeys: (cfg.narrow?.excludeKeys ?? []).filter(
+      key => !rotating.has(key)
+    ),
+  };
+}
+
+/**
  * Find one raw row by exact key, bypassing the exposure boundary.
  *
  * Only the rotation path uses this, and only to reach the lease record, which

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/providers.mjs
@@ -244,23 +244,16 @@ export function fetchAll(cfg) {
 }
 
 /**
- * The provider view the rotation path sees: `excludeKeys` waived for declared
- * rotating names only.
+ * The provider view the rotation path reads.
  *
- * `excludeKeys` exists to keep a credential off a **surface's disk**. Applying it
- * to the rotation path conflated that with hiding the record from the provider,
- * which made `rotating` and `excludeKeys` mutually exclusive for the same name —
- * a credential you cannot see is one you cannot write back to, so `doctor`
- * correctly errored. That is exactly backwards for a consumable credential: the
- * kind you least want materialized onto an untrusted surface is the kind that
- * most needs a proven write path.
+ * `excludeKeys` keeps a credential off a **surface's disk**. Applying it here
+ * too hid the provider record, making `rotating` and `excludeKeys` mutually
+ * exclusive — and a credential you cannot see is one you cannot write back to.
+ * That is backwards for a consumable credential: the kind you least want
+ * materialized is the kind that most needs a proven write path.
  *
- * The waiver is deliberately narrow. It applies only to names listed in
- * `secrets.rotating`, which is config and therefore reviewed — the same
- * declared-never-inferred rule the write path already enforces. Project
- * narrowing still applies untouched, because that is the provider's own grant
- * boundary and this must never widen it. Nothing here materializes anything;
- * `fetchAll` remains the only view that feeds a surface.
+ * Nothing here materializes anything. `fetchAll` remains the only view feeding
+ * a surface, so an excluded rotating credential still never reaches disk.
  * @param {object} cfg Resolved configuration.
  * @returns {Map<string, {value: string, note: string, id: string|null}>} Selected secrets by name.
  */
@@ -269,12 +262,13 @@ export function fetchRotatable(cfg) {
 }
 
 /**
- * The narrowing the rotation view applies: project grants intact, `excludeKeys`
- * waived for declared rotating names only.
+ * Narrowing for the rotation view: project grants intact, `excludeKeys` waived
+ * for declared rotating names only.
  *
- * Split out from {@link fetchRotatable} so the decision is testable without a
- * provider, matching how the toolchain planner separates planning from
- * execution.
+ * The waiver reaches only names in `secrets.rotating` — config, and therefore
+ * reviewed, the same declared-never-inferred rule the write path enforces.
+ * Project narrowing is the provider's own boundary and is never widened. Split
+ * from {@link fetchRotatable} so the decision is testable without a provider.
  * @param {object} cfg Resolved configuration.
  * @returns {{projectIds: string[], excludeKeys: string[]}} Narrowing controls.
  */

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/rotate-secret.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/rotate-secret.mjs
@@ -30,7 +30,12 @@
 import { readFileSync } from "node:fs";
 import { hostname } from "node:os";
 
-import { LEASE_KEY, fetchAll, rawByKey, writeSecret } from "./providers.mjs";
+import {
+  LEASE_KEY,
+  fetchRotatable,
+  rawByKey,
+  writeSecret,
+} from "./providers.mjs";
 import { readConfig } from "./surfaces.mjs";
 
 /** How long a lease is honoured before it is treated as abandoned. */
@@ -63,7 +68,10 @@ function assertRotating(name, cfg) {
  * @returns {{value: string, id: string}} The current entry.
  */
 function entryFor(name, cfg) {
-  const hit = fetchAll(cfg).get(name);
+  // Rotation view, not the materialization view: a name may be excluded from
+  // every surface and still need its replacement persisted. assertRotating has
+  // already proved this name is declared in config.
+  const hit = fetchRotatable(cfg).get(name);
   if (!hit) throw new Error(`${name} is not available to this account`);
   if (!hit.id) {
     throw new Error(

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -19,7 +19,7 @@
 
 import { createHash } from "node:crypto";
 
-import { fetchAll } from "./providers.mjs";
+import { fetchAll, fetchRotatable } from "./providers.mjs";
 import { readMaterialized } from "./resolve-secret.mjs";
 import { readConfig } from "./surfaces.mjs";
 
@@ -220,7 +220,7 @@ function main() {
   checkRequired(cfg, provider, file, report);
   checkNaming(provider, report);
   checkNotes(provider, report);
-  checkRotating(cfg, provider, report);
+  checkRotating(cfg, fetchRotatable(cfg), report);
   checkTwoStores(provider, file, report);
 
   const order = { error: 0, warn: 1, ok: 2 };

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/providers.mjs
@@ -244,6 +244,51 @@ export function fetchAll(cfg) {
 }
 
 /**
+ * The provider view the rotation path sees: `excludeKeys` waived for declared
+ * rotating names only.
+ *
+ * `excludeKeys` exists to keep a credential off a **surface's disk**. Applying it
+ * to the rotation path conflated that with hiding the record from the provider,
+ * which made `rotating` and `excludeKeys` mutually exclusive for the same name —
+ * a credential you cannot see is one you cannot write back to, so `doctor`
+ * correctly errored. That is exactly backwards for a consumable credential: the
+ * kind you least want materialized onto an untrusted surface is the kind that
+ * most needs a proven write path.
+ *
+ * The waiver is deliberately narrow. It applies only to names listed in
+ * `secrets.rotating`, which is config and therefore reviewed — the same
+ * declared-never-inferred rule the write path already enforces. Project
+ * narrowing still applies untouched, because that is the provider's own grant
+ * boundary and this must never widen it. Nothing here materializes anything;
+ * `fetchAll` remains the only view that feeds a surface.
+ * @param {object} cfg Resolved configuration.
+ * @returns {Map<string, {value: string, note: string, id: string|null}>} Selected secrets by name.
+ */
+export function fetchRotatable(cfg) {
+  return normalizeRows(fetchRaw(cfg), rotationNarrow(cfg));
+}
+
+/**
+ * The narrowing the rotation view applies: project grants intact, `excludeKeys`
+ * waived for declared rotating names only.
+ *
+ * Split out from {@link fetchRotatable} so the decision is testable without a
+ * provider, matching how the toolchain planner separates planning from
+ * execution.
+ * @param {object} cfg Resolved configuration.
+ * @returns {{projectIds: string[], excludeKeys: string[]}} Narrowing controls.
+ */
+export function rotationNarrow(cfg) {
+  const rotating = new Set(cfg.rotating ?? []);
+  return {
+    projectIds: cfg.narrow?.projectIds ?? [],
+    excludeKeys: (cfg.narrow?.excludeKeys ?? []).filter(
+      key => !rotating.has(key)
+    ),
+  };
+}
+
+/**
  * Find one raw row by exact key, bypassing the exposure boundary.
  *
  * Only the rotation path uses this, and only to reach the lease record, which

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/providers.mjs
@@ -244,23 +244,16 @@ export function fetchAll(cfg) {
 }
 
 /**
- * The provider view the rotation path sees: `excludeKeys` waived for declared
- * rotating names only.
+ * The provider view the rotation path reads.
  *
- * `excludeKeys` exists to keep a credential off a **surface's disk**. Applying it
- * to the rotation path conflated that with hiding the record from the provider,
- * which made `rotating` and `excludeKeys` mutually exclusive for the same name —
- * a credential you cannot see is one you cannot write back to, so `doctor`
- * correctly errored. That is exactly backwards for a consumable credential: the
- * kind you least want materialized onto an untrusted surface is the kind that
- * most needs a proven write path.
+ * `excludeKeys` keeps a credential off a **surface's disk**. Applying it here
+ * too hid the provider record, making `rotating` and `excludeKeys` mutually
+ * exclusive — and a credential you cannot see is one you cannot write back to.
+ * That is backwards for a consumable credential: the kind you least want
+ * materialized is the kind that most needs a proven write path.
  *
- * The waiver is deliberately narrow. It applies only to names listed in
- * `secrets.rotating`, which is config and therefore reviewed — the same
- * declared-never-inferred rule the write path already enforces. Project
- * narrowing still applies untouched, because that is the provider's own grant
- * boundary and this must never widen it. Nothing here materializes anything;
- * `fetchAll` remains the only view that feeds a surface.
+ * Nothing here materializes anything. `fetchAll` remains the only view feeding
+ * a surface, so an excluded rotating credential still never reaches disk.
  * @param {object} cfg Resolved configuration.
  * @returns {Map<string, {value: string, note: string, id: string|null}>} Selected secrets by name.
  */
@@ -269,12 +262,13 @@ export function fetchRotatable(cfg) {
 }
 
 /**
- * The narrowing the rotation view applies: project grants intact, `excludeKeys`
- * waived for declared rotating names only.
+ * Narrowing for the rotation view: project grants intact, `excludeKeys` waived
+ * for declared rotating names only.
  *
- * Split out from {@link fetchRotatable} so the decision is testable without a
- * provider, matching how the toolchain planner separates planning from
- * execution.
+ * The waiver reaches only names in `secrets.rotating` — config, and therefore
+ * reviewed, the same declared-never-inferred rule the write path enforces.
+ * Project narrowing is the provider's own boundary and is never widened. Split
+ * from {@link fetchRotatable} so the decision is testable without a provider.
  * @param {object} cfg Resolved configuration.
  * @returns {{projectIds: string[], excludeKeys: string[]}} Narrowing controls.
  */

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/rotate-secret.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/rotate-secret.mjs
@@ -30,7 +30,12 @@
 import { readFileSync } from "node:fs";
 import { hostname } from "node:os";
 
-import { LEASE_KEY, fetchAll, rawByKey, writeSecret } from "./providers.mjs";
+import {
+  LEASE_KEY,
+  fetchRotatable,
+  rawByKey,
+  writeSecret,
+} from "./providers.mjs";
 import { readConfig } from "./surfaces.mjs";
 
 /** How long a lease is honoured before it is treated as abandoned. */
@@ -63,7 +68,10 @@ function assertRotating(name, cfg) {
  * @returns {{value: string, id: string}} The current entry.
  */
 function entryFor(name, cfg) {
-  const hit = fetchAll(cfg).get(name);
+  // Rotation view, not the materialization view: a name may be excluded from
+  // every surface and still need its replacement persisted. assertRotating has
+  // already proved this name is declared in config.
+  const hit = fetchRotatable(cfg).get(name);
   if (!hit) throw new Error(`${name} is not available to this account`);
   if (!hit.id) {
     throw new Error(

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -19,7 +19,7 @@
 
 import { createHash } from "node:crypto";
 
-import { fetchAll } from "./providers.mjs";
+import { fetchAll, fetchRotatable } from "./providers.mjs";
 import { readMaterialized } from "./resolve-secret.mjs";
 import { readConfig } from "./surfaces.mjs";
 
@@ -220,7 +220,7 @@ function main() {
   checkRequired(cfg, provider, file, report);
   checkNaming(provider, report);
   checkNotes(provider, report);
-  checkRotating(cfg, provider, report);
+  checkRotating(cfg, fetchRotatable(cfg), report);
   checkTwoStores(provider, file, report);
 
   const order = { error: 0, warn: 1, ok: 2 };

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/providers.mjs
@@ -244,6 +244,51 @@ export function fetchAll(cfg) {
 }
 
 /**
+ * The provider view the rotation path sees: `excludeKeys` waived for declared
+ * rotating names only.
+ *
+ * `excludeKeys` exists to keep a credential off a **surface's disk**. Applying it
+ * to the rotation path conflated that with hiding the record from the provider,
+ * which made `rotating` and `excludeKeys` mutually exclusive for the same name —
+ * a credential you cannot see is one you cannot write back to, so `doctor`
+ * correctly errored. That is exactly backwards for a consumable credential: the
+ * kind you least want materialized onto an untrusted surface is the kind that
+ * most needs a proven write path.
+ *
+ * The waiver is deliberately narrow. It applies only to names listed in
+ * `secrets.rotating`, which is config and therefore reviewed — the same
+ * declared-never-inferred rule the write path already enforces. Project
+ * narrowing still applies untouched, because that is the provider's own grant
+ * boundary and this must never widen it. Nothing here materializes anything;
+ * `fetchAll` remains the only view that feeds a surface.
+ * @param {object} cfg Resolved configuration.
+ * @returns {Map<string, {value: string, note: string, id: string|null}>} Selected secrets by name.
+ */
+export function fetchRotatable(cfg) {
+  return normalizeRows(fetchRaw(cfg), rotationNarrow(cfg));
+}
+
+/**
+ * The narrowing the rotation view applies: project grants intact, `excludeKeys`
+ * waived for declared rotating names only.
+ *
+ * Split out from {@link fetchRotatable} so the decision is testable without a
+ * provider, matching how the toolchain planner separates planning from
+ * execution.
+ * @param {object} cfg Resolved configuration.
+ * @returns {{projectIds: string[], excludeKeys: string[]}} Narrowing controls.
+ */
+export function rotationNarrow(cfg) {
+  const rotating = new Set(cfg.rotating ?? []);
+  return {
+    projectIds: cfg.narrow?.projectIds ?? [],
+    excludeKeys: (cfg.narrow?.excludeKeys ?? []).filter(
+      key => !rotating.has(key)
+    ),
+  };
+}
+
+/**
  * Find one raw row by exact key, bypassing the exposure boundary.
  *
  * Only the rotation path uses this, and only to reach the lease record, which

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/providers.mjs
@@ -244,23 +244,16 @@ export function fetchAll(cfg) {
 }
 
 /**
- * The provider view the rotation path sees: `excludeKeys` waived for declared
- * rotating names only.
+ * The provider view the rotation path reads.
  *
- * `excludeKeys` exists to keep a credential off a **surface's disk**. Applying it
- * to the rotation path conflated that with hiding the record from the provider,
- * which made `rotating` and `excludeKeys` mutually exclusive for the same name —
- * a credential you cannot see is one you cannot write back to, so `doctor`
- * correctly errored. That is exactly backwards for a consumable credential: the
- * kind you least want materialized onto an untrusted surface is the kind that
- * most needs a proven write path.
+ * `excludeKeys` keeps a credential off a **surface's disk**. Applying it here
+ * too hid the provider record, making `rotating` and `excludeKeys` mutually
+ * exclusive — and a credential you cannot see is one you cannot write back to.
+ * That is backwards for a consumable credential: the kind you least want
+ * materialized is the kind that most needs a proven write path.
  *
- * The waiver is deliberately narrow. It applies only to names listed in
- * `secrets.rotating`, which is config and therefore reviewed — the same
- * declared-never-inferred rule the write path already enforces. Project
- * narrowing still applies untouched, because that is the provider's own grant
- * boundary and this must never widen it. Nothing here materializes anything;
- * `fetchAll` remains the only view that feeds a surface.
+ * Nothing here materializes anything. `fetchAll` remains the only view feeding
+ * a surface, so an excluded rotating credential still never reaches disk.
  * @param {object} cfg Resolved configuration.
  * @returns {Map<string, {value: string, note: string, id: string|null}>} Selected secrets by name.
  */
@@ -269,12 +262,13 @@ export function fetchRotatable(cfg) {
 }
 
 /**
- * The narrowing the rotation view applies: project grants intact, `excludeKeys`
- * waived for declared rotating names only.
+ * Narrowing for the rotation view: project grants intact, `excludeKeys` waived
+ * for declared rotating names only.
  *
- * Split out from {@link fetchRotatable} so the decision is testable without a
- * provider, matching how the toolchain planner separates planning from
- * execution.
+ * The waiver reaches only names in `secrets.rotating` — config, and therefore
+ * reviewed, the same declared-never-inferred rule the write path enforces.
+ * Project narrowing is the provider's own boundary and is never widened. Split
+ * from {@link fetchRotatable} so the decision is testable without a provider.
  * @param {object} cfg Resolved configuration.
  * @returns {{projectIds: string[], excludeKeys: string[]}} Narrowing controls.
  */

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/rotate-secret.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/rotate-secret.mjs
@@ -30,7 +30,12 @@
 import { readFileSync } from "node:fs";
 import { hostname } from "node:os";
 
-import { LEASE_KEY, fetchAll, rawByKey, writeSecret } from "./providers.mjs";
+import {
+  LEASE_KEY,
+  fetchRotatable,
+  rawByKey,
+  writeSecret,
+} from "./providers.mjs";
 import { readConfig } from "./surfaces.mjs";
 
 /** How long a lease is honoured before it is treated as abandoned. */
@@ -63,7 +68,10 @@ function assertRotating(name, cfg) {
  * @returns {{value: string, id: string}} The current entry.
  */
 function entryFor(name, cfg) {
-  const hit = fetchAll(cfg).get(name);
+  // Rotation view, not the materialization view: a name may be excluded from
+  // every surface and still need its replacement persisted. assertRotating has
+  // already proved this name is declared in config.
+  const hit = fetchRotatable(cfg).get(name);
   if (!hit) throw new Error(`${name} is not available to this account`);
   if (!hit.id) {
     throw new Error(

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -19,7 +19,7 @@
 
 import { createHash } from "node:crypto";
 
-import { fetchAll } from "./providers.mjs";
+import { fetchAll, fetchRotatable } from "./providers.mjs";
 import { readMaterialized } from "./resolve-secret.mjs";
 import { readConfig } from "./surfaces.mjs";
 
@@ -220,7 +220,7 @@ function main() {
   checkRequired(cfg, provider, file, report);
   checkNaming(provider, report);
   checkNotes(provider, report);
-  checkRotating(cfg, provider, report);
+  checkRotating(cfg, fetchRotatable(cfg), report);
   checkTwoStores(provider, file, report);
 
   const order = { error: 0, warn: 1, ok: 2 };

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/providers.mjs
@@ -244,6 +244,51 @@ export function fetchAll(cfg) {
 }
 
 /**
+ * The provider view the rotation path sees: `excludeKeys` waived for declared
+ * rotating names only.
+ *
+ * `excludeKeys` exists to keep a credential off a **surface's disk**. Applying it
+ * to the rotation path conflated that with hiding the record from the provider,
+ * which made `rotating` and `excludeKeys` mutually exclusive for the same name —
+ * a credential you cannot see is one you cannot write back to, so `doctor`
+ * correctly errored. That is exactly backwards for a consumable credential: the
+ * kind you least want materialized onto an untrusted surface is the kind that
+ * most needs a proven write path.
+ *
+ * The waiver is deliberately narrow. It applies only to names listed in
+ * `secrets.rotating`, which is config and therefore reviewed — the same
+ * declared-never-inferred rule the write path already enforces. Project
+ * narrowing still applies untouched, because that is the provider's own grant
+ * boundary and this must never widen it. Nothing here materializes anything;
+ * `fetchAll` remains the only view that feeds a surface.
+ * @param {object} cfg Resolved configuration.
+ * @returns {Map<string, {value: string, note: string, id: string|null}>} Selected secrets by name.
+ */
+export function fetchRotatable(cfg) {
+  return normalizeRows(fetchRaw(cfg), rotationNarrow(cfg));
+}
+
+/**
+ * The narrowing the rotation view applies: project grants intact, `excludeKeys`
+ * waived for declared rotating names only.
+ *
+ * Split out from {@link fetchRotatable} so the decision is testable without a
+ * provider, matching how the toolchain planner separates planning from
+ * execution.
+ * @param {object} cfg Resolved configuration.
+ * @returns {{projectIds: string[], excludeKeys: string[]}} Narrowing controls.
+ */
+export function rotationNarrow(cfg) {
+  const rotating = new Set(cfg.rotating ?? []);
+  return {
+    projectIds: cfg.narrow?.projectIds ?? [],
+    excludeKeys: (cfg.narrow?.excludeKeys ?? []).filter(
+      key => !rotating.has(key)
+    ),
+  };
+}
+
+/**
  * Find one raw row by exact key, bypassing the exposure boundary.
  *
  * Only the rotation path uses this, and only to reach the lease record, which

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/providers.mjs
@@ -244,23 +244,16 @@ export function fetchAll(cfg) {
 }
 
 /**
- * The provider view the rotation path sees: `excludeKeys` waived for declared
- * rotating names only.
+ * The provider view the rotation path reads.
  *
- * `excludeKeys` exists to keep a credential off a **surface's disk**. Applying it
- * to the rotation path conflated that with hiding the record from the provider,
- * which made `rotating` and `excludeKeys` mutually exclusive for the same name —
- * a credential you cannot see is one you cannot write back to, so `doctor`
- * correctly errored. That is exactly backwards for a consumable credential: the
- * kind you least want materialized onto an untrusted surface is the kind that
- * most needs a proven write path.
+ * `excludeKeys` keeps a credential off a **surface's disk**. Applying it here
+ * too hid the provider record, making `rotating` and `excludeKeys` mutually
+ * exclusive — and a credential you cannot see is one you cannot write back to.
+ * That is backwards for a consumable credential: the kind you least want
+ * materialized is the kind that most needs a proven write path.
  *
- * The waiver is deliberately narrow. It applies only to names listed in
- * `secrets.rotating`, which is config and therefore reviewed — the same
- * declared-never-inferred rule the write path already enforces. Project
- * narrowing still applies untouched, because that is the provider's own grant
- * boundary and this must never widen it. Nothing here materializes anything;
- * `fetchAll` remains the only view that feeds a surface.
+ * Nothing here materializes anything. `fetchAll` remains the only view feeding
+ * a surface, so an excluded rotating credential still never reaches disk.
  * @param {object} cfg Resolved configuration.
  * @returns {Map<string, {value: string, note: string, id: string|null}>} Selected secrets by name.
  */
@@ -269,12 +262,13 @@ export function fetchRotatable(cfg) {
 }
 
 /**
- * The narrowing the rotation view applies: project grants intact, `excludeKeys`
- * waived for declared rotating names only.
+ * Narrowing for the rotation view: project grants intact, `excludeKeys` waived
+ * for declared rotating names only.
  *
- * Split out from {@link fetchRotatable} so the decision is testable without a
- * provider, matching how the toolchain planner separates planning from
- * execution.
+ * The waiver reaches only names in `secrets.rotating` — config, and therefore
+ * reviewed, the same declared-never-inferred rule the write path enforces.
+ * Project narrowing is the provider's own boundary and is never widened. Split
+ * from {@link fetchRotatable} so the decision is testable without a provider.
  * @param {object} cfg Resolved configuration.
  * @returns {{projectIds: string[], excludeKeys: string[]}} Narrowing controls.
  */

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/rotate-secret.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/rotate-secret.mjs
@@ -30,7 +30,12 @@
 import { readFileSync } from "node:fs";
 import { hostname } from "node:os";
 
-import { LEASE_KEY, fetchAll, rawByKey, writeSecret } from "./providers.mjs";
+import {
+  LEASE_KEY,
+  fetchRotatable,
+  rawByKey,
+  writeSecret,
+} from "./providers.mjs";
 import { readConfig } from "./surfaces.mjs";
 
 /** How long a lease is honoured before it is treated as abandoned. */
@@ -63,7 +68,10 @@ function assertRotating(name, cfg) {
  * @returns {{value: string, id: string}} The current entry.
  */
 function entryFor(name, cfg) {
-  const hit = fetchAll(cfg).get(name);
+  // Rotation view, not the materialization view: a name may be excluded from
+  // every surface and still need its replacement persisted. assertRotating has
+  // already proved this name is declared in config.
+  const hit = fetchRotatable(cfg).get(name);
   if (!hit) throw new Error(`${name} is not available to this account`);
   if (!hit.id) {
     throw new Error(

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -19,7 +19,7 @@
 
 import { createHash } from "node:crypto";
 
-import { fetchAll } from "./providers.mjs";
+import { fetchAll, fetchRotatable } from "./providers.mjs";
 import { readMaterialized } from "./resolve-secret.mjs";
 import { readConfig } from "./surfaces.mjs";
 
@@ -220,7 +220,7 @@ function main() {
   checkRequired(cfg, provider, file, report);
   checkNaming(provider, report);
   checkNotes(provider, report);
-  checkRotating(cfg, provider, report);
+  checkRotating(cfg, fetchRotatable(cfg), report);
   checkTwoStores(provider, file, report);
 
   const order = { error: 0, warn: 1, ok: 2 };

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs
@@ -244,6 +244,45 @@ export function fetchAll(cfg) {
 }
 
 /**
+ * The provider view the rotation path reads.
+ *
+ * `excludeKeys` keeps a credential off a **surface's disk**. Applying it here
+ * too hid the provider record, making `rotating` and `excludeKeys` mutually
+ * exclusive — and a credential you cannot see is one you cannot write back to.
+ * That is backwards for a consumable credential: the kind you least want
+ * materialized is the kind that most needs a proven write path.
+ *
+ * Nothing here materializes anything. `fetchAll` remains the only view feeding
+ * a surface, so an excluded rotating credential still never reaches disk.
+ * @param {object} cfg Resolved configuration.
+ * @returns {Map<string, {value: string, note: string, id: string|null}>} Selected secrets by name.
+ */
+export function fetchRotatable(cfg) {
+  return normalizeRows(fetchRaw(cfg), rotationNarrow(cfg));
+}
+
+/**
+ * Narrowing for the rotation view: project grants intact, `excludeKeys` waived
+ * for declared rotating names only.
+ *
+ * The waiver reaches only names in `secrets.rotating` — config, and therefore
+ * reviewed, the same declared-never-inferred rule the write path enforces.
+ * Project narrowing is the provider's own boundary and is never widened. Split
+ * from {@link fetchRotatable} so the decision is testable without a provider.
+ * @param {object} cfg Resolved configuration.
+ * @returns {{projectIds: string[], excludeKeys: string[]}} Narrowing controls.
+ */
+export function rotationNarrow(cfg) {
+  const rotating = new Set(cfg.rotating ?? []);
+  return {
+    projectIds: cfg.narrow?.projectIds ?? [],
+    excludeKeys: (cfg.narrow?.excludeKeys ?? []).filter(
+      key => !rotating.has(key)
+    ),
+  };
+}
+
+/**
  * Find one raw row by exact key, bypassing the exposure boundary.
  *
  * Only the rotation path uses this, and only to reach the lease record, which

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/rotate-secret.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/rotate-secret.mjs
@@ -30,7 +30,12 @@
 import { readFileSync } from "node:fs";
 import { hostname } from "node:os";
 
-import { LEASE_KEY, fetchAll, rawByKey, writeSecret } from "./providers.mjs";
+import {
+  LEASE_KEY,
+  fetchRotatable,
+  rawByKey,
+  writeSecret,
+} from "./providers.mjs";
 import { readConfig } from "./surfaces.mjs";
 
 /** How long a lease is honoured before it is treated as abandoned. */
@@ -63,7 +68,10 @@ function assertRotating(name, cfg) {
  * @returns {{value: string, id: string}} The current entry.
  */
 function entryFor(name, cfg) {
-  const hit = fetchAll(cfg).get(name);
+  // Rotation view, not the materialization view: a name may be excluded from
+  // every surface and still need its replacement persisted. assertRotating has
+  // already proved this name is declared in config.
+  const hit = fetchRotatable(cfg).get(name);
   if (!hit) throw new Error(`${name} is not available to this account`);
   if (!hit.id) {
     throw new Error(

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1073,19 +1073,19 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/SKILL.md":
       "9d7346864b04304e5b4bbb90512c7f2e701d69ab012b4fcf3b7b687221fc76bd",
     "plugins/src/base/skills/lisa-secrets-access/scripts/doctor-secrets.mjs":
-      "62cd565234b55c1d269d94103bc33bc4f9edb4077a76ab3b975d8989fa10ebc9",
+      "f203c71457da958cdb49637c87e4a9c43e964f98ecef3dd0e933b419d565f98e",
     "plugins/src/base/skills/lisa-secrets-access/scripts/envfile.mjs":
       "be4e38ce85f9268b52b29dbde264ecd8d50973c2b63a15410336234a921d9644",
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs":
       "4b4448cd680a8fe7b1f51bad840c2655f898e9bc08ca06c385cd1d21dca3c3d4",
     "plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs":
-      "be748382c81440c1807d6d4101b0ee97c467f30e3976dc1561bc61c01fcb2e99",
+      "fec38ca937570c1e1c21e6e8f7314a9d8f4e9264779d0394b40d5158924da0da",
     "plugins/src/base/skills/lisa-secrets-access/scripts/read-secret-note.mjs":
       "1471d2108058f3059e242f9c71208c99fdbc212bde32de34b798eaa9a27ffbcc",
     "plugins/src/base/skills/lisa-secrets-access/scripts/resolve-secret.mjs":
       "04ab89bc1f890526ba3b693cd3b022abc5a24e078b93c08fe7dfd586452b70b1",
     "plugins/src/base/skills/lisa-secrets-access/scripts/rotate-secret.mjs":
-      "f896ef08c53c9f6a859c4ddb527f7e765c542e1fd8bb198c6d75c8f260185669",
+      "546dc1c2f279cee6db56c0f55c01aabae0c316842f32d3219c5af6d638936a9c",
     "plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs":
       "da3fdf62b88f77c6c2ae09f5352797818813fccb0dafe551c801b58f25de2711",
     "plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs":
@@ -8339,6 +8339,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/remote-env-phases.test.ts": true,
     "tests/unit/secrets/remote-env-skill-resolution.test.ts": true,
     "tests/unit/secrets/remote-env-toolchain.test.ts": true,
+    "tests/unit/secrets/rotation-view.test.ts": true,
     "tests/unit/secrets/secrets-access-contract.test.ts": true,
     "tests/unit/secrets/validate-config.test.ts": true,
     "tests/unit/sonar/sonar-installer.test.ts": true,

--- a/tests/unit/secrets/rotation-view.test.ts
+++ b/tests/unit/secrets/rotation-view.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Contract tests for the rotation view of the provider.
+ *
+ * `excludeKeys` keeps a credential off a surface's disk. It was also applied to
+ * the rotation path, which hid the provider record itself — so `rotating` and
+ * `excludeKeys` became mutually exclusive for one name, and a credential you
+ * cannot see is one you cannot write back to. These pin the narrow waiver that
+ * resolves it, and the boundaries it must never cross.
+ * @module tests/unit/secrets/rotation-view
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeRows,
+  rotationNarrow,
+} from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs";
+
+/** A synthetic provider row, shaped like what `fetchRaw` returns. */
+type Row = {
+  key: string;
+  value: string;
+  note?: string;
+  projectId?: string | null;
+  id?: string | null;
+};
+
+/** The project every synthetic row belongs to unless a test says otherwise. */
+const PROJECT = "project-a";
+
+const row = (key: string, value: string, extra: Partial<Row> = {}): Row => ({
+  key,
+  value,
+  note: "",
+  projectId: PROJECT,
+  id: `id-${key}`,
+  ...extra,
+});
+
+describe("rotation view", () => {
+  // That mutual exclusion is backwards for a consumable credential: the kind you
+  // least want materialized onto an untrusted surface is the kind that most
+  // needs a proven write path.
+
+  it("waives an exclusion for a declared rotating name", () => {
+    const narrow = rotationNarrow({
+      rotating: ["ROTATING_TOKEN"],
+      narrow: { projectIds: [], excludeKeys: ["ROTATING_TOKEN"] },
+    });
+    expect(narrow.excludeKeys).toEqual([]);
+
+    const rows = [row("ROTATING_TOKEN", "v", { id: "abc-123" })];
+    expect(normalizeRows(rows, narrow).get("ROTATING_TOKEN")?.id).toBe(
+      "abc-123"
+    );
+  });
+
+  it("keeps the exclusion for a name that is not declared rotating", () => {
+    const narrow = rotationNarrow({
+      rotating: ["ROTATING_TOKEN"],
+      narrow: { projectIds: [], excludeKeys: ["ROTATING_TOKEN", "PLAIN_KEY"] },
+    });
+    expect(narrow.excludeKeys).toEqual(["PLAIN_KEY"]);
+
+    const rows = [row("PLAIN_KEY", "1"), row("ROTATING_TOKEN", "2")];
+    expect([...normalizeRows(rows, narrow).keys()]).toEqual(["ROTATING_TOKEN"]);
+  });
+
+  it("never widens the provider's own project grant", () => {
+    // The waiver is for the repo-declared exclusion list only. Project scoping
+    // is the provider's boundary and must survive untouched.
+    const narrow = rotationNarrow({
+      rotating: ["ROTATING_TOKEN"],
+      narrow: { projectIds: [PROJECT], excludeKeys: ["ROTATING_TOKEN"] },
+    });
+    expect(narrow.projectIds).toEqual([PROJECT]);
+
+    const rows = [
+      row("ROTATING_TOKEN", "1", { projectId: "project-b" }),
+      row("IN_SCOPE", "2", { projectId: PROJECT }),
+    ];
+    expect([...normalizeRows(rows, narrow).keys()]).toEqual(["IN_SCOPE"]);
+  });
+
+  it("is a no-op when nothing is declared rotating", () => {
+    const narrow = rotationNarrow({
+      narrow: { projectIds: [], excludeKeys: ["DROP"] },
+    });
+    expect(narrow.excludeKeys).toEqual(["DROP"]);
+  });
+});


### PR DESCRIPTION
Closes #2178.

## The bind

`excludeKeys` exists to keep a credential off a **surface's disk**. It was also applied to the rotation path, which hid the provider record itself — so `rotating` and `excludeKeys` became mutually exclusive for one name, and `doctor` correctly reported:

```
ERROR NAME is declared rotating but has no provider identifier to write back to
```

That is backwards for a consumable credential. **The kind you least want materialized onto an untrusted surface is exactly the kind that most needs a proven write path.**

Hit in `gunnertech/frontend`: the Codex Cloud authoring task is an untrusted lane, `excludeKeys` exists to keep the renewable Codex OAuth profile out of it, and a Feedly OAuth profile that must rotate could not be given the same protection without forfeiting the lease, preflight and single-writer guard — the machinery that exists because losing a refresh token already cost a QuickBooks re-authorisation.

## The fix

`fetchRotatable(cfg)` is the view the rotation path reads, and the pure `rotationNarrow(cfg)` decides it — split out so the decision is testable without a provider, matching how the toolchain planner separates planning from execution.

The waiver is deliberately narrow:

- **Declared, never inferred.** It reaches only names in `secrets.rotating`, which is config and therefore reviewed — the same rule the write path already enforces. Both `entryFor` call sites are immediately preceded by `assertRotating`, so it is unreachable for an undeclared name.
- **Project narrowing untouched.** That is the provider's own grant boundary and this never widens it.
- **Nothing is materialized.** `fetchAll` remains the only view that feeds a surface, so an excluded rotating credential still never reaches `secrets.env`.

## Worth noting

This restores a capability rather than inventing one. The hand-rolled bootstrap this contract replaced supported per-surface exclusion via a `CODEX_SECRETS_EXCLUDE_KEYS` environment variable, so migrating a project onto the contract was a regression on this axis.

## Evidence

Four contract tests in a new `tests/unit/secrets/rotation-view.test.ts`: the waiver applies to a declared name, does **not** apply to an undeclared one, never widens the project grant, and is a no-op when nothing is declared rotating.

```
Test Files  10 passed (10)
     Tests  185 passed (185)
check:plugins  ✓ Plugin artifacts are in sync with plugins/src.
```

Split into its own test file because the four tests pushed `secrets-access-contract.test.ts` past the 300-line budget; that file is byte-identical to `main`.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2178
