### PR TITLE
Surface every e2e runner, and skip what npm already provides

### DIFF
--- a/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -205,8 +205,16 @@ export function toolsFromSecretNotes(notes) {
  */
 export function toolsFromQuality(config) {
   const found = new Map();
-  if (config?.quality?.e2eCoverage?.playwright) {
-    found.set("playwright", "quality.e2eCoverage.playwright is configured");
+  // Every runner under e2eCoverage, not a hardcoded one. Naming `playwright`
+  // explicitly meant `quality.e2eCoverage.maestro` — configured in this very
+  // repository — produced no signal at all, so the one tool that genuinely
+  // needs a pinned binary and genuinely was not declared stayed invisible to
+  // the detector built to find it. A gate that reports "nothing outstanding"
+  // while the gap is right there is worse than no gate.
+  for (const runner of Object.keys(config?.quality?.e2eCoverage ?? {})) {
+    if (Object.hasOwn(KNOWN_TOOLS, runner)) {
+      found.set(runner, `quality.e2eCoverage.${runner} is configured`);
+    }
   }
   if (config?.quality?.sonar || config?.sonar) {
     found.set("sonar-scanner", "Sonar analysis is configured");
@@ -239,6 +247,32 @@ export function declaredTools(config, surface = "remote") {
 }
 
 /**
+ * Whether a tool already reaches this project as an npm dependency.
+ *
+ * A package that declares `@playwright/test` gets the `playwright` binary in
+ * `node_modules/.bin`, and its npm scripts resolve it from there. It never
+ * needs to be on PATH, so proposing a manifest entry for it is noise — and
+ * noise is how a detector teaches people to skim it, which is the one failure
+ * this skill's own documentation warns about.
+ *
+ * Only the CLI is covered by this. Anything else the tool needs at runtime —
+ * Playwright's browsers, for instance — is a separate concern that a package
+ * manager does not solve and this function does not claim to.
+ * @param {object|null} pkg Parsed package.json.
+ * @param {string} tool Tool name.
+ * @returns {boolean} Whether npm already provides the binary.
+ */
+export function satisfiedByNpm(pkg, tool) {
+  const viaNpm = KNOWN_TOOLS[tool]?.viaNpm;
+  if (!viaNpm) return false;
+  const declared = {
+    ...(pkg?.dependencies ?? {}),
+    ...(pkg?.devDependencies ?? {}),
+  };
+  return Object.hasOwn(declared, viaNpm);
+}
+
+/**
  * Collect every signal and subtract what the manifest already covers.
  * @param {string} [cwd] Project root.
  * @returns {Array<{name: string, why: string, evidence: string[]}>} Proposals.
@@ -261,6 +295,8 @@ export function detectTooling(cwd = process.cwd()) {
   for (const signal of signals) {
     for (const [tool, evidence] of signal) {
       if (declared.has(tool)) continue;
+      // Already provided by the package manager, so there is nothing to pin.
+      if (satisfiedByNpm(pkg, tool)) continue;
       const entry = merged.get(tool) ?? { evidence: [] };
       entry.evidence.push(evidence);
       merged.set(tool, entry);

--- a/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -205,8 +205,16 @@ export function toolsFromSecretNotes(notes) {
  */
 export function toolsFromQuality(config) {
   const found = new Map();
-  if (config?.quality?.e2eCoverage?.playwright) {
-    found.set("playwright", "quality.e2eCoverage.playwright is configured");
+  // Every runner under e2eCoverage, not a hardcoded one. Naming `playwright`
+  // explicitly meant `quality.e2eCoverage.maestro` — configured in this very
+  // repository — produced no signal at all, so the one tool that genuinely
+  // needs a pinned binary and genuinely was not declared stayed invisible to
+  // the detector built to find it. A gate that reports "nothing outstanding"
+  // while the gap is right there is worse than no gate.
+  for (const runner of Object.keys(config?.quality?.e2eCoverage ?? {})) {
+    if (Object.hasOwn(KNOWN_TOOLS, runner)) {
+      found.set(runner, `quality.e2eCoverage.${runner} is configured`);
+    }
   }
   if (config?.quality?.sonar || config?.sonar) {
     found.set("sonar-scanner", "Sonar analysis is configured");
@@ -239,6 +247,32 @@ export function declaredTools(config, surface = "remote") {
 }
 
 /**
+ * Whether a tool already reaches this project as an npm dependency.
+ *
+ * A package that declares `@playwright/test` gets the `playwright` binary in
+ * `node_modules/.bin`, and its npm scripts resolve it from there. It never
+ * needs to be on PATH, so proposing a manifest entry for it is noise — and
+ * noise is how a detector teaches people to skim it, which is the one failure
+ * this skill's own documentation warns about.
+ *
+ * Only the CLI is covered by this. Anything else the tool needs at runtime —
+ * Playwright's browsers, for instance — is a separate concern that a package
+ * manager does not solve and this function does not claim to.
+ * @param {object|null} pkg Parsed package.json.
+ * @param {string} tool Tool name.
+ * @returns {boolean} Whether npm already provides the binary.
+ */
+export function satisfiedByNpm(pkg, tool) {
+  const viaNpm = KNOWN_TOOLS[tool]?.viaNpm;
+  if (!viaNpm) return false;
+  const declared = {
+    ...(pkg?.dependencies ?? {}),
+    ...(pkg?.devDependencies ?? {}),
+  };
+  return Object.hasOwn(declared, viaNpm);
+}
+
+/**
  * Collect every signal and subtract what the manifest already covers.
  * @param {string} [cwd] Project root.
  * @returns {Array<{name: string, why: string, evidence: string[]}>} Proposals.
@@ -261,6 +295,8 @@ export function detectTooling(cwd = process.cwd()) {
   for (const signal of signals) {
     for (const [tool, evidence] of signal) {
       if (declared.has(tool)) continue;
+      // Already provided by the package manager, so there is nothing to pin.
+      if (satisfiedByNpm(pkg, tool)) continue;
       const entry = merged.get(tool) ?? { evidence: [] };
       entry.evidence.push(evidence);
       merged.set(tool, entry);

--- a/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -205,8 +205,16 @@ export function toolsFromSecretNotes(notes) {
  */
 export function toolsFromQuality(config) {
   const found = new Map();
-  if (config?.quality?.e2eCoverage?.playwright) {
-    found.set("playwright", "quality.e2eCoverage.playwright is configured");
+  // Every runner under e2eCoverage, not a hardcoded one. Naming `playwright`
+  // explicitly meant `quality.e2eCoverage.maestro` — configured in this very
+  // repository — produced no signal at all, so the one tool that genuinely
+  // needs a pinned binary and genuinely was not declared stayed invisible to
+  // the detector built to find it. A gate that reports "nothing outstanding"
+  // while the gap is right there is worse than no gate.
+  for (const runner of Object.keys(config?.quality?.e2eCoverage ?? {})) {
+    if (Object.hasOwn(KNOWN_TOOLS, runner)) {
+      found.set(runner, `quality.e2eCoverage.${runner} is configured`);
+    }
   }
   if (config?.quality?.sonar || config?.sonar) {
     found.set("sonar-scanner", "Sonar analysis is configured");
@@ -239,6 +247,32 @@ export function declaredTools(config, surface = "remote") {
 }
 
 /**
+ * Whether a tool already reaches this project as an npm dependency.
+ *
+ * A package that declares `@playwright/test` gets the `playwright` binary in
+ * `node_modules/.bin`, and its npm scripts resolve it from there. It never
+ * needs to be on PATH, so proposing a manifest entry for it is noise — and
+ * noise is how a detector teaches people to skim it, which is the one failure
+ * this skill's own documentation warns about.
+ *
+ * Only the CLI is covered by this. Anything else the tool needs at runtime —
+ * Playwright's browsers, for instance — is a separate concern that a package
+ * manager does not solve and this function does not claim to.
+ * @param {object|null} pkg Parsed package.json.
+ * @param {string} tool Tool name.
+ * @returns {boolean} Whether npm already provides the binary.
+ */
+export function satisfiedByNpm(pkg, tool) {
+  const viaNpm = KNOWN_TOOLS[tool]?.viaNpm;
+  if (!viaNpm) return false;
+  const declared = {
+    ...(pkg?.dependencies ?? {}),
+    ...(pkg?.devDependencies ?? {}),
+  };
+  return Object.hasOwn(declared, viaNpm);
+}
+
+/**
  * Collect every signal and subtract what the manifest already covers.
  * @param {string} [cwd] Project root.
  * @returns {Array<{name: string, why: string, evidence: string[]}>} Proposals.
@@ -261,6 +295,8 @@ export function detectTooling(cwd = process.cwd()) {
   for (const signal of signals) {
     for (const [tool, evidence] of signal) {
       if (declared.has(tool)) continue;
+      // Already provided by the package manager, so there is nothing to pin.
+      if (satisfiedByNpm(pkg, tool)) continue;
       const entry = merged.get(tool) ?? { evidence: [] };
       entry.evidence.push(evidence);
       merged.set(tool, entry);

--- a/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -205,8 +205,16 @@ export function toolsFromSecretNotes(notes) {
  */
 export function toolsFromQuality(config) {
   const found = new Map();
-  if (config?.quality?.e2eCoverage?.playwright) {
-    found.set("playwright", "quality.e2eCoverage.playwright is configured");
+  // Every runner under e2eCoverage, not a hardcoded one. Naming `playwright`
+  // explicitly meant `quality.e2eCoverage.maestro` — configured in this very
+  // repository — produced no signal at all, so the one tool that genuinely
+  // needs a pinned binary and genuinely was not declared stayed invisible to
+  // the detector built to find it. A gate that reports "nothing outstanding"
+  // while the gap is right there is worse than no gate.
+  for (const runner of Object.keys(config?.quality?.e2eCoverage ?? {})) {
+    if (Object.hasOwn(KNOWN_TOOLS, runner)) {
+      found.set(runner, `quality.e2eCoverage.${runner} is configured`);
+    }
   }
   if (config?.quality?.sonar || config?.sonar) {
     found.set("sonar-scanner", "Sonar analysis is configured");
@@ -239,6 +247,32 @@ export function declaredTools(config, surface = "remote") {
 }
 
 /**
+ * Whether a tool already reaches this project as an npm dependency.
+ *
+ * A package that declares `@playwright/test` gets the `playwright` binary in
+ * `node_modules/.bin`, and its npm scripts resolve it from there. It never
+ * needs to be on PATH, so proposing a manifest entry for it is noise — and
+ * noise is how a detector teaches people to skim it, which is the one failure
+ * this skill's own documentation warns about.
+ *
+ * Only the CLI is covered by this. Anything else the tool needs at runtime —
+ * Playwright's browsers, for instance — is a separate concern that a package
+ * manager does not solve and this function does not claim to.
+ * @param {object|null} pkg Parsed package.json.
+ * @param {string} tool Tool name.
+ * @returns {boolean} Whether npm already provides the binary.
+ */
+export function satisfiedByNpm(pkg, tool) {
+  const viaNpm = KNOWN_TOOLS[tool]?.viaNpm;
+  if (!viaNpm) return false;
+  const declared = {
+    ...(pkg?.dependencies ?? {}),
+    ...(pkg?.devDependencies ?? {}),
+  };
+  return Object.hasOwn(declared, viaNpm);
+}
+
+/**
  * Collect every signal and subtract what the manifest already covers.
  * @param {string} [cwd] Project root.
  * @returns {Array<{name: string, why: string, evidence: string[]}>} Proposals.
@@ -261,6 +295,8 @@ export function detectTooling(cwd = process.cwd()) {
   for (const signal of signals) {
     for (const [tool, evidence] of signal) {
       if (declared.has(tool)) continue;
+      // Already provided by the package manager, so there is nothing to pin.
+      if (satisfiedByNpm(pkg, tool)) continue;
       const entry = merged.get(tool) ?? { evidence: [] };
       entry.evidence.push(evidence);
       merged.set(tool, entry);

--- a/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -205,8 +205,16 @@ export function toolsFromSecretNotes(notes) {
  */
 export function toolsFromQuality(config) {
   const found = new Map();
-  if (config?.quality?.e2eCoverage?.playwright) {
-    found.set("playwright", "quality.e2eCoverage.playwright is configured");
+  // Every runner under e2eCoverage, not a hardcoded one. Naming `playwright`
+  // explicitly meant `quality.e2eCoverage.maestro` — configured in this very
+  // repository — produced no signal at all, so the one tool that genuinely
+  // needs a pinned binary and genuinely was not declared stayed invisible to
+  // the detector built to find it. A gate that reports "nothing outstanding"
+  // while the gap is right there is worse than no gate.
+  for (const runner of Object.keys(config?.quality?.e2eCoverage ?? {})) {
+    if (Object.hasOwn(KNOWN_TOOLS, runner)) {
+      found.set(runner, `quality.e2eCoverage.${runner} is configured`);
+    }
   }
   if (config?.quality?.sonar || config?.sonar) {
     found.set("sonar-scanner", "Sonar analysis is configured");
@@ -239,6 +247,32 @@ export function declaredTools(config, surface = "remote") {
 }
 
 /**
+ * Whether a tool already reaches this project as an npm dependency.
+ *
+ * A package that declares `@playwright/test` gets the `playwright` binary in
+ * `node_modules/.bin`, and its npm scripts resolve it from there. It never
+ * needs to be on PATH, so proposing a manifest entry for it is noise — and
+ * noise is how a detector teaches people to skim it, which is the one failure
+ * this skill's own documentation warns about.
+ *
+ * Only the CLI is covered by this. Anything else the tool needs at runtime —
+ * Playwright's browsers, for instance — is a separate concern that a package
+ * manager does not solve and this function does not claim to.
+ * @param {object|null} pkg Parsed package.json.
+ * @param {string} tool Tool name.
+ * @returns {boolean} Whether npm already provides the binary.
+ */
+export function satisfiedByNpm(pkg, tool) {
+  const viaNpm = KNOWN_TOOLS[tool]?.viaNpm;
+  if (!viaNpm) return false;
+  const declared = {
+    ...(pkg?.dependencies ?? {}),
+    ...(pkg?.devDependencies ?? {}),
+  };
+  return Object.hasOwn(declared, viaNpm);
+}
+
+/**
  * Collect every signal and subtract what the manifest already covers.
  * @param {string} [cwd] Project root.
  * @returns {Array<{name: string, why: string, evidence: string[]}>} Proposals.
@@ -261,6 +295,8 @@ export function detectTooling(cwd = process.cwd()) {
   for (const signal of signals) {
     for (const [tool, evidence] of signal) {
       if (declared.has(tool)) continue;
+      // Already provided by the package manager, so there is nothing to pin.
+      if (satisfiedByNpm(pkg, tool)) continue;
       const entry = merged.get(tool) ?? { evidence: [] };
       entry.evidence.push(evidence);
       merged.set(tool, entry);

--- a/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -205,8 +205,16 @@ export function toolsFromSecretNotes(notes) {
  */
 export function toolsFromQuality(config) {
   const found = new Map();
-  if (config?.quality?.e2eCoverage?.playwright) {
-    found.set("playwright", "quality.e2eCoverage.playwright is configured");
+  // Every runner under e2eCoverage, not a hardcoded one. Naming `playwright`
+  // explicitly meant `quality.e2eCoverage.maestro` — configured in this very
+  // repository — produced no signal at all, so the one tool that genuinely
+  // needs a pinned binary and genuinely was not declared stayed invisible to
+  // the detector built to find it. A gate that reports "nothing outstanding"
+  // while the gap is right there is worse than no gate.
+  for (const runner of Object.keys(config?.quality?.e2eCoverage ?? {})) {
+    if (Object.hasOwn(KNOWN_TOOLS, runner)) {
+      found.set(runner, `quality.e2eCoverage.${runner} is configured`);
+    }
   }
   if (config?.quality?.sonar || config?.sonar) {
     found.set("sonar-scanner", "Sonar analysis is configured");
@@ -239,6 +247,32 @@ export function declaredTools(config, surface = "remote") {
 }
 
 /**
+ * Whether a tool already reaches this project as an npm dependency.
+ *
+ * A package that declares `@playwright/test` gets the `playwright` binary in
+ * `node_modules/.bin`, and its npm scripts resolve it from there. It never
+ * needs to be on PATH, so proposing a manifest entry for it is noise — and
+ * noise is how a detector teaches people to skim it, which is the one failure
+ * this skill's own documentation warns about.
+ *
+ * Only the CLI is covered by this. Anything else the tool needs at runtime —
+ * Playwright's browsers, for instance — is a separate concern that a package
+ * manager does not solve and this function does not claim to.
+ * @param {object|null} pkg Parsed package.json.
+ * @param {string} tool Tool name.
+ * @returns {boolean} Whether npm already provides the binary.
+ */
+export function satisfiedByNpm(pkg, tool) {
+  const viaNpm = KNOWN_TOOLS[tool]?.viaNpm;
+  if (!viaNpm) return false;
+  const declared = {
+    ...(pkg?.dependencies ?? {}),
+    ...(pkg?.devDependencies ?? {}),
+  };
+  return Object.hasOwn(declared, viaNpm);
+}
+
+/**
  * Collect every signal and subtract what the manifest already covers.
  * @param {string} [cwd] Project root.
  * @returns {Array<{name: string, why: string, evidence: string[]}>} Proposals.
@@ -261,6 +295,8 @@ export function detectTooling(cwd = process.cwd()) {
   for (const signal of signals) {
     for (const [tool, evidence] of signal) {
       if (declared.has(tool)) continue;
+      // Already provided by the package manager, so there is nothing to pin.
+      if (satisfiedByNpm(pkg, tool)) continue;
       const entry = merged.get(tool) ?? { evidence: [] };
       entry.evidence.push(evidence);
       merged.set(tool, entry);

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -851,7 +851,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-detect-tooling/SKILL.md":
       "1778a009d06099b3bd2d9a33b37bec34836b295e21fad220ae926491d3557208",
     "plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs":
-      "ccbd2cf7251e792467ca74c664088a22b1c50ead579ad2279a55daa5d0ba0693",
+      "05e0c4808e64fbdc277419ad00b6a68da96766a9261a5b97f3a4961bbab107c4",
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
       "fb41a1e63c5332d47a46e715aff52551f3df867033b5e4f37dfaeee30019b891",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":

--- a/tests/unit/secrets/detect-tooling.test.ts
+++ b/tests/unit/secrets/detect-tooling.test.ts
@@ -18,9 +18,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   declaredTools,
+  satisfiedByNpm,
   detectTooling,
   proposedEntries,
   toolsFromMcp,
+  toolsFromQuality,
   toolsFromScripts,
   toolsFromSecretNotes,
 } from "../../../plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs";
@@ -183,5 +185,72 @@ describe("against this repository", () => {
       expect(proposal.evidence.length).toBeGreaterThan(0);
       expect(proposal.why).not.toBe("");
     }
+  });
+});
+
+describe("quality signals", () => {
+  it("surfaces every configured e2e runner, not a hardcoded one", () => {
+    // quality.e2eCoverage.maestro is configured in this repository and produced
+    // no signal, so the detector reported "nothing outstanding" while maestro —
+    // the tool whose absence started this work — was undeclared and invisible.
+    const found = toolsFromQuality({
+      quality: { e2eCoverage: { playwright: {}, maestro: {} } },
+    });
+
+    expect([...found.keys()]).toEqual(
+      expect.arrayContaining(["playwright", "maestro"])
+    );
+  });
+
+  it("ignores a runner it knows nothing about", () => {
+    // A signal for an unknown name would propose a manifest entry naming a
+    // tool the detector cannot describe or pin.
+    const found = toolsFromQuality({
+      quality: { e2eCoverage: { somethingElse: {} } },
+    });
+
+    expect([...found.keys()]).toHaveLength(0);
+  });
+});
+
+describe("tools the package manager already provides", () => {
+  // The false positive this removes: `quality.e2eCoverage.playwright` is
+  // configured, so the detector proposed pinning a playwright binary — while
+  // `@playwright/test` is a declared devDependency and `playwright test`
+  // resolves from node_modules/.bin. It never needs to be on PATH.
+  //
+  // Noise is how a detector teaches people to skim it, which is the failure
+  // this skill's own documentation warns about.
+  it("recognises a tool declared as a devDependency", () => {
+    expect(
+      satisfiedByNpm(
+        { devDependencies: { "@playwright/test": "^1.57.0" } },
+        "playwright"
+      )
+    ).toBe(true);
+  });
+
+  it("recognises one declared as a runtime dependency too", () => {
+    expect(
+      satisfiedByNpm(
+        { dependencies: { "@playwright/test": "^1.57.0" } },
+        "playwright"
+      )
+    ).toBe(true);
+  });
+
+  it("does not claim to cover a tool npm cannot deliver", () => {
+    // Maestro ships no npm package, so a devDependency list says nothing about
+    // whether its binary is present.
+    expect(
+      satisfiedByNpm(
+        { devDependencies: { "@playwright/test": "1" } },
+        "maestro"
+      )
+    ).toBe(false);
+  });
+
+  it("still proposes when the package is absent", () => {
+    expect(satisfiedByNpm({ devDependencies: {} }, "playwright")).toBe(false);
   });
 });


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2256

Two defects, found by checking the detector’s output against reality rather than reading it.

## 1. It reported "nothing outstanding" while maestro was missing

```js
if (config?.quality?.e2eCoverage?.playwright) { ... }   // one runner, by hand
```

`quality.e2eCoverage.maestro` is configured **in this repository** and produced no signal. So the detector said *"Every tool this project appears to use is already declared"* while `maestro` — the tool that genuinely needs a pinned binary, and whose absence started this entire line of work — was undeclared and invisible.

A gate that reports nothing outstanding while the gap is right there is worse than no gate.

Every known runner under `e2eCoverage` now produces a signal. An unknown name still produces none, since a proposal must be able to name what it pins.

```
1 tool(s) look required but are not declared:

  maestro
    evidence: quality.e2eCoverage.maestro is configured
    tools.install: {"name":"maestro", ... "surfaces":["remote"]}
    tools.require: {"name":"maestro","surfaces":["local"]}
```

## 2. It proposed pinning a tool npm already provides

`@playwright/test` is a declared devDependency and `playwright test` resolves from `node_modules/.bin` — the binary never needs to be on `PATH`.

**Evidence that a tool is used is not evidence that it is missing.** Signals are now checked against the project’s dependencies before becoming proposals, the same shape as the access-layer allowlist that silenced Linear. Scoped to the CLI: Playwright’s browsers are a separate concern npm does not solve, and this must not be read as covering them.

## Flagged, not changed

#2252 pinned `playwright` as `npm-global @playwright/test 1.62.1`, while the expo and phaser templates declare `^1.57.0` and `^1.56.1` as devDependencies — a global copy at a different version alongside the project-local one that actually resolves. Given the CLI arrives with the devDependency, that entry looks redundant and version-skewed rather than load-bearing. It is the other change’s call, so this flags it rather than removing it.

495 files, 8392 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tooling detection now recognizes all supported end-to-end test runners configured in project quality settings.
  * Avoids suggesting tools that are already provided by declared npm packages.

* **Bug Fixes**
  * Reduced false-positive tooling recommendations for npm-provided command-line tools.

* **Tests**
  * Added coverage for quality runner detection and npm-provided tooling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->