### PR TITLE
A synced threshold is not evidence a tool is used

### DIFF
--- a/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -25,6 +25,9 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+/** The tool named by the Expo template's scripts and its flows directory. */
+const MAESTRO = "maestro";
+
 /**
  * Tools Lisa or its templates invoke, and how to recognise a need for them.
  *
@@ -33,9 +36,12 @@ import { join } from "node:path";
  * ones that only appear when the tool is genuinely used.
  */
 const KNOWN_TOOLS = Object.freeze({
-  maestro: {
+  [MAESTRO]: {
+    // A flows directory is the artifact maestro consumes; its presence is
+    // usage, where a synced threshold default is not.
+    artifacts: ".maestro",
     why: "Expo's template ships npm scripts that invoke `maestro`, and nothing installs the binary.",
-    mcpFallback: "maestro",
+    mcpFallback: MAESTRO,
   },
   gh: {
     why: "The work-item guardrails shell out to `gh` for every tracker read.",
@@ -199,22 +205,52 @@ export function toolsFromSecretNotes(notes) {
 }
 
 /**
- * Tools implied by quality configuration.
+ * Whether anything in the project actually reaches for this tool.
+ *
+ * Corroboration for a threshold, which on its own says only that a default was
+ * synced. Two independent witnesses: a script that names the binary, or the
+ * directory of artifacts the tool consumes.
+ * @param {string} tool Tool name.
+ * @param {object|null} pkg Parsed package.json.
+ * @param {string} cwd Project root.
+ * @returns {boolean} Whether the project uses it.
+ */
+function usedByProject(tool, pkg, cwd) {
+  const invoked = [...toolsFromScripts(pkg).keys()].includes(tool);
+  if (invoked) return true;
+  const artifacts = KNOWN_TOOLS[tool]?.artifacts;
+  return Boolean(artifacts && existsSync(join(cwd, artifacts)));
+}
+
+/**
+ * Tools a project's quality configuration CORROBORATES — never establishes.
+ *
+ * A threshold is not usage. `quality.e2eCoverage` defaults are synced into
+ * every project by `src/sync/registry.ts`, so this repository carries a
+ * `maestro` entry while having no `.maestro` directory and no script that
+ * invokes it. Treating that as evidence proposed pinning a 300MB JVM
+ * application into a container for a tool nothing runs.
+ *
+ * Evidence that a tool is CONFIGURED is not evidence that it is NEEDED — the
+ * same mistake as proposing a binary npm already provides. So a threshold only
+ * counts when something corroborates it: a script that invokes the tool, or the
+ * artifacts it consumes. In a real Expo project the script signal fires and
+ * this adds nothing; in a project that merely inherited the defaults, it
+ * correctly stays quiet.
  * @param {object|null} config Parsed .lisa.config.json.
+ * @param {object|null} [pkg] Parsed package.json, for corroboration.
+ * @param {string} [cwd] Project root, for artifact corroboration.
  * @returns {Map<string, string>} Tool name to the setting that implies it.
  */
-export function toolsFromQuality(config) {
+export function toolsFromQuality(config, pkg = null, cwd = process.cwd()) {
   const found = new Map();
-  // Every runner under e2eCoverage, not a hardcoded one. Naming `playwright`
-  // explicitly meant `quality.e2eCoverage.maestro` — configured in this very
-  // repository — produced no signal at all, so the one tool that genuinely
-  // needs a pinned binary and genuinely was not declared stayed invisible to
-  // the detector built to find it. A gate that reports "nothing outstanding"
-  // while the gap is right there is worse than no gate.
   for (const runner of Object.keys(config?.quality?.e2eCoverage ?? {})) {
-    if (Object.hasOwn(KNOWN_TOOLS, runner)) {
-      found.set(runner, `quality.e2eCoverage.${runner} is configured`);
-    }
+    if (!Object.hasOwn(KNOWN_TOOLS, runner)) continue;
+    if (!usedByProject(runner, pkg, cwd)) continue;
+    found.set(
+      runner,
+      `quality.e2eCoverage.${runner} is configured, and the project uses it`
+    );
   }
   if (config?.quality?.sonar || config?.sonar) {
     found.set("sonar-scanner", "Sonar analysis is configured");
@@ -288,7 +324,7 @@ export function detectTooling(cwd = process.cwd()) {
     toolsFromScripts(pkg),
     toolsFromMcp(mcp),
     toolsFromSecretNotes(notes),
-    toolsFromQuality(config),
+    toolsFromQuality(config, pkg, cwd),
   ];
 
   const merged = new Map();

--- a/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,7 +22,7 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 /** The tool named by the Expo template's scripts and its flows directory. */
@@ -219,7 +219,17 @@ function usedByProject(tool, pkg, cwd) {
   const invoked = [...toolsFromScripts(pkg).keys()].includes(tool);
   if (invoked) return true;
   const artifacts = KNOWN_TOOLS[tool]?.artifacts;
-  return Boolean(artifacts && existsSync(join(cwd, artifacts)));
+  if (!artifacts) return false;
+  // A DIRECTORY, not merely an entry with that name. `existsSync` is true for a
+  // regular file too, so a stray `.maestro` note or editor artifact would have
+  // corroborated the threshold and reintroduced the 300MB proposal this check
+  // exists to prevent — a false positive arriving through the very guard added
+  // to stop one.
+  try {
+    return statSync(join(cwd, artifacts)).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -25,6 +25,9 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+/** The tool named by the Expo template's scripts and its flows directory. */
+const MAESTRO = "maestro";
+
 /**
  * Tools Lisa or its templates invoke, and how to recognise a need for them.
  *
@@ -33,9 +36,12 @@ import { join } from "node:path";
  * ones that only appear when the tool is genuinely used.
  */
 const KNOWN_TOOLS = Object.freeze({
-  maestro: {
+  [MAESTRO]: {
+    // A flows directory is the artifact maestro consumes; its presence is
+    // usage, where a synced threshold default is not.
+    artifacts: ".maestro",
     why: "Expo's template ships npm scripts that invoke `maestro`, and nothing installs the binary.",
-    mcpFallback: "maestro",
+    mcpFallback: MAESTRO,
   },
   gh: {
     why: "The work-item guardrails shell out to `gh` for every tracker read.",
@@ -199,22 +205,52 @@ export function toolsFromSecretNotes(notes) {
 }
 
 /**
- * Tools implied by quality configuration.
+ * Whether anything in the project actually reaches for this tool.
+ *
+ * Corroboration for a threshold, which on its own says only that a default was
+ * synced. Two independent witnesses: a script that names the binary, or the
+ * directory of artifacts the tool consumes.
+ * @param {string} tool Tool name.
+ * @param {object|null} pkg Parsed package.json.
+ * @param {string} cwd Project root.
+ * @returns {boolean} Whether the project uses it.
+ */
+function usedByProject(tool, pkg, cwd) {
+  const invoked = [...toolsFromScripts(pkg).keys()].includes(tool);
+  if (invoked) return true;
+  const artifacts = KNOWN_TOOLS[tool]?.artifacts;
+  return Boolean(artifacts && existsSync(join(cwd, artifacts)));
+}
+
+/**
+ * Tools a project's quality configuration CORROBORATES — never establishes.
+ *
+ * A threshold is not usage. `quality.e2eCoverage` defaults are synced into
+ * every project by `src/sync/registry.ts`, so this repository carries a
+ * `maestro` entry while having no `.maestro` directory and no script that
+ * invokes it. Treating that as evidence proposed pinning a 300MB JVM
+ * application into a container for a tool nothing runs.
+ *
+ * Evidence that a tool is CONFIGURED is not evidence that it is NEEDED — the
+ * same mistake as proposing a binary npm already provides. So a threshold only
+ * counts when something corroborates it: a script that invokes the tool, or the
+ * artifacts it consumes. In a real Expo project the script signal fires and
+ * this adds nothing; in a project that merely inherited the defaults, it
+ * correctly stays quiet.
  * @param {object|null} config Parsed .lisa.config.json.
+ * @param {object|null} [pkg] Parsed package.json, for corroboration.
+ * @param {string} [cwd] Project root, for artifact corroboration.
  * @returns {Map<string, string>} Tool name to the setting that implies it.
  */
-export function toolsFromQuality(config) {
+export function toolsFromQuality(config, pkg = null, cwd = process.cwd()) {
   const found = new Map();
-  // Every runner under e2eCoverage, not a hardcoded one. Naming `playwright`
-  // explicitly meant `quality.e2eCoverage.maestro` — configured in this very
-  // repository — produced no signal at all, so the one tool that genuinely
-  // needs a pinned binary and genuinely was not declared stayed invisible to
-  // the detector built to find it. A gate that reports "nothing outstanding"
-  // while the gap is right there is worse than no gate.
   for (const runner of Object.keys(config?.quality?.e2eCoverage ?? {})) {
-    if (Object.hasOwn(KNOWN_TOOLS, runner)) {
-      found.set(runner, `quality.e2eCoverage.${runner} is configured`);
-    }
+    if (!Object.hasOwn(KNOWN_TOOLS, runner)) continue;
+    if (!usedByProject(runner, pkg, cwd)) continue;
+    found.set(
+      runner,
+      `quality.e2eCoverage.${runner} is configured, and the project uses it`
+    );
   }
   if (config?.quality?.sonar || config?.sonar) {
     found.set("sonar-scanner", "Sonar analysis is configured");
@@ -288,7 +324,7 @@ export function detectTooling(cwd = process.cwd()) {
     toolsFromScripts(pkg),
     toolsFromMcp(mcp),
     toolsFromSecretNotes(notes),
-    toolsFromQuality(config),
+    toolsFromQuality(config, pkg, cwd),
   ];
 
   const merged = new Map();

--- a/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,7 +22,7 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 /** The tool named by the Expo template's scripts and its flows directory. */
@@ -219,7 +219,17 @@ function usedByProject(tool, pkg, cwd) {
   const invoked = [...toolsFromScripts(pkg).keys()].includes(tool);
   if (invoked) return true;
   const artifacts = KNOWN_TOOLS[tool]?.artifacts;
-  return Boolean(artifacts && existsSync(join(cwd, artifacts)));
+  if (!artifacts) return false;
+  // A DIRECTORY, not merely an entry with that name. `existsSync` is true for a
+  // regular file too, so a stray `.maestro` note or editor artifact would have
+  // corroborated the threshold and reintroduced the 300MB proposal this check
+  // exists to prevent — a false positive arriving through the very guard added
+  // to stop one.
+  try {
+    return statSync(join(cwd, artifacts)).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -25,6 +25,9 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+/** The tool named by the Expo template's scripts and its flows directory. */
+const MAESTRO = "maestro";
+
 /**
  * Tools Lisa or its templates invoke, and how to recognise a need for them.
  *
@@ -33,9 +36,12 @@ import { join } from "node:path";
  * ones that only appear when the tool is genuinely used.
  */
 const KNOWN_TOOLS = Object.freeze({
-  maestro: {
+  [MAESTRO]: {
+    // A flows directory is the artifact maestro consumes; its presence is
+    // usage, where a synced threshold default is not.
+    artifacts: ".maestro",
     why: "Expo's template ships npm scripts that invoke `maestro`, and nothing installs the binary.",
-    mcpFallback: "maestro",
+    mcpFallback: MAESTRO,
   },
   gh: {
     why: "The work-item guardrails shell out to `gh` for every tracker read.",
@@ -199,22 +205,52 @@ export function toolsFromSecretNotes(notes) {
 }
 
 /**
- * Tools implied by quality configuration.
+ * Whether anything in the project actually reaches for this tool.
+ *
+ * Corroboration for a threshold, which on its own says only that a default was
+ * synced. Two independent witnesses: a script that names the binary, or the
+ * directory of artifacts the tool consumes.
+ * @param {string} tool Tool name.
+ * @param {object|null} pkg Parsed package.json.
+ * @param {string} cwd Project root.
+ * @returns {boolean} Whether the project uses it.
+ */
+function usedByProject(tool, pkg, cwd) {
+  const invoked = [...toolsFromScripts(pkg).keys()].includes(tool);
+  if (invoked) return true;
+  const artifacts = KNOWN_TOOLS[tool]?.artifacts;
+  return Boolean(artifacts && existsSync(join(cwd, artifacts)));
+}
+
+/**
+ * Tools a project's quality configuration CORROBORATES — never establishes.
+ *
+ * A threshold is not usage. `quality.e2eCoverage` defaults are synced into
+ * every project by `src/sync/registry.ts`, so this repository carries a
+ * `maestro` entry while having no `.maestro` directory and no script that
+ * invokes it. Treating that as evidence proposed pinning a 300MB JVM
+ * application into a container for a tool nothing runs.
+ *
+ * Evidence that a tool is CONFIGURED is not evidence that it is NEEDED — the
+ * same mistake as proposing a binary npm already provides. So a threshold only
+ * counts when something corroborates it: a script that invokes the tool, or the
+ * artifacts it consumes. In a real Expo project the script signal fires and
+ * this adds nothing; in a project that merely inherited the defaults, it
+ * correctly stays quiet.
  * @param {object|null} config Parsed .lisa.config.json.
+ * @param {object|null} [pkg] Parsed package.json, for corroboration.
+ * @param {string} [cwd] Project root, for artifact corroboration.
  * @returns {Map<string, string>} Tool name to the setting that implies it.
  */
-export function toolsFromQuality(config) {
+export function toolsFromQuality(config, pkg = null, cwd = process.cwd()) {
   const found = new Map();
-  // Every runner under e2eCoverage, not a hardcoded one. Naming `playwright`
-  // explicitly meant `quality.e2eCoverage.maestro` — configured in this very
-  // repository — produced no signal at all, so the one tool that genuinely
-  // needs a pinned binary and genuinely was not declared stayed invisible to
-  // the detector built to find it. A gate that reports "nothing outstanding"
-  // while the gap is right there is worse than no gate.
   for (const runner of Object.keys(config?.quality?.e2eCoverage ?? {})) {
-    if (Object.hasOwn(KNOWN_TOOLS, runner)) {
-      found.set(runner, `quality.e2eCoverage.${runner} is configured`);
-    }
+    if (!Object.hasOwn(KNOWN_TOOLS, runner)) continue;
+    if (!usedByProject(runner, pkg, cwd)) continue;
+    found.set(
+      runner,
+      `quality.e2eCoverage.${runner} is configured, and the project uses it`
+    );
   }
   if (config?.quality?.sonar || config?.sonar) {
     found.set("sonar-scanner", "Sonar analysis is configured");
@@ -288,7 +324,7 @@ export function detectTooling(cwd = process.cwd()) {
     toolsFromScripts(pkg),
     toolsFromMcp(mcp),
     toolsFromSecretNotes(notes),
-    toolsFromQuality(config),
+    toolsFromQuality(config, pkg, cwd),
   ];
 
   const merged = new Map();

--- a/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,7 +22,7 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 /** The tool named by the Expo template's scripts and its flows directory. */
@@ -219,7 +219,17 @@ function usedByProject(tool, pkg, cwd) {
   const invoked = [...toolsFromScripts(pkg).keys()].includes(tool);
   if (invoked) return true;
   const artifacts = KNOWN_TOOLS[tool]?.artifacts;
-  return Boolean(artifacts && existsSync(join(cwd, artifacts)));
+  if (!artifacts) return false;
+  // A DIRECTORY, not merely an entry with that name. `existsSync` is true for a
+  // regular file too, so a stray `.maestro` note or editor artifact would have
+  // corroborated the threshold and reintroduced the 300MB proposal this check
+  // exists to prevent — a false positive arriving through the very guard added
+  // to stop one.
+  try {
+    return statSync(join(cwd, artifacts)).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -25,6 +25,9 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+/** The tool named by the Expo template's scripts and its flows directory. */
+const MAESTRO = "maestro";
+
 /**
  * Tools Lisa or its templates invoke, and how to recognise a need for them.
  *
@@ -33,9 +36,12 @@ import { join } from "node:path";
  * ones that only appear when the tool is genuinely used.
  */
 const KNOWN_TOOLS = Object.freeze({
-  maestro: {
+  [MAESTRO]: {
+    // A flows directory is the artifact maestro consumes; its presence is
+    // usage, where a synced threshold default is not.
+    artifacts: ".maestro",
     why: "Expo's template ships npm scripts that invoke `maestro`, and nothing installs the binary.",
-    mcpFallback: "maestro",
+    mcpFallback: MAESTRO,
   },
   gh: {
     why: "The work-item guardrails shell out to `gh` for every tracker read.",
@@ -199,22 +205,52 @@ export function toolsFromSecretNotes(notes) {
 }
 
 /**
- * Tools implied by quality configuration.
+ * Whether anything in the project actually reaches for this tool.
+ *
+ * Corroboration for a threshold, which on its own says only that a default was
+ * synced. Two independent witnesses: a script that names the binary, or the
+ * directory of artifacts the tool consumes.
+ * @param {string} tool Tool name.
+ * @param {object|null} pkg Parsed package.json.
+ * @param {string} cwd Project root.
+ * @returns {boolean} Whether the project uses it.
+ */
+function usedByProject(tool, pkg, cwd) {
+  const invoked = [...toolsFromScripts(pkg).keys()].includes(tool);
+  if (invoked) return true;
+  const artifacts = KNOWN_TOOLS[tool]?.artifacts;
+  return Boolean(artifacts && existsSync(join(cwd, artifacts)));
+}
+
+/**
+ * Tools a project's quality configuration CORROBORATES — never establishes.
+ *
+ * A threshold is not usage. `quality.e2eCoverage` defaults are synced into
+ * every project by `src/sync/registry.ts`, so this repository carries a
+ * `maestro` entry while having no `.maestro` directory and no script that
+ * invokes it. Treating that as evidence proposed pinning a 300MB JVM
+ * application into a container for a tool nothing runs.
+ *
+ * Evidence that a tool is CONFIGURED is not evidence that it is NEEDED — the
+ * same mistake as proposing a binary npm already provides. So a threshold only
+ * counts when something corroborates it: a script that invokes the tool, or the
+ * artifacts it consumes. In a real Expo project the script signal fires and
+ * this adds nothing; in a project that merely inherited the defaults, it
+ * correctly stays quiet.
  * @param {object|null} config Parsed .lisa.config.json.
+ * @param {object|null} [pkg] Parsed package.json, for corroboration.
+ * @param {string} [cwd] Project root, for artifact corroboration.
  * @returns {Map<string, string>} Tool name to the setting that implies it.
  */
-export function toolsFromQuality(config) {
+export function toolsFromQuality(config, pkg = null, cwd = process.cwd()) {
   const found = new Map();
-  // Every runner under e2eCoverage, not a hardcoded one. Naming `playwright`
-  // explicitly meant `quality.e2eCoverage.maestro` — configured in this very
-  // repository — produced no signal at all, so the one tool that genuinely
-  // needs a pinned binary and genuinely was not declared stayed invisible to
-  // the detector built to find it. A gate that reports "nothing outstanding"
-  // while the gap is right there is worse than no gate.
   for (const runner of Object.keys(config?.quality?.e2eCoverage ?? {})) {
-    if (Object.hasOwn(KNOWN_TOOLS, runner)) {
-      found.set(runner, `quality.e2eCoverage.${runner} is configured`);
-    }
+    if (!Object.hasOwn(KNOWN_TOOLS, runner)) continue;
+    if (!usedByProject(runner, pkg, cwd)) continue;
+    found.set(
+      runner,
+      `quality.e2eCoverage.${runner} is configured, and the project uses it`
+    );
   }
   if (config?.quality?.sonar || config?.sonar) {
     found.set("sonar-scanner", "Sonar analysis is configured");
@@ -288,7 +324,7 @@ export function detectTooling(cwd = process.cwd()) {
     toolsFromScripts(pkg),
     toolsFromMcp(mcp),
     toolsFromSecretNotes(notes),
-    toolsFromQuality(config),
+    toolsFromQuality(config, pkg, cwd),
   ];
 
   const merged = new Map();

--- a/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,7 +22,7 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 /** The tool named by the Expo template's scripts and its flows directory. */
@@ -219,7 +219,17 @@ function usedByProject(tool, pkg, cwd) {
   const invoked = [...toolsFromScripts(pkg).keys()].includes(tool);
   if (invoked) return true;
   const artifacts = KNOWN_TOOLS[tool]?.artifacts;
-  return Boolean(artifacts && existsSync(join(cwd, artifacts)));
+  if (!artifacts) return false;
+  // A DIRECTORY, not merely an entry with that name. `existsSync` is true for a
+  // regular file too, so a stray `.maestro` note or editor artifact would have
+  // corroborated the threshold and reintroduced the 300MB proposal this check
+  // exists to prevent — a false positive arriving through the very guard added
+  // to stop one.
+  try {
+    return statSync(join(cwd, artifacts)).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -25,6 +25,9 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+/** The tool named by the Expo template's scripts and its flows directory. */
+const MAESTRO = "maestro";
+
 /**
  * Tools Lisa or its templates invoke, and how to recognise a need for them.
  *
@@ -33,9 +36,12 @@ import { join } from "node:path";
  * ones that only appear when the tool is genuinely used.
  */
 const KNOWN_TOOLS = Object.freeze({
-  maestro: {
+  [MAESTRO]: {
+    // A flows directory is the artifact maestro consumes; its presence is
+    // usage, where a synced threshold default is not.
+    artifacts: ".maestro",
     why: "Expo's template ships npm scripts that invoke `maestro`, and nothing installs the binary.",
-    mcpFallback: "maestro",
+    mcpFallback: MAESTRO,
   },
   gh: {
     why: "The work-item guardrails shell out to `gh` for every tracker read.",
@@ -199,22 +205,52 @@ export function toolsFromSecretNotes(notes) {
 }
 
 /**
- * Tools implied by quality configuration.
+ * Whether anything in the project actually reaches for this tool.
+ *
+ * Corroboration for a threshold, which on its own says only that a default was
+ * synced. Two independent witnesses: a script that names the binary, or the
+ * directory of artifacts the tool consumes.
+ * @param {string} tool Tool name.
+ * @param {object|null} pkg Parsed package.json.
+ * @param {string} cwd Project root.
+ * @returns {boolean} Whether the project uses it.
+ */
+function usedByProject(tool, pkg, cwd) {
+  const invoked = [...toolsFromScripts(pkg).keys()].includes(tool);
+  if (invoked) return true;
+  const artifacts = KNOWN_TOOLS[tool]?.artifacts;
+  return Boolean(artifacts && existsSync(join(cwd, artifacts)));
+}
+
+/**
+ * Tools a project's quality configuration CORROBORATES — never establishes.
+ *
+ * A threshold is not usage. `quality.e2eCoverage` defaults are synced into
+ * every project by `src/sync/registry.ts`, so this repository carries a
+ * `maestro` entry while having no `.maestro` directory and no script that
+ * invokes it. Treating that as evidence proposed pinning a 300MB JVM
+ * application into a container for a tool nothing runs.
+ *
+ * Evidence that a tool is CONFIGURED is not evidence that it is NEEDED — the
+ * same mistake as proposing a binary npm already provides. So a threshold only
+ * counts when something corroborates it: a script that invokes the tool, or the
+ * artifacts it consumes. In a real Expo project the script signal fires and
+ * this adds nothing; in a project that merely inherited the defaults, it
+ * correctly stays quiet.
  * @param {object|null} config Parsed .lisa.config.json.
+ * @param {object|null} [pkg] Parsed package.json, for corroboration.
+ * @param {string} [cwd] Project root, for artifact corroboration.
  * @returns {Map<string, string>} Tool name to the setting that implies it.
  */
-export function toolsFromQuality(config) {
+export function toolsFromQuality(config, pkg = null, cwd = process.cwd()) {
   const found = new Map();
-  // Every runner under e2eCoverage, not a hardcoded one. Naming `playwright`
-  // explicitly meant `quality.e2eCoverage.maestro` — configured in this very
-  // repository — produced no signal at all, so the one tool that genuinely
-  // needs a pinned binary and genuinely was not declared stayed invisible to
-  // the detector built to find it. A gate that reports "nothing outstanding"
-  // while the gap is right there is worse than no gate.
   for (const runner of Object.keys(config?.quality?.e2eCoverage ?? {})) {
-    if (Object.hasOwn(KNOWN_TOOLS, runner)) {
-      found.set(runner, `quality.e2eCoverage.${runner} is configured`);
-    }
+    if (!Object.hasOwn(KNOWN_TOOLS, runner)) continue;
+    if (!usedByProject(runner, pkg, cwd)) continue;
+    found.set(
+      runner,
+      `quality.e2eCoverage.${runner} is configured, and the project uses it`
+    );
   }
   if (config?.quality?.sonar || config?.sonar) {
     found.set("sonar-scanner", "Sonar analysis is configured");
@@ -288,7 +324,7 @@ export function detectTooling(cwd = process.cwd()) {
     toolsFromScripts(pkg),
     toolsFromMcp(mcp),
     toolsFromSecretNotes(notes),
-    toolsFromQuality(config),
+    toolsFromQuality(config, pkg, cwd),
   ];
 
   const merged = new Map();

--- a/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,7 +22,7 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 /** The tool named by the Expo template's scripts and its flows directory. */
@@ -219,7 +219,17 @@ function usedByProject(tool, pkg, cwd) {
   const invoked = [...toolsFromScripts(pkg).keys()].includes(tool);
   if (invoked) return true;
   const artifacts = KNOWN_TOOLS[tool]?.artifacts;
-  return Boolean(artifacts && existsSync(join(cwd, artifacts)));
+  if (!artifacts) return false;
+  // A DIRECTORY, not merely an entry with that name. `existsSync` is true for a
+  // regular file too, so a stray `.maestro` note or editor artifact would have
+  // corroborated the threshold and reintroduced the 300MB proposal this check
+  // exists to prevent — a false positive arriving through the very guard added
+  // to stop one.
+  try {
+    return statSync(join(cwd, artifacts)).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -25,6 +25,9 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+/** The tool named by the Expo template's scripts and its flows directory. */
+const MAESTRO = "maestro";
+
 /**
  * Tools Lisa or its templates invoke, and how to recognise a need for them.
  *
@@ -33,9 +36,12 @@ import { join } from "node:path";
  * ones that only appear when the tool is genuinely used.
  */
 const KNOWN_TOOLS = Object.freeze({
-  maestro: {
+  [MAESTRO]: {
+    // A flows directory is the artifact maestro consumes; its presence is
+    // usage, where a synced threshold default is not.
+    artifacts: ".maestro",
     why: "Expo's template ships npm scripts that invoke `maestro`, and nothing installs the binary.",
-    mcpFallback: "maestro",
+    mcpFallback: MAESTRO,
   },
   gh: {
     why: "The work-item guardrails shell out to `gh` for every tracker read.",
@@ -199,22 +205,52 @@ export function toolsFromSecretNotes(notes) {
 }
 
 /**
- * Tools implied by quality configuration.
+ * Whether anything in the project actually reaches for this tool.
+ *
+ * Corroboration for a threshold, which on its own says only that a default was
+ * synced. Two independent witnesses: a script that names the binary, or the
+ * directory of artifacts the tool consumes.
+ * @param {string} tool Tool name.
+ * @param {object|null} pkg Parsed package.json.
+ * @param {string} cwd Project root.
+ * @returns {boolean} Whether the project uses it.
+ */
+function usedByProject(tool, pkg, cwd) {
+  const invoked = [...toolsFromScripts(pkg).keys()].includes(tool);
+  if (invoked) return true;
+  const artifacts = KNOWN_TOOLS[tool]?.artifacts;
+  return Boolean(artifacts && existsSync(join(cwd, artifacts)));
+}
+
+/**
+ * Tools a project's quality configuration CORROBORATES — never establishes.
+ *
+ * A threshold is not usage. `quality.e2eCoverage` defaults are synced into
+ * every project by `src/sync/registry.ts`, so this repository carries a
+ * `maestro` entry while having no `.maestro` directory and no script that
+ * invokes it. Treating that as evidence proposed pinning a 300MB JVM
+ * application into a container for a tool nothing runs.
+ *
+ * Evidence that a tool is CONFIGURED is not evidence that it is NEEDED — the
+ * same mistake as proposing a binary npm already provides. So a threshold only
+ * counts when something corroborates it: a script that invokes the tool, or the
+ * artifacts it consumes. In a real Expo project the script signal fires and
+ * this adds nothing; in a project that merely inherited the defaults, it
+ * correctly stays quiet.
  * @param {object|null} config Parsed .lisa.config.json.
+ * @param {object|null} [pkg] Parsed package.json, for corroboration.
+ * @param {string} [cwd] Project root, for artifact corroboration.
  * @returns {Map<string, string>} Tool name to the setting that implies it.
  */
-export function toolsFromQuality(config) {
+export function toolsFromQuality(config, pkg = null, cwd = process.cwd()) {
   const found = new Map();
-  // Every runner under e2eCoverage, not a hardcoded one. Naming `playwright`
-  // explicitly meant `quality.e2eCoverage.maestro` — configured in this very
-  // repository — produced no signal at all, so the one tool that genuinely
-  // needs a pinned binary and genuinely was not declared stayed invisible to
-  // the detector built to find it. A gate that reports "nothing outstanding"
-  // while the gap is right there is worse than no gate.
   for (const runner of Object.keys(config?.quality?.e2eCoverage ?? {})) {
-    if (Object.hasOwn(KNOWN_TOOLS, runner)) {
-      found.set(runner, `quality.e2eCoverage.${runner} is configured`);
-    }
+    if (!Object.hasOwn(KNOWN_TOOLS, runner)) continue;
+    if (!usedByProject(runner, pkg, cwd)) continue;
+    found.set(
+      runner,
+      `quality.e2eCoverage.${runner} is configured, and the project uses it`
+    );
   }
   if (config?.quality?.sonar || config?.sonar) {
     found.set("sonar-scanner", "Sonar analysis is configured");
@@ -288,7 +324,7 @@ export function detectTooling(cwd = process.cwd()) {
     toolsFromScripts(pkg),
     toolsFromMcp(mcp),
     toolsFromSecretNotes(notes),
-    toolsFromQuality(config),
+    toolsFromQuality(config, pkg, cwd),
   ];
 
   const merged = new Map();

--- a/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,7 +22,7 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 /** The tool named by the Expo template's scripts and its flows directory. */
@@ -219,7 +219,17 @@ function usedByProject(tool, pkg, cwd) {
   const invoked = [...toolsFromScripts(pkg).keys()].includes(tool);
   if (invoked) return true;
   const artifacts = KNOWN_TOOLS[tool]?.artifacts;
-  return Boolean(artifacts && existsSync(join(cwd, artifacts)));
+  if (!artifacts) return false;
+  // A DIRECTORY, not merely an entry with that name. `existsSync` is true for a
+  // regular file too, so a stray `.maestro` note or editor artifact would have
+  // corroborated the threshold and reintroduced the 300MB proposal this check
+  // exists to prevent — a false positive arriving through the very guard added
+  // to stop one.
+  try {
+    return statSync(join(cwd, artifacts)).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -851,7 +851,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-detect-tooling/SKILL.md":
       "1778a009d06099b3bd2d9a33b37bec34836b295e21fad220ae926491d3557208",
     "plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs":
-      "05e0c4808e64fbdc277419ad00b6a68da96766a9261a5b97f3a4961bbab107c4",
+      "d307227b1033c09a2cd0a0959e5283291e662e5eb99ce80b5675edb4c40e69a0",
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
       "fb41a1e63c5332d47a46e715aff52551f3df867033b5e4f37dfaeee30019b891",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -851,7 +851,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-detect-tooling/SKILL.md":
       "1778a009d06099b3bd2d9a33b37bec34836b295e21fad220ae926491d3557208",
     "plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs":
-      "d307227b1033c09a2cd0a0959e5283291e662e5eb99ce80b5675edb4c40e69a0",
+      "d2ff0e79dd8a3f79252d425d8203dab54f9e2afd387d113cb8b1a7637a5082e7",
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
       "fb41a1e63c5332d47a46e715aff52551f3df867033b5e4f37dfaeee30019b891",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":

--- a/tests/unit/secrets/detect-tooling.test.ts
+++ b/tests/unit/secrets/detect-tooling.test.ts
@@ -27,13 +27,19 @@ import {
   toolsFromSecretNotes,
 } from "../../../plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs";
 
+/** The Expo template's own script body — the strongest usage signal. */
+const MAESTRO_SCRIPT = "maestro test .maestro/flows";
+
+/** A root with no artifacts, so only the explicit inputs decide. */
+const NO_PROJECT = "/nonexistent-project";
+
 describe("signals", () => {
   it("reads the body of an npm script, not its name", () => {
     // A script NAMED maestro:test proves nothing; one that RUNS `maestro test`
     // is the project stating a dependency in executable form. The Expo template
     // ships exactly this, and nothing installs the binary.
     const found = toolsFromScripts({
-      scripts: { "maestro:test": "maestro test .maestro/flows" },
+      scripts: { "maestro:test": MAESTRO_SCRIPT },
     });
 
     expect([...found.keys()]).toContain("maestro");
@@ -189,13 +195,49 @@ describe("against this repository", () => {
 });
 
 describe("quality signals", () => {
+  it("stays quiet for a threshold nothing corroborates", () => {
+    // quality.e2eCoverage defaults are synced into every project by
+    // src/sync/registry.ts. This repository carries a maestro entry while
+    // having no .maestro directory and no script that invokes it — treating
+    // that as evidence proposed pinning a 300MB JVM application into a
+    // container for a tool nothing runs.
+    //
+    // Evidence that a tool is CONFIGURED is not evidence that it is NEEDED.
+    const found = toolsFromQuality(
+      { quality: { e2eCoverage: { maestro: {} } } },
+      { scripts: { test: "vitest" } },
+      NO_PROJECT
+    );
+
+    expect([...found.keys()]).toHaveLength(0);
+  });
+
+  it("fires when a script actually invokes the runner", () => {
+    // A real Expo project: the template ships `maestro test` scripts, so the
+    // threshold is corroborated and the gap is still reported.
+    const found = toolsFromQuality(
+      { quality: { e2eCoverage: { maestro: {} } } },
+      { scripts: { "maestro:test": MAESTRO_SCRIPT } },
+      NO_PROJECT
+    );
+
+    expect([...found.keys()]).toContain("maestro");
+  });
+
   it("surfaces every configured e2e runner, not a hardcoded one", () => {
     // quality.e2eCoverage.maestro is configured in this repository and produced
     // no signal, so the detector reported "nothing outstanding" while maestro —
     // the tool whose absence started this work — was undeclared and invisible.
-    const found = toolsFromQuality({
-      quality: { e2eCoverage: { playwright: {}, maestro: {} } },
-    });
+    const found = toolsFromQuality(
+      { quality: { e2eCoverage: { playwright: {}, maestro: {} } } },
+      {
+        scripts: {
+          e2e: "playwright test",
+          "maestro:test": MAESTRO_SCRIPT,
+        },
+      },
+      NO_PROJECT
+    );
 
     expect([...found.keys()]).toEqual(
       expect.arrayContaining(["playwright", "maestro"])
@@ -205,9 +247,11 @@ describe("quality signals", () => {
   it("ignores a runner it knows nothing about", () => {
     // A signal for an unknown name would propose a manifest entry naming a
     // tool the detector cannot describe or pin.
-    const found = toolsFromQuality({
-      quality: { e2eCoverage: { somethingElse: {} } },
-    });
+    const found = toolsFromQuality(
+      { quality: { e2eCoverage: { somethingElse: {} } } },
+      { scripts: { x: "somethingElse run" } },
+      NO_PROJECT
+    );
 
     expect([...found.keys()]).toHaveLength(0);
   });

--- a/tests/unit/secrets/detect-tooling.test.ts
+++ b/tests/unit/secrets/detect-tooling.test.ts
@@ -14,7 +14,11 @@
  * install path, which is precisely what `assertPinned` exists to prevent.
  * @module tests/unit/secrets/detect-tooling
  */
-import { describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   declaredTools,
@@ -296,5 +300,56 @@ describe("tools the package manager already provides", () => {
 
   it("still proposes when the package is absent", () => {
     expect(satisfiedByNpm({ devDependencies: {} }, "playwright")).toBe(false);
+  });
+});
+
+describe("artifact corroboration", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const dir of roots.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * A project carrying only the synced threshold, plus whatever artifact the
+   * case plants.
+   * @returns Absolute path to the throwaway project
+   */
+  function project(): string {
+    const root = mkdtempSync(path.join(tmpdir(), "lisa-artifact-"));
+    roots.push(root);
+    return root;
+  }
+
+  it("accepts the flows DIRECTORY as evidence the tool is used", () => {
+    const root = project();
+    mkdirSync(path.join(root, ".maestro"), { recursive: true });
+
+    const found = toolsFromQuality(
+      { quality: { e2eCoverage: { maestro: {} } } },
+      { scripts: { test: "vitest" } },
+      root
+    );
+
+    expect([...found.keys()]).toContain("maestro");
+  });
+
+  it("rejects a regular FILE of the same name", () => {
+    // `existsSync` is true for a file too, so a stray `.maestro` note or editor
+    // artifact would have corroborated the threshold and reintroduced the
+    // 300MB proposal this check exists to prevent — a false positive arriving
+    // through the very guard added to stop one.
+    const root = project();
+    writeFileSync(path.join(root, ".maestro"), "just a note\n");
+
+    const found = toolsFromQuality(
+      { quality: { e2eCoverage: { maestro: {} } } },
+      { scripts: { test: "vitest" } },
+      root
+    );
+
+    expect([...found.keys()]).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2261

The detector proposed pinning **Maestro** into Lisa’s container. Checking before acting on it:

```
.maestro directory:   none
maestro npm scripts:  none
quality.e2eCoverage:  {"playwright":{...},"maestro":{...}}   ← synced defaults
```

Those thresholds are written into **every** project by `src/sync/registry.ts`. They say a default exists, not that this repository runs Maestro. Acting on it would have added a **300 MB JVM application** to every cloud environment build for a tool nothing invokes.

Same class as proposing a binary npm already provides (#2256): **evidence that a tool is configured is not evidence that it is needed.** Widening the signal to every runner fixed a real blind spot and introduced this one in the same change, because a threshold reads like usage and is not.

## The fix

A threshold now **corroborates** rather than establishes — it counts only alongside a second witness: a script that invokes the binary, or the artifact directory the tool consumes.

```
QUIET     threshold default, nothing uses it
PROPOSES  threshold + npm script invoking it
PROPOSES  threshold + a .maestro flows directory
```

The middle case is the one that must not regress: in a real Expo project the script signal fires, which is the entire reason this feature exists.

## Recorded rather than applied

The Maestro pin is verified and on #2261 so nobody re-derives it — its checksum matches the vendor’s published `checksums_sha256.txt`:

```
cli-2.8.0 · maestro.zip · release-zip
sha256 b3e561161904fb391875ca5834d5b22cf0b01c052dd1b408ad83e30d8f8951b3
binary maestro/bin/maestro   (JVM launcher — a project pinning it should also require java)
```

That belongs in an Expo project’s config, not Lisa’s.

495 files, 8394 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection support for Maestro projects through metadata and project artifacts.
  * Tooling detection now recognizes configured tools when supported by project scripts or artifacts.
* **Bug Fixes**
  * Reduced false positives caused by inherited quality settings that do not reflect actual project usage.
  * Improved detection accuracy by considering project context and usage evidence.
* **Tests**
  * Expanded coverage for Maestro detection, configured runners, matching scripts, and unsupported tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->