### PR TITLE
Declare Playwright remote tooling

### DIFF
--- a/.lisa.config.json
+++ b/.lisa.config.json
@@ -204,6 +204,12 @@
           "surfaces": [
             "remote"
           ]
+        },
+        {
+          "name": "playwright",
+          "install": "npm-global",
+          "package": "@playwright/test",
+          "version": "1.62.1"
         }
       ]
     },

--- a/plugins/lisa-agy/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-detect-tooling/SKILL.md
@@ -13,7 +13,7 @@ Lisa provisions tooling through four unrelated mechanisms, and only one of them 
 | playwright, stryker | npm devDependency from a stack template | nothing — a local `node_modules` binary |
 | maestro | npm **scripts** in the Expo template | **nothing** |
 | sonar | `src/sonar/sonar-installer.ts` | nothing |
-| linear | MCP server | nothing, and it needs browser OAuth |
+| linear | MCP server or `LINEAR_API_KEY` | `lisa-linear-access`, not a CLI |
 | bws, gh | `remoteEnv.tools` — pinned and checksummed | this, and only this |
 
 Nothing populates that last row. So a project can ship scripts that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and configure Playwright thresholds, while the manifest that actually provisions binaries stays empty — and every one of those fails at the moment of use rather than at setup.
@@ -25,7 +25,7 @@ That is the same failure this repository has now paid for twice: `gh` was declar
 Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
 
 - **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
-- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one.
+- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one. Do not infer a CLI for access layers that already define their own headless substrate; Linear is handled by `lisa-linear-access` through `LINEAR_API_KEY` + GraphQL when MCP OAuth is unavailable.
 - **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
 - **Quality configuration**, where a threshold implies the tool that produces it.
 

--- a/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -99,6 +99,20 @@ export function toolsFromScripts(pkg) {
 }
 
 /**
+ * MCP servers that are access substrates rather than evidence for a CLI.
+ *
+ * Linear is the important case: Lisa's `lisa-linear-access` skill owns the
+ * headless path through `LINEAR_API_KEY` + GraphQL. There is no official Linear
+ * CLI to pin, and the unrelated `linear` npm package is not a tracker binary.
+ * Treating the MCP server as CLI evidence would push operators toward an
+ * arbitrary third-party executable instead of the access-layer contract.
+ */
+const MCP_ACCESS_LAYER_SUBSTRATES = Object.freeze({
+  "linear-server":
+    "lisa-linear-access uses LINEAR_API_KEY in headless sessions",
+});
+
+/**
  * Tools implied by MCP servers that also have a CLI.
  *
  * An MCP server is not a substitute for the binary. Several authenticate by
@@ -114,6 +128,14 @@ export function toolsFromMcp(mcp) {
   for (const [tool, meta] of Object.entries(KNOWN_TOOLS)) {
     if (!meta.mcpFallback) continue;
     const server = servers.find(name => name.includes(meta.mcpFallback));
+    if (
+      server &&
+      Object.keys(MCP_ACCESS_LAYER_SUBSTRATES).some(substrate =>
+        server.includes(substrate)
+      )
+    ) {
+      continue;
+    }
     if (server) {
       found.set(
         tool,

--- a/plugins/lisa-copilot/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-detect-tooling/SKILL.md
@@ -13,7 +13,7 @@ Lisa provisions tooling through four unrelated mechanisms, and only one of them 
 | playwright, stryker | npm devDependency from a stack template | nothing — a local `node_modules` binary |
 | maestro | npm **scripts** in the Expo template | **nothing** |
 | sonar | `src/sonar/sonar-installer.ts` | nothing |
-| linear | MCP server | nothing, and it needs browser OAuth |
+| linear | MCP server or `LINEAR_API_KEY` | `lisa-linear-access`, not a CLI |
 | bws, gh | `remoteEnv.tools` — pinned and checksummed | this, and only this |
 
 Nothing populates that last row. So a project can ship scripts that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and configure Playwright thresholds, while the manifest that actually provisions binaries stays empty — and every one of those fails at the moment of use rather than at setup.
@@ -25,7 +25,7 @@ That is the same failure this repository has now paid for twice: `gh` was declar
 Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
 
 - **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
-- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one.
+- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one. Do not infer a CLI for access layers that already define their own headless substrate; Linear is handled by `lisa-linear-access` through `LINEAR_API_KEY` + GraphQL when MCP OAuth is unavailable.
 - **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
 - **Quality configuration**, where a threshold implies the tool that produces it.
 

--- a/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -99,6 +99,20 @@ export function toolsFromScripts(pkg) {
 }
 
 /**
+ * MCP servers that are access substrates rather than evidence for a CLI.
+ *
+ * Linear is the important case: Lisa's `lisa-linear-access` skill owns the
+ * headless path through `LINEAR_API_KEY` + GraphQL. There is no official Linear
+ * CLI to pin, and the unrelated `linear` npm package is not a tracker binary.
+ * Treating the MCP server as CLI evidence would push operators toward an
+ * arbitrary third-party executable instead of the access-layer contract.
+ */
+const MCP_ACCESS_LAYER_SUBSTRATES = Object.freeze({
+  "linear-server":
+    "lisa-linear-access uses LINEAR_API_KEY in headless sessions",
+});
+
+/**
  * Tools implied by MCP servers that also have a CLI.
  *
  * An MCP server is not a substitute for the binary. Several authenticate by
@@ -114,6 +128,14 @@ export function toolsFromMcp(mcp) {
   for (const [tool, meta] of Object.entries(KNOWN_TOOLS)) {
     if (!meta.mcpFallback) continue;
     const server = servers.find(name => name.includes(meta.mcpFallback));
+    if (
+      server &&
+      Object.keys(MCP_ACCESS_LAYER_SUBSTRATES).some(substrate =>
+        server.includes(substrate)
+      )
+    ) {
+      continue;
+    }
     if (server) {
       found.set(
         tool,

--- a/plugins/lisa-cursor/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-detect-tooling/SKILL.md
@@ -13,7 +13,7 @@ Lisa provisions tooling through four unrelated mechanisms, and only one of them 
 | playwright, stryker | npm devDependency from a stack template | nothing — a local `node_modules` binary |
 | maestro | npm **scripts** in the Expo template | **nothing** |
 | sonar | `src/sonar/sonar-installer.ts` | nothing |
-| linear | MCP server | nothing, and it needs browser OAuth |
+| linear | MCP server or `LINEAR_API_KEY` | `lisa-linear-access`, not a CLI |
 | bws, gh | `remoteEnv.tools` — pinned and checksummed | this, and only this |
 
 Nothing populates that last row. So a project can ship scripts that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and configure Playwright thresholds, while the manifest that actually provisions binaries stays empty — and every one of those fails at the moment of use rather than at setup.
@@ -25,7 +25,7 @@ That is the same failure this repository has now paid for twice: `gh` was declar
 Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
 
 - **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
-- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one.
+- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one. Do not infer a CLI for access layers that already define their own headless substrate; Linear is handled by `lisa-linear-access` through `LINEAR_API_KEY` + GraphQL when MCP OAuth is unavailable.
 - **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
 - **Quality configuration**, where a threshold implies the tool that produces it.
 

--- a/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -99,6 +99,20 @@ export function toolsFromScripts(pkg) {
 }
 
 /**
+ * MCP servers that are access substrates rather than evidence for a CLI.
+ *
+ * Linear is the important case: Lisa's `lisa-linear-access` skill owns the
+ * headless path through `LINEAR_API_KEY` + GraphQL. There is no official Linear
+ * CLI to pin, and the unrelated `linear` npm package is not a tracker binary.
+ * Treating the MCP server as CLI evidence would push operators toward an
+ * arbitrary third-party executable instead of the access-layer contract.
+ */
+const MCP_ACCESS_LAYER_SUBSTRATES = Object.freeze({
+  "linear-server":
+    "lisa-linear-access uses LINEAR_API_KEY in headless sessions",
+});
+
+/**
  * Tools implied by MCP servers that also have a CLI.
  *
  * An MCP server is not a substitute for the binary. Several authenticate by
@@ -114,6 +128,14 @@ export function toolsFromMcp(mcp) {
   for (const [tool, meta] of Object.entries(KNOWN_TOOLS)) {
     if (!meta.mcpFallback) continue;
     const server = servers.find(name => name.includes(meta.mcpFallback));
+    if (
+      server &&
+      Object.keys(MCP_ACCESS_LAYER_SUBSTRATES).some(substrate =>
+        server.includes(substrate)
+      )
+    ) {
+      continue;
+    }
     if (server) {
       found.set(
         tool,

--- a/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/SKILL.md
@@ -13,7 +13,7 @@ Lisa provisions tooling through four unrelated mechanisms, and only one of them 
 | playwright, stryker | npm devDependency from a stack template | nothing — a local `node_modules` binary |
 | maestro | npm **scripts** in the Expo template | **nothing** |
 | sonar | `src/sonar/sonar-installer.ts` | nothing |
-| linear | MCP server | nothing, and it needs browser OAuth |
+| linear | MCP server or `LINEAR_API_KEY` | `lisa-linear-access`, not a CLI |
 | bws, gh | `remoteEnv.tools` — pinned and checksummed | this, and only this |
 
 Nothing populates that last row. So a project can ship scripts that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and configure Playwright thresholds, while the manifest that actually provisions binaries stays empty — and every one of those fails at the moment of use rather than at setup.
@@ -25,7 +25,7 @@ That is the same failure this repository has now paid for twice: `gh` was declar
 Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
 
 - **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
-- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one.
+- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one. Do not infer a CLI for access layers that already define their own headless substrate; Linear is handled by `lisa-linear-access` through `LINEAR_API_KEY` + GraphQL when MCP OAuth is unavailable.
 - **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
 - **Quality configuration**, where a threshold implies the tool that produces it.
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -99,6 +99,20 @@ export function toolsFromScripts(pkg) {
 }
 
 /**
+ * MCP servers that are access substrates rather than evidence for a CLI.
+ *
+ * Linear is the important case: Lisa's `lisa-linear-access` skill owns the
+ * headless path through `LINEAR_API_KEY` + GraphQL. There is no official Linear
+ * CLI to pin, and the unrelated `linear` npm package is not a tracker binary.
+ * Treating the MCP server as CLI evidence would push operators toward an
+ * arbitrary third-party executable instead of the access-layer contract.
+ */
+const MCP_ACCESS_LAYER_SUBSTRATES = Object.freeze({
+  "linear-server":
+    "lisa-linear-access uses LINEAR_API_KEY in headless sessions",
+});
+
+/**
  * Tools implied by MCP servers that also have a CLI.
  *
  * An MCP server is not a substitute for the binary. Several authenticate by
@@ -114,6 +128,14 @@ export function toolsFromMcp(mcp) {
   for (const [tool, meta] of Object.entries(KNOWN_TOOLS)) {
     if (!meta.mcpFallback) continue;
     const server = servers.find(name => name.includes(meta.mcpFallback));
+    if (
+      server &&
+      Object.keys(MCP_ACCESS_LAYER_SUBSTRATES).some(substrate =>
+        server.includes(substrate)
+      )
+    ) {
+      continue;
+    }
     if (server) {
       found.set(
         tool,

--- a/plugins/lisa/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa/skills/lisa-detect-tooling/SKILL.md
@@ -13,7 +13,7 @@ Lisa provisions tooling through four unrelated mechanisms, and only one of them 
 | playwright, stryker | npm devDependency from a stack template | nothing — a local `node_modules` binary |
 | maestro | npm **scripts** in the Expo template | **nothing** |
 | sonar | `src/sonar/sonar-installer.ts` | nothing |
-| linear | MCP server | nothing, and it needs browser OAuth |
+| linear | MCP server or `LINEAR_API_KEY` | `lisa-linear-access`, not a CLI |
 | bws, gh | `remoteEnv.tools` — pinned and checksummed | this, and only this |
 
 Nothing populates that last row. So a project can ship scripts that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and configure Playwright thresholds, while the manifest that actually provisions binaries stays empty — and every one of those fails at the moment of use rather than at setup.
@@ -25,7 +25,7 @@ That is the same failure this repository has now paid for twice: `gh` was declar
 Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
 
 - **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
-- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one.
+- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one. Do not infer a CLI for access layers that already define their own headless substrate; Linear is handled by `lisa-linear-access` through `LINEAR_API_KEY` + GraphQL when MCP OAuth is unavailable.
 - **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
 - **Quality configuration**, where a threshold implies the tool that produces it.
 

--- a/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -99,6 +99,20 @@ export function toolsFromScripts(pkg) {
 }
 
 /**
+ * MCP servers that are access substrates rather than evidence for a CLI.
+ *
+ * Linear is the important case: Lisa's `lisa-linear-access` skill owns the
+ * headless path through `LINEAR_API_KEY` + GraphQL. There is no official Linear
+ * CLI to pin, and the unrelated `linear` npm package is not a tracker binary.
+ * Treating the MCP server as CLI evidence would push operators toward an
+ * arbitrary third-party executable instead of the access-layer contract.
+ */
+const MCP_ACCESS_LAYER_SUBSTRATES = Object.freeze({
+  "linear-server":
+    "lisa-linear-access uses LINEAR_API_KEY in headless sessions",
+});
+
+/**
  * Tools implied by MCP servers that also have a CLI.
  *
  * An MCP server is not a substitute for the binary. Several authenticate by
@@ -114,6 +128,14 @@ export function toolsFromMcp(mcp) {
   for (const [tool, meta] of Object.entries(KNOWN_TOOLS)) {
     if (!meta.mcpFallback) continue;
     const server = servers.find(name => name.includes(meta.mcpFallback));
+    if (
+      server &&
+      Object.keys(MCP_ACCESS_LAYER_SUBSTRATES).some(substrate =>
+        server.includes(substrate)
+      )
+    ) {
+      continue;
+    }
     if (server) {
       found.set(
         tool,

--- a/plugins/src/base/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/src/base/skills/lisa-detect-tooling/SKILL.md
@@ -13,7 +13,7 @@ Lisa provisions tooling through four unrelated mechanisms, and only one of them 
 | playwright, stryker | npm devDependency from a stack template | nothing — a local `node_modules` binary |
 | maestro | npm **scripts** in the Expo template | **nothing** |
 | sonar | `src/sonar/sonar-installer.ts` | nothing |
-| linear | MCP server | nothing, and it needs browser OAuth |
+| linear | MCP server or `LINEAR_API_KEY` | `lisa-linear-access`, not a CLI |
 | bws, gh | `remoteEnv.tools` — pinned and checksummed | this, and only this |
 
 Nothing populates that last row. So a project can ship scripts that invoke `maestro`, wire an MCP server whose CLI it also shells out to, and configure Playwright thresholds, while the manifest that actually provisions binaries stays empty — and every one of those fails at the moment of use rather than at setup.
@@ -25,7 +25,7 @@ That is the same failure this repository has now paid for twice: `gh` was declar
 Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
 
 - **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
-- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one.
+- **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one. Do not infer a CLI for access layers that already define their own headless substrate; Linear is handled by `lisa-linear-access` through `LINEAR_API_KEY` + GraphQL when MCP OAuth is unavailable.
 - **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
 - **Quality configuration**, where a threshold implies the tool that produces it.
 

--- a/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -99,6 +99,20 @@ export function toolsFromScripts(pkg) {
 }
 
 /**
+ * MCP servers that are access substrates rather than evidence for a CLI.
+ *
+ * Linear is the important case: Lisa's `lisa-linear-access` skill owns the
+ * headless path through `LINEAR_API_KEY` + GraphQL. There is no official Linear
+ * CLI to pin, and the unrelated `linear` npm package is not a tracker binary.
+ * Treating the MCP server as CLI evidence would push operators toward an
+ * arbitrary third-party executable instead of the access-layer contract.
+ */
+const MCP_ACCESS_LAYER_SUBSTRATES = Object.freeze({
+  "linear-server":
+    "lisa-linear-access uses LINEAR_API_KEY in headless sessions",
+});
+
+/**
  * Tools implied by MCP servers that also have a CLI.
  *
  * An MCP server is not a substitute for the binary. Several authenticate by
@@ -114,6 +128,14 @@ export function toolsFromMcp(mcp) {
   for (const [tool, meta] of Object.entries(KNOWN_TOOLS)) {
     if (!meta.mcpFallback) continue;
     const server = servers.find(name => name.includes(meta.mcpFallback));
+    if (
+      server &&
+      Object.keys(MCP_ACCESS_LAYER_SUBSTRATES).some(substrate =>
+        server.includes(substrate)
+      )
+    ) {
+      continue;
+    }
     if (server) {
       found.set(
         tool,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -849,9 +849,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-delivery-effectiveness/SKILL.md":
       "21bc55fa0e86a9694bd22269fd089dbfae0c54c199262f46a4955447acea0f35",
     "plugins/src/base/skills/lisa-detect-tooling/SKILL.md":
-      "e29b3b8ebc256468bb67e5d10e2ae3cb4eda9ba20dfd2e065201b00864134734",
+      "1778a009d06099b3bd2d9a33b37bec34836b295e21fad220ae926491d3557208",
     "plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs":
-      "043c3f59d6a7a21a3ab4fce8ae8dc88e8650c19c5a57bba40f567c5257684747",
+      "90086ca11dafb5250ee930fa78fd3cc7d4bd601ad57f3e3c1a49920f7d7a1493",
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
       "fb41a1e63c5332d47a46e715aff52551f3df867033b5e4f37dfaeee30019b891",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":

--- a/tests/unit/secrets/detect-tooling.test.ts
+++ b/tests/unit/secrets/detect-tooling.test.ts
@@ -46,14 +46,13 @@ describe("signals", () => {
     expect([...found.keys()]).not.toContain("maestro");
   });
 
-  it("treats an MCP server as evidence the CLI is needed", () => {
-    // An MCP server is not a substitute for the binary: Linear authenticates by
-    // browser OAuth, which a container cannot do at all, so a remote session has
-    // no integration rather than a degraded one.
+  it("does not invent a Linear CLI when the access layer owns headless auth", () => {
+    // Linear's headless substrate is LINEAR_API_KEY through lisa-linear-access.
+    // There is no official Linear CLI to pin; turning MCP into CLI evidence
+    // would make the detector propose an arbitrary third-party binary.
     const found = toolsFromMcp({ mcpServers: { "linear-server": {} } });
 
-    expect([...found.keys()]).toContain("linear");
-    expect(found.get("linear")).toMatch(/OAuth/i);
+    expect([...found.keys()]).not.toContain("linear");
   });
 
   it("reads a credential usage note", () => {
@@ -127,12 +126,14 @@ describe("proposals", () => {
 
 describe("against this repository", () => {
   it("never proposes something already declared", () => {
-    // gh and bws are declared, so a detector that re-proposed them would train
-    // the reader to skim its output.
+    // gh, bws, and Playwright are declared, so a detector that re-proposed them
+    // would train the reader to skim its output.
     const names = detectTooling(process.cwd()).map(p => p.name);
 
     expect(names).not.toContain("gh");
     expect(names).not.toContain("bws");
+    expect(names).not.toContain("playwright");
+    expect(names).not.toContain("linear");
   });
 
   it("gives evidence for everything it proposes", () => {

--- a/tests/unit/secrets/toolchain-surfaces.test.ts
+++ b/tests/unit/secrets/toolchain-surfaces.test.ts
@@ -68,7 +68,11 @@ describe("one manifest, many surfaces", () => {
     };
     const local = planToolchain(cfg.remoteEnv.tools, PROBE, "local");
 
-    expect(local.filter(step => step.action === "install")).toHaveLength(0);
+    expect(
+      local.filter(
+        step => step.action === "install" && ["gh", "bws"].includes(step.name)
+      )
+    ).toHaveLength(0);
     // Still asserted there, so a missing tool is loud rather than discovered
     // at the moment of use.
     expect(local.map(step => step.name)).toContain("gh");


### PR DESCRIPTION
## Summary
- pin Playwright as a global npm tool in `remoteEnv.tools.install`
- keep Linear on the existing `lisa-linear-access` headless substrate instead of inventing a CLI install
- update the detector, generated plugin copies, tests, and upstream evidence manifest

## Verification
- `bun test tests/unit/secrets/detect-tooling.test.ts tests/unit/secrets/remote-env-toolchain.test.ts tests/unit/secrets/toolchain-surfaces.test.ts tests/unit/secrets/validate-config.test.ts`
- `bun run check:plugins`
- `bun run check:upstream-evidence-manifest`
- `bun plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs .`
- pre-push: typecheck, security audit, slow lint, knip, full unit coverage, integration tests, plugin parity

Work-Item: CodySwannGT/lisa#2251


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Playwright support for remote testing environments.
  * Improved Linear access detection, including API-key and GraphQL fallback handling.

* **Bug Fixes**
  * Prevented Linear MCP configuration from incorrectly triggering a separate CLI installation recommendation.
  * Avoided unnecessary installation suggestions for Playwright, GitHub CLI, and Bitwarden Secrets Manager.

* **Tests**
  * Updated tooling detection coverage for the revised recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->