### PR TITLE
Stop the entrypoint check depending on binding state

### DIFF
--- a/tests/unit/scripts/work-item-github-failure-diagnosis.test.ts
+++ b/tests/unit/scripts/work-item-github-failure-diagnosis.test.ts
@@ -114,17 +114,19 @@ describe("the guardrail actually runs from both entrypoints", () => {
     ],
   ] as const;
 
-  it.each(entrypoints)(
-    "refuses an unbound worktree via %s",
-    (_label, entry) => {
-      const result = spawnSync(process.execPath, [entry, "current"], {
-        encoding: "utf8",
-      });
+  it.each(entrypoints)("runs the CLI via %s", (_label, entry) => {
+    // An unrecognised subcommand, because the only property under test is
+    // whether `main()` ran at all. The first version asked for a refusal
+    // about an unbound worktree, which is a fact about the machine rather
+    // than about the entrypoint: any worktree with a work item bound — the
+    // normal state during a task — exits 0 with empty stderr, and the test
+    // failed on main within the hour.
+    const result = spawnSync(process.execPath, [entry, "not-a-real-command"], {
+      encoding: "utf8",
+    });
 
-      expect(result.stderr).toMatch(
-        /Work-item tracking blocked this operation/
-      );
-      expect(result.status).not.toBe(0);
-    }
-  );
+    expect(result.stderr).toMatch(/Work-item tracking blocked this operation/);
+    expect(result.stderr).toMatch(/Usage: lisa-work-item\.mjs/);
+    expect(result.status).not.toBe(0);
+  });
 });


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2226

The test added in #2222 proves `main()` runs from both entrypoints by asserting the guardrail refuses an **unbound** worktree. That is a fact about the machine, not about the entrypoint.

A worktree with a work item bound — the normal state during any task — makes `current` exit 0 with empty stderr, so it went red on `main` within the hour:

```
AssertionError: expected '' to match /Work-item tracking blocked this operation/
```

An unrecognised subcommand is refused unconditionally and proves the same property, which is only ever "did `main()` run at all". It also asserts the usage text, so the refusal it sees is the one it means.

Caught by running the full suite on `main` rather than only the touched file — which is the argument for doing that.