### PR TITLE
fix(skills): stop drive-pr-to-merge disabling auto-merge before a push

### DIFF
--- a/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,35 +126,47 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-**Leave the latch ARMED when you push a fix. Never disable it.** A pull request
-that needs a fix cannot merge anyway: auto-merge fires only once every required
-check passes, so disarming buys nothing in the ordinary case — and it costs a
-failure that is both silent and worse than the race it guards.
+**Leave the latch ARMED. Never disable auto-merge.**
 
-Disabling is a durable state change on GitHub; re-enabling is one more step you
-have to reach. When a run ends in between — turns exhausted, job timeout, or you
-concluding the work while checks are still pending — the latch stays off and
-nothing restores it. The pull request is then left WORSE OFF THAN IF THIS SKILL
-HAD NEVER RUN: it has lost the mechanism that merges it while no agent is
-watching, and the run reports success. Measured on `gunnertech/frontend#282`,
-where the latch went off 14s before the fix commit and the PR sat 26 minutes
-after going green, against ~3 minutes for PRs this skill never touched.
+Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
+the PR's current head, so a new commit whose checks have not reported leaves the
+PR blocked. Auto-merge cannot ship a commit nothing has verified.
 
-The race the old disarm guarded is the seconds after a push, before GitHub has
-registered any check for the NEW head. GitHub already closes it: a required check
-that has not reported for the head SHA leaves the PR blocked, not mergeable. And
-a repo with no required checks has no protection the disarm could add. So keeping
-the latch fails safe (at worst something merges a little early), while disarming
-fails unsafe (the PR silently cannot merge at all).
+The only window a disarm ever protected is the gap between deciding to fix
+something and that fix landing — during which the PR is genuinely green and
+genuinely mergeable, and auto-merge firing is GitHub behaving correctly. Two
+merges in this repo's history are attributed to that window (#1392, and the
+release that shipped the `./hooks/` Cursor bug). Both were fixed forward within
+minutes; one was a one-line docs inconsistency.
 
-Instead of disarming, treat the push as a merge race: immediately re-read
-`headRefOid` and reset `verify_commit` to the pushed head, so the verification in
-step 3 is against what you actually pushed rather than the commit you replaced.
+That evidence is also weaker than it looks: **auto-merge attributes the merge to
+whoever enabled it**, so an auto-merge and a human pressing Merge are
+indistinguishable in the timeline. The record cannot tell us those PRs were not
+simply merged by hand while the latch happened to be armed.
 
-**Invariant:** this skill must never terminate having left auto-merge OFF on an
-open PR when `auto_merge=true`. If some future path does disable it, restoring it
-is a terminal obligation on EVERY exit — including give-up, budget-exhausted and
-error paths — not a later step in a sequence.
+Against that, disarming costs something certain. Disabling is a durable state
+change on GitHub; re-enabling is one more step the run has to reach. When a run
+ends in between — turns exhausted, job timeout, or you concluding the work while
+checks are still pending — the latch stays off and nothing restores it. The PR is
+left WORSE OFF THAN IF THIS SKILL HAD NEVER RUN: it has lost the mechanism that
+merges it while no agent is watching, and the run reports success. Measured on
+`gunnertech/frontend#282`, the latch went off 14s before the fix commit and the
+PR sat 26 minutes after going green, against ~3 minutes for PRs this skill never
+touched.
+
+So the trade is a rare, unproven miss that costs a fix-forward PR, against a
+frequent, silent stall on every PR this skill repairs. Take the rare one.
+
+What still applies on a push: immediately re-read `headRefOid` and reset
+`verify_commit` to the pushed head, so the shipped-verification in step 3 checks
+what you actually pushed rather than the commit you replaced. That ancestry check
+is what CATCHES a raced merge — it fails loudly when the fix SHA is not an
+ancestor of the base branch — so the rare miss is detected rather than silent.
+
+**Invariant:** never terminate having left auto-merge OFF on an open PR when
+`auto_merge=true`. If some future path does disable it, restoring it is a
+terminal obligation on EVERY exit — including give-up, budget-exhausted and error
+paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,13 +126,35 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-If any later step will push commits, temporarily remove the auto-merge latch
-before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
-or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
-reset `verify_commit` to the pushed head, wait until that head's checks have
-started, then re-enable auto-merge. Do not leave auto-merge armed while a
-required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
-still in flight.
+**Leave the latch ARMED when you push a fix. Never disable it.** A pull request
+that needs a fix cannot merge anyway: auto-merge fires only once every required
+check passes, so disarming buys nothing in the ordinary case — and it costs a
+failure that is both silent and worse than the race it guards.
+
+Disabling is a durable state change on GitHub; re-enabling is one more step you
+have to reach. When a run ends in between — turns exhausted, job timeout, or you
+concluding the work while checks are still pending — the latch stays off and
+nothing restores it. The pull request is then left WORSE OFF THAN IF THIS SKILL
+HAD NEVER RUN: it has lost the mechanism that merges it while no agent is
+watching, and the run reports success. Measured on `gunnertech/frontend#282`,
+where the latch went off 14s before the fix commit and the PR sat 26 minutes
+after going green, against ~3 minutes for PRs this skill never touched.
+
+The race the old disarm guarded is the seconds after a push, before GitHub has
+registered any check for the NEW head. GitHub already closes it: a required check
+that has not reported for the head SHA leaves the PR blocked, not mergeable. And
+a repo with no required checks has no protection the disarm could add. So keeping
+the latch fails safe (at worst something merges a little early), while disarming
+fails unsafe (the PR silently cannot merge at all).
+
+Instead of disarming, treat the push as a merge race: immediately re-read
+`headRefOid` and reset `verify_commit` to the pushed head, so the verification in
+step 3 is against what you actually pushed rather than the commit you replaced.
+
+**Invariant:** this skill must never terminate having left auto-merge OFF on an
+open PR when `auto_merge=true`. If some future path does disable it, restoring it
+is a terminal obligation on EVERY exit — including give-up, budget-exhausted and
+error paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,35 +126,47 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-**Leave the latch ARMED when you push a fix. Never disable it.** A pull request
-that needs a fix cannot merge anyway: auto-merge fires only once every required
-check passes, so disarming buys nothing in the ordinary case — and it costs a
-failure that is both silent and worse than the race it guards.
+**Leave the latch ARMED. Never disable auto-merge.**
 
-Disabling is a durable state change on GitHub; re-enabling is one more step you
-have to reach. When a run ends in between — turns exhausted, job timeout, or you
-concluding the work while checks are still pending — the latch stays off and
-nothing restores it. The pull request is then left WORSE OFF THAN IF THIS SKILL
-HAD NEVER RUN: it has lost the mechanism that merges it while no agent is
-watching, and the run reports success. Measured on `gunnertech/frontend#282`,
-where the latch went off 14s before the fix commit and the PR sat 26 minutes
-after going green, against ~3 minutes for PRs this skill never touched.
+Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
+the PR's current head, so a new commit whose checks have not reported leaves the
+PR blocked. Auto-merge cannot ship a commit nothing has verified.
 
-The race the old disarm guarded is the seconds after a push, before GitHub has
-registered any check for the NEW head. GitHub already closes it: a required check
-that has not reported for the head SHA leaves the PR blocked, not mergeable. And
-a repo with no required checks has no protection the disarm could add. So keeping
-the latch fails safe (at worst something merges a little early), while disarming
-fails unsafe (the PR silently cannot merge at all).
+The only window a disarm ever protected is the gap between deciding to fix
+something and that fix landing — during which the PR is genuinely green and
+genuinely mergeable, and auto-merge firing is GitHub behaving correctly. Two
+merges in this repo's history are attributed to that window (#1392, and the
+release that shipped the `./hooks/` Cursor bug). Both were fixed forward within
+minutes; one was a one-line docs inconsistency.
 
-Instead of disarming, treat the push as a merge race: immediately re-read
-`headRefOid` and reset `verify_commit` to the pushed head, so the verification in
-step 3 is against what you actually pushed rather than the commit you replaced.
+That evidence is also weaker than it looks: **auto-merge attributes the merge to
+whoever enabled it**, so an auto-merge and a human pressing Merge are
+indistinguishable in the timeline. The record cannot tell us those PRs were not
+simply merged by hand while the latch happened to be armed.
 
-**Invariant:** this skill must never terminate having left auto-merge OFF on an
-open PR when `auto_merge=true`. If some future path does disable it, restoring it
-is a terminal obligation on EVERY exit — including give-up, budget-exhausted and
-error paths — not a later step in a sequence.
+Against that, disarming costs something certain. Disabling is a durable state
+change on GitHub; re-enabling is one more step the run has to reach. When a run
+ends in between — turns exhausted, job timeout, or you concluding the work while
+checks are still pending — the latch stays off and nothing restores it. The PR is
+left WORSE OFF THAN IF THIS SKILL HAD NEVER RUN: it has lost the mechanism that
+merges it while no agent is watching, and the run reports success. Measured on
+`gunnertech/frontend#282`, the latch went off 14s before the fix commit and the
+PR sat 26 minutes after going green, against ~3 minutes for PRs this skill never
+touched.
+
+So the trade is a rare, unproven miss that costs a fix-forward PR, against a
+frequent, silent stall on every PR this skill repairs. Take the rare one.
+
+What still applies on a push: immediately re-read `headRefOid` and reset
+`verify_commit` to the pushed head, so the shipped-verification in step 3 checks
+what you actually pushed rather than the commit you replaced. That ancestry check
+is what CATCHES a raced merge — it fails loudly when the fix SHA is not an
+ancestor of the base branch — so the rare miss is detected rather than silent.
+
+**Invariant:** never terminate having left auto-merge OFF on an open PR when
+`auto_merge=true`. If some future path does disable it, restoring it is a
+terminal obligation on EVERY exit — including give-up, budget-exhausted and error
+paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,13 +126,35 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-If any later step will push commits, temporarily remove the auto-merge latch
-before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
-or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
-reset `verify_commit` to the pushed head, wait until that head's checks have
-started, then re-enable auto-merge. Do not leave auto-merge armed while a
-required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
-still in flight.
+**Leave the latch ARMED when you push a fix. Never disable it.** A pull request
+that needs a fix cannot merge anyway: auto-merge fires only once every required
+check passes, so disarming buys nothing in the ordinary case — and it costs a
+failure that is both silent and worse than the race it guards.
+
+Disabling is a durable state change on GitHub; re-enabling is one more step you
+have to reach. When a run ends in between — turns exhausted, job timeout, or you
+concluding the work while checks are still pending — the latch stays off and
+nothing restores it. The pull request is then left WORSE OFF THAN IF THIS SKILL
+HAD NEVER RUN: it has lost the mechanism that merges it while no agent is
+watching, and the run reports success. Measured on `gunnertech/frontend#282`,
+where the latch went off 14s before the fix commit and the PR sat 26 minutes
+after going green, against ~3 minutes for PRs this skill never touched.
+
+The race the old disarm guarded is the seconds after a push, before GitHub has
+registered any check for the NEW head. GitHub already closes it: a required check
+that has not reported for the head SHA leaves the PR blocked, not mergeable. And
+a repo with no required checks has no protection the disarm could add. So keeping
+the latch fails safe (at worst something merges a little early), while disarming
+fails unsafe (the PR silently cannot merge at all).
+
+Instead of disarming, treat the push as a merge race: immediately re-read
+`headRefOid` and reset `verify_commit` to the pushed head, so the verification in
+step 3 is against what you actually pushed rather than the commit you replaced.
+
+**Invariant:** this skill must never terminate having left auto-merge OFF on an
+open PR when `auto_merge=true`. If some future path does disable it, restoring it
+is a terminal obligation on EVERY exit — including give-up, budget-exhausted and
+error paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,35 +126,47 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-**Leave the latch ARMED when you push a fix. Never disable it.** A pull request
-that needs a fix cannot merge anyway: auto-merge fires only once every required
-check passes, so disarming buys nothing in the ordinary case — and it costs a
-failure that is both silent and worse than the race it guards.
+**Leave the latch ARMED. Never disable auto-merge.**
 
-Disabling is a durable state change on GitHub; re-enabling is one more step you
-have to reach. When a run ends in between — turns exhausted, job timeout, or you
-concluding the work while checks are still pending — the latch stays off and
-nothing restores it. The pull request is then left WORSE OFF THAN IF THIS SKILL
-HAD NEVER RUN: it has lost the mechanism that merges it while no agent is
-watching, and the run reports success. Measured on `gunnertech/frontend#282`,
-where the latch went off 14s before the fix commit and the PR sat 26 minutes
-after going green, against ~3 minutes for PRs this skill never touched.
+Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
+the PR's current head, so a new commit whose checks have not reported leaves the
+PR blocked. Auto-merge cannot ship a commit nothing has verified.
 
-The race the old disarm guarded is the seconds after a push, before GitHub has
-registered any check for the NEW head. GitHub already closes it: a required check
-that has not reported for the head SHA leaves the PR blocked, not mergeable. And
-a repo with no required checks has no protection the disarm could add. So keeping
-the latch fails safe (at worst something merges a little early), while disarming
-fails unsafe (the PR silently cannot merge at all).
+The only window a disarm ever protected is the gap between deciding to fix
+something and that fix landing — during which the PR is genuinely green and
+genuinely mergeable, and auto-merge firing is GitHub behaving correctly. Two
+merges in this repo's history are attributed to that window (#1392, and the
+release that shipped the `./hooks/` Cursor bug). Both were fixed forward within
+minutes; one was a one-line docs inconsistency.
 
-Instead of disarming, treat the push as a merge race: immediately re-read
-`headRefOid` and reset `verify_commit` to the pushed head, so the verification in
-step 3 is against what you actually pushed rather than the commit you replaced.
+That evidence is also weaker than it looks: **auto-merge attributes the merge to
+whoever enabled it**, so an auto-merge and a human pressing Merge are
+indistinguishable in the timeline. The record cannot tell us those PRs were not
+simply merged by hand while the latch happened to be armed.
 
-**Invariant:** this skill must never terminate having left auto-merge OFF on an
-open PR when `auto_merge=true`. If some future path does disable it, restoring it
-is a terminal obligation on EVERY exit — including give-up, budget-exhausted and
-error paths — not a later step in a sequence.
+Against that, disarming costs something certain. Disabling is a durable state
+change on GitHub; re-enabling is one more step the run has to reach. When a run
+ends in between — turns exhausted, job timeout, or you concluding the work while
+checks are still pending — the latch stays off and nothing restores it. The PR is
+left WORSE OFF THAN IF THIS SKILL HAD NEVER RUN: it has lost the mechanism that
+merges it while no agent is watching, and the run reports success. Measured on
+`gunnertech/frontend#282`, the latch went off 14s before the fix commit and the
+PR sat 26 minutes after going green, against ~3 minutes for PRs this skill never
+touched.
+
+So the trade is a rare, unproven miss that costs a fix-forward PR, against a
+frequent, silent stall on every PR this skill repairs. Take the rare one.
+
+What still applies on a push: immediately re-read `headRefOid` and reset
+`verify_commit` to the pushed head, so the shipped-verification in step 3 checks
+what you actually pushed rather than the commit you replaced. That ancestry check
+is what CATCHES a raced merge — it fails loudly when the fix SHA is not an
+ancestor of the base branch — so the rare miss is detected rather than silent.
+
+**Invariant:** never terminate having left auto-merge OFF on an open PR when
+`auto_merge=true`. If some future path does disable it, restoring it is a
+terminal obligation on EVERY exit — including give-up, budget-exhausted and error
+paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,13 +126,35 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-If any later step will push commits, temporarily remove the auto-merge latch
-before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
-or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
-reset `verify_commit` to the pushed head, wait until that head's checks have
-started, then re-enable auto-merge. Do not leave auto-merge armed while a
-required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
-still in flight.
+**Leave the latch ARMED when you push a fix. Never disable it.** A pull request
+that needs a fix cannot merge anyway: auto-merge fires only once every required
+check passes, so disarming buys nothing in the ordinary case — and it costs a
+failure that is both silent and worse than the race it guards.
+
+Disabling is a durable state change on GitHub; re-enabling is one more step you
+have to reach. When a run ends in between — turns exhausted, job timeout, or you
+concluding the work while checks are still pending — the latch stays off and
+nothing restores it. The pull request is then left WORSE OFF THAN IF THIS SKILL
+HAD NEVER RUN: it has lost the mechanism that merges it while no agent is
+watching, and the run reports success. Measured on `gunnertech/frontend#282`,
+where the latch went off 14s before the fix commit and the PR sat 26 minutes
+after going green, against ~3 minutes for PRs this skill never touched.
+
+The race the old disarm guarded is the seconds after a push, before GitHub has
+registered any check for the NEW head. GitHub already closes it: a required check
+that has not reported for the head SHA leaves the PR blocked, not mergeable. And
+a repo with no required checks has no protection the disarm could add. So keeping
+the latch fails safe (at worst something merges a little early), while disarming
+fails unsafe (the PR silently cannot merge at all).
+
+Instead of disarming, treat the push as a merge race: immediately re-read
+`headRefOid` and reset `verify_commit` to the pushed head, so the verification in
+step 3 is against what you actually pushed rather than the commit you replaced.
+
+**Invariant:** this skill must never terminate having left auto-merge OFF on an
+open PR when `auto_merge=true`. If some future path does disable it, restoring it
+is a terminal obligation on EVERY exit — including give-up, budget-exhausted and
+error paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,35 +126,47 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-**Leave the latch ARMED when you push a fix. Never disable it.** A pull request
-that needs a fix cannot merge anyway: auto-merge fires only once every required
-check passes, so disarming buys nothing in the ordinary case — and it costs a
-failure that is both silent and worse than the race it guards.
+**Leave the latch ARMED. Never disable auto-merge.**
 
-Disabling is a durable state change on GitHub; re-enabling is one more step you
-have to reach. When a run ends in between — turns exhausted, job timeout, or you
-concluding the work while checks are still pending — the latch stays off and
-nothing restores it. The pull request is then left WORSE OFF THAN IF THIS SKILL
-HAD NEVER RUN: it has lost the mechanism that merges it while no agent is
-watching, and the run reports success. Measured on `gunnertech/frontend#282`,
-where the latch went off 14s before the fix commit and the PR sat 26 minutes
-after going green, against ~3 minutes for PRs this skill never touched.
+Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
+the PR's current head, so a new commit whose checks have not reported leaves the
+PR blocked. Auto-merge cannot ship a commit nothing has verified.
 
-The race the old disarm guarded is the seconds after a push, before GitHub has
-registered any check for the NEW head. GitHub already closes it: a required check
-that has not reported for the head SHA leaves the PR blocked, not mergeable. And
-a repo with no required checks has no protection the disarm could add. So keeping
-the latch fails safe (at worst something merges a little early), while disarming
-fails unsafe (the PR silently cannot merge at all).
+The only window a disarm ever protected is the gap between deciding to fix
+something and that fix landing — during which the PR is genuinely green and
+genuinely mergeable, and auto-merge firing is GitHub behaving correctly. Two
+merges in this repo's history are attributed to that window (#1392, and the
+release that shipped the `./hooks/` Cursor bug). Both were fixed forward within
+minutes; one was a one-line docs inconsistency.
 
-Instead of disarming, treat the push as a merge race: immediately re-read
-`headRefOid` and reset `verify_commit` to the pushed head, so the verification in
-step 3 is against what you actually pushed rather than the commit you replaced.
+That evidence is also weaker than it looks: **auto-merge attributes the merge to
+whoever enabled it**, so an auto-merge and a human pressing Merge are
+indistinguishable in the timeline. The record cannot tell us those PRs were not
+simply merged by hand while the latch happened to be armed.
 
-**Invariant:** this skill must never terminate having left auto-merge OFF on an
-open PR when `auto_merge=true`. If some future path does disable it, restoring it
-is a terminal obligation on EVERY exit — including give-up, budget-exhausted and
-error paths — not a later step in a sequence.
+Against that, disarming costs something certain. Disabling is a durable state
+change on GitHub; re-enabling is one more step the run has to reach. When a run
+ends in between — turns exhausted, job timeout, or you concluding the work while
+checks are still pending — the latch stays off and nothing restores it. The PR is
+left WORSE OFF THAN IF THIS SKILL HAD NEVER RUN: it has lost the mechanism that
+merges it while no agent is watching, and the run reports success. Measured on
+`gunnertech/frontend#282`, the latch went off 14s before the fix commit and the
+PR sat 26 minutes after going green, against ~3 minutes for PRs this skill never
+touched.
+
+So the trade is a rare, unproven miss that costs a fix-forward PR, against a
+frequent, silent stall on every PR this skill repairs. Take the rare one.
+
+What still applies on a push: immediately re-read `headRefOid` and reset
+`verify_commit` to the pushed head, so the shipped-verification in step 3 checks
+what you actually pushed rather than the commit you replaced. That ancestry check
+is what CATCHES a raced merge — it fails loudly when the fix SHA is not an
+ancestor of the base branch — so the rare miss is detected rather than silent.
+
+**Invariant:** never terminate having left auto-merge OFF on an open PR when
+`auto_merge=true`. If some future path does disable it, restoring it is a
+terminal obligation on EVERY exit — including give-up, budget-exhausted and error
+paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,13 +126,35 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-If any later step will push commits, temporarily remove the auto-merge latch
-before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
-or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
-reset `verify_commit` to the pushed head, wait until that head's checks have
-started, then re-enable auto-merge. Do not leave auto-merge armed while a
-required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
-still in flight.
+**Leave the latch ARMED when you push a fix. Never disable it.** A pull request
+that needs a fix cannot merge anyway: auto-merge fires only once every required
+check passes, so disarming buys nothing in the ordinary case — and it costs a
+failure that is both silent and worse than the race it guards.
+
+Disabling is a durable state change on GitHub; re-enabling is one more step you
+have to reach. When a run ends in between — turns exhausted, job timeout, or you
+concluding the work while checks are still pending — the latch stays off and
+nothing restores it. The pull request is then left WORSE OFF THAN IF THIS SKILL
+HAD NEVER RUN: it has lost the mechanism that merges it while no agent is
+watching, and the run reports success. Measured on `gunnertech/frontend#282`,
+where the latch went off 14s before the fix commit and the PR sat 26 minutes
+after going green, against ~3 minutes for PRs this skill never touched.
+
+The race the old disarm guarded is the seconds after a push, before GitHub has
+registered any check for the NEW head. GitHub already closes it: a required check
+that has not reported for the head SHA leaves the PR blocked, not mergeable. And
+a repo with no required checks has no protection the disarm could add. So keeping
+the latch fails safe (at worst something merges a little early), while disarming
+fails unsafe (the PR silently cannot merge at all).
+
+Instead of disarming, treat the push as a merge race: immediately re-read
+`headRefOid` and reset `verify_commit` to the pushed head, so the verification in
+step 3 is against what you actually pushed rather than the commit you replaced.
+
+**Invariant:** this skill must never terminate having left auto-merge OFF on an
+open PR when `auto_merge=true`. If some future path does disable it, restoring it
+is a terminal obligation on EVERY exit — including give-up, budget-exhausted and
+error paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,35 +126,47 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-**Leave the latch ARMED when you push a fix. Never disable it.** A pull request
-that needs a fix cannot merge anyway: auto-merge fires only once every required
-check passes, so disarming buys nothing in the ordinary case — and it costs a
-failure that is both silent and worse than the race it guards.
+**Leave the latch ARMED. Never disable auto-merge.**
 
-Disabling is a durable state change on GitHub; re-enabling is one more step you
-have to reach. When a run ends in between — turns exhausted, job timeout, or you
-concluding the work while checks are still pending — the latch stays off and
-nothing restores it. The pull request is then left WORSE OFF THAN IF THIS SKILL
-HAD NEVER RUN: it has lost the mechanism that merges it while no agent is
-watching, and the run reports success. Measured on `gunnertech/frontend#282`,
-where the latch went off 14s before the fix commit and the PR sat 26 minutes
-after going green, against ~3 minutes for PRs this skill never touched.
+Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
+the PR's current head, so a new commit whose checks have not reported leaves the
+PR blocked. Auto-merge cannot ship a commit nothing has verified.
 
-The race the old disarm guarded is the seconds after a push, before GitHub has
-registered any check for the NEW head. GitHub already closes it: a required check
-that has not reported for the head SHA leaves the PR blocked, not mergeable. And
-a repo with no required checks has no protection the disarm could add. So keeping
-the latch fails safe (at worst something merges a little early), while disarming
-fails unsafe (the PR silently cannot merge at all).
+The only window a disarm ever protected is the gap between deciding to fix
+something and that fix landing — during which the PR is genuinely green and
+genuinely mergeable, and auto-merge firing is GitHub behaving correctly. Two
+merges in this repo's history are attributed to that window (#1392, and the
+release that shipped the `./hooks/` Cursor bug). Both were fixed forward within
+minutes; one was a one-line docs inconsistency.
 
-Instead of disarming, treat the push as a merge race: immediately re-read
-`headRefOid` and reset `verify_commit` to the pushed head, so the verification in
-step 3 is against what you actually pushed rather than the commit you replaced.
+That evidence is also weaker than it looks: **auto-merge attributes the merge to
+whoever enabled it**, so an auto-merge and a human pressing Merge are
+indistinguishable in the timeline. The record cannot tell us those PRs were not
+simply merged by hand while the latch happened to be armed.
 
-**Invariant:** this skill must never terminate having left auto-merge OFF on an
-open PR when `auto_merge=true`. If some future path does disable it, restoring it
-is a terminal obligation on EVERY exit — including give-up, budget-exhausted and
-error paths — not a later step in a sequence.
+Against that, disarming costs something certain. Disabling is a durable state
+change on GitHub; re-enabling is one more step the run has to reach. When a run
+ends in between — turns exhausted, job timeout, or you concluding the work while
+checks are still pending — the latch stays off and nothing restores it. The PR is
+left WORSE OFF THAN IF THIS SKILL HAD NEVER RUN: it has lost the mechanism that
+merges it while no agent is watching, and the run reports success. Measured on
+`gunnertech/frontend#282`, the latch went off 14s before the fix commit and the
+PR sat 26 minutes after going green, against ~3 minutes for PRs this skill never
+touched.
+
+So the trade is a rare, unproven miss that costs a fix-forward PR, against a
+frequent, silent stall on every PR this skill repairs. Take the rare one.
+
+What still applies on a push: immediately re-read `headRefOid` and reset
+`verify_commit` to the pushed head, so the shipped-verification in step 3 checks
+what you actually pushed rather than the commit you replaced. That ancestry check
+is what CATCHES a raced merge — it fails loudly when the fix SHA is not an
+ancestor of the base branch — so the rare miss is detected rather than silent.
+
+**Invariant:** never terminate having left auto-merge OFF on an open PR when
+`auto_merge=true`. If some future path does disable it, restoring it is a
+terminal obligation on EVERY exit — including give-up, budget-exhausted and error
+paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,13 +126,35 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-If any later step will push commits, temporarily remove the auto-merge latch
-before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
-or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
-reset `verify_commit` to the pushed head, wait until that head's checks have
-started, then re-enable auto-merge. Do not leave auto-merge armed while a
-required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
-still in flight.
+**Leave the latch ARMED when you push a fix. Never disable it.** A pull request
+that needs a fix cannot merge anyway: auto-merge fires only once every required
+check passes, so disarming buys nothing in the ordinary case — and it costs a
+failure that is both silent and worse than the race it guards.
+
+Disabling is a durable state change on GitHub; re-enabling is one more step you
+have to reach. When a run ends in between — turns exhausted, job timeout, or you
+concluding the work while checks are still pending — the latch stays off and
+nothing restores it. The pull request is then left WORSE OFF THAN IF THIS SKILL
+HAD NEVER RUN: it has lost the mechanism that merges it while no agent is
+watching, and the run reports success. Measured on `gunnertech/frontend#282`,
+where the latch went off 14s before the fix commit and the PR sat 26 minutes
+after going green, against ~3 minutes for PRs this skill never touched.
+
+The race the old disarm guarded is the seconds after a push, before GitHub has
+registered any check for the NEW head. GitHub already closes it: a required check
+that has not reported for the head SHA leaves the PR blocked, not mergeable. And
+a repo with no required checks has no protection the disarm could add. So keeping
+the latch fails safe (at worst something merges a little early), while disarming
+fails unsafe (the PR silently cannot merge at all).
+
+Instead of disarming, treat the push as a merge race: immediately re-read
+`headRefOid` and reset `verify_commit` to the pushed head, so the verification in
+step 3 is against what you actually pushed rather than the commit you replaced.
+
+**Invariant:** this skill must never terminate having left auto-merge OFF on an
+open PR when `auto_merge=true`. If some future path does disable it, restoring it
+is a terminal obligation on EVERY exit — including give-up, budget-exhausted and
+error paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,35 +126,47 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-**Leave the latch ARMED when you push a fix. Never disable it.** A pull request
-that needs a fix cannot merge anyway: auto-merge fires only once every required
-check passes, so disarming buys nothing in the ordinary case — and it costs a
-failure that is both silent and worse than the race it guards.
+**Leave the latch ARMED. Never disable auto-merge.**
 
-Disabling is a durable state change on GitHub; re-enabling is one more step you
-have to reach. When a run ends in between — turns exhausted, job timeout, or you
-concluding the work while checks are still pending — the latch stays off and
-nothing restores it. The pull request is then left WORSE OFF THAN IF THIS SKILL
-HAD NEVER RUN: it has lost the mechanism that merges it while no agent is
-watching, and the run reports success. Measured on `gunnertech/frontend#282`,
-where the latch went off 14s before the fix commit and the PR sat 26 minutes
-after going green, against ~3 minutes for PRs this skill never touched.
+Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
+the PR's current head, so a new commit whose checks have not reported leaves the
+PR blocked. Auto-merge cannot ship a commit nothing has verified.
 
-The race the old disarm guarded is the seconds after a push, before GitHub has
-registered any check for the NEW head. GitHub already closes it: a required check
-that has not reported for the head SHA leaves the PR blocked, not mergeable. And
-a repo with no required checks has no protection the disarm could add. So keeping
-the latch fails safe (at worst something merges a little early), while disarming
-fails unsafe (the PR silently cannot merge at all).
+The only window a disarm ever protected is the gap between deciding to fix
+something and that fix landing — during which the PR is genuinely green and
+genuinely mergeable, and auto-merge firing is GitHub behaving correctly. Two
+merges in this repo's history are attributed to that window (#1392, and the
+release that shipped the `./hooks/` Cursor bug). Both were fixed forward within
+minutes; one was a one-line docs inconsistency.
 
-Instead of disarming, treat the push as a merge race: immediately re-read
-`headRefOid` and reset `verify_commit` to the pushed head, so the verification in
-step 3 is against what you actually pushed rather than the commit you replaced.
+That evidence is also weaker than it looks: **auto-merge attributes the merge to
+whoever enabled it**, so an auto-merge and a human pressing Merge are
+indistinguishable in the timeline. The record cannot tell us those PRs were not
+simply merged by hand while the latch happened to be armed.
 
-**Invariant:** this skill must never terminate having left auto-merge OFF on an
-open PR when `auto_merge=true`. If some future path does disable it, restoring it
-is a terminal obligation on EVERY exit — including give-up, budget-exhausted and
-error paths — not a later step in a sequence.
+Against that, disarming costs something certain. Disabling is a durable state
+change on GitHub; re-enabling is one more step the run has to reach. When a run
+ends in between — turns exhausted, job timeout, or you concluding the work while
+checks are still pending — the latch stays off and nothing restores it. The PR is
+left WORSE OFF THAN IF THIS SKILL HAD NEVER RUN: it has lost the mechanism that
+merges it while no agent is watching, and the run reports success. Measured on
+`gunnertech/frontend#282`, the latch went off 14s before the fix commit and the
+PR sat 26 minutes after going green, against ~3 minutes for PRs this skill never
+touched.
+
+So the trade is a rare, unproven miss that costs a fix-forward PR, against a
+frequent, silent stall on every PR this skill repairs. Take the rare one.
+
+What still applies on a push: immediately re-read `headRefOid` and reset
+`verify_commit` to the pushed head, so the shipped-verification in step 3 checks
+what you actually pushed rather than the commit you replaced. That ancestry check
+is what CATCHES a raced merge — it fails loudly when the fix SHA is not an
+ancestor of the base branch — so the rare miss is detected rather than silent.
+
+**Invariant:** never terminate having left auto-merge OFF on an open PR when
+`auto_merge=true`. If some future path does disable it, restoring it is a
+terminal obligation on EVERY exit — including give-up, budget-exhausted and error
+paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,13 +126,35 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-If any later step will push commits, temporarily remove the auto-merge latch
-before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
-or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
-reset `verify_commit` to the pushed head, wait until that head's checks have
-started, then re-enable auto-merge. Do not leave auto-merge armed while a
-required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
-still in flight.
+**Leave the latch ARMED when you push a fix. Never disable it.** A pull request
+that needs a fix cannot merge anyway: auto-merge fires only once every required
+check passes, so disarming buys nothing in the ordinary case — and it costs a
+failure that is both silent and worse than the race it guards.
+
+Disabling is a durable state change on GitHub; re-enabling is one more step you
+have to reach. When a run ends in between — turns exhausted, job timeout, or you
+concluding the work while checks are still pending — the latch stays off and
+nothing restores it. The pull request is then left WORSE OFF THAN IF THIS SKILL
+HAD NEVER RUN: it has lost the mechanism that merges it while no agent is
+watching, and the run reports success. Measured on `gunnertech/frontend#282`,
+where the latch went off 14s before the fix commit and the PR sat 26 minutes
+after going green, against ~3 minutes for PRs this skill never touched.
+
+The race the old disarm guarded is the seconds after a push, before GitHub has
+registered any check for the NEW head. GitHub already closes it: a required check
+that has not reported for the head SHA leaves the PR blocked, not mergeable. And
+a repo with no required checks has no protection the disarm could add. So keeping
+the latch fails safe (at worst something merges a little early), while disarming
+fails unsafe (the PR silently cannot merge at all).
+
+Instead of disarming, treat the push as a merge race: immediately re-read
+`headRefOid` and reset `verify_commit` to the pushed head, so the verification in
+step 3 is against what you actually pushed rather than the commit you replaced.
+
+**Invariant:** this skill must never terminate having left auto-merge OFF on an
+open PR when `auto_merge=true`. If some future path does disable it, restoring it
+is a terminal obligation on EVERY exit — including give-up, budget-exhausted and
+error paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -869,7 +869,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
       "fb41a1e63c5332d47a46e715aff52551f3df867033b5e4f37dfaeee30019b891",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
-      "c78ae2ba32c830d0b2cd7d24de91adf99e2b3cef4c7cab1c417580d86f41351f",
+      "84e42a50d46cc33b6218484da7510dda8888930b799b84a056ce080316722e13",
     "plugins/src/base/skills/lisa-epic-triage/SKILL.md":
       "d02760411249bddbd396f283191fe3e82bb7b95bf9393a19a7025dc5a57c3ab7",
     "plugins/src/base/skills/lisa-evaluation-suite/SKILL.md":

--- a/tests/unit/strategies/drive-pr-auto-merge-race.test.ts
+++ b/tests/unit/strategies/drive-pr-auto-merge-race.test.ts
@@ -36,10 +36,39 @@ describe.each(ROOTS)("drive-pr-to-merge auto-merge race guard (%s)", root => {
     expect(content).toMatch(/Never enable\s+auto-merge against a stale head/i);
   });
 
-  it("requires auto-merge to be disarmed or treated as race-prone before fix pushes", () => {
-    expect(content).toMatch(/disablePullRequestAutoMerge/);
-    expect(content).toMatch(/Do not leave auto-merge armed/i);
-    expect(content).toMatch(/required fix, CodeRabbit follow-up/i);
+  it("keeps auto-merge ARMED across fix pushes, and says why that is safe", () => {
+    // Reversed from the original #1395 guard, deliberately. That guard required
+    // the latch to be DISARMED before a fix push. Disarming is a durable change
+    // on GitHub while re-arming is one more step the run has to reach, so a run
+    // that ended in between left the PR unable to merge unattended — worse off
+    // than if the skill had never touched it, and reported as success.
+    //
+    // The window a disarm protected is only the gap between deciding to fix and
+    // the fix landing; once a commit is pushed, GitHub blocks on required checks
+    // that have not reported for the new head. The two merges attributed to that
+    // window were fixed forward within minutes, one a docs typo — and are not
+    // even distinguishable from a human pressing Merge, since auto-merge is
+    // attributed to whoever enabled it.
+    expect(content).toMatch(/Leave the latch ARMED/i);
+    expect(content).toMatch(/Never disable auto-merge/i);
+    // The reasoning has to travel with the rule: an agent that finds only the
+    // instruction and not the trade-off will re-add the disarm the first time a
+    // race is suspected.
+    expect(content).toMatch(/required checks against\s+the PR's current head/i);
+  });
+
+  it("never instructs disabling the latch on the happy path", () => {
+    // The mutation this file exists to catch, now pointing the other way: a
+    // reinstated disarm. `auto_merge=false` is a different thing — that mode
+    // deliberately disarms a pre-existing latch and must stay untouched — so
+    // this asserts on the section that runs when auto_merge=true.
+    const armSection = content.slice(
+      content.indexOf("## 1. Enable auto-merge"),
+      content.indexOf("## 2.")
+    );
+    expect(armSection.length).toBeGreaterThan(500);
+    expect(armSection).not.toMatch(/disablePullRequestAutoMerge/);
+    expect(armSection).not.toMatch(/Do not leave auto-merge armed/i);
   });
 
   it("resets verify_commit to the pushed head before re-enabling auto-merge", () => {


### PR DESCRIPTION
Closes #2299.

## The change

`drive-pr-to-merge` no longer disables auto-merge before pushing a fix. It keeps the latch armed and relies on required checks to hold the gate.

## Correcting my own first version of this

The initial commit argued that the race the disarm guarded was the seconds *after* a push, before GitHub registers checks for the new head. **That was wrong**, and the review — plus lisa's own #1395 regression test — caught it. GitHub evaluates required checks against the PR's current head, so a pushed commit whose checks have not reported leaves the PR blocked. The latch is already safe once a fix lands.

The window a disarm actually protects is narrower: the gap between **deciding** to fix something and the fix **landing**, during which the PR is genuinely green and auto-merge firing is GitHub behaving correctly. #1393 says exactly this:

> #1392 auto-merged on its prior head the instant the CodeRabbit status check went green, **before this fix commit could push**

## Why that window is not worth the guard

- **Two merges** in this repo are attributed to it. Both were fixed forward within minutes; one (#1392) was a one-line docs inconsistency between the lifecycle prompt and the stage list.
- **The attribution is not verifiable.** Auto-merge is recorded as a merge by whoever *enabled* it, so it is indistinguishable in the timeline from a human pressing Merge while the latch happened to be armed. Neither PR has an `auto_merge_disabled` event; that is all the record can tell us.
- **A raced merge is already caught.** The ancestry check from #1071 fails loudly when the fix SHA is not an ancestor of the base branch, so the rare miss is detected rather than silent.
- **Disarming costs something certain.** Disabling is durable on GitHub; re-enabling is one more step the run has to reach. A run that ends in between leaves the PR unable to merge unattended — worse off than if the skill had never run, and reported as success. On `gunnertech/frontend#282` the latch went off 14s before the fix commit and the PR sat 26 minutes after going green, against ~3 minutes for PRs the skill never touched.

So: a rare, unproven miss costing a fix-forward PR, against a frequent silent stall on every PR this skill repairs. This takes the rare one.

## The #1395 guard is flipped, not deleted

`drive-pr-auto-merge-race.test.ts` now asserts the opposite invariant across all six plugin roots:

- the latch stays **armed** (`Leave the latch ARMED`, `Never disable auto-merge`);
- the **reasoning travels with the rule**, so an agent finding only the instruction cannot re-add the disarm the first time a race is suspected;
- **no disarm is reinstated** anywhere in the `auto_merge=true` section.

`auto_merge=false` is untouched — that mode deliberately disarms a pre-existing latch and keeps its own assertions.

## Verification

- `bun run check:plugins` — ✓ artifacts in sync, ✓ marketplace registers every plugin
- `drive-pr-auto-merge-race` + `upstream-evidence-manifest` — 63 passed
- Remaining local failures (`ast-grep-template`, `enforcement-gates-e2e`) reproduce on the unmodified tree — pre-existing environment, not this change. `learnings-writer` passes 3/3 in isolation (parallel-load flake).

## Downstream

gunnertech/frontend#293 adds a re-arm step as a local mitigation; once this lands that step is unnecessary and should be deleted.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2299


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-merge now stays enabled while fixes are pushed, reducing the chance of merge interruptions.
  * After each push, the latest PR head is rechecked so verification uses the exact code that was shipped.
  * Open pull requests with auto-merge enabled will no longer be left in a disabled state when the process exits, including on errors or timeouts.

* **Tests**
  * Updated coverage to reflect the new auto-merge behavior and race protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->