### PR TITLE
Refresh Lisa's own installed remote-env scripts, and guard the copy

### DIFF
--- a/scripts/lisa-remote-env/setup.sh
+++ b/scripts/lisa-remote-env/setup.sh
@@ -13,14 +13,82 @@
 # and emphatically not in a vendor settings field.
 set -euo pipefail
 
+# Claude Code web runs the environment setup field from $HOME, while the
+# checkout lives at $HOME/<repo>. If this installed copy is invoked by absolute
+# path, move back to the repository root before resolving project-local files.
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+case "$script_dir" in
+  */scripts/lisa-remote-env)
+    cd "$script_dir/../.."
+    ;;
+esac
+
 # Node is the one thing that cannot be installed by the installer, since the
-# installer is written in it. Fail with an actionable message rather than a
-# "command not found" forty lines deep.
+# installer is written in it. Checked before the dependency install rather than
+# after: every package manager below is itself a node program, so a missing node
+# would otherwise surface as that manager failing under `set -e`, and the script
+# would exit on a confusing error instead of this actionable one.
 if ! command -v node >/dev/null 2>&1; then
   echo "node is required to prepare this environment but is not present." >&2
   echo "It cannot be installed by the toolchain step, because that step runs" >&2
   echo "on node. Pin a base image that provides it." >&2
   exit 1
+fi
+
+# Install the project's dependencies, unless the caller already did.
+#
+# This lives here rather than in the vendor's settings field so that field can
+# be one identical line for every project. Naming the package manager there
+# meant a Claude environment for an npm project and one for a bun project
+# differed by a string a human had to get right, in a box with no review, no
+# version history, and no test.
+#
+# Which manager is decided by the lockfile that is actually committed, never
+# guessed: a guessed one fails on the container's first command with an error
+# blaming the project rather than the guess.
+#
+# Skipped when node_modules already exists, which is what makes this cheap on a
+# resumed container and correct to run twice.
+if [ "${LISA_SKIP_INSTALL:-}" != "1" ] && [ ! -d node_modules ]; then
+  if [ -f bun.lock ] || [ -f bun.lockb ]; then install_cmd="bun install"
+  elif [ -f pnpm-lock.yaml ]; then install_cmd="pnpm install --frozen-lockfile"
+  elif [ -f yarn.lock ]; then
+    # Yarn Classic and Berry spell the same intent differently, and each
+    # rejects the other's flag. The lockfile itself says which is in use:
+    # Yarn 1 writes a "# yarn lockfile v1" header, Berry does not.
+    if head -5 yarn.lock | grep -q "yarn lockfile v1"; then
+      install_cmd="yarn install --frozen-lockfile"
+    else
+      install_cmd="yarn install --immutable"
+    fi
+  elif [ -f package-lock.json ]; then install_cmd="npm ci"
+  else install_cmd=""
+  fi
+
+  if [ -n "$install_cmd" ]; then
+    echo "Installing dependencies with: $install_cmd"
+    # CI=1 so lifecycle scripts take their automation path and leave the
+    # checkout alone. A remote-env setup is automation by definition, and a
+    # postinstall that rewrites tracked files here breaks any skill with a
+    # clean-checkout precondition — which the publishing skills have, because
+    # their diff is contractually bounded and merged without human review.
+    #
+    # Lisa's own postinstall already guards on exactly this variable, so this
+    # is an existing convention rather than a new one.
+    #
+    # NOT --ignore-scripts: that would also stop patch-package, so a project
+    # relying on patched dependencies would silently get unpatched ones — a
+    # quieter failure than the one being fixed.
+    #
+    # Without it the bug is cache-dependent, not deterministic: a fresh
+    # container installs and dirties the tree, a resumed one skips the install
+    # and succeeds. That reads as flakiness rather than a cause.
+    CI=1 $install_cmd
+  else
+    # Not fatal on its own. A project may carry no lockfile and still have the
+    # skill in a checkout directory, so let the resolver below decide.
+    echo "No lockfile found; skipping dependency install." >&2
+  fi
 fi
 
 # Where the skill lives depends on how this project's harness receives it, and
@@ -57,9 +125,10 @@ if [ -z "$runner" ]; then
   echo "yet: Claude and Codex receive Lisa skills as an installed plugin, which" >&2
   echo "is not part of a clone, so node_modules is the only copy present." >&2
   echo >&2
-  echo "Install dependencies before this script runs. The environment's setup" >&2
-  echo "command should be the install and this script together, for example:" >&2
-  echo "  bun install && bash scripts/lisa-remote-env/setup.sh" >&2
+  echo "This script installs dependencies itself, so reaching here means the" >&2
+  echo "install did not produce the package, or the project has no lockfile" >&2
+  echo "identifying its package manager. Check that @codyswann/lisa is a" >&2
+  echo "dependency and that a lockfile is committed." >&2
   echo >&2
   echo "If dependencies are installed, run 'lisa apply' so the skills are" >&2
   echo "present, then re-run setup." >&2

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1981,7 +1981,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/lisa-remote-env/session-start.sh":
       "6e3871ec2f8d56b8ebb85376ebdd3956f3ed8fa4f7b278c2ed90ca9b8845897c",
     "scripts/lisa-remote-env/setup.sh":
-      "a043074dd52e3f9b4b4a32bdd8b5eaa728160e5a0622a8a18388e6e26c7d25e3",
+      "7f7cf8a2248dbaa31f2f039fdaf147d083427a21633f7cf06ad612f38344d6c1",
     "scripts/lisa-update-local.sh":
       "c811f9e10dbcb38499a9791c1ae9051460b347051d04a1d2046925bab9a53c96",
     "scripts/lisa-work-item.mjs":
@@ -8338,6 +8338,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/remote-dispatch-claude-web.test.ts": true,
     "tests/unit/secrets/remote-dispatch.test.ts": true,
     "tests/unit/secrets/remote-env-bindir-path.test.ts": true,
+    "tests/unit/secrets/remote-env-installed-copy.test.ts": true,
     "tests/unit/secrets/remote-env-phases.test.ts": true,
     "tests/unit/secrets/remote-env-setup-field.test.ts": true,
     "tests/unit/secrets/remote-env-skill-resolution.test.ts": true,

--- a/tests/unit/secrets/remote-env-installed-copy.test.ts
+++ b/tests/unit/secrets/remote-env-installed-copy.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Drift guard for the remote-env scripts Lisa installs into itself.
+ *
+ * `/lisa:setup:remote-env --install` copies its assets into
+ * `scripts/lisa-remote-env/`, and those copies are committed on purpose: a
+ * container that has just cloned the repository has never seen the plugin they
+ * came from, so the copy is what actually executes there.
+ *
+ * Being a copy is what makes it rot. The assets are covered by tests and the
+ * installed files were covered by nothing, so they fell 74 lines behind —
+ * missing the dependency install, the node ordering fix and Yarn Classic
+ * detection. Every one of those was written for remote containers, and every
+ * one of them was invisible in a remote container, because the file the
+ * container runs had not been refreshed.
+ *
+ * The failure is silent by construction: nothing errors, the old script just
+ * keeps working the old way. So the check is byte equality, and the fix when it
+ * goes red is to re-run `--install` and commit the result.
+ * @module tests/unit/secrets/remote-env-installed-copy
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/** Where the reviewed, tested originals live. */
+const ASSETS = "plugins/src/base/skills/lisa-setup-remote-env/assets";
+
+/** Where `--install` puts them, and where a container finds them. */
+const INSTALLED = path.join("scripts", "lisa-remote-env");
+
+/** Every asset the installer writes. */
+const SCRIPTS = ["setup.sh", "session-start.sh"] as const;
+
+describe("installed remote-env scripts", () => {
+  it.each(SCRIPTS)(
+    "%s is identical to the asset it was installed from",
+    script => {
+      expect(readFileSync(path.join(INSTALLED, script), "utf8")).toBe(
+        readFileSync(path.join(ASSETS, script), "utf8")
+      );
+    }
+  );
+});


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2200

`scripts/lisa-remote-env/setup.sh` is a committed copy of the skill asset — deliberately, because a container that has just cloned the repository has never seen the plugin the asset lives in, so the copy is what actually executes there.

Being a copy is what made it rot. It sat **74 lines behind** the asset: no dependency install (#2194), no node ordering fix, no Yarn Classic detection. Every one of those changes was written *for* remote containers and was invisible *in* one, because the file the container runs had not been refreshed.

Nothing caught it — the asset has tests, the installed copy had none, and the failure is silent by construction: nothing errors, the old script just keeps doing the old thing.

So the copies are now asserted byte-identical to their assets. Confirmed to bite rather than assumed:

```
× setup.sh is identical to the asset it was installed from
  Tests  1 failed | 1 passed (2)     <- previous file restored
  Tests  2 passed (2)                <- refreshed
```