### PR TITLE
Name which GitHub failure the work-item guardrail actually hit

### DIFF
--- a/all/copy-overwrite/scripts/lisa-work-item.mjs
+++ b/all/copy-overwrite/scripts/lisa-work-item.mjs
@@ -15,6 +15,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const RELEASE_SUBJECT =
   /^chore\(release\): \d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)? \[skip ci\]$/;
@@ -26,6 +27,46 @@ const GUIDANCE = [
 ].join("\n");
 
 class TrackingError extends Error {}
+
+/**
+ * Say which of three different failures a `gh` invocation actually hit.
+ *
+ * The three are indistinguishable from an exit status alone, and they send the
+ * reader to three different places: a missing binary is an environment to
+ * provision, a refused credential is an access grant to obtain, and only the
+ * third is anything to do with the ticket.
+ *
+ * Collapsing them cost a real round trip. On Claude Code web, where `gh` is not
+ * pre-installed, every commit was refused with "issue #2202 does not exist or
+ * is inaccessible" — about an issue that was open and correct. The message
+ * accused the ticket, so that is where the reader went.
+ * @param {{status: number|null, error?: Error, stderr?: string}} result Spawn result.
+ * @param {string} ref Work item reference, for the message.
+ * @param {string} noun What the reference names.
+ * @returns {string} A message naming the actual fault.
+ */
+export function githubFailureReason(result, ref, noun) {
+  if (result.error?.code === "ENOENT") {
+    return (
+      `the GitHub CLI (gh) is not installed, so ${noun} ${ref} could not be ` +
+      `checked.\nThis is an environment gap, not a problem with the work item. ` +
+      `Pin gh in remoteEnv.tools.install for surfaces that lack it.`
+    );
+  }
+  const stderr = String(result.stderr ?? "");
+  if (
+    /not enabled for this session|gh auth login|HTTP 40[13]|Bad credentials|authentication/i.test(
+      stderr
+    )
+  ) {
+    return (
+      `the GitHub CLI cannot authenticate, so ${noun} ${ref} could not be ` +
+      `checked.\nThis is a credential gap, not a problem with the work item.` +
+      `\n${stderr.trim().slice(0, 300)}`
+    );
+  }
+  return `${noun} ${ref} does not exist or is inaccessible`;
+}
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
@@ -537,9 +578,7 @@ function githubIssue(ref, contract) {
     }
   );
   if (result.status !== 0)
-    throw new TrackingError(
-      `GitHub issue ${ref} does not exist or is inaccessible`
-    );
+    throw new TrackingError(githubFailureReason(result, ref, "GitHub issue"));
   const issue = safeJson(result.stdout, `GitHub issue ${ref}`);
   if (String(issue.number) !== number)
     throw new TrackingError(`GitHub returned the wrong issue for ${ref}`);
@@ -1165,12 +1204,40 @@ function main() {
   );
 }
 
-try {
-  main();
-} catch (error) {
-  const detail = error instanceof Error ? error.message : String(error);
-  console.error(
-    `\n❌ Work-item tracking blocked this operation: ${detail}\n\n${GUIDANCE}\n`
-  );
-  process.exitCode = 1;
+/**
+ * Run the CLI, reporting any refusal the way the Git hooks expect.
+ *
+ * Exported so the thin entrypoint at `scripts/lisa-work-item.mjs` can invoke it
+ * explicitly. That entrypoint re-exports this module rather than duplicating
+ * it, so inside here `import.meta.url` names THIS file while `argv[1]` names
+ * the entrypoint — the two never match, and a guard comparing them would leave
+ * Lisa's own hooks doing nothing at all, silently and with exit 0. An exported
+ * call is unambiguous where a path comparison is a guess.
+ */
+export function runCli() {
+  try {
+    main();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.error(
+      `\n❌ Work-item tracking blocked this operation: ${detail}\n\n${GUIDANCE}\n`
+    );
+    process.exitCode = 1;
+  }
+}
+
+// Only when invoked as a program. Running on import made every function here
+// unreachable from a test: importing the module executed the CLI, so the only
+// way to exercise any of it was to spawn a process and drive it through the
+// filesystem and PATH. That is why a bug in the message above shipped — the
+// branch that produced it had no way to be asserted on.
+//
+// This branch covers a host project, where the file is copied to
+// `scripts/lisa-work-item.mjs` and invoked directly. Lisa's own checkout keeps
+// a re-exporting entrypoint instead, which calls runCli() itself.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  runCli();
 }

--- a/scripts/lisa-work-item.mjs
+++ b/scripts/lisa-work-item.mjs
@@ -2,4 +2,11 @@
 
 // The installed copy lives under all/copy-overwrite. Keeping this tiny entrypoint
 // makes the exact same implementation available to Lisa's own hooks and CI.
-await import("../all/copy-overwrite/scripts/lisa-work-item.mjs");
+//
+// runCli() is called explicitly rather than left to the implementation's own
+// "am I the program?" check: from in there, import.meta.url names that file
+// while argv[1] names this one, so the check cannot fire through this path and
+// the hooks would pass silently while validating nothing.
+import { runCli } from "../all/copy-overwrite/scripts/lisa-work-item.mjs";
+
+runCli();

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7,7 +7,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-contents/gitignore":
       "2dbf7fd2f2020fc7824c432342002d9ca3ebb57b2872e761b14e942b23479a11",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
-      "5eb31c284e820a51312d4484f0669128007326af55ee515923fec33700d003a1",
+      "96a87c131606b3edd43e52485e68f8ffbf5c528cb4beb7a1185263519a9632ce",
     "all/create-only/.claude/rules/PROJECT_RULES.md":
       "6e1c7923ad2a15356babc60c97e7f97be728d790af285b6a7cd7d1b4d39cd97f",
     "all/create-only/.lisaignore":
@@ -1985,7 +1985,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/lisa-update-local.sh":
       "c811f9e10dbcb38499a9791c1ae9051460b347051d04a1d2046925bab9a53c96",
     "scripts/lisa-work-item.mjs":
-      "acb359ed7a39150fd5e1e68f4c95144045e75d9d53b735da4a7a9271f063044e",
+      "51081847e980f314a764c2e50a7a121b1ced9ef4b980f33898057de4c7b852e6",
     "scripts/migrate-deploy-order.sh":
       "77d909b4cbbfc05169a79168d7868600ea7f56f846feefb7d5121618c54800c3",
     "scripts/plugin-parity-drift.mjs":
@@ -8334,6 +8334,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/threshold-ratchet.test.ts": true,
     "tests/unit/scripts/upstream-evidence-manifest.test.ts": true,
     "tests/unit/scripts/verification-coverage.test.ts": true,
+    "tests/unit/scripts/work-item-github-failure-diagnosis.test.ts": true,
     "tests/unit/secrets/automation-workflow.test.ts": true,
     "tests/unit/secrets/bootstrap-key-naming.test.ts": true,
     "tests/unit/secrets/doctor-secrets.test.ts": true,

--- a/tests/unit/scripts/work-item-github-failure-diagnosis.test.ts
+++ b/tests/unit/scripts/work-item-github-failure-diagnosis.test.ts
@@ -1,0 +1,130 @@
+/**
+ * The work-item guardrail must name the fault it actually hit.
+ *
+ * Its GitHub path shells out to `gh` and treated any non-zero exit as one
+ * thing: "does not exist or is inaccessible". Three failures reach that line
+ * and they send the reader to three different places — a missing binary is an
+ * environment to provision, a refused credential is an access grant to obtain,
+ * and only the third has anything to do with the ticket.
+ *
+ * The collapse cost a real round trip. On Claude Code web, where `gh` is not
+ * pre-installed, every commit was refused with "GitHub issue #2202 does not
+ * exist or is inaccessible" — about an issue that was open and correct. The
+ * message accused the ticket, so that is where the reader went, and the run
+ * ended in a `--no-verify` bypass instead.
+ *
+ * This file could not have existed before the module grew a main guard. The
+ * script ran on import, so importing it executed the CLI, and the only way to
+ * reach any branch was to spawn a process and drive it through the filesystem
+ * and PATH. A branch with no way to be asserted on is how the bug shipped.
+ * @module tests/unit/scripts/work-item-github-failure-diagnosis
+ */
+import { spawnSync } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+import { githubFailureReason } from "../../../all/copy-overwrite/scripts/lisa-work-item.mjs";
+
+/** A reference whose shape is valid, so only the `gh` outcome varies. */
+const REF = "CodySwannGT/lisa#2202";
+
+/** The noun the guardrail uses for a GitHub work item. */
+const NOUN = "GitHub issue";
+
+/** Verbatim from the Claude Code web container that hit this. */
+const PROXY_REFUSAL =
+  '{"message":"GitHub access is not enabled for this session. An org admin must connect the Claude GitHub App for this organization."}';
+
+describe("work-item guardrail: which GitHub failure happened", () => {
+  it("names a missing gh as an environment gap, not a bad ticket", () => {
+    const reason = githubFailureReason(
+      {
+        status: null,
+        error: Object.assign(new Error("spawn gh ENOENT"), { code: "ENOENT" }),
+      },
+      REF,
+      NOUN
+    );
+
+    expect(reason).toMatch(/gh\) is not installed/i);
+    expect(reason).toMatch(/not a problem with the work item/i);
+    expect(reason).not.toMatch(/does not exist or is inaccessible/i);
+    // The remedy, since the reader cannot be expected to know that a cloud
+    // container ships without it.
+    expect(reason).toMatch(/remoteEnv\.tools\.install/);
+  });
+
+  it("names a refused credential as a credential gap, and quotes the refusal", () => {
+    const reason = githubFailureReason(
+      { status: 1, stderr: PROXY_REFUSAL },
+      REF,
+      NOUN
+    );
+
+    expect(reason).toMatch(/cannot authenticate/i);
+    expect(reason).toMatch(/not a problem with the work item/i);
+    // Quoted verbatim, because the remedy is in the refusal and nowhere else:
+    // no status code implies "an org admin must connect the GitHub App".
+    expect(reason).toMatch(/org admin must connect the Claude GitHub App/);
+  });
+
+  it("treats an unauthenticated CLI as the same class of problem", () => {
+    const reason = githubFailureReason(
+      { status: 1, stderr: "gh auth login required" },
+      REF,
+      NOUN
+    );
+
+    expect(reason).toMatch(/cannot authenticate/i);
+  });
+
+  it("still says the issue is inaccessible when that is what happened", () => {
+    // The original message is right for the original case, and losing it would
+    // trade one misdiagnosis for another.
+    const reason = githubFailureReason(
+      { status: 1, stderr: "GraphQL: Could not resolve to an Issue" },
+      REF,
+      NOUN
+    );
+
+    expect(reason).toBe(`${NOUN} ${REF} does not exist or is inaccessible`);
+  });
+
+  it("does not mistake an empty stderr for an auth failure", () => {
+    // A generic non-zero exit carries no evidence either way, and guessing
+    // "credential" there would resurrect the original bug pointing elsewhere.
+    const reason = githubFailureReason({ status: 1 }, REF, NOUN);
+
+    expect(reason).toBe(`${NOUN} ${REF} does not exist or is inaccessible`);
+  });
+});
+
+describe("the guardrail actually runs from both entrypoints", () => {
+  // The dangerous failure here is not a crash, it is exit 0 with no output: the
+  // hooks would report success while validating nothing, and nobody would know
+  // until an unbound commit reached main. Adding a main guard introduced exactly
+  // that for Lisa's own checkout, because its entrypoint re-exports the
+  // implementation, so `import.meta.url` and `argv[1]` name different files and
+  // the check could never fire.
+  const entrypoints = [
+    ["Lisa's re-exporting entrypoint", "scripts/lisa-work-item.mjs"],
+    [
+      "a host project's direct copy",
+      "all/copy-overwrite/scripts/lisa-work-item.mjs",
+    ],
+  ] as const;
+
+  it.each(entrypoints)(
+    "refuses an unbound worktree via %s",
+    (_label, entry) => {
+      const result = spawnSync(process.execPath, [entry, "current"], {
+        encoding: "utf8",
+      });
+
+      expect(result.stderr).toMatch(
+        /Work-item tracking blocked this operation/
+      );
+      expect(result.status).not.toBe(0);
+    }
+  );
+});


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2218

Scope item 2 of #2218. The `gh` install and credential questions stay open there; #2221 covers why the bypass was possible at all.

## The bug

Any non-zero exit from `gh` became one message:

```js
if (result.status !== 0)
  throw new TrackingError(`GitHub issue ${ref} does not exist or is inaccessible`);
```

Three failures reach that line and they send the reader to three different places — a missing binary is an environment to provision, a refused credential is an access grant to obtain, and only the third has anything to do with the ticket.

On Claude Code web, where `gh` is not pre-installed, every commit was refused with `GitHub issue CodySwannGT/lisa#2202 does not exist or is inaccessible` — about an issue that was open and correct. The message accused the ticket, so that is where the reader went.

A refused credential now quotes the refusal **verbatim**, because the remedy is in it and nowhere else — no status code implies *"an org admin must connect the Claude GitHub App"*. The original wording survives for its own case, and an empty stderr still resolves to it rather than guessing: guessing "credential" there would resurrect the same bug pointing elsewhere.

## Why it shipped, and the part that fixes that

The module ran `main()` **on import**, so importing it executed the CLI and the only way to reach any branch was to spawn a process and drive it through the filesystem and PATH. I tried exactly that first and it turned into a fight with `sonarjs/no-os-command-from-path` over a deliberately writeable sandbox. A branch with no way to be asserted on is how the bug shipped.

## A bug this nearly introduced

Adding a main guard broke Lisa's own hooks — **silently**. The entrypoint at `scripts/lisa-work-item.mjs` re-exports the implementation, so inside it `import.meta.url` names one file and `argv[1]` names the other. They never match:

```
$ node scripts/lisa-work-item.mjs current
$ echo $?
0                    # no output, no validation, exit 0
```

Hooks would have reported success while validating nothing. Replaced the path comparison with an explicit exported `runCli()` the entrypoint calls — unambiguous where a path comparison is a guess — and both entrypoints now have a regression test, because silent success is invisible by construction.

7 tests. The commit was also refused once, correctly, because #2218 was still `status:ready`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GitHub work-item validation messages to distinguish missing CLI tools, authentication problems, inaccessible issues, and ambiguous failures.
  - CLI commands now return clear diagnostic output and a nonzero exit status when run from an invalid or unbound worktree.
  - Importing the work-item tooling no longer unintentionally starts command-line execution.

- **Tests**
  - Added coverage for GitHub failure diagnosis, authentication scenarios, inaccessible issues, and CLI guardrails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->