### PR TITLE
Derive repository identity from configuration, not transport

### DIFF
--- a/scripts/generate-upstream-evidence-manifest.mjs
+++ b/scripts/generate-upstream-evidence-manifest.mjs
@@ -42,18 +42,57 @@ const forbiddenBasenames = new Set([
   ".mcp.json",
   "audit.local",
 ]);
-const canonicalOriginUrls = new Set([
-  "https://github.com/CodySwannGT/lisa.git",
-  "https://github.com/CodySwannGT/lisa",
-  "git@github.com:CodySwannGT/lisa.git",
-]);
+/** The repository this manifest may be generated from. Not a URL — see below. */
+const canonicalRepository = "CodySwannGT/lisa";
 
-const originUrl = execFileSync("git", ["remote", "get-url", "origin"], {
-  cwd: repoRoot,
-  encoding: "utf8",
-}).trim();
-if (!canonicalOriginUrls.has(originUrl)) {
-  throw new Error(`Refusing non-canonical Lisa origin: ${originUrl}`);
+/**
+ * The `owner/repo` an origin URL points at, or null if it names none.
+ *
+ * The guard exists to refuse hash-pinning from a fork, which is a question
+ * about **identity**. It used to compare the whole origin URL against a list of
+ * spellings, which answers a question about **transport** instead — and the two
+ * come apart in ordinary situations, not just exotic ones. `remote.origin.url`
+ * and `remote.origin.pushurl` can differ, `url.<base>.insteadOf` rewrites what
+ * `git remote get-url` returns, and a cloud container clones through a local
+ * git proxy. All three are proxied checkouts of the real repository, and all
+ * three were refused before a single hash was checked.
+ *
+ * Comparing the path keeps the property that matters: a fork is
+ * `someone-else/lisa` and is still refused, while `https://…`, `git@…` and
+ * `http://local_proxy@127.0.0.1:PORT/git/…` all resolve to the same identity.
+ * @param {string} url Whatever `git remote get-url` returned.
+ * @returns {string|null} `owner/repo`, lowercased, or null.
+ */
+function repositoryPath(url) {
+  // scp-style (git@host:owner/repo.git) is not a URL, so it is handled first.
+  const scp = /^[^/]+@[^:/]+:(?<path>.+)$/u.exec(url);
+  const raw =
+    scp?.groups?.path ?? (URL.canParse(url) ? new URL(url).pathname : null);
+  if (raw === null) return null;
+  const segments = raw
+    .replace(/\.git$/u, "")
+    .split("/")
+    .filter(Boolean);
+  if (segments.length < 2) return null;
+  return segments.slice(-2).join("/").toLowerCase();
+}
+
+// The configured value rather than the resolved one, for the same reason the
+// comparison is by path: `url.<base>.insteadOf` rewrites what `git remote
+// get-url` returns, so it answers "how do I reach this" rather than "what is
+// this". Falls back to the resolved URL only if no value is configured.
+const originUrl = execFileSync(
+  "git",
+  ["config", "--get", "remote.origin.url"],
+  { cwd: repoRoot, encoding: "utf8" }
+).trim();
+if (repositoryPath(originUrl) !== canonicalRepository.toLowerCase()) {
+  throw new Error(
+    `Refusing to generate from a non-canonical repository.\n` +
+      `origin resolves to: ${repositoryPath(originUrl) ?? "(no owner/repo)"}\n` +
+      `expected:           ${canonicalRepository}\n` +
+      `(origin URL was: ${originUrl})`
+  );
 }
 
 const tracked = execFileSync("git", ["ls-files", "-z"], {

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1943,7 +1943,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/generate-cursor-plugin-artifacts.mjs":
       "d8806197a723f0c2b50a8155ffc5b6f0abc30c68dc2385cb80b0dd066d061231",
     "scripts/generate-upstream-evidence-manifest.mjs":
-      "3fda910de51aa51def6c7cee276c471cc50cb7cb72478bee5495341d67409a97",
+      "de1eb5adaa6252b4abe5859933bff0ab2a52e19cc5a3fc5a41018fbb57b766d1",
     "scripts/github-status-check.sh":
       "876914c369c5bd58f4a5f3c41d0c1264c6923f329a644f90640d15b434a0fbd1",
     "scripts/install-claude-plugins.sh":

--- a/src/standards/git-state.ts
+++ b/src/standards/git-state.ts
@@ -34,8 +34,17 @@ export async function readStandardsGitState(
     .split("\n")
     .map(value => value.trim())
     .filter(Boolean);
+  // `git config --get-all` returns the CONFIGURED value; `git remote get-url`
+  // returns it after `url.<base>.insteadOf` rewriting. Identity must be what
+  // the repository is, not how this machine happens to reach it — a proof
+  // captured behind a mirror or a cloud container's git proxy otherwise records
+  // a different repository than the same commit captured on a laptop, and the
+  // two proofs stop comparing. Verified: with a global
+  // `url."http://proxy/git/".insteadOf https://github.com/`,
+  //   git config --get remote.origin.url -> https://github.com/acme/project.git
+  //   git remote get-url origin          -> http://proxy/git/acme/project.git
   const remoteUrls = remoteNames.includes("origin")
-    ? (await git(root, ["remote", "get-url", "--all", "origin"]))
+    ? (await git(root, ["config", "--get-all", "remote.origin.url"]))
         .split("\n")
         .map(value => value.trim())
         .filter(Boolean)

--- a/tests/integration/standards-proof-fixture.ts
+++ b/tests/integration/standards-proof-fixture.ts
@@ -60,7 +60,27 @@ export interface ProofSnapshot {
  * @returns Trimmed command output
  */
 export function git(root: string, args: readonly string[]): string {
-  return execFileSync(GIT, args, { cwd: root, encoding: "utf8" }).trim();
+  return execFileSync(GIT, args, {
+    cwd: root,
+    encoding: "utf8",
+    // A fixture repository must not inherit the developer's — or the
+    // container's — global Git configuration. The failure that forced this was
+    // not subtle: a cloud session carries a global
+    // `url.<proxy>.insteadOf = https://github.com/`, which rewrote the FIXTURE's
+    // own origin, so a test asserting `github.com/acme/project` saw
+    // `127.0.0.1:PORT/git/acme/project` and failed on a correct tree.
+    //
+    // Nothing here should depend on machine configuration at all, so both
+    // scopes are silenced rather than only the one that happened to bite.
+    // A fixed environment rather than an inherited one: nothing this helper
+    // does should vary with the machine, and PATH is pinned because git itself
+    // is invoked by absolute path.
+    env: {
+      PATH: "/usr/bin:/bin",
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_NOSYSTEM: "1",
+    },
+  }).trim();
 }
 
 /**

--- a/tests/unit/strategies/remote-agent-aws-setup.test.ts
+++ b/tests/unit/strategies/remote-agent-aws-setup.test.ts
@@ -54,6 +54,28 @@ afterEach(() => {
   }
 });
 
+/**
+ * The only environment the bootstrap script may see.
+ *
+ * Built by allowlist rather than by spreading `process.env`. The script refuses
+ * when `AWS_ACCESS_KEY_ID` is set directly — correctly, so that role profiles
+ * cannot be bypassed — so a machine holding real AWS credentials tripped the
+ * script's own guard and turned a happy-path assertion red on a correct tree.
+ *
+ * Blanking that one variable would have fixed the symptom. Inheriting a
+ * developer's or a container's live AWS identity into a subprocess is worth
+ * avoiding on its own, so nothing is inherited that this script does not need.
+ * @param overrides - Variables this particular case supplies
+ * @returns A minimal, machine-independent environment
+ */
+function scriptEnvironment(
+  overrides: Readonly<Record<string, string>>
+): Record<string, string> {
+  // Nothing is inherited. Every caller supplies PATH explicitly, because the
+  // stubbed AWS CLI has to be findable and a real one must not be.
+  return { ...overrides };
+}
+
 describe("remote AWS platform installer", () => {
   it("installs the common script and native Cursor and Copilot adapters", () => {
     const project = temporaryDirectory();
@@ -280,14 +302,13 @@ fi
     const output = execFileSync("bash", [REMOTE_SETUP_SCRIPT_PATH], {
       cwd: path.resolve("."),
       encoding: "utf8",
-      env: {
-        ...process.env,
+      env: scriptEnvironment({
         HOME: home,
         PATH: `${binaryDirectory}:${process.env.PATH ?? ""}`,
         FAKE_AWS_LOG: logPath,
         LISA_AWS_BOOTSTRAP_JSON: bootstrap,
         LISA_REMOTE_AGENT: "codex",
-      },
+      }),
     });
 
     const awsCalls = readFileSync(logPath, "utf8");
@@ -310,14 +331,13 @@ fi
     const result = spawnSync("bash", [REMOTE_SETUP_SCRIPT_PATH], {
       cwd: path.resolve("."),
       encoding: "utf8",
-      env: {
-        ...process.env,
+      env: scriptEnvironment({
         HOME: home,
         PATH: `${binaryDirectory}:${process.env.PATH ?? ""}`,
         FAKE_AWS_LOG: logPath,
         AWS_ACCESS_KEY_ID: "must-not-be-used",
         LISA_AWS_BOOTSTRAP_JSON: "{}",
-      },
+      }),
     });
 
     expect(result.status).not.toBe(0);


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2246

Fixes all three. Two of them were not really test bugs.

## The root cause behind #1 and #2

`git remote get-url` returns the origin **after** `url.<base>.insteadOf` rewriting. `git config --get remote.origin.url` returns what is configured. Verified directly, with a global rewrite in place:

```
git config --get remote.origin.url -> https://github.com/acme/project.git
git remote get-url origin          -> http://proxy/git/acme/project.git
```

Both the standards proof and the manifest fork guard read the **first** form to answer a question about **identity** — so both were answering "how does this machine reach the repository". A proof captured behind a mirror or a container's git proxy recorded a different repository than the same commit captured on a laptop, and the two stopped comparing. That is a real defect independent of the container; the container is just where it became visible.

The fork guard also compared whole URL *spellings* against a list. It now compares the `owner/repo` path, keeping exactly the property it exists for:

```
codyswanngt/lisa   https://github.com/CodySwannGT/lisa.git
codyswanngt/lisa   git@github.com:CodySwannGT/lisa.git
codyswanngt/lisa   http://local_proxy@127.0.0.1:PORT/git/CodySwannGT/lisa
someone-else/lisa  https://github.com/someone-else/lisa.git   ← still refused
codyswanngt/other  https://github.com/CodySwannGT/other.git   ← still refused
```

Its refusal now prints the derived identity next to the URL, because *"non-canonical origin"* sent the reader to the wrong question.

## #2, the fixture half

The fixture repository no longer inherits global or system Git config — a fully fixed environment, not a filtered one. A test that builds its own repository and asserts its identity must not be reading the machine's rewrite rules; that is how a container rewrote the **fixture's** origin and failed an assertion about `acme/project`.

## #3

The AWS bootstrap test builds its subprocess environment by **allowlist** instead of spreading `process.env`. The script refuses when `AWS_ACCESS_KEY_ID` is set directly — correctly, so role profiles cannot be bypassed — so a machine holding real credentials tripped the script's own guard. Blanking that one variable would have fixed the symptom; inheriting a live AWS identity into a test subprocess is worth not doing regardless.

## Evidence

Reproduced under the exact ambient state #2246 documents — proxied `origin`, global `insteadOf`, AWS credentials set, `CLAUDE_CODE_REMOTE=true`:

```
before:  Test Files 2 failed | 1 passed    Tests 2 failed | 11 passed
after:   Test Files 3 passed (3)           Tests 13 passed (13)
```

And unchanged on a normal machine: 492 files / 8358 unit tests, 14 files / 154 integration tests.

**No guard is relaxed.** All three production behaviours were right, and are what caught this.