### PR TITLE
Leave cloud-session plugin installs to Claude Code

### DIFF
--- a/scripts/install-claude-plugins.sh
+++ b/scripts/install-claude-plugins.sh
@@ -290,6 +290,29 @@ fi
 # Install plugins only when claude CLI is available
 if ! command -v claude &>/dev/null; then exit 0; fi
 
+# Not in a cloud session: the platform already does this, and does it at the
+# only moment it can work.
+#
+# Claude Code installs the plugins a repository declares in .claude/settings.json
+# at session start, from the marketplace that file names. This script runs from a
+# package manager's postinstall, which in a container happens during the setup
+# script — before Claude Code has launched and before any marketplace is
+# registered. Every install therefore failed:
+#
+#   Installing plugin "lisa@lisa"...× Plugin "lisa" not found in marketplace "lisa"
+#
+# Eight of eight, the official marketplace's plugins included, which is what
+# ruled out anything project-specific. The failures are harmless on their own
+# (`|| true`), but they leave an empty installed_plugins.json and several
+# screens of red in the setup log that read as the cause of whatever fails next.
+#
+# Standing down is the fix rather than racing the platform with an earlier
+# install, because there is no earlier moment at which one could succeed.
+if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
+  echo "Cloud session: leaving plugin installation to Claude Code, which installs what .claude/settings.json declares at session start."
+  exit 0
+fi
+
 # Version-gated plugin sync (perf). `claude plugin marketplace update` is a
 # network git pull of the whole Lisa repo and every `claude plugin install`
 # spawns the Claude CLI (seconds each); re-running all of it on every install

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1947,7 +1947,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/github-status-check.sh":
       "876914c369c5bd58f4a5f3c41d0c1264c6923f329a644f90640d15b434a0fbd1",
     "scripts/install-claude-plugins.sh":
-      "5f4bedb983900dc17f8843f73876fc7c445909eb12792b3330728ff03842f50b",
+      "ed60ed3afc25175b81439330dbf26ff639f55fabec54223df4c7266805c84f22",
     "scripts/internal-agy-skill-policy.json":
       "c2ce87d2eeebfdc9f24d6486425c010cf9289376f8a459f4767ca22d2bf8670d",
     "scripts/internal-codex-skill-policy.json":
@@ -8187,6 +8187,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/config/oxlint-typescript.test.ts": true,
     "tests/unit/config/phaser-template.test.ts": true,
     "tests/unit/config/postinstall-ci-guard.test.ts": true,
+    "tests/unit/config/postinstall-cloud-session-guard.test.ts": true,
     "tests/unit/config/rails-template.test.ts": true,
     "tests/unit/config/release-push-retry.test.ts": true,
     "tests/unit/config/sync-down-single-env.test.ts": true,

--- a/tests/unit/config/postinstall-cloud-session-guard.test.ts
+++ b/tests/unit/config/postinstall-cloud-session-guard.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Guards the cloud-session skip on Lisa's Claude plugin postinstall.
+ *
+ * Background: Claude Code installs the plugins a repository declares in
+ * `.claude/settings.json` at session start, from the marketplace that file
+ * names. Lisa's postinstall was doing the same job from a package manager's
+ * lifecycle script — which inside a cloud container runs during the environment
+ * setup script, before Claude Code has launched and before any marketplace is
+ * registered.
+ *
+ * Every install therefore failed, eight of eight, the official marketplace's
+ * plugins included:
+ *
+ *   Installing plugin "lisa@lisa"...× Plugin "lisa" not found in marketplace "lisa"
+ *
+ * Each one is swallowed by `|| true`, so the damage is not a broken build. It is
+ * an empty `installed_plugins.json` and several screens of red in the setup log
+ * that read as the cause of whatever fails next — which is precisely how they
+ * were read.
+ *
+ * Standing down is the fix rather than racing the platform with an earlier
+ * install: there is no earlier moment at which one could succeed.
+ * @module tests/unit/config/postinstall-cloud-session-guard
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SCRIPT = path.join(REPO_ROOT, "scripts", "install-claude-plugins.sh");
+
+/** The variable the platform sets, and the only reliable cloud signal. */
+const REMOTE_FLAG = "CLAUDE_CODE_REMOTE";
+
+describe("Claude plugin postinstall in a cloud session", () => {
+  const script = readFileSync(SCRIPT, "utf8");
+
+  it("stands down when the platform will do the install itself", () => {
+    expect(script).toContain(`if [ "\${${REMOTE_FLAG}:-}" = "true" ]`);
+  });
+
+  it("stands down BEFORE it installs anything", () => {
+    // Ordering is the whole guard. Placed after the first `claude plugin
+    // install`, it would still emit the failures it exists to prevent.
+    const guard = script.indexOf(`\${${REMOTE_FLAG}:-}`);
+    const firstInstall = script.indexOf("claude plugin install");
+    expect(guard).toBeGreaterThan(-1);
+    expect(firstInstall).toBeGreaterThan(-1);
+    expect(guard).toBeLessThan(firstInstall);
+  });
+
+  it("says why it skipped rather than exiting silently", () => {
+    // A postinstall that goes quiet in one environment and not another looks
+    // like a broken install to the next person reading the setup log.
+    expect(script).toMatch(/Cloud session: leaving plugin installation/);
+  });
+
+  it("leaves local installs alone", () => {
+    // The guard tests one variable against one value. Anything broader would
+    // change behaviour on developer machines, where this script is the thing
+    // that installs the plugins.
+    expect(script).not.toContain(`if [ -n "\${${REMOTE_FLAG}:-}" ]`);
+  });
+});


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2215

Claude Code [installs the plugins a repository declares](https://code.claude.com/docs/en/cloud-environments#what-carries-over-from-your-setup) in `.claude/settings.json` at session start, from the marketplace that file names. `scripts/install-claude-plugins.sh` was doing the same job from a package manager’s postinstall — which inside a container runs during the **environment setup script**, before Claude Code has launched and before any marketplace is registered.

All eight installs failed there, the official marketplace’s plugins included:

```
Installing plugin "lisa@lisa"...× Plugin "lisa" not found in marketplace "lisa".
Installing plugin "typescript-lsp@claude-plugins-official"...× Plugin not found in marketplace
```

That *every* marketplace failed rather than only Lisa’s is what rules out anything project-specific: nothing had fetched an index yet, because nothing that fetches one had started.

## Why this matters even though nothing broke

Each failure is swallowed by `|| true`. The cost is an empty `installed_plugins.json` and several screens of red in a setup log, which read as the cause of whatever fails next — exactly how they were read while diagnosing #2212.

## Why stand down rather than fix the install

There is no earlier moment at which one could succeed. Racing the platform means running before the thing that registers marketplaces exists.

The guard tests one variable against one value and sits ahead of the first `claude plugin install`. A developer machine — where this script *is* what installs the plugins — is untouched. Ordering is pinned by a test, since a guard placed after that call would still emit the failures it exists to prevent.

The script previously had **no** `CLAUDE_CODE_REMOTE` guard anywhere.