### PR TITLE
Reach the checkout wherever it is, and resolve the skill when the checkout is Lisa

### DIFF
--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
@@ -13,8 +13,8 @@ Prepare a remote surface so a host project can execute there. Today that means *
 The remote environment's own configuration fields stay **one line into the repository**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
-maintenance: n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+setup:       n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
+maintenance: n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
 ```
 
 **That line is identical for every project AND every surface.** Nothing in it names the
@@ -164,8 +164,8 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
-Maintenance:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+Setup script:      n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
+Maintenance:       n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
                    (identical for every project — the script finds the
                    checkout and installs from the committed lockfile)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/assets/setup.sh
@@ -105,11 +105,21 @@ fi
 # plugin-delivered harnesses work at all. Lisa is a dependency of every project
 # it is applied to, so `node_modules` carries the same skill at the version that
 # project pins, which is the version its setup should run.
+#
+# `plugins/lisa/skills/` sits between them, and exists for exactly one project:
+# Lisa itself. There the checkout IS Lisa, at HEAD, while `node_modules` holds
+# whatever version its own lockfile pins — which was four months and a hundred
+# skills behind, so this file did not exist there at all and setup aborted
+# claiming the skill could not be found. The one place it was is the only place
+# that was not searched. It is ahead of node_modules because a checkout that
+# builds this skill is newer than any published copy of it, and harmless
+# everywhere else because no other project has that directory.
 runner=""
 for candidate in \
   ".claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".agents/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  "plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   "node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
   if [ -f "$candidate" ]; then
     runner="$candidate"
@@ -132,6 +142,18 @@ if [ -z "$runner" ]; then
   echo >&2
   echo "If dependencies are installed, run 'lisa apply' so the skills are" >&2
   echo "present, then re-run setup." >&2
+  echo >&2
+  # The version actually resolved, because "not found" and "found, but too old
+  # to contain this skill" read identically above and are fixed differently.
+  # The second is what happened on Lisa itself: node_modules held a release
+  # from before this skill existed, so every path checked was legitimately
+  # absent and the message blamed the install.
+  if [ -f node_modules/@codyswann/lisa/package.json ]; then
+    echo "For reference, node_modules has @codyswann/lisa version:" >&2
+    node -p "require('./node_modules/@codyswann/lisa/package.json').version" >&2 2>/dev/null ||
+      echo "  (unreadable)" >&2
+    echo "If that predates this skill, the pin is the problem, not the install." >&2
+  fi
   exit 1
 fi
 

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -308,28 +308,44 @@ export function installAssets(cwd = process.cwd()) {
  * at all — so a `$HOME` glob matched nothing there and bash was handed a path
  * still containing a literal asterisk.
  *
- * Both candidates are therefore tried relative to cwd, and EVERY match is
- * prepared rather than the first. A Claude Code web environment can hold more
- * than one checkout, so stopping at the first hit would prepare whichever
- * repository sorts first and silently ignore the rest — arbitrary rather than
- * merely limited. Each script anchors itself on its own repository root and
- * each project materializes under its own `secrets.namespace`, so preparing
- * several is well defined rather than a collision.
+ * Candidates are therefore tried relative to cwd first, then under `$HOME` and
+ * `/workspace` — the container roots the two surfaces actually use — because
+ * cwd is not reliably either of them. A Claude environment reported `$HOME` as
+ * `/root` with no checkout beneath it, which a cwd-only search cannot reach.
+ *
+ * EVERY match is prepared rather than the first. A Claude Code web environment
+ * can hold more than one checkout, so stopping at the first hit would prepare
+ * whichever repository sorts first and silently ignore the rest — arbitrary
+ * rather than merely limited. Each script anchors itself on its own repository
+ * root and each project materializes under its own `secrets.namespace`, so
+ * preparing several is well defined rather than a collision. Matches are
+ * deduplicated by resolved directory, since the candidate globs overlap
+ * whenever cwd happens to be one of the roots.
  *
  * The status is the first failure and every checkout is still attempted: one
  * broken repository must neither hide the others nor report success. The
  * explicit `exit 1` on no matches matters because a `for` loop over a glob that
  * matches nothing otherwise exits 0 — the quiet success this guards against.
  *
+ * Failure prints the layout it found rather than only the path it wanted. This
+ * field lives in a vendor settings box with a slow edit-and-retry loop, and a
+ * miss that reports nothing costs a whole round trip to learn one fact; the
+ * listing means the next message names the layout instead of repeating it.
+ *
  * A field that named the repository and package manager was a string a human
  * had to get right, in a settings box with no review, no version history and no
  * test — and the logic it encoded belongs in a file that has all three.
  */
 export const SETUP_FIELD =
-  "n=0; rc=0; " +
-  "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; " +
-  'do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; ' +
-  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; ' +
+  'n=0; rc=0; seen=""; ' +
+  "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh " +
+  '"$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh ' +
+  "/workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; " +
+  'do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); ' +
+  'case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; ' +
+  'n=$((n+1)); bash "$f" || rc=$?; done; ' +
+  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. ' +
+  'PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; ' +
   'exit "$rc"';
 
 /**

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
@@ -13,8 +13,8 @@ Prepare a remote surface so a host project can execute there. Today that means *
 The remote environment's own configuration fields stay **one line into the repository**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
-maintenance: n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+setup:       n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
+maintenance: n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
 ```
 
 **That line is identical for every project AND every surface.** Nothing in it names the
@@ -164,8 +164,8 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
-Maintenance:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+Setup script:      n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
+Maintenance:       n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
                    (identical for every project — the script finds the
                    checkout and installs from the committed lockfile)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/assets/setup.sh
@@ -105,11 +105,21 @@ fi
 # plugin-delivered harnesses work at all. Lisa is a dependency of every project
 # it is applied to, so `node_modules` carries the same skill at the version that
 # project pins, which is the version its setup should run.
+#
+# `plugins/lisa/skills/` sits between them, and exists for exactly one project:
+# Lisa itself. There the checkout IS Lisa, at HEAD, while `node_modules` holds
+# whatever version its own lockfile pins — which was four months and a hundred
+# skills behind, so this file did not exist there at all and setup aborted
+# claiming the skill could not be found. The one place it was is the only place
+# that was not searched. It is ahead of node_modules because a checkout that
+# builds this skill is newer than any published copy of it, and harmless
+# everywhere else because no other project has that directory.
 runner=""
 for candidate in \
   ".claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".agents/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  "plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   "node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
   if [ -f "$candidate" ]; then
     runner="$candidate"
@@ -132,6 +142,18 @@ if [ -z "$runner" ]; then
   echo >&2
   echo "If dependencies are installed, run 'lisa apply' so the skills are" >&2
   echo "present, then re-run setup." >&2
+  echo >&2
+  # The version actually resolved, because "not found" and "found, but too old
+  # to contain this skill" read identically above and are fixed differently.
+  # The second is what happened on Lisa itself: node_modules held a release
+  # from before this skill existed, so every path checked was legitimately
+  # absent and the message blamed the install.
+  if [ -f node_modules/@codyswann/lisa/package.json ]; then
+    echo "For reference, node_modules has @codyswann/lisa version:" >&2
+    node -p "require('./node_modules/@codyswann/lisa/package.json').version" >&2 2>/dev/null ||
+      echo "  (unreadable)" >&2
+    echo "If that predates this skill, the pin is the problem, not the install." >&2
+  fi
   exit 1
 fi
 

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -308,28 +308,44 @@ export function installAssets(cwd = process.cwd()) {
  * at all — so a `$HOME` glob matched nothing there and bash was handed a path
  * still containing a literal asterisk.
  *
- * Both candidates are therefore tried relative to cwd, and EVERY match is
- * prepared rather than the first. A Claude Code web environment can hold more
- * than one checkout, so stopping at the first hit would prepare whichever
- * repository sorts first and silently ignore the rest — arbitrary rather than
- * merely limited. Each script anchors itself on its own repository root and
- * each project materializes under its own `secrets.namespace`, so preparing
- * several is well defined rather than a collision.
+ * Candidates are therefore tried relative to cwd first, then under `$HOME` and
+ * `/workspace` — the container roots the two surfaces actually use — because
+ * cwd is not reliably either of them. A Claude environment reported `$HOME` as
+ * `/root` with no checkout beneath it, which a cwd-only search cannot reach.
+ *
+ * EVERY match is prepared rather than the first. A Claude Code web environment
+ * can hold more than one checkout, so stopping at the first hit would prepare
+ * whichever repository sorts first and silently ignore the rest — arbitrary
+ * rather than merely limited. Each script anchors itself on its own repository
+ * root and each project materializes under its own `secrets.namespace`, so
+ * preparing several is well defined rather than a collision. Matches are
+ * deduplicated by resolved directory, since the candidate globs overlap
+ * whenever cwd happens to be one of the roots.
  *
  * The status is the first failure and every checkout is still attempted: one
  * broken repository must neither hide the others nor report success. The
  * explicit `exit 1` on no matches matters because a `for` loop over a glob that
  * matches nothing otherwise exits 0 — the quiet success this guards against.
  *
+ * Failure prints the layout it found rather than only the path it wanted. This
+ * field lives in a vendor settings box with a slow edit-and-retry loop, and a
+ * miss that reports nothing costs a whole round trip to learn one fact; the
+ * listing means the next message names the layout instead of repeating it.
+ *
  * A field that named the repository and package manager was a string a human
  * had to get right, in a settings box with no review, no version history and no
  * test — and the logic it encoded belongs in a file that has all three.
  */
 export const SETUP_FIELD =
-  "n=0; rc=0; " +
-  "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; " +
-  'do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; ' +
-  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; ' +
+  'n=0; rc=0; seen=""; ' +
+  "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh " +
+  '"$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh ' +
+  "/workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; " +
+  'do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); ' +
+  'case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; ' +
+  'n=$((n+1)); bash "$f" || rc=$?; done; ' +
+  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. ' +
+  'PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; ' +
   'exit "$rc"';
 
 /**

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
@@ -13,8 +13,8 @@ Prepare a remote surface so a host project can execute there. Today that means *
 The remote environment's own configuration fields stay **one line into the repository**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
-maintenance: n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+setup:       n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
+maintenance: n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
 ```
 
 **That line is identical for every project AND every surface.** Nothing in it names the
@@ -164,8 +164,8 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
-Maintenance:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+Setup script:      n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
+Maintenance:       n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
                    (identical for every project — the script finds the
                    checkout and installs from the committed lockfile)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/assets/setup.sh
@@ -105,11 +105,21 @@ fi
 # plugin-delivered harnesses work at all. Lisa is a dependency of every project
 # it is applied to, so `node_modules` carries the same skill at the version that
 # project pins, which is the version its setup should run.
+#
+# `plugins/lisa/skills/` sits between them, and exists for exactly one project:
+# Lisa itself. There the checkout IS Lisa, at HEAD, while `node_modules` holds
+# whatever version its own lockfile pins — which was four months and a hundred
+# skills behind, so this file did not exist there at all and setup aborted
+# claiming the skill could not be found. The one place it was is the only place
+# that was not searched. It is ahead of node_modules because a checkout that
+# builds this skill is newer than any published copy of it, and harmless
+# everywhere else because no other project has that directory.
 runner=""
 for candidate in \
   ".claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".agents/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  "plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   "node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
   if [ -f "$candidate" ]; then
     runner="$candidate"
@@ -132,6 +142,18 @@ if [ -z "$runner" ]; then
   echo >&2
   echo "If dependencies are installed, run 'lisa apply' so the skills are" >&2
   echo "present, then re-run setup." >&2
+  echo >&2
+  # The version actually resolved, because "not found" and "found, but too old
+  # to contain this skill" read identically above and are fixed differently.
+  # The second is what happened on Lisa itself: node_modules held a release
+  # from before this skill existed, so every path checked was legitimately
+  # absent and the message blamed the install.
+  if [ -f node_modules/@codyswann/lisa/package.json ]; then
+    echo "For reference, node_modules has @codyswann/lisa version:" >&2
+    node -p "require('./node_modules/@codyswann/lisa/package.json').version" >&2 2>/dev/null ||
+      echo "  (unreadable)" >&2
+    echo "If that predates this skill, the pin is the problem, not the install." >&2
+  fi
   exit 1
 fi
 

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -308,28 +308,44 @@ export function installAssets(cwd = process.cwd()) {
  * at all — so a `$HOME` glob matched nothing there and bash was handed a path
  * still containing a literal asterisk.
  *
- * Both candidates are therefore tried relative to cwd, and EVERY match is
- * prepared rather than the first. A Claude Code web environment can hold more
- * than one checkout, so stopping at the first hit would prepare whichever
- * repository sorts first and silently ignore the rest — arbitrary rather than
- * merely limited. Each script anchors itself on its own repository root and
- * each project materializes under its own `secrets.namespace`, so preparing
- * several is well defined rather than a collision.
+ * Candidates are therefore tried relative to cwd first, then under `$HOME` and
+ * `/workspace` — the container roots the two surfaces actually use — because
+ * cwd is not reliably either of them. A Claude environment reported `$HOME` as
+ * `/root` with no checkout beneath it, which a cwd-only search cannot reach.
+ *
+ * EVERY match is prepared rather than the first. A Claude Code web environment
+ * can hold more than one checkout, so stopping at the first hit would prepare
+ * whichever repository sorts first and silently ignore the rest — arbitrary
+ * rather than merely limited. Each script anchors itself on its own repository
+ * root and each project materializes under its own `secrets.namespace`, so
+ * preparing several is well defined rather than a collision. Matches are
+ * deduplicated by resolved directory, since the candidate globs overlap
+ * whenever cwd happens to be one of the roots.
  *
  * The status is the first failure and every checkout is still attempted: one
  * broken repository must neither hide the others nor report success. The
  * explicit `exit 1` on no matches matters because a `for` loop over a glob that
  * matches nothing otherwise exits 0 — the quiet success this guards against.
  *
+ * Failure prints the layout it found rather than only the path it wanted. This
+ * field lives in a vendor settings box with a slow edit-and-retry loop, and a
+ * miss that reports nothing costs a whole round trip to learn one fact; the
+ * listing means the next message names the layout instead of repeating it.
+ *
  * A field that named the repository and package manager was a string a human
  * had to get right, in a settings box with no review, no version history and no
  * test — and the logic it encoded belongs in a file that has all three.
  */
 export const SETUP_FIELD =
-  "n=0; rc=0; " +
-  "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; " +
-  'do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; ' +
-  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; ' +
+  'n=0; rc=0; seen=""; ' +
+  "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh " +
+  '"$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh ' +
+  "/workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; " +
+  'do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); ' +
+  'case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; ' +
+  'n=$((n+1)); bash "$f" || rc=$?; done; ' +
+  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. ' +
+  'PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; ' +
   'exit "$rc"';
 
 /**

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
@@ -13,8 +13,8 @@ Prepare a remote surface so a host project can execute there. Today that means *
 The remote environment's own configuration fields stay **one line into the repository**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
-maintenance: n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+setup:       n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
+maintenance: n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
 ```
 
 **That line is identical for every project AND every surface.** Nothing in it names the
@@ -164,8 +164,8 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
-Maintenance:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+Setup script:      n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
+Maintenance:       n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
                    (identical for every project — the script finds the
                    checkout and installs from the committed lockfile)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/assets/setup.sh
@@ -105,11 +105,21 @@ fi
 # plugin-delivered harnesses work at all. Lisa is a dependency of every project
 # it is applied to, so `node_modules` carries the same skill at the version that
 # project pins, which is the version its setup should run.
+#
+# `plugins/lisa/skills/` sits between them, and exists for exactly one project:
+# Lisa itself. There the checkout IS Lisa, at HEAD, while `node_modules` holds
+# whatever version its own lockfile pins — which was four months and a hundred
+# skills behind, so this file did not exist there at all and setup aborted
+# claiming the skill could not be found. The one place it was is the only place
+# that was not searched. It is ahead of node_modules because a checkout that
+# builds this skill is newer than any published copy of it, and harmless
+# everywhere else because no other project has that directory.
 runner=""
 for candidate in \
   ".claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".agents/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  "plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   "node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
   if [ -f "$candidate" ]; then
     runner="$candidate"
@@ -132,6 +142,18 @@ if [ -z "$runner" ]; then
   echo >&2
   echo "If dependencies are installed, run 'lisa apply' so the skills are" >&2
   echo "present, then re-run setup." >&2
+  echo >&2
+  # The version actually resolved, because "not found" and "found, but too old
+  # to contain this skill" read identically above and are fixed differently.
+  # The second is what happened on Lisa itself: node_modules held a release
+  # from before this skill existed, so every path checked was legitimately
+  # absent and the message blamed the install.
+  if [ -f node_modules/@codyswann/lisa/package.json ]; then
+    echo "For reference, node_modules has @codyswann/lisa version:" >&2
+    node -p "require('./node_modules/@codyswann/lisa/package.json').version" >&2 2>/dev/null ||
+      echo "  (unreadable)" >&2
+    echo "If that predates this skill, the pin is the problem, not the install." >&2
+  fi
   exit 1
 fi
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -308,28 +308,44 @@ export function installAssets(cwd = process.cwd()) {
  * at all — so a `$HOME` glob matched nothing there and bash was handed a path
  * still containing a literal asterisk.
  *
- * Both candidates are therefore tried relative to cwd, and EVERY match is
- * prepared rather than the first. A Claude Code web environment can hold more
- * than one checkout, so stopping at the first hit would prepare whichever
- * repository sorts first and silently ignore the rest — arbitrary rather than
- * merely limited. Each script anchors itself on its own repository root and
- * each project materializes under its own `secrets.namespace`, so preparing
- * several is well defined rather than a collision.
+ * Candidates are therefore tried relative to cwd first, then under `$HOME` and
+ * `/workspace` — the container roots the two surfaces actually use — because
+ * cwd is not reliably either of them. A Claude environment reported `$HOME` as
+ * `/root` with no checkout beneath it, which a cwd-only search cannot reach.
+ *
+ * EVERY match is prepared rather than the first. A Claude Code web environment
+ * can hold more than one checkout, so stopping at the first hit would prepare
+ * whichever repository sorts first and silently ignore the rest — arbitrary
+ * rather than merely limited. Each script anchors itself on its own repository
+ * root and each project materializes under its own `secrets.namespace`, so
+ * preparing several is well defined rather than a collision. Matches are
+ * deduplicated by resolved directory, since the candidate globs overlap
+ * whenever cwd happens to be one of the roots.
  *
  * The status is the first failure and every checkout is still attempted: one
  * broken repository must neither hide the others nor report success. The
  * explicit `exit 1` on no matches matters because a `for` loop over a glob that
  * matches nothing otherwise exits 0 — the quiet success this guards against.
  *
+ * Failure prints the layout it found rather than only the path it wanted. This
+ * field lives in a vendor settings box with a slow edit-and-retry loop, and a
+ * miss that reports nothing costs a whole round trip to learn one fact; the
+ * listing means the next message names the layout instead of repeating it.
+ *
  * A field that named the repository and package manager was a string a human
  * had to get right, in a settings box with no review, no version history and no
  * test — and the logic it encoded belongs in a file that has all three.
  */
 export const SETUP_FIELD =
-  "n=0; rc=0; " +
-  "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; " +
-  'do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; ' +
-  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; ' +
+  'n=0; rc=0; seen=""; ' +
+  "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh " +
+  '"$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh ' +
+  "/workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; " +
+  'do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); ' +
+  'case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; ' +
+  'n=$((n+1)); bash "$f" || rc=$?; done; ' +
+  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. ' +
+  'PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; ' +
   'exit "$rc"';
 
 /**

--- a/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
@@ -13,8 +13,8 @@ Prepare a remote surface so a host project can execute there. Today that means *
 The remote environment's own configuration fields stay **one line into the repository**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
-maintenance: n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+setup:       n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
+maintenance: n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
 ```
 
 **That line is identical for every project AND every surface.** Nothing in it names the
@@ -164,8 +164,8 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
-Maintenance:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+Setup script:      n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
+Maintenance:       n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
                    (identical for every project — the script finds the
                    checkout and installs from the committed lockfile)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud

--- a/plugins/lisa/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa/skills/lisa-setup-remote-env/assets/setup.sh
@@ -105,11 +105,21 @@ fi
 # plugin-delivered harnesses work at all. Lisa is a dependency of every project
 # it is applied to, so `node_modules` carries the same skill at the version that
 # project pins, which is the version its setup should run.
+#
+# `plugins/lisa/skills/` sits between them, and exists for exactly one project:
+# Lisa itself. There the checkout IS Lisa, at HEAD, while `node_modules` holds
+# whatever version its own lockfile pins — which was four months and a hundred
+# skills behind, so this file did not exist there at all and setup aborted
+# claiming the skill could not be found. The one place it was is the only place
+# that was not searched. It is ahead of node_modules because a checkout that
+# builds this skill is newer than any published copy of it, and harmless
+# everywhere else because no other project has that directory.
 runner=""
 for candidate in \
   ".claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".agents/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  "plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   "node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
   if [ -f "$candidate" ]; then
     runner="$candidate"
@@ -132,6 +142,18 @@ if [ -z "$runner" ]; then
   echo >&2
   echo "If dependencies are installed, run 'lisa apply' so the skills are" >&2
   echo "present, then re-run setup." >&2
+  echo >&2
+  # The version actually resolved, because "not found" and "found, but too old
+  # to contain this skill" read identically above and are fixed differently.
+  # The second is what happened on Lisa itself: node_modules held a release
+  # from before this skill existed, so every path checked was legitimately
+  # absent and the message blamed the install.
+  if [ -f node_modules/@codyswann/lisa/package.json ]; then
+    echo "For reference, node_modules has @codyswann/lisa version:" >&2
+    node -p "require('./node_modules/@codyswann/lisa/package.json').version" >&2 2>/dev/null ||
+      echo "  (unreadable)" >&2
+    echo "If that predates this skill, the pin is the problem, not the install." >&2
+  fi
   exit 1
 fi
 

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -308,28 +308,44 @@ export function installAssets(cwd = process.cwd()) {
  * at all — so a `$HOME` glob matched nothing there and bash was handed a path
  * still containing a literal asterisk.
  *
- * Both candidates are therefore tried relative to cwd, and EVERY match is
- * prepared rather than the first. A Claude Code web environment can hold more
- * than one checkout, so stopping at the first hit would prepare whichever
- * repository sorts first and silently ignore the rest — arbitrary rather than
- * merely limited. Each script anchors itself on its own repository root and
- * each project materializes under its own `secrets.namespace`, so preparing
- * several is well defined rather than a collision.
+ * Candidates are therefore tried relative to cwd first, then under `$HOME` and
+ * `/workspace` — the container roots the two surfaces actually use — because
+ * cwd is not reliably either of them. A Claude environment reported `$HOME` as
+ * `/root` with no checkout beneath it, which a cwd-only search cannot reach.
+ *
+ * EVERY match is prepared rather than the first. A Claude Code web environment
+ * can hold more than one checkout, so stopping at the first hit would prepare
+ * whichever repository sorts first and silently ignore the rest — arbitrary
+ * rather than merely limited. Each script anchors itself on its own repository
+ * root and each project materializes under its own `secrets.namespace`, so
+ * preparing several is well defined rather than a collision. Matches are
+ * deduplicated by resolved directory, since the candidate globs overlap
+ * whenever cwd happens to be one of the roots.
  *
  * The status is the first failure and every checkout is still attempted: one
  * broken repository must neither hide the others nor report success. The
  * explicit `exit 1` on no matches matters because a `for` loop over a glob that
  * matches nothing otherwise exits 0 — the quiet success this guards against.
  *
+ * Failure prints the layout it found rather than only the path it wanted. This
+ * field lives in a vendor settings box with a slow edit-and-retry loop, and a
+ * miss that reports nothing costs a whole round trip to learn one fact; the
+ * listing means the next message names the layout instead of repeating it.
+ *
  * A field that named the repository and package manager was a string a human
  * had to get right, in a settings box with no review, no version history and no
  * test — and the logic it encoded belongs in a file that has all three.
  */
 export const SETUP_FIELD =
-  "n=0; rc=0; " +
-  "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; " +
-  'do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; ' +
-  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; ' +
+  'n=0; rc=0; seen=""; ' +
+  "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh " +
+  '"$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh ' +
+  "/workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; " +
+  'do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); ' +
+  'case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; ' +
+  'n=$((n+1)); bash "$f" || rc=$?; done; ' +
+  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. ' +
+  'PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; ' +
   'exit "$rc"';
 
 /**

--- a/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
@@ -13,8 +13,8 @@ Prepare a remote surface so a host project can execute there. Today that means *
 The remote environment's own configuration fields stay **one line into the repository**. Nothing else is pasted into a vendor UI.
 
 ```text
-setup:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
-maintenance: n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+setup:       n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
+maintenance: n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
 ```
 
 **That line is identical for every project AND every surface.** Nothing in it names the
@@ -164,8 +164,8 @@ When emitting, produce exactly:
 ```text
 Environment name:  <project> remote executor
 Repository:        <org>/<repo>        (must be the default checkout)
-Setup script:      n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
-Maintenance:       n=0; rc=0; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; exit "$rc"
+Setup script:      n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
+Maintenance:       n=0; rc=0; seen=""; for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh "$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh /workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; n=$((n+1)); bash "$f" || rc=$?; done; [ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; exit "$rc"
                    (identical for every project — the script finds the
                    checkout and installs from the committed lockfile)
 Environment vars:  LISA_SECRETS_SURFACE=codex-cloud

--- a/plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh
@@ -105,11 +105,21 @@ fi
 # plugin-delivered harnesses work at all. Lisa is a dependency of every project
 # it is applied to, so `node_modules` carries the same skill at the version that
 # project pins, which is the version its setup should run.
+#
+# `plugins/lisa/skills/` sits between them, and exists for exactly one project:
+# Lisa itself. There the checkout IS Lisa, at HEAD, while `node_modules` holds
+# whatever version its own lockfile pins — which was four months and a hundred
+# skills behind, so this file did not exist there at all and setup aborted
+# claiming the skill could not be found. The one place it was is the only place
+# that was not searched. It is ahead of node_modules because a checkout that
+# builds this skill is newer than any published copy of it, and harmless
+# everywhere else because no other project has that directory.
 runner=""
 for candidate in \
   ".claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".agents/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  "plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   "node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
   if [ -f "$candidate" ]; then
     runner="$candidate"
@@ -132,6 +142,18 @@ if [ -z "$runner" ]; then
   echo >&2
   echo "If dependencies are installed, run 'lisa apply' so the skills are" >&2
   echo "present, then re-run setup." >&2
+  echo >&2
+  # The version actually resolved, because "not found" and "found, but too old
+  # to contain this skill" read identically above and are fixed differently.
+  # The second is what happened on Lisa itself: node_modules held a release
+  # from before this skill existed, so every path checked was legitimately
+  # absent and the message blamed the install.
+  if [ -f node_modules/@codyswann/lisa/package.json ]; then
+    echo "For reference, node_modules has @codyswann/lisa version:" >&2
+    node -p "require('./node_modules/@codyswann/lisa/package.json').version" >&2 2>/dev/null ||
+      echo "  (unreadable)" >&2
+    echo "If that predates this skill, the pin is the problem, not the install." >&2
+  fi
   exit 1
 fi
 

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -308,28 +308,44 @@ export function installAssets(cwd = process.cwd()) {
  * at all — so a `$HOME` glob matched nothing there and bash was handed a path
  * still containing a literal asterisk.
  *
- * Both candidates are therefore tried relative to cwd, and EVERY match is
- * prepared rather than the first. A Claude Code web environment can hold more
- * than one checkout, so stopping at the first hit would prepare whichever
- * repository sorts first and silently ignore the rest — arbitrary rather than
- * merely limited. Each script anchors itself on its own repository root and
- * each project materializes under its own `secrets.namespace`, so preparing
- * several is well defined rather than a collision.
+ * Candidates are therefore tried relative to cwd first, then under `$HOME` and
+ * `/workspace` — the container roots the two surfaces actually use — because
+ * cwd is not reliably either of them. A Claude environment reported `$HOME` as
+ * `/root` with no checkout beneath it, which a cwd-only search cannot reach.
+ *
+ * EVERY match is prepared rather than the first. A Claude Code web environment
+ * can hold more than one checkout, so stopping at the first hit would prepare
+ * whichever repository sorts first and silently ignore the rest — arbitrary
+ * rather than merely limited. Each script anchors itself on its own repository
+ * root and each project materializes under its own `secrets.namespace`, so
+ * preparing several is well defined rather than a collision. Matches are
+ * deduplicated by resolved directory, since the candidate globs overlap
+ * whenever cwd happens to be one of the roots.
  *
  * The status is the first failure and every checkout is still attempted: one
  * broken repository must neither hide the others nor report success. The
  * explicit `exit 1` on no matches matters because a `for` loop over a glob that
  * matches nothing otherwise exits 0 — the quiet success this guards against.
  *
+ * Failure prints the layout it found rather than only the path it wanted. This
+ * field lives in a vendor settings box with a slow edit-and-retry loop, and a
+ * miss that reports nothing costs a whole round trip to learn one fact; the
+ * listing means the next message names the layout instead of repeating it.
+ *
  * A field that named the repository and package manager was a string a human
  * had to get right, in a settings box with no review, no version history and no
  * test — and the logic it encoded belongs in a file that has all three.
  */
 export const SETUP_FIELD =
-  "n=0; rc=0; " +
-  "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh; " +
-  'do [ -f "$f" ] || continue; n=$((n+1)); bash "$f" || rc=$?; done; ' +
-  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found under $PWD" >&2; exit 1; }; ' +
+  'n=0; rc=0; seen=""; ' +
+  "for f in scripts/lisa-remote-env/setup.sh */scripts/lisa-remote-env/setup.sh " +
+  '"$HOME"/scripts/lisa-remote-env/setup.sh "$HOME"/*/scripts/lisa-remote-env/setup.sh ' +
+  "/workspace/scripts/lisa-remote-env/setup.sh /workspace/*/scripts/lisa-remote-env/setup.sh; " +
+  'do [ -f "$f" ] || continue; d=$(cd "$(dirname "$f")" && pwd -P); ' +
+  'case " $seen " in *" $d "*) continue;; esac; seen="$seen $d"; ' +
+  'n=$((n+1)); bash "$f" || rc=$?; done; ' +
+  '[ "$n" -gt 0 ] || { echo "lisa-remote-env entrypoint not found. ' +
+  'PWD=$PWD HOME=$HOME" >&2; ls -1 . "$HOME" /workspace 2>&1 | head -40 >&2; exit 1; }; ' +
   'exit "$rc"';
 
 /**

--- a/scripts/lisa-remote-env/setup.sh
+++ b/scripts/lisa-remote-env/setup.sh
@@ -105,11 +105,21 @@ fi
 # plugin-delivered harnesses work at all. Lisa is a dependency of every project
 # it is applied to, so `node_modules` carries the same skill at the version that
 # project pins, which is the version its setup should run.
+#
+# `plugins/lisa/skills/` sits between them, and exists for exactly one project:
+# Lisa itself. There the checkout IS Lisa, at HEAD, while `node_modules` holds
+# whatever version its own lockfile pins — which was four months and a hundred
+# skills behind, so this file did not exist there at all and setup aborted
+# claiming the skill could not be found. The one place it was is the only place
+# that was not searched. It is ahead of node_modules because a checkout that
+# builds this skill is newer than any published copy of it, and harmless
+# everywhere else because no other project has that directory.
 runner=""
 for candidate in \
   ".claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".agents/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   ".codex/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
+  "plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs" \
   "node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs"; do
   if [ -f "$candidate" ]; then
     runner="$candidate"
@@ -132,6 +142,18 @@ if [ -z "$runner" ]; then
   echo >&2
   echo "If dependencies are installed, run 'lisa apply' so the skills are" >&2
   echo "present, then re-run setup." >&2
+  echo >&2
+  # The version actually resolved, because "not found" and "found, but too old
+  # to contain this skill" read identically above and are fixed differently.
+  # The second is what happened on Lisa itself: node_modules held a release
+  # from before this skill existed, so every path checked was legitimately
+  # absent and the message blamed the install.
+  if [ -f node_modules/@codyswann/lisa/package.json ]; then
+    echo "For reference, node_modules has @codyswann/lisa version:" >&2
+    node -p "require('./node_modules/@codyswann/lisa/package.json').version" >&2 2>/dev/null ||
+      echo "  (unreadable)" >&2
+    echo "If that predates this skill, the pin is the problem, not the install." >&2
+  fi
   exit 1
 fi
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1119,13 +1119,13 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md":
       "80fbf157f9c562c033886c25a99b37356602edd9e61cd2d492f339769ddcf97e",
     "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md":
-      "4fe124678cfc2b37188370af3b4e16895fcbad4d4b6f13b0fc7ac02bd99b0d26",
+      "f706b5c94267d128bf41ef1a5fa6b68ea184e22c7929bda126128f08e1728b86",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh":
       "6e3871ec2f8d56b8ebb85376ebdd3956f3ed8fa4f7b278c2ed90ca9b8845897c",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "7f7cf8a2248dbaa31f2f039fdaf147d083427a21633f7cf06ad612f38344d6c1",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "e8f1e74dd29104dc880eb2540024549d18d2a9c958b2b6fce0610ab0afd55cbb",
+      "f468dcf72512ff0b7d0d0ff6a38e81e5b57d83361ffff45c5265147f67ca01df",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
       "ff66d33ba41a068d09be18f81ac68988238c2afa1d4e3733ae906b73eea74324",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1123,7 +1123,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh":
       "6e3871ec2f8d56b8ebb85376ebdd3956f3ed8fa4f7b278c2ed90ca9b8845897c",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
-      "7f7cf8a2248dbaa31f2f039fdaf147d083427a21633f7cf06ad612f38344d6c1",
+      "c04afb1cf8e14a2713645228e679fa7772559488330a240ec0297cae6afd03e2",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
       "f468dcf72512ff0b7d0d0ff6a38e81e5b57d83361ffff45c5265147f67ca01df",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
@@ -1981,7 +1981,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/lisa-remote-env/session-start.sh":
       "6e3871ec2f8d56b8ebb85376ebdd3956f3ed8fa4f7b278c2ed90ca9b8845897c",
     "scripts/lisa-remote-env/setup.sh":
-      "7f7cf8a2248dbaa31f2f039fdaf147d083427a21633f7cf06ad612f38344d6c1",
+      "c04afb1cf8e14a2713645228e679fa7772559488330a240ec0297cae6afd03e2",
     "scripts/lisa-update-local.sh":
       "c811f9e10dbcb38499a9791c1ae9051460b347051d04a1d2046925bab9a53c96",
     "scripts/lisa-work-item.mjs":

--- a/tests/unit/secrets/remote-env-phases.test.ts
+++ b/tests/unit/secrets/remote-env-phases.test.ts
@@ -255,10 +255,16 @@ describe("emitted Claude configuration", () => {
     // by a string a human had to get right — in a settings box with no review,
     // no version history and no test. The script finds the checkout itself and
     // reads the package manager from the committed lockfile.
+    // cwd-relative FIRST. Codex Cloud's checkout is not under $HOME at all, so
+    // a field that led with a $HOME glob matched nothing there and bash got a
+    // path containing a literal asterisk. $HOME is a later fallback, for the
+    // case where cwd is neither the checkout nor its parent — that ordering is
+    // the invariant, which the behavioural tests in remote-env-setup-field
+    // exercise against each layout.
     expect(emitted).toContain("for f in scripts/lisa-remote-env/setup.sh");
-    // Not $HOME: Codex Cloud's checkout is not under it, so a $HOME glob
-    // matched nothing there and bash got a path with a literal asterisk.
-    expect(emitted).not.toContain('"$HOME"/*/');
+    expect(emitted.indexOf("for f in scripts/")).toBeLessThan(
+      emitted.indexOf('"$HOME"')
+    );
     expect(emitted).not.toMatch(/cd '?lisa'?/);
     expect(emitted).not.toContain("bun install &&");
   });

--- a/tests/unit/secrets/remote-env-setup-field.test.ts
+++ b/tests/unit/secrets/remote-env-setup-field.test.ts
@@ -88,11 +88,17 @@ describe("documented remote-env setup field", () => {
   /**
    * Run the documented field with a given working directory.
    * @param cwd Directory the vendor would run the field from.
+   * @param home Value of `$HOME` in the container, which defaults to `cwd`
+   *   because on Claude Code web they are the same directory.
    * @returns Combined output of the field.
    */
-  const runField = (cwd: string): string =>
+  const runField = (cwd: string, home = cwd): string =>
     execFileSync(BASH, ["-c", documentedSetupField()], {
       cwd,
+      // The field consults $HOME, so the tests must control it. Inheriting the
+      // developer's real home would make them depend on that machine's layout
+      // and would let a passing run mean nothing.
+      env: { ...process.env, HOME: home },
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     }).trim();
@@ -109,11 +115,42 @@ describe("documented remote-env setup field", () => {
     expect(runField(home)).toBe("FOUND-claude-web");
   });
 
-  it("never depends on $HOME containing the checkout", () => {
-    // The field this replaced was `bash "$HOME"/*/scripts/...`, which is correct
-    // on Claude Code web and wrong on Codex Cloud, where the checkout lives at
+  it("never DEPENDS on $HOME containing the checkout", () => {
+    // The field this replaced was `bash "$HOME"/*/scripts/...`, correct on
+    // Claude Code web and wrong on Codex Cloud, where the checkout lives at
     // /workspace/<repo> and is not under $HOME at all.
-    expect(documentedSetupField()).not.toContain("$HOME");
+    //
+    // Asserted by behaviour rather than by the absence of the string. $HOME is
+    // now one candidate among several, and forbidding the text would forbid the
+    // fallback below along with the bug — the guard is that a checkout outside
+    // $HOME is still found, which is the property that actually broke.
+    const home = path.join(temporary, "elsewhere");
+    mkdirSync(home, { recursive: true });
+    checkout(temporary, "FOUND-outside-home");
+    expect(runField(temporary, home)).toBe("FOUND-outside-home");
+  });
+
+  it("finds a checkout under $HOME when cwd is neither", () => {
+    // Reported from a live Claude environment: `$HOME` was `/root`, the field
+    // ran somewhere with no checkout beneath it, and a cwd-only search could
+    // not reach the repository at all —
+    //   bash: /root/*/scripts/lisa-remote-env/setup.sh: No such file or directory
+    // Nothing guarantees cwd is the checkout OR its parent, so the roots the
+    // surfaces actually use are searched too.
+    const home = path.join(temporary, "home");
+    const elsewhere = path.join(temporary, "root");
+    mkdirSync(elsewhere, { recursive: true });
+    checkout(path.join(home, "frontend"), "FOUND-under-home");
+    expect(runField(elsewhere, home)).toBe("FOUND-under-home");
+  });
+
+  it("prepares a checkout exactly once when the candidates overlap", () => {
+    // cwd, $HOME and the checkout can all be the same directory, and several
+    // candidate globs then match it. Preparing it twice is not merely wasteful:
+    // a doubled log reads as two repositories, which is the opposite of what
+    // the multi-checkout support above is there to make legible.
+    checkout(temporary, "ONCE");
+    expect(runField(temporary, temporary).split("ONCE")).toHaveLength(2);
   });
 
   it("prepares EVERY checkout, not whichever one sorts first", () => {
@@ -161,6 +198,31 @@ describe("documented remote-env setup field", () => {
   it("fails loudly when no entrypoint exists, rather than succeeding silently", () => {
     const empty = path.join(temporary, "empty");
     mkdirSync(empty, { recursive: true });
-    expect(() => runField(empty)).toThrow();
+    expect(() => runField(empty, empty)).toThrow();
+  });
+
+  it("describes the layout it found when it finds no entrypoint", () => {
+    // This field lives in a vendor settings box with a slow edit-and-retry
+    // loop, and the vendor surfaces only its stderr. A miss that names just the
+    // path it wanted costs a whole round trip to learn one fact — which is
+    // exactly what happened: `/root/*/scripts/...: No such file or directory`
+    // said where it looked and nothing about where the checkout actually was.
+    const empty = path.join(temporary, "empty");
+    const home = path.join(temporary, "home");
+    mkdirSync(empty, { recursive: true });
+    mkdirSync(path.join(home, "a-directory-that-is-there"), {
+      recursive: true,
+    });
+
+    let stderr = "";
+    try {
+      runField(empty, home);
+    } catch (error) {
+      stderr = (error as { stderr?: string }).stderr ?? "";
+    }
+
+    expect(stderr).toContain("PWD=");
+    expect(stderr).toContain("HOME=");
+    expect(stderr).toContain("a-directory-that-is-there");
   });
 });

--- a/tests/unit/secrets/remote-env-skill-resolution.test.ts
+++ b/tests/unit/secrets/remote-env-skill-resolution.test.ts
@@ -48,6 +48,13 @@ const NODE_MODULES_RUNNER =
 const CLAUDE_RUNNER =
   ".claude/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs";
 
+/** Where the Lisa monorepo itself keeps the skill, at HEAD. */
+const CHECKOUT_PLUGIN_RUNNER =
+  "plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs";
+
+/** Distinct marker for the checkout's own plugin copy. */
+const CHECKOUT_PLUGIN_MARKER = "ran-from-checkout-plugins";
+
 /** Distinct markers, so a test can tell which runner actually executed. */
 const NODE_MODULES_MARKER = "ran-from-node-modules";
 const CLAUDE_MARKER = "ran-from-claude-skills";
@@ -204,6 +211,54 @@ describe("remote-env entrypoint skill resolution", () => {
 
     expect(result.status).toBe(0);
     expect(result.stderr).toContain("No lockfile found");
+  });
+
+  it("resolves from the checkout's own plugins directory (Lisa on Lisa)", () => {
+    // Lisa applied to Lisa is the case every other rung misses. The checkout
+    // IS Lisa, at HEAD; node_modules holds whatever its own lockfile pins,
+    // which was four months and a hundred skills behind — so this file did not
+    // exist there and setup aborted saying the skill could not be found. The
+    // one place it was is the one place that was not searched.
+    const root = temporaryDirectory();
+    plantRunner(root, CHECKOUT_PLUGIN_RUNNER, CHECKOUT_PLUGIN_MARKER);
+
+    const result = runEntrypoint(root);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(CHECKOUT_PLUGIN_MARKER);
+  });
+
+  it("prefers the checkout's plugins directory over a stale node_modules", () => {
+    // A checkout that builds this skill is by construction newer than any
+    // published copy of it, so HEAD wins over the pinned release.
+    const root = temporaryDirectory();
+    plantRunner(root, NODE_MODULES_RUNNER, NODE_MODULES_MARKER);
+    plantRunner(root, CHECKOUT_PLUGIN_RUNNER, CHECKOUT_PLUGIN_MARKER);
+
+    const result = runEntrypoint(root);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(CHECKOUT_PLUGIN_MARKER);
+    expect(result.stdout).not.toContain(NODE_MODULES_MARKER);
+  });
+
+  it("names the resolved package version when nothing matches", () => {
+    // "Not installed" and "installed, but predates this skill" read identically
+    // and are fixed differently — the second is what happened, and the message
+    // sent the operator to fix an install that had worked.
+    const root = temporaryDirectory();
+    const pkg = path.join(root, "node_modules", "@codyswann", "lisa");
+    mkdirSync(pkg, { recursive: true });
+    writeFileSync(
+      path.join(pkg, "package.json"),
+      JSON.stringify({ name: "@codyswann/lisa", version: "2.195.6" })
+    );
+
+    const result = runEntrypoint(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("2.195.6");
+    expect(result.stderr).toMatch(/pin is the problem/i);
   });
 
   it("prefers an agent skill directory over node_modules", () => {


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2212

Two failures from one live Claude Code web container, both of which reported the wrong cause.

## 1. The field could not reach the checkout

```
Setup script failed with exit code 127.
bash: /root/*/scripts/lisa-remote-env/setup.sh: No such file or directory
```

`HOME=/root`; the checkout was at `/home/user/lisa`. The `$HOME`-glob field predates #2197 and is already fixed on `main` — but the incident shows the assumption underneath is still too narrow: **nothing guarantees cwd is the checkout or its parent.**

`$HOME` and `/workspace` — the roots the two surfaces actually use — are now searched *after* the cwd-relative candidates. The ordering is the invariant and is pinned: cwd first, because Codex Cloud's checkout is not under `$HOME`, and leading with a `$HOME` glob was the original bug.

Matches are deduplicated by resolved directory, since the globs overlap whenever cwd is one of the roots. Preparing a checkout twice isn't just wasteful — a doubled log reads as two repositories, the opposite of what preparing every checkout exists to make legible.

**Failure now prints the layout it found**, not only the path it wanted. This field lives in a vendor settings box whose edit-and-retry loop costs a whole session, and the vendor surfaces only stderr — the message above bought exactly one fact per round trip.

The `not.toContain("$HOME")` guard is **replaced, not deleted**. Its subject was a field that depended on `$HOME` *alone*, and forbidding the text would forbid the fallback along with the bug. The property is now behavioural: a checkout outside `$HOME` is still found.

## 2. Setup aborted saying its own skill was missing

```
Cannot find the lisa-setup-remote-env skill.
Searched the agent skill directories and node_modules...
```

The skill was present the whole time, in the one directory the ladder does not list.

**Lisa applied to Lisa is the case the ladder was not written for.** Everywhere else the checkout is a host project and `node_modules/@codyswann/lisa` is the newest Lisa in the container. On Lisa itself the checkout *is* Lisa at HEAD, while node_modules holds what its own lockfile pins — **2.195.6, four months and a hundred skills behind**, from before this skill existed. Every path checked was legitimately absent, so the message blamed a dependency install that had succeeded.

`plugins/lisa/skills/` is added between the agent directories and node_modules: ahead of node_modules because a checkout that *builds* this skill is by construction newer than any published copy, harmless everywhere else because no other project has that directory.

The failure message also prints the version node_modules resolved. "Not installed" and "installed, but predates this skill" read identically and are fixed differently — the second sent an operator to repair a working install.

## Evidence

Every layout is executed, not inspected — including the reported one:

```
cwd is the checkout (Codex Cloud)      CHECKOUT-IS-CWD          exit=0
checkout below cwd (Claude web)        ONE-LEVEL-DOWN           exit=0
checkout under HOME, cwd elsewhere     UNDER-HOME-NOT-CWD       exit=0   <- the report
two checkouts side by side             REPO-ONE, REPO-TWO       exit=0
cwd == HOME == checkout                SAME-DIR-ONCE (once)     exit=0
one broken, one good                   BAD-REPO, GOOD-REPO      exit=3
no checkout at all                     lists PWD, HOME, contents exit=1
```

Reverting the field turns three of the new guards red. `tests/unit/secrets` — 230 passed.
