### PR TITLE
Document the release-tar install kind

### DIFF
--- a/.lisa.config.json
+++ b/.lisa.config.json
@@ -166,6 +166,9 @@
         },
         {
           "name": "unzip"
+        },
+        {
+          "name": "tar"
         }
       ],
       "install": [

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
@@ -108,6 +108,14 @@ The selection comes from the surface's `materializeAt` capability in `lisa-secre
           "sha256": "<sha256 published with that exact release>"
         },
         {
+          "name": "gh",
+          "version": "2.83.0",
+          "install": "release-tar",
+          "url": "https://<vendor>/releases/download/v2.83.0/gh_2.83.0_linux_amd64.tar.gz",
+          "sha256": "<sha256 published with that exact release>",
+          "binary": "gh_2.83.0_linux_amd64/bin/gh"
+        },
+        {
           "name": "codex",
           "version": "0.144.6",
           "install": "npm-global",
@@ -132,6 +140,22 @@ The selection comes from the surface's `materializeAt` capability in `lisa-secre
 **`install`** — provision it, pinned and checksummed. Only for what genuinely is not there.
 
 Expected shape for most projects: a short `require` list, an empty or near-empty `install` list, and the provider CLI as the only thing always provisioned.
+
+### The three `install` methods
+
+| `install` | Required fields | Use it when |
+| --- | --- | --- |
+| `release-zip` | `url` **and** `sha256` | The vendor publishes a Linux zip of the release. |
+| `release-tar` | `url` **and** `sha256` — plus `binary` in practice | The vendor publishes no zip for Linux, only a `.tar.gz`. |
+| `npm-global` | `package` | The tool ships on the npm registry. |
+
+Anything else is rejected by name at plan time, so a typo fails loudly rather than silently installing nothing.
+
+Both archive kinds carry the **same** obligation and differ only in how they are unpacked: `url` and `sha256` are both mandatory, the checksum is verified *before* the archive is unpacked, and a version bump must move the checksum in the same reviewed commit. Neither is a weaker path than the other — `release-tar` exists because some tools worth pinning simply do not publish a zip. `gh` is the case that forced it: it ships `.deb`, `.rpm` and `.tar.gz` and nothing else, so a zip-only installer could not pin the CLI that Lisa's own commit guardrails shell out to.
+
+**`binary` means something different for a tarball.** It defaults to the tool's `name` and is resolved relative to the unpacked directory. Release tarballs almost always nest their contents under a versioned top-level directory, so for `release-tar` it must be the path *within* the archive — `gh_2.83.0_linux_amd64/bin/gh`, not `gh`. A bare name there resolves to nothing after a download that otherwise succeeded, and the install fails at the copy step rather than at the fetch, which reads as a broken release when it is a manifest mistake. Bump the version and this path moves with it, alongside the `url` and the `sha256`.
+
+Because `release-tar` unpacks with `tar` rather than `unzip`, a project using it should assert `tar` in its `require` list the same way a zip-installing project asserts `unzip` — the base image providing it is an assumption, not a contract.
 
 ### Rules
 

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
@@ -108,6 +108,14 @@ The selection comes from the surface's `materializeAt` capability in `lisa-secre
           "sha256": "<sha256 published with that exact release>"
         },
         {
+          "name": "gh",
+          "version": "2.83.0",
+          "install": "release-tar",
+          "url": "https://<vendor>/releases/download/v2.83.0/gh_2.83.0_linux_amd64.tar.gz",
+          "sha256": "<sha256 published with that exact release>",
+          "binary": "gh_2.83.0_linux_amd64/bin/gh"
+        },
+        {
           "name": "codex",
           "version": "0.144.6",
           "install": "npm-global",
@@ -132,6 +140,22 @@ The selection comes from the surface's `materializeAt` capability in `lisa-secre
 **`install`** — provision it, pinned and checksummed. Only for what genuinely is not there.
 
 Expected shape for most projects: a short `require` list, an empty or near-empty `install` list, and the provider CLI as the only thing always provisioned.
+
+### The three `install` methods
+
+| `install` | Required fields | Use it when |
+| --- | --- | --- |
+| `release-zip` | `url` **and** `sha256` | The vendor publishes a Linux zip of the release. |
+| `release-tar` | `url` **and** `sha256` — plus `binary` in practice | The vendor publishes no zip for Linux, only a `.tar.gz`. |
+| `npm-global` | `package` | The tool ships on the npm registry. |
+
+Anything else is rejected by name at plan time, so a typo fails loudly rather than silently installing nothing.
+
+Both archive kinds carry the **same** obligation and differ only in how they are unpacked: `url` and `sha256` are both mandatory, the checksum is verified *before* the archive is unpacked, and a version bump must move the checksum in the same reviewed commit. Neither is a weaker path than the other — `release-tar` exists because some tools worth pinning simply do not publish a zip. `gh` is the case that forced it: it ships `.deb`, `.rpm` and `.tar.gz` and nothing else, so a zip-only installer could not pin the CLI that Lisa's own commit guardrails shell out to.
+
+**`binary` means something different for a tarball.** It defaults to the tool's `name` and is resolved relative to the unpacked directory. Release tarballs almost always nest their contents under a versioned top-level directory, so for `release-tar` it must be the path *within* the archive — `gh_2.83.0_linux_amd64/bin/gh`, not `gh`. A bare name there resolves to nothing after a download that otherwise succeeded, and the install fails at the copy step rather than at the fetch, which reads as a broken release when it is a manifest mistake. Bump the version and this path moves with it, alongside the `url` and the `sha256`.
+
+Because `release-tar` unpacks with `tar` rather than `unzip`, a project using it should assert `tar` in its `require` list the same way a zip-installing project asserts `unzip` — the base image providing it is an assumption, not a contract.
 
 ### Rules
 

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
@@ -108,6 +108,14 @@ The selection comes from the surface's `materializeAt` capability in `lisa-secre
           "sha256": "<sha256 published with that exact release>"
         },
         {
+          "name": "gh",
+          "version": "2.83.0",
+          "install": "release-tar",
+          "url": "https://<vendor>/releases/download/v2.83.0/gh_2.83.0_linux_amd64.tar.gz",
+          "sha256": "<sha256 published with that exact release>",
+          "binary": "gh_2.83.0_linux_amd64/bin/gh"
+        },
+        {
           "name": "codex",
           "version": "0.144.6",
           "install": "npm-global",
@@ -132,6 +140,22 @@ The selection comes from the surface's `materializeAt` capability in `lisa-secre
 **`install`** — provision it, pinned and checksummed. Only for what genuinely is not there.
 
 Expected shape for most projects: a short `require` list, an empty or near-empty `install` list, and the provider CLI as the only thing always provisioned.
+
+### The three `install` methods
+
+| `install` | Required fields | Use it when |
+| --- | --- | --- |
+| `release-zip` | `url` **and** `sha256` | The vendor publishes a Linux zip of the release. |
+| `release-tar` | `url` **and** `sha256` — plus `binary` in practice | The vendor publishes no zip for Linux, only a `.tar.gz`. |
+| `npm-global` | `package` | The tool ships on the npm registry. |
+
+Anything else is rejected by name at plan time, so a typo fails loudly rather than silently installing nothing.
+
+Both archive kinds carry the **same** obligation and differ only in how they are unpacked: `url` and `sha256` are both mandatory, the checksum is verified *before* the archive is unpacked, and a version bump must move the checksum in the same reviewed commit. Neither is a weaker path than the other — `release-tar` exists because some tools worth pinning simply do not publish a zip. `gh` is the case that forced it: it ships `.deb`, `.rpm` and `.tar.gz` and nothing else, so a zip-only installer could not pin the CLI that Lisa's own commit guardrails shell out to.
+
+**`binary` means something different for a tarball.** It defaults to the tool's `name` and is resolved relative to the unpacked directory. Release tarballs almost always nest their contents under a versioned top-level directory, so for `release-tar` it must be the path *within* the archive — `gh_2.83.0_linux_amd64/bin/gh`, not `gh`. A bare name there resolves to nothing after a download that otherwise succeeded, and the install fails at the copy step rather than at the fetch, which reads as a broken release when it is a manifest mistake. Bump the version and this path moves with it, alongside the `url` and the `sha256`.
+
+Because `release-tar` unpacks with `tar` rather than `unzip`, a project using it should assert `tar` in its `require` list the same way a zip-installing project asserts `unzip` — the base image providing it is an assumption, not a contract.
 
 ### Rules
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
@@ -108,6 +108,14 @@ The selection comes from the surface's `materializeAt` capability in `lisa-secre
           "sha256": "<sha256 published with that exact release>"
         },
         {
+          "name": "gh",
+          "version": "2.83.0",
+          "install": "release-tar",
+          "url": "https://<vendor>/releases/download/v2.83.0/gh_2.83.0_linux_amd64.tar.gz",
+          "sha256": "<sha256 published with that exact release>",
+          "binary": "gh_2.83.0_linux_amd64/bin/gh"
+        },
+        {
           "name": "codex",
           "version": "0.144.6",
           "install": "npm-global",
@@ -132,6 +140,22 @@ The selection comes from the surface's `materializeAt` capability in `lisa-secre
 **`install`** — provision it, pinned and checksummed. Only for what genuinely is not there.
 
 Expected shape for most projects: a short `require` list, an empty or near-empty `install` list, and the provider CLI as the only thing always provisioned.
+
+### The three `install` methods
+
+| `install` | Required fields | Use it when |
+| --- | --- | --- |
+| `release-zip` | `url` **and** `sha256` | The vendor publishes a Linux zip of the release. |
+| `release-tar` | `url` **and** `sha256` — plus `binary` in practice | The vendor publishes no zip for Linux, only a `.tar.gz`. |
+| `npm-global` | `package` | The tool ships on the npm registry. |
+
+Anything else is rejected by name at plan time, so a typo fails loudly rather than silently installing nothing.
+
+Both archive kinds carry the **same** obligation and differ only in how they are unpacked: `url` and `sha256` are both mandatory, the checksum is verified *before* the archive is unpacked, and a version bump must move the checksum in the same reviewed commit. Neither is a weaker path than the other — `release-tar` exists because some tools worth pinning simply do not publish a zip. `gh` is the case that forced it: it ships `.deb`, `.rpm` and `.tar.gz` and nothing else, so a zip-only installer could not pin the CLI that Lisa's own commit guardrails shell out to.
+
+**`binary` means something different for a tarball.** It defaults to the tool's `name` and is resolved relative to the unpacked directory. Release tarballs almost always nest their contents under a versioned top-level directory, so for `release-tar` it must be the path *within* the archive — `gh_2.83.0_linux_amd64/bin/gh`, not `gh`. A bare name there resolves to nothing after a download that otherwise succeeded, and the install fails at the copy step rather than at the fetch, which reads as a broken release when it is a manifest mistake. Bump the version and this path moves with it, alongside the `url` and the `sha256`.
+
+Because `release-tar` unpacks with `tar` rather than `unzip`, a project using it should assert `tar` in its `require` list the same way a zip-installing project asserts `unzip` — the base image providing it is an assumption, not a contract.
 
 ### Rules
 

--- a/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
@@ -108,6 +108,14 @@ The selection comes from the surface's `materializeAt` capability in `lisa-secre
           "sha256": "<sha256 published with that exact release>"
         },
         {
+          "name": "gh",
+          "version": "2.83.0",
+          "install": "release-tar",
+          "url": "https://<vendor>/releases/download/v2.83.0/gh_2.83.0_linux_amd64.tar.gz",
+          "sha256": "<sha256 published with that exact release>",
+          "binary": "gh_2.83.0_linux_amd64/bin/gh"
+        },
+        {
           "name": "codex",
           "version": "0.144.6",
           "install": "npm-global",
@@ -132,6 +140,22 @@ The selection comes from the surface's `materializeAt` capability in `lisa-secre
 **`install`** — provision it, pinned and checksummed. Only for what genuinely is not there.
 
 Expected shape for most projects: a short `require` list, an empty or near-empty `install` list, and the provider CLI as the only thing always provisioned.
+
+### The three `install` methods
+
+| `install` | Required fields | Use it when |
+| --- | --- | --- |
+| `release-zip` | `url` **and** `sha256` | The vendor publishes a Linux zip of the release. |
+| `release-tar` | `url` **and** `sha256` — plus `binary` in practice | The vendor publishes no zip for Linux, only a `.tar.gz`. |
+| `npm-global` | `package` | The tool ships on the npm registry. |
+
+Anything else is rejected by name at plan time, so a typo fails loudly rather than silently installing nothing.
+
+Both archive kinds carry the **same** obligation and differ only in how they are unpacked: `url` and `sha256` are both mandatory, the checksum is verified *before* the archive is unpacked, and a version bump must move the checksum in the same reviewed commit. Neither is a weaker path than the other — `release-tar` exists because some tools worth pinning simply do not publish a zip. `gh` is the case that forced it: it ships `.deb`, `.rpm` and `.tar.gz` and nothing else, so a zip-only installer could not pin the CLI that Lisa's own commit guardrails shell out to.
+
+**`binary` means something different for a tarball.** It defaults to the tool's `name` and is resolved relative to the unpacked directory. Release tarballs almost always nest their contents under a versioned top-level directory, so for `release-tar` it must be the path *within* the archive — `gh_2.83.0_linux_amd64/bin/gh`, not `gh`. A bare name there resolves to nothing after a download that otherwise succeeded, and the install fails at the copy step rather than at the fetch, which reads as a broken release when it is a manifest mistake. Bump the version and this path moves with it, alongside the `url` and the `sha256`.
+
+Because `release-tar` unpacks with `tar` rather than `unzip`, a project using it should assert `tar` in its `require` list the same way a zip-installing project asserts `unzip` — the base image providing it is an assumption, not a contract.
 
 ### Rules
 

--- a/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
@@ -108,6 +108,14 @@ The selection comes from the surface's `materializeAt` capability in `lisa-secre
           "sha256": "<sha256 published with that exact release>"
         },
         {
+          "name": "gh",
+          "version": "2.83.0",
+          "install": "release-tar",
+          "url": "https://<vendor>/releases/download/v2.83.0/gh_2.83.0_linux_amd64.tar.gz",
+          "sha256": "<sha256 published with that exact release>",
+          "binary": "gh_2.83.0_linux_amd64/bin/gh"
+        },
+        {
           "name": "codex",
           "version": "0.144.6",
           "install": "npm-global",
@@ -132,6 +140,22 @@ The selection comes from the surface's `materializeAt` capability in `lisa-secre
 **`install`** — provision it, pinned and checksummed. Only for what genuinely is not there.
 
 Expected shape for most projects: a short `require` list, an empty or near-empty `install` list, and the provider CLI as the only thing always provisioned.
+
+### The three `install` methods
+
+| `install` | Required fields | Use it when |
+| --- | --- | --- |
+| `release-zip` | `url` **and** `sha256` | The vendor publishes a Linux zip of the release. |
+| `release-tar` | `url` **and** `sha256` — plus `binary` in practice | The vendor publishes no zip for Linux, only a `.tar.gz`. |
+| `npm-global` | `package` | The tool ships on the npm registry. |
+
+Anything else is rejected by name at plan time, so a typo fails loudly rather than silently installing nothing.
+
+Both archive kinds carry the **same** obligation and differ only in how they are unpacked: `url` and `sha256` are both mandatory, the checksum is verified *before* the archive is unpacked, and a version bump must move the checksum in the same reviewed commit. Neither is a weaker path than the other — `release-tar` exists because some tools worth pinning simply do not publish a zip. `gh` is the case that forced it: it ships `.deb`, `.rpm` and `.tar.gz` and nothing else, so a zip-only installer could not pin the CLI that Lisa's own commit guardrails shell out to.
+
+**`binary` means something different for a tarball.** It defaults to the tool's `name` and is resolved relative to the unpacked directory. Release tarballs almost always nest their contents under a versioned top-level directory, so for `release-tar` it must be the path *within* the archive — `gh_2.83.0_linux_amd64/bin/gh`, not `gh`. A bare name there resolves to nothing after a download that otherwise succeeded, and the install fails at the copy step rather than at the fetch, which reads as a broken release when it is a manifest mistake. Bump the version and this path moves with it, alongside the `url` and the `sha256`.
+
+Because `release-tar` unpacks with `tar` rather than `unzip`, a project using it should assert `tar` in its `require` list the same way a zip-installing project asserts `unzip` — the base image providing it is an assumption, not a contract.
 
 ### Rules
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1119,7 +1119,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md":
       "80fbf157f9c562c033886c25a99b37356602edd9e61cd2d492f339769ddcf97e",
     "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md":
-      "5627c45a4ce7d0f0d122791f699b6dd2841602adf873678c693ad08a48eab401",
+      "821f9f7db39259c3aef24dc369c7cdcfb55a85d61742b32ac2a961e1b3e263a4",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh":
       "cb63d08b14ab7aa2d405e6770e0cf7db5d6588ae1dcb924ea6224b026fcff496",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2231

The installer grew a third install kind in #2230 and the skill still described two, so a reader configuring a toolchain had no way to learn `release-tar` exists short of reading `toolchain.mjs`.

Adds a table of the three kinds, and is explicit that the two archive kinds carry the **identical** obligation — `url` and `sha256`, checksum verified *before* unpacking, both moving in one reviewed commit. `release-tar` is not a weaker path; it exists because some tools worth pinning publish no zip at all.

`binary` gets its own paragraph, because it means something different for a tarball: release tarballs nest under a versioned directory, so it must be the path *within* the archive. A bare name resolves to nothing after a download that otherwise succeeded, and the failure lands at the copy step — which reads as a broken release when it is a manifest mistake.

Also asserts `tar` in this project's own `require` list, which is exactly what the new text tells every other project to do. Lisa pinning `gh` without it was the same shape of omission as never pinning `gh` at all: advice given and not taken.

## Provenance

Written and verified by a dispatched Claude cloud session, which **could not commit it**. `gh` has no usable credential on that surface, so the work-item guardrail refused — and `lisa-enforcement-fallback.sh` (#2224) correctly refused the `--no-verify` that the previous session got away with. It escalated, labelled the ticket `status:blocked` + `human-needed`, and preserved the patch on the issue rather than losing it with the container.

**Both guardrails behaved exactly as designed.** The credential gap is tracked separately; this PR is the work itself, landed from the escalation.