### PR TITLE
Install the toolchain every session, not only on cache build

### DIFF
--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/assets/session-start.sh
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/assets/session-start.sh
@@ -27,4 +27,21 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 fi
 
 here="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+
+# The toolchain first, for the same reason the secrets are here at all.
+#
+# It used to run only from the environment setup script, which a cached
+# environment skips — so a tool added to remoteEnv.tools was invisible until the
+# cache expired about a week later, or until someone edited the vendor's setup
+# field to force a rebuild. Neither is a thing a project can rely on, and the
+# symptom is a container missing a tool its own committed config pins.
+#
+# It is cheap to repeat: the plan probes each tool and installs only what is
+# absent or below its pinned version, so on a warm container this is a handful
+# of --version calls and nothing else.
+#
+# Before secrets, because materializing needs the provider CLI that this step
+# installs. A failure here is fatal for the same reason: continuing would report
+# a missing credential when the real fault was a missing binary.
+bash "${here}/setup.sh" --phase=toolchain "$@"
 exec bash "${here}/setup.sh" --phase=secrets "$@"

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/assets/session-start.sh
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/assets/session-start.sh
@@ -27,4 +27,21 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 fi
 
 here="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+
+# The toolchain first, for the same reason the secrets are here at all.
+#
+# It used to run only from the environment setup script, which a cached
+# environment skips — so a tool added to remoteEnv.tools was invisible until the
+# cache expired about a week later, or until someone edited the vendor's setup
+# field to force a rebuild. Neither is a thing a project can rely on, and the
+# symptom is a container missing a tool its own committed config pins.
+#
+# It is cheap to repeat: the plan probes each tool and installs only what is
+# absent or below its pinned version, so on a warm container this is a handful
+# of --version calls and nothing else.
+#
+# Before secrets, because materializing needs the provider CLI that this step
+# installs. A failure here is fatal for the same reason: continuing would report
+# a missing credential when the real fault was a missing binary.
+bash "${here}/setup.sh" --phase=toolchain "$@"
 exec bash "${here}/setup.sh" --phase=secrets "$@"

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/assets/session-start.sh
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/assets/session-start.sh
@@ -27,4 +27,21 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 fi
 
 here="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+
+# The toolchain first, for the same reason the secrets are here at all.
+#
+# It used to run only from the environment setup script, which a cached
+# environment skips — so a tool added to remoteEnv.tools was invisible until the
+# cache expired about a week later, or until someone edited the vendor's setup
+# field to force a rebuild. Neither is a thing a project can rely on, and the
+# symptom is a container missing a tool its own committed config pins.
+#
+# It is cheap to repeat: the plan probes each tool and installs only what is
+# absent or below its pinned version, so on a warm container this is a handful
+# of --version calls and nothing else.
+#
+# Before secrets, because materializing needs the provider CLI that this step
+# installs. A failure here is fatal for the same reason: continuing would report
+# a missing credential when the real fault was a missing binary.
+bash "${here}/setup.sh" --phase=toolchain "$@"
 exec bash "${here}/setup.sh" --phase=secrets "$@"

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/assets/session-start.sh
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/assets/session-start.sh
@@ -27,4 +27,21 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 fi
 
 here="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+
+# The toolchain first, for the same reason the secrets are here at all.
+#
+# It used to run only from the environment setup script, which a cached
+# environment skips — so a tool added to remoteEnv.tools was invisible until the
+# cache expired about a week later, or until someone edited the vendor's setup
+# field to force a rebuild. Neither is a thing a project can rely on, and the
+# symptom is a container missing a tool its own committed config pins.
+#
+# It is cheap to repeat: the plan probes each tool and installs only what is
+# absent or below its pinned version, so on a warm container this is a handful
+# of --version calls and nothing else.
+#
+# Before secrets, because materializing needs the provider CLI that this step
+# installs. A failure here is fatal for the same reason: continuing would report
+# a missing credential when the real fault was a missing binary.
+bash "${here}/setup.sh" --phase=toolchain "$@"
 exec bash "${here}/setup.sh" --phase=secrets "$@"

--- a/plugins/lisa/skills/lisa-setup-remote-env/assets/session-start.sh
+++ b/plugins/lisa/skills/lisa-setup-remote-env/assets/session-start.sh
@@ -27,4 +27,21 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 fi
 
 here="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+
+# The toolchain first, for the same reason the secrets are here at all.
+#
+# It used to run only from the environment setup script, which a cached
+# environment skips — so a tool added to remoteEnv.tools was invisible until the
+# cache expired about a week later, or until someone edited the vendor's setup
+# field to force a rebuild. Neither is a thing a project can rely on, and the
+# symptom is a container missing a tool its own committed config pins.
+#
+# It is cheap to repeat: the plan probes each tool and installs only what is
+# absent or below its pinned version, so on a warm container this is a handful
+# of --version calls and nothing else.
+#
+# Before secrets, because materializing needs the provider CLI that this step
+# installs. A failure here is fatal for the same reason: continuing would report
+# a missing credential when the real fault was a missing binary.
+bash "${here}/setup.sh" --phase=toolchain "$@"
 exec bash "${here}/setup.sh" --phase=secrets "$@"

--- a/plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh
+++ b/plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh
@@ -27,4 +27,21 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 fi
 
 here="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+
+# The toolchain first, for the same reason the secrets are here at all.
+#
+# It used to run only from the environment setup script, which a cached
+# environment skips — so a tool added to remoteEnv.tools was invisible until the
+# cache expired about a week later, or until someone edited the vendor's setup
+# field to force a rebuild. Neither is a thing a project can rely on, and the
+# symptom is a container missing a tool its own committed config pins.
+#
+# It is cheap to repeat: the plan probes each tool and installs only what is
+# absent or below its pinned version, so on a warm container this is a handful
+# of --version calls and nothing else.
+#
+# Before secrets, because materializing needs the provider CLI that this step
+# installs. A failure here is fatal for the same reason: continuing would report
+# a missing credential when the real fault was a missing binary.
+bash "${here}/setup.sh" --phase=toolchain "$@"
 exec bash "${here}/setup.sh" --phase=secrets "$@"

--- a/scripts/lisa-remote-env/session-start.sh
+++ b/scripts/lisa-remote-env/session-start.sh
@@ -27,4 +27,21 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 fi
 
 here="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+
+# The toolchain first, for the same reason the secrets are here at all.
+#
+# It used to run only from the environment setup script, which a cached
+# environment skips — so a tool added to remoteEnv.tools was invisible until the
+# cache expired about a week later, or until someone edited the vendor's setup
+# field to force a rebuild. Neither is a thing a project can rely on, and the
+# symptom is a container missing a tool its own committed config pins.
+#
+# It is cheap to repeat: the plan probes each tool and installs only what is
+# absent or below its pinned version, so on a warm container this is a handful
+# of --version calls and nothing else.
+#
+# Before secrets, because materializing needs the provider CLI that this step
+# installs. A failure here is fatal for the same reason: continuing would report
+# a missing credential when the real fault was a missing binary.
+bash "${here}/setup.sh" --phase=toolchain "$@"
 exec bash "${here}/setup.sh" --phase=secrets "$@"

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1121,7 +1121,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md":
       "5627c45a4ce7d0f0d122791f699b6dd2841602adf873678c693ad08a48eab401",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh":
-      "6e3871ec2f8d56b8ebb85376ebdd3956f3ed8fa4f7b278c2ed90ca9b8845897c",
+      "cb63d08b14ab7aa2d405e6770e0cf7db5d6588ae1dcb924ea6224b026fcff496",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "c04afb1cf8e14a2713645228e679fa7772559488330a240ec0297cae6afd03e2",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
@@ -1981,7 +1981,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/lisa-github-rulesets.sh":
       "920a43ba268421b6fe55096062bd85850468bee9389f6006ad7c671010e7cccb",
     "scripts/lisa-remote-env/session-start.sh":
-      "6e3871ec2f8d56b8ebb85376ebdd3956f3ed8fa4f7b278c2ed90ca9b8845897c",
+      "cb63d08b14ab7aa2d405e6770e0cf7db5d6588ae1dcb924ea6224b026fcff496",
     "scripts/lisa-remote-env/setup.sh":
       "c04afb1cf8e14a2713645228e679fa7772559488330a240ec0297cae6afd03e2",
     "scripts/lisa-update-local.sh":
@@ -8347,6 +8347,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/remote-env-bindir-path.test.ts": true,
     "tests/unit/secrets/remote-env-installed-copy.test.ts": true,
     "tests/unit/secrets/remote-env-phases.test.ts": true,
+    "tests/unit/secrets/remote-env-session-start-hook.test.ts": true,
     "tests/unit/secrets/remote-env-setup-field.test.ts": true,
     "tests/unit/secrets/remote-env-skill-resolution.test.ts": true,
     "tests/unit/secrets/remote-env-toolchain.test.ts": true,

--- a/tests/unit/secrets/remote-env-session-start-hook.test.ts
+++ b/tests/unit/secrets/remote-env-session-start-hook.test.ts
@@ -1,0 +1,52 @@
+/**
+ * What the session-start hook is responsible for running.
+ *
+ * A cloud environment skips its setup script whenever a filesystem cache
+ * exists, so anything that only runs there goes stale: it is re-run when the
+ * vendor's setup field changes, or after roughly seven days, and not otherwise.
+ *
+ * This hook is part of the clone rather than the snapshot, which makes it the
+ * one place that runs on every session regardless of cache state. The secrets
+ * phase already lived here for that reason. The toolchain had the same
+ * staleness problem and no answer to it — a tool added to `remoteEnv.tools` was
+ * invisible to a cached container, so a pin could be merged, correct, and
+ * simply absent from the next session.
+ * @module tests/unit/secrets/remote-env-session-start-hook
+ */
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+describe("session-start hook covers the toolchain too", () => {
+  const HOOK = readFileSync(
+    "plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh",
+    "utf8"
+  );
+
+  it("runs the toolchain phase, not only secrets", () => {
+    // The toolchain used to run only from the environment setup script, which a
+    // cached environment SKIPS. A tool added to remoteEnv.tools was therefore
+    // invisible until the cache expired about a week later, or until someone
+    // edited the vendor's setup field by hand to force a rebuild — so a
+    // container could be missing a tool its own committed config pins.
+    //
+    // This hook is part of the clone, so it is the one place that runs every
+    // session regardless of cache state.
+    expect(HOOK).toContain("--phase=toolchain");
+    expect(HOOK).toContain("--phase=secrets");
+  });
+
+  it("installs the toolchain before materializing secrets", () => {
+    // Materializing needs the provider CLI the toolchain step installs. Run the
+    // other way round, a missing binary is reported as a missing credential.
+    expect(HOOK.indexOf("--phase=toolchain")).toBeLessThan(
+      HOOK.indexOf("--phase=secrets")
+    );
+  });
+
+  it("still does nothing at all on a developer machine", () => {
+    // The hook is committed, so it fires on every local session too. Doing the
+    // remote work there would be noise on every single startup.
+    expect(HOOK).toContain('if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]');
+  });
+});


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2233

The toolchain phase ran only from the environment **setup script**, and a cloud environment [skips that script whenever a filesystem cache exists](https://code.claude.com/docs/en/cloud-environments#environment-caching). It re-runs when the vendor's setup field or allowed hosts change, or after roughly seven days — and not otherwise.

```
claude-web, from the setup script:  ["toolchain","hook"]   ← skipped when cached
claude-web, from the session hook:  ["secrets"]            ← runs every session
```

So a tool added to `remoteEnv.tools.install` is **invisible** until the cache expires or someone hand-edits a vendor settings box. Neither is something a project can rely on, and the symptom is a container missing a tool its own committed config pins.

This was about to bite immediately: #2230 pinned `gh` so cloud sessions can run Lisa's commit guardrails, and on any environment cached before that merge — including the one in use — `gh` would still have been absent. Merged, correct, and simply not there.

## The fix

Run the toolchain from the **session-start hook**, before secrets.

The hook is part of the clone rather than the snapshot, so it is the one place that runs every session regardless of cache state — which is already why the secrets phase lives there. Same staleness problem, same answer. It also means this fix applies itself: the hook arrives with the clone, so no cache rebuild is needed to pick it up.

Repeating it is cheap. The plan probes each tool and installs only what is absent or below its pinned version, so a warm container spends a handful of `--version` calls and does nothing else.

**Ordering is load-bearing** and pinned by a test: toolchain before secrets, because materializing needs the provider CLI the toolchain installs. Reversed, a missing binary reports as a missing credential — a misdiagnosis this repo has already paid for once (#2218).

Still inert on a developer machine, guarded on `CLAUDE_CODE_REMOTE`.