### PR TITLE
fix(detect-tooling): discover tools no allowlist mentions, and read git hooks

### DIFF
--- a/plugins/lisa-agy/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-detect-tooling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-detect-tooling
-description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts whatever remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
+description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads git hooks and npm scripts for what the project actually RUNS — discovering tools no list mentions — plus MCP servers, credential usage notes and quality configuration. Subtracts whatever remoteEnv.tools, node_modules and the workstation layer already cover, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
 allowed-tools: ["Bash", "Read", "AskUserQuestion"]
 ---
 
@@ -20,14 +20,44 @@ Nothing populates that last row. So a project can ship scripts that invoke `maes
 
 That is the same failure this repository has now paid for twice: `gh` was declared nowhere and a cloud session could not commit; `tar` was needed by an install method and asserted by nothing.
 
+## Discovery, not recognition
+
+The first version of this could only find tools it had been told about: it matched script bodies against a fixed `KNOWN_TOOLS` list. That makes the detector useful for exactly the set that needs it least — the tools someone already thought of.
+
+An Expo project invoking `eas` from **eight** npm scripts and six CI steps produced no proposal, because `eas` was not on the list. `gitleaks`, which runs on every commit in every one of these repositories, produced no proposal either.
+
+So the question asked of executable sources is now the open one — *what does this project actually run* — and everything already provided is subtracted afterwards:
+
+- what `remoteEnv.tools` declares
+- what `node_modules/.bin` provides (a dependency's binary never needs to be on PATH)
+- what `lisa-setup-workstation` owns (coding agents belong to the machine, not the checkout)
+
+The curated list stays, because a vetted `why` is worth more than an observed one — proposals say which they are, `[curated]` or `[discovered]`.
+
 ## What it does
 
-Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
+Reads six signals, subtracts what is already covered, and prints what is left with the evidence for each:
 
-- **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
+- **git hooks** (`.husky/*`, `.git/hooks/*`) that invoke a binary. The **strongest** signal available, stronger than an npm script: a hook runs on every commit and push whether anyone asked or not, so a machine without the tool cannot commit at all.
+
+  A `command -v` guard counts as evidence rather than as "optional", because the guarded shape is the worse one. Lisa's pre-commit hook wraps its secret scan in `command -v gitleaks`, so on a machine without gitleaks the scan is **skipped silently** — the hook passes, the commit succeeds, and nothing was scanned. A guard makes the absence invisible precisely where it matters.
+
+- **npm scripts** that invoke a binary — a script running `maestro test` is the project stating a dependency in executable form. Read from the script *body*, not its name, because the name is a label.
 - **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one. Do not infer a CLI for access layers that already define their own headless substrate; Linear is handled by `lisa-linear-access` through `LINEAR_API_KEY` + GraphQL when MCP OAuth is unavailable.
 - **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
 - **Quality configuration**, where a threshold implies the tool that produces it.
+
+## Reading shell is the hard part
+
+Discovery only works if "what does this run" can be answered from shell text without inventing commands. Three things had to be right, each found by running it against real repositories:
+
+**Only the first word of a command position counts.** Word-scanning this repo's own hooks proposed `ltrimstr`, `map` and `select` (jq filter internals), `console.log` and `process.exit` (embedded JavaScript), and `load_audit_cves` (a function the hook defines three lines up). Reading only where a command can actually start removes all of them without a denylist entry for any.
+
+**Quoting and commenting nest, so neither can be stripped independently.** The comment on line 9 of `pre-push.local` ends `...the script's exit code)`. That lone apostrophe pairs with the next real quote 28 lines later, blanks everything between, and leaks a `node -e` payload's JavaScript into the results. Stripping comments first does not fix it, because a `#` inside a quoted string is not a comment. One character scanner tracking both is the only correct shape.
+
+**`$( )` restarts the quoting context.** In `"$(printf '%s' "$JSON" | node -e '…')"`, quotes inside the substitution pair among themselves. A flat scanner falls out of phase on the first one and starts reporting the payload's own string literals.
+
+Against Lisa and the three TunnlAI repositories, what survives is `gitleaks`, `jq`, `gtimeout` and `eas` — every one a real, undeclared invocation, with no false positives.
 
 ## What it will not do
 

--- a/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/commands.mjs
+++ b/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/commands.mjs
@@ -1,0 +1,479 @@
+/**
+ * Pull the commands out of a shell body.
+ *
+ * `lisa-detect-tooling` used to match script bodies against a fixed list of tool
+ * names, which meant it could only ever re-find tools someone had already
+ * thought of — the set that needs a detector least. An Expo project invoking
+ * `eas` from eight npm scripts produced nothing, because `eas` was not in the
+ * list.
+ *
+ * So the question this module answers is the open one: what does this shell text
+ * actually RUN? Everything downstream then subtracts what is already provided.
+ *
+ * ## Only the first word of a command position
+ *
+ * Naive word-scanning of this repository's own hooks proposed `ltrimstr`, `map`
+ * and `select` (jq filter internals), `console.log` and `process.exit` (embedded
+ * JavaScript), and `load_audit_cves` (a function the hook defines three lines
+ * up). None of those are tools; all of them appear where a word-scanner looks.
+ *
+ * A command runs at a command POSITION — the start of the text, or just after a
+ * separator. Reading only that position removes every one of those false
+ * positives without a denylist entry for any of them.
+ * @module commands
+ */
+
+/**
+ * Shell keywords and coreutils: present on any machine, never provisioned.
+ *
+ * This is a floor, not a policy. Anything genuinely absent from a minimal
+ * container belongs in the manifest, and a few of these (`unzip`, `curl`) are
+ * already declared there by projects that need them — being listed here only
+ * means discovery will not RAISE them, not that they are assumed present.
+ */
+export const SHELL_VOCABULARY = new Set([
+  // Keywords and builtins.
+  "if",
+  "then",
+  "else",
+  "elif",
+  "fi",
+  "for",
+  "while",
+  "until",
+  "do",
+  "done",
+  "case",
+  "esac",
+  "in",
+  "function",
+  "return",
+  "break",
+  "continue",
+  "exit",
+  "local",
+  "readonly",
+  "declare",
+  "export",
+  "unset",
+  "shift",
+  "eval",
+  "exec",
+  "source",
+  "set",
+  "trap",
+  "wait",
+  "read",
+  "echo",
+  "printf",
+  "cd",
+  "pwd",
+  "true",
+  "false",
+  "test",
+  "let",
+  "alias",
+  "shopt",
+  "getopts",
+  "umask",
+  // Coreutils and the usual POSIX furniture.
+  "cat",
+  "grep",
+  "egrep",
+  "fgrep",
+  "sed",
+  "awk",
+  "cut",
+  "tr",
+  "sort",
+  "uniq",
+  "head",
+  "tail",
+  "wc",
+  "tee",
+  "xargs",
+  "find",
+  "ls",
+  "mkdir",
+  "rmdir",
+  "rm",
+  "mv",
+  "cp",
+  "ln",
+  "touch",
+  "chmod",
+  "chown",
+  "stat",
+  "du",
+  "df",
+  "dirname",
+  "basename",
+  "realpath",
+  "readlink",
+  "mktemp",
+  "date",
+  "sleep",
+  "seq",
+  "env",
+  "kill",
+  "pgrep",
+  "pkill",
+  "ps",
+  "diff",
+  "comm",
+  "join",
+  "paste",
+  "split",
+  "tar",
+  "gzip",
+  "gunzip",
+  "zip",
+  "unzip",
+  "curl",
+  "wget",
+  "sh",
+  "bash",
+  "zsh",
+  "dash",
+  "nohup",
+  "timeout",
+  "yes",
+  "tty",
+  "id",
+  "whoami",
+  "uname",
+  "hostname",
+]);
+
+/**
+ * Runtimes and package managers whose presence is assumed by everything here.
+ *
+ * Separate from the vocabulary above because these are genuinely provisioned —
+ * just not by this detector. `node` is what runs it; proposing it would be
+ * circular.
+ */
+export const RUNTIMES = new Set([
+  "node",
+  "npm",
+  "npx",
+  "bun",
+  "bunx",
+  "yarn",
+  "pnpm",
+  "pnpx",
+  "corepack",
+  "git",
+  "python",
+  "python3",
+  "pip",
+  "pip3",
+  "ruby",
+  "bundle",
+  "go",
+  "cargo",
+  "docker",
+  "make",
+]);
+
+/**
+ * Commands that RESOLVE the next word from `node_modules`.
+ *
+ * `npx playwright test` needs no manifest entry: npm put the binary in
+ * `node_modules/.bin` and npx finds it there. Reading the mediated word as a
+ * tool would propose pinning something the package manager already provides —
+ * the noise that teaches a reader to skim the output.
+ */
+const MEDIATORS = new Set(["npx", "bunx", "pnpx", "dlx"]);
+
+/** Sub-commands after a package manager that mean "run something local". */
+const LOCAL_RUNNERS = new Set(["run", "exec", "x", "dlx", "run-script"]);
+
+/**
+ * Commands that TEST for another command rather than running it.
+ *
+ * `command -v gitleaks` is the single most valuable signal a hook can carry, and
+ * a word-scanner reading only the first position would throw it away. It is also
+ * the shape of the worst failure mode in this codebase: a hook that guards its
+ * own tool with `command -v` SKIPS SILENTLY when the tool is absent. The commit
+ * succeeds and nothing was scanned.
+ *
+ * A guarded tool is therefore stronger evidence than an unguarded one, not
+ * weaker — its absence is invisible at the moment it matters.
+ */
+const PROBES = new Set(["command", "which", "type", "hash"]);
+
+/**
+ * Words that stand in FRONT of a command without being one.
+ *
+ * Control keywords have to be skipped past rather than treated as the command,
+ * or the very shape this exists to catch is missed: in
+ * `if ! command -v gitleaks; then`, stopping at `if` never reaches the probe.
+ */
+const PREFIXES = new Set([
+  "!",
+  "sudo",
+  "time",
+  "nice",
+  "builtin",
+  "exec",
+  "if",
+  "then",
+  "elif",
+  "else",
+  "while",
+  "until",
+  "do",
+]);
+
+/** A name that could plausibly be an executable on PATH. */
+const TOOL_NAME = /^[a-z][a-z0-9_-]*$/u;
+
+/**
+ * Names the text defines as shell functions, which are never PATH tools.
+ *
+ * This repository's `pre-push` hook defines `load_audit_cves` and
+ * `missing_opencode_metadata` and then calls them, which reads exactly like a
+ * command invocation because it is one — just not of anything installable.
+ * @param {string} text Shell body.
+ * @returns {Set<string>} Locally defined function names.
+ */
+export function localFunctions(text) {
+  const names = new Set();
+  const pattern =
+    /(?:^|\n)\s*(?:function\s+)?([a-z_][a-z0-9_]*)\s*\(\)\s*\{/giu;
+  let match = pattern.exec(text);
+  while (match) {
+    names.add(match[1].toLowerCase());
+    match = pattern.exec(text);
+  }
+  return names;
+}
+
+/**
+ * Pull out `sh -c '...'` payloads so their contents are parsed as shell too.
+ *
+ * Done BEFORE quoted spans are stripped, because the payload is precisely a
+ * quoted span — and it is the one kind that really is a command. Frontend's
+ * `eas:publish:e2e` script wraps its `eas update` in exactly this shape.
+ * @param {string} text Shell body.
+ * @returns {{stripped: string, payloads: string[]}} Text and nested bodies.
+ */
+export function extractShellPayloads(text) {
+  const payloads = [];
+  const stripped = text.replace(
+    /\b(?:sh|bash|zsh)\s+-[a-z]*c\s+('([^']*)'|"([^"]*)")/gu,
+    (_all, _quoted, single, double) => {
+      payloads.push(single ?? double ?? "");
+      return " ";
+    }
+  );
+  return { stripped, payloads };
+}
+
+/**
+ * Blank out quoted spans and comments, keeping only text at command level.
+ *
+ * Quoted text is where embedded programs live — the jq filters and `node -e`
+ * snippets that produced `ltrimstr` and `console.log`. A command inside quotes
+ * is an argument to something else, with one exception, which
+ * `extractShellPayloads` has already lifted out by the time this runs.
+ *
+ * This is a character scanner rather than a chain of regexes because quoting and
+ * commenting are MUTUALLY nested and no ordering of independent passes gets it
+ * right. This repository's own `pre-push.local` proves it: the comment on line 9
+ * ends `...the script's exit code)`, and that lone apostrophe pairs with the
+ * next real quote 28 lines later, blanking everything between — including the
+ * `node -e` payload, whose JavaScript then leaked out as `try`, `catch`,
+ * `const` and `unreadable` proposals.
+ *
+ * Stripping comments first does not fix it either, since a `#` inside a quoted
+ * string is not a comment. One pass that tracks both is the only correct shape.
+ *
+ * Newlines survive so command positions are preserved; everything else inside a
+ * masked span becomes a space.
+ * @param {string} text Shell body.
+ * @returns {string} Text with non-command spans blanked.
+ */
+export function stripNonCommandSpans(text) {
+  const out = [];
+  let state = "normal";
+  // `$( )` restarts the quoting context: inside it, quotes pair among
+  // themselves rather than continuing the enclosing span. A flat scanner falls
+  // out of phase on the very first one — this repository's
+  // `"$(printf '%s' "$JSON" | node -e '...')"` left the payload's own string
+  // literals exposed at command level, proposing `data`, `end` and `stale`.
+  const enclosing = [];
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const previous = index > 0 ? text[index - 1] : "";
+
+    // A substitution opens a fresh context from inside ANY state but a
+    // single-quoted one, where shell performs no substitution at all.
+    if (
+      state !== "single" &&
+      state !== "comment" &&
+      char === "$" &&
+      text[index + 1] === "("
+    ) {
+      enclosing.push(state);
+      state = "normal";
+      out.push("\n");
+      index += 1;
+      continue;
+    }
+    if (state === "normal" && char === ")" && enclosing.length > 0) {
+      state = enclosing.pop();
+      out.push("\n");
+      continue;
+    }
+
+    if (state === "normal") {
+      if (char === "\\") {
+        // An escaped character is never a delimiter. Skip both.
+        out.push(" ");
+        index += 1;
+        if (text[index] === "\n") out.push("\n");
+        else out.push(" ");
+        continue;
+      }
+      if (char === "'") {
+        state = "single";
+        out.push(" ");
+        continue;
+      }
+      if (char === '"') {
+        state = "double";
+        out.push(" ");
+        continue;
+      }
+      // A `#` only opens a comment at the start of a word.
+      if (char === "#" && (previous === "" || /\s/u.test(previous))) {
+        state = "comment";
+        out.push(" ");
+        continue;
+      }
+      out.push(char);
+      continue;
+    }
+
+    if (state === "comment") {
+      if (char === "\n") {
+        state = "normal";
+        out.push("\n");
+        continue;
+      }
+      out.push(" ");
+      continue;
+    }
+
+    // Inside quotes. A single-quoted span has no escapes at all in shell.
+    if (state === "double" && char === "\\") {
+      out.push(" ");
+      index += 1;
+      out.push(text[index] === "\n" ? "\n" : " ");
+      continue;
+    }
+    if (
+      (state === "single" && char === "'") ||
+      (state === "double" && char === '"')
+    ) {
+      state = "normal";
+      out.push(" ");
+      continue;
+    }
+    out.push(char === "\n" ? "\n" : " ");
+  }
+
+  // Redirections last, on text that is already command-level.
+  return out.join("").replace(/\d?[<>]+&?\S*/gu, " ");
+}
+
+/**
+ * Whether a word can be a tool this detector should raise.
+ *
+ * One gate, applied to every path into the results. Probed names used to skip
+ * it, which is how `command -v bun` — a hook checking its own runtime — became
+ * a proposal to pin bun on every repository scanned.
+ * @param {string} word Candidate command name.
+ * @param {Set<string>} defined Function names the text defines itself.
+ * @returns {boolean} Whether to raise it.
+ */
+function admissible(word, defined) {
+  // A path is not a PATH lookup: `./scripts/check.sh` is project code.
+  if (word.includes("/") || word.includes("$")) return false;
+  if (!TOOL_NAME.test(word)) return false;
+  if (SHELL_VOCABULARY.has(word)) return false;
+  // `bun run build` resolves locally, and the runtime itself is assumed.
+  if (RUNTIMES.has(word)) return false;
+  return !defined.has(word);
+}
+
+/**
+ * Read the tool a probe is testing for.
+ * @param {string[]} words Words after the probe.
+ * @returns {string|null} The probed name, or null.
+ */
+function probedTool(words) {
+  for (const word of words) {
+    if (word.startsWith("-")) continue;
+    return TOOL_NAME.test(word) ? word : null;
+  }
+  return null;
+}
+
+/**
+ * Every command this shell text runs, at a command position.
+ * @param {string} text Shell body.
+ * @returns {string[]} Command names, deduplicated, in first-seen order.
+ */
+export function commandsIn(text) {
+  if (typeof text !== "string" || text.trim() === "") return [];
+
+  const { stripped, payloads } = extractShellPayloads(text);
+  const defined = localFunctions(text);
+  const found = new Set();
+
+  // Nested `sh -c` bodies are shell in their own right, so they get the same
+  // treatment rather than a weaker one.
+  for (const payload of payloads) {
+    for (const command of commandsIn(payload)) found.add(command);
+  }
+
+  const segments = stripNonCommandSpans(stripped).split(
+    /\|\||&&|\$\(|[;|&\n(){}`]/u
+  );
+
+  for (const segment of segments) {
+    const words = segment.trim().split(/\s+/u).filter(Boolean);
+    let index = 0;
+    // Environment assignments and decorations sit in front of the command.
+    while (
+      index < words.length &&
+      (/^[A-Za-z_][A-Za-z0-9_]*=/u.test(words[index]) ||
+        PREFIXES.has(words[index]))
+    ) {
+      index += 1;
+    }
+
+    const word = words[index]?.toLowerCase();
+    if (!word) continue;
+
+    if (PROBES.has(word)) {
+      // `command -v gitleaks` — the probed name is the evidence. It goes
+      // through the SAME filters as a directly invoked command: reading it
+      // straight into the results proposed `bun` and `yarn` on every repo,
+      // because `command -v bun` is how a hook checks its own runtime.
+      const probed = probedTool(words.slice(index + 1));
+      if (probed && admissible(probed, defined)) found.add(probed);
+      continue;
+    }
+    if (MEDIATORS.has(word)) continue;
+    if (LOCAL_RUNNERS.has(word)) continue;
+    if (!admissible(word, defined)) continue;
+
+    found.add(word);
+  }
+
+  return [...found];
+}

--- a/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,8 +22,10 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
+
+import { commandsIn } from "./commands.mjs";
 
 /** The tool named by the Expo template's scripts and its flows directory. */
 const MAESTRO = "maestro";
@@ -107,6 +109,128 @@ export function toolsFromScripts(pkg) {
     }
   }
   return found;
+}
+
+/** Where git hooks live, strongest signal first. */
+const HOOK_DIRECTORIES = [".husky", join(".git", "hooks")];
+
+/**
+ * Coding agents, which a PROJECT manifest must never try to provision.
+ *
+ * A hook that shells out to `claude` is real evidence of a real dependency, but
+ * `remoteEnv.tools` is the wrong place to answer it: agents belong to the
+ * machine, not the checkout, and each is installed by its vendor's own method
+ * into a version directory it manages itself. Pinning one as a release archive
+ * would fight the self-updater that owns that directory.
+ *
+ * That layer is `lisa-setup-workstation`. Named here rather than imported from
+ * it, because a detector that stops working when a sibling skill is absent is
+ * worse than one carrying six strings.
+ *
+ * Deliberately NOT extended to `gh`, `bws`, `aws` or `sonar`: those genuinely
+ * belong in a project manifest, and `gh` going undeclared is the incident this
+ * skill was written after.
+ */
+const WORKSTATION_PROVISIONED = new Set([
+  "claude",
+  "codex",
+  "cursor-agent",
+  "opencode",
+  "agy",
+  "copilot",
+]);
+
+/**
+ * Tools a git hook runs — the strongest signal a project can give.
+ *
+ * Stronger than an npm script, because a hook runs on EVERY commit and push
+ * whether anyone asked or not. A container missing one of these cannot commit at
+ * all; the failure arrives mid-task, unattended, at the moment of use.
+ *
+ * The worst shape is the guarded one. This repository's pre-commit hook wraps
+ * its secret scan in `command -v gitleaks`, so on a machine without gitleaks the
+ * scan is SKIPPED SILENTLY — the hook passes, the commit succeeds, and nothing
+ * was scanned. A guard makes the absence invisible exactly where it matters
+ * most, which is why a probed name counts as evidence rather than being read as
+ * "optional".
+ * @param {string} cwd Project root.
+ * @returns {Map<string, string>} Tool name to the hook that proves it.
+ */
+export function toolsFromGitHooks(cwd) {
+  const found = new Map();
+  for (const directory of HOOK_DIRECTORIES) {
+    const full = join(cwd, directory);
+    let names = [];
+    try {
+      names = readdirSync(full);
+    } catch {
+      continue;
+    }
+    for (const name of names.sort()) {
+      // `.sample` files ship with git and run nothing.
+      if (name.endsWith(".sample")) continue;
+      let body;
+      try {
+        body = readFileSync(join(full, name), "utf8");
+      } catch {
+        continue;
+      }
+      for (const tool of commandsIn(body)) {
+        if (!found.has(tool)) found.set(tool, `git hook ${directory}/${name}`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools an npm script invokes, discovered rather than matched against a list.
+ *
+ * `toolsFromScripts` answers "which of the tools I already know about appear
+ * here". This answers the open question — what does this project actually RUN —
+ * which is the one that finds a tool nobody thought to add. An Expo project
+ * invoking `eas` from eight scripts produced nothing under the old shape,
+ * because `eas` was not in `KNOWN_TOOLS`.
+ * @param {object|null} pkg Parsed package.json.
+ * @returns {Map<string, string>} Tool name to the script that proves it.
+ */
+export function toolsDiscoveredInScripts(pkg) {
+  const found = new Map();
+  for (const [name, body] of Object.entries(pkg?.scripts ?? {})) {
+    if (typeof body !== "string") continue;
+    for (const tool of commandsIn(body)) {
+      if (found.has(tool)) continue;
+      found.set(tool, `npm script "${name}": ${body.trim().slice(0, 60)}`);
+    }
+  }
+  return found;
+}
+
+/**
+ * Whether the package manager already puts this binary on the local path.
+ *
+ * A dependency's binary lands in `node_modules/.bin`, where npm scripts resolve
+ * it without it ever being on PATH. Proposing a manifest entry for one is noise,
+ * and noise is how a detector teaches people to skim it.
+ *
+ * Only meaningful once dependencies are installed, which is why
+ * `dependenciesInstalled` exists rather than this quietly returning false on a
+ * fresh clone and over-proposing every dev tool in the project.
+ * @param {string} cwd Project root.
+ * @param {string} tool Tool name.
+ * @returns {boolean} Whether npm already provides it.
+ */
+export function providedByNodeModules(cwd, tool) {
+  return existsSync(join(cwd, "node_modules", ".bin", tool));
+}
+
+/**
+ * Whether `node_modules` is populated, so its absence can be reported.
+ * @param {string} cwd Project root.
+ * @returns {boolean} Whether dependencies are installed.
+ */
+export function dependenciesInstalled(cwd) {
+  return existsSync(join(cwd, "node_modules", ".bin"));
 }
 
 /**
@@ -330,8 +454,14 @@ export function detectTooling(cwd = process.cwd()) {
   const notes = readJson(join(cwd, ".lisa", "secret-notes.json"));
 
   const declared = declaredTools(config);
+  // Curated signals carry a vetted `why`. Discovered ones carry only the fact
+  // that the project runs the thing — weaker prose, identical standing as
+  // evidence, and the only kind that can find a tool nobody listed.
+  const hooks = toolsFromGitHooks(cwd);
   const signals = [
+    hooks,
     toolsFromScripts(pkg),
+    toolsDiscoveredInScripts(pkg),
     toolsFromMcp(mcp),
     toolsFromSecretNotes(notes),
     toolsFromQuality(config, pkg, cwd),
@@ -343,8 +473,11 @@ export function detectTooling(cwd = process.cwd()) {
       if (declared.has(tool)) continue;
       // Already provided by the package manager, so there is nothing to pin.
       if (satisfiedByNpm(pkg, tool)) continue;
+      if (providedByNodeModules(cwd, tool)) continue;
+      // Real dependency, wrong manifest — the workstation layer owns it.
+      if (WORKSTATION_PROVISIONED.has(tool)) continue;
       const entry = merged.get(tool) ?? { evidence: [] };
-      entry.evidence.push(evidence);
+      if (!entry.evidence.includes(evidence)) entry.evidence.push(evidence);
       merged.set(tool, entry);
     }
   }
@@ -352,10 +485,33 @@ export function detectTooling(cwd = process.cwd()) {
   return [...merged.entries()]
     .map(([name, entry]) => ({
       name,
-      why: KNOWN_TOOLS[name]?.why ?? "",
+      why: KNOWN_TOOLS[name]?.why ?? discoveredWhy(name, hooks.has(name)),
       evidence: entry.evidence,
+      // Says which vocabulary the `why` came from, so a reader can weigh it.
+      // A curated entry has been thought about; a discovered one has only been
+      // observed.
+      source: Object.hasOwn(KNOWN_TOOLS, name) ? "curated" : "discovered",
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * The `why` for a tool nobody wrote prose for.
+ *
+ * Every proposal must carry one — a proposal without a reason is an assertion,
+ * and this program's whole boundary is that it asserts nothing. So a discovered
+ * tool states the observation plainly rather than borrowing confidence it has
+ * not earned.
+ * @param {string} name Tool name.
+ * @param {boolean} fromHook Whether a git hook runs it.
+ * @returns {string} A reason a reader can check.
+ */
+export function discoveredWhy(name, fromHook) {
+  return fromHook
+    ? `A git hook runs \`${name}\` on every commit or push, and nothing ` +
+        `declares it — a machine without it fails at commit time, or skips the ` +
+        `check silently if the hook guards it.`
+    : `An npm script invokes \`${name}\`, and nothing puts it on PATH.`;
 }
 
 /**
@@ -438,8 +594,18 @@ if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
     console.log(
       `${proposals.length} tool(s) look required but are not declared:\n`
     );
+    if (!dependenciesInstalled(process.cwd())) {
+      // Without node_modules there is no way to tell a tool that needs PATH
+      // from one npm already provides, so every dev dependency looks missing.
+      // Said out loud rather than silently over-proposing.
+      console.log(
+        "note: dependencies are not installed, so binaries npm would provide " +
+          "cannot be\n      excluded. Run the install first for a shorter, " +
+          "more accurate list.\n"
+      );
+    }
     for (const proposal of proposals) {
-      console.log(`  ${proposal.name}`);
+      console.log(`  ${proposal.name}  [${proposal.source}]`);
       console.log(`    why: ${proposal.why}`);
       for (const evidence of proposal.evidence) {
         console.log(`    evidence: ${evidence}`);

--- a/plugins/lisa-copilot/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-detect-tooling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-detect-tooling
-description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts whatever remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
+description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads git hooks and npm scripts for what the project actually RUNS — discovering tools no list mentions — plus MCP servers, credential usage notes and quality configuration. Subtracts whatever remoteEnv.tools, node_modules and the workstation layer already cover, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
 allowed-tools: ["Bash", "Read", "AskUserQuestion"]
 ---
 
@@ -20,14 +20,44 @@ Nothing populates that last row. So a project can ship scripts that invoke `maes
 
 That is the same failure this repository has now paid for twice: `gh` was declared nowhere and a cloud session could not commit; `tar` was needed by an install method and asserted by nothing.
 
+## Discovery, not recognition
+
+The first version of this could only find tools it had been told about: it matched script bodies against a fixed `KNOWN_TOOLS` list. That makes the detector useful for exactly the set that needs it least — the tools someone already thought of.
+
+An Expo project invoking `eas` from **eight** npm scripts and six CI steps produced no proposal, because `eas` was not on the list. `gitleaks`, which runs on every commit in every one of these repositories, produced no proposal either.
+
+So the question asked of executable sources is now the open one — *what does this project actually run* — and everything already provided is subtracted afterwards:
+
+- what `remoteEnv.tools` declares
+- what `node_modules/.bin` provides (a dependency's binary never needs to be on PATH)
+- what `lisa-setup-workstation` owns (coding agents belong to the machine, not the checkout)
+
+The curated list stays, because a vetted `why` is worth more than an observed one — proposals say which they are, `[curated]` or `[discovered]`.
+
 ## What it does
 
-Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
+Reads six signals, subtracts what is already covered, and prints what is left with the evidence for each:
 
-- **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
+- **git hooks** (`.husky/*`, `.git/hooks/*`) that invoke a binary. The **strongest** signal available, stronger than an npm script: a hook runs on every commit and push whether anyone asked or not, so a machine without the tool cannot commit at all.
+
+  A `command -v` guard counts as evidence rather than as "optional", because the guarded shape is the worse one. Lisa's pre-commit hook wraps its secret scan in `command -v gitleaks`, so on a machine without gitleaks the scan is **skipped silently** — the hook passes, the commit succeeds, and nothing was scanned. A guard makes the absence invisible precisely where it matters.
+
+- **npm scripts** that invoke a binary — a script running `maestro test` is the project stating a dependency in executable form. Read from the script *body*, not its name, because the name is a label.
 - **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one. Do not infer a CLI for access layers that already define their own headless substrate; Linear is handled by `lisa-linear-access` through `LINEAR_API_KEY` + GraphQL when MCP OAuth is unavailable.
 - **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
 - **Quality configuration**, where a threshold implies the tool that produces it.
+
+## Reading shell is the hard part
+
+Discovery only works if "what does this run" can be answered from shell text without inventing commands. Three things had to be right, each found by running it against real repositories:
+
+**Only the first word of a command position counts.** Word-scanning this repo's own hooks proposed `ltrimstr`, `map` and `select` (jq filter internals), `console.log` and `process.exit` (embedded JavaScript), and `load_audit_cves` (a function the hook defines three lines up). Reading only where a command can actually start removes all of them without a denylist entry for any.
+
+**Quoting and commenting nest, so neither can be stripped independently.** The comment on line 9 of `pre-push.local` ends `...the script's exit code)`. That lone apostrophe pairs with the next real quote 28 lines later, blanks everything between, and leaks a `node -e` payload's JavaScript into the results. Stripping comments first does not fix it, because a `#` inside a quoted string is not a comment. One character scanner tracking both is the only correct shape.
+
+**`$( )` restarts the quoting context.** In `"$(printf '%s' "$JSON" | node -e '…')"`, quotes inside the substitution pair among themselves. A flat scanner falls out of phase on the first one and starts reporting the payload's own string literals.
+
+Against Lisa and the three TunnlAI repositories, what survives is `gitleaks`, `jq`, `gtimeout` and `eas` — every one a real, undeclared invocation, with no false positives.
 
 ## What it will not do
 

--- a/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/commands.mjs
+++ b/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/commands.mjs
@@ -1,0 +1,479 @@
+/**
+ * Pull the commands out of a shell body.
+ *
+ * `lisa-detect-tooling` used to match script bodies against a fixed list of tool
+ * names, which meant it could only ever re-find tools someone had already
+ * thought of — the set that needs a detector least. An Expo project invoking
+ * `eas` from eight npm scripts produced nothing, because `eas` was not in the
+ * list.
+ *
+ * So the question this module answers is the open one: what does this shell text
+ * actually RUN? Everything downstream then subtracts what is already provided.
+ *
+ * ## Only the first word of a command position
+ *
+ * Naive word-scanning of this repository's own hooks proposed `ltrimstr`, `map`
+ * and `select` (jq filter internals), `console.log` and `process.exit` (embedded
+ * JavaScript), and `load_audit_cves` (a function the hook defines three lines
+ * up). None of those are tools; all of them appear where a word-scanner looks.
+ *
+ * A command runs at a command POSITION — the start of the text, or just after a
+ * separator. Reading only that position removes every one of those false
+ * positives without a denylist entry for any of them.
+ * @module commands
+ */
+
+/**
+ * Shell keywords and coreutils: present on any machine, never provisioned.
+ *
+ * This is a floor, not a policy. Anything genuinely absent from a minimal
+ * container belongs in the manifest, and a few of these (`unzip`, `curl`) are
+ * already declared there by projects that need them — being listed here only
+ * means discovery will not RAISE them, not that they are assumed present.
+ */
+export const SHELL_VOCABULARY = new Set([
+  // Keywords and builtins.
+  "if",
+  "then",
+  "else",
+  "elif",
+  "fi",
+  "for",
+  "while",
+  "until",
+  "do",
+  "done",
+  "case",
+  "esac",
+  "in",
+  "function",
+  "return",
+  "break",
+  "continue",
+  "exit",
+  "local",
+  "readonly",
+  "declare",
+  "export",
+  "unset",
+  "shift",
+  "eval",
+  "exec",
+  "source",
+  "set",
+  "trap",
+  "wait",
+  "read",
+  "echo",
+  "printf",
+  "cd",
+  "pwd",
+  "true",
+  "false",
+  "test",
+  "let",
+  "alias",
+  "shopt",
+  "getopts",
+  "umask",
+  // Coreutils and the usual POSIX furniture.
+  "cat",
+  "grep",
+  "egrep",
+  "fgrep",
+  "sed",
+  "awk",
+  "cut",
+  "tr",
+  "sort",
+  "uniq",
+  "head",
+  "tail",
+  "wc",
+  "tee",
+  "xargs",
+  "find",
+  "ls",
+  "mkdir",
+  "rmdir",
+  "rm",
+  "mv",
+  "cp",
+  "ln",
+  "touch",
+  "chmod",
+  "chown",
+  "stat",
+  "du",
+  "df",
+  "dirname",
+  "basename",
+  "realpath",
+  "readlink",
+  "mktemp",
+  "date",
+  "sleep",
+  "seq",
+  "env",
+  "kill",
+  "pgrep",
+  "pkill",
+  "ps",
+  "diff",
+  "comm",
+  "join",
+  "paste",
+  "split",
+  "tar",
+  "gzip",
+  "gunzip",
+  "zip",
+  "unzip",
+  "curl",
+  "wget",
+  "sh",
+  "bash",
+  "zsh",
+  "dash",
+  "nohup",
+  "timeout",
+  "yes",
+  "tty",
+  "id",
+  "whoami",
+  "uname",
+  "hostname",
+]);
+
+/**
+ * Runtimes and package managers whose presence is assumed by everything here.
+ *
+ * Separate from the vocabulary above because these are genuinely provisioned —
+ * just not by this detector. `node` is what runs it; proposing it would be
+ * circular.
+ */
+export const RUNTIMES = new Set([
+  "node",
+  "npm",
+  "npx",
+  "bun",
+  "bunx",
+  "yarn",
+  "pnpm",
+  "pnpx",
+  "corepack",
+  "git",
+  "python",
+  "python3",
+  "pip",
+  "pip3",
+  "ruby",
+  "bundle",
+  "go",
+  "cargo",
+  "docker",
+  "make",
+]);
+
+/**
+ * Commands that RESOLVE the next word from `node_modules`.
+ *
+ * `npx playwright test` needs no manifest entry: npm put the binary in
+ * `node_modules/.bin` and npx finds it there. Reading the mediated word as a
+ * tool would propose pinning something the package manager already provides —
+ * the noise that teaches a reader to skim the output.
+ */
+const MEDIATORS = new Set(["npx", "bunx", "pnpx", "dlx"]);
+
+/** Sub-commands after a package manager that mean "run something local". */
+const LOCAL_RUNNERS = new Set(["run", "exec", "x", "dlx", "run-script"]);
+
+/**
+ * Commands that TEST for another command rather than running it.
+ *
+ * `command -v gitleaks` is the single most valuable signal a hook can carry, and
+ * a word-scanner reading only the first position would throw it away. It is also
+ * the shape of the worst failure mode in this codebase: a hook that guards its
+ * own tool with `command -v` SKIPS SILENTLY when the tool is absent. The commit
+ * succeeds and nothing was scanned.
+ *
+ * A guarded tool is therefore stronger evidence than an unguarded one, not
+ * weaker — its absence is invisible at the moment it matters.
+ */
+const PROBES = new Set(["command", "which", "type", "hash"]);
+
+/**
+ * Words that stand in FRONT of a command without being one.
+ *
+ * Control keywords have to be skipped past rather than treated as the command,
+ * or the very shape this exists to catch is missed: in
+ * `if ! command -v gitleaks; then`, stopping at `if` never reaches the probe.
+ */
+const PREFIXES = new Set([
+  "!",
+  "sudo",
+  "time",
+  "nice",
+  "builtin",
+  "exec",
+  "if",
+  "then",
+  "elif",
+  "else",
+  "while",
+  "until",
+  "do",
+]);
+
+/** A name that could plausibly be an executable on PATH. */
+const TOOL_NAME = /^[a-z][a-z0-9_-]*$/u;
+
+/**
+ * Names the text defines as shell functions, which are never PATH tools.
+ *
+ * This repository's `pre-push` hook defines `load_audit_cves` and
+ * `missing_opencode_metadata` and then calls them, which reads exactly like a
+ * command invocation because it is one — just not of anything installable.
+ * @param {string} text Shell body.
+ * @returns {Set<string>} Locally defined function names.
+ */
+export function localFunctions(text) {
+  const names = new Set();
+  const pattern =
+    /(?:^|\n)\s*(?:function\s+)?([a-z_][a-z0-9_]*)\s*\(\)\s*\{/giu;
+  let match = pattern.exec(text);
+  while (match) {
+    names.add(match[1].toLowerCase());
+    match = pattern.exec(text);
+  }
+  return names;
+}
+
+/**
+ * Pull out `sh -c '...'` payloads so their contents are parsed as shell too.
+ *
+ * Done BEFORE quoted spans are stripped, because the payload is precisely a
+ * quoted span — and it is the one kind that really is a command. Frontend's
+ * `eas:publish:e2e` script wraps its `eas update` in exactly this shape.
+ * @param {string} text Shell body.
+ * @returns {{stripped: string, payloads: string[]}} Text and nested bodies.
+ */
+export function extractShellPayloads(text) {
+  const payloads = [];
+  const stripped = text.replace(
+    /\b(?:sh|bash|zsh)\s+-[a-z]*c\s+('([^']*)'|"([^"]*)")/gu,
+    (_all, _quoted, single, double) => {
+      payloads.push(single ?? double ?? "");
+      return " ";
+    }
+  );
+  return { stripped, payloads };
+}
+
+/**
+ * Blank out quoted spans and comments, keeping only text at command level.
+ *
+ * Quoted text is where embedded programs live — the jq filters and `node -e`
+ * snippets that produced `ltrimstr` and `console.log`. A command inside quotes
+ * is an argument to something else, with one exception, which
+ * `extractShellPayloads` has already lifted out by the time this runs.
+ *
+ * This is a character scanner rather than a chain of regexes because quoting and
+ * commenting are MUTUALLY nested and no ordering of independent passes gets it
+ * right. This repository's own `pre-push.local` proves it: the comment on line 9
+ * ends `...the script's exit code)`, and that lone apostrophe pairs with the
+ * next real quote 28 lines later, blanking everything between — including the
+ * `node -e` payload, whose JavaScript then leaked out as `try`, `catch`,
+ * `const` and `unreadable` proposals.
+ *
+ * Stripping comments first does not fix it either, since a `#` inside a quoted
+ * string is not a comment. One pass that tracks both is the only correct shape.
+ *
+ * Newlines survive so command positions are preserved; everything else inside a
+ * masked span becomes a space.
+ * @param {string} text Shell body.
+ * @returns {string} Text with non-command spans blanked.
+ */
+export function stripNonCommandSpans(text) {
+  const out = [];
+  let state = "normal";
+  // `$( )` restarts the quoting context: inside it, quotes pair among
+  // themselves rather than continuing the enclosing span. A flat scanner falls
+  // out of phase on the very first one — this repository's
+  // `"$(printf '%s' "$JSON" | node -e '...')"` left the payload's own string
+  // literals exposed at command level, proposing `data`, `end` and `stale`.
+  const enclosing = [];
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const previous = index > 0 ? text[index - 1] : "";
+
+    // A substitution opens a fresh context from inside ANY state but a
+    // single-quoted one, where shell performs no substitution at all.
+    if (
+      state !== "single" &&
+      state !== "comment" &&
+      char === "$" &&
+      text[index + 1] === "("
+    ) {
+      enclosing.push(state);
+      state = "normal";
+      out.push("\n");
+      index += 1;
+      continue;
+    }
+    if (state === "normal" && char === ")" && enclosing.length > 0) {
+      state = enclosing.pop();
+      out.push("\n");
+      continue;
+    }
+
+    if (state === "normal") {
+      if (char === "\\") {
+        // An escaped character is never a delimiter. Skip both.
+        out.push(" ");
+        index += 1;
+        if (text[index] === "\n") out.push("\n");
+        else out.push(" ");
+        continue;
+      }
+      if (char === "'") {
+        state = "single";
+        out.push(" ");
+        continue;
+      }
+      if (char === '"') {
+        state = "double";
+        out.push(" ");
+        continue;
+      }
+      // A `#` only opens a comment at the start of a word.
+      if (char === "#" && (previous === "" || /\s/u.test(previous))) {
+        state = "comment";
+        out.push(" ");
+        continue;
+      }
+      out.push(char);
+      continue;
+    }
+
+    if (state === "comment") {
+      if (char === "\n") {
+        state = "normal";
+        out.push("\n");
+        continue;
+      }
+      out.push(" ");
+      continue;
+    }
+
+    // Inside quotes. A single-quoted span has no escapes at all in shell.
+    if (state === "double" && char === "\\") {
+      out.push(" ");
+      index += 1;
+      out.push(text[index] === "\n" ? "\n" : " ");
+      continue;
+    }
+    if (
+      (state === "single" && char === "'") ||
+      (state === "double" && char === '"')
+    ) {
+      state = "normal";
+      out.push(" ");
+      continue;
+    }
+    out.push(char === "\n" ? "\n" : " ");
+  }
+
+  // Redirections last, on text that is already command-level.
+  return out.join("").replace(/\d?[<>]+&?\S*/gu, " ");
+}
+
+/**
+ * Whether a word can be a tool this detector should raise.
+ *
+ * One gate, applied to every path into the results. Probed names used to skip
+ * it, which is how `command -v bun` — a hook checking its own runtime — became
+ * a proposal to pin bun on every repository scanned.
+ * @param {string} word Candidate command name.
+ * @param {Set<string>} defined Function names the text defines itself.
+ * @returns {boolean} Whether to raise it.
+ */
+function admissible(word, defined) {
+  // A path is not a PATH lookup: `./scripts/check.sh` is project code.
+  if (word.includes("/") || word.includes("$")) return false;
+  if (!TOOL_NAME.test(word)) return false;
+  if (SHELL_VOCABULARY.has(word)) return false;
+  // `bun run build` resolves locally, and the runtime itself is assumed.
+  if (RUNTIMES.has(word)) return false;
+  return !defined.has(word);
+}
+
+/**
+ * Read the tool a probe is testing for.
+ * @param {string[]} words Words after the probe.
+ * @returns {string|null} The probed name, or null.
+ */
+function probedTool(words) {
+  for (const word of words) {
+    if (word.startsWith("-")) continue;
+    return TOOL_NAME.test(word) ? word : null;
+  }
+  return null;
+}
+
+/**
+ * Every command this shell text runs, at a command position.
+ * @param {string} text Shell body.
+ * @returns {string[]} Command names, deduplicated, in first-seen order.
+ */
+export function commandsIn(text) {
+  if (typeof text !== "string" || text.trim() === "") return [];
+
+  const { stripped, payloads } = extractShellPayloads(text);
+  const defined = localFunctions(text);
+  const found = new Set();
+
+  // Nested `sh -c` bodies are shell in their own right, so they get the same
+  // treatment rather than a weaker one.
+  for (const payload of payloads) {
+    for (const command of commandsIn(payload)) found.add(command);
+  }
+
+  const segments = stripNonCommandSpans(stripped).split(
+    /\|\||&&|\$\(|[;|&\n(){}`]/u
+  );
+
+  for (const segment of segments) {
+    const words = segment.trim().split(/\s+/u).filter(Boolean);
+    let index = 0;
+    // Environment assignments and decorations sit in front of the command.
+    while (
+      index < words.length &&
+      (/^[A-Za-z_][A-Za-z0-9_]*=/u.test(words[index]) ||
+        PREFIXES.has(words[index]))
+    ) {
+      index += 1;
+    }
+
+    const word = words[index]?.toLowerCase();
+    if (!word) continue;
+
+    if (PROBES.has(word)) {
+      // `command -v gitleaks` — the probed name is the evidence. It goes
+      // through the SAME filters as a directly invoked command: reading it
+      // straight into the results proposed `bun` and `yarn` on every repo,
+      // because `command -v bun` is how a hook checks its own runtime.
+      const probed = probedTool(words.slice(index + 1));
+      if (probed && admissible(probed, defined)) found.add(probed);
+      continue;
+    }
+    if (MEDIATORS.has(word)) continue;
+    if (LOCAL_RUNNERS.has(word)) continue;
+    if (!admissible(word, defined)) continue;
+
+    found.add(word);
+  }
+
+  return [...found];
+}

--- a/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,8 +22,10 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
+
+import { commandsIn } from "./commands.mjs";
 
 /** The tool named by the Expo template's scripts and its flows directory. */
 const MAESTRO = "maestro";
@@ -107,6 +109,128 @@ export function toolsFromScripts(pkg) {
     }
   }
   return found;
+}
+
+/** Where git hooks live, strongest signal first. */
+const HOOK_DIRECTORIES = [".husky", join(".git", "hooks")];
+
+/**
+ * Coding agents, which a PROJECT manifest must never try to provision.
+ *
+ * A hook that shells out to `claude` is real evidence of a real dependency, but
+ * `remoteEnv.tools` is the wrong place to answer it: agents belong to the
+ * machine, not the checkout, and each is installed by its vendor's own method
+ * into a version directory it manages itself. Pinning one as a release archive
+ * would fight the self-updater that owns that directory.
+ *
+ * That layer is `lisa-setup-workstation`. Named here rather than imported from
+ * it, because a detector that stops working when a sibling skill is absent is
+ * worse than one carrying six strings.
+ *
+ * Deliberately NOT extended to `gh`, `bws`, `aws` or `sonar`: those genuinely
+ * belong in a project manifest, and `gh` going undeclared is the incident this
+ * skill was written after.
+ */
+const WORKSTATION_PROVISIONED = new Set([
+  "claude",
+  "codex",
+  "cursor-agent",
+  "opencode",
+  "agy",
+  "copilot",
+]);
+
+/**
+ * Tools a git hook runs — the strongest signal a project can give.
+ *
+ * Stronger than an npm script, because a hook runs on EVERY commit and push
+ * whether anyone asked or not. A container missing one of these cannot commit at
+ * all; the failure arrives mid-task, unattended, at the moment of use.
+ *
+ * The worst shape is the guarded one. This repository's pre-commit hook wraps
+ * its secret scan in `command -v gitleaks`, so on a machine without gitleaks the
+ * scan is SKIPPED SILENTLY — the hook passes, the commit succeeds, and nothing
+ * was scanned. A guard makes the absence invisible exactly where it matters
+ * most, which is why a probed name counts as evidence rather than being read as
+ * "optional".
+ * @param {string} cwd Project root.
+ * @returns {Map<string, string>} Tool name to the hook that proves it.
+ */
+export function toolsFromGitHooks(cwd) {
+  const found = new Map();
+  for (const directory of HOOK_DIRECTORIES) {
+    const full = join(cwd, directory);
+    let names = [];
+    try {
+      names = readdirSync(full);
+    } catch {
+      continue;
+    }
+    for (const name of names.sort()) {
+      // `.sample` files ship with git and run nothing.
+      if (name.endsWith(".sample")) continue;
+      let body;
+      try {
+        body = readFileSync(join(full, name), "utf8");
+      } catch {
+        continue;
+      }
+      for (const tool of commandsIn(body)) {
+        if (!found.has(tool)) found.set(tool, `git hook ${directory}/${name}`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools an npm script invokes, discovered rather than matched against a list.
+ *
+ * `toolsFromScripts` answers "which of the tools I already know about appear
+ * here". This answers the open question — what does this project actually RUN —
+ * which is the one that finds a tool nobody thought to add. An Expo project
+ * invoking `eas` from eight scripts produced nothing under the old shape,
+ * because `eas` was not in `KNOWN_TOOLS`.
+ * @param {object|null} pkg Parsed package.json.
+ * @returns {Map<string, string>} Tool name to the script that proves it.
+ */
+export function toolsDiscoveredInScripts(pkg) {
+  const found = new Map();
+  for (const [name, body] of Object.entries(pkg?.scripts ?? {})) {
+    if (typeof body !== "string") continue;
+    for (const tool of commandsIn(body)) {
+      if (found.has(tool)) continue;
+      found.set(tool, `npm script "${name}": ${body.trim().slice(0, 60)}`);
+    }
+  }
+  return found;
+}
+
+/**
+ * Whether the package manager already puts this binary on the local path.
+ *
+ * A dependency's binary lands in `node_modules/.bin`, where npm scripts resolve
+ * it without it ever being on PATH. Proposing a manifest entry for one is noise,
+ * and noise is how a detector teaches people to skim it.
+ *
+ * Only meaningful once dependencies are installed, which is why
+ * `dependenciesInstalled` exists rather than this quietly returning false on a
+ * fresh clone and over-proposing every dev tool in the project.
+ * @param {string} cwd Project root.
+ * @param {string} tool Tool name.
+ * @returns {boolean} Whether npm already provides it.
+ */
+export function providedByNodeModules(cwd, tool) {
+  return existsSync(join(cwd, "node_modules", ".bin", tool));
+}
+
+/**
+ * Whether `node_modules` is populated, so its absence can be reported.
+ * @param {string} cwd Project root.
+ * @returns {boolean} Whether dependencies are installed.
+ */
+export function dependenciesInstalled(cwd) {
+  return existsSync(join(cwd, "node_modules", ".bin"));
 }
 
 /**
@@ -330,8 +454,14 @@ export function detectTooling(cwd = process.cwd()) {
   const notes = readJson(join(cwd, ".lisa", "secret-notes.json"));
 
   const declared = declaredTools(config);
+  // Curated signals carry a vetted `why`. Discovered ones carry only the fact
+  // that the project runs the thing — weaker prose, identical standing as
+  // evidence, and the only kind that can find a tool nobody listed.
+  const hooks = toolsFromGitHooks(cwd);
   const signals = [
+    hooks,
     toolsFromScripts(pkg),
+    toolsDiscoveredInScripts(pkg),
     toolsFromMcp(mcp),
     toolsFromSecretNotes(notes),
     toolsFromQuality(config, pkg, cwd),
@@ -343,8 +473,11 @@ export function detectTooling(cwd = process.cwd()) {
       if (declared.has(tool)) continue;
       // Already provided by the package manager, so there is nothing to pin.
       if (satisfiedByNpm(pkg, tool)) continue;
+      if (providedByNodeModules(cwd, tool)) continue;
+      // Real dependency, wrong manifest — the workstation layer owns it.
+      if (WORKSTATION_PROVISIONED.has(tool)) continue;
       const entry = merged.get(tool) ?? { evidence: [] };
-      entry.evidence.push(evidence);
+      if (!entry.evidence.includes(evidence)) entry.evidence.push(evidence);
       merged.set(tool, entry);
     }
   }
@@ -352,10 +485,33 @@ export function detectTooling(cwd = process.cwd()) {
   return [...merged.entries()]
     .map(([name, entry]) => ({
       name,
-      why: KNOWN_TOOLS[name]?.why ?? "",
+      why: KNOWN_TOOLS[name]?.why ?? discoveredWhy(name, hooks.has(name)),
       evidence: entry.evidence,
+      // Says which vocabulary the `why` came from, so a reader can weigh it.
+      // A curated entry has been thought about; a discovered one has only been
+      // observed.
+      source: Object.hasOwn(KNOWN_TOOLS, name) ? "curated" : "discovered",
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * The `why` for a tool nobody wrote prose for.
+ *
+ * Every proposal must carry one — a proposal without a reason is an assertion,
+ * and this program's whole boundary is that it asserts nothing. So a discovered
+ * tool states the observation plainly rather than borrowing confidence it has
+ * not earned.
+ * @param {string} name Tool name.
+ * @param {boolean} fromHook Whether a git hook runs it.
+ * @returns {string} A reason a reader can check.
+ */
+export function discoveredWhy(name, fromHook) {
+  return fromHook
+    ? `A git hook runs \`${name}\` on every commit or push, and nothing ` +
+        `declares it — a machine without it fails at commit time, or skips the ` +
+        `check silently if the hook guards it.`
+    : `An npm script invokes \`${name}\`, and nothing puts it on PATH.`;
 }
 
 /**
@@ -438,8 +594,18 @@ if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
     console.log(
       `${proposals.length} tool(s) look required but are not declared:\n`
     );
+    if (!dependenciesInstalled(process.cwd())) {
+      // Without node_modules there is no way to tell a tool that needs PATH
+      // from one npm already provides, so every dev dependency looks missing.
+      // Said out loud rather than silently over-proposing.
+      console.log(
+        "note: dependencies are not installed, so binaries npm would provide " +
+          "cannot be\n      excluded. Run the install first for a shorter, " +
+          "more accurate list.\n"
+      );
+    }
     for (const proposal of proposals) {
-      console.log(`  ${proposal.name}`);
+      console.log(`  ${proposal.name}  [${proposal.source}]`);
       console.log(`    why: ${proposal.why}`);
       for (const evidence of proposal.evidence) {
         console.log(`    evidence: ${evidence}`);

--- a/plugins/lisa-cursor/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-detect-tooling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-detect-tooling
-description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts whatever remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
+description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads git hooks and npm scripts for what the project actually RUNS — discovering tools no list mentions — plus MCP servers, credential usage notes and quality configuration. Subtracts whatever remoteEnv.tools, node_modules and the workstation layer already cover, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
 allowed-tools: ["Bash", "Read", "AskUserQuestion"]
 ---
 
@@ -20,14 +20,44 @@ Nothing populates that last row. So a project can ship scripts that invoke `maes
 
 That is the same failure this repository has now paid for twice: `gh` was declared nowhere and a cloud session could not commit; `tar` was needed by an install method and asserted by nothing.
 
+## Discovery, not recognition
+
+The first version of this could only find tools it had been told about: it matched script bodies against a fixed `KNOWN_TOOLS` list. That makes the detector useful for exactly the set that needs it least — the tools someone already thought of.
+
+An Expo project invoking `eas` from **eight** npm scripts and six CI steps produced no proposal, because `eas` was not on the list. `gitleaks`, which runs on every commit in every one of these repositories, produced no proposal either.
+
+So the question asked of executable sources is now the open one — *what does this project actually run* — and everything already provided is subtracted afterwards:
+
+- what `remoteEnv.tools` declares
+- what `node_modules/.bin` provides (a dependency's binary never needs to be on PATH)
+- what `lisa-setup-workstation` owns (coding agents belong to the machine, not the checkout)
+
+The curated list stays, because a vetted `why` is worth more than an observed one — proposals say which they are, `[curated]` or `[discovered]`.
+
 ## What it does
 
-Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
+Reads six signals, subtracts what is already covered, and prints what is left with the evidence for each:
 
-- **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
+- **git hooks** (`.husky/*`, `.git/hooks/*`) that invoke a binary. The **strongest** signal available, stronger than an npm script: a hook runs on every commit and push whether anyone asked or not, so a machine without the tool cannot commit at all.
+
+  A `command -v` guard counts as evidence rather than as "optional", because the guarded shape is the worse one. Lisa's pre-commit hook wraps its secret scan in `command -v gitleaks`, so on a machine without gitleaks the scan is **skipped silently** — the hook passes, the commit succeeds, and nothing was scanned. A guard makes the absence invisible precisely where it matters.
+
+- **npm scripts** that invoke a binary — a script running `maestro test` is the project stating a dependency in executable form. Read from the script *body*, not its name, because the name is a label.
 - **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one. Do not infer a CLI for access layers that already define their own headless substrate; Linear is handled by `lisa-linear-access` through `LINEAR_API_KEY` + GraphQL when MCP OAuth is unavailable.
 - **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
 - **Quality configuration**, where a threshold implies the tool that produces it.
+
+## Reading shell is the hard part
+
+Discovery only works if "what does this run" can be answered from shell text without inventing commands. Three things had to be right, each found by running it against real repositories:
+
+**Only the first word of a command position counts.** Word-scanning this repo's own hooks proposed `ltrimstr`, `map` and `select` (jq filter internals), `console.log` and `process.exit` (embedded JavaScript), and `load_audit_cves` (a function the hook defines three lines up). Reading only where a command can actually start removes all of them without a denylist entry for any.
+
+**Quoting and commenting nest, so neither can be stripped independently.** The comment on line 9 of `pre-push.local` ends `...the script's exit code)`. That lone apostrophe pairs with the next real quote 28 lines later, blanks everything between, and leaks a `node -e` payload's JavaScript into the results. Stripping comments first does not fix it, because a `#` inside a quoted string is not a comment. One character scanner tracking both is the only correct shape.
+
+**`$( )` restarts the quoting context.** In `"$(printf '%s' "$JSON" | node -e '…')"`, quotes inside the substitution pair among themselves. A flat scanner falls out of phase on the first one and starts reporting the payload's own string literals.
+
+Against Lisa and the three TunnlAI repositories, what survives is `gitleaks`, `jq`, `gtimeout` and `eas` — every one a real, undeclared invocation, with no false positives.
 
 ## What it will not do
 

--- a/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/commands.mjs
+++ b/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/commands.mjs
@@ -1,0 +1,479 @@
+/**
+ * Pull the commands out of a shell body.
+ *
+ * `lisa-detect-tooling` used to match script bodies against a fixed list of tool
+ * names, which meant it could only ever re-find tools someone had already
+ * thought of — the set that needs a detector least. An Expo project invoking
+ * `eas` from eight npm scripts produced nothing, because `eas` was not in the
+ * list.
+ *
+ * So the question this module answers is the open one: what does this shell text
+ * actually RUN? Everything downstream then subtracts what is already provided.
+ *
+ * ## Only the first word of a command position
+ *
+ * Naive word-scanning of this repository's own hooks proposed `ltrimstr`, `map`
+ * and `select` (jq filter internals), `console.log` and `process.exit` (embedded
+ * JavaScript), and `load_audit_cves` (a function the hook defines three lines
+ * up). None of those are tools; all of them appear where a word-scanner looks.
+ *
+ * A command runs at a command POSITION — the start of the text, or just after a
+ * separator. Reading only that position removes every one of those false
+ * positives without a denylist entry for any of them.
+ * @module commands
+ */
+
+/**
+ * Shell keywords and coreutils: present on any machine, never provisioned.
+ *
+ * This is a floor, not a policy. Anything genuinely absent from a minimal
+ * container belongs in the manifest, and a few of these (`unzip`, `curl`) are
+ * already declared there by projects that need them — being listed here only
+ * means discovery will not RAISE them, not that they are assumed present.
+ */
+export const SHELL_VOCABULARY = new Set([
+  // Keywords and builtins.
+  "if",
+  "then",
+  "else",
+  "elif",
+  "fi",
+  "for",
+  "while",
+  "until",
+  "do",
+  "done",
+  "case",
+  "esac",
+  "in",
+  "function",
+  "return",
+  "break",
+  "continue",
+  "exit",
+  "local",
+  "readonly",
+  "declare",
+  "export",
+  "unset",
+  "shift",
+  "eval",
+  "exec",
+  "source",
+  "set",
+  "trap",
+  "wait",
+  "read",
+  "echo",
+  "printf",
+  "cd",
+  "pwd",
+  "true",
+  "false",
+  "test",
+  "let",
+  "alias",
+  "shopt",
+  "getopts",
+  "umask",
+  // Coreutils and the usual POSIX furniture.
+  "cat",
+  "grep",
+  "egrep",
+  "fgrep",
+  "sed",
+  "awk",
+  "cut",
+  "tr",
+  "sort",
+  "uniq",
+  "head",
+  "tail",
+  "wc",
+  "tee",
+  "xargs",
+  "find",
+  "ls",
+  "mkdir",
+  "rmdir",
+  "rm",
+  "mv",
+  "cp",
+  "ln",
+  "touch",
+  "chmod",
+  "chown",
+  "stat",
+  "du",
+  "df",
+  "dirname",
+  "basename",
+  "realpath",
+  "readlink",
+  "mktemp",
+  "date",
+  "sleep",
+  "seq",
+  "env",
+  "kill",
+  "pgrep",
+  "pkill",
+  "ps",
+  "diff",
+  "comm",
+  "join",
+  "paste",
+  "split",
+  "tar",
+  "gzip",
+  "gunzip",
+  "zip",
+  "unzip",
+  "curl",
+  "wget",
+  "sh",
+  "bash",
+  "zsh",
+  "dash",
+  "nohup",
+  "timeout",
+  "yes",
+  "tty",
+  "id",
+  "whoami",
+  "uname",
+  "hostname",
+]);
+
+/**
+ * Runtimes and package managers whose presence is assumed by everything here.
+ *
+ * Separate from the vocabulary above because these are genuinely provisioned —
+ * just not by this detector. `node` is what runs it; proposing it would be
+ * circular.
+ */
+export const RUNTIMES = new Set([
+  "node",
+  "npm",
+  "npx",
+  "bun",
+  "bunx",
+  "yarn",
+  "pnpm",
+  "pnpx",
+  "corepack",
+  "git",
+  "python",
+  "python3",
+  "pip",
+  "pip3",
+  "ruby",
+  "bundle",
+  "go",
+  "cargo",
+  "docker",
+  "make",
+]);
+
+/**
+ * Commands that RESOLVE the next word from `node_modules`.
+ *
+ * `npx playwright test` needs no manifest entry: npm put the binary in
+ * `node_modules/.bin` and npx finds it there. Reading the mediated word as a
+ * tool would propose pinning something the package manager already provides —
+ * the noise that teaches a reader to skim the output.
+ */
+const MEDIATORS = new Set(["npx", "bunx", "pnpx", "dlx"]);
+
+/** Sub-commands after a package manager that mean "run something local". */
+const LOCAL_RUNNERS = new Set(["run", "exec", "x", "dlx", "run-script"]);
+
+/**
+ * Commands that TEST for another command rather than running it.
+ *
+ * `command -v gitleaks` is the single most valuable signal a hook can carry, and
+ * a word-scanner reading only the first position would throw it away. It is also
+ * the shape of the worst failure mode in this codebase: a hook that guards its
+ * own tool with `command -v` SKIPS SILENTLY when the tool is absent. The commit
+ * succeeds and nothing was scanned.
+ *
+ * A guarded tool is therefore stronger evidence than an unguarded one, not
+ * weaker — its absence is invisible at the moment it matters.
+ */
+const PROBES = new Set(["command", "which", "type", "hash"]);
+
+/**
+ * Words that stand in FRONT of a command without being one.
+ *
+ * Control keywords have to be skipped past rather than treated as the command,
+ * or the very shape this exists to catch is missed: in
+ * `if ! command -v gitleaks; then`, stopping at `if` never reaches the probe.
+ */
+const PREFIXES = new Set([
+  "!",
+  "sudo",
+  "time",
+  "nice",
+  "builtin",
+  "exec",
+  "if",
+  "then",
+  "elif",
+  "else",
+  "while",
+  "until",
+  "do",
+]);
+
+/** A name that could plausibly be an executable on PATH. */
+const TOOL_NAME = /^[a-z][a-z0-9_-]*$/u;
+
+/**
+ * Names the text defines as shell functions, which are never PATH tools.
+ *
+ * This repository's `pre-push` hook defines `load_audit_cves` and
+ * `missing_opencode_metadata` and then calls them, which reads exactly like a
+ * command invocation because it is one — just not of anything installable.
+ * @param {string} text Shell body.
+ * @returns {Set<string>} Locally defined function names.
+ */
+export function localFunctions(text) {
+  const names = new Set();
+  const pattern =
+    /(?:^|\n)\s*(?:function\s+)?([a-z_][a-z0-9_]*)\s*\(\)\s*\{/giu;
+  let match = pattern.exec(text);
+  while (match) {
+    names.add(match[1].toLowerCase());
+    match = pattern.exec(text);
+  }
+  return names;
+}
+
+/**
+ * Pull out `sh -c '...'` payloads so their contents are parsed as shell too.
+ *
+ * Done BEFORE quoted spans are stripped, because the payload is precisely a
+ * quoted span — and it is the one kind that really is a command. Frontend's
+ * `eas:publish:e2e` script wraps its `eas update` in exactly this shape.
+ * @param {string} text Shell body.
+ * @returns {{stripped: string, payloads: string[]}} Text and nested bodies.
+ */
+export function extractShellPayloads(text) {
+  const payloads = [];
+  const stripped = text.replace(
+    /\b(?:sh|bash|zsh)\s+-[a-z]*c\s+('([^']*)'|"([^"]*)")/gu,
+    (_all, _quoted, single, double) => {
+      payloads.push(single ?? double ?? "");
+      return " ";
+    }
+  );
+  return { stripped, payloads };
+}
+
+/**
+ * Blank out quoted spans and comments, keeping only text at command level.
+ *
+ * Quoted text is where embedded programs live — the jq filters and `node -e`
+ * snippets that produced `ltrimstr` and `console.log`. A command inside quotes
+ * is an argument to something else, with one exception, which
+ * `extractShellPayloads` has already lifted out by the time this runs.
+ *
+ * This is a character scanner rather than a chain of regexes because quoting and
+ * commenting are MUTUALLY nested and no ordering of independent passes gets it
+ * right. This repository's own `pre-push.local` proves it: the comment on line 9
+ * ends `...the script's exit code)`, and that lone apostrophe pairs with the
+ * next real quote 28 lines later, blanking everything between — including the
+ * `node -e` payload, whose JavaScript then leaked out as `try`, `catch`,
+ * `const` and `unreadable` proposals.
+ *
+ * Stripping comments first does not fix it either, since a `#` inside a quoted
+ * string is not a comment. One pass that tracks both is the only correct shape.
+ *
+ * Newlines survive so command positions are preserved; everything else inside a
+ * masked span becomes a space.
+ * @param {string} text Shell body.
+ * @returns {string} Text with non-command spans blanked.
+ */
+export function stripNonCommandSpans(text) {
+  const out = [];
+  let state = "normal";
+  // `$( )` restarts the quoting context: inside it, quotes pair among
+  // themselves rather than continuing the enclosing span. A flat scanner falls
+  // out of phase on the very first one — this repository's
+  // `"$(printf '%s' "$JSON" | node -e '...')"` left the payload's own string
+  // literals exposed at command level, proposing `data`, `end` and `stale`.
+  const enclosing = [];
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const previous = index > 0 ? text[index - 1] : "";
+
+    // A substitution opens a fresh context from inside ANY state but a
+    // single-quoted one, where shell performs no substitution at all.
+    if (
+      state !== "single" &&
+      state !== "comment" &&
+      char === "$" &&
+      text[index + 1] === "("
+    ) {
+      enclosing.push(state);
+      state = "normal";
+      out.push("\n");
+      index += 1;
+      continue;
+    }
+    if (state === "normal" && char === ")" && enclosing.length > 0) {
+      state = enclosing.pop();
+      out.push("\n");
+      continue;
+    }
+
+    if (state === "normal") {
+      if (char === "\\") {
+        // An escaped character is never a delimiter. Skip both.
+        out.push(" ");
+        index += 1;
+        if (text[index] === "\n") out.push("\n");
+        else out.push(" ");
+        continue;
+      }
+      if (char === "'") {
+        state = "single";
+        out.push(" ");
+        continue;
+      }
+      if (char === '"') {
+        state = "double";
+        out.push(" ");
+        continue;
+      }
+      // A `#` only opens a comment at the start of a word.
+      if (char === "#" && (previous === "" || /\s/u.test(previous))) {
+        state = "comment";
+        out.push(" ");
+        continue;
+      }
+      out.push(char);
+      continue;
+    }
+
+    if (state === "comment") {
+      if (char === "\n") {
+        state = "normal";
+        out.push("\n");
+        continue;
+      }
+      out.push(" ");
+      continue;
+    }
+
+    // Inside quotes. A single-quoted span has no escapes at all in shell.
+    if (state === "double" && char === "\\") {
+      out.push(" ");
+      index += 1;
+      out.push(text[index] === "\n" ? "\n" : " ");
+      continue;
+    }
+    if (
+      (state === "single" && char === "'") ||
+      (state === "double" && char === '"')
+    ) {
+      state = "normal";
+      out.push(" ");
+      continue;
+    }
+    out.push(char === "\n" ? "\n" : " ");
+  }
+
+  // Redirections last, on text that is already command-level.
+  return out.join("").replace(/\d?[<>]+&?\S*/gu, " ");
+}
+
+/**
+ * Whether a word can be a tool this detector should raise.
+ *
+ * One gate, applied to every path into the results. Probed names used to skip
+ * it, which is how `command -v bun` — a hook checking its own runtime — became
+ * a proposal to pin bun on every repository scanned.
+ * @param {string} word Candidate command name.
+ * @param {Set<string>} defined Function names the text defines itself.
+ * @returns {boolean} Whether to raise it.
+ */
+function admissible(word, defined) {
+  // A path is not a PATH lookup: `./scripts/check.sh` is project code.
+  if (word.includes("/") || word.includes("$")) return false;
+  if (!TOOL_NAME.test(word)) return false;
+  if (SHELL_VOCABULARY.has(word)) return false;
+  // `bun run build` resolves locally, and the runtime itself is assumed.
+  if (RUNTIMES.has(word)) return false;
+  return !defined.has(word);
+}
+
+/**
+ * Read the tool a probe is testing for.
+ * @param {string[]} words Words after the probe.
+ * @returns {string|null} The probed name, or null.
+ */
+function probedTool(words) {
+  for (const word of words) {
+    if (word.startsWith("-")) continue;
+    return TOOL_NAME.test(word) ? word : null;
+  }
+  return null;
+}
+
+/**
+ * Every command this shell text runs, at a command position.
+ * @param {string} text Shell body.
+ * @returns {string[]} Command names, deduplicated, in first-seen order.
+ */
+export function commandsIn(text) {
+  if (typeof text !== "string" || text.trim() === "") return [];
+
+  const { stripped, payloads } = extractShellPayloads(text);
+  const defined = localFunctions(text);
+  const found = new Set();
+
+  // Nested `sh -c` bodies are shell in their own right, so they get the same
+  // treatment rather than a weaker one.
+  for (const payload of payloads) {
+    for (const command of commandsIn(payload)) found.add(command);
+  }
+
+  const segments = stripNonCommandSpans(stripped).split(
+    /\|\||&&|\$\(|[;|&\n(){}`]/u
+  );
+
+  for (const segment of segments) {
+    const words = segment.trim().split(/\s+/u).filter(Boolean);
+    let index = 0;
+    // Environment assignments and decorations sit in front of the command.
+    while (
+      index < words.length &&
+      (/^[A-Za-z_][A-Za-z0-9_]*=/u.test(words[index]) ||
+        PREFIXES.has(words[index]))
+    ) {
+      index += 1;
+    }
+
+    const word = words[index]?.toLowerCase();
+    if (!word) continue;
+
+    if (PROBES.has(word)) {
+      // `command -v gitleaks` — the probed name is the evidence. It goes
+      // through the SAME filters as a directly invoked command: reading it
+      // straight into the results proposed `bun` and `yarn` on every repo,
+      // because `command -v bun` is how a hook checks its own runtime.
+      const probed = probedTool(words.slice(index + 1));
+      if (probed && admissible(probed, defined)) found.add(probed);
+      continue;
+    }
+    if (MEDIATORS.has(word)) continue;
+    if (LOCAL_RUNNERS.has(word)) continue;
+    if (!admissible(word, defined)) continue;
+
+    found.add(word);
+  }
+
+  return [...found];
+}

--- a/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,8 +22,10 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
+
+import { commandsIn } from "./commands.mjs";
 
 /** The tool named by the Expo template's scripts and its flows directory. */
 const MAESTRO = "maestro";
@@ -107,6 +109,128 @@ export function toolsFromScripts(pkg) {
     }
   }
   return found;
+}
+
+/** Where git hooks live, strongest signal first. */
+const HOOK_DIRECTORIES = [".husky", join(".git", "hooks")];
+
+/**
+ * Coding agents, which a PROJECT manifest must never try to provision.
+ *
+ * A hook that shells out to `claude` is real evidence of a real dependency, but
+ * `remoteEnv.tools` is the wrong place to answer it: agents belong to the
+ * machine, not the checkout, and each is installed by its vendor's own method
+ * into a version directory it manages itself. Pinning one as a release archive
+ * would fight the self-updater that owns that directory.
+ *
+ * That layer is `lisa-setup-workstation`. Named here rather than imported from
+ * it, because a detector that stops working when a sibling skill is absent is
+ * worse than one carrying six strings.
+ *
+ * Deliberately NOT extended to `gh`, `bws`, `aws` or `sonar`: those genuinely
+ * belong in a project manifest, and `gh` going undeclared is the incident this
+ * skill was written after.
+ */
+const WORKSTATION_PROVISIONED = new Set([
+  "claude",
+  "codex",
+  "cursor-agent",
+  "opencode",
+  "agy",
+  "copilot",
+]);
+
+/**
+ * Tools a git hook runs — the strongest signal a project can give.
+ *
+ * Stronger than an npm script, because a hook runs on EVERY commit and push
+ * whether anyone asked or not. A container missing one of these cannot commit at
+ * all; the failure arrives mid-task, unattended, at the moment of use.
+ *
+ * The worst shape is the guarded one. This repository's pre-commit hook wraps
+ * its secret scan in `command -v gitleaks`, so on a machine without gitleaks the
+ * scan is SKIPPED SILENTLY — the hook passes, the commit succeeds, and nothing
+ * was scanned. A guard makes the absence invisible exactly where it matters
+ * most, which is why a probed name counts as evidence rather than being read as
+ * "optional".
+ * @param {string} cwd Project root.
+ * @returns {Map<string, string>} Tool name to the hook that proves it.
+ */
+export function toolsFromGitHooks(cwd) {
+  const found = new Map();
+  for (const directory of HOOK_DIRECTORIES) {
+    const full = join(cwd, directory);
+    let names = [];
+    try {
+      names = readdirSync(full);
+    } catch {
+      continue;
+    }
+    for (const name of names.sort()) {
+      // `.sample` files ship with git and run nothing.
+      if (name.endsWith(".sample")) continue;
+      let body;
+      try {
+        body = readFileSync(join(full, name), "utf8");
+      } catch {
+        continue;
+      }
+      for (const tool of commandsIn(body)) {
+        if (!found.has(tool)) found.set(tool, `git hook ${directory}/${name}`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools an npm script invokes, discovered rather than matched against a list.
+ *
+ * `toolsFromScripts` answers "which of the tools I already know about appear
+ * here". This answers the open question — what does this project actually RUN —
+ * which is the one that finds a tool nobody thought to add. An Expo project
+ * invoking `eas` from eight scripts produced nothing under the old shape,
+ * because `eas` was not in `KNOWN_TOOLS`.
+ * @param {object|null} pkg Parsed package.json.
+ * @returns {Map<string, string>} Tool name to the script that proves it.
+ */
+export function toolsDiscoveredInScripts(pkg) {
+  const found = new Map();
+  for (const [name, body] of Object.entries(pkg?.scripts ?? {})) {
+    if (typeof body !== "string") continue;
+    for (const tool of commandsIn(body)) {
+      if (found.has(tool)) continue;
+      found.set(tool, `npm script "${name}": ${body.trim().slice(0, 60)}`);
+    }
+  }
+  return found;
+}
+
+/**
+ * Whether the package manager already puts this binary on the local path.
+ *
+ * A dependency's binary lands in `node_modules/.bin`, where npm scripts resolve
+ * it without it ever being on PATH. Proposing a manifest entry for one is noise,
+ * and noise is how a detector teaches people to skim it.
+ *
+ * Only meaningful once dependencies are installed, which is why
+ * `dependenciesInstalled` exists rather than this quietly returning false on a
+ * fresh clone and over-proposing every dev tool in the project.
+ * @param {string} cwd Project root.
+ * @param {string} tool Tool name.
+ * @returns {boolean} Whether npm already provides it.
+ */
+export function providedByNodeModules(cwd, tool) {
+  return existsSync(join(cwd, "node_modules", ".bin", tool));
+}
+
+/**
+ * Whether `node_modules` is populated, so its absence can be reported.
+ * @param {string} cwd Project root.
+ * @returns {boolean} Whether dependencies are installed.
+ */
+export function dependenciesInstalled(cwd) {
+  return existsSync(join(cwd, "node_modules", ".bin"));
 }
 
 /**
@@ -330,8 +454,14 @@ export function detectTooling(cwd = process.cwd()) {
   const notes = readJson(join(cwd, ".lisa", "secret-notes.json"));
 
   const declared = declaredTools(config);
+  // Curated signals carry a vetted `why`. Discovered ones carry only the fact
+  // that the project runs the thing — weaker prose, identical standing as
+  // evidence, and the only kind that can find a tool nobody listed.
+  const hooks = toolsFromGitHooks(cwd);
   const signals = [
+    hooks,
     toolsFromScripts(pkg),
+    toolsDiscoveredInScripts(pkg),
     toolsFromMcp(mcp),
     toolsFromSecretNotes(notes),
     toolsFromQuality(config, pkg, cwd),
@@ -343,8 +473,11 @@ export function detectTooling(cwd = process.cwd()) {
       if (declared.has(tool)) continue;
       // Already provided by the package manager, so there is nothing to pin.
       if (satisfiedByNpm(pkg, tool)) continue;
+      if (providedByNodeModules(cwd, tool)) continue;
+      // Real dependency, wrong manifest — the workstation layer owns it.
+      if (WORKSTATION_PROVISIONED.has(tool)) continue;
       const entry = merged.get(tool) ?? { evidence: [] };
-      entry.evidence.push(evidence);
+      if (!entry.evidence.includes(evidence)) entry.evidence.push(evidence);
       merged.set(tool, entry);
     }
   }
@@ -352,10 +485,33 @@ export function detectTooling(cwd = process.cwd()) {
   return [...merged.entries()]
     .map(([name, entry]) => ({
       name,
-      why: KNOWN_TOOLS[name]?.why ?? "",
+      why: KNOWN_TOOLS[name]?.why ?? discoveredWhy(name, hooks.has(name)),
       evidence: entry.evidence,
+      // Says which vocabulary the `why` came from, so a reader can weigh it.
+      // A curated entry has been thought about; a discovered one has only been
+      // observed.
+      source: Object.hasOwn(KNOWN_TOOLS, name) ? "curated" : "discovered",
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * The `why` for a tool nobody wrote prose for.
+ *
+ * Every proposal must carry one — a proposal without a reason is an assertion,
+ * and this program's whole boundary is that it asserts nothing. So a discovered
+ * tool states the observation plainly rather than borrowing confidence it has
+ * not earned.
+ * @param {string} name Tool name.
+ * @param {boolean} fromHook Whether a git hook runs it.
+ * @returns {string} A reason a reader can check.
+ */
+export function discoveredWhy(name, fromHook) {
+  return fromHook
+    ? `A git hook runs \`${name}\` on every commit or push, and nothing ` +
+        `declares it — a machine without it fails at commit time, or skips the ` +
+        `check silently if the hook guards it.`
+    : `An npm script invokes \`${name}\`, and nothing puts it on PATH.`;
 }
 
 /**
@@ -438,8 +594,18 @@ if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
     console.log(
       `${proposals.length} tool(s) look required but are not declared:\n`
     );
+    if (!dependenciesInstalled(process.cwd())) {
+      // Without node_modules there is no way to tell a tool that needs PATH
+      // from one npm already provides, so every dev dependency looks missing.
+      // Said out loud rather than silently over-proposing.
+      console.log(
+        "note: dependencies are not installed, so binaries npm would provide " +
+          "cannot be\n      excluded. Run the install first for a shorter, " +
+          "more accurate list.\n"
+      );
+    }
     for (const proposal of proposals) {
-      console.log(`  ${proposal.name}`);
+      console.log(`  ${proposal.name}  [${proposal.source}]`);
       console.log(`    why: ${proposal.why}`);
       for (const evidence of proposal.evidence) {
         console.log(`    evidence: ${evidence}`);

--- a/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/SKILL.md
@@ -20,14 +20,44 @@ Nothing populates that last row. So a project can ship scripts that invoke `maes
 
 That is the same failure this repository has now paid for twice: `gh` was declared nowhere and a cloud session could not commit; `tar` was needed by an install method and asserted by nothing.
 
+## Discovery, not recognition
+
+The first version of this could only find tools it had been told about: it matched script bodies against a fixed `KNOWN_TOOLS` list. That makes the detector useful for exactly the set that needs it least — the tools someone already thought of.
+
+An Expo project invoking `eas` from **eight** npm scripts and six CI steps produced no proposal, because `eas` was not on the list. `gitleaks`, which runs on every commit in every one of these repositories, produced no proposal either.
+
+So the question asked of executable sources is now the open one — *what does this project actually run* — and everything already provided is subtracted afterwards:
+
+- what `remoteEnv.tools` declares
+- what `node_modules/.bin` provides (a dependency's binary never needs to be on PATH)
+- what `lisa-setup-workstation` owns (coding agents belong to the machine, not the checkout)
+
+The curated list stays, because a vetted `why` is worth more than an observed one — proposals say which they are, `[curated]` or `[discovered]`.
+
 ## What it does
 
-Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
+Reads six signals, subtracts what is already covered, and prints what is left with the evidence for each:
 
-- **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
+- **git hooks** (`.husky/*`, `.git/hooks/*`) that invoke a binary. The **strongest** signal available, stronger than an npm script: a hook runs on every commit and push whether anyone asked or not, so a machine without the tool cannot commit at all.
+
+  A `command -v` guard counts as evidence rather than as "optional", because the guarded shape is the worse one. Lisa's pre-commit hook wraps its secret scan in `command -v gitleaks`, so on a machine without gitleaks the scan is **skipped silently** — the hook passes, the commit succeeds, and nothing was scanned. A guard makes the absence invisible precisely where it matters.
+
+- **npm scripts** that invoke a binary — a script running `maestro test` is the project stating a dependency in executable form. Read from the script *body*, not its name, because the name is a label.
 - **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one. Do not infer a CLI for access layers that already define their own headless substrate; Linear is handled by `lisa-linear-access` through `LINEAR_API_KEY` + GraphQL when MCP OAuth is unavailable.
 - **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
 - **Quality configuration**, where a threshold implies the tool that produces it.
+
+## Reading shell is the hard part
+
+Discovery only works if "what does this run" can be answered from shell text without inventing commands. Three things had to be right, each found by running it against real repositories:
+
+**Only the first word of a command position counts.** Word-scanning this repo's own hooks proposed `ltrimstr`, `map` and `select` (jq filter internals), `console.log` and `process.exit` (embedded JavaScript), and `load_audit_cves` (a function the hook defines three lines up). Reading only where a command can actually start removes all of them without a denylist entry for any.
+
+**Quoting and commenting nest, so neither can be stripped independently.** The comment on line 9 of `pre-push.local` ends `...the script's exit code)`. That lone apostrophe pairs with the next real quote 28 lines later, blanks everything between, and leaks a `node -e` payload's JavaScript into the results. Stripping comments first does not fix it, because a `#` inside a quoted string is not a comment. One character scanner tracking both is the only correct shape.
+
+**`$( )` restarts the quoting context.** In `"$(printf '%s' "$JSON" | node -e '…')"`, quotes inside the substitution pair among themselves. A flat scanner falls out of phase on the first one and starts reporting the payload's own string literals.
+
+Against Lisa and the three TunnlAI repositories, what survives is `gitleaks`, `jq`, `gtimeout` and `eas` — every one a real, undeclared invocation, with no false positives.
 
 ## What it will not do
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/commands.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/commands.mjs
@@ -1,0 +1,479 @@
+/**
+ * Pull the commands out of a shell body.
+ *
+ * `lisa-detect-tooling` used to match script bodies against a fixed list of tool
+ * names, which meant it could only ever re-find tools someone had already
+ * thought of — the set that needs a detector least. An Expo project invoking
+ * `eas` from eight npm scripts produced nothing, because `eas` was not in the
+ * list.
+ *
+ * So the question this module answers is the open one: what does this shell text
+ * actually RUN? Everything downstream then subtracts what is already provided.
+ *
+ * ## Only the first word of a command position
+ *
+ * Naive word-scanning of this repository's own hooks proposed `ltrimstr`, `map`
+ * and `select` (jq filter internals), `console.log` and `process.exit` (embedded
+ * JavaScript), and `load_audit_cves` (a function the hook defines three lines
+ * up). None of those are tools; all of them appear where a word-scanner looks.
+ *
+ * A command runs at a command POSITION — the start of the text, or just after a
+ * separator. Reading only that position removes every one of those false
+ * positives without a denylist entry for any of them.
+ * @module commands
+ */
+
+/**
+ * Shell keywords and coreutils: present on any machine, never provisioned.
+ *
+ * This is a floor, not a policy. Anything genuinely absent from a minimal
+ * container belongs in the manifest, and a few of these (`unzip`, `curl`) are
+ * already declared there by projects that need them — being listed here only
+ * means discovery will not RAISE them, not that they are assumed present.
+ */
+export const SHELL_VOCABULARY = new Set([
+  // Keywords and builtins.
+  "if",
+  "then",
+  "else",
+  "elif",
+  "fi",
+  "for",
+  "while",
+  "until",
+  "do",
+  "done",
+  "case",
+  "esac",
+  "in",
+  "function",
+  "return",
+  "break",
+  "continue",
+  "exit",
+  "local",
+  "readonly",
+  "declare",
+  "export",
+  "unset",
+  "shift",
+  "eval",
+  "exec",
+  "source",
+  "set",
+  "trap",
+  "wait",
+  "read",
+  "echo",
+  "printf",
+  "cd",
+  "pwd",
+  "true",
+  "false",
+  "test",
+  "let",
+  "alias",
+  "shopt",
+  "getopts",
+  "umask",
+  // Coreutils and the usual POSIX furniture.
+  "cat",
+  "grep",
+  "egrep",
+  "fgrep",
+  "sed",
+  "awk",
+  "cut",
+  "tr",
+  "sort",
+  "uniq",
+  "head",
+  "tail",
+  "wc",
+  "tee",
+  "xargs",
+  "find",
+  "ls",
+  "mkdir",
+  "rmdir",
+  "rm",
+  "mv",
+  "cp",
+  "ln",
+  "touch",
+  "chmod",
+  "chown",
+  "stat",
+  "du",
+  "df",
+  "dirname",
+  "basename",
+  "realpath",
+  "readlink",
+  "mktemp",
+  "date",
+  "sleep",
+  "seq",
+  "env",
+  "kill",
+  "pgrep",
+  "pkill",
+  "ps",
+  "diff",
+  "comm",
+  "join",
+  "paste",
+  "split",
+  "tar",
+  "gzip",
+  "gunzip",
+  "zip",
+  "unzip",
+  "curl",
+  "wget",
+  "sh",
+  "bash",
+  "zsh",
+  "dash",
+  "nohup",
+  "timeout",
+  "yes",
+  "tty",
+  "id",
+  "whoami",
+  "uname",
+  "hostname",
+]);
+
+/**
+ * Runtimes and package managers whose presence is assumed by everything here.
+ *
+ * Separate from the vocabulary above because these are genuinely provisioned —
+ * just not by this detector. `node` is what runs it; proposing it would be
+ * circular.
+ */
+export const RUNTIMES = new Set([
+  "node",
+  "npm",
+  "npx",
+  "bun",
+  "bunx",
+  "yarn",
+  "pnpm",
+  "pnpx",
+  "corepack",
+  "git",
+  "python",
+  "python3",
+  "pip",
+  "pip3",
+  "ruby",
+  "bundle",
+  "go",
+  "cargo",
+  "docker",
+  "make",
+]);
+
+/**
+ * Commands that RESOLVE the next word from `node_modules`.
+ *
+ * `npx playwright test` needs no manifest entry: npm put the binary in
+ * `node_modules/.bin` and npx finds it there. Reading the mediated word as a
+ * tool would propose pinning something the package manager already provides —
+ * the noise that teaches a reader to skim the output.
+ */
+const MEDIATORS = new Set(["npx", "bunx", "pnpx", "dlx"]);
+
+/** Sub-commands after a package manager that mean "run something local". */
+const LOCAL_RUNNERS = new Set(["run", "exec", "x", "dlx", "run-script"]);
+
+/**
+ * Commands that TEST for another command rather than running it.
+ *
+ * `command -v gitleaks` is the single most valuable signal a hook can carry, and
+ * a word-scanner reading only the first position would throw it away. It is also
+ * the shape of the worst failure mode in this codebase: a hook that guards its
+ * own tool with `command -v` SKIPS SILENTLY when the tool is absent. The commit
+ * succeeds and nothing was scanned.
+ *
+ * A guarded tool is therefore stronger evidence than an unguarded one, not
+ * weaker — its absence is invisible at the moment it matters.
+ */
+const PROBES = new Set(["command", "which", "type", "hash"]);
+
+/**
+ * Words that stand in FRONT of a command without being one.
+ *
+ * Control keywords have to be skipped past rather than treated as the command,
+ * or the very shape this exists to catch is missed: in
+ * `if ! command -v gitleaks; then`, stopping at `if` never reaches the probe.
+ */
+const PREFIXES = new Set([
+  "!",
+  "sudo",
+  "time",
+  "nice",
+  "builtin",
+  "exec",
+  "if",
+  "then",
+  "elif",
+  "else",
+  "while",
+  "until",
+  "do",
+]);
+
+/** A name that could plausibly be an executable on PATH. */
+const TOOL_NAME = /^[a-z][a-z0-9_-]*$/u;
+
+/**
+ * Names the text defines as shell functions, which are never PATH tools.
+ *
+ * This repository's `pre-push` hook defines `load_audit_cves` and
+ * `missing_opencode_metadata` and then calls them, which reads exactly like a
+ * command invocation because it is one — just not of anything installable.
+ * @param {string} text Shell body.
+ * @returns {Set<string>} Locally defined function names.
+ */
+export function localFunctions(text) {
+  const names = new Set();
+  const pattern =
+    /(?:^|\n)\s*(?:function\s+)?([a-z_][a-z0-9_]*)\s*\(\)\s*\{/giu;
+  let match = pattern.exec(text);
+  while (match) {
+    names.add(match[1].toLowerCase());
+    match = pattern.exec(text);
+  }
+  return names;
+}
+
+/**
+ * Pull out `sh -c '...'` payloads so their contents are parsed as shell too.
+ *
+ * Done BEFORE quoted spans are stripped, because the payload is precisely a
+ * quoted span — and it is the one kind that really is a command. Frontend's
+ * `eas:publish:e2e` script wraps its `eas update` in exactly this shape.
+ * @param {string} text Shell body.
+ * @returns {{stripped: string, payloads: string[]}} Text and nested bodies.
+ */
+export function extractShellPayloads(text) {
+  const payloads = [];
+  const stripped = text.replace(
+    /\b(?:sh|bash|zsh)\s+-[a-z]*c\s+('([^']*)'|"([^"]*)")/gu,
+    (_all, _quoted, single, double) => {
+      payloads.push(single ?? double ?? "");
+      return " ";
+    }
+  );
+  return { stripped, payloads };
+}
+
+/**
+ * Blank out quoted spans and comments, keeping only text at command level.
+ *
+ * Quoted text is where embedded programs live — the jq filters and `node -e`
+ * snippets that produced `ltrimstr` and `console.log`. A command inside quotes
+ * is an argument to something else, with one exception, which
+ * `extractShellPayloads` has already lifted out by the time this runs.
+ *
+ * This is a character scanner rather than a chain of regexes because quoting and
+ * commenting are MUTUALLY nested and no ordering of independent passes gets it
+ * right. This repository's own `pre-push.local` proves it: the comment on line 9
+ * ends `...the script's exit code)`, and that lone apostrophe pairs with the
+ * next real quote 28 lines later, blanking everything between — including the
+ * `node -e` payload, whose JavaScript then leaked out as `try`, `catch`,
+ * `const` and `unreadable` proposals.
+ *
+ * Stripping comments first does not fix it either, since a `#` inside a quoted
+ * string is not a comment. One pass that tracks both is the only correct shape.
+ *
+ * Newlines survive so command positions are preserved; everything else inside a
+ * masked span becomes a space.
+ * @param {string} text Shell body.
+ * @returns {string} Text with non-command spans blanked.
+ */
+export function stripNonCommandSpans(text) {
+  const out = [];
+  let state = "normal";
+  // `$( )` restarts the quoting context: inside it, quotes pair among
+  // themselves rather than continuing the enclosing span. A flat scanner falls
+  // out of phase on the very first one — this repository's
+  // `"$(printf '%s' "$JSON" | node -e '...')"` left the payload's own string
+  // literals exposed at command level, proposing `data`, `end` and `stale`.
+  const enclosing = [];
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const previous = index > 0 ? text[index - 1] : "";
+
+    // A substitution opens a fresh context from inside ANY state but a
+    // single-quoted one, where shell performs no substitution at all.
+    if (
+      state !== "single" &&
+      state !== "comment" &&
+      char === "$" &&
+      text[index + 1] === "("
+    ) {
+      enclosing.push(state);
+      state = "normal";
+      out.push("\n");
+      index += 1;
+      continue;
+    }
+    if (state === "normal" && char === ")" && enclosing.length > 0) {
+      state = enclosing.pop();
+      out.push("\n");
+      continue;
+    }
+
+    if (state === "normal") {
+      if (char === "\\") {
+        // An escaped character is never a delimiter. Skip both.
+        out.push(" ");
+        index += 1;
+        if (text[index] === "\n") out.push("\n");
+        else out.push(" ");
+        continue;
+      }
+      if (char === "'") {
+        state = "single";
+        out.push(" ");
+        continue;
+      }
+      if (char === '"') {
+        state = "double";
+        out.push(" ");
+        continue;
+      }
+      // A `#` only opens a comment at the start of a word.
+      if (char === "#" && (previous === "" || /\s/u.test(previous))) {
+        state = "comment";
+        out.push(" ");
+        continue;
+      }
+      out.push(char);
+      continue;
+    }
+
+    if (state === "comment") {
+      if (char === "\n") {
+        state = "normal";
+        out.push("\n");
+        continue;
+      }
+      out.push(" ");
+      continue;
+    }
+
+    // Inside quotes. A single-quoted span has no escapes at all in shell.
+    if (state === "double" && char === "\\") {
+      out.push(" ");
+      index += 1;
+      out.push(text[index] === "\n" ? "\n" : " ");
+      continue;
+    }
+    if (
+      (state === "single" && char === "'") ||
+      (state === "double" && char === '"')
+    ) {
+      state = "normal";
+      out.push(" ");
+      continue;
+    }
+    out.push(char === "\n" ? "\n" : " ");
+  }
+
+  // Redirections last, on text that is already command-level.
+  return out.join("").replace(/\d?[<>]+&?\S*/gu, " ");
+}
+
+/**
+ * Whether a word can be a tool this detector should raise.
+ *
+ * One gate, applied to every path into the results. Probed names used to skip
+ * it, which is how `command -v bun` — a hook checking its own runtime — became
+ * a proposal to pin bun on every repository scanned.
+ * @param {string} word Candidate command name.
+ * @param {Set<string>} defined Function names the text defines itself.
+ * @returns {boolean} Whether to raise it.
+ */
+function admissible(word, defined) {
+  // A path is not a PATH lookup: `./scripts/check.sh` is project code.
+  if (word.includes("/") || word.includes("$")) return false;
+  if (!TOOL_NAME.test(word)) return false;
+  if (SHELL_VOCABULARY.has(word)) return false;
+  // `bun run build` resolves locally, and the runtime itself is assumed.
+  if (RUNTIMES.has(word)) return false;
+  return !defined.has(word);
+}
+
+/**
+ * Read the tool a probe is testing for.
+ * @param {string[]} words Words after the probe.
+ * @returns {string|null} The probed name, or null.
+ */
+function probedTool(words) {
+  for (const word of words) {
+    if (word.startsWith("-")) continue;
+    return TOOL_NAME.test(word) ? word : null;
+  }
+  return null;
+}
+
+/**
+ * Every command this shell text runs, at a command position.
+ * @param {string} text Shell body.
+ * @returns {string[]} Command names, deduplicated, in first-seen order.
+ */
+export function commandsIn(text) {
+  if (typeof text !== "string" || text.trim() === "") return [];
+
+  const { stripped, payloads } = extractShellPayloads(text);
+  const defined = localFunctions(text);
+  const found = new Set();
+
+  // Nested `sh -c` bodies are shell in their own right, so they get the same
+  // treatment rather than a weaker one.
+  for (const payload of payloads) {
+    for (const command of commandsIn(payload)) found.add(command);
+  }
+
+  const segments = stripNonCommandSpans(stripped).split(
+    /\|\||&&|\$\(|[;|&\n(){}`]/u
+  );
+
+  for (const segment of segments) {
+    const words = segment.trim().split(/\s+/u).filter(Boolean);
+    let index = 0;
+    // Environment assignments and decorations sit in front of the command.
+    while (
+      index < words.length &&
+      (/^[A-Za-z_][A-Za-z0-9_]*=/u.test(words[index]) ||
+        PREFIXES.has(words[index]))
+    ) {
+      index += 1;
+    }
+
+    const word = words[index]?.toLowerCase();
+    if (!word) continue;
+
+    if (PROBES.has(word)) {
+      // `command -v gitleaks` — the probed name is the evidence. It goes
+      // through the SAME filters as a directly invoked command: reading it
+      // straight into the results proposed `bun` and `yarn` on every repo,
+      // because `command -v bun` is how a hook checks its own runtime.
+      const probed = probedTool(words.slice(index + 1));
+      if (probed && admissible(probed, defined)) found.add(probed);
+      continue;
+    }
+    if (MEDIATORS.has(word)) continue;
+    if (LOCAL_RUNNERS.has(word)) continue;
+    if (!admissible(word, defined)) continue;
+
+    found.add(word);
+  }
+
+  return [...found];
+}

--- a/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,8 +22,10 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
+
+import { commandsIn } from "./commands.mjs";
 
 /** The tool named by the Expo template's scripts and its flows directory. */
 const MAESTRO = "maestro";
@@ -107,6 +109,128 @@ export function toolsFromScripts(pkg) {
     }
   }
   return found;
+}
+
+/** Where git hooks live, strongest signal first. */
+const HOOK_DIRECTORIES = [".husky", join(".git", "hooks")];
+
+/**
+ * Coding agents, which a PROJECT manifest must never try to provision.
+ *
+ * A hook that shells out to `claude` is real evidence of a real dependency, but
+ * `remoteEnv.tools` is the wrong place to answer it: agents belong to the
+ * machine, not the checkout, and each is installed by its vendor's own method
+ * into a version directory it manages itself. Pinning one as a release archive
+ * would fight the self-updater that owns that directory.
+ *
+ * That layer is `lisa-setup-workstation`. Named here rather than imported from
+ * it, because a detector that stops working when a sibling skill is absent is
+ * worse than one carrying six strings.
+ *
+ * Deliberately NOT extended to `gh`, `bws`, `aws` or `sonar`: those genuinely
+ * belong in a project manifest, and `gh` going undeclared is the incident this
+ * skill was written after.
+ */
+const WORKSTATION_PROVISIONED = new Set([
+  "claude",
+  "codex",
+  "cursor-agent",
+  "opencode",
+  "agy",
+  "copilot",
+]);
+
+/**
+ * Tools a git hook runs — the strongest signal a project can give.
+ *
+ * Stronger than an npm script, because a hook runs on EVERY commit and push
+ * whether anyone asked or not. A container missing one of these cannot commit at
+ * all; the failure arrives mid-task, unattended, at the moment of use.
+ *
+ * The worst shape is the guarded one. This repository's pre-commit hook wraps
+ * its secret scan in `command -v gitleaks`, so on a machine without gitleaks the
+ * scan is SKIPPED SILENTLY — the hook passes, the commit succeeds, and nothing
+ * was scanned. A guard makes the absence invisible exactly where it matters
+ * most, which is why a probed name counts as evidence rather than being read as
+ * "optional".
+ * @param {string} cwd Project root.
+ * @returns {Map<string, string>} Tool name to the hook that proves it.
+ */
+export function toolsFromGitHooks(cwd) {
+  const found = new Map();
+  for (const directory of HOOK_DIRECTORIES) {
+    const full = join(cwd, directory);
+    let names = [];
+    try {
+      names = readdirSync(full);
+    } catch {
+      continue;
+    }
+    for (const name of names.sort()) {
+      // `.sample` files ship with git and run nothing.
+      if (name.endsWith(".sample")) continue;
+      let body;
+      try {
+        body = readFileSync(join(full, name), "utf8");
+      } catch {
+        continue;
+      }
+      for (const tool of commandsIn(body)) {
+        if (!found.has(tool)) found.set(tool, `git hook ${directory}/${name}`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools an npm script invokes, discovered rather than matched against a list.
+ *
+ * `toolsFromScripts` answers "which of the tools I already know about appear
+ * here". This answers the open question — what does this project actually RUN —
+ * which is the one that finds a tool nobody thought to add. An Expo project
+ * invoking `eas` from eight scripts produced nothing under the old shape,
+ * because `eas` was not in `KNOWN_TOOLS`.
+ * @param {object|null} pkg Parsed package.json.
+ * @returns {Map<string, string>} Tool name to the script that proves it.
+ */
+export function toolsDiscoveredInScripts(pkg) {
+  const found = new Map();
+  for (const [name, body] of Object.entries(pkg?.scripts ?? {})) {
+    if (typeof body !== "string") continue;
+    for (const tool of commandsIn(body)) {
+      if (found.has(tool)) continue;
+      found.set(tool, `npm script "${name}": ${body.trim().slice(0, 60)}`);
+    }
+  }
+  return found;
+}
+
+/**
+ * Whether the package manager already puts this binary on the local path.
+ *
+ * A dependency's binary lands in `node_modules/.bin`, where npm scripts resolve
+ * it without it ever being on PATH. Proposing a manifest entry for one is noise,
+ * and noise is how a detector teaches people to skim it.
+ *
+ * Only meaningful once dependencies are installed, which is why
+ * `dependenciesInstalled` exists rather than this quietly returning false on a
+ * fresh clone and over-proposing every dev tool in the project.
+ * @param {string} cwd Project root.
+ * @param {string} tool Tool name.
+ * @returns {boolean} Whether npm already provides it.
+ */
+export function providedByNodeModules(cwd, tool) {
+  return existsSync(join(cwd, "node_modules", ".bin", tool));
+}
+
+/**
+ * Whether `node_modules` is populated, so its absence can be reported.
+ * @param {string} cwd Project root.
+ * @returns {boolean} Whether dependencies are installed.
+ */
+export function dependenciesInstalled(cwd) {
+  return existsSync(join(cwd, "node_modules", ".bin"));
 }
 
 /**
@@ -330,8 +454,14 @@ export function detectTooling(cwd = process.cwd()) {
   const notes = readJson(join(cwd, ".lisa", "secret-notes.json"));
 
   const declared = declaredTools(config);
+  // Curated signals carry a vetted `why`. Discovered ones carry only the fact
+  // that the project runs the thing — weaker prose, identical standing as
+  // evidence, and the only kind that can find a tool nobody listed.
+  const hooks = toolsFromGitHooks(cwd);
   const signals = [
+    hooks,
     toolsFromScripts(pkg),
+    toolsDiscoveredInScripts(pkg),
     toolsFromMcp(mcp),
     toolsFromSecretNotes(notes),
     toolsFromQuality(config, pkg, cwd),
@@ -343,8 +473,11 @@ export function detectTooling(cwd = process.cwd()) {
       if (declared.has(tool)) continue;
       // Already provided by the package manager, so there is nothing to pin.
       if (satisfiedByNpm(pkg, tool)) continue;
+      if (providedByNodeModules(cwd, tool)) continue;
+      // Real dependency, wrong manifest — the workstation layer owns it.
+      if (WORKSTATION_PROVISIONED.has(tool)) continue;
       const entry = merged.get(tool) ?? { evidence: [] };
-      entry.evidence.push(evidence);
+      if (!entry.evidence.includes(evidence)) entry.evidence.push(evidence);
       merged.set(tool, entry);
     }
   }
@@ -352,10 +485,33 @@ export function detectTooling(cwd = process.cwd()) {
   return [...merged.entries()]
     .map(([name, entry]) => ({
       name,
-      why: KNOWN_TOOLS[name]?.why ?? "",
+      why: KNOWN_TOOLS[name]?.why ?? discoveredWhy(name, hooks.has(name)),
       evidence: entry.evidence,
+      // Says which vocabulary the `why` came from, so a reader can weigh it.
+      // A curated entry has been thought about; a discovered one has only been
+      // observed.
+      source: Object.hasOwn(KNOWN_TOOLS, name) ? "curated" : "discovered",
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * The `why` for a tool nobody wrote prose for.
+ *
+ * Every proposal must carry one — a proposal without a reason is an assertion,
+ * and this program's whole boundary is that it asserts nothing. So a discovered
+ * tool states the observation plainly rather than borrowing confidence it has
+ * not earned.
+ * @param {string} name Tool name.
+ * @param {boolean} fromHook Whether a git hook runs it.
+ * @returns {string} A reason a reader can check.
+ */
+export function discoveredWhy(name, fromHook) {
+  return fromHook
+    ? `A git hook runs \`${name}\` on every commit or push, and nothing ` +
+        `declares it — a machine without it fails at commit time, or skips the ` +
+        `check silently if the hook guards it.`
+    : `An npm script invokes \`${name}\`, and nothing puts it on PATH.`;
 }
 
 /**
@@ -438,8 +594,18 @@ if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
     console.log(
       `${proposals.length} tool(s) look required but are not declared:\n`
     );
+    if (!dependenciesInstalled(process.cwd())) {
+      // Without node_modules there is no way to tell a tool that needs PATH
+      // from one npm already provides, so every dev dependency looks missing.
+      // Said out loud rather than silently over-proposing.
+      console.log(
+        "note: dependencies are not installed, so binaries npm would provide " +
+          "cannot be\n      excluded. Run the install first for a shorter, " +
+          "more accurate list.\n"
+      );
+    }
     for (const proposal of proposals) {
-      console.log(`  ${proposal.name}`);
+      console.log(`  ${proposal.name}  [${proposal.source}]`);
       console.log(`    why: ${proposal.why}`);
       for (const evidence of proposal.evidence) {
         console.log(`    evidence: ${evidence}`);

--- a/plugins/lisa/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/lisa/skills/lisa-detect-tooling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-detect-tooling
-description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts whatever remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
+description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads git hooks and npm scripts for what the project actually RUNS — discovering tools no list mentions — plus MCP servers, credential usage notes and quality configuration. Subtracts whatever remoteEnv.tools, node_modules and the workstation layer already cover, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
 allowed-tools: ["Bash", "Read", "AskUserQuestion"]
 ---
 
@@ -20,14 +20,44 @@ Nothing populates that last row. So a project can ship scripts that invoke `maes
 
 That is the same failure this repository has now paid for twice: `gh` was declared nowhere and a cloud session could not commit; `tar` was needed by an install method and asserted by nothing.
 
+## Discovery, not recognition
+
+The first version of this could only find tools it had been told about: it matched script bodies against a fixed `KNOWN_TOOLS` list. That makes the detector useful for exactly the set that needs it least — the tools someone already thought of.
+
+An Expo project invoking `eas` from **eight** npm scripts and six CI steps produced no proposal, because `eas` was not on the list. `gitleaks`, which runs on every commit in every one of these repositories, produced no proposal either.
+
+So the question asked of executable sources is now the open one — *what does this project actually run* — and everything already provided is subtracted afterwards:
+
+- what `remoteEnv.tools` declares
+- what `node_modules/.bin` provides (a dependency's binary never needs to be on PATH)
+- what `lisa-setup-workstation` owns (coding agents belong to the machine, not the checkout)
+
+The curated list stays, because a vetted `why` is worth more than an observed one — proposals say which they are, `[curated]` or `[discovered]`.
+
 ## What it does
 
-Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
+Reads six signals, subtracts what is already covered, and prints what is left with the evidence for each:
 
-- **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
+- **git hooks** (`.husky/*`, `.git/hooks/*`) that invoke a binary. The **strongest** signal available, stronger than an npm script: a hook runs on every commit and push whether anyone asked or not, so a machine without the tool cannot commit at all.
+
+  A `command -v` guard counts as evidence rather than as "optional", because the guarded shape is the worse one. Lisa's pre-commit hook wraps its secret scan in `command -v gitleaks`, so on a machine without gitleaks the scan is **skipped silently** — the hook passes, the commit succeeds, and nothing was scanned. A guard makes the absence invisible precisely where it matters.
+
+- **npm scripts** that invoke a binary — a script running `maestro test` is the project stating a dependency in executable form. Read from the script *body*, not its name, because the name is a label.
 - **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one. Do not infer a CLI for access layers that already define their own headless substrate; Linear is handled by `lisa-linear-access` through `LINEAR_API_KEY` + GraphQL when MCP OAuth is unavailable.
 - **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
 - **Quality configuration**, where a threshold implies the tool that produces it.
+
+## Reading shell is the hard part
+
+Discovery only works if "what does this run" can be answered from shell text without inventing commands. Three things had to be right, each found by running it against real repositories:
+
+**Only the first word of a command position counts.** Word-scanning this repo's own hooks proposed `ltrimstr`, `map` and `select` (jq filter internals), `console.log` and `process.exit` (embedded JavaScript), and `load_audit_cves` (a function the hook defines three lines up). Reading only where a command can actually start removes all of them without a denylist entry for any.
+
+**Quoting and commenting nest, so neither can be stripped independently.** The comment on line 9 of `pre-push.local` ends `...the script's exit code)`. That lone apostrophe pairs with the next real quote 28 lines later, blanks everything between, and leaks a `node -e` payload's JavaScript into the results. Stripping comments first does not fix it, because a `#` inside a quoted string is not a comment. One character scanner tracking both is the only correct shape.
+
+**`$( )` restarts the quoting context.** In `"$(printf '%s' "$JSON" | node -e '…')"`, quotes inside the substitution pair among themselves. A flat scanner falls out of phase on the first one and starts reporting the payload's own string literals.
+
+Against Lisa and the three TunnlAI repositories, what survives is `gitleaks`, `jq`, `gtimeout` and `eas` — every one a real, undeclared invocation, with no false positives.
 
 ## What it will not do
 

--- a/plugins/lisa/skills/lisa-detect-tooling/scripts/commands.mjs
+++ b/plugins/lisa/skills/lisa-detect-tooling/scripts/commands.mjs
@@ -1,0 +1,479 @@
+/**
+ * Pull the commands out of a shell body.
+ *
+ * `lisa-detect-tooling` used to match script bodies against a fixed list of tool
+ * names, which meant it could only ever re-find tools someone had already
+ * thought of — the set that needs a detector least. An Expo project invoking
+ * `eas` from eight npm scripts produced nothing, because `eas` was not in the
+ * list.
+ *
+ * So the question this module answers is the open one: what does this shell text
+ * actually RUN? Everything downstream then subtracts what is already provided.
+ *
+ * ## Only the first word of a command position
+ *
+ * Naive word-scanning of this repository's own hooks proposed `ltrimstr`, `map`
+ * and `select` (jq filter internals), `console.log` and `process.exit` (embedded
+ * JavaScript), and `load_audit_cves` (a function the hook defines three lines
+ * up). None of those are tools; all of them appear where a word-scanner looks.
+ *
+ * A command runs at a command POSITION — the start of the text, or just after a
+ * separator. Reading only that position removes every one of those false
+ * positives without a denylist entry for any of them.
+ * @module commands
+ */
+
+/**
+ * Shell keywords and coreutils: present on any machine, never provisioned.
+ *
+ * This is a floor, not a policy. Anything genuinely absent from a minimal
+ * container belongs in the manifest, and a few of these (`unzip`, `curl`) are
+ * already declared there by projects that need them — being listed here only
+ * means discovery will not RAISE them, not that they are assumed present.
+ */
+export const SHELL_VOCABULARY = new Set([
+  // Keywords and builtins.
+  "if",
+  "then",
+  "else",
+  "elif",
+  "fi",
+  "for",
+  "while",
+  "until",
+  "do",
+  "done",
+  "case",
+  "esac",
+  "in",
+  "function",
+  "return",
+  "break",
+  "continue",
+  "exit",
+  "local",
+  "readonly",
+  "declare",
+  "export",
+  "unset",
+  "shift",
+  "eval",
+  "exec",
+  "source",
+  "set",
+  "trap",
+  "wait",
+  "read",
+  "echo",
+  "printf",
+  "cd",
+  "pwd",
+  "true",
+  "false",
+  "test",
+  "let",
+  "alias",
+  "shopt",
+  "getopts",
+  "umask",
+  // Coreutils and the usual POSIX furniture.
+  "cat",
+  "grep",
+  "egrep",
+  "fgrep",
+  "sed",
+  "awk",
+  "cut",
+  "tr",
+  "sort",
+  "uniq",
+  "head",
+  "tail",
+  "wc",
+  "tee",
+  "xargs",
+  "find",
+  "ls",
+  "mkdir",
+  "rmdir",
+  "rm",
+  "mv",
+  "cp",
+  "ln",
+  "touch",
+  "chmod",
+  "chown",
+  "stat",
+  "du",
+  "df",
+  "dirname",
+  "basename",
+  "realpath",
+  "readlink",
+  "mktemp",
+  "date",
+  "sleep",
+  "seq",
+  "env",
+  "kill",
+  "pgrep",
+  "pkill",
+  "ps",
+  "diff",
+  "comm",
+  "join",
+  "paste",
+  "split",
+  "tar",
+  "gzip",
+  "gunzip",
+  "zip",
+  "unzip",
+  "curl",
+  "wget",
+  "sh",
+  "bash",
+  "zsh",
+  "dash",
+  "nohup",
+  "timeout",
+  "yes",
+  "tty",
+  "id",
+  "whoami",
+  "uname",
+  "hostname",
+]);
+
+/**
+ * Runtimes and package managers whose presence is assumed by everything here.
+ *
+ * Separate from the vocabulary above because these are genuinely provisioned —
+ * just not by this detector. `node` is what runs it; proposing it would be
+ * circular.
+ */
+export const RUNTIMES = new Set([
+  "node",
+  "npm",
+  "npx",
+  "bun",
+  "bunx",
+  "yarn",
+  "pnpm",
+  "pnpx",
+  "corepack",
+  "git",
+  "python",
+  "python3",
+  "pip",
+  "pip3",
+  "ruby",
+  "bundle",
+  "go",
+  "cargo",
+  "docker",
+  "make",
+]);
+
+/**
+ * Commands that RESOLVE the next word from `node_modules`.
+ *
+ * `npx playwright test` needs no manifest entry: npm put the binary in
+ * `node_modules/.bin` and npx finds it there. Reading the mediated word as a
+ * tool would propose pinning something the package manager already provides —
+ * the noise that teaches a reader to skim the output.
+ */
+const MEDIATORS = new Set(["npx", "bunx", "pnpx", "dlx"]);
+
+/** Sub-commands after a package manager that mean "run something local". */
+const LOCAL_RUNNERS = new Set(["run", "exec", "x", "dlx", "run-script"]);
+
+/**
+ * Commands that TEST for another command rather than running it.
+ *
+ * `command -v gitleaks` is the single most valuable signal a hook can carry, and
+ * a word-scanner reading only the first position would throw it away. It is also
+ * the shape of the worst failure mode in this codebase: a hook that guards its
+ * own tool with `command -v` SKIPS SILENTLY when the tool is absent. The commit
+ * succeeds and nothing was scanned.
+ *
+ * A guarded tool is therefore stronger evidence than an unguarded one, not
+ * weaker — its absence is invisible at the moment it matters.
+ */
+const PROBES = new Set(["command", "which", "type", "hash"]);
+
+/**
+ * Words that stand in FRONT of a command without being one.
+ *
+ * Control keywords have to be skipped past rather than treated as the command,
+ * or the very shape this exists to catch is missed: in
+ * `if ! command -v gitleaks; then`, stopping at `if` never reaches the probe.
+ */
+const PREFIXES = new Set([
+  "!",
+  "sudo",
+  "time",
+  "nice",
+  "builtin",
+  "exec",
+  "if",
+  "then",
+  "elif",
+  "else",
+  "while",
+  "until",
+  "do",
+]);
+
+/** A name that could plausibly be an executable on PATH. */
+const TOOL_NAME = /^[a-z][a-z0-9_-]*$/u;
+
+/**
+ * Names the text defines as shell functions, which are never PATH tools.
+ *
+ * This repository's `pre-push` hook defines `load_audit_cves` and
+ * `missing_opencode_metadata` and then calls them, which reads exactly like a
+ * command invocation because it is one — just not of anything installable.
+ * @param {string} text Shell body.
+ * @returns {Set<string>} Locally defined function names.
+ */
+export function localFunctions(text) {
+  const names = new Set();
+  const pattern =
+    /(?:^|\n)\s*(?:function\s+)?([a-z_][a-z0-9_]*)\s*\(\)\s*\{/giu;
+  let match = pattern.exec(text);
+  while (match) {
+    names.add(match[1].toLowerCase());
+    match = pattern.exec(text);
+  }
+  return names;
+}
+
+/**
+ * Pull out `sh -c '...'` payloads so their contents are parsed as shell too.
+ *
+ * Done BEFORE quoted spans are stripped, because the payload is precisely a
+ * quoted span — and it is the one kind that really is a command. Frontend's
+ * `eas:publish:e2e` script wraps its `eas update` in exactly this shape.
+ * @param {string} text Shell body.
+ * @returns {{stripped: string, payloads: string[]}} Text and nested bodies.
+ */
+export function extractShellPayloads(text) {
+  const payloads = [];
+  const stripped = text.replace(
+    /\b(?:sh|bash|zsh)\s+-[a-z]*c\s+('([^']*)'|"([^"]*)")/gu,
+    (_all, _quoted, single, double) => {
+      payloads.push(single ?? double ?? "");
+      return " ";
+    }
+  );
+  return { stripped, payloads };
+}
+
+/**
+ * Blank out quoted spans and comments, keeping only text at command level.
+ *
+ * Quoted text is where embedded programs live — the jq filters and `node -e`
+ * snippets that produced `ltrimstr` and `console.log`. A command inside quotes
+ * is an argument to something else, with one exception, which
+ * `extractShellPayloads` has already lifted out by the time this runs.
+ *
+ * This is a character scanner rather than a chain of regexes because quoting and
+ * commenting are MUTUALLY nested and no ordering of independent passes gets it
+ * right. This repository's own `pre-push.local` proves it: the comment on line 9
+ * ends `...the script's exit code)`, and that lone apostrophe pairs with the
+ * next real quote 28 lines later, blanking everything between — including the
+ * `node -e` payload, whose JavaScript then leaked out as `try`, `catch`,
+ * `const` and `unreadable` proposals.
+ *
+ * Stripping comments first does not fix it either, since a `#` inside a quoted
+ * string is not a comment. One pass that tracks both is the only correct shape.
+ *
+ * Newlines survive so command positions are preserved; everything else inside a
+ * masked span becomes a space.
+ * @param {string} text Shell body.
+ * @returns {string} Text with non-command spans blanked.
+ */
+export function stripNonCommandSpans(text) {
+  const out = [];
+  let state = "normal";
+  // `$( )` restarts the quoting context: inside it, quotes pair among
+  // themselves rather than continuing the enclosing span. A flat scanner falls
+  // out of phase on the very first one — this repository's
+  // `"$(printf '%s' "$JSON" | node -e '...')"` left the payload's own string
+  // literals exposed at command level, proposing `data`, `end` and `stale`.
+  const enclosing = [];
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const previous = index > 0 ? text[index - 1] : "";
+
+    // A substitution opens a fresh context from inside ANY state but a
+    // single-quoted one, where shell performs no substitution at all.
+    if (
+      state !== "single" &&
+      state !== "comment" &&
+      char === "$" &&
+      text[index + 1] === "("
+    ) {
+      enclosing.push(state);
+      state = "normal";
+      out.push("\n");
+      index += 1;
+      continue;
+    }
+    if (state === "normal" && char === ")" && enclosing.length > 0) {
+      state = enclosing.pop();
+      out.push("\n");
+      continue;
+    }
+
+    if (state === "normal") {
+      if (char === "\\") {
+        // An escaped character is never a delimiter. Skip both.
+        out.push(" ");
+        index += 1;
+        if (text[index] === "\n") out.push("\n");
+        else out.push(" ");
+        continue;
+      }
+      if (char === "'") {
+        state = "single";
+        out.push(" ");
+        continue;
+      }
+      if (char === '"') {
+        state = "double";
+        out.push(" ");
+        continue;
+      }
+      // A `#` only opens a comment at the start of a word.
+      if (char === "#" && (previous === "" || /\s/u.test(previous))) {
+        state = "comment";
+        out.push(" ");
+        continue;
+      }
+      out.push(char);
+      continue;
+    }
+
+    if (state === "comment") {
+      if (char === "\n") {
+        state = "normal";
+        out.push("\n");
+        continue;
+      }
+      out.push(" ");
+      continue;
+    }
+
+    // Inside quotes. A single-quoted span has no escapes at all in shell.
+    if (state === "double" && char === "\\") {
+      out.push(" ");
+      index += 1;
+      out.push(text[index] === "\n" ? "\n" : " ");
+      continue;
+    }
+    if (
+      (state === "single" && char === "'") ||
+      (state === "double" && char === '"')
+    ) {
+      state = "normal";
+      out.push(" ");
+      continue;
+    }
+    out.push(char === "\n" ? "\n" : " ");
+  }
+
+  // Redirections last, on text that is already command-level.
+  return out.join("").replace(/\d?[<>]+&?\S*/gu, " ");
+}
+
+/**
+ * Whether a word can be a tool this detector should raise.
+ *
+ * One gate, applied to every path into the results. Probed names used to skip
+ * it, which is how `command -v bun` — a hook checking its own runtime — became
+ * a proposal to pin bun on every repository scanned.
+ * @param {string} word Candidate command name.
+ * @param {Set<string>} defined Function names the text defines itself.
+ * @returns {boolean} Whether to raise it.
+ */
+function admissible(word, defined) {
+  // A path is not a PATH lookup: `./scripts/check.sh` is project code.
+  if (word.includes("/") || word.includes("$")) return false;
+  if (!TOOL_NAME.test(word)) return false;
+  if (SHELL_VOCABULARY.has(word)) return false;
+  // `bun run build` resolves locally, and the runtime itself is assumed.
+  if (RUNTIMES.has(word)) return false;
+  return !defined.has(word);
+}
+
+/**
+ * Read the tool a probe is testing for.
+ * @param {string[]} words Words after the probe.
+ * @returns {string|null} The probed name, or null.
+ */
+function probedTool(words) {
+  for (const word of words) {
+    if (word.startsWith("-")) continue;
+    return TOOL_NAME.test(word) ? word : null;
+  }
+  return null;
+}
+
+/**
+ * Every command this shell text runs, at a command position.
+ * @param {string} text Shell body.
+ * @returns {string[]} Command names, deduplicated, in first-seen order.
+ */
+export function commandsIn(text) {
+  if (typeof text !== "string" || text.trim() === "") return [];
+
+  const { stripped, payloads } = extractShellPayloads(text);
+  const defined = localFunctions(text);
+  const found = new Set();
+
+  // Nested `sh -c` bodies are shell in their own right, so they get the same
+  // treatment rather than a weaker one.
+  for (const payload of payloads) {
+    for (const command of commandsIn(payload)) found.add(command);
+  }
+
+  const segments = stripNonCommandSpans(stripped).split(
+    /\|\||&&|\$\(|[;|&\n(){}`]/u
+  );
+
+  for (const segment of segments) {
+    const words = segment.trim().split(/\s+/u).filter(Boolean);
+    let index = 0;
+    // Environment assignments and decorations sit in front of the command.
+    while (
+      index < words.length &&
+      (/^[A-Za-z_][A-Za-z0-9_]*=/u.test(words[index]) ||
+        PREFIXES.has(words[index]))
+    ) {
+      index += 1;
+    }
+
+    const word = words[index]?.toLowerCase();
+    if (!word) continue;
+
+    if (PROBES.has(word)) {
+      // `command -v gitleaks` — the probed name is the evidence. It goes
+      // through the SAME filters as a directly invoked command: reading it
+      // straight into the results proposed `bun` and `yarn` on every repo,
+      // because `command -v bun` is how a hook checks its own runtime.
+      const probed = probedTool(words.slice(index + 1));
+      if (probed && admissible(probed, defined)) found.add(probed);
+      continue;
+    }
+    if (MEDIATORS.has(word)) continue;
+    if (LOCAL_RUNNERS.has(word)) continue;
+    if (!admissible(word, defined)) continue;
+
+    found.add(word);
+  }
+
+  return [...found];
+}

--- a/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,8 +22,10 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
+
+import { commandsIn } from "./commands.mjs";
 
 /** The tool named by the Expo template's scripts and its flows directory. */
 const MAESTRO = "maestro";
@@ -107,6 +109,128 @@ export function toolsFromScripts(pkg) {
     }
   }
   return found;
+}
+
+/** Where git hooks live, strongest signal first. */
+const HOOK_DIRECTORIES = [".husky", join(".git", "hooks")];
+
+/**
+ * Coding agents, which a PROJECT manifest must never try to provision.
+ *
+ * A hook that shells out to `claude` is real evidence of a real dependency, but
+ * `remoteEnv.tools` is the wrong place to answer it: agents belong to the
+ * machine, not the checkout, and each is installed by its vendor's own method
+ * into a version directory it manages itself. Pinning one as a release archive
+ * would fight the self-updater that owns that directory.
+ *
+ * That layer is `lisa-setup-workstation`. Named here rather than imported from
+ * it, because a detector that stops working when a sibling skill is absent is
+ * worse than one carrying six strings.
+ *
+ * Deliberately NOT extended to `gh`, `bws`, `aws` or `sonar`: those genuinely
+ * belong in a project manifest, and `gh` going undeclared is the incident this
+ * skill was written after.
+ */
+const WORKSTATION_PROVISIONED = new Set([
+  "claude",
+  "codex",
+  "cursor-agent",
+  "opencode",
+  "agy",
+  "copilot",
+]);
+
+/**
+ * Tools a git hook runs — the strongest signal a project can give.
+ *
+ * Stronger than an npm script, because a hook runs on EVERY commit and push
+ * whether anyone asked or not. A container missing one of these cannot commit at
+ * all; the failure arrives mid-task, unattended, at the moment of use.
+ *
+ * The worst shape is the guarded one. This repository's pre-commit hook wraps
+ * its secret scan in `command -v gitleaks`, so on a machine without gitleaks the
+ * scan is SKIPPED SILENTLY — the hook passes, the commit succeeds, and nothing
+ * was scanned. A guard makes the absence invisible exactly where it matters
+ * most, which is why a probed name counts as evidence rather than being read as
+ * "optional".
+ * @param {string} cwd Project root.
+ * @returns {Map<string, string>} Tool name to the hook that proves it.
+ */
+export function toolsFromGitHooks(cwd) {
+  const found = new Map();
+  for (const directory of HOOK_DIRECTORIES) {
+    const full = join(cwd, directory);
+    let names = [];
+    try {
+      names = readdirSync(full);
+    } catch {
+      continue;
+    }
+    for (const name of names.sort()) {
+      // `.sample` files ship with git and run nothing.
+      if (name.endsWith(".sample")) continue;
+      let body;
+      try {
+        body = readFileSync(join(full, name), "utf8");
+      } catch {
+        continue;
+      }
+      for (const tool of commandsIn(body)) {
+        if (!found.has(tool)) found.set(tool, `git hook ${directory}/${name}`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools an npm script invokes, discovered rather than matched against a list.
+ *
+ * `toolsFromScripts` answers "which of the tools I already know about appear
+ * here". This answers the open question — what does this project actually RUN —
+ * which is the one that finds a tool nobody thought to add. An Expo project
+ * invoking `eas` from eight scripts produced nothing under the old shape,
+ * because `eas` was not in `KNOWN_TOOLS`.
+ * @param {object|null} pkg Parsed package.json.
+ * @returns {Map<string, string>} Tool name to the script that proves it.
+ */
+export function toolsDiscoveredInScripts(pkg) {
+  const found = new Map();
+  for (const [name, body] of Object.entries(pkg?.scripts ?? {})) {
+    if (typeof body !== "string") continue;
+    for (const tool of commandsIn(body)) {
+      if (found.has(tool)) continue;
+      found.set(tool, `npm script "${name}": ${body.trim().slice(0, 60)}`);
+    }
+  }
+  return found;
+}
+
+/**
+ * Whether the package manager already puts this binary on the local path.
+ *
+ * A dependency's binary lands in `node_modules/.bin`, where npm scripts resolve
+ * it without it ever being on PATH. Proposing a manifest entry for one is noise,
+ * and noise is how a detector teaches people to skim it.
+ *
+ * Only meaningful once dependencies are installed, which is why
+ * `dependenciesInstalled` exists rather than this quietly returning false on a
+ * fresh clone and over-proposing every dev tool in the project.
+ * @param {string} cwd Project root.
+ * @param {string} tool Tool name.
+ * @returns {boolean} Whether npm already provides it.
+ */
+export function providedByNodeModules(cwd, tool) {
+  return existsSync(join(cwd, "node_modules", ".bin", tool));
+}
+
+/**
+ * Whether `node_modules` is populated, so its absence can be reported.
+ * @param {string} cwd Project root.
+ * @returns {boolean} Whether dependencies are installed.
+ */
+export function dependenciesInstalled(cwd) {
+  return existsSync(join(cwd, "node_modules", ".bin"));
 }
 
 /**
@@ -330,8 +454,14 @@ export function detectTooling(cwd = process.cwd()) {
   const notes = readJson(join(cwd, ".lisa", "secret-notes.json"));
 
   const declared = declaredTools(config);
+  // Curated signals carry a vetted `why`. Discovered ones carry only the fact
+  // that the project runs the thing — weaker prose, identical standing as
+  // evidence, and the only kind that can find a tool nobody listed.
+  const hooks = toolsFromGitHooks(cwd);
   const signals = [
+    hooks,
     toolsFromScripts(pkg),
+    toolsDiscoveredInScripts(pkg),
     toolsFromMcp(mcp),
     toolsFromSecretNotes(notes),
     toolsFromQuality(config, pkg, cwd),
@@ -343,8 +473,11 @@ export function detectTooling(cwd = process.cwd()) {
       if (declared.has(tool)) continue;
       // Already provided by the package manager, so there is nothing to pin.
       if (satisfiedByNpm(pkg, tool)) continue;
+      if (providedByNodeModules(cwd, tool)) continue;
+      // Real dependency, wrong manifest — the workstation layer owns it.
+      if (WORKSTATION_PROVISIONED.has(tool)) continue;
       const entry = merged.get(tool) ?? { evidence: [] };
-      entry.evidence.push(evidence);
+      if (!entry.evidence.includes(evidence)) entry.evidence.push(evidence);
       merged.set(tool, entry);
     }
   }
@@ -352,10 +485,33 @@ export function detectTooling(cwd = process.cwd()) {
   return [...merged.entries()]
     .map(([name, entry]) => ({
       name,
-      why: KNOWN_TOOLS[name]?.why ?? "",
+      why: KNOWN_TOOLS[name]?.why ?? discoveredWhy(name, hooks.has(name)),
       evidence: entry.evidence,
+      // Says which vocabulary the `why` came from, so a reader can weigh it.
+      // A curated entry has been thought about; a discovered one has only been
+      // observed.
+      source: Object.hasOwn(KNOWN_TOOLS, name) ? "curated" : "discovered",
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * The `why` for a tool nobody wrote prose for.
+ *
+ * Every proposal must carry one — a proposal without a reason is an assertion,
+ * and this program's whole boundary is that it asserts nothing. So a discovered
+ * tool states the observation plainly rather than borrowing confidence it has
+ * not earned.
+ * @param {string} name Tool name.
+ * @param {boolean} fromHook Whether a git hook runs it.
+ * @returns {string} A reason a reader can check.
+ */
+export function discoveredWhy(name, fromHook) {
+  return fromHook
+    ? `A git hook runs \`${name}\` on every commit or push, and nothing ` +
+        `declares it — a machine without it fails at commit time, or skips the ` +
+        `check silently if the hook guards it.`
+    : `An npm script invokes \`${name}\`, and nothing puts it on PATH.`;
 }
 
 /**
@@ -438,8 +594,18 @@ if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
     console.log(
       `${proposals.length} tool(s) look required but are not declared:\n`
     );
+    if (!dependenciesInstalled(process.cwd())) {
+      // Without node_modules there is no way to tell a tool that needs PATH
+      // from one npm already provides, so every dev dependency looks missing.
+      // Said out loud rather than silently over-proposing.
+      console.log(
+        "note: dependencies are not installed, so binaries npm would provide " +
+          "cannot be\n      excluded. Run the install first for a shorter, " +
+          "more accurate list.\n"
+      );
+    }
     for (const proposal of proposals) {
-      console.log(`  ${proposal.name}`);
+      console.log(`  ${proposal.name}  [${proposal.source}]`);
       console.log(`    why: ${proposal.why}`);
       for (const evidence of proposal.evidence) {
         console.log(`    evidence: ${evidence}`);

--- a/plugins/src/base/skills/lisa-detect-tooling/SKILL.md
+++ b/plugins/src/base/skills/lisa-detect-tooling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lisa-detect-tooling
-description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads npm scripts, MCP servers, credential usage notes and quality configuration, subtracts whatever remoteEnv.tools already covers, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
+description: "Find the command-line tools a project needs but never declares, and propose pinned manifest entries for them. Reads git hooks and npm scripts for what the project actually RUNS — discovering tools no list mentions — plus MCP servers, credential usage notes and quality configuration. Subtracts whatever remoteEnv.tools, node_modules and the workstation layer already cover, and prints proposals with evidence. Writes nothing and installs nothing — a tool reaches a machine only when a human has reviewed a pinned, checksummed entry. Invoked by lisa-setup-remote-env before provisioning, and runnable on its own."
 allowed-tools: ["Bash", "Read", "AskUserQuestion"]
 ---
 
@@ -20,14 +20,44 @@ Nothing populates that last row. So a project can ship scripts that invoke `maes
 
 That is the same failure this repository has now paid for twice: `gh` was declared nowhere and a cloud session could not commit; `tar` was needed by an install method and asserted by nothing.
 
+## Discovery, not recognition
+
+The first version of this could only find tools it had been told about: it matched script bodies against a fixed `KNOWN_TOOLS` list. That makes the detector useful for exactly the set that needs it least — the tools someone already thought of.
+
+An Expo project invoking `eas` from **eight** npm scripts and six CI steps produced no proposal, because `eas` was not on the list. `gitleaks`, which runs on every commit in every one of these repositories, produced no proposal either.
+
+So the question asked of executable sources is now the open one — *what does this project actually run* — and everything already provided is subtracted afterwards:
+
+- what `remoteEnv.tools` declares
+- what `node_modules/.bin` provides (a dependency's binary never needs to be on PATH)
+- what `lisa-setup-workstation` owns (coding agents belong to the machine, not the checkout)
+
+The curated list stays, because a vetted `why` is worth more than an observed one — proposals say which they are, `[curated]` or `[discovered]`.
+
 ## What it does
 
-Reads four signals, subtracts what `remoteEnv.tools` already declares, and prints what is left with the evidence for each:
+Reads six signals, subtracts what is already covered, and prints what is left with the evidence for each:
 
-- **npm scripts** that invoke a binary. The strongest signal there is — a script running `maestro test` is the project stating a dependency in executable form. Matched on the script *body*, not its name, because the name is a label.
+- **git hooks** (`.husky/*`, `.git/hooks/*`) that invoke a binary. The **strongest** signal available, stronger than an npm script: a hook runs on every commit and push whether anyone asked or not, so a machine without the tool cannot commit at all.
+
+  A `command -v` guard counts as evidence rather than as "optional", because the guarded shape is the worse one. Lisa's pre-commit hook wraps its secret scan in `command -v gitleaks`, so on a machine without gitleaks the scan is **skipped silently** — the hook passes, the commit succeeds, and nothing was scanned. A guard makes the absence invisible precisely where it matters.
+
+- **npm scripts** that invoke a binary — a script running `maestro test` is the project stating a dependency in executable form. Read from the script *body*, not its name, because the name is a label.
 - **MCP servers with a CLI equivalent.** An MCP server is not a substitute for the binary: several authenticate by browser OAuth, which a container cannot do, so a project relying on one remotely has *no* integration rather than a degraded one. Do not infer a CLI for access layers that already define their own headless substrate; Linear is handled by `lisa-linear-access` through `LINEAR_API_KEY` + GraphQL when MCP OAuth is unavailable.
 - **Credential usage notes.** A note explaining what a token is for usually names the program that consumes it. `lisa-secrets-access` already exposes these without touching a value, which makes them a first-class input rather than a trick.
 - **Quality configuration**, where a threshold implies the tool that produces it.
+
+## Reading shell is the hard part
+
+Discovery only works if "what does this run" can be answered from shell text without inventing commands. Three things had to be right, each found by running it against real repositories:
+
+**Only the first word of a command position counts.** Word-scanning this repo's own hooks proposed `ltrimstr`, `map` and `select` (jq filter internals), `console.log` and `process.exit` (embedded JavaScript), and `load_audit_cves` (a function the hook defines three lines up). Reading only where a command can actually start removes all of them without a denylist entry for any.
+
+**Quoting and commenting nest, so neither can be stripped independently.** The comment on line 9 of `pre-push.local` ends `...the script's exit code)`. That lone apostrophe pairs with the next real quote 28 lines later, blanks everything between, and leaks a `node -e` payload's JavaScript into the results. Stripping comments first does not fix it, because a `#` inside a quoted string is not a comment. One character scanner tracking both is the only correct shape.
+
+**`$( )` restarts the quoting context.** In `"$(printf '%s' "$JSON" | node -e '…')"`, quotes inside the substitution pair among themselves. A flat scanner falls out of phase on the first one and starts reporting the payload's own string literals.
+
+Against Lisa and the three TunnlAI repositories, what survives is `gitleaks`, `jq`, `gtimeout` and `eas` — every one a real, undeclared invocation, with no false positives.
 
 ## What it will not do
 

--- a/plugins/src/base/skills/lisa-detect-tooling/scripts/commands.mjs
+++ b/plugins/src/base/skills/lisa-detect-tooling/scripts/commands.mjs
@@ -1,0 +1,479 @@
+/**
+ * Pull the commands out of a shell body.
+ *
+ * `lisa-detect-tooling` used to match script bodies against a fixed list of tool
+ * names, which meant it could only ever re-find tools someone had already
+ * thought of — the set that needs a detector least. An Expo project invoking
+ * `eas` from eight npm scripts produced nothing, because `eas` was not in the
+ * list.
+ *
+ * So the question this module answers is the open one: what does this shell text
+ * actually RUN? Everything downstream then subtracts what is already provided.
+ *
+ * ## Only the first word of a command position
+ *
+ * Naive word-scanning of this repository's own hooks proposed `ltrimstr`, `map`
+ * and `select` (jq filter internals), `console.log` and `process.exit` (embedded
+ * JavaScript), and `load_audit_cves` (a function the hook defines three lines
+ * up). None of those are tools; all of them appear where a word-scanner looks.
+ *
+ * A command runs at a command POSITION — the start of the text, or just after a
+ * separator. Reading only that position removes every one of those false
+ * positives without a denylist entry for any of them.
+ * @module commands
+ */
+
+/**
+ * Shell keywords and coreutils: present on any machine, never provisioned.
+ *
+ * This is a floor, not a policy. Anything genuinely absent from a minimal
+ * container belongs in the manifest, and a few of these (`unzip`, `curl`) are
+ * already declared there by projects that need them — being listed here only
+ * means discovery will not RAISE them, not that they are assumed present.
+ */
+export const SHELL_VOCABULARY = new Set([
+  // Keywords and builtins.
+  "if",
+  "then",
+  "else",
+  "elif",
+  "fi",
+  "for",
+  "while",
+  "until",
+  "do",
+  "done",
+  "case",
+  "esac",
+  "in",
+  "function",
+  "return",
+  "break",
+  "continue",
+  "exit",
+  "local",
+  "readonly",
+  "declare",
+  "export",
+  "unset",
+  "shift",
+  "eval",
+  "exec",
+  "source",
+  "set",
+  "trap",
+  "wait",
+  "read",
+  "echo",
+  "printf",
+  "cd",
+  "pwd",
+  "true",
+  "false",
+  "test",
+  "let",
+  "alias",
+  "shopt",
+  "getopts",
+  "umask",
+  // Coreutils and the usual POSIX furniture.
+  "cat",
+  "grep",
+  "egrep",
+  "fgrep",
+  "sed",
+  "awk",
+  "cut",
+  "tr",
+  "sort",
+  "uniq",
+  "head",
+  "tail",
+  "wc",
+  "tee",
+  "xargs",
+  "find",
+  "ls",
+  "mkdir",
+  "rmdir",
+  "rm",
+  "mv",
+  "cp",
+  "ln",
+  "touch",
+  "chmod",
+  "chown",
+  "stat",
+  "du",
+  "df",
+  "dirname",
+  "basename",
+  "realpath",
+  "readlink",
+  "mktemp",
+  "date",
+  "sleep",
+  "seq",
+  "env",
+  "kill",
+  "pgrep",
+  "pkill",
+  "ps",
+  "diff",
+  "comm",
+  "join",
+  "paste",
+  "split",
+  "tar",
+  "gzip",
+  "gunzip",
+  "zip",
+  "unzip",
+  "curl",
+  "wget",
+  "sh",
+  "bash",
+  "zsh",
+  "dash",
+  "nohup",
+  "timeout",
+  "yes",
+  "tty",
+  "id",
+  "whoami",
+  "uname",
+  "hostname",
+]);
+
+/**
+ * Runtimes and package managers whose presence is assumed by everything here.
+ *
+ * Separate from the vocabulary above because these are genuinely provisioned —
+ * just not by this detector. `node` is what runs it; proposing it would be
+ * circular.
+ */
+export const RUNTIMES = new Set([
+  "node",
+  "npm",
+  "npx",
+  "bun",
+  "bunx",
+  "yarn",
+  "pnpm",
+  "pnpx",
+  "corepack",
+  "git",
+  "python",
+  "python3",
+  "pip",
+  "pip3",
+  "ruby",
+  "bundle",
+  "go",
+  "cargo",
+  "docker",
+  "make",
+]);
+
+/**
+ * Commands that RESOLVE the next word from `node_modules`.
+ *
+ * `npx playwright test` needs no manifest entry: npm put the binary in
+ * `node_modules/.bin` and npx finds it there. Reading the mediated word as a
+ * tool would propose pinning something the package manager already provides —
+ * the noise that teaches a reader to skim the output.
+ */
+const MEDIATORS = new Set(["npx", "bunx", "pnpx", "dlx"]);
+
+/** Sub-commands after a package manager that mean "run something local". */
+const LOCAL_RUNNERS = new Set(["run", "exec", "x", "dlx", "run-script"]);
+
+/**
+ * Commands that TEST for another command rather than running it.
+ *
+ * `command -v gitleaks` is the single most valuable signal a hook can carry, and
+ * a word-scanner reading only the first position would throw it away. It is also
+ * the shape of the worst failure mode in this codebase: a hook that guards its
+ * own tool with `command -v` SKIPS SILENTLY when the tool is absent. The commit
+ * succeeds and nothing was scanned.
+ *
+ * A guarded tool is therefore stronger evidence than an unguarded one, not
+ * weaker — its absence is invisible at the moment it matters.
+ */
+const PROBES = new Set(["command", "which", "type", "hash"]);
+
+/**
+ * Words that stand in FRONT of a command without being one.
+ *
+ * Control keywords have to be skipped past rather than treated as the command,
+ * or the very shape this exists to catch is missed: in
+ * `if ! command -v gitleaks; then`, stopping at `if` never reaches the probe.
+ */
+const PREFIXES = new Set([
+  "!",
+  "sudo",
+  "time",
+  "nice",
+  "builtin",
+  "exec",
+  "if",
+  "then",
+  "elif",
+  "else",
+  "while",
+  "until",
+  "do",
+]);
+
+/** A name that could plausibly be an executable on PATH. */
+const TOOL_NAME = /^[a-z][a-z0-9_-]*$/u;
+
+/**
+ * Names the text defines as shell functions, which are never PATH tools.
+ *
+ * This repository's `pre-push` hook defines `load_audit_cves` and
+ * `missing_opencode_metadata` and then calls them, which reads exactly like a
+ * command invocation because it is one — just not of anything installable.
+ * @param {string} text Shell body.
+ * @returns {Set<string>} Locally defined function names.
+ */
+export function localFunctions(text) {
+  const names = new Set();
+  const pattern =
+    /(?:^|\n)\s*(?:function\s+)?([a-z_][a-z0-9_]*)\s*\(\)\s*\{/giu;
+  let match = pattern.exec(text);
+  while (match) {
+    names.add(match[1].toLowerCase());
+    match = pattern.exec(text);
+  }
+  return names;
+}
+
+/**
+ * Pull out `sh -c '...'` payloads so their contents are parsed as shell too.
+ *
+ * Done BEFORE quoted spans are stripped, because the payload is precisely a
+ * quoted span — and it is the one kind that really is a command. Frontend's
+ * `eas:publish:e2e` script wraps its `eas update` in exactly this shape.
+ * @param {string} text Shell body.
+ * @returns {{stripped: string, payloads: string[]}} Text and nested bodies.
+ */
+export function extractShellPayloads(text) {
+  const payloads = [];
+  const stripped = text.replace(
+    /\b(?:sh|bash|zsh)\s+-[a-z]*c\s+('([^']*)'|"([^"]*)")/gu,
+    (_all, _quoted, single, double) => {
+      payloads.push(single ?? double ?? "");
+      return " ";
+    }
+  );
+  return { stripped, payloads };
+}
+
+/**
+ * Blank out quoted spans and comments, keeping only text at command level.
+ *
+ * Quoted text is where embedded programs live — the jq filters and `node -e`
+ * snippets that produced `ltrimstr` and `console.log`. A command inside quotes
+ * is an argument to something else, with one exception, which
+ * `extractShellPayloads` has already lifted out by the time this runs.
+ *
+ * This is a character scanner rather than a chain of regexes because quoting and
+ * commenting are MUTUALLY nested and no ordering of independent passes gets it
+ * right. This repository's own `pre-push.local` proves it: the comment on line 9
+ * ends `...the script's exit code)`, and that lone apostrophe pairs with the
+ * next real quote 28 lines later, blanking everything between — including the
+ * `node -e` payload, whose JavaScript then leaked out as `try`, `catch`,
+ * `const` and `unreadable` proposals.
+ *
+ * Stripping comments first does not fix it either, since a `#` inside a quoted
+ * string is not a comment. One pass that tracks both is the only correct shape.
+ *
+ * Newlines survive so command positions are preserved; everything else inside a
+ * masked span becomes a space.
+ * @param {string} text Shell body.
+ * @returns {string} Text with non-command spans blanked.
+ */
+export function stripNonCommandSpans(text) {
+  const out = [];
+  let state = "normal";
+  // `$( )` restarts the quoting context: inside it, quotes pair among
+  // themselves rather than continuing the enclosing span. A flat scanner falls
+  // out of phase on the very first one — this repository's
+  // `"$(printf '%s' "$JSON" | node -e '...')"` left the payload's own string
+  // literals exposed at command level, proposing `data`, `end` and `stale`.
+  const enclosing = [];
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const previous = index > 0 ? text[index - 1] : "";
+
+    // A substitution opens a fresh context from inside ANY state but a
+    // single-quoted one, where shell performs no substitution at all.
+    if (
+      state !== "single" &&
+      state !== "comment" &&
+      char === "$" &&
+      text[index + 1] === "("
+    ) {
+      enclosing.push(state);
+      state = "normal";
+      out.push("\n");
+      index += 1;
+      continue;
+    }
+    if (state === "normal" && char === ")" && enclosing.length > 0) {
+      state = enclosing.pop();
+      out.push("\n");
+      continue;
+    }
+
+    if (state === "normal") {
+      if (char === "\\") {
+        // An escaped character is never a delimiter. Skip both.
+        out.push(" ");
+        index += 1;
+        if (text[index] === "\n") out.push("\n");
+        else out.push(" ");
+        continue;
+      }
+      if (char === "'") {
+        state = "single";
+        out.push(" ");
+        continue;
+      }
+      if (char === '"') {
+        state = "double";
+        out.push(" ");
+        continue;
+      }
+      // A `#` only opens a comment at the start of a word.
+      if (char === "#" && (previous === "" || /\s/u.test(previous))) {
+        state = "comment";
+        out.push(" ");
+        continue;
+      }
+      out.push(char);
+      continue;
+    }
+
+    if (state === "comment") {
+      if (char === "\n") {
+        state = "normal";
+        out.push("\n");
+        continue;
+      }
+      out.push(" ");
+      continue;
+    }
+
+    // Inside quotes. A single-quoted span has no escapes at all in shell.
+    if (state === "double" && char === "\\") {
+      out.push(" ");
+      index += 1;
+      out.push(text[index] === "\n" ? "\n" : " ");
+      continue;
+    }
+    if (
+      (state === "single" && char === "'") ||
+      (state === "double" && char === '"')
+    ) {
+      state = "normal";
+      out.push(" ");
+      continue;
+    }
+    out.push(char === "\n" ? "\n" : " ");
+  }
+
+  // Redirections last, on text that is already command-level.
+  return out.join("").replace(/\d?[<>]+&?\S*/gu, " ");
+}
+
+/**
+ * Whether a word can be a tool this detector should raise.
+ *
+ * One gate, applied to every path into the results. Probed names used to skip
+ * it, which is how `command -v bun` — a hook checking its own runtime — became
+ * a proposal to pin bun on every repository scanned.
+ * @param {string} word Candidate command name.
+ * @param {Set<string>} defined Function names the text defines itself.
+ * @returns {boolean} Whether to raise it.
+ */
+function admissible(word, defined) {
+  // A path is not a PATH lookup: `./scripts/check.sh` is project code.
+  if (word.includes("/") || word.includes("$")) return false;
+  if (!TOOL_NAME.test(word)) return false;
+  if (SHELL_VOCABULARY.has(word)) return false;
+  // `bun run build` resolves locally, and the runtime itself is assumed.
+  if (RUNTIMES.has(word)) return false;
+  return !defined.has(word);
+}
+
+/**
+ * Read the tool a probe is testing for.
+ * @param {string[]} words Words after the probe.
+ * @returns {string|null} The probed name, or null.
+ */
+function probedTool(words) {
+  for (const word of words) {
+    if (word.startsWith("-")) continue;
+    return TOOL_NAME.test(word) ? word : null;
+  }
+  return null;
+}
+
+/**
+ * Every command this shell text runs, at a command position.
+ * @param {string} text Shell body.
+ * @returns {string[]} Command names, deduplicated, in first-seen order.
+ */
+export function commandsIn(text) {
+  if (typeof text !== "string" || text.trim() === "") return [];
+
+  const { stripped, payloads } = extractShellPayloads(text);
+  const defined = localFunctions(text);
+  const found = new Set();
+
+  // Nested `sh -c` bodies are shell in their own right, so they get the same
+  // treatment rather than a weaker one.
+  for (const payload of payloads) {
+    for (const command of commandsIn(payload)) found.add(command);
+  }
+
+  const segments = stripNonCommandSpans(stripped).split(
+    /\|\||&&|\$\(|[;|&\n(){}`]/u
+  );
+
+  for (const segment of segments) {
+    const words = segment.trim().split(/\s+/u).filter(Boolean);
+    let index = 0;
+    // Environment assignments and decorations sit in front of the command.
+    while (
+      index < words.length &&
+      (/^[A-Za-z_][A-Za-z0-9_]*=/u.test(words[index]) ||
+        PREFIXES.has(words[index]))
+    ) {
+      index += 1;
+    }
+
+    const word = words[index]?.toLowerCase();
+    if (!word) continue;
+
+    if (PROBES.has(word)) {
+      // `command -v gitleaks` — the probed name is the evidence. It goes
+      // through the SAME filters as a directly invoked command: reading it
+      // straight into the results proposed `bun` and `yarn` on every repo,
+      // because `command -v bun` is how a hook checks its own runtime.
+      const probed = probedTool(words.slice(index + 1));
+      if (probed && admissible(probed, defined)) found.add(probed);
+      continue;
+    }
+    if (MEDIATORS.has(word)) continue;
+    if (LOCAL_RUNNERS.has(word)) continue;
+    if (!admissible(word, defined)) continue;
+
+    found.add(word);
+  }
+
+  return [...found];
+}

--- a/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,8 +22,10 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
+
+import { commandsIn } from "./commands.mjs";
 
 /** The tool named by the Expo template's scripts and its flows directory. */
 const MAESTRO = "maestro";
@@ -107,6 +109,128 @@ export function toolsFromScripts(pkg) {
     }
   }
   return found;
+}
+
+/** Where git hooks live, strongest signal first. */
+const HOOK_DIRECTORIES = [".husky", join(".git", "hooks")];
+
+/**
+ * Coding agents, which a PROJECT manifest must never try to provision.
+ *
+ * A hook that shells out to `claude` is real evidence of a real dependency, but
+ * `remoteEnv.tools` is the wrong place to answer it: agents belong to the
+ * machine, not the checkout, and each is installed by its vendor's own method
+ * into a version directory it manages itself. Pinning one as a release archive
+ * would fight the self-updater that owns that directory.
+ *
+ * That layer is `lisa-setup-workstation`. Named here rather than imported from
+ * it, because a detector that stops working when a sibling skill is absent is
+ * worse than one carrying six strings.
+ *
+ * Deliberately NOT extended to `gh`, `bws`, `aws` or `sonar`: those genuinely
+ * belong in a project manifest, and `gh` going undeclared is the incident this
+ * skill was written after.
+ */
+const WORKSTATION_PROVISIONED = new Set([
+  "claude",
+  "codex",
+  "cursor-agent",
+  "opencode",
+  "agy",
+  "copilot",
+]);
+
+/**
+ * Tools a git hook runs — the strongest signal a project can give.
+ *
+ * Stronger than an npm script, because a hook runs on EVERY commit and push
+ * whether anyone asked or not. A container missing one of these cannot commit at
+ * all; the failure arrives mid-task, unattended, at the moment of use.
+ *
+ * The worst shape is the guarded one. This repository's pre-commit hook wraps
+ * its secret scan in `command -v gitleaks`, so on a machine without gitleaks the
+ * scan is SKIPPED SILENTLY — the hook passes, the commit succeeds, and nothing
+ * was scanned. A guard makes the absence invisible exactly where it matters
+ * most, which is why a probed name counts as evidence rather than being read as
+ * "optional".
+ * @param {string} cwd Project root.
+ * @returns {Map<string, string>} Tool name to the hook that proves it.
+ */
+export function toolsFromGitHooks(cwd) {
+  const found = new Map();
+  for (const directory of HOOK_DIRECTORIES) {
+    const full = join(cwd, directory);
+    let names = [];
+    try {
+      names = readdirSync(full);
+    } catch {
+      continue;
+    }
+    for (const name of names.sort()) {
+      // `.sample` files ship with git and run nothing.
+      if (name.endsWith(".sample")) continue;
+      let body;
+      try {
+        body = readFileSync(join(full, name), "utf8");
+      } catch {
+        continue;
+      }
+      for (const tool of commandsIn(body)) {
+        if (!found.has(tool)) found.set(tool, `git hook ${directory}/${name}`);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Tools an npm script invokes, discovered rather than matched against a list.
+ *
+ * `toolsFromScripts` answers "which of the tools I already know about appear
+ * here". This answers the open question — what does this project actually RUN —
+ * which is the one that finds a tool nobody thought to add. An Expo project
+ * invoking `eas` from eight scripts produced nothing under the old shape,
+ * because `eas` was not in `KNOWN_TOOLS`.
+ * @param {object|null} pkg Parsed package.json.
+ * @returns {Map<string, string>} Tool name to the script that proves it.
+ */
+export function toolsDiscoveredInScripts(pkg) {
+  const found = new Map();
+  for (const [name, body] of Object.entries(pkg?.scripts ?? {})) {
+    if (typeof body !== "string") continue;
+    for (const tool of commandsIn(body)) {
+      if (found.has(tool)) continue;
+      found.set(tool, `npm script "${name}": ${body.trim().slice(0, 60)}`);
+    }
+  }
+  return found;
+}
+
+/**
+ * Whether the package manager already puts this binary on the local path.
+ *
+ * A dependency's binary lands in `node_modules/.bin`, where npm scripts resolve
+ * it without it ever being on PATH. Proposing a manifest entry for one is noise,
+ * and noise is how a detector teaches people to skim it.
+ *
+ * Only meaningful once dependencies are installed, which is why
+ * `dependenciesInstalled` exists rather than this quietly returning false on a
+ * fresh clone and over-proposing every dev tool in the project.
+ * @param {string} cwd Project root.
+ * @param {string} tool Tool name.
+ * @returns {boolean} Whether npm already provides it.
+ */
+export function providedByNodeModules(cwd, tool) {
+  return existsSync(join(cwd, "node_modules", ".bin", tool));
+}
+
+/**
+ * Whether `node_modules` is populated, so its absence can be reported.
+ * @param {string} cwd Project root.
+ * @returns {boolean} Whether dependencies are installed.
+ */
+export function dependenciesInstalled(cwd) {
+  return existsSync(join(cwd, "node_modules", ".bin"));
 }
 
 /**
@@ -330,8 +454,14 @@ export function detectTooling(cwd = process.cwd()) {
   const notes = readJson(join(cwd, ".lisa", "secret-notes.json"));
 
   const declared = declaredTools(config);
+  // Curated signals carry a vetted `why`. Discovered ones carry only the fact
+  // that the project runs the thing — weaker prose, identical standing as
+  // evidence, and the only kind that can find a tool nobody listed.
+  const hooks = toolsFromGitHooks(cwd);
   const signals = [
+    hooks,
     toolsFromScripts(pkg),
+    toolsDiscoveredInScripts(pkg),
     toolsFromMcp(mcp),
     toolsFromSecretNotes(notes),
     toolsFromQuality(config, pkg, cwd),
@@ -343,8 +473,11 @@ export function detectTooling(cwd = process.cwd()) {
       if (declared.has(tool)) continue;
       // Already provided by the package manager, so there is nothing to pin.
       if (satisfiedByNpm(pkg, tool)) continue;
+      if (providedByNodeModules(cwd, tool)) continue;
+      // Real dependency, wrong manifest — the workstation layer owns it.
+      if (WORKSTATION_PROVISIONED.has(tool)) continue;
       const entry = merged.get(tool) ?? { evidence: [] };
-      entry.evidence.push(evidence);
+      if (!entry.evidence.includes(evidence)) entry.evidence.push(evidence);
       merged.set(tool, entry);
     }
   }
@@ -352,10 +485,33 @@ export function detectTooling(cwd = process.cwd()) {
   return [...merged.entries()]
     .map(([name, entry]) => ({
       name,
-      why: KNOWN_TOOLS[name]?.why ?? "",
+      why: KNOWN_TOOLS[name]?.why ?? discoveredWhy(name, hooks.has(name)),
       evidence: entry.evidence,
+      // Says which vocabulary the `why` came from, so a reader can weigh it.
+      // A curated entry has been thought about; a discovered one has only been
+      // observed.
+      source: Object.hasOwn(KNOWN_TOOLS, name) ? "curated" : "discovered",
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * The `why` for a tool nobody wrote prose for.
+ *
+ * Every proposal must carry one — a proposal without a reason is an assertion,
+ * and this program's whole boundary is that it asserts nothing. So a discovered
+ * tool states the observation plainly rather than borrowing confidence it has
+ * not earned.
+ * @param {string} name Tool name.
+ * @param {boolean} fromHook Whether a git hook runs it.
+ * @returns {string} A reason a reader can check.
+ */
+export function discoveredWhy(name, fromHook) {
+  return fromHook
+    ? `A git hook runs \`${name}\` on every commit or push, and nothing ` +
+        `declares it — a machine without it fails at commit time, or skips the ` +
+        `check silently if the hook guards it.`
+    : `An npm script invokes \`${name}\`, and nothing puts it on PATH.`;
 }
 
 /**
@@ -438,8 +594,18 @@ if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
     console.log(
       `${proposals.length} tool(s) look required but are not declared:\n`
     );
+    if (!dependenciesInstalled(process.cwd())) {
+      // Without node_modules there is no way to tell a tool that needs PATH
+      // from one npm already provides, so every dev dependency looks missing.
+      // Said out loud rather than silently over-proposing.
+      console.log(
+        "note: dependencies are not installed, so binaries npm would provide " +
+          "cannot be\n      excluded. Run the install first for a shorter, " +
+          "more accurate list.\n"
+      );
+    }
     for (const proposal of proposals) {
-      console.log(`  ${proposal.name}`);
+      console.log(`  ${proposal.name}  [${proposal.source}]`);
       console.log(`    why: ${proposal.why}`);
       for (const evidence of proposal.evidence) {
         console.log(`    evidence: ${evidence}`);

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -853,9 +853,11 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-delivery-effectiveness/SKILL.md":
       "21bc55fa0e86a9694bd22269fd089dbfae0c54c199262f46a4955447acea0f35",
     "plugins/src/base/skills/lisa-detect-tooling/SKILL.md":
-      "7424cdbd43caa6f371b4cbf010491285e47f3bf00723c82caec023057b018985",
+      "4ef9b5004e13beb46cac5ae994c24d91c3715363771e3d89c32b0610408fc887",
+    "plugins/src/base/skills/lisa-detect-tooling/scripts/commands.mjs":
+      "e28bd61fdde4a336b56ae3395423026943a5816015719d31d04f0d5a0ab50eec",
     "plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs":
-      "6582180a039ba5ca8cd59abeaf909205b3e5d5de355bad47da28bc5c02db6090",
+      "e24e6ac3e073097d4a9991b398386f19f10a8abe2dfba57196d615f5e6a6cf63",
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
       "fb41a1e63c5332d47a46e715aff52551f3df867033b5e4f37dfaeee30019b891",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
@@ -3156,6 +3158,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-agy/skills/lisa-debrief/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-delivery-effectiveness/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-detect-tooling/SKILL.md": true,
+    "plugins/lisa-agy/skills/lisa-detect-tooling/scripts/commands.mjs": true,
     "plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs": true,
     "plugins/lisa-agy/skills/lisa-doctor/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md": true,
@@ -3577,6 +3580,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/skills/lisa-debrief/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-delivery-effectiveness/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-detect-tooling/SKILL.md": true,
+    "plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/commands.mjs": true,
     "plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs": true,
     "plugins/lisa-copilot/skills/lisa-doctor/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md": true,
@@ -3984,6 +3988,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/skills/lisa-debrief/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-delivery-effectiveness/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-detect-tooling/SKILL.md": true,
+    "plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/commands.mjs": true,
     "plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs": true,
     "plugins/lisa-cursor/skills/lisa-doctor/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md": true,
@@ -5902,6 +5907,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/.codex-plugin/skills/lisa-delivery-effectiveness/agents/openai.yaml": true,
     "plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/SKILL.md": true,
     "plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/agents/openai.yaml": true,
+    "plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/commands.mjs": true,
     "plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs": true,
     "plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md": true,
     "plugins/lisa/.codex-plugin/skills/lisa-doctor/agents/openai.yaml": true,
@@ -6487,6 +6493,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/skills/lisa-delivery-effectiveness/agents/openai.yaml": true,
     "plugins/lisa/skills/lisa-detect-tooling/SKILL.md": true,
     "plugins/lisa/skills/lisa-detect-tooling/agents/openai.yaml": true,
+    "plugins/lisa/skills/lisa-detect-tooling/scripts/commands.mjs": true,
     "plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs": true,
     "plugins/lisa/skills/lisa-doctor/SKILL.md": true,
     "plugins/lisa/skills/lisa-doctor/agents/openai.yaml": true,
@@ -7053,6 +7060,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/skills/lisa-debrief/SKILL.md": true,
     "plugins/src/base/skills/lisa-delivery-effectiveness/SKILL.md": true,
     "plugins/src/base/skills/lisa-detect-tooling/SKILL.md": true,
+    "plugins/src/base/skills/lisa-detect-tooling/scripts/commands.mjs": true,
     "plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs": true,
     "plugins/src/base/skills/lisa-doctor/SKILL.md": true,
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md": true,
@@ -8410,6 +8418,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/work-item-tracker-unreachable.test.ts": true,
     "tests/unit/secrets/automation-workflow.test.ts": true,
     "tests/unit/secrets/bootstrap-key-naming.test.ts": true,
+    "tests/unit/secrets/detect-tooling-discovery.test.ts": true,
     "tests/unit/secrets/detect-tooling.test.ts": true,
     "tests/unit/secrets/doctor-secrets.test.ts": true,
     "tests/unit/secrets/local-env-command.test.ts": true,

--- a/tests/unit/secrets/detect-tooling-discovery.test.ts
+++ b/tests/unit/secrets/detect-tooling-discovery.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for open-ended tool discovery.
+ *
+ * The detector used to match script bodies against a fixed list, so it could
+ * only re-find tools someone had already thought of — the set that needs a
+ * detector least. An Expo project invoking `eas` from eight npm scripts produced
+ * nothing, and `gitleaks` running on every commit produced nothing.
+ *
+ * Every case here is built on a real temporary project rather than a mock,
+ * because the failure being prevented is about what is on disk.
+ * @module tests/unit/secrets/detect-tooling-discovery
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  commandsIn,
+  localFunctions,
+  stripNonCommandSpans,
+} from "../../../plugins/src/base/skills/lisa-detect-tooling/scripts/commands.mjs";
+import {
+  detectTooling,
+  toolsDiscoveredInScripts,
+  toolsFromGitHooks,
+} from "../../../plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs";
+
+/** The hook path used by most fixtures here. */
+const PRE_COMMIT = ".husky/pre-commit";
+
+/** A minimal hook body that invokes the canonical undeclared tool. */
+const GITLEAKS_HOOK = "#!/bin/sh\ngitleaks protect\n";
+
+/** The Expo build script that the old allowlist could not see. */
+const EAS_SCRIPT = "eas build --profile production";
+
+/** Projects created for a single test, removed afterwards. */
+const created: string[] = [];
+
+/**
+ * Build a throwaway project on disk.
+ * @param files Relative path to file contents.
+ * @returns The project root.
+ */
+function project(files: Record<string, string>): string {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-detect-"));
+  created.push(root);
+  for (const [relative, contents] of Object.entries(files)) {
+    const full = path.join(root, relative);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, contents);
+  }
+  return root;
+}
+
+afterEach(() => {
+  while (created.length > 0) {
+    rmSync(created.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe("commandsIn", () => {
+  it("finds a tool nobody put on a list", () => {
+    // The whole point. `eas` was in no allowlist and in eight npm scripts.
+    expect(
+      commandsIn("eas build --profile production --non-interactive")
+    ).toContain("eas");
+  });
+
+  it("reads every command position, not just the first", () => {
+    const found = commandsIn("gitleaks detect && sentry-cli releases new");
+    expect(found).toContain("gitleaks");
+    expect(found).toContain("sentry-cli");
+  });
+
+  it("treats a `command -v` guard as evidence", () => {
+    // A guarded tool is STRONGER evidence than an unguarded one: when it is
+    // absent the hook skips silently, so the commit succeeds having scanned
+    // nothing. That invisibility is the failure.
+    expect(
+      commandsIn("if ! command -v gitleaks >/dev/null 2>&1; then\n  exit 0\nfi")
+    ).toContain("gitleaks");
+  });
+
+  it("ignores what the package manager resolves", () => {
+    const found = commandsIn("npx playwright test && bun run build");
+    expect(found).not.toContain("playwright");
+    expect(found).not.toContain("build");
+    expect(found).not.toContain("bun");
+  });
+
+  it("ignores the runtime a probe is testing for", () => {
+    // `command -v bun` is how a hook checks its own runtime. Reading probed
+    // names without the normal filters proposed bun and yarn on every repo.
+    expect(commandsIn("command -v bun >/dev/null")).toEqual([]);
+  });
+
+  it("ignores shell vocabulary and paths", () => {
+    const found = commandsIn(
+      'for f in *.ts; do\n  ./scripts/check.sh "$f"\ndone'
+    );
+    expect(found).toEqual([]);
+  });
+
+  it("ignores functions the script defines itself", () => {
+    // This repository's pre-push hook defines `load_audit_cves` and calls it,
+    // which reads exactly like a command invocation because it is one.
+    const body = "load_audit_cves() {\n  echo hi\n}\nload_audit_cves\n";
+    expect(localFunctions(body)).toContain("load_audit_cves");
+    expect(commandsIn(body)).toEqual([]);
+  });
+
+  it("reads into a quoted `sh -c` payload", () => {
+    // Frontend's eas:publish:e2e wraps its real command in exactly this shape.
+    expect(commandsIn(`sh -c 'set -e; eas update --auto'`)).toContain("eas");
+  });
+
+  it("does not read embedded programs as commands", () => {
+    // jq filter internals and `node -e` payloads are arguments, not commands.
+    const found = commandsIn(
+      `jq -r '.results | map(select(.status)) | length' file.json`
+    );
+    expect(found).toContain("jq");
+    expect(found).not.toContain("map");
+    expect(found).not.toContain("select");
+    expect(found).not.toContain("length");
+  });
+});
+
+describe("stripNonCommandSpans", () => {
+  it("survives an apostrophe inside a comment", () => {
+    // The regression that leaked JavaScript. A lone apostrophe in `# the
+    // script's exit code` paired with the next real quote 28 lines later and
+    // blanked everything between, exposing a node -e payload.
+    const text = "# the script's exit code\ngitleaks detect\n";
+    expect(stripNonCommandSpans(text)).toContain("gitleaks");
+    expect(commandsIn(text)).toContain("gitleaks");
+  });
+
+  it("restarts quoting inside a command substitution", () => {
+    // `$( )` opens a fresh quoting context. A flat scanner falls out of phase
+    // on the first one and exposes the payload's own string literals.
+    const text = `OUT="$(printf '%s' "$JSON" | node -e 'x("data")')"\ngitleaks detect`;
+    const found = commandsIn(text);
+    expect(found).toContain("gitleaks");
+    expect(found).not.toContain("data");
+  });
+});
+
+describe("toolsFromGitHooks", () => {
+  it("reads .husky hooks", () => {
+    const root = project({
+      [PRE_COMMIT]: "#!/bin/sh\ngitleaks protect --staged\n",
+    });
+    expect([...toolsFromGitHooks(root).keys()]).toContain("gitleaks");
+  });
+
+  it("reads .git/hooks but skips the samples git ships", () => {
+    const root = project({
+      ".git/hooks/pre-push": "#!/bin/sh\ntrufflehog git file://.\n",
+      ".git/hooks/pre-commit.sample": "#!/bin/sh\nsomethingelse --run\n",
+    });
+    const found = [...toolsFromGitHooks(root).keys()];
+    expect(found).toContain("trufflehog");
+    expect(found).not.toContain("somethingelse");
+  });
+
+  it("names the hook as evidence", () => {
+    const root = project({
+      [PRE_COMMIT]: GITLEAKS_HOOK,
+    });
+    expect(toolsFromGitHooks(root).get("gitleaks")).toContain(PRE_COMMIT);
+  });
+
+  it("returns nothing when a project has no hooks", () => {
+    expect([...toolsFromGitHooks(project({})).keys()]).toEqual([]);
+  });
+});
+
+describe("toolsDiscoveredInScripts", () => {
+  it("finds a tool no allowlist mentions", () => {
+    const found = toolsDiscoveredInScripts({
+      scripts: { "eas:deploy": EAS_SCRIPT },
+    });
+    expect([...found.keys()]).toContain("eas");
+    expect(found.get("eas")).toContain("eas:deploy");
+  });
+});
+
+describe("detectTooling with discovery", () => {
+  it("proposes eas for an Expo project that invokes it", () => {
+    const root = project({
+      "package.json": JSON.stringify({
+        scripts: { "eas:deploy:production": EAS_SCRIPT },
+      }),
+      ".lisa.config.json": JSON.stringify({ remoteEnv: { tools: {} } }),
+    });
+    const names = detectTooling(root).map(p => p.name);
+    expect(names).toContain("eas");
+  });
+
+  it("proposes gitleaks for a repo whose hook runs it", () => {
+    const root = project({
+      "package.json": "{}",
+      ".husky/pre-commit":
+        "#!/bin/sh\ncommand -v gitleaks && gitleaks protect\n",
+    });
+    expect(detectTooling(root).map(p => p.name)).toContain("gitleaks");
+  });
+
+  it("stays silent about a tool the manifest already declares", () => {
+    const root = project({
+      "package.json": JSON.stringify({
+        scripts: { deploy: EAS_SCRIPT },
+      }),
+      ".lisa.config.json": JSON.stringify({
+        remoteEnv: { tools: { install: [{ name: "eas" }] } },
+      }),
+    });
+    expect(detectTooling(root).map(p => p.name)).not.toContain("eas");
+  });
+
+  it("stays silent about a binary node_modules already provides", () => {
+    const root = project({
+      "package.json": JSON.stringify({ scripts: { test: "jest --ci" } }),
+      "node_modules/.bin/jest": "#!/bin/sh\n",
+    });
+    expect(detectTooling(root).map(p => p.name)).not.toContain("jest");
+  });
+
+  it("never proposes a coding agent, which belongs to the machine", () => {
+    // Real evidence, wrong manifest: agents are installed by their vendor into
+    // a version directory they manage, and lisa-setup-workstation owns that.
+    const root = project({
+      "package.json": "{}",
+      ".husky/post-checkout": "#!/bin/sh\ntimeout 45 claude plugin install\n",
+    });
+    expect(detectTooling(root).map(p => p.name)).not.toContain("claude");
+  });
+
+  it("gives every proposal a reason and a source", () => {
+    // A proposal without a reason is an assertion, and this program asserts
+    // nothing.
+    const root = project({
+      "package.json": "{}",
+      [PRE_COMMIT]: GITLEAKS_HOOK,
+    });
+    for (const proposal of detectTooling(root)) {
+      expect(proposal.why).not.toBe("");
+      expect(["curated", "discovered"]).toContain(proposal.source);
+    }
+  });
+
+  it("marks a hook-discovered tool as discovered, not curated", () => {
+    const root = project({
+      "package.json": "{}",
+      [PRE_COMMIT]: GITLEAKS_HOOK,
+    });
+    const found = detectTooling(root).find(p => p.name === "gitleaks");
+    expect(found?.source).toBe("discovered");
+    expect(found?.why).toContain("git hook");
+  });
+});


### PR DESCRIPTION
Fixes the false negatives that let `eas` and `gitleaks` through.

## The bug

`toolsFromScripts` iterated `Object.keys(KNOWN_TOOLS)` and matched those names against script bodies. The detector could therefore only ever re-find tools someone had already thought of — the set that needs a detector least.

An Expo project invoking `eas` from **eight** npm scripts and six CI steps produced no proposal, because `eas` was not on the list. Git hooks were not read at all, so `gitleaks` — which runs on **every commit** in every one of these repositories — produced no proposal either.

The skill's own docstring names the standard it was failing:

> A false positive costs a human a moment's review; a false negative is the failure this exists to prevent.

## The fix

Executable sources are now asked the open question — *what does this project actually run* — and everything already provided is subtracted afterwards:

- `remoteEnv.tools` declarations
- `node_modules/.bin` (a dependency's binary never needs to be on PATH)
- coding agents, which belong to `lisa-setup-workstation`, not to a project manifest

The curated list stays, because a vetted `why` is worth more than an observed one. Proposals now say which they are, `[curated]` or `[discovered]`.

**Git hooks rank above npm scripts.** A hook runs on every commit and push whether anyone asked or not, so a machine without the tool cannot commit at all.

A `command -v` guard counts as **evidence**, not as an "optional" marker — the guarded shape is the worse one. Lisa's pre-commit hook wraps its secret scan in `command -v gitleaks`, so on a machine without gitleaks the scan is **skipped silently**: hook passes, commit succeeds, nothing scanned. The guard makes the absence invisible exactly where it matters.

## Reading shell was the hard part

Running it against real repositories found three bugs a synthetic fixture never would.

**Only the first word of a command position counts.** Word-scanning this repo's own hooks proposed `ltrimstr`, `map` and `select` (jq filter internals), `console.log` and `process.exit` (embedded JavaScript), and `load_audit_cves` (a function the hook defines three lines up). Reading only where a command can actually start removes every one, with no denylist entry for any.

**Quoting and commenting nest, so no ordering of independent regex passes is correct.** The comment on line 9 of `pre-push.local` ends `...the script's exit code)`. That lone apostrophe paired with the next real quote 28 lines later, blanked everything between, and leaked a `node -e` payload's JavaScript into the results as `try`, `catch`, `const`, `unreadable`. Stripping comments first doesn't fix it either — a `#` inside a quoted string is not a comment. Replaced with a single character scanner tracking both.

**`$( )` restarts the quoting context.** In `"$(printf '%s' "$JSON" | node -e '…')"` the quotes inside the substitution pair among themselves. A flat scanner falls out of phase on the first one and starts reporting the payload's own string literals — that was `data`, `end`, `stale`.

Separately, probed names had to go through the **same** filters as invoked ones. Without that, `command -v bun` — a hook checking its own runtime — proposed pinning bun on every repository scanned.

## Verification

Run against Lisa and all three TunnlAI repositories. What survives:

| tool | evidence | real? |
| --- | --- | --- |
| `gitleaks` | `.husky/pre-commit`, guarded by `command -v` | yes — silently skipped today |
| `jq` | 22 invocations in `.husky/pre-push` | yes |
| `gtimeout` | `.husky/post-checkout` | yes — macOS coreutils |
| `eas` | 8 npm scripts | yes |

No false positives. `claude` is correctly withheld — real evidence, wrong manifest.

- 23 new tests, each built on a real temporary project rather than a mock, since the failure is about what is on disk
- Full suite: 503 files / 8516 tests green; typecheck and lint clean
- Fans out to all five agent variants

**Unchanged:** this writes nothing and installs nothing. Output is still a proposal with `<pin>`, `<release url>` and `<sha256>` left for a human.

🤖 Generated with Claude Code

---

Work-Item: CodySwannGT/lisa#2289
