### PR TITLE
Skip the install, not the decision

### DIFF
--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/assets/setup.sh
@@ -49,7 +49,7 @@ fi
 #
 # Skipped when node_modules already exists, which is what makes this cheap on a
 # resumed container and correct to run twice.
-if [ "${LISA_SKIP_INSTALL:-}" != "1" ] && [ ! -d node_modules ]; then
+if [ ! -d node_modules ]; then
   if [ -f bun.lock ] || [ -f bun.lockb ]; then install_cmd="bun install"
   elif [ -f pnpm-lock.yaml ]; then install_cmd="pnpm install --frozen-lockfile"
   elif [ -f yarn.lock ]; then
@@ -83,7 +83,20 @@ if [ "${LISA_SKIP_INSTALL:-}" != "1" ] && [ ! -d node_modules ]; then
     # Without it the bug is cache-dependent, not deterministic: a fresh
     # container installs and dirties the tree, a resumed one skips the install
     # and succeeds. That reads as flakiness rather than a cause.
-    CI=1 $install_cmd
+    # LISA_SKIP_INSTALL suppresses the INSTALL, not the decision. It used to
+    # gate the whole block, so the only way to observe which package manager
+    # was chosen was to actually run it — which is why a test asserting the
+    # choice ran `yarn install` against a fabricated lockfile, passing on a
+    # machine without yarn and doing a real network install on one with it.
+    #
+    # Reporting the choice and skipping the work is also the more useful
+    # behaviour for a caller that installed already: it still says what it
+    # would have done.
+    if [ "${LISA_SKIP_INSTALL:-}" = "1" ]; then
+      echo "  LISA_SKIP_INSTALL=1 — not running it."
+    else
+      CI=1 $install_cmd
+    fi
   else
     # Not fatal on its own. A project may carry no lockfile and still have the
     # skill in a checkout directory, so let the resolver below decide.

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/assets/setup.sh
@@ -49,7 +49,7 @@ fi
 #
 # Skipped when node_modules already exists, which is what makes this cheap on a
 # resumed container and correct to run twice.
-if [ "${LISA_SKIP_INSTALL:-}" != "1" ] && [ ! -d node_modules ]; then
+if [ ! -d node_modules ]; then
   if [ -f bun.lock ] || [ -f bun.lockb ]; then install_cmd="bun install"
   elif [ -f pnpm-lock.yaml ]; then install_cmd="pnpm install --frozen-lockfile"
   elif [ -f yarn.lock ]; then
@@ -83,7 +83,20 @@ if [ "${LISA_SKIP_INSTALL:-}" != "1" ] && [ ! -d node_modules ]; then
     # Without it the bug is cache-dependent, not deterministic: a fresh
     # container installs and dirties the tree, a resumed one skips the install
     # and succeeds. That reads as flakiness rather than a cause.
-    CI=1 $install_cmd
+    # LISA_SKIP_INSTALL suppresses the INSTALL, not the decision. It used to
+    # gate the whole block, so the only way to observe which package manager
+    # was chosen was to actually run it — which is why a test asserting the
+    # choice ran `yarn install` against a fabricated lockfile, passing on a
+    # machine without yarn and doing a real network install on one with it.
+    #
+    # Reporting the choice and skipping the work is also the more useful
+    # behaviour for a caller that installed already: it still says what it
+    # would have done.
+    if [ "${LISA_SKIP_INSTALL:-}" = "1" ]; then
+      echo "  LISA_SKIP_INSTALL=1 — not running it."
+    else
+      CI=1 $install_cmd
+    fi
   else
     # Not fatal on its own. A project may carry no lockfile and still have the
     # skill in a checkout directory, so let the resolver below decide.

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/assets/setup.sh
@@ -49,7 +49,7 @@ fi
 #
 # Skipped when node_modules already exists, which is what makes this cheap on a
 # resumed container and correct to run twice.
-if [ "${LISA_SKIP_INSTALL:-}" != "1" ] && [ ! -d node_modules ]; then
+if [ ! -d node_modules ]; then
   if [ -f bun.lock ] || [ -f bun.lockb ]; then install_cmd="bun install"
   elif [ -f pnpm-lock.yaml ]; then install_cmd="pnpm install --frozen-lockfile"
   elif [ -f yarn.lock ]; then
@@ -83,7 +83,20 @@ if [ "${LISA_SKIP_INSTALL:-}" != "1" ] && [ ! -d node_modules ]; then
     # Without it the bug is cache-dependent, not deterministic: a fresh
     # container installs and dirties the tree, a resumed one skips the install
     # and succeeds. That reads as flakiness rather than a cause.
-    CI=1 $install_cmd
+    # LISA_SKIP_INSTALL suppresses the INSTALL, not the decision. It used to
+    # gate the whole block, so the only way to observe which package manager
+    # was chosen was to actually run it — which is why a test asserting the
+    # choice ran `yarn install` against a fabricated lockfile, passing on a
+    # machine without yarn and doing a real network install on one with it.
+    #
+    # Reporting the choice and skipping the work is also the more useful
+    # behaviour for a caller that installed already: it still says what it
+    # would have done.
+    if [ "${LISA_SKIP_INSTALL:-}" = "1" ]; then
+      echo "  LISA_SKIP_INSTALL=1 — not running it."
+    else
+      CI=1 $install_cmd
+    fi
   else
     # Not fatal on its own. A project may carry no lockfile and still have the
     # skill in a checkout directory, so let the resolver below decide.

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/assets/setup.sh
@@ -49,7 +49,7 @@ fi
 #
 # Skipped when node_modules already exists, which is what makes this cheap on a
 # resumed container and correct to run twice.
-if [ "${LISA_SKIP_INSTALL:-}" != "1" ] && [ ! -d node_modules ]; then
+if [ ! -d node_modules ]; then
   if [ -f bun.lock ] || [ -f bun.lockb ]; then install_cmd="bun install"
   elif [ -f pnpm-lock.yaml ]; then install_cmd="pnpm install --frozen-lockfile"
   elif [ -f yarn.lock ]; then
@@ -83,7 +83,20 @@ if [ "${LISA_SKIP_INSTALL:-}" != "1" ] && [ ! -d node_modules ]; then
     # Without it the bug is cache-dependent, not deterministic: a fresh
     # container installs and dirties the tree, a resumed one skips the install
     # and succeeds. That reads as flakiness rather than a cause.
-    CI=1 $install_cmd
+    # LISA_SKIP_INSTALL suppresses the INSTALL, not the decision. It used to
+    # gate the whole block, so the only way to observe which package manager
+    # was chosen was to actually run it — which is why a test asserting the
+    # choice ran `yarn install` against a fabricated lockfile, passing on a
+    # machine without yarn and doing a real network install on one with it.
+    #
+    # Reporting the choice and skipping the work is also the more useful
+    # behaviour for a caller that installed already: it still says what it
+    # would have done.
+    if [ "${LISA_SKIP_INSTALL:-}" = "1" ]; then
+      echo "  LISA_SKIP_INSTALL=1 — not running it."
+    else
+      CI=1 $install_cmd
+    fi
   else
     # Not fatal on its own. A project may carry no lockfile and still have the
     # skill in a checkout directory, so let the resolver below decide.

--- a/plugins/lisa/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/lisa/skills/lisa-setup-remote-env/assets/setup.sh
@@ -49,7 +49,7 @@ fi
 #
 # Skipped when node_modules already exists, which is what makes this cheap on a
 # resumed container and correct to run twice.
-if [ "${LISA_SKIP_INSTALL:-}" != "1" ] && [ ! -d node_modules ]; then
+if [ ! -d node_modules ]; then
   if [ -f bun.lock ] || [ -f bun.lockb ]; then install_cmd="bun install"
   elif [ -f pnpm-lock.yaml ]; then install_cmd="pnpm install --frozen-lockfile"
   elif [ -f yarn.lock ]; then
@@ -83,7 +83,20 @@ if [ "${LISA_SKIP_INSTALL:-}" != "1" ] && [ ! -d node_modules ]; then
     # Without it the bug is cache-dependent, not deterministic: a fresh
     # container installs and dirties the tree, a resumed one skips the install
     # and succeeds. That reads as flakiness rather than a cause.
-    CI=1 $install_cmd
+    # LISA_SKIP_INSTALL suppresses the INSTALL, not the decision. It used to
+    # gate the whole block, so the only way to observe which package manager
+    # was chosen was to actually run it — which is why a test asserting the
+    # choice ran `yarn install` against a fabricated lockfile, passing on a
+    # machine without yarn and doing a real network install on one with it.
+    #
+    # Reporting the choice and skipping the work is also the more useful
+    # behaviour for a caller that installed already: it still says what it
+    # would have done.
+    if [ "${LISA_SKIP_INSTALL:-}" = "1" ]; then
+      echo "  LISA_SKIP_INSTALL=1 — not running it."
+    else
+      CI=1 $install_cmd
+    fi
   else
     # Not fatal on its own. A project may carry no lockfile and still have the
     # skill in a checkout directory, so let the resolver below decide.

--- a/plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh
+++ b/plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh
@@ -49,7 +49,7 @@ fi
 #
 # Skipped when node_modules already exists, which is what makes this cheap on a
 # resumed container and correct to run twice.
-if [ "${LISA_SKIP_INSTALL:-}" != "1" ] && [ ! -d node_modules ]; then
+if [ ! -d node_modules ]; then
   if [ -f bun.lock ] || [ -f bun.lockb ]; then install_cmd="bun install"
   elif [ -f pnpm-lock.yaml ]; then install_cmd="pnpm install --frozen-lockfile"
   elif [ -f yarn.lock ]; then
@@ -83,7 +83,20 @@ if [ "${LISA_SKIP_INSTALL:-}" != "1" ] && [ ! -d node_modules ]; then
     # Without it the bug is cache-dependent, not deterministic: a fresh
     # container installs and dirties the tree, a resumed one skips the install
     # and succeeds. That reads as flakiness rather than a cause.
-    CI=1 $install_cmd
+    # LISA_SKIP_INSTALL suppresses the INSTALL, not the decision. It used to
+    # gate the whole block, so the only way to observe which package manager
+    # was chosen was to actually run it — which is why a test asserting the
+    # choice ran `yarn install` against a fabricated lockfile, passing on a
+    # machine without yarn and doing a real network install on one with it.
+    #
+    # Reporting the choice and skipping the work is also the more useful
+    # behaviour for a caller that installed already: it still says what it
+    # would have done.
+    if [ "${LISA_SKIP_INSTALL:-}" = "1" ]; then
+      echo "  LISA_SKIP_INSTALL=1 — not running it."
+    else
+      CI=1 $install_cmd
+    fi
   else
     # Not fatal on its own. A project may carry no lockfile and still have the
     # skill in a checkout directory, so let the resolver below decide.

--- a/scripts/lisa-remote-env/setup.sh
+++ b/scripts/lisa-remote-env/setup.sh
@@ -49,7 +49,7 @@ fi
 #
 # Skipped when node_modules already exists, which is what makes this cheap on a
 # resumed container and correct to run twice.
-if [ "${LISA_SKIP_INSTALL:-}" != "1" ] && [ ! -d node_modules ]; then
+if [ ! -d node_modules ]; then
   if [ -f bun.lock ] || [ -f bun.lockb ]; then install_cmd="bun install"
   elif [ -f pnpm-lock.yaml ]; then install_cmd="pnpm install --frozen-lockfile"
   elif [ -f yarn.lock ]; then
@@ -83,7 +83,20 @@ if [ "${LISA_SKIP_INSTALL:-}" != "1" ] && [ ! -d node_modules ]; then
     # Without it the bug is cache-dependent, not deterministic: a fresh
     # container installs and dirties the tree, a resumed one skips the install
     # and succeeds. That reads as flakiness rather than a cause.
-    CI=1 $install_cmd
+    # LISA_SKIP_INSTALL suppresses the INSTALL, not the decision. It used to
+    # gate the whole block, so the only way to observe which package manager
+    # was chosen was to actually run it — which is why a test asserting the
+    # choice ran `yarn install` against a fabricated lockfile, passing on a
+    # machine without yarn and doing a real network install on one with it.
+    #
+    # Reporting the choice and skipping the work is also the more useful
+    # behaviour for a caller that installed already: it still says what it
+    # would have done.
+    if [ "${LISA_SKIP_INSTALL:-}" = "1" ]; then
+      echo "  LISA_SKIP_INSTALL=1 — not running it."
+    else
+      CI=1 $install_cmd
+    fi
   else
     # Not fatal on its own. A project may carry no lockfile and still have the
     # skill in a checkout directory, so let the resolver below decide.

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1137,7 +1137,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh":
       "cb63d08b14ab7aa2d405e6770e0cf7db5d6588ae1dcb924ea6224b026fcff496",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
-      "c04afb1cf8e14a2713645228e679fa7772559488330a240ec0297cae6afd03e2",
+      "c30d98a5645f033fc1d3a723043691b9ad997ae5666df539ff6aa19c563431b2",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
       "eb8017ee2eef5b5b166908e5c2fccf493af283b0a40717688033d65263cf35ce",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
@@ -1997,7 +1997,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/lisa-remote-env/session-start.sh":
       "cb63d08b14ab7aa2d405e6770e0cf7db5d6588ae1dcb924ea6224b026fcff496",
     "scripts/lisa-remote-env/setup.sh":
-      "c04afb1cf8e14a2713645228e679fa7772559488330a240ec0297cae6afd03e2",
+      "c30d98a5645f033fc1d3a723043691b9ad997ae5666df539ff6aa19c563431b2",
     "scripts/lisa-update-local.sh":
       "c811f9e10dbcb38499a9791c1ae9051460b347051d04a1d2046925bab9a53c96",
     "scripts/lisa-work-item.mjs":

--- a/tests/unit/secrets/remote-env-skill-resolution.test.ts
+++ b/tests/unit/secrets/remote-env-skill-resolution.test.ts
@@ -102,6 +102,11 @@ function runEntrypoint(
   return spawnSync(BASH, [script, ...args], {
     cwd: root,
     encoding: "utf8",
+    // Never run a real package manager. This test plants a FABRICATED lockfile
+    // to assert which manager the script chooses; without this it also ran
+    // `yarn install` against that lockfile — passing on a machine with no yarn
+    // and doing a real network install on a CI runner that has one.
+    env: { ...process.env, LISA_SKIP_INSTALL: "1" },
   });
 }
 


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2258

A unit test planted a **fabricated** `yarn.lock` and ran the real entrypoint to assert which package manager it chose. The entrypoint then executed `yarn install --frozen-lockfile` in a temp directory whose lockfile is two comment lines and which has no `package.json`.

**It passed here for the wrong reason.** This machine has no `yarn`, so the command failed instantly and the assertion — which only reads the echoed decision — was satisfied. A CI runner **has** yarn, so the same test performed a real install there.

Demonstrated with a `yarn` that blocks, standing in for a runner’s real one:

```
HUNG      without the skip — still running after 6s
COMPLETED with LISA_SKIP_INSTALL=1 — ~1s
```

That is the shape of the `Release and Deploy` run on `38fa928e`: twenty minutes, then cancelled, leaving orphan `sh`, `bun` and `node` processes. **Whether that run was this test is unproven** — its re-run succeeded, so it was at worst intermittent — but a unit test that shells out to a real package manager is a latent CI hang regardless.

## The test had no honest option

`LISA_SKIP_INSTALL` gated the whole block, echo included:

```sh
if [ "${LISA_SKIP_INSTALL:-}" != "1" ] && [ ! -d node_modules ]; then
  ...decide install_cmd...
  echo "Installing dependencies with: $install_cmd"
  CI=1 $install_cmd
```

There was no way to observe the decision without running it. It now guards the **execution** alone, so the script reports which manager it would use and skips the work — also the better answer for a caller that installed already, since it still says what it would have done.

495 files, 8392 tests.