### PR TITLE
feat(hooks): refuse agent writes to AGENTS.md and CLAUDE.md

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,6 +39,15 @@
             "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/lisa-enforcement-fallback.sh"
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/lisa-enforcement-fallback.sh"
+          }
+        ]
       }
     ]
   },

--- a/all/copy-overwrite/scripts/lisa-enforcement-fallback.sh
+++ b/all/copy-overwrite/scripts/lisa-enforcement-fallback.sh
@@ -4,7 +4,8 @@
 # is not installed.
 #
 # Every PreToolUse guard — block-no-verify, parity-safety-net,
-# block-shell-json-parsing — is declared in the Lisa plugin. A cloud session
+# block-shell-json-parsing, block-instruction-file-edits — is declared in the
+# Lisa plugin. A cloud session
 # installs plugins at session start from the marketplace the repository
 # declares, and when that does not happen the container runs with
 # `installed_plugins.json` empty and no enforcement whatsoever.
@@ -41,7 +42,8 @@ fi
 # host project whose plugin install fails has exactly the same hole and no
 # `plugins/` directory to fall back on.
 status=0
-for guard in block-no-verify parity-safety-net block-shell-json-parsing; do
+for guard in block-no-verify parity-safety-net block-shell-json-parsing \
+  block-instruction-file-edits; do
   script=""
   for candidate in \
     "$repo_root/scripts/lisa-hooks/$guard.sh" \

--- a/all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# PreToolUse hook: refuse agent writes to the session-instruction files.
+#
+# `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` are the files
+# every agent loads at session start. They are human-authored and curated on
+# purpose — Lisa's own contract says so in two places:
+#   - plugins/src/base/rules/reference/project-learnings.md
+#   - plugins/src/base/skills/lisa-debrief-apply/SKILL.md ("CLAUDE.md is
+#     human-authored ... apply never writes to any of the three")
+#
+# Nothing enforced it, so agents appended their own findings anyway: one fleet
+# repo reached 949 lines of ticket-keyed trap dumps in `AGENTS.md` while its
+# learnings ledger held 22. Every one of those lines is charged to the context
+# of every later session in that project, forever. Prose did not hold; this is
+# the executable control that does.
+#
+# Blocked signatures:
+#   1. Write / Edit / MultiEdit / NotebookEdit whose target basename is one of
+#      the instruction files;
+#   2. Bash output redirection (`>`, `>>`), `tee`, or `sed -i` aimed at one.
+#      Reads (`cat AGENTS.md`, `rg pattern AGENTS.md`) never fire.
+#
+# Exemptions (allowed):
+#   - `LISA_ALLOW_INSTRUCTION_FILE_WRITE` set — the operator's explicit override,
+#     named in the refusal so a human who really wants the edit can take it;
+#   - payloads carrying a `<!-- LISA_` marker: Lisa's own marker-bounded regions
+#     (the agy project-learnings bridge, cross-pollinate's rule section) replace
+#     in place on re-run and cannot grow the file;
+#   - paths under `node_modules/` or `dist/` — vendored copies, not the host's.
+set -euo pipefail
+
+input="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+# The operator's override. Checked before anything else so it is always the
+# cheapest way out of a refusal a human deliberately wants to overrule.
+if [ -n "${LISA_ALLOW_INSTRUCTION_FILE_WRITE:-}" ]; then
+  exit 0
+fi
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+[ -n "$tool_name" ] || exit 0
+
+# Lisa's own bounded bridges write marked regions. A payload carrying a marker
+# is replacing a delimited block, not appending prose, so it cannot be the
+# unbounded growth this guard exists to stop.
+if printf '%s' "$input" | grep -q '<!-- LISA_'; then
+  exit 0
+fi
+
+# Basename match, case-insensitively: `agents.md` and `AGENTS.md` are the same
+# file on the macOS checkouts this fleet runs on.
+is_instruction_file() {
+  local candidate="$1"
+  case "$candidate" in
+    */node_modules/* | node_modules/* | */dist/* | dist/*) return 1 ;;
+  esac
+  local base="${candidate##*/}"
+  case "$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')" in
+    agents.md | claude.md | copilot-instructions.md) return 0 ;;
+  esac
+  return 1
+}
+
+refuse() {
+  local target="$1"
+  cat >&2 <<EOF
+BLOCKED: refusing to write \`$target\`.
+
+WHY: this is a session-instruction file, not a place to record what you just
+learned. Every line in it is loaded into the context of every agent, in every
+future session, in this project, forever. It is human-curated on purpose. An
+agent appending its own findings is how these files grow into hundreds of lines
+of stale, ticket-specific trivia that every later session pays for and half of
+which was only ever true once.
+
+WHERE IT GOES INSTEAD — take the first one that fits:
+
+1. Every agent genuinely needs this in every session, and only in this project.
+   That is a project rule — but do not write it yourself. Capture it with
+   \`/lisa:persist-learning\` so it lands in the learnings ledger with provenance
+   and a confidence score. The gardener (\`/lisa:learnings:audit\`) then proposes
+   promotion into \`.claude/rules/PROJECT_RULES.md\` as a human-gated ticket.
+
+2. It changes how an existing skill should behave. Edit that skill's SKILL.md.
+   Knowledge belongs next to the procedure it modifies, not in a global preamble.
+
+3. It is true beyond this project. Propose it upstream to Lisa via
+   \`/lisa:cross-pollinate\`, or open an issue on CodySwannGT/lisa. A local copy of
+   a general rule silently drifts the moment upstream changes.
+
+4. None of the above — it is background someone may want to look up, not a
+   standing instruction. Write it into the project documentation (\`wiki/\` or
+   \`docs/\`).
+
+If a human explicitly asked for this edit, they can re-run with
+\`LISA_ALLOW_INSTRUCTION_FILE_WRITE=1\` set, which bypasses this guard.
+EOF
+  exit 2
+}
+
+case "$tool_name" in
+  Write | Edit | MultiEdit | NotebookEdit | Update)
+    # `file_path` covers Write/Edit; `edits[].file_path` covers the MultiEdit
+    # shapes that carry a path per edit; `notebook_path` covers NotebookEdit.
+    paths="$(printf '%s' "$input" | jq -r '
+      [ .tool_input.file_path?,
+        .tool_input.path?,
+        .tool_input.notebook_path?,
+        (.tool_input.edits? // [] | .[].file_path?)
+      ] | map(select(. != null and . != "")) | .[]' 2>/dev/null || true)"
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      if is_instruction_file "$candidate"; then
+        refuse "$candidate"
+      fi
+    done <<EOF
+$paths
+EOF
+    ;;
+  Bash)
+    command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+    [ -n "$command_str" ] || exit 0
+    # Fast path: no instruction filename mentioned means nothing to classify.
+    if ! printf '%s' "$command_str" |
+      grep -Eqi '(agents|claude|copilot-instructions)\.md'; then
+      exit 0
+    fi
+    # Write signatures only. A bare mention (`cat AGENTS.md`, `rg x AGENTS.md`)
+    # is a read and must stay allowed — the filename has to appear as the target
+    # of a redirection, a tee, or an in-place sed.
+    write_target='[^ |;&]*(agents|claude|copilot-instructions)\.md'
+    if printf '%s' "$command_str" |
+      grep -Eqi ">>?[[:space:]]*['\"]?$write_target|tee([[:space:]]+-[a-z]+)*[[:space:]]+['\"]?$write_target|sed[[:space:]]+[^|;&]*-i[^|;&]*$write_target"; then
+      refuse "$(printf '%s' "$command_str" |
+        grep -Eoi "$write_target" | head -1)"
+    fi
+    ;;
+esac
+
+exit 0

--- a/all/merge/.claude/settings.json
+++ b/all/merge/.claude/settings.json
@@ -48,6 +48,15 @@
             "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/lisa-enforcement-fallback.sh"
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/lisa-enforcement-fallback.sh"
+          }
+        ]
       }
     ]
   }

--- a/plugins/lisa-agy/hooks.json
+++ b/plugins/lisa-agy/hooks.json
@@ -37,5 +37,18 @@
         ]
       }
     ]
+  },
+  "lisa-block-instruction-file-edits": {
+    "PreToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.gemini/config/plugins/lisa/hooks/block-instruction-file-edits.agy.sh\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/plugins/lisa-agy/hooks/block-instruction-file-edits.agy.sh
+++ b/plugins/lisa-agy/hooks/block-instruction-file-edits.agy.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Antigravity (agy) PreToolUse adapter for Lisa's instruction-file guard.
+#
+# agy sends `{toolCall:{name:"run_command",args:{CommandLine:"..."}}}` and
+# expects an allow/deny JSON object on stdout. The canonical hook consumes the
+# Claude Bash-hook envelope and communicates denial with exit status 2. This
+# adapter only translates protocols; all classification stays in the canonical
+# block-instruction-file-edits.sh beside it (same delegation pattern as
+# block-shell-json-parsing.agy.sh).
+#
+# Scope note: agy plugin hooks match `run_command`, so only the Bash arm of the
+# guard reaches agy — an agy file-edit tool call writing AGENTS.md cannot be
+# intercepted. That gap is accepted and recorded here rather than papered over.
+#
+# Fail-open on missing runtimes: a missed refusal here costs context bloat in a
+# markdown file, not data loss.
+set -uo pipefail
+
+allow() {
+  printf '%s\n' '{"decision":"allow"}'
+  exit 0
+}
+
+deny() {
+  local reason="$1"
+  if command -v jq >/dev/null 2>&1; then
+    jq -cn --arg reason "$reason" '{decision:"deny",reason:$reason}'
+  else
+    printf '%s\n' '{"decision":"allow"}'
+  fi
+  exit 0
+}
+
+input="$(cat 2>/dev/null || true)"
+[ -z "$input" ] && allow
+command -v jq >/dev/null 2>&1 || allow
+
+tool_name="$(printf '%s' "$input" | jq -r '.toolCall.name // empty' 2>/dev/null || true)"
+[ "$tool_name" != "run_command" ] && allow
+command_str="$(printf '%s' "$input" | jq -r '.toolCall.args.CommandLine // empty' 2>/dev/null || true)"
+[ -z "$command_str" ] && allow
+
+hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+canonical_hook="$hook_dir/block-instruction-file-edits.sh"
+[ -r "$canonical_hook" ] || allow
+
+canonical_input="$(jq -cn --arg command "$command_str" '{tool_name:"Bash",tool_input:{command:$command}}')"
+canonical_output=""
+canonical_status=0
+if canonical_output="$(printf '%s' "$canonical_input" | /bin/bash "$canonical_hook" 2>&1)"; then
+  canonical_status=0
+else
+  canonical_status=$?
+fi
+
+[ "$canonical_status" -eq 0 ] && allow
+[ -n "$canonical_output" ] || canonical_output="Blocked: AGENTS.md / CLAUDE.md are human-authored session-instruction files."
+deny "$canonical_output"

--- a/plugins/lisa-agy/hooks/block-instruction-file-edits.sh
+++ b/plugins/lisa-agy/hooks/block-instruction-file-edits.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# PreToolUse hook: refuse agent writes to the session-instruction files.
+#
+# `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` are the files
+# every agent loads at session start. They are human-authored and curated on
+# purpose — Lisa's own contract says so in two places:
+#   - plugins/src/base/rules/reference/project-learnings.md
+#   - plugins/src/base/skills/lisa-debrief-apply/SKILL.md ("CLAUDE.md is
+#     human-authored ... apply never writes to any of the three")
+#
+# Nothing enforced it, so agents appended their own findings anyway: one fleet
+# repo reached 949 lines of ticket-keyed trap dumps in `AGENTS.md` while its
+# learnings ledger held 22. Every one of those lines is charged to the context
+# of every later session in that project, forever. Prose did not hold; this is
+# the executable control that does.
+#
+# Blocked signatures:
+#   1. Write / Edit / MultiEdit / NotebookEdit whose target basename is one of
+#      the instruction files;
+#   2. Bash output redirection (`>`, `>>`), `tee`, or `sed -i` aimed at one.
+#      Reads (`cat AGENTS.md`, `rg pattern AGENTS.md`) never fire.
+#
+# Exemptions (allowed):
+#   - `LISA_ALLOW_INSTRUCTION_FILE_WRITE` set — the operator's explicit override,
+#     named in the refusal so a human who really wants the edit can take it;
+#   - payloads carrying a `<!-- LISA_` marker: Lisa's own marker-bounded regions
+#     (the agy project-learnings bridge, cross-pollinate's rule section) replace
+#     in place on re-run and cannot grow the file;
+#   - paths under `node_modules/` or `dist/` — vendored copies, not the host's.
+set -euo pipefail
+
+input="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+# The operator's override. Checked before anything else so it is always the
+# cheapest way out of a refusal a human deliberately wants to overrule.
+if [ -n "${LISA_ALLOW_INSTRUCTION_FILE_WRITE:-}" ]; then
+  exit 0
+fi
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+[ -n "$tool_name" ] || exit 0
+
+# Lisa's own bounded bridges write marked regions. A payload carrying a marker
+# is replacing a delimited block, not appending prose, so it cannot be the
+# unbounded growth this guard exists to stop.
+if printf '%s' "$input" | grep -q '<!-- LISA_'; then
+  exit 0
+fi
+
+# Basename match, case-insensitively: `agents.md` and `AGENTS.md` are the same
+# file on the macOS checkouts this fleet runs on.
+is_instruction_file() {
+  local candidate="$1"
+  case "$candidate" in
+    */node_modules/* | node_modules/* | */dist/* | dist/*) return 1 ;;
+  esac
+  local base="${candidate##*/}"
+  case "$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')" in
+    agents.md | claude.md | copilot-instructions.md) return 0 ;;
+  esac
+  return 1
+}
+
+refuse() {
+  local target="$1"
+  cat >&2 <<EOF
+BLOCKED: refusing to write \`$target\`.
+
+WHY: this is a session-instruction file, not a place to record what you just
+learned. Every line in it is loaded into the context of every agent, in every
+future session, in this project, forever. It is human-curated on purpose. An
+agent appending its own findings is how these files grow into hundreds of lines
+of stale, ticket-specific trivia that every later session pays for and half of
+which was only ever true once.
+
+WHERE IT GOES INSTEAD — take the first one that fits:
+
+1. Every agent genuinely needs this in every session, and only in this project.
+   That is a project rule — but do not write it yourself. Capture it with
+   \`/lisa:persist-learning\` so it lands in the learnings ledger with provenance
+   and a confidence score. The gardener (\`/lisa:learnings:audit\`) then proposes
+   promotion into \`.claude/rules/PROJECT_RULES.md\` as a human-gated ticket.
+
+2. It changes how an existing skill should behave. Edit that skill's SKILL.md.
+   Knowledge belongs next to the procedure it modifies, not in a global preamble.
+
+3. It is true beyond this project. Propose it upstream to Lisa via
+   \`/lisa:cross-pollinate\`, or open an issue on CodySwannGT/lisa. A local copy of
+   a general rule silently drifts the moment upstream changes.
+
+4. None of the above — it is background someone may want to look up, not a
+   standing instruction. Write it into the project documentation (\`wiki/\` or
+   \`docs/\`).
+
+If a human explicitly asked for this edit, they can re-run with
+\`LISA_ALLOW_INSTRUCTION_FILE_WRITE=1\` set, which bypasses this guard.
+EOF
+  exit 2
+}
+
+case "$tool_name" in
+  Write | Edit | MultiEdit | NotebookEdit | Update)
+    # `file_path` covers Write/Edit; `edits[].file_path` covers the MultiEdit
+    # shapes that carry a path per edit; `notebook_path` covers NotebookEdit.
+    paths="$(printf '%s' "$input" | jq -r '
+      [ .tool_input.file_path?,
+        .tool_input.path?,
+        .tool_input.notebook_path?,
+        (.tool_input.edits? // [] | .[].file_path?)
+      ] | map(select(. != null and . != "")) | .[]' 2>/dev/null || true)"
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      if is_instruction_file "$candidate"; then
+        refuse "$candidate"
+      fi
+    done <<EOF
+$paths
+EOF
+    ;;
+  Bash)
+    command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+    [ -n "$command_str" ] || exit 0
+    # Fast path: no instruction filename mentioned means nothing to classify.
+    if ! printf '%s' "$command_str" |
+      grep -Eqi '(agents|claude|copilot-instructions)\.md'; then
+      exit 0
+    fi
+    # Write signatures only. A bare mention (`cat AGENTS.md`, `rg x AGENTS.md`)
+    # is a read and must stay allowed — the filename has to appear as the target
+    # of a redirection, a tee, or an in-place sed.
+    write_target='[^ |;&]*(agents|claude|copilot-instructions)\.md'
+    if printf '%s' "$command_str" |
+      grep -Eqi ">>?[[:space:]]*['\"]?$write_target|tee([[:space:]]+-[a-z]+)*[[:space:]]+['\"]?$write_target|sed[[:space:]]+[^|;&]*-i[^|;&]*$write_target"; then
+      refuse "$(printf '%s' "$command_str" |
+        grep -Eoi "$write_target" | head -1)"
+    fi
+    ;;
+esac
+
+exit 0

--- a/plugins/lisa-copilot/.claude-plugin/plugin.json
+++ b/plugins/lisa-copilot/.claude-plugin/plugin.json
@@ -52,6 +52,19 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-shell-json-parsing.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-instruction-file-edits.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-instruction-file-edits.sh"
           }
         ]
       },

--- a/plugins/lisa-copilot/hooks/block-instruction-file-edits.sh
+++ b/plugins/lisa-copilot/hooks/block-instruction-file-edits.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# PreToolUse hook: refuse agent writes to the session-instruction files.
+#
+# `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` are the files
+# every agent loads at session start. They are human-authored and curated on
+# purpose — Lisa's own contract says so in two places:
+#   - plugins/src/base/rules/reference/project-learnings.md
+#   - plugins/src/base/skills/lisa-debrief-apply/SKILL.md ("CLAUDE.md is
+#     human-authored ... apply never writes to any of the three")
+#
+# Nothing enforced it, so agents appended their own findings anyway: one fleet
+# repo reached 949 lines of ticket-keyed trap dumps in `AGENTS.md` while its
+# learnings ledger held 22. Every one of those lines is charged to the context
+# of every later session in that project, forever. Prose did not hold; this is
+# the executable control that does.
+#
+# Blocked signatures:
+#   1. Write / Edit / MultiEdit / NotebookEdit whose target basename is one of
+#      the instruction files;
+#   2. Bash output redirection (`>`, `>>`), `tee`, or `sed -i` aimed at one.
+#      Reads (`cat AGENTS.md`, `rg pattern AGENTS.md`) never fire.
+#
+# Exemptions (allowed):
+#   - `LISA_ALLOW_INSTRUCTION_FILE_WRITE` set — the operator's explicit override,
+#     named in the refusal so a human who really wants the edit can take it;
+#   - payloads carrying a `<!-- LISA_` marker: Lisa's own marker-bounded regions
+#     (the agy project-learnings bridge, cross-pollinate's rule section) replace
+#     in place on re-run and cannot grow the file;
+#   - paths under `node_modules/` or `dist/` — vendored copies, not the host's.
+set -euo pipefail
+
+input="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+# The operator's override. Checked before anything else so it is always the
+# cheapest way out of a refusal a human deliberately wants to overrule.
+if [ -n "${LISA_ALLOW_INSTRUCTION_FILE_WRITE:-}" ]; then
+  exit 0
+fi
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+[ -n "$tool_name" ] || exit 0
+
+# Lisa's own bounded bridges write marked regions. A payload carrying a marker
+# is replacing a delimited block, not appending prose, so it cannot be the
+# unbounded growth this guard exists to stop.
+if printf '%s' "$input" | grep -q '<!-- LISA_'; then
+  exit 0
+fi
+
+# Basename match, case-insensitively: `agents.md` and `AGENTS.md` are the same
+# file on the macOS checkouts this fleet runs on.
+is_instruction_file() {
+  local candidate="$1"
+  case "$candidate" in
+    */node_modules/* | node_modules/* | */dist/* | dist/*) return 1 ;;
+  esac
+  local base="${candidate##*/}"
+  case "$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')" in
+    agents.md | claude.md | copilot-instructions.md) return 0 ;;
+  esac
+  return 1
+}
+
+refuse() {
+  local target="$1"
+  cat >&2 <<EOF
+BLOCKED: refusing to write \`$target\`.
+
+WHY: this is a session-instruction file, not a place to record what you just
+learned. Every line in it is loaded into the context of every agent, in every
+future session, in this project, forever. It is human-curated on purpose. An
+agent appending its own findings is how these files grow into hundreds of lines
+of stale, ticket-specific trivia that every later session pays for and half of
+which was only ever true once.
+
+WHERE IT GOES INSTEAD — take the first one that fits:
+
+1. Every agent genuinely needs this in every session, and only in this project.
+   That is a project rule — but do not write it yourself. Capture it with
+   \`/lisa:persist-learning\` so it lands in the learnings ledger with provenance
+   and a confidence score. The gardener (\`/lisa:learnings:audit\`) then proposes
+   promotion into \`.claude/rules/PROJECT_RULES.md\` as a human-gated ticket.
+
+2. It changes how an existing skill should behave. Edit that skill's SKILL.md.
+   Knowledge belongs next to the procedure it modifies, not in a global preamble.
+
+3. It is true beyond this project. Propose it upstream to Lisa via
+   \`/lisa:cross-pollinate\`, or open an issue on CodySwannGT/lisa. A local copy of
+   a general rule silently drifts the moment upstream changes.
+
+4. None of the above — it is background someone may want to look up, not a
+   standing instruction. Write it into the project documentation (\`wiki/\` or
+   \`docs/\`).
+
+If a human explicitly asked for this edit, they can re-run with
+\`LISA_ALLOW_INSTRUCTION_FILE_WRITE=1\` set, which bypasses this guard.
+EOF
+  exit 2
+}
+
+case "$tool_name" in
+  Write | Edit | MultiEdit | NotebookEdit | Update)
+    # `file_path` covers Write/Edit; `edits[].file_path` covers the MultiEdit
+    # shapes that carry a path per edit; `notebook_path` covers NotebookEdit.
+    paths="$(printf '%s' "$input" | jq -r '
+      [ .tool_input.file_path?,
+        .tool_input.path?,
+        .tool_input.notebook_path?,
+        (.tool_input.edits? // [] | .[].file_path?)
+      ] | map(select(. != null and . != "")) | .[]' 2>/dev/null || true)"
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      if is_instruction_file "$candidate"; then
+        refuse "$candidate"
+      fi
+    done <<EOF
+$paths
+EOF
+    ;;
+  Bash)
+    command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+    [ -n "$command_str" ] || exit 0
+    # Fast path: no instruction filename mentioned means nothing to classify.
+    if ! printf '%s' "$command_str" |
+      grep -Eqi '(agents|claude|copilot-instructions)\.md'; then
+      exit 0
+    fi
+    # Write signatures only. A bare mention (`cat AGENTS.md`, `rg x AGENTS.md`)
+    # is a read and must stay allowed — the filename has to appear as the target
+    # of a redirection, a tee, or an in-place sed.
+    write_target='[^ |;&]*(agents|claude|copilot-instructions)\.md'
+    if printf '%s' "$command_str" |
+      grep -Eqi ">>?[[:space:]]*['\"]?$write_target|tee([[:space:]]+-[a-z]+)*[[:space:]]+['\"]?$write_target|sed[[:space:]]+[^|;&]*-i[^|;&]*$write_target"; then
+      refuse "$(printf '%s' "$command_str" |
+        grep -Eoi "$write_target" | head -1)"
+    fi
+    ;;
+esac
+
+exit 0

--- a/plugins/lisa-cursor/hooks/block-instruction-file-edits.sh
+++ b/plugins/lisa-cursor/hooks/block-instruction-file-edits.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# PreToolUse hook: refuse agent writes to the session-instruction files.
+#
+# `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` are the files
+# every agent loads at session start. They are human-authored and curated on
+# purpose — Lisa's own contract says so in two places:
+#   - plugins/src/base/rules/reference/project-learnings.md
+#   - plugins/src/base/skills/lisa-debrief-apply/SKILL.md ("CLAUDE.md is
+#     human-authored ... apply never writes to any of the three")
+#
+# Nothing enforced it, so agents appended their own findings anyway: one fleet
+# repo reached 949 lines of ticket-keyed trap dumps in `AGENTS.md` while its
+# learnings ledger held 22. Every one of those lines is charged to the context
+# of every later session in that project, forever. Prose did not hold; this is
+# the executable control that does.
+#
+# Blocked signatures:
+#   1. Write / Edit / MultiEdit / NotebookEdit whose target basename is one of
+#      the instruction files;
+#   2. Bash output redirection (`>`, `>>`), `tee`, or `sed -i` aimed at one.
+#      Reads (`cat AGENTS.md`, `rg pattern AGENTS.md`) never fire.
+#
+# Exemptions (allowed):
+#   - `LISA_ALLOW_INSTRUCTION_FILE_WRITE` set — the operator's explicit override,
+#     named in the refusal so a human who really wants the edit can take it;
+#   - payloads carrying a `<!-- LISA_` marker: Lisa's own marker-bounded regions
+#     (the agy project-learnings bridge, cross-pollinate's rule section) replace
+#     in place on re-run and cannot grow the file;
+#   - paths under `node_modules/` or `dist/` — vendored copies, not the host's.
+set -euo pipefail
+
+input="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+# The operator's override. Checked before anything else so it is always the
+# cheapest way out of a refusal a human deliberately wants to overrule.
+if [ -n "${LISA_ALLOW_INSTRUCTION_FILE_WRITE:-}" ]; then
+  exit 0
+fi
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+[ -n "$tool_name" ] || exit 0
+
+# Lisa's own bounded bridges write marked regions. A payload carrying a marker
+# is replacing a delimited block, not appending prose, so it cannot be the
+# unbounded growth this guard exists to stop.
+if printf '%s' "$input" | grep -q '<!-- LISA_'; then
+  exit 0
+fi
+
+# Basename match, case-insensitively: `agents.md` and `AGENTS.md` are the same
+# file on the macOS checkouts this fleet runs on.
+is_instruction_file() {
+  local candidate="$1"
+  case "$candidate" in
+    */node_modules/* | node_modules/* | */dist/* | dist/*) return 1 ;;
+  esac
+  local base="${candidate##*/}"
+  case "$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')" in
+    agents.md | claude.md | copilot-instructions.md) return 0 ;;
+  esac
+  return 1
+}
+
+refuse() {
+  local target="$1"
+  cat >&2 <<EOF
+BLOCKED: refusing to write \`$target\`.
+
+WHY: this is a session-instruction file, not a place to record what you just
+learned. Every line in it is loaded into the context of every agent, in every
+future session, in this project, forever. It is human-curated on purpose. An
+agent appending its own findings is how these files grow into hundreds of lines
+of stale, ticket-specific trivia that every later session pays for and half of
+which was only ever true once.
+
+WHERE IT GOES INSTEAD — take the first one that fits:
+
+1. Every agent genuinely needs this in every session, and only in this project.
+   That is a project rule — but do not write it yourself. Capture it with
+   \`/lisa:persist-learning\` so it lands in the learnings ledger with provenance
+   and a confidence score. The gardener (\`/lisa:learnings:audit\`) then proposes
+   promotion into \`.claude/rules/PROJECT_RULES.md\` as a human-gated ticket.
+
+2. It changes how an existing skill should behave. Edit that skill's SKILL.md.
+   Knowledge belongs next to the procedure it modifies, not in a global preamble.
+
+3. It is true beyond this project. Propose it upstream to Lisa via
+   \`/lisa:cross-pollinate\`, or open an issue on CodySwannGT/lisa. A local copy of
+   a general rule silently drifts the moment upstream changes.
+
+4. None of the above — it is background someone may want to look up, not a
+   standing instruction. Write it into the project documentation (\`wiki/\` or
+   \`docs/\`).
+
+If a human explicitly asked for this edit, they can re-run with
+\`LISA_ALLOW_INSTRUCTION_FILE_WRITE=1\` set, which bypasses this guard.
+EOF
+  exit 2
+}
+
+case "$tool_name" in
+  Write | Edit | MultiEdit | NotebookEdit | Update)
+    # `file_path` covers Write/Edit; `edits[].file_path` covers the MultiEdit
+    # shapes that carry a path per edit; `notebook_path` covers NotebookEdit.
+    paths="$(printf '%s' "$input" | jq -r '
+      [ .tool_input.file_path?,
+        .tool_input.path?,
+        .tool_input.notebook_path?,
+        (.tool_input.edits? // [] | .[].file_path?)
+      ] | map(select(. != null and . != "")) | .[]' 2>/dev/null || true)"
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      if is_instruction_file "$candidate"; then
+        refuse "$candidate"
+      fi
+    done <<EOF
+$paths
+EOF
+    ;;
+  Bash)
+    command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+    [ -n "$command_str" ] || exit 0
+    # Fast path: no instruction filename mentioned means nothing to classify.
+    if ! printf '%s' "$command_str" |
+      grep -Eqi '(agents|claude|copilot-instructions)\.md'; then
+      exit 0
+    fi
+    # Write signatures only. A bare mention (`cat AGENTS.md`, `rg x AGENTS.md`)
+    # is a read and must stay allowed — the filename has to appear as the target
+    # of a redirection, a tee, or an in-place sed.
+    write_target='[^ |;&]*(agents|claude|copilot-instructions)\.md'
+    if printf '%s' "$command_str" |
+      grep -Eqi ">>?[[:space:]]*['\"]?$write_target|tee([[:space:]]+-[a-z]+)*[[:space:]]+['\"]?$write_target|sed[[:space:]]+[^|;&]*-i[^|;&]*$write_target"; then
+      refuse "$(printf '%s' "$command_str" |
+        grep -Eoi "$write_target" | head -1)"
+    fi
+    ;;
+esac
+
+exit 0

--- a/plugins/lisa-cursor/hooks/hooks.json
+++ b/plugins/lisa-cursor/hooks/hooks.json
@@ -30,6 +30,14 @@
         "matcher": "Bash"
       },
       {
+        "command": "${CURSOR_PLUGIN_ROOT}/hooks/block-instruction-file-edits.sh",
+        "matcher": "Bash"
+      },
+      {
+        "command": "${CURSOR_PLUGIN_ROOT}/hooks/block-instruction-file-edits.sh",
+        "matcher": "Write|Edit|MultiEdit"
+      },
+      {
         "command": "${CURSOR_PLUGIN_ROOT}/hooks/enforce-verification-gate.sh"
       }
     ],

--- a/plugins/lisa/.claude-plugin/plugin.json
+++ b/plugins/lisa/.claude-plugin/plugin.json
@@ -106,6 +106,19 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-shell-json-parsing.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-instruction-file-edits.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-instruction-file-edits.sh"
           }
         ]
       },

--- a/plugins/lisa/.codex-plugin/hooks.json
+++ b/plugins/lisa/.codex-plugin/hooks.json
@@ -46,6 +46,19 @@
           {
             "type": "command",
             "command": "${PLUGIN_ROOT}/hooks/block-shell-json-parsing.sh"
+          },
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/block-instruction-file-edits.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/block-instruction-file-edits.sh"
           }
         ]
       },

--- a/plugins/lisa/hooks/block-instruction-file-edits.agy.sh
+++ b/plugins/lisa/hooks/block-instruction-file-edits.agy.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Antigravity (agy) PreToolUse adapter for Lisa's instruction-file guard.
+#
+# agy sends `{toolCall:{name:"run_command",args:{CommandLine:"..."}}}` and
+# expects an allow/deny JSON object on stdout. The canonical hook consumes the
+# Claude Bash-hook envelope and communicates denial with exit status 2. This
+# adapter only translates protocols; all classification stays in the canonical
+# block-instruction-file-edits.sh beside it (same delegation pattern as
+# block-shell-json-parsing.agy.sh).
+#
+# Scope note: agy plugin hooks match `run_command`, so only the Bash arm of the
+# guard reaches agy — an agy file-edit tool call writing AGENTS.md cannot be
+# intercepted. That gap is accepted and recorded here rather than papered over.
+#
+# Fail-open on missing runtimes: a missed refusal here costs context bloat in a
+# markdown file, not data loss.
+set -uo pipefail
+
+allow() {
+  printf '%s\n' '{"decision":"allow"}'
+  exit 0
+}
+
+deny() {
+  local reason="$1"
+  if command -v jq >/dev/null 2>&1; then
+    jq -cn --arg reason "$reason" '{decision:"deny",reason:$reason}'
+  else
+    printf '%s\n' '{"decision":"allow"}'
+  fi
+  exit 0
+}
+
+input="$(cat 2>/dev/null || true)"
+[ -z "$input" ] && allow
+command -v jq >/dev/null 2>&1 || allow
+
+tool_name="$(printf '%s' "$input" | jq -r '.toolCall.name // empty' 2>/dev/null || true)"
+[ "$tool_name" != "run_command" ] && allow
+command_str="$(printf '%s' "$input" | jq -r '.toolCall.args.CommandLine // empty' 2>/dev/null || true)"
+[ -z "$command_str" ] && allow
+
+hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+canonical_hook="$hook_dir/block-instruction-file-edits.sh"
+[ -r "$canonical_hook" ] || allow
+
+canonical_input="$(jq -cn --arg command "$command_str" '{tool_name:"Bash",tool_input:{command:$command}}')"
+canonical_output=""
+canonical_status=0
+if canonical_output="$(printf '%s' "$canonical_input" | /bin/bash "$canonical_hook" 2>&1)"; then
+  canonical_status=0
+else
+  canonical_status=$?
+fi
+
+[ "$canonical_status" -eq 0 ] && allow
+[ -n "$canonical_output" ] || canonical_output="Blocked: AGENTS.md / CLAUDE.md are human-authored session-instruction files."
+deny "$canonical_output"

--- a/plugins/lisa/hooks/block-instruction-file-edits.sh
+++ b/plugins/lisa/hooks/block-instruction-file-edits.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# PreToolUse hook: refuse agent writes to the session-instruction files.
+#
+# `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` are the files
+# every agent loads at session start. They are human-authored and curated on
+# purpose — Lisa's own contract says so in two places:
+#   - plugins/src/base/rules/reference/project-learnings.md
+#   - plugins/src/base/skills/lisa-debrief-apply/SKILL.md ("CLAUDE.md is
+#     human-authored ... apply never writes to any of the three")
+#
+# Nothing enforced it, so agents appended their own findings anyway: one fleet
+# repo reached 949 lines of ticket-keyed trap dumps in `AGENTS.md` while its
+# learnings ledger held 22. Every one of those lines is charged to the context
+# of every later session in that project, forever. Prose did not hold; this is
+# the executable control that does.
+#
+# Blocked signatures:
+#   1. Write / Edit / MultiEdit / NotebookEdit whose target basename is one of
+#      the instruction files;
+#   2. Bash output redirection (`>`, `>>`), `tee`, or `sed -i` aimed at one.
+#      Reads (`cat AGENTS.md`, `rg pattern AGENTS.md`) never fire.
+#
+# Exemptions (allowed):
+#   - `LISA_ALLOW_INSTRUCTION_FILE_WRITE` set — the operator's explicit override,
+#     named in the refusal so a human who really wants the edit can take it;
+#   - payloads carrying a `<!-- LISA_` marker: Lisa's own marker-bounded regions
+#     (the agy project-learnings bridge, cross-pollinate's rule section) replace
+#     in place on re-run and cannot grow the file;
+#   - paths under `node_modules/` or `dist/` — vendored copies, not the host's.
+set -euo pipefail
+
+input="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+# The operator's override. Checked before anything else so it is always the
+# cheapest way out of a refusal a human deliberately wants to overrule.
+if [ -n "${LISA_ALLOW_INSTRUCTION_FILE_WRITE:-}" ]; then
+  exit 0
+fi
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+[ -n "$tool_name" ] || exit 0
+
+# Lisa's own bounded bridges write marked regions. A payload carrying a marker
+# is replacing a delimited block, not appending prose, so it cannot be the
+# unbounded growth this guard exists to stop.
+if printf '%s' "$input" | grep -q '<!-- LISA_'; then
+  exit 0
+fi
+
+# Basename match, case-insensitively: `agents.md` and `AGENTS.md` are the same
+# file on the macOS checkouts this fleet runs on.
+is_instruction_file() {
+  local candidate="$1"
+  case "$candidate" in
+    */node_modules/* | node_modules/* | */dist/* | dist/*) return 1 ;;
+  esac
+  local base="${candidate##*/}"
+  case "$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')" in
+    agents.md | claude.md | copilot-instructions.md) return 0 ;;
+  esac
+  return 1
+}
+
+refuse() {
+  local target="$1"
+  cat >&2 <<EOF
+BLOCKED: refusing to write \`$target\`.
+
+WHY: this is a session-instruction file, not a place to record what you just
+learned. Every line in it is loaded into the context of every agent, in every
+future session, in this project, forever. It is human-curated on purpose. An
+agent appending its own findings is how these files grow into hundreds of lines
+of stale, ticket-specific trivia that every later session pays for and half of
+which was only ever true once.
+
+WHERE IT GOES INSTEAD — take the first one that fits:
+
+1. Every agent genuinely needs this in every session, and only in this project.
+   That is a project rule — but do not write it yourself. Capture it with
+   \`/lisa:persist-learning\` so it lands in the learnings ledger with provenance
+   and a confidence score. The gardener (\`/lisa:learnings:audit\`) then proposes
+   promotion into \`.claude/rules/PROJECT_RULES.md\` as a human-gated ticket.
+
+2. It changes how an existing skill should behave. Edit that skill's SKILL.md.
+   Knowledge belongs next to the procedure it modifies, not in a global preamble.
+
+3. It is true beyond this project. Propose it upstream to Lisa via
+   \`/lisa:cross-pollinate\`, or open an issue on CodySwannGT/lisa. A local copy of
+   a general rule silently drifts the moment upstream changes.
+
+4. None of the above — it is background someone may want to look up, not a
+   standing instruction. Write it into the project documentation (\`wiki/\` or
+   \`docs/\`).
+
+If a human explicitly asked for this edit, they can re-run with
+\`LISA_ALLOW_INSTRUCTION_FILE_WRITE=1\` set, which bypasses this guard.
+EOF
+  exit 2
+}
+
+case "$tool_name" in
+  Write | Edit | MultiEdit | NotebookEdit | Update)
+    # `file_path` covers Write/Edit; `edits[].file_path` covers the MultiEdit
+    # shapes that carry a path per edit; `notebook_path` covers NotebookEdit.
+    paths="$(printf '%s' "$input" | jq -r '
+      [ .tool_input.file_path?,
+        .tool_input.path?,
+        .tool_input.notebook_path?,
+        (.tool_input.edits? // [] | .[].file_path?)
+      ] | map(select(. != null and . != "")) | .[]' 2>/dev/null || true)"
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      if is_instruction_file "$candidate"; then
+        refuse "$candidate"
+      fi
+    done <<EOF
+$paths
+EOF
+    ;;
+  Bash)
+    command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+    [ -n "$command_str" ] || exit 0
+    # Fast path: no instruction filename mentioned means nothing to classify.
+    if ! printf '%s' "$command_str" |
+      grep -Eqi '(agents|claude|copilot-instructions)\.md'; then
+      exit 0
+    fi
+    # Write signatures only. A bare mention (`cat AGENTS.md`, `rg x AGENTS.md`)
+    # is a read and must stay allowed — the filename has to appear as the target
+    # of a redirection, a tee, or an in-place sed.
+    write_target='[^ |;&]*(agents|claude|copilot-instructions)\.md'
+    if printf '%s' "$command_str" |
+      grep -Eqi ">>?[[:space:]]*['\"]?$write_target|tee([[:space:]]+-[a-z]+)*[[:space:]]+['\"]?$write_target|sed[[:space:]]+[^|;&]*-i[^|;&]*$write_target"; then
+      refuse "$(printf '%s' "$command_str" |
+        grep -Eoi "$write_target" | head -1)"
+    fi
+    ;;
+esac
+
+exit 0

--- a/plugins/src/base/.claude-plugin/plugin.json
+++ b/plugins/src/base/.claude-plugin/plugin.json
@@ -106,6 +106,19 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-shell-json-parsing.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-instruction-file-edits.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-instruction-file-edits.sh"
           }
         ]
       },

--- a/plugins/src/base/hooks/block-instruction-file-edits.agy.sh
+++ b/plugins/src/base/hooks/block-instruction-file-edits.agy.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Antigravity (agy) PreToolUse adapter for Lisa's instruction-file guard.
+#
+# agy sends `{toolCall:{name:"run_command",args:{CommandLine:"..."}}}` and
+# expects an allow/deny JSON object on stdout. The canonical hook consumes the
+# Claude Bash-hook envelope and communicates denial with exit status 2. This
+# adapter only translates protocols; all classification stays in the canonical
+# block-instruction-file-edits.sh beside it (same delegation pattern as
+# block-shell-json-parsing.agy.sh).
+#
+# Scope note: agy plugin hooks match `run_command`, so only the Bash arm of the
+# guard reaches agy — an agy file-edit tool call writing AGENTS.md cannot be
+# intercepted. That gap is accepted and recorded here rather than papered over.
+#
+# Fail-open on missing runtimes: a missed refusal here costs context bloat in a
+# markdown file, not data loss.
+set -uo pipefail
+
+allow() {
+  printf '%s\n' '{"decision":"allow"}'
+  exit 0
+}
+
+deny() {
+  local reason="$1"
+  if command -v jq >/dev/null 2>&1; then
+    jq -cn --arg reason "$reason" '{decision:"deny",reason:$reason}'
+  else
+    printf '%s\n' '{"decision":"allow"}'
+  fi
+  exit 0
+}
+
+input="$(cat 2>/dev/null || true)"
+[ -z "$input" ] && allow
+command -v jq >/dev/null 2>&1 || allow
+
+tool_name="$(printf '%s' "$input" | jq -r '.toolCall.name // empty' 2>/dev/null || true)"
+[ "$tool_name" != "run_command" ] && allow
+command_str="$(printf '%s' "$input" | jq -r '.toolCall.args.CommandLine // empty' 2>/dev/null || true)"
+[ -z "$command_str" ] && allow
+
+hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+canonical_hook="$hook_dir/block-instruction-file-edits.sh"
+[ -r "$canonical_hook" ] || allow
+
+canonical_input="$(jq -cn --arg command "$command_str" '{tool_name:"Bash",tool_input:{command:$command}}')"
+canonical_output=""
+canonical_status=0
+if canonical_output="$(printf '%s' "$canonical_input" | /bin/bash "$canonical_hook" 2>&1)"; then
+  canonical_status=0
+else
+  canonical_status=$?
+fi
+
+[ "$canonical_status" -eq 0 ] && allow
+[ -n "$canonical_output" ] || canonical_output="Blocked: AGENTS.md / CLAUDE.md are human-authored session-instruction files."
+deny "$canonical_output"

--- a/plugins/src/base/hooks/block-instruction-file-edits.sh
+++ b/plugins/src/base/hooks/block-instruction-file-edits.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# PreToolUse hook: refuse agent writes to the session-instruction files.
+#
+# `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` are the files
+# every agent loads at session start. They are human-authored and curated on
+# purpose — Lisa's own contract says so in two places:
+#   - plugins/src/base/rules/reference/project-learnings.md
+#   - plugins/src/base/skills/lisa-debrief-apply/SKILL.md ("CLAUDE.md is
+#     human-authored ... apply never writes to any of the three")
+#
+# Nothing enforced it, so agents appended their own findings anyway: one fleet
+# repo reached 949 lines of ticket-keyed trap dumps in `AGENTS.md` while its
+# learnings ledger held 22. Every one of those lines is charged to the context
+# of every later session in that project, forever. Prose did not hold; this is
+# the executable control that does.
+#
+# Blocked signatures:
+#   1. Write / Edit / MultiEdit / NotebookEdit whose target basename is one of
+#      the instruction files;
+#   2. Bash output redirection (`>`, `>>`), `tee`, or `sed -i` aimed at one.
+#      Reads (`cat AGENTS.md`, `rg pattern AGENTS.md`) never fire.
+#
+# Exemptions (allowed):
+#   - `LISA_ALLOW_INSTRUCTION_FILE_WRITE` set — the operator's explicit override,
+#     named in the refusal so a human who really wants the edit can take it;
+#   - payloads carrying a `<!-- LISA_` marker: Lisa's own marker-bounded regions
+#     (the agy project-learnings bridge, cross-pollinate's rule section) replace
+#     in place on re-run and cannot grow the file;
+#   - paths under `node_modules/` or `dist/` — vendored copies, not the host's.
+set -euo pipefail
+
+input="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+# The operator's override. Checked before anything else so it is always the
+# cheapest way out of a refusal a human deliberately wants to overrule.
+if [ -n "${LISA_ALLOW_INSTRUCTION_FILE_WRITE:-}" ]; then
+  exit 0
+fi
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+[ -n "$tool_name" ] || exit 0
+
+# Lisa's own bounded bridges write marked regions. A payload carrying a marker
+# is replacing a delimited block, not appending prose, so it cannot be the
+# unbounded growth this guard exists to stop.
+if printf '%s' "$input" | grep -q '<!-- LISA_'; then
+  exit 0
+fi
+
+# Basename match, case-insensitively: `agents.md` and `AGENTS.md` are the same
+# file on the macOS checkouts this fleet runs on.
+is_instruction_file() {
+  local candidate="$1"
+  case "$candidate" in
+    */node_modules/* | node_modules/* | */dist/* | dist/*) return 1 ;;
+  esac
+  local base="${candidate##*/}"
+  case "$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')" in
+    agents.md | claude.md | copilot-instructions.md) return 0 ;;
+  esac
+  return 1
+}
+
+refuse() {
+  local target="$1"
+  cat >&2 <<EOF
+BLOCKED: refusing to write \`$target\`.
+
+WHY: this is a session-instruction file, not a place to record what you just
+learned. Every line in it is loaded into the context of every agent, in every
+future session, in this project, forever. It is human-curated on purpose. An
+agent appending its own findings is how these files grow into hundreds of lines
+of stale, ticket-specific trivia that every later session pays for and half of
+which was only ever true once.
+
+WHERE IT GOES INSTEAD — take the first one that fits:
+
+1. Every agent genuinely needs this in every session, and only in this project.
+   That is a project rule — but do not write it yourself. Capture it with
+   \`/lisa:persist-learning\` so it lands in the learnings ledger with provenance
+   and a confidence score. The gardener (\`/lisa:learnings:audit\`) then proposes
+   promotion into \`.claude/rules/PROJECT_RULES.md\` as a human-gated ticket.
+
+2. It changes how an existing skill should behave. Edit that skill's SKILL.md.
+   Knowledge belongs next to the procedure it modifies, not in a global preamble.
+
+3. It is true beyond this project. Propose it upstream to Lisa via
+   \`/lisa:cross-pollinate\`, or open an issue on CodySwannGT/lisa. A local copy of
+   a general rule silently drifts the moment upstream changes.
+
+4. None of the above — it is background someone may want to look up, not a
+   standing instruction. Write it into the project documentation (\`wiki/\` or
+   \`docs/\`).
+
+If a human explicitly asked for this edit, they can re-run with
+\`LISA_ALLOW_INSTRUCTION_FILE_WRITE=1\` set, which bypasses this guard.
+EOF
+  exit 2
+}
+
+case "$tool_name" in
+  Write | Edit | MultiEdit | NotebookEdit | Update)
+    # `file_path` covers Write/Edit; `edits[].file_path` covers the MultiEdit
+    # shapes that carry a path per edit; `notebook_path` covers NotebookEdit.
+    paths="$(printf '%s' "$input" | jq -r '
+      [ .tool_input.file_path?,
+        .tool_input.path?,
+        .tool_input.notebook_path?,
+        (.tool_input.edits? // [] | .[].file_path?)
+      ] | map(select(. != null and . != "")) | .[]' 2>/dev/null || true)"
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      if is_instruction_file "$candidate"; then
+        refuse "$candidate"
+      fi
+    done <<EOF
+$paths
+EOF
+    ;;
+  Bash)
+    command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+    [ -n "$command_str" ] || exit 0
+    # Fast path: no instruction filename mentioned means nothing to classify.
+    if ! printf '%s' "$command_str" |
+      grep -Eqi '(agents|claude|copilot-instructions)\.md'; then
+      exit 0
+    fi
+    # Write signatures only. A bare mention (`cat AGENTS.md`, `rg x AGENTS.md`)
+    # is a read and must stay allowed — the filename has to appear as the target
+    # of a redirection, a tee, or an in-place sed.
+    write_target='[^ |;&]*(agents|claude|copilot-instructions)\.md'
+    if printf '%s' "$command_str" |
+      grep -Eqi ">>?[[:space:]]*['\"]?$write_target|tee([[:space:]]+-[a-z]+)*[[:space:]]+['\"]?$write_target|sed[[:space:]]+[^|;&]*-i[^|;&]*$write_target"; then
+      refuse "$(printf '%s' "$command_str" |
+        grep -Eoi "$write_target" | head -1)"
+    fi
+    ;;
+esac
+
+exit 0

--- a/scripts/build-plugins.sh
+++ b/scripts/build-plugins.sh
@@ -105,7 +105,8 @@ HOST_GUARD_DIR="$ROOT_DIR/all/copy-overwrite/scripts/lisa-hooks"
 if [ -d "$SRC_DIR/base/hooks" ]; then
   mkdir -p "$HOST_GUARD_DIR"
 fi
-for guard in block-no-verify parity-safety-net block-shell-json-parsing; do
+for guard in block-no-verify parity-safety-net block-shell-json-parsing \
+  block-instruction-file-edits; do
   if [ -f "$SRC_DIR/base/hooks/$guard.sh" ]; then
     cp "$SRC_DIR/base/hooks/$guard.sh" "$HOST_GUARD_DIR/$guard.sh"
     chmod +x "$HOST_GUARD_DIR/$guard.sh"

--- a/scripts/generate-agy-plugin-artifacts.mjs
+++ b/scripts/generate-agy-plugin-artifacts.mjs
@@ -234,6 +234,17 @@ const AGY_PLUGIN_HOOKS = [
     agyScript: "block-shell-json-parsing.agy.sh",
     supportScripts: ["block-shell-json-parsing.sh"],
   },
+  {
+    // Bash arm only. agy matches `run_command`, so its file-edit tool calls
+    // cannot be intercepted the way Claude's Write/Edit/MultiEdit are; the
+    // redirection / tee / sed -i signatures are what agy gets.
+    sourceScript: "block-instruction-file-edits.sh",
+    hookName: "lisa-block-instruction-file-edits",
+    event: "PreToolUse",
+    matcher: "run_command",
+    agyScript: "block-instruction-file-edits.agy.sh",
+    supportScripts: ["block-instruction-file-edits.sh"],
+  },
 ];
 
 /**

--- a/scripts/lib/per-agent-hook-filter.mjs
+++ b/scripts/lib/per-agent-hook-filter.mjs
@@ -50,6 +50,16 @@ const SCRIPT_RULES = {
     agy: true, // ships via AGY_PLUGIN_HOOKS (agy-protocol adapter), like the other PreToolUse guards
     copilot: true,
   },
+  "block-instruction-file-edits.sh": {
+    claude: true,
+    codex: true,
+    cursor: true,
+    // agy receives only the Bash arm: agy's plugin hooks match `run_command`,
+    // so its file-edit tool calls cannot be intercepted. Documented gap — the
+    // redirection/tee/sed-i signatures still hold there.
+    agy: true,
+    copilot: true,
+  },
   "enforce-team-first.sh": {
     claude: true,
     codex: false,

--- a/scripts/lisa-enforcement-fallback.sh
+++ b/scripts/lisa-enforcement-fallback.sh
@@ -4,7 +4,8 @@
 # is not installed.
 #
 # Every PreToolUse guard — block-no-verify, parity-safety-net,
-# block-shell-json-parsing — is declared in the Lisa plugin. A cloud session
+# block-shell-json-parsing, block-instruction-file-edits — is declared in the
+# Lisa plugin. A cloud session
 # installs plugins at session start from the marketplace the repository
 # declares, and when that does not happen the container runs with
 # `installed_plugins.json` empty and no enforcement whatsoever.
@@ -41,7 +42,8 @@ fi
 # host project whose plugin install fails has exactly the same hole and no
 # `plugins/` directory to fall back on.
 status=0
-for guard in block-no-verify parity-safety-net block-shell-json-parsing; do
+for guard in block-no-verify parity-safety-net block-shell-json-parsing \
+  block-instruction-file-edits; do
   script=""
   for candidate in \
     "$repo_root/scripts/lisa-hooks/$guard.sh" \

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7,9 +7,11 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-contents/gitignore":
       "2dbf7fd2f2020fc7824c432342002d9ca3ebb57b2872e761b14e942b23479a11",
     "all/copy-overwrite/scripts/lisa-enforcement-fallback.sh":
-      "9cab71562d01421d57c6719318a4d03a6249a45c1aea434db3ff26e3065eeb66",
+      "e17c45f7cadf0fb55dd07270776caf211af99b7d4771a4fde75aafe5919e8dbe",
     "all/copy-overwrite/scripts/lisa-floor-collisions.mjs":
       "a612f172282d13ba9318fe5e03689d7c6ff42a0122d0c9d5d39051e1967b93dc",
+    "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
+      "8996e0bcbf1db085a5d99734e797c91f5025997bd967bc374efff8348dac14c2",
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh":
       "aa95a84f9f9224914947a09b858535aa8bd052199ff64cb53768cf78fb69b687",
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh":
@@ -35,7 +37,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/github-rulesets/protect-tags.json":
       "387f824e3ea58a803223e42e08326504a39e6a7a0c650a0bbfdfb4653854b722",
     "all/merge/.claude/settings.json":
-      "4d41a745030e5f33eb4d4fe1f1b12268680f104ea55a30c4d9f55a6e22ad6fca",
+      "c3ea6760913c0104350f731646fc5abd22122ce0a303c95536e7769f12294654",
     "cdk/copy-overwrite/.github/workflows/.keep":
       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "cdk/copy-overwrite/eslint.cdk.ts":
@@ -584,6 +586,10 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "ffbc553ec86e77845da72b5b0eb0dbb2b5a93b781ac8a7dbb2ef0f31f38f7b96",
     "plugins/src/base/commands/wiki/install.md":
       "51392cf053c17edd549bfbaba5d19ce669dc79021aafa7cfa100324ad38de11f",
+    "plugins/src/base/hooks/block-instruction-file-edits.agy.sh":
+      "aa249cae53caeb3e0fb6d6af114e2756084f45a2896332fb063a9f20e4902125",
+    "plugins/src/base/hooks/block-instruction-file-edits.sh":
+      "8996e0bcbf1db085a5d99734e797c91f5025997bd967bc374efff8348dac14c2",
     "plugins/src/base/hooks/block-no-verify.agy.sh":
       "1a36c841b6339a2c664938d65c5a4542f97d05f584e467de448bb72ac6bdba55",
     "plugins/src/base/hooks/block-no-verify.sh":
@@ -1921,7 +1927,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/merge/.claude/settings.json":
       "9c49f8c7c453f8749c90def3e22d412c3345c533d24b30dc7745ffa052ad6fa1",
     "scripts/build-plugins.sh":
-      "b57413e6e003be102e82e0a8a6b44a137f5d0aeed8da4c1f4f99919a0d7e8b04",
+      "d4332a862d57798280e0d0c96826bbdc6b07855659dae529f8de32de994d2da9",
     "scripts/check-duplicate-versions.mjs":
       "84d97e94eb834522848ddce951bb54ae9da1e4be252e2c51fed0c01c4f4d6b72",
     "scripts/check-learnings-budget.ts":
@@ -1957,7 +1963,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/fix-test-assertions.mjs":
       "59b5e8cc31e7c7323d20bd180f2ae97c08a9685758483b6fe00ba77317a845f2",
     "scripts/generate-agy-plugin-artifacts.mjs":
-      "bcecec726f2590036c57247d41eadf361b8613d827d93366e18b419bbd801346",
+      "0d9380e0533b2cd24ab418da64817a06672f0d12c9a7f648a3d57286d35c7983",
     "scripts/generate-codex-plugin-artifacts.mjs":
       "1d1a362afb8dba408741a3eed9fe583296f6bcb048608979f73f359cd609c03d",
     "scripts/generate-copilot-plugin-artifacts.mjs":
@@ -1985,7 +1991,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/lib/nest-plugin-commands.mjs":
       "c52b2f48edbc17edcc60ae33536549829cbc279c60c5d85d912ac6609cae9bea",
     "scripts/lib/per-agent-hook-filter.mjs":
-      "2565e2cb414f253fa7fd014021120ec9760f4e716bf0ae69e5f7de09a5b966c1",
+      "6038a4ebee750672042ba706269b8a4c1d9055cfd83c436364e2e40d6242dcd9",
     "scripts/lib/reusable-workflow-contract.d.mts":
       "791f01b55dd7a6b5d9a5f4cb9c44167caa146c2fc3c31a2ae4c2d8a350adc2f1",
     "scripts/lib/reusable-workflow-contract.mjs":
@@ -1993,7 +1999,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/lisa-commit-and-pr-local.sh":
       "605409c3ce6ec38ad3275604291a1ceae98f7807a605654263bc14f811c03903",
     "scripts/lisa-enforcement-fallback.sh":
-      "9cab71562d01421d57c6719318a4d03a6249a45c1aea434db3ff26e3065eeb66",
+      "e17c45f7cadf0fb55dd07270776caf211af99b7d4771a4fde75aafe5919e8dbe",
     "scripts/lisa-github-environments.sh":
       "0a76e92f108519abaf3e29991299ec3b0db20ea533e69e6d2a53d802dba9c370",
     "scripts/lisa-github-repo-settings.sh":
@@ -2337,6 +2343,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "all/copy-contents/gitignore": true,
     "all/copy-overwrite/scripts/lisa-enforcement-fallback.sh": true,
     "all/copy-overwrite/scripts/lisa-floor-collisions.mjs": true,
+    "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh": true,
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh": true,
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh": true,
     "all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh": true,
@@ -3112,6 +3119,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-agy/commands/lisa/verify.md": true,
     "plugins/lisa-agy/commands/lisa/wiki/install.md": true,
     "plugins/lisa-agy/hooks.json": true,
+    "plugins/lisa-agy/hooks/block-instruction-file-edits.agy.sh": true,
+    "plugins/lisa-agy/hooks/block-instruction-file-edits.sh": true,
     "plugins/lisa-agy/hooks/block-no-verify.agy.sh": true,
     "plugins/lisa-agy/hooks/block-shell-json-parsing.agy.sh": true,
     "plugins/lisa-agy/hooks/block-shell-json-parsing.sh": true,
@@ -3450,6 +3459,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/commands/lisa/verify-workflow-change.md": true,
     "plugins/lisa-copilot/commands/lisa/verify.md": true,
     "plugins/lisa-copilot/commands/lisa/wiki/install.md": true,
+    "plugins/lisa-copilot/hooks/block-instruction-file-edits.sh": true,
     "plugins/lisa-copilot/hooks/block-no-verify.sh": true,
     "plugins/lisa-copilot/hooks/block-shell-json-parsing.sh": true,
     "plugins/lisa-copilot/hooks/cleanup-stale-worktrees.sh": true,
@@ -3856,6 +3866,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/commands/lisa/verify-workflow-change.md": true,
     "plugins/lisa-cursor/commands/lisa/verify.md": true,
     "plugins/lisa-cursor/commands/lisa/wiki/install.md": true,
+    "plugins/lisa-cursor/hooks/block-instruction-file-edits.sh": true,
     "plugins/lisa-cursor/hooks/block-no-verify.sh": true,
     "plugins/lisa-cursor/hooks/block-shell-json-parsing.sh": true,
     "plugins/lisa-cursor/hooks/cleanup-stale-worktrees.sh": true,
@@ -6333,6 +6344,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/commands/verify-workflow-change.md": true,
     "plugins/lisa/commands/verify.md": true,
     "plugins/lisa/commands/wiki/install.md": true,
+    "plugins/lisa/hooks/block-instruction-file-edits.agy.sh": true,
+    "plugins/lisa/hooks/block-instruction-file-edits.sh": true,
     "plugins/lisa/hooks/block-no-verify.agy.sh": true,
     "plugins/lisa/hooks/block-no-verify.sh": true,
     "plugins/lisa/hooks/block-shell-json-parsing.agy.sh": true,
@@ -6918,6 +6931,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/commands/verify-workflow-change.md": true,
     "plugins/src/base/commands/verify.md": true,
     "plugins/src/base/commands/wiki/install.md": true,
+    "plugins/src/base/hooks/block-instruction-file-edits.agy.sh": true,
+    "plugins/src/base/hooks/block-instruction-file-edits.sh": true,
     "plugins/src/base/hooks/block-no-verify.agy.sh": true,
     "plugins/src/base/hooks/block-no-verify.sh": true,
     "plugins/src/base/hooks/block-shell-json-parsing.agy.sh": true,
@@ -7961,6 +7976,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/opencode/hooks-installer.ts": true,
     "src/opencode/manifest.ts": true,
     "src/opencode/mcp-installer.ts": true,
+    "src/opencode/plugin-catalog.ts": true,
+    "src/opencode/plugin-templates/lisa-block-instruction-file-edits.ts": true,
     "src/opencode/plugin-templates/lisa-block-migration-edits.ts": true,
     "src/opencode/plugin-templates/lisa-block-suppress-directives.ts": true,
     "src/opencode/plugin-templates/lisa-lint-on-edit.ts": true,
@@ -8315,6 +8332,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/health/package-surfaces.test.ts": true,
     "tests/unit/health/storage.test.ts": true,
     "tests/unit/hooks/block-generated-artifact-edits.test.ts": true,
+    "tests/unit/hooks/block-instruction-file-edits.test.ts": true,
     "tests/unit/hooks/block-no-verify.test.ts": true,
     "tests/unit/hooks/block-shell-json-parsing.test.ts": true,
     "tests/unit/hooks/blocking-hook-exit.test.ts": true,

--- a/src/opencode/hooks-installer.ts
+++ b/src/opencode/hooks-installer.ts
@@ -38,6 +38,7 @@ import {
   type ParseError,
 } from "jsonc-parser";
 import type { ProjectType } from "../core/config.js";
+import { PLUGIN_CATALOG, type PluginCatalogEntry } from "./plugin-catalog.js";
 import { mirrorLisaRules } from "../core/lisa-rules-mirror.js";
 import { OPENCODE_CONFIG_DIR } from "./manifest.js";
 import { OPENCODE_SCHEMA_URL } from "./settings-installer.js";
@@ -70,58 +71,6 @@ const NO_VERIFY_DENY_PATTERNS: Readonly<Record<string, "deny">> = {
   "*HUSKY_SKIP_HOOKS=*": "deny",
   "*core.hooksPath*/dev/null*": "deny",
 };
-
-/** One Lisa-shipped OpenCode plugin template. */
-interface PluginCatalogEntry {
-  /** Stable identifier (also the basename without the `lisa-`/`.ts`) */
-  readonly id: string;
-  /** Template filename in `plugin-templates/` and the dest filename verbatim */
-  readonly templateFilename: string;
-  /** Project types this plugin ships for. `["*"]` ships for every stack. */
-  readonly forProjectTypes: readonly (ProjectType | "*")[];
-}
-
-/**
- * Plugin catalog — the OpenCode counterpart of the Codex HOOK_CATALOG. Adding a
- * plugin? Drop a template in `plugin-templates/`, add an entry here, add tests.
- */
-const PLUGIN_CATALOG: readonly PluginCatalogEntry[] = [
-  {
-    id: "parity-safety-net",
-    templateFilename: "lisa-parity-safety-net.ts",
-    forProjectTypes: ["*"],
-  },
-  {
-    id: "session-bootstrap",
-    templateFilename: "lisa-session-bootstrap.ts",
-    forProjectTypes: ["*"],
-  },
-  {
-    id: "block-suppress-directives",
-    templateFilename: "lisa-block-suppress-directives.ts",
-    forProjectTypes: ["typescript"],
-  },
-  {
-    id: "lint-on-edit",
-    templateFilename: "lisa-lint-on-edit.ts",
-    forProjectTypes: ["typescript"],
-  },
-  {
-    id: "sg-scan-on-edit",
-    templateFilename: "lisa-sg-scan-on-edit.ts",
-    forProjectTypes: ["typescript", "rails"],
-  },
-  {
-    id: "block-migration-edits",
-    templateFilename: "lisa-block-migration-edits.ts",
-    forProjectTypes: ["nestjs"],
-  },
-  {
-    id: "rubocop-on-edit",
-    templateFilename: "lisa-rubocop-on-edit.ts",
-    forProjectTypes: ["rails"],
-  },
-];
 
 /** Canonical policy files used by universal OpenCode adapters. */
 const PLUGIN_SUPPORT_FILES = [

--- a/src/opencode/plugin-catalog.ts
+++ b/src/opencode/plugin-catalog.ts
@@ -1,0 +1,67 @@
+/**
+ * The OpenCode plugin catalog — which Lisa-shipped `.opencode/plugin/lisa-*.ts`
+ * templates ship, and for which project types.
+ *
+ * Extracted from `hooks-installer.ts` so the closed registry stays one
+ * auditable list that can grow without pushing the installer past its
+ * line budget. The installer consumes it; nothing else should.
+ * @module opencode/plugin-catalog
+ */
+import type { ProjectType } from "../core/config.js";
+
+/** One Lisa-shipped OpenCode plugin template. */
+export interface PluginCatalogEntry {
+  /** Stable identifier (also the basename without the `lisa-`/`.ts`) */
+  readonly id: string;
+  /** Template filename in `plugin-templates/` and the dest filename verbatim */
+  readonly templateFilename: string;
+  /** Project types this plugin ships for. `["*"]` ships for every stack. */
+  readonly forProjectTypes: readonly (ProjectType | "*")[];
+}
+
+/**
+ * Plugin catalog — the OpenCode counterpart of the Codex HOOK_CATALOG. Adding a
+ * plugin? Drop a template in `plugin-templates/`, add an entry here, add tests.
+ */
+export const PLUGIN_CATALOG: readonly PluginCatalogEntry[] = [
+  {
+    id: "parity-safety-net",
+    templateFilename: "lisa-parity-safety-net.ts",
+    forProjectTypes: ["*"],
+  },
+  {
+    id: "session-bootstrap",
+    templateFilename: "lisa-session-bootstrap.ts",
+    forProjectTypes: ["*"],
+  },
+  {
+    id: "block-instruction-file-edits",
+    templateFilename: "lisa-block-instruction-file-edits.ts",
+    forProjectTypes: ["*"],
+  },
+  {
+    id: "block-suppress-directives",
+    templateFilename: "lisa-block-suppress-directives.ts",
+    forProjectTypes: ["typescript"],
+  },
+  {
+    id: "lint-on-edit",
+    templateFilename: "lisa-lint-on-edit.ts",
+    forProjectTypes: ["typescript"],
+  },
+  {
+    id: "sg-scan-on-edit",
+    templateFilename: "lisa-sg-scan-on-edit.ts",
+    forProjectTypes: ["typescript", "rails"],
+  },
+  {
+    id: "block-migration-edits",
+    templateFilename: "lisa-block-migration-edits.ts",
+    forProjectTypes: ["nestjs"],
+  },
+  {
+    id: "rubocop-on-edit",
+    templateFilename: "lisa-rubocop-on-edit.ts",
+    forProjectTypes: ["rails"],
+  },
+];

--- a/src/opencode/plugin-templates/lisa-block-instruction-file-edits.ts
+++ b/src/opencode/plugin-templates/lisa-block-instruction-file-edits.ts
@@ -1,0 +1,72 @@
+/**
+ * Lisa-managed OpenCode plugin (tool.execute.before).
+ *
+ * Blocks agent writes to the session-instruction files (`AGENTS.md`,
+ * `CLAUDE.md`, `.github/copilot-instructions.md`). These are human-authored and
+ * curated: every line is loaded into every agent's context in every future
+ * session for the project. Agents appending their own findings is how they grow
+ * into hundreds of lines of stale, ticket-specific trivia.
+ *
+ * Port of Lisa's canonical hook `block-instruction-file-edits.sh`. OpenCode
+ * exposes only `edit` / `write` filesystem tools (no `apply_patch`), so the file
+ * path comes straight from `output.args.filePath`. Throwing in
+ * `tool.execute.before` cancels the tool call and surfaces the message to the
+ * agent.
+ *
+ * NOTE: This file is a template Lisa copies verbatim into a host project's
+ * `.opencode/plugin/`. It is intentionally excluded from this repo's tsconfig
+ * and eslint config — it runs under OpenCode's Bun runtime, not here.
+ */
+export /**
+ *
+ */
+const LisaBlockInstructionFileEdits = async () => {
+  const INSTRUCTION_FILES = new Set([
+    "agents.md",
+    "claude.md",
+    "copilot-instructions.md",
+  ]);
+  return {
+    "tool.execute.before": async (
+      input: { tool: string },
+      output: { args?: { filePath?: string; content?: string } }
+    ) => {
+      if (input.tool !== "edit" && input.tool !== "write") return;
+      const filePath = String(output.args?.filePath ?? "");
+      if (!filePath) return;
+      if (/(^|\/)(node_modules|dist)\//.test(filePath)) return;
+      // The operator's explicit override, named in the refusal below.
+      if (process.env["LISA_ALLOW_INSTRUCTION_FILE_WRITE"]) return;
+      // Lisa's own marker-bounded regions replace in place and cannot grow the
+      // file, so they are never the unbounded append this guard exists to stop.
+      if (String(output.args?.content ?? "").includes("<!-- LISA_")) return;
+      const base = (filePath.split("/").pop() ?? "").toLowerCase();
+      if (!INSTRUCTION_FILES.has(base)) return;
+      throw new Error(
+        [
+          `block-instruction-file-edits: refusing to write ${filePath}.`,
+          "",
+          "WHY: this is a session-instruction file, not a place to record what",
+          "you just learned. Every line in it loads into the context of every",
+          "agent, in every future session, in this project, forever. It is",
+          "human-curated on purpose.",
+          "",
+          "WHERE IT GOES INSTEAD — take the first one that fits:",
+          "",
+          "1. Every agent needs it every session, only in this project? That is a",
+          "   project rule — capture it with /lisa:persist-learning so it lands in",
+          "   the learnings ledger. The gardener (/lisa:learnings:audit) proposes",
+          "   promotion into .claude/rules/PROJECT_RULES.md as a human-gated ticket.",
+          "2. It changes how an existing skill behaves? Edit that skill's SKILL.md.",
+          "3. It is true beyond this project? Propose it upstream via",
+          "   /lisa:cross-pollinate, or open an issue on CodySwannGT/lisa.",
+          "4. Otherwise it is background, not a standing instruction — write it",
+          "   into the project documentation (wiki/ or docs/).",
+          "",
+          "If a human explicitly asked for this edit, re-run with",
+          "LISA_ALLOW_INSTRUCTION_FILE_WRITE=1 set.",
+        ].join("\n")
+      );
+    },
+  };
+};

--- a/tests/unit/hooks/block-instruction-file-edits.test.ts
+++ b/tests/unit/hooks/block-instruction-file-edits.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for block-instruction-file-edits.sh — the PreToolUse guard that refuses
+ * agent writes to the session-instruction files (AGENTS.md, CLAUDE.md,
+ * .github/copilot-instructions.md).
+ *
+ * The guard exists because Lisa's prose contract ("CLAUDE.md is human-authored
+ * ... apply never writes to any of the three") did not hold: fleet repos
+ * accumulated hundreds of lines of agent-appended trap dumps. These tests pin
+ * both arms — the edit tools and the Bash write signatures — and, just as
+ * importantly, pin the reads and the marker-bounded Lisa writes that must
+ * still pass.
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = path.resolve(
+  "plugins/src/base/hooks/block-instruction-file-edits.sh"
+);
+const BASH_PATH = "/bin/bash";
+
+const EXIT_BLOCKED = 2;
+const EXIT_ALLOWED = 0;
+
+const runHook = (
+  payload: unknown,
+  env: Readonly<Record<string, string>> = {}
+): { status: number | null; stderr: string } => {
+  const result = spawnSync(BASH_PATH, [SCRIPT_PATH], {
+    env: { ...process.env, LISA_ALLOW_INSTRUCTION_FILE_WRITE: "", ...env },
+    input: JSON.stringify(payload),
+    encoding: "utf-8",
+  });
+  return { status: result.status, stderr: result.stderr };
+};
+
+const edit = (toolName: string, filePath: string, newString = "some text") => ({
+  tool_name: toolName,
+  tool_input: { file_path: filePath, new_string: newString },
+});
+
+const bash = (command: string) => ({
+  tool_name: "Bash",
+  tool_input: { command },
+});
+
+describe("block-instruction-file-edits.sh", () => {
+  describe("edit tools", () => {
+    it.each([
+      ["Edit", "AGENTS.md"],
+      ["Write", "CLAUDE.md"],
+      ["MultiEdit", "/repo/projects/frontend/AGENTS.md"],
+      ["Write", ".github/copilot-instructions.md"],
+    ])("blocks %s on %s", (tool, file) => {
+      const { status } = runHook(edit(tool, file));
+
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("blocks a lowercase agents.md (case-insensitive basename match)", () => {
+      const { status } = runHook(edit("Edit", "agents.md"));
+
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it("allows edits to any other markdown file", () => {
+      const { status } = runHook(edit("Edit", "wiki/architecture/overview.md"));
+
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows edits to a vendored copy under node_modules", () => {
+      const { status } = runHook(
+        edit("Edit", "node_modules/@codyswann/lisa/AGENTS.md")
+      );
+
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("blocks when a MultiEdit carries the path per edit", () => {
+      const { status } = runHook({
+        tool_name: "MultiEdit",
+        tool_input: {
+          edits: [{ file_path: "AGENTS.md", new_string: "trap notes" }],
+        },
+      });
+
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+  });
+
+  describe("bash write signatures", () => {
+    it.each([
+      ["append redirection", "echo 'trap' >> AGENTS.md"],
+      ["truncating redirection", "printf '%s' x > CLAUDE.md"],
+      ["heredoc into the file", "cat > AGENTS.md <<'EOF'\nnotes\nEOF"],
+      ["tee append", "echo note | tee -a projects/frontend/AGENTS.md"],
+      ["in-place sed", "sed -i '' 's/a/b/' AGENTS.md"],
+    ])("blocks %s", (_label, command) => {
+      const { status } = runHook(bash(command));
+
+      expect(status).toBe(EXIT_BLOCKED);
+    });
+
+    it.each([
+      ["cat read", "cat AGENTS.md"],
+      ["ripgrep search", "rg 'deploy' AGENTS.md"],
+      ["redirecting a read elsewhere", "cat AGENTS.md > /tmp/copy.txt"],
+      ["wc read", "wc -l CLAUDE.md"],
+    ])("allows %s", (_label, command) => {
+      const { status } = runHook(bash(command));
+
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows an unrelated command that never names the files", () => {
+      const { status } = runHook(bash("echo hello >> notes.md"));
+
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("exemptions", () => {
+    it("allows the write when the operator override is set", () => {
+      const { status } = runHook(edit("Edit", "AGENTS.md"), {
+        LISA_ALLOW_INSTRUCTION_FILE_WRITE: "1",
+      });
+
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("allows a Lisa marker-bounded region (agy learnings bridge)", () => {
+      const { status } = runHook(
+        edit(
+          "Edit",
+          "AGENTS.md",
+          "<!-- LISA_PROJECT_LEARNINGS_START -->\nbridge\n<!-- LISA_PROJECT_LEARNINGS_END -->"
+        )
+      );
+
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+  });
+
+  describe("refusal message", () => {
+    it("names the file, the reason, and all four routing destinations", () => {
+      const { stderr } = runHook(edit("Edit", "AGENTS.md"));
+
+      expect(stderr).toContain("AGENTS.md");
+      expect(stderr).toContain("session-instruction file");
+      expect(stderr).toContain("/lisa:persist-learning");
+      expect(stderr).toContain("SKILL.md");
+      expect(stderr).toContain("/lisa:cross-pollinate");
+      expect(stderr).toContain("LISA_ALLOW_INSTRUCTION_FILE_WRITE=1");
+    });
+  });
+
+  describe("unrelated payloads", () => {
+    it("ignores tools it does not guard", () => {
+      const { status } = runHook({
+        tool_name: "Read",
+        tool_input: { file_path: "AGENTS.md" },
+      });
+
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+  });
+});

--- a/tests/unit/opencode/hooks-installer.test.ts
+++ b/tests/unit/opencode/hooks-installer.test.ts
@@ -28,6 +28,7 @@ const SUPPRESS = "lisa-block-suppress-directives.ts";
 const SGSCAN = "lisa-sg-scan-on-edit.ts";
 const MIGRATION = "lisa-block-migration-edits.ts";
 const RUBOCOP = "lisa-rubocop-on-edit.ts";
+const INSTR = "lisa-block-instruction-file-edits.ts";
 const BASE_RULES = "base-rules.md";
 
 describe("opencode/hooks-installer", () => {
@@ -39,8 +40,7 @@ describe("opencode/hooks-installer", () => {
     tempDir = await createTempDir();
     lisaDir = path.join(tempDir, "lisa");
     destDir = path.join(tempDir, "project");
-    await fs.ensureDir(lisaDir);
-    await fs.ensureDir(destDir);
+    await Promise.all([fs.ensureDir(lisaDir), fs.ensureDir(destDir)]);
   });
 
   afterEach(async () => {
@@ -250,7 +250,7 @@ describe("opencode/hooks-installer", () => {
     it("ships the typescript guards for a typescript project", async () => {
       await installHooks(lisaDir, destDir, ["typescript"], []);
       const files = await listInstalledPluginFiles(destDir);
-      expect(files).toEqual([SUPPRESS, LINT, PARITY, SESSION, SGSCAN]);
+      expect(files).toEqual([INSTR, SUPPRESS, LINT, PARITY, SESSION, SGSCAN]);
     });
 
     it("adds the migration guard for a nestjs project", async () => {
@@ -264,7 +264,7 @@ describe("opencode/hooks-installer", () => {
     it("ships the rails guards for a rails project", async () => {
       await installHooks(lisaDir, destDir, ["rails"], []);
       const files = await listInstalledPluginFiles(destDir);
-      expect(files).toEqual([PARITY, RUBOCOP, SESSION, SGSCAN]);
+      expect(files).toEqual([INSTR, PARITY, RUBOCOP, SESSION, SGSCAN]);
     });
 
     it("does not ship typescript guards to a rails-only project", async () => {


### PR DESCRIPTION
## Why

Lisa's contract already said the session-instruction files are human-authored:

- `plugins/src/base/rules/reference/project-learnings.md` — the debrief flow "no longer writes to machine-local memory, `PROJECT_RULES.md`, or `CLAUDE.md`".
- `plugins/src/base/skills/lisa-debrief-apply/SKILL.md` — "**`CLAUDE.md` is human-authored** ... `apply` never writes to any of the three."

Nothing enforced it, so agents appended anyway. In `tunnlai/projects/frontend`, `AGENTS.md` reached **949 lines** of ticket-keyed trap dumps — `## The API-domain guard also scans process.env (TUN-409)`, `## Agent-artifact PII guard (TUN-367)`, `## Playwright timeout hierarchy (TUN-420)` — each landed inside that ticket's own feature commit, while `.lisa/PROJECT_LEARNINGS.md` held **22 lines**. That ratio is the tell: this is learnings-ledger content in the wrong file. Every one of those lines is charged to the context of every later session in that project, forever.

Also drifting: `gunnertech/projects/frontend` (671), `publishing-backlog-zero-pr` (492).

Prose did not hold. This is the EXECUTABLE-CONTROL rung.

## What

A `PreToolUse` guard refusing agent writes to `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` — one shared block for all three, since the third is the same file class in Lisa's fan-out and would otherwise be the obvious loophole.

Covers `Write`/`Edit`/`MultiEdit` and the Bash write signatures (`>`, `>>`, `tee`, `sed -i`) that would route around the edit tools. Precision-first: a filename mention is not a write, so `cat AGENTS.md`, `rg x AGENTS.md`, and even `cat AGENTS.md > /tmp/copy` all pass.

**The refusal is the point.** It names the file, explains that every line loads into every agent's context in every future session, then routes the content to the first destination that fits:

1. Needed by every agent every session, only here → capture via `/lisa:persist-learning`; the gardener proposes promotion to `PROJECT_RULES.md` as a human-gated ticket.
2. Changes how a skill behaves → edit that `SKILL.md`.
3. True beyond this project → `/lisa:cross-pollinate` or an upstream issue.
4. Background, not a standing instruction → project documentation.

It closes by naming `LISA_ALLOW_INSTRUCTION_FILE_WRITE=1`, so a human who genuinely wants the edit is never stuck.

**Exempt:** that override; Lisa's own marker-bounded regions (the agy project-learnings bridge, cross-pollinate's rule section — they replace in place and cannot grow the file); vendored copies under `node_modules`/`dist`.

## Parity

| Surface | Delivery |
|---|---|
| Claude, Codex, Cursor, Copilot | plugin `PreToolUse` (`Bash` + `Write\|Edit\|MultiEdit`) |
| Antigravity | Bash arm only — agy hooks match `run_command`, so its file-edit calls cannot be intercepted. Gap recorded in the adapter rather than dropped silently. |
| OpenCode | `tool.execute.before` runtime plugin — its `permission.bash` deny globs cannot distinguish a redirect target from a read argument |
| Host fallback | `lisa-enforcement-fallback.sh`, for projects where the plugin never installs — exactly the population that needs it most |

## Note on the refactor

Adding the OpenCode catalog entry pushed `hooks-installer.ts` past its 300-line budget. Lisa blocks `eslint-disable` directives, so rather than take a suppression the catalog moved into a new `src/opencode/plugin-catalog.ts`. Mechanical extraction, no behavior change.

## Verification

Verified by run, not only by unit test:

- **22 new unit tests**; full suite **8472 passed**. (`check-learnings-budget` fails identically on a stashed clean tree — pre-existing, ledger at capacity.)
- **Fallback dispatcher end-to-end:** refuses with exit 2 when the plugin is absent; self-skips when installed.
- **OpenCode installer against a scratch host project:** shipped `plugin/lisa-block-instruction-file-edits.ts`; the emitted plugin blocks `edit AGENTS.md` and `write CLAUDE.md`, allows `wiki/notes.md` and read tools.
- Lint, typecheck, and the upstream-evidence manifest all clean.

## Out of scope

Migrating the existing polluted files in downstream repos. The guard stops new growth; the backlog is a separate pass.

Work-Item: CodySwannGT/lisa#2292

🤖 Generated with Claude Code
