### PR TITLE
fix(workstation): agy is installable — Google ships a headless installer

### DIFF
--- a/plugins/lisa-agy/skills/lisa-setup-workstation/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-workstation/SKILL.md
@@ -137,6 +137,7 @@ than stopping.
 - **Install a credential manager you did not pick.**
 - **Reinstall over a tool that is already there**, whatever installed it.
 - **Install anything without `--install`.**
-- **Install `agy`.** Antigravity publishes no headless installer; it is reported as manual
-  with a pointer, because "not installed" and "cannot be installed by this tool" are
-  different answers to the operator.
+- **Install a tool whose vendor publishes no headless installer.** Such an entry is
+  reported as manual with a pointer, because "not installed" and "cannot be installed by
+  this tool" are different answers to the operator. No agent is currently in that state —
+  Antigravity was listed there in error and does publish a bootstrapper.

--- a/plugins/lisa-agy/skills/lisa-setup-workstation/scripts/catalogue.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-workstation/scripts/catalogue.mjs
@@ -66,11 +66,13 @@ export const AGENTS = [
   {
     name: "agy",
     label: "Antigravity",
-    kind: "manual",
-    // No headless installer published. Reported as absent with a pointer
-    // rather than silently skipped, because "not installed" and "cannot be
-    // installed by this tool" are different answers to the operator.
-    note: "no headless installer published; install from the vendor",
+    kind: "vendor-script",
+    // Google does publish a headless bootstrapper; this entry previously said
+    // otherwise and reported the agent as uninstallable. Confirmed live —
+    // `content-type: application/x-sh`, and the payload is a bash script that
+    // downloads and verifies the flat native build.
+    script: "https://antigravity.google/cli/install.sh",
+    selfUpdates: true,
   },
   {
     name: "copilot",

--- a/plugins/lisa-copilot/skills/lisa-setup-workstation/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-workstation/SKILL.md
@@ -137,6 +137,7 @@ than stopping.
 - **Install a credential manager you did not pick.**
 - **Reinstall over a tool that is already there**, whatever installed it.
 - **Install anything without `--install`.**
-- **Install `agy`.** Antigravity publishes no headless installer; it is reported as manual
-  with a pointer, because "not installed" and "cannot be installed by this tool" are
-  different answers to the operator.
+- **Install a tool whose vendor publishes no headless installer.** Such an entry is
+  reported as manual with a pointer, because "not installed" and "cannot be installed by
+  this tool" are different answers to the operator. No agent is currently in that state —
+  Antigravity was listed there in error and does publish a bootstrapper.

--- a/plugins/lisa-copilot/skills/lisa-setup-workstation/scripts/catalogue.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-workstation/scripts/catalogue.mjs
@@ -66,11 +66,13 @@ export const AGENTS = [
   {
     name: "agy",
     label: "Antigravity",
-    kind: "manual",
-    // No headless installer published. Reported as absent with a pointer
-    // rather than silently skipped, because "not installed" and "cannot be
-    // installed by this tool" are different answers to the operator.
-    note: "no headless installer published; install from the vendor",
+    kind: "vendor-script",
+    // Google does publish a headless bootstrapper; this entry previously said
+    // otherwise and reported the agent as uninstallable. Confirmed live —
+    // `content-type: application/x-sh`, and the payload is a bash script that
+    // downloads and verifies the flat native build.
+    script: "https://antigravity.google/cli/install.sh",
+    selfUpdates: true,
   },
   {
     name: "copilot",

--- a/plugins/lisa-cursor/skills/lisa-setup-workstation/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-workstation/SKILL.md
@@ -137,6 +137,7 @@ than stopping.
 - **Install a credential manager you did not pick.**
 - **Reinstall over a tool that is already there**, whatever installed it.
 - **Install anything without `--install`.**
-- **Install `agy`.** Antigravity publishes no headless installer; it is reported as manual
-  with a pointer, because "not installed" and "cannot be installed by this tool" are
-  different answers to the operator.
+- **Install a tool whose vendor publishes no headless installer.** Such an entry is
+  reported as manual with a pointer, because "not installed" and "cannot be installed by
+  this tool" are different answers to the operator. No agent is currently in that state —
+  Antigravity was listed there in error and does publish a bootstrapper.

--- a/plugins/lisa-cursor/skills/lisa-setup-workstation/scripts/catalogue.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-workstation/scripts/catalogue.mjs
@@ -66,11 +66,13 @@ export const AGENTS = [
   {
     name: "agy",
     label: "Antigravity",
-    kind: "manual",
-    // No headless installer published. Reported as absent with a pointer
-    // rather than silently skipped, because "not installed" and "cannot be
-    // installed by this tool" are different answers to the operator.
-    note: "no headless installer published; install from the vendor",
+    kind: "vendor-script",
+    // Google does publish a headless bootstrapper; this entry previously said
+    // otherwise and reported the agent as uninstallable. Confirmed live —
+    // `content-type: application/x-sh`, and the payload is a bash script that
+    // downloads and verifies the flat native build.
+    script: "https://antigravity.google/cli/install.sh",
+    selfUpdates: true,
   },
   {
     name: "copilot",

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-workstation/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-workstation/SKILL.md
@@ -137,6 +137,7 @@ than stopping.
 - **Install a credential manager you did not pick.**
 - **Reinstall over a tool that is already there**, whatever installed it.
 - **Install anything without `--install`.**
-- **Install `agy`.** Antigravity publishes no headless installer; it is reported as manual
-  with a pointer, because "not installed" and "cannot be installed by this tool" are
-  different answers to the operator.
+- **Install a tool whose vendor publishes no headless installer.** Such an entry is
+  reported as manual with a pointer, because "not installed" and "cannot be installed by
+  this tool" are different answers to the operator. No agent is currently in that state —
+  Antigravity was listed there in error and does publish a bootstrapper.

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-workstation/scripts/catalogue.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-workstation/scripts/catalogue.mjs
@@ -66,11 +66,13 @@ export const AGENTS = [
   {
     name: "agy",
     label: "Antigravity",
-    kind: "manual",
-    // No headless installer published. Reported as absent with a pointer
-    // rather than silently skipped, because "not installed" and "cannot be
-    // installed by this tool" are different answers to the operator.
-    note: "no headless installer published; install from the vendor",
+    kind: "vendor-script",
+    // Google does publish a headless bootstrapper; this entry previously said
+    // otherwise and reported the agent as uninstallable. Confirmed live —
+    // `content-type: application/x-sh`, and the payload is a bash script that
+    // downloads and verifies the flat native build.
+    script: "https://antigravity.google/cli/install.sh",
+    selfUpdates: true,
   },
   {
     name: "copilot",

--- a/plugins/lisa/skills/lisa-setup-workstation/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-workstation/SKILL.md
@@ -137,6 +137,7 @@ than stopping.
 - **Install a credential manager you did not pick.**
 - **Reinstall over a tool that is already there**, whatever installed it.
 - **Install anything without `--install`.**
-- **Install `agy`.** Antigravity publishes no headless installer; it is reported as manual
-  with a pointer, because "not installed" and "cannot be installed by this tool" are
-  different answers to the operator.
+- **Install a tool whose vendor publishes no headless installer.** Such an entry is
+  reported as manual with a pointer, because "not installed" and "cannot be installed by
+  this tool" are different answers to the operator. No agent is currently in that state —
+  Antigravity was listed there in error and does publish a bootstrapper.

--- a/plugins/lisa/skills/lisa-setup-workstation/scripts/catalogue.mjs
+++ b/plugins/lisa/skills/lisa-setup-workstation/scripts/catalogue.mjs
@@ -66,11 +66,13 @@ export const AGENTS = [
   {
     name: "agy",
     label: "Antigravity",
-    kind: "manual",
-    // No headless installer published. Reported as absent with a pointer
-    // rather than silently skipped, because "not installed" and "cannot be
-    // installed by this tool" are different answers to the operator.
-    note: "no headless installer published; install from the vendor",
+    kind: "vendor-script",
+    // Google does publish a headless bootstrapper; this entry previously said
+    // otherwise and reported the agent as uninstallable. Confirmed live —
+    // `content-type: application/x-sh`, and the payload is a bash script that
+    // downloads and verifies the flat native build.
+    script: "https://antigravity.google/cli/install.sh",
+    selfUpdates: true,
   },
   {
     name: "copilot",

--- a/plugins/src/base/skills/lisa-setup-workstation/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-workstation/SKILL.md
@@ -137,6 +137,7 @@ than stopping.
 - **Install a credential manager you did not pick.**
 - **Reinstall over a tool that is already there**, whatever installed it.
 - **Install anything without `--install`.**
-- **Install `agy`.** Antigravity publishes no headless installer; it is reported as manual
-  with a pointer, because "not installed" and "cannot be installed by this tool" are
-  different answers to the operator.
+- **Install a tool whose vendor publishes no headless installer.** Such an entry is
+  reported as manual with a pointer, because "not installed" and "cannot be installed by
+  this tool" are different answers to the operator. No agent is currently in that state —
+  Antigravity was listed there in error and does publish a bootstrapper.

--- a/plugins/src/base/skills/lisa-setup-workstation/scripts/catalogue.mjs
+++ b/plugins/src/base/skills/lisa-setup-workstation/scripts/catalogue.mjs
@@ -66,11 +66,13 @@ export const AGENTS = [
   {
     name: "agy",
     label: "Antigravity",
-    kind: "manual",
-    // No headless installer published. Reported as absent with a pointer
-    // rather than silently skipped, because "not installed" and "cannot be
-    // installed by this tool" are different answers to the operator.
-    note: "no headless installer published; install from the vendor",
+    kind: "vendor-script",
+    // Google does publish a headless bootstrapper; this entry previously said
+    // otherwise and reported the agent as uninstallable. Confirmed live —
+    // `content-type: application/x-sh`, and the payload is a bash script that
+    // downloads and verifies the flat native build.
+    script: "https://antigravity.google/cli/install.sh",
+    selfUpdates: true,
   },
   {
     name: "copilot",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1165,9 +1165,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-sonar/SKILL.md":
       "53fbd8acce4b5e47e88195a7b90d5be424fa6ef7ad872f52c50467c690664c3b",
     "plugins/src/base/skills/lisa-setup-workstation/SKILL.md":
-      "4bc4413bbe381ab97e2aa10eaeda574f8113f69e6eb5f5a6e625c04f1dff1ad5",
+      "e57e64083c292f0402b704eeb647244be0f33ab17394a688bce57a1efd59f169",
     "plugins/src/base/skills/lisa-setup-workstation/scripts/catalogue.mjs":
-      "3fa13e7e2885aa5f3b4efdd12fc87958494a57d8bfeb81ab8489558592780b90",
+      "eb0b8ec8a5d4fd81402dcbf40e6ccb55eb5e0c960f11aa928e45b99de43fabbc",
     "plugins/src/base/skills/lisa-setup-workstation/scripts/cli.mjs":
       "cb64e501a6e8bf0b12fd865aa0be3407f54c5a08537a36dc71d2ead4764f5da0",
     "plugins/src/base/skills/lisa-setup-workstation/scripts/workstation.mjs":

--- a/tests/unit/workstation/workstation-plan.test.ts
+++ b/tests/unit/workstation/workstation-plan.test.ts
@@ -87,6 +87,19 @@ describe("catalogue integrity", () => {
     }
   });
 
+  it("marks every agent installable, since each vendor ships a bootstrapper", () => {
+    // Antigravity was carried as `manual` on the claim that it published no
+    // headless installer. It does — https://antigravity.google/cli/install.sh
+    // returns application/x-sh — so the entry made a real agent look
+    // unprovisionable. A wrong "cannot" is worse than a missing entry: it stops
+    // anyone from looking again.
+    for (const agent of AGENTS) {
+      expect(INSTALLABLE, `${agent.name} is ${agent.kind}`).toContain(
+        agent.kind
+      );
+    }
+  });
+
   it("puts the pinned bin directory first on PATH", () => {
     // A pinned, checksummed binary must win over whatever an image ships under
     // the same name.
@@ -177,8 +190,8 @@ describe("planEntry", () => {
   it("reports a manual-only tool as manual, not installable", async () => {
     const row = planEntry(
       {
-        name: "agy",
-        label: "Antigravity",
+        name: "vendor-only-tool",
+        label: "A tool with no headless installer",
         kind: "manual",
         note: "no installer",
       },


### PR DESCRIPTION
## The bug

The workstation catalogue carried Antigravity as unprovisionable:

```js
{ name: "agy", label: "Antigravity", kind: "manual",
  note: "no headless installer published; install from the vendor" }
```

Google publishes one:

```
$ curl -sSI -L https://antigravity.google/cli/install.sh | grep -i content-type
content-type: application/x-sh

$ curl -fsSL https://antigravity.google/cli/install.sh | head -3
#!/bin/bash
#
# Antigravity CLI - Unix Bootstrapper Script (Bash/Zsh/Fish)
```

**A wrong "cannot be installed" is worse than a missing entry.** A missing entry invites someone to add it; a confident `manual` *with a note explaining why* tells every future reader the question is settled. Every container built from this skill has come up without Antigravity for no reason.

## Verification

In `ubuntu:24.04`, where the agent is genuinely absent (it reports `present` on my laptop via Homebrew, so a local run proves nothing):

```
✅ Antigravity CLI installed successfully at /root/.local/bin/agy
  installed  Antigravity  ok
```

## Also in this PR

- **A regression guard**: every agent in the catalogue must be installable, so a revert to a wrong "cannot" fails loudly rather than sitting unnoticed.
- **Renamed a test fixture.** The plan test used `agy` as its example of a manual-kind tool. It passed either way — the kind is supplied inline — but naming a tool that *is* installable teaches the next reader the wrong thing.
- **Corrected SKILL.md**, whose "will not do" list named Antigravity as uninstallable. It now describes the shape without naming an agent, since none is currently in that state.

## Provenance

Found by comparing against a duplicate implementation of #2286 — PR #2287, built concurrently by a Codex agent and superseded by #2288. The two catalogues agreed on every entry except this one. Before closing the losing branch I diffed it, which is the only reason this surfaced.

🤖 Generated with Claude Code

---

Work-Item: CodySwannGT/lisa#2297


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Antigravity can now be installed automatically through its supported headless installer.
  * Antigravity installations support self-updates.

* **Documentation**
  * Clarified that tools without headless installers are reported as manual with setup guidance.
  * Updated workstation setup guidance to reflect Antigravity’s available bootstrapper.

* **Tests**
  * Added validation ensuring all catalogued tools have a supported installation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->