### PR TITLE
Detect the CLIs a project needs, and provision them locally too

### DIFF
--- a/.lisa.config.json
+++ b/.lisa.config.json
@@ -169,6 +169,18 @@
         },
         {
           "name": "tar"
+        },
+        {
+          "name": "bws",
+          "surfaces": [
+            "local"
+          ]
+        },
+        {
+          "name": "gh",
+          "surfaces": [
+            "local"
+          ]
         }
       ],
       "install": [
@@ -177,7 +189,10 @@
           "version": "2.1.0",
           "install": "release-zip",
           "url": "https://github.com/bitwarden/sdk-sm/releases/download/bws-v2.1.0/bws-x86_64-unknown-linux-gnu-2.1.0.zip",
-          "sha256": "ba8233c3a4aee5d43e3c73bbd04d99e9bc5aba13bbbfd06d89b073abe732b860"
+          "sha256": "ba8233c3a4aee5d43e3c73bbd04d99e9bc5aba13bbbfd06d89b073abe732b860",
+          "surfaces": [
+            "remote"
+          ]
         },
         {
           "name": "gh",
@@ -185,7 +200,10 @@
           "install": "release-tar",
           "url": "https://github.com/cli/cli/releases/download/v2.83.0/gh_2.83.0_linux_amd64.tar.gz",
           "sha256": "a5cf6cdb40fc67751adf561126b3314044779cea81ba4f254fbe8e9a69f1676f",
-          "binary": "gh_2.83.0_linux_amd64/bin/gh"
+          "binary": "gh_2.83.0_linux_amd64/bin/gh",
+          "surfaces": [
+            "remote"
+          ]
         }
       ]
     },

--- a/plugins/lisa-agy/commands/lisa/detect-tooling.md
+++ b/plugins/lisa-agy/commands/lisa/detect-tooling.md
@@ -1,0 +1,7 @@
+---
+description: "Find the command-line tools this project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts what remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only once a human has reviewed a pinned, checksummed entry."
+allowed-tools: ["Skill"]
+argument-hint: "[--json]"
+---
+
+Use the /lisa-detect-tooling skill to find undeclared command-line tooling and propose manifest entries for it. $ARGUMENTS

--- a/plugins/lisa-agy/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-detect-tooling/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lisa-detect-tooling
 description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts whatever remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
-allowed-tools: ["Bash", "Read", "Edit", "AskUserQuestion"]
+allowed-tools: ["Bash", "Read", "AskUserQuestion"]
 ---
 
 # Detect Tooling
@@ -55,4 +55,6 @@ node scripts/detect-tooling.mjs          # human-readable proposals
 node scripts/detect-tooling.mjs --json   # machine-readable
 ```
 
-Confirm each proposal with the operator before editing `.lisa.config.json`. When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on; a rejected proposal is a normal outcome, not a failure.
+Confirm each proposal with the operator, then hand it to them to apply. **This skill does not hold `Edit`**, deliberately: a skill that both decides a tool is needed and writes the entry that installs it is the second unreviewed install path this design exists to avoid. Granting `Edit` while documenting "writes nothing" would have made the prose the only thing stopping it.
+
+When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on. A rejected proposal is a normal outcome, not a failure.

--- a/plugins/lisa-agy/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-detect-tooling/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: lisa-detect-tooling
+description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts whatever remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
+allowed-tools: ["Bash", "Read", "Edit", "AskUserQuestion"]
+---
+
+# Detect Tooling
+
+Lisa provisions tooling through four unrelated mechanisms, and only one of them puts a binary on `PATH`:
+
+| tool | how it arrives | what puts it on PATH |
+| --- | --- | --- |
+| playwright, stryker | npm devDependency from a stack template | nothing — a local `node_modules` binary |
+| maestro | npm **scripts** in the Expo template | **nothing** |
+| sonar | `src/sonar/sonar-installer.ts` | nothing |
+| linear | MCP server | nothing, and it needs browser OAuth |
+| bws, gh | `remoteEnv.tools` — pinned and checksummed | this, and only this |
+
+Nothing populates that last row. So a project can ship scripts that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and configure Playwright thresholds, while the manifest that actually provisions binaries stays empty — and every one of those fails at the moment of use rather than at setup.
+
+That is the same failure this repository has now paid for twice: `gh` was declared nowhere and a cloud session could not commit; `tar` was needed by an install method and asserted by nothing.
+
+## What it does
+
+Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
+
+- **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
+- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one.
+- **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
+- **Quality configuration**, where a threshold implies the tool that produces it.
+
+## What it will not do
+
+**It writes nothing and installs nothing.** Output is a proposal with `<pin>`, `<release url>` and `<sha256>` left for a human.
+
+That boundary is the whole design. A tool should reach a machine because someone reviewed a pinned entry with a checksum, never because a detector was confident. Detection is evidence; the manifest is the decision. An auto-writing detector would quietly become a second, unreviewed install path — exactly what `assertPinned` exists to prevent.
+
+## Surfaces
+
+One declaration per tool, with an optional `surfaces` list, rather than separate blocks per surface. Most tools are needed *everywhere* — a Maestro or Sonar CLI is as required on a laptop as in a container — and duplicated blocks drift.
+
+What genuinely differs is **consent**, not the list:
+
+- A remote container is disposable and nobody is watching, so it provisions silently.
+- A developer machine belongs to a person, so `--phase=toolchain` reports what is missing and installs nothing unless `--install-tools` is passed.
+
+Omitting `surfaces` means every surface, because that is true of most tools and the cost of forgetting should be a redundant check rather than a silent absence.
+
+A platform-specific pin is the exception worth knowing: a Linux release archive must be `surfaces: ["remote"]`, with a matching `require` entry for `local`, so a laptop asserts the tool without being offered a binary it cannot run.
+
+## Usage
+
+```sh
+node scripts/detect-tooling.mjs          # human-readable proposals
+node scripts/detect-tooling.mjs --json   # machine-readable
+```
+
+Confirm each proposal with the operator before editing `.lisa.config.json`. When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on; a rejected proposal is a normal outcome, not a failure.

--- a/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * Find the command-line tools a project needs but never declares.
+ *
+ * Lisa provisions tooling through several unrelated mechanisms — npm
+ * devDependencies from a stack template, MCP servers, a dedicated installer for
+ * Sonar, and the pinned `remoteEnv.tools` manifest. Only the last one puts a
+ * binary on PATH, and nothing populates it. So a project can ship npm scripts
+ * that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and
+ * declare Playwright coverage thresholds, while the manifest that actually
+ * provisions binaries stays empty and every one of those fails at the moment of
+ * use rather than at setup.
+ *
+ * This program only ever *proposes*. It writes nothing, installs nothing, and
+ * emits manifest entries with the fields a human still has to fill — a pinned
+ * version, a URL, a checksum. That boundary is the point: a tool should reach a
+ * machine because someone reviewed a pinned entry, never because a detector was
+ * confident. Detection is evidence; the manifest is the decision.
+ *
+ * Usage:
+ *   detect-tooling.mjs [--json]
+ * @module detect-tooling
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Tools Lisa or its templates invoke, and how to recognise a need for them.
+ *
+ * Deliberately conservative. A false positive costs a human a moment's review;
+ * a false negative is the failure this exists to prevent, so the signals are
+ * ones that only appear when the tool is genuinely used.
+ */
+const KNOWN_TOOLS = Object.freeze({
+  maestro: {
+    why: "Expo's template ships npm scripts that invoke `maestro`, and nothing installs the binary.",
+    mcpFallback: "maestro",
+  },
+  gh: {
+    why: "The work-item guardrails shell out to `gh` for every tracker read.",
+  },
+  bws: {
+    why: "The Bitwarden CLI is how every secret is resolved.",
+  },
+  "sonar-scanner": {
+    why: "Sonar analysis runs a scanner binary, which the Sonar installer configures but does not place on PATH.",
+  },
+  playwright: {
+    why: "Playwright drives browser E2E and its coverage thresholds are configured.",
+    viaNpm: "@playwright/test",
+  },
+  linear: {
+    why: "Linear is wired as an MCP server, which needs browser OAuth and so cannot authenticate in a container.",
+    mcpFallback: "linear-server",
+  },
+});
+
+/**
+ * Read a JSON file, treating absence or damage as "no signal".
+ *
+ * A detector that throws on a malformed config is worse than one that misses a
+ * signal: it blocks the very command an operator runs to find out what is wrong.
+ * @param {string} path File to read.
+ * @returns {object|null} Parsed contents, or null.
+ */
+function readJson(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Tools named by npm scripts, which is the strongest signal there is.
+ *
+ * A script that runs `maestro test` is a project stating it needs Maestro, in
+ * executable form. Word-boundary matched so `maestro:test` as a script *name*
+ * does not count while `maestro test` as its body does — the name is a label,
+ * the body is a dependency.
+ * @param {object|null} pkg Parsed package.json.
+ * @returns {Map<string, string>} Tool name to the script that proves it.
+ */
+export function toolsFromScripts(pkg) {
+  const found = new Map();
+  const scripts = pkg?.scripts ?? {};
+  for (const [name, body] of Object.entries(scripts)) {
+    if (typeof body !== "string") continue;
+    for (const tool of Object.keys(KNOWN_TOOLS)) {
+      const pattern = new RegExp(`(^|[\\s;&|(])${tool}(\\s|$)`, "u");
+      if (pattern.test(body) && !found.has(tool)) {
+        found.set(tool, `npm script "${name}": ${body.trim().slice(0, 60)}`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools implied by MCP servers that also have a CLI.
+ *
+ * An MCP server is not a substitute for the binary. Several authenticate by
+ * browser OAuth, which a container cannot do at all, so a project relying on one
+ * remotely has no integration rather than a degraded one — the CLI is the form
+ * that survives the trip.
+ * @param {object|null} mcp Parsed .mcp.json.
+ * @returns {Map<string, string>} Tool name to the server that implies it.
+ */
+export function toolsFromMcp(mcp) {
+  const found = new Map();
+  const servers = Object.keys(mcp?.mcpServers ?? {});
+  for (const [tool, meta] of Object.entries(KNOWN_TOOLS)) {
+    if (!meta.mcpFallback) continue;
+    const server = servers.find(name => name.includes(meta.mcpFallback));
+    if (server) {
+      found.set(
+        tool,
+        `MCP server "${server}" (browser OAuth cannot run remotely)`
+      );
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools named in credential usage notes.
+ *
+ * A note explaining what a token is *for* usually names the program that
+ * consumes it, and those notes are already readable without touching a value —
+ * `read-secret-note.mjs` exists precisely so an agent can learn a credential's
+ * blast radius safely. That makes them a first-class detection input rather than
+ * a clever trick.
+ * @param {object|null} notes Parsed secret-notes.json.
+ * @returns {Map<string, string>} Tool name to the credential that names it.
+ */
+export function toolsFromSecretNotes(notes) {
+  const found = new Map();
+  const entries = Object.entries(notes?.notes ?? notes ?? {});
+  for (const [secret, note] of entries) {
+    const text = typeof note === "string" ? note : JSON.stringify(note ?? "");
+    for (const tool of Object.keys(KNOWN_TOOLS)) {
+      const pattern = new RegExp(
+        `(^|[^A-Za-z0-9-])${tool}([^A-Za-z0-9-]|$)`,
+        "iu"
+      );
+      if (pattern.test(text) && !found.has(tool)) {
+        found.set(tool, `usage note on credential "${secret}"`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools implied by quality configuration.
+ * @param {object|null} config Parsed .lisa.config.json.
+ * @returns {Map<string, string>} Tool name to the setting that implies it.
+ */
+export function toolsFromQuality(config) {
+  const found = new Map();
+  if (config?.quality?.e2eCoverage?.playwright) {
+    found.set("playwright", "quality.e2eCoverage.playwright is configured");
+  }
+  if (config?.quality?.sonar || config?.sonar) {
+    found.set("sonar-scanner", "Sonar analysis is configured");
+  }
+  return found;
+}
+
+/**
+ * Everything already declared, by name, so proposals exclude them.
+ * @param {object|null} config Parsed .lisa.config.json.
+ * @returns {Set<string>} Declared tool names.
+ */
+export function declaredTools(config) {
+  const tools = config?.remoteEnv?.tools ?? {};
+  return new Set(
+    [...(tools.require ?? []), ...(tools.install ?? [])].map(t => t.name)
+  );
+}
+
+/**
+ * Collect every signal and subtract what the manifest already covers.
+ * @param {string} [cwd] Project root.
+ * @returns {Array<{name: string, why: string, evidence: string[]}>} Proposals.
+ */
+export function detectTooling(cwd = process.cwd()) {
+  const config = readJson(join(cwd, ".lisa.config.json"));
+  const pkg = readJson(join(cwd, "package.json"));
+  const mcp = readJson(join(cwd, ".mcp.json"));
+  const notes = readJson(join(cwd, ".lisa", "secret-notes.json"));
+
+  const declared = declaredTools(config);
+  const signals = [
+    toolsFromScripts(pkg),
+    toolsFromMcp(mcp),
+    toolsFromSecretNotes(notes),
+    toolsFromQuality(config),
+  ];
+
+  const merged = new Map();
+  for (const signal of signals) {
+    for (const [tool, evidence] of signal) {
+      if (declared.has(tool)) continue;
+      const entry = merged.get(tool) ?? { evidence: [] };
+      entry.evidence.push(evidence);
+      merged.set(tool, entry);
+    }
+  }
+
+  return [...merged.entries()]
+    .map(([name, entry]) => ({
+      name,
+      why: KNOWN_TOOLS[name]?.why ?? "",
+      evidence: entry.evidence,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * A manifest entry an operator can paste, with the parts only they can supply.
+ * @param {{name: string}} proposal One detected tool.
+ * @returns {object} A `remoteEnv.tools.install` skeleton.
+ */
+export function proposedEntry(proposal) {
+  const viaNpm = KNOWN_TOOLS[proposal.name]?.viaNpm;
+  return viaNpm
+    ? {
+        name: proposal.name,
+        install: "npm-global",
+        package: viaNpm,
+        version: "<pin>",
+      }
+    : {
+        name: proposal.name,
+        version: "<pin>",
+        install: "release-tar",
+        url: "<release url for this exact version>",
+        sha256: "<sha256 published with that release>",
+        surfaces: ["remote"],
+      };
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  const proposals = detectTooling();
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(proposals, null, 2));
+  } else if (proposals.length === 0) {
+    console.log(
+      "Every tool this project appears to use is already declared in remoteEnv.tools."
+    );
+  } else {
+    console.log(
+      `${proposals.length} tool(s) look required but are not declared:\n`
+    );
+    for (const proposal of proposals) {
+      console.log(`  ${proposal.name}`);
+      console.log(`    why: ${proposal.why}`);
+      for (const evidence of proposal.evidence) {
+        console.log(`    evidence: ${evidence}`);
+      }
+      console.log(`    proposed: ${JSON.stringify(proposedEntry(proposal))}\n`);
+    }
+    console.log(
+      "Nothing has been written or installed. Confirm each entry, supply the\n" +
+        "pin and checksum, and add it to remoteEnv.tools in .lisa.config.json."
+    );
+  }
+}

--- a/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -174,10 +174,22 @@ export function toolsFromQuality(config) {
  * @param {object|null} config Parsed .lisa.config.json.
  * @returns {Set<string>} Declared tool names.
  */
-export function declaredTools(config) {
+export function declaredTools(config, surface = "remote") {
   const tools = config?.remoteEnv?.tools ?? {};
+  const applies = tool => {
+    const surfaces = tool.surfaces;
+    if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+    return surfaces.includes(surface);
+  };
+  // Filtered by surface, because a declaration that applies somewhere else is
+  // not coverage here. A local-only `require` entry would otherwise suppress
+  // the proposal for a tool genuinely missing from the remote manifest — the
+  // detector reporting "already declared" about the one surface where it is
+  // not.
   return new Set(
-    [...(tools.require ?? []), ...(tools.install ?? [])].map(t => t.name)
+    [...(tools.require ?? []), ...(tools.install ?? [])]
+      .filter(applies)
+      .map(tool => tool.name)
   );
 }
 
@@ -220,27 +232,48 @@ export function detectTooling(cwd = process.cwd()) {
 }
 
 /**
- * A manifest entry an operator can paste, with the parts only they can supply.
+ * The manifest entries an operator can paste, with the parts only they supply.
+ *
+ * Returns both lists because a platform-specific archive needs both: an
+ * `install` entry for the surface it is built for, and a `require` entry so the
+ * other surface still asserts the tool instead of silently ignoring it.
  * @param {{name: string}} proposal One detected tool.
- * @returns {object} A `remoteEnv.tools.install` skeleton.
+ * @returns {{install: object[], require: object[]}} Manifest skeletons.
  */
-export function proposedEntry(proposal) {
+export function proposedEntries(proposal) {
   const viaNpm = KNOWN_TOOLS[proposal.name]?.viaNpm;
-  return viaNpm
-    ? {
-        name: proposal.name,
-        install: "npm-global",
-        package: viaNpm,
-        version: "<pin>",
-      }
-    : {
+  if (viaNpm) {
+    // npm resolves per platform, so one entry serves every surface.
+    return {
+      install: [
+        {
+          name: proposal.name,
+          install: "npm-global",
+          package: viaNpm,
+          version: "<pin>",
+        },
+      ],
+      require: [],
+    };
+  }
+  // A release archive is built for one platform, so it is proposed as
+  // remote-install plus a local `require`. Proposing only the install entry
+  // produced a manifest that either offered a Linux binary to a laptop or —
+  // once narrowed to remote — stopped checking for the tool locally at all.
+  // Both halves or neither.
+  return {
+    install: [
+      {
         name: proposal.name,
         version: "<pin>",
         install: "release-tar",
-        url: "<release url for this exact version>",
+        url: "<release url for this exact version, for the remote platform>",
         sha256: "<sha256 published with that release>",
         surfaces: ["remote"],
-      };
+      },
+    ],
+    require: [{ name: proposal.name, surfaces: ["local"] }],
+  };
 }
 
 if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
@@ -261,7 +294,14 @@ if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
       for (const evidence of proposal.evidence) {
         console.log(`    evidence: ${evidence}`);
       }
-      console.log(`    proposed: ${JSON.stringify(proposedEntry(proposal))}\n`);
+      const entries = proposedEntries(proposal);
+      for (const entry of entries.install) {
+        console.log(`    tools.install: ${JSON.stringify(entry)}`);
+      }
+      for (const entry of entries.require) {
+        console.log(`    tools.require: ${JSON.stringify(entry)}`);
+      }
+      console.log("");
     }
     console.log(
       "Nothing has been written or installed. Confirm each entry, supply the\n" +

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
@@ -87,6 +87,14 @@ bash scripts/lisa-remote-env/session-start.sh   # guard; delegates to --phase=se
 
 The selection comes from the surface's `materializeAt` capability in `lisa-secrets-access`, not from its name, so adding a surface does not mean editing a branch. The hook is committed to the repository, so it also fires on a developer's machine — it exits `0` immediately there rather than failing, because a correct local session must not look broken.
 
+## Detect before you provision
+
+Run `/lisa:detect-tooling` first, every time. The manifest is the only thing that puts a binary on `PATH`, and nothing populates it — so a project ships npm scripts invoking `maestro`, wires an MCP server whose CLI it also shells out to, and configures Playwright thresholds, while `remoteEnv.tools` stays empty and each of those fails at the moment of use instead of at setup.
+
+This repository has paid for that twice: `gh` was declared nowhere and a cloud session could not commit anything; `tar` was needed by an install method and asserted by nothing.
+
+The detector proposes and a human decides. It writes nothing, so provisioning still only ever happens from a reviewed, pinned, checksummed entry.
+
 ## Toolchain manifest — two entry kinds
 
 ```json
@@ -165,9 +173,9 @@ Because `release-tar` unpacks with `tar` rather than `unzip`, a project using it
 - **Prefer what is there.** A second Node beside the image's creates PATH ambiguity and wastes container time.
 - **Pin and checksum together, in one reviewed commit.** A version bump that does not move the checksum fails before installation, not after. An archive is verified *before* it is unpacked, so unexpected contents never reach a directory on PATH.
 
-## Tooling is never derived from secret notes
+## Tooling is never *authorised* by secret notes
 
-Deliberately rejected:
+Deliberately rejected — notes may not cause an install:
 
 - Most tooling has **no credential** — `jq`, ripgrep, browsers, a linter — so notes could only ever cover a subset, and a second mechanism would be needed anyway.
 - Most credentials **imply no tool**: a webhook is curl'd, a REST key needs no CLI.
@@ -176,6 +184,14 @@ Deliberately rejected:
 - It is a **supply-chain path** — provider write access would become arbitrary install access.
 
 **Notes are an assertion target instead.** At verify time, a tool that declares a credential which is not materialized is an **error**; a credential materialized with no declared consumer is a **warning**. The arrow points the safe way: the repository declares intent, and the provider is checked against it.
+
+### Reading a note as *evidence* is a different act
+
+`lisa-detect-tooling` does read notes, and this section is why it may. Every objection above is an objection to a note **causing** something: authorising an install, being the sole source, deciding a version. None of that changes.
+
+What the detector produces is a proposal with `<pin>`, `<release url>` and `<sha256>` left blank, printed for a human. It cannot install, cannot write config, and its output is inert until someone commits a pinned, checksummed entry that `assertPinned` then enforces. Provider write access therefore buys an attacker one line of text in a proposal a human reads — not arbitrary install access, which is the specific escalation this section exists to block.
+
+The other objections stay true and stay unfixed: most tooling has no credential and most credentials imply no tool, so notes are one signal among four and the weakest of them. They are read *after* npm scripts and MCP servers, and a note alone should be the least persuasive reason to add anything.
 
 ## Provisioning tiers
 

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -221,8 +221,9 @@ function installTool(tool, binDir) {
  * @param {boolean} dryRun Whether to plan only.
  * @returns {Array<object>} The plan that was applied.
  */
-function applyToolchain(tools, dryRun) {
-  const plan = planToolchain(tools, probe);
+function applyToolchain(tools, dryRun, options = {}) {
+  const { surface = "remote", consent = true } = options;
+  const plan = planToolchain(tools, probe, surface);
   const blocked = plan.filter(
     p => p.action === "missing" || p.action === "invalid"
   );
@@ -233,6 +234,34 @@ function applyToolchain(tools, dryRun) {
   const binDir = join(process.env.HOME ?? "", ".local", "bin");
   mkdirSync(binDir, { recursive: true, mode: 0o755 });
   const byName = new Map((tools.install ?? []).map(t => [t.name, t]));
+
+  // Installing is a different act on a laptop than in a container. A container
+  // is disposable and provisioning it silently is the whole point; a developer
+  // machine belongs to a person, and putting pinned binaries in their
+  // ~/.local/bin without being asked is not ours to decide. So the same
+  // manifest drives both, and only the consent differs.
+  //
+  // Reporting still happens either way — knowing the machine diverges from what
+  // the project declares is most of the value, and is what nothing did before.
+  if (!consent) {
+    const missing = plan.filter(step => step.action === "install");
+    if (missing.length === 0) {
+      console.log("  every declared tool is already present");
+      return plan;
+    }
+    console.log(
+      `  ${missing.length} declared tool(s) are missing or below their pin:`
+    );
+    for (const step of missing) {
+      const tool = byName.get(step.name);
+      console.log(`    ${step.name}${tool?.version ? ` ${tool.version}` : ""}`);
+    }
+    console.log(
+      "\n  Not installing without confirmation. Re-run with --install-tools\n" +
+        "  to provision them, or install them yourself."
+    );
+    return plan;
+  }
 
   // Installing a binary somewhere nothing looks is the same as not installing
   // it. `~/.local/bin` is on PATH by default on a developer workstation and is
@@ -641,7 +670,14 @@ async function main() {
 
   if (phases.includes("toolchain")) {
     console.log("Toolchain:");
-    applyToolchain(cfg.tools, dryRun);
+    // A remote container consents by construction: it is disposable, nobody is
+    // watching, and provisioning it is why the script exists. Locally the
+    // operator opts in per run.
+    const remote = Boolean(materializeAt);
+    applyToolchain(cfg.tools, dryRun, {
+      surface: remote ? "remote" : "local",
+      consent: remote || process.argv.includes("--install-tools"),
+    });
   }
 
   if (phases.includes("secrets")) {

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -556,6 +556,40 @@ export function emitClaudeWeb({ bootstrapKey }) {
 }
 
 /**
+ * Report tooling the project appears to need but has not declared.
+ *
+ * Called before the toolchain is applied, because the manifest is the only
+ * thing that puts a binary on PATH and nothing populates it — so provisioning
+ * "the declared toolchain" happily succeeds while the tool a project actually
+ * uses is absent, and fails later at the moment of use instead of here.
+ *
+ * Informational, never blocking. The detector proposes and a human decides, so
+ * an undeclared tool must not stop a setup that was asked to provision what IS
+ * declared; failing here would make a advisory signal into a gate nobody chose.
+ * Its own absence is silent for the same reason: an older installed copy of the
+ * skills has no detector, and that is not a reason to refuse to provision.
+ * @param {Function} [exec] Seam for tests.
+ */
+function reportUndeclaredTooling(exec = execFileSync) {
+  let script;
+  try {
+    script = siblingScript("lisa-detect-tooling", "detect-tooling.mjs");
+  } catch {
+    return;
+  }
+  try {
+    const out = exec("node", [script], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const text = String(out).trim();
+    if (text) console.log(`\n${text}\n`);
+  } catch {
+    // A detector that cannot run is a missing hint, not a failed setup.
+  }
+}
+
+/**
  * Decide which phases this invocation runs.
  *
  * An explicit `--phase` always wins, because that is how a session-start hook
@@ -669,6 +703,7 @@ async function main() {
   }
 
   if (phases.includes("toolchain")) {
+    reportUndeclaredTooling();
     console.log("Toolchain:");
     // A remote container consents by construction: it is disposable, nobody is
     // watching, and provisioning it is why the script exists. Locally the

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -124,6 +124,9 @@ function planInstallable(tool, found) {
   };
 }
 
+/** Surfaces a manifest entry may name. */
+const KNOWN_SURFACES = new Set(["local", "remote"]);
+
 /**
  * Whether a manifest entry applies to the surface being provisioned.
  *
@@ -143,7 +146,26 @@ function planInstallable(tool, found) {
  */
 export function appliesToSurface(tool, surface) {
   const surfaces = tool.surfaces;
-  if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+  if (surfaces === undefined) return true;
+  // A typo must not silently widen scope. Treating any non-array as "omitted"
+  // meant `surfaces: "remote"` — an easy thing to write — quietly applied the
+  // entry to every surface, which for a platform-specific archive means
+  // offering a Linux binary to a laptop. Absent means everywhere; malformed
+  // means stop.
+  if (!Array.isArray(surfaces)) {
+    throw new Error(
+      `${tool.name}: surfaces must be an array, got ${typeof surfaces}.\n` +
+        `Omit it to mean every surface; write ["remote"] or ["local"] to narrow.`
+    );
+  }
+  if (surfaces.length === 0) return true;
+  const unknown = surfaces.filter(entry => !KNOWN_SURFACES.has(entry));
+  if (unknown.length > 0) {
+    throw new Error(
+      `${tool.name}: unknown surface(s) ${unknown.join(", ")}.\n` +
+        `Known: ${[...KNOWN_SURFACES].join(", ")}.`
+    );
+  }
   return surfaces.includes(surface);
 }
 

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -125,17 +125,42 @@ function planInstallable(tool, found) {
 }
 
 /**
+ * Whether a manifest entry applies to the surface being provisioned.
+ *
+ * One declaration per tool, not one block per surface. Most tools a project
+ * needs are needed *everywhere* — a Maestro or Sonar CLI is as required on a
+ * laptop as in a container — and duplicated blocks drift, which this repository
+ * has paid for more than once. What actually differs between surfaces is the
+ * install method and, more importantly, consent: a disposable container may
+ * install silently, a developer's machine may not.
+ *
+ * Omitting `surfaces` means every surface, because that is true of most tools
+ * and the failure of forgetting it should be "checked somewhere unnecessary"
+ * rather than "silently absent where it was needed".
+ * @param {object} tool Manifest entry.
+ * @param {string} surface Surface being provisioned.
+ * @returns {boolean} Whether this entry applies.
+ */
+export function appliesToSurface(tool, surface) {
+  const surfaces = tool.surfaces;
+  if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+  return surfaces.includes(surface);
+}
+
+/**
  * Produce the complete plan for a toolchain manifest.
  * @param {{require?: object[], install?: object[]}} tools Manifest.
  * @param {(name: string) => {version: string|null, present: boolean}} probe Version probe.
  * @returns {Array<{name: string, action: string, reason: string}>} Ordered decisions.
  */
-export function planToolchain(tools, probe) {
+export function planToolchain(tools, probe, surface = "remote") {
   const plan = [];
   for (const tool of tools.require ?? [])
-    plan.push(planRequired(tool, probe(tool.name)));
+    if (appliesToSurface(tool, surface))
+      plan.push(planRequired(tool, probe(tool.name)));
   for (const tool of tools.install ?? [])
-    plan.push(planInstallable(tool, probe(tool.name)));
+    if (appliesToSurface(tool, surface))
+      plan.push(planInstallable(tool, probe(tool.name)));
   return plan;
 }
 

--- a/plugins/lisa-copilot/commands/lisa/detect-tooling.md
+++ b/plugins/lisa-copilot/commands/lisa/detect-tooling.md
@@ -1,0 +1,7 @@
+---
+description: "Find the command-line tools this project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts what remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only once a human has reviewed a pinned, checksummed entry."
+allowed-tools: ["Skill"]
+argument-hint: "[--json]"
+---
+
+Use the /lisa-detect-tooling skill to find undeclared command-line tooling and propose manifest entries for it. $ARGUMENTS

--- a/plugins/lisa-copilot/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-detect-tooling/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lisa-detect-tooling
 description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts whatever remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
-allowed-tools: ["Bash", "Read", "Edit", "AskUserQuestion"]
+allowed-tools: ["Bash", "Read", "AskUserQuestion"]
 ---
 
 # Detect Tooling
@@ -55,4 +55,6 @@ node scripts/detect-tooling.mjs          # human-readable proposals
 node scripts/detect-tooling.mjs --json   # machine-readable
 ```
 
-Confirm each proposal with the operator before editing `.lisa.config.json`. When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on; a rejected proposal is a normal outcome, not a failure.
+Confirm each proposal with the operator, then hand it to them to apply. **This skill does not hold `Edit`**, deliberately: a skill that both decides a tool is needed and writes the entry that installs it is the second unreviewed install path this design exists to avoid. Granting `Edit` while documenting "writes nothing" would have made the prose the only thing stopping it.
+
+When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on. A rejected proposal is a normal outcome, not a failure.

--- a/plugins/lisa-copilot/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-detect-tooling/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: lisa-detect-tooling
+description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts whatever remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
+allowed-tools: ["Bash", "Read", "Edit", "AskUserQuestion"]
+---
+
+# Detect Tooling
+
+Lisa provisions tooling through four unrelated mechanisms, and only one of them puts a binary on `PATH`:
+
+| tool | how it arrives | what puts it on PATH |
+| --- | --- | --- |
+| playwright, stryker | npm devDependency from a stack template | nothing — a local `node_modules` binary |
+| maestro | npm **scripts** in the Expo template | **nothing** |
+| sonar | `src/sonar/sonar-installer.ts` | nothing |
+| linear | MCP server | nothing, and it needs browser OAuth |
+| bws, gh | `remoteEnv.tools` — pinned and checksummed | this, and only this |
+
+Nothing populates that last row. So a project can ship scripts that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and configure Playwright thresholds, while the manifest that actually provisions binaries stays empty — and every one of those fails at the moment of use rather than at setup.
+
+That is the same failure this repository has now paid for twice: `gh` was declared nowhere and a cloud session could not commit; `tar` was needed by an install method and asserted by nothing.
+
+## What it does
+
+Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
+
+- **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
+- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one.
+- **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
+- **Quality configuration**, where a threshold implies the tool that produces it.
+
+## What it will not do
+
+**It writes nothing and installs nothing.** Output is a proposal with `<pin>`, `<release url>` and `<sha256>` left for a human.
+
+That boundary is the whole design. A tool should reach a machine because someone reviewed a pinned entry with a checksum, never because a detector was confident. Detection is evidence; the manifest is the decision. An auto-writing detector would quietly become a second, unreviewed install path — exactly what `assertPinned` exists to prevent.
+
+## Surfaces
+
+One declaration per tool, with an optional `surfaces` list, rather than separate blocks per surface. Most tools are needed *everywhere* — a Maestro or Sonar CLI is as required on a laptop as in a container — and duplicated blocks drift.
+
+What genuinely differs is **consent**, not the list:
+
+- A remote container is disposable and nobody is watching, so it provisions silently.
+- A developer machine belongs to a person, so `--phase=toolchain` reports what is missing and installs nothing unless `--install-tools` is passed.
+
+Omitting `surfaces` means every surface, because that is true of most tools and the cost of forgetting should be a redundant check rather than a silent absence.
+
+A platform-specific pin is the exception worth knowing: a Linux release archive must be `surfaces: ["remote"]`, with a matching `require` entry for `local`, so a laptop asserts the tool without being offered a binary it cannot run.
+
+## Usage
+
+```sh
+node scripts/detect-tooling.mjs          # human-readable proposals
+node scripts/detect-tooling.mjs --json   # machine-readable
+```
+
+Confirm each proposal with the operator before editing `.lisa.config.json`. When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on; a rejected proposal is a normal outcome, not a failure.

--- a/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * Find the command-line tools a project needs but never declares.
+ *
+ * Lisa provisions tooling through several unrelated mechanisms — npm
+ * devDependencies from a stack template, MCP servers, a dedicated installer for
+ * Sonar, and the pinned `remoteEnv.tools` manifest. Only the last one puts a
+ * binary on PATH, and nothing populates it. So a project can ship npm scripts
+ * that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and
+ * declare Playwright coverage thresholds, while the manifest that actually
+ * provisions binaries stays empty and every one of those fails at the moment of
+ * use rather than at setup.
+ *
+ * This program only ever *proposes*. It writes nothing, installs nothing, and
+ * emits manifest entries with the fields a human still has to fill — a pinned
+ * version, a URL, a checksum. That boundary is the point: a tool should reach a
+ * machine because someone reviewed a pinned entry, never because a detector was
+ * confident. Detection is evidence; the manifest is the decision.
+ *
+ * Usage:
+ *   detect-tooling.mjs [--json]
+ * @module detect-tooling
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Tools Lisa or its templates invoke, and how to recognise a need for them.
+ *
+ * Deliberately conservative. A false positive costs a human a moment's review;
+ * a false negative is the failure this exists to prevent, so the signals are
+ * ones that only appear when the tool is genuinely used.
+ */
+const KNOWN_TOOLS = Object.freeze({
+  maestro: {
+    why: "Expo's template ships npm scripts that invoke `maestro`, and nothing installs the binary.",
+    mcpFallback: "maestro",
+  },
+  gh: {
+    why: "The work-item guardrails shell out to `gh` for every tracker read.",
+  },
+  bws: {
+    why: "The Bitwarden CLI is how every secret is resolved.",
+  },
+  "sonar-scanner": {
+    why: "Sonar analysis runs a scanner binary, which the Sonar installer configures but does not place on PATH.",
+  },
+  playwright: {
+    why: "Playwright drives browser E2E and its coverage thresholds are configured.",
+    viaNpm: "@playwright/test",
+  },
+  linear: {
+    why: "Linear is wired as an MCP server, which needs browser OAuth and so cannot authenticate in a container.",
+    mcpFallback: "linear-server",
+  },
+});
+
+/**
+ * Read a JSON file, treating absence or damage as "no signal".
+ *
+ * A detector that throws on a malformed config is worse than one that misses a
+ * signal: it blocks the very command an operator runs to find out what is wrong.
+ * @param {string} path File to read.
+ * @returns {object|null} Parsed contents, or null.
+ */
+function readJson(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Tools named by npm scripts, which is the strongest signal there is.
+ *
+ * A script that runs `maestro test` is a project stating it needs Maestro, in
+ * executable form. Word-boundary matched so `maestro:test` as a script *name*
+ * does not count while `maestro test` as its body does — the name is a label,
+ * the body is a dependency.
+ * @param {object|null} pkg Parsed package.json.
+ * @returns {Map<string, string>} Tool name to the script that proves it.
+ */
+export function toolsFromScripts(pkg) {
+  const found = new Map();
+  const scripts = pkg?.scripts ?? {};
+  for (const [name, body] of Object.entries(scripts)) {
+    if (typeof body !== "string") continue;
+    for (const tool of Object.keys(KNOWN_TOOLS)) {
+      const pattern = new RegExp(`(^|[\\s;&|(])${tool}(\\s|$)`, "u");
+      if (pattern.test(body) && !found.has(tool)) {
+        found.set(tool, `npm script "${name}": ${body.trim().slice(0, 60)}`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools implied by MCP servers that also have a CLI.
+ *
+ * An MCP server is not a substitute for the binary. Several authenticate by
+ * browser OAuth, which a container cannot do at all, so a project relying on one
+ * remotely has no integration rather than a degraded one — the CLI is the form
+ * that survives the trip.
+ * @param {object|null} mcp Parsed .mcp.json.
+ * @returns {Map<string, string>} Tool name to the server that implies it.
+ */
+export function toolsFromMcp(mcp) {
+  const found = new Map();
+  const servers = Object.keys(mcp?.mcpServers ?? {});
+  for (const [tool, meta] of Object.entries(KNOWN_TOOLS)) {
+    if (!meta.mcpFallback) continue;
+    const server = servers.find(name => name.includes(meta.mcpFallback));
+    if (server) {
+      found.set(
+        tool,
+        `MCP server "${server}" (browser OAuth cannot run remotely)`
+      );
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools named in credential usage notes.
+ *
+ * A note explaining what a token is *for* usually names the program that
+ * consumes it, and those notes are already readable without touching a value —
+ * `read-secret-note.mjs` exists precisely so an agent can learn a credential's
+ * blast radius safely. That makes them a first-class detection input rather than
+ * a clever trick.
+ * @param {object|null} notes Parsed secret-notes.json.
+ * @returns {Map<string, string>} Tool name to the credential that names it.
+ */
+export function toolsFromSecretNotes(notes) {
+  const found = new Map();
+  const entries = Object.entries(notes?.notes ?? notes ?? {});
+  for (const [secret, note] of entries) {
+    const text = typeof note === "string" ? note : JSON.stringify(note ?? "");
+    for (const tool of Object.keys(KNOWN_TOOLS)) {
+      const pattern = new RegExp(
+        `(^|[^A-Za-z0-9-])${tool}([^A-Za-z0-9-]|$)`,
+        "iu"
+      );
+      if (pattern.test(text) && !found.has(tool)) {
+        found.set(tool, `usage note on credential "${secret}"`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools implied by quality configuration.
+ * @param {object|null} config Parsed .lisa.config.json.
+ * @returns {Map<string, string>} Tool name to the setting that implies it.
+ */
+export function toolsFromQuality(config) {
+  const found = new Map();
+  if (config?.quality?.e2eCoverage?.playwright) {
+    found.set("playwright", "quality.e2eCoverage.playwright is configured");
+  }
+  if (config?.quality?.sonar || config?.sonar) {
+    found.set("sonar-scanner", "Sonar analysis is configured");
+  }
+  return found;
+}
+
+/**
+ * Everything already declared, by name, so proposals exclude them.
+ * @param {object|null} config Parsed .lisa.config.json.
+ * @returns {Set<string>} Declared tool names.
+ */
+export function declaredTools(config) {
+  const tools = config?.remoteEnv?.tools ?? {};
+  return new Set(
+    [...(tools.require ?? []), ...(tools.install ?? [])].map(t => t.name)
+  );
+}
+
+/**
+ * Collect every signal and subtract what the manifest already covers.
+ * @param {string} [cwd] Project root.
+ * @returns {Array<{name: string, why: string, evidence: string[]}>} Proposals.
+ */
+export function detectTooling(cwd = process.cwd()) {
+  const config = readJson(join(cwd, ".lisa.config.json"));
+  const pkg = readJson(join(cwd, "package.json"));
+  const mcp = readJson(join(cwd, ".mcp.json"));
+  const notes = readJson(join(cwd, ".lisa", "secret-notes.json"));
+
+  const declared = declaredTools(config);
+  const signals = [
+    toolsFromScripts(pkg),
+    toolsFromMcp(mcp),
+    toolsFromSecretNotes(notes),
+    toolsFromQuality(config),
+  ];
+
+  const merged = new Map();
+  for (const signal of signals) {
+    for (const [tool, evidence] of signal) {
+      if (declared.has(tool)) continue;
+      const entry = merged.get(tool) ?? { evidence: [] };
+      entry.evidence.push(evidence);
+      merged.set(tool, entry);
+    }
+  }
+
+  return [...merged.entries()]
+    .map(([name, entry]) => ({
+      name,
+      why: KNOWN_TOOLS[name]?.why ?? "",
+      evidence: entry.evidence,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * A manifest entry an operator can paste, with the parts only they can supply.
+ * @param {{name: string}} proposal One detected tool.
+ * @returns {object} A `remoteEnv.tools.install` skeleton.
+ */
+export function proposedEntry(proposal) {
+  const viaNpm = KNOWN_TOOLS[proposal.name]?.viaNpm;
+  return viaNpm
+    ? {
+        name: proposal.name,
+        install: "npm-global",
+        package: viaNpm,
+        version: "<pin>",
+      }
+    : {
+        name: proposal.name,
+        version: "<pin>",
+        install: "release-tar",
+        url: "<release url for this exact version>",
+        sha256: "<sha256 published with that release>",
+        surfaces: ["remote"],
+      };
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  const proposals = detectTooling();
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(proposals, null, 2));
+  } else if (proposals.length === 0) {
+    console.log(
+      "Every tool this project appears to use is already declared in remoteEnv.tools."
+    );
+  } else {
+    console.log(
+      `${proposals.length} tool(s) look required but are not declared:\n`
+    );
+    for (const proposal of proposals) {
+      console.log(`  ${proposal.name}`);
+      console.log(`    why: ${proposal.why}`);
+      for (const evidence of proposal.evidence) {
+        console.log(`    evidence: ${evidence}`);
+      }
+      console.log(`    proposed: ${JSON.stringify(proposedEntry(proposal))}\n`);
+    }
+    console.log(
+      "Nothing has been written or installed. Confirm each entry, supply the\n" +
+        "pin and checksum, and add it to remoteEnv.tools in .lisa.config.json."
+    );
+  }
+}

--- a/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -174,10 +174,22 @@ export function toolsFromQuality(config) {
  * @param {object|null} config Parsed .lisa.config.json.
  * @returns {Set<string>} Declared tool names.
  */
-export function declaredTools(config) {
+export function declaredTools(config, surface = "remote") {
   const tools = config?.remoteEnv?.tools ?? {};
+  const applies = tool => {
+    const surfaces = tool.surfaces;
+    if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+    return surfaces.includes(surface);
+  };
+  // Filtered by surface, because a declaration that applies somewhere else is
+  // not coverage here. A local-only `require` entry would otherwise suppress
+  // the proposal for a tool genuinely missing from the remote manifest — the
+  // detector reporting "already declared" about the one surface where it is
+  // not.
   return new Set(
-    [...(tools.require ?? []), ...(tools.install ?? [])].map(t => t.name)
+    [...(tools.require ?? []), ...(tools.install ?? [])]
+      .filter(applies)
+      .map(tool => tool.name)
   );
 }
 
@@ -220,27 +232,48 @@ export function detectTooling(cwd = process.cwd()) {
 }
 
 /**
- * A manifest entry an operator can paste, with the parts only they can supply.
+ * The manifest entries an operator can paste, with the parts only they supply.
+ *
+ * Returns both lists because a platform-specific archive needs both: an
+ * `install` entry for the surface it is built for, and a `require` entry so the
+ * other surface still asserts the tool instead of silently ignoring it.
  * @param {{name: string}} proposal One detected tool.
- * @returns {object} A `remoteEnv.tools.install` skeleton.
+ * @returns {{install: object[], require: object[]}} Manifest skeletons.
  */
-export function proposedEntry(proposal) {
+export function proposedEntries(proposal) {
   const viaNpm = KNOWN_TOOLS[proposal.name]?.viaNpm;
-  return viaNpm
-    ? {
-        name: proposal.name,
-        install: "npm-global",
-        package: viaNpm,
-        version: "<pin>",
-      }
-    : {
+  if (viaNpm) {
+    // npm resolves per platform, so one entry serves every surface.
+    return {
+      install: [
+        {
+          name: proposal.name,
+          install: "npm-global",
+          package: viaNpm,
+          version: "<pin>",
+        },
+      ],
+      require: [],
+    };
+  }
+  // A release archive is built for one platform, so it is proposed as
+  // remote-install plus a local `require`. Proposing only the install entry
+  // produced a manifest that either offered a Linux binary to a laptop or —
+  // once narrowed to remote — stopped checking for the tool locally at all.
+  // Both halves or neither.
+  return {
+    install: [
+      {
         name: proposal.name,
         version: "<pin>",
         install: "release-tar",
-        url: "<release url for this exact version>",
+        url: "<release url for this exact version, for the remote platform>",
         sha256: "<sha256 published with that release>",
         surfaces: ["remote"],
-      };
+      },
+    ],
+    require: [{ name: proposal.name, surfaces: ["local"] }],
+  };
 }
 
 if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
@@ -261,7 +294,14 @@ if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
       for (const evidence of proposal.evidence) {
         console.log(`    evidence: ${evidence}`);
       }
-      console.log(`    proposed: ${JSON.stringify(proposedEntry(proposal))}\n`);
+      const entries = proposedEntries(proposal);
+      for (const entry of entries.install) {
+        console.log(`    tools.install: ${JSON.stringify(entry)}`);
+      }
+      for (const entry of entries.require) {
+        console.log(`    tools.require: ${JSON.stringify(entry)}`);
+      }
+      console.log("");
     }
     console.log(
       "Nothing has been written or installed. Confirm each entry, supply the\n" +

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
@@ -87,6 +87,14 @@ bash scripts/lisa-remote-env/session-start.sh   # guard; delegates to --phase=se
 
 The selection comes from the surface's `materializeAt` capability in `lisa-secrets-access`, not from its name, so adding a surface does not mean editing a branch. The hook is committed to the repository, so it also fires on a developer's machine — it exits `0` immediately there rather than failing, because a correct local session must not look broken.
 
+## Detect before you provision
+
+Run `/lisa:detect-tooling` first, every time. The manifest is the only thing that puts a binary on `PATH`, and nothing populates it — so a project ships npm scripts invoking `maestro`, wires an MCP server whose CLI it also shells out to, and configures Playwright thresholds, while `remoteEnv.tools` stays empty and each of those fails at the moment of use instead of at setup.
+
+This repository has paid for that twice: `gh` was declared nowhere and a cloud session could not commit anything; `tar` was needed by an install method and asserted by nothing.
+
+The detector proposes and a human decides. It writes nothing, so provisioning still only ever happens from a reviewed, pinned, checksummed entry.
+
 ## Toolchain manifest — two entry kinds
 
 ```json
@@ -165,9 +173,9 @@ Because `release-tar` unpacks with `tar` rather than `unzip`, a project using it
 - **Prefer what is there.** A second Node beside the image's creates PATH ambiguity and wastes container time.
 - **Pin and checksum together, in one reviewed commit.** A version bump that does not move the checksum fails before installation, not after. An archive is verified *before* it is unpacked, so unexpected contents never reach a directory on PATH.
 
-## Tooling is never derived from secret notes
+## Tooling is never *authorised* by secret notes
 
-Deliberately rejected:
+Deliberately rejected — notes may not cause an install:
 
 - Most tooling has **no credential** — `jq`, ripgrep, browsers, a linter — so notes could only ever cover a subset, and a second mechanism would be needed anyway.
 - Most credentials **imply no tool**: a webhook is curl'd, a REST key needs no CLI.
@@ -176,6 +184,14 @@ Deliberately rejected:
 - It is a **supply-chain path** — provider write access would become arbitrary install access.
 
 **Notes are an assertion target instead.** At verify time, a tool that declares a credential which is not materialized is an **error**; a credential materialized with no declared consumer is a **warning**. The arrow points the safe way: the repository declares intent, and the provider is checked against it.
+
+### Reading a note as *evidence* is a different act
+
+`lisa-detect-tooling` does read notes, and this section is why it may. Every objection above is an objection to a note **causing** something: authorising an install, being the sole source, deciding a version. None of that changes.
+
+What the detector produces is a proposal with `<pin>`, `<release url>` and `<sha256>` left blank, printed for a human. It cannot install, cannot write config, and its output is inert until someone commits a pinned, checksummed entry that `assertPinned` then enforces. Provider write access therefore buys an attacker one line of text in a proposal a human reads — not arbitrary install access, which is the specific escalation this section exists to block.
+
+The other objections stay true and stay unfixed: most tooling has no credential and most credentials imply no tool, so notes are one signal among four and the weakest of them. They are read *after* npm scripts and MCP servers, and a note alone should be the least persuasive reason to add anything.
 
 ## Provisioning tiers
 

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -221,8 +221,9 @@ function installTool(tool, binDir) {
  * @param {boolean} dryRun Whether to plan only.
  * @returns {Array<object>} The plan that was applied.
  */
-function applyToolchain(tools, dryRun) {
-  const plan = planToolchain(tools, probe);
+function applyToolchain(tools, dryRun, options = {}) {
+  const { surface = "remote", consent = true } = options;
+  const plan = planToolchain(tools, probe, surface);
   const blocked = plan.filter(
     p => p.action === "missing" || p.action === "invalid"
   );
@@ -233,6 +234,34 @@ function applyToolchain(tools, dryRun) {
   const binDir = join(process.env.HOME ?? "", ".local", "bin");
   mkdirSync(binDir, { recursive: true, mode: 0o755 });
   const byName = new Map((tools.install ?? []).map(t => [t.name, t]));
+
+  // Installing is a different act on a laptop than in a container. A container
+  // is disposable and provisioning it silently is the whole point; a developer
+  // machine belongs to a person, and putting pinned binaries in their
+  // ~/.local/bin without being asked is not ours to decide. So the same
+  // manifest drives both, and only the consent differs.
+  //
+  // Reporting still happens either way — knowing the machine diverges from what
+  // the project declares is most of the value, and is what nothing did before.
+  if (!consent) {
+    const missing = plan.filter(step => step.action === "install");
+    if (missing.length === 0) {
+      console.log("  every declared tool is already present");
+      return plan;
+    }
+    console.log(
+      `  ${missing.length} declared tool(s) are missing or below their pin:`
+    );
+    for (const step of missing) {
+      const tool = byName.get(step.name);
+      console.log(`    ${step.name}${tool?.version ? ` ${tool.version}` : ""}`);
+    }
+    console.log(
+      "\n  Not installing without confirmation. Re-run with --install-tools\n" +
+        "  to provision them, or install them yourself."
+    );
+    return plan;
+  }
 
   // Installing a binary somewhere nothing looks is the same as not installing
   // it. `~/.local/bin` is on PATH by default on a developer workstation and is
@@ -641,7 +670,14 @@ async function main() {
 
   if (phases.includes("toolchain")) {
     console.log("Toolchain:");
-    applyToolchain(cfg.tools, dryRun);
+    // A remote container consents by construction: it is disposable, nobody is
+    // watching, and provisioning it is why the script exists. Locally the
+    // operator opts in per run.
+    const remote = Boolean(materializeAt);
+    applyToolchain(cfg.tools, dryRun, {
+      surface: remote ? "remote" : "local",
+      consent: remote || process.argv.includes("--install-tools"),
+    });
   }
 
   if (phases.includes("secrets")) {

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -556,6 +556,40 @@ export function emitClaudeWeb({ bootstrapKey }) {
 }
 
 /**
+ * Report tooling the project appears to need but has not declared.
+ *
+ * Called before the toolchain is applied, because the manifest is the only
+ * thing that puts a binary on PATH and nothing populates it — so provisioning
+ * "the declared toolchain" happily succeeds while the tool a project actually
+ * uses is absent, and fails later at the moment of use instead of here.
+ *
+ * Informational, never blocking. The detector proposes and a human decides, so
+ * an undeclared tool must not stop a setup that was asked to provision what IS
+ * declared; failing here would make a advisory signal into a gate nobody chose.
+ * Its own absence is silent for the same reason: an older installed copy of the
+ * skills has no detector, and that is not a reason to refuse to provision.
+ * @param {Function} [exec] Seam for tests.
+ */
+function reportUndeclaredTooling(exec = execFileSync) {
+  let script;
+  try {
+    script = siblingScript("lisa-detect-tooling", "detect-tooling.mjs");
+  } catch {
+    return;
+  }
+  try {
+    const out = exec("node", [script], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const text = String(out).trim();
+    if (text) console.log(`\n${text}\n`);
+  } catch {
+    // A detector that cannot run is a missing hint, not a failed setup.
+  }
+}
+
+/**
  * Decide which phases this invocation runs.
  *
  * An explicit `--phase` always wins, because that is how a session-start hook
@@ -669,6 +703,7 @@ async function main() {
   }
 
   if (phases.includes("toolchain")) {
+    reportUndeclaredTooling();
     console.log("Toolchain:");
     // A remote container consents by construction: it is disposable, nobody is
     // watching, and provisioning it is why the script exists. Locally the

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -124,6 +124,9 @@ function planInstallable(tool, found) {
   };
 }
 
+/** Surfaces a manifest entry may name. */
+const KNOWN_SURFACES = new Set(["local", "remote"]);
+
 /**
  * Whether a manifest entry applies to the surface being provisioned.
  *
@@ -143,7 +146,26 @@ function planInstallable(tool, found) {
  */
 export function appliesToSurface(tool, surface) {
   const surfaces = tool.surfaces;
-  if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+  if (surfaces === undefined) return true;
+  // A typo must not silently widen scope. Treating any non-array as "omitted"
+  // meant `surfaces: "remote"` — an easy thing to write — quietly applied the
+  // entry to every surface, which for a platform-specific archive means
+  // offering a Linux binary to a laptop. Absent means everywhere; malformed
+  // means stop.
+  if (!Array.isArray(surfaces)) {
+    throw new Error(
+      `${tool.name}: surfaces must be an array, got ${typeof surfaces}.\n` +
+        `Omit it to mean every surface; write ["remote"] or ["local"] to narrow.`
+    );
+  }
+  if (surfaces.length === 0) return true;
+  const unknown = surfaces.filter(entry => !KNOWN_SURFACES.has(entry));
+  if (unknown.length > 0) {
+    throw new Error(
+      `${tool.name}: unknown surface(s) ${unknown.join(", ")}.\n` +
+        `Known: ${[...KNOWN_SURFACES].join(", ")}.`
+    );
+  }
   return surfaces.includes(surface);
 }
 

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -125,17 +125,42 @@ function planInstallable(tool, found) {
 }
 
 /**
+ * Whether a manifest entry applies to the surface being provisioned.
+ *
+ * One declaration per tool, not one block per surface. Most tools a project
+ * needs are needed *everywhere* — a Maestro or Sonar CLI is as required on a
+ * laptop as in a container — and duplicated blocks drift, which this repository
+ * has paid for more than once. What actually differs between surfaces is the
+ * install method and, more importantly, consent: a disposable container may
+ * install silently, a developer's machine may not.
+ *
+ * Omitting `surfaces` means every surface, because that is true of most tools
+ * and the failure of forgetting it should be "checked somewhere unnecessary"
+ * rather than "silently absent where it was needed".
+ * @param {object} tool Manifest entry.
+ * @param {string} surface Surface being provisioned.
+ * @returns {boolean} Whether this entry applies.
+ */
+export function appliesToSurface(tool, surface) {
+  const surfaces = tool.surfaces;
+  if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+  return surfaces.includes(surface);
+}
+
+/**
  * Produce the complete plan for a toolchain manifest.
  * @param {{require?: object[], install?: object[]}} tools Manifest.
  * @param {(name: string) => {version: string|null, present: boolean}} probe Version probe.
  * @returns {Array<{name: string, action: string, reason: string}>} Ordered decisions.
  */
-export function planToolchain(tools, probe) {
+export function planToolchain(tools, probe, surface = "remote") {
   const plan = [];
   for (const tool of tools.require ?? [])
-    plan.push(planRequired(tool, probe(tool.name)));
+    if (appliesToSurface(tool, surface))
+      plan.push(planRequired(tool, probe(tool.name)));
   for (const tool of tools.install ?? [])
-    plan.push(planInstallable(tool, probe(tool.name)));
+    if (appliesToSurface(tool, surface))
+      plan.push(planInstallable(tool, probe(tool.name)));
   return plan;
 }
 

--- a/plugins/lisa-cursor/commands/lisa/detect-tooling.md
+++ b/plugins/lisa-cursor/commands/lisa/detect-tooling.md
@@ -1,0 +1,7 @@
+---
+description: "Find the command-line tools this project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts what remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only once a human has reviewed a pinned, checksummed entry."
+allowed-tools: ["Skill"]
+argument-hint: "[--json]"
+---
+
+Use the /lisa-detect-tooling skill to find undeclared command-line tooling and propose manifest entries for it. $ARGUMENTS

--- a/plugins/lisa-cursor/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-detect-tooling/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lisa-detect-tooling
 description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts whatever remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
-allowed-tools: ["Bash", "Read", "Edit", "AskUserQuestion"]
+allowed-tools: ["Bash", "Read", "AskUserQuestion"]
 ---
 
 # Detect Tooling
@@ -55,4 +55,6 @@ node scripts/detect-tooling.mjs          # human-readable proposals
 node scripts/detect-tooling.mjs --json   # machine-readable
 ```
 
-Confirm each proposal with the operator before editing `.lisa.config.json`. When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on; a rejected proposal is a normal outcome, not a failure.
+Confirm each proposal with the operator, then hand it to them to apply. **This skill does not hold `Edit`**, deliberately: a skill that both decides a tool is needed and writes the entry that installs it is the second unreviewed install path this design exists to avoid. Granting `Edit` while documenting "writes nothing" would have made the prose the only thing stopping it.
+
+When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on. A rejected proposal is a normal outcome, not a failure.

--- a/plugins/lisa-cursor/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-detect-tooling/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: lisa-detect-tooling
+description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts whatever remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
+allowed-tools: ["Bash", "Read", "Edit", "AskUserQuestion"]
+---
+
+# Detect Tooling
+
+Lisa provisions tooling through four unrelated mechanisms, and only one of them puts a binary on `PATH`:
+
+| tool | how it arrives | what puts it on PATH |
+| --- | --- | --- |
+| playwright, stryker | npm devDependency from a stack template | nothing — a local `node_modules` binary |
+| maestro | npm **scripts** in the Expo template | **nothing** |
+| sonar | `src/sonar/sonar-installer.ts` | nothing |
+| linear | MCP server | nothing, and it needs browser OAuth |
+| bws, gh | `remoteEnv.tools` — pinned and checksummed | this, and only this |
+
+Nothing populates that last row. So a project can ship scripts that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and configure Playwright thresholds, while the manifest that actually provisions binaries stays empty — and every one of those fails at the moment of use rather than at setup.
+
+That is the same failure this repository has now paid for twice: `gh` was declared nowhere and a cloud session could not commit; `tar` was needed by an install method and asserted by nothing.
+
+## What it does
+
+Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
+
+- **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
+- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one.
+- **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
+- **Quality configuration**, where a threshold implies the tool that produces it.
+
+## What it will not do
+
+**It writes nothing and installs nothing.** Output is a proposal with `<pin>`, `<release url>` and `<sha256>` left for a human.
+
+That boundary is the whole design. A tool should reach a machine because someone reviewed a pinned entry with a checksum, never because a detector was confident. Detection is evidence; the manifest is the decision. An auto-writing detector would quietly become a second, unreviewed install path — exactly what `assertPinned` exists to prevent.
+
+## Surfaces
+
+One declaration per tool, with an optional `surfaces` list, rather than separate blocks per surface. Most tools are needed *everywhere* — a Maestro or Sonar CLI is as required on a laptop as in a container — and duplicated blocks drift.
+
+What genuinely differs is **consent**, not the list:
+
+- A remote container is disposable and nobody is watching, so it provisions silently.
+- A developer machine belongs to a person, so `--phase=toolchain` reports what is missing and installs nothing unless `--install-tools` is passed.
+
+Omitting `surfaces` means every surface, because that is true of most tools and the cost of forgetting should be a redundant check rather than a silent absence.
+
+A platform-specific pin is the exception worth knowing: a Linux release archive must be `surfaces: ["remote"]`, with a matching `require` entry for `local`, so a laptop asserts the tool without being offered a binary it cannot run.
+
+## Usage
+
+```sh
+node scripts/detect-tooling.mjs          # human-readable proposals
+node scripts/detect-tooling.mjs --json   # machine-readable
+```
+
+Confirm each proposal with the operator before editing `.lisa.config.json`. When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on; a rejected proposal is a normal outcome, not a failure.

--- a/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * Find the command-line tools a project needs but never declares.
+ *
+ * Lisa provisions tooling through several unrelated mechanisms — npm
+ * devDependencies from a stack template, MCP servers, a dedicated installer for
+ * Sonar, and the pinned `remoteEnv.tools` manifest. Only the last one puts a
+ * binary on PATH, and nothing populates it. So a project can ship npm scripts
+ * that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and
+ * declare Playwright coverage thresholds, while the manifest that actually
+ * provisions binaries stays empty and every one of those fails at the moment of
+ * use rather than at setup.
+ *
+ * This program only ever *proposes*. It writes nothing, installs nothing, and
+ * emits manifest entries with the fields a human still has to fill — a pinned
+ * version, a URL, a checksum. That boundary is the point: a tool should reach a
+ * machine because someone reviewed a pinned entry, never because a detector was
+ * confident. Detection is evidence; the manifest is the decision.
+ *
+ * Usage:
+ *   detect-tooling.mjs [--json]
+ * @module detect-tooling
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Tools Lisa or its templates invoke, and how to recognise a need for them.
+ *
+ * Deliberately conservative. A false positive costs a human a moment's review;
+ * a false negative is the failure this exists to prevent, so the signals are
+ * ones that only appear when the tool is genuinely used.
+ */
+const KNOWN_TOOLS = Object.freeze({
+  maestro: {
+    why: "Expo's template ships npm scripts that invoke `maestro`, and nothing installs the binary.",
+    mcpFallback: "maestro",
+  },
+  gh: {
+    why: "The work-item guardrails shell out to `gh` for every tracker read.",
+  },
+  bws: {
+    why: "The Bitwarden CLI is how every secret is resolved.",
+  },
+  "sonar-scanner": {
+    why: "Sonar analysis runs a scanner binary, which the Sonar installer configures but does not place on PATH.",
+  },
+  playwright: {
+    why: "Playwright drives browser E2E and its coverage thresholds are configured.",
+    viaNpm: "@playwright/test",
+  },
+  linear: {
+    why: "Linear is wired as an MCP server, which needs browser OAuth and so cannot authenticate in a container.",
+    mcpFallback: "linear-server",
+  },
+});
+
+/**
+ * Read a JSON file, treating absence or damage as "no signal".
+ *
+ * A detector that throws on a malformed config is worse than one that misses a
+ * signal: it blocks the very command an operator runs to find out what is wrong.
+ * @param {string} path File to read.
+ * @returns {object|null} Parsed contents, or null.
+ */
+function readJson(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Tools named by npm scripts, which is the strongest signal there is.
+ *
+ * A script that runs `maestro test` is a project stating it needs Maestro, in
+ * executable form. Word-boundary matched so `maestro:test` as a script *name*
+ * does not count while `maestro test` as its body does — the name is a label,
+ * the body is a dependency.
+ * @param {object|null} pkg Parsed package.json.
+ * @returns {Map<string, string>} Tool name to the script that proves it.
+ */
+export function toolsFromScripts(pkg) {
+  const found = new Map();
+  const scripts = pkg?.scripts ?? {};
+  for (const [name, body] of Object.entries(scripts)) {
+    if (typeof body !== "string") continue;
+    for (const tool of Object.keys(KNOWN_TOOLS)) {
+      const pattern = new RegExp(`(^|[\\s;&|(])${tool}(\\s|$)`, "u");
+      if (pattern.test(body) && !found.has(tool)) {
+        found.set(tool, `npm script "${name}": ${body.trim().slice(0, 60)}`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools implied by MCP servers that also have a CLI.
+ *
+ * An MCP server is not a substitute for the binary. Several authenticate by
+ * browser OAuth, which a container cannot do at all, so a project relying on one
+ * remotely has no integration rather than a degraded one — the CLI is the form
+ * that survives the trip.
+ * @param {object|null} mcp Parsed .mcp.json.
+ * @returns {Map<string, string>} Tool name to the server that implies it.
+ */
+export function toolsFromMcp(mcp) {
+  const found = new Map();
+  const servers = Object.keys(mcp?.mcpServers ?? {});
+  for (const [tool, meta] of Object.entries(KNOWN_TOOLS)) {
+    if (!meta.mcpFallback) continue;
+    const server = servers.find(name => name.includes(meta.mcpFallback));
+    if (server) {
+      found.set(
+        tool,
+        `MCP server "${server}" (browser OAuth cannot run remotely)`
+      );
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools named in credential usage notes.
+ *
+ * A note explaining what a token is *for* usually names the program that
+ * consumes it, and those notes are already readable without touching a value —
+ * `read-secret-note.mjs` exists precisely so an agent can learn a credential's
+ * blast radius safely. That makes them a first-class detection input rather than
+ * a clever trick.
+ * @param {object|null} notes Parsed secret-notes.json.
+ * @returns {Map<string, string>} Tool name to the credential that names it.
+ */
+export function toolsFromSecretNotes(notes) {
+  const found = new Map();
+  const entries = Object.entries(notes?.notes ?? notes ?? {});
+  for (const [secret, note] of entries) {
+    const text = typeof note === "string" ? note : JSON.stringify(note ?? "");
+    for (const tool of Object.keys(KNOWN_TOOLS)) {
+      const pattern = new RegExp(
+        `(^|[^A-Za-z0-9-])${tool}([^A-Za-z0-9-]|$)`,
+        "iu"
+      );
+      if (pattern.test(text) && !found.has(tool)) {
+        found.set(tool, `usage note on credential "${secret}"`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools implied by quality configuration.
+ * @param {object|null} config Parsed .lisa.config.json.
+ * @returns {Map<string, string>} Tool name to the setting that implies it.
+ */
+export function toolsFromQuality(config) {
+  const found = new Map();
+  if (config?.quality?.e2eCoverage?.playwright) {
+    found.set("playwright", "quality.e2eCoverage.playwright is configured");
+  }
+  if (config?.quality?.sonar || config?.sonar) {
+    found.set("sonar-scanner", "Sonar analysis is configured");
+  }
+  return found;
+}
+
+/**
+ * Everything already declared, by name, so proposals exclude them.
+ * @param {object|null} config Parsed .lisa.config.json.
+ * @returns {Set<string>} Declared tool names.
+ */
+export function declaredTools(config) {
+  const tools = config?.remoteEnv?.tools ?? {};
+  return new Set(
+    [...(tools.require ?? []), ...(tools.install ?? [])].map(t => t.name)
+  );
+}
+
+/**
+ * Collect every signal and subtract what the manifest already covers.
+ * @param {string} [cwd] Project root.
+ * @returns {Array<{name: string, why: string, evidence: string[]}>} Proposals.
+ */
+export function detectTooling(cwd = process.cwd()) {
+  const config = readJson(join(cwd, ".lisa.config.json"));
+  const pkg = readJson(join(cwd, "package.json"));
+  const mcp = readJson(join(cwd, ".mcp.json"));
+  const notes = readJson(join(cwd, ".lisa", "secret-notes.json"));
+
+  const declared = declaredTools(config);
+  const signals = [
+    toolsFromScripts(pkg),
+    toolsFromMcp(mcp),
+    toolsFromSecretNotes(notes),
+    toolsFromQuality(config),
+  ];
+
+  const merged = new Map();
+  for (const signal of signals) {
+    for (const [tool, evidence] of signal) {
+      if (declared.has(tool)) continue;
+      const entry = merged.get(tool) ?? { evidence: [] };
+      entry.evidence.push(evidence);
+      merged.set(tool, entry);
+    }
+  }
+
+  return [...merged.entries()]
+    .map(([name, entry]) => ({
+      name,
+      why: KNOWN_TOOLS[name]?.why ?? "",
+      evidence: entry.evidence,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * A manifest entry an operator can paste, with the parts only they can supply.
+ * @param {{name: string}} proposal One detected tool.
+ * @returns {object} A `remoteEnv.tools.install` skeleton.
+ */
+export function proposedEntry(proposal) {
+  const viaNpm = KNOWN_TOOLS[proposal.name]?.viaNpm;
+  return viaNpm
+    ? {
+        name: proposal.name,
+        install: "npm-global",
+        package: viaNpm,
+        version: "<pin>",
+      }
+    : {
+        name: proposal.name,
+        version: "<pin>",
+        install: "release-tar",
+        url: "<release url for this exact version>",
+        sha256: "<sha256 published with that release>",
+        surfaces: ["remote"],
+      };
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  const proposals = detectTooling();
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(proposals, null, 2));
+  } else if (proposals.length === 0) {
+    console.log(
+      "Every tool this project appears to use is already declared in remoteEnv.tools."
+    );
+  } else {
+    console.log(
+      `${proposals.length} tool(s) look required but are not declared:\n`
+    );
+    for (const proposal of proposals) {
+      console.log(`  ${proposal.name}`);
+      console.log(`    why: ${proposal.why}`);
+      for (const evidence of proposal.evidence) {
+        console.log(`    evidence: ${evidence}`);
+      }
+      console.log(`    proposed: ${JSON.stringify(proposedEntry(proposal))}\n`);
+    }
+    console.log(
+      "Nothing has been written or installed. Confirm each entry, supply the\n" +
+        "pin and checksum, and add it to remoteEnv.tools in .lisa.config.json."
+    );
+  }
+}

--- a/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -174,10 +174,22 @@ export function toolsFromQuality(config) {
  * @param {object|null} config Parsed .lisa.config.json.
  * @returns {Set<string>} Declared tool names.
  */
-export function declaredTools(config) {
+export function declaredTools(config, surface = "remote") {
   const tools = config?.remoteEnv?.tools ?? {};
+  const applies = tool => {
+    const surfaces = tool.surfaces;
+    if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+    return surfaces.includes(surface);
+  };
+  // Filtered by surface, because a declaration that applies somewhere else is
+  // not coverage here. A local-only `require` entry would otherwise suppress
+  // the proposal for a tool genuinely missing from the remote manifest — the
+  // detector reporting "already declared" about the one surface where it is
+  // not.
   return new Set(
-    [...(tools.require ?? []), ...(tools.install ?? [])].map(t => t.name)
+    [...(tools.require ?? []), ...(tools.install ?? [])]
+      .filter(applies)
+      .map(tool => tool.name)
   );
 }
 
@@ -220,27 +232,48 @@ export function detectTooling(cwd = process.cwd()) {
 }
 
 /**
- * A manifest entry an operator can paste, with the parts only they can supply.
+ * The manifest entries an operator can paste, with the parts only they supply.
+ *
+ * Returns both lists because a platform-specific archive needs both: an
+ * `install` entry for the surface it is built for, and a `require` entry so the
+ * other surface still asserts the tool instead of silently ignoring it.
  * @param {{name: string}} proposal One detected tool.
- * @returns {object} A `remoteEnv.tools.install` skeleton.
+ * @returns {{install: object[], require: object[]}} Manifest skeletons.
  */
-export function proposedEntry(proposal) {
+export function proposedEntries(proposal) {
   const viaNpm = KNOWN_TOOLS[proposal.name]?.viaNpm;
-  return viaNpm
-    ? {
-        name: proposal.name,
-        install: "npm-global",
-        package: viaNpm,
-        version: "<pin>",
-      }
-    : {
+  if (viaNpm) {
+    // npm resolves per platform, so one entry serves every surface.
+    return {
+      install: [
+        {
+          name: proposal.name,
+          install: "npm-global",
+          package: viaNpm,
+          version: "<pin>",
+        },
+      ],
+      require: [],
+    };
+  }
+  // A release archive is built for one platform, so it is proposed as
+  // remote-install plus a local `require`. Proposing only the install entry
+  // produced a manifest that either offered a Linux binary to a laptop or —
+  // once narrowed to remote — stopped checking for the tool locally at all.
+  // Both halves or neither.
+  return {
+    install: [
+      {
         name: proposal.name,
         version: "<pin>",
         install: "release-tar",
-        url: "<release url for this exact version>",
+        url: "<release url for this exact version, for the remote platform>",
         sha256: "<sha256 published with that release>",
         surfaces: ["remote"],
-      };
+      },
+    ],
+    require: [{ name: proposal.name, surfaces: ["local"] }],
+  };
 }
 
 if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
@@ -261,7 +294,14 @@ if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
       for (const evidence of proposal.evidence) {
         console.log(`    evidence: ${evidence}`);
       }
-      console.log(`    proposed: ${JSON.stringify(proposedEntry(proposal))}\n`);
+      const entries = proposedEntries(proposal);
+      for (const entry of entries.install) {
+        console.log(`    tools.install: ${JSON.stringify(entry)}`);
+      }
+      for (const entry of entries.require) {
+        console.log(`    tools.require: ${JSON.stringify(entry)}`);
+      }
+      console.log("");
     }
     console.log(
       "Nothing has been written or installed. Confirm each entry, supply the\n" +

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
@@ -87,6 +87,14 @@ bash scripts/lisa-remote-env/session-start.sh   # guard; delegates to --phase=se
 
 The selection comes from the surface's `materializeAt` capability in `lisa-secrets-access`, not from its name, so adding a surface does not mean editing a branch. The hook is committed to the repository, so it also fires on a developer's machine — it exits `0` immediately there rather than failing, because a correct local session must not look broken.
 
+## Detect before you provision
+
+Run `/lisa:detect-tooling` first, every time. The manifest is the only thing that puts a binary on `PATH`, and nothing populates it — so a project ships npm scripts invoking `maestro`, wires an MCP server whose CLI it also shells out to, and configures Playwright thresholds, while `remoteEnv.tools` stays empty and each of those fails at the moment of use instead of at setup.
+
+This repository has paid for that twice: `gh` was declared nowhere and a cloud session could not commit anything; `tar` was needed by an install method and asserted by nothing.
+
+The detector proposes and a human decides. It writes nothing, so provisioning still only ever happens from a reviewed, pinned, checksummed entry.
+
 ## Toolchain manifest — two entry kinds
 
 ```json
@@ -165,9 +173,9 @@ Because `release-tar` unpacks with `tar` rather than `unzip`, a project using it
 - **Prefer what is there.** A second Node beside the image's creates PATH ambiguity and wastes container time.
 - **Pin and checksum together, in one reviewed commit.** A version bump that does not move the checksum fails before installation, not after. An archive is verified *before* it is unpacked, so unexpected contents never reach a directory on PATH.
 
-## Tooling is never derived from secret notes
+## Tooling is never *authorised* by secret notes
 
-Deliberately rejected:
+Deliberately rejected — notes may not cause an install:
 
 - Most tooling has **no credential** — `jq`, ripgrep, browsers, a linter — so notes could only ever cover a subset, and a second mechanism would be needed anyway.
 - Most credentials **imply no tool**: a webhook is curl'd, a REST key needs no CLI.
@@ -176,6 +184,14 @@ Deliberately rejected:
 - It is a **supply-chain path** — provider write access would become arbitrary install access.
 
 **Notes are an assertion target instead.** At verify time, a tool that declares a credential which is not materialized is an **error**; a credential materialized with no declared consumer is a **warning**. The arrow points the safe way: the repository declares intent, and the provider is checked against it.
+
+### Reading a note as *evidence* is a different act
+
+`lisa-detect-tooling` does read notes, and this section is why it may. Every objection above is an objection to a note **causing** something: authorising an install, being the sole source, deciding a version. None of that changes.
+
+What the detector produces is a proposal with `<pin>`, `<release url>` and `<sha256>` left blank, printed for a human. It cannot install, cannot write config, and its output is inert until someone commits a pinned, checksummed entry that `assertPinned` then enforces. Provider write access therefore buys an attacker one line of text in a proposal a human reads — not arbitrary install access, which is the specific escalation this section exists to block.
+
+The other objections stay true and stay unfixed: most tooling has no credential and most credentials imply no tool, so notes are one signal among four and the weakest of them. They are read *after* npm scripts and MCP servers, and a note alone should be the least persuasive reason to add anything.
 
 ## Provisioning tiers
 

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -221,8 +221,9 @@ function installTool(tool, binDir) {
  * @param {boolean} dryRun Whether to plan only.
  * @returns {Array<object>} The plan that was applied.
  */
-function applyToolchain(tools, dryRun) {
-  const plan = planToolchain(tools, probe);
+function applyToolchain(tools, dryRun, options = {}) {
+  const { surface = "remote", consent = true } = options;
+  const plan = planToolchain(tools, probe, surface);
   const blocked = plan.filter(
     p => p.action === "missing" || p.action === "invalid"
   );
@@ -233,6 +234,34 @@ function applyToolchain(tools, dryRun) {
   const binDir = join(process.env.HOME ?? "", ".local", "bin");
   mkdirSync(binDir, { recursive: true, mode: 0o755 });
   const byName = new Map((tools.install ?? []).map(t => [t.name, t]));
+
+  // Installing is a different act on a laptop than in a container. A container
+  // is disposable and provisioning it silently is the whole point; a developer
+  // machine belongs to a person, and putting pinned binaries in their
+  // ~/.local/bin without being asked is not ours to decide. So the same
+  // manifest drives both, and only the consent differs.
+  //
+  // Reporting still happens either way — knowing the machine diverges from what
+  // the project declares is most of the value, and is what nothing did before.
+  if (!consent) {
+    const missing = plan.filter(step => step.action === "install");
+    if (missing.length === 0) {
+      console.log("  every declared tool is already present");
+      return plan;
+    }
+    console.log(
+      `  ${missing.length} declared tool(s) are missing or below their pin:`
+    );
+    for (const step of missing) {
+      const tool = byName.get(step.name);
+      console.log(`    ${step.name}${tool?.version ? ` ${tool.version}` : ""}`);
+    }
+    console.log(
+      "\n  Not installing without confirmation. Re-run with --install-tools\n" +
+        "  to provision them, or install them yourself."
+    );
+    return plan;
+  }
 
   // Installing a binary somewhere nothing looks is the same as not installing
   // it. `~/.local/bin` is on PATH by default on a developer workstation and is
@@ -641,7 +670,14 @@ async function main() {
 
   if (phases.includes("toolchain")) {
     console.log("Toolchain:");
-    applyToolchain(cfg.tools, dryRun);
+    // A remote container consents by construction: it is disposable, nobody is
+    // watching, and provisioning it is why the script exists. Locally the
+    // operator opts in per run.
+    const remote = Boolean(materializeAt);
+    applyToolchain(cfg.tools, dryRun, {
+      surface: remote ? "remote" : "local",
+      consent: remote || process.argv.includes("--install-tools"),
+    });
   }
 
   if (phases.includes("secrets")) {

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -556,6 +556,40 @@ export function emitClaudeWeb({ bootstrapKey }) {
 }
 
 /**
+ * Report tooling the project appears to need but has not declared.
+ *
+ * Called before the toolchain is applied, because the manifest is the only
+ * thing that puts a binary on PATH and nothing populates it — so provisioning
+ * "the declared toolchain" happily succeeds while the tool a project actually
+ * uses is absent, and fails later at the moment of use instead of here.
+ *
+ * Informational, never blocking. The detector proposes and a human decides, so
+ * an undeclared tool must not stop a setup that was asked to provision what IS
+ * declared; failing here would make a advisory signal into a gate nobody chose.
+ * Its own absence is silent for the same reason: an older installed copy of the
+ * skills has no detector, and that is not a reason to refuse to provision.
+ * @param {Function} [exec] Seam for tests.
+ */
+function reportUndeclaredTooling(exec = execFileSync) {
+  let script;
+  try {
+    script = siblingScript("lisa-detect-tooling", "detect-tooling.mjs");
+  } catch {
+    return;
+  }
+  try {
+    const out = exec("node", [script], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const text = String(out).trim();
+    if (text) console.log(`\n${text}\n`);
+  } catch {
+    // A detector that cannot run is a missing hint, not a failed setup.
+  }
+}
+
+/**
  * Decide which phases this invocation runs.
  *
  * An explicit `--phase` always wins, because that is how a session-start hook
@@ -669,6 +703,7 @@ async function main() {
   }
 
   if (phases.includes("toolchain")) {
+    reportUndeclaredTooling();
     console.log("Toolchain:");
     // A remote container consents by construction: it is disposable, nobody is
     // watching, and provisioning it is why the script exists. Locally the

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -124,6 +124,9 @@ function planInstallable(tool, found) {
   };
 }
 
+/** Surfaces a manifest entry may name. */
+const KNOWN_SURFACES = new Set(["local", "remote"]);
+
 /**
  * Whether a manifest entry applies to the surface being provisioned.
  *
@@ -143,7 +146,26 @@ function planInstallable(tool, found) {
  */
 export function appliesToSurface(tool, surface) {
   const surfaces = tool.surfaces;
-  if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+  if (surfaces === undefined) return true;
+  // A typo must not silently widen scope. Treating any non-array as "omitted"
+  // meant `surfaces: "remote"` — an easy thing to write — quietly applied the
+  // entry to every surface, which for a platform-specific archive means
+  // offering a Linux binary to a laptop. Absent means everywhere; malformed
+  // means stop.
+  if (!Array.isArray(surfaces)) {
+    throw new Error(
+      `${tool.name}: surfaces must be an array, got ${typeof surfaces}.\n` +
+        `Omit it to mean every surface; write ["remote"] or ["local"] to narrow.`
+    );
+  }
+  if (surfaces.length === 0) return true;
+  const unknown = surfaces.filter(entry => !KNOWN_SURFACES.has(entry));
+  if (unknown.length > 0) {
+    throw new Error(
+      `${tool.name}: unknown surface(s) ${unknown.join(", ")}.\n` +
+        `Known: ${[...KNOWN_SURFACES].join(", ")}.`
+    );
+  }
   return surfaces.includes(surface);
 }
 

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -125,17 +125,42 @@ function planInstallable(tool, found) {
 }
 
 /**
+ * Whether a manifest entry applies to the surface being provisioned.
+ *
+ * One declaration per tool, not one block per surface. Most tools a project
+ * needs are needed *everywhere* — a Maestro or Sonar CLI is as required on a
+ * laptop as in a container — and duplicated blocks drift, which this repository
+ * has paid for more than once. What actually differs between surfaces is the
+ * install method and, more importantly, consent: a disposable container may
+ * install silently, a developer's machine may not.
+ *
+ * Omitting `surfaces` means every surface, because that is true of most tools
+ * and the failure of forgetting it should be "checked somewhere unnecessary"
+ * rather than "silently absent where it was needed".
+ * @param {object} tool Manifest entry.
+ * @param {string} surface Surface being provisioned.
+ * @returns {boolean} Whether this entry applies.
+ */
+export function appliesToSurface(tool, surface) {
+  const surfaces = tool.surfaces;
+  if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+  return surfaces.includes(surface);
+}
+
+/**
  * Produce the complete plan for a toolchain manifest.
  * @param {{require?: object[], install?: object[]}} tools Manifest.
  * @param {(name: string) => {version: string|null, present: boolean}} probe Version probe.
  * @returns {Array<{name: string, action: string, reason: string}>} Ordered decisions.
  */
-export function planToolchain(tools, probe) {
+export function planToolchain(tools, probe, surface = "remote") {
   const plan = [];
   for (const tool of tools.require ?? [])
-    plan.push(planRequired(tool, probe(tool.name)));
+    if (appliesToSurface(tool, surface))
+      plan.push(planRequired(tool, probe(tool.name)));
   for (const tool of tools.install ?? [])
-    plan.push(planInstallable(tool, probe(tool.name)));
+    if (appliesToSurface(tool, surface))
+      plan.push(planInstallable(tool, probe(tool.name)));
   return plan;
 }
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lisa-detect-tooling
 description: "Find the command-line tools a…"
-allowed-tools: ["Bash", "Read", "Edit", "AskUserQuestion"]
+allowed-tools: ["Bash", "Read", "AskUserQuestion"]
 ---
 
 # Detect Tooling
@@ -55,4 +55,6 @@ node scripts/detect-tooling.mjs          # human-readable proposals
 node scripts/detect-tooling.mjs --json   # machine-readable
 ```
 
-Confirm each proposal with the operator before editing `.lisa.config.json`. When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on; a rejected proposal is a normal outcome, not a failure.
+Confirm each proposal with the operator, then hand it to them to apply. **This skill does not hold `Edit`**, deliberately: a skill that both decides a tool is needed and writes the entry that installs it is the second unreviewed install path this design exists to avoid. Granting `Edit` while documenting "writes nothing" would have made the prose the only thing stopping it.
+
+When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on. A rejected proposal is a normal outcome, not a failure.

--- a/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: lisa-detect-tooling
+description: "Find the command-line tools a…"
+allowed-tools: ["Bash", "Read", "Edit", "AskUserQuestion"]
+---
+
+# Detect Tooling
+
+Lisa provisions tooling through four unrelated mechanisms, and only one of them puts a binary on `PATH`:
+
+| tool | how it arrives | what puts it on PATH |
+| --- | --- | --- |
+| playwright, stryker | npm devDependency from a stack template | nothing — a local `node_modules` binary |
+| maestro | npm **scripts** in the Expo template | **nothing** |
+| sonar | `src/sonar/sonar-installer.ts` | nothing |
+| linear | MCP server | nothing, and it needs browser OAuth |
+| bws, gh | `remoteEnv.tools` — pinned and checksummed | this, and only this |
+
+Nothing populates that last row. So a project can ship scripts that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and configure Playwright thresholds, while the manifest that actually provisions binaries stays empty — and every one of those fails at the moment of use rather than at setup.
+
+That is the same failure this repository has now paid for twice: `gh` was declared nowhere and a cloud session could not commit; `tar` was needed by an install method and asserted by nothing.
+
+## What it does
+
+Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
+
+- **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
+- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one.
+- **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
+- **Quality configuration**, where a threshold implies the tool that produces it.
+
+## What it will not do
+
+**It writes nothing and installs nothing.** Output is a proposal with `<pin>`, `<release url>` and `<sha256>` left for a human.
+
+That boundary is the whole design. A tool should reach a machine because someone reviewed a pinned entry with a checksum, never because a detector was confident. Detection is evidence; the manifest is the decision. An auto-writing detector would quietly become a second, unreviewed install path — exactly what `assertPinned` exists to prevent.
+
+## Surfaces
+
+One declaration per tool, with an optional `surfaces` list, rather than separate blocks per surface. Most tools are needed *everywhere* — a Maestro or Sonar CLI is as required on a laptop as in a container — and duplicated blocks drift.
+
+What genuinely differs is **consent**, not the list:
+
+- A remote container is disposable and nobody is watching, so it provisions silently.
+- A developer machine belongs to a person, so `--phase=toolchain` reports what is missing and installs nothing unless `--install-tools` is passed.
+
+Omitting `surfaces` means every surface, because that is true of most tools and the cost of forgetting should be a redundant check rather than a silent absence.
+
+A platform-specific pin is the exception worth knowing: a Linux release archive must be `surfaces: ["remote"]`, with a matching `require` entry for `local`, so a laptop asserts the tool without being offered a binary it cannot run.
+
+## Usage
+
+```sh
+node scripts/detect-tooling.mjs          # human-readable proposals
+node scripts/detect-tooling.mjs --json   # machine-readable
+```
+
+Confirm each proposal with the operator before editing `.lisa.config.json`. When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on; a rejected proposal is a normal outcome, not a failure.

--- a/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/agents/openai.yaml
+++ b/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Detect Tooling"
+short_description: "Find the command-line tools a…"
+default_prompt:
+  - "Use $lisa-detect-tooling: Find the command-line tools a…."

--- a/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * Find the command-line tools a project needs but never declares.
+ *
+ * Lisa provisions tooling through several unrelated mechanisms — npm
+ * devDependencies from a stack template, MCP servers, a dedicated installer for
+ * Sonar, and the pinned `remoteEnv.tools` manifest. Only the last one puts a
+ * binary on PATH, and nothing populates it. So a project can ship npm scripts
+ * that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and
+ * declare Playwright coverage thresholds, while the manifest that actually
+ * provisions binaries stays empty and every one of those fails at the moment of
+ * use rather than at setup.
+ *
+ * This program only ever *proposes*. It writes nothing, installs nothing, and
+ * emits manifest entries with the fields a human still has to fill — a pinned
+ * version, a URL, a checksum. That boundary is the point: a tool should reach a
+ * machine because someone reviewed a pinned entry, never because a detector was
+ * confident. Detection is evidence; the manifest is the decision.
+ *
+ * Usage:
+ *   detect-tooling.mjs [--json]
+ * @module detect-tooling
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Tools Lisa or its templates invoke, and how to recognise a need for them.
+ *
+ * Deliberately conservative. A false positive costs a human a moment's review;
+ * a false negative is the failure this exists to prevent, so the signals are
+ * ones that only appear when the tool is genuinely used.
+ */
+const KNOWN_TOOLS = Object.freeze({
+  maestro: {
+    why: "Expo's template ships npm scripts that invoke `maestro`, and nothing installs the binary.",
+    mcpFallback: "maestro",
+  },
+  gh: {
+    why: "The work-item guardrails shell out to `gh` for every tracker read.",
+  },
+  bws: {
+    why: "The Bitwarden CLI is how every secret is resolved.",
+  },
+  "sonar-scanner": {
+    why: "Sonar analysis runs a scanner binary, which the Sonar installer configures but does not place on PATH.",
+  },
+  playwright: {
+    why: "Playwright drives browser E2E and its coverage thresholds are configured.",
+    viaNpm: "@playwright/test",
+  },
+  linear: {
+    why: "Linear is wired as an MCP server, which needs browser OAuth and so cannot authenticate in a container.",
+    mcpFallback: "linear-server",
+  },
+});
+
+/**
+ * Read a JSON file, treating absence or damage as "no signal".
+ *
+ * A detector that throws on a malformed config is worse than one that misses a
+ * signal: it blocks the very command an operator runs to find out what is wrong.
+ * @param {string} path File to read.
+ * @returns {object|null} Parsed contents, or null.
+ */
+function readJson(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Tools named by npm scripts, which is the strongest signal there is.
+ *
+ * A script that runs `maestro test` is a project stating it needs Maestro, in
+ * executable form. Word-boundary matched so `maestro:test` as a script *name*
+ * does not count while `maestro test` as its body does — the name is a label,
+ * the body is a dependency.
+ * @param {object|null} pkg Parsed package.json.
+ * @returns {Map<string, string>} Tool name to the script that proves it.
+ */
+export function toolsFromScripts(pkg) {
+  const found = new Map();
+  const scripts = pkg?.scripts ?? {};
+  for (const [name, body] of Object.entries(scripts)) {
+    if (typeof body !== "string") continue;
+    for (const tool of Object.keys(KNOWN_TOOLS)) {
+      const pattern = new RegExp(`(^|[\\s;&|(])${tool}(\\s|$)`, "u");
+      if (pattern.test(body) && !found.has(tool)) {
+        found.set(tool, `npm script "${name}": ${body.trim().slice(0, 60)}`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools implied by MCP servers that also have a CLI.
+ *
+ * An MCP server is not a substitute for the binary. Several authenticate by
+ * browser OAuth, which a container cannot do at all, so a project relying on one
+ * remotely has no integration rather than a degraded one — the CLI is the form
+ * that survives the trip.
+ * @param {object|null} mcp Parsed .mcp.json.
+ * @returns {Map<string, string>} Tool name to the server that implies it.
+ */
+export function toolsFromMcp(mcp) {
+  const found = new Map();
+  const servers = Object.keys(mcp?.mcpServers ?? {});
+  for (const [tool, meta] of Object.entries(KNOWN_TOOLS)) {
+    if (!meta.mcpFallback) continue;
+    const server = servers.find(name => name.includes(meta.mcpFallback));
+    if (server) {
+      found.set(
+        tool,
+        `MCP server "${server}" (browser OAuth cannot run remotely)`
+      );
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools named in credential usage notes.
+ *
+ * A note explaining what a token is *for* usually names the program that
+ * consumes it, and those notes are already readable without touching a value —
+ * `read-secret-note.mjs` exists precisely so an agent can learn a credential's
+ * blast radius safely. That makes them a first-class detection input rather than
+ * a clever trick.
+ * @param {object|null} notes Parsed secret-notes.json.
+ * @returns {Map<string, string>} Tool name to the credential that names it.
+ */
+export function toolsFromSecretNotes(notes) {
+  const found = new Map();
+  const entries = Object.entries(notes?.notes ?? notes ?? {});
+  for (const [secret, note] of entries) {
+    const text = typeof note === "string" ? note : JSON.stringify(note ?? "");
+    for (const tool of Object.keys(KNOWN_TOOLS)) {
+      const pattern = new RegExp(
+        `(^|[^A-Za-z0-9-])${tool}([^A-Za-z0-9-]|$)`,
+        "iu"
+      );
+      if (pattern.test(text) && !found.has(tool)) {
+        found.set(tool, `usage note on credential "${secret}"`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools implied by quality configuration.
+ * @param {object|null} config Parsed .lisa.config.json.
+ * @returns {Map<string, string>} Tool name to the setting that implies it.
+ */
+export function toolsFromQuality(config) {
+  const found = new Map();
+  if (config?.quality?.e2eCoverage?.playwright) {
+    found.set("playwright", "quality.e2eCoverage.playwright is configured");
+  }
+  if (config?.quality?.sonar || config?.sonar) {
+    found.set("sonar-scanner", "Sonar analysis is configured");
+  }
+  return found;
+}
+
+/**
+ * Everything already declared, by name, so proposals exclude them.
+ * @param {object|null} config Parsed .lisa.config.json.
+ * @returns {Set<string>} Declared tool names.
+ */
+export function declaredTools(config) {
+  const tools = config?.remoteEnv?.tools ?? {};
+  return new Set(
+    [...(tools.require ?? []), ...(tools.install ?? [])].map(t => t.name)
+  );
+}
+
+/**
+ * Collect every signal and subtract what the manifest already covers.
+ * @param {string} [cwd] Project root.
+ * @returns {Array<{name: string, why: string, evidence: string[]}>} Proposals.
+ */
+export function detectTooling(cwd = process.cwd()) {
+  const config = readJson(join(cwd, ".lisa.config.json"));
+  const pkg = readJson(join(cwd, "package.json"));
+  const mcp = readJson(join(cwd, ".mcp.json"));
+  const notes = readJson(join(cwd, ".lisa", "secret-notes.json"));
+
+  const declared = declaredTools(config);
+  const signals = [
+    toolsFromScripts(pkg),
+    toolsFromMcp(mcp),
+    toolsFromSecretNotes(notes),
+    toolsFromQuality(config),
+  ];
+
+  const merged = new Map();
+  for (const signal of signals) {
+    for (const [tool, evidence] of signal) {
+      if (declared.has(tool)) continue;
+      const entry = merged.get(tool) ?? { evidence: [] };
+      entry.evidence.push(evidence);
+      merged.set(tool, entry);
+    }
+  }
+
+  return [...merged.entries()]
+    .map(([name, entry]) => ({
+      name,
+      why: KNOWN_TOOLS[name]?.why ?? "",
+      evidence: entry.evidence,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * A manifest entry an operator can paste, with the parts only they can supply.
+ * @param {{name: string}} proposal One detected tool.
+ * @returns {object} A `remoteEnv.tools.install` skeleton.
+ */
+export function proposedEntry(proposal) {
+  const viaNpm = KNOWN_TOOLS[proposal.name]?.viaNpm;
+  return viaNpm
+    ? {
+        name: proposal.name,
+        install: "npm-global",
+        package: viaNpm,
+        version: "<pin>",
+      }
+    : {
+        name: proposal.name,
+        version: "<pin>",
+        install: "release-tar",
+        url: "<release url for this exact version>",
+        sha256: "<sha256 published with that release>",
+        surfaces: ["remote"],
+      };
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  const proposals = detectTooling();
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(proposals, null, 2));
+  } else if (proposals.length === 0) {
+    console.log(
+      "Every tool this project appears to use is already declared in remoteEnv.tools."
+    );
+  } else {
+    console.log(
+      `${proposals.length} tool(s) look required but are not declared:\n`
+    );
+    for (const proposal of proposals) {
+      console.log(`  ${proposal.name}`);
+      console.log(`    why: ${proposal.why}`);
+      for (const evidence of proposal.evidence) {
+        console.log(`    evidence: ${evidence}`);
+      }
+      console.log(`    proposed: ${JSON.stringify(proposedEntry(proposal))}\n`);
+    }
+    console.log(
+      "Nothing has been written or installed. Confirm each entry, supply the\n" +
+        "pin and checksum, and add it to remoteEnv.tools in .lisa.config.json."
+    );
+  }
+}

--- a/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -174,10 +174,22 @@ export function toolsFromQuality(config) {
  * @param {object|null} config Parsed .lisa.config.json.
  * @returns {Set<string>} Declared tool names.
  */
-export function declaredTools(config) {
+export function declaredTools(config, surface = "remote") {
   const tools = config?.remoteEnv?.tools ?? {};
+  const applies = tool => {
+    const surfaces = tool.surfaces;
+    if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+    return surfaces.includes(surface);
+  };
+  // Filtered by surface, because a declaration that applies somewhere else is
+  // not coverage here. A local-only `require` entry would otherwise suppress
+  // the proposal for a tool genuinely missing from the remote manifest — the
+  // detector reporting "already declared" about the one surface where it is
+  // not.
   return new Set(
-    [...(tools.require ?? []), ...(tools.install ?? [])].map(t => t.name)
+    [...(tools.require ?? []), ...(tools.install ?? [])]
+      .filter(applies)
+      .map(tool => tool.name)
   );
 }
 
@@ -220,27 +232,48 @@ export function detectTooling(cwd = process.cwd()) {
 }
 
 /**
- * A manifest entry an operator can paste, with the parts only they can supply.
+ * The manifest entries an operator can paste, with the parts only they supply.
+ *
+ * Returns both lists because a platform-specific archive needs both: an
+ * `install` entry for the surface it is built for, and a `require` entry so the
+ * other surface still asserts the tool instead of silently ignoring it.
  * @param {{name: string}} proposal One detected tool.
- * @returns {object} A `remoteEnv.tools.install` skeleton.
+ * @returns {{install: object[], require: object[]}} Manifest skeletons.
  */
-export function proposedEntry(proposal) {
+export function proposedEntries(proposal) {
   const viaNpm = KNOWN_TOOLS[proposal.name]?.viaNpm;
-  return viaNpm
-    ? {
-        name: proposal.name,
-        install: "npm-global",
-        package: viaNpm,
-        version: "<pin>",
-      }
-    : {
+  if (viaNpm) {
+    // npm resolves per platform, so one entry serves every surface.
+    return {
+      install: [
+        {
+          name: proposal.name,
+          install: "npm-global",
+          package: viaNpm,
+          version: "<pin>",
+        },
+      ],
+      require: [],
+    };
+  }
+  // A release archive is built for one platform, so it is proposed as
+  // remote-install plus a local `require`. Proposing only the install entry
+  // produced a manifest that either offered a Linux binary to a laptop or —
+  // once narrowed to remote — stopped checking for the tool locally at all.
+  // Both halves or neither.
+  return {
+    install: [
+      {
         name: proposal.name,
         version: "<pin>",
         install: "release-tar",
-        url: "<release url for this exact version>",
+        url: "<release url for this exact version, for the remote platform>",
         sha256: "<sha256 published with that release>",
         surfaces: ["remote"],
-      };
+      },
+    ],
+    require: [{ name: proposal.name, surfaces: ["local"] }],
+  };
 }
 
 if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
@@ -261,7 +294,14 @@ if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
       for (const evidence of proposal.evidence) {
         console.log(`    evidence: ${evidence}`);
       }
-      console.log(`    proposed: ${JSON.stringify(proposedEntry(proposal))}\n`);
+      const entries = proposedEntries(proposal);
+      for (const entry of entries.install) {
+        console.log(`    tools.install: ${JSON.stringify(entry)}`);
+      }
+      for (const entry of entries.require) {
+        console.log(`    tools.require: ${JSON.stringify(entry)}`);
+      }
+      console.log("");
     }
     console.log(
       "Nothing has been written or installed. Confirm each entry, supply the\n" +

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
@@ -87,6 +87,14 @@ bash scripts/lisa-remote-env/session-start.sh   # guard; delegates to --phase=se
 
 The selection comes from the surface's `materializeAt` capability in `lisa-secrets-access`, not from its name, so adding a surface does not mean editing a branch. The hook is committed to the repository, so it also fires on a developer's machine — it exits `0` immediately there rather than failing, because a correct local session must not look broken.
 
+## Detect before you provision
+
+Run `/lisa:detect-tooling` first, every time. The manifest is the only thing that puts a binary on `PATH`, and nothing populates it — so a project ships npm scripts invoking `maestro`, wires an MCP server whose CLI it also shells out to, and configures Playwright thresholds, while `remoteEnv.tools` stays empty and each of those fails at the moment of use instead of at setup.
+
+This repository has paid for that twice: `gh` was declared nowhere and a cloud session could not commit anything; `tar` was needed by an install method and asserted by nothing.
+
+The detector proposes and a human decides. It writes nothing, so provisioning still only ever happens from a reviewed, pinned, checksummed entry.
+
 ## Toolchain manifest — two entry kinds
 
 ```json
@@ -165,9 +173,9 @@ Because `release-tar` unpacks with `tar` rather than `unzip`, a project using it
 - **Prefer what is there.** A second Node beside the image's creates PATH ambiguity and wastes container time.
 - **Pin and checksum together, in one reviewed commit.** A version bump that does not move the checksum fails before installation, not after. An archive is verified *before* it is unpacked, so unexpected contents never reach a directory on PATH.
 
-## Tooling is never derived from secret notes
+## Tooling is never *authorised* by secret notes
 
-Deliberately rejected:
+Deliberately rejected — notes may not cause an install:
 
 - Most tooling has **no credential** — `jq`, ripgrep, browsers, a linter — so notes could only ever cover a subset, and a second mechanism would be needed anyway.
 - Most credentials **imply no tool**: a webhook is curl'd, a REST key needs no CLI.
@@ -176,6 +184,14 @@ Deliberately rejected:
 - It is a **supply-chain path** — provider write access would become arbitrary install access.
 
 **Notes are an assertion target instead.** At verify time, a tool that declares a credential which is not materialized is an **error**; a credential materialized with no declared consumer is a **warning**. The arrow points the safe way: the repository declares intent, and the provider is checked against it.
+
+### Reading a note as *evidence* is a different act
+
+`lisa-detect-tooling` does read notes, and this section is why it may. Every objection above is an objection to a note **causing** something: authorising an install, being the sole source, deciding a version. None of that changes.
+
+What the detector produces is a proposal with `<pin>`, `<release url>` and `<sha256>` left blank, printed for a human. It cannot install, cannot write config, and its output is inert until someone commits a pinned, checksummed entry that `assertPinned` then enforces. Provider write access therefore buys an attacker one line of text in a proposal a human reads — not arbitrary install access, which is the specific escalation this section exists to block.
+
+The other objections stay true and stay unfixed: most tooling has no credential and most credentials imply no tool, so notes are one signal among four and the weakest of them. They are read *after* npm scripts and MCP servers, and a note alone should be the least persuasive reason to add anything.
 
 ## Provisioning tiers
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -221,8 +221,9 @@ function installTool(tool, binDir) {
  * @param {boolean} dryRun Whether to plan only.
  * @returns {Array<object>} The plan that was applied.
  */
-function applyToolchain(tools, dryRun) {
-  const plan = planToolchain(tools, probe);
+function applyToolchain(tools, dryRun, options = {}) {
+  const { surface = "remote", consent = true } = options;
+  const plan = planToolchain(tools, probe, surface);
   const blocked = plan.filter(
     p => p.action === "missing" || p.action === "invalid"
   );
@@ -233,6 +234,34 @@ function applyToolchain(tools, dryRun) {
   const binDir = join(process.env.HOME ?? "", ".local", "bin");
   mkdirSync(binDir, { recursive: true, mode: 0o755 });
   const byName = new Map((tools.install ?? []).map(t => [t.name, t]));
+
+  // Installing is a different act on a laptop than in a container. A container
+  // is disposable and provisioning it silently is the whole point; a developer
+  // machine belongs to a person, and putting pinned binaries in their
+  // ~/.local/bin without being asked is not ours to decide. So the same
+  // manifest drives both, and only the consent differs.
+  //
+  // Reporting still happens either way — knowing the machine diverges from what
+  // the project declares is most of the value, and is what nothing did before.
+  if (!consent) {
+    const missing = plan.filter(step => step.action === "install");
+    if (missing.length === 0) {
+      console.log("  every declared tool is already present");
+      return plan;
+    }
+    console.log(
+      `  ${missing.length} declared tool(s) are missing or below their pin:`
+    );
+    for (const step of missing) {
+      const tool = byName.get(step.name);
+      console.log(`    ${step.name}${tool?.version ? ` ${tool.version}` : ""}`);
+    }
+    console.log(
+      "\n  Not installing without confirmation. Re-run with --install-tools\n" +
+        "  to provision them, or install them yourself."
+    );
+    return plan;
+  }
 
   // Installing a binary somewhere nothing looks is the same as not installing
   // it. `~/.local/bin` is on PATH by default on a developer workstation and is
@@ -641,7 +670,14 @@ async function main() {
 
   if (phases.includes("toolchain")) {
     console.log("Toolchain:");
-    applyToolchain(cfg.tools, dryRun);
+    // A remote container consents by construction: it is disposable, nobody is
+    // watching, and provisioning it is why the script exists. Locally the
+    // operator opts in per run.
+    const remote = Boolean(materializeAt);
+    applyToolchain(cfg.tools, dryRun, {
+      surface: remote ? "remote" : "local",
+      consent: remote || process.argv.includes("--install-tools"),
+    });
   }
 
   if (phases.includes("secrets")) {

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -556,6 +556,40 @@ export function emitClaudeWeb({ bootstrapKey }) {
 }
 
 /**
+ * Report tooling the project appears to need but has not declared.
+ *
+ * Called before the toolchain is applied, because the manifest is the only
+ * thing that puts a binary on PATH and nothing populates it — so provisioning
+ * "the declared toolchain" happily succeeds while the tool a project actually
+ * uses is absent, and fails later at the moment of use instead of here.
+ *
+ * Informational, never blocking. The detector proposes and a human decides, so
+ * an undeclared tool must not stop a setup that was asked to provision what IS
+ * declared; failing here would make a advisory signal into a gate nobody chose.
+ * Its own absence is silent for the same reason: an older installed copy of the
+ * skills has no detector, and that is not a reason to refuse to provision.
+ * @param {Function} [exec] Seam for tests.
+ */
+function reportUndeclaredTooling(exec = execFileSync) {
+  let script;
+  try {
+    script = siblingScript("lisa-detect-tooling", "detect-tooling.mjs");
+  } catch {
+    return;
+  }
+  try {
+    const out = exec("node", [script], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const text = String(out).trim();
+    if (text) console.log(`\n${text}\n`);
+  } catch {
+    // A detector that cannot run is a missing hint, not a failed setup.
+  }
+}
+
+/**
  * Decide which phases this invocation runs.
  *
  * An explicit `--phase` always wins, because that is how a session-start hook
@@ -669,6 +703,7 @@ async function main() {
   }
 
   if (phases.includes("toolchain")) {
+    reportUndeclaredTooling();
     console.log("Toolchain:");
     // A remote container consents by construction: it is disposable, nobody is
     // watching, and provisioning it is why the script exists. Locally the

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -124,6 +124,9 @@ function planInstallable(tool, found) {
   };
 }
 
+/** Surfaces a manifest entry may name. */
+const KNOWN_SURFACES = new Set(["local", "remote"]);
+
 /**
  * Whether a manifest entry applies to the surface being provisioned.
  *
@@ -143,7 +146,26 @@ function planInstallable(tool, found) {
  */
 export function appliesToSurface(tool, surface) {
   const surfaces = tool.surfaces;
-  if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+  if (surfaces === undefined) return true;
+  // A typo must not silently widen scope. Treating any non-array as "omitted"
+  // meant `surfaces: "remote"` — an easy thing to write — quietly applied the
+  // entry to every surface, which for a platform-specific archive means
+  // offering a Linux binary to a laptop. Absent means everywhere; malformed
+  // means stop.
+  if (!Array.isArray(surfaces)) {
+    throw new Error(
+      `${tool.name}: surfaces must be an array, got ${typeof surfaces}.\n` +
+        `Omit it to mean every surface; write ["remote"] or ["local"] to narrow.`
+    );
+  }
+  if (surfaces.length === 0) return true;
+  const unknown = surfaces.filter(entry => !KNOWN_SURFACES.has(entry));
+  if (unknown.length > 0) {
+    throw new Error(
+      `${tool.name}: unknown surface(s) ${unknown.join(", ")}.\n` +
+        `Known: ${[...KNOWN_SURFACES].join(", ")}.`
+    );
+  }
   return surfaces.includes(surface);
 }
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -125,17 +125,42 @@ function planInstallable(tool, found) {
 }
 
 /**
+ * Whether a manifest entry applies to the surface being provisioned.
+ *
+ * One declaration per tool, not one block per surface. Most tools a project
+ * needs are needed *everywhere* — a Maestro or Sonar CLI is as required on a
+ * laptop as in a container — and duplicated blocks drift, which this repository
+ * has paid for more than once. What actually differs between surfaces is the
+ * install method and, more importantly, consent: a disposable container may
+ * install silently, a developer's machine may not.
+ *
+ * Omitting `surfaces` means every surface, because that is true of most tools
+ * and the failure of forgetting it should be "checked somewhere unnecessary"
+ * rather than "silently absent where it was needed".
+ * @param {object} tool Manifest entry.
+ * @param {string} surface Surface being provisioned.
+ * @returns {boolean} Whether this entry applies.
+ */
+export function appliesToSurface(tool, surface) {
+  const surfaces = tool.surfaces;
+  if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+  return surfaces.includes(surface);
+}
+
+/**
  * Produce the complete plan for a toolchain manifest.
  * @param {{require?: object[], install?: object[]}} tools Manifest.
  * @param {(name: string) => {version: string|null, present: boolean}} probe Version probe.
  * @returns {Array<{name: string, action: string, reason: string}>} Ordered decisions.
  */
-export function planToolchain(tools, probe) {
+export function planToolchain(tools, probe, surface = "remote") {
   const plan = [];
   for (const tool of tools.require ?? [])
-    plan.push(planRequired(tool, probe(tool.name)));
+    if (appliesToSurface(tool, surface))
+      plan.push(planRequired(tool, probe(tool.name)));
   for (const tool of tools.install ?? [])
-    plan.push(planInstallable(tool, probe(tool.name)));
+    if (appliesToSurface(tool, surface))
+      plan.push(planInstallable(tool, probe(tool.name)));
   return plan;
 }
 

--- a/plugins/lisa/commands/detect-tooling.md
+++ b/plugins/lisa/commands/detect-tooling.md
@@ -1,0 +1,7 @@
+---
+description: "Find the command-line tools this project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts what remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only once a human has reviewed a pinned, checksummed entry."
+allowed-tools: ["Skill"]
+argument-hint: "[--json]"
+---
+
+Use the /lisa-detect-tooling skill to find undeclared command-line tooling and propose manifest entries for it. $ARGUMENTS

--- a/plugins/lisa/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa/skills/lisa-detect-tooling/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lisa-detect-tooling
 description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts whatever remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
-allowed-tools: ["Bash", "Read", "Edit", "AskUserQuestion"]
+allowed-tools: ["Bash", "Read", "AskUserQuestion"]
 ---
 
 # Detect Tooling
@@ -55,4 +55,6 @@ node scripts/detect-tooling.mjs          # human-readable proposals
 node scripts/detect-tooling.mjs --json   # machine-readable
 ```
 
-Confirm each proposal with the operator before editing `.lisa.config.json`. When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on; a rejected proposal is a normal outcome, not a failure.
+Confirm each proposal with the operator, then hand it to them to apply. **This skill does not hold `Edit`**, deliberately: a skill that both decides a tool is needed and writes the entry that installs it is the second unreviewed install path this design exists to avoid. Granting `Edit` while documenting "writes nothing" would have made the prose the only thing stopping it.
+
+When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on. A rejected proposal is a normal outcome, not a failure.

--- a/plugins/lisa/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa/skills/lisa-detect-tooling/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: lisa-detect-tooling
+description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts whatever remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
+allowed-tools: ["Bash", "Read", "Edit", "AskUserQuestion"]
+---
+
+# Detect Tooling
+
+Lisa provisions tooling through four unrelated mechanisms, and only one of them puts a binary on `PATH`:
+
+| tool | how it arrives | what puts it on PATH |
+| --- | --- | --- |
+| playwright, stryker | npm devDependency from a stack template | nothing — a local `node_modules` binary |
+| maestro | npm **scripts** in the Expo template | **nothing** |
+| sonar | `src/sonar/sonar-installer.ts` | nothing |
+| linear | MCP server | nothing, and it needs browser OAuth |
+| bws, gh | `remoteEnv.tools` — pinned and checksummed | this, and only this |
+
+Nothing populates that last row. So a project can ship scripts that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and configure Playwright thresholds, while the manifest that actually provisions binaries stays empty — and every one of those fails at the moment of use rather than at setup.
+
+That is the same failure this repository has now paid for twice: `gh` was declared nowhere and a cloud session could not commit; `tar` was needed by an install method and asserted by nothing.
+
+## What it does
+
+Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
+
+- **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
+- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one.
+- **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
+- **Quality configuration**, where a threshold implies the tool that produces it.
+
+## What it will not do
+
+**It writes nothing and installs nothing.** Output is a proposal with `<pin>`, `<release url>` and `<sha256>` left for a human.
+
+That boundary is the whole design. A tool should reach a machine because someone reviewed a pinned entry with a checksum, never because a detector was confident. Detection is evidence; the manifest is the decision. An auto-writing detector would quietly become a second, unreviewed install path — exactly what `assertPinned` exists to prevent.
+
+## Surfaces
+
+One declaration per tool, with an optional `surfaces` list, rather than separate blocks per surface. Most tools are needed *everywhere* — a Maestro or Sonar CLI is as required on a laptop as in a container — and duplicated blocks drift.
+
+What genuinely differs is **consent**, not the list:
+
+- A remote container is disposable and nobody is watching, so it provisions silently.
+- A developer machine belongs to a person, so `--phase=toolchain` reports what is missing and installs nothing unless `--install-tools` is passed.
+
+Omitting `surfaces` means every surface, because that is true of most tools and the cost of forgetting should be a redundant check rather than a silent absence.
+
+A platform-specific pin is the exception worth knowing: a Linux release archive must be `surfaces: ["remote"]`, with a matching `require` entry for `local`, so a laptop asserts the tool without being offered a binary it cannot run.
+
+## Usage
+
+```sh
+node scripts/detect-tooling.mjs          # human-readable proposals
+node scripts/detect-tooling.mjs --json   # machine-readable
+```
+
+Confirm each proposal with the operator before editing `.lisa.config.json`. When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on; a rejected proposal is a normal outcome, not a failure.

--- a/plugins/lisa/skills/lisa-detect-tooling/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-detect-tooling/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Detect Tooling"
+short_description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them"
+default_prompt:
+  - "Use $lisa-detect-tooling: Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them."

--- a/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * Find the command-line tools a project needs but never declares.
+ *
+ * Lisa provisions tooling through several unrelated mechanisms — npm
+ * devDependencies from a stack template, MCP servers, a dedicated installer for
+ * Sonar, and the pinned `remoteEnv.tools` manifest. Only the last one puts a
+ * binary on PATH, and nothing populates it. So a project can ship npm scripts
+ * that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and
+ * declare Playwright coverage thresholds, while the manifest that actually
+ * provisions binaries stays empty and every one of those fails at the moment of
+ * use rather than at setup.
+ *
+ * This program only ever *proposes*. It writes nothing, installs nothing, and
+ * emits manifest entries with the fields a human still has to fill — a pinned
+ * version, a URL, a checksum. That boundary is the point: a tool should reach a
+ * machine because someone reviewed a pinned entry, never because a detector was
+ * confident. Detection is evidence; the manifest is the decision.
+ *
+ * Usage:
+ *   detect-tooling.mjs [--json]
+ * @module detect-tooling
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Tools Lisa or its templates invoke, and how to recognise a need for them.
+ *
+ * Deliberately conservative. A false positive costs a human a moment's review;
+ * a false negative is the failure this exists to prevent, so the signals are
+ * ones that only appear when the tool is genuinely used.
+ */
+const KNOWN_TOOLS = Object.freeze({
+  maestro: {
+    why: "Expo's template ships npm scripts that invoke `maestro`, and nothing installs the binary.",
+    mcpFallback: "maestro",
+  },
+  gh: {
+    why: "The work-item guardrails shell out to `gh` for every tracker read.",
+  },
+  bws: {
+    why: "The Bitwarden CLI is how every secret is resolved.",
+  },
+  "sonar-scanner": {
+    why: "Sonar analysis runs a scanner binary, which the Sonar installer configures but does not place on PATH.",
+  },
+  playwright: {
+    why: "Playwright drives browser E2E and its coverage thresholds are configured.",
+    viaNpm: "@playwright/test",
+  },
+  linear: {
+    why: "Linear is wired as an MCP server, which needs browser OAuth and so cannot authenticate in a container.",
+    mcpFallback: "linear-server",
+  },
+});
+
+/**
+ * Read a JSON file, treating absence or damage as "no signal".
+ *
+ * A detector that throws on a malformed config is worse than one that misses a
+ * signal: it blocks the very command an operator runs to find out what is wrong.
+ * @param {string} path File to read.
+ * @returns {object|null} Parsed contents, or null.
+ */
+function readJson(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Tools named by npm scripts, which is the strongest signal there is.
+ *
+ * A script that runs `maestro test` is a project stating it needs Maestro, in
+ * executable form. Word-boundary matched so `maestro:test` as a script *name*
+ * does not count while `maestro test` as its body does — the name is a label,
+ * the body is a dependency.
+ * @param {object|null} pkg Parsed package.json.
+ * @returns {Map<string, string>} Tool name to the script that proves it.
+ */
+export function toolsFromScripts(pkg) {
+  const found = new Map();
+  const scripts = pkg?.scripts ?? {};
+  for (const [name, body] of Object.entries(scripts)) {
+    if (typeof body !== "string") continue;
+    for (const tool of Object.keys(KNOWN_TOOLS)) {
+      const pattern = new RegExp(`(^|[\\s;&|(])${tool}(\\s|$)`, "u");
+      if (pattern.test(body) && !found.has(tool)) {
+        found.set(tool, `npm script "${name}": ${body.trim().slice(0, 60)}`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools implied by MCP servers that also have a CLI.
+ *
+ * An MCP server is not a substitute for the binary. Several authenticate by
+ * browser OAuth, which a container cannot do at all, so a project relying on one
+ * remotely has no integration rather than a degraded one — the CLI is the form
+ * that survives the trip.
+ * @param {object|null} mcp Parsed .mcp.json.
+ * @returns {Map<string, string>} Tool name to the server that implies it.
+ */
+export function toolsFromMcp(mcp) {
+  const found = new Map();
+  const servers = Object.keys(mcp?.mcpServers ?? {});
+  for (const [tool, meta] of Object.entries(KNOWN_TOOLS)) {
+    if (!meta.mcpFallback) continue;
+    const server = servers.find(name => name.includes(meta.mcpFallback));
+    if (server) {
+      found.set(
+        tool,
+        `MCP server "${server}" (browser OAuth cannot run remotely)`
+      );
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools named in credential usage notes.
+ *
+ * A note explaining what a token is *for* usually names the program that
+ * consumes it, and those notes are already readable without touching a value —
+ * `read-secret-note.mjs` exists precisely so an agent can learn a credential's
+ * blast radius safely. That makes them a first-class detection input rather than
+ * a clever trick.
+ * @param {object|null} notes Parsed secret-notes.json.
+ * @returns {Map<string, string>} Tool name to the credential that names it.
+ */
+export function toolsFromSecretNotes(notes) {
+  const found = new Map();
+  const entries = Object.entries(notes?.notes ?? notes ?? {});
+  for (const [secret, note] of entries) {
+    const text = typeof note === "string" ? note : JSON.stringify(note ?? "");
+    for (const tool of Object.keys(KNOWN_TOOLS)) {
+      const pattern = new RegExp(
+        `(^|[^A-Za-z0-9-])${tool}([^A-Za-z0-9-]|$)`,
+        "iu"
+      );
+      if (pattern.test(text) && !found.has(tool)) {
+        found.set(tool, `usage note on credential "${secret}"`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools implied by quality configuration.
+ * @param {object|null} config Parsed .lisa.config.json.
+ * @returns {Map<string, string>} Tool name to the setting that implies it.
+ */
+export function toolsFromQuality(config) {
+  const found = new Map();
+  if (config?.quality?.e2eCoverage?.playwright) {
+    found.set("playwright", "quality.e2eCoverage.playwright is configured");
+  }
+  if (config?.quality?.sonar || config?.sonar) {
+    found.set("sonar-scanner", "Sonar analysis is configured");
+  }
+  return found;
+}
+
+/**
+ * Everything already declared, by name, so proposals exclude them.
+ * @param {object|null} config Parsed .lisa.config.json.
+ * @returns {Set<string>} Declared tool names.
+ */
+export function declaredTools(config) {
+  const tools = config?.remoteEnv?.tools ?? {};
+  return new Set(
+    [...(tools.require ?? []), ...(tools.install ?? [])].map(t => t.name)
+  );
+}
+
+/**
+ * Collect every signal and subtract what the manifest already covers.
+ * @param {string} [cwd] Project root.
+ * @returns {Array<{name: string, why: string, evidence: string[]}>} Proposals.
+ */
+export function detectTooling(cwd = process.cwd()) {
+  const config = readJson(join(cwd, ".lisa.config.json"));
+  const pkg = readJson(join(cwd, "package.json"));
+  const mcp = readJson(join(cwd, ".mcp.json"));
+  const notes = readJson(join(cwd, ".lisa", "secret-notes.json"));
+
+  const declared = declaredTools(config);
+  const signals = [
+    toolsFromScripts(pkg),
+    toolsFromMcp(mcp),
+    toolsFromSecretNotes(notes),
+    toolsFromQuality(config),
+  ];
+
+  const merged = new Map();
+  for (const signal of signals) {
+    for (const [tool, evidence] of signal) {
+      if (declared.has(tool)) continue;
+      const entry = merged.get(tool) ?? { evidence: [] };
+      entry.evidence.push(evidence);
+      merged.set(tool, entry);
+    }
+  }
+
+  return [...merged.entries()]
+    .map(([name, entry]) => ({
+      name,
+      why: KNOWN_TOOLS[name]?.why ?? "",
+      evidence: entry.evidence,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * A manifest entry an operator can paste, with the parts only they can supply.
+ * @param {{name: string}} proposal One detected tool.
+ * @returns {object} A `remoteEnv.tools.install` skeleton.
+ */
+export function proposedEntry(proposal) {
+  const viaNpm = KNOWN_TOOLS[proposal.name]?.viaNpm;
+  return viaNpm
+    ? {
+        name: proposal.name,
+        install: "npm-global",
+        package: viaNpm,
+        version: "<pin>",
+      }
+    : {
+        name: proposal.name,
+        version: "<pin>",
+        install: "release-tar",
+        url: "<release url for this exact version>",
+        sha256: "<sha256 published with that release>",
+        surfaces: ["remote"],
+      };
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  const proposals = detectTooling();
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(proposals, null, 2));
+  } else if (proposals.length === 0) {
+    console.log(
+      "Every tool this project appears to use is already declared in remoteEnv.tools."
+    );
+  } else {
+    console.log(
+      `${proposals.length} tool(s) look required but are not declared:\n`
+    );
+    for (const proposal of proposals) {
+      console.log(`  ${proposal.name}`);
+      console.log(`    why: ${proposal.why}`);
+      for (const evidence of proposal.evidence) {
+        console.log(`    evidence: ${evidence}`);
+      }
+      console.log(`    proposed: ${JSON.stringify(proposedEntry(proposal))}\n`);
+    }
+    console.log(
+      "Nothing has been written or installed. Confirm each entry, supply the\n" +
+        "pin and checksum, and add it to remoteEnv.tools in .lisa.config.json."
+    );
+  }
+}

--- a/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -174,10 +174,22 @@ export function toolsFromQuality(config) {
  * @param {object|null} config Parsed .lisa.config.json.
  * @returns {Set<string>} Declared tool names.
  */
-export function declaredTools(config) {
+export function declaredTools(config, surface = "remote") {
   const tools = config?.remoteEnv?.tools ?? {};
+  const applies = tool => {
+    const surfaces = tool.surfaces;
+    if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+    return surfaces.includes(surface);
+  };
+  // Filtered by surface, because a declaration that applies somewhere else is
+  // not coverage here. A local-only `require` entry would otherwise suppress
+  // the proposal for a tool genuinely missing from the remote manifest — the
+  // detector reporting "already declared" about the one surface where it is
+  // not.
   return new Set(
-    [...(tools.require ?? []), ...(tools.install ?? [])].map(t => t.name)
+    [...(tools.require ?? []), ...(tools.install ?? [])]
+      .filter(applies)
+      .map(tool => tool.name)
   );
 }
 
@@ -220,27 +232,48 @@ export function detectTooling(cwd = process.cwd()) {
 }
 
 /**
- * A manifest entry an operator can paste, with the parts only they can supply.
+ * The manifest entries an operator can paste, with the parts only they supply.
+ *
+ * Returns both lists because a platform-specific archive needs both: an
+ * `install` entry for the surface it is built for, and a `require` entry so the
+ * other surface still asserts the tool instead of silently ignoring it.
  * @param {{name: string}} proposal One detected tool.
- * @returns {object} A `remoteEnv.tools.install` skeleton.
+ * @returns {{install: object[], require: object[]}} Manifest skeletons.
  */
-export function proposedEntry(proposal) {
+export function proposedEntries(proposal) {
   const viaNpm = KNOWN_TOOLS[proposal.name]?.viaNpm;
-  return viaNpm
-    ? {
-        name: proposal.name,
-        install: "npm-global",
-        package: viaNpm,
-        version: "<pin>",
-      }
-    : {
+  if (viaNpm) {
+    // npm resolves per platform, so one entry serves every surface.
+    return {
+      install: [
+        {
+          name: proposal.name,
+          install: "npm-global",
+          package: viaNpm,
+          version: "<pin>",
+        },
+      ],
+      require: [],
+    };
+  }
+  // A release archive is built for one platform, so it is proposed as
+  // remote-install plus a local `require`. Proposing only the install entry
+  // produced a manifest that either offered a Linux binary to a laptop or —
+  // once narrowed to remote — stopped checking for the tool locally at all.
+  // Both halves or neither.
+  return {
+    install: [
+      {
         name: proposal.name,
         version: "<pin>",
         install: "release-tar",
-        url: "<release url for this exact version>",
+        url: "<release url for this exact version, for the remote platform>",
         sha256: "<sha256 published with that release>",
         surfaces: ["remote"],
-      };
+      },
+    ],
+    require: [{ name: proposal.name, surfaces: ["local"] }],
+  };
 }
 
 if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
@@ -261,7 +294,14 @@ if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
       for (const evidence of proposal.evidence) {
         console.log(`    evidence: ${evidence}`);
       }
-      console.log(`    proposed: ${JSON.stringify(proposedEntry(proposal))}\n`);
+      const entries = proposedEntries(proposal);
+      for (const entry of entries.install) {
+        console.log(`    tools.install: ${JSON.stringify(entry)}`);
+      }
+      for (const entry of entries.require) {
+        console.log(`    tools.require: ${JSON.stringify(entry)}`);
+      }
+      console.log("");
     }
     console.log(
       "Nothing has been written or installed. Confirm each entry, supply the\n" +

--- a/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
@@ -87,6 +87,14 @@ bash scripts/lisa-remote-env/session-start.sh   # guard; delegates to --phase=se
 
 The selection comes from the surface's `materializeAt` capability in `lisa-secrets-access`, not from its name, so adding a surface does not mean editing a branch. The hook is committed to the repository, so it also fires on a developer's machine — it exits `0` immediately there rather than failing, because a correct local session must not look broken.
 
+## Detect before you provision
+
+Run `/lisa:detect-tooling` first, every time. The manifest is the only thing that puts a binary on `PATH`, and nothing populates it — so a project ships npm scripts invoking `maestro`, wires an MCP server whose CLI it also shells out to, and configures Playwright thresholds, while `remoteEnv.tools` stays empty and each of those fails at the moment of use instead of at setup.
+
+This repository has paid for that twice: `gh` was declared nowhere and a cloud session could not commit anything; `tar` was needed by an install method and asserted by nothing.
+
+The detector proposes and a human decides. It writes nothing, so provisioning still only ever happens from a reviewed, pinned, checksummed entry.
+
 ## Toolchain manifest — two entry kinds
 
 ```json
@@ -165,9 +173,9 @@ Because `release-tar` unpacks with `tar` rather than `unzip`, a project using it
 - **Prefer what is there.** A second Node beside the image's creates PATH ambiguity and wastes container time.
 - **Pin and checksum together, in one reviewed commit.** A version bump that does not move the checksum fails before installation, not after. An archive is verified *before* it is unpacked, so unexpected contents never reach a directory on PATH.
 
-## Tooling is never derived from secret notes
+## Tooling is never *authorised* by secret notes
 
-Deliberately rejected:
+Deliberately rejected — notes may not cause an install:
 
 - Most tooling has **no credential** — `jq`, ripgrep, browsers, a linter — so notes could only ever cover a subset, and a second mechanism would be needed anyway.
 - Most credentials **imply no tool**: a webhook is curl'd, a REST key needs no CLI.
@@ -176,6 +184,14 @@ Deliberately rejected:
 - It is a **supply-chain path** — provider write access would become arbitrary install access.
 
 **Notes are an assertion target instead.** At verify time, a tool that declares a credential which is not materialized is an **error**; a credential materialized with no declared consumer is a **warning**. The arrow points the safe way: the repository declares intent, and the provider is checked against it.
+
+### Reading a note as *evidence* is a different act
+
+`lisa-detect-tooling` does read notes, and this section is why it may. Every objection above is an objection to a note **causing** something: authorising an install, being the sole source, deciding a version. None of that changes.
+
+What the detector produces is a proposal with `<pin>`, `<release url>` and `<sha256>` left blank, printed for a human. It cannot install, cannot write config, and its output is inert until someone commits a pinned, checksummed entry that `assertPinned` then enforces. Provider write access therefore buys an attacker one line of text in a proposal a human reads — not arbitrary install access, which is the specific escalation this section exists to block.
+
+The other objections stay true and stay unfixed: most tooling has no credential and most credentials imply no tool, so notes are one signal among four and the weakest of them. They are read *after* npm scripts and MCP servers, and a note alone should be the least persuasive reason to add anything.
 
 ## Provisioning tiers
 

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -221,8 +221,9 @@ function installTool(tool, binDir) {
  * @param {boolean} dryRun Whether to plan only.
  * @returns {Array<object>} The plan that was applied.
  */
-function applyToolchain(tools, dryRun) {
-  const plan = planToolchain(tools, probe);
+function applyToolchain(tools, dryRun, options = {}) {
+  const { surface = "remote", consent = true } = options;
+  const plan = planToolchain(tools, probe, surface);
   const blocked = plan.filter(
     p => p.action === "missing" || p.action === "invalid"
   );
@@ -233,6 +234,34 @@ function applyToolchain(tools, dryRun) {
   const binDir = join(process.env.HOME ?? "", ".local", "bin");
   mkdirSync(binDir, { recursive: true, mode: 0o755 });
   const byName = new Map((tools.install ?? []).map(t => [t.name, t]));
+
+  // Installing is a different act on a laptop than in a container. A container
+  // is disposable and provisioning it silently is the whole point; a developer
+  // machine belongs to a person, and putting pinned binaries in their
+  // ~/.local/bin without being asked is not ours to decide. So the same
+  // manifest drives both, and only the consent differs.
+  //
+  // Reporting still happens either way — knowing the machine diverges from what
+  // the project declares is most of the value, and is what nothing did before.
+  if (!consent) {
+    const missing = plan.filter(step => step.action === "install");
+    if (missing.length === 0) {
+      console.log("  every declared tool is already present");
+      return plan;
+    }
+    console.log(
+      `  ${missing.length} declared tool(s) are missing or below their pin:`
+    );
+    for (const step of missing) {
+      const tool = byName.get(step.name);
+      console.log(`    ${step.name}${tool?.version ? ` ${tool.version}` : ""}`);
+    }
+    console.log(
+      "\n  Not installing without confirmation. Re-run with --install-tools\n" +
+        "  to provision them, or install them yourself."
+    );
+    return plan;
+  }
 
   // Installing a binary somewhere nothing looks is the same as not installing
   // it. `~/.local/bin` is on PATH by default on a developer workstation and is
@@ -641,7 +670,14 @@ async function main() {
 
   if (phases.includes("toolchain")) {
     console.log("Toolchain:");
-    applyToolchain(cfg.tools, dryRun);
+    // A remote container consents by construction: it is disposable, nobody is
+    // watching, and provisioning it is why the script exists. Locally the
+    // operator opts in per run.
+    const remote = Boolean(materializeAt);
+    applyToolchain(cfg.tools, dryRun, {
+      surface: remote ? "remote" : "local",
+      consent: remote || process.argv.includes("--install-tools"),
+    });
   }
 
   if (phases.includes("secrets")) {

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -556,6 +556,40 @@ export function emitClaudeWeb({ bootstrapKey }) {
 }
 
 /**
+ * Report tooling the project appears to need but has not declared.
+ *
+ * Called before the toolchain is applied, because the manifest is the only
+ * thing that puts a binary on PATH and nothing populates it — so provisioning
+ * "the declared toolchain" happily succeeds while the tool a project actually
+ * uses is absent, and fails later at the moment of use instead of here.
+ *
+ * Informational, never blocking. The detector proposes and a human decides, so
+ * an undeclared tool must not stop a setup that was asked to provision what IS
+ * declared; failing here would make a advisory signal into a gate nobody chose.
+ * Its own absence is silent for the same reason: an older installed copy of the
+ * skills has no detector, and that is not a reason to refuse to provision.
+ * @param {Function} [exec] Seam for tests.
+ */
+function reportUndeclaredTooling(exec = execFileSync) {
+  let script;
+  try {
+    script = siblingScript("lisa-detect-tooling", "detect-tooling.mjs");
+  } catch {
+    return;
+  }
+  try {
+    const out = exec("node", [script], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const text = String(out).trim();
+    if (text) console.log(`\n${text}\n`);
+  } catch {
+    // A detector that cannot run is a missing hint, not a failed setup.
+  }
+}
+
+/**
  * Decide which phases this invocation runs.
  *
  * An explicit `--phase` always wins, because that is how a session-start hook
@@ -669,6 +703,7 @@ async function main() {
   }
 
   if (phases.includes("toolchain")) {
+    reportUndeclaredTooling();
     console.log("Toolchain:");
     // A remote container consents by construction: it is disposable, nobody is
     // watching, and provisioning it is why the script exists. Locally the

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -124,6 +124,9 @@ function planInstallable(tool, found) {
   };
 }
 
+/** Surfaces a manifest entry may name. */
+const KNOWN_SURFACES = new Set(["local", "remote"]);
+
 /**
  * Whether a manifest entry applies to the surface being provisioned.
  *
@@ -143,7 +146,26 @@ function planInstallable(tool, found) {
  */
 export function appliesToSurface(tool, surface) {
   const surfaces = tool.surfaces;
-  if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+  if (surfaces === undefined) return true;
+  // A typo must not silently widen scope. Treating any non-array as "omitted"
+  // meant `surfaces: "remote"` — an easy thing to write — quietly applied the
+  // entry to every surface, which for a platform-specific archive means
+  // offering a Linux binary to a laptop. Absent means everywhere; malformed
+  // means stop.
+  if (!Array.isArray(surfaces)) {
+    throw new Error(
+      `${tool.name}: surfaces must be an array, got ${typeof surfaces}.\n` +
+        `Omit it to mean every surface; write ["remote"] or ["local"] to narrow.`
+    );
+  }
+  if (surfaces.length === 0) return true;
+  const unknown = surfaces.filter(entry => !KNOWN_SURFACES.has(entry));
+  if (unknown.length > 0) {
+    throw new Error(
+      `${tool.name}: unknown surface(s) ${unknown.join(", ")}.\n` +
+        `Known: ${[...KNOWN_SURFACES].join(", ")}.`
+    );
+  }
   return surfaces.includes(surface);
 }
 

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -125,17 +125,42 @@ function planInstallable(tool, found) {
 }
 
 /**
+ * Whether a manifest entry applies to the surface being provisioned.
+ *
+ * One declaration per tool, not one block per surface. Most tools a project
+ * needs are needed *everywhere* — a Maestro or Sonar CLI is as required on a
+ * laptop as in a container — and duplicated blocks drift, which this repository
+ * has paid for more than once. What actually differs between surfaces is the
+ * install method and, more importantly, consent: a disposable container may
+ * install silently, a developer's machine may not.
+ *
+ * Omitting `surfaces` means every surface, because that is true of most tools
+ * and the failure of forgetting it should be "checked somewhere unnecessary"
+ * rather than "silently absent where it was needed".
+ * @param {object} tool Manifest entry.
+ * @param {string} surface Surface being provisioned.
+ * @returns {boolean} Whether this entry applies.
+ */
+export function appliesToSurface(tool, surface) {
+  const surfaces = tool.surfaces;
+  if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+  return surfaces.includes(surface);
+}
+
+/**
  * Produce the complete plan for a toolchain manifest.
  * @param {{require?: object[], install?: object[]}} tools Manifest.
  * @param {(name: string) => {version: string|null, present: boolean}} probe Version probe.
  * @returns {Array<{name: string, action: string, reason: string}>} Ordered decisions.
  */
-export function planToolchain(tools, probe) {
+export function planToolchain(tools, probe, surface = "remote") {
   const plan = [];
   for (const tool of tools.require ?? [])
-    plan.push(planRequired(tool, probe(tool.name)));
+    if (appliesToSurface(tool, surface))
+      plan.push(planRequired(tool, probe(tool.name)));
   for (const tool of tools.install ?? [])
-    plan.push(planInstallable(tool, probe(tool.name)));
+    if (appliesToSurface(tool, surface))
+      plan.push(planInstallable(tool, probe(tool.name)));
   return plan;
 }
 

--- a/plugins/src/base/commands/detect-tooling.md
+++ b/plugins/src/base/commands/detect-tooling.md
@@ -1,0 +1,7 @@
+---
+description: "Find the command-line tools this project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts what remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only once a human has reviewed a pinned, checksummed entry."
+allowed-tools: ["Skill"]
+argument-hint: "[--json]"
+---
+
+Use the /lisa-detect-tooling skill to find undeclared command-line tooling and propose manifest entries for it. $ARGUMENTS

--- a/plugins/src/base/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/src/base/skills/lisa-detect-tooling/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lisa-detect-tooling
 description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts whatever remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
-allowed-tools: ["Bash", "Read", "Edit", "AskUserQuestion"]
+allowed-tools: ["Bash", "Read", "AskUserQuestion"]
 ---
 
 # Detect Tooling
@@ -55,4 +55,6 @@ node scripts/detect-tooling.mjs          # human-readable proposals
 node scripts/detect-tooling.mjs --json   # machine-readable
 ```
 
-Confirm each proposal with the operator before editing `.lisa.config.json`. When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on; a rejected proposal is a normal outcome, not a failure.
+Confirm each proposal with the operator, then hand it to them to apply. **This skill does not hold `Edit`**, deliberately: a skill that both decides a tool is needed and writes the entry that installs it is the second unreviewed install path this design exists to avoid. Granting `Edit` while documenting "writes nothing" would have made the prose the only thing stopping it.
+
+When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on. A rejected proposal is a normal outcome, not a failure.

--- a/plugins/src/base/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/src/base/skills/lisa-detect-tooling/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: lisa-detect-tooling
+description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts whatever remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
+allowed-tools: ["Bash", "Read", "Edit", "AskUserQuestion"]
+---
+
+# Detect Tooling
+
+Lisa provisions tooling through four unrelated mechanisms, and only one of them puts a binary on `PATH`:
+
+| tool | how it arrives | what puts it on PATH |
+| --- | --- | --- |
+| playwright, stryker | npm devDependency from a stack template | nothing — a local `node_modules` binary |
+| maestro | npm **scripts** in the Expo template | **nothing** |
+| sonar | `src/sonar/sonar-installer.ts` | nothing |
+| linear | MCP server | nothing, and it needs browser OAuth |
+| bws, gh | `remoteEnv.tools` — pinned and checksummed | this, and only this |
+
+Nothing populates that last row. So a project can ship scripts that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and configure Playwright thresholds, while the manifest that actually provisions binaries stays empty — and every one of those fails at the moment of use rather than at setup.
+
+That is the same failure this repository has now paid for twice: `gh` was declared nowhere and a cloud session could not commit; `tar` was needed by an install method and asserted by nothing.
+
+## What it does
+
+Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
+
+- **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
+- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one.
+- **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
+- **Quality configuration**, where a threshold implies the tool that produces it.
+
+## What it will not do
+
+**It writes nothing and installs nothing.** Output is a proposal with `<pin>`, `<release url>` and `<sha256>` left for a human.
+
+That boundary is the whole design. A tool should reach a machine because someone reviewed a pinned entry with a checksum, never because a detector was confident. Detection is evidence; the manifest is the decision. An auto-writing detector would quietly become a second, unreviewed install path — exactly what `assertPinned` exists to prevent.
+
+## Surfaces
+
+One declaration per tool, with an optional `surfaces` list, rather than separate blocks per surface. Most tools are needed *everywhere* — a Maestro or Sonar CLI is as required on a laptop as in a container — and duplicated blocks drift.
+
+What genuinely differs is **consent**, not the list:
+
+- A remote container is disposable and nobody is watching, so it provisions silently.
+- A developer machine belongs to a person, so `--phase=toolchain` reports what is missing and installs nothing unless `--install-tools` is passed.
+
+Omitting `surfaces` means every surface, because that is true of most tools and the cost of forgetting should be a redundant check rather than a silent absence.
+
+A platform-specific pin is the exception worth knowing: a Linux release archive must be `surfaces: ["remote"]`, with a matching `require` entry for `local`, so a laptop asserts the tool without being offered a binary it cannot run.
+
+## Usage
+
+```sh
+node scripts/detect-tooling.mjs          # human-readable proposals
+node scripts/detect-tooling.mjs --json   # machine-readable
+```
+
+Confirm each proposal with the operator before editing `.lisa.config.json`. When a proposal is wrong — the tool is genuinely unused, or arrives another way — say so and move on; a rejected proposal is a normal outcome, not a failure.

--- a/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * Find the command-line tools a project needs but never declares.
+ *
+ * Lisa provisions tooling through several unrelated mechanisms — npm
+ * devDependencies from a stack template, MCP servers, a dedicated installer for
+ * Sonar, and the pinned `remoteEnv.tools` manifest. Only the last one puts a
+ * binary on PATH, and nothing populates it. So a project can ship npm scripts
+ * that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and
+ * declare Playwright coverage thresholds, while the manifest that actually
+ * provisions binaries stays empty and every one of those fails at the moment of
+ * use rather than at setup.
+ *
+ * This program only ever *proposes*. It writes nothing, installs nothing, and
+ * emits manifest entries with the fields a human still has to fill — a pinned
+ * version, a URL, a checksum. That boundary is the point: a tool should reach a
+ * machine because someone reviewed a pinned entry, never because a detector was
+ * confident. Detection is evidence; the manifest is the decision.
+ *
+ * Usage:
+ *   detect-tooling.mjs [--json]
+ * @module detect-tooling
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Tools Lisa or its templates invoke, and how to recognise a need for them.
+ *
+ * Deliberately conservative. A false positive costs a human a moment's review;
+ * a false negative is the failure this exists to prevent, so the signals are
+ * ones that only appear when the tool is genuinely used.
+ */
+const KNOWN_TOOLS = Object.freeze({
+  maestro: {
+    why: "Expo's template ships npm scripts that invoke `maestro`, and nothing installs the binary.",
+    mcpFallback: "maestro",
+  },
+  gh: {
+    why: "The work-item guardrails shell out to `gh` for every tracker read.",
+  },
+  bws: {
+    why: "The Bitwarden CLI is how every secret is resolved.",
+  },
+  "sonar-scanner": {
+    why: "Sonar analysis runs a scanner binary, which the Sonar installer configures but does not place on PATH.",
+  },
+  playwright: {
+    why: "Playwright drives browser E2E and its coverage thresholds are configured.",
+    viaNpm: "@playwright/test",
+  },
+  linear: {
+    why: "Linear is wired as an MCP server, which needs browser OAuth and so cannot authenticate in a container.",
+    mcpFallback: "linear-server",
+  },
+});
+
+/**
+ * Read a JSON file, treating absence or damage as "no signal".
+ *
+ * A detector that throws on a malformed config is worse than one that misses a
+ * signal: it blocks the very command an operator runs to find out what is wrong.
+ * @param {string} path File to read.
+ * @returns {object|null} Parsed contents, or null.
+ */
+function readJson(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Tools named by npm scripts, which is the strongest signal there is.
+ *
+ * A script that runs `maestro test` is a project stating it needs Maestro, in
+ * executable form. Word-boundary matched so `maestro:test` as a script *name*
+ * does not count while `maestro test` as its body does — the name is a label,
+ * the body is a dependency.
+ * @param {object|null} pkg Parsed package.json.
+ * @returns {Map<string, string>} Tool name to the script that proves it.
+ */
+export function toolsFromScripts(pkg) {
+  const found = new Map();
+  const scripts = pkg?.scripts ?? {};
+  for (const [name, body] of Object.entries(scripts)) {
+    if (typeof body !== "string") continue;
+    for (const tool of Object.keys(KNOWN_TOOLS)) {
+      const pattern = new RegExp(`(^|[\\s;&|(])${tool}(\\s|$)`, "u");
+      if (pattern.test(body) && !found.has(tool)) {
+        found.set(tool, `npm script "${name}": ${body.trim().slice(0, 60)}`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools implied by MCP servers that also have a CLI.
+ *
+ * An MCP server is not a substitute for the binary. Several authenticate by
+ * browser OAuth, which a container cannot do at all, so a project relying on one
+ * remotely has no integration rather than a degraded one — the CLI is the form
+ * that survives the trip.
+ * @param {object|null} mcp Parsed .mcp.json.
+ * @returns {Map<string, string>} Tool name to the server that implies it.
+ */
+export function toolsFromMcp(mcp) {
+  const found = new Map();
+  const servers = Object.keys(mcp?.mcpServers ?? {});
+  for (const [tool, meta] of Object.entries(KNOWN_TOOLS)) {
+    if (!meta.mcpFallback) continue;
+    const server = servers.find(name => name.includes(meta.mcpFallback));
+    if (server) {
+      found.set(
+        tool,
+        `MCP server "${server}" (browser OAuth cannot run remotely)`
+      );
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools named in credential usage notes.
+ *
+ * A note explaining what a token is *for* usually names the program that
+ * consumes it, and those notes are already readable without touching a value —
+ * `read-secret-note.mjs` exists precisely so an agent can learn a credential's
+ * blast radius safely. That makes them a first-class detection input rather than
+ * a clever trick.
+ * @param {object|null} notes Parsed secret-notes.json.
+ * @returns {Map<string, string>} Tool name to the credential that names it.
+ */
+export function toolsFromSecretNotes(notes) {
+  const found = new Map();
+  const entries = Object.entries(notes?.notes ?? notes ?? {});
+  for (const [secret, note] of entries) {
+    const text = typeof note === "string" ? note : JSON.stringify(note ?? "");
+    for (const tool of Object.keys(KNOWN_TOOLS)) {
+      const pattern = new RegExp(
+        `(^|[^A-Za-z0-9-])${tool}([^A-Za-z0-9-]|$)`,
+        "iu"
+      );
+      if (pattern.test(text) && !found.has(tool)) {
+        found.set(tool, `usage note on credential "${secret}"`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools implied by quality configuration.
+ * @param {object|null} config Parsed .lisa.config.json.
+ * @returns {Map<string, string>} Tool name to the setting that implies it.
+ */
+export function toolsFromQuality(config) {
+  const found = new Map();
+  if (config?.quality?.e2eCoverage?.playwright) {
+    found.set("playwright", "quality.e2eCoverage.playwright is configured");
+  }
+  if (config?.quality?.sonar || config?.sonar) {
+    found.set("sonar-scanner", "Sonar analysis is configured");
+  }
+  return found;
+}
+
+/**
+ * Everything already declared, by name, so proposals exclude them.
+ * @param {object|null} config Parsed .lisa.config.json.
+ * @returns {Set<string>} Declared tool names.
+ */
+export function declaredTools(config) {
+  const tools = config?.remoteEnv?.tools ?? {};
+  return new Set(
+    [...(tools.require ?? []), ...(tools.install ?? [])].map(t => t.name)
+  );
+}
+
+/**
+ * Collect every signal and subtract what the manifest already covers.
+ * @param {string} [cwd] Project root.
+ * @returns {Array<{name: string, why: string, evidence: string[]}>} Proposals.
+ */
+export function detectTooling(cwd = process.cwd()) {
+  const config = readJson(join(cwd, ".lisa.config.json"));
+  const pkg = readJson(join(cwd, "package.json"));
+  const mcp = readJson(join(cwd, ".mcp.json"));
+  const notes = readJson(join(cwd, ".lisa", "secret-notes.json"));
+
+  const declared = declaredTools(config);
+  const signals = [
+    toolsFromScripts(pkg),
+    toolsFromMcp(mcp),
+    toolsFromSecretNotes(notes),
+    toolsFromQuality(config),
+  ];
+
+  const merged = new Map();
+  for (const signal of signals) {
+    for (const [tool, evidence] of signal) {
+      if (declared.has(tool)) continue;
+      const entry = merged.get(tool) ?? { evidence: [] };
+      entry.evidence.push(evidence);
+      merged.set(tool, entry);
+    }
+  }
+
+  return [...merged.entries()]
+    .map(([name, entry]) => ({
+      name,
+      why: KNOWN_TOOLS[name]?.why ?? "",
+      evidence: entry.evidence,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * A manifest entry an operator can paste, with the parts only they can supply.
+ * @param {{name: string}} proposal One detected tool.
+ * @returns {object} A `remoteEnv.tools.install` skeleton.
+ */
+export function proposedEntry(proposal) {
+  const viaNpm = KNOWN_TOOLS[proposal.name]?.viaNpm;
+  return viaNpm
+    ? {
+        name: proposal.name,
+        install: "npm-global",
+        package: viaNpm,
+        version: "<pin>",
+      }
+    : {
+        name: proposal.name,
+        version: "<pin>",
+        install: "release-tar",
+        url: "<release url for this exact version>",
+        sha256: "<sha256 published with that release>",
+        surfaces: ["remote"],
+      };
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  const proposals = detectTooling();
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(proposals, null, 2));
+  } else if (proposals.length === 0) {
+    console.log(
+      "Every tool this project appears to use is already declared in remoteEnv.tools."
+    );
+  } else {
+    console.log(
+      `${proposals.length} tool(s) look required but are not declared:\n`
+    );
+    for (const proposal of proposals) {
+      console.log(`  ${proposal.name}`);
+      console.log(`    why: ${proposal.why}`);
+      for (const evidence of proposal.evidence) {
+        console.log(`    evidence: ${evidence}`);
+      }
+      console.log(`    proposed: ${JSON.stringify(proposedEntry(proposal))}\n`);
+    }
+    console.log(
+      "Nothing has been written or installed. Confirm each entry, supply the\n" +
+        "pin and checksum, and add it to remoteEnv.tools in .lisa.config.json."
+    );
+  }
+}

--- a/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -174,10 +174,22 @@ export function toolsFromQuality(config) {
  * @param {object|null} config Parsed .lisa.config.json.
  * @returns {Set<string>} Declared tool names.
  */
-export function declaredTools(config) {
+export function declaredTools(config, surface = "remote") {
   const tools = config?.remoteEnv?.tools ?? {};
+  const applies = tool => {
+    const surfaces = tool.surfaces;
+    if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+    return surfaces.includes(surface);
+  };
+  // Filtered by surface, because a declaration that applies somewhere else is
+  // not coverage here. A local-only `require` entry would otherwise suppress
+  // the proposal for a tool genuinely missing from the remote manifest — the
+  // detector reporting "already declared" about the one surface where it is
+  // not.
   return new Set(
-    [...(tools.require ?? []), ...(tools.install ?? [])].map(t => t.name)
+    [...(tools.require ?? []), ...(tools.install ?? [])]
+      .filter(applies)
+      .map(tool => tool.name)
   );
 }
 
@@ -220,27 +232,48 @@ export function detectTooling(cwd = process.cwd()) {
 }
 
 /**
- * A manifest entry an operator can paste, with the parts only they can supply.
+ * The manifest entries an operator can paste, with the parts only they supply.
+ *
+ * Returns both lists because a platform-specific archive needs both: an
+ * `install` entry for the surface it is built for, and a `require` entry so the
+ * other surface still asserts the tool instead of silently ignoring it.
  * @param {{name: string}} proposal One detected tool.
- * @returns {object} A `remoteEnv.tools.install` skeleton.
+ * @returns {{install: object[], require: object[]}} Manifest skeletons.
  */
-export function proposedEntry(proposal) {
+export function proposedEntries(proposal) {
   const viaNpm = KNOWN_TOOLS[proposal.name]?.viaNpm;
-  return viaNpm
-    ? {
-        name: proposal.name,
-        install: "npm-global",
-        package: viaNpm,
-        version: "<pin>",
-      }
-    : {
+  if (viaNpm) {
+    // npm resolves per platform, so one entry serves every surface.
+    return {
+      install: [
+        {
+          name: proposal.name,
+          install: "npm-global",
+          package: viaNpm,
+          version: "<pin>",
+        },
+      ],
+      require: [],
+    };
+  }
+  // A release archive is built for one platform, so it is proposed as
+  // remote-install plus a local `require`. Proposing only the install entry
+  // produced a manifest that either offered a Linux binary to a laptop or —
+  // once narrowed to remote — stopped checking for the tool locally at all.
+  // Both halves or neither.
+  return {
+    install: [
+      {
         name: proposal.name,
         version: "<pin>",
         install: "release-tar",
-        url: "<release url for this exact version>",
+        url: "<release url for this exact version, for the remote platform>",
         sha256: "<sha256 published with that release>",
         surfaces: ["remote"],
-      };
+      },
+    ],
+    require: [{ name: proposal.name, surfaces: ["local"] }],
+  };
 }
 
 if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
@@ -261,7 +294,14 @@ if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
       for (const evidence of proposal.evidence) {
         console.log(`    evidence: ${evidence}`);
       }
-      console.log(`    proposed: ${JSON.stringify(proposedEntry(proposal))}\n`);
+      const entries = proposedEntries(proposal);
+      for (const entry of entries.install) {
+        console.log(`    tools.install: ${JSON.stringify(entry)}`);
+      }
+      for (const entry of entries.require) {
+        console.log(`    tools.require: ${JSON.stringify(entry)}`);
+      }
+      console.log("");
     }
     console.log(
       "Nothing has been written or installed. Confirm each entry, supply the\n" +

--- a/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
@@ -87,6 +87,14 @@ bash scripts/lisa-remote-env/session-start.sh   # guard; delegates to --phase=se
 
 The selection comes from the surface's `materializeAt` capability in `lisa-secrets-access`, not from its name, so adding a surface does not mean editing a branch. The hook is committed to the repository, so it also fires on a developer's machine — it exits `0` immediately there rather than failing, because a correct local session must not look broken.
 
+## Detect before you provision
+
+Run `/lisa:detect-tooling` first, every time. The manifest is the only thing that puts a binary on `PATH`, and nothing populates it — so a project ships npm scripts invoking `maestro`, wires an MCP server whose CLI it also shells out to, and configures Playwright thresholds, while `remoteEnv.tools` stays empty and each of those fails at the moment of use instead of at setup.
+
+This repository has paid for that twice: `gh` was declared nowhere and a cloud session could not commit anything; `tar` was needed by an install method and asserted by nothing.
+
+The detector proposes and a human decides. It writes nothing, so provisioning still only ever happens from a reviewed, pinned, checksummed entry.
+
 ## Toolchain manifest — two entry kinds
 
 ```json
@@ -165,9 +173,9 @@ Because `release-tar` unpacks with `tar` rather than `unzip`, a project using it
 - **Prefer what is there.** A second Node beside the image's creates PATH ambiguity and wastes container time.
 - **Pin and checksum together, in one reviewed commit.** A version bump that does not move the checksum fails before installation, not after. An archive is verified *before* it is unpacked, so unexpected contents never reach a directory on PATH.
 
-## Tooling is never derived from secret notes
+## Tooling is never *authorised* by secret notes
 
-Deliberately rejected:
+Deliberately rejected — notes may not cause an install:
 
 - Most tooling has **no credential** — `jq`, ripgrep, browsers, a linter — so notes could only ever cover a subset, and a second mechanism would be needed anyway.
 - Most credentials **imply no tool**: a webhook is curl'd, a REST key needs no CLI.
@@ -176,6 +184,14 @@ Deliberately rejected:
 - It is a **supply-chain path** — provider write access would become arbitrary install access.
 
 **Notes are an assertion target instead.** At verify time, a tool that declares a credential which is not materialized is an **error**; a credential materialized with no declared consumer is a **warning**. The arrow points the safe way: the repository declares intent, and the provider is checked against it.
+
+### Reading a note as *evidence* is a different act
+
+`lisa-detect-tooling` does read notes, and this section is why it may. Every objection above is an objection to a note **causing** something: authorising an install, being the sole source, deciding a version. None of that changes.
+
+What the detector produces is a proposal with `<pin>`, `<release url>` and `<sha256>` left blank, printed for a human. It cannot install, cannot write config, and its output is inert until someone commits a pinned, checksummed entry that `assertPinned` then enforces. Provider write access therefore buys an attacker one line of text in a proposal a human reads — not arbitrary install access, which is the specific escalation this section exists to block.
+
+The other objections stay true and stay unfixed: most tooling has no credential and most credentials imply no tool, so notes are one signal among four and the weakest of them. They are read *after* npm scripts and MCP servers, and a note alone should be the least persuasive reason to add anything.
 
 ## Provisioning tiers
 

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -221,8 +221,9 @@ function installTool(tool, binDir) {
  * @param {boolean} dryRun Whether to plan only.
  * @returns {Array<object>} The plan that was applied.
  */
-function applyToolchain(tools, dryRun) {
-  const plan = planToolchain(tools, probe);
+function applyToolchain(tools, dryRun, options = {}) {
+  const { surface = "remote", consent = true } = options;
+  const plan = planToolchain(tools, probe, surface);
   const blocked = plan.filter(
     p => p.action === "missing" || p.action === "invalid"
   );
@@ -233,6 +234,34 @@ function applyToolchain(tools, dryRun) {
   const binDir = join(process.env.HOME ?? "", ".local", "bin");
   mkdirSync(binDir, { recursive: true, mode: 0o755 });
   const byName = new Map((tools.install ?? []).map(t => [t.name, t]));
+
+  // Installing is a different act on a laptop than in a container. A container
+  // is disposable and provisioning it silently is the whole point; a developer
+  // machine belongs to a person, and putting pinned binaries in their
+  // ~/.local/bin without being asked is not ours to decide. So the same
+  // manifest drives both, and only the consent differs.
+  //
+  // Reporting still happens either way — knowing the machine diverges from what
+  // the project declares is most of the value, and is what nothing did before.
+  if (!consent) {
+    const missing = plan.filter(step => step.action === "install");
+    if (missing.length === 0) {
+      console.log("  every declared tool is already present");
+      return plan;
+    }
+    console.log(
+      `  ${missing.length} declared tool(s) are missing or below their pin:`
+    );
+    for (const step of missing) {
+      const tool = byName.get(step.name);
+      console.log(`    ${step.name}${tool?.version ? ` ${tool.version}` : ""}`);
+    }
+    console.log(
+      "\n  Not installing without confirmation. Re-run with --install-tools\n" +
+        "  to provision them, or install them yourself."
+    );
+    return plan;
+  }
 
   // Installing a binary somewhere nothing looks is the same as not installing
   // it. `~/.local/bin` is on PATH by default on a developer workstation and is
@@ -641,7 +670,14 @@ async function main() {
 
   if (phases.includes("toolchain")) {
     console.log("Toolchain:");
-    applyToolchain(cfg.tools, dryRun);
+    // A remote container consents by construction: it is disposable, nobody is
+    // watching, and provisioning it is why the script exists. Locally the
+    // operator opts in per run.
+    const remote = Boolean(materializeAt);
+    applyToolchain(cfg.tools, dryRun, {
+      surface: remote ? "remote" : "local",
+      consent: remote || process.argv.includes("--install-tools"),
+    });
   }
 
   if (phases.includes("secrets")) {

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -556,6 +556,40 @@ export function emitClaudeWeb({ bootstrapKey }) {
 }
 
 /**
+ * Report tooling the project appears to need but has not declared.
+ *
+ * Called before the toolchain is applied, because the manifest is the only
+ * thing that puts a binary on PATH and nothing populates it — so provisioning
+ * "the declared toolchain" happily succeeds while the tool a project actually
+ * uses is absent, and fails later at the moment of use instead of here.
+ *
+ * Informational, never blocking. The detector proposes and a human decides, so
+ * an undeclared tool must not stop a setup that was asked to provision what IS
+ * declared; failing here would make a advisory signal into a gate nobody chose.
+ * Its own absence is silent for the same reason: an older installed copy of the
+ * skills has no detector, and that is not a reason to refuse to provision.
+ * @param {Function} [exec] Seam for tests.
+ */
+function reportUndeclaredTooling(exec = execFileSync) {
+  let script;
+  try {
+    script = siblingScript("lisa-detect-tooling", "detect-tooling.mjs");
+  } catch {
+    return;
+  }
+  try {
+    const out = exec("node", [script], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const text = String(out).trim();
+    if (text) console.log(`\n${text}\n`);
+  } catch {
+    // A detector that cannot run is a missing hint, not a failed setup.
+  }
+}
+
+/**
  * Decide which phases this invocation runs.
  *
  * An explicit `--phase` always wins, because that is how a session-start hook
@@ -669,6 +703,7 @@ async function main() {
   }
 
   if (phases.includes("toolchain")) {
+    reportUndeclaredTooling();
     console.log("Toolchain:");
     // A remote container consents by construction: it is disposable, nobody is
     // watching, and provisioning it is why the script exists. Locally the

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -124,6 +124,9 @@ function planInstallable(tool, found) {
   };
 }
 
+/** Surfaces a manifest entry may name. */
+const KNOWN_SURFACES = new Set(["local", "remote"]);
+
 /**
  * Whether a manifest entry applies to the surface being provisioned.
  *
@@ -143,7 +146,26 @@ function planInstallable(tool, found) {
  */
 export function appliesToSurface(tool, surface) {
   const surfaces = tool.surfaces;
-  if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+  if (surfaces === undefined) return true;
+  // A typo must not silently widen scope. Treating any non-array as "omitted"
+  // meant `surfaces: "remote"` — an easy thing to write — quietly applied the
+  // entry to every surface, which for a platform-specific archive means
+  // offering a Linux binary to a laptop. Absent means everywhere; malformed
+  // means stop.
+  if (!Array.isArray(surfaces)) {
+    throw new Error(
+      `${tool.name}: surfaces must be an array, got ${typeof surfaces}.\n` +
+        `Omit it to mean every surface; write ["remote"] or ["local"] to narrow.`
+    );
+  }
+  if (surfaces.length === 0) return true;
+  const unknown = surfaces.filter(entry => !KNOWN_SURFACES.has(entry));
+  if (unknown.length > 0) {
+    throw new Error(
+      `${tool.name}: unknown surface(s) ${unknown.join(", ")}.\n` +
+        `Known: ${[...KNOWN_SURFACES].join(", ")}.`
+    );
+  }
   return surfaces.includes(surface);
 }
 

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -125,17 +125,42 @@ function planInstallable(tool, found) {
 }
 
 /**
+ * Whether a manifest entry applies to the surface being provisioned.
+ *
+ * One declaration per tool, not one block per surface. Most tools a project
+ * needs are needed *everywhere* — a Maestro or Sonar CLI is as required on a
+ * laptop as in a container — and duplicated blocks drift, which this repository
+ * has paid for more than once. What actually differs between surfaces is the
+ * install method and, more importantly, consent: a disposable container may
+ * install silently, a developer's machine may not.
+ *
+ * Omitting `surfaces` means every surface, because that is true of most tools
+ * and the failure of forgetting it should be "checked somewhere unnecessary"
+ * rather than "silently absent where it was needed".
+ * @param {object} tool Manifest entry.
+ * @param {string} surface Surface being provisioned.
+ * @returns {boolean} Whether this entry applies.
+ */
+export function appliesToSurface(tool, surface) {
+  const surfaces = tool.surfaces;
+  if (!Array.isArray(surfaces) || surfaces.length === 0) return true;
+  return surfaces.includes(surface);
+}
+
+/**
  * Produce the complete plan for a toolchain manifest.
  * @param {{require?: object[], install?: object[]}} tools Manifest.
  * @param {(name: string) => {version: string|null, present: boolean}} probe Version probe.
  * @returns {Array<{name: string, action: string, reason: string}>} Ordered decisions.
  */
-export function planToolchain(tools, probe) {
+export function planToolchain(tools, probe, surface = "remote") {
   const plan = [];
   for (const tool of tools.require ?? [])
-    plan.push(planRequired(tool, probe(tool.name)));
+    if (appliesToSurface(tool, surface))
+      plan.push(planRequired(tool, probe(tool.name)));
   for (const tool of tools.install ?? [])
-    plan.push(planInstallable(tool, probe(tool.name)));
+    if (appliesToSurface(tool, surface))
+      plan.push(planInstallable(tool, probe(tool.name)));
   return plan;
 }
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -456,6 +456,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "b254a4264b25c6436a39035e72c5d53bdc219a6d612be5ee44d054d5f0bac205",
     "plugins/src/base/commands/debrief/apply.md":
       "2c31e0eb000c742be4dd8d5ee0ee64b1f0736389bcaa4202fc05c6b31602aab8",
+    "plugins/src/base/commands/detect-tooling.md":
+      "3e0b2b71b3049b76743822558ecf69102289bdb4578f7c42036c80df88afeb2b",
     "plugins/src/base/commands/doctor.md":
       "308132cc6b34fbc33d01b0cb1a529b413efedc1c80579c61f42801e49eaa0449",
     "plugins/src/base/commands/exploratory-qa.md":
@@ -846,6 +848,10 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "47e4cda36b07994ff47ab15fb04a17dd6b0c310ad804f9cae9d69637edaaa72a",
     "plugins/src/base/skills/lisa-delivery-effectiveness/SKILL.md":
       "21bc55fa0e86a9694bd22269fd089dbfae0c54c199262f46a4955447acea0f35",
+    "plugins/src/base/skills/lisa-detect-tooling/SKILL.md":
+      "107f92e48d78d4ec707fdc3ac84862a30d5e6bf8b5d9c64a953648a36cbabb47",
+    "plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs":
+      "f3cc865fbc88755bcf83bb8cc8dc94dda97321ede7ee6265c4021b57c610a75c",
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
       "fb41a1e63c5332d47a46e715aff52551f3df867033b5e4f37dfaeee30019b891",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
@@ -1127,15 +1133,15 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md":
       "80fbf157f9c562c033886c25a99b37356602edd9e61cd2d492f339769ddcf97e",
     "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md":
-      "821f9f7db39259c3aef24dc369c7cdcfb55a85d61742b32ac2a961e1b3e263a4",
+      "77a537460aaa1a7f9da74128161d24fa3bf758ae1fec6f6dcbc47bde9f078750",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh":
       "cb63d08b14ab7aa2d405e6770e0cf7db5d6588ae1dcb924ea6224b026fcff496",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "c04afb1cf8e14a2713645228e679fa7772559488330a240ec0297cae6afd03e2",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "1f451881342364d086640b59914a3b07286a3734caa63f01efe64531d3bde7e4",
+      "ef2a9de46233315f382f5ad74b6dbcd81eb50223abbe335d449b4fdff8db5794",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
-      "8822af39d0251a2e4fb0eac9157ba9e63ea813d914240ca0cacacd6cb7cbb5bb",
+      "3e523c7056746fabb127b5b0942d3512eb6d77eb0261eb7273ada96633204e65",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
       "82bc2a27a0a5afb2ff413a88365c619fd7f0eaada5de3ccabf2000938f0607a4",
     "plugins/src/base/skills/lisa-setup-sonar/SKILL.md":
@@ -3033,6 +3039,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-agy/commands/lisa/cross-pollinate.md": true,
     "plugins/lisa-agy/commands/lisa/debrief.md": true,
     "plugins/lisa-agy/commands/lisa/debrief/apply.md": true,
+    "plugins/lisa-agy/commands/lisa/detect-tooling.md": true,
     "plugins/lisa-agy/commands/lisa/doctor.md": true,
     "plugins/lisa-agy/commands/lisa/exploratory-qa.md": true,
     "plugins/lisa-agy/commands/lisa/fix/linter-error.md": true,
@@ -3138,6 +3145,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-agy/skills/lisa-debrief-apply/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-debrief/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-delivery-effectiveness/SKILL.md": true,
+    "plugins/lisa-agy/skills/lisa-detect-tooling/SKILL.md": true,
+    "plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs": true,
     "plugins/lisa-agy/skills/lisa-doctor/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-epic-triage/SKILL.md": true,
@@ -3366,6 +3375,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/commands/lisa/cross-pollinate.md": true,
     "plugins/lisa-copilot/commands/lisa/debrief.md": true,
     "plugins/lisa-copilot/commands/lisa/debrief/apply.md": true,
+    "plugins/lisa-copilot/commands/lisa/detect-tooling.md": true,
     "plugins/lisa-copilot/commands/lisa/doctor.md": true,
     "plugins/lisa-copilot/commands/lisa/exploratory-qa.md": true,
     "plugins/lisa-copilot/commands/lisa/fix/linter-error.md": true,
@@ -3553,6 +3563,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/skills/lisa-debrief-apply/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-debrief/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-delivery-effectiveness/SKILL.md": true,
+    "plugins/lisa-copilot/skills/lisa-detect-tooling/SKILL.md": true,
+    "plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs": true,
     "plugins/lisa-copilot/skills/lisa-doctor/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-epic-triage/SKILL.md": true,
@@ -3766,6 +3778,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/commands/lisa/cross-pollinate.md": true,
     "plugins/lisa-cursor/commands/lisa/debrief.md": true,
     "plugins/lisa-cursor/commands/lisa/debrief/apply.md": true,
+    "plugins/lisa-cursor/commands/lisa/detect-tooling.md": true,
     "plugins/lisa-cursor/commands/lisa/doctor.md": true,
     "plugins/lisa-cursor/commands/lisa/exploratory-qa.md": true,
     "plugins/lisa-cursor/commands/lisa/fix/linter-error.md": true,
@@ -3954,6 +3967,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/skills/lisa-debrief-apply/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-debrief/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-delivery-effectiveness/SKILL.md": true,
+    "plugins/lisa-cursor/skills/lisa-detect-tooling/SKILL.md": true,
+    "plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs": true,
     "plugins/lisa-cursor/skills/lisa-doctor/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-epic-triage/SKILL.md": true,
@@ -5867,6 +5882,9 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/.codex-plugin/skills/lisa-debrief/agents/openai.yaml": true,
     "plugins/lisa/.codex-plugin/skills/lisa-delivery-effectiveness/SKILL.md": true,
     "plugins/lisa/.codex-plugin/skills/lisa-delivery-effectiveness/agents/openai.yaml": true,
+    "plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/SKILL.md": true,
+    "plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/agents/openai.yaml": true,
+    "plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs": true,
     "plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md": true,
     "plugins/lisa/.codex-plugin/skills/lisa-doctor/agents/openai.yaml": true,
     "plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md": true,
@@ -6231,6 +6249,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/commands/cross-pollinate.md": true,
     "plugins/lisa/commands/debrief.md": true,
     "plugins/lisa/commands/debrief/apply.md": true,
+    "plugins/lisa/commands/detect-tooling.md": true,
     "plugins/lisa/commands/doctor.md": true,
     "plugins/lisa/commands/exploratory-qa.md": true,
     "plugins/lisa/commands/fix/linter-error.md": true,
@@ -6444,6 +6463,9 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/skills/lisa-debrief/agents/openai.yaml": true,
     "plugins/lisa/skills/lisa-delivery-effectiveness/SKILL.md": true,
     "plugins/lisa/skills/lisa-delivery-effectiveness/agents/openai.yaml": true,
+    "plugins/lisa/skills/lisa-detect-tooling/SKILL.md": true,
+    "plugins/lisa/skills/lisa-detect-tooling/agents/openai.yaml": true,
+    "plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs": true,
     "plugins/lisa/skills/lisa-doctor/SKILL.md": true,
     "plugins/lisa/skills/lisa-doctor/agents/openai.yaml": true,
     "plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md": true,
@@ -6808,6 +6830,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/commands/cross-pollinate.md": true,
     "plugins/src/base/commands/debrief.md": true,
     "plugins/src/base/commands/debrief/apply.md": true,
+    "plugins/src/base/commands/detect-tooling.md": true,
     "plugins/src/base/commands/doctor.md": true,
     "plugins/src/base/commands/exploratory-qa.md": true,
     "plugins/src/base/commands/fix/linter-error.md": true,
@@ -7003,6 +7026,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/skills/lisa-debrief-apply/SKILL.md": true,
     "plugins/src/base/skills/lisa-debrief/SKILL.md": true,
     "plugins/src/base/skills/lisa-delivery-effectiveness/SKILL.md": true,
+    "plugins/src/base/skills/lisa-detect-tooling/SKILL.md": true,
+    "plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs": true,
     "plugins/src/base/skills/lisa-doctor/SKILL.md": true,
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md": true,
     "plugins/src/base/skills/lisa-epic-triage/SKILL.md": true,
@@ -8355,6 +8380,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/work-item-tracker-unreachable.test.ts": true,
     "tests/unit/secrets/automation-workflow.test.ts": true,
     "tests/unit/secrets/bootstrap-key-naming.test.ts": true,
+    "tests/unit/secrets/detect-tooling.test.ts": true,
     "tests/unit/secrets/doctor-secrets.test.ts": true,
     "tests/unit/secrets/remote-dispatch-claude-web.test.ts": true,
     "tests/unit/secrets/remote-dispatch.test.ts": true,
@@ -8367,6 +8393,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/remote-env-toolchain.test.ts": true,
     "tests/unit/secrets/rotation-view.test.ts": true,
     "tests/unit/secrets/secrets-access-contract.test.ts": true,
+    "tests/unit/secrets/toolchain-surfaces.test.ts": true,
     "tests/unit/secrets/validate-config.test.ts": true,
     "tests/unit/sonar/sonar-installer.test.ts": true,
     "tests/unit/standards/capture.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -849,9 +849,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-delivery-effectiveness/SKILL.md":
       "21bc55fa0e86a9694bd22269fd089dbfae0c54c199262f46a4955447acea0f35",
     "plugins/src/base/skills/lisa-detect-tooling/SKILL.md":
-      "107f92e48d78d4ec707fdc3ac84862a30d5e6bf8b5d9c64a953648a36cbabb47",
+      "e29b3b8ebc256468bb67e5d10e2ae3cb4eda9ba20dfd2e065201b00864134734",
     "plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs":
-      "f3cc865fbc88755bcf83bb8cc8dc94dda97321ede7ee6265c4021b57c610a75c",
+      "043c3f59d6a7a21a3ab4fce8ae8dc88e8650c19c5a57bba40f567c5257684747",
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
       "fb41a1e63c5332d47a46e715aff52551f3df867033b5e4f37dfaeee30019b891",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
@@ -1139,9 +1139,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "c04afb1cf8e14a2713645228e679fa7772559488330a240ec0297cae6afd03e2",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "ef2a9de46233315f382f5ad74b6dbcd81eb50223abbe335d449b4fdff8db5794",
+      "eb8017ee2eef5b5b166908e5c2fccf493af283b0a40717688033d65263cf35ce",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
-      "3e523c7056746fabb127b5b0942d3512eb6d77eb0261eb7273ada96633204e65",
+      "341e8058e1d20e7e52276007aae9ceda1504b995615cf8421c9494b60b550ef9",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
       "82bc2a27a0a5afb2ff413a88365c619fd7f0eaada5de3ccabf2000938f0607a4",
     "plugins/src/base/skills/lisa-setup-sonar/SKILL.md":

--- a/tests/unit/secrets/detect-tooling.test.ts
+++ b/tests/unit/secrets/detect-tooling.test.ts
@@ -17,8 +17,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  declaredTools,
   detectTooling,
-  proposedEntry,
+  proposedEntries,
   toolsFromMcp,
   toolsFromScripts,
   toolsFromSecretNotes,
@@ -77,29 +78,50 @@ describe("proposals", () => {
     // The boundary that keeps this from becoming a second install path. A tool
     // reaches a machine because someone reviewed a pinned entry, never because
     // a detector was confident.
-    const entry = proposedEntry({ name: "maestro" }) as Record<string, string>;
+    const [entry] = proposedEntries({ name: "maestro" }).install as Record<
+      string,
+      string
+    >[];
 
-    expect(entry.version).toBe("<pin>");
-    expect(entry.sha256).toMatch(/^</);
-    expect(entry.url).toMatch(/^</);
+    expect(entry?.version).toBe("<pin>");
+    expect(entry?.sha256).toMatch(/^</);
+    expect(entry?.url).toMatch(/^</);
   });
 
   it("proposes an npm install where the tool ships on npm", () => {
-    const entry = proposedEntry({ name: "playwright" }) as Record<
-      string,
-      string
-    >;
+    const proposal = proposedEntries({ name: "playwright" });
+    const [entry] = proposal.install as Record<string, string>[];
 
-    expect(entry.install).toBe("npm-global");
-    expect(entry.package).toBe("@playwright/test");
+    expect(entry?.install).toBe("npm-global");
+    expect(entry?.package).toBe("@playwright/test");
+    // npm resolves per platform, so no local `require` companion is needed.
+    expect(proposal.require).toHaveLength(0);
   });
 
-  it("marks a pinned archive remote-only", () => {
-    // A Linux release archive must never be offered to a laptop, which is the
-    // concrete reason `surfaces` exists rather than a second config block.
-    const entry = proposedEntry({ name: "maestro" }) as { surfaces: string[] };
+  it("pairs a remote-only archive with a local require entry", () => {
+    // A Linux release archive must never be offered to a laptop — the concrete
+    // reason `surfaces` exists. But narrowing the install to remote without a
+    // local `require` would stop checking for the tool locally at all, trading
+    // one silent gap for another. Both halves or neither.
+    const proposal = proposedEntries({ name: "maestro" });
+    const [install] = proposal.install as { surfaces: string[] }[];
+    const [required] = proposal.require as { surfaces: string[] }[];
 
-    expect(entry.surfaces).toEqual(["remote"]);
+    expect(install?.surfaces).toEqual(["remote"]);
+    expect(required?.surfaces).toEqual(["local"]);
+  });
+
+  it("does not let a local-only declaration hide a missing remote tool", () => {
+    // declaredTools() filtered by name alone, so a `require` entry scoped to
+    // local reported the tool as covered on remote, where it was absent.
+    const config = {
+      remoteEnv: {
+        tools: { require: [{ name: "maestro", surfaces: ["local"] }] },
+      },
+    };
+
+    expect([...declaredTools(config, "local")]).toContain("maestro");
+    expect([...declaredTools(config, "remote")]).not.toContain("maestro");
   });
 });
 

--- a/tests/unit/secrets/detect-tooling.test.ts
+++ b/tests/unit/secrets/detect-tooling.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Finding the tools a project needs but never declares.
+ *
+ * `remoteEnv.tools` is the only mechanism that puts a binary on `PATH`, and
+ * nothing populated it. So a project could ship npm scripts invoking `maestro`,
+ * wire an MCP server whose CLI it also shells out to, and configure Playwright
+ * thresholds, while the manifest stayed empty — and every one of those failed at
+ * the moment of use rather than at setup. This repository paid for that twice:
+ * `gh` was declared nowhere and a cloud session could not commit, and `tar` was
+ * needed by an install method and asserted by nothing.
+ *
+ * The detector's boundary is the part worth protecting: it proposes, and a
+ * human decides. An auto-writing detector would become a second, unreviewed
+ * install path, which is precisely what `assertPinned` exists to prevent.
+ * @module tests/unit/secrets/detect-tooling
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  detectTooling,
+  proposedEntry,
+  toolsFromMcp,
+  toolsFromScripts,
+  toolsFromSecretNotes,
+} from "../../../plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs";
+
+describe("signals", () => {
+  it("reads the body of an npm script, not its name", () => {
+    // A script NAMED maestro:test proves nothing; one that RUNS `maestro test`
+    // is the project stating a dependency in executable form. The Expo template
+    // ships exactly this, and nothing installs the binary.
+    const found = toolsFromScripts({
+      scripts: { "maestro:test": "maestro test .maestro/flows" },
+    });
+
+    expect([...found.keys()]).toContain("maestro");
+    expect(found.get("maestro")).toMatch(/npm script/);
+  });
+
+  it("does not fire on a script that merely mentions a tool in its name", () => {
+    const found = toolsFromScripts({
+      scripts: { "maestro:studio": "echo no" },
+    });
+
+    expect([...found.keys()]).not.toContain("maestro");
+  });
+
+  it("treats an MCP server as evidence the CLI is needed", () => {
+    // An MCP server is not a substitute for the binary: Linear authenticates by
+    // browser OAuth, which a container cannot do at all, so a remote session has
+    // no integration rather than a degraded one.
+    const found = toolsFromMcp({ mcpServers: { "linear-server": {} } });
+
+    expect([...found.keys()]).toContain("linear");
+    expect(found.get("linear")).toMatch(/OAuth/i);
+  });
+
+  it("reads a credential usage note", () => {
+    const found = toolsFromSecretNotes({
+      SONAR_TOKEN: "Used by sonar-scanner in CI. Rotate quarterly.",
+    });
+
+    expect([...found.keys()]).toContain("sonar-scanner");
+  });
+
+  it("survives a malformed config instead of throwing", () => {
+    // A detector that dies on a broken file blocks the very command someone
+    // runs to find out what is broken.
+    expect(() => toolsFromScripts(null)).not.toThrow();
+    expect(() => toolsFromMcp(null)).not.toThrow();
+    expect(() => toolsFromSecretNotes(null)).not.toThrow();
+  });
+});
+
+describe("proposals", () => {
+  it("leaves the pin and checksum for a human", () => {
+    // The boundary that keeps this from becoming a second install path. A tool
+    // reaches a machine because someone reviewed a pinned entry, never because
+    // a detector was confident.
+    const entry = proposedEntry({ name: "maestro" }) as Record<string, string>;
+
+    expect(entry.version).toBe("<pin>");
+    expect(entry.sha256).toMatch(/^</);
+    expect(entry.url).toMatch(/^</);
+  });
+
+  it("proposes an npm install where the tool ships on npm", () => {
+    const entry = proposedEntry({ name: "playwright" }) as Record<
+      string,
+      string
+    >;
+
+    expect(entry.install).toBe("npm-global");
+    expect(entry.package).toBe("@playwright/test");
+  });
+
+  it("marks a pinned archive remote-only", () => {
+    // A Linux release archive must never be offered to a laptop, which is the
+    // concrete reason `surfaces` exists rather than a second config block.
+    const entry = proposedEntry({ name: "maestro" }) as { surfaces: string[] };
+
+    expect(entry.surfaces).toEqual(["remote"]);
+  });
+});
+
+describe("against this repository", () => {
+  it("never proposes something already declared", () => {
+    // gh and bws are declared, so a detector that re-proposed them would train
+    // the reader to skim its output.
+    const names = detectTooling(process.cwd()).map(p => p.name);
+
+    expect(names).not.toContain("gh");
+    expect(names).not.toContain("bws");
+  });
+
+  it("gives evidence for everything it proposes", () => {
+    // A proposal without evidence is an assertion, and this file is the one
+    // place that must not make assertions about a machine.
+    for (const proposal of detectTooling(process.cwd())) {
+      expect(proposal.evidence.length).toBeGreaterThan(0);
+      expect(proposal.why).not.toBe("");
+    }
+  });
+});

--- a/tests/unit/secrets/toolchain-surfaces.test.ts
+++ b/tests/unit/secrets/toolchain-surfaces.test.ts
@@ -40,6 +40,18 @@ describe("one manifest, many surfaces", () => {
     expect(appliesToSurface({ name: "jq" }, "remote")).toBe(true);
   });
 
+  it("refuses a malformed surfaces value instead of widening scope", () => {
+    // Treating any non-array as "omitted" meant `surfaces: "remote"` — an easy
+    // thing to write — quietly applied to every surface, which for a
+    // platform-specific archive means offering a Linux binary to a laptop.
+    expect(() =>
+      appliesToSurface({ name: "gh", surfaces: "remote" }, "local")
+    ).toThrow(/must be an array/);
+    expect(() =>
+      appliesToSurface({ name: "gh", surfaces: ["cloud"] }, "local")
+    ).toThrow(/unknown surface/);
+  });
+
   it("honours an explicit surface list", () => {
     const tool = { name: "gh", surfaces: ["remote"] };
 
@@ -60,6 +72,9 @@ describe("one manifest, many surfaces", () => {
     // Still asserted there, so a missing tool is loud rather than discovered
     // at the moment of use.
     expect(local.map(step => step.name)).toContain("gh");
+    // bws too: asserting only one left the test passing if the other's local
+    // require entry were dropped.
+    expect(local.map(step => step.name)).toContain("bws");
   });
 
   it("still installs them remotely", () => {

--- a/tests/unit/secrets/toolchain-surfaces.test.ts
+++ b/tests/unit/secrets/toolchain-surfaces.test.ts
@@ -1,0 +1,75 @@
+/**
+ * One toolchain manifest, consumed by several surfaces.
+ *
+ * Not two config blocks. Most tools a project needs are needed everywhere — a
+ * Maestro or Sonar CLI is as required on a laptop as in a container — and
+ * duplicated blocks drift, which this repository has paid for more than once.
+ * What genuinely differs between surfaces is the install method and, above all,
+ * the consent: a disposable container may provision itself silently, a
+ * developer's machine may not.
+ * @module tests/unit/secrets/toolchain-surfaces
+ */
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  appliesToSurface,
+  planToolchain,
+} from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs";
+
+describe("one manifest, many surfaces", () => {
+  // Not two config blocks. Most tools a project needs are needed everywhere — a
+  // Maestro or Sonar CLI is as required on a laptop as in a container — and
+  // duplicated blocks drift, which this repository has paid for more than once.
+  // What differs between surfaces is the install method and the consent.
+  /**
+   *
+   */
+  /**
+   * A probe that reports every tool absent, so the plan is the manifest's
+   * decision rather than this machine's contents.
+   * @returns A uniform "not installed" result
+   */
+  const PROBE = () => ({ present: false, version: null });
+
+  it("applies an entry to every surface when none is named", () => {
+    // Forgetting `surfaces` should cost a redundant check, never a silent
+    // absence on the surface that needed it.
+    expect(appliesToSurface({ name: "jq" }, "local")).toBe(true);
+    expect(appliesToSurface({ name: "jq" }, "remote")).toBe(true);
+  });
+
+  it("honours an explicit surface list", () => {
+    const tool = { name: "gh", surfaces: ["remote"] };
+
+    expect(appliesToSurface(tool, "remote")).toBe(true);
+    expect(appliesToSurface(tool, "local")).toBe(false);
+  });
+
+  it("never offers a linux-only archive to a laptop", () => {
+    // The concrete reason this exists. Lisa pins gh and bws as Linux release
+    // archives; installing either on a developer's machine would place a
+    // binary that cannot run.
+    const cfg = JSON.parse(readFileSync(".lisa.config.json", "utf8")) as {
+      remoteEnv: { tools: Record<string, readonly Record<string, string>[]> };
+    };
+    const local = planToolchain(cfg.remoteEnv.tools, PROBE, "local");
+
+    expect(local.filter(step => step.action === "install")).toHaveLength(0);
+    // Still asserted there, so a missing tool is loud rather than discovered
+    // at the moment of use.
+    expect(local.map(step => step.name)).toContain("gh");
+  });
+
+  it("still installs them remotely", () => {
+    const cfg = JSON.parse(readFileSync(".lisa.config.json", "utf8")) as {
+      remoteEnv: { tools: Record<string, readonly Record<string, string>[]> };
+    };
+    const remote = planToolchain(cfg.remoteEnv.tools, PROBE, "remote");
+
+    expect(
+      remote.filter(step => step.action === "install").map(s => s.name)
+    ).toEqual(expect.arrayContaining(["gh", "bws"]));
+  });
+});


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2249

`remoteEnv.tools` is the only mechanism that puts a binary on `PATH`, and **nothing populated it**.

| tool | how it arrives | on PATH? |
| --- | --- | --- |
| playwright, stryker | npm devDependency from a stack template | no |
| maestro | npm **scripts** in the Expo template | **no** |
| sonar | `src/sonar/sonar-installer.ts` | no |
| linear | MCP server | no, and it needs browser OAuth |
| bws, gh | `remoteEnv.tools` — pinned, checksummed | **yes** |

So a project ships scripts invoking `maestro`, wires an MCP server whose CLI it also shells out to, and configures Playwright thresholds — while the manifest stays empty and each fails at the moment of use rather than at setup. Paid for twice already: `gh` (#2229) and `tar` (#2231).

**MCP is not a substitute for a CLI.** Linear authenticates by browser OAuth, which a container cannot perform — so a remote session relying on it has *no* integration, not a degraded one.

## `/lisa:detect-tooling`

Reads four signals — npm script **bodies**, MCP servers with a CLI equivalent, credential usage notes, quality config — subtracts what is declared, prints the rest with evidence. Run against this repository it immediately named two real gaps:

```
linear      evidence: MCP server "linear-server" (browser OAuth cannot run remotely)
playwright  evidence: quality.e2eCoverage.playwright is configured
```

**It writes nothing and installs nothing.** Proposals carry `<pin>`, `<release url>`, `<sha256>` for a human. A tool should reach a machine because someone reviewed a pinned entry, never because a detector was confident — an auto-writing detector becomes a second unreviewed install path, exactly what `assertPinned` prevents.

`lisa-setup-remote-env` now invokes it before provisioning, so the manifest is never assumed correct.

## One manifest, per-entry `surfaces`

Not a block per surface. Most tools are needed *everywhere*, duplicated blocks drift, and what genuinely differs is **consent**:

- a disposable container provisions itself silently
- locally, the toolchain phase **reports** what is missing and installs nothing without `--install-tools`

Omitting `surfaces` means everywhere, so forgetting it costs a redundant check rather than a silent absence.

Immediate use: `gh` and `bws` are Linux release archives, so they are now `surfaces: ["remote"]` with matching `require` entries for local. A laptop asserts them and is never offered a binary it cannot run — which the previous local run did try to do.

## Secret notes: narrowed, not reversed

`lisa-setup-remote-env` deliberately rejects deriving tooling from notes. **That stands** — notes may not *authorise* an install, and provider write access must never become install access.

Reading one as *evidence* for a proposal a human reviews is a different act: it buys an attacker one line of text in a proposal, not arbitrary install access. The section now says which is which, and keeps the objections that survive — most tooling has no credential, most credentials imply no tool, so notes are the weakest of the four signals.

495 files, 8381 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tooling detection command that identifies undeclared CLI tools and provides evidence-backed, pinned, checksummed configuration proposals.
  * Detection supports human-readable and JSON output without modifying files or installing tools.
  * Added platform-aware tool provisioning for local and remote environments.
* **Bug Fixes**
  * Local setup no longer installs missing tools automatically; installation requires explicit approval.
  * Remote setup continues automatic provisioning while respecting surface-specific tool requirements.
* **Documentation**
  * Clarified review, consent, and security requirements for detected tooling and secret notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->