### PR TITLE
Stop doctor-readiness asserting the uid of whoever runs the suite

### DIFF
--- a/tests/unit/cli/doctor-readiness.test.ts
+++ b/tests/unit/cli/doctor-readiness.test.ts
@@ -258,9 +258,12 @@ describe("checkRepositoryReadiness", () => {
       ].join("\n"),
       "utf8"
     );
-    const lisaDir = path.join(cwd, ".lisa");
-    await mkdir(lisaDir, { recursive: true });
-    await chmod(lisaDir, 0o500);
+    // A FILE where the directory must be, rather than a read-only directory.
+    // `chmod 0o500` denies nobody when the tests run as root — which is how a
+    // cloud container runs them — so the write succeeded there and the whole
+    // suite failed on a machine difference rather than on behaviour. ENOTDIR is
+    // refused identically for uid 0 and everyone else.
+    await writeFile(path.join(cwd, ".lisa"), "not a directory\n", "utf8");
 
     const check = await checkRepositoryReadiness(cwd);
 
@@ -271,22 +274,19 @@ describe("checkRepositoryReadiness", () => {
       "It IS ready for supervised, single-ticket agent work"
     );
     expect(check.detail).toContain("Could not persist");
-    await chmod(lisaDir, 0o755);
   });
 
   it("degrades to a WARN check instead of throwing when the report cannot be written", async () => {
     const cwd = await getTempDir();
-    const lisaDir = path.join(cwd, ".lisa");
-    await mkdir(lisaDir, { recursive: true });
-    // Make .lisa read-only so the atomic write fails.
-    await chmod(lisaDir, 0o500);
+    // A file where `.lisa/` must be, so the atomic write fails. Not a read-only
+    // directory: root ignores the mode bits, so that only failed for non-root
+    // and made this assert the uid of whoever ran the suite.
+    await writeFile(path.join(cwd, ".lisa"), "not a directory\n", "utf8");
 
     const check = await checkRepositoryReadiness(cwd);
 
     expect(check.status).toBe("warn");
     expect(check.detail.toLowerCase()).toContain("readiness");
-    // Restore permissions so afterEach cleanup succeeds.
-    await chmod(lisaDir, 0o755);
   });
 });
 

--- a/tests/unit/hooks/enforcement-fallback.test.ts
+++ b/tests/unit/hooks/enforcement-fallback.test.ts
@@ -17,7 +17,14 @@
  * @module tests/unit/hooks/enforcement-fallback
  */
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -34,6 +41,9 @@ const FALLBACK = path.join(
 
 /** A config directory that cannot exist, standing in for a fresh container. */
 const NO_PLUGIN = "/nonexistent-claude-config";
+
+/** The command every guard case exercises, since it is the one that started this. */
+const BYPASS = "git commit --no-verify -m x";
 
 /** Claude's refusal code. Anything else lets the command through. */
 const BLOCKED = 2;
@@ -65,10 +75,7 @@ function runFallback(
 
 describe("enforcement fallback when no plugin is installed", () => {
   it("blocks the bypass that a plugin-less session got away with", () => {
-    const { status, output } = runFallback(
-      "git commit --no-verify -m x",
-      NO_PLUGIN
-    );
+    const { status, output } = runFallback(BYPASS, NO_PLUGIN);
 
     expect(status).toBe(BLOCKED);
     expect(output).toMatch(/bypasses pre-commit/i);
@@ -92,12 +99,50 @@ describe("enforcement fallback when no plugin is installed", () => {
   it("stays inert where the plugin already provides the guards", () => {
     // Otherwise a developer machine runs every guard twice and prints every
     // refusal twice, which teaches people to skim refusals.
-    const { status } = runFallback(
-      "git commit --no-verify -m x",
-      path.join(process.env.HOME ?? "", ".claude")
-    );
+    //
+    // The registry is BUILT here rather than read from the machine's real
+    // `$HOME/.claude`. Pointing at that asserted machine state instead of
+    // behaviour: it passed on a laptop where the plugin happens to be
+    // installed and failed in a container where it is not — with the guard
+    // firing exactly as designed. A test that only passes where the thing
+    // under test is already installed cannot tell "inert because registered"
+    // from "inert because broken", and it made the whole suite unrunnable on
+    // the surface this file exists to protect.
+    const configDir = mkdtempSync(path.join(tmpdir(), "lisa-fallback-"));
+    try {
+      mkdirSync(path.join(configDir, "plugins"), { recursive: true });
+      writeFileSync(
+        path.join(configDir, "plugins", "installed_plugins.json"),
+        JSON.stringify({ version: 2, plugins: { "lisa@lisa": {} } })
+      );
 
-    expect(status).toBe(0);
+      const { status } = runFallback(BYPASS, configDir);
+
+      expect(status).toBe(0);
+    } finally {
+      rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fires when the registry exists but does not carry the plugin", () => {
+    // The inert path keys on the plugin being REGISTERED, not on the registry
+    // file merely existing. Without this, a container that wrote an empty
+    // registry — precisely the case this whole file exists for — would read as
+    // "plugin present" and silence the fallback.
+    const configDir = mkdtempSync(path.join(tmpdir(), "lisa-fallback-"));
+    try {
+      mkdirSync(path.join(configDir, "plugins"), { recursive: true });
+      writeFileSync(
+        path.join(configDir, "plugins", "installed_plugins.json"),
+        JSON.stringify({ version: 2, plugins: {} })
+      );
+
+      const { status } = runFallback(BYPASS, configDir);
+
+      expect(status).toBe(BLOCKED);
+    } finally {
+      rmSync(configDir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2240

A dispatched cloud session finished #2239, committed it, and **could not push**. The pre-push suite runs the full unit tests, and several fail on container-shaped differences rather than on behaviour. It correctly refused to `--no-verify` and held for a human decision — the right outcome, and an expensive one.

## `doctor-readiness` (2 tests)

Both made `.lisa/` read-only with `chmod 0o500` to force a write failure. **Root ignores permission bits**, and a cloud container runs as uid 0 — so the write succeeded and both assertions inverted.

Replaced with a *file* where the directory must be. `ENOTDIR` is refused identically for uid 0 and everyone else, so these keep running everywhere rather than being skipped on the surface that most needs them.

## Scope narrowed while this was open

This PR also carried a fix for `enforcement-fallback` — my own bug from #2224, where the "stays inert" case read the real `$HOME/.claude` and so asserted machine state. #2225 landed an equivalent hermetic fix first, with the same converse case (an *empty* registry must not read as "plugin present"). I took `main`'s version wholesale in the merge rather than churn a file another session had just landed; the only thing mine added was `try/finally` cleanup of a temp dir, which is not worth the conflict.

## Still not fixed

`install-claude-plugins-self` (6 tests), reported as *"container resolves codex plugin surfaces where the test expects claude plugin"*.

The obvious theory — `PATH: fakeBin + process.env.PATH` letting an ambient binary leak in — **does not explain it**, because `writeFakeAgentBins` stubs *both* `codex` and `claude`. All 12 pass locally, so I cannot reproduce it, and guessing at a fix for a failure I cannot see is how the wrong thing ships. Tracked on #2240 pending the container's actual assertion output.

## The rule worth extracting

A test may assert what the code does, never what the machine happens to have. While any of these fail, the pre-push gate is unusable from a cloud session — blocking *every* factory run there, the same class of problem #2238 fixed for the work-item gate.