### PR TITLE
fix(remote-env): prepare every checkout, not whichever one sorts first

### DIFF
--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
@@ -13,8 +13,8 @@ Prepare a remote surface so a host project can execute there. Today that means *
 The remote environment's own configuration fields stay **one line into the repository**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
-maintenance: for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
+setup:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+maintenance: n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
 ```
 
 **That line is identical for every project AND every surface.** Nothing in it names the
@@ -34,10 +34,18 @@ and neither mentions `$HOME`. An earlier version of this field used
 the checkout is not under `$HOME` at all: the glob matches nothing and bash reports
 `No such file or directory` for a path still containing a literal `*`.
 
-`exec` on the first hit means no subshell and no `ls` output to parse, and the explicit
-`exit 1` means a missing entrypoint says so rather than the field silently succeeding. The
-script then anchors itself on the repository root, so it behaves the same however it was
-reached.
+**Every** match is prepared, not the first. A Claude Code web environment can hold more than
+one checkout, and stopping at the first glob hit would prepare whichever repository sorts
+first and silently ignore the rest — arbitrary rather than merely limited. Each script
+anchors itself on its own repository root, and each project's secrets land under its own
+`secrets.namespace`, so preparing several is well defined rather than a collision.
+
+The exit status is the **first failure**, and every checkout is still attempted: one broken
+repository must not hide the state of the others, and it must not report success either.
+
+The explicit `exit 1` on `n=0` means a missing entrypoint says so rather than the field
+silently succeeding — a `for` loop over a glob that matches nothing otherwise exits `0`,
+which is the quiet failure this whole section exists to avoid.
 
 They are the same command. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
 
@@ -156,8 +164,8 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
-Maintenance:       for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
+Setup script:      n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+Maintenance:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
                    (identical for every project — the script finds the
                    checkout and installs from the committed lockfile)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -308,20 +308,29 @@ export function installAssets(cwd = process.cwd()) {
  * at all — so a `$HOME` glob matched nothing there and bash was handed a path
  * still containing a literal asterisk.
  *
- * Both candidates are therefore tried relative to cwd. `exec` on the first hit
- * avoids a subshell and avoids parsing `ls`; the explicit `exit 1` means a
- * missing entrypoint says so rather than the field quietly succeeding. The
- * script then anchors itself on the repository root and installs dependencies
- * from whichever lockfile the project commits.
+ * Both candidates are therefore tried relative to cwd, and EVERY match is
+ * prepared rather than the first. A Claude Code web environment can hold more
+ * than one checkout, so stopping at the first hit would prepare whichever
+ * repository sorts first and silently ignore the rest — arbitrary rather than
+ * merely limited. Each script anchors itself on its own repository root and
+ * each project materializes under its own `secrets.namespace`, so preparing
+ * several is well defined rather than a collision.
+ *
+ * The status is the first failure and every checkout is still attempted: one
+ * broken repository must neither hide the others nor report success. The
+ * explicit `exit 1` on no matches matters because a `for` loop over a glob that
+ * matches nothing otherwise exits 0 — the quiet success this guards against.
  *
  * A field that named the repository and package manager was a string a human
  * had to get right, in a settings box with no review, no version history and no
  * test — and the logic it encoded belongs in a file that has all three.
  */
 export const SETUP_FIELD =
+  "n=0; rc=0; " +
   "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; " +
-  'do [ -f "$f" ] && exec bash "$f"; done; ' +
-  'echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1';
+  'do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; ' +
+  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; ' +
+  'exit "$rc"';
 
 /**
  * The settings block that wires the session-start hook into a repository.

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
@@ -13,8 +13,8 @@ Prepare a remote surface so a host project can execute there. Today that means *
 The remote environment's own configuration fields stay **one line into the repository**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
-maintenance: for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
+setup:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+maintenance: n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
 ```
 
 **That line is identical for every project AND every surface.** Nothing in it names the
@@ -34,10 +34,18 @@ and neither mentions `$HOME`. An earlier version of this field used
 the checkout is not under `$HOME` at all: the glob matches nothing and bash reports
 `No such file or directory` for a path still containing a literal `*`.
 
-`exec` on the first hit means no subshell and no `ls` output to parse, and the explicit
-`exit 1` means a missing entrypoint says so rather than the field silently succeeding. The
-script then anchors itself on the repository root, so it behaves the same however it was
-reached.
+**Every** match is prepared, not the first. A Claude Code web environment can hold more than
+one checkout, and stopping at the first glob hit would prepare whichever repository sorts
+first and silently ignore the rest — arbitrary rather than merely limited. Each script
+anchors itself on its own repository root, and each project's secrets land under its own
+`secrets.namespace`, so preparing several is well defined rather than a collision.
+
+The exit status is the **first failure**, and every checkout is still attempted: one broken
+repository must not hide the state of the others, and it must not report success either.
+
+The explicit `exit 1` on `n=0` means a missing entrypoint says so rather than the field
+silently succeeding — a `for` loop over a glob that matches nothing otherwise exits `0`,
+which is the quiet failure this whole section exists to avoid.
 
 They are the same command. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
 
@@ -156,8 +164,8 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
-Maintenance:       for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
+Setup script:      n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+Maintenance:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
                    (identical for every project — the script finds the
                    checkout and installs from the committed lockfile)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -308,20 +308,29 @@ export function installAssets(cwd = process.cwd()) {
  * at all — so a `$HOME` glob matched nothing there and bash was handed a path
  * still containing a literal asterisk.
  *
- * Both candidates are therefore tried relative to cwd. `exec` on the first hit
- * avoids a subshell and avoids parsing `ls`; the explicit `exit 1` means a
- * missing entrypoint says so rather than the field quietly succeeding. The
- * script then anchors itself on the repository root and installs dependencies
- * from whichever lockfile the project commits.
+ * Both candidates are therefore tried relative to cwd, and EVERY match is
+ * prepared rather than the first. A Claude Code web environment can hold more
+ * than one checkout, so stopping at the first hit would prepare whichever
+ * repository sorts first and silently ignore the rest — arbitrary rather than
+ * merely limited. Each script anchors itself on its own repository root and
+ * each project materializes under its own `secrets.namespace`, so preparing
+ * several is well defined rather than a collision.
+ *
+ * The status is the first failure and every checkout is still attempted: one
+ * broken repository must neither hide the others nor report success. The
+ * explicit `exit 1` on no matches matters because a `for` loop over a glob that
+ * matches nothing otherwise exits 0 — the quiet success this guards against.
  *
  * A field that named the repository and package manager was a string a human
  * had to get right, in a settings box with no review, no version history and no
  * test — and the logic it encoded belongs in a file that has all three.
  */
 export const SETUP_FIELD =
+  "n=0; rc=0; " +
   "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; " +
-  'do [ -f "$f" ] && exec bash "$f"; done; ' +
-  'echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1';
+  'do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; ' +
+  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; ' +
+  'exit "$rc"';
 
 /**
  * The settings block that wires the session-start hook into a repository.

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
@@ -13,8 +13,8 @@ Prepare a remote surface so a host project can execute there. Today that means *
 The remote environment's own configuration fields stay **one line into the repository**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
-maintenance: for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
+setup:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+maintenance: n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
 ```
 
 **That line is identical for every project AND every surface.** Nothing in it names the
@@ -34,10 +34,18 @@ and neither mentions `$HOME`. An earlier version of this field used
 the checkout is not under `$HOME` at all: the glob matches nothing and bash reports
 `No such file or directory` for a path still containing a literal `*`.
 
-`exec` on the first hit means no subshell and no `ls` output to parse, and the explicit
-`exit 1` means a missing entrypoint says so rather than the field silently succeeding. The
-script then anchors itself on the repository root, so it behaves the same however it was
-reached.
+**Every** match is prepared, not the first. A Claude Code web environment can hold more than
+one checkout, and stopping at the first glob hit would prepare whichever repository sorts
+first and silently ignore the rest — arbitrary rather than merely limited. Each script
+anchors itself on its own repository root, and each project's secrets land under its own
+`secrets.namespace`, so preparing several is well defined rather than a collision.
+
+The exit status is the **first failure**, and every checkout is still attempted: one broken
+repository must not hide the state of the others, and it must not report success either.
+
+The explicit `exit 1` on `n=0` means a missing entrypoint says so rather than the field
+silently succeeding — a `for` loop over a glob that matches nothing otherwise exits `0`,
+which is the quiet failure this whole section exists to avoid.
 
 They are the same command. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
 
@@ -156,8 +164,8 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
-Maintenance:       for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
+Setup script:      n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+Maintenance:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
                    (identical for every project — the script finds the
                    checkout and installs from the committed lockfile)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -308,20 +308,29 @@ export function installAssets(cwd = process.cwd()) {
  * at all — so a `$HOME` glob matched nothing there and bash was handed a path
  * still containing a literal asterisk.
  *
- * Both candidates are therefore tried relative to cwd. `exec` on the first hit
- * avoids a subshell and avoids parsing `ls`; the explicit `exit 1` means a
- * missing entrypoint says so rather than the field quietly succeeding. The
- * script then anchors itself on the repository root and installs dependencies
- * from whichever lockfile the project commits.
+ * Both candidates are therefore tried relative to cwd, and EVERY match is
+ * prepared rather than the first. A Claude Code web environment can hold more
+ * than one checkout, so stopping at the first hit would prepare whichever
+ * repository sorts first and silently ignore the rest — arbitrary rather than
+ * merely limited. Each script anchors itself on its own repository root and
+ * each project materializes under its own `secrets.namespace`, so preparing
+ * several is well defined rather than a collision.
+ *
+ * The status is the first failure and every checkout is still attempted: one
+ * broken repository must neither hide the others nor report success. The
+ * explicit `exit 1` on no matches matters because a `for` loop over a glob that
+ * matches nothing otherwise exits 0 — the quiet success this guards against.
  *
  * A field that named the repository and package manager was a string a human
  * had to get right, in a settings box with no review, no version history and no
  * test — and the logic it encoded belongs in a file that has all three.
  */
 export const SETUP_FIELD =
+  "n=0; rc=0; " +
   "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; " +
-  'do [ -f "$f" ] && exec bash "$f"; done; ' +
-  'echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1';
+  'do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; ' +
+  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; ' +
+  'exit "$rc"';
 
 /**
  * The settings block that wires the session-start hook into a repository.

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
@@ -13,8 +13,8 @@ Prepare a remote surface so a host project can execute there. Today that means *
 The remote environment's own configuration fields stay **one line into the repository**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
-maintenance: for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
+setup:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+maintenance: n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
 ```
 
 **That line is identical for every project AND every surface.** Nothing in it names the
@@ -34,10 +34,18 @@ and neither mentions `$HOME`. An earlier version of this field used
 the checkout is not under `$HOME` at all: the glob matches nothing and bash reports
 `No such file or directory` for a path still containing a literal `*`.
 
-`exec` on the first hit means no subshell and no `ls` output to parse, and the explicit
-`exit 1` means a missing entrypoint says so rather than the field silently succeeding. The
-script then anchors itself on the repository root, so it behaves the same however it was
-reached.
+**Every** match is prepared, not the first. A Claude Code web environment can hold more than
+one checkout, and stopping at the first glob hit would prepare whichever repository sorts
+first and silently ignore the rest — arbitrary rather than merely limited. Each script
+anchors itself on its own repository root, and each project's secrets land under its own
+`secrets.namespace`, so preparing several is well defined rather than a collision.
+
+The exit status is the **first failure**, and every checkout is still attempted: one broken
+repository must not hide the state of the others, and it must not report success either.
+
+The explicit `exit 1` on `n=0` means a missing entrypoint says so rather than the field
+silently succeeding — a `for` loop over a glob that matches nothing otherwise exits `0`,
+which is the quiet failure this whole section exists to avoid.
 
 They are the same command. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
 
@@ -156,8 +164,8 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
-Maintenance:       for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
+Setup script:      n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+Maintenance:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
                    (identical for every project — the script finds the
                    checkout and installs from the committed lockfile)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -308,20 +308,29 @@ export function installAssets(cwd = process.cwd()) {
  * at all — so a `$HOME` glob matched nothing there and bash was handed a path
  * still containing a literal asterisk.
  *
- * Both candidates are therefore tried relative to cwd. `exec` on the first hit
- * avoids a subshell and avoids parsing `ls`; the explicit `exit 1` means a
- * missing entrypoint says so rather than the field quietly succeeding. The
- * script then anchors itself on the repository root and installs dependencies
- * from whichever lockfile the project commits.
+ * Both candidates are therefore tried relative to cwd, and EVERY match is
+ * prepared rather than the first. A Claude Code web environment can hold more
+ * than one checkout, so stopping at the first hit would prepare whichever
+ * repository sorts first and silently ignore the rest — arbitrary rather than
+ * merely limited. Each script anchors itself on its own repository root and
+ * each project materializes under its own `secrets.namespace`, so preparing
+ * several is well defined rather than a collision.
+ *
+ * The status is the first failure and every checkout is still attempted: one
+ * broken repository must neither hide the others nor report success. The
+ * explicit `exit 1` on no matches matters because a `for` loop over a glob that
+ * matches nothing otherwise exits 0 — the quiet success this guards against.
  *
  * A field that named the repository and package manager was a string a human
  * had to get right, in a settings box with no review, no version history and no
  * test — and the logic it encoded belongs in a file that has all three.
  */
 export const SETUP_FIELD =
+  "n=0; rc=0; " +
   "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; " +
-  'do [ -f "$f" ] && exec bash "$f"; done; ' +
-  'echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1';
+  'do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; ' +
+  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; ' +
+  'exit "$rc"';
 
 /**
  * The settings block that wires the session-start hook into a repository.

--- a/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
@@ -13,8 +13,8 @@ Prepare a remote surface so a host project can execute there. Today that means *
 The remote environment's own configuration fields stay **one line into the repository**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
-maintenance: for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
+setup:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+maintenance: n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
 ```
 
 **That line is identical for every project AND every surface.** Nothing in it names the
@@ -34,10 +34,18 @@ and neither mentions `$HOME`. An earlier version of this field used
 the checkout is not under `$HOME` at all: the glob matches nothing and bash reports
 `No such file or directory` for a path still containing a literal `*`.
 
-`exec` on the first hit means no subshell and no `ls` output to parse, and the explicit
-`exit 1` means a missing entrypoint says so rather than the field silently succeeding. The
-script then anchors itself on the repository root, so it behaves the same however it was
-reached.
+**Every** match is prepared, not the first. A Claude Code web environment can hold more than
+one checkout, and stopping at the first glob hit would prepare whichever repository sorts
+first and silently ignore the rest — arbitrary rather than merely limited. Each script
+anchors itself on its own repository root, and each project's secrets land under its own
+`secrets.namespace`, so preparing several is well defined rather than a collision.
+
+The exit status is the **first failure**, and every checkout is still attempted: one broken
+repository must not hide the state of the others, and it must not report success either.
+
+The explicit `exit 1` on `n=0` means a missing entrypoint says so rather than the field
+silently succeeding — a `for` loop over a glob that matches nothing otherwise exits `0`,
+which is the quiet failure this whole section exists to avoid.
 
 They are the same command. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
 
@@ -156,8 +164,8 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
-Maintenance:       for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
+Setup script:      n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+Maintenance:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
                    (identical for every project — the script finds the
                    checkout and installs from the committed lockfile)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -308,20 +308,29 @@ export function installAssets(cwd = process.cwd()) {
  * at all — so a `$HOME` glob matched nothing there and bash was handed a path
  * still containing a literal asterisk.
  *
- * Both candidates are therefore tried relative to cwd. `exec` on the first hit
- * avoids a subshell and avoids parsing `ls`; the explicit `exit 1` means a
- * missing entrypoint says so rather than the field quietly succeeding. The
- * script then anchors itself on the repository root and installs dependencies
- * from whichever lockfile the project commits.
+ * Both candidates are therefore tried relative to cwd, and EVERY match is
+ * prepared rather than the first. A Claude Code web environment can hold more
+ * than one checkout, so stopping at the first hit would prepare whichever
+ * repository sorts first and silently ignore the rest — arbitrary rather than
+ * merely limited. Each script anchors itself on its own repository root and
+ * each project materializes under its own `secrets.namespace`, so preparing
+ * several is well defined rather than a collision.
+ *
+ * The status is the first failure and every checkout is still attempted: one
+ * broken repository must neither hide the others nor report success. The
+ * explicit `exit 1` on no matches matters because a `for` loop over a glob that
+ * matches nothing otherwise exits 0 — the quiet success this guards against.
  *
  * A field that named the repository and package manager was a string a human
  * had to get right, in a settings box with no review, no version history and no
  * test — and the logic it encoded belongs in a file that has all three.
  */
 export const SETUP_FIELD =
+  "n=0; rc=0; " +
   "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; " +
-  'do [ -f "$f" ] && exec bash "$f"; done; ' +
-  'echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1';
+  'do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; ' +
+  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; ' +
+  'exit "$rc"';
 
 /**
  * The settings block that wires the session-start hook into a repository.

--- a/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
@@ -13,8 +13,8 @@ Prepare a remote surface so a host project can execute there. Today that means *
 The remote environment's own configuration fields stay **one line into the repository**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
-maintenance: for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
+setup:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+maintenance: n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
 ```
 
 **That line is identical for every project AND every surface.** Nothing in it names the
@@ -34,10 +34,18 @@ and neither mentions `$HOME`. An earlier version of this field used
 the checkout is not under `$HOME` at all: the glob matches nothing and bash reports
 `No such file or directory` for a path still containing a literal `*`.
 
-`exec` on the first hit means no subshell and no `ls` output to parse, and the explicit
-`exit 1` means a missing entrypoint says so rather than the field silently succeeding. The
-script then anchors itself on the repository root, so it behaves the same however it was
-reached.
+**Every** match is prepared, not the first. A Claude Code web environment can hold more than
+one checkout, and stopping at the first glob hit would prepare whichever repository sorts
+first and silently ignore the rest — arbitrary rather than merely limited. Each script
+anchors itself on its own repository root, and each project's secrets land under its own
+`secrets.namespace`, so preparing several is well defined rather than a collision.
+
+The exit status is the **first failure**, and every checkout is still attempted: one broken
+repository must not hide the state of the others, and it must not report success either.
+
+The explicit `exit 1` on `n=0` means a missing entrypoint says so rather than the field
+silently succeeding — a `for` loop over a glob that matches nothing otherwise exits `0`,
+which is the quiet failure this whole section exists to avoid.
 
 They are the same command. A container may be built fresh or resumed from cache; every step is idempotent and version-aware, so running it twice is correct, and running it on resume is what picks up a rotated value, an edited note, or a changed version pin.
 
@@ -156,8 +164,8 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
-Maintenance:       for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] && exec bash "$f"; done; echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1
+Setup script:      n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+Maintenance:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
                    (identical for every project — the script finds the
                    checkout and installs from the committed lockfile)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -308,20 +308,29 @@ export function installAssets(cwd = process.cwd()) {
  * at all — so a `$HOME` glob matched nothing there and bash was handed a path
  * still containing a literal asterisk.
  *
- * Both candidates are therefore tried relative to cwd. `exec` on the first hit
- * avoids a subshell and avoids parsing `ls`; the explicit `exit 1` means a
- * missing entrypoint says so rather than the field quietly succeeding. The
- * script then anchors itself on the repository root and installs dependencies
- * from whichever lockfile the project commits.
+ * Both candidates are therefore tried relative to cwd, and EVERY match is
+ * prepared rather than the first. A Claude Code web environment can hold more
+ * than one checkout, so stopping at the first hit would prepare whichever
+ * repository sorts first and silently ignore the rest — arbitrary rather than
+ * merely limited. Each script anchors itself on its own repository root and
+ * each project materializes under its own `secrets.namespace`, so preparing
+ * several is well defined rather than a collision.
+ *
+ * The status is the first failure and every checkout is still attempted: one
+ * broken repository must neither hide the others nor report success. The
+ * explicit `exit 1` on no matches matters because a `for` loop over a glob that
+ * matches nothing otherwise exits 0 — the quiet success this guards against.
  *
  * A field that named the repository and package manager was a string a human
  * had to get right, in a settings box with no review, no version history and no
  * test — and the logic it encoded belongs in a file that has all three.
  */
 export const SETUP_FIELD =
+  "n=0; rc=0; " +
   "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; " +
-  'do [ -f "$f" ] && exec bash "$f"; done; ' +
-  'echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1';
+  'do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; ' +
+  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; ' +
+  'exit "$rc"';
 
 /**
  * The settings block that wires the session-start hook into a repository.

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1119,13 +1119,13 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md":
       "80fbf157f9c562c033886c25a99b37356602edd9e61cd2d492f339769ddcf97e",
     "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md":
-      "e6530485e2564f35592a28bc5e547d185a38bf2a061feb210d533304acdc5cc2",
+      "4fe124678cfc2b37188370af3b4e16895fcbad4d4b6f13b0fc7ac02bd99b0d26",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh":
       "6e3871ec2f8d56b8ebb85376ebdd3956f3ed8fa4f7b278c2ed90ca9b8845897c",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "7f7cf8a2248dbaa31f2f039fdaf147d083427a21633f7cf06ad612f38344d6c1",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "c3fedb3f9cc50e706c197129cfe69baf705a96ab93194152c6d2f952f2d6d3b7",
+      "e8f1e74dd29104dc880eb2540024549d18d2a9c958b2b6fce0610ab0afd55cbb",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
       "ff66d33ba41a068d09be18f81ac68988238c2afa1d4e3733ae906b73eea74324",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":

--- a/tests/unit/secrets/remote-env-setup-field.test.ts
+++ b/tests/unit/secrets/remote-env-setup-field.test.ts
@@ -31,6 +31,10 @@ const SKILL = "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md";
 /** Where the entrypoint lives inside a checkout. */
 const ENTRYPOINT = "scripts/lisa-remote-env/setup.sh";
 
+/** Markers for the two checkouts in the multi-repo fixtures, named to sort apart. */
+const ALPHA = "FOUND-alpha";
+const ZULU = "FOUND-zulu";
+
 /** Absolute, so the interpreter is never resolved through a writeable PATH. */
 const BASH = "/bin/bash";
 
@@ -110,6 +114,48 @@ describe("documented remote-env setup field", () => {
     // on Claude Code web and wrong on Codex Cloud, where the checkout lives at
     // /workspace/<repo> and is not under $HOME at all.
     expect(documentedSetupField()).not.toContain("$HOME");
+  });
+
+  it("prepares EVERY checkout, not whichever one sorts first", () => {
+    // A Claude Code web environment can hold more than one repository. Stopping
+    // at the first glob hit would prepare one chosen alphabetically and ignore
+    // the rest — arbitrary, not merely limited.
+    const home = path.join(temporary, "home");
+    mkdirSync(home, { recursive: true });
+    checkout(path.join(home, "alpha"), ALPHA);
+    checkout(path.join(home, "zulu"), ZULU);
+
+    const out = runField(home);
+    expect(out).toContain(ALPHA);
+    expect(out).toContain(ZULU);
+  });
+
+  it("reports a failure in one checkout without skipping the others", () => {
+    const home = path.join(temporary, "home");
+    mkdirSync(home, { recursive: true });
+    checkout(path.join(home, "alpha"), ALPHA);
+
+    // A broken second repository: must not hide the first, must not pass.
+    const broken = path.join(home, "zulu", path.dirname(ENTRYPOINT));
+    mkdirSync(broken, { recursive: true });
+    writeFileSync(
+      path.join(home, "zulu", ENTRYPOINT),
+      `echo ${ZULU}\nexit 3\n`
+    );
+
+    let status = 0;
+    let output = "";
+    try {
+      output = runField(home);
+    } catch (error) {
+      const failure = error as { status?: number; stdout?: string };
+      status = failure.status ?? 0;
+      output = failure.stdout ?? "";
+    }
+
+    expect(status).not.toBe(0);
+    expect(output).toContain(ALPHA);
+    expect(output).toContain(ZULU);
   });
 
   it("fails loudly when no entrypoint exists, rather than succeeding silently", () => {


### PR DESCRIPTION
Closes #2206. Follow-up to #2197, raised while setting this field for a Claude Code web environment as well as Codex Cloud.

## The bug

The field `exec`s on the first glob hit. A Claude Code web environment can hold **more than one checkout**, so that prepares whichever repository sorts first alphabetically and silently ignores the rest.

It fails in the direction that looks like success: exit `0`, having prepared the wrong repository. Codex Cloud is single-checkout, so this only bites on the surface the generic field was introduced to *also* serve.

## The fix

Prepare every match.

That is well defined rather than a collision — each script anchors on its own repository root, and each project materializes under its own `secrets.namespace`.

The status is the **first failure** and every checkout is still attempted: one broken repository must neither hide the others nor report success. The explicit `exit 1` on no matches stays load-bearing, because a `for` loop over a glob matching nothing otherwise exits `0` — the quiet success this section exists to prevent.

## The drift test earned its keep

I changed `SKILL.md` and not the emitted `SETUP_FIELD`, and the test added upstream caught them disagreeing immediately — which is exactly what it is for. Both are updated here.

## Evidence

Proven to bite rather than assumed. Reverting to exec-on-first-hit:

```
× is the same line the documentation tells operators to paste
× prepares EVERY checkout, not whichever one sorts first
× reports a failure in one checkout without skipping the others
  Tests  3 failed | 4 passed (7)
```

Restored: `7 passed`.

```
Test Files  14 passed (14)
     Tests  218 passed (218)
```

Plugin artifacts regenerated, evidence manifest refreshed, eslint clean — the duplicate-literal findings on the new tests are fixed by extracting constants rather than suppressed.

🤖 Generated with Claude Code