### PR TITLE
Fix release version floor race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,6 +401,13 @@ jobs:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
+      - name: Refresh release branch tip
+        if: github.ref_type == 'branch'
+        run: |
+          target_ref="${{ github.ref_name }}"
+          git fetch origin "$target_ref" --tags --force
+          git reset --hard "origin/$target_ref"
+
       - name: Setup Release Logger
         id: logger
         run: |
@@ -552,6 +559,21 @@ jobs:
 
           # Normalize any leading "v" regardless of strategy so "tag=v$VERSION" never yields "vv"
           VERSION="${VERSION#v}"
+
+          case "$RELEASE_ENVIRONMENT" in
+            main|master|prod|production)
+              PACKAGE_NAME=$(node -p 'require("./package.json").name || ""')
+              if [ -n "$PACKAGE_NAME" ]; then
+                PUBLISHED_VERSION=$(npm view "$PACKAGE_NAME" version 2>/dev/null || true)
+                if [ -n "$PUBLISHED_VERSION" ] && npx semver "$PUBLISHED_VERSION" >/dev/null 2>&1; then
+                  while [ "$(npx semver "$VERSION" "$PUBLISHED_VERSION" | tail -1)" = "$PUBLISHED_VERSION" ]; do
+                    echo "::warning::Computed version $VERSION is not above published $PUBLISHED_VERSION; bumping patch"
+                    VERSION=$(npx semver -i patch "$PUBLISHED_VERSION")
+                  done
+                fi
+              fi
+              ;;
+          esac
 
           # Environment-scoped release tags (standard-version strategy).
           # Tags are repo-global but version counters are branch-local, so

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "brace-expansion": ">=5.0.9"
   },
   "name": "@codyswann/lisa",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Claude Code governance framework that applies guardrails, guidance, and automated enforcement to projects",
   "main": "dist/index.js",
   "exports": {

--- a/plugins/lisa-agy/plugin.json
+++ b/plugins/lisa-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-cdk-agy/plugin.json
+++ b/plugins/lisa-cdk-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-cdk",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "AWS CDK-specific plugin",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-cdk-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-cdk-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-cdk",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "AWS CDK-specific plugin",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-cdk-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-cdk-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-cdk",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "AWS CDK-specific plugin",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-cdk/.claude-plugin/plugin.json
+++ b/plugins/lisa-cdk/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-cdk",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "AWS CDK-specific plugin",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-cdk/.codex-plugin/plugin.json
+++ b/plugins/lisa-cdk/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-cdk",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "AWS CDK-specific Lisa plugin.",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-expo-agy/plugin.json
+++ b/plugins/lisa-expo-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-expo",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Expo/React Native-specific skills, agents, rules, and MCP servers",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-expo-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-expo-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-expo",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Expo/React Native-specific skills, agents, rules, and MCP servers",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-expo-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-expo-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-expo",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Expo/React Native-specific skills, agents, rules, and MCP servers",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-expo/.claude-plugin/plugin.json
+++ b/plugins/lisa-expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-expo",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Expo/React Native-specific skills, agents, rules, and MCP servers",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-expo/.codex-plugin/plugin.json
+++ b/plugins/lisa-expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-expo",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Expo and React Native-specific skills, agents, rules, and MCP servers.",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-harper-fabric-agy/plugin.json
+++ b/plugins/lisa-harper-fabric-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-harper-fabric",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Harper/Fabric-specific rules for TypeScript component apps",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-harper-fabric-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-harper-fabric-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-harper-fabric",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Harper/Fabric-specific rules for TypeScript component apps",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-harper-fabric-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-harper-fabric-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-harper-fabric",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Harper/Fabric-specific rules for TypeScript component apps",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-harper-fabric/.claude-plugin/plugin.json
+++ b/plugins/lisa-harper-fabric/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-harper-fabric",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Harper/Fabric-specific rules for TypeScript component apps",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-harper-fabric/.codex-plugin/plugin.json
+++ b/plugins/lisa-harper-fabric/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-harper-fabric",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Harper/Fabric-specific Lisa rules for TypeScript component apps.",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-nestjs-agy/plugin.json
+++ b/plugins/lisa-nestjs-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-nestjs",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "NestJS-specific skills (GraphQL, TypeORM) and hooks (migration write-protection)",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-nestjs-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-nestjs-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-nestjs",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "NestJS-specific skills (GraphQL, TypeORM) and hooks (migration write-protection)",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-nestjs-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-nestjs-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-nestjs",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "NestJS-specific skills (GraphQL, TypeORM) and hooks (migration write-protection)",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-nestjs/.claude-plugin/plugin.json
+++ b/plugins/lisa-nestjs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-nestjs",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "NestJS-specific skills (GraphQL, TypeORM) and hooks (migration write-protection)",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-nestjs/.codex-plugin/plugin.json
+++ b/plugins/lisa-nestjs/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-nestjs",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "NestJS-specific skills and migration write-protection hooks.",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-openclaw-agy/plugin.json
+++ b/plugins/lisa-openclaw-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-openclaw",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Connect staff roles to Telegram or Slack via OpenClaw — facilitator/specialist hub-and-spoke routing and repo-coding topics, for Claude Code and Codex",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-openclaw-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-openclaw-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-openclaw",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Connect staff roles to Telegram or Slack via OpenClaw — facilitator/specialist hub-and-spoke routing and repo-coding topics, for Claude Code and Codex",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-openclaw-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-openclaw-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-openclaw",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Connect staff roles to Telegram or Slack via OpenClaw — facilitator/specialist hub-and-spoke routing and repo-coding topics, for Claude Code and Codex",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-openclaw/.claude-plugin/plugin.json
+++ b/plugins/lisa-openclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-openclaw",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Connect staff roles to Telegram or Slack via OpenClaw — facilitator/specialist hub-and-spoke routing and repo-coding topics, for Claude Code and Codex",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-openclaw/.codex-plugin/plugin.json
+++ b/plugins/lisa-openclaw/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-openclaw",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Connect staff roles to Telegram or Slack via OpenClaw — facilitator/specialist hub-and-spoke routing and repo-coding topics, across Claude and Codex.",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-phaser-agy/plugin.json
+++ b/plugins/lisa-phaser-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-phaser",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Phaser 4 game-development rules for TypeScript projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-phaser-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-phaser-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-phaser",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Phaser 4 game-development rules for TypeScript projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-phaser-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-phaser-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-phaser",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Phaser 4 game-development rules for TypeScript projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-phaser/.claude-plugin/plugin.json
+++ b/plugins/lisa-phaser/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-phaser",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Phaser 4 game-development rules for TypeScript projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-phaser/.codex-plugin/plugin.json
+++ b/plugins/lisa-phaser/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-phaser",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Phaser 4 game-development rules for TypeScript projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-rails-agy/plugin.json
+++ b/plugins/lisa-rails-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-rails",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Ruby on Rails-specific hooks — RuboCop linting/formatting and ast-grep scanning on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-rails-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-rails-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-rails",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Ruby on Rails-specific hooks — RuboCop linting/formatting and ast-grep scanning on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-rails-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-rails-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-rails",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Ruby on Rails-specific hooks — RuboCop linting/formatting and ast-grep scanning on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-rails/.claude-plugin/plugin.json
+++ b/plugins/lisa-rails/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-rails",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Ruby on Rails-specific hooks — RuboCop linting/formatting and ast-grep scanning on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-rails/.codex-plugin/plugin.json
+++ b/plugins/lisa-rails/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-rails",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Ruby on Rails-specific skills and hooks for RuboCop and ast-grep scanning on edit.",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-typescript-agy/plugin.json
+++ b/plugins/lisa-typescript-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-typescript",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, ast-grep scanning, and error-suppression blocking on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-typescript-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-typescript-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-typescript",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, ast-grep scanning, and error-suppression blocking on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-typescript-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-typescript-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-typescript",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, ast-grep scanning, and error-suppression blocking on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-typescript/.claude-plugin/plugin.json
+++ b/plugins/lisa-typescript/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-typescript",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, ast-grep scanning, and error-suppression blocking on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-typescript/.codex-plugin/plugin.json
+++ b/plugins/lisa-typescript/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-typescript",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "TypeScript-specific hooks for formatting, linting, and ast-grep scanning on edit.",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-wiki-agy/plugin.json
+++ b/plugins/lisa-wiki-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-wiki",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "LLM Wiki — a distributable, git-native markdown knowledge base for Claude Code and Codex",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-wiki-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-wiki-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-wiki",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "LLM Wiki — a distributable, git-native markdown knowledge base for Claude Code and Codex",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-wiki-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-wiki-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-wiki",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "LLM Wiki — a distributable, git-native markdown knowledge base for Claude Code and Codex",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-wiki/.claude-plugin/plugin.json
+++ b/plugins/lisa-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-wiki",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "LLM Wiki — a distributable, git-native markdown knowledge base for Claude Code and Codex",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-wiki/.codex-plugin/plugin.json
+++ b/plugins/lisa-wiki/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-wiki",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Distributable LLM Wiki kernel — ingest, query, lint, and maintain a git-native markdown knowledge base across Claude and Codex.",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa/.claude-plugin/plugin.json
+++ b/plugins/lisa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa/.codex-plugin/plugin.json
+++ b/plugins/lisa/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Universal governance: agents, skills, commands, hooks, and rules for all projects.",
   "author": {
     "name": "Cody Swann"


### PR DESCRIPTION
## Summary
- refresh the release branch checkout to the live branch tip before version calculation
- guard production release versions against the latest version already published to npm
- restore the repository/plugin manifest floor to 2.326.0 so the next release bumps above npm latest

## Verification
- bun run check:plugins
- bun run check:upstream-evidence-manifest
- bun run check:workflow-inputs
- bun run check:duplicate-versions (advisory: existing duplicates only, 0 drifted)
- pre-push hook: typecheck, audit, lint:slow, knip, vitest coverage, integration tests, plugin parity drift

Work-Item: CodySwannGT/lisa#2267