### PR TITLE
chore(tests): name the remedy when the learnings suite is run under npx

### DIFF
--- a/tests/unit/scripts/check-learnings-budget-helpers.ts
+++ b/tests/unit/scripts/check-learnings-budget-helpers.ts
@@ -157,7 +157,16 @@ export function resolveBunExecutable(executable: string | undefined): string {
   }
   const packageRunner = path.basename(executable);
   if (!/^bunx?(?:\.exe)?$/u.test(packageRunner)) {
-    throw new Error(`Expected Bun's package runner, received: ${executable}`);
+    // Name the remedy, not just the symptom. This suite shells out to Bun and
+    // resolves it from the runner that launched vitest, so `npx vitest` fails
+    // here with nothing wrong in the repository. Without the second sentence
+    // that reads as a broken suite — it misled me into reporting it as a
+    // pre-existing failure on main, in two pull request descriptions, when
+    // `bun run test:unit` passes all 14.
+    throw new Error(
+      `Expected Bun's package runner, received: ${executable}. ` +
+        `Run this suite with Bun — 'bun run test:unit' — rather than npx.`
+    );
   }
   const bunName = packageRunner.replace(/^bunx/u, "bun");
   const bunExecutable = realpathSync(


### PR DESCRIPTION
Closes #2265.

Work-Item: CodySwannGT/lisa#2265

## Not a broken suite

`tests/unit/scripts/check-learnings-budget.test.ts` shells out to Bun and resolves it from whichever runner launched vitest. Under `npx vitest` it throws before any test runs:

```
Expected Bun's package runner, received: .../npm-cli.js
Test Files  1 failed (1)
Tests  no tests
```

Under the runner the project actually uses, it is fine:

```
bunx vitest run tests/unit/scripts/check-learnings-budget.test.ts
Tests  14 passed (14)
```

## Why it was worth changing

The message named the symptom and not the remedy, so it reads as a repository-level failure. It read that way to me: I reported it as a pre-existing failure on `main` in **two** PR descriptions (#2260, #2264) and only discovered it was my own invocation when asked to fix it. Both bodies are now corrected.

An error that survives being misread by the next person is worth two extra sentences.

## After

```
Expected Bun's package runner, received: .../npm-cli.js. Run this suite
with Bun — 'bun run test:unit' — rather than npx.
```

Behaviour under Bun is unchanged: 14 passed.