### PR TITLE
fix(release): a release may not publish a version below the registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,6 +297,49 @@ jobs:
               ;;
           esac
 
+          # A computed version must exceed what the registry already serves.
+          #
+          # The release job checks out `ref: github.sha` — the commit that
+          # triggered it, not the tip of the branch. When two merges land close
+          # together, the second run computes from a tree that predates the
+          # first run's release commit, produces a LOWER version, and commits it
+          # to the branch. The repository then declares a version below the
+          # published one, npm refuses the `latest` tag, and every subsequent
+          # release fails for everyone until a human corrects the base version.
+          #
+          # That is what happened at 2.325.6 vs a published 2.326.0. The publish
+          # step already fails in this case, but only AFTER the release commit
+          # has landed — so the branch is left corrupted by a job that reported
+          # the problem too late to prevent it.
+          #
+          # Checked before anything is committed, and only against the registry,
+          # because the registry is the one authority on what has actually been
+          # published. A registry that cannot be reached is not evidence of
+          # anything, so it is allowed through rather than blocking a release on
+          # a network blip.
+          PKG_NAME=$(node -p "require('./package.json').name" 2>/dev/null || echo "")
+          if [ -n "$PKG_NAME" ] && [ -n "$VERSION" ]; then
+            PUBLISHED=$(npm view "$PKG_NAME" version 2>/dev/null || echo "")
+            if [ -n "$PUBLISHED" ]; then
+              HIGHEST=$(printf '%s\n%s\n' "$VERSION" "$PUBLISHED" | sort -V | tail -1)
+              if [ "$VERSION" = "$PUBLISHED" ] || [ "$HIGHEST" != "$VERSION" ]; then
+                {
+                  echo "❌ Computed version $VERSION is not above the published $PUBLISHED."
+                  echo ""
+                  echo "This run checked out ${{ github.sha }}, whose package.json predates"
+                  echo "a release that has already been published. Committing this version"
+                  echo "would leave the branch declaring less than the registry serves and"
+                  echo "break every later release."
+                  echo ""
+                  echo "Re-run this workflow against the current tip of the branch."
+                } >> $GITHUB_STEP_SUMMARY
+                echo "allowed=false" >> $GITHUB_OUTPUT
+                echo "reason=computed $VERSION is not above published $PUBLISHED" >> $GITHUB_OUTPUT
+                exit 0
+              fi
+            fi
+          fi
+
           # Handle blackout
           if [ "$IS_BLACKOUT" == "true" ]; then
             if [ "${{ inputs.override_blackout }}" == "true" ]; then

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "brace-expansion": ">=5.0.9"
   },
   "name": "@codyswann/lisa",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Claude Code governance framework that applies guardrails, guidance, and automated enforcement to projects",
   "main": "dist/index.js",
   "exports": {

--- a/plugins/lisa-agy/plugin.json
+++ b/plugins/lisa-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-cdk-agy/plugin.json
+++ b/plugins/lisa-cdk-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-cdk",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "AWS CDK-specific plugin",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-cdk-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-cdk-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-cdk",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "AWS CDK-specific plugin",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-cdk-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-cdk-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-cdk",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "AWS CDK-specific plugin",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-cdk/.claude-plugin/plugin.json
+++ b/plugins/lisa-cdk/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-cdk",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "AWS CDK-specific plugin",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-cdk/.codex-plugin/plugin.json
+++ b/plugins/lisa-cdk/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-cdk",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "AWS CDK-specific Lisa plugin.",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-expo-agy/plugin.json
+++ b/plugins/lisa-expo-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-expo",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Expo/React Native-specific skills, agents, rules, and MCP servers",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-expo-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-expo-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-expo",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Expo/React Native-specific skills, agents, rules, and MCP servers",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-expo-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-expo-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-expo",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Expo/React Native-specific skills, agents, rules, and MCP servers",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-expo/.claude-plugin/plugin.json
+++ b/plugins/lisa-expo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-expo",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Expo/React Native-specific skills, agents, rules, and MCP servers",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-expo/.codex-plugin/plugin.json
+++ b/plugins/lisa-expo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-expo",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Expo and React Native-specific skills, agents, rules, and MCP servers.",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-harper-fabric-agy/plugin.json
+++ b/plugins/lisa-harper-fabric-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-harper-fabric",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Harper/Fabric-specific rules for TypeScript component apps",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-harper-fabric-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-harper-fabric-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-harper-fabric",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Harper/Fabric-specific rules for TypeScript component apps",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-harper-fabric-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-harper-fabric-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-harper-fabric",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Harper/Fabric-specific rules for TypeScript component apps",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-harper-fabric/.claude-plugin/plugin.json
+++ b/plugins/lisa-harper-fabric/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-harper-fabric",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Harper/Fabric-specific rules for TypeScript component apps",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-harper-fabric/.codex-plugin/plugin.json
+++ b/plugins/lisa-harper-fabric/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-harper-fabric",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Harper/Fabric-specific Lisa rules for TypeScript component apps.",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-nestjs-agy/plugin.json
+++ b/plugins/lisa-nestjs-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-nestjs",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "NestJS-specific skills (GraphQL, TypeORM) and hooks (migration write-protection)",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-nestjs-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-nestjs-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-nestjs",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "NestJS-specific skills (GraphQL, TypeORM) and hooks (migration write-protection)",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-nestjs-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-nestjs-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-nestjs",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "NestJS-specific skills (GraphQL, TypeORM) and hooks (migration write-protection)",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-nestjs/.claude-plugin/plugin.json
+++ b/plugins/lisa-nestjs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-nestjs",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "NestJS-specific skills (GraphQL, TypeORM) and hooks (migration write-protection)",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-nestjs/.codex-plugin/plugin.json
+++ b/plugins/lisa-nestjs/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-nestjs",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "NestJS-specific skills and migration write-protection hooks.",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-openclaw-agy/plugin.json
+++ b/plugins/lisa-openclaw-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-openclaw",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Connect staff roles to Telegram or Slack via OpenClaw — facilitator/specialist hub-and-spoke routing and repo-coding topics, for Claude Code and Codex",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-openclaw-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-openclaw-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-openclaw",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Connect staff roles to Telegram or Slack via OpenClaw — facilitator/specialist hub-and-spoke routing and repo-coding topics, for Claude Code and Codex",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-openclaw-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-openclaw-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-openclaw",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Connect staff roles to Telegram or Slack via OpenClaw — facilitator/specialist hub-and-spoke routing and repo-coding topics, for Claude Code and Codex",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-openclaw/.claude-plugin/plugin.json
+++ b/plugins/lisa-openclaw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-openclaw",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Connect staff roles to Telegram or Slack via OpenClaw — facilitator/specialist hub-and-spoke routing and repo-coding topics, for Claude Code and Codex",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-openclaw/.codex-plugin/plugin.json
+++ b/plugins/lisa-openclaw/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-openclaw",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Connect staff roles to Telegram or Slack via OpenClaw — facilitator/specialist hub-and-spoke routing and repo-coding topics, across Claude and Codex.",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-phaser-agy/plugin.json
+++ b/plugins/lisa-phaser-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-phaser",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Phaser 4 game-development rules for TypeScript projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-phaser-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-phaser-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-phaser",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Phaser 4 game-development rules for TypeScript projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-phaser-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-phaser-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-phaser",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Phaser 4 game-development rules for TypeScript projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-phaser/.claude-plugin/plugin.json
+++ b/plugins/lisa-phaser/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-phaser",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Phaser 4 game-development rules for TypeScript projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-phaser/.codex-plugin/plugin.json
+++ b/plugins/lisa-phaser/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-phaser",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Phaser 4 game-development rules for TypeScript projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-rails-agy/plugin.json
+++ b/plugins/lisa-rails-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-rails",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Ruby on Rails-specific hooks — RuboCop linting/formatting and ast-grep scanning on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-rails-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-rails-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-rails",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Ruby on Rails-specific hooks — RuboCop linting/formatting and ast-grep scanning on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-rails-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-rails-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-rails",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Ruby on Rails-specific hooks — RuboCop linting/formatting and ast-grep scanning on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-rails/.claude-plugin/plugin.json
+++ b/plugins/lisa-rails/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-rails",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Ruby on Rails-specific hooks — RuboCop linting/formatting and ast-grep scanning on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-rails/.codex-plugin/plugin.json
+++ b/plugins/lisa-rails/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-rails",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Ruby on Rails-specific skills and hooks for RuboCop and ast-grep scanning on edit.",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-typescript-agy/plugin.json
+++ b/plugins/lisa-typescript-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-typescript",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, ast-grep scanning, and error-suppression blocking on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-typescript-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-typescript-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-typescript",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, ast-grep scanning, and error-suppression blocking on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-typescript-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-typescript-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-typescript",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, ast-grep scanning, and error-suppression blocking on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-typescript/.claude-plugin/plugin.json
+++ b/plugins/lisa-typescript/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-typescript",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "TypeScript-specific hooks — Prettier formatting, ESLint linting, ast-grep scanning, and error-suppression blocking on edit",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-typescript/.codex-plugin/plugin.json
+++ b/plugins/lisa-typescript/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-typescript",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "TypeScript-specific hooks for formatting, linting, and ast-grep scanning on edit.",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-wiki-agy/plugin.json
+++ b/plugins/lisa-wiki-agy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-wiki",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "LLM Wiki — a distributable, git-native markdown knowledge base for Claude Code and Codex",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-wiki-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-wiki-copilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-wiki",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "LLM Wiki — a distributable, git-native markdown knowledge base for Claude Code and Codex",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-wiki-cursor/.claude-plugin/plugin.json
+++ b/plugins/lisa-wiki-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-wiki",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "LLM Wiki — a distributable, git-native markdown knowledge base for Claude Code and Codex",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-wiki/.claude-plugin/plugin.json
+++ b/plugins/lisa-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-wiki",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "LLM Wiki — a distributable, git-native markdown knowledge base for Claude Code and Codex",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa-wiki/.codex-plugin/plugin.json
+++ b/plugins/lisa-wiki/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa-wiki",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Distributable LLM Wiki kernel — ingest, query, lint, and maintain a git-native markdown knowledge base across Claude and Codex.",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa/.claude-plugin/plugin.json
+++ b/plugins/lisa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Universal governance — agents, skills, commands, hooks, and rules for all projects",
   "author": {
     "name": "Cody Swann"

--- a/plugins/lisa/.codex-plugin/plugin.json
+++ b/plugins/lisa/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lisa",
-  "version": "2.325.6",
+  "version": "2.326.0",
   "description": "Universal governance: agents, skills, commands, hooks, and rules for all projects.",
   "author": {
     "name": "Cody Swann"


### PR DESCRIPTION
Publishing is currently broken for everyone. `main` declares **2.325.6** while npm serves **2.326.0**, so npm refuses the `latest` tag and every release since has inherited the same failure.

## What actually caused it

Not the concurrency group — `deploy.yml` already has one, and it does not cancel in progress. The release job checks out the commit that *triggered* it:

```yaml
- uses: actions/checkout@v6
  with:
    ref: ${{ github.sha }}
```

When two merges land close together, the second run computes `standard-version` from a tree that predates the first run's release commit. It produces a **lower** version and commits it. The branch is left declaring less than has been published — and the job only notices at the publish step, long after the damage is on `main`.

That ordering is why serializing the runs would not have helped: each run is pinned to a stale tree regardless of when it executes.

## The fix

**Unblock** — `package.json` moves to `2.326.0` so the next computed bump clears the registry. Plugin version stamps regenerate from it.

**Prevent** — the computed version is checked against the registry *before anything is committed*, because the registry is the one authority on what has actually been published. A version not strictly above it stops the run with the reason and the remedy, instead of corrupting the branch and failing later. An unreachable registry is not evidence of anything, so it is allowed through rather than blocking a release on a network blip.

## Verification

The comparison uses `sort -V`, exercised directly against the failure and its edges:

```
BLOCK  computed 2.325.6  published 2.326.0    ← the case that broke the pipeline
ALLOW  computed 2.326.1  published 2.326.0
ALLOW  computed 2.327.0  published 2.326.0
ALLOW  computed 2.330.0  published 2.329.12
BLOCK  computed 2.326.0  published 2.326.0    ← republish of the same version
BLOCK  computed 2.9.0    published 2.10.0     ← numeric; a string compare gets this wrong
ALLOW  computed 2.10.0   published 2.9.0
```

The two numeric cases are the ones that matter: a lexicographic comparison would have allowed `2.9.0` over `2.10.0` exactly when a release must be stopped.

Full suite: **496 files, 8414 tests passing.** Plugin stamp confirmed at `2.326.0`.

## Note for review

This rewrites shared version state, which is one-way once published. The jump to `2.326.0` skips no published version — it matches what npm already serves, so the next release increments from reality rather than from a tree that has been overtaken.

Work-Item: CodySwannGT/lisa#2267

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release validation now checks the package registry and requires new versions to exceed any already-published version.
- **Bug Fixes**
  - Release checks now provide a clear failure summary when the proposed version is not higher.
  - Registry lookup or incomplete version information no longer unnecessarily blocks releases.
- **Chores**
  - Updated the package and all associated plugins to version **2.326.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->