### PR TITLE
Stop a dashed executionEnv from silently running the work locally

### DIFF
--- a/plugins/lisa-agy/skills/lisa-remote-dispatch/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-remote-dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-remote-dispatch
-description: "Route one unit of work to a remote execution surface. Reads the executionEnv parameter (local by default, codex-cloud today), verifies the environment is provisioned and bound to this repository, submits a thin skill invocation, records the task identifier to .lisa/remote-dispatch.json, and exits without polling. Routing only — the remote runs the identical skill from the identical repository. Composable and inline: other skills invoke it via the Skill tool rather than users calling it directly."
+description: "Route one unit of work to a remote execution surface. Reads the executionEnv parameter (local by default, codex-cloud or claude-web today), verifies the environment is provisioned and bound to this repository, submits a thin skill invocation, records the task identifier to .lisa/remote-dispatch.json, and exits without polling. Routing only — the remote runs the identical skill from the identical repository. Composable and inline: other skills invoke it via the Skill tool rather than users calling it directly."
 allowed-tools: ["Bash", "Read", "Skill"]
 ---
 
@@ -16,8 +16,11 @@ It changes **where** work happens and nothing about **what** happens. The remote
 | --- | --- |
 | omitted / `local` | The calling skill proceeds normally. Nothing is dispatched. |
 | `codex-cloud` | Submit to the project's Codex Cloud environment and return. |
+| `claude-web` | Fire the project's Claude routine, which starts a cloud session, and return. |
 
 Any other value is **rejected explicitly**. A silently ignored `executionEnv` would run the work locally while the operator believes it went remote, and nothing downstream would contradict that belief.
+
+For the same reason, the parameter is accepted as both `executionEnv=…` and `--executionEnv=…`, and a *dashed* parameter this skill does not recognise is an error rather than payload. The bare form is the documented one, but the dashed form is what anyone who has used a CLI will type, and a misspelling of either is indistinguishable from not asking at all — which is the one failure an operator cannot act on. A bare `key=value` still belongs to the payload, since prose may legitimately contain an equals sign.
 
 If a behaviour must differ between local and remote, it belongs in the calling skill as an explicit branch — never here. The moment this file starts encoding domain behaviour, there are two implementations to keep in sync.
 

--- a/plugins/lisa-agy/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa-agy/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -68,11 +68,25 @@ const LEDGER = join(".lisa", "remote-dispatch.json");
 /** This file's directory, for locating the sibling secrets skill. */
 const HERE = dirname(fileURLToPath(import.meta.url));
 
+/** Every parameter this program reads. Anything else is a typo. */
+const KNOWN_PARAMS = new Set(["executionEnv"]);
+
 /**
  * Split `key=value` parameters from the rest of an invocation.
  *
  * The remainder is passed through untouched. It is the caller's payload — a
  * ticket key, a description — and this program has no business interpreting it.
+ *
+ * A leading `--` is accepted and stripped. The bare form is the documented one,
+ * but `--executionEnv=claude-web` is what anyone who has used a CLI this decade
+ * types, and it previously fell through to the payload and left the surface at
+ * its default. That is precisely the outcome this skill says it exists to
+ * prevent: work runs locally while the operator believes it went remote, and
+ * nothing downstream contradicts them.
+ *
+ * An unrecognised parameter is rejected for the same reason. A misspelled
+ * `executionEnvv=claude-web` is indistinguishable from not asking at all, and
+ * silence is the one response that cannot be acted on.
  * @param {string} input Raw argument string.
  * @returns {{params: Record<string, string>, rest: string}} Parsed invocation.
  */
@@ -83,9 +97,19 @@ export function parseInvocation(input) {
     .trim()
     .split(/\s+/)
     .filter(Boolean)) {
-    const match = /^([A-Za-z][A-Za-z0-9_]*)=(.*)$/.exec(token);
-    if (match) params[match[1]] = match[2];
-    else rest.push(token);
+    const match = /^(--)?([A-Za-z][A-Za-z0-9_]*)=(.*)$/.exec(token);
+    // Only a dashed token is required to be a known parameter. A bare `x=y` may
+    // legitimately be part of a payload — a description, a query — and this
+    // program has no business rejecting the caller's prose.
+    if (match && (match[1] || KNOWN_PARAMS.has(match[2]))) {
+      if (!KNOWN_PARAMS.has(match[2])) {
+        throw new Error(
+          `unknown parameter "${match[2]}".\n` +
+            `Supported: ${[...KNOWN_PARAMS].join(", ")}.`
+        );
+      }
+      params[match[2]] = match[3];
+    } else rest.push(token);
   }
   return { params, rest: rest.join(" ") };
 }

--- a/plugins/lisa-copilot/skills/lisa-remote-dispatch/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-remote-dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-remote-dispatch
-description: "Route one unit of work to a remote execution surface. Reads the executionEnv parameter (local by default, codex-cloud today), verifies the environment is provisioned and bound to this repository, submits a thin skill invocation, records the task identifier to .lisa/remote-dispatch.json, and exits without polling. Routing only — the remote runs the identical skill from the identical repository. Composable and inline: other skills invoke it via the Skill tool rather than users calling it directly."
+description: "Route one unit of work to a remote execution surface. Reads the executionEnv parameter (local by default, codex-cloud or claude-web today), verifies the environment is provisioned and bound to this repository, submits a thin skill invocation, records the task identifier to .lisa/remote-dispatch.json, and exits without polling. Routing only — the remote runs the identical skill from the identical repository. Composable and inline: other skills invoke it via the Skill tool rather than users calling it directly."
 allowed-tools: ["Bash", "Read", "Skill"]
 ---
 
@@ -16,8 +16,11 @@ It changes **where** work happens and nothing about **what** happens. The remote
 | --- | --- |
 | omitted / `local` | The calling skill proceeds normally. Nothing is dispatched. |
 | `codex-cloud` | Submit to the project's Codex Cloud environment and return. |
+| `claude-web` | Fire the project's Claude routine, which starts a cloud session, and return. |
 
 Any other value is **rejected explicitly**. A silently ignored `executionEnv` would run the work locally while the operator believes it went remote, and nothing downstream would contradict that belief.
+
+For the same reason, the parameter is accepted as both `executionEnv=…` and `--executionEnv=…`, and a *dashed* parameter this skill does not recognise is an error rather than payload. The bare form is the documented one, but the dashed form is what anyone who has used a CLI will type, and a misspelling of either is indistinguishable from not asking at all — which is the one failure an operator cannot act on. A bare `key=value` still belongs to the payload, since prose may legitimately contain an equals sign.
 
 If a behaviour must differ between local and remote, it belongs in the calling skill as an explicit branch — never here. The moment this file starts encoding domain behaviour, there are two implementations to keep in sync.
 

--- a/plugins/lisa-copilot/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa-copilot/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -68,11 +68,25 @@ const LEDGER = join(".lisa", "remote-dispatch.json");
 /** This file's directory, for locating the sibling secrets skill. */
 const HERE = dirname(fileURLToPath(import.meta.url));
 
+/** Every parameter this program reads. Anything else is a typo. */
+const KNOWN_PARAMS = new Set(["executionEnv"]);
+
 /**
  * Split `key=value` parameters from the rest of an invocation.
  *
  * The remainder is passed through untouched. It is the caller's payload — a
  * ticket key, a description — and this program has no business interpreting it.
+ *
+ * A leading `--` is accepted and stripped. The bare form is the documented one,
+ * but `--executionEnv=claude-web` is what anyone who has used a CLI this decade
+ * types, and it previously fell through to the payload and left the surface at
+ * its default. That is precisely the outcome this skill says it exists to
+ * prevent: work runs locally while the operator believes it went remote, and
+ * nothing downstream contradicts them.
+ *
+ * An unrecognised parameter is rejected for the same reason. A misspelled
+ * `executionEnvv=claude-web` is indistinguishable from not asking at all, and
+ * silence is the one response that cannot be acted on.
  * @param {string} input Raw argument string.
  * @returns {{params: Record<string, string>, rest: string}} Parsed invocation.
  */
@@ -83,9 +97,19 @@ export function parseInvocation(input) {
     .trim()
     .split(/\s+/)
     .filter(Boolean)) {
-    const match = /^([A-Za-z][A-Za-z0-9_]*)=(.*)$/.exec(token);
-    if (match) params[match[1]] = match[2];
-    else rest.push(token);
+    const match = /^(--)?([A-Za-z][A-Za-z0-9_]*)=(.*)$/.exec(token);
+    // Only a dashed token is required to be a known parameter. A bare `x=y` may
+    // legitimately be part of a payload — a description, a query — and this
+    // program has no business rejecting the caller's prose.
+    if (match && (match[1] || KNOWN_PARAMS.has(match[2]))) {
+      if (!KNOWN_PARAMS.has(match[2])) {
+        throw new Error(
+          `unknown parameter "${match[2]}".\n` +
+            `Supported: ${[...KNOWN_PARAMS].join(", ")}.`
+        );
+      }
+      params[match[2]] = match[3];
+    } else rest.push(token);
   }
   return { params, rest: rest.join(" ") };
 }

--- a/plugins/lisa-cursor/skills/lisa-remote-dispatch/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-remote-dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-remote-dispatch
-description: "Route one unit of work to a remote execution surface. Reads the executionEnv parameter (local by default, codex-cloud today), verifies the environment is provisioned and bound to this repository, submits a thin skill invocation, records the task identifier to .lisa/remote-dispatch.json, and exits without polling. Routing only — the remote runs the identical skill from the identical repository. Composable and inline: other skills invoke it via the Skill tool rather than users calling it directly."
+description: "Route one unit of work to a remote execution surface. Reads the executionEnv parameter (local by default, codex-cloud or claude-web today), verifies the environment is provisioned and bound to this repository, submits a thin skill invocation, records the task identifier to .lisa/remote-dispatch.json, and exits without polling. Routing only — the remote runs the identical skill from the identical repository. Composable and inline: other skills invoke it via the Skill tool rather than users calling it directly."
 allowed-tools: ["Bash", "Read", "Skill"]
 ---
 
@@ -16,8 +16,11 @@ It changes **where** work happens and nothing about **what** happens. The remote
 | --- | --- |
 | omitted / `local` | The calling skill proceeds normally. Nothing is dispatched. |
 | `codex-cloud` | Submit to the project's Codex Cloud environment and return. |
+| `claude-web` | Fire the project's Claude routine, which starts a cloud session, and return. |
 
 Any other value is **rejected explicitly**. A silently ignored `executionEnv` would run the work locally while the operator believes it went remote, and nothing downstream would contradict that belief.
+
+For the same reason, the parameter is accepted as both `executionEnv=…` and `--executionEnv=…`, and a *dashed* parameter this skill does not recognise is an error rather than payload. The bare form is the documented one, but the dashed form is what anyone who has used a CLI will type, and a misspelling of either is indistinguishable from not asking at all — which is the one failure an operator cannot act on. A bare `key=value` still belongs to the payload, since prose may legitimately contain an equals sign.
 
 If a behaviour must differ between local and remote, it belongs in the calling skill as an explicit branch — never here. The moment this file starts encoding domain behaviour, there are two implementations to keep in sync.
 

--- a/plugins/lisa-cursor/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa-cursor/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -68,11 +68,25 @@ const LEDGER = join(".lisa", "remote-dispatch.json");
 /** This file's directory, for locating the sibling secrets skill. */
 const HERE = dirname(fileURLToPath(import.meta.url));
 
+/** Every parameter this program reads. Anything else is a typo. */
+const KNOWN_PARAMS = new Set(["executionEnv"]);
+
 /**
  * Split `key=value` parameters from the rest of an invocation.
  *
  * The remainder is passed through untouched. It is the caller's payload — a
  * ticket key, a description — and this program has no business interpreting it.
+ *
+ * A leading `--` is accepted and stripped. The bare form is the documented one,
+ * but `--executionEnv=claude-web` is what anyone who has used a CLI this decade
+ * types, and it previously fell through to the payload and left the surface at
+ * its default. That is precisely the outcome this skill says it exists to
+ * prevent: work runs locally while the operator believes it went remote, and
+ * nothing downstream contradicts them.
+ *
+ * An unrecognised parameter is rejected for the same reason. A misspelled
+ * `executionEnvv=claude-web` is indistinguishable from not asking at all, and
+ * silence is the one response that cannot be acted on.
  * @param {string} input Raw argument string.
  * @returns {{params: Record<string, string>, rest: string}} Parsed invocation.
  */
@@ -83,9 +97,19 @@ export function parseInvocation(input) {
     .trim()
     .split(/\s+/)
     .filter(Boolean)) {
-    const match = /^([A-Za-z][A-Za-z0-9_]*)=(.*)$/.exec(token);
-    if (match) params[match[1]] = match[2];
-    else rest.push(token);
+    const match = /^(--)?([A-Za-z][A-Za-z0-9_]*)=(.*)$/.exec(token);
+    // Only a dashed token is required to be a known parameter. A bare `x=y` may
+    // legitimately be part of a payload — a description, a query — and this
+    // program has no business rejecting the caller's prose.
+    if (match && (match[1] || KNOWN_PARAMS.has(match[2]))) {
+      if (!KNOWN_PARAMS.has(match[2])) {
+        throw new Error(
+          `unknown parameter "${match[2]}".\n` +
+            `Supported: ${[...KNOWN_PARAMS].join(", ")}.`
+        );
+      }
+      params[match[2]] = match[3];
+    } else rest.push(token);
   }
   return { params, rest: rest.join(" ") };
 }

--- a/plugins/lisa/.codex-plugin/skills/lisa-remote-dispatch/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-remote-dispatch/SKILL.md
@@ -16,8 +16,11 @@ It changes **where** work happens and nothing about **what** happens. The remote
 | --- | --- |
 | omitted / `local` | The calling skill proceeds normally. Nothing is dispatched. |
 | `codex-cloud` | Submit to the project's Codex Cloud environment and return. |
+| `claude-web` | Fire the project's Claude routine, which starts a cloud session, and return. |
 
 Any other value is **rejected explicitly**. A silently ignored `executionEnv` would run the work locally while the operator believes it went remote, and nothing downstream would contradict that belief.
+
+For the same reason, the parameter is accepted as both `executionEnv=…` and `--executionEnv=…`, and a *dashed* parameter this skill does not recognise is an error rather than payload. The bare form is the documented one, but the dashed form is what anyone who has used a CLI will type, and a misspelling of either is indistinguishable from not asking at all — which is the one failure an operator cannot act on. A bare `key=value` still belongs to the payload, since prose may legitimately contain an equals sign.
 
 If a behaviour must differ between local and remote, it belongs in the calling skill as an explicit branch — never here. The moment this file starts encoding domain behaviour, there are two implementations to keep in sync.
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -68,11 +68,25 @@ const LEDGER = join(".lisa", "remote-dispatch.json");
 /** This file's directory, for locating the sibling secrets skill. */
 const HERE = dirname(fileURLToPath(import.meta.url));
 
+/** Every parameter this program reads. Anything else is a typo. */
+const KNOWN_PARAMS = new Set(["executionEnv"]);
+
 /**
  * Split `key=value` parameters from the rest of an invocation.
  *
  * The remainder is passed through untouched. It is the caller's payload — a
  * ticket key, a description — and this program has no business interpreting it.
+ *
+ * A leading `--` is accepted and stripped. The bare form is the documented one,
+ * but `--executionEnv=claude-web` is what anyone who has used a CLI this decade
+ * types, and it previously fell through to the payload and left the surface at
+ * its default. That is precisely the outcome this skill says it exists to
+ * prevent: work runs locally while the operator believes it went remote, and
+ * nothing downstream contradicts them.
+ *
+ * An unrecognised parameter is rejected for the same reason. A misspelled
+ * `executionEnvv=claude-web` is indistinguishable from not asking at all, and
+ * silence is the one response that cannot be acted on.
  * @param {string} input Raw argument string.
  * @returns {{params: Record<string, string>, rest: string}} Parsed invocation.
  */
@@ -83,9 +97,19 @@ export function parseInvocation(input) {
     .trim()
     .split(/\s+/)
     .filter(Boolean)) {
-    const match = /^([A-Za-z][A-Za-z0-9_]*)=(.*)$/.exec(token);
-    if (match) params[match[1]] = match[2];
-    else rest.push(token);
+    const match = /^(--)?([A-Za-z][A-Za-z0-9_]*)=(.*)$/.exec(token);
+    // Only a dashed token is required to be a known parameter. A bare `x=y` may
+    // legitimately be part of a payload — a description, a query — and this
+    // program has no business rejecting the caller's prose.
+    if (match && (match[1] || KNOWN_PARAMS.has(match[2]))) {
+      if (!KNOWN_PARAMS.has(match[2])) {
+        throw new Error(
+          `unknown parameter "${match[2]}".\n` +
+            `Supported: ${[...KNOWN_PARAMS].join(", ")}.`
+        );
+      }
+      params[match[2]] = match[3];
+    } else rest.push(token);
   }
   return { params, rest: rest.join(" ") };
 }

--- a/plugins/lisa/skills/lisa-remote-dispatch/SKILL.md
+++ b/plugins/lisa/skills/lisa-remote-dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-remote-dispatch
-description: "Route one unit of work to a remote execution surface. Reads the executionEnv parameter (local by default, codex-cloud today), verifies the environment is provisioned and bound to this repository, submits a thin skill invocation, records the task identifier to .lisa/remote-dispatch.json, and exits without polling. Routing only — the remote runs the identical skill from the identical repository. Composable and inline: other skills invoke it via the Skill tool rather than users calling it directly."
+description: "Route one unit of work to a remote execution surface. Reads the executionEnv parameter (local by default, codex-cloud or claude-web today), verifies the environment is provisioned and bound to this repository, submits a thin skill invocation, records the task identifier to .lisa/remote-dispatch.json, and exits without polling. Routing only — the remote runs the identical skill from the identical repository. Composable and inline: other skills invoke it via the Skill tool rather than users calling it directly."
 allowed-tools: ["Bash", "Read", "Skill"]
 ---
 
@@ -16,8 +16,11 @@ It changes **where** work happens and nothing about **what** happens. The remote
 | --- | --- |
 | omitted / `local` | The calling skill proceeds normally. Nothing is dispatched. |
 | `codex-cloud` | Submit to the project's Codex Cloud environment and return. |
+| `claude-web` | Fire the project's Claude routine, which starts a cloud session, and return. |
 
 Any other value is **rejected explicitly**. A silently ignored `executionEnv` would run the work locally while the operator believes it went remote, and nothing downstream would contradict that belief.
+
+For the same reason, the parameter is accepted as both `executionEnv=…` and `--executionEnv=…`, and a *dashed* parameter this skill does not recognise is an error rather than payload. The bare form is the documented one, but the dashed form is what anyone who has used a CLI will type, and a misspelling of either is indistinguishable from not asking at all — which is the one failure an operator cannot act on. A bare `key=value` still belongs to the payload, since prose may legitimately contain an equals sign.
 
 If a behaviour must differ between local and remote, it belongs in the calling skill as an explicit branch — never here. The moment this file starts encoding domain behaviour, there are two implementations to keep in sync.
 

--- a/plugins/lisa/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -68,11 +68,25 @@ const LEDGER = join(".lisa", "remote-dispatch.json");
 /** This file's directory, for locating the sibling secrets skill. */
 const HERE = dirname(fileURLToPath(import.meta.url));
 
+/** Every parameter this program reads. Anything else is a typo. */
+const KNOWN_PARAMS = new Set(["executionEnv"]);
+
 /**
  * Split `key=value` parameters from the rest of an invocation.
  *
  * The remainder is passed through untouched. It is the caller's payload — a
  * ticket key, a description — and this program has no business interpreting it.
+ *
+ * A leading `--` is accepted and stripped. The bare form is the documented one,
+ * but `--executionEnv=claude-web` is what anyone who has used a CLI this decade
+ * types, and it previously fell through to the payload and left the surface at
+ * its default. That is precisely the outcome this skill says it exists to
+ * prevent: work runs locally while the operator believes it went remote, and
+ * nothing downstream contradicts them.
+ *
+ * An unrecognised parameter is rejected for the same reason. A misspelled
+ * `executionEnvv=claude-web` is indistinguishable from not asking at all, and
+ * silence is the one response that cannot be acted on.
  * @param {string} input Raw argument string.
  * @returns {{params: Record<string, string>, rest: string}} Parsed invocation.
  */
@@ -83,9 +97,19 @@ export function parseInvocation(input) {
     .trim()
     .split(/\s+/)
     .filter(Boolean)) {
-    const match = /^([A-Za-z][A-Za-z0-9_]*)=(.*)$/.exec(token);
-    if (match) params[match[1]] = match[2];
-    else rest.push(token);
+    const match = /^(--)?([A-Za-z][A-Za-z0-9_]*)=(.*)$/.exec(token);
+    // Only a dashed token is required to be a known parameter. A bare `x=y` may
+    // legitimately be part of a payload — a description, a query — and this
+    // program has no business rejecting the caller's prose.
+    if (match && (match[1] || KNOWN_PARAMS.has(match[2]))) {
+      if (!KNOWN_PARAMS.has(match[2])) {
+        throw new Error(
+          `unknown parameter "${match[2]}".\n` +
+            `Supported: ${[...KNOWN_PARAMS].join(", ")}.`
+        );
+      }
+      params[match[2]] = match[3];
+    } else rest.push(token);
   }
   return { params, rest: rest.join(" ") };
 }

--- a/plugins/src/base/skills/lisa-remote-dispatch/SKILL.md
+++ b/plugins/src/base/skills/lisa-remote-dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-remote-dispatch
-description: "Route one unit of work to a remote execution surface. Reads the executionEnv parameter (local by default, codex-cloud today), verifies the environment is provisioned and bound to this repository, submits a thin skill invocation, records the task identifier to .lisa/remote-dispatch.json, and exits without polling. Routing only — the remote runs the identical skill from the identical repository. Composable and inline: other skills invoke it via the Skill tool rather than users calling it directly."
+description: "Route one unit of work to a remote execution surface. Reads the executionEnv parameter (local by default, codex-cloud or claude-web today), verifies the environment is provisioned and bound to this repository, submits a thin skill invocation, records the task identifier to .lisa/remote-dispatch.json, and exits without polling. Routing only — the remote runs the identical skill from the identical repository. Composable and inline: other skills invoke it via the Skill tool rather than users calling it directly."
 allowed-tools: ["Bash", "Read", "Skill"]
 ---
 
@@ -16,8 +16,11 @@ It changes **where** work happens and nothing about **what** happens. The remote
 | --- | --- |
 | omitted / `local` | The calling skill proceeds normally. Nothing is dispatched. |
 | `codex-cloud` | Submit to the project's Codex Cloud environment and return. |
+| `claude-web` | Fire the project's Claude routine, which starts a cloud session, and return. |
 
 Any other value is **rejected explicitly**. A silently ignored `executionEnv` would run the work locally while the operator believes it went remote, and nothing downstream would contradict that belief.
+
+For the same reason, the parameter is accepted as both `executionEnv=…` and `--executionEnv=…`, and a *dashed* parameter this skill does not recognise is an error rather than payload. The bare form is the documented one, but the dashed form is what anyone who has used a CLI will type, and a misspelling of either is indistinguishable from not asking at all — which is the one failure an operator cannot act on. A bare `key=value` still belongs to the payload, since prose may legitimately contain an equals sign.
 
 If a behaviour must differ between local and remote, it belongs in the calling skill as an explicit branch — never here. The moment this file starts encoding domain behaviour, there are two implementations to keep in sync.
 

--- a/plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -68,11 +68,25 @@ const LEDGER = join(".lisa", "remote-dispatch.json");
 /** This file's directory, for locating the sibling secrets skill. */
 const HERE = dirname(fileURLToPath(import.meta.url));
 
+/** Every parameter this program reads. Anything else is a typo. */
+const KNOWN_PARAMS = new Set(["executionEnv"]);
+
 /**
  * Split `key=value` parameters from the rest of an invocation.
  *
  * The remainder is passed through untouched. It is the caller's payload — a
  * ticket key, a description — and this program has no business interpreting it.
+ *
+ * A leading `--` is accepted and stripped. The bare form is the documented one,
+ * but `--executionEnv=claude-web` is what anyone who has used a CLI this decade
+ * types, and it previously fell through to the payload and left the surface at
+ * its default. That is precisely the outcome this skill says it exists to
+ * prevent: work runs locally while the operator believes it went remote, and
+ * nothing downstream contradicts them.
+ *
+ * An unrecognised parameter is rejected for the same reason. A misspelled
+ * `executionEnvv=claude-web` is indistinguishable from not asking at all, and
+ * silence is the one response that cannot be acted on.
  * @param {string} input Raw argument string.
  * @returns {{params: Record<string, string>, rest: string}} Parsed invocation.
  */
@@ -83,9 +97,19 @@ export function parseInvocation(input) {
     .trim()
     .split(/\s+/)
     .filter(Boolean)) {
-    const match = /^([A-Za-z][A-Za-z0-9_]*)=(.*)$/.exec(token);
-    if (match) params[match[1]] = match[2];
-    else rest.push(token);
+    const match = /^(--)?([A-Za-z][A-Za-z0-9_]*)=(.*)$/.exec(token);
+    // Only a dashed token is required to be a known parameter. A bare `x=y` may
+    // legitimately be part of a payload — a description, a query — and this
+    // program has no business rejecting the caller's prose.
+    if (match && (match[1] || KNOWN_PARAMS.has(match[2]))) {
+      if (!KNOWN_PARAMS.has(match[2])) {
+        throw new Error(
+          `unknown parameter "${match[2]}".\n` +
+            `Supported: ${[...KNOWN_PARAMS].join(", ")}.`
+        );
+      }
+      params[match[2]] = match[3];
+    } else rest.push(token);
   }
   return { params, rest: rest.join(" ") };
 }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1053,9 +1053,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-queue-status/SKILL.md":
       "87c6d34d0511d4afd812d1af3fee80fa3b7aa47db8449760b12f2699fedc1d78",
     "plugins/src/base/skills/lisa-remote-dispatch/SKILL.md":
-      "2cc999d2c3b61b10aabb849e0833fd58edb444c5013c05108dd58e5d7d60c4ba",
+      "f3c48120a206d01db45f849ca5b61690d572abc16bc36d559a4cacc8f9422c06",
     "plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs":
-      "c473e8eddf0fd5f220a5ea7ff9eb92f5482cfb2893e77edce59acc36671418a3",
+      "475963ed64d9e72a6cbd6cbb61c8b57a419f2e1805e3ddfa76066047c590deeb",
     "plugins/src/base/skills/lisa-repair-intake/SKILL.md":
       "4f85ac1381631e9f250d9cf3239baba633ae0df9ba1959f8835ed662592e2d77",
     "plugins/src/base/skills/lisa-reproduce-bug/SKILL.md":

--- a/tests/unit/secrets/remote-dispatch.test.ts
+++ b/tests/unit/secrets/remote-dispatch.test.ts
@@ -83,6 +83,35 @@ describe("invocation parsing", () => {
   it("tolerates an empty invocation", () => {
     expect(parseInvocation("")).toEqual({ params: {}, rest: "" });
   });
+
+  it("accepts the dashed form anyone who has used a CLI will type", () => {
+    // `--executionEnv=...` previously fell through to the payload and left the
+    // surface at its default, which is exactly the outcome this skill says it
+    // exists to prevent: the work runs locally while the operator believes it
+    // went remote, and nothing downstream contradicts them.
+    const { params, rest } = parseInvocation(
+      "SE-45434 --executionEnv=claude-web"
+    );
+    expect(params.executionEnv).toBe("claude-web");
+    expect(rest).toBe("SE-45434");
+  });
+
+  it("rejects a misspelled parameter rather than ignoring it", () => {
+    // Indistinguishable from not asking at all, and silence is the one response
+    // an operator cannot act on.
+    expect(() =>
+      parseInvocation("SE-45434 --executionEnvv=claude-web")
+    ).toThrow(/unknown parameter "executionEnvv"/);
+  });
+
+  it("still lets a bare key=value belong to the payload", () => {
+    // Only the dashed form claims to be a parameter. Prose may contain an
+    // equals sign, and this dispatcher has no business rejecting the caller's
+    // description because of one.
+    const { params, rest } = parseInvocation("describe the a=b mapping");
+    expect(params).toEqual({});
+    expect(rest).toBe("describe the a=b mapping");
+  });
 });
 
 describe("executionEnv resolution", () => {


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2209

Only the bare `key=value` form was recognised, so a token starting with `--` failed the parameter regex, fell through to the payload, and left the surface at its `local` default:

```
$ node dispatch.mjs --skill lisa-implement 'CodySwannGT/lisa#2202 --executionEnv=claude-web'
local
```

That is the exact outcome this skill's own `SKILL.md` says it exists to prevent:

> A silently ignored `executionEnv` would run the work locally while the operator believes it went remote, and nothing downstream would contradict that belief.

And the dashed form is not an exotic typo — it is what anyone who has used a CLI this decade types first. I hit it myself on the first real dispatch.

## Change

A leading `--` is accepted and stripped, and a **dashed** parameter that is not recognised is an error — `--executionEnvv=claude-web` was indistinguishable from not asking at all.

A **bare** `key=value` still falls through to the payload. Prose may legitimately contain an equals sign, and this dispatcher has no licence to reject the caller's description over one, so only the dashed form claims to be a parameter.

```
"SE-45434 executionEnv=claude-web"     -> params {executionEnv: claude-web}, rest "SE-45434"
"SE-45434 --executionEnv=claude-web"   -> params {executionEnv: claude-web}, rest "SE-45434"
"SE-45434 --executionEnvv=claude-web"  -> throws: unknown parameter "executionEnvv"
"describe the a=b mapping"             -> params {}, rest "describe the a=b mapping"
```

Also refreshes `SKILL.md`, whose frontmatter still said `codex-cloud today` and whose routing table omitted `claude-web` entirely.

`tests/unit/secrets` — 222 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `claude-web` remote execution environment.
  * Added support for both bare and dashed `executionEnv` parameters.
  * Preserved bare `key=value` entries as payload content.

* **Bug Fixes**
  * Unrecognized dashed parameters are now rejected with an error.
  * Improved invocation parsing for remote dispatch requests.

* **Tests**
  * Added coverage for dashed parameters, invalid options, and payload handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->