### PR TITLE
fix(secrets): export AWS credentials over any ambient pair the host injects

### DIFF
--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -1,0 +1,102 @@
+/**
+ * Turn the AWS bootstrap bundle into environment variables the AWS SDKs obey.
+ *
+ * `LISA_AWS_BOOTSTRAP_JSON` carries the agent's AWS identity as one JSON blob.
+ * Materializing it verbatim is not enough, because nothing reads that name:
+ * every AWS SDK and the CLI look for `AWS_ACCESS_KEY_ID` and
+ * `AWS_SECRET_ACCESS_KEY`, or for a profile.
+ *
+ * Writing profiles alone is also not enough, and that is the failure this
+ * module exists for. A Claude cloud container ships its own
+ * `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in the ambient environment, and
+ * **environment variables outrank profile files in the credential chain**. So a
+ * session with correctly written `~/.aws/credentials` still failed:
+ *
+ *     aws sts get-caller-identity
+ *     InvalidClientTokenId: The security token included in the request is invalid.
+ *
+ * Deriving the pair into the materialized env file fixes it, because that file
+ * is sourced into the session and the last export wins. Exporting over a
+ * variable this project did not set is a real intrusion, so it is deliberate,
+ * narrow, and never silent:
+ *
+ *   - only when the bundle actually parses and carries both halves
+ *   - never over a value the secret store itself supplies under those names,
+ *     which is a project stating an explicit intent
+ *   - recorded in the notes file, so the override is discoverable by the same
+ *     read-the-note path as any other credential
+ * @module aws-bootstrap
+ */
+
+/** The names every AWS SDK and the CLI actually read. */
+const ACCESS_KEY = "AWS_ACCESS_KEY_ID";
+const SECRET_KEY = "AWS_SECRET_ACCESS_KEY";
+const REGION = "AWS_DEFAULT_REGION";
+
+/** The bundle that carries the agent's identity. */
+export const BOOTSTRAP_KEY = "LISA_AWS_BOOTSTRAP_JSON";
+
+/**
+ * Read the bootstrap bundle, treating anything malformed as absent.
+ *
+ * A parse failure must not take materialization down with it: every other
+ * secret in the run is still valid and still needed, and a session with most of
+ * its credentials beats a session with none.
+ * @param {string} raw Bundle contents.
+ * @returns {object|null} Parsed bundle, or null.
+ */
+export function parseBootstrap(raw) {
+  if (typeof raw !== "string" || raw.trim() === "") return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Derive the AWS variables implied by an already-selected secret set.
+ *
+ * Returns only additions; the caller merges. Nothing here mutates its input,
+ * so a caller can decide what to do with the result — including reporting it.
+ * @param {Map<string, {value: string}>} selected Secrets by exact name.
+ * @returns {Map<string, {value: string, note: string}>} Derived variables.
+ */
+export function deriveAwsEnvironment(selected) {
+  const derived = new Map();
+  const bundle = parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value);
+  if (!bundle) return derived;
+
+  const accessKeyId = bundle.accessKeyId ?? bundle.aws_access_key_id;
+  const secretAccessKey =
+    bundle.secretAccessKey ?? bundle.aws_secret_access_key;
+  // Both halves or neither. Half a credential is not a weaker credential, it is
+  // a confusing failure — the SDK reports a signature error rather than a
+  // missing one.
+  if (!accessKeyId || !secretAccessKey) return derived;
+
+  // A project that stores these under their own names has said something
+  // explicit. Overriding that would be this module guessing against an operator.
+  if (selected.has(ACCESS_KEY) || selected.has(SECRET_KEY)) return derived;
+
+  const note =
+    `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Exported ` +
+    `deliberately so it overrides any ambient ${ACCESS_KEY} the host injects — ` +
+    `environment variables outrank profile files in the AWS credential chain, ` +
+    `so without this a stale host value wins and every call fails with ` +
+    `InvalidClientTokenId. This is the assume-only bootstrap identity; real ` +
+    `work assumes a role from it.`;
+
+  derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
+  derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+
+  const region = bundle.region ?? bundle.defaultRegion;
+  if (region && !selected.has(REGION)) {
+    derived.set(REGION, {
+      value: String(region),
+      note: `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access.`,
+    });
+  }
+  return derived;
+}

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -27,6 +27,7 @@ import {
   writeFileSync,
 } from "node:fs";
 
+import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
 import { fetchAll } from "./providers.mjs";
 import { materializedPaths, readConfig } from "./surfaces.mjs";
@@ -74,12 +75,20 @@ export function materialize(cfg = readConfig()) {
     );
   }
 
+  // The AWS bundle is stored as one JSON blob under a name no SDK reads, so
+  // the variables it implies are derived here. Without them a host-injected
+  // AWS_ACCESS_KEY_ID wins — environment variables outrank profile files in the
+  // credential chain — and every AWS call fails with InvalidClientTokenId even
+  // though the real credential materialized correctly.
+  const derived = deriveAwsEnvironment(selected);
+  for (const [name, entry] of derived) selected.set(name, entry);
+
   const { dir, valuesFile, notesFile } = materializedPaths(cfg.namespace);
   mkdirSync(dir, { recursive: true, mode: 0o700 });
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, dir };
+  return { count: selected.size, derived: derived.size, dir };
 }
 
 function main() {
@@ -91,8 +100,15 @@ function main() {
     console.log([...selected.keys()].sort().join("\n"));
     return;
   }
-  const { count, dir } = materialize(cfg);
+  const { count, derived, dir } = materialize(cfg);
   console.log(`materialized ${count} secret(s) and their notes into ${dir}`);
+  if (derived > 0) {
+    // Said out loud: this run exported variables the host may also have set.
+    console.log(
+      `  ${derived} AWS variable(s) derived from the bootstrap bundle, ` +
+        `overriding any ambient value`
+    );
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -95,6 +95,13 @@ function main() {
   const cfg = readConfig();
   if (process.argv.includes("--dry-run")) {
     const selected = fetchAll(cfg);
+    // Derive here too, or the preview lies in the one place it matters most:
+    // the derived names are exactly the ones that override ambient host
+    // credentials, so omitting them hides the most surprising effect of the run
+    // and reports a smaller count than the real write produces.
+    for (const [name, entry] of deriveAwsEnvironment(selected)) {
+      selected.set(name, entry);
+    }
     const { dir } = materializedPaths(cfg.namespace);
     console.log(`would write ${selected.size} secret(s) to ${dir}`);
     console.log([...selected.keys()].sort().join("\n"));

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -1,0 +1,102 @@
+/**
+ * Turn the AWS bootstrap bundle into environment variables the AWS SDKs obey.
+ *
+ * `LISA_AWS_BOOTSTRAP_JSON` carries the agent's AWS identity as one JSON blob.
+ * Materializing it verbatim is not enough, because nothing reads that name:
+ * every AWS SDK and the CLI look for `AWS_ACCESS_KEY_ID` and
+ * `AWS_SECRET_ACCESS_KEY`, or for a profile.
+ *
+ * Writing profiles alone is also not enough, and that is the failure this
+ * module exists for. A Claude cloud container ships its own
+ * `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in the ambient environment, and
+ * **environment variables outrank profile files in the credential chain**. So a
+ * session with correctly written `~/.aws/credentials` still failed:
+ *
+ *     aws sts get-caller-identity
+ *     InvalidClientTokenId: The security token included in the request is invalid.
+ *
+ * Deriving the pair into the materialized env file fixes it, because that file
+ * is sourced into the session and the last export wins. Exporting over a
+ * variable this project did not set is a real intrusion, so it is deliberate,
+ * narrow, and never silent:
+ *
+ *   - only when the bundle actually parses and carries both halves
+ *   - never over a value the secret store itself supplies under those names,
+ *     which is a project stating an explicit intent
+ *   - recorded in the notes file, so the override is discoverable by the same
+ *     read-the-note path as any other credential
+ * @module aws-bootstrap
+ */
+
+/** The names every AWS SDK and the CLI actually read. */
+const ACCESS_KEY = "AWS_ACCESS_KEY_ID";
+const SECRET_KEY = "AWS_SECRET_ACCESS_KEY";
+const REGION = "AWS_DEFAULT_REGION";
+
+/** The bundle that carries the agent's identity. */
+export const BOOTSTRAP_KEY = "LISA_AWS_BOOTSTRAP_JSON";
+
+/**
+ * Read the bootstrap bundle, treating anything malformed as absent.
+ *
+ * A parse failure must not take materialization down with it: every other
+ * secret in the run is still valid and still needed, and a session with most of
+ * its credentials beats a session with none.
+ * @param {string} raw Bundle contents.
+ * @returns {object|null} Parsed bundle, or null.
+ */
+export function parseBootstrap(raw) {
+  if (typeof raw !== "string" || raw.trim() === "") return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Derive the AWS variables implied by an already-selected secret set.
+ *
+ * Returns only additions; the caller merges. Nothing here mutates its input,
+ * so a caller can decide what to do with the result — including reporting it.
+ * @param {Map<string, {value: string}>} selected Secrets by exact name.
+ * @returns {Map<string, {value: string, note: string}>} Derived variables.
+ */
+export function deriveAwsEnvironment(selected) {
+  const derived = new Map();
+  const bundle = parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value);
+  if (!bundle) return derived;
+
+  const accessKeyId = bundle.accessKeyId ?? bundle.aws_access_key_id;
+  const secretAccessKey =
+    bundle.secretAccessKey ?? bundle.aws_secret_access_key;
+  // Both halves or neither. Half a credential is not a weaker credential, it is
+  // a confusing failure — the SDK reports a signature error rather than a
+  // missing one.
+  if (!accessKeyId || !secretAccessKey) return derived;
+
+  // A project that stores these under their own names has said something
+  // explicit. Overriding that would be this module guessing against an operator.
+  if (selected.has(ACCESS_KEY) || selected.has(SECRET_KEY)) return derived;
+
+  const note =
+    `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Exported ` +
+    `deliberately so it overrides any ambient ${ACCESS_KEY} the host injects — ` +
+    `environment variables outrank profile files in the AWS credential chain, ` +
+    `so without this a stale host value wins and every call fails with ` +
+    `InvalidClientTokenId. This is the assume-only bootstrap identity; real ` +
+    `work assumes a role from it.`;
+
+  derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
+  derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+
+  const region = bundle.region ?? bundle.defaultRegion;
+  if (region && !selected.has(REGION)) {
+    derived.set(REGION, {
+      value: String(region),
+      note: `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access.`,
+    });
+  }
+  return derived;
+}

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -27,6 +27,7 @@ import {
   writeFileSync,
 } from "node:fs";
 
+import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
 import { fetchAll } from "./providers.mjs";
 import { materializedPaths, readConfig } from "./surfaces.mjs";
@@ -74,12 +75,20 @@ export function materialize(cfg = readConfig()) {
     );
   }
 
+  // The AWS bundle is stored as one JSON blob under a name no SDK reads, so
+  // the variables it implies are derived here. Without them a host-injected
+  // AWS_ACCESS_KEY_ID wins — environment variables outrank profile files in the
+  // credential chain — and every AWS call fails with InvalidClientTokenId even
+  // though the real credential materialized correctly.
+  const derived = deriveAwsEnvironment(selected);
+  for (const [name, entry] of derived) selected.set(name, entry);
+
   const { dir, valuesFile, notesFile } = materializedPaths(cfg.namespace);
   mkdirSync(dir, { recursive: true, mode: 0o700 });
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, dir };
+  return { count: selected.size, derived: derived.size, dir };
 }
 
 function main() {
@@ -91,8 +100,15 @@ function main() {
     console.log([...selected.keys()].sort().join("\n"));
     return;
   }
-  const { count, dir } = materialize(cfg);
+  const { count, derived, dir } = materialize(cfg);
   console.log(`materialized ${count} secret(s) and their notes into ${dir}`);
+  if (derived > 0) {
+    // Said out loud: this run exported variables the host may also have set.
+    console.log(
+      `  ${derived} AWS variable(s) derived from the bootstrap bundle, ` +
+        `overriding any ambient value`
+    );
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -95,6 +95,13 @@ function main() {
   const cfg = readConfig();
   if (process.argv.includes("--dry-run")) {
     const selected = fetchAll(cfg);
+    // Derive here too, or the preview lies in the one place it matters most:
+    // the derived names are exactly the ones that override ambient host
+    // credentials, so omitting them hides the most surprising effect of the run
+    // and reports a smaller count than the real write produces.
+    for (const [name, entry] of deriveAwsEnvironment(selected)) {
+      selected.set(name, entry);
+    }
     const { dir } = materializedPaths(cfg.namespace);
     console.log(`would write ${selected.size} secret(s) to ${dir}`);
     console.log([...selected.keys()].sort().join("\n"));

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -1,0 +1,102 @@
+/**
+ * Turn the AWS bootstrap bundle into environment variables the AWS SDKs obey.
+ *
+ * `LISA_AWS_BOOTSTRAP_JSON` carries the agent's AWS identity as one JSON blob.
+ * Materializing it verbatim is not enough, because nothing reads that name:
+ * every AWS SDK and the CLI look for `AWS_ACCESS_KEY_ID` and
+ * `AWS_SECRET_ACCESS_KEY`, or for a profile.
+ *
+ * Writing profiles alone is also not enough, and that is the failure this
+ * module exists for. A Claude cloud container ships its own
+ * `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in the ambient environment, and
+ * **environment variables outrank profile files in the credential chain**. So a
+ * session with correctly written `~/.aws/credentials` still failed:
+ *
+ *     aws sts get-caller-identity
+ *     InvalidClientTokenId: The security token included in the request is invalid.
+ *
+ * Deriving the pair into the materialized env file fixes it, because that file
+ * is sourced into the session and the last export wins. Exporting over a
+ * variable this project did not set is a real intrusion, so it is deliberate,
+ * narrow, and never silent:
+ *
+ *   - only when the bundle actually parses and carries both halves
+ *   - never over a value the secret store itself supplies under those names,
+ *     which is a project stating an explicit intent
+ *   - recorded in the notes file, so the override is discoverable by the same
+ *     read-the-note path as any other credential
+ * @module aws-bootstrap
+ */
+
+/** The names every AWS SDK and the CLI actually read. */
+const ACCESS_KEY = "AWS_ACCESS_KEY_ID";
+const SECRET_KEY = "AWS_SECRET_ACCESS_KEY";
+const REGION = "AWS_DEFAULT_REGION";
+
+/** The bundle that carries the agent's identity. */
+export const BOOTSTRAP_KEY = "LISA_AWS_BOOTSTRAP_JSON";
+
+/**
+ * Read the bootstrap bundle, treating anything malformed as absent.
+ *
+ * A parse failure must not take materialization down with it: every other
+ * secret in the run is still valid and still needed, and a session with most of
+ * its credentials beats a session with none.
+ * @param {string} raw Bundle contents.
+ * @returns {object|null} Parsed bundle, or null.
+ */
+export function parseBootstrap(raw) {
+  if (typeof raw !== "string" || raw.trim() === "") return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Derive the AWS variables implied by an already-selected secret set.
+ *
+ * Returns only additions; the caller merges. Nothing here mutates its input,
+ * so a caller can decide what to do with the result — including reporting it.
+ * @param {Map<string, {value: string}>} selected Secrets by exact name.
+ * @returns {Map<string, {value: string, note: string}>} Derived variables.
+ */
+export function deriveAwsEnvironment(selected) {
+  const derived = new Map();
+  const bundle = parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value);
+  if (!bundle) return derived;
+
+  const accessKeyId = bundle.accessKeyId ?? bundle.aws_access_key_id;
+  const secretAccessKey =
+    bundle.secretAccessKey ?? bundle.aws_secret_access_key;
+  // Both halves or neither. Half a credential is not a weaker credential, it is
+  // a confusing failure — the SDK reports a signature error rather than a
+  // missing one.
+  if (!accessKeyId || !secretAccessKey) return derived;
+
+  // A project that stores these under their own names has said something
+  // explicit. Overriding that would be this module guessing against an operator.
+  if (selected.has(ACCESS_KEY) || selected.has(SECRET_KEY)) return derived;
+
+  const note =
+    `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Exported ` +
+    `deliberately so it overrides any ambient ${ACCESS_KEY} the host injects — ` +
+    `environment variables outrank profile files in the AWS credential chain, ` +
+    `so without this a stale host value wins and every call fails with ` +
+    `InvalidClientTokenId. This is the assume-only bootstrap identity; real ` +
+    `work assumes a role from it.`;
+
+  derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
+  derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+
+  const region = bundle.region ?? bundle.defaultRegion;
+  if (region && !selected.has(REGION)) {
+    derived.set(REGION, {
+      value: String(region),
+      note: `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access.`,
+    });
+  }
+  return derived;
+}

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -27,6 +27,7 @@ import {
   writeFileSync,
 } from "node:fs";
 
+import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
 import { fetchAll } from "./providers.mjs";
 import { materializedPaths, readConfig } from "./surfaces.mjs";
@@ -74,12 +75,20 @@ export function materialize(cfg = readConfig()) {
     );
   }
 
+  // The AWS bundle is stored as one JSON blob under a name no SDK reads, so
+  // the variables it implies are derived here. Without them a host-injected
+  // AWS_ACCESS_KEY_ID wins — environment variables outrank profile files in the
+  // credential chain — and every AWS call fails with InvalidClientTokenId even
+  // though the real credential materialized correctly.
+  const derived = deriveAwsEnvironment(selected);
+  for (const [name, entry] of derived) selected.set(name, entry);
+
   const { dir, valuesFile, notesFile } = materializedPaths(cfg.namespace);
   mkdirSync(dir, { recursive: true, mode: 0o700 });
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, dir };
+  return { count: selected.size, derived: derived.size, dir };
 }
 
 function main() {
@@ -91,8 +100,15 @@ function main() {
     console.log([...selected.keys()].sort().join("\n"));
     return;
   }
-  const { count, dir } = materialize(cfg);
+  const { count, derived, dir } = materialize(cfg);
   console.log(`materialized ${count} secret(s) and their notes into ${dir}`);
+  if (derived > 0) {
+    // Said out loud: this run exported variables the host may also have set.
+    console.log(
+      `  ${derived} AWS variable(s) derived from the bootstrap bundle, ` +
+        `overriding any ambient value`
+    );
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -95,6 +95,13 @@ function main() {
   const cfg = readConfig();
   if (process.argv.includes("--dry-run")) {
     const selected = fetchAll(cfg);
+    // Derive here too, or the preview lies in the one place it matters most:
+    // the derived names are exactly the ones that override ambient host
+    // credentials, so omitting them hides the most surprising effect of the run
+    // and reports a smaller count than the real write produces.
+    for (const [name, entry] of deriveAwsEnvironment(selected)) {
+      selected.set(name, entry);
+    }
     const { dir } = materializedPaths(cfg.namespace);
     console.log(`would write ${selected.size} secret(s) to ${dir}`);
     console.log([...selected.keys()].sort().join("\n"));

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -1,0 +1,102 @@
+/**
+ * Turn the AWS bootstrap bundle into environment variables the AWS SDKs obey.
+ *
+ * `LISA_AWS_BOOTSTRAP_JSON` carries the agent's AWS identity as one JSON blob.
+ * Materializing it verbatim is not enough, because nothing reads that name:
+ * every AWS SDK and the CLI look for `AWS_ACCESS_KEY_ID` and
+ * `AWS_SECRET_ACCESS_KEY`, or for a profile.
+ *
+ * Writing profiles alone is also not enough, and that is the failure this
+ * module exists for. A Claude cloud container ships its own
+ * `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in the ambient environment, and
+ * **environment variables outrank profile files in the credential chain**. So a
+ * session with correctly written `~/.aws/credentials` still failed:
+ *
+ *     aws sts get-caller-identity
+ *     InvalidClientTokenId: The security token included in the request is invalid.
+ *
+ * Deriving the pair into the materialized env file fixes it, because that file
+ * is sourced into the session and the last export wins. Exporting over a
+ * variable this project did not set is a real intrusion, so it is deliberate,
+ * narrow, and never silent:
+ *
+ *   - only when the bundle actually parses and carries both halves
+ *   - never over a value the secret store itself supplies under those names,
+ *     which is a project stating an explicit intent
+ *   - recorded in the notes file, so the override is discoverable by the same
+ *     read-the-note path as any other credential
+ * @module aws-bootstrap
+ */
+
+/** The names every AWS SDK and the CLI actually read. */
+const ACCESS_KEY = "AWS_ACCESS_KEY_ID";
+const SECRET_KEY = "AWS_SECRET_ACCESS_KEY";
+const REGION = "AWS_DEFAULT_REGION";
+
+/** The bundle that carries the agent's identity. */
+export const BOOTSTRAP_KEY = "LISA_AWS_BOOTSTRAP_JSON";
+
+/**
+ * Read the bootstrap bundle, treating anything malformed as absent.
+ *
+ * A parse failure must not take materialization down with it: every other
+ * secret in the run is still valid and still needed, and a session with most of
+ * its credentials beats a session with none.
+ * @param {string} raw Bundle contents.
+ * @returns {object|null} Parsed bundle, or null.
+ */
+export function parseBootstrap(raw) {
+  if (typeof raw !== "string" || raw.trim() === "") return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Derive the AWS variables implied by an already-selected secret set.
+ *
+ * Returns only additions; the caller merges. Nothing here mutates its input,
+ * so a caller can decide what to do with the result — including reporting it.
+ * @param {Map<string, {value: string}>} selected Secrets by exact name.
+ * @returns {Map<string, {value: string, note: string}>} Derived variables.
+ */
+export function deriveAwsEnvironment(selected) {
+  const derived = new Map();
+  const bundle = parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value);
+  if (!bundle) return derived;
+
+  const accessKeyId = bundle.accessKeyId ?? bundle.aws_access_key_id;
+  const secretAccessKey =
+    bundle.secretAccessKey ?? bundle.aws_secret_access_key;
+  // Both halves or neither. Half a credential is not a weaker credential, it is
+  // a confusing failure — the SDK reports a signature error rather than a
+  // missing one.
+  if (!accessKeyId || !secretAccessKey) return derived;
+
+  // A project that stores these under their own names has said something
+  // explicit. Overriding that would be this module guessing against an operator.
+  if (selected.has(ACCESS_KEY) || selected.has(SECRET_KEY)) return derived;
+
+  const note =
+    `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Exported ` +
+    `deliberately so it overrides any ambient ${ACCESS_KEY} the host injects — ` +
+    `environment variables outrank profile files in the AWS credential chain, ` +
+    `so without this a stale host value wins and every call fails with ` +
+    `InvalidClientTokenId. This is the assume-only bootstrap identity; real ` +
+    `work assumes a role from it.`;
+
+  derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
+  derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+
+  const region = bundle.region ?? bundle.defaultRegion;
+  if (region && !selected.has(REGION)) {
+    derived.set(REGION, {
+      value: String(region),
+      note: `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access.`,
+    });
+  }
+  return derived;
+}

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -27,6 +27,7 @@ import {
   writeFileSync,
 } from "node:fs";
 
+import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
 import { fetchAll } from "./providers.mjs";
 import { materializedPaths, readConfig } from "./surfaces.mjs";
@@ -74,12 +75,20 @@ export function materialize(cfg = readConfig()) {
     );
   }
 
+  // The AWS bundle is stored as one JSON blob under a name no SDK reads, so
+  // the variables it implies are derived here. Without them a host-injected
+  // AWS_ACCESS_KEY_ID wins — environment variables outrank profile files in the
+  // credential chain — and every AWS call fails with InvalidClientTokenId even
+  // though the real credential materialized correctly.
+  const derived = deriveAwsEnvironment(selected);
+  for (const [name, entry] of derived) selected.set(name, entry);
+
   const { dir, valuesFile, notesFile } = materializedPaths(cfg.namespace);
   mkdirSync(dir, { recursive: true, mode: 0o700 });
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, dir };
+  return { count: selected.size, derived: derived.size, dir };
 }
 
 function main() {
@@ -91,8 +100,15 @@ function main() {
     console.log([...selected.keys()].sort().join("\n"));
     return;
   }
-  const { count, dir } = materialize(cfg);
+  const { count, derived, dir } = materialize(cfg);
   console.log(`materialized ${count} secret(s) and their notes into ${dir}`);
+  if (derived > 0) {
+    // Said out loud: this run exported variables the host may also have set.
+    console.log(
+      `  ${derived} AWS variable(s) derived from the bootstrap bundle, ` +
+        `overriding any ambient value`
+    );
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -95,6 +95,13 @@ function main() {
   const cfg = readConfig();
   if (process.argv.includes("--dry-run")) {
     const selected = fetchAll(cfg);
+    // Derive here too, or the preview lies in the one place it matters most:
+    // the derived names are exactly the ones that override ambient host
+    // credentials, so omitting them hides the most surprising effect of the run
+    // and reports a smaller count than the real write produces.
+    for (const [name, entry] of deriveAwsEnvironment(selected)) {
+      selected.set(name, entry);
+    }
     const { dir } = materializedPaths(cfg.namespace);
     console.log(`would write ${selected.size} secret(s) to ${dir}`);
     console.log([...selected.keys()].sort().join("\n"));

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -1,0 +1,102 @@
+/**
+ * Turn the AWS bootstrap bundle into environment variables the AWS SDKs obey.
+ *
+ * `LISA_AWS_BOOTSTRAP_JSON` carries the agent's AWS identity as one JSON blob.
+ * Materializing it verbatim is not enough, because nothing reads that name:
+ * every AWS SDK and the CLI look for `AWS_ACCESS_KEY_ID` and
+ * `AWS_SECRET_ACCESS_KEY`, or for a profile.
+ *
+ * Writing profiles alone is also not enough, and that is the failure this
+ * module exists for. A Claude cloud container ships its own
+ * `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in the ambient environment, and
+ * **environment variables outrank profile files in the credential chain**. So a
+ * session with correctly written `~/.aws/credentials` still failed:
+ *
+ *     aws sts get-caller-identity
+ *     InvalidClientTokenId: The security token included in the request is invalid.
+ *
+ * Deriving the pair into the materialized env file fixes it, because that file
+ * is sourced into the session and the last export wins. Exporting over a
+ * variable this project did not set is a real intrusion, so it is deliberate,
+ * narrow, and never silent:
+ *
+ *   - only when the bundle actually parses and carries both halves
+ *   - never over a value the secret store itself supplies under those names,
+ *     which is a project stating an explicit intent
+ *   - recorded in the notes file, so the override is discoverable by the same
+ *     read-the-note path as any other credential
+ * @module aws-bootstrap
+ */
+
+/** The names every AWS SDK and the CLI actually read. */
+const ACCESS_KEY = "AWS_ACCESS_KEY_ID";
+const SECRET_KEY = "AWS_SECRET_ACCESS_KEY";
+const REGION = "AWS_DEFAULT_REGION";
+
+/** The bundle that carries the agent's identity. */
+export const BOOTSTRAP_KEY = "LISA_AWS_BOOTSTRAP_JSON";
+
+/**
+ * Read the bootstrap bundle, treating anything malformed as absent.
+ *
+ * A parse failure must not take materialization down with it: every other
+ * secret in the run is still valid and still needed, and a session with most of
+ * its credentials beats a session with none.
+ * @param {string} raw Bundle contents.
+ * @returns {object|null} Parsed bundle, or null.
+ */
+export function parseBootstrap(raw) {
+  if (typeof raw !== "string" || raw.trim() === "") return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Derive the AWS variables implied by an already-selected secret set.
+ *
+ * Returns only additions; the caller merges. Nothing here mutates its input,
+ * so a caller can decide what to do with the result — including reporting it.
+ * @param {Map<string, {value: string}>} selected Secrets by exact name.
+ * @returns {Map<string, {value: string, note: string}>} Derived variables.
+ */
+export function deriveAwsEnvironment(selected) {
+  const derived = new Map();
+  const bundle = parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value);
+  if (!bundle) return derived;
+
+  const accessKeyId = bundle.accessKeyId ?? bundle.aws_access_key_id;
+  const secretAccessKey =
+    bundle.secretAccessKey ?? bundle.aws_secret_access_key;
+  // Both halves or neither. Half a credential is not a weaker credential, it is
+  // a confusing failure — the SDK reports a signature error rather than a
+  // missing one.
+  if (!accessKeyId || !secretAccessKey) return derived;
+
+  // A project that stores these under their own names has said something
+  // explicit. Overriding that would be this module guessing against an operator.
+  if (selected.has(ACCESS_KEY) || selected.has(SECRET_KEY)) return derived;
+
+  const note =
+    `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Exported ` +
+    `deliberately so it overrides any ambient ${ACCESS_KEY} the host injects — ` +
+    `environment variables outrank profile files in the AWS credential chain, ` +
+    `so without this a stale host value wins and every call fails with ` +
+    `InvalidClientTokenId. This is the assume-only bootstrap identity; real ` +
+    `work assumes a role from it.`;
+
+  derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
+  derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+
+  const region = bundle.region ?? bundle.defaultRegion;
+  if (region && !selected.has(REGION)) {
+    derived.set(REGION, {
+      value: String(region),
+      note: `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access.`,
+    });
+  }
+  return derived;
+}

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -27,6 +27,7 @@ import {
   writeFileSync,
 } from "node:fs";
 
+import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
 import { fetchAll } from "./providers.mjs";
 import { materializedPaths, readConfig } from "./surfaces.mjs";
@@ -74,12 +75,20 @@ export function materialize(cfg = readConfig()) {
     );
   }
 
+  // The AWS bundle is stored as one JSON blob under a name no SDK reads, so
+  // the variables it implies are derived here. Without them a host-injected
+  // AWS_ACCESS_KEY_ID wins — environment variables outrank profile files in the
+  // credential chain — and every AWS call fails with InvalidClientTokenId even
+  // though the real credential materialized correctly.
+  const derived = deriveAwsEnvironment(selected);
+  for (const [name, entry] of derived) selected.set(name, entry);
+
   const { dir, valuesFile, notesFile } = materializedPaths(cfg.namespace);
   mkdirSync(dir, { recursive: true, mode: 0o700 });
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, dir };
+  return { count: selected.size, derived: derived.size, dir };
 }
 
 function main() {
@@ -91,8 +100,15 @@ function main() {
     console.log([...selected.keys()].sort().join("\n"));
     return;
   }
-  const { count, dir } = materialize(cfg);
+  const { count, derived, dir } = materialize(cfg);
   console.log(`materialized ${count} secret(s) and their notes into ${dir}`);
+  if (derived > 0) {
+    // Said out loud: this run exported variables the host may also have set.
+    console.log(
+      `  ${derived} AWS variable(s) derived from the bootstrap bundle, ` +
+        `overriding any ambient value`
+    );
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -95,6 +95,13 @@ function main() {
   const cfg = readConfig();
   if (process.argv.includes("--dry-run")) {
     const selected = fetchAll(cfg);
+    // Derive here too, or the preview lies in the one place it matters most:
+    // the derived names are exactly the ones that override ambient host
+    // credentials, so omitting them hides the most surprising effect of the run
+    // and reports a smaller count than the real write produces.
+    for (const [name, entry] of deriveAwsEnvironment(selected)) {
+      selected.set(name, entry);
+    }
     const { dir } = materializedPaths(cfg.namespace);
     console.log(`would write ${selected.size} secret(s) to ${dir}`);
     console.log([...selected.keys()].sort().join("\n"));

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -1,0 +1,102 @@
+/**
+ * Turn the AWS bootstrap bundle into environment variables the AWS SDKs obey.
+ *
+ * `LISA_AWS_BOOTSTRAP_JSON` carries the agent's AWS identity as one JSON blob.
+ * Materializing it verbatim is not enough, because nothing reads that name:
+ * every AWS SDK and the CLI look for `AWS_ACCESS_KEY_ID` and
+ * `AWS_SECRET_ACCESS_KEY`, or for a profile.
+ *
+ * Writing profiles alone is also not enough, and that is the failure this
+ * module exists for. A Claude cloud container ships its own
+ * `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in the ambient environment, and
+ * **environment variables outrank profile files in the credential chain**. So a
+ * session with correctly written `~/.aws/credentials` still failed:
+ *
+ *     aws sts get-caller-identity
+ *     InvalidClientTokenId: The security token included in the request is invalid.
+ *
+ * Deriving the pair into the materialized env file fixes it, because that file
+ * is sourced into the session and the last export wins. Exporting over a
+ * variable this project did not set is a real intrusion, so it is deliberate,
+ * narrow, and never silent:
+ *
+ *   - only when the bundle actually parses and carries both halves
+ *   - never over a value the secret store itself supplies under those names,
+ *     which is a project stating an explicit intent
+ *   - recorded in the notes file, so the override is discoverable by the same
+ *     read-the-note path as any other credential
+ * @module aws-bootstrap
+ */
+
+/** The names every AWS SDK and the CLI actually read. */
+const ACCESS_KEY = "AWS_ACCESS_KEY_ID";
+const SECRET_KEY = "AWS_SECRET_ACCESS_KEY";
+const REGION = "AWS_DEFAULT_REGION";
+
+/** The bundle that carries the agent's identity. */
+export const BOOTSTRAP_KEY = "LISA_AWS_BOOTSTRAP_JSON";
+
+/**
+ * Read the bootstrap bundle, treating anything malformed as absent.
+ *
+ * A parse failure must not take materialization down with it: every other
+ * secret in the run is still valid and still needed, and a session with most of
+ * its credentials beats a session with none.
+ * @param {string} raw Bundle contents.
+ * @returns {object|null} Parsed bundle, or null.
+ */
+export function parseBootstrap(raw) {
+  if (typeof raw !== "string" || raw.trim() === "") return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Derive the AWS variables implied by an already-selected secret set.
+ *
+ * Returns only additions; the caller merges. Nothing here mutates its input,
+ * so a caller can decide what to do with the result — including reporting it.
+ * @param {Map<string, {value: string}>} selected Secrets by exact name.
+ * @returns {Map<string, {value: string, note: string}>} Derived variables.
+ */
+export function deriveAwsEnvironment(selected) {
+  const derived = new Map();
+  const bundle = parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value);
+  if (!bundle) return derived;
+
+  const accessKeyId = bundle.accessKeyId ?? bundle.aws_access_key_id;
+  const secretAccessKey =
+    bundle.secretAccessKey ?? bundle.aws_secret_access_key;
+  // Both halves or neither. Half a credential is not a weaker credential, it is
+  // a confusing failure — the SDK reports a signature error rather than a
+  // missing one.
+  if (!accessKeyId || !secretAccessKey) return derived;
+
+  // A project that stores these under their own names has said something
+  // explicit. Overriding that would be this module guessing against an operator.
+  if (selected.has(ACCESS_KEY) || selected.has(SECRET_KEY)) return derived;
+
+  const note =
+    `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Exported ` +
+    `deliberately so it overrides any ambient ${ACCESS_KEY} the host injects — ` +
+    `environment variables outrank profile files in the AWS credential chain, ` +
+    `so without this a stale host value wins and every call fails with ` +
+    `InvalidClientTokenId. This is the assume-only bootstrap identity; real ` +
+    `work assumes a role from it.`;
+
+  derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
+  derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+
+  const region = bundle.region ?? bundle.defaultRegion;
+  if (region && !selected.has(REGION)) {
+    derived.set(REGION, {
+      value: String(region),
+      note: `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access.`,
+    });
+  }
+  return derived;
+}

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -27,6 +27,7 @@ import {
   writeFileSync,
 } from "node:fs";
 
+import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
 import { fetchAll } from "./providers.mjs";
 import { materializedPaths, readConfig } from "./surfaces.mjs";
@@ -74,12 +75,20 @@ export function materialize(cfg = readConfig()) {
     );
   }
 
+  // The AWS bundle is stored as one JSON blob under a name no SDK reads, so
+  // the variables it implies are derived here. Without them a host-injected
+  // AWS_ACCESS_KEY_ID wins — environment variables outrank profile files in the
+  // credential chain — and every AWS call fails with InvalidClientTokenId even
+  // though the real credential materialized correctly.
+  const derived = deriveAwsEnvironment(selected);
+  for (const [name, entry] of derived) selected.set(name, entry);
+
   const { dir, valuesFile, notesFile } = materializedPaths(cfg.namespace);
   mkdirSync(dir, { recursive: true, mode: 0o700 });
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, dir };
+  return { count: selected.size, derived: derived.size, dir };
 }
 
 function main() {
@@ -91,8 +100,15 @@ function main() {
     console.log([...selected.keys()].sort().join("\n"));
     return;
   }
-  const { count, dir } = materialize(cfg);
+  const { count, derived, dir } = materialize(cfg);
   console.log(`materialized ${count} secret(s) and their notes into ${dir}`);
+  if (derived > 0) {
+    // Said out loud: this run exported variables the host may also have set.
+    console.log(
+      `  ${derived} AWS variable(s) derived from the bootstrap bundle, ` +
+        `overriding any ambient value`
+    );
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -95,6 +95,13 @@ function main() {
   const cfg = readConfig();
   if (process.argv.includes("--dry-run")) {
     const selected = fetchAll(cfg);
+    // Derive here too, or the preview lies in the one place it matters most:
+    // the derived names are exactly the ones that override ambient host
+    // credentials, so omitting them hides the most surprising effect of the run
+    // and reports a smaller count than the real write produces.
+    for (const [name, entry] of deriveAwsEnvironment(selected)) {
+      selected.set(name, entry);
+    }
     const { dir } = materializedPaths(cfg.namespace);
     console.log(`would write ${selected.size} secret(s) to ${dir}`);
     console.log([...selected.keys()].sort().join("\n"));

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1107,7 +1107,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/envfile.mjs":
       "be4e38ce85f9268b52b29dbde264ecd8d50973c2b63a15410336234a921d9644",
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs":
-      "048f261f49056e5d3b1f917e36df7f76529b88a1de5164e500ccf64537bff116",
+      "b535ed8babf7237374de9886fca7967519f4719ab8a1c03f16dfddef05f0a138",
     "plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs":
       "fec38ca937570c1e1c21e6e8f7314a9d8f4e9264779d0394b40d5158924da0da",
     "plugins/src/base/skills/lisa-secrets-access/scripts/read-secret-note.mjs":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1100,12 +1100,14 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "3fa14217ca36b238ebb8203d18f10eaaf98a3647f949cdada6cb9f56ddf9ed50",
     "plugins/src/base/skills/lisa-secrets-access/SKILL.md":
       "9d7346864b04304e5b4bbb90512c7f2e701d69ab012b4fcf3b7b687221fc76bd",
+    "plugins/src/base/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs":
+      "5403ddeec18b670d10257beb3859cd220d92fab5d4768535a35a56a7d8a280da",
     "plugins/src/base/skills/lisa-secrets-access/scripts/doctor-secrets.mjs":
       "f203c71457da958cdb49637c87e4a9c43e964f98ecef3dd0e933b419d565f98e",
     "plugins/src/base/skills/lisa-secrets-access/scripts/envfile.mjs":
       "be4e38ce85f9268b52b29dbde264ecd8d50973c2b63a15410336234a921d9644",
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs":
-      "4b4448cd680a8fe7b1f51bad840c2655f898e9bc08ca06c385cd1d21dca3c3d4",
+      "048f261f49056e5d3b1f917e36df7f76529b88a1de5164e500ccf64537bff116",
     "plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs":
       "fec38ca937570c1e1c21e6e8f7314a9d8f4e9264779d0394b40d5158924da0da",
     "plugins/src/base/skills/lisa-secrets-access/scripts/read-secret-note.mjs":
@@ -3296,6 +3298,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-agy/skills/lisa-rework-triage/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-root-cause-analysis/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-secrets-access/SKILL.md": true,
+    "plugins/lisa-agy/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs": true,
     "plugins/lisa-agy/skills/lisa-secrets-access/scripts/doctor-secrets.mjs": true,
     "plugins/lisa-agy/skills/lisa-secrets-access/scripts/envfile.mjs": true,
     "plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs": true,
@@ -3724,6 +3727,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/skills/lisa-rework-triage/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-root-cause-analysis/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-secrets-access/SKILL.md": true,
+    "plugins/lisa-copilot/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs": true,
     "plugins/lisa-copilot/skills/lisa-secrets-access/scripts/doctor-secrets.mjs": true,
     "plugins/lisa-copilot/skills/lisa-secrets-access/scripts/envfile.mjs": true,
     "plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs": true,
@@ -4138,6 +4142,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/skills/lisa-rework-triage/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-root-cause-analysis/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-secrets-access/SKILL.md": true,
+    "plugins/lisa-cursor/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs": true,
     "plugins/lisa-cursor/skills/lisa-secrets-access/scripts/doctor-secrets.mjs": true,
     "plugins/lisa-cursor/skills/lisa-secrets-access/scripts/envfile.mjs": true,
     "plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs": true,
@@ -6167,6 +6172,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/.codex-plugin/skills/lisa-root-cause-analysis/agents/openai.yaml": true,
     "plugins/lisa/.codex-plugin/skills/lisa-secrets-access/SKILL.md": true,
     "plugins/lisa/.codex-plugin/skills/lisa-secrets-access/agents/openai.yaml": true,
+    "plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs": true,
     "plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/doctor-secrets.mjs": true,
     "plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/envfile.mjs": true,
     "plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs": true,
@@ -6761,6 +6767,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/skills/lisa-root-cause-analysis/agents/openai.yaml": true,
     "plugins/lisa/skills/lisa-secrets-access/SKILL.md": true,
     "plugins/lisa/skills/lisa-secrets-access/agents/openai.yaml": true,
+    "plugins/lisa/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs": true,
     "plugins/lisa/skills/lisa-secrets-access/scripts/doctor-secrets.mjs": true,
     "plugins/lisa/skills/lisa-secrets-access/scripts/envfile.mjs": true,
     "plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs": true,
@@ -7231,6 +7238,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/skills/lisa-rework-triage/SKILL.md": true,
     "plugins/src/base/skills/lisa-root-cause-analysis/SKILL.md": true,
     "plugins/src/base/skills/lisa-secrets-access/SKILL.md": true,
+    "plugins/src/base/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs": true,
     "plugins/src/base/skills/lisa-secrets-access/scripts/doctor-secrets.mjs": true,
     "plugins/src/base/skills/lisa-secrets-access/scripts/envfile.mjs": true,
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs": true,
@@ -8478,6 +8486,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/work-item-github-failure-diagnosis.test.ts": true,
     "tests/unit/scripts/work-item-tracker-unreachable.test.ts": true,
     "tests/unit/secrets/automation-workflow.test.ts": true,
+    "tests/unit/secrets/aws-bootstrap-derivation.test.ts": true,
     "tests/unit/secrets/bootstrap-key-naming.test.ts": true,
     "tests/unit/secrets/detect-tooling-discovery.test.ts": true,
     "tests/unit/secrets/detect-tooling.test.ts": true,

--- a/tests/unit/secrets/aws-bootstrap-derivation.test.ts
+++ b/tests/unit/secrets/aws-bootstrap-derivation.test.ts
@@ -40,7 +40,9 @@ const BUNDLE = JSON.stringify({
  * @param entries Name to value.
  * @returns The map materialize() would hold.
  */
-const selection = (entries: Record<string, string>) =>
+const selection = (
+  entries: Record<string, string>
+): Map<string, { value: string }> =>
   new Map(Object.entries(entries).map(([k, v]) => [k, { value: v }]));
 
 describe("parseBootstrap", () => {

--- a/tests/unit/secrets/aws-bootstrap-derivation.test.ts
+++ b/tests/unit/secrets/aws-bootstrap-derivation.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for deriving AWS variables from the bootstrap bundle.
+ *
+ * `LISA_AWS_BOOTSTRAP_JSON` is a name no AWS SDK reads. Materializing it alone
+ * leaves a session whose credential is present and unusable — and worse than
+ * unusable, because a Claude cloud container ships its own stale
+ * `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, and environment variables
+ * outrank profile files in the credential chain. A real session failed exactly
+ * that way:
+ *
+ *     InvalidClientTokenId: The security token included in the request is invalid.
+ * @module tests/unit/secrets/aws-bootstrap-derivation
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BOOTSTRAP_KEY,
+  deriveAwsEnvironment,
+  parseBootstrap,
+} from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs";
+
+/** The example access key id, repeated across cases. */
+const KEY_ID = "AKIAEXAMPLE";
+
+/** The example secret half. */
+const SECRET = "s3cret-example";
+
+/** A realistic bundle: assume-only user plus the roles it may assume. */
+const BUNDLE = JSON.stringify({
+  accessKeyId: KEY_ID,
+  secretAccessKey: SECRET,
+  roleName: "RemoteAgent",
+  externalId: "example-external-id",
+  profiles: { dev: "111111111111", production: "222222222222" },
+});
+
+/**
+ * Build a selected-secrets map.
+ * @param entries Name to value.
+ * @returns The map materialize() would hold.
+ */
+const selection = (entries: Record<string, string>) =>
+  new Map(Object.entries(entries).map(([k, v]) => [k, { value: v }]));
+
+describe("parseBootstrap", () => {
+  it("parses a well-formed bundle", () => {
+    expect(parseBootstrap(BUNDLE)?.roleName).toBe("RemoteAgent");
+  });
+
+  it.each([
+    ["malformed JSON", "{not json"],
+    ["empty", ""],
+    ["a bare string", '"just-a-string"'],
+  ])("treats %s as absent rather than throwing", (_label, raw) => {
+    // A parse failure must not take materialization down with it: every other
+    // secret in the run is still valid, and a session with most of its
+    // credentials beats a session with none.
+    expect(parseBootstrap(raw)).toBeNull();
+  });
+});
+
+describe("deriveAwsEnvironment", () => {
+  it("derives the pair the SDKs actually read", () => {
+    const derived = deriveAwsEnvironment(
+      selection({ [BOOTSTRAP_KEY]: BUNDLE })
+    );
+    expect(derived.get("AWS_ACCESS_KEY_ID")?.value).toBe(KEY_ID);
+    expect(derived.get("AWS_SECRET_ACCESS_KEY")?.value).toBe(SECRET);
+  });
+
+  it("explains in the note why it overrides an ambient value", () => {
+    // The override is an intrusion — this project exporting over a variable it
+    // did not set. It has to be discoverable through the same read-the-note
+    // path as any other credential, not buried in a commit message.
+    const derived = deriveAwsEnvironment(
+      selection({ [BOOTSTRAP_KEY]: BUNDLE })
+    );
+    const note = derived.get("AWS_ACCESS_KEY_ID")?.note ?? "";
+    expect(note).toContain("outrank profile files");
+    expect(note).toContain("InvalidClientTokenId");
+  });
+
+  it("yields nothing when the bundle is absent", () => {
+    expect(deriveAwsEnvironment(selection({ OTHER: "x" })).size).toBe(0);
+  });
+
+  it("yields nothing when the bundle is malformed", () => {
+    expect(
+      deriveAwsEnvironment(selection({ [BOOTSTRAP_KEY]: "{broken" })).size
+    ).toBe(0);
+  });
+
+  it("refuses half a credential", () => {
+    // Half a credential is not a weaker credential; it is a confusing failure.
+    // The SDK reports a signature error rather than a missing one.
+    const half = JSON.stringify({ accessKeyId: KEY_ID });
+    expect(
+      deriveAwsEnvironment(selection({ [BOOTSTRAP_KEY]: half })).size
+    ).toBe(0);
+  });
+
+  it("never overrides names the secret store itself supplies", () => {
+    // A project storing these under their own names has stated an explicit
+    // intent. Overriding it would be this module guessing against an operator.
+    const derived = deriveAwsEnvironment(
+      selection({
+        [BOOTSTRAP_KEY]: BUNDLE,
+        AWS_ACCESS_KEY_ID: "AKIAFROMSTORE",
+        AWS_SECRET_ACCESS_KEY: "from-store",
+      })
+    );
+    expect(derived.size).toBe(0);
+  });
+
+  it("carries a region through when the bundle names one", () => {
+    const withRegion = JSON.stringify({
+      accessKeyId: KEY_ID,
+      secretAccessKey: SECRET,
+      region: "us-east-1",
+    });
+    const derived = deriveAwsEnvironment(
+      selection({ [BOOTSTRAP_KEY]: withRegion })
+    );
+    expect(derived.get("AWS_DEFAULT_REGION")?.value).toBe("us-east-1");
+  });
+
+  it("does not mutate the selection it was given", () => {
+    // The caller decides what to merge and what to report; a function that
+    // edited its input would make that choice invisible.
+    const input = selection({ [BOOTSTRAP_KEY]: BUNDLE });
+    deriveAwsEnvironment(input);
+    expect([...input.keys()]).toEqual([BOOTSTRAP_KEY]);
+  });
+});


### PR DESCRIPTION
## The bug

`LISA_AWS_BOOTSTRAP_JSON` is a name **no AWS SDK reads**. Materializing it alone leaves a session whose credential is present and unusable — and worse than unusable, because a Claude cloud container ships its own stale `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, and **environment variables outrank profile files in AWS's credential chain**.

So a session with correctly written `~/.aws/credentials` profiles still failed:

```
aws sts get-caller-identity
InvalidClientTokenId: The security token included in the request is invalid.
```

Observed in a real Claude Code web session. Extracting the bootstrap pair by hand resolved cleanly to `arn:aws:iam::777997078669:user/remote-agent` — the credential was always fine, only its precedence was wrong.

## The fix

The pair is derived into the materialized env file, which is sourced into the session, so the last export wins.

Exporting over a variable this project did not set is a real intrusion, so it is deliberate, narrow, and never silent:

- **Only when the bundle parses AND carries both halves.** Half a credential is not a weaker credential — the SDK reports a *signature* error rather than a *missing* one, which is a worse thing to debug.
- **Never over a value the secret store itself supplies** under those names. A project doing that has stated an explicit intent, and overriding it would be Lisa guessing against an operator.
- **Recorded in the notes file**, so the override is discoverable through the same read-the-note path as any other credential rather than buried in a commit message.
- **Reported on stdout** at materialization time, naming how many variables were derived.

A malformed bundle yields nothing rather than throwing: every other secret in the run is still valid, and a session with most of its credentials beats a session with none.

This remains the assume-only bootstrap identity. Real work still assumes a role from it — unchanged.

## Tests

12 cases, including the refusals, which are the parts most likely to rot:

- half a credential → nothing derived
- store-supplied `AWS_ACCESS_KEY_ID` → nothing derived
- malformed / empty / non-object bundle → nothing derived, no throw
- the input map is not mutated

Full suite green.

## Note on provenance

This was the second commit on #2302, but that PR merged at the first commit while this one was still being pushed — the branch was auto-deleted and the push recreated it orphaned. Same auto-merge timing hazard as CodySwannGT/lisa#2300 describes. Caught by diffing `origin/main` rather than trusting the merge.

🤖 Generated with Claude Code

---

Work-Item: CodySwannGT/lisa#2301


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AWS credentials and regions can now be derived automatically from bootstrap configuration.
  * Explicitly selected AWS values are preserved.
  * Materialized secrets now include derived AWS environment variables.

* **Bug Fixes**
  * Invalid or incomplete bootstrap data is safely ignored.

* **Documentation**
  * CLI output reports derived variables and warns when they override ambient AWS values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->