### PR TITLE
Address each agent with the skill prefix it understands

### DIFF
--- a/plugins/lisa-agy/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa-agy/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -416,6 +416,28 @@ function resolveBearerToken(block) {
   }
 }
 
+/**
+ * How each agent spells "run this skill".
+ *
+ * Codex invokes a skill with `$name`, Claude with `/name`. The prefix is the
+ * whole invocation: get it wrong and the agent reads a sentence that merely
+ * mentions a skill rather than a command that runs one — and being a capable
+ * model it will often do *something*, which is worse than failing, because the
+ * run looks successful while executing none of the skill's contract.
+ *
+ * Nothing downstream catches it either. The routine accepts any text, so the
+ * dispatch succeeds, a session identifier is recorded, and the ledger says the
+ * work was handed off. Only reading the session shows otherwise.
+ * @param {string} surface Execution surface.
+ * @param {string} skill Skill slug, without a prefix.
+ * @param {string} rest The payload the skill is invoked with.
+ * @returns {string} The thin invocation to send.
+ */
+export function buildInvocation(surface, skill, rest) {
+  const prefix = surface === "claude-web" ? "/" : "$";
+  return `${prefix}${skill} ${rest}`.trim();
+}
+
 async function main() {
   const { skill, raw } = splitSkillFlag(process.argv.slice(2));
   const { params, rest } = parseInvocation(raw);
@@ -432,7 +454,7 @@ async function main() {
   // The invocation stays thin on purpose. Every durable instruction lives in
   // the repository-local skill, so an interactive run, a scheduled run, and a
   // recovery run all execute one contract.
-  const prompt = `$${skill} ${rest}`.trim();
+  const prompt = buildInvocation(surface, skill, rest);
 
   if (surface === "claude-web") {
     const { sessionId, url } = await dispatchClaudeWeb(block, prompt, rest);

--- a/plugins/lisa-copilot/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa-copilot/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -416,6 +416,28 @@ function resolveBearerToken(block) {
   }
 }
 
+/**
+ * How each agent spells "run this skill".
+ *
+ * Codex invokes a skill with `$name`, Claude with `/name`. The prefix is the
+ * whole invocation: get it wrong and the agent reads a sentence that merely
+ * mentions a skill rather than a command that runs one — and being a capable
+ * model it will often do *something*, which is worse than failing, because the
+ * run looks successful while executing none of the skill's contract.
+ *
+ * Nothing downstream catches it either. The routine accepts any text, so the
+ * dispatch succeeds, a session identifier is recorded, and the ledger says the
+ * work was handed off. Only reading the session shows otherwise.
+ * @param {string} surface Execution surface.
+ * @param {string} skill Skill slug, without a prefix.
+ * @param {string} rest The payload the skill is invoked with.
+ * @returns {string} The thin invocation to send.
+ */
+export function buildInvocation(surface, skill, rest) {
+  const prefix = surface === "claude-web" ? "/" : "$";
+  return `${prefix}${skill} ${rest}`.trim();
+}
+
 async function main() {
   const { skill, raw } = splitSkillFlag(process.argv.slice(2));
   const { params, rest } = parseInvocation(raw);
@@ -432,7 +454,7 @@ async function main() {
   // The invocation stays thin on purpose. Every durable instruction lives in
   // the repository-local skill, so an interactive run, a scheduled run, and a
   // recovery run all execute one contract.
-  const prompt = `$${skill} ${rest}`.trim();
+  const prompt = buildInvocation(surface, skill, rest);
 
   if (surface === "claude-web") {
     const { sessionId, url } = await dispatchClaudeWeb(block, prompt, rest);

--- a/plugins/lisa-cursor/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa-cursor/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -416,6 +416,28 @@ function resolveBearerToken(block) {
   }
 }
 
+/**
+ * How each agent spells "run this skill".
+ *
+ * Codex invokes a skill with `$name`, Claude with `/name`. The prefix is the
+ * whole invocation: get it wrong and the agent reads a sentence that merely
+ * mentions a skill rather than a command that runs one — and being a capable
+ * model it will often do *something*, which is worse than failing, because the
+ * run looks successful while executing none of the skill's contract.
+ *
+ * Nothing downstream catches it either. The routine accepts any text, so the
+ * dispatch succeeds, a session identifier is recorded, and the ledger says the
+ * work was handed off. Only reading the session shows otherwise.
+ * @param {string} surface Execution surface.
+ * @param {string} skill Skill slug, without a prefix.
+ * @param {string} rest The payload the skill is invoked with.
+ * @returns {string} The thin invocation to send.
+ */
+export function buildInvocation(surface, skill, rest) {
+  const prefix = surface === "claude-web" ? "/" : "$";
+  return `${prefix}${skill} ${rest}`.trim();
+}
+
 async function main() {
   const { skill, raw } = splitSkillFlag(process.argv.slice(2));
   const { params, rest } = parseInvocation(raw);
@@ -432,7 +454,7 @@ async function main() {
   // The invocation stays thin on purpose. Every durable instruction lives in
   // the repository-local skill, so an interactive run, a scheduled run, and a
   // recovery run all execute one contract.
-  const prompt = `$${skill} ${rest}`.trim();
+  const prompt = buildInvocation(surface, skill, rest);
 
   if (surface === "claude-web") {
     const { sessionId, url } = await dispatchClaudeWeb(block, prompt, rest);

--- a/plugins/lisa/.codex-plugin/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -416,6 +416,28 @@ function resolveBearerToken(block) {
   }
 }
 
+/**
+ * How each agent spells "run this skill".
+ *
+ * Codex invokes a skill with `$name`, Claude with `/name`. The prefix is the
+ * whole invocation: get it wrong and the agent reads a sentence that merely
+ * mentions a skill rather than a command that runs one — and being a capable
+ * model it will often do *something*, which is worse than failing, because the
+ * run looks successful while executing none of the skill's contract.
+ *
+ * Nothing downstream catches it either. The routine accepts any text, so the
+ * dispatch succeeds, a session identifier is recorded, and the ledger says the
+ * work was handed off. Only reading the session shows otherwise.
+ * @param {string} surface Execution surface.
+ * @param {string} skill Skill slug, without a prefix.
+ * @param {string} rest The payload the skill is invoked with.
+ * @returns {string} The thin invocation to send.
+ */
+export function buildInvocation(surface, skill, rest) {
+  const prefix = surface === "claude-web" ? "/" : "$";
+  return `${prefix}${skill} ${rest}`.trim();
+}
+
 async function main() {
   const { skill, raw } = splitSkillFlag(process.argv.slice(2));
   const { params, rest } = parseInvocation(raw);
@@ -432,7 +454,7 @@ async function main() {
   // The invocation stays thin on purpose. Every durable instruction lives in
   // the repository-local skill, so an interactive run, a scheduled run, and a
   // recovery run all execute one contract.
-  const prompt = `$${skill} ${rest}`.trim();
+  const prompt = buildInvocation(surface, skill, rest);
 
   if (surface === "claude-web") {
     const { sessionId, url } = await dispatchClaudeWeb(block, prompt, rest);

--- a/plugins/lisa/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -416,6 +416,28 @@ function resolveBearerToken(block) {
   }
 }
 
+/**
+ * How each agent spells "run this skill".
+ *
+ * Codex invokes a skill with `$name`, Claude with `/name`. The prefix is the
+ * whole invocation: get it wrong and the agent reads a sentence that merely
+ * mentions a skill rather than a command that runs one — and being a capable
+ * model it will often do *something*, which is worse than failing, because the
+ * run looks successful while executing none of the skill's contract.
+ *
+ * Nothing downstream catches it either. The routine accepts any text, so the
+ * dispatch succeeds, a session identifier is recorded, and the ledger says the
+ * work was handed off. Only reading the session shows otherwise.
+ * @param {string} surface Execution surface.
+ * @param {string} skill Skill slug, without a prefix.
+ * @param {string} rest The payload the skill is invoked with.
+ * @returns {string} The thin invocation to send.
+ */
+export function buildInvocation(surface, skill, rest) {
+  const prefix = surface === "claude-web" ? "/" : "$";
+  return `${prefix}${skill} ${rest}`.trim();
+}
+
 async function main() {
   const { skill, raw } = splitSkillFlag(process.argv.slice(2));
   const { params, rest } = parseInvocation(raw);
@@ -432,7 +454,7 @@ async function main() {
   // The invocation stays thin on purpose. Every durable instruction lives in
   // the repository-local skill, so an interactive run, a scheduled run, and a
   // recovery run all execute one contract.
-  const prompt = `$${skill} ${rest}`.trim();
+  const prompt = buildInvocation(surface, skill, rest);
 
   if (surface === "claude-web") {
     const { sessionId, url } = await dispatchClaudeWeb(block, prompt, rest);

--- a/plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -416,6 +416,28 @@ function resolveBearerToken(block) {
   }
 }
 
+/**
+ * How each agent spells "run this skill".
+ *
+ * Codex invokes a skill with `$name`, Claude with `/name`. The prefix is the
+ * whole invocation: get it wrong and the agent reads a sentence that merely
+ * mentions a skill rather than a command that runs one — and being a capable
+ * model it will often do *something*, which is worse than failing, because the
+ * run looks successful while executing none of the skill's contract.
+ *
+ * Nothing downstream catches it either. The routine accepts any text, so the
+ * dispatch succeeds, a session identifier is recorded, and the ledger says the
+ * work was handed off. Only reading the session shows otherwise.
+ * @param {string} surface Execution surface.
+ * @param {string} skill Skill slug, without a prefix.
+ * @param {string} rest The payload the skill is invoked with.
+ * @returns {string} The thin invocation to send.
+ */
+export function buildInvocation(surface, skill, rest) {
+  const prefix = surface === "claude-web" ? "/" : "$";
+  return `${prefix}${skill} ${rest}`.trim();
+}
+
 async function main() {
   const { skill, raw } = splitSkillFlag(process.argv.slice(2));
   const { params, rest } = parseInvocation(raw);
@@ -432,7 +454,7 @@ async function main() {
   // The invocation stays thin on purpose. Every durable instruction lives in
   // the repository-local skill, so an interactive run, a scheduled run, and a
   // recovery run all execute one contract.
-  const prompt = `$${skill} ${rest}`.trim();
+  const prompt = buildInvocation(surface, skill, rest);
 
   if (surface === "claude-web") {
     const { sessionId, url } = await dispatchClaudeWeb(block, prompt, rest);

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1055,7 +1055,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-remote-dispatch/SKILL.md":
       "2cc999d2c3b61b10aabb849e0833fd58edb444c5013c05108dd58e5d7d60c4ba",
     "plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs":
-      "6ce559964964c65154d2105a017c751bba086dcb8b4ea209ea42ce7b4fdb7d63",
+      "c473e8eddf0fd5f220a5ea7ff9eb92f5482cfb2893e77edce59acc36671418a3",
     "plugins/src/base/skills/lisa-repair-intake/SKILL.md":
       "4f85ac1381631e9f250d9cf3239baba633ae0df9ba1959f8835ed662592e2d77",
     "plugins/src/base/skills/lisa-reproduce-bug/SKILL.md":

--- a/tests/unit/secrets/remote-dispatch-claude-web.test.ts
+++ b/tests/unit/secrets/remote-dispatch-claude-web.test.ts
@@ -21,6 +21,7 @@ import {
   EXECUTION_ENVS,
   assertPreconditions,
   dispatchClaudeWeb,
+  buildInvocation,
   readFireResponse,
   resolveExecutionEnv,
 } from "../../../plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs";
@@ -230,5 +231,34 @@ describe("fire response", () => {
   it("tolerates a missing url without losing the identifier", () => {
     const body = JSON.stringify({ claude_code_session_id: SESSION_ID });
     expect(readFireResponse(body)).toEqual({ sessionId: SESSION_ID, url: "" });
+  });
+});
+
+describe("skill invocation syntax", () => {
+  // The prefix IS the invocation. Codex runs a skill with `$name`, Claude with
+  // `/name`, and sending one agent the other's spelling produces a sentence
+  // that mentions a skill rather than a command that runs one.
+  //
+  // Nothing downstream catches that. The routine accepts any text, so the
+  // dispatch succeeds, a session identifier is recorded, and the ledger says
+  // the work was handed off — while the session executes none of the skill's
+  // contract. Being a capable model it will usually do *something*, which is
+  // worse than failing outright, because it leaves no signal to act on.
+  it("addresses a Claude session with the prefix Claude understands", () => {
+    expect(buildInvocation(CLAUDE_WEB, "lisa-implement", "org/repo#7")).toBe(
+      "/lisa-implement org/repo#7"
+    );
+  });
+
+  it("still addresses Codex with its own prefix", () => {
+    expect(buildInvocation("codex-cloud", "lisa-implement", "org/repo#7")).toBe(
+      "$lisa-implement org/repo#7"
+    );
+  });
+
+  it("emits a bare command when there is no payload", () => {
+    // The trailing space is trimmed rather than sent verbatim. Harmless on one
+    // agent is not a reason to rely on it on the other.
+    expect(buildInvocation(CLAUDE_WEB, "lisa-verify", "")).toBe("/lisa-verify");
   });
 });


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2205

The dispatcher built one invocation for every surface:

```js
const prompt = `$${skill} ${rest}`.trim();
```

`$name` is how **Codex** invokes a skill. Claude uses `/name`. So every `claude-web` dispatch sent a sentence that *mentions* a skill rather than a command that *runs* one.

Found the only way it can be found — by dispatching a real work item (`session_01RpFPTr69NJ439bDZzhgEAT`, issue #2202) and watching nothing happen.

## Why it is worse than a plain failure

Nothing downstream contradicts it. The routine accepts any text, so the request returns 200, a session identifier comes back, the ledger records the handoff, and the skill reports success. The session then executes none of the skill's contract — and being a capable model it does *something* anyway, so there is no signal to act on. The prefix is the entire difference between a dispatch and a suggestion.

## Change

`buildInvocation(surface, skill, rest)` picks the prefix by surface. Both spellings are pinned by tests, including that the trailing space is trimmed when a skill is dispatched with no payload — harmless on one agent is not a reason to rely on it on the other.

```
/lisa-implement CodySwannGT/lisa#2202     <- claude-web
$lisa-implement CodySwannGT/lisa#2202     <- codex-cloud
/lisa-verify                              <- no payload
```

`tests/unit/secrets` — 219 passed.
