### PR TITLE
fix(secrets): claude-web must materialize at setup as well as session start

### DIFF
--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -56,7 +56,28 @@ export const SURFACES = {
   "claude-web": {
     materialized: true,
     mayWriteValues: true,
-    materializeAt: "session-start",
+    // BOTH, and the two cover disjoint failures rather than duplicating work.
+    //
+    // The hook alone was the original design, for a real reason: this surface
+    // skips its setup script whenever a cached environment exists, so
+    // materializing only there would write values once and never refresh them.
+    //
+    // What that missed is that the hook is PROJECT-scoped — it lives in a
+    // repository's `.claude/settings.json` and only loads when Claude Code's
+    // project directory is that repository. A cloud environment configured with
+    // more than one repository starts in their parent:
+    //
+    //     HOME=/root  PWD=/home/user
+    //     /home/user/backend  /home/user/infrastructure
+    //
+    // `/home/user` is not a project root, so no settings load, no hook
+    // registers, and nothing materializes at all. Verified in a real session.
+    //
+    // So the setup run is the FLOOR — a fresh environment has its secrets even
+    // where the hook cannot fire — and the hook is the REFRESH, picking up
+    // rotation on resumed sessions that skip setup. A stale secret is
+    // recoverable; an absent one means the environment does not work.
+    materializeAt: "both",
   },
 };
 

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -736,7 +736,7 @@ export function selectPhases(requested, materializeAt) {
         `unknown --phase "${requested}". Known: ${PHASES.join(", ")}.`
       );
     }
-    if (requested === "secrets" && materializeAt !== "session-start") {
+    if (requested === "secrets" && !materializesAtSessionStart(materializeAt)) {
       // Not an error: the hook is committed to the repository and runs on every
       // surface the project is ever checked out on. Refusing loudly would make
       // a correct local session look broken every time it started.
@@ -745,8 +745,32 @@ export function selectPhases(requested, materializeAt) {
     return [requested];
   }
   return PHASES.filter(
-    phase => phase !== "secrets" || materializeAt === "setup"
+    phase => phase !== "secrets" || materializesAtSetup(materializeAt)
   );
+}
+
+/**
+ * Whether the setup run itself should materialize.
+ *
+ * `"both"` means the surface materializes in the setup run AND from the
+ * session-start hook, because on that surface either one alone has a hole: the
+ * setup run is skipped when a cached environment is reused, and the hook cannot
+ * fire when Claude Code's project directory is not the repository — which is
+ * every cloud environment configured with more than one repo.
+ * @param {string|null} materializeAt Surface capability.
+ * @returns {boolean} Whether to materialize during setup.
+ */
+export function materializesAtSetup(materializeAt) {
+  return materializeAt === "setup" || materializeAt === "both";
+}
+
+/**
+ * Whether the committed session-start hook should materialize.
+ * @param {string|null} materializeAt Surface capability.
+ * @returns {boolean} Whether the hook does the work.
+ */
+export function materializesAtSessionStart(materializeAt) {
+  return materializeAt === "session-start" || materializeAt === "both";
 }
 
 /**

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -56,7 +56,28 @@ export const SURFACES = {
   "claude-web": {
     materialized: true,
     mayWriteValues: true,
-    materializeAt: "session-start",
+    // BOTH, and the two cover disjoint failures rather than duplicating work.
+    //
+    // The hook alone was the original design, for a real reason: this surface
+    // skips its setup script whenever a cached environment exists, so
+    // materializing only there would write values once and never refresh them.
+    //
+    // What that missed is that the hook is PROJECT-scoped — it lives in a
+    // repository's `.claude/settings.json` and only loads when Claude Code's
+    // project directory is that repository. A cloud environment configured with
+    // more than one repository starts in their parent:
+    //
+    //     HOME=/root  PWD=/home/user
+    //     /home/user/backend  /home/user/infrastructure
+    //
+    // `/home/user` is not a project root, so no settings load, no hook
+    // registers, and nothing materializes at all. Verified in a real session.
+    //
+    // So the setup run is the FLOOR — a fresh environment has its secrets even
+    // where the hook cannot fire — and the hook is the REFRESH, picking up
+    // rotation on resumed sessions that skip setup. A stale secret is
+    // recoverable; an absent one means the environment does not work.
+    materializeAt: "both",
   },
 };
 

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -736,7 +736,7 @@ export function selectPhases(requested, materializeAt) {
         `unknown --phase "${requested}". Known: ${PHASES.join(", ")}.`
       );
     }
-    if (requested === "secrets" && materializeAt !== "session-start") {
+    if (requested === "secrets" && !materializesAtSessionStart(materializeAt)) {
       // Not an error: the hook is committed to the repository and runs on every
       // surface the project is ever checked out on. Refusing loudly would make
       // a correct local session look broken every time it started.
@@ -745,8 +745,32 @@ export function selectPhases(requested, materializeAt) {
     return [requested];
   }
   return PHASES.filter(
-    phase => phase !== "secrets" || materializeAt === "setup"
+    phase => phase !== "secrets" || materializesAtSetup(materializeAt)
   );
+}
+
+/**
+ * Whether the setup run itself should materialize.
+ *
+ * `"both"` means the surface materializes in the setup run AND from the
+ * session-start hook, because on that surface either one alone has a hole: the
+ * setup run is skipped when a cached environment is reused, and the hook cannot
+ * fire when Claude Code's project directory is not the repository — which is
+ * every cloud environment configured with more than one repo.
+ * @param {string|null} materializeAt Surface capability.
+ * @returns {boolean} Whether to materialize during setup.
+ */
+export function materializesAtSetup(materializeAt) {
+  return materializeAt === "setup" || materializeAt === "both";
+}
+
+/**
+ * Whether the committed session-start hook should materialize.
+ * @param {string|null} materializeAt Surface capability.
+ * @returns {boolean} Whether the hook does the work.
+ */
+export function materializesAtSessionStart(materializeAt) {
+  return materializeAt === "session-start" || materializeAt === "both";
 }
 
 /**

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -56,7 +56,28 @@ export const SURFACES = {
   "claude-web": {
     materialized: true,
     mayWriteValues: true,
-    materializeAt: "session-start",
+    // BOTH, and the two cover disjoint failures rather than duplicating work.
+    //
+    // The hook alone was the original design, for a real reason: this surface
+    // skips its setup script whenever a cached environment exists, so
+    // materializing only there would write values once and never refresh them.
+    //
+    // What that missed is that the hook is PROJECT-scoped — it lives in a
+    // repository's `.claude/settings.json` and only loads when Claude Code's
+    // project directory is that repository. A cloud environment configured with
+    // more than one repository starts in their parent:
+    //
+    //     HOME=/root  PWD=/home/user
+    //     /home/user/backend  /home/user/infrastructure
+    //
+    // `/home/user` is not a project root, so no settings load, no hook
+    // registers, and nothing materializes at all. Verified in a real session.
+    //
+    // So the setup run is the FLOOR — a fresh environment has its secrets even
+    // where the hook cannot fire — and the hook is the REFRESH, picking up
+    // rotation on resumed sessions that skip setup. A stale secret is
+    // recoverable; an absent one means the environment does not work.
+    materializeAt: "both",
   },
 };
 

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -736,7 +736,7 @@ export function selectPhases(requested, materializeAt) {
         `unknown --phase "${requested}". Known: ${PHASES.join(", ")}.`
       );
     }
-    if (requested === "secrets" && materializeAt !== "session-start") {
+    if (requested === "secrets" && !materializesAtSessionStart(materializeAt)) {
       // Not an error: the hook is committed to the repository and runs on every
       // surface the project is ever checked out on. Refusing loudly would make
       // a correct local session look broken every time it started.
@@ -745,8 +745,32 @@ export function selectPhases(requested, materializeAt) {
     return [requested];
   }
   return PHASES.filter(
-    phase => phase !== "secrets" || materializeAt === "setup"
+    phase => phase !== "secrets" || materializesAtSetup(materializeAt)
   );
+}
+
+/**
+ * Whether the setup run itself should materialize.
+ *
+ * `"both"` means the surface materializes in the setup run AND from the
+ * session-start hook, because on that surface either one alone has a hole: the
+ * setup run is skipped when a cached environment is reused, and the hook cannot
+ * fire when Claude Code's project directory is not the repository — which is
+ * every cloud environment configured with more than one repo.
+ * @param {string|null} materializeAt Surface capability.
+ * @returns {boolean} Whether to materialize during setup.
+ */
+export function materializesAtSetup(materializeAt) {
+  return materializeAt === "setup" || materializeAt === "both";
+}
+
+/**
+ * Whether the committed session-start hook should materialize.
+ * @param {string|null} materializeAt Surface capability.
+ * @returns {boolean} Whether the hook does the work.
+ */
+export function materializesAtSessionStart(materializeAt) {
+  return materializeAt === "session-start" || materializeAt === "both";
 }
 
 /**

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -56,7 +56,28 @@ export const SURFACES = {
   "claude-web": {
     materialized: true,
     mayWriteValues: true,
-    materializeAt: "session-start",
+    // BOTH, and the two cover disjoint failures rather than duplicating work.
+    //
+    // The hook alone was the original design, for a real reason: this surface
+    // skips its setup script whenever a cached environment exists, so
+    // materializing only there would write values once and never refresh them.
+    //
+    // What that missed is that the hook is PROJECT-scoped — it lives in a
+    // repository's `.claude/settings.json` and only loads when Claude Code's
+    // project directory is that repository. A cloud environment configured with
+    // more than one repository starts in their parent:
+    //
+    //     HOME=/root  PWD=/home/user
+    //     /home/user/backend  /home/user/infrastructure
+    //
+    // `/home/user` is not a project root, so no settings load, no hook
+    // registers, and nothing materializes at all. Verified in a real session.
+    //
+    // So the setup run is the FLOOR — a fresh environment has its secrets even
+    // where the hook cannot fire — and the hook is the REFRESH, picking up
+    // rotation on resumed sessions that skip setup. A stale secret is
+    // recoverable; an absent one means the environment does not work.
+    materializeAt: "both",
   },
 };
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -736,7 +736,7 @@ export function selectPhases(requested, materializeAt) {
         `unknown --phase "${requested}". Known: ${PHASES.join(", ")}.`
       );
     }
-    if (requested === "secrets" && materializeAt !== "session-start") {
+    if (requested === "secrets" && !materializesAtSessionStart(materializeAt)) {
       // Not an error: the hook is committed to the repository and runs on every
       // surface the project is ever checked out on. Refusing loudly would make
       // a correct local session look broken every time it started.
@@ -745,8 +745,32 @@ export function selectPhases(requested, materializeAt) {
     return [requested];
   }
   return PHASES.filter(
-    phase => phase !== "secrets" || materializeAt === "setup"
+    phase => phase !== "secrets" || materializesAtSetup(materializeAt)
   );
+}
+
+/**
+ * Whether the setup run itself should materialize.
+ *
+ * `"both"` means the surface materializes in the setup run AND from the
+ * session-start hook, because on that surface either one alone has a hole: the
+ * setup run is skipped when a cached environment is reused, and the hook cannot
+ * fire when Claude Code's project directory is not the repository — which is
+ * every cloud environment configured with more than one repo.
+ * @param {string|null} materializeAt Surface capability.
+ * @returns {boolean} Whether to materialize during setup.
+ */
+export function materializesAtSetup(materializeAt) {
+  return materializeAt === "setup" || materializeAt === "both";
+}
+
+/**
+ * Whether the committed session-start hook should materialize.
+ * @param {string|null} materializeAt Surface capability.
+ * @returns {boolean} Whether the hook does the work.
+ */
+export function materializesAtSessionStart(materializeAt) {
+  return materializeAt === "session-start" || materializeAt === "both";
 }
 
 /**

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -56,7 +56,28 @@ export const SURFACES = {
   "claude-web": {
     materialized: true,
     mayWriteValues: true,
-    materializeAt: "session-start",
+    // BOTH, and the two cover disjoint failures rather than duplicating work.
+    //
+    // The hook alone was the original design, for a real reason: this surface
+    // skips its setup script whenever a cached environment exists, so
+    // materializing only there would write values once and never refresh them.
+    //
+    // What that missed is that the hook is PROJECT-scoped — it lives in a
+    // repository's `.claude/settings.json` and only loads when Claude Code's
+    // project directory is that repository. A cloud environment configured with
+    // more than one repository starts in their parent:
+    //
+    //     HOME=/root  PWD=/home/user
+    //     /home/user/backend  /home/user/infrastructure
+    //
+    // `/home/user` is not a project root, so no settings load, no hook
+    // registers, and nothing materializes at all. Verified in a real session.
+    //
+    // So the setup run is the FLOOR — a fresh environment has its secrets even
+    // where the hook cannot fire — and the hook is the REFRESH, picking up
+    // rotation on resumed sessions that skip setup. A stale secret is
+    // recoverable; an absent one means the environment does not work.
+    materializeAt: "both",
   },
 };
 

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -736,7 +736,7 @@ export function selectPhases(requested, materializeAt) {
         `unknown --phase "${requested}". Known: ${PHASES.join(", ")}.`
       );
     }
-    if (requested === "secrets" && materializeAt !== "session-start") {
+    if (requested === "secrets" && !materializesAtSessionStart(materializeAt)) {
       // Not an error: the hook is committed to the repository and runs on every
       // surface the project is ever checked out on. Refusing loudly would make
       // a correct local session look broken every time it started.
@@ -745,8 +745,32 @@ export function selectPhases(requested, materializeAt) {
     return [requested];
   }
   return PHASES.filter(
-    phase => phase !== "secrets" || materializeAt === "setup"
+    phase => phase !== "secrets" || materializesAtSetup(materializeAt)
   );
+}
+
+/**
+ * Whether the setup run itself should materialize.
+ *
+ * `"both"` means the surface materializes in the setup run AND from the
+ * session-start hook, because on that surface either one alone has a hole: the
+ * setup run is skipped when a cached environment is reused, and the hook cannot
+ * fire when Claude Code's project directory is not the repository — which is
+ * every cloud environment configured with more than one repo.
+ * @param {string|null} materializeAt Surface capability.
+ * @returns {boolean} Whether to materialize during setup.
+ */
+export function materializesAtSetup(materializeAt) {
+  return materializeAt === "setup" || materializeAt === "both";
+}
+
+/**
+ * Whether the committed session-start hook should materialize.
+ * @param {string|null} materializeAt Surface capability.
+ * @returns {boolean} Whether the hook does the work.
+ */
+export function materializesAtSessionStart(materializeAt) {
+  return materializeAt === "session-start" || materializeAt === "both";
 }
 
 /**

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -56,7 +56,28 @@ export const SURFACES = {
   "claude-web": {
     materialized: true,
     mayWriteValues: true,
-    materializeAt: "session-start",
+    // BOTH, and the two cover disjoint failures rather than duplicating work.
+    //
+    // The hook alone was the original design, for a real reason: this surface
+    // skips its setup script whenever a cached environment exists, so
+    // materializing only there would write values once and never refresh them.
+    //
+    // What that missed is that the hook is PROJECT-scoped — it lives in a
+    // repository's `.claude/settings.json` and only loads when Claude Code's
+    // project directory is that repository. A cloud environment configured with
+    // more than one repository starts in their parent:
+    //
+    //     HOME=/root  PWD=/home/user
+    //     /home/user/backend  /home/user/infrastructure
+    //
+    // `/home/user` is not a project root, so no settings load, no hook
+    // registers, and nothing materializes at all. Verified in a real session.
+    //
+    // So the setup run is the FLOOR — a fresh environment has its secrets even
+    // where the hook cannot fire — and the hook is the REFRESH, picking up
+    // rotation on resumed sessions that skip setup. A stale secret is
+    // recoverable; an absent one means the environment does not work.
+    materializeAt: "both",
   },
 };
 

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -736,7 +736,7 @@ export function selectPhases(requested, materializeAt) {
         `unknown --phase "${requested}". Known: ${PHASES.join(", ")}.`
       );
     }
-    if (requested === "secrets" && materializeAt !== "session-start") {
+    if (requested === "secrets" && !materializesAtSessionStart(materializeAt)) {
       // Not an error: the hook is committed to the repository and runs on every
       // surface the project is ever checked out on. Refusing loudly would make
       // a correct local session look broken every time it started.
@@ -745,8 +745,32 @@ export function selectPhases(requested, materializeAt) {
     return [requested];
   }
   return PHASES.filter(
-    phase => phase !== "secrets" || materializeAt === "setup"
+    phase => phase !== "secrets" || materializesAtSetup(materializeAt)
   );
+}
+
+/**
+ * Whether the setup run itself should materialize.
+ *
+ * `"both"` means the surface materializes in the setup run AND from the
+ * session-start hook, because on that surface either one alone has a hole: the
+ * setup run is skipped when a cached environment is reused, and the hook cannot
+ * fire when Claude Code's project directory is not the repository — which is
+ * every cloud environment configured with more than one repo.
+ * @param {string|null} materializeAt Surface capability.
+ * @returns {boolean} Whether to materialize during setup.
+ */
+export function materializesAtSetup(materializeAt) {
+  return materializeAt === "setup" || materializeAt === "both";
+}
+
+/**
+ * Whether the committed session-start hook should materialize.
+ * @param {string|null} materializeAt Surface capability.
+ * @returns {boolean} Whether the hook does the work.
+ */
+export function materializesAtSessionStart(materializeAt) {
+  return materializeAt === "session-start" || materializeAt === "both";
 }
 
 /**

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1115,7 +1115,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/rotate-secret.mjs":
       "546dc1c2f279cee6db56c0f55c01aabae0c316842f32d3219c5af6d638936a9c",
     "plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs":
-      "da3fdf62b88f77c6c2ae09f5352797818813fccb0dafe551c801b58f25de2711",
+      "f8d4404ab105284ee072a26319366a71333c89abb14f9d71aafe461e7ea0686a",
     "plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs":
       "058d8cf474e05985a781e5575efcade371b20699c1dc5f6d4df156eeafba0831",
     "plugins/src/base/skills/lisa-security-review/SKILL.md":
@@ -1157,7 +1157,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "c30d98a5645f033fc1d3a723043691b9ad997ae5666df539ff6aa19c563431b2",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "fe5b7231c8fb82de22a8b6d14f50aea2f9ddc068a2deddf817660dd1e4db83a2",
+      "cafc8cc0917f767719d7591b6c2031eb9d4f2b451e28090d73519a09808a86d3",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
       "b2fa53bf577400851e8c2991cbe822d29dcdd2d090ff1cd1d0fa2d76bfcaa20b",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
@@ -8487,6 +8487,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/remote-dispatch.test.ts": true,
     "tests/unit/secrets/remote-env-bindir-path.test.ts": true,
     "tests/unit/secrets/remote-env-installed-copy.test.ts": true,
+    "tests/unit/secrets/remote-env-materialize-both.test.ts": true,
     "tests/unit/secrets/remote-env-phases.test.ts": true,
     "tests/unit/secrets/remote-env-session-start-hook.test.ts": true,
     "tests/unit/secrets/remote-env-setup-field.test.ts": true,

--- a/tests/unit/secrets/remote-env-materialize-both.test.ts
+++ b/tests/unit/secrets/remote-env-materialize-both.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression tests for the `both` materialization timing on `claude-web`.
+ *
+ * The surface used to materialize only from its committed SessionStart hook.
+ * That hook is PROJECT-scoped — it lives in a repository's
+ * `.claude/settings.json` and only loads when Claude Code's project directory is
+ * that repository. A cloud environment configured with more than one repository
+ * starts in their parent:
+ *
+ *     HOME=/root   PWD=/home/user
+ *     /home/user/backend   /home/user/infrastructure
+ *
+ * `/home/user` is not a project root, so no settings load, no hook registers,
+ * and nothing materializes at all. Confirmed in a real Claude Code web session:
+ * `~/.config/tunnl/` absent and `CLAUDE_PROJECT_DIR` unset, while running the
+ * same hook by hand wrote 12 secrets and exited 0.
+ * @module tests/unit/secrets/remote-env-materialize-both
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  materializesAtSessionStart,
+  materializesAtSetup,
+  selectPhases,
+} from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs";
+import { SURFACES } from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs";
+
+/** Materializes in the setup run AND from the session-start hook. */
+const BOTH = "both";
+
+/** Every phase the setup run performs, in order. */
+const ALL_PHASES = ["toolchain", "secrets", "hook"];
+
+describe("claude-web materializes in both places", () => {
+  it("declares the both timing", () => {
+    expect(SURFACES["claude-web"].materializeAt).toBe(BOTH);
+  });
+
+  it("materializes during setup, so a fresh multi-repo environment works", () => {
+    // The floor. Without this, a Claude web environment holding more than one
+    // repository materialized NOTHING, because the hook could never fire.
+    expect(selectPhases(undefined, BOTH)).toEqual(ALL_PHASES);
+  });
+
+  it("still honours an explicit --phase=secrets, so the hook keeps working", () => {
+    // The refresh. The committed hook re-enters the script this way; returning
+    // an empty list would make it a silent no-op and lose rotation pickup on
+    // resumed sessions, which skip setup entirely.
+    expect(selectPhases("secrets", BOTH)).toEqual(["secrets"]);
+  });
+});
+
+describe("timing predicates", () => {
+  it.each([
+    ["setup", true, false],
+    ["session-start", false, true],
+    [BOTH, true, true],
+    [null, false, false],
+  ])("%s -> setup=%s sessionStart=%s", (timing, atSetup, atSessionStart) => {
+    // Asserted through the predicates rather than string equality, so adding a
+    // fourth timing cannot silently take a branch nobody considered.
+    expect(materializesAtSetup(timing)).toBe(atSetup);
+    expect(materializesAtSessionStart(timing)).toBe(atSessionStart);
+  });
+});
+
+describe("other surfaces are unchanged", () => {
+  it("codex-cloud still materializes only during setup", () => {
+    // It has no equivalent hole: its setup field runs inside the checkout.
+    expect(SURFACES["codex-cloud"].materializeAt).toBe("setup");
+    expect(selectPhases(undefined, "setup")).toEqual(ALL_PHASES);
+    expect(selectPhases("secrets", "setup")).toEqual([]);
+  });
+
+  it("local and github-actions never materialize", () => {
+    // A developer machine and a CI runner read credentials from their own
+    // stores; writing a copy to disk there would be a leak, not a feature.
+    expect(SURFACES.local.materializeAt).toBeNull();
+    expect(SURFACES["github-actions"].materializeAt).toBeNull();
+    expect(selectPhases(undefined, null)).toEqual(["toolchain", "hook"]);
+  });
+});

--- a/tests/unit/secrets/remote-env-phases.test.ts
+++ b/tests/unit/secrets/remote-env-phases.test.ts
@@ -43,6 +43,9 @@ type Finding = { ok: boolean; label: string; detail: string };
 const AT_SETUP = "setup";
 const AT_SESSION_START = "session-start";
 
+/** Materializes in the setup run AND from the session-start hook. */
+const AT_BOTH = "both";
+
 /**
  * Collect findings without touching the module's own results array.
  * @returns A collector holding its own findings and a matching reporter.
@@ -60,9 +63,14 @@ const collect = (): {
 
 describe("materialize timing", () => {
   it("records when each surface materializes, not merely whether", () => {
-    // Both remote surfaces may write; only one of them may write during setup.
+    // Both remote surfaces may write. codex-cloud writes during setup;
+    // claude-web writes in BOTH places, because on that surface either one
+    // alone has a hole — the setup run is skipped when a cached environment is
+    // reused, and the session-start hook cannot fire when Claude Code's project
+    // directory is not the repository, which is every cloud environment
+    // configured with more than one repo.
     expect(SURFACES["codex-cloud"].materializeAt).toBe(AT_SETUP);
-    expect(SURFACES["claude-web"].materializeAt).toBe(AT_SESSION_START);
+    expect(SURFACES["claude-web"].materializeAt).toBe(AT_BOTH);
     expect(SURFACES.local.materializeAt).toBe(null);
     expect(SURFACES["github-actions"].materializeAt).toBe(null);
   });


### PR DESCRIPTION
## The bug

On `claude-web`, `materializeAt` was `"session-start"`, so `selectPhases` removed the secrets phase from the setup run entirely and everything rested on the committed SessionStart hook.

**That hook is project-scoped.** It lives in a repository's `.claude/settings.json` and only loads when Claude Code's project directory *is* that repository. A cloud environment configured with more than one repository starts in their parent:

```
HOME=/root   PWD=/home/user
/home/user/backend   /home/user/infrastructure
```

`/home/user` is not a project root — no `.claude/settings.json`, not a git repo — so no settings load, no hook registers, and **nothing materializes at all**.

Confirmed in a real Claude Code web session: `~/.config/tunnl/` absent, `CLAUDE_PROJECT_DIR` unset. Running the same hook by hand exited 0 and wrote 12 secrets with correct modes — the hook was never the problem, only its triggering.

## Why it was hook-only, and what that missed

The original choice had a real reason, recorded in the code: this surface **skips its setup script whenever a cached environment exists**, so materializing only there would write values once and never refresh them — a rotated credential would stay stale until the cache expired.

Sound, but it optimized for refresh and gave up the floor. A stale secret is recoverable; an absent one means the environment does not work.

## The fix

`claude-web` materializes in **both** places, covering disjoint failures rather than duplicating work:

| | role | covers |
| --- | --- | --- |
| setup run | the **floor** | a fresh environment where the hook cannot fire |
| session hook | the **refresh** | rotation on resumed sessions, which skip setup |

`codex-cloud` keeps `"setup"`; `local` and `github-actions` keep `null`.

The comparison now lives behind two named predicates rather than repeated string equality, so a third timing value can't be added without every call site being considered.

## Verification

Reproduced the reported layout in a container — two repos under a non-project parent, no settings file, hook unfireable — and ran the same check against `origin/main` as a negative control:

```
before (origin/main):  phases = [toolchain, hook]           exit 1
after:                 phases = [toolchain, secrets, hook]  exit 0
```

`--phase=secrets` still returns `[secrets]`, so the hook's refresh path is unchanged.

- 9 new tests in a dedicated file; full suite 8621 green
- Fans out to all five agent variants

## Second commit: AWS credentials now override the ambient pair

The same session surfaced a second failure. `LISA_AWS_BOOTSTRAP_JSON` is a name no AWS SDK reads, and the container ships its own stale `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`. **Environment variables outrank profile files in AWS's credential chain**, so even correctly written `~/.aws/credentials` profiles were shadowed:

```
aws sts get-caller-identity
InvalidClientTokenId: The security token included in the request is invalid.
```

Extracting the bootstrap pair by hand resolved cleanly to `arn:aws:iam::777997078669:user/remote-agent` — the credential was always fine, only its precedence was wrong.

The pair is now derived into the materialized env file, which is sourced into the session, so the last export wins.

Exporting over a variable this project did not set is a real intrusion, so it is deliberate, narrow and never silent:

- only when the bundle parses **and** carries both halves — half a credential produces a signature error rather than a missing-credential error, which is worse to debug
- **never** over a value the secret store itself supplies under those names; a project doing that has stated an explicit intent
- recorded in the notes file, discoverable through the same read-the-note path as any other credential
- reported on stdout at materialization time, naming how many variables were derived

A malformed bundle yields nothing rather than throwing — every other secret in the run is still valid, and a session with most of its credentials beats one with none. This remains the assume-only bootstrap identity; real work still assumes a role from it.

12 tests cover the derivation, including the refusals.

🤖 Generated with Claude Code

---

Work-Item: CodySwannGT/lisa#2301
