### PR TITLE
fix(remote-env): put the install directory on PATH

### DIFF
--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -37,7 +37,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
@@ -197,12 +197,41 @@ function applyToolchain(tools, dryRun) {
   mkdirSync(binDir, { recursive: true, mode: 0o755 });
   const byName = new Map((tools.install ?? []).map(t => [t.name, t]));
 
+  // Installing a binary somewhere nothing looks is the same as not installing
+  // it. `~/.local/bin` is on PATH by default on a developer workstation and is
+  // NOT on a minimal container, so the toolchain step reported `install bws`,
+  // the file landed at ~/.local/bin/bws mode 755, and the very next step died
+  // with `spawnSync bws ENOENT`.
+  //
+  // This was invisible in every local test because a workstation shell already
+  // exports the directory — the environment doing the hiding was the one used
+  // to verify the fix.
+  //
+  // Prepended, not appended: a pinned-and-checksummed binary must win over
+  // whatever an image happens to ship under the same name.
+  if (!pathContains(binDir)) {
+    process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
+  }
+
   for (const step of plan) {
     console.log(`  ${step.action.padEnd(8)} ${step.reason}`);
     if (step.action === "install" && !dryRun)
       installTool(byName.get(step.name), binDir);
   }
   return plan;
+}
+
+/**
+ * Whether a directory is already on PATH.
+ *
+ * Compared entry by entry rather than by substring: a substring test would
+ * consider `/root/.local/bin` present because `/root/.local/bin/extra` is, and
+ * would then skip the prepend that makes the tool findable.
+ * @param {string} dir Directory to look for.
+ * @returns {boolean} True when PATH already contains exactly that entry.
+ */
+export function pathContains(dir, path = process.env.PATH ?? "") {
+  return path.split(delimiter).filter(Boolean).includes(dir);
 }
 
 /**

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -37,7 +37,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
@@ -197,12 +197,41 @@ function applyToolchain(tools, dryRun) {
   mkdirSync(binDir, { recursive: true, mode: 0o755 });
   const byName = new Map((tools.install ?? []).map(t => [t.name, t]));
 
+  // Installing a binary somewhere nothing looks is the same as not installing
+  // it. `~/.local/bin` is on PATH by default on a developer workstation and is
+  // NOT on a minimal container, so the toolchain step reported `install bws`,
+  // the file landed at ~/.local/bin/bws mode 755, and the very next step died
+  // with `spawnSync bws ENOENT`.
+  //
+  // This was invisible in every local test because a workstation shell already
+  // exports the directory — the environment doing the hiding was the one used
+  // to verify the fix.
+  //
+  // Prepended, not appended: a pinned-and-checksummed binary must win over
+  // whatever an image happens to ship under the same name.
+  if (!pathContains(binDir)) {
+    process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
+  }
+
   for (const step of plan) {
     console.log(`  ${step.action.padEnd(8)} ${step.reason}`);
     if (step.action === "install" && !dryRun)
       installTool(byName.get(step.name), binDir);
   }
   return plan;
+}
+
+/**
+ * Whether a directory is already on PATH.
+ *
+ * Compared entry by entry rather than by substring: a substring test would
+ * consider `/root/.local/bin` present because `/root/.local/bin/extra` is, and
+ * would then skip the prepend that makes the tool findable.
+ * @param {string} dir Directory to look for.
+ * @returns {boolean} True when PATH already contains exactly that entry.
+ */
+export function pathContains(dir, path = process.env.PATH ?? "") {
+  return path.split(delimiter).filter(Boolean).includes(dir);
 }
 
 /**

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -37,7 +37,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
@@ -197,12 +197,41 @@ function applyToolchain(tools, dryRun) {
   mkdirSync(binDir, { recursive: true, mode: 0o755 });
   const byName = new Map((tools.install ?? []).map(t => [t.name, t]));
 
+  // Installing a binary somewhere nothing looks is the same as not installing
+  // it. `~/.local/bin` is on PATH by default on a developer workstation and is
+  // NOT on a minimal container, so the toolchain step reported `install bws`,
+  // the file landed at ~/.local/bin/bws mode 755, and the very next step died
+  // with `spawnSync bws ENOENT`.
+  //
+  // This was invisible in every local test because a workstation shell already
+  // exports the directory — the environment doing the hiding was the one used
+  // to verify the fix.
+  //
+  // Prepended, not appended: a pinned-and-checksummed binary must win over
+  // whatever an image happens to ship under the same name.
+  if (!pathContains(binDir)) {
+    process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
+  }
+
   for (const step of plan) {
     console.log(`  ${step.action.padEnd(8)} ${step.reason}`);
     if (step.action === "install" && !dryRun)
       installTool(byName.get(step.name), binDir);
   }
   return plan;
+}
+
+/**
+ * Whether a directory is already on PATH.
+ *
+ * Compared entry by entry rather than by substring: a substring test would
+ * consider `/root/.local/bin` present because `/root/.local/bin/extra` is, and
+ * would then skip the prepend that makes the tool findable.
+ * @param {string} dir Directory to look for.
+ * @returns {boolean} True when PATH already contains exactly that entry.
+ */
+export function pathContains(dir, path = process.env.PATH ?? "") {
+  return path.split(delimiter).filter(Boolean).includes(dir);
 }
 
 /**

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -37,7 +37,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
@@ -197,12 +197,41 @@ function applyToolchain(tools, dryRun) {
   mkdirSync(binDir, { recursive: true, mode: 0o755 });
   const byName = new Map((tools.install ?? []).map(t => [t.name, t]));
 
+  // Installing a binary somewhere nothing looks is the same as not installing
+  // it. `~/.local/bin` is on PATH by default on a developer workstation and is
+  // NOT on a minimal container, so the toolchain step reported `install bws`,
+  // the file landed at ~/.local/bin/bws mode 755, and the very next step died
+  // with `spawnSync bws ENOENT`.
+  //
+  // This was invisible in every local test because a workstation shell already
+  // exports the directory — the environment doing the hiding was the one used
+  // to verify the fix.
+  //
+  // Prepended, not appended: a pinned-and-checksummed binary must win over
+  // whatever an image happens to ship under the same name.
+  if (!pathContains(binDir)) {
+    process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
+  }
+
   for (const step of plan) {
     console.log(`  ${step.action.padEnd(8)} ${step.reason}`);
     if (step.action === "install" && !dryRun)
       installTool(byName.get(step.name), binDir);
   }
   return plan;
+}
+
+/**
+ * Whether a directory is already on PATH.
+ *
+ * Compared entry by entry rather than by substring: a substring test would
+ * consider `/root/.local/bin` present because `/root/.local/bin/extra` is, and
+ * would then skip the prepend that makes the tool findable.
+ * @param {string} dir Directory to look for.
+ * @returns {boolean} True when PATH already contains exactly that entry.
+ */
+export function pathContains(dir, path = process.env.PATH ?? "") {
+  return path.split(delimiter).filter(Boolean).includes(dir);
 }
 
 /**

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -37,7 +37,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
@@ -197,12 +197,41 @@ function applyToolchain(tools, dryRun) {
   mkdirSync(binDir, { recursive: true, mode: 0o755 });
   const byName = new Map((tools.install ?? []).map(t => [t.name, t]));
 
+  // Installing a binary somewhere nothing looks is the same as not installing
+  // it. `~/.local/bin` is on PATH by default on a developer workstation and is
+  // NOT on a minimal container, so the toolchain step reported `install bws`,
+  // the file landed at ~/.local/bin/bws mode 755, and the very next step died
+  // with `spawnSync bws ENOENT`.
+  //
+  // This was invisible in every local test because a workstation shell already
+  // exports the directory — the environment doing the hiding was the one used
+  // to verify the fix.
+  //
+  // Prepended, not appended: a pinned-and-checksummed binary must win over
+  // whatever an image happens to ship under the same name.
+  if (!pathContains(binDir)) {
+    process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
+  }
+
   for (const step of plan) {
     console.log(`  ${step.action.padEnd(8)} ${step.reason}`);
     if (step.action === "install" && !dryRun)
       installTool(byName.get(step.name), binDir);
   }
   return plan;
+}
+
+/**
+ * Whether a directory is already on PATH.
+ *
+ * Compared entry by entry rather than by substring: a substring test would
+ * consider `/root/.local/bin` present because `/root/.local/bin/extra` is, and
+ * would then skip the prepend that makes the tool findable.
+ * @param {string} dir Directory to look for.
+ * @returns {boolean} True when PATH already contains exactly that entry.
+ */
+export function pathContains(dir, path = process.env.PATH ?? "") {
+  return path.split(delimiter).filter(Boolean).includes(dir);
 }
 
 /**

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -37,7 +37,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { assertPinned, extractVersion, planToolchain } from "./toolchain.mjs";
@@ -197,12 +197,41 @@ function applyToolchain(tools, dryRun) {
   mkdirSync(binDir, { recursive: true, mode: 0o755 });
   const byName = new Map((tools.install ?? []).map(t => [t.name, t]));
 
+  // Installing a binary somewhere nothing looks is the same as not installing
+  // it. `~/.local/bin` is on PATH by default on a developer workstation and is
+  // NOT on a minimal container, so the toolchain step reported `install bws`,
+  // the file landed at ~/.local/bin/bws mode 755, and the very next step died
+  // with `spawnSync bws ENOENT`.
+  //
+  // This was invisible in every local test because a workstation shell already
+  // exports the directory — the environment doing the hiding was the one used
+  // to verify the fix.
+  //
+  // Prepended, not appended: a pinned-and-checksummed binary must win over
+  // whatever an image happens to ship under the same name.
+  if (!pathContains(binDir)) {
+    process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
+  }
+
   for (const step of plan) {
     console.log(`  ${step.action.padEnd(8)} ${step.reason}`);
     if (step.action === "install" && !dryRun)
       installTool(byName.get(step.name), binDir);
   }
   return plan;
+}
+
+/**
+ * Whether a directory is already on PATH.
+ *
+ * Compared entry by entry rather than by substring: a substring test would
+ * consider `/root/.local/bin` present because `/root/.local/bin/extra` is, and
+ * would then skip the prepend that makes the tool findable.
+ * @param {string} dir Directory to look for.
+ * @returns {boolean} True when PATH already contains exactly that entry.
+ */
+export function pathContains(dir, path = process.env.PATH ?? "") {
+  return path.split(delimiter).filter(Boolean).includes(dir);
 }
 
 /**

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1125,7 +1125,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "f1b492196f41adcceb1c2a2ada048355e7f36735de3be0dfe028e472b452f28c",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "0ac27775b2a11cc7ab6368aba4df7466cbf8cf57fd5470a807e24547b36cc94f",
+      "ceba67f85f1db0f390b0cbe66c63401cc03eaa8a27b254ba3d4b0c271103a53d",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
       "ff66d33ba41a068d09be18f81ac68988238c2afa1d4e3733ae906b73eea74324",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
@@ -8336,6 +8336,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/bootstrap-key-naming.test.ts": true,
     "tests/unit/secrets/doctor-secrets.test.ts": true,
     "tests/unit/secrets/remote-dispatch.test.ts": true,
+    "tests/unit/secrets/remote-env-bindir-path.test.ts": true,
     "tests/unit/secrets/remote-env-phases.test.ts": true,
     "tests/unit/secrets/remote-env-skill-resolution.test.ts": true,
     "tests/unit/secrets/remote-env-toolchain.test.ts": true,

--- a/tests/unit/secrets/remote-env-bindir-path.test.ts
+++ b/tests/unit/secrets/remote-env-bindir-path.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression tests for putting the install directory on PATH.
+ *
+ * The toolchain step installs pinned binaries into `~/.local/bin` and then the
+ * secrets step spawns them by bare name. That directory is on PATH by default
+ * on a developer workstation and is NOT on a minimal container, so the step
+ * reported `install bws`, the file landed correctly at mode 755, and the next
+ * step died with `spawnSync bws ENOENT`.
+ *
+ * Every local run passed while every container run failed, because the shell
+ * used to verify already exported the directory. The environment doing the
+ * verifying was the environment hiding the bug — which is why this is asserted
+ * against an explicit PATH string rather than against `process.env`.
+ * @module tests/unit/secrets/remote-env-bindir-path
+ */
+import { delimiter } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { pathContains } from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs";
+
+/** The directory pinned tools are installed into. */
+const BIN_DIR = "/root/.local/bin";
+
+describe("pathContains", () => {
+  it("finds the directory when it is present", () => {
+    expect(pathContains(BIN_DIR, ["/usr/bin", BIN_DIR].join(delimiter))).toBe(
+      true
+    );
+  });
+
+  it("reports absent on a container-shaped PATH", () => {
+    // The exact PATH a fresh ubuntu:24.04 container presents.
+    const container = [
+      "/usr/local/sbin",
+      "/usr/local/bin",
+      "/usr/sbin",
+      "/usr/bin",
+      "/sbin",
+      "/bin",
+    ].join(delimiter);
+
+    expect(pathContains(BIN_DIR, container)).toBe(false);
+  });
+
+  // A substring test would call this present because the string appears inside
+  // a longer entry, skip the prepend, and leave the binary unfindable — the
+  // same end state as the original bug, reached a different way.
+  it("does not mistake a longer entry for the directory", () => {
+    expect(
+      pathContains(BIN_DIR, ["/usr/bin", `${BIN_DIR}/extra`].join(delimiter))
+    ).toBe(false);
+  });
+
+  it("does not mistake a prefix of the directory for it", () => {
+    expect(pathContains(BIN_DIR, ["/root/.local"].join(delimiter))).toBe(false);
+  });
+
+  it("tolerates empty entries rather than matching them", () => {
+    expect(pathContains(BIN_DIR, `${delimiter}${delimiter}/usr/bin`)).toBe(
+      false
+    );
+    expect(pathContains("", "/usr/bin")).toBe(false);
+  });
+
+  it("handles an entirely empty PATH", () => {
+    expect(pathContains(BIN_DIR, "")).toBe(false);
+  });
+});


### PR DESCRIPTION
`setupToolchain` installs pinned binaries into `$HOME/.local/bin` and never added that directory to `PATH`. The next phase spawns them by bare name.

That directory is on `PATH` by default on a developer workstation and **not** on a minimal container, so every Codex Cloud setup failed:

```
Toolchain:
  install  bws 2.1.0 not installed     ← reported success
Secrets:
spawnSync bws ENOENT                   ← could not find what it just installed
```

## Confirmed, then proved

In a clean `ubuntu:24.04` container the binary lands exactly where it should — `~/.local/bin/bws`, 12 MB, mode 755 — and is unreachable. Same container, with this fix:

```
install  bws 2.1.0 not installed
Secrets:
materialized 12 secret(s) and their notes into /root/.config/tunnl
Remote environment ready.
exit: 0
```

## Why it survived every local test

All of them passed. The shell running them exports `~/.local/bin` ahead of every command, so **the missing `PATH` entry was being supplied by the test environment itself**. The environment doing the verifying was the environment hiding the bug.

So the regression test asserts against explicit `PATH` strings — including the exact one a fresh `ubuntu:24.04` presents — rather than against `process.env`. No ambient shell can rescue it.

## Two details that matter

**Entry-by-entry, not substring.** A substring test would treat `/root/.local/bin` as present because `/root/.local/bin/extra` is, skip the prepend, and reproduce the identical failure by another route. There's a test for that case.

**Prepended, not appended**, so a pinned and checksummed binary wins over whatever an image happens to ship under the same name.

## Separate follow-up (not in this PR)

`remoteEnv.tools.install` pins an architecture-specific URL (`bws-x86_64-unknown-linux-gnu`). Correct for Codex's x86_64 image, silently wrong anywhere else — an aarch64 host installs a binary that dies at the dynamic loader. Worth selecting by `uname -m` or asserting the expected architecture rather than leaving it implicit. Noted in #2188.

**8441 tests across 498 files** pass.

Work-Item: CodySwannGT/lisa#2188

🤖 Generated with Claude Code
