### PR TITLE
Neutralise CLAUDE_CODE_REMOTE, which the plugin suite made load-bearing

### DIFF
--- a/tests/unit/scripts/install-claude-plugins-self.test.ts
+++ b/tests/unit/scripts/install-claude-plugins-self.test.ts
@@ -325,6 +325,12 @@ describe("install-claude-plugins self postinstall path", () => {
         HOME: projectRoot,
         CI: "",
         CODEX_THREAD_ID: "",
+        // Neutralised for the same reason as the two above: the script stands
+        // down entirely when this is "true", so a run inside a cloud container
+        // — where the platform sets it — exercised none of the Claude plugin
+        // work these cases assert, and only the Codex sections that run before
+        // the guard appeared in the log.
+        CLAUDE_CODE_REMOTE: "",
         LISA_TEST_COMMAND_LOG: commandLog,
         PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
       },
@@ -339,6 +345,43 @@ describe("install-claude-plugins self postinstall path", () => {
     expect(log).toContain(CLAUDE_INSTALL_BASE);
     expect(log).toContain(CODEX_SELF_OVERLAY_LOG);
     expect(log).not.toContain("apply self");
+  });
+
+  it("stands down entirely inside a cloud session", async () => {
+    // The positive case for the guard every other test here neutralises.
+    // Claude Code installs the plugins a repository declares at session start,
+    // and this script runs from a package manager's postinstall — inside a
+    // container that is during the environment setup script, before Claude has
+    // launched and before any marketplace exists, so all eight installs failed.
+    //
+    // Without this case the guard would be asserted only as a string in the
+    // source, and neutralising the variable everywhere else would have left the
+    // behaviour it controls untested by construction.
+    const projectRoot = await makeTempRoot();
+    const fakeBin = path.join(projectRoot, "bin");
+    const commandLog = path.join(projectRoot, COMMAND_LOG);
+    await writeSelfProject(projectRoot);
+    const selfScriptPath = await writeSelfLisaScript(projectRoot);
+    await writeFakeAgentBins(fakeBin);
+
+    const { stdout } = await execFileAsync("bash", [selfScriptPath], {
+      env: {
+        ...process.env,
+        HOME: projectRoot,
+        CI: "",
+        CODEX_THREAD_ID: "",
+        CLAUDE_CODE_REMOTE: "true",
+        LISA_TEST_COMMAND_LOG: commandLog,
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+
+    const log = await readFile(commandLog, "utf8");
+    expect(log).not.toContain(CLAUDE_INSTALL_BASE);
+    // Says why, rather than going quiet. A postinstall that is silent in one
+    // environment and not another reads as a broken install to whoever is
+    // next looking at the setup log.
+    expect(stdout).toContain("Cloud session");
   });
 
   it("runs downstream apply before Codex user-wide cleanup", async () => {
@@ -357,6 +400,12 @@ describe("install-claude-plugins self postinstall path", () => {
         HOME: projectRoot,
         CI: "",
         CODEX_THREAD_ID: "",
+        // Neutralised for the same reason as the two above: the script stands
+        // down entirely when this is "true", so a run inside a cloud container
+        // — where the platform sets it — exercised none of the Claude plugin
+        // work these cases assert, and only the Codex sections that run before
+        // the guard appeared in the log.
+        CLAUDE_CODE_REMOTE: "",
         LISA_TEST_COMMAND_LOG: commandLog,
         PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
       },
@@ -386,6 +435,12 @@ describe("install-claude-plugins self postinstall path", () => {
         HOME: projectRoot,
         CI: "",
         CODEX_THREAD_ID: "",
+        // Neutralised for the same reason as the two above: the script stands
+        // down entirely when this is "true", so a run inside a cloud container
+        // — where the platform sets it — exercised none of the Claude plugin
+        // work these cases assert, and only the Codex sections that run before
+        // the guard appeared in the log.
+        CLAUDE_CODE_REMOTE: "",
         LISA_TEST_COMMAND_LOG: commandLog,
         PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
       },
@@ -415,6 +470,12 @@ describe("install-claude-plugins self postinstall path", () => {
         HOME: projectRoot,
         CI: "",
         CODEX_THREAD_ID: "",
+        // Neutralised for the same reason as the two above: the script stands
+        // down entirely when this is "true", so a run inside a cloud container
+        // — where the platform sets it — exercised none of the Claude plugin
+        // work these cases assert, and only the Codex sections that run before
+        // the guard appeared in the log.
+        CLAUDE_CODE_REMOTE: "",
         INIT_CWD: leakedRoot,
         npm_config_local_prefix: leakedRoot,
         LISA_TEST_COMMAND_LOG: commandLog,
@@ -445,6 +506,12 @@ describe("install-claude-plugins self postinstall path", () => {
         HOME: projectRoot,
         CI: "",
         CODEX_THREAD_ID: "",
+        // Neutralised for the same reason as the two above: the script stands
+        // down entirely when this is "true", so a run inside a cloud container
+        // — where the platform sets it — exercised none of the Claude plugin
+        // work these cases assert, and only the Codex sections that run before
+        // the guard appeared in the log.
+        CLAUDE_CODE_REMOTE: "",
         LISA_TEST_COMMAND_LOG: commandLog,
         PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
       },
@@ -512,6 +579,12 @@ describe("install-claude-plugins self postinstall path", () => {
         HOME: projectRoot,
         CI: "",
         CODEX_THREAD_ID: "",
+        // Neutralised for the same reason as the two above: the script stands
+        // down entirely when this is "true", so a run inside a cloud container
+        // — where the platform sets it — exercised none of the Claude plugin
+        // work these cases assert, and only the Codex sections that run before
+        // the guard appeared in the log.
+        CLAUDE_CODE_REMOTE: "",
         LISA_TEST_COMMAND_LOG: commandLog,
         PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
       },
@@ -572,6 +645,12 @@ describe("install-claude-plugins self postinstall path", () => {
         HOME: projectRoot,
         CI: "",
         CODEX_THREAD_ID: "",
+        // Neutralised for the same reason as the two above: the script stands
+        // down entirely when this is "true", so a run inside a cloud container
+        // — where the platform sets it — exercised none of the Claude plugin
+        // work these cases assert, and only the Codex sections that run before
+        // the guard appeared in the log.
+        CLAUDE_CODE_REMOTE: "",
         LISA_TEST_COMMAND_LOG: commandLog,
         LISA_TEST_INSTALLED_PLUGINS: JSON.stringify(installedPlugins),
         PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
@@ -621,6 +700,12 @@ describe("install-claude-plugins self postinstall path", () => {
         HOME: projectRoot,
         CI: "",
         CODEX_THREAD_ID: "",
+        // Neutralised for the same reason as the two above: the script stands
+        // down entirely when this is "true", so a run inside a cloud container
+        // — where the platform sets it — exercised none of the Claude plugin
+        // work these cases assert, and only the Codex sections that run before
+        // the guard appeared in the log.
+        CLAUDE_CODE_REMOTE: "",
         LISA_TEST_COMMAND_LOG: commandLog,
         LISA_TEST_INSTALLED_PLUGINS: JSON.stringify(installedPlugins),
         PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
@@ -675,6 +760,12 @@ describe("install-claude-plugins self postinstall path", () => {
         HOME: root,
         CI: "",
         CODEX_THREAD_ID: "",
+        // Neutralised for the same reason as the two above: the script stands
+        // down entirely when this is "true", so a run inside a cloud container
+        // — where the platform sets it — exercised none of the Claude plugin
+        // work these cases assert, and only the Codex sections that run before
+        // the guard appeared in the log.
+        CLAUDE_CODE_REMOTE: "",
         LISA_TEST_COMMAND_LOG: commandLog,
         PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
       },
@@ -719,6 +810,12 @@ describe("install-claude-plugins self postinstall path", () => {
         HOME: root,
         CI: "",
         CODEX_THREAD_ID: "",
+        // Neutralised for the same reason as the two above: the script stands
+        // down entirely when this is "true", so a run inside a cloud container
+        // — where the platform sets it — exercised none of the Claude plugin
+        // work these cases assert, and only the Codex sections that run before
+        // the guard appeared in the log.
+        CLAUDE_CODE_REMOTE: "",
         LISA_TEST_COMMAND_LOG: commandLog,
         PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
       },


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2240

The six `install-claude-plugins-self` failures reported from a cloud container are **mine**, from #2216 — the commit that made the postinstall stand down in a cloud session.

That guard exits the script before any Claude plugin work. These tests already blank `CI` and `CODEX_THREAD_ID` for exactly this reason, but nothing blanked the variable the guard reads. So inside a container the script stood down, only the Codex sections that run *earlier* reached the log, and six cases failed asserting Claude plugin installs that never happened — reported as *"resolves codex surfaces where the test expects claude plugin"*, which is precisely what that looks like from outside.

## Reproduced before fixing, not guessed at

```
CLAUDE_CODE_REMOTE unset    12 passed
CLAUDE_CODE_REMOTE=true      6 failed | 6 passed
```

The same six the session named. My earlier PATH-leak theory was wrong and I said so rather than shipping against it.

## The positive case

Neutralising the variable everywhere would have left the guard tested only as a *string in the source*, so this adds the behavioural case: inside a cloud session the script installs nothing **and says why**. A postinstall that goes quiet in one environment and not another reads as a broken install to whoever is next looking at a setup log.

## The condition that actually matters

```
$ CLAUDE_CODE_REMOTE=true bunx vitest run tests/unit
Test Files  492 passed (492)
     Tests  8358 passed (8358)
```

The whole suite green with the variable set is the precondition for a cloud session being able to push at all. Together with the `doctor-readiness` uid fix already on this branch, that closes every failure blocking `claude/cool-galileo-n0nmr2`.