### PR TITLE
Resolve the skill scripts the generated automation workflow actually runs

### DIFF
--- a/plugins/lisa-agy/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -63,6 +63,51 @@ export function readAutomation(name, cwd = process.cwd()) {
 }
 
 /**
+ * Emit shell that locates a Lisa skill script before running it.
+ *
+ * A hardcoded `.claude/skills/...` path is wrong in exactly the place this
+ * workflow runs. Claude and Codex receive Lisa skills as an installed plugin
+ * living in the user's home directory, which is emphatically not part of a
+ * clone — and a scheduled run is always a fresh clone with no plugin install.
+ * So the one path that reliably exists on a runner is the npm package, at the
+ * version the project pins, which is the version its automation should run.
+ *
+ * The same candidate list the remote-env entrypoint uses, for the same reason:
+ * the in-checkout copies are cheapest and need nothing installed, and
+ * `node_modules` is the fallback that makes the plugin-delivered harnesses work
+ * at all.
+ * @param {string} skill Skill slug that owns the script.
+ * @param {string} script Script filename.
+ * @param {string[]} args Arguments appended to the invocation, one per line.
+ * @returns {string} Shell, indented for a workflow `run:` block.
+ */
+function runSkillScript(skill, script, args) {
+  const candidates = [
+    `.claude/skills/${skill}/scripts/${script}`,
+    `.agents/skills/${skill}/scripts/${script}`,
+    `.codex/skills/${skill}/scripts/${script}`,
+    `node_modules/@codyswann/lisa/plugins/lisa/skills/${skill}/scripts/${script}`,
+  ]
+    .map(candidate => `            "${candidate}"`)
+    .join(" \\\n");
+  const tail = args.map(arg => `            ${arg}`).join(" \\\n");
+  return `          runner=""
+          for candidate in \\
+${candidates}; do
+            if [ -f "$candidate" ]; then runner="$candidate"; break; fi
+          done
+          if [ -z "$runner" ]; then
+            echo "cannot find ${skill}/scripts/${script}" >&2
+            echo "Checked the agent skill directories and node_modules." >&2
+            echo "Lisa skills reach Claude and Codex as an installed plugin," >&2
+            echo "so node_modules is the only copy a runner ever has." >&2
+            exit 1
+          fi
+          node "$runner" \\
+${tail}`;
+}
+
+/**
  * Render the workflow YAML for one loop.
  *
  * Three choices here are load-bearing rather than stylistic.
@@ -112,7 +157,7 @@ export function renderWorkflow(name, loop) {
           ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          node .claude/skills/lisa-secrets-access/scripts/rotate-secret.mjs leases`;
+${runSkillScript("lisa-secrets-access", "rotate-secret.mjs", ["leases"])}`;
 
   const trigger = loop.enabled
     ? `  schedule:\n    - cron: '${loop.schedule}'\n  workflow_dispatch:`
@@ -172,9 +217,10 @@ jobs:
           ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          node .claude/skills/lisa-remote-dispatch/scripts/dispatch.mjs \\
-            'executionEnv=${loop.executionEnv} ${loop.payload ?? ""}' \\
-            --skill ${loop.skill ?? `lisa-${name}`}
+${runSkillScript("lisa-remote-dispatch", "dispatch.mjs", [
+  `'executionEnv=${loop.executionEnv} ${loop.payload ?? ""}'`,
+  `--skill ${loop.skill ?? `lisa-${name}`}`,
+])}
 
 ${rotation}
 `;

--- a/plugins/lisa-copilot/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -63,6 +63,51 @@ export function readAutomation(name, cwd = process.cwd()) {
 }
 
 /**
+ * Emit shell that locates a Lisa skill script before running it.
+ *
+ * A hardcoded `.claude/skills/...` path is wrong in exactly the place this
+ * workflow runs. Claude and Codex receive Lisa skills as an installed plugin
+ * living in the user's home directory, which is emphatically not part of a
+ * clone — and a scheduled run is always a fresh clone with no plugin install.
+ * So the one path that reliably exists on a runner is the npm package, at the
+ * version the project pins, which is the version its automation should run.
+ *
+ * The same candidate list the remote-env entrypoint uses, for the same reason:
+ * the in-checkout copies are cheapest and need nothing installed, and
+ * `node_modules` is the fallback that makes the plugin-delivered harnesses work
+ * at all.
+ * @param {string} skill Skill slug that owns the script.
+ * @param {string} script Script filename.
+ * @param {string[]} args Arguments appended to the invocation, one per line.
+ * @returns {string} Shell, indented for a workflow `run:` block.
+ */
+function runSkillScript(skill, script, args) {
+  const candidates = [
+    `.claude/skills/${skill}/scripts/${script}`,
+    `.agents/skills/${skill}/scripts/${script}`,
+    `.codex/skills/${skill}/scripts/${script}`,
+    `node_modules/@codyswann/lisa/plugins/lisa/skills/${skill}/scripts/${script}`,
+  ]
+    .map(candidate => `            "${candidate}"`)
+    .join(" \\\n");
+  const tail = args.map(arg => `            ${arg}`).join(" \\\n");
+  return `          runner=""
+          for candidate in \\
+${candidates}; do
+            if [ -f "$candidate" ]; then runner="$candidate"; break; fi
+          done
+          if [ -z "$runner" ]; then
+            echo "cannot find ${skill}/scripts/${script}" >&2
+            echo "Checked the agent skill directories and node_modules." >&2
+            echo "Lisa skills reach Claude and Codex as an installed plugin," >&2
+            echo "so node_modules is the only copy a runner ever has." >&2
+            exit 1
+          fi
+          node "$runner" \\
+${tail}`;
+}
+
+/**
  * Render the workflow YAML for one loop.
  *
  * Three choices here are load-bearing rather than stylistic.
@@ -112,7 +157,7 @@ export function renderWorkflow(name, loop) {
           ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          node .claude/skills/lisa-secrets-access/scripts/rotate-secret.mjs leases`;
+${runSkillScript("lisa-secrets-access", "rotate-secret.mjs", ["leases"])}`;
 
   const trigger = loop.enabled
     ? `  schedule:\n    - cron: '${loop.schedule}'\n  workflow_dispatch:`
@@ -172,9 +217,10 @@ jobs:
           ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          node .claude/skills/lisa-remote-dispatch/scripts/dispatch.mjs \\
-            'executionEnv=${loop.executionEnv} ${loop.payload ?? ""}' \\
-            --skill ${loop.skill ?? `lisa-${name}`}
+${runSkillScript("lisa-remote-dispatch", "dispatch.mjs", [
+  `'executionEnv=${loop.executionEnv} ${loop.payload ?? ""}'`,
+  `--skill ${loop.skill ?? `lisa-${name}`}`,
+])}
 
 ${rotation}
 `;

--- a/plugins/lisa-cursor/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -63,6 +63,51 @@ export function readAutomation(name, cwd = process.cwd()) {
 }
 
 /**
+ * Emit shell that locates a Lisa skill script before running it.
+ *
+ * A hardcoded `.claude/skills/...` path is wrong in exactly the place this
+ * workflow runs. Claude and Codex receive Lisa skills as an installed plugin
+ * living in the user's home directory, which is emphatically not part of a
+ * clone — and a scheduled run is always a fresh clone with no plugin install.
+ * So the one path that reliably exists on a runner is the npm package, at the
+ * version the project pins, which is the version its automation should run.
+ *
+ * The same candidate list the remote-env entrypoint uses, for the same reason:
+ * the in-checkout copies are cheapest and need nothing installed, and
+ * `node_modules` is the fallback that makes the plugin-delivered harnesses work
+ * at all.
+ * @param {string} skill Skill slug that owns the script.
+ * @param {string} script Script filename.
+ * @param {string[]} args Arguments appended to the invocation, one per line.
+ * @returns {string} Shell, indented for a workflow `run:` block.
+ */
+function runSkillScript(skill, script, args) {
+  const candidates = [
+    `.claude/skills/${skill}/scripts/${script}`,
+    `.agents/skills/${skill}/scripts/${script}`,
+    `.codex/skills/${skill}/scripts/${script}`,
+    `node_modules/@codyswann/lisa/plugins/lisa/skills/${skill}/scripts/${script}`,
+  ]
+    .map(candidate => `            "${candidate}"`)
+    .join(" \\\n");
+  const tail = args.map(arg => `            ${arg}`).join(" \\\n");
+  return `          runner=""
+          for candidate in \\
+${candidates}; do
+            if [ -f "$candidate" ]; then runner="$candidate"; break; fi
+          done
+          if [ -z "$runner" ]; then
+            echo "cannot find ${skill}/scripts/${script}" >&2
+            echo "Checked the agent skill directories and node_modules." >&2
+            echo "Lisa skills reach Claude and Codex as an installed plugin," >&2
+            echo "so node_modules is the only copy a runner ever has." >&2
+            exit 1
+          fi
+          node "$runner" \\
+${tail}`;
+}
+
+/**
  * Render the workflow YAML for one loop.
  *
  * Three choices here are load-bearing rather than stylistic.
@@ -112,7 +157,7 @@ export function renderWorkflow(name, loop) {
           ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          node .claude/skills/lisa-secrets-access/scripts/rotate-secret.mjs leases`;
+${runSkillScript("lisa-secrets-access", "rotate-secret.mjs", ["leases"])}`;
 
   const trigger = loop.enabled
     ? `  schedule:\n    - cron: '${loop.schedule}'\n  workflow_dispatch:`
@@ -172,9 +217,10 @@ jobs:
           ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          node .claude/skills/lisa-remote-dispatch/scripts/dispatch.mjs \\
-            'executionEnv=${loop.executionEnv} ${loop.payload ?? ""}' \\
-            --skill ${loop.skill ?? `lisa-${name}`}
+${runSkillScript("lisa-remote-dispatch", "dispatch.mjs", [
+  `'executionEnv=${loop.executionEnv} ${loop.payload ?? ""}'`,
+  `--skill ${loop.skill ?? `lisa-${name}`}`,
+])}
 
 ${rotation}
 `;

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -63,6 +63,51 @@ export function readAutomation(name, cwd = process.cwd()) {
 }
 
 /**
+ * Emit shell that locates a Lisa skill script before running it.
+ *
+ * A hardcoded `.claude/skills/...` path is wrong in exactly the place this
+ * workflow runs. Claude and Codex receive Lisa skills as an installed plugin
+ * living in the user's home directory, which is emphatically not part of a
+ * clone — and a scheduled run is always a fresh clone with no plugin install.
+ * So the one path that reliably exists on a runner is the npm package, at the
+ * version the project pins, which is the version its automation should run.
+ *
+ * The same candidate list the remote-env entrypoint uses, for the same reason:
+ * the in-checkout copies are cheapest and need nothing installed, and
+ * `node_modules` is the fallback that makes the plugin-delivered harnesses work
+ * at all.
+ * @param {string} skill Skill slug that owns the script.
+ * @param {string} script Script filename.
+ * @param {string[]} args Arguments appended to the invocation, one per line.
+ * @returns {string} Shell, indented for a workflow `run:` block.
+ */
+function runSkillScript(skill, script, args) {
+  const candidates = [
+    `.claude/skills/${skill}/scripts/${script}`,
+    `.agents/skills/${skill}/scripts/${script}`,
+    `.codex/skills/${skill}/scripts/${script}`,
+    `node_modules/@codyswann/lisa/plugins/lisa/skills/${skill}/scripts/${script}`,
+  ]
+    .map(candidate => `            "${candidate}"`)
+    .join(" \\\n");
+  const tail = args.map(arg => `            ${arg}`).join(" \\\n");
+  return `          runner=""
+          for candidate in \\
+${candidates}; do
+            if [ -f "$candidate" ]; then runner="$candidate"; break; fi
+          done
+          if [ -z "$runner" ]; then
+            echo "cannot find ${skill}/scripts/${script}" >&2
+            echo "Checked the agent skill directories and node_modules." >&2
+            echo "Lisa skills reach Claude and Codex as an installed plugin," >&2
+            echo "so node_modules is the only copy a runner ever has." >&2
+            exit 1
+          fi
+          node "$runner" \\
+${tail}`;
+}
+
+/**
  * Render the workflow YAML for one loop.
  *
  * Three choices here are load-bearing rather than stylistic.
@@ -112,7 +157,7 @@ export function renderWorkflow(name, loop) {
           ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          node .claude/skills/lisa-secrets-access/scripts/rotate-secret.mjs leases`;
+${runSkillScript("lisa-secrets-access", "rotate-secret.mjs", ["leases"])}`;
 
   const trigger = loop.enabled
     ? `  schedule:\n    - cron: '${loop.schedule}'\n  workflow_dispatch:`
@@ -172,9 +217,10 @@ jobs:
           ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          node .claude/skills/lisa-remote-dispatch/scripts/dispatch.mjs \\
-            'executionEnv=${loop.executionEnv} ${loop.payload ?? ""}' \\
-            --skill ${loop.skill ?? `lisa-${name}`}
+${runSkillScript("lisa-remote-dispatch", "dispatch.mjs", [
+  `'executionEnv=${loop.executionEnv} ${loop.payload ?? ""}'`,
+  `--skill ${loop.skill ?? `lisa-${name}`}`,
+])}
 
 ${rotation}
 `;

--- a/plugins/lisa/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/lisa/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -63,6 +63,51 @@ export function readAutomation(name, cwd = process.cwd()) {
 }
 
 /**
+ * Emit shell that locates a Lisa skill script before running it.
+ *
+ * A hardcoded `.claude/skills/...` path is wrong in exactly the place this
+ * workflow runs. Claude and Codex receive Lisa skills as an installed plugin
+ * living in the user's home directory, which is emphatically not part of a
+ * clone — and a scheduled run is always a fresh clone with no plugin install.
+ * So the one path that reliably exists on a runner is the npm package, at the
+ * version the project pins, which is the version its automation should run.
+ *
+ * The same candidate list the remote-env entrypoint uses, for the same reason:
+ * the in-checkout copies are cheapest and need nothing installed, and
+ * `node_modules` is the fallback that makes the plugin-delivered harnesses work
+ * at all.
+ * @param {string} skill Skill slug that owns the script.
+ * @param {string} script Script filename.
+ * @param {string[]} args Arguments appended to the invocation, one per line.
+ * @returns {string} Shell, indented for a workflow `run:` block.
+ */
+function runSkillScript(skill, script, args) {
+  const candidates = [
+    `.claude/skills/${skill}/scripts/${script}`,
+    `.agents/skills/${skill}/scripts/${script}`,
+    `.codex/skills/${skill}/scripts/${script}`,
+    `node_modules/@codyswann/lisa/plugins/lisa/skills/${skill}/scripts/${script}`,
+  ]
+    .map(candidate => `            "${candidate}"`)
+    .join(" \\\n");
+  const tail = args.map(arg => `            ${arg}`).join(" \\\n");
+  return `          runner=""
+          for candidate in \\
+${candidates}; do
+            if [ -f "$candidate" ]; then runner="$candidate"; break; fi
+          done
+          if [ -z "$runner" ]; then
+            echo "cannot find ${skill}/scripts/${script}" >&2
+            echo "Checked the agent skill directories and node_modules." >&2
+            echo "Lisa skills reach Claude and Codex as an installed plugin," >&2
+            echo "so node_modules is the only copy a runner ever has." >&2
+            exit 1
+          fi
+          node "$runner" \\
+${tail}`;
+}
+
+/**
  * Render the workflow YAML for one loop.
  *
  * Three choices here are load-bearing rather than stylistic.
@@ -112,7 +157,7 @@ export function renderWorkflow(name, loop) {
           ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          node .claude/skills/lisa-secrets-access/scripts/rotate-secret.mjs leases`;
+${runSkillScript("lisa-secrets-access", "rotate-secret.mjs", ["leases"])}`;
 
   const trigger = loop.enabled
     ? `  schedule:\n    - cron: '${loop.schedule}'\n  workflow_dispatch:`
@@ -172,9 +217,10 @@ jobs:
           ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          node .claude/skills/lisa-remote-dispatch/scripts/dispatch.mjs \\
-            'executionEnv=${loop.executionEnv} ${loop.payload ?? ""}' \\
-            --skill ${loop.skill ?? `lisa-${name}`}
+${runSkillScript("lisa-remote-dispatch", "dispatch.mjs", [
+  `'executionEnv=${loop.executionEnv} ${loop.payload ?? ""}'`,
+  `--skill ${loop.skill ?? `lisa-${name}`}`,
+])}
 
 ${rotation}
 `;

--- a/plugins/src/base/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/src/base/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -63,6 +63,51 @@ export function readAutomation(name, cwd = process.cwd()) {
 }
 
 /**
+ * Emit shell that locates a Lisa skill script before running it.
+ *
+ * A hardcoded `.claude/skills/...` path is wrong in exactly the place this
+ * workflow runs. Claude and Codex receive Lisa skills as an installed plugin
+ * living in the user's home directory, which is emphatically not part of a
+ * clone — and a scheduled run is always a fresh clone with no plugin install.
+ * So the one path that reliably exists on a runner is the npm package, at the
+ * version the project pins, which is the version its automation should run.
+ *
+ * The same candidate list the remote-env entrypoint uses, for the same reason:
+ * the in-checkout copies are cheapest and need nothing installed, and
+ * `node_modules` is the fallback that makes the plugin-delivered harnesses work
+ * at all.
+ * @param {string} skill Skill slug that owns the script.
+ * @param {string} script Script filename.
+ * @param {string[]} args Arguments appended to the invocation, one per line.
+ * @returns {string} Shell, indented for a workflow `run:` block.
+ */
+function runSkillScript(skill, script, args) {
+  const candidates = [
+    `.claude/skills/${skill}/scripts/${script}`,
+    `.agents/skills/${skill}/scripts/${script}`,
+    `.codex/skills/${skill}/scripts/${script}`,
+    `node_modules/@codyswann/lisa/plugins/lisa/skills/${skill}/scripts/${script}`,
+  ]
+    .map(candidate => `            "${candidate}"`)
+    .join(" \\\n");
+  const tail = args.map(arg => `            ${arg}`).join(" \\\n");
+  return `          runner=""
+          for candidate in \\
+${candidates}; do
+            if [ -f "$candidate" ]; then runner="$candidate"; break; fi
+          done
+          if [ -z "$runner" ]; then
+            echo "cannot find ${skill}/scripts/${script}" >&2
+            echo "Checked the agent skill directories and node_modules." >&2
+            echo "Lisa skills reach Claude and Codex as an installed plugin," >&2
+            echo "so node_modules is the only copy a runner ever has." >&2
+            exit 1
+          fi
+          node "$runner" \\
+${tail}`;
+}
+
+/**
  * Render the workflow YAML for one loop.
  *
  * Three choices here are load-bearing rather than stylistic.
@@ -112,7 +157,7 @@ export function renderWorkflow(name, loop) {
           ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          node .claude/skills/lisa-secrets-access/scripts/rotate-secret.mjs leases`;
+${runSkillScript("lisa-secrets-access", "rotate-secret.mjs", ["leases"])}`;
 
   const trigger = loop.enabled
     ? `  schedule:\n    - cron: '${loop.schedule}'\n  workflow_dispatch:`
@@ -172,9 +217,10 @@ jobs:
           ${bootstrap}: \${{ secrets.${bootstrap} }}
         run: |
           set -euo pipefail
-          node .claude/skills/lisa-remote-dispatch/scripts/dispatch.mjs \\
-            'executionEnv=${loop.executionEnv} ${loop.payload ?? ""}' \\
-            --skill ${loop.skill ?? `lisa-${name}`}
+${runSkillScript("lisa-remote-dispatch", "dispatch.mjs", [
+  `'executionEnv=${loop.executionEnv} ${loop.payload ?? ""}'`,
+  `--skill ${loop.skill ?? `lisa-${name}`}`,
+])}
 
 ${rotation}
 `;

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1101,7 +1101,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-automations/SKILL.md":
       "3ad004148a54571a50df90f23abec71e8510ef3ea3562ac812f8e2e11beb157a",
     "plugins/src/base/skills/lisa-setup-automations/scripts/generate-workflow.mjs":
-      "bfb3867cc62dd37d84367859e4d796edb7a0c046595b3e0194ddb0b6d3b63d61",
+      "f639c3f174378f0068b9c9d56e59b356c6da988730a1390c61e4348b4a4073ac",
     "plugins/src/base/skills/lisa-setup-confluence/SKILL.md":
       "e92d762dbdaeae671c3e52dfe8e10d40a10b606b5e050589181a3898649faedc",
     "plugins/src/base/skills/lisa-setup-github-repo/SKILL.md":

--- a/tests/unit/secrets/automation-workflow.test.ts
+++ b/tests/unit/secrets/automation-workflow.test.ts
@@ -139,3 +139,39 @@ describe("declaration validation", () => {
     expect(yaml).toContain("--skill lisa-repair-intake");
   });
 });
+
+describe("skill script resolution", () => {
+  // A scheduled run is always a fresh clone that has never installed a plugin,
+  // and Claude and Codex receive Lisa skills as an installed plugin living in
+  // the user's home directory. So a hardcoded `.claude/skills/...` path names
+  // a file that does not exist in the one place this workflow runs — the
+  // failure lands unattended, at 7am, in the half of the feature that exists
+  // so nobody has to be watching.
+  const scripts = [
+    ["lisa-remote-dispatch", "dispatch.mjs"],
+    ["lisa-secrets-access", "rotate-secret.mjs"],
+  ] as const;
+
+  it.each(scripts)("falls back to node_modules for %s", (skill, script) => {
+    expect(renderWorkflow("intake", LOOP)).toContain(
+      `node_modules/@codyswann/lisa/plugins/lisa/skills/${skill}/scripts/${script}`
+    );
+  });
+
+  it.each(scripts)("never invokes %s by a fixed path", (skill, script) => {
+    expect(renderWorkflow("intake", LOOP)).not.toContain(
+      `node .claude/skills/${skill}/scripts/${script}`
+    );
+  });
+
+  it("says which script it could not find rather than failing on node", () => {
+    // `node <missing>` reports a path with no hint that the cause is a delivery
+    // model rather than a broken checkout, which is the wrong thing to read at
+    // 7am with no session open.
+    const yaml = renderWorkflow("intake", LOOP);
+    expect(yaml).toContain(
+      "cannot find lisa-remote-dispatch/scripts/dispatch.mjs"
+    );
+    expect(yaml).toContain("node_modules is the only copy a runner ever has");
+  });
+});


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2203

The generated workflow invoked both skill scripts by hardcoded path:

```yaml
node .claude/skills/lisa-remote-dispatch/scripts/dispatch.mjs ...
node .claude/skills/lisa-secrets-access/scripts/rotate-secret.mjs leases
```

Neither exists on a runner. Claude and Codex receive Lisa skills as an **installed plugin** in the user’s home directory — not part of a clone — and a scheduled run is always a fresh clone that has never installed a plugin. Lisa’s own checkout has `.claude/skills/`, but not these skills; they live under `plugins/`.

So the scheduled path failed on its first run, in the half of the feature whose whole point is that nobody is watching it.

Both now resolve through the same candidate list `setup.sh` already uses: the three agent skill directories first (cheapest, nothing installed), then `node_modules/@codyswann/lisa/...`, which is the copy a runner actually has, at the version the project pins. A miss names the delivery model rather than letting `node` report a path — that message gets read at 7am with no session open.

## Proven by execution, not by inspection

Generated YAML parsed with a real parser, the `run:` block extracted and executed:

```
$ bash dispatch-step.sh            # with the package planted
RESOLVED-FROM-NODE-MODULES: executionEnv=claude-web  --skill lisa-verify

$ bash dispatch-step.sh            # with nothing present
cannot find lisa-remote-dispatch/scripts/dispatch.mjs
...
so node_modules is the only copy a runner ever has.
exit=1
```