### PR TITLE
feat(toolchain): add release-tree so tree-shaped artifacts stop installing broken

### DIFF
--- a/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -563,7 +563,8 @@ export function proposedEntries(proposal) {
   // the checksum cannot vouch for, which is the one property that makes a
   // pinned entry worth reviewing.
   const archive = platform => ({
-    install: "<release-tar or release-zip, whichever this platform ships>",
+    install:
+      "<release-tar | release-zip | release-tree — tree when the archive is a directory whose entry point loads its own siblings>",
     url: `<release url for this exact version, for ${platform}>`,
     sha256: `<sha256 published with the ${platform} release>`,
   });

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
@@ -165,15 +165,27 @@ by platform. Before that existed, the only way to keep a Linux binary off a lapt
 
 Expected shape for most projects: a short `require` list, an empty or near-empty `install` list, and the provider CLI as the only thing always provisioned.
 
-### The three `install` methods
+### The four `install` methods
 
 | `install` | Required fields | Use it when |
 | --- | --- | --- |
 | `release-zip` | `url` **and** `sha256` | The vendor publishes a Linux zip of the release. |
 | `release-tar` | `url` **and** `sha256` — plus `binary` in practice | The vendor publishes no zip for Linux, only a `.tar.gz`. |
+| `release-tree` | `url`, `sha256` **and** `binary` | The archive is a **directory**, not a single binary — an entry point that resolves its own siblings at run time. |
 | `npm-global` | `package` | The tool ships on the npm registry. |
 
 Anything else is rejected by name at plan time, so a typo fails loudly rather than silently installing nothing.
+
+**`release-tree` exists because the single-file kinds fail silently on a tree.** They extract the archive and copy *one* file onto PATH, which is right for a static binary and wrong for anything that locates its own resources. Maestro is the case that forced it — one 314 MB zip containing:
+
+```text
+maestro/bin/maestro     <- launcher
+maestro/lib/*.jar       <- 100+ MB of classpath
+```
+
+and a launcher that computes `CLASSPATH=$APP_HOME/lib/*` where `APP_HOME` is the parent of wherever the script itself sits. Declared as `release-zip` with `binary: maestro/bin/maestro`, the launcher lands in `~/.local/bin`, `APP_HOME` resolves to `~/.local`, and the classpath points at an empty directory. **The install reports success and the tool dies at first use** with `Could not find or load main class` — exactly the failure this manifest exists to turn into a loud setup error.
+
+So `release-tree` extracts the whole archive to `~/.local/share/<name>/<version>` and puts a **wrapper** on PATH that `exec`s the entry point in place. Not a copy, and deliberately not a symlink either: a launcher that does not resolve symlinks before computing its own location would read the link's directory as its home and look for its resources beside the link — the same broken install, narrowed to a subset of tools. `binary` has no default here, because the archive root is a directory and guessing would install a directory as a binary.
 
 Both archive kinds carry the **same** obligation and differ only in how they are unpacked: `url` and `sha256` are both mandatory, the checksum is verified *before* the archive is unpacked, and a version bump must move the checksum in the same reviewed commit. Neither is a weaker path than the other — `release-tar` exists because some tools worth pinning simply do not publish a zip. `gh` is the case that forced it: it ships `.deb`, `.rpm` and `.tar.gz` and nothing else, so a zip-only installer could not pin the CLI that Lisa's own commit guardrails shell out to.
 

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -213,6 +213,94 @@ function installReleaseTar(tool, binDir) {
 }
 
 /**
+ * Where a tree-shaped tool's extracted contents live.
+ *
+ * Versioned so a re-pin lands beside the old copy rather than on top of it, and
+ * outside `binDir` because only the entry point belongs on PATH.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory holding the symlink.
+ * @returns {string} Absolute prefix for this tool and version.
+ */
+export function treePrefix(tool, binDir) {
+  return join(binDir, "..", "share", tool.name, String(tool.version));
+}
+
+/**
+ * Install a pinned archive that is a DIRECTORY, not a single binary.
+ *
+ * `release-zip` and `release-tar` extract and then copy one file onto PATH,
+ * which is right for a static binary and silently wrong for anything that
+ * resolves its own siblings at run time. Maestro is the case that forced this:
+ *
+ *     maestro/bin/maestro   <- launcher
+ *     maestro/lib/*.jar     <- 100+ MB of classpath
+ *
+ * and the launcher computes `CLASSPATH=$APP_HOME/lib/*` where `APP_HOME` is the
+ * parent of wherever the script itself sits. Copy that launcher to
+ * `~/.local/bin` and APP_HOME becomes `~/.local`, so the classpath resolves to
+ * an empty directory. The install reports success and the tool fails at first
+ * use — the failure this manifest exists to turn into a loud setup error.
+ *
+ * So the whole tree is extracted and the entry point is SYMLINKED. A symlink,
+ * not a copy, precisely so that resolution walks back into the extracted tree.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to link the entry point into.
+ */
+function installReleaseTree(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  const prefix = treePrefix(tool, binDir);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const archive = join(temporary, "download.archive");
+    execFileSync("curl", ["-fsSL", tool.url, "-o", archive], {
+      stdio: "inherit",
+    });
+    // Verify before unpacking, as everywhere else here: an unexpected archive
+    // must fail before any of its contents reach the filesystem.
+    verifyChecksum(archive, tool.sha256, tool.name);
+
+    // Replace rather than layer. Extracting over a previous version leaves both
+    // sets of jars on the classpath, which fails in a way that looks like a
+    // version bug rather than a stale install.
+    rmSync(prefix, { recursive: true, force: true });
+    mkdirSync(prefix, { recursive: true });
+    if (tool.url.endsWith(".zip")) {
+      execFileSync("unzip", ["-q", "-o", archive, "-d", prefix], {
+        stdio: "inherit",
+      });
+    } else {
+      execFileSync("tar", ["-xzf", archive, "-C", prefix], {
+        stdio: "inherit",
+      });
+    }
+
+    const entry = join(prefix, tool.binary);
+    if (!existsSync(entry)) {
+      throw new Error(
+        `${tool.name}: "binary" points at ${tool.binary}, which is not in the ` +
+          `archive.\nList the archive and use the path to the entry point ` +
+          `inside it, such as "maestro/bin/maestro".`
+      );
+    }
+    chmodSync(entry, 0o755);
+
+    // A WRAPPER, not a symlink. Both keep the tree intact, but a symlink only
+    // works for launchers that resolve symlinks before computing their own
+    // location — gradle's template does, and plenty of others do not. One that
+    // does not sees the link's directory as its home and looks for its
+    // classpath beside the link instead of beside itself, which is the same
+    // broken install this kind exists to prevent, reintroduced for a subset of
+    // tools. Exec'ing the absolute path removes the assumption entirely.
+    const shim = join(binDir, tool.name);
+    rmSync(shim, { force: true });
+    writeFileSync(shim, `#!/bin/sh\nexec ${JSON.stringify(entry)} "$@"\n`);
+    chmodSync(shim, 0o755);
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -239,6 +327,7 @@ export function installTool(tool, binDir) {
   assertPinned(tool);
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
   else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
+  else if (tool.install === "release-tree") installReleaseTree(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -334,6 +334,26 @@ export function assertPinned(tool) {
     }
     return;
   }
+  // A tree carries the same checksum obligation and one more: which file inside
+  // it is the entry point. There is no sane default — the archive root is a
+  // directory, so guessing would install a directory as a binary.
+  if (tool.install === "release-tree") {
+    if (!tool.url || !tool.sha256) {
+      throw new Error(
+        `${tool.name}: a release-tree install needs both url and sha256.\n` +
+          `A version bump must move the checksum in the same reviewed commit.`
+      );
+    }
+    if (!tool.binary) {
+      throw new Error(
+        `${tool.name}: a release-tree install needs "binary" — the path to the ` +
+          `entry point INSIDE the archive, such as "maestro/bin/maestro".\n` +
+          `Unlike the single-file kinds there is nothing to fall back to: the ` +
+          `archive root is a directory.`
+      );
+    }
+    return;
+  }
   if (tool.install === "npm-global") {
     if (!tool.package)
       throw new Error(`${tool.name}: npm-global install needs a package`);
@@ -341,6 +361,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, npm-global.`
+      `Supported: release-zip, release-tar, release-tree, npm-global.`
   );
 }

--- a/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -563,7 +563,8 @@ export function proposedEntries(proposal) {
   // the checksum cannot vouch for, which is the one property that makes a
   // pinned entry worth reviewing.
   const archive = platform => ({
-    install: "<release-tar or release-zip, whichever this platform ships>",
+    install:
+      "<release-tar | release-zip | release-tree — tree when the archive is a directory whose entry point loads its own siblings>",
     url: `<release url for this exact version, for ${platform}>`,
     sha256: `<sha256 published with the ${platform} release>`,
   });

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
@@ -165,15 +165,27 @@ by platform. Before that existed, the only way to keep a Linux binary off a lapt
 
 Expected shape for most projects: a short `require` list, an empty or near-empty `install` list, and the provider CLI as the only thing always provisioned.
 
-### The three `install` methods
+### The four `install` methods
 
 | `install` | Required fields | Use it when |
 | --- | --- | --- |
 | `release-zip` | `url` **and** `sha256` | The vendor publishes a Linux zip of the release. |
 | `release-tar` | `url` **and** `sha256` — plus `binary` in practice | The vendor publishes no zip for Linux, only a `.tar.gz`. |
+| `release-tree` | `url`, `sha256` **and** `binary` | The archive is a **directory**, not a single binary — an entry point that resolves its own siblings at run time. |
 | `npm-global` | `package` | The tool ships on the npm registry. |
 
 Anything else is rejected by name at plan time, so a typo fails loudly rather than silently installing nothing.
+
+**`release-tree` exists because the single-file kinds fail silently on a tree.** They extract the archive and copy *one* file onto PATH, which is right for a static binary and wrong for anything that locates its own resources. Maestro is the case that forced it — one 314 MB zip containing:
+
+```text
+maestro/bin/maestro     <- launcher
+maestro/lib/*.jar       <- 100+ MB of classpath
+```
+
+and a launcher that computes `CLASSPATH=$APP_HOME/lib/*` where `APP_HOME` is the parent of wherever the script itself sits. Declared as `release-zip` with `binary: maestro/bin/maestro`, the launcher lands in `~/.local/bin`, `APP_HOME` resolves to `~/.local`, and the classpath points at an empty directory. **The install reports success and the tool dies at first use** with `Could not find or load main class` — exactly the failure this manifest exists to turn into a loud setup error.
+
+So `release-tree` extracts the whole archive to `~/.local/share/<name>/<version>` and puts a **wrapper** on PATH that `exec`s the entry point in place. Not a copy, and deliberately not a symlink either: a launcher that does not resolve symlinks before computing its own location would read the link's directory as its home and look for its resources beside the link — the same broken install, narrowed to a subset of tools. `binary` has no default here, because the archive root is a directory and guessing would install a directory as a binary.
 
 Both archive kinds carry the **same** obligation and differ only in how they are unpacked: `url` and `sha256` are both mandatory, the checksum is verified *before* the archive is unpacked, and a version bump must move the checksum in the same reviewed commit. Neither is a weaker path than the other — `release-tar` exists because some tools worth pinning simply do not publish a zip. `gh` is the case that forced it: it ships `.deb`, `.rpm` and `.tar.gz` and nothing else, so a zip-only installer could not pin the CLI that Lisa's own commit guardrails shell out to.
 

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -213,6 +213,94 @@ function installReleaseTar(tool, binDir) {
 }
 
 /**
+ * Where a tree-shaped tool's extracted contents live.
+ *
+ * Versioned so a re-pin lands beside the old copy rather than on top of it, and
+ * outside `binDir` because only the entry point belongs on PATH.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory holding the symlink.
+ * @returns {string} Absolute prefix for this tool and version.
+ */
+export function treePrefix(tool, binDir) {
+  return join(binDir, "..", "share", tool.name, String(tool.version));
+}
+
+/**
+ * Install a pinned archive that is a DIRECTORY, not a single binary.
+ *
+ * `release-zip` and `release-tar` extract and then copy one file onto PATH,
+ * which is right for a static binary and silently wrong for anything that
+ * resolves its own siblings at run time. Maestro is the case that forced this:
+ *
+ *     maestro/bin/maestro   <- launcher
+ *     maestro/lib/*.jar     <- 100+ MB of classpath
+ *
+ * and the launcher computes `CLASSPATH=$APP_HOME/lib/*` where `APP_HOME` is the
+ * parent of wherever the script itself sits. Copy that launcher to
+ * `~/.local/bin` and APP_HOME becomes `~/.local`, so the classpath resolves to
+ * an empty directory. The install reports success and the tool fails at first
+ * use — the failure this manifest exists to turn into a loud setup error.
+ *
+ * So the whole tree is extracted and the entry point is SYMLINKED. A symlink,
+ * not a copy, precisely so that resolution walks back into the extracted tree.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to link the entry point into.
+ */
+function installReleaseTree(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  const prefix = treePrefix(tool, binDir);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const archive = join(temporary, "download.archive");
+    execFileSync("curl", ["-fsSL", tool.url, "-o", archive], {
+      stdio: "inherit",
+    });
+    // Verify before unpacking, as everywhere else here: an unexpected archive
+    // must fail before any of its contents reach the filesystem.
+    verifyChecksum(archive, tool.sha256, tool.name);
+
+    // Replace rather than layer. Extracting over a previous version leaves both
+    // sets of jars on the classpath, which fails in a way that looks like a
+    // version bug rather than a stale install.
+    rmSync(prefix, { recursive: true, force: true });
+    mkdirSync(prefix, { recursive: true });
+    if (tool.url.endsWith(".zip")) {
+      execFileSync("unzip", ["-q", "-o", archive, "-d", prefix], {
+        stdio: "inherit",
+      });
+    } else {
+      execFileSync("tar", ["-xzf", archive, "-C", prefix], {
+        stdio: "inherit",
+      });
+    }
+
+    const entry = join(prefix, tool.binary);
+    if (!existsSync(entry)) {
+      throw new Error(
+        `${tool.name}: "binary" points at ${tool.binary}, which is not in the ` +
+          `archive.\nList the archive and use the path to the entry point ` +
+          `inside it, such as "maestro/bin/maestro".`
+      );
+    }
+    chmodSync(entry, 0o755);
+
+    // A WRAPPER, not a symlink. Both keep the tree intact, but a symlink only
+    // works for launchers that resolve symlinks before computing their own
+    // location — gradle's template does, and plenty of others do not. One that
+    // does not sees the link's directory as its home and looks for its
+    // classpath beside the link instead of beside itself, which is the same
+    // broken install this kind exists to prevent, reintroduced for a subset of
+    // tools. Exec'ing the absolute path removes the assumption entirely.
+    const shim = join(binDir, tool.name);
+    rmSync(shim, { force: true });
+    writeFileSync(shim, `#!/bin/sh\nexec ${JSON.stringify(entry)} "$@"\n`);
+    chmodSync(shim, 0o755);
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -239,6 +327,7 @@ export function installTool(tool, binDir) {
   assertPinned(tool);
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
   else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
+  else if (tool.install === "release-tree") installReleaseTree(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -334,6 +334,26 @@ export function assertPinned(tool) {
     }
     return;
   }
+  // A tree carries the same checksum obligation and one more: which file inside
+  // it is the entry point. There is no sane default — the archive root is a
+  // directory, so guessing would install a directory as a binary.
+  if (tool.install === "release-tree") {
+    if (!tool.url || !tool.sha256) {
+      throw new Error(
+        `${tool.name}: a release-tree install needs both url and sha256.\n` +
+          `A version bump must move the checksum in the same reviewed commit.`
+      );
+    }
+    if (!tool.binary) {
+      throw new Error(
+        `${tool.name}: a release-tree install needs "binary" — the path to the ` +
+          `entry point INSIDE the archive, such as "maestro/bin/maestro".\n` +
+          `Unlike the single-file kinds there is nothing to fall back to: the ` +
+          `archive root is a directory.`
+      );
+    }
+    return;
+  }
   if (tool.install === "npm-global") {
     if (!tool.package)
       throw new Error(`${tool.name}: npm-global install needs a package`);
@@ -341,6 +361,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, npm-global.`
+      `Supported: release-zip, release-tar, release-tree, npm-global.`
   );
 }

--- a/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -563,7 +563,8 @@ export function proposedEntries(proposal) {
   // the checksum cannot vouch for, which is the one property that makes a
   // pinned entry worth reviewing.
   const archive = platform => ({
-    install: "<release-tar or release-zip, whichever this platform ships>",
+    install:
+      "<release-tar | release-zip | release-tree — tree when the archive is a directory whose entry point loads its own siblings>",
     url: `<release url for this exact version, for ${platform}>`,
     sha256: `<sha256 published with the ${platform} release>`,
   });

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
@@ -165,15 +165,27 @@ by platform. Before that existed, the only way to keep a Linux binary off a lapt
 
 Expected shape for most projects: a short `require` list, an empty or near-empty `install` list, and the provider CLI as the only thing always provisioned.
 
-### The three `install` methods
+### The four `install` methods
 
 | `install` | Required fields | Use it when |
 | --- | --- | --- |
 | `release-zip` | `url` **and** `sha256` | The vendor publishes a Linux zip of the release. |
 | `release-tar` | `url` **and** `sha256` — plus `binary` in practice | The vendor publishes no zip for Linux, only a `.tar.gz`. |
+| `release-tree` | `url`, `sha256` **and** `binary` | The archive is a **directory**, not a single binary — an entry point that resolves its own siblings at run time. |
 | `npm-global` | `package` | The tool ships on the npm registry. |
 
 Anything else is rejected by name at plan time, so a typo fails loudly rather than silently installing nothing.
+
+**`release-tree` exists because the single-file kinds fail silently on a tree.** They extract the archive and copy *one* file onto PATH, which is right for a static binary and wrong for anything that locates its own resources. Maestro is the case that forced it — one 314 MB zip containing:
+
+```text
+maestro/bin/maestro     <- launcher
+maestro/lib/*.jar       <- 100+ MB of classpath
+```
+
+and a launcher that computes `CLASSPATH=$APP_HOME/lib/*` where `APP_HOME` is the parent of wherever the script itself sits. Declared as `release-zip` with `binary: maestro/bin/maestro`, the launcher lands in `~/.local/bin`, `APP_HOME` resolves to `~/.local`, and the classpath points at an empty directory. **The install reports success and the tool dies at first use** with `Could not find or load main class` — exactly the failure this manifest exists to turn into a loud setup error.
+
+So `release-tree` extracts the whole archive to `~/.local/share/<name>/<version>` and puts a **wrapper** on PATH that `exec`s the entry point in place. Not a copy, and deliberately not a symlink either: a launcher that does not resolve symlinks before computing its own location would read the link's directory as its home and look for its resources beside the link — the same broken install, narrowed to a subset of tools. `binary` has no default here, because the archive root is a directory and guessing would install a directory as a binary.
 
 Both archive kinds carry the **same** obligation and differ only in how they are unpacked: `url` and `sha256` are both mandatory, the checksum is verified *before* the archive is unpacked, and a version bump must move the checksum in the same reviewed commit. Neither is a weaker path than the other — `release-tar` exists because some tools worth pinning simply do not publish a zip. `gh` is the case that forced it: it ships `.deb`, `.rpm` and `.tar.gz` and nothing else, so a zip-only installer could not pin the CLI that Lisa's own commit guardrails shell out to.
 

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -213,6 +213,94 @@ function installReleaseTar(tool, binDir) {
 }
 
 /**
+ * Where a tree-shaped tool's extracted contents live.
+ *
+ * Versioned so a re-pin lands beside the old copy rather than on top of it, and
+ * outside `binDir` because only the entry point belongs on PATH.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory holding the symlink.
+ * @returns {string} Absolute prefix for this tool and version.
+ */
+export function treePrefix(tool, binDir) {
+  return join(binDir, "..", "share", tool.name, String(tool.version));
+}
+
+/**
+ * Install a pinned archive that is a DIRECTORY, not a single binary.
+ *
+ * `release-zip` and `release-tar` extract and then copy one file onto PATH,
+ * which is right for a static binary and silently wrong for anything that
+ * resolves its own siblings at run time. Maestro is the case that forced this:
+ *
+ *     maestro/bin/maestro   <- launcher
+ *     maestro/lib/*.jar     <- 100+ MB of classpath
+ *
+ * and the launcher computes `CLASSPATH=$APP_HOME/lib/*` where `APP_HOME` is the
+ * parent of wherever the script itself sits. Copy that launcher to
+ * `~/.local/bin` and APP_HOME becomes `~/.local`, so the classpath resolves to
+ * an empty directory. The install reports success and the tool fails at first
+ * use — the failure this manifest exists to turn into a loud setup error.
+ *
+ * So the whole tree is extracted and the entry point is SYMLINKED. A symlink,
+ * not a copy, precisely so that resolution walks back into the extracted tree.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to link the entry point into.
+ */
+function installReleaseTree(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  const prefix = treePrefix(tool, binDir);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const archive = join(temporary, "download.archive");
+    execFileSync("curl", ["-fsSL", tool.url, "-o", archive], {
+      stdio: "inherit",
+    });
+    // Verify before unpacking, as everywhere else here: an unexpected archive
+    // must fail before any of its contents reach the filesystem.
+    verifyChecksum(archive, tool.sha256, tool.name);
+
+    // Replace rather than layer. Extracting over a previous version leaves both
+    // sets of jars on the classpath, which fails in a way that looks like a
+    // version bug rather than a stale install.
+    rmSync(prefix, { recursive: true, force: true });
+    mkdirSync(prefix, { recursive: true });
+    if (tool.url.endsWith(".zip")) {
+      execFileSync("unzip", ["-q", "-o", archive, "-d", prefix], {
+        stdio: "inherit",
+      });
+    } else {
+      execFileSync("tar", ["-xzf", archive, "-C", prefix], {
+        stdio: "inherit",
+      });
+    }
+
+    const entry = join(prefix, tool.binary);
+    if (!existsSync(entry)) {
+      throw new Error(
+        `${tool.name}: "binary" points at ${tool.binary}, which is not in the ` +
+          `archive.\nList the archive and use the path to the entry point ` +
+          `inside it, such as "maestro/bin/maestro".`
+      );
+    }
+    chmodSync(entry, 0o755);
+
+    // A WRAPPER, not a symlink. Both keep the tree intact, but a symlink only
+    // works for launchers that resolve symlinks before computing their own
+    // location — gradle's template does, and plenty of others do not. One that
+    // does not sees the link's directory as its home and looks for its
+    // classpath beside the link instead of beside itself, which is the same
+    // broken install this kind exists to prevent, reintroduced for a subset of
+    // tools. Exec'ing the absolute path removes the assumption entirely.
+    const shim = join(binDir, tool.name);
+    rmSync(shim, { force: true });
+    writeFileSync(shim, `#!/bin/sh\nexec ${JSON.stringify(entry)} "$@"\n`);
+    chmodSync(shim, 0o755);
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -239,6 +327,7 @@ export function installTool(tool, binDir) {
   assertPinned(tool);
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
   else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
+  else if (tool.install === "release-tree") installReleaseTree(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -334,6 +334,26 @@ export function assertPinned(tool) {
     }
     return;
   }
+  // A tree carries the same checksum obligation and one more: which file inside
+  // it is the entry point. There is no sane default — the archive root is a
+  // directory, so guessing would install a directory as a binary.
+  if (tool.install === "release-tree") {
+    if (!tool.url || !tool.sha256) {
+      throw new Error(
+        `${tool.name}: a release-tree install needs both url and sha256.\n` +
+          `A version bump must move the checksum in the same reviewed commit.`
+      );
+    }
+    if (!tool.binary) {
+      throw new Error(
+        `${tool.name}: a release-tree install needs "binary" — the path to the ` +
+          `entry point INSIDE the archive, such as "maestro/bin/maestro".\n` +
+          `Unlike the single-file kinds there is nothing to fall back to: the ` +
+          `archive root is a directory.`
+      );
+    }
+    return;
+  }
   if (tool.install === "npm-global") {
     if (!tool.package)
       throw new Error(`${tool.name}: npm-global install needs a package`);
@@ -341,6 +361,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, npm-global.`
+      `Supported: release-zip, release-tar, release-tree, npm-global.`
   );
 }

--- a/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -563,7 +563,8 @@ export function proposedEntries(proposal) {
   // the checksum cannot vouch for, which is the one property that makes a
   // pinned entry worth reviewing.
   const archive = platform => ({
-    install: "<release-tar or release-zip, whichever this platform ships>",
+    install:
+      "<release-tar | release-zip | release-tree — tree when the archive is a directory whose entry point loads its own siblings>",
     url: `<release url for this exact version, for ${platform}>`,
     sha256: `<sha256 published with the ${platform} release>`,
   });

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
@@ -165,15 +165,27 @@ by platform. Before that existed, the only way to keep a Linux binary off a lapt
 
 Expected shape for most projects: a short `require` list, an empty or near-empty `install` list, and the provider CLI as the only thing always provisioned.
 
-### The three `install` methods
+### The four `install` methods
 
 | `install` | Required fields | Use it when |
 | --- | --- | --- |
 | `release-zip` | `url` **and** `sha256` | The vendor publishes a Linux zip of the release. |
 | `release-tar` | `url` **and** `sha256` — plus `binary` in practice | The vendor publishes no zip for Linux, only a `.tar.gz`. |
+| `release-tree` | `url`, `sha256` **and** `binary` | The archive is a **directory**, not a single binary — an entry point that resolves its own siblings at run time. |
 | `npm-global` | `package` | The tool ships on the npm registry. |
 
 Anything else is rejected by name at plan time, so a typo fails loudly rather than silently installing nothing.
+
+**`release-tree` exists because the single-file kinds fail silently on a tree.** They extract the archive and copy *one* file onto PATH, which is right for a static binary and wrong for anything that locates its own resources. Maestro is the case that forced it — one 314 MB zip containing:
+
+```text
+maestro/bin/maestro     <- launcher
+maestro/lib/*.jar       <- 100+ MB of classpath
+```
+
+and a launcher that computes `CLASSPATH=$APP_HOME/lib/*` where `APP_HOME` is the parent of wherever the script itself sits. Declared as `release-zip` with `binary: maestro/bin/maestro`, the launcher lands in `~/.local/bin`, `APP_HOME` resolves to `~/.local`, and the classpath points at an empty directory. **The install reports success and the tool dies at first use** with `Could not find or load main class` — exactly the failure this manifest exists to turn into a loud setup error.
+
+So `release-tree` extracts the whole archive to `~/.local/share/<name>/<version>` and puts a **wrapper** on PATH that `exec`s the entry point in place. Not a copy, and deliberately not a symlink either: a launcher that does not resolve symlinks before computing its own location would read the link's directory as its home and look for its resources beside the link — the same broken install, narrowed to a subset of tools. `binary` has no default here, because the archive root is a directory and guessing would install a directory as a binary.
 
 Both archive kinds carry the **same** obligation and differ only in how they are unpacked: `url` and `sha256` are both mandatory, the checksum is verified *before* the archive is unpacked, and a version bump must move the checksum in the same reviewed commit. Neither is a weaker path than the other — `release-tar` exists because some tools worth pinning simply do not publish a zip. `gh` is the case that forced it: it ships `.deb`, `.rpm` and `.tar.gz` and nothing else, so a zip-only installer could not pin the CLI that Lisa's own commit guardrails shell out to.
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -213,6 +213,94 @@ function installReleaseTar(tool, binDir) {
 }
 
 /**
+ * Where a tree-shaped tool's extracted contents live.
+ *
+ * Versioned so a re-pin lands beside the old copy rather than on top of it, and
+ * outside `binDir` because only the entry point belongs on PATH.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory holding the symlink.
+ * @returns {string} Absolute prefix for this tool and version.
+ */
+export function treePrefix(tool, binDir) {
+  return join(binDir, "..", "share", tool.name, String(tool.version));
+}
+
+/**
+ * Install a pinned archive that is a DIRECTORY, not a single binary.
+ *
+ * `release-zip` and `release-tar` extract and then copy one file onto PATH,
+ * which is right for a static binary and silently wrong for anything that
+ * resolves its own siblings at run time. Maestro is the case that forced this:
+ *
+ *     maestro/bin/maestro   <- launcher
+ *     maestro/lib/*.jar     <- 100+ MB of classpath
+ *
+ * and the launcher computes `CLASSPATH=$APP_HOME/lib/*` where `APP_HOME` is the
+ * parent of wherever the script itself sits. Copy that launcher to
+ * `~/.local/bin` and APP_HOME becomes `~/.local`, so the classpath resolves to
+ * an empty directory. The install reports success and the tool fails at first
+ * use — the failure this manifest exists to turn into a loud setup error.
+ *
+ * So the whole tree is extracted and the entry point is SYMLINKED. A symlink,
+ * not a copy, precisely so that resolution walks back into the extracted tree.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to link the entry point into.
+ */
+function installReleaseTree(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  const prefix = treePrefix(tool, binDir);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const archive = join(temporary, "download.archive");
+    execFileSync("curl", ["-fsSL", tool.url, "-o", archive], {
+      stdio: "inherit",
+    });
+    // Verify before unpacking, as everywhere else here: an unexpected archive
+    // must fail before any of its contents reach the filesystem.
+    verifyChecksum(archive, tool.sha256, tool.name);
+
+    // Replace rather than layer. Extracting over a previous version leaves both
+    // sets of jars on the classpath, which fails in a way that looks like a
+    // version bug rather than a stale install.
+    rmSync(prefix, { recursive: true, force: true });
+    mkdirSync(prefix, { recursive: true });
+    if (tool.url.endsWith(".zip")) {
+      execFileSync("unzip", ["-q", "-o", archive, "-d", prefix], {
+        stdio: "inherit",
+      });
+    } else {
+      execFileSync("tar", ["-xzf", archive, "-C", prefix], {
+        stdio: "inherit",
+      });
+    }
+
+    const entry = join(prefix, tool.binary);
+    if (!existsSync(entry)) {
+      throw new Error(
+        `${tool.name}: "binary" points at ${tool.binary}, which is not in the ` +
+          `archive.\nList the archive and use the path to the entry point ` +
+          `inside it, such as "maestro/bin/maestro".`
+      );
+    }
+    chmodSync(entry, 0o755);
+
+    // A WRAPPER, not a symlink. Both keep the tree intact, but a symlink only
+    // works for launchers that resolve symlinks before computing their own
+    // location — gradle's template does, and plenty of others do not. One that
+    // does not sees the link's directory as its home and looks for its
+    // classpath beside the link instead of beside itself, which is the same
+    // broken install this kind exists to prevent, reintroduced for a subset of
+    // tools. Exec'ing the absolute path removes the assumption entirely.
+    const shim = join(binDir, tool.name);
+    rmSync(shim, { force: true });
+    writeFileSync(shim, `#!/bin/sh\nexec ${JSON.stringify(entry)} "$@"\n`);
+    chmodSync(shim, 0o755);
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -239,6 +327,7 @@ export function installTool(tool, binDir) {
   assertPinned(tool);
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
   else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
+  else if (tool.install === "release-tree") installReleaseTree(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -334,6 +334,26 @@ export function assertPinned(tool) {
     }
     return;
   }
+  // A tree carries the same checksum obligation and one more: which file inside
+  // it is the entry point. There is no sane default — the archive root is a
+  // directory, so guessing would install a directory as a binary.
+  if (tool.install === "release-tree") {
+    if (!tool.url || !tool.sha256) {
+      throw new Error(
+        `${tool.name}: a release-tree install needs both url and sha256.\n` +
+          `A version bump must move the checksum in the same reviewed commit.`
+      );
+    }
+    if (!tool.binary) {
+      throw new Error(
+        `${tool.name}: a release-tree install needs "binary" — the path to the ` +
+          `entry point INSIDE the archive, such as "maestro/bin/maestro".\n` +
+          `Unlike the single-file kinds there is nothing to fall back to: the ` +
+          `archive root is a directory.`
+      );
+    }
+    return;
+  }
   if (tool.install === "npm-global") {
     if (!tool.package)
       throw new Error(`${tool.name}: npm-global install needs a package`);
@@ -341,6 +361,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, npm-global.`
+      `Supported: release-zip, release-tar, release-tree, npm-global.`
   );
 }

--- a/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -563,7 +563,8 @@ export function proposedEntries(proposal) {
   // the checksum cannot vouch for, which is the one property that makes a
   // pinned entry worth reviewing.
   const archive = platform => ({
-    install: "<release-tar or release-zip, whichever this platform ships>",
+    install:
+      "<release-tar | release-zip | release-tree — tree when the archive is a directory whose entry point loads its own siblings>",
     url: `<release url for this exact version, for ${platform}>`,
     sha256: `<sha256 published with the ${platform} release>`,
   });

--- a/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
@@ -165,15 +165,27 @@ by platform. Before that existed, the only way to keep a Linux binary off a lapt
 
 Expected shape for most projects: a short `require` list, an empty or near-empty `install` list, and the provider CLI as the only thing always provisioned.
 
-### The three `install` methods
+### The four `install` methods
 
 | `install` | Required fields | Use it when |
 | --- | --- | --- |
 | `release-zip` | `url` **and** `sha256` | The vendor publishes a Linux zip of the release. |
 | `release-tar` | `url` **and** `sha256` — plus `binary` in practice | The vendor publishes no zip for Linux, only a `.tar.gz`. |
+| `release-tree` | `url`, `sha256` **and** `binary` | The archive is a **directory**, not a single binary — an entry point that resolves its own siblings at run time. |
 | `npm-global` | `package` | The tool ships on the npm registry. |
 
 Anything else is rejected by name at plan time, so a typo fails loudly rather than silently installing nothing.
+
+**`release-tree` exists because the single-file kinds fail silently on a tree.** They extract the archive and copy *one* file onto PATH, which is right for a static binary and wrong for anything that locates its own resources. Maestro is the case that forced it — one 314 MB zip containing:
+
+```text
+maestro/bin/maestro     <- launcher
+maestro/lib/*.jar       <- 100+ MB of classpath
+```
+
+and a launcher that computes `CLASSPATH=$APP_HOME/lib/*` where `APP_HOME` is the parent of wherever the script itself sits. Declared as `release-zip` with `binary: maestro/bin/maestro`, the launcher lands in `~/.local/bin`, `APP_HOME` resolves to `~/.local`, and the classpath points at an empty directory. **The install reports success and the tool dies at first use** with `Could not find or load main class` — exactly the failure this manifest exists to turn into a loud setup error.
+
+So `release-tree` extracts the whole archive to `~/.local/share/<name>/<version>` and puts a **wrapper** on PATH that `exec`s the entry point in place. Not a copy, and deliberately not a symlink either: a launcher that does not resolve symlinks before computing its own location would read the link's directory as its home and look for its resources beside the link — the same broken install, narrowed to a subset of tools. `binary` has no default here, because the archive root is a directory and guessing would install a directory as a binary.
 
 Both archive kinds carry the **same** obligation and differ only in how they are unpacked: `url` and `sha256` are both mandatory, the checksum is verified *before* the archive is unpacked, and a version bump must move the checksum in the same reviewed commit. Neither is a weaker path than the other — `release-tar` exists because some tools worth pinning simply do not publish a zip. `gh` is the case that forced it: it ships `.deb`, `.rpm` and `.tar.gz` and nothing else, so a zip-only installer could not pin the CLI that Lisa's own commit guardrails shell out to.
 

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -213,6 +213,94 @@ function installReleaseTar(tool, binDir) {
 }
 
 /**
+ * Where a tree-shaped tool's extracted contents live.
+ *
+ * Versioned so a re-pin lands beside the old copy rather than on top of it, and
+ * outside `binDir` because only the entry point belongs on PATH.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory holding the symlink.
+ * @returns {string} Absolute prefix for this tool and version.
+ */
+export function treePrefix(tool, binDir) {
+  return join(binDir, "..", "share", tool.name, String(tool.version));
+}
+
+/**
+ * Install a pinned archive that is a DIRECTORY, not a single binary.
+ *
+ * `release-zip` and `release-tar` extract and then copy one file onto PATH,
+ * which is right for a static binary and silently wrong for anything that
+ * resolves its own siblings at run time. Maestro is the case that forced this:
+ *
+ *     maestro/bin/maestro   <- launcher
+ *     maestro/lib/*.jar     <- 100+ MB of classpath
+ *
+ * and the launcher computes `CLASSPATH=$APP_HOME/lib/*` where `APP_HOME` is the
+ * parent of wherever the script itself sits. Copy that launcher to
+ * `~/.local/bin` and APP_HOME becomes `~/.local`, so the classpath resolves to
+ * an empty directory. The install reports success and the tool fails at first
+ * use — the failure this manifest exists to turn into a loud setup error.
+ *
+ * So the whole tree is extracted and the entry point is SYMLINKED. A symlink,
+ * not a copy, precisely so that resolution walks back into the extracted tree.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to link the entry point into.
+ */
+function installReleaseTree(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  const prefix = treePrefix(tool, binDir);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const archive = join(temporary, "download.archive");
+    execFileSync("curl", ["-fsSL", tool.url, "-o", archive], {
+      stdio: "inherit",
+    });
+    // Verify before unpacking, as everywhere else here: an unexpected archive
+    // must fail before any of its contents reach the filesystem.
+    verifyChecksum(archive, tool.sha256, tool.name);
+
+    // Replace rather than layer. Extracting over a previous version leaves both
+    // sets of jars on the classpath, which fails in a way that looks like a
+    // version bug rather than a stale install.
+    rmSync(prefix, { recursive: true, force: true });
+    mkdirSync(prefix, { recursive: true });
+    if (tool.url.endsWith(".zip")) {
+      execFileSync("unzip", ["-q", "-o", archive, "-d", prefix], {
+        stdio: "inherit",
+      });
+    } else {
+      execFileSync("tar", ["-xzf", archive, "-C", prefix], {
+        stdio: "inherit",
+      });
+    }
+
+    const entry = join(prefix, tool.binary);
+    if (!existsSync(entry)) {
+      throw new Error(
+        `${tool.name}: "binary" points at ${tool.binary}, which is not in the ` +
+          `archive.\nList the archive and use the path to the entry point ` +
+          `inside it, such as "maestro/bin/maestro".`
+      );
+    }
+    chmodSync(entry, 0o755);
+
+    // A WRAPPER, not a symlink. Both keep the tree intact, but a symlink only
+    // works for launchers that resolve symlinks before computing their own
+    // location — gradle's template does, and plenty of others do not. One that
+    // does not sees the link's directory as its home and looks for its
+    // classpath beside the link instead of beside itself, which is the same
+    // broken install this kind exists to prevent, reintroduced for a subset of
+    // tools. Exec'ing the absolute path removes the assumption entirely.
+    const shim = join(binDir, tool.name);
+    rmSync(shim, { force: true });
+    writeFileSync(shim, `#!/bin/sh\nexec ${JSON.stringify(entry)} "$@"\n`);
+    chmodSync(shim, 0o755);
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -239,6 +327,7 @@ export function installTool(tool, binDir) {
   assertPinned(tool);
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
   else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
+  else if (tool.install === "release-tree") installReleaseTree(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -334,6 +334,26 @@ export function assertPinned(tool) {
     }
     return;
   }
+  // A tree carries the same checksum obligation and one more: which file inside
+  // it is the entry point. There is no sane default — the archive root is a
+  // directory, so guessing would install a directory as a binary.
+  if (tool.install === "release-tree") {
+    if (!tool.url || !tool.sha256) {
+      throw new Error(
+        `${tool.name}: a release-tree install needs both url and sha256.\n` +
+          `A version bump must move the checksum in the same reviewed commit.`
+      );
+    }
+    if (!tool.binary) {
+      throw new Error(
+        `${tool.name}: a release-tree install needs "binary" — the path to the ` +
+          `entry point INSIDE the archive, such as "maestro/bin/maestro".\n` +
+          `Unlike the single-file kinds there is nothing to fall back to: the ` +
+          `archive root is a directory.`
+      );
+    }
+    return;
+  }
   if (tool.install === "npm-global") {
     if (!tool.package)
       throw new Error(`${tool.name}: npm-global install needs a package`);
@@ -341,6 +361,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, npm-global.`
+      `Supported: release-zip, release-tar, release-tree, npm-global.`
   );
 }

--- a/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -563,7 +563,8 @@ export function proposedEntries(proposal) {
   // the checksum cannot vouch for, which is the one property that makes a
   // pinned entry worth reviewing.
   const archive = platform => ({
-    install: "<release-tar or release-zip, whichever this platform ships>",
+    install:
+      "<release-tar | release-zip | release-tree — tree when the archive is a directory whose entry point loads its own siblings>",
     url: `<release url for this exact version, for ${platform}>`,
     sha256: `<sha256 published with the ${platform} release>`,
   });

--- a/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
@@ -165,15 +165,27 @@ by platform. Before that existed, the only way to keep a Linux binary off a lapt
 
 Expected shape for most projects: a short `require` list, an empty or near-empty `install` list, and the provider CLI as the only thing always provisioned.
 
-### The three `install` methods
+### The four `install` methods
 
 | `install` | Required fields | Use it when |
 | --- | --- | --- |
 | `release-zip` | `url` **and** `sha256` | The vendor publishes a Linux zip of the release. |
 | `release-tar` | `url` **and** `sha256` — plus `binary` in practice | The vendor publishes no zip for Linux, only a `.tar.gz`. |
+| `release-tree` | `url`, `sha256` **and** `binary` | The archive is a **directory**, not a single binary — an entry point that resolves its own siblings at run time. |
 | `npm-global` | `package` | The tool ships on the npm registry. |
 
 Anything else is rejected by name at plan time, so a typo fails loudly rather than silently installing nothing.
+
+**`release-tree` exists because the single-file kinds fail silently on a tree.** They extract the archive and copy *one* file onto PATH, which is right for a static binary and wrong for anything that locates its own resources. Maestro is the case that forced it — one 314 MB zip containing:
+
+```text
+maestro/bin/maestro     <- launcher
+maestro/lib/*.jar       <- 100+ MB of classpath
+```
+
+and a launcher that computes `CLASSPATH=$APP_HOME/lib/*` where `APP_HOME` is the parent of wherever the script itself sits. Declared as `release-zip` with `binary: maestro/bin/maestro`, the launcher lands in `~/.local/bin`, `APP_HOME` resolves to `~/.local`, and the classpath points at an empty directory. **The install reports success and the tool dies at first use** with `Could not find or load main class` — exactly the failure this manifest exists to turn into a loud setup error.
+
+So `release-tree` extracts the whole archive to `~/.local/share/<name>/<version>` and puts a **wrapper** on PATH that `exec`s the entry point in place. Not a copy, and deliberately not a symlink either: a launcher that does not resolve symlinks before computing its own location would read the link's directory as its home and look for its resources beside the link — the same broken install, narrowed to a subset of tools. `binary` has no default here, because the archive root is a directory and guessing would install a directory as a binary.
 
 Both archive kinds carry the **same** obligation and differ only in how they are unpacked: `url` and `sha256` are both mandatory, the checksum is verified *before* the archive is unpacked, and a version bump must move the checksum in the same reviewed commit. Neither is a weaker path than the other — `release-tar` exists because some tools worth pinning simply do not publish a zip. `gh` is the case that forced it: it ships `.deb`, `.rpm` and `.tar.gz` and nothing else, so a zip-only installer could not pin the CLI that Lisa's own commit guardrails shell out to.
 

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -213,6 +213,94 @@ function installReleaseTar(tool, binDir) {
 }
 
 /**
+ * Where a tree-shaped tool's extracted contents live.
+ *
+ * Versioned so a re-pin lands beside the old copy rather than on top of it, and
+ * outside `binDir` because only the entry point belongs on PATH.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory holding the symlink.
+ * @returns {string} Absolute prefix for this tool and version.
+ */
+export function treePrefix(tool, binDir) {
+  return join(binDir, "..", "share", tool.name, String(tool.version));
+}
+
+/**
+ * Install a pinned archive that is a DIRECTORY, not a single binary.
+ *
+ * `release-zip` and `release-tar` extract and then copy one file onto PATH,
+ * which is right for a static binary and silently wrong for anything that
+ * resolves its own siblings at run time. Maestro is the case that forced this:
+ *
+ *     maestro/bin/maestro   <- launcher
+ *     maestro/lib/*.jar     <- 100+ MB of classpath
+ *
+ * and the launcher computes `CLASSPATH=$APP_HOME/lib/*` where `APP_HOME` is the
+ * parent of wherever the script itself sits. Copy that launcher to
+ * `~/.local/bin` and APP_HOME becomes `~/.local`, so the classpath resolves to
+ * an empty directory. The install reports success and the tool fails at first
+ * use — the failure this manifest exists to turn into a loud setup error.
+ *
+ * So the whole tree is extracted and the entry point is SYMLINKED. A symlink,
+ * not a copy, precisely so that resolution walks back into the extracted tree.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to link the entry point into.
+ */
+function installReleaseTree(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  const prefix = treePrefix(tool, binDir);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const archive = join(temporary, "download.archive");
+    execFileSync("curl", ["-fsSL", tool.url, "-o", archive], {
+      stdio: "inherit",
+    });
+    // Verify before unpacking, as everywhere else here: an unexpected archive
+    // must fail before any of its contents reach the filesystem.
+    verifyChecksum(archive, tool.sha256, tool.name);
+
+    // Replace rather than layer. Extracting over a previous version leaves both
+    // sets of jars on the classpath, which fails in a way that looks like a
+    // version bug rather than a stale install.
+    rmSync(prefix, { recursive: true, force: true });
+    mkdirSync(prefix, { recursive: true });
+    if (tool.url.endsWith(".zip")) {
+      execFileSync("unzip", ["-q", "-o", archive, "-d", prefix], {
+        stdio: "inherit",
+      });
+    } else {
+      execFileSync("tar", ["-xzf", archive, "-C", prefix], {
+        stdio: "inherit",
+      });
+    }
+
+    const entry = join(prefix, tool.binary);
+    if (!existsSync(entry)) {
+      throw new Error(
+        `${tool.name}: "binary" points at ${tool.binary}, which is not in the ` +
+          `archive.\nList the archive and use the path to the entry point ` +
+          `inside it, such as "maestro/bin/maestro".`
+      );
+    }
+    chmodSync(entry, 0o755);
+
+    // A WRAPPER, not a symlink. Both keep the tree intact, but a symlink only
+    // works for launchers that resolve symlinks before computing their own
+    // location — gradle's template does, and plenty of others do not. One that
+    // does not sees the link's directory as its home and looks for its
+    // classpath beside the link instead of beside itself, which is the same
+    // broken install this kind exists to prevent, reintroduced for a subset of
+    // tools. Exec'ing the absolute path removes the assumption entirely.
+    const shim = join(binDir, tool.name);
+    rmSync(shim, { force: true });
+    writeFileSync(shim, `#!/bin/sh\nexec ${JSON.stringify(entry)} "$@"\n`);
+    chmodSync(shim, 0o755);
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -239,6 +327,7 @@ export function installTool(tool, binDir) {
   assertPinned(tool);
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
   else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
+  else if (tool.install === "release-tree") installReleaseTree(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -334,6 +334,26 @@ export function assertPinned(tool) {
     }
     return;
   }
+  // A tree carries the same checksum obligation and one more: which file inside
+  // it is the entry point. There is no sane default — the archive root is a
+  // directory, so guessing would install a directory as a binary.
+  if (tool.install === "release-tree") {
+    if (!tool.url || !tool.sha256) {
+      throw new Error(
+        `${tool.name}: a release-tree install needs both url and sha256.\n` +
+          `A version bump must move the checksum in the same reviewed commit.`
+      );
+    }
+    if (!tool.binary) {
+      throw new Error(
+        `${tool.name}: a release-tree install needs "binary" — the path to the ` +
+          `entry point INSIDE the archive, such as "maestro/bin/maestro".\n` +
+          `Unlike the single-file kinds there is nothing to fall back to: the ` +
+          `archive root is a directory.`
+      );
+    }
+    return;
+  }
   if (tool.install === "npm-global") {
     if (!tool.package)
       throw new Error(`${tool.name}: npm-global install needs a package`);
@@ -341,6 +361,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, npm-global.`
+      `Supported: release-zip, release-tar, release-tree, npm-global.`
   );
 }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -865,7 +865,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-detect-tooling/scripts/commands.mjs":
       "e28bd61fdde4a336b56ae3395423026943a5816015719d31d04f0d5a0ab50eec",
     "plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs":
-      "e24e6ac3e073097d4a9991b398386f19f10a8abe2dfba57196d615f5e6a6cf63",
+      "9d06590e6b99cce33e5fb10bd5b9e7515318133e3635368ef47162abc123bdfa",
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
       "fb41a1e63c5332d47a46e715aff52551f3df867033b5e4f37dfaeee30019b891",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
@@ -1151,15 +1151,15 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md":
       "80fbf157f9c562c033886c25a99b37356602edd9e61cd2d492f339769ddcf97e",
     "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md":
-      "33eff2e0bd777030070b2616a83bb073e845d17823c12ed95c1e84c6f6b27bf4",
+      "b570ebc3faa5099dc8e43f33f5ba51bdc1e2312b3c49d28d04a3ae67f138041f",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh":
       "cb63d08b14ab7aa2d405e6770e0cf7db5d6588ae1dcb924ea6224b026fcff496",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "c30d98a5645f033fc1d3a723043691b9ad997ae5666df539ff6aa19c563431b2",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "e3e54f281297e28d54769b45c0b87a40b93e8ab88ac1cd57aea4050d40dc4b5e",
+      "fe5b7231c8fb82de22a8b6d14f50aea2f9ddc068a2deddf817660dd1e4db83a2",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
-      "cb98159f9432ce0c4f93a8b5386c61fc1b7d3a299bbb041d6bd005b790291277",
+      "b2fa53bf577400851e8c2991cbe822d29dcdd2d090ff1cd1d0fa2d76bfcaa20b",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
       "82bc2a27a0a5afb2ff413a88365c619fd7f0eaada5de3ccabf2000938f0607a4",
     "plugins/src/base/skills/lisa-setup-sonar/SKILL.md":
@@ -8495,6 +8495,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/rotation-view.test.ts": true,
     "tests/unit/secrets/secrets-access-contract.test.ts": true,
     "tests/unit/secrets/toolchain-platforms.test.ts": true,
+    "tests/unit/secrets/toolchain-release-tree.test.ts": true,
     "tests/unit/secrets/toolchain-surfaces.test.ts": true,
     "tests/unit/secrets/validate-config.test.ts": true,
     "tests/unit/sonar/sonar-installer.test.ts": true,

--- a/tests/unit/secrets/remote-env-phases.test.ts
+++ b/tests/unit/secrets/remote-env-phases.test.ts
@@ -381,7 +381,7 @@ describe("pinned tarball installs", () => {
   it("names the tar kind when refusing an unknown one", () => {
     // The message is where an operator learns which kinds exist at all.
     expect(() => assertPinned({ name: "x", install: "release-deb" })).toThrow(
-      /Supported: release-zip, release-tar, npm-global/
+      /Supported: release-zip, release-tar, release-tree, npm-global/
     );
   });
 

--- a/tests/unit/secrets/toolchain-release-tree.test.ts
+++ b/tests/unit/secrets/toolchain-release-tree.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Tests for the `release-tree` install kind.
+ *
+ * `release-zip` and `release-tar` extract an archive and copy ONE file onto
+ * PATH. That is right for a static binary and silently wrong for an artifact
+ * whose entry point resolves its own siblings — the install reports success and
+ * the tool fails at first use, which is the failure the toolchain manifest
+ * exists to convert into a loud setup error.
+ *
+ * Maestro is the case that forced it: a launcher computing
+ * `CLASSPATH=$APP_HOME/lib/*` from its own location. Installed as `release-zip`
+ * it reports success and then dies with `Could not find or load main class`.
+ *
+ * The archives here are built on the fly rather than downloaded, so the suite
+ * stays fast and offline while still exercising the real unpack-and-link path.
+ * @module tests/unit/secrets/toolchain-release-tree
+ */
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  installTool,
+  treePrefix,
+} from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs";
+import { assertPinned } from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs";
+
+/** Directories created for a single test. */
+const created: string[] = [];
+
+/** The fixture tool's name, used as its directory and its name on PATH. */
+const TOY = "toy";
+
+/** The entry point path inside every fixture archive. */
+const ENTRY = `${TOY}/bin/${TOY}`;
+
+/** What the fixture launcher prints when its siblings are reachable. */
+const PAYLOAD = "classpath-ok";
+
+/** A stand-in release URL; never fetched, only asserted on. */
+const MAESTRO_URL = "https://example.invalid/maestro.zip";
+
+/** Maestro's real entry point path, the case that motivated this kind. */
+const MAESTRO_ENTRY = "maestro/bin/maestro";
+
+/** An absolute archiver path, so the test never resolves a command via PATH. */
+const ZIP = "/usr/bin/zip";
+
+/** The install kind under test. */
+const RELEASE_TREE = "release-tree";
+
+/** A well-formed digest for entries that are never actually fetched. */
+const FAKE_SHA = "a".repeat(64);
+
+/** Description of a fixture archive on disk. */
+interface Fixture {
+  /** `file://` URL the installer downloads from. */
+  readonly url: string;
+  /** Digest of the archive, for the pin. */
+  readonly sha256: string;
+  /** Scratch directory holding the archive. */
+  readonly root: string;
+}
+
+/**
+ * Build a zip whose entry point reads a sibling file, like a real JVM launcher.
+ *
+ * The sibling is the whole point: a copy-one-file installer loses it, and the
+ * script then fails exactly where maestro fails. This launcher deliberately
+ * does NOT resolve symlinks, which is what caught an earlier symlink-based
+ * implementation — plenty of real launchers behave the same way.
+ * @returns The fixture archive.
+ */
+function toyArchive(): Fixture {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-tree-"));
+  const stage = path.join(root, "stage");
+  const archive = path.join(root, "toy.zip");
+  const launcher = [
+    "#!/bin/sh",
+    'here=$(cd -P "$(dirname "$0")" && pwd)',
+    'app_home=$(cd -P "$here/.." && pwd)',
+    'cat "$app_home/lib/payload"',
+    "",
+  ].join("\n");
+
+  created.push(root);
+  mkdirSync(path.join(stage, TOY, "bin"), { recursive: true });
+  mkdirSync(path.join(stage, TOY, "lib"), { recursive: true });
+  writeFileSync(path.join(stage, TOY, "lib", "payload"), `${PAYLOAD}\n`);
+  writeFileSync(path.join(stage, ENTRY), launcher);
+  chmodSync(path.join(stage, ENTRY), 0o755);
+  execFileSync(ZIP, ["-qr", archive, TOY], { cwd: stage });
+
+  return {
+    url: `file://${archive}`,
+    sha256: createHash("sha256").update(readFileSync(archive)).digest("hex"),
+    root,
+  };
+}
+
+/**
+ * Build a manifest entry for a fixture archive.
+ * @param archive Fixture from {@link toyArchive}.
+ * @param overrides Fields to replace.
+ * @returns A manifest entry.
+ */
+function entry(
+  archive: Fixture,
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    name: TOY,
+    version: "1.0.0",
+    install: RELEASE_TREE,
+    url: archive.url,
+    sha256: archive.sha256,
+    binary: ENTRY,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a fixture and the bin directory an install would target.
+ * @returns The fixture and its bin directory.
+ */
+function installed(): { archive: Fixture; binDir: string } {
+  const archive = toyArchive();
+  const binDir = path.join(archive.root, "bin");
+  mkdirSync(binDir, { recursive: true });
+  return { archive, binDir };
+}
+
+afterEach(() => {
+  while (created.length > 0) {
+    rmSync(created.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe("assertPinned for release-tree", () => {
+  it("accepts a fully pinned entry", () => {
+    expect(() =>
+      assertPinned({
+        name: "maestro",
+        version: "2.8.0",
+        install: RELEASE_TREE,
+        url: MAESTRO_URL,
+        sha256: FAKE_SHA,
+        binary: MAESTRO_ENTRY,
+      })
+    ).not.toThrow();
+  });
+
+  it("refuses an entry with no checksum", () => {
+    expect(() =>
+      assertPinned({
+        name: "maestro",
+        install: RELEASE_TREE,
+        url: MAESTRO_URL,
+        binary: MAESTRO_ENTRY,
+      })
+    ).toThrow(/needs both url and sha256/);
+  });
+
+  it("refuses an entry with no entry point, since there is nothing to guess", () => {
+    // The archive root is a directory. Falling back to the tool name — which the
+    // single-file kinds do — would install a directory as a binary.
+    expect(() =>
+      assertPinned({
+        name: "maestro",
+        install: RELEASE_TREE,
+        url: MAESTRO_URL,
+        sha256: FAKE_SHA,
+      })
+    ).toThrow(/needs "binary"/);
+  });
+
+  it("names release-tree among the supported methods", () => {
+    expect(() => assertPinned({ name: "x", install: "nonsense" })).toThrow(
+      /release-tree/
+    );
+  });
+});
+
+describe("installTool with release-tree", () => {
+  it("puts a wrapper on PATH that execs the entry point in place", () => {
+    // Not a copy, and deliberately not a symlink either: a launcher that does
+    // not resolve symlinks would read the link's directory as its home and look
+    // for its resources beside the link — the same broken install, for a subset
+    // of tools.
+    const { archive, binDir } = installed();
+    installTool(entry(archive), binDir);
+
+    const shim = path.join(binDir, TOY);
+    expect(lstatSync(shim).isSymbolicLink()).toBe(false);
+    expect(readFileSync(shim, "utf8")).toContain(
+      path.join(treePrefix(entry(archive), binDir), ENTRY)
+    );
+  });
+
+  it("produces an entry point that can actually resolve its siblings", () => {
+    // The real assertion. "A file appeared on PATH" is what the broken kind
+    // also achieved.
+    const { archive, binDir } = installed();
+    installTool(entry(archive), binDir);
+
+    const out = execFileSync(path.join(binDir, TOY), {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    expect(out.trim()).toBe(PAYLOAD);
+  });
+
+  it("keeps the tree out of the bin directory", () => {
+    const { archive, binDir } = installed();
+    installTool(entry(archive), binDir);
+
+    const prefix = treePrefix(entry(archive), binDir);
+    expect(existsSync(path.join(prefix, TOY, "lib"))).toBe(true);
+    expect(existsSync(path.join(binDir, TOY, "lib"))).toBe(false);
+  });
+
+  it("replaces a previous install rather than layering onto it", () => {
+    // Extracting over a stale tree leaves both versions' payloads in place,
+    // which fails in a way that reads as a version bug rather than a stale
+    // install.
+    const { archive, binDir } = installed();
+    installTool(entry(archive), binDir);
+
+    const stale = path.join(
+      treePrefix(entry(archive), binDir),
+      TOY,
+      "lib",
+      "leftover"
+    );
+    writeFileSync(stale, "from an older pin\n");
+    installTool(entry(archive), binDir);
+
+    expect(existsSync(stale)).toBe(false);
+  });
+
+  it("is idempotent — a second install still runs", () => {
+    const { archive, binDir } = installed();
+    installTool(entry(archive), binDir);
+    installTool(entry(archive), binDir);
+
+    const out = execFileSync(path.join(binDir, TOY), {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    expect(out.trim()).toBe(PAYLOAD);
+  });
+
+  it("refuses an archive whose checksum does not match, before unpacking", () => {
+    const { archive, binDir } = installed();
+
+    expect(() =>
+      installTool(entry(archive, { sha256: "b".repeat(64) }), binDir)
+    ).toThrow(/checksum mismatch/);
+    expect(existsSync(path.join(binDir, TOY))).toBe(false);
+  });
+
+  it("says so plainly when the entry point is not in the archive", () => {
+    const { archive, binDir } = installed();
+
+    expect(() =>
+      installTool(entry(archive, { binary: `${TOY}/bin/wrong` }), binDir)
+    ).toThrow(/not in the archive/);
+  });
+});


### PR DESCRIPTION
## The bug

`release-zip` and `release-tar` extract an archive and copy **one file** onto PATH. Right for a static binary; silently wrong for an artifact whose entry point resolves its own siblings at run time.

Maestro is the case that forced it — one 314 MB zip:

```text
maestro/bin/maestro     <- launcher
maestro/lib/*.jar       <- 100+ MB of classpath
```

with a launcher that computes `CLASSPATH=$APP_HOME/lib/*`, where `APP_HOME` is the parent of wherever the script itself sits. Declared as `release-zip` with `binary: maestro/bin/maestro`, the launcher lands in `~/.local/bin`, `APP_HOME` becomes `~/.local`, and the classpath points at an empty directory.

Reproduced against the real artifact before writing any code:

```
release-zip install: reported SUCCESS
  but running it FAILS: Could not find or load main class JvmVersion
```

An install that reports success and dies at first use is exactly the failure this manifest exists to convert into a loud setup error. AWS CLI v2 hit the same wall and is carried as a bespoke `aws-cli` kind in `lisa-setup-workstation` — two tools, one missing primitive.

## The fix

`release-tree` extracts the whole archive to `~/.local/share/<name>/<version>` and puts a wrapper on PATH that `exec`s the entry point in place.

```json
{
  "name": "maestro",
  "version": "2.8.0",
  "install": "release-tree",
  "url": "https://github.com/mobile-dev-inc/Maestro/releases/download/cli-2.8.0/maestro.zip",
  "sha256": "b3e561161904fb391875ca5834d5b22cf0b01c052dd1b408ad83e30d8f8951b3",
  "binary": "maestro/bin/maestro"
}
```

**A wrapper, not a symlink — and the tests are what forced that.** The first implementation symlinked, and real maestro worked, because gradle's launcher template resolves symlinks before computing its own location. A fixture launcher that does *not* resolve symlinks failed immediately: it read the link's directory as its home and looked for its resources beside the link. That is the same broken install, narrowed to a subset of tools. Exec'ing an absolute path removes the assumption entirely.

Had I only tested with maestro, the symlink version would have shipped and broken every tool whose launcher isn't gradle-generated.

**`binary` is mandatory here**, with no fallback to the tool name: the archive root is a directory, so guessing would install a directory as a binary.

Checksum is verified **before** unpacking, as with the existing kinds. A re-install replaces the version prefix rather than layering onto it — extracting over a stale tree leaves both versions' jars on the classpath, which fails in a way that reads as a version bug rather than a stale install.

## Verification

Against the real 314 MB artifact:

```
assertPinned: ok
is a symlink: false
wrapper: exec ".../share/maestro/2.8.0/maestro/bin/maestro" "$@"
classpath present: true
launcher runs: 2.8.0
```

- 11 new tests, archives built on the fly so the suite stays fast and offline
- One existing assertion updated: the `Supported:` list legitimately gained a member
- Full suite: 508 files / 8618 tests green; typecheck and lint clean
- Fans out to all five agent variants

Unchanged behaviour for `release-zip`, `release-tar` and `npm-global`.

🤖 Generated with Claude Code

---

Work-Item: CodySwannGT/lisa#2295
