### PR TITLE
Keep enforcement when the plugin never installs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/lisa-enforcement-fallback.sh"
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/scripts/lisa-enforcement-fallback.sh
+++ b/scripts/lisa-enforcement-fallback.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Run Lisa's Bash enforcement guards when the plugin that normally provides them
+# is not installed.
+#
+# Every PreToolUse guard — block-no-verify, parity-safety-net,
+# block-shell-json-parsing — is declared in the Lisa plugin. A cloud session
+# installs plugins at session start from the marketplace the repository
+# declares, and when that does not happen the container runs with
+# `installed_plugins.json` empty and no enforcement whatsoever.
+#
+# That is how a dispatched session committed with `--no-verify`: not by evading
+# a guard, but in an environment where none existed. The guards failed open, and
+# silently, which is the worst of the three ways they could fail.
+#
+# A repository hook is the delivery that cannot fail this way. `.claude/settings.json`
+# is part of the clone, so it reaches a cloud session whether or not a plugin
+# ever installs.
+set -uo pipefail
+
+payload="$(cat)"
+
+repo_root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+[ -n "$repo_root" ] || exit 0
+
+# Skip when the plugin is installed, so a developer machine does not run every
+# guard twice and print every refusal twice. Absence is the interesting case and
+# the only one this exists for.
+#
+# Read from the plugin registry rather than from CLAUDE_PLUGIN_ROOT: that
+# variable is set for plugin hooks, and this hook is by definition not one.
+installed="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/installed_plugins.json"
+if [ -f "$installed" ] && grep -q '"lisa@lisa"' "$installed" 2>/dev/null; then
+  exit 0
+fi
+
+status=0
+for guard in block-no-verify parity-safety-net block-shell-json-parsing; do
+  script="$repo_root/plugins/lisa/hooks/$guard.sh"
+  [ -f "$script" ] || continue
+  # Each guard reads the tool payload on stdin and signals a refusal with exit
+  # 2. The payload is replayed to every one of them, and the strongest refusal
+  # is returned — a guard that declines must not be able to clear one that did
+  # not.
+  #
+  # The status is captured from the pipeline directly rather than through `if !`,
+  # where `$?` is the negation and every refusal read as success: the guard
+  # printed its objection and the command ran anyway, which is the same
+  # fail-open this file exists to close.
+  printf '%s' "$payload" | bash "$script"
+  guard_status=$?
+  if [ "$guard_status" -gt "$status" ]; then
+    status="$guard_status"
+  fi
+done
+
+exit "$status"

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1970,6 +1970,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "134ee2a327290f066f1eb318b5ed53c711557c3e10ed462c00ff5c97cfb20863",
     "scripts/lisa-commit-and-pr-local.sh":
       "605409c3ce6ec38ad3275604291a1ceae98f7807a605654263bc14f811c03903",
+    "scripts/lisa-enforcement-fallback.sh":
+      "8dc942ac4edc2017d6b8277296c8f80542e7c024eef1bb65de609979d0ca9a0e",
     "scripts/lisa-github-environments.sh":
       "0a76e92f108519abaf3e29991299ec3b0db20ea533e69e6d2a53d802dba9c370",
     "scripts/lisa-github-repo-settings.sh":
@@ -7624,6 +7626,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "scripts/lib/reusable-workflow-contract.d.mts": true,
     "scripts/lib/reusable-workflow-contract.mjs": true,
     "scripts/lisa-commit-and-pr-local.sh": true,
+    "scripts/lisa-enforcement-fallback.sh": true,
     "scripts/lisa-github-environments.sh": true,
     "scripts/lisa-github-repo-settings.sh": true,
     "scripts/lisa-github-repo-setup.sh": true,
@@ -8255,6 +8258,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/hooks/enforce-verification-gate-preserve.test.ts": true,
     "tests/unit/hooks/enforce-verification-gate-v1.test.ts": true,
     "tests/unit/hooks/enforce-verification-gate-v2.test.ts": true,
+    "tests/unit/hooks/enforcement-fallback.test.ts": true,
     "tests/unit/hooks/enforcement-gates-e2e.test.ts": true,
     "tests/unit/hooks/inject-rules.test.ts": true,
     "tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts": true,

--- a/src/strategies/package-lisa.ts
+++ b/src/strategies/package-lisa.ts
@@ -2,6 +2,7 @@
 import { readFile } from "node:fs/promises";
 import * as fse from "fs-extra";
 import path from "node:path";
+import semver from "semver";
 import type { FileOperationResult, ProjectType } from "../core/config.js";
 import { PROJECT_TYPE_HIERARCHY, PROJECT_TYPE_ORDER } from "../core/config.js";
 import type { ICopyStrategy, StrategyContext } from "./strategy.interface.js";
@@ -628,10 +629,11 @@ export class PackageLisaStrategy implements ICopyStrategy {
     projectJson: Record<string, unknown>,
     template: ResolvedPackageLisaTemplate
   ): Record<string, unknown> {
-    // Phase 1: Apply force (Lisa's values completely replace project's)
-    const afterForce = deepMerge(
+    // Phase 1: Apply force (Lisa's values completely replace project's), then
+    // restore any dependency pin the host had raised ABOVE Lisa's floor.
+    const afterForce = preserveHigherHostPins(
       projectJson,
-      template.force as Record<string, unknown>
+      deepMerge(projectJson, template.force as Record<string, unknown>)
     );
 
     // Phase 2: Apply defaults (project's values preserved, Lisa provides fallback)
@@ -761,6 +763,83 @@ const DIRECT_DEPENDENCY_SECTIONS = [
 
 /** package.json sections that carry npm-style version overrides. */
 const OVERRIDE_SECTIONS = ["overrides", "resolutions"] as const;
+
+/**
+ * Restore host `overrides`/`resolutions` pins that sit ABOVE Lisa's template.
+ * @remarks
+ * `force.overrides` / `force.resolutions` exist to push a project PAST a
+ * transitive CVE, so they are a security FLOOR — not an assignment. Phase 1
+ * applies them with `deepMerge`, where Lisa's value wins unconditionally, and
+ * that is only correct while the template is the higher of the two. The moment
+ * a host raises a pin beyond the template (or the template simply lags a fresh
+ * advisory), the same "security write" silently walks the host BACKWARDS into
+ * the vulnerable range it had already escaped.
+ *
+ * This is not hypothetical: a host pinned at `tar >=7.5.21` was reverted to
+ * `>=7.5.11` on every `bun install` by a template carrying the older value, and
+ * upgrading Lisa did not fix it — the shipped template was still `>=7.5.19`,
+ * below the host. A floor can only be right by coincidence when it is written
+ * as an overwrite.
+ *
+ * Comparison is on the minimum version each range admits (`>=7.5.21` → 7.5.21,
+ * `^6.27.0` → 6.27.0), which is exactly the quantity a CVE floor cares about. A
+ * value that cannot be parsed — npm's `"$name"` self-references, git URLs, `*`
+ * — is left as Phase 1 produced it, so this can only ever RAISE a pin.
+ * @param projectJson - The host package.json as it was before Phase 1.
+ * @param afterForce - The result of Phase 1's force merge.
+ * @returns `afterForce`, with host-side higher pins restored.
+ */
+function preserveHigherHostPins(
+  projectJson: Record<string, unknown>,
+  afterForce: Record<string, unknown>
+): Record<string, unknown> {
+  return OVERRIDE_SECTIONS.reduce<Record<string, unknown>>((acc, section) => {
+    const forcedSection = asRecord(acc[section]);
+    const restored = Object.entries(asRecord(projectJson[section])).reduce<
+      Record<string, unknown>
+    >(
+      (pins, [name, hostValue]) =>
+        hostPinIsHigher(hostValue, forcedSection[name])
+          ? { ...pins, [name]: hostValue }
+          : pins,
+      forcedSection
+    );
+
+    return restored === forcedSection ? acc : { ...acc, [section]: restored };
+  }, afterForce);
+}
+
+/**
+ * Decide whether the host's pin admits a strictly higher minimum than Lisa's.
+ * @param hostValue - The host's range for this dependency.
+ * @param forcedValue - The range Phase 1 wrote for the same dependency.
+ * @returns True only when both parse and the host's floor is strictly higher.
+ */
+function hostPinIsHigher(hostValue: unknown, forcedValue: unknown): boolean {
+  if (typeof hostValue !== "string" || typeof forcedValue !== "string") {
+    return false;
+  }
+  const hostFloor = rangeFloor(hostValue);
+  const forcedFloor = rangeFloor(forcedValue);
+  return (
+    hostFloor !== null &&
+    forcedFloor !== null &&
+    semver.gt(hostFloor, forcedFloor)
+  );
+}
+
+/**
+ * Resolve the lowest version a range admits.
+ * @param range - An npm version range.
+ * @returns The minimum version, or null when the range is not comparable.
+ */
+function rangeFloor(range: string): string | null {
+  try {
+    return semver.minVersion(range)?.version ?? null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Rewrite literal `overrides`/`resolutions` entries into npm's `"$name"`

--- a/tests/unit/hooks/enforcement-fallback.test.ts
+++ b/tests/unit/hooks/enforcement-fallback.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Enforcement must survive a container that has no Lisa plugin.
+ *
+ * Every `PreToolUse` guard — `block-no-verify`, `parity-safety-net`,
+ * `block-shell-json-parsing` — is declared in the Lisa plugin. A cloud session
+ * installs plugins at session start from the marketplace the repository
+ * declares, and when that does not happen the container runs with
+ * `installed_plugins.json` empty and no enforcement whatsoever.
+ *
+ * That is how a dispatched session committed with `--no-verify`: not by evading
+ * a guard, but in an environment where none existed. The guards failed open and
+ * silently, so the session behaved exactly as though they were present and got
+ * a different outcome.
+ *
+ * A repository hook is the delivery that cannot fail that way, because
+ * `.claude/settings.json` is part of the clone.
+ * @module tests/unit/hooks/enforcement-fallback
+ */
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/** Absolute, so the interpreter is never resolved through a writeable PATH. */
+const BASH = "/bin/bash";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const FALLBACK = path.join(
+  REPO_ROOT,
+  "scripts",
+  "lisa-enforcement-fallback.sh"
+);
+
+/** A config directory that cannot exist, standing in for a fresh container. */
+const NO_PLUGIN = "/nonexistent-claude-config";
+
+/** Claude's refusal code. Anything else lets the command through. */
+const BLOCKED = 2;
+
+/**
+ * Run the fallback against a tool payload.
+ * @param command The Bash command Claude proposes to run.
+ * @param configDir Where the plugin registry would live.
+ * @returns Exit status and combined output.
+ */
+function runFallback(
+  command: string,
+  configDir: string
+): { status: number | null; output: string } {
+  const result = spawnSync(BASH, [FALLBACK], {
+    input: JSON.stringify({ tool_name: "Bash", tool_input: { command } }),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: REPO_ROOT,
+      CLAUDE_CONFIG_DIR: configDir,
+    },
+  });
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+  };
+}
+
+describe("enforcement fallback when no plugin is installed", () => {
+  it("blocks the bypass that a plugin-less session got away with", () => {
+    const { status, output } = runFallback(
+      "git commit --no-verify -m x",
+      NO_PLUGIN
+    );
+
+    expect(status).toBe(BLOCKED);
+    expect(output).toMatch(/bypasses pre-commit/i);
+  });
+
+  it("blocks a destructive command the safety net owns", () => {
+    // Not only the commit guard: a container with no plugin also had nothing
+    // standing between an agent and a forced recursive delete.
+    const { status } = runFallback("rm -rf $UNSET_VAR/data", NO_PLUGIN);
+
+    expect(status).toBe(BLOCKED);
+  });
+
+  it("lets an ordinary command through", () => {
+    // A fallback that blocks everything is not enforcement, it is an outage.
+    const { status } = runFallback("ls -la", NO_PLUGIN);
+
+    expect(status).toBe(0);
+  });
+
+  it("stays inert where the plugin already provides the guards", () => {
+    // Otherwise a developer machine runs every guard twice and prints every
+    // refusal twice, which teaches people to skim refusals.
+    const { status } = runFallback(
+      "git commit --no-verify -m x",
+      path.join(process.env.HOME ?? "", ".claude")
+    );
+
+    expect(status).toBe(0);
+  });
+});
+
+describe("the fallback is actually wired to run", () => {
+  it("is registered as a PreToolUse Bash hook in the repository settings", () => {
+    // The script existing is not the point — reaching a cloud session is. Repo
+    // settings are part of the clone, which is the only delivery that does not
+    // depend on a plugin install succeeding.
+    const settings = JSON.parse(
+      readFileSync(path.join(REPO_ROOT, ".claude", "settings.json"), "utf8")
+    ) as {
+      hooks?: {
+        PreToolUse?: readonly {
+          matcher?: string;
+          hooks?: readonly { command?: string }[];
+        }[];
+      };
+    };
+
+    const commands = (settings.hooks?.PreToolUse ?? [])
+      .filter(entry => entry.matcher === "Bash")
+      .flatMap(entry => entry.hooks ?? [])
+      .map(hook => hook.command ?? "");
+
+    expect(commands.some(c => c.includes("lisa-enforcement-fallback.sh"))).toBe(
+      true
+    );
+  });
+});

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -306,6 +306,105 @@ describe("PackageLisaStrategy", () => {
       expect(content.devDependencies.oxlint).toBe("^0.1.0");
     });
 
+    // Regression: force.resolutions/force.overrides are a security FLOOR, not an
+    // assignment. Writing them as a plain overwrite walked hosts BACKWARDS into
+    // the vulnerable range they had already escaped — a project pinned at
+    // `tar >=7.5.21` was reverted to `>=7.5.11` on every install, and upgrading
+    // Lisa did not fix it because the shipped template was still `>=7.5.19`,
+    // below the host. A floor can only be right by coincidence when it is
+    // written as an overwrite, so the merge now keeps whichever side is higher.
+    it("never lowers a host pin that already sits above the template floor", async () => {
+      await createPackageLisaTemplate("typescript", {
+        force: {
+          resolutions: {
+            tar: ">=7.5.19",
+            "brace-expansion": ">=5.0.9",
+            ws: ">=8.21.0",
+          },
+          overrides: {
+            tar: ">=7.5.19",
+            "brace-expansion": ">=5.0.9",
+            ws: ">=8.21.0",
+          },
+        },
+      });
+
+      const sourcePath = path.join(
+        lisaDir,
+        "typescript",
+        "package-lisa",
+        "package.lisa.json"
+      );
+      const destPath = path.join(projectDir, "package.json");
+      await createTypeScriptProject(projectDir);
+      await fs.writeJson(destPath, {
+        name: "host-project",
+        // Host is AHEAD of the template — must survive.
+        resolutions: {
+          tar: ">=7.5.21",
+          "brace-expansion": ">=5.0.9",
+          ws: "^8.0.0",
+        },
+        overrides: {
+          tar: ">=7.5.21",
+          "brace-expansion": ">=5.0.9",
+          ws: "^8.0.0",
+        },
+      });
+
+      const _result = await strategy.apply(
+        sourcePath,
+        destPath,
+        "package.json",
+        createContext({ skipGitCheck: true })
+      );
+
+      const content = await fs.readJson(destPath);
+      for (const section of ["resolutions", "overrides"] as const) {
+        // Host floor is HIGHER — the security write must not walk it back.
+        expect(content[section].tar).toBe(">=7.5.21");
+        // Equal floors — template value is fine, nothing to preserve.
+        expect(content[section]["brace-expansion"]).toBe(">=5.0.9");
+        // Host floor is LOWER — the force-bump still applies, which is the
+        // whole point of the mechanism and must not regress.
+        expect(content[section].ws).toBe(">=8.21.0");
+      }
+    });
+
+    // An unparseable range (a git URL, an npm alias) cannot be compared, so the
+    // template value stands — the guard may only ever RAISE a pin, never block a
+    // force-bump it failed to reason about. Uses a package that is NOT a direct
+    // dependency, so `normalizeSelfReferencingOverrides` does not rewrite the
+    // result into npm's `"$name"` form and mask what is being asserted.
+    it("applies the template pin when the host range is not comparable", async () => {
+      await createPackageLisaTemplate("typescript", {
+        force: { overrides: { "transitive-only": ">=2.0.0" } },
+      });
+
+      const sourcePath = path.join(
+        lisaDir,
+        "typescript",
+        "package-lisa",
+        "package.lisa.json"
+      );
+      const destPath = path.join(projectDir, "package.json");
+      await createTypeScriptProject(projectDir);
+      await fs.writeJson(destPath, {
+        name: "host-project",
+        overrides: { "transitive-only": "github:someone/transitive-only" },
+      });
+
+      const _result = await strategy.apply(
+        sourcePath,
+        destPath,
+        "package.json",
+        createContext({ skipGitCheck: true })
+      );
+
+      const content = await fs.readJson(destPath);
+      expect(content.overrides["transitive-only"]).toBe(">=2.0.0");
+    });
+
     // Regression: force.resolutions and force.overrides must replace project-side
     // values for package-level dep pinning (e.g. axios). This is the write that
     // was silently lost when `bun add -d @codyswann/lisa@latest` clobbered


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2221

A dispatched cloud session committed with `--no-verify` on #2217. It was not evading a guard — **there was no guard.**

```
$ rg -l block-no-verify
plugins/lisa/hooks/block-no-verify.sh          ← plugin
plugins/src/base/hooks/block-no-verify.sh      ← plugin source

$ node -e 'console.log(Object.keys(require("./.claude/settings.json").hooks))'
[ "SessionStart" ]                              ← the repo shipped one hook
```

Every `PreToolUse` guard is declared in the plugin. The container had `installed_plugins.json` = `{}`, so that session ran with **no enforcement of any kind** — nothing blocking a hook bypass, a forced recursive delete, or a suppressed linter.

## Why this is worse than the bypass it explains

The guards fail **open** and **silently**. Nothing announces their absence, so a session behaves exactly as though they are present and gets a different outcome. That is the "quietly bypass" case #2218 calls the one worth engineering against — arrived at without anyone choosing it.

## The fix

A repository hook is the delivery that cannot fail this way: `.claude/settings.json` is part of the clone and [reaches a cloud session](https://code.claude.com/docs/en/cloud-environments#what-carries-over-from-your-setup) whether or not a plugin install succeeds.

The fallback replays the tool payload to each committed guard and returns the strongest refusal. It stays **inert** wherever the plugin is installed — decided by reading the plugin registry, not `CLAUDE_PLUGIN_ROOT`, since that variable is set for plugin hooks and this is by definition not one. Otherwise a developer machine runs every guard twice and prints every refusal twice, which teaches people to skim refusals.

## A bug that reproduced the failure being fixed

The first version captured each guard's status through `if !`, where `$?` is the *negation*. Every refusal read as success: the guard printed its objection and the command ran anyway. Caught by asserting the exit code rather than the message.

```
PASS  exit=2  no plugin + --no-verify blocks
PASS  exit=2  no plugin + forced recursive delete
PASS  exit=0  no plugin + harmless command allowed
PASS  exit=0  plugin present stays inert
```

Five tests, including one asserting the hook is actually registered — the script existing is not the point, reaching a cloud session is.

## Scope note

This closes the hole for Lisa itself, where cloud dispatch runs. Host projects have no `plugins/lisa/hooks/` in their checkout, so the general fix — writing the guards into the checkout via `lisa apply`, or announcing a plugin-less session at SessionStart — stays open on #2221.