### PR TITLE
fix(cli): make the workstation bootstrap reachable without an agent or a repo

### DIFF
--- a/plugins/lisa-agy/commands/lisa/setup/workstation.md
+++ b/plugins/lisa-agy/commands/lisa/setup/workstation.md
@@ -5,3 +5,5 @@ argument-hint: "[--install] [--agents=claude,codex] [--provider=bitwarden] [--js
 ---
 
 Use the /lisa-setup-workstation skill to report and optionally install the coding agents, credential manager, and base tools this machine needs. $ARGUMENTS
+
+Note: on a machine with no agent and no checkout — which is what this prepares — reach the same bootstrap without Lisa installed at all: `npx -y @codyswann/lisa@latest workstation --install`.

--- a/plugins/lisa-agy/skills/lisa-setup-workstation/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-workstation/SKILL.md
@@ -25,14 +25,35 @@ repository, and nothing here duplicates that manifest.
 
 ## Usage
 
+**Start here — this is the entry point that presumes nothing:**
+
 ```sh
-node scripts/cli.mjs                              # report what is present and missing
-node scripts/cli.mjs --install                    # install what is missing
-node scripts/cli.mjs --install --agents=claude,codex   # only these agents
-node scripts/cli.mjs --provider=bitwarden         # credential manager (asked if a TTY)
-node scripts/cli.mjs --json                       # machine-readable plan
-node scripts/cli.mjs --print-dockerfile           # an image that runs this same script
+npx -y @codyswann/lisa@latest workstation             # report what is present and missing
+npx -y @codyswann/lisa@latest workstation --install   # install what is missing
 ```
+
+That form needs only Node. No checkout, no agent, no Lisa install — npx resolves
+the package into its own cache.
+
+**Why it matters:** this skill exists to prepare a machine with *no coding agent*
+and *no checkout*. But a skill can only be invoked by typing a slash command into
+an agent, and Lisa ships as a devDependency, so it does not exist until a repo is
+cloned and its dependencies installed. Both are exactly the state this is meant to
+create — so as a skill alone, the bootstrap was unreachable in the one scenario it
+was designed for. The CLI is the way in; the skill is the surface for people who
+already have an agent.
+
+Every flag is the same either way:
+
+```sh
+lisa workstation --install --agents=claude,codex   # only these agents
+lisa workstation --provider=bitwarden              # credential manager (asked if a TTY)
+lisa workstation --json                            # machine-readable plan
+lisa workstation --print-dockerfile                # an image that runs this same script
+```
+
+Inside an agent, `/lisa:setup:workstation` runs the identical script; and the
+script itself is directly runnable as `node scripts/cli.mjs …`.
 
 Nothing is installed or written without `--install`. Exit status is non-zero when a required
 tool is absent or an install fails, so this is usable as a gate.

--- a/plugins/lisa-copilot/commands/lisa/setup/workstation.md
+++ b/plugins/lisa-copilot/commands/lisa/setup/workstation.md
@@ -5,3 +5,5 @@ argument-hint: "[--install] [--agents=claude,codex] [--provider=bitwarden] [--js
 ---
 
 Use the /lisa-setup-workstation skill to report and optionally install the coding agents, credential manager, and base tools this machine needs. $ARGUMENTS
+
+Note: on a machine with no agent and no checkout — which is what this prepares — reach the same bootstrap without Lisa installed at all: `npx -y @codyswann/lisa@latest workstation --install`.

--- a/plugins/lisa-copilot/skills/lisa-setup-workstation/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-workstation/SKILL.md
@@ -25,14 +25,35 @@ repository, and nothing here duplicates that manifest.
 
 ## Usage
 
+**Start here — this is the entry point that presumes nothing:**
+
 ```sh
-node scripts/cli.mjs                              # report what is present and missing
-node scripts/cli.mjs --install                    # install what is missing
-node scripts/cli.mjs --install --agents=claude,codex   # only these agents
-node scripts/cli.mjs --provider=bitwarden         # credential manager (asked if a TTY)
-node scripts/cli.mjs --json                       # machine-readable plan
-node scripts/cli.mjs --print-dockerfile           # an image that runs this same script
+npx -y @codyswann/lisa@latest workstation             # report what is present and missing
+npx -y @codyswann/lisa@latest workstation --install   # install what is missing
 ```
+
+That form needs only Node. No checkout, no agent, no Lisa install — npx resolves
+the package into its own cache.
+
+**Why it matters:** this skill exists to prepare a machine with *no coding agent*
+and *no checkout*. But a skill can only be invoked by typing a slash command into
+an agent, and Lisa ships as a devDependency, so it does not exist until a repo is
+cloned and its dependencies installed. Both are exactly the state this is meant to
+create — so as a skill alone, the bootstrap was unreachable in the one scenario it
+was designed for. The CLI is the way in; the skill is the surface for people who
+already have an agent.
+
+Every flag is the same either way:
+
+```sh
+lisa workstation --install --agents=claude,codex   # only these agents
+lisa workstation --provider=bitwarden              # credential manager (asked if a TTY)
+lisa workstation --json                            # machine-readable plan
+lisa workstation --print-dockerfile                # an image that runs this same script
+```
+
+Inside an agent, `/lisa:setup:workstation` runs the identical script; and the
+script itself is directly runnable as `node scripts/cli.mjs …`.
 
 Nothing is installed or written without `--install`. Exit status is non-zero when a required
 tool is absent or an install fails, so this is usable as a gate.

--- a/plugins/lisa-cursor/commands/lisa/setup/workstation.md
+++ b/plugins/lisa-cursor/commands/lisa/setup/workstation.md
@@ -5,3 +5,5 @@ argument-hint: "[--install] [--agents=claude,codex] [--provider=bitwarden] [--js
 ---
 
 Use the /lisa-setup-workstation skill to report and optionally install the coding agents, credential manager, and base tools this machine needs. $ARGUMENTS
+
+Note: on a machine with no agent and no checkout — which is what this prepares — reach the same bootstrap without Lisa installed at all: `npx -y @codyswann/lisa@latest workstation --install`.

--- a/plugins/lisa-cursor/skills/lisa-setup-workstation/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-workstation/SKILL.md
@@ -25,14 +25,35 @@ repository, and nothing here duplicates that manifest.
 
 ## Usage
 
+**Start here — this is the entry point that presumes nothing:**
+
 ```sh
-node scripts/cli.mjs                              # report what is present and missing
-node scripts/cli.mjs --install                    # install what is missing
-node scripts/cli.mjs --install --agents=claude,codex   # only these agents
-node scripts/cli.mjs --provider=bitwarden         # credential manager (asked if a TTY)
-node scripts/cli.mjs --json                       # machine-readable plan
-node scripts/cli.mjs --print-dockerfile           # an image that runs this same script
+npx -y @codyswann/lisa@latest workstation             # report what is present and missing
+npx -y @codyswann/lisa@latest workstation --install   # install what is missing
 ```
+
+That form needs only Node. No checkout, no agent, no Lisa install — npx resolves
+the package into its own cache.
+
+**Why it matters:** this skill exists to prepare a machine with *no coding agent*
+and *no checkout*. But a skill can only be invoked by typing a slash command into
+an agent, and Lisa ships as a devDependency, so it does not exist until a repo is
+cloned and its dependencies installed. Both are exactly the state this is meant to
+create — so as a skill alone, the bootstrap was unreachable in the one scenario it
+was designed for. The CLI is the way in; the skill is the surface for people who
+already have an agent.
+
+Every flag is the same either way:
+
+```sh
+lisa workstation --install --agents=claude,codex   # only these agents
+lisa workstation --provider=bitwarden              # credential manager (asked if a TTY)
+lisa workstation --json                            # machine-readable plan
+lisa workstation --print-dockerfile                # an image that runs this same script
+```
+
+Inside an agent, `/lisa:setup:workstation` runs the identical script; and the
+script itself is directly runnable as `node scripts/cli.mjs …`.
 
 Nothing is installed or written without `--install`. Exit status is non-zero when a required
 tool is absent or an install fails, so this is usable as a gate.

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-workstation/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-workstation/SKILL.md
@@ -25,14 +25,35 @@ repository, and nothing here duplicates that manifest.
 
 ## Usage
 
+**Start here — this is the entry point that presumes nothing:**
+
 ```sh
-node scripts/cli.mjs                              # report what is present and missing
-node scripts/cli.mjs --install                    # install what is missing
-node scripts/cli.mjs --install --agents=claude,codex   # only these agents
-node scripts/cli.mjs --provider=bitwarden         # credential manager (asked if a TTY)
-node scripts/cli.mjs --json                       # machine-readable plan
-node scripts/cli.mjs --print-dockerfile           # an image that runs this same script
+npx -y @codyswann/lisa@latest workstation             # report what is present and missing
+npx -y @codyswann/lisa@latest workstation --install   # install what is missing
 ```
+
+That form needs only Node. No checkout, no agent, no Lisa install — npx resolves
+the package into its own cache.
+
+**Why it matters:** this skill exists to prepare a machine with *no coding agent*
+and *no checkout*. But a skill can only be invoked by typing a slash command into
+an agent, and Lisa ships as a devDependency, so it does not exist until a repo is
+cloned and its dependencies installed. Both are exactly the state this is meant to
+create — so as a skill alone, the bootstrap was unreachable in the one scenario it
+was designed for. The CLI is the way in; the skill is the surface for people who
+already have an agent.
+
+Every flag is the same either way:
+
+```sh
+lisa workstation --install --agents=claude,codex   # only these agents
+lisa workstation --provider=bitwarden              # credential manager (asked if a TTY)
+lisa workstation --json                            # machine-readable plan
+lisa workstation --print-dockerfile                # an image that runs this same script
+```
+
+Inside an agent, `/lisa:setup:workstation` runs the identical script; and the
+script itself is directly runnable as `node scripts/cli.mjs …`.
 
 Nothing is installed or written without `--install`. Exit status is non-zero when a required
 tool is absent or an install fails, so this is usable as a gate.

--- a/plugins/lisa/commands/setup/workstation.md
+++ b/plugins/lisa/commands/setup/workstation.md
@@ -5,3 +5,5 @@ argument-hint: "[--install] [--agents=claude,codex] [--provider=bitwarden] [--js
 ---
 
 Use the /lisa-setup-workstation skill to report and optionally install the coding agents, credential manager, and base tools this machine needs. $ARGUMENTS
+
+Note: on a machine with no agent and no checkout — which is what this prepares — reach the same bootstrap without Lisa installed at all: `npx -y @codyswann/lisa@latest workstation --install`.

--- a/plugins/lisa/skills/lisa-setup-workstation/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-workstation/SKILL.md
@@ -25,14 +25,35 @@ repository, and nothing here duplicates that manifest.
 
 ## Usage
 
+**Start here — this is the entry point that presumes nothing:**
+
 ```sh
-node scripts/cli.mjs                              # report what is present and missing
-node scripts/cli.mjs --install                    # install what is missing
-node scripts/cli.mjs --install --agents=claude,codex   # only these agents
-node scripts/cli.mjs --provider=bitwarden         # credential manager (asked if a TTY)
-node scripts/cli.mjs --json                       # machine-readable plan
-node scripts/cli.mjs --print-dockerfile           # an image that runs this same script
+npx -y @codyswann/lisa@latest workstation             # report what is present and missing
+npx -y @codyswann/lisa@latest workstation --install   # install what is missing
 ```
+
+That form needs only Node. No checkout, no agent, no Lisa install — npx resolves
+the package into its own cache.
+
+**Why it matters:** this skill exists to prepare a machine with *no coding agent*
+and *no checkout*. But a skill can only be invoked by typing a slash command into
+an agent, and Lisa ships as a devDependency, so it does not exist until a repo is
+cloned and its dependencies installed. Both are exactly the state this is meant to
+create — so as a skill alone, the bootstrap was unreachable in the one scenario it
+was designed for. The CLI is the way in; the skill is the surface for people who
+already have an agent.
+
+Every flag is the same either way:
+
+```sh
+lisa workstation --install --agents=claude,codex   # only these agents
+lisa workstation --provider=bitwarden              # credential manager (asked if a TTY)
+lisa workstation --json                            # machine-readable plan
+lisa workstation --print-dockerfile                # an image that runs this same script
+```
+
+Inside an agent, `/lisa:setup:workstation` runs the identical script; and the
+script itself is directly runnable as `node scripts/cli.mjs …`.
 
 Nothing is installed or written without `--install`. Exit status is non-zero when a required
 tool is absent or an install fails, so this is usable as a gate.

--- a/plugins/src/base/commands/setup/workstation.md
+++ b/plugins/src/base/commands/setup/workstation.md
@@ -5,3 +5,5 @@ argument-hint: "[--install] [--agents=claude,codex] [--provider=bitwarden] [--js
 ---
 
 Use the /lisa-setup-workstation skill to report and optionally install the coding agents, credential manager, and base tools this machine needs. $ARGUMENTS
+
+Note: on a machine with no agent and no checkout — which is what this prepares — reach the same bootstrap without Lisa installed at all: `npx -y @codyswann/lisa@latest workstation --install`.

--- a/plugins/src/base/skills/lisa-setup-workstation/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-workstation/SKILL.md
@@ -25,14 +25,35 @@ repository, and nothing here duplicates that manifest.
 
 ## Usage
 
+**Start here — this is the entry point that presumes nothing:**
+
 ```sh
-node scripts/cli.mjs                              # report what is present and missing
-node scripts/cli.mjs --install                    # install what is missing
-node scripts/cli.mjs --install --agents=claude,codex   # only these agents
-node scripts/cli.mjs --provider=bitwarden         # credential manager (asked if a TTY)
-node scripts/cli.mjs --json                       # machine-readable plan
-node scripts/cli.mjs --print-dockerfile           # an image that runs this same script
+npx -y @codyswann/lisa@latest workstation             # report what is present and missing
+npx -y @codyswann/lisa@latest workstation --install   # install what is missing
 ```
+
+That form needs only Node. No checkout, no agent, no Lisa install — npx resolves
+the package into its own cache.
+
+**Why it matters:** this skill exists to prepare a machine with *no coding agent*
+and *no checkout*. But a skill can only be invoked by typing a slash command into
+an agent, and Lisa ships as a devDependency, so it does not exist until a repo is
+cloned and its dependencies installed. Both are exactly the state this is meant to
+create — so as a skill alone, the bootstrap was unreachable in the one scenario it
+was designed for. The CLI is the way in; the skill is the surface for people who
+already have an agent.
+
+Every flag is the same either way:
+
+```sh
+lisa workstation --install --agents=claude,codex   # only these agents
+lisa workstation --provider=bitwarden              # credential manager (asked if a TTY)
+lisa workstation --json                            # machine-readable plan
+lisa workstation --print-dockerfile                # an image that runs this same script
+```
+
+Inside an agent, `/lisa:setup:workstation` runs the identical script; and the
+script itself is directly runnable as `node scripts/cli.mjs …`.
 
 Nothing is installed or written without `--install`. Exit status is non-zero when a required
 tool is absent or an install fails, so this is usable as a gate.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,13 +23,17 @@ import {
 import { runSetupWiki } from "./setup-wiki.js";
 import { addSharedOptions, type CLIOptions } from "./shared-options.js";
 import { SETUP_TYPES } from "./starters.js";
-import { runStandardsProofCli } from "./standards-proof-cmd.js";
+import {
+  addStandardsProofCommand,
+  runStandardsProofCli,
+} from "./standards-proof-cmd.js";
 import { runSync, type SyncCmdOptions } from "./sync-cmd.js";
 import { runUi, type UiCmdOptions } from "./ui-cmd.js";
 import { runUpdate } from "./update-cmd.js";
 import { runUpdateCheck } from "./update-check.js";
 import { addUpdateCheckHook } from "./update-check-hook.js";
 import { runVersion } from "./version-cmd.js";
+import { addWorkstationCommand } from "./workstation-cmd.js";
 import { getPackageVersion } from "./version.js";
 
 /**
@@ -205,26 +209,6 @@ function addHealthCommand(program: Command, deps: ProgramDependencies): void {
 }
 
 /**
- * Register the explicit, mutating standards proof command.
- * @param program - Commander program to mutate
- * @param deps - Program dependencies
- */
-function addStandardsProofCommand(
-  program: Command,
-  deps: ProgramDependencies
-): void {
-  program
-    .command("standards-proof")
-    .description(
-      "Run all applicable Lisa standards checks and prove the current Git artifact"
-    )
-    .argument("[path]", PATH_ARG_DESCRIPTION)
-    .action(async (targetPath: string | undefined) => {
-      await deps.runStandardsProofCli(targetPath);
-    });
-}
-
-/**
  * Register CLI maintenance commands that do not run the root update warning.
  * @param program - Commander program to mutate
  * @param deps - Program dependencies
@@ -254,6 +238,7 @@ function addMaintenanceCommands(
       }
     });
 
+  addWorkstationCommand(program);
   addDoctorCommand(program, deps);
   addHealthCommand(program, deps);
   addStandardsProofCommand(program, deps);

--- a/src/cli/standards-proof-cmd.ts
+++ b/src/cli/standards-proof-cmd.ts
@@ -1,3 +1,5 @@
+import type { Command } from "commander";
+
 /** CLI adapter for explicit standards-conformance proof capture. */
 import path from "node:path";
 import { captureStandardsProof } from "../standards/capture.js";
@@ -16,4 +18,39 @@ export async function runStandardsProofCli(
   process.stdout.write(
     `standards-proof: PASS ${proof.repository.identity}@${proof.repository.head} (${proof.results.length} checks)\n`
   );
+}
+
+/**
+ * The only dependency this registration needs, structurally.
+ *
+ * Declared here rather than importing `ProgramDependencies` from the program
+ * module, which would import this one back.
+ */
+interface StandardsProofCommandDeps {
+  /** Runs every standards command and writes freshness-bound proof. */
+  readonly runStandardsProofCli: typeof runStandardsProofCli;
+}
+
+/**
+ * Register the explicit, mutating standards proof command.
+ *
+ * Lives beside its command rather than in the program module, matching
+ * `addGateCommands` — registration is part of the command, and keeping it here
+ * is what stops the program file growing without bound.
+ * @param program Commander program to mutate.
+ * @param deps Program dependencies.
+ */
+export function addStandardsProofCommand(
+  program: Command,
+  deps: StandardsProofCommandDeps
+): void {
+  program
+    .command("standards-proof")
+    .description(
+      "Run all applicable Lisa standards checks and prove the current Git artifact"
+    )
+    .argument("[path]", "Project path (default: current directory)")
+    .action(async (targetPath: string | undefined) => {
+      await deps.runStandardsProofCli(targetPath);
+    });
 }

--- a/src/cli/workstation-cmd.ts
+++ b/src/cli/workstation-cmd.ts
@@ -1,0 +1,185 @@
+/**
+ * CLI entry point for the workstation bootstrap.
+ *
+ * `lisa-setup-workstation` exists to prepare a machine that has no coding agent
+ * and no checkout. As a skill it could only be reached by typing a slash command
+ * into an agent — and Lisa ships as a devDependency, so it does not exist until
+ * a repo is cloned and its dependencies installed.
+ *
+ * Both of those are precisely the state the skill is supposed to CREATE. The
+ * bootstrap was unreachable in the one scenario it was designed for.
+ *
+ * This is the way in that presumes nothing:
+ *
+ *     npx -y `@codyswann/lisa@latest` workstation --install --provider=bitwarden
+ *
+ * npx resolves the package into its own cache, so no repository is involved and
+ * no agent has to exist yet. The skill stays as the surface for people who
+ * already have an agent; this is for people who do not.
+ * @module cli/workstation-cmd
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import type { Command } from "commander";
+
+import { getCliInstallPath } from "./version-cmd.js";
+
+/**
+ * The only dependency this command needs, structurally.
+ *
+ * Declared here rather than importing `ProgramDependencies` from the program
+ * module, which imports this one — a cycle for the sake of a single field.
+ */
+interface WorkstationCommandDeps {
+  /** Runs the bootstrap and returns its exit code. */
+  readonly runWorkstation: (flags: readonly string[]) => number;
+}
+
+/**
+ * Register `lisa workstation`.
+ *
+ * Kept out of the program module so registering it does not push that file past
+ * its size limits — the same reason `addGateCommands` lives beside its own
+ * command rather than in the middle of the program.
+ * @param program Commander program to mutate.
+ * @param deps Program dependencies.
+ */
+export function addWorkstationCommand(
+  program: Command,
+  deps: WorkstationCommandDeps = { runWorkstation }
+): void {
+  program
+    .command("workstation")
+    .description(
+      "Prepare this machine to run coding agents — before any repo exists. " +
+        "Detects installed agents, asks which credential manager to use, and " +
+        "installs what is missing. Needs no checkout and no agent: run it with " +
+        "'npx -y @codyswann/lisa@latest workstation --install'."
+    )
+    // Flags belong to the bootstrap script, not to commander. Re-declaring them
+    // here would give the CLI and the skill two vocabularies to keep in step.
+    //
+    // Read straight off argv rather than via passThroughOptions, which
+    // commander only permits once the PARENT enables positional options — a
+    // global parsing change affecting every other command, to serve one.
+    .allowUnknownOption(true)
+    .argument("[flags...]", "flags forwarded to the bootstrap")
+    .action(() => {
+      const code = deps.runWorkstation(flagsAfterCommand(process.argv));
+      if (code !== 0) {
+        process.exitCode = code;
+      }
+    });
+}
+
+/**
+ * Everything the operator typed after the subcommand name.
+ *
+ * Taken from argv because the flags are the bootstrap script's vocabulary, not
+ * commander's, and forwarding them verbatim is what keeps the CLI and the skill
+ * from drifting into two dialects.
+ *
+ * Searched from index 2 so a project path that happens to be named
+ * `workstation` cannot be mistaken for the subcommand.
+ * @param argv Full process argv.
+ * @param name Subcommand name.
+ * @returns Forwarded flags, empty when the subcommand is absent.
+ */
+export function flagsAfterCommand(
+  argv: readonly string[],
+  name = "workstation"
+): string[] {
+  const at = argv.indexOf(name, 2);
+  return at === -1 ? [] : argv.slice(at + 1);
+}
+
+/** Where the bootstrap script sits inside the published package. */
+const SCRIPT_RELATIVE = path.join(
+  "plugins",
+  "src",
+  "base",
+  "skills",
+  "lisa-setup-workstation",
+  "scripts",
+  "cli.mjs"
+);
+
+/** Injectable seams so the command is testable without provisioning anything. */
+export interface WorkstationDeps {
+  /** Resolve the installed package root. */
+  readonly installPath?: () => string;
+  /** Run the script. */
+  readonly run?: (command: string, args: string[]) => { status: number | null };
+  /** Report a problem. */
+  readonly error?: (message: string) => void;
+}
+
+/**
+ * Locate the bootstrap script inside the installed package.
+ *
+ * Resolved from the MODULE's own location rather than the working directory:
+ * under npx the cwd is wherever the operator happens to be standing, and is
+ * frequently not a project at all — which is the entire point of this command.
+ * @param installPath Package root.
+ * @returns Absolute path to the script.
+ * @throws {Error} When the package is incomplete.
+ */
+export function resolveWorkstationScript(
+  installPath: string = getCliInstallPath()
+): string {
+  const script = path.join(installPath, SCRIPT_RELATIVE);
+  if (!existsSync(script)) {
+    throw new Error(
+      `cannot find the workstation script at ${script}.\n` +
+        `This means the installed Lisa package is incomplete — reinstall, or ` +
+        `run a newer version with 'npx -y @codyswann/lisa@latest workstation'.`
+    );
+  }
+  return script;
+}
+
+/**
+ * Run the workstation bootstrap, passing every flag through untouched.
+ *
+ * Flags are forwarded rather than re-declared. Restating `--install`,
+ * `--agents`, `--provider` and the rest here would give the CLI and the skill
+ * two vocabularies to keep in step, and the one nobody runs is the one that
+ * drifts.
+ * @param flags Arguments for the script.
+ * @param deps Injected seams.
+ * @returns Process exit code.
+ */
+export function runWorkstation(
+  flags: readonly string[] = [],
+  deps: WorkstationDeps = {}
+): number {
+  const report =
+    deps.error ?? ((message: string) => process.stderr.write(message));
+
+  const located = ((): string | null => {
+    try {
+      return resolveWorkstationScript(
+        (deps.installPath ?? getCliInstallPath)()
+      );
+    } catch (error) {
+      report(`${(error as Error).message}\n`);
+      return null;
+    }
+  })();
+  if (located === null) return 1;
+
+  const run =
+    deps.run ??
+    ((command: string, args: string[]) =>
+      spawnSync(command, args, { stdio: "inherit" }));
+
+  // Spawned rather than imported: the script is plain ESM with no build step,
+  // and running it as its own process keeps the interactive prompt attached to
+  // the real terminal — a credential-manager question read through a bundler's
+  // stdio is how a bootstrap ends up hanging with nothing on screen.
+  const result = run(process.execPath, [located, ...flags]);
+  return result.status ?? 1;
+}

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -569,7 +569,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/commands/setup/sonar.md":
       "1d2e94fd9f21988ce6d4be2ce4268b8c0bb020eb7cd7baf8ca65def7d8a4f5bc",
     "plugins/src/base/commands/setup/workstation.md":
-      "2da226aa1a7efea41735eeb58d61ad70896eccadc59765f86c971aa331d11358",
+      "57ea736ded92d97c6914dde5354f631532cca46ddefc9bd9cdf89edd6d08dd9f",
     "plugins/src/base/commands/sync-down.md":
       "4e974cb9745a4fd680f4a55f859d31fa8cf3cb28afa739b40a2e1a99de31e034",
     "plugins/src/base/commands/tear-down-automations.md":
@@ -1159,7 +1159,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-sonar/SKILL.md":
       "53fbd8acce4b5e47e88195a7b90d5be424fa6ef7ad872f52c50467c690664c3b",
     "plugins/src/base/skills/lisa-setup-workstation/SKILL.md":
-      "433168d83749709f9808fa0b45ff74e0944707a26fb0039d1de28ffaadaa8db1",
+      "4bc4413bbe381ab97e2aa10eaeda574f8113f69e6eb5f5a6e625c04f1dff1ad5",
     "plugins/src/base/skills/lisa-setup-workstation/scripts/catalogue.mjs":
       "3fa13e7e2885aa5f3b4efdd12fc87958494a57d8bfeb81ab8489558592780b90",
     "plugins/src/base/skills/lisa-setup-workstation/scripts/cli.mjs":
@@ -7868,6 +7868,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/cli/update-cmd.ts": true,
     "src/cli/version-cmd.ts": true,
     "src/cli/version.ts": true,
+    "src/cli/workstation-cmd.ts": true,
     "src/codex/agent-installer.ts": true,
     "src/codex/agent-transformer.ts": true,
     "src/codex/agents-md-installer.ts": true,
@@ -8257,6 +8258,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/update-check.test.ts": true,
     "tests/unit/cli/update-cmd.test.ts": true,
     "tests/unit/cli/version-cmd.test.ts": true,
+    "tests/unit/cli/workstation-cmd.test.ts": true,
     "tests/unit/codex/agent-installer.test.ts": true,
     "tests/unit/codex/agent-transformer.test.ts": true,
     "tests/unit/codex/agents-md-installer.test.ts": true,

--- a/tests/unit/cli/workstation-cmd.test.ts
+++ b/tests/unit/cli/workstation-cmd.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for the workstation CLI bootstrap.
+ *
+ * The skill this fronts exists to prepare a machine with no coding agent and no
+ * checkout — but as a skill it could only be reached by typing a slash command
+ * into an agent, from a repo that had installed Lisa as a devDependency. Both
+ * are the state it is supposed to create.
+ *
+ * So the property under test is reachability: this must run with nothing but
+ * node, from anywhere, and forward what the operator typed without inventing a
+ * second vocabulary for it.
+ * @module tests/unit/cli/workstation-cmd
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  flagsAfterCommand,
+  resolveWorkstationScript,
+  runWorkstation,
+} from "../../../src/cli/workstation-cmd.js";
+
+/** The argv entries every fixture shares before the subcommand. */
+const ARGV_PREFIX = ["/usr/bin/node", "/pkg/dist/index.js"];
+
+/** Package roots created for a single test. */
+const created: string[] = [];
+
+/** Where the bootstrap script lives inside the published package. */
+const SCRIPT_PATH = path.join(
+  "plugins",
+  "src",
+  "base",
+  "skills",
+  "lisa-setup-workstation",
+  "scripts",
+  "cli.mjs"
+);
+
+/**
+ * Build a throwaway package root, optionally containing the script.
+ * @param withScript Whether to create the bootstrap script.
+ * @returns The package root.
+ */
+function packageRoot(withScript: boolean): string {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-workstation-"));
+  created.push(root);
+  if (withScript) {
+    const full = path.join(root, SCRIPT_PATH);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, "// bootstrap\n");
+  }
+  return root;
+}
+
+afterEach(() => {
+  while (created.length > 0) {
+    rmSync(created.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe("flagsAfterCommand", () => {
+  it("forwards everything typed after the subcommand", () => {
+    expect(
+      flagsAfterCommand([
+        ...ARGV_PREFIX,
+        "workstation",
+        "--install",
+        "--provider=bitwarden",
+      ])
+    ).toEqual(["--install", "--provider=bitwarden"]);
+  });
+
+  it("returns nothing when the subcommand is absent", () => {
+    expect(flagsAfterCommand([...ARGV_PREFIX, "doctor"])).toEqual([]);
+  });
+
+  it("forwards an empty list when no flags follow", () => {
+    expect(flagsAfterCommand([...ARGV_PREFIX, "workstation"])).toEqual([]);
+  });
+
+  it("ignores an argv[1] that happens to be named workstation", () => {
+    // The search starts at index 2 so the script path cannot be mistaken for
+    // the subcommand.
+    expect(
+      flagsAfterCommand([
+        "/usr/bin/node",
+        "/opt/workstation",
+        "workstation",
+        "--json",
+      ])
+    ).toEqual(["--json"]);
+  });
+});
+
+describe("resolveWorkstationScript", () => {
+  it("finds the script inside the installed package", () => {
+    const root = packageRoot(true);
+    expect(resolveWorkstationScript(root)).toBe(path.join(root, SCRIPT_PATH));
+  });
+
+  it("fails with a fix rather than a stack trace when the package is incomplete", () => {
+    expect(() => resolveWorkstationScript(packageRoot(false))).toThrow(
+      /npx -y @codyswann\/lisa@latest workstation/
+    );
+  });
+});
+
+describe("runWorkstation", () => {
+  it("runs the script on the current node, not a PATH lookup", () => {
+    // The bootstrap's whole premise is a machine that may have nothing on it.
+    // Resolving `node` through PATH would assume the very thing in question.
+    const calls: { command: string; args: string[] }[] = [];
+    const root = packageRoot(true);
+    runWorkstation(["--install"], {
+      installPath: () => root,
+      run: (command, args) => {
+        calls.push({ command, args });
+        return { status: 0 };
+      },
+    });
+    expect(calls[0].command).toBe(process.execPath);
+    expect(calls[0].args).toEqual([path.join(root, SCRIPT_PATH), "--install"]);
+  });
+
+  it("propagates the script's exit code", () => {
+    // A bad provider or a failed install must fail the command, or a container
+    // build would carry on with a machine that is not prepared.
+    const root = packageRoot(true);
+    const code = runWorkstation([], {
+      installPath: () => root,
+      run: () => ({ status: 1 }),
+    });
+    expect(code).toBe(1);
+  });
+
+  it("treats a script that never ran as a failure", () => {
+    // spawnSync reports a null status when the process could not be spawned.
+    const root = packageRoot(true);
+    const code = runWorkstation([], {
+      installPath: () => root,
+      run: () => ({ status: null }),
+    });
+    expect(code).toBe(1);
+  });
+
+  it("reports an incomplete package without throwing", () => {
+    const messages: string[] = [];
+    const code = runWorkstation([], {
+      installPath: () => packageRoot(false),
+      run: () => ({ status: 0 }),
+      error: message => messages.push(message),
+    });
+    expect(code).toBe(1);
+    expect(messages.join("")).toContain("workstation script");
+  });
+
+  it("does not run the script when it cannot be found", () => {
+    let ran = false;
+    runWorkstation([], {
+      installPath: () => packageRoot(false),
+      run: () => {
+        ran = true;
+        return { status: 0 };
+      },
+      error: () => undefined,
+    });
+    expect(ran).toBe(false);
+  });
+});


### PR DESCRIPTION
## The bootstrap paradox

`lisa-setup-workstation` (#2288) prepares a machine that has **no coding agent** and **no checkout**. But:

1. A skill can only be invoked by typing a slash command into an agent.
2. Lisa ships as a **devDependency**, so it does not exist until a repo is cloned and its dependencies installed.

Both preconditions are exactly the state the skill is supposed to *create*. On a bare machine there is no agent to type into and no checkout to install Lisa from — the bootstrap was unreachable in the one scenario it was designed for.

## The path that works

`npx -y @codyswann/lisa@latest <cmd>` runs from a completely empty directory with no repo and no agent. Verified against the published package before writing any code:

```
$ cd /empty && npx -y @codyswann/lisa@latest version
local: 2.328.5
latest: 2.328.5
```

`plugins/` is already in the published `files`, so the workstation scripts ship. This PR adds the command that uses that path:

```sh
npx -y @codyswann/lisa@latest workstation --install --provider=bitwarden
```

Node is the only prerequisite. The skill stays as the surface for people who already have an agent; the CLI is the way in for people who do not. Docs now lead with the CLI form, because the skill form presumes the state the user is trying to reach.

## Implementation notes

**Flags are forwarded verbatim, not re-declared.** Restating `--install`, `--agents`, `--provider` in commander would give the CLI and the skill two vocabularies to keep in step, and the one nobody runs is the one that drifts.

**Read off argv, not via `passThroughOptions`.** Commander only permits that once the *parent* enables positional options — a global parsing change affecting every other command, to serve one.

**Runs on `process.execPath`, not a PATH lookup for `node`.** The bootstrap's whole premise is a machine that may have nothing on it; resolving `node` through PATH would assume the very thing in question.

**Spawned, not imported**, so the credential-manager prompt stays attached to the real terminal.

## One structural change

`addStandardsProofCommand` moves out of the program module to sit beside its own command, matching the existing `addGateCommands` precedent. Registering a new command pushed `index.ts` past its 300-line ceiling — that rule exists to force exactly this extraction, and registration belongs with the command either way. No behaviour change; `standards-proof` verified still registered.

## Verification

End to end from an empty directory, against the built CLI:

| invocation | result |
| --- | --- |
| `workstation` | full report |
| `workstation --json` | machine-readable plan |
| `workstation --provider=bitwarden` | credential row present |
| `workstation --print-dockerfile` | Dockerfile emitted |
| `workstation --provider=lastpass` | **exit 1** |
| `--help` | both `workstation` and `standards-proof` listed |

- 11 new unit tests, all seams injected so none touch the host
- Full suite: 506 files / 8585 tests green; typecheck and lint clean
- Fans out to all five agent variants

🤖 Generated with Claude Code

---

Work-Item: CodySwannGT/lisa#2291
