### PR TITLE
Skip live validation only when the tracker cannot be reached

### DIFF
--- a/all/copy-overwrite/scripts/lisa-work-item.mjs
+++ b/all/copy-overwrite/scripts/lisa-work-item.mjs
@@ -45,6 +45,29 @@ class TrackingError extends Error {}
  * @param {string} noun What the reference names.
  * @returns {string} A message naming the actual fault.
  */
+export class TrackerUnreachableError extends TrackingError {}
+
+/**
+ * Turn a failed `gh` invocation into the right kind of refusal.
+ *
+ * The distinction is the whole point: a missing binary or a refused credential
+ * means the tracker could not be ASKED, while a "no" from the tracker is an
+ * answer. Absence of evidence is not evidence of absence, and only the first
+ * kind may be degraded — treating them alike would either strand finished work
+ * or wave through an item that genuinely is not committable.
+ * @param {{status: number|null, error?: Error, stderr?: string}} result Spawn result.
+ * @param {string} ref Work item reference.
+ * @returns {Error} The error to throw.
+ */
+export function githubFailure(result, ref) {
+  const reason = githubFailureReason(result, ref, "GitHub issue");
+  const unreachable =
+    result.error?.code === "ENOENT" || /cannot authenticate/.test(reason);
+  return unreachable
+    ? new TrackerUnreachableError(reason)
+    : new TrackingError(reason);
+}
+
 export function githubFailureReason(result, ref, noun) {
   if (result.error?.code === "ENOENT") {
     return (
@@ -577,8 +600,7 @@ function githubIssue(ref, contract) {
       allowFailure: true,
     }
   );
-  if (result.status !== 0)
-    throw new TrackingError(githubFailureReason(result, ref, "GitHub issue"));
+  if (result.status !== 0) throw githubFailure(result, ref);
   const issue = safeJson(result.stdout, `GitHub issue ${ref}`);
   if (String(issue.number) !== number)
     throw new TrackingError(`GitHub returned the wrong issue for ${ref}`);
@@ -814,10 +836,48 @@ function linearIssue(ref, contract) {
   return issue;
 }
 
+/**
+ * Ask the tracker whether this work item may be committed against.
+ *
+ * When the tracker cannot be REACHED, the live checks are reported as skipped
+ * rather than enforced or silently dropped. Everything checkable without a
+ * network — the trailer is present, well formed, and matches this branch's
+ * binding — has already run by the time this is called, and the semantic
+ * checks it cannot do here are re-run in CI by a REQUIRED status check
+ * ("Work-Item Traceability"), with credentials, before anything can merge.
+ *
+ * So the guarantee is not lost; it moves to a gate that cannot be bypassed.
+ * That is the whole justification, and it holds only while that check stays
+ * required — if it is ever made optional, this degradation becomes a hole.
+ *
+ * The alternative was worse in both directions. Refusing outright strands
+ * finished, green work on any surface without a GitHub credential — a cloud
+ * container, for one — and the agent's only remaining move is a bypass that
+ * skips the offline checks too. Enforcing nothing hides the difference between
+ * "could not ask" and "the tracker said no".
+ * @param {string} ref Work item reference.
+ * @param {object} [contract] Tracker contract.
+ * @returns {object|undefined} The live item, or undefined when unreachable.
+ */
 function validateLive(ref, contract = trackerContract()) {
-  if (contract.provider === "github") return githubIssue(ref, contract);
-  if (contract.provider === "jira") return jiraIssue(ref, contract);
-  return linearIssue(ref, contract);
+  try {
+    if (contract.provider === "github") return githubIssue(ref, contract);
+    if (contract.provider === "jira") return jiraIssue(ref, contract);
+    return linearIssue(ref, contract);
+  } catch (error) {
+    if (!(error instanceof TrackerUnreachableError)) throw error;
+    // Loud on stderr, never silent: a degradation nobody sees is the failure
+    // mode this exists to avoid, not a milder version of it.
+    console.error(
+      `\n⚠️  Work-item live validation SKIPPED for ${ref}.\n` +
+        `${error.message}\n\n` +
+        `The offline checks still ran: the trailer is present, well formed and ` +
+        `bound to this branch.\nWhat could not be checked here — that the item ` +
+        `is open, claimed and a leaf — is re-run\nwith credentials by the ` +
+        `required "Work-Item Traceability" check before this can merge.\n`
+    );
+    return undefined;
+  }
 }
 
 function textContainsBacklink(value, prUrl) {
@@ -836,6 +896,18 @@ function assertBacklink(
   contract,
   issue = validateLive(ref, contract)
 ) {
+  // The PR check never degrades, because it IS the re-check the local hooks
+  // degrade in favour of. A required status check that passes when it could
+  // not reach the tracker would make the whole arrangement circular: local
+  // defers to CI, CI defers to nothing.
+  if (!issue) {
+    throw new TrackingError(
+      `cannot verify ${ref} against the tracker, and this check is the one ` +
+        `that must.\nLocal hooks may skip live validation when the tracker ` +
+        `is unreachable; this check may not,\nbecause it is what they defer ` +
+        `to. Fix the tracker credential for this run.`
+    );
+  }
   if (contract.provider === "github") {
     const native = (issue.closedByPullRequestsReferences ?? []).some(
       pr => pr.url === prUrl

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7,7 +7,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-contents/gitignore":
       "2dbf7fd2f2020fc7824c432342002d9ca3ebb57b2872e761b14e942b23479a11",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
-      "96a87c131606b3edd43e52485e68f8ffbf5c528cb4beb7a1185263519a9632ce",
+      "6a8be8577242588f14ab52b25b2a22b6def53aefa9513b4d3d7c49f4d8027079",
     "all/create-only/.claude/rules/PROJECT_RULES.md":
       "6e1c7923ad2a15356babc60c97e7f97be728d790af285b6a7cd7d1b4d39cd97f",
     "all/create-only/.lisaignore":
@@ -8339,6 +8339,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/upstream-evidence-manifest.test.ts": true,
     "tests/unit/scripts/verification-coverage.test.ts": true,
     "tests/unit/scripts/work-item-github-failure-diagnosis.test.ts": true,
+    "tests/unit/scripts/work-item-tracker-unreachable.test.ts": true,
     "tests/unit/secrets/automation-workflow.test.ts": true,
     "tests/unit/secrets/bootstrap-key-naming.test.ts": true,
     "tests/unit/secrets/doctor-secrets.test.ts": true,

--- a/tests/unit/scripts/work-item-tracker-unreachable.test.ts
+++ b/tests/unit/scripts/work-item-tracker-unreachable.test.ts
@@ -1,0 +1,72 @@
+/**
+ * "Could not ask the tracker" and "the tracker said no" are different facts.
+ *
+ * A cloud session finished its work and could not commit it: `gh` has no usable
+ * credential there, so the work-item guardrail refused, and the enforcement
+ * fallback correctly refused the bypass. Two correct behaviours composed into
+ * finished, green work that could not be saved.
+ *
+ * The way out is not to weaken the gate. Everything checkable offline — the
+ * trailer is present, well formed, and bound to this branch — still runs, and
+ * the semantic checks that need the tracker are re-run in CI by the REQUIRED
+ * "Work-Item Traceability" status check before anything can merge. The
+ * guarantee moves to a gate that cannot be bypassed rather than disappearing.
+ *
+ * That reasoning holds only for unreachability. An answer of "this issue is
+ * closed" or "does not exist" is evidence, and evidence is never degraded.
+ * @module tests/unit/scripts/work-item-tracker-unreachable
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  TrackerUnreachableError,
+  githubFailure,
+} from "../../../all/copy-overwrite/scripts/lisa-work-item.mjs";
+
+const REF = "CodySwannGT/lisa#2231";
+
+/** Verbatim from the cloud container that could not commit. */
+const PROXY_REFUSAL =
+  "GitHub access is not enabled for this session. An org admin must connect the Claude GitHub App for this organization.";
+
+describe("could not ask the tracker", () => {
+  it("treats a missing gh as unreachable", () => {
+    const error = githubFailure(
+      {
+        status: null,
+        error: Object.assign(new Error("spawn"), { code: "ENOENT" }),
+      },
+      REF
+    );
+
+    expect(error).toBeInstanceOf(TrackerUnreachableError);
+  });
+
+  it("treats a refused credential as unreachable", () => {
+    const error = githubFailure({ status: 1, stderr: PROXY_REFUSAL }, REF);
+
+    expect(error).toBeInstanceOf(TrackerUnreachableError);
+  });
+});
+
+describe("the tracker answered", () => {
+  it("does NOT treat a missing issue as unreachable", () => {
+    // The difference that keeps this from being a hole. Degrading here would
+    // wave through a commit against an issue that does not exist.
+    const error = githubFailure(
+      { status: 1, stderr: "GraphQL: Could not resolve to an Issue" },
+      REF
+    );
+
+    expect(error).not.toBeInstanceOf(TrackerUnreachableError);
+    expect(error.message).toMatch(/does not exist or is inaccessible/);
+  });
+
+  it("does NOT treat an unexplained failure as unreachable", () => {
+    // No evidence either way. Guessing "unreachable" would convert every
+    // unrecognised gh failure into a skipped check.
+    const error = githubFailure({ status: 1 }, REF);
+
+    expect(error).not.toBeInstanceOf(TrackerUnreachableError);
+  });
+});


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2237

Scope item 3 of #2218: what a flow should do when the guardrail's own dependency is unavailable.

A dispatched cloud session completed its work and **could not commit it**. `gh` has no usable credential there, so `validate-commit` refused — and `lisa-enforcement-fallback.sh` (#2224) correctly refused the `--no-verify`. Two correct behaviours composing into finished, green work with no way to save it.

## The distinction that makes this safe rather than a hole

**"Could not ask the tracker" and "the tracker said no" are different facts.** Only the first degrades:

| gh outcome | classification |
| --- | --- |
| binary missing (`ENOENT`) | unreachable — may degrade |
| credential refused / 403 | unreachable — may degrade |
| `Could not resolve to an Issue` | an answer — **still refuses** |
| unexplained non-zero exit | no evidence either way — **still refuses** |

Absence of evidence is not evidence of absence. Degrading on a genuine "no" would wave through a commit against an issue that does not exist — and guessing "unreachable" for an unexplained failure would turn every unrecognised `gh` error into a skipped check.

## Why the guarantee is not lost

Everything checkable offline still runs: trailer present, well formed, bound to this branch. The semantic checks — open, claimed, leaf — are re-run by `🔍 Quality Checks / 🔗 Work-Item Traceability`, which is a **required status check on `main`**:

```
$ gh api repos/CodySwannGT/lisa/rules/branches/main
"🔍 Quality Checks / 🔗 Work-Item Traceability"
```

The guarantee moves to a gate that cannot be bypassed rather than disappearing. **This holds only while that check stays required** — if it is ever made optional, this becomes a hole. That dependency is stated in the code comment where someone editing it will see it.

## What must not degrade

`assertBacklink` — the PR check — now refuses explicitly when the tracker is unreachable, because it *is* what the local hooks defer to. A required check that passed when it could not reach the tracker would make the arrangement circular: local defers to CI, CI defers to nothing.

The skip is **loud on stderr** and names what went unchecked. A degradation nobody sees is the failure mode this exists to avoid, not a milder version of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable GitHub tooling and credentials during work-item validation.
  * Live validation now provides a clear warning when GitHub cannot be reached while preserving genuine validation failures.
  * Required pull request checks now reject cases where live validation was never performed.
  * Improved distinction between unavailable tracking services and missing work items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->