### PR TITLE
Pin gh so a cloud session can run the commit guardrails

### DIFF
--- a/.lisa.config.json
+++ b/.lisa.config.json
@@ -175,6 +175,14 @@
           "install": "release-zip",
           "url": "https://github.com/bitwarden/sdk-sm/releases/download/bws-v2.1.0/bws-x86_64-unknown-linux-gnu-2.1.0.zip",
           "sha256": "ba8233c3a4aee5d43e3c73bbd04d99e9bc5aba13bbbfd06d89b073abe732b860"
+        },
+        {
+          "name": "gh",
+          "version": "2.83.0",
+          "install": "release-tar",
+          "url": "https://github.com/cli/cli/releases/download/v2.83.0/gh_2.83.0_linux_amd64.tar.gz",
+          "sha256": "a5cf6cdb40fc67751adf561126b3314044779cea81ba4f254fbe8e9a69f1676f",
+          "binary": "gh_2.83.0_linux_amd64/bin/gh"
         }
       ]
     },

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -154,6 +154,42 @@ function installReleaseZip(tool, binDir) {
 }
 
 /**
+ * Install a pinned tarball, refusing anything whose checksum does not match.
+ *
+ * Same contract as the zip path and the same ordering — verify, then unpack —
+ * because an unexpected archive must fail before any of its contents reach a
+ * directory that is on PATH. It exists because several tools worth pinning
+ * publish no zip for Linux: gh ships .deb, .rpm and .tar.gz and nothing else.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to install into.
+ */
+function installReleaseTar(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const archive = join(temporary, "download.tar.gz");
+    execFileSync("curl", ["-fsSL", tool.url, "-o", archive], {
+      stdio: "inherit",
+    });
+    execFileSync("sha256sum", ["-c", "-"], {
+      input: `${tool.sha256}  ${archive}\n`,
+      stdio: ["pipe", "ignore", "inherit"],
+    });
+    execFileSync("tar", ["-xzf", archive, "-C", temporary], {
+      stdio: "inherit",
+    });
+    // Release tarballs usually nest under a versioned directory, so `binary` is
+    // a path within the archive rather than a bare name.
+    const binary = join(temporary, tool.binary ?? tool.name);
+    execFileSync("install", ["-m", "0755", binary, join(binDir, tool.name)], {
+      stdio: "inherit",
+    });
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -175,6 +211,7 @@ function installNpmGlobal(tool) {
 function installTool(tool, binDir) {
   assertPinned(tool);
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
+  else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -148,10 +148,14 @@ export function planToolchain(tools, probe) {
  * @param {object} tool Manifest entry.
  */
 export function assertPinned(tool) {
-  if (tool.install === "release-zip") {
+  // Both archive kinds carry the same obligation, and differ only in how they
+  // are unpacked. gh, for one, publishes no zip for Linux at all — only .deb,
+  // .rpm and .tar.gz — so a zip-only installer could not pin the CLI that
+  // Lisa's own guardrails shell out to.
+  if (tool.install === "release-zip" || tool.install === "release-tar") {
     if (!tool.url || !tool.sha256) {
       throw new Error(
-        `${tool.name}: a release-zip install needs both url and sha256.\n` +
+        `${tool.name}: a ${tool.install} install needs both url and sha256.\n` +
           `A version bump must move the checksum in the same reviewed commit.`
       );
     }
@@ -164,6 +168,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, npm-global.`
+      `Supported: release-zip, release-tar, npm-global.`
   );
 }

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -154,6 +154,42 @@ function installReleaseZip(tool, binDir) {
 }
 
 /**
+ * Install a pinned tarball, refusing anything whose checksum does not match.
+ *
+ * Same contract as the zip path and the same ordering — verify, then unpack —
+ * because an unexpected archive must fail before any of its contents reach a
+ * directory that is on PATH. It exists because several tools worth pinning
+ * publish no zip for Linux: gh ships .deb, .rpm and .tar.gz and nothing else.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to install into.
+ */
+function installReleaseTar(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const archive = join(temporary, "download.tar.gz");
+    execFileSync("curl", ["-fsSL", tool.url, "-o", archive], {
+      stdio: "inherit",
+    });
+    execFileSync("sha256sum", ["-c", "-"], {
+      input: `${tool.sha256}  ${archive}\n`,
+      stdio: ["pipe", "ignore", "inherit"],
+    });
+    execFileSync("tar", ["-xzf", archive, "-C", temporary], {
+      stdio: "inherit",
+    });
+    // Release tarballs usually nest under a versioned directory, so `binary` is
+    // a path within the archive rather than a bare name.
+    const binary = join(temporary, tool.binary ?? tool.name);
+    execFileSync("install", ["-m", "0755", binary, join(binDir, tool.name)], {
+      stdio: "inherit",
+    });
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -175,6 +211,7 @@ function installNpmGlobal(tool) {
 function installTool(tool, binDir) {
   assertPinned(tool);
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
+  else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -148,10 +148,14 @@ export function planToolchain(tools, probe) {
  * @param {object} tool Manifest entry.
  */
 export function assertPinned(tool) {
-  if (tool.install === "release-zip") {
+  // Both archive kinds carry the same obligation, and differ only in how they
+  // are unpacked. gh, for one, publishes no zip for Linux at all — only .deb,
+  // .rpm and .tar.gz — so a zip-only installer could not pin the CLI that
+  // Lisa's own guardrails shell out to.
+  if (tool.install === "release-zip" || tool.install === "release-tar") {
     if (!tool.url || !tool.sha256) {
       throw new Error(
-        `${tool.name}: a release-zip install needs both url and sha256.\n` +
+        `${tool.name}: a ${tool.install} install needs both url and sha256.\n` +
           `A version bump must move the checksum in the same reviewed commit.`
       );
     }
@@ -164,6 +168,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, npm-global.`
+      `Supported: release-zip, release-tar, npm-global.`
   );
 }

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -154,6 +154,42 @@ function installReleaseZip(tool, binDir) {
 }
 
 /**
+ * Install a pinned tarball, refusing anything whose checksum does not match.
+ *
+ * Same contract as the zip path and the same ordering — verify, then unpack —
+ * because an unexpected archive must fail before any of its contents reach a
+ * directory that is on PATH. It exists because several tools worth pinning
+ * publish no zip for Linux: gh ships .deb, .rpm and .tar.gz and nothing else.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to install into.
+ */
+function installReleaseTar(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const archive = join(temporary, "download.tar.gz");
+    execFileSync("curl", ["-fsSL", tool.url, "-o", archive], {
+      stdio: "inherit",
+    });
+    execFileSync("sha256sum", ["-c", "-"], {
+      input: `${tool.sha256}  ${archive}\n`,
+      stdio: ["pipe", "ignore", "inherit"],
+    });
+    execFileSync("tar", ["-xzf", archive, "-C", temporary], {
+      stdio: "inherit",
+    });
+    // Release tarballs usually nest under a versioned directory, so `binary` is
+    // a path within the archive rather than a bare name.
+    const binary = join(temporary, tool.binary ?? tool.name);
+    execFileSync("install", ["-m", "0755", binary, join(binDir, tool.name)], {
+      stdio: "inherit",
+    });
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -175,6 +211,7 @@ function installNpmGlobal(tool) {
 function installTool(tool, binDir) {
   assertPinned(tool);
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
+  else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -148,10 +148,14 @@ export function planToolchain(tools, probe) {
  * @param {object} tool Manifest entry.
  */
 export function assertPinned(tool) {
-  if (tool.install === "release-zip") {
+  // Both archive kinds carry the same obligation, and differ only in how they
+  // are unpacked. gh, for one, publishes no zip for Linux at all — only .deb,
+  // .rpm and .tar.gz — so a zip-only installer could not pin the CLI that
+  // Lisa's own guardrails shell out to.
+  if (tool.install === "release-zip" || tool.install === "release-tar") {
     if (!tool.url || !tool.sha256) {
       throw new Error(
-        `${tool.name}: a release-zip install needs both url and sha256.\n` +
+        `${tool.name}: a ${tool.install} install needs both url and sha256.\n` +
           `A version bump must move the checksum in the same reviewed commit.`
       );
     }
@@ -164,6 +168,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, npm-global.`
+      `Supported: release-zip, release-tar, npm-global.`
   );
 }

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -154,6 +154,42 @@ function installReleaseZip(tool, binDir) {
 }
 
 /**
+ * Install a pinned tarball, refusing anything whose checksum does not match.
+ *
+ * Same contract as the zip path and the same ordering — verify, then unpack —
+ * because an unexpected archive must fail before any of its contents reach a
+ * directory that is on PATH. It exists because several tools worth pinning
+ * publish no zip for Linux: gh ships .deb, .rpm and .tar.gz and nothing else.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to install into.
+ */
+function installReleaseTar(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const archive = join(temporary, "download.tar.gz");
+    execFileSync("curl", ["-fsSL", tool.url, "-o", archive], {
+      stdio: "inherit",
+    });
+    execFileSync("sha256sum", ["-c", "-"], {
+      input: `${tool.sha256}  ${archive}\n`,
+      stdio: ["pipe", "ignore", "inherit"],
+    });
+    execFileSync("tar", ["-xzf", archive, "-C", temporary], {
+      stdio: "inherit",
+    });
+    // Release tarballs usually nest under a versioned directory, so `binary` is
+    // a path within the archive rather than a bare name.
+    const binary = join(temporary, tool.binary ?? tool.name);
+    execFileSync("install", ["-m", "0755", binary, join(binDir, tool.name)], {
+      stdio: "inherit",
+    });
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -175,6 +211,7 @@ function installNpmGlobal(tool) {
 function installTool(tool, binDir) {
   assertPinned(tool);
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
+  else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -148,10 +148,14 @@ export function planToolchain(tools, probe) {
  * @param {object} tool Manifest entry.
  */
 export function assertPinned(tool) {
-  if (tool.install === "release-zip") {
+  // Both archive kinds carry the same obligation, and differ only in how they
+  // are unpacked. gh, for one, publishes no zip for Linux at all — only .deb,
+  // .rpm and .tar.gz — so a zip-only installer could not pin the CLI that
+  // Lisa's own guardrails shell out to.
+  if (tool.install === "release-zip" || tool.install === "release-tar") {
     if (!tool.url || !tool.sha256) {
       throw new Error(
-        `${tool.name}: a release-zip install needs both url and sha256.\n` +
+        `${tool.name}: a ${tool.install} install needs both url and sha256.\n` +
           `A version bump must move the checksum in the same reviewed commit.`
       );
     }
@@ -164,6 +168,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, npm-global.`
+      `Supported: release-zip, release-tar, npm-global.`
   );
 }

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -154,6 +154,42 @@ function installReleaseZip(tool, binDir) {
 }
 
 /**
+ * Install a pinned tarball, refusing anything whose checksum does not match.
+ *
+ * Same contract as the zip path and the same ordering — verify, then unpack —
+ * because an unexpected archive must fail before any of its contents reach a
+ * directory that is on PATH. It exists because several tools worth pinning
+ * publish no zip for Linux: gh ships .deb, .rpm and .tar.gz and nothing else.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to install into.
+ */
+function installReleaseTar(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const archive = join(temporary, "download.tar.gz");
+    execFileSync("curl", ["-fsSL", tool.url, "-o", archive], {
+      stdio: "inherit",
+    });
+    execFileSync("sha256sum", ["-c", "-"], {
+      input: `${tool.sha256}  ${archive}\n`,
+      stdio: ["pipe", "ignore", "inherit"],
+    });
+    execFileSync("tar", ["-xzf", archive, "-C", temporary], {
+      stdio: "inherit",
+    });
+    // Release tarballs usually nest under a versioned directory, so `binary` is
+    // a path within the archive rather than a bare name.
+    const binary = join(temporary, tool.binary ?? tool.name);
+    execFileSync("install", ["-m", "0755", binary, join(binDir, tool.name)], {
+      stdio: "inherit",
+    });
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -175,6 +211,7 @@ function installNpmGlobal(tool) {
 function installTool(tool, binDir) {
   assertPinned(tool);
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
+  else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -148,10 +148,14 @@ export function planToolchain(tools, probe) {
  * @param {object} tool Manifest entry.
  */
 export function assertPinned(tool) {
-  if (tool.install === "release-zip") {
+  // Both archive kinds carry the same obligation, and differ only in how they
+  // are unpacked. gh, for one, publishes no zip for Linux at all — only .deb,
+  // .rpm and .tar.gz — so a zip-only installer could not pin the CLI that
+  // Lisa's own guardrails shell out to.
+  if (tool.install === "release-zip" || tool.install === "release-tar") {
     if (!tool.url || !tool.sha256) {
       throw new Error(
-        `${tool.name}: a release-zip install needs both url and sha256.\n` +
+        `${tool.name}: a ${tool.install} install needs both url and sha256.\n` +
           `A version bump must move the checksum in the same reviewed commit.`
       );
     }
@@ -164,6 +168,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, npm-global.`
+      `Supported: release-zip, release-tar, npm-global.`
   );
 }

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -154,6 +154,42 @@ function installReleaseZip(tool, binDir) {
 }
 
 /**
+ * Install a pinned tarball, refusing anything whose checksum does not match.
+ *
+ * Same contract as the zip path and the same ordering — verify, then unpack —
+ * because an unexpected archive must fail before any of its contents reach a
+ * directory that is on PATH. It exists because several tools worth pinning
+ * publish no zip for Linux: gh ships .deb, .rpm and .tar.gz and nothing else.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to install into.
+ */
+function installReleaseTar(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const archive = join(temporary, "download.tar.gz");
+    execFileSync("curl", ["-fsSL", tool.url, "-o", archive], {
+      stdio: "inherit",
+    });
+    execFileSync("sha256sum", ["-c", "-"], {
+      input: `${tool.sha256}  ${archive}\n`,
+      stdio: ["pipe", "ignore", "inherit"],
+    });
+    execFileSync("tar", ["-xzf", archive, "-C", temporary], {
+      stdio: "inherit",
+    });
+    // Release tarballs usually nest under a versioned directory, so `binary` is
+    // a path within the archive rather than a bare name.
+    const binary = join(temporary, tool.binary ?? tool.name);
+    execFileSync("install", ["-m", "0755", binary, join(binDir, tool.name)], {
+      stdio: "inherit",
+    });
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -175,6 +211,7 @@ function installNpmGlobal(tool) {
 function installTool(tool, binDir) {
   assertPinned(tool);
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
+  else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -148,10 +148,14 @@ export function planToolchain(tools, probe) {
  * @param {object} tool Manifest entry.
  */
 export function assertPinned(tool) {
-  if (tool.install === "release-zip") {
+  // Both archive kinds carry the same obligation, and differ only in how they
+  // are unpacked. gh, for one, publishes no zip for Linux at all — only .deb,
+  // .rpm and .tar.gz — so a zip-only installer could not pin the CLI that
+  // Lisa's own guardrails shell out to.
+  if (tool.install === "release-zip" || tool.install === "release-tar") {
     if (!tool.url || !tool.sha256) {
       throw new Error(
-        `${tool.name}: a release-zip install needs both url and sha256.\n` +
+        `${tool.name}: a ${tool.install} install needs both url and sha256.\n` +
           `A version bump must move the checksum in the same reviewed commit.`
       );
     }
@@ -164,6 +168,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, npm-global.`
+      `Supported: release-zip, release-tar, npm-global.`
   );
 }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1125,9 +1125,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "c04afb1cf8e14a2713645228e679fa7772559488330a240ec0297cae6afd03e2",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "68339117f7d2fe1fdb9f05c8039ffe719f24da7cf700bc3c940bfccbf82cded2",
+      "1f451881342364d086640b59914a3b07286a3734caa63f01efe64531d3bde7e4",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
-      "ff66d33ba41a068d09be18f81ac68988238c2afa1d4e3733ae906b73eea74324",
+      "8822af39d0251a2e4fb0eac9157ba9e63ea813d914240ca0cacacd6cb7cbb5bb",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
       "82bc2a27a0a5afb2ff413a88365c619fd7f0eaada5de3ccabf2000938f0607a4",
     "plugins/src/base/skills/lisa-setup-sonar/SKILL.md":

--- a/tests/unit/secrets/remote-env-phases.test.ts
+++ b/tests/unit/secrets/remote-env-phases.test.ts
@@ -26,6 +26,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { SURFACES } from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs";
+import { assertPinned } from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs";
 import {
   installAssets,
   pinEnvironment,
@@ -346,5 +347,58 @@ describe("proxy read-back", () => {
     verifyNotProxied(["MISSING"], {}, report);
     expect(findings[0].ok).toBe(false);
     expect(findings[0].detail).toMatch(/not present/i);
+  });
+});
+
+/** The install kind gh needs, since it publishes no Linux zip. */
+const RELEASE_TAR = "release-tar";
+
+describe("pinned tarball installs", () => {
+  // gh publishes no zip for Linux — only .deb, .rpm and .tar.gz — so a
+  // zip-only installer could not pin the very CLI that Lisa's own commit and
+  // push guardrails shell out to. A cloud container ships without it, which is
+  // why a dispatched session could not commit at all.
+  it("requires a url and a checksum, exactly like a zip", () => {
+    expect(() =>
+      assertPinned({ name: "gh", install: RELEASE_TAR, url: "https://x/y.tgz" })
+    ).toThrow(/needs both url and sha256/);
+    expect(() =>
+      assertPinned({ name: "gh", install: RELEASE_TAR, sha256: "a".repeat(64) })
+    ).toThrow(/needs both url and sha256/);
+  });
+
+  it("accepts a fully pinned tarball", () => {
+    expect(() =>
+      assertPinned({
+        name: "gh",
+        install: RELEASE_TAR,
+        url: "https://x/y.tgz",
+        sha256: "a".repeat(64),
+      })
+    ).not.toThrow();
+  });
+
+  it("names the tar kind when refusing an unknown one", () => {
+    // The message is where an operator learns which kinds exist at all.
+    expect(() => assertPinned({ name: "x", install: "release-deb" })).toThrow(
+      /Supported: release-zip, release-tar, npm-global/
+    );
+  });
+
+  it("pins gh with a checksum and a path inside the archive", () => {
+    // Release tarballs nest under a versioned directory, so a bare name would
+    // resolve to nothing and the install would fail after the download.
+    const cfg = JSON.parse(readFileSync(".lisa.config.json", "utf8")) as {
+      remoteEnv: { tools: { install: readonly Record<string, string>[] } };
+    };
+    const gh = cfg.remoteEnv.tools.install.find(t => t.name === "gh");
+
+    expect(gh).toBeDefined();
+    expect(gh?.install).toBe(RELEASE_TAR);
+    expect(gh?.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(gh?.binary).toMatch(/\/bin\/gh$/);
+    // The pin and the URL must agree, or a version bump silently installs the
+    // old binary under the new number.
+    expect(gh?.url).toContain(`v${gh?.version}`);
   });
 });


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2229

A dispatched cloud session **cannot commit at all**.

Lisa's `commit-msg` and `pre-push` hooks call `lisa-work-item.mjs`, whose GitHub path shells out to `gh`. [`gh` is not pre-installed](https://code.claude.com/docs/en/cloud-environments#installed-tools) on the cloud base image, and `remoteEnv.tools.install` never pinned it — despite this very skill telling other projects to do exactly that.

Since #2224 restored enforcement in plugin-less containers, the session can no longer `--no-verify` past the refusal either. **Two correct behaviours compose into a session that finishes its work and cannot commit it.**

## Why a new install kind

`gh` publishes **no zip for Linux** — only `.deb`, `.rpm` and `.tar.gz` — and the installer supported `release-zip` and `npm-global` only.

`release-tar` carries the identical obligation: url plus sha256, verified **before** unpacking, so an unexpected archive fails before any of its contents reach a directory on PATH. `binary` is a path *within* the archive rather than a bare name, because release tarballs nest under a versioned directory (`gh_2.83.0_linux_amd64/bin/gh`) and a bare name would resolve to nothing after a successful download.

## Proven against the real artifact, not a fixture

```
PASS  installs gh from the pinned tarball
PASS  refuses a wrong checksum, leaving nothing behind
```

Plus unit tests pinning that the config's URL and `version` agree — otherwise a version bump silently installs the old binary under the new number.

## Explicitly out of scope

Whether `gh` can **authenticate** once installed. `GH_TOKEN` reads as `proxy-injected`, and the 403 recorded in #2218 came from `curl`, not `gh` — the docs say the proxy substitutes real credentials for `gh` specifically. Installing it is a precondition either way, and makes the question answerable instead of theoretical.