### PR TITLE
feat(quality): fail when a security floor can be collapsed away

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -55,7 +55,7 @@ on:
         default: 'npm'
         type: string
       skip_jobs:
-        description: 'Jobs to skip (comma-separated: lint,lint_slow,typecheck,test,test:unit,test:mutation,test:integration,test:e2e,maestro_e2e,playwright_e2e,e2e_coverage,learnings_budget,threshold_ratchet,work_item_traceability,format,build,dead_code,sg_scan,npm_security_scan,zap_baseline,github_issue)'
+        description: 'Jobs to skip (comma-separated: lint,lint_slow,typecheck,test,test:unit,test:mutation,test:integration,test:e2e,maestro_e2e,playwright_e2e,e2e_coverage,learnings_budget,threshold_ratchet,work_item_traceability,format,build,dead_code,sg_scan,floor_collisions,npm_security_scan,zap_baseline,github_issue)'
         required: false
         default: ''
         type: string
@@ -1849,6 +1849,48 @@ jobs:
         run: |
           echo "::warning::ast-grep scan skipped - no rules defined in ast-grep/rules/"
           echo "To enable ast-grep scanning, add rule YAML files to ast-grep/rules/"
+
+  floor_collisions:
+    name: 🧱 Security Floor Collisions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Catches a security floor that a package manager will silently delete.
+    #
+    # An override naming a package the project also depends on directly gets
+    # rewritten by bun to `$name` on every install, at which point the override
+    # adopts the dependency line's range instead of its own. When that line is
+    # lower — the normal case, since the override exists *because* it is too
+    # low — the floor is gone. Seen in gunnertech/frontend on bun 1.3.11:
+    # `"postcss": ">=8.5.18"` became `"$postcss"` against `^8.5.0`, back inside
+    # the range GHSA patches at 8.5.18. It reads as a tidy-up in the diff and
+    # recurs on every install, so restoring it by hand never holds.
+    #
+    # Deliberately offline and dependency-free: it is a structural question
+    # about the manifest, not a question about the advisory database, so it
+    # cannot go quiet when a network call fails. Whether a surviving floor is
+    # high enough is the separate job of the advisory check.
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',floor_collisions,') }}
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version: ${{ inputs.node_version }}
+
+      - name: 🧱 Check for collapsible security floors
+        run: |
+          set -o pipefail
+          script=scripts/lisa-floor-collisions.mjs
+          if [ ! -f "$script" ]; then
+            echo "::notice::$script is absent; run 'lisa apply' to install it."
+            exit 0
+          fi
+          node "$script" | tee -a "$GITHUB_STEP_SUMMARY"
 
   npm_security_scan:
     name: 🔒 Security Scan

--- a/all/copy-overwrite/scripts/lisa-floor-collisions.mjs
+++ b/all/copy-overwrite/scripts/lisa-floor-collisions.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * @file Fail when a security override can be collapsed into a weaker floor.
+ *
+ * npm and bun both let an override be written as `$name`, meaning "use whatever
+ * the root package pins this to". bun does not merely permit that form — it
+ * REWRITES to it, on every `bun install`, whenever an override names a package
+ * the project also depends on directly. The override stops carrying its own
+ * floor and adopts the dependency line's.
+ *
+ * That is fine when the two agree. It is a silent security regression when the
+ * dependency line is lower, which is the normal case: an override exists
+ * *because* the direct range was too permissive. Observed in
+ * gunnertech/frontend on bun 1.3.11, from a clean tree:
+ *
+ *   "postcss": ">=8.5.18"  ->  "$postcss"   with devDependencies ^8.5.0
+ *   "prettier": "3.8.3"    ->  "$prettier"  with devDependencies ^3.3.3
+ *
+ * postcss 8.5.0 is inside the range GHSA patches at 8.5.18. The rewrite reads
+ * as a tidy-up in the diff, recurs on every install, and defeats any attempt to
+ * restore the floor by hand.
+ *
+ * This check is deliberately OFFLINE and deterministic. It asks one structural
+ * question — can this override be collapsed into something weaker? — and needs
+ * no advisory lookup to answer it, so it runs in every project's CI in
+ * milliseconds and cannot go quiet when a network call fails. Whether a given
+ * floor is high enough for current advisories is a separate question, answered
+ * by check-security-floors.mjs against the advisory database.
+ *
+ * The fix it asks for is always the same: raise the dependency line to the
+ * floor. Removing the override is the wrong move — it is what carries the floor
+ * to transitive copies, which is the case it was written for.
+ *
+ * Usage:
+ *   lisa-floor-collisions.mjs [--manifest package.json] [--json]
+ *
+ * Exit 1 when any override would collapse to a weaker range.
+ */
+
+import { readFileSync } from "node:fs";
+
+const OVERRIDE_SECTIONS = ["overrides", "resolutions"];
+const DEPENDENCY_SECTIONS = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+];
+
+/**
+ * Lowest version a range permits, as a comparable tuple.
+ *
+ * Deliberately crude: it reads the first version in the spec, which is the
+ * lower bound for every form used in practice (`>=1.2.3`, `^1.2.3`, `~1.2.3`,
+ * `1.2.3`, `>=1.2.3 <2`). A spec carrying no version — `*`, `workspace:*`,
+ * `latest` — has no floor to compare and returns null.
+ * @param {string} spec A version range.
+ * @returns {number[]|null} [major, minor, patch], or null when there is none.
+ */
+export function lowestPermitted(spec) {
+  const match = /(\d+)\.(\d+)\.(\d+)/.exec(spec ?? "");
+  return match ? match.slice(1, 4).map(Number) : null;
+}
+
+/**
+ * Compare two version tuples.
+ * @param {number[]} left First version.
+ * @param {number[]} right Second version.
+ * @returns {number} Negative, zero, or positive.
+ */
+function compare(left, right) {
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}
+
+/**
+ * Every direct dependency range, flattened across sections.
+ *
+ * Later sections do not overwrite earlier ones: the FIRST declaration wins, and
+ * a package declared twice is a different problem this check does not own.
+ * @param {object} manifest A parsed package.json.
+ * @returns {Map<string, {spec: string, section: string}>} By package name.
+ */
+export function directDependencies(manifest) {
+  const found = new Map();
+  for (const section of DEPENDENCY_SECTIONS) {
+    for (const [name, spec] of Object.entries(manifest[section] ?? {})) {
+      if (typeof spec === "string" && !found.has(name)) {
+        found.set(name, { spec, section });
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Overrides that a package manager could collapse into a weaker floor.
+ *
+ * Only INTACT overrides are judged. A `$name` override is skipped, and the
+ * reason is that the evidence is already gone: once collapsed, the manifest no
+ * longer records what the floor used to be, so there is nothing to compare the
+ * dependency line against. Reporting every collapsed override instead would
+ * fire on the correct end state — an override collapsed onto a dependency that
+ * already carries the floor is exactly what a fixed project looks like after
+ * its next install — and a check that fails on the fix is one that gets
+ * skipped rather than heeded.
+ *
+ * That leaves a genuine gap for a project whose floor was lost before this
+ * check ever ran. Nothing offline can recover it; the advisory-database check
+ * is what covers that case, by asking whether the surviving range is high
+ * enough rather than whether it changed.
+ * @param {object} manifest A parsed package.json.
+ * @returns {Array<{name: string, override: string, dependency: string,
+ *   section: string, from: string}>} Collisions found.
+ */
+export function collisions(manifest) {
+  const direct = directDependencies(manifest);
+  const found = [];
+
+  for (const from of OVERRIDE_SECTIONS) {
+    for (const [name, spec] of Object.entries(manifest[from] ?? {})) {
+      if (typeof spec !== "string" || spec.startsWith("$")) continue;
+      const dependency = direct.get(name);
+      if (!dependency) continue;
+
+      const floor = lowestPermitted(spec);
+      const target = lowestPermitted(dependency.spec);
+      if (!floor || !target) continue;
+      if (compare(target, floor) >= 0) continue;
+
+      found.push({
+        name,
+        override: spec,
+        dependency: dependency.spec,
+        section: dependency.section,
+        from,
+      });
+    }
+  }
+  return found;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const asJson = argv.includes("--json");
+  const manifestIndex = argv.indexOf("--manifest");
+  const manifestPath =
+    manifestIndex >= 0 ? argv[manifestIndex + 1] : "package.json";
+
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  } catch (error) {
+    process.stderr.write(`${manifestPath} is not readable: ${error.message}\n`);
+    process.exit(2);
+  }
+
+  const found = collisions(manifest);
+
+  if (asJson) {
+    console.log(JSON.stringify({ manifest: manifestPath, found }, null, 2));
+  } else if (found.length === 0) {
+    console.log(
+      "## Floor collisions\n\nNo override can be collapsed into a weaker range."
+    );
+  } else {
+    console.log("## Floor collisions\n");
+    console.log(
+      "Each override below names a package this project also depends on directly, whose range permits a LOWER version. `bun install` rewrites such an override to `$name`, at which point the floor becomes the dependency line and the protection is gone.\n"
+    );
+    console.log("| package | override | direct dependency |");
+    console.log("|---|---|---|");
+    for (const row of found) {
+      console.log(
+        `| \`${row.name}\` | \`${row.override}\` (${row.from}) | \`${row.dependency}\` (${row.section}) |`
+      );
+    }
+    console.log(
+      "\nRaise the direct dependency to the floor. Do not delete the override — it is what carries the floor to transitive copies, which is the case it was written for."
+    );
+  }
+
+  if (found.length > 0) process.exitCode = 1;
+}
+
+if (import.meta.main) main();

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8,6 +8,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "2dbf7fd2f2020fc7824c432342002d9ca3ebb57b2872e761b14e942b23479a11",
     "all/copy-overwrite/scripts/lisa-enforcement-fallback.sh":
       "9cab71562d01421d57c6719318a4d03a6249a45c1aea434db3ff26e3065eeb66",
+    "all/copy-overwrite/scripts/lisa-floor-collisions.mjs":
+      "a612f172282d13ba9318fe5e03689d7c6ff42a0122d0c9d5d39051e1967b93dc",
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh":
       "aa95a84f9f9224914947a09b858535aa8bd052199ff64cb53768cf78fb69b687",
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh":
@@ -2328,6 +2330,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "all/copy-contents/.gitattributes": true,
     "all/copy-contents/gitignore": true,
     "all/copy-overwrite/scripts/lisa-enforcement-fallback.sh": true,
+    "all/copy-overwrite/scripts/lisa-floor-collisions.mjs": true,
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh": true,
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh": true,
     "all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh": true,
@@ -8352,6 +8355,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/detect-stale-workflow-inputs-helpers.ts": true,
     "tests/unit/scripts/detect-stale-workflow-inputs.test.ts": true,
     "tests/unit/scripts/e2e-coverage.test.ts": true,
+    "tests/unit/scripts/floor-collisions.test.ts": true,
     "tests/unit/scripts/generate-agy-plugin-artifacts.test.ts": true,
     "tests/unit/scripts/generate-copilot-plugin-artifacts.test.ts": true,
     "tests/unit/scripts/generate-cursor-plugin-artifacts.artifacts.test.ts": true,

--- a/tests/unit/scripts/floor-collisions.test.ts
+++ b/tests/unit/scripts/floor-collisions.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the offline floor-collision check.
+ *
+ * The check exists because `bun install` rewrites an override that names a
+ * direct dependency into `$name`, silently replacing the override's floor with
+ * the dependency line's. Observed in gunnertech/frontend on bun 1.3.11:
+ * `"postcss": ">=8.5.18"` became `"$postcss"` against `devDependencies ^8.5.0`,
+ * putting postcss back inside the range GHSA patches at 8.5.18.
+ *
+ * The most important case here is the FALSE POSITIVE one. A first draft
+ * reported every `$name` override, which fires on the correct end state — a
+ * fixed project looks exactly like that after its next install — and a check
+ * that fails on the fix is one people switch off. That draft was caught by
+ * running it against a synthetic post-install manifest rather than by review.
+ * @module tests/unit/scripts/floor-collisions
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  collisions,
+  directDependencies,
+  lowestPermitted,
+} from "../../../all/copy-overwrite/scripts/lisa-floor-collisions.mjs";
+
+describe("lowestPermitted", () => {
+  it("reads the floor out of every range form in practical use", () => {
+    expect(lowestPermitted(">=8.5.18")).toEqual([8, 5, 18]);
+    expect(lowestPermitted("^8.5.0")).toEqual([8, 5, 0]);
+    expect(lowestPermitted("~3.3.3")).toEqual([3, 3, 3]);
+    expect(lowestPermitted("3.8.3")).toEqual([3, 8, 3]);
+    expect(lowestPermitted(">=1.2.3 <2.0.0")).toEqual([1, 2, 3]);
+  });
+
+  it("returns null for a spec carrying no version", () => {
+    expect(lowestPermitted("*")).toBeNull();
+    expect(lowestPermitted("workspace:*")).toBeNull();
+    expect(lowestPermitted("")).toBeNull();
+  });
+});
+
+describe("directDependencies", () => {
+  it("flattens every dependency section", () => {
+    const found = directDependencies({
+      dependencies: { a: "1.0.0" },
+      devDependencies: { b: "2.0.0" },
+      peerDependencies: { c: "3.0.0" },
+      optionalDependencies: { d: "4.0.0" },
+    });
+    expect(
+      [...found.keys()].sort((left, right) => left.localeCompare(right))
+    ).toEqual(["a", "b", "c", "d"]);
+    expect(found.get("b")).toEqual({
+      spec: "2.0.0",
+      section: "devDependencies",
+    });
+  });
+
+  it("keeps the first declaration when a package appears twice", () => {
+    const found = directDependencies({
+      dependencies: { a: "1.0.0" },
+      devDependencies: { a: "9.0.0" },
+    });
+    expect(found.get("a")?.section).toBe("dependencies");
+  });
+});
+
+describe("collisions", () => {
+  it("flags an override whose direct dependency permits something lower", () => {
+    // The exact shape of the real defect.
+    const found = collisions({
+      devDependencies: { postcss: "^8.5.0" },
+      overrides: { postcss: ">=8.5.18" },
+    });
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      name: "postcss",
+      override: ">=8.5.18",
+      dependency: "^8.5.0",
+      section: "devDependencies",
+      from: "overrides",
+    });
+  });
+
+  it("does not flag an override whose dependency already carries the floor", () => {
+    // The fix. It must read as clean, or the fix looks like a failure.
+    expect(
+      collisions({
+        devDependencies: { postcss: ">=8.5.18" },
+        overrides: { postcss: ">=8.5.18" },
+      })
+    ).toEqual([]);
+  });
+
+  it("does not flag an override with no matching direct dependency", () => {
+    // Transitive-only overrides are the normal case and cannot be collapsed:
+    // there is no dependency line for `$name` to point at.
+    expect(
+      collisions({
+        devDependencies: { postcss: ">=8.5.18" },
+        overrides: { lodash: ">=4.18.1" },
+      })
+    ).toEqual([]);
+  });
+
+  it("does not flag an ALREADY collapsed override, whatever its target", () => {
+    // The false positive that mattered. A collapsed override onto an adequate
+    // dependency is what a fixed project looks like after its next install.
+    // Flagging it would fail every project post-install, including the fixed
+    // ones, and the check would be skipped rather than heeded.
+    expect(
+      collisions({
+        devDependencies: { postcss: "^8.5.0", prettier: "3.8.3" },
+        overrides: { postcss: "$postcss", prettier: "$prettier" },
+      })
+    ).toEqual([]);
+  });
+
+  it("checks resolutions as well as overrides", () => {
+    // bun rewrites both, so a check covering only one is half a check.
+    const found = collisions({
+      devDependencies: { prettier: "^3.3.3" },
+      resolutions: { prettier: "3.8.3" },
+    });
+    expect(found).toHaveLength(1);
+    expect(found[0].from).toBe("resolutions");
+  });
+
+  it("reports the same package once per section it collides in", () => {
+    // Both sections need raising, so both are worth naming.
+    const found = collisions({
+      devDependencies: { postcss: "^8.5.0" },
+      overrides: { postcss: ">=8.5.18" },
+      resolutions: { postcss: ">=8.5.18" },
+    });
+    expect(
+      found
+        .map(row => row.from)
+        .sort((left, right) => left.localeCompare(right))
+    ).toEqual(["overrides", "resolutions"]);
+  });
+
+  it("ignores specs with no comparable version on either side", () => {
+    expect(
+      collisions({
+        devDependencies: { a: "workspace:*" },
+        overrides: { a: ">=1.0.0" },
+      })
+    ).toEqual([]);
+  });
+
+  it("is clean on a manifest with no overrides at all", () => {
+    expect(collisions({ dependencies: { a: "1.0.0" } })).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #2263.

Work-Item: CodySwannGT/lisa#2263

## The problem

`bun install` rewrites an override that names a direct dependency into `$name`. The override stops carrying its own floor and adopts the dependency line's. Fine when they agree; a silent security regression when the dependency line is lower — which is the normal case, because the override exists *because* that line is too permissive.

Reproduced in `gunnertech/frontend` from a clean tree on bun 1.3.11:

| | override before | after | dependency line | effective floor |
|---|---|---|---|---|
| `postcss` | `>=8.5.18` | `$postcss` | `^8.5.0` | **8.5.0 — inside the GHSA-patched range** |
| `prettier` | `3.8.3` | `$prettier` | `^3.3.3` | **3.3.3** |

It reads as a tidy-up in the diff and recurs on every install, so restoring the floor by hand never holds.

**Nothing detected it.** `check-security-floors.mjs` reads lisa's own `package.lisa.json` templates and never looks at a managed project's `package.json`.

## The check

A new `floor_collisions` job in the reusable quality workflow, backed by `scripts/lisa-floor-collisions.mjs` shipped into every project.

Deliberately **offline**. It asks a structural question — can this override be collapsed into something weaker? — which needs no advisory lookup, so it runs in milliseconds and cannot go quiet when the network fails. Whether a *surviving* floor is high enough remains the advisory check's job.

The remedy it prints is deliberately not the obvious one: **raise the dependency line**. Deleting the override would lose the floor for transitive copies, which is the case it was written for.

## The boundary that matters

It **skips overrides that are already collapsed**, and that decision is the interesting one.

A first draft reported all of them. That fires on the correct end state — a fixed project looks exactly like that after its next install — and a check that fails on the fix gets switched off rather than heeded. My own probe against a synthetic post-install manifest caught it; review did not.

The cost is a real gap, stated rather than hidden: a floor lost *before* this check ever ran cannot be recovered from the manifest, because the manifest no longer records what it used to be. The advisory check covers that case by asking whether the surviving range is high enough rather than whether it changed.

## Verified against the real manifests, not only synthetics

```
pre-fix  package.json  ->  exit 1, names postcss and prettier
post-fix package.json  ->  exit 0
```

Guards proved by mutation, each asserting it landed first:

| mutation | result |
|---|---|
| check `overrides` only, drop `resolutions` | 2 failed |
| report collapsed overrides again (the false positive) | 1 failed |
| invert the comparison | 3 failed |
| restored | 12 passed |

~~`check-learnings-budget.test.ts` also fails on this branch — it fails identically on `main`, so it is pre-existing and untouched here.~~

**Correction:** that was wrong. The suite is healthy — `bun run test:unit` passes all 14. It failed only because I was invoking vitest through `npx`, and the suite resolves Bun from whichever runner launched it. Nothing is pre-existing and nothing is broken. Error message improved in #2265 so the next reader is not misled the same way.

## Not in this PR

The advisory check on downstream manifests, for floors already lost. Tracked in #2263.

🤖 Generated with Claude Code

