### PR TITLE
Route Lisa work to a Claude cloud session with executionEnv=claude-web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,6 +224,12 @@ expo-env.d.ts
 # Freshness-bound standards proof is local runtime evidence, not knowledge.
 .lisa/standards/latest.json
 
+# Remote-dispatch ledger. Records the sessions this machine started so a later
+# run can find them. Per developer by construction — each fires their own
+# routine under their own account — so committing it would collide on every
+# dispatch while telling a teammate nothing they can act on.
+.lisa/remote-dispatch.json
+
 # Automation run outcomes — local scheduler observations read by
 # /lisa:automation-status. Runbooks are project knowledge; run records are not.
 .lisa/automations/runs/

--- a/.lisa.config.json
+++ b/.lisa.config.json
@@ -167,6 +167,13 @@
           "sha256": "ba8233c3a4aee5d43e3c73bbd04d99e9bc5aba13bbbfd06d89b073abe732b860"
         }
       ]
+    },
+    "surfaces": {
+      "claude-web": {
+        "routineId": "trig_01Szp6mAMiK9V8dKWSJLJkRo",
+        "fireUrl": "https://api.anthropic.com/v1/claude_code/routines/trig_01Szp6mAMiK9V8dKWSJLJkRo/fire",
+        "tokenKey": "CLAUDE_ROUTINE_TOKEN"
+      }
     }
   }
 }

--- a/all/copy-contents/gitignore
+++ b/all/copy-contents/gitignore
@@ -238,6 +238,12 @@ expo-env.d.ts
 # /lisa:automation-status. Runbooks are project knowledge; run records are not.
 .lisa/automations/runs/
 
+# Remote-dispatch ledger. Records the sessions this machine started so a later
+# run can find them. Per developer by construction — each fires their own
+# routine under their own account — so committing it would collide on every
+# dispatch while telling a teammate nothing they can act on.
+.lisa/remote-dispatch.json
+
 # Lisa-generated project Codex overlay. Keep host-owned config.toml and
 # hooks.json visible so projects can commit their own merged configuration.
 .codex/.lisa-managed.json

--- a/plugins/lisa-agy/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa-agy/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -50,6 +50,18 @@ const SURFACE_PRECONDITIONS = {
  */
 const ROUTINE_BETA = "experimental-cc-routine-2026-04-01";
 
+/**
+ * How long to wait for the routine to accept the dispatch.
+ *
+ * `fetch` has no timeout of its own, so a routine endpoint that accepts the
+ * connection and then says nothing leaves dispatch waiting forever — the one
+ * failure mode that never reaches the error path below and never reaches the
+ * operator either. Generous, because the endpoint only has to *accept* the
+ * dispatch: the session's own work happens long after this call returns, so
+ * this bounds a handshake rather than a run.
+ */
+const FIRE_TIMEOUT_MS = 30_000;
+
 /** Where dispatched work is recorded so a later session can find it. */
 const LEDGER = join(".lisa", "remote-dispatch.json");
 
@@ -329,9 +341,18 @@ export async function dispatchClaudeWeb(block, prompt, payload, options = {}) {
         "content-type": "application/json",
       },
       body: JSON.stringify({ text: prompt }),
+      signal: AbortSignal.timeout(FIRE_TIMEOUT_MS),
     });
   } catch (err) {
-    throw new Error(`could not reach the routine endpoint: ${err.message}`);
+    // A timeout arrives here as an abort rather than a network error, and
+    // "could not reach" is the true and useful thing to say about both. It is
+    // named separately so the operator can tell a silent endpoint from a
+    // refused connection, since only one of those is worth retrying.
+    const reason =
+      err.name === "TimeoutError"
+        ? `no response within ${FIRE_TIMEOUT_MS / 1000}s`
+        : err.message;
+    throw new Error(`could not reach the routine endpoint: ${reason}`);
   }
 
   const body = await response.text();

--- a/plugins/lisa-agy/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa-agy/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -21,13 +21,40 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /** Surfaces this dispatcher knows how to reach. `local` means "do not dispatch". */
-export const EXECUTION_ENVS = new Set(["local", "codex-cloud"]);
+export const EXECUTION_ENVS = new Set(["local", "codex-cloud", "claude-web"]);
+
+/**
+ * What each surface must have recorded before anything may dispatch to it.
+ *
+ * Not uniform, because the two surfaces do not bind the same way. A Codex Cloud
+ * environment is bound to one repository, so naming both is what proves the
+ * environment is the right one. A Claude cloud environment binds no repository
+ * at all — it is account-scoped configuration and the repository arrives per
+ * session — so its durable handle is the routine that dispatch fires.
+ */
+const SURFACE_PRECONDITIONS = {
+  "codex-cloud": ["environmentId", "repository"],
+  "claude-web": ["routineId", "fireUrl"],
+};
+
+/**
+ * The beta this endpoint ships under.
+ *
+ * Dated and rotating: the two most recent previous versions keep working, so a
+ * bump here is a migration with a window rather than a break. Stated once so
+ * there is a single place to move it.
+ */
+const ROUTINE_BETA = "experimental-cc-routine-2026-04-01";
 
 /** Where dispatched work is recorded so a later session can find it. */
 const LEDGER = join(".lisa", "remote-dispatch.json");
+
+/** This file's directory, for locating the sibling secrets skill. */
+const HERE = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Split `key=value` parameters from the rest of an invocation.
@@ -101,9 +128,11 @@ export function readSurfaceConfig(surface, cwd = process.cwd()) {
  * @param {string} surface Execution surface.
  */
 export function assertPreconditions(block, surface) {
-  const missing = [];
-  if (!block.environmentId) missing.push("environmentId");
-  if (!block.repository) missing.push("repository");
+  const required = SURFACE_PRECONDITIONS[surface] ?? [
+    "environmentId",
+    "repository",
+  ];
+  const missing = required.filter(field => !block[field]);
   if (missing.length) {
     throw new Error(
       `remoteEnv.surfaces["${surface}"] is missing: ${missing.join(", ")}.\n` +
@@ -230,7 +259,143 @@ export function splitSkillFlag(argv) {
   return { skill, raw: rest.join(" ") };
 }
 
-function main() {
+/**
+ * Read the response a routine returns when it accepts a dispatch.
+ *
+ * Kept separate from the request so the shape can be exercised against a
+ * recorded body. The identifier is a field here rather than something scraped
+ * out of console output, which is the one respect in which this surface is
+ * easier to reconcile than the other.
+ * @param {string} body Raw response body.
+ * @returns {{sessionId: string, url: string}} The accepted session.
+ */
+export function readFireResponse(body) {
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new Error(
+      `routine returned a body that is not JSON:\n${String(body).slice(0, 400)}`
+    );
+  }
+  const sessionId = parsed.claude_code_session_id;
+  const url = parsed.claude_code_session_url;
+  if (!sessionId) {
+    throw new Error(
+      `routine accepted the request but returned no session identifier.\n` +
+        `${JSON.stringify(parsed).slice(0, 400)}\n` +
+        `Refusing to report success: without the identifier nothing can ` +
+        `reconcile this run, and a retry would duplicate it.`
+    );
+  }
+  return { sessionId, url: url ?? "" };
+}
+
+/**
+ * Fire a routine and record the session it created.
+ *
+ * The payload is deliberately the work item and nothing else. It arrives on the
+ * far side wrapped in a block the platform marks as untrusted data, and a
+ * routine acts on it only because its saved prompt says to — which is the
+ * boundary this plan wanted anyway, enforced by the platform rather than by
+ * convention. Nothing here can widen the remote run's authority.
+ *
+ * The bearer token is resolved through the secrets chokepoint at the moment of
+ * use and never stored in configuration.
+ * Its three side effects — resolving a credential, making a request, writing the
+ * ledger — are all injectable, so the accept and refuse paths can be exercised
+ * without a token, a network, or a write into the working repository.
+ * @param {object} block Surface configuration.
+ * @param {string} prompt The thin skill invocation.
+ * @param {string} payload The caller's original payload, for the record.
+ * @param {{post?: Function, getToken?: Function, cwd?: string}} [options] Seams for tests.
+ * @returns {Promise<{sessionId: string, url: string}>} The accepted session.
+ */
+export async function dispatchClaudeWeb(block, prompt, payload, options = {}) {
+  const {
+    post = fetch,
+    getToken = resolveBearerToken,
+    cwd = process.cwd(),
+  } = options;
+  const token = getToken(block);
+  let response;
+  try {
+    response = await post(block.fireUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "anthropic-beta": ROUTINE_BETA,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ text: prompt }),
+    });
+  } catch (err) {
+    throw new Error(`could not reach the routine endpoint: ${err.message}`);
+  }
+
+  const body = await response.text();
+  if (!response.ok) {
+    // The token is the usual cause and the usual thing to leak, so the message
+    // names the status and the routine rather than echoing the request.
+    throw new Error(
+      `routine ${block.routineId} refused the dispatch (HTTP ${response.status}).\n` +
+        `${body.slice(0, 400)}\n` +
+        `A 401 means the bearer token is wrong, revoked, or regenerated.`
+    );
+  }
+
+  const { sessionId, url } = readFireResponse(body);
+  record(
+    {
+      taskId: sessionId,
+      surface: "claude-web",
+      routineId: block.routineId,
+      sessionUrl: url,
+      prompt,
+      payload,
+      dispatchedAt: new Date().toISOString(),
+    },
+    cwd
+  );
+  return { sessionId, url };
+}
+
+/**
+ * Resolve the dispatcher's own credential through the secrets chokepoint.
+ *
+ * Never read from configuration: the token authorises starting work on someone
+ * else's infrastructure, and it can be regenerated and revoked, so it belongs
+ * in the credential manager and in `secrets.rotating` alongside it.
+ * @param {object} block Surface configuration.
+ * @returns {string} The bearer token.
+ */
+function resolveBearerToken(block) {
+  const name = block.tokenKey ?? "CLAUDE_ROUTINE_TOKEN";
+  const resolver = resolve(
+    HERE,
+    "..",
+    "..",
+    "lisa-secrets-access",
+    "scripts",
+    "resolve-secret.mjs"
+  );
+  try {
+    return execFileSync("node", [resolver, "get", name], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (err) {
+    throw new Error(
+      `could not resolve ${name} through lisa-secrets-access.\n` +
+        `${String(err.stderr ?? err.message).trim()}\n` +
+        `It is the dispatcher's own credential; store it in the provider ` +
+        `rather than in .lisa.config.json.`
+    );
+  }
+}
+
+async function main() {
   const { skill, raw } = splitSkillFlag(process.argv.slice(2));
   const { params, rest } = parseInvocation(raw);
   const surface = resolveExecutionEnv(params);
@@ -247,6 +412,15 @@ function main() {
   // the repository-local skill, so an interactive run, a scheduled run, and a
   // recovery run all execute one contract.
   const prompt = `$${skill} ${rest}`.trim();
+
+  if (surface === "claude-web") {
+    const { sessionId, url } = await dispatchClaudeWeb(block, prompt, rest);
+    console.log(`dispatched: ${sessionId}`);
+    if (url) console.log(url);
+    console.log(`recorded in ${LEDGER}; not polling — this process is done.`);
+    return;
+  }
+
   const taskId = dispatchCodexCloud(block, prompt, rest);
 
   console.log(`dispatched: ${taskId}`);
@@ -255,10 +429,11 @@ function main() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  try {
-    main();
-  } catch (err) {
+  // Awaited rather than called bare: one dispatch path is async, so a synchronous
+  // try/catch would let a rejection escape as an unhandled rejection and exit 0 —
+  // reporting dispatched work that was never accepted.
+  main().catch(err => {
     console.error(err.message);
     process.exit(1);
-  }
+  });
 }

--- a/plugins/lisa-copilot/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa-copilot/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -50,6 +50,18 @@ const SURFACE_PRECONDITIONS = {
  */
 const ROUTINE_BETA = "experimental-cc-routine-2026-04-01";
 
+/**
+ * How long to wait for the routine to accept the dispatch.
+ *
+ * `fetch` has no timeout of its own, so a routine endpoint that accepts the
+ * connection and then says nothing leaves dispatch waiting forever — the one
+ * failure mode that never reaches the error path below and never reaches the
+ * operator either. Generous, because the endpoint only has to *accept* the
+ * dispatch: the session's own work happens long after this call returns, so
+ * this bounds a handshake rather than a run.
+ */
+const FIRE_TIMEOUT_MS = 30_000;
+
 /** Where dispatched work is recorded so a later session can find it. */
 const LEDGER = join(".lisa", "remote-dispatch.json");
 
@@ -329,9 +341,18 @@ export async function dispatchClaudeWeb(block, prompt, payload, options = {}) {
         "content-type": "application/json",
       },
       body: JSON.stringify({ text: prompt }),
+      signal: AbortSignal.timeout(FIRE_TIMEOUT_MS),
     });
   } catch (err) {
-    throw new Error(`could not reach the routine endpoint: ${err.message}`);
+    // A timeout arrives here as an abort rather than a network error, and
+    // "could not reach" is the true and useful thing to say about both. It is
+    // named separately so the operator can tell a silent endpoint from a
+    // refused connection, since only one of those is worth retrying.
+    const reason =
+      err.name === "TimeoutError"
+        ? `no response within ${FIRE_TIMEOUT_MS / 1000}s`
+        : err.message;
+    throw new Error(`could not reach the routine endpoint: ${reason}`);
   }
 
   const body = await response.text();

--- a/plugins/lisa-copilot/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa-copilot/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -21,13 +21,40 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /** Surfaces this dispatcher knows how to reach. `local` means "do not dispatch". */
-export const EXECUTION_ENVS = new Set(["local", "codex-cloud"]);
+export const EXECUTION_ENVS = new Set(["local", "codex-cloud", "claude-web"]);
+
+/**
+ * What each surface must have recorded before anything may dispatch to it.
+ *
+ * Not uniform, because the two surfaces do not bind the same way. A Codex Cloud
+ * environment is bound to one repository, so naming both is what proves the
+ * environment is the right one. A Claude cloud environment binds no repository
+ * at all — it is account-scoped configuration and the repository arrives per
+ * session — so its durable handle is the routine that dispatch fires.
+ */
+const SURFACE_PRECONDITIONS = {
+  "codex-cloud": ["environmentId", "repository"],
+  "claude-web": ["routineId", "fireUrl"],
+};
+
+/**
+ * The beta this endpoint ships under.
+ *
+ * Dated and rotating: the two most recent previous versions keep working, so a
+ * bump here is a migration with a window rather than a break. Stated once so
+ * there is a single place to move it.
+ */
+const ROUTINE_BETA = "experimental-cc-routine-2026-04-01";
 
 /** Where dispatched work is recorded so a later session can find it. */
 const LEDGER = join(".lisa", "remote-dispatch.json");
+
+/** This file's directory, for locating the sibling secrets skill. */
+const HERE = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Split `key=value` parameters from the rest of an invocation.
@@ -101,9 +128,11 @@ export function readSurfaceConfig(surface, cwd = process.cwd()) {
  * @param {string} surface Execution surface.
  */
 export function assertPreconditions(block, surface) {
-  const missing = [];
-  if (!block.environmentId) missing.push("environmentId");
-  if (!block.repository) missing.push("repository");
+  const required = SURFACE_PRECONDITIONS[surface] ?? [
+    "environmentId",
+    "repository",
+  ];
+  const missing = required.filter(field => !block[field]);
   if (missing.length) {
     throw new Error(
       `remoteEnv.surfaces["${surface}"] is missing: ${missing.join(", ")}.\n` +
@@ -230,7 +259,143 @@ export function splitSkillFlag(argv) {
   return { skill, raw: rest.join(" ") };
 }
 
-function main() {
+/**
+ * Read the response a routine returns when it accepts a dispatch.
+ *
+ * Kept separate from the request so the shape can be exercised against a
+ * recorded body. The identifier is a field here rather than something scraped
+ * out of console output, which is the one respect in which this surface is
+ * easier to reconcile than the other.
+ * @param {string} body Raw response body.
+ * @returns {{sessionId: string, url: string}} The accepted session.
+ */
+export function readFireResponse(body) {
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new Error(
+      `routine returned a body that is not JSON:\n${String(body).slice(0, 400)}`
+    );
+  }
+  const sessionId = parsed.claude_code_session_id;
+  const url = parsed.claude_code_session_url;
+  if (!sessionId) {
+    throw new Error(
+      `routine accepted the request but returned no session identifier.\n` +
+        `${JSON.stringify(parsed).slice(0, 400)}\n` +
+        `Refusing to report success: without the identifier nothing can ` +
+        `reconcile this run, and a retry would duplicate it.`
+    );
+  }
+  return { sessionId, url: url ?? "" };
+}
+
+/**
+ * Fire a routine and record the session it created.
+ *
+ * The payload is deliberately the work item and nothing else. It arrives on the
+ * far side wrapped in a block the platform marks as untrusted data, and a
+ * routine acts on it only because its saved prompt says to — which is the
+ * boundary this plan wanted anyway, enforced by the platform rather than by
+ * convention. Nothing here can widen the remote run's authority.
+ *
+ * The bearer token is resolved through the secrets chokepoint at the moment of
+ * use and never stored in configuration.
+ * Its three side effects — resolving a credential, making a request, writing the
+ * ledger — are all injectable, so the accept and refuse paths can be exercised
+ * without a token, a network, or a write into the working repository.
+ * @param {object} block Surface configuration.
+ * @param {string} prompt The thin skill invocation.
+ * @param {string} payload The caller's original payload, for the record.
+ * @param {{post?: Function, getToken?: Function, cwd?: string}} [options] Seams for tests.
+ * @returns {Promise<{sessionId: string, url: string}>} The accepted session.
+ */
+export async function dispatchClaudeWeb(block, prompt, payload, options = {}) {
+  const {
+    post = fetch,
+    getToken = resolveBearerToken,
+    cwd = process.cwd(),
+  } = options;
+  const token = getToken(block);
+  let response;
+  try {
+    response = await post(block.fireUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "anthropic-beta": ROUTINE_BETA,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ text: prompt }),
+    });
+  } catch (err) {
+    throw new Error(`could not reach the routine endpoint: ${err.message}`);
+  }
+
+  const body = await response.text();
+  if (!response.ok) {
+    // The token is the usual cause and the usual thing to leak, so the message
+    // names the status and the routine rather than echoing the request.
+    throw new Error(
+      `routine ${block.routineId} refused the dispatch (HTTP ${response.status}).\n` +
+        `${body.slice(0, 400)}\n` +
+        `A 401 means the bearer token is wrong, revoked, or regenerated.`
+    );
+  }
+
+  const { sessionId, url } = readFireResponse(body);
+  record(
+    {
+      taskId: sessionId,
+      surface: "claude-web",
+      routineId: block.routineId,
+      sessionUrl: url,
+      prompt,
+      payload,
+      dispatchedAt: new Date().toISOString(),
+    },
+    cwd
+  );
+  return { sessionId, url };
+}
+
+/**
+ * Resolve the dispatcher's own credential through the secrets chokepoint.
+ *
+ * Never read from configuration: the token authorises starting work on someone
+ * else's infrastructure, and it can be regenerated and revoked, so it belongs
+ * in the credential manager and in `secrets.rotating` alongside it.
+ * @param {object} block Surface configuration.
+ * @returns {string} The bearer token.
+ */
+function resolveBearerToken(block) {
+  const name = block.tokenKey ?? "CLAUDE_ROUTINE_TOKEN";
+  const resolver = resolve(
+    HERE,
+    "..",
+    "..",
+    "lisa-secrets-access",
+    "scripts",
+    "resolve-secret.mjs"
+  );
+  try {
+    return execFileSync("node", [resolver, "get", name], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (err) {
+    throw new Error(
+      `could not resolve ${name} through lisa-secrets-access.\n` +
+        `${String(err.stderr ?? err.message).trim()}\n` +
+        `It is the dispatcher's own credential; store it in the provider ` +
+        `rather than in .lisa.config.json.`
+    );
+  }
+}
+
+async function main() {
   const { skill, raw } = splitSkillFlag(process.argv.slice(2));
   const { params, rest } = parseInvocation(raw);
   const surface = resolveExecutionEnv(params);
@@ -247,6 +412,15 @@ function main() {
   // the repository-local skill, so an interactive run, a scheduled run, and a
   // recovery run all execute one contract.
   const prompt = `$${skill} ${rest}`.trim();
+
+  if (surface === "claude-web") {
+    const { sessionId, url } = await dispatchClaudeWeb(block, prompt, rest);
+    console.log(`dispatched: ${sessionId}`);
+    if (url) console.log(url);
+    console.log(`recorded in ${LEDGER}; not polling — this process is done.`);
+    return;
+  }
+
   const taskId = dispatchCodexCloud(block, prompt, rest);
 
   console.log(`dispatched: ${taskId}`);
@@ -255,10 +429,11 @@ function main() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  try {
-    main();
-  } catch (err) {
+  // Awaited rather than called bare: one dispatch path is async, so a synchronous
+  // try/catch would let a rejection escape as an unhandled rejection and exit 0 —
+  // reporting dispatched work that was never accepted.
+  main().catch(err => {
     console.error(err.message);
     process.exit(1);
-  }
+  });
 }

--- a/plugins/lisa-cursor/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa-cursor/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -50,6 +50,18 @@ const SURFACE_PRECONDITIONS = {
  */
 const ROUTINE_BETA = "experimental-cc-routine-2026-04-01";
 
+/**
+ * How long to wait for the routine to accept the dispatch.
+ *
+ * `fetch` has no timeout of its own, so a routine endpoint that accepts the
+ * connection and then says nothing leaves dispatch waiting forever — the one
+ * failure mode that never reaches the error path below and never reaches the
+ * operator either. Generous, because the endpoint only has to *accept* the
+ * dispatch: the session's own work happens long after this call returns, so
+ * this bounds a handshake rather than a run.
+ */
+const FIRE_TIMEOUT_MS = 30_000;
+
 /** Where dispatched work is recorded so a later session can find it. */
 const LEDGER = join(".lisa", "remote-dispatch.json");
 
@@ -329,9 +341,18 @@ export async function dispatchClaudeWeb(block, prompt, payload, options = {}) {
         "content-type": "application/json",
       },
       body: JSON.stringify({ text: prompt }),
+      signal: AbortSignal.timeout(FIRE_TIMEOUT_MS),
     });
   } catch (err) {
-    throw new Error(`could not reach the routine endpoint: ${err.message}`);
+    // A timeout arrives here as an abort rather than a network error, and
+    // "could not reach" is the true and useful thing to say about both. It is
+    // named separately so the operator can tell a silent endpoint from a
+    // refused connection, since only one of those is worth retrying.
+    const reason =
+      err.name === "TimeoutError"
+        ? `no response within ${FIRE_TIMEOUT_MS / 1000}s`
+        : err.message;
+    throw new Error(`could not reach the routine endpoint: ${reason}`);
   }
 
   const body = await response.text();

--- a/plugins/lisa-cursor/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa-cursor/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -21,13 +21,40 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /** Surfaces this dispatcher knows how to reach. `local` means "do not dispatch". */
-export const EXECUTION_ENVS = new Set(["local", "codex-cloud"]);
+export const EXECUTION_ENVS = new Set(["local", "codex-cloud", "claude-web"]);
+
+/**
+ * What each surface must have recorded before anything may dispatch to it.
+ *
+ * Not uniform, because the two surfaces do not bind the same way. A Codex Cloud
+ * environment is bound to one repository, so naming both is what proves the
+ * environment is the right one. A Claude cloud environment binds no repository
+ * at all — it is account-scoped configuration and the repository arrives per
+ * session — so its durable handle is the routine that dispatch fires.
+ */
+const SURFACE_PRECONDITIONS = {
+  "codex-cloud": ["environmentId", "repository"],
+  "claude-web": ["routineId", "fireUrl"],
+};
+
+/**
+ * The beta this endpoint ships under.
+ *
+ * Dated and rotating: the two most recent previous versions keep working, so a
+ * bump here is a migration with a window rather than a break. Stated once so
+ * there is a single place to move it.
+ */
+const ROUTINE_BETA = "experimental-cc-routine-2026-04-01";
 
 /** Where dispatched work is recorded so a later session can find it. */
 const LEDGER = join(".lisa", "remote-dispatch.json");
+
+/** This file's directory, for locating the sibling secrets skill. */
+const HERE = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Split `key=value` parameters from the rest of an invocation.
@@ -101,9 +128,11 @@ export function readSurfaceConfig(surface, cwd = process.cwd()) {
  * @param {string} surface Execution surface.
  */
 export function assertPreconditions(block, surface) {
-  const missing = [];
-  if (!block.environmentId) missing.push("environmentId");
-  if (!block.repository) missing.push("repository");
+  const required = SURFACE_PRECONDITIONS[surface] ?? [
+    "environmentId",
+    "repository",
+  ];
+  const missing = required.filter(field => !block[field]);
   if (missing.length) {
     throw new Error(
       `remoteEnv.surfaces["${surface}"] is missing: ${missing.join(", ")}.\n` +
@@ -230,7 +259,143 @@ export function splitSkillFlag(argv) {
   return { skill, raw: rest.join(" ") };
 }
 
-function main() {
+/**
+ * Read the response a routine returns when it accepts a dispatch.
+ *
+ * Kept separate from the request so the shape can be exercised against a
+ * recorded body. The identifier is a field here rather than something scraped
+ * out of console output, which is the one respect in which this surface is
+ * easier to reconcile than the other.
+ * @param {string} body Raw response body.
+ * @returns {{sessionId: string, url: string}} The accepted session.
+ */
+export function readFireResponse(body) {
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new Error(
+      `routine returned a body that is not JSON:\n${String(body).slice(0, 400)}`
+    );
+  }
+  const sessionId = parsed.claude_code_session_id;
+  const url = parsed.claude_code_session_url;
+  if (!sessionId) {
+    throw new Error(
+      `routine accepted the request but returned no session identifier.\n` +
+        `${JSON.stringify(parsed).slice(0, 400)}\n` +
+        `Refusing to report success: without the identifier nothing can ` +
+        `reconcile this run, and a retry would duplicate it.`
+    );
+  }
+  return { sessionId, url: url ?? "" };
+}
+
+/**
+ * Fire a routine and record the session it created.
+ *
+ * The payload is deliberately the work item and nothing else. It arrives on the
+ * far side wrapped in a block the platform marks as untrusted data, and a
+ * routine acts on it only because its saved prompt says to — which is the
+ * boundary this plan wanted anyway, enforced by the platform rather than by
+ * convention. Nothing here can widen the remote run's authority.
+ *
+ * The bearer token is resolved through the secrets chokepoint at the moment of
+ * use and never stored in configuration.
+ * Its three side effects — resolving a credential, making a request, writing the
+ * ledger — are all injectable, so the accept and refuse paths can be exercised
+ * without a token, a network, or a write into the working repository.
+ * @param {object} block Surface configuration.
+ * @param {string} prompt The thin skill invocation.
+ * @param {string} payload The caller's original payload, for the record.
+ * @param {{post?: Function, getToken?: Function, cwd?: string}} [options] Seams for tests.
+ * @returns {Promise<{sessionId: string, url: string}>} The accepted session.
+ */
+export async function dispatchClaudeWeb(block, prompt, payload, options = {}) {
+  const {
+    post = fetch,
+    getToken = resolveBearerToken,
+    cwd = process.cwd(),
+  } = options;
+  const token = getToken(block);
+  let response;
+  try {
+    response = await post(block.fireUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "anthropic-beta": ROUTINE_BETA,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ text: prompt }),
+    });
+  } catch (err) {
+    throw new Error(`could not reach the routine endpoint: ${err.message}`);
+  }
+
+  const body = await response.text();
+  if (!response.ok) {
+    // The token is the usual cause and the usual thing to leak, so the message
+    // names the status and the routine rather than echoing the request.
+    throw new Error(
+      `routine ${block.routineId} refused the dispatch (HTTP ${response.status}).\n` +
+        `${body.slice(0, 400)}\n` +
+        `A 401 means the bearer token is wrong, revoked, or regenerated.`
+    );
+  }
+
+  const { sessionId, url } = readFireResponse(body);
+  record(
+    {
+      taskId: sessionId,
+      surface: "claude-web",
+      routineId: block.routineId,
+      sessionUrl: url,
+      prompt,
+      payload,
+      dispatchedAt: new Date().toISOString(),
+    },
+    cwd
+  );
+  return { sessionId, url };
+}
+
+/**
+ * Resolve the dispatcher's own credential through the secrets chokepoint.
+ *
+ * Never read from configuration: the token authorises starting work on someone
+ * else's infrastructure, and it can be regenerated and revoked, so it belongs
+ * in the credential manager and in `secrets.rotating` alongside it.
+ * @param {object} block Surface configuration.
+ * @returns {string} The bearer token.
+ */
+function resolveBearerToken(block) {
+  const name = block.tokenKey ?? "CLAUDE_ROUTINE_TOKEN";
+  const resolver = resolve(
+    HERE,
+    "..",
+    "..",
+    "lisa-secrets-access",
+    "scripts",
+    "resolve-secret.mjs"
+  );
+  try {
+    return execFileSync("node", [resolver, "get", name], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (err) {
+    throw new Error(
+      `could not resolve ${name} through lisa-secrets-access.\n` +
+        `${String(err.stderr ?? err.message).trim()}\n` +
+        `It is the dispatcher's own credential; store it in the provider ` +
+        `rather than in .lisa.config.json.`
+    );
+  }
+}
+
+async function main() {
   const { skill, raw } = splitSkillFlag(process.argv.slice(2));
   const { params, rest } = parseInvocation(raw);
   const surface = resolveExecutionEnv(params);
@@ -247,6 +412,15 @@ function main() {
   // the repository-local skill, so an interactive run, a scheduled run, and a
   // recovery run all execute one contract.
   const prompt = `$${skill} ${rest}`.trim();
+
+  if (surface === "claude-web") {
+    const { sessionId, url } = await dispatchClaudeWeb(block, prompt, rest);
+    console.log(`dispatched: ${sessionId}`);
+    if (url) console.log(url);
+    console.log(`recorded in ${LEDGER}; not polling — this process is done.`);
+    return;
+  }
+
   const taskId = dispatchCodexCloud(block, prompt, rest);
 
   console.log(`dispatched: ${taskId}`);
@@ -255,10 +429,11 @@ function main() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  try {
-    main();
-  } catch (err) {
+  // Awaited rather than called bare: one dispatch path is async, so a synchronous
+  // try/catch would let a rejection escape as an unhandled rejection and exit 0 —
+  // reporting dispatched work that was never accepted.
+  main().catch(err => {
     console.error(err.message);
     process.exit(1);
-  }
+  });
 }

--- a/plugins/lisa/.codex-plugin/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -50,6 +50,18 @@ const SURFACE_PRECONDITIONS = {
  */
 const ROUTINE_BETA = "experimental-cc-routine-2026-04-01";
 
+/**
+ * How long to wait for the routine to accept the dispatch.
+ *
+ * `fetch` has no timeout of its own, so a routine endpoint that accepts the
+ * connection and then says nothing leaves dispatch waiting forever — the one
+ * failure mode that never reaches the error path below and never reaches the
+ * operator either. Generous, because the endpoint only has to *accept* the
+ * dispatch: the session's own work happens long after this call returns, so
+ * this bounds a handshake rather than a run.
+ */
+const FIRE_TIMEOUT_MS = 30_000;
+
 /** Where dispatched work is recorded so a later session can find it. */
 const LEDGER = join(".lisa", "remote-dispatch.json");
 
@@ -329,9 +341,18 @@ export async function dispatchClaudeWeb(block, prompt, payload, options = {}) {
         "content-type": "application/json",
       },
       body: JSON.stringify({ text: prompt }),
+      signal: AbortSignal.timeout(FIRE_TIMEOUT_MS),
     });
   } catch (err) {
-    throw new Error(`could not reach the routine endpoint: ${err.message}`);
+    // A timeout arrives here as an abort rather than a network error, and
+    // "could not reach" is the true and useful thing to say about both. It is
+    // named separately so the operator can tell a silent endpoint from a
+    // refused connection, since only one of those is worth retrying.
+    const reason =
+      err.name === "TimeoutError"
+        ? `no response within ${FIRE_TIMEOUT_MS / 1000}s`
+        : err.message;
+    throw new Error(`could not reach the routine endpoint: ${reason}`);
   }
 
   const body = await response.text();

--- a/plugins/lisa/.codex-plugin/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -21,13 +21,40 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /** Surfaces this dispatcher knows how to reach. `local` means "do not dispatch". */
-export const EXECUTION_ENVS = new Set(["local", "codex-cloud"]);
+export const EXECUTION_ENVS = new Set(["local", "codex-cloud", "claude-web"]);
+
+/**
+ * What each surface must have recorded before anything may dispatch to it.
+ *
+ * Not uniform, because the two surfaces do not bind the same way. A Codex Cloud
+ * environment is bound to one repository, so naming both is what proves the
+ * environment is the right one. A Claude cloud environment binds no repository
+ * at all — it is account-scoped configuration and the repository arrives per
+ * session — so its durable handle is the routine that dispatch fires.
+ */
+const SURFACE_PRECONDITIONS = {
+  "codex-cloud": ["environmentId", "repository"],
+  "claude-web": ["routineId", "fireUrl"],
+};
+
+/**
+ * The beta this endpoint ships under.
+ *
+ * Dated and rotating: the two most recent previous versions keep working, so a
+ * bump here is a migration with a window rather than a break. Stated once so
+ * there is a single place to move it.
+ */
+const ROUTINE_BETA = "experimental-cc-routine-2026-04-01";
 
 /** Where dispatched work is recorded so a later session can find it. */
 const LEDGER = join(".lisa", "remote-dispatch.json");
+
+/** This file's directory, for locating the sibling secrets skill. */
+const HERE = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Split `key=value` parameters from the rest of an invocation.
@@ -101,9 +128,11 @@ export function readSurfaceConfig(surface, cwd = process.cwd()) {
  * @param {string} surface Execution surface.
  */
 export function assertPreconditions(block, surface) {
-  const missing = [];
-  if (!block.environmentId) missing.push("environmentId");
-  if (!block.repository) missing.push("repository");
+  const required = SURFACE_PRECONDITIONS[surface] ?? [
+    "environmentId",
+    "repository",
+  ];
+  const missing = required.filter(field => !block[field]);
   if (missing.length) {
     throw new Error(
       `remoteEnv.surfaces["${surface}"] is missing: ${missing.join(", ")}.\n` +
@@ -230,7 +259,143 @@ export function splitSkillFlag(argv) {
   return { skill, raw: rest.join(" ") };
 }
 
-function main() {
+/**
+ * Read the response a routine returns when it accepts a dispatch.
+ *
+ * Kept separate from the request so the shape can be exercised against a
+ * recorded body. The identifier is a field here rather than something scraped
+ * out of console output, which is the one respect in which this surface is
+ * easier to reconcile than the other.
+ * @param {string} body Raw response body.
+ * @returns {{sessionId: string, url: string}} The accepted session.
+ */
+export function readFireResponse(body) {
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new Error(
+      `routine returned a body that is not JSON:\n${String(body).slice(0, 400)}`
+    );
+  }
+  const sessionId = parsed.claude_code_session_id;
+  const url = parsed.claude_code_session_url;
+  if (!sessionId) {
+    throw new Error(
+      `routine accepted the request but returned no session identifier.\n` +
+        `${JSON.stringify(parsed).slice(0, 400)}\n` +
+        `Refusing to report success: without the identifier nothing can ` +
+        `reconcile this run, and a retry would duplicate it.`
+    );
+  }
+  return { sessionId, url: url ?? "" };
+}
+
+/**
+ * Fire a routine and record the session it created.
+ *
+ * The payload is deliberately the work item and nothing else. It arrives on the
+ * far side wrapped in a block the platform marks as untrusted data, and a
+ * routine acts on it only because its saved prompt says to — which is the
+ * boundary this plan wanted anyway, enforced by the platform rather than by
+ * convention. Nothing here can widen the remote run's authority.
+ *
+ * The bearer token is resolved through the secrets chokepoint at the moment of
+ * use and never stored in configuration.
+ * Its three side effects — resolving a credential, making a request, writing the
+ * ledger — are all injectable, so the accept and refuse paths can be exercised
+ * without a token, a network, or a write into the working repository.
+ * @param {object} block Surface configuration.
+ * @param {string} prompt The thin skill invocation.
+ * @param {string} payload The caller's original payload, for the record.
+ * @param {{post?: Function, getToken?: Function, cwd?: string}} [options] Seams for tests.
+ * @returns {Promise<{sessionId: string, url: string}>} The accepted session.
+ */
+export async function dispatchClaudeWeb(block, prompt, payload, options = {}) {
+  const {
+    post = fetch,
+    getToken = resolveBearerToken,
+    cwd = process.cwd(),
+  } = options;
+  const token = getToken(block);
+  let response;
+  try {
+    response = await post(block.fireUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "anthropic-beta": ROUTINE_BETA,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ text: prompt }),
+    });
+  } catch (err) {
+    throw new Error(`could not reach the routine endpoint: ${err.message}`);
+  }
+
+  const body = await response.text();
+  if (!response.ok) {
+    // The token is the usual cause and the usual thing to leak, so the message
+    // names the status and the routine rather than echoing the request.
+    throw new Error(
+      `routine ${block.routineId} refused the dispatch (HTTP ${response.status}).\n` +
+        `${body.slice(0, 400)}\n` +
+        `A 401 means the bearer token is wrong, revoked, or regenerated.`
+    );
+  }
+
+  const { sessionId, url } = readFireResponse(body);
+  record(
+    {
+      taskId: sessionId,
+      surface: "claude-web",
+      routineId: block.routineId,
+      sessionUrl: url,
+      prompt,
+      payload,
+      dispatchedAt: new Date().toISOString(),
+    },
+    cwd
+  );
+  return { sessionId, url };
+}
+
+/**
+ * Resolve the dispatcher's own credential through the secrets chokepoint.
+ *
+ * Never read from configuration: the token authorises starting work on someone
+ * else's infrastructure, and it can be regenerated and revoked, so it belongs
+ * in the credential manager and in `secrets.rotating` alongside it.
+ * @param {object} block Surface configuration.
+ * @returns {string} The bearer token.
+ */
+function resolveBearerToken(block) {
+  const name = block.tokenKey ?? "CLAUDE_ROUTINE_TOKEN";
+  const resolver = resolve(
+    HERE,
+    "..",
+    "..",
+    "lisa-secrets-access",
+    "scripts",
+    "resolve-secret.mjs"
+  );
+  try {
+    return execFileSync("node", [resolver, "get", name], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (err) {
+    throw new Error(
+      `could not resolve ${name} through lisa-secrets-access.\n` +
+        `${String(err.stderr ?? err.message).trim()}\n` +
+        `It is the dispatcher's own credential; store it in the provider ` +
+        `rather than in .lisa.config.json.`
+    );
+  }
+}
+
+async function main() {
   const { skill, raw } = splitSkillFlag(process.argv.slice(2));
   const { params, rest } = parseInvocation(raw);
   const surface = resolveExecutionEnv(params);
@@ -247,6 +412,15 @@ function main() {
   // the repository-local skill, so an interactive run, a scheduled run, and a
   // recovery run all execute one contract.
   const prompt = `$${skill} ${rest}`.trim();
+
+  if (surface === "claude-web") {
+    const { sessionId, url } = await dispatchClaudeWeb(block, prompt, rest);
+    console.log(`dispatched: ${sessionId}`);
+    if (url) console.log(url);
+    console.log(`recorded in ${LEDGER}; not polling — this process is done.`);
+    return;
+  }
+
   const taskId = dispatchCodexCloud(block, prompt, rest);
 
   console.log(`dispatched: ${taskId}`);
@@ -255,10 +429,11 @@ function main() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  try {
-    main();
-  } catch (err) {
+  // Awaited rather than called bare: one dispatch path is async, so a synchronous
+  // try/catch would let a rejection escape as an unhandled rejection and exit 0 —
+  // reporting dispatched work that was never accepted.
+  main().catch(err => {
     console.error(err.message);
     process.exit(1);
-  }
+  });
 }

--- a/plugins/lisa/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -50,6 +50,18 @@ const SURFACE_PRECONDITIONS = {
  */
 const ROUTINE_BETA = "experimental-cc-routine-2026-04-01";
 
+/**
+ * How long to wait for the routine to accept the dispatch.
+ *
+ * `fetch` has no timeout of its own, so a routine endpoint that accepts the
+ * connection and then says nothing leaves dispatch waiting forever — the one
+ * failure mode that never reaches the error path below and never reaches the
+ * operator either. Generous, because the endpoint only has to *accept* the
+ * dispatch: the session's own work happens long after this call returns, so
+ * this bounds a handshake rather than a run.
+ */
+const FIRE_TIMEOUT_MS = 30_000;
+
 /** Where dispatched work is recorded so a later session can find it. */
 const LEDGER = join(".lisa", "remote-dispatch.json");
 
@@ -329,9 +341,18 @@ export async function dispatchClaudeWeb(block, prompt, payload, options = {}) {
         "content-type": "application/json",
       },
       body: JSON.stringify({ text: prompt }),
+      signal: AbortSignal.timeout(FIRE_TIMEOUT_MS),
     });
   } catch (err) {
-    throw new Error(`could not reach the routine endpoint: ${err.message}`);
+    // A timeout arrives here as an abort rather than a network error, and
+    // "could not reach" is the true and useful thing to say about both. It is
+    // named separately so the operator can tell a silent endpoint from a
+    // refused connection, since only one of those is worth retrying.
+    const reason =
+      err.name === "TimeoutError"
+        ? `no response within ${FIRE_TIMEOUT_MS / 1000}s`
+        : err.message;
+    throw new Error(`could not reach the routine endpoint: ${reason}`);
   }
 
   const body = await response.text();

--- a/plugins/lisa/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -21,13 +21,40 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /** Surfaces this dispatcher knows how to reach. `local` means "do not dispatch". */
-export const EXECUTION_ENVS = new Set(["local", "codex-cloud"]);
+export const EXECUTION_ENVS = new Set(["local", "codex-cloud", "claude-web"]);
+
+/**
+ * What each surface must have recorded before anything may dispatch to it.
+ *
+ * Not uniform, because the two surfaces do not bind the same way. A Codex Cloud
+ * environment is bound to one repository, so naming both is what proves the
+ * environment is the right one. A Claude cloud environment binds no repository
+ * at all — it is account-scoped configuration and the repository arrives per
+ * session — so its durable handle is the routine that dispatch fires.
+ */
+const SURFACE_PRECONDITIONS = {
+  "codex-cloud": ["environmentId", "repository"],
+  "claude-web": ["routineId", "fireUrl"],
+};
+
+/**
+ * The beta this endpoint ships under.
+ *
+ * Dated and rotating: the two most recent previous versions keep working, so a
+ * bump here is a migration with a window rather than a break. Stated once so
+ * there is a single place to move it.
+ */
+const ROUTINE_BETA = "experimental-cc-routine-2026-04-01";
 
 /** Where dispatched work is recorded so a later session can find it. */
 const LEDGER = join(".lisa", "remote-dispatch.json");
+
+/** This file's directory, for locating the sibling secrets skill. */
+const HERE = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Split `key=value` parameters from the rest of an invocation.
@@ -101,9 +128,11 @@ export function readSurfaceConfig(surface, cwd = process.cwd()) {
  * @param {string} surface Execution surface.
  */
 export function assertPreconditions(block, surface) {
-  const missing = [];
-  if (!block.environmentId) missing.push("environmentId");
-  if (!block.repository) missing.push("repository");
+  const required = SURFACE_PRECONDITIONS[surface] ?? [
+    "environmentId",
+    "repository",
+  ];
+  const missing = required.filter(field => !block[field]);
   if (missing.length) {
     throw new Error(
       `remoteEnv.surfaces["${surface}"] is missing: ${missing.join(", ")}.\n` +
@@ -230,7 +259,143 @@ export function splitSkillFlag(argv) {
   return { skill, raw: rest.join(" ") };
 }
 
-function main() {
+/**
+ * Read the response a routine returns when it accepts a dispatch.
+ *
+ * Kept separate from the request so the shape can be exercised against a
+ * recorded body. The identifier is a field here rather than something scraped
+ * out of console output, which is the one respect in which this surface is
+ * easier to reconcile than the other.
+ * @param {string} body Raw response body.
+ * @returns {{sessionId: string, url: string}} The accepted session.
+ */
+export function readFireResponse(body) {
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new Error(
+      `routine returned a body that is not JSON:\n${String(body).slice(0, 400)}`
+    );
+  }
+  const sessionId = parsed.claude_code_session_id;
+  const url = parsed.claude_code_session_url;
+  if (!sessionId) {
+    throw new Error(
+      `routine accepted the request but returned no session identifier.\n` +
+        `${JSON.stringify(parsed).slice(0, 400)}\n` +
+        `Refusing to report success: without the identifier nothing can ` +
+        `reconcile this run, and a retry would duplicate it.`
+    );
+  }
+  return { sessionId, url: url ?? "" };
+}
+
+/**
+ * Fire a routine and record the session it created.
+ *
+ * The payload is deliberately the work item and nothing else. It arrives on the
+ * far side wrapped in a block the platform marks as untrusted data, and a
+ * routine acts on it only because its saved prompt says to — which is the
+ * boundary this plan wanted anyway, enforced by the platform rather than by
+ * convention. Nothing here can widen the remote run's authority.
+ *
+ * The bearer token is resolved through the secrets chokepoint at the moment of
+ * use and never stored in configuration.
+ * Its three side effects — resolving a credential, making a request, writing the
+ * ledger — are all injectable, so the accept and refuse paths can be exercised
+ * without a token, a network, or a write into the working repository.
+ * @param {object} block Surface configuration.
+ * @param {string} prompt The thin skill invocation.
+ * @param {string} payload The caller's original payload, for the record.
+ * @param {{post?: Function, getToken?: Function, cwd?: string}} [options] Seams for tests.
+ * @returns {Promise<{sessionId: string, url: string}>} The accepted session.
+ */
+export async function dispatchClaudeWeb(block, prompt, payload, options = {}) {
+  const {
+    post = fetch,
+    getToken = resolveBearerToken,
+    cwd = process.cwd(),
+  } = options;
+  const token = getToken(block);
+  let response;
+  try {
+    response = await post(block.fireUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "anthropic-beta": ROUTINE_BETA,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ text: prompt }),
+    });
+  } catch (err) {
+    throw new Error(`could not reach the routine endpoint: ${err.message}`);
+  }
+
+  const body = await response.text();
+  if (!response.ok) {
+    // The token is the usual cause and the usual thing to leak, so the message
+    // names the status and the routine rather than echoing the request.
+    throw new Error(
+      `routine ${block.routineId} refused the dispatch (HTTP ${response.status}).\n` +
+        `${body.slice(0, 400)}\n` +
+        `A 401 means the bearer token is wrong, revoked, or regenerated.`
+    );
+  }
+
+  const { sessionId, url } = readFireResponse(body);
+  record(
+    {
+      taskId: sessionId,
+      surface: "claude-web",
+      routineId: block.routineId,
+      sessionUrl: url,
+      prompt,
+      payload,
+      dispatchedAt: new Date().toISOString(),
+    },
+    cwd
+  );
+  return { sessionId, url };
+}
+
+/**
+ * Resolve the dispatcher's own credential through the secrets chokepoint.
+ *
+ * Never read from configuration: the token authorises starting work on someone
+ * else's infrastructure, and it can be regenerated and revoked, so it belongs
+ * in the credential manager and in `secrets.rotating` alongside it.
+ * @param {object} block Surface configuration.
+ * @returns {string} The bearer token.
+ */
+function resolveBearerToken(block) {
+  const name = block.tokenKey ?? "CLAUDE_ROUTINE_TOKEN";
+  const resolver = resolve(
+    HERE,
+    "..",
+    "..",
+    "lisa-secrets-access",
+    "scripts",
+    "resolve-secret.mjs"
+  );
+  try {
+    return execFileSync("node", [resolver, "get", name], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (err) {
+    throw new Error(
+      `could not resolve ${name} through lisa-secrets-access.\n` +
+        `${String(err.stderr ?? err.message).trim()}\n` +
+        `It is the dispatcher's own credential; store it in the provider ` +
+        `rather than in .lisa.config.json.`
+    );
+  }
+}
+
+async function main() {
   const { skill, raw } = splitSkillFlag(process.argv.slice(2));
   const { params, rest } = parseInvocation(raw);
   const surface = resolveExecutionEnv(params);
@@ -247,6 +412,15 @@ function main() {
   // the repository-local skill, so an interactive run, a scheduled run, and a
   // recovery run all execute one contract.
   const prompt = `$${skill} ${rest}`.trim();
+
+  if (surface === "claude-web") {
+    const { sessionId, url } = await dispatchClaudeWeb(block, prompt, rest);
+    console.log(`dispatched: ${sessionId}`);
+    if (url) console.log(url);
+    console.log(`recorded in ${LEDGER}; not polling — this process is done.`);
+    return;
+  }
+
   const taskId = dispatchCodexCloud(block, prompt, rest);
 
   console.log(`dispatched: ${taskId}`);
@@ -255,10 +429,11 @@ function main() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  try {
-    main();
-  } catch (err) {
+  // Awaited rather than called bare: one dispatch path is async, so a synchronous
+  // try/catch would let a rejection escape as an unhandled rejection and exit 0 —
+  // reporting dispatched work that was never accepted.
+  main().catch(err => {
     console.error(err.message);
     process.exit(1);
-  }
+  });
 }

--- a/plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -50,6 +50,18 @@ const SURFACE_PRECONDITIONS = {
  */
 const ROUTINE_BETA = "experimental-cc-routine-2026-04-01";
 
+/**
+ * How long to wait for the routine to accept the dispatch.
+ *
+ * `fetch` has no timeout of its own, so a routine endpoint that accepts the
+ * connection and then says nothing leaves dispatch waiting forever — the one
+ * failure mode that never reaches the error path below and never reaches the
+ * operator either. Generous, because the endpoint only has to *accept* the
+ * dispatch: the session's own work happens long after this call returns, so
+ * this bounds a handshake rather than a run.
+ */
+const FIRE_TIMEOUT_MS = 30_000;
+
 /** Where dispatched work is recorded so a later session can find it. */
 const LEDGER = join(".lisa", "remote-dispatch.json");
 
@@ -329,9 +341,18 @@ export async function dispatchClaudeWeb(block, prompt, payload, options = {}) {
         "content-type": "application/json",
       },
       body: JSON.stringify({ text: prompt }),
+      signal: AbortSignal.timeout(FIRE_TIMEOUT_MS),
     });
   } catch (err) {
-    throw new Error(`could not reach the routine endpoint: ${err.message}`);
+    // A timeout arrives here as an abort rather than a network error, and
+    // "could not reach" is the true and useful thing to say about both. It is
+    // named separately so the operator can tell a silent endpoint from a
+    // refused connection, since only one of those is worth retrying.
+    const reason =
+      err.name === "TimeoutError"
+        ? `no response within ${FIRE_TIMEOUT_MS / 1000}s`
+        : err.message;
+    throw new Error(`could not reach the routine endpoint: ${reason}`);
   }
 
   const body = await response.text();

--- a/plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -21,13 +21,40 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /** Surfaces this dispatcher knows how to reach. `local` means "do not dispatch". */
-export const EXECUTION_ENVS = new Set(["local", "codex-cloud"]);
+export const EXECUTION_ENVS = new Set(["local", "codex-cloud", "claude-web"]);
+
+/**
+ * What each surface must have recorded before anything may dispatch to it.
+ *
+ * Not uniform, because the two surfaces do not bind the same way. A Codex Cloud
+ * environment is bound to one repository, so naming both is what proves the
+ * environment is the right one. A Claude cloud environment binds no repository
+ * at all — it is account-scoped configuration and the repository arrives per
+ * session — so its durable handle is the routine that dispatch fires.
+ */
+const SURFACE_PRECONDITIONS = {
+  "codex-cloud": ["environmentId", "repository"],
+  "claude-web": ["routineId", "fireUrl"],
+};
+
+/**
+ * The beta this endpoint ships under.
+ *
+ * Dated and rotating: the two most recent previous versions keep working, so a
+ * bump here is a migration with a window rather than a break. Stated once so
+ * there is a single place to move it.
+ */
+const ROUTINE_BETA = "experimental-cc-routine-2026-04-01";
 
 /** Where dispatched work is recorded so a later session can find it. */
 const LEDGER = join(".lisa", "remote-dispatch.json");
+
+/** This file's directory, for locating the sibling secrets skill. */
+const HERE = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Split `key=value` parameters from the rest of an invocation.
@@ -101,9 +128,11 @@ export function readSurfaceConfig(surface, cwd = process.cwd()) {
  * @param {string} surface Execution surface.
  */
 export function assertPreconditions(block, surface) {
-  const missing = [];
-  if (!block.environmentId) missing.push("environmentId");
-  if (!block.repository) missing.push("repository");
+  const required = SURFACE_PRECONDITIONS[surface] ?? [
+    "environmentId",
+    "repository",
+  ];
+  const missing = required.filter(field => !block[field]);
   if (missing.length) {
     throw new Error(
       `remoteEnv.surfaces["${surface}"] is missing: ${missing.join(", ")}.\n` +
@@ -230,7 +259,143 @@ export function splitSkillFlag(argv) {
   return { skill, raw: rest.join(" ") };
 }
 
-function main() {
+/**
+ * Read the response a routine returns when it accepts a dispatch.
+ *
+ * Kept separate from the request so the shape can be exercised against a
+ * recorded body. The identifier is a field here rather than something scraped
+ * out of console output, which is the one respect in which this surface is
+ * easier to reconcile than the other.
+ * @param {string} body Raw response body.
+ * @returns {{sessionId: string, url: string}} The accepted session.
+ */
+export function readFireResponse(body) {
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new Error(
+      `routine returned a body that is not JSON:\n${String(body).slice(0, 400)}`
+    );
+  }
+  const sessionId = parsed.claude_code_session_id;
+  const url = parsed.claude_code_session_url;
+  if (!sessionId) {
+    throw new Error(
+      `routine accepted the request but returned no session identifier.\n` +
+        `${JSON.stringify(parsed).slice(0, 400)}\n` +
+        `Refusing to report success: without the identifier nothing can ` +
+        `reconcile this run, and a retry would duplicate it.`
+    );
+  }
+  return { sessionId, url: url ?? "" };
+}
+
+/**
+ * Fire a routine and record the session it created.
+ *
+ * The payload is deliberately the work item and nothing else. It arrives on the
+ * far side wrapped in a block the platform marks as untrusted data, and a
+ * routine acts on it only because its saved prompt says to — which is the
+ * boundary this plan wanted anyway, enforced by the platform rather than by
+ * convention. Nothing here can widen the remote run's authority.
+ *
+ * The bearer token is resolved through the secrets chokepoint at the moment of
+ * use and never stored in configuration.
+ * Its three side effects — resolving a credential, making a request, writing the
+ * ledger — are all injectable, so the accept and refuse paths can be exercised
+ * without a token, a network, or a write into the working repository.
+ * @param {object} block Surface configuration.
+ * @param {string} prompt The thin skill invocation.
+ * @param {string} payload The caller's original payload, for the record.
+ * @param {{post?: Function, getToken?: Function, cwd?: string}} [options] Seams for tests.
+ * @returns {Promise<{sessionId: string, url: string}>} The accepted session.
+ */
+export async function dispatchClaudeWeb(block, prompt, payload, options = {}) {
+  const {
+    post = fetch,
+    getToken = resolveBearerToken,
+    cwd = process.cwd(),
+  } = options;
+  const token = getToken(block);
+  let response;
+  try {
+    response = await post(block.fireUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "anthropic-beta": ROUTINE_BETA,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ text: prompt }),
+    });
+  } catch (err) {
+    throw new Error(`could not reach the routine endpoint: ${err.message}`);
+  }
+
+  const body = await response.text();
+  if (!response.ok) {
+    // The token is the usual cause and the usual thing to leak, so the message
+    // names the status and the routine rather than echoing the request.
+    throw new Error(
+      `routine ${block.routineId} refused the dispatch (HTTP ${response.status}).\n` +
+        `${body.slice(0, 400)}\n` +
+        `A 401 means the bearer token is wrong, revoked, or regenerated.`
+    );
+  }
+
+  const { sessionId, url } = readFireResponse(body);
+  record(
+    {
+      taskId: sessionId,
+      surface: "claude-web",
+      routineId: block.routineId,
+      sessionUrl: url,
+      prompt,
+      payload,
+      dispatchedAt: new Date().toISOString(),
+    },
+    cwd
+  );
+  return { sessionId, url };
+}
+
+/**
+ * Resolve the dispatcher's own credential through the secrets chokepoint.
+ *
+ * Never read from configuration: the token authorises starting work on someone
+ * else's infrastructure, and it can be regenerated and revoked, so it belongs
+ * in the credential manager and in `secrets.rotating` alongside it.
+ * @param {object} block Surface configuration.
+ * @returns {string} The bearer token.
+ */
+function resolveBearerToken(block) {
+  const name = block.tokenKey ?? "CLAUDE_ROUTINE_TOKEN";
+  const resolver = resolve(
+    HERE,
+    "..",
+    "..",
+    "lisa-secrets-access",
+    "scripts",
+    "resolve-secret.mjs"
+  );
+  try {
+    return execFileSync("node", [resolver, "get", name], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (err) {
+    throw new Error(
+      `could not resolve ${name} through lisa-secrets-access.\n` +
+        `${String(err.stderr ?? err.message).trim()}\n` +
+        `It is the dispatcher's own credential; store it in the provider ` +
+        `rather than in .lisa.config.json.`
+    );
+  }
+}
+
+async function main() {
   const { skill, raw } = splitSkillFlag(process.argv.slice(2));
   const { params, rest } = parseInvocation(raw);
   const surface = resolveExecutionEnv(params);
@@ -247,6 +412,15 @@ function main() {
   // the repository-local skill, so an interactive run, a scheduled run, and a
   // recovery run all execute one contract.
   const prompt = `$${skill} ${rest}`.trim();
+
+  if (surface === "claude-web") {
+    const { sessionId, url } = await dispatchClaudeWeb(block, prompt, rest);
+    console.log(`dispatched: ${sessionId}`);
+    if (url) console.log(url);
+    console.log(`recorded in ${LEDGER}; not polling — this process is done.`);
+    return;
+  }
+
   const taskId = dispatchCodexCloud(block, prompt, rest);
 
   console.log(`dispatched: ${taskId}`);
@@ -255,10 +429,11 @@ function main() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  try {
-    main();
-  } catch (err) {
+  // Awaited rather than called bare: one dispatch path is async, so a synchronous
+  // try/catch would let a rejection escape as an unhandled rejection and exit 0 —
+  // reporting dispatched work that was never accepted.
+  main().catch(err => {
     console.error(err.message);
     process.exit(1);
-  }
+  });
 }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -5,7 +5,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-contents/.gitattributes":
       "9d3831007e681186a3673e1037ef3fc82980cab2fc04e27c0868e562912c9e9f",
     "all/copy-contents/gitignore":
-      "46f11b3fe840006c2d49fe83bf0fb873851f671ada417823674c3374b4774413",
+      "2dbf7fd2f2020fc7824c432342002d9ca3ebb57b2872e761b14e942b23479a11",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
       "5eb31c284e820a51312d4484f0669128007326af55ee515923fec33700d003a1",
     "all/create-only/.claude/rules/PROJECT_RULES.md":
@@ -1055,7 +1055,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-remote-dispatch/SKILL.md":
       "2cc999d2c3b61b10aabb849e0833fd58edb444c5013c05108dd58e5d7d60c4ba",
     "plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs":
-      "3bf6c019de34a53a1c84b131ffeb9702441e8c1c7c1794f522f97c0de5ee5ce4",
+      "845b3ad36e32d8b1a317e1c7d2856a759b9db42621174e02528dc36a1a2f52a7",
     "plugins/src/base/skills/lisa-repair-intake/SKILL.md":
       "4f85ac1381631e9f250d9cf3239baba633ae0df9ba1959f8835ed662592e2d77",
     "plugins/src/base/skills/lisa-reproduce-bug/SKILL.md":
@@ -8335,6 +8335,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/automation-workflow.test.ts": true,
     "tests/unit/secrets/bootstrap-key-naming.test.ts": true,
     "tests/unit/secrets/doctor-secrets.test.ts": true,
+    "tests/unit/secrets/remote-dispatch-claude-web.test.ts": true,
     "tests/unit/secrets/remote-dispatch.test.ts": true,
     "tests/unit/secrets/remote-env-phases.test.ts": true,
     "tests/unit/secrets/remote-env-skill-resolution.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1055,7 +1055,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-remote-dispatch/SKILL.md":
       "2cc999d2c3b61b10aabb849e0833fd58edb444c5013c05108dd58e5d7d60c4ba",
     "plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs":
-      "845b3ad36e32d8b1a317e1c7d2856a759b9db42621174e02528dc36a1a2f52a7",
+      "6ce559964964c65154d2105a017c751bba086dcb8b4ea209ea42ce7b4fdb7d63",
     "plugins/src/base/skills/lisa-repair-intake/SKILL.md":
       "4f85ac1381631e9f250d9cf3239baba633ae0df9ba1959f8835ed662592e2d77",
     "plugins/src/base/skills/lisa-reproduce-bug/SKILL.md":

--- a/tests/unit/secrets/remote-dispatch-claude-web.test.ts
+++ b/tests/unit/secrets/remote-dispatch-claude-web.test.ts
@@ -176,6 +176,28 @@ describe("dispatching", () => {
       dispatchClaudeWeb(BLOCK, "p", "p", { post, getToken, cwd: root })
     ).rejects.toThrow(/could not reach the routine endpoint/i);
   });
+
+  it("bounds the wait, so a silent endpoint fails rather than hangs", async () => {
+    // The failure `fetch` does not have an answer for on its own: a connection
+    // that is accepted and then never spoken on. Without a deadline that is not
+    // a failed dispatch at all, it is a dispatch that never returns — no error,
+    // no ledger entry, no operator.
+    let deadline: AbortSignal | undefined;
+    const post = async (_url: string, init: RequestInit): Promise<Response> => {
+      deadline = init.signal ?? undefined;
+      // What an aborted fetch actually throws, named the way the handler reads.
+      const err = new Error("The operation was aborted due to timeout");
+      err.name = "TimeoutError";
+      throw err;
+    };
+
+    await expect(
+      dispatchClaudeWeb(BLOCK, "p", "p", { post, getToken, cwd: root })
+    ).rejects.toThrow(
+      /could not reach the routine endpoint: no response within/i
+    );
+    expect(deadline).toBeInstanceOf(AbortSignal);
+  });
 });
 
 describe("fire response", () => {

--- a/tests/unit/secrets/remote-dispatch-claude-web.test.ts
+++ b/tests/unit/secrets/remote-dispatch-claude-web.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Contract tests for dispatching to a Claude cloud session.
+ *
+ * The rule these protect is that a dispatch is only successful when something
+ * durable came back. An accepted request whose identifier was not captured is
+ * worse than a refused one: nothing can reconcile the run, and a retry
+ * duplicates irreversible work.
+ *
+ * The request runner is injected, so every case here exercises the real
+ * response handling against recorded bodies without reaching the network or
+ * needing a credential.
+ * @module tests/unit/secrets/remote-dispatch-claude-web
+ */
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  EXECUTION_ENVS,
+  assertPreconditions,
+  dispatchClaudeWeb,
+  readFireResponse,
+  resolveExecutionEnv,
+} from "../../../plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs";
+
+/** The surface under test, named once so the literal cannot drift. */
+const CLAUDE_WEB = "claude-web";
+
+/** A session identifier shaped like the endpoint returns. */
+const SESSION_ID = "session_01HJKLMNOPQRSTUVWXYZ";
+const SESSION_URL = `https://claude.ai/code/${SESSION_ID}`;
+
+describe("execution surfaces", () => {
+  it("accepts claude-web as a routing target", () => {
+    expect(EXECUTION_ENVS.has(CLAUDE_WEB)).toBe(true);
+    expect(resolveExecutionEnv({ executionEnv: CLAUDE_WEB })).toBe(CLAUDE_WEB);
+  });
+
+  it("still rejects an unknown surface rather than running locally", () => {
+    // A silently ignored executionEnv runs the work on the operator's machine
+    // while they believe it went remote, and nothing downstream contradicts it.
+    expect(() => resolveExecutionEnv({ executionEnv: "claude-cloud" })).toThrow(
+      /unknown executionEnv/i
+    );
+  });
+});
+
+describe("preconditions", () => {
+  it("requires the routine, not a repository", () => {
+    // A Claude cloud environment binds no repository — it is account-scoped and
+    // the repository arrives per session — so demanding one would ask for a
+    // field that cannot be true of this surface.
+    expect(() =>
+      assertPreconditions({ repository: "org/repo" }, CLAUDE_WEB)
+    ).toThrow(/routineId/);
+  });
+
+  it("names every missing field at once", () => {
+    expect(() => assertPreconditions({}, CLAUDE_WEB)).toThrow(
+      /routineId, fireUrl/
+    );
+  });
+
+  it("passes a surface bound to a routine", () => {
+    expect(() =>
+      assertPreconditions(
+        { routineId: "trig_01ABC", fireUrl: "https://example/fire" },
+        "claude-web"
+      )
+    ).not.toThrow();
+  });
+
+  it("leaves the Codex contract unchanged", () => {
+    expect(() =>
+      assertPreconditions({ environmentId: "env_1" }, "codex-cloud")
+    ).toThrow(/repository/);
+  });
+});
+
+describe("dispatching", () => {
+  const BLOCK = {
+    routineId: "trig_01ABC",
+    fireUrl:
+      "https://api.anthropic.com/v1/claude_code/routines/trig_01ABC/fire",
+  };
+  const getToken = (): string => "sk-ant-oat01-fake";
+  let root: string;
+
+  const accepted = (): Response =>
+    ({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          claude_code_session_id: SESSION_ID,
+          claude_code_session_url: SESSION_URL,
+        }),
+    }) as unknown as Response;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "lisa-dispatch-"));
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it("sends the payload as untrusted text and records the session", async () => {
+    let seen: { url?: string; init?: RequestInit } = {};
+    const post = async (url: string, init: RequestInit): Promise<Response> => {
+      seen = { url, init };
+      return accepted();
+    };
+
+    const result = await dispatchClaudeWeb(
+      BLOCK,
+      "$lisa-implement SE-1",
+      "SE-1",
+      {
+        post,
+        getToken,
+        cwd: root,
+      }
+    );
+
+    expect(result).toEqual({ sessionId: SESSION_ID, url: SESSION_URL });
+    expect(seen.url).toBe(BLOCK.fireUrl);
+    expect(JSON.parse(String(seen.init?.body))).toEqual({
+      text: "$lisa-implement SE-1",
+    });
+
+    const ledger = JSON.parse(
+      readFileSync(path.join(root, ".lisa", "remote-dispatch.json"), "utf8")
+    );
+    expect(ledger.dispatches[0].taskId).toBe(SESSION_ID);
+    expect(ledger.dispatches[0].surface).toBe(CLAUDE_WEB);
+  });
+
+  it("carries the bearer token and the dated beta", async () => {
+    let headers: Record<string, string> = {};
+    const post = async (_url: string, init: RequestInit): Promise<Response> => {
+      headers = init.headers as Record<string, string>;
+      return accepted();
+    };
+
+    await dispatchClaudeWeb(BLOCK, "p", "p", { post, getToken, cwd: root });
+
+    expect(headers.authorization).toBe("Bearer sk-ant-oat01-fake");
+    expect(headers["anthropic-beta"]).toBe(
+      "experimental-cc-routine-2026-04-01"
+    );
+  });
+
+  it("refuses and writes nothing when the routine rejects the token", async () => {
+    const post = async (): Promise<Response> =>
+      ({
+        ok: false,
+        status: 401,
+        text: async () => '{"error":"unauthorized"}',
+      }) as unknown as Response;
+
+    await expect(
+      dispatchClaudeWeb(BLOCK, "p", "p", { post, getToken, cwd: root })
+    ).rejects.toThrow(/HTTP 401[\s\S]*revoked/i);
+    expect(existsSync(path.join(root, ".lisa", "remote-dispatch.json"))).toBe(
+      false
+    );
+  });
+
+  it("reports an unreachable endpoint as a failed dispatch", async () => {
+    const post = async (): Promise<Response> => {
+      throw new Error("getaddrinfo ENOTFOUND");
+    };
+
+    await expect(
+      dispatchClaudeWeb(BLOCK, "p", "p", { post, getToken, cwd: root })
+    ).rejects.toThrow(/could not reach the routine endpoint/i);
+  });
+});
+
+describe("fire response", () => {
+  it("reads the identifier from a field rather than scraping output", () => {
+    const body = JSON.stringify({
+      type: "routine_fire",
+      claude_code_session_id: SESSION_ID,
+      claude_code_session_url: SESSION_URL,
+    });
+    expect(readFireResponse(body)).toEqual({
+      sessionId: SESSION_ID,
+      url: SESSION_URL,
+    });
+  });
+
+  it("treats an accepted request with no identifier as a failed dispatch", () => {
+    // Reporting success here would leave irreversible remote work that nothing
+    // can reconcile, and a retry would start it a second time.
+    expect(() =>
+      readFireResponse(JSON.stringify({ type: "routine_fire" }))
+    ).toThrow(/no session identifier/i);
+  });
+
+  it("says so when the endpoint returns something other than JSON", () => {
+    expect(() => readFireResponse("<html>502 Bad Gateway</html>")).toThrow(
+      /not JSON/i
+    );
+  });
+
+  it("tolerates a missing url without losing the identifier", () => {
+    const body = JSON.stringify({ claude_code_session_id: SESSION_ID });
+    expect(readFireResponse(body)).toEqual({ sessionId: SESSION_ID, url: "" });
+  });
+});

--- a/tests/unit/secrets/remote-dispatch.test.ts
+++ b/tests/unit/secrets/remote-dispatch.test.ts
@@ -99,9 +99,13 @@ describe("executionEnv resolution", () => {
   it("rejects an unknown surface rather than falling back to local", () => {
     // Falling back would run the work locally while the operator believes it
     // went remote — a wrong outcome that looks exactly like a right one.
-    expect(() => resolveExecutionEnv({ executionEnv: "claude-web" })).toThrow(
-      /unknown executionEnv/i
-    );
+    //
+    // This case used "claude-web" as its unknown surface until that surface was
+    // implemented. A placeholder that can become real is a test which quietly
+    // stops asserting anything, so this one names a surface no vendor has.
+    expect(() =>
+      resolveExecutionEnv({ executionEnv: "nowhere-cloud" })
+    ).toThrow(/unknown executionEnv/i);
   });
 
   it("names the supported surfaces in the rejection", () => {


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2186

Completes the Claude Code web surface. Follows #2174, #2176, #2179, #2184.

## What this closes

Codex Cloud could already take a work item and run it with the laptop shut. Claude could not — which left `AGENTS.md`'s premise half-true, since it describes factories running "with as few humans as possible" on "Claude Routines, Codex Automations, or the equivalent".

```
/lisa:implement executionEnv=claude-web SE-45434
```

now POSTs the work item to a routine's `/fire` endpoint, records the session, and exits.

## Why not `claude --cloud`

It refuses non-interactive invocation — verified by live probe, recorded as U1 in the plan:

```
Error: --cloud requires an interactive terminal.
Non-interactive invocations (piped stdout, --init-only, --sdk-url) run locally
and would silently ignore --cloud.
```

That is a deliberate guard against a scripted dispatch silently executing *locally* while the operator believes it went remote, so wrapping it in a PTY to defeat it would reintroduce exactly the risk it prevents.

The endpoint turns out to be the better mechanism regardless: the session identifier arrives as a **JSON field** rather than something scraped out of console output, and the dispatching machine needs no CLI and no login — only the token.

## Design notes

**An accepted request with no identifier is a failed dispatch.** Same rule as the Codex path. Untracked remote work is worse than none: nothing can reconcile it and a retry starts it twice.

**Preconditions are surface-aware.** This surface requires the routine and refuses to require a repository, because a Claude cloud environment binds none — it is account-scoped configuration, and the repository arrives per session.

**The token is not declared rotating.** It can be regenerated and revoked, but it is not *consumed by being used*, so it does not meet this contract's definition ("using the credential can invalidate the stored copy"). Declaring it rotating would invoke the write-scope preflight and advisory lease for a credential needing neither.

**The ledger is gitignored.** Each developer fires their own routine under their own account, so committing it would collide on every dispatch while telling a teammate nothing actionable. Added to the host-project template too.

**One existing test used `claude-web` as its example of an unknown surface.** A placeholder that can become real is a test that quietly stops asserting anything, so it now names a surface no vendor has.

## Verification

Proven with a **live dispatch**, not only in tests:

```
$ dispatch.mjs 'executionEnv=claude-web ...' --skill lisa-doctor
dispatched: session_01HqpS8qv94ypiH5bDXaiM42
https://claude.ai/code/session_01HqpS8qv94ypiH5bDXaiM42
recorded in .lisa/remote-dispatch.json; not polling — this process is done.
```

The ledger recorded the session id, surface, routine id, url, prompt and timestamp. The bearer token resolved through `lisa-secrets-access` from the `lisa` Bitwarden project, and is stored there with a usage note.

484 files / 8295 tests pass; typecheck, lint, plugin sync and evidence manifest all green. The credential, request and ledger write are injected in tests, so none of them touches a real token, the network, or the working repository.

## Left for a follow-up

Scheduling. A routine can carry a cron trigger alongside the API trigger, so the remaining work is registration and stopped-clock detection in `lisa-automation-status` — not a second mechanism.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Claude Web as a remote execution option alongside existing execution methods.
  - Added session tracking and reporting for Claude Web requests.
  - Added configuration support for Claude Web connection details.

- **Bug Fixes**
  - Improved validation and error handling for failed, malformed, or incomplete remote requests.

- **Tests**
  - Added coverage for Claude Web dispatch, authentication, request handling, response parsing, and session persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->