### PR TITLE
fix(scripts): resolve $name floors instead of skipping them

### DIFF
--- a/scripts/check-security-floors.mjs
+++ b/scripts/check-security-floors.mjs
@@ -44,11 +44,44 @@ const GATING_SEVERITIES = new Set(["high", "critical"]);
 const ADVISORY_ENDPOINT = "https://api.github.com/advisories";
 
 /**
+ * Resolve a `$name` self-reference to the range the manifest pins it to.
+ *
+ * Searches the dependency sections of every governance group, because a
+ * template may declare the target in `force`, `defaults` or `merge` and the
+ * reference means the same thing in each. Constraint sections that are
+ * themselves override maps are skipped, so a `$name` cannot resolve to another
+ * `$name` and loop.
+ * @param {object} manifest A parsed package.lisa.json.
+ * @param {string} name The referenced package.
+ * @returns {string|null} The pinned range, or null when nothing declares it.
+ */
+export function resolveSelfReference(manifest, name) {
+  const DEPENDENCY_SECTIONS = [
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+  ];
+  for (const group of GOVERNANCE_GROUPS) {
+    const block = manifest[group];
+    if (!block || typeof block !== "object") continue;
+    for (const section of DEPENDENCY_SECTIONS) {
+      const spec = block[section]?.[name];
+      if (typeof spec === "string" && !spec.startsWith("$")) return spec;
+    }
+  }
+  return null;
+}
+
+/**
  * Every version constraint declared across the template manifests.
- * @returns {Map<string, Array<{file: string, path: string, spec: string}>>} By package name.
+ * @returns {{found: Map<string, Array<{file: string, path: string, spec: string}>>,
+ *   unresolved: Array<{file: string, path: string, name: string, spec: string}>}}
+ *   Constraints by package name, plus self-references pointing at nothing.
  */
 function collectFloors() {
   const found = new Map();
+  /** `$name` references pointing at nothing this manifest declares. */
+  const unresolved = [];
   const files = globSync("*/package-lisa/package.lisa.json").filter(
     file => !file.includes("node_modules") && !file.includes(".worktrees")
   );
@@ -66,17 +99,45 @@ function collectFloors() {
         const entries = block[section];
         if (!entries || typeof entries !== "object") continue;
         for (const [name, spec] of Object.entries(entries)) {
-          // `$name` self-references defer to the project's own pin and carry
-          // no floor of their own; a literal like "workspace:*" likewise.
-          if (typeof spec !== "string" || !/\d/.test(spec)) continue;
-          if (spec.startsWith("$")) continue;
+          if (typeof spec !== "string") continue;
+          // A `$name` self-reference carries no floor of its own — it adopts
+          // whatever the manifest pins that package to elsewhere. Resolve it
+          // and check THAT, rather than skipping.
+          //
+          // Skipping was safe only by coincidence: every `$name` in the
+          // templates today happens to target a package also declared as a
+          // literal in a scanned group, so the range got checked under its own
+          // entry. Nothing enforces that. The first `$name` whose target is
+          // declared only downstream — or not at all — would be a floor
+          // nothing checks, reported as clean, which is worse than no check.
+          if (spec.startsWith("$")) {
+            const target = resolveSelfReference(manifest, spec.slice(1));
+            if (target === null) {
+              unresolved.push({
+                file,
+                path: `${group}.${section}`,
+                name,
+                spec,
+              });
+              continue;
+            }
+            if (!/\d/.test(target)) continue;
+            if (!found.has(name)) found.set(name, []);
+            found
+              .get(name)
+              .push({ file, path: `${group}.${section}`, spec: target });
+            continue;
+          }
+          // A literal carrying no digits — "workspace:*", "latest" — is not a
+          // floor and there is nothing to compare.
+          if (!/\d/.test(spec)) continue;
           if (!found.has(name)) found.set(name, []);
           found.get(name).push({ file, path: `${group}.${section}`, spec });
         }
       }
     }
   }
-  return found;
+  return { found, unresolved };
 }
 
 /**
@@ -185,10 +246,10 @@ async function advisoriesFor(name) {
 
 /**
  * Audit every collected floor.
- * @returns {Promise<{problems: Array, unreachable: string[], checked: number}>} Findings.
+ * @returns {Promise<{problems: Array, unreachable: Array, unresolved: Array, checked: number}>} Findings.
  */
 async function audit() {
-  const floors = collectFloors();
+  const { found: floors, unresolved } = collectFloors();
   const problems = [];
   const unreachable = [];
   for (const [name, sites] of floors) {
@@ -220,16 +281,18 @@ async function audit() {
       }
     }
   }
-  return { problems, unreachable, checked: floors.size };
+  return { problems, unreachable, unresolved, checked: floors.size };
 }
 
 async function main() {
   const strict = process.argv.includes("--strict");
   const asJson = process.argv.includes("--json");
-  const { problems, unreachable, checked } = await audit();
+  const { problems, unreachable, unresolved, checked } = await audit();
 
   if (asJson) {
-    console.log(JSON.stringify({ problems, unreachable, checked }, null, 2));
+    console.log(
+      JSON.stringify({ problems, unreachable, unresolved, checked }, null, 2)
+    );
   } else if (problems.length === 0) {
     console.log(
       `## Security floors\n\nNo force-pinned floor permits a high or critical vulnerable release. ${checked} package(s) checked.`
@@ -251,7 +314,24 @@ async function main() {
     );
   }
 
-  if (unreachable.length > 0) {
+  // Markdown notes belong to the human report only. Printed in --json mode
+  // they follow the document and break every parser reading it; the same
+  // facts are already fields in the JSON.
+  if (!asJson && unresolved.length > 0) {
+    console.log(
+      `\n> **${unresolved.length} self-reference(s) resolve to nothing.** A \`$name\` adopts whatever the manifest pins that package to; when nothing pins it, there is no floor to check and no floor to enforce. Reported rather than skipped, because silence here is indistinguishable from a clean result.`
+    );
+    for (const entry of unresolved) {
+      console.log(
+        `> - \`${entry.name}: ${entry.spec}\` in ${entry.file} ${entry.path}`
+      );
+    }
+    console.log(
+      "> Fix by declaring the target in a governance dependency section, or by replacing the reference with an explicit floor."
+    );
+  }
+
+  if (!asJson && unreachable.length > 0) {
     const limited = unreachable.filter(entry =>
       entry.reason.includes("rate limited")
     );
@@ -275,7 +355,12 @@ async function main() {
   // Under --strict an inconclusive run also fails: it proves nothing, and
   // treating "could not check" as "checked and clean" is exactly the silent
   // degradation this script exists to prevent.
-  if (strict && (problems.length > 0 || unreachable.length > 0)) {
+  // An unresolved self-reference gates for the same reason an inconclusive one
+  // does: it is a floor nobody checked, and letting it pass reports it clean.
+  if (
+    strict &&
+    (problems.length > 0 || unreachable.length > 0 || unresolved.length > 0)
+  ) {
     process.exitCode = 1;
   }
 }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1923,7 +1923,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/check-rules-pairing.sh":
       "4d4a0d9e8d36794a22020f419c879d7336b1c5bfe883acdcc826d26764560c7a",
     "scripts/check-security-floors.mjs":
-      "3d3c0d0ddff2d810bf3470ff88926566210a3373954761727bd4281c38fe8d8c",
+      "0060a0f65885b54fc93bd3885ca249cbb1ac822c52813817aae640bc1303827b",
     "scripts/claude-remote-setup.sh":
       "0e33accf8aa057c70497f01c38bef9f9f3801d649272f583578d89201b242655",
     "scripts/clean-dist.mjs":

--- a/tests/unit/scripts/security-floors.test.ts
+++ b/tests/unit/scripts/security-floors.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   lowestPermitted,
+  resolveSelfReference,
   withinRange,
 } from "../../../scripts/check-security-floors.mjs";
 
@@ -81,5 +82,68 @@ describe("withinRange", () => {
 
   it("treats an empty range as no constraint rather than a match", () => {
     expect(withinRange([1, 0, 0], "")).toBe(false);
+  });
+});
+
+/**
+ * `$name` self-references, which the collector used to skip outright.
+ *
+ * The skip was justified as "defers to the project's own pin and carries no
+ * floor of its own". That is true of the reference and false of the outcome:
+ * the pin it defers to may itself sit below the advisory floor, and skipping
+ * meant nothing ever compared it. It was safe only by coincidence — every
+ * `$name` in the templates today happens to target a package also declared as
+ * a literal elsewhere, so the range got checked under its own entry. Nothing
+ * enforced that, and the first reference to an undeclared target would have
+ * been an unchecked floor reported as clean.
+ */
+describe("resolveSelfReference", () => {
+  it("finds the target in a force dependency section", () => {
+    const manifest = { force: { devDependencies: { vite: "^8.0.16" } } };
+    expect(resolveSelfReference(manifest, "vite")).toBe("^8.0.16");
+  });
+
+  it("finds the target in any governance group, not just force", () => {
+    // phaser declares its vite pin under `defaults`, cdk under `force`. A
+    // resolver that only looked at one would silently miss the other.
+    const manifest = { defaults: { devDependencies: { vite: "^8.0.16" } } };
+    expect(resolveSelfReference(manifest, "vite")).toBe("^8.0.16");
+  });
+
+  it("returns the range so a WEAK target can be compared, not waved through", () => {
+    // The whole point: a reference is only as strong as what it points at.
+    const manifest = { force: { dependencies: { postcss: "^8.5.0" } } };
+    const resolved = resolveSelfReference(manifest, "postcss");
+    expect(resolved).toBe("^8.5.0");
+    expect(lowestPermitted(resolved as string)).toEqual([8, 5, 0]);
+    // ^8.5.0 permits 8.5.0, which sits inside a range patched at 8.5.18.
+    expect(withinRange([8, 5, 0], ">= 8.0.0, < 8.5.18")).toBe(true);
+  });
+
+  it("returns null when nothing declares the target", () => {
+    // Not an error and not a pass — the caller reports it, because a floor
+    // nobody checked must not read as a floor that passed.
+    expect(
+      resolveSelfReference({ force: { overrides: {} } }, "vite")
+    ).toBeNull();
+  });
+
+  it("does not resolve a reference to another reference", () => {
+    // Otherwise a `$a -> $b` pair could loop, or resolve to a string that is
+    // not a version at all.
+    const manifest = { force: { dependencies: { vite: "$vite" } } };
+    expect(resolveSelfReference(manifest, "vite")).toBeNull();
+  });
+
+  it("ignores constraint sections that are themselves override maps", () => {
+    // `overrides`/`resolutions` are where `$name` lives; resolving into them
+    // would find the reference again rather than the pin.
+    const manifest = {
+      force: {
+        overrides: { vite: "$vite" },
+        devDependencies: { vite: "^8.0.16" },
+      },
+    };
+    expect(resolveSelfReference(manifest, "vite")).toBe("^8.0.16");
   });
 });


### PR DESCRIPTION
Closes #2255.

Work-Item: CodySwannGT/lisa#2255

## The hole

`collectFloors` skipped any `$name` spec, justified in the code as *"defers to the project's own pin and carries no floor of its own"*. That is true of the reference and false of the outcome: the pin it defers to may itself sit below the advisory floor, and skipping meant nothing ever compared it.

The skip was safe only **by coincidence**. Every `$name` in the templates today — `vite`, `esbuild`, `aws-cdk-lib` — targets a package also declared as a literal in a scanned governance group, so its range got checked under its own entry. Nothing enforced that. The first reference to a target declared only downstream, or nowhere, would have been an unchecked floor reported as **clean** — the same shape as the stale floors the file's own header already warns about.

## The fix

References resolve to the range the manifest pins, and that range is checked. A reference resolving to nothing is reported and gates under `--strict`, alongside the inconclusive results it resembles — both are floors nobody verified, and both would otherwise read as clean.

`resolveSelfReference` searches dependency sections across **all** governance groups, because templates disagree about where they declare: `cdk` pins `vite` under `force`, `phaser` under `defaults`. It refuses to resolve a reference to another reference, so `$a → $b` cannot loop or land on a non-version string.

## This closes a latent hole, not a live weakening

Worth stating plainly, because the issue as I filed it implied otherwise. Verified against the real templates:

```
problems: 0   unresolved: 0   checked: 189
```

## Correction to the issue

The issue also claimed this was why downstream `bun install` rewrites go unnoticed. **That part was wrong.** This script globs `*/package-lisa/package.lisa.json` — lisa's own templates — and never reads a downstream `package.json`, so it could not have caught that either way. The downstream rewrite is real and separate; I have corrected the issue rather than leaving the wrong causal claim standing.

## Also fixed: `--json` was not JSON

The unreachable/unresolved notes are markdown and printed unconditionally, so `--json` emitted a JSON document followed by prose:

```
jq: parse error: Invalid numeric literal at line 525, column 2
```

Found by using the flag while verifying this change. The notes belong to the human report; their content is already fields in the JSON.

## Proof the guards bite

Each mutation asserts it landed before running:

| mutation | result |
|---|---|
| resolver returns null for everything (the old skip) | 4 failed |
| search only `force`, not `defaults`/`merge` | 1 failed |
| allow a reference to resolve to another reference | 1 failed |
| restored | 19 passed |

~~`check-learnings-budget.test.ts` also fails on this branch — it fails identically on `main`, so it is pre-existing and untouched here.~~

**Correction:** that was wrong. The suite is healthy — `bun run test:unit` passes all 14. It failed only because I was invoking vitest through `npx`, and the suite resolves Bun from whichever runner launched it. Nothing is pre-existing and nothing is broken. Error message improved in #2265 so the next reader is not misled the same way.

🤖 Generated with Claude Code

