### PR TITLE
feat(secrets): install bare release binaries via a checksummed pin

### DIFF
--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -301,6 +301,44 @@ function installReleaseTree(tool, binDir) {
 }
 
 /**
+ * Install a pinned artifact that IS the binary, with no archive around it.
+ *
+ * Several tools worth pinning publish a raw executable rather than an archive —
+ * jq ships `jq-linux-amd64` and a `sha256sum.txt`, which is ideal material for a
+ * checksummed pin and fits none of the archive kinds.
+ *
+ * Without this the only entry that passes `assertPinned` is `release-zip`, which
+ * then fails at install when `unzip` is handed a binary. A manifest entry that
+ * validates and cannot install is worse than one that is rejected outright: the
+ * error arrives during provisioning rather than during review.
+ *
+ * There is no `binary` field here, deliberately — the download is the binary,
+ * so there is nothing inside it to name.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to install into.
+ */
+function installReleaseBinary(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const artifact = join(temporary, tool.name);
+    execFileSync("curl", ["-fsSL", tool.url, "-o", artifact], {
+      stdio: "inherit",
+    });
+    // Verify before it reaches a directory on PATH. For this kind that ordering
+    // matters more than for the archives: the downloaded file is directly
+    // executable, so a wrong artifact placed first is a wrong artifact that can
+    // be run.
+    verifyChecksum(artifact, tool.sha256, tool.name);
+    execFileSync("install", ["-m", "0755", artifact, join(binDir, tool.name)], {
+      stdio: "inherit",
+    });
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -328,6 +366,8 @@ export function installTool(tool, binDir) {
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
   else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
   else if (tool.install === "release-tree") installReleaseTree(tool, binDir);
+  else if (tool.install === "release-binary")
+    installReleaseBinary(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -354,6 +354,18 @@ export function assertPinned(tool) {
     }
     return;
   }
+  // The download IS the binary, so there is no `binary` path to require — but
+  // the checksum matters more here than anywhere else, because the artifact is
+  // directly executable rather than something that has to be unpacked first.
+  if (tool.install === "release-binary") {
+    if (!tool.url || !tool.sha256) {
+      throw new Error(
+        `${tool.name}: a release-binary install needs both url and sha256.\n` +
+          `A version bump must move the checksum in the same reviewed commit.`
+      );
+    }
+    return;
+  }
   if (tool.install === "npm-global") {
     if (!tool.package)
       throw new Error(`${tool.name}: npm-global install needs a package`);
@@ -361,6 +373,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, release-tree, npm-global.`
+      `Supported: release-zip, release-tar, release-tree, release-binary, npm-global.`
   );
 }

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -301,6 +301,44 @@ function installReleaseTree(tool, binDir) {
 }
 
 /**
+ * Install a pinned artifact that IS the binary, with no archive around it.
+ *
+ * Several tools worth pinning publish a raw executable rather than an archive —
+ * jq ships `jq-linux-amd64` and a `sha256sum.txt`, which is ideal material for a
+ * checksummed pin and fits none of the archive kinds.
+ *
+ * Without this the only entry that passes `assertPinned` is `release-zip`, which
+ * then fails at install when `unzip` is handed a binary. A manifest entry that
+ * validates and cannot install is worse than one that is rejected outright: the
+ * error arrives during provisioning rather than during review.
+ *
+ * There is no `binary` field here, deliberately — the download is the binary,
+ * so there is nothing inside it to name.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to install into.
+ */
+function installReleaseBinary(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const artifact = join(temporary, tool.name);
+    execFileSync("curl", ["-fsSL", tool.url, "-o", artifact], {
+      stdio: "inherit",
+    });
+    // Verify before it reaches a directory on PATH. For this kind that ordering
+    // matters more than for the archives: the downloaded file is directly
+    // executable, so a wrong artifact placed first is a wrong artifact that can
+    // be run.
+    verifyChecksum(artifact, tool.sha256, tool.name);
+    execFileSync("install", ["-m", "0755", artifact, join(binDir, tool.name)], {
+      stdio: "inherit",
+    });
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -328,6 +366,8 @@ export function installTool(tool, binDir) {
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
   else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
   else if (tool.install === "release-tree") installReleaseTree(tool, binDir);
+  else if (tool.install === "release-binary")
+    installReleaseBinary(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -354,6 +354,18 @@ export function assertPinned(tool) {
     }
     return;
   }
+  // The download IS the binary, so there is no `binary` path to require — but
+  // the checksum matters more here than anywhere else, because the artifact is
+  // directly executable rather than something that has to be unpacked first.
+  if (tool.install === "release-binary") {
+    if (!tool.url || !tool.sha256) {
+      throw new Error(
+        `${tool.name}: a release-binary install needs both url and sha256.\n` +
+          `A version bump must move the checksum in the same reviewed commit.`
+      );
+    }
+    return;
+  }
   if (tool.install === "npm-global") {
     if (!tool.package)
       throw new Error(`${tool.name}: npm-global install needs a package`);
@@ -361,6 +373,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, release-tree, npm-global.`
+      `Supported: release-zip, release-tar, release-tree, release-binary, npm-global.`
   );
 }

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -301,6 +301,44 @@ function installReleaseTree(tool, binDir) {
 }
 
 /**
+ * Install a pinned artifact that IS the binary, with no archive around it.
+ *
+ * Several tools worth pinning publish a raw executable rather than an archive —
+ * jq ships `jq-linux-amd64` and a `sha256sum.txt`, which is ideal material for a
+ * checksummed pin and fits none of the archive kinds.
+ *
+ * Without this the only entry that passes `assertPinned` is `release-zip`, which
+ * then fails at install when `unzip` is handed a binary. A manifest entry that
+ * validates and cannot install is worse than one that is rejected outright: the
+ * error arrives during provisioning rather than during review.
+ *
+ * There is no `binary` field here, deliberately — the download is the binary,
+ * so there is nothing inside it to name.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to install into.
+ */
+function installReleaseBinary(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const artifact = join(temporary, tool.name);
+    execFileSync("curl", ["-fsSL", tool.url, "-o", artifact], {
+      stdio: "inherit",
+    });
+    // Verify before it reaches a directory on PATH. For this kind that ordering
+    // matters more than for the archives: the downloaded file is directly
+    // executable, so a wrong artifact placed first is a wrong artifact that can
+    // be run.
+    verifyChecksum(artifact, tool.sha256, tool.name);
+    execFileSync("install", ["-m", "0755", artifact, join(binDir, tool.name)], {
+      stdio: "inherit",
+    });
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -328,6 +366,8 @@ export function installTool(tool, binDir) {
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
   else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
   else if (tool.install === "release-tree") installReleaseTree(tool, binDir);
+  else if (tool.install === "release-binary")
+    installReleaseBinary(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -354,6 +354,18 @@ export function assertPinned(tool) {
     }
     return;
   }
+  // The download IS the binary, so there is no `binary` path to require — but
+  // the checksum matters more here than anywhere else, because the artifact is
+  // directly executable rather than something that has to be unpacked first.
+  if (tool.install === "release-binary") {
+    if (!tool.url || !tool.sha256) {
+      throw new Error(
+        `${tool.name}: a release-binary install needs both url and sha256.\n` +
+          `A version bump must move the checksum in the same reviewed commit.`
+      );
+    }
+    return;
+  }
   if (tool.install === "npm-global") {
     if (!tool.package)
       throw new Error(`${tool.name}: npm-global install needs a package`);
@@ -361,6 +373,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, release-tree, npm-global.`
+      `Supported: release-zip, release-tar, release-tree, release-binary, npm-global.`
   );
 }

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -301,6 +301,44 @@ function installReleaseTree(tool, binDir) {
 }
 
 /**
+ * Install a pinned artifact that IS the binary, with no archive around it.
+ *
+ * Several tools worth pinning publish a raw executable rather than an archive —
+ * jq ships `jq-linux-amd64` and a `sha256sum.txt`, which is ideal material for a
+ * checksummed pin and fits none of the archive kinds.
+ *
+ * Without this the only entry that passes `assertPinned` is `release-zip`, which
+ * then fails at install when `unzip` is handed a binary. A manifest entry that
+ * validates and cannot install is worse than one that is rejected outright: the
+ * error arrives during provisioning rather than during review.
+ *
+ * There is no `binary` field here, deliberately — the download is the binary,
+ * so there is nothing inside it to name.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to install into.
+ */
+function installReleaseBinary(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const artifact = join(temporary, tool.name);
+    execFileSync("curl", ["-fsSL", tool.url, "-o", artifact], {
+      stdio: "inherit",
+    });
+    // Verify before it reaches a directory on PATH. For this kind that ordering
+    // matters more than for the archives: the downloaded file is directly
+    // executable, so a wrong artifact placed first is a wrong artifact that can
+    // be run.
+    verifyChecksum(artifact, tool.sha256, tool.name);
+    execFileSync("install", ["-m", "0755", artifact, join(binDir, tool.name)], {
+      stdio: "inherit",
+    });
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -328,6 +366,8 @@ export function installTool(tool, binDir) {
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
   else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
   else if (tool.install === "release-tree") installReleaseTree(tool, binDir);
+  else if (tool.install === "release-binary")
+    installReleaseBinary(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -354,6 +354,18 @@ export function assertPinned(tool) {
     }
     return;
   }
+  // The download IS the binary, so there is no `binary` path to require — but
+  // the checksum matters more here than anywhere else, because the artifact is
+  // directly executable rather than something that has to be unpacked first.
+  if (tool.install === "release-binary") {
+    if (!tool.url || !tool.sha256) {
+      throw new Error(
+        `${tool.name}: a release-binary install needs both url and sha256.\n` +
+          `A version bump must move the checksum in the same reviewed commit.`
+      );
+    }
+    return;
+  }
   if (tool.install === "npm-global") {
     if (!tool.package)
       throw new Error(`${tool.name}: npm-global install needs a package`);
@@ -361,6 +373,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, release-tree, npm-global.`
+      `Supported: release-zip, release-tar, release-tree, release-binary, npm-global.`
   );
 }

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -301,6 +301,44 @@ function installReleaseTree(tool, binDir) {
 }
 
 /**
+ * Install a pinned artifact that IS the binary, with no archive around it.
+ *
+ * Several tools worth pinning publish a raw executable rather than an archive —
+ * jq ships `jq-linux-amd64` and a `sha256sum.txt`, which is ideal material for a
+ * checksummed pin and fits none of the archive kinds.
+ *
+ * Without this the only entry that passes `assertPinned` is `release-zip`, which
+ * then fails at install when `unzip` is handed a binary. A manifest entry that
+ * validates and cannot install is worse than one that is rejected outright: the
+ * error arrives during provisioning rather than during review.
+ *
+ * There is no `binary` field here, deliberately — the download is the binary,
+ * so there is nothing inside it to name.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to install into.
+ */
+function installReleaseBinary(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const artifact = join(temporary, tool.name);
+    execFileSync("curl", ["-fsSL", tool.url, "-o", artifact], {
+      stdio: "inherit",
+    });
+    // Verify before it reaches a directory on PATH. For this kind that ordering
+    // matters more than for the archives: the downloaded file is directly
+    // executable, so a wrong artifact placed first is a wrong artifact that can
+    // be run.
+    verifyChecksum(artifact, tool.sha256, tool.name);
+    execFileSync("install", ["-m", "0755", artifact, join(binDir, tool.name)], {
+      stdio: "inherit",
+    });
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -328,6 +366,8 @@ export function installTool(tool, binDir) {
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
   else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
   else if (tool.install === "release-tree") installReleaseTree(tool, binDir);
+  else if (tool.install === "release-binary")
+    installReleaseBinary(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -354,6 +354,18 @@ export function assertPinned(tool) {
     }
     return;
   }
+  // The download IS the binary, so there is no `binary` path to require — but
+  // the checksum matters more here than anywhere else, because the artifact is
+  // directly executable rather than something that has to be unpacked first.
+  if (tool.install === "release-binary") {
+    if (!tool.url || !tool.sha256) {
+      throw new Error(
+        `${tool.name}: a release-binary install needs both url and sha256.\n` +
+          `A version bump must move the checksum in the same reviewed commit.`
+      );
+    }
+    return;
+  }
   if (tool.install === "npm-global") {
     if (!tool.package)
       throw new Error(`${tool.name}: npm-global install needs a package`);
@@ -361,6 +373,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, release-tree, npm-global.`
+      `Supported: release-zip, release-tar, release-tree, release-binary, npm-global.`
   );
 }

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -301,6 +301,44 @@ function installReleaseTree(tool, binDir) {
 }
 
 /**
+ * Install a pinned artifact that IS the binary, with no archive around it.
+ *
+ * Several tools worth pinning publish a raw executable rather than an archive —
+ * jq ships `jq-linux-amd64` and a `sha256sum.txt`, which is ideal material for a
+ * checksummed pin and fits none of the archive kinds.
+ *
+ * Without this the only entry that passes `assertPinned` is `release-zip`, which
+ * then fails at install when `unzip` is handed a binary. A manifest entry that
+ * validates and cannot install is worse than one that is rejected outright: the
+ * error arrives during provisioning rather than during review.
+ *
+ * There is no `binary` field here, deliberately — the download is the binary,
+ * so there is nothing inside it to name.
+ * @param {object} tool Manifest entry.
+ * @param {string} binDir Directory to install into.
+ */
+function installReleaseBinary(tool, binDir) {
+  const temporary = join(binDir, `.${tool.name}-download`);
+  mkdirSync(temporary, { recursive: true });
+  try {
+    const artifact = join(temporary, tool.name);
+    execFileSync("curl", ["-fsSL", tool.url, "-o", artifact], {
+      stdio: "inherit",
+    });
+    // Verify before it reaches a directory on PATH. For this kind that ordering
+    // matters more than for the archives: the downloaded file is directly
+    // executable, so a wrong artifact placed first is a wrong artifact that can
+    // be run.
+    verifyChecksum(artifact, tool.sha256, tool.name);
+    execFileSync("install", ["-m", "0755", artifact, join(binDir, tool.name)], {
+      stdio: "inherit",
+    });
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+/**
  * Install a pinned global npm package.
  * @param {object} tool Manifest entry.
  */
@@ -328,6 +366,8 @@ export function installTool(tool, binDir) {
   if (tool.install === "release-zip") installReleaseZip(tool, binDir);
   else if (tool.install === "release-tar") installReleaseTar(tool, binDir);
   else if (tool.install === "release-tree") installReleaseTree(tool, binDir);
+  else if (tool.install === "release-binary")
+    installReleaseBinary(tool, binDir);
   else installNpmGlobal(tool);
 }
 

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -354,6 +354,18 @@ export function assertPinned(tool) {
     }
     return;
   }
+  // The download IS the binary, so there is no `binary` path to require — but
+  // the checksum matters more here than anywhere else, because the artifact is
+  // directly executable rather than something that has to be unpacked first.
+  if (tool.install === "release-binary") {
+    if (!tool.url || !tool.sha256) {
+      throw new Error(
+        `${tool.name}: a release-binary install needs both url and sha256.\n` +
+          `A version bump must move the checksum in the same reviewed commit.`
+      );
+    }
+    return;
+  }
   if (tool.install === "npm-global") {
     if (!tool.package)
       throw new Error(`${tool.name}: npm-global install needs a package`);
@@ -361,6 +373,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, release-tree, npm-global.`
+      `Supported: release-zip, release-tar, release-tree, release-binary, npm-global.`
   );
 }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1159,9 +1159,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "c30d98a5645f033fc1d3a723043691b9ad997ae5666df539ff6aa19c563431b2",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "cafc8cc0917f767719d7591b6c2031eb9d4f2b451e28090d73519a09808a86d3",
+      "2a91430fc2918f2e7df328d58d07feda35fcc0f11f1d9e29623e4f2552617d29",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
-      "b2fa53bf577400851e8c2991cbe822d29dcdd2d090ff1cd1d0fa2d76bfcaa20b",
+      "30695136eb4ae3ab92d26fe33b5eda60dd04d2e03f760dcf9d66df5d0144f5ae",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
       "82bc2a27a0a5afb2ff413a88365c619fd7f0eaada5de3ccabf2000938f0607a4",
     "plugins/src/base/skills/lisa-setup-sonar/SKILL.md":
@@ -8505,6 +8505,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/rotation-view.test.ts": true,
     "tests/unit/secrets/secrets-access-contract.test.ts": true,
     "tests/unit/secrets/toolchain-platforms.test.ts": true,
+    "tests/unit/secrets/toolchain-release-binary.test.ts": true,
     "tests/unit/secrets/toolchain-release-tree.test.ts": true,
     "tests/unit/secrets/toolchain-surfaces.test.ts": true,
     "tests/unit/secrets/validate-config.test.ts": true,

--- a/tests/unit/secrets/remote-env-phases.test.ts
+++ b/tests/unit/secrets/remote-env-phases.test.ts
@@ -389,7 +389,7 @@ describe("pinned tarball installs", () => {
   it("names the tar kind when refusing an unknown one", () => {
     // The message is where an operator learns which kinds exist at all.
     expect(() => assertPinned({ name: "x", install: "release-deb" })).toThrow(
-      /Supported: release-zip, release-tar, release-tree, npm-global/
+      /Supported: release-zip, release-tar, release-tree, release-binary, npm-global/
     );
   });
 

--- a/tests/unit/secrets/toolchain-release-binary.test.ts
+++ b/tests/unit/secrets/toolchain-release-binary.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for the `release-binary` install kind.
+ *
+ * Several tools worth pinning publish a raw executable rather than an archive —
+ * `jq` ships `jq-linux-amd64` plus a `sha256sum.txt`, ideal material for a
+ * checksummed pin and inexpressible by any archive kind.
+ *
+ * The failure this prevents is the bad sort: `release-zip` PASSES `assertPinned`
+ * for such an entry and then dies at install when `unzip` is handed a binary. An
+ * entry that validates and cannot install surfaces during provisioning instead
+ * of during review.
+ * @module tests/unit/secrets/toolchain-release-binary
+ */
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { installTool } from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs";
+import { assertPinned } from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs";
+
+/** Directories created for a single test. */
+const created: string[] = [];
+
+/** The install kind under test. */
+const RELEASE_BINARY = "release-binary";
+
+/** A well-formed digest for entries that are never fetched. */
+const FAKE_SHA = "a".repeat(64);
+
+/** What the fixture binary prints, proving it ran rather than merely landed. */
+const OUTPUT = "binary-ran";
+
+/**
+ * Publish a bare executable to a `file://` URL, as a vendor release would.
+ * @returns The url, its digest, and a scratch root.
+ */
+function bareBinary(): { url: string; sha256: string; root: string } {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-binary-"));
+  const artifact = path.join(root, "toy");
+
+  created.push(root);
+  writeFileSync(artifact, `#!/bin/sh\necho ${OUTPUT}\n`);
+
+  return {
+    url: `file://${artifact}`,
+    sha256: createHash("sha256").update(readFileSync(artifact)).digest("hex"),
+    root,
+  };
+}
+
+afterEach(() => {
+  while (created.length > 0) {
+    rmSync(created.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe("assertPinned for release-binary", () => {
+  it("accepts url + sha256 without a binary path", () => {
+    // The download IS the binary, so there is nothing inside it to name.
+    expect(() =>
+      assertPinned({
+        name: "jq",
+        version: "1.8.2",
+        install: RELEASE_BINARY,
+        url: "https://example.invalid/jq-linux-amd64",
+        sha256: FAKE_SHA,
+      })
+    ).not.toThrow();
+  });
+
+  it("refuses an entry with no checksum", () => {
+    // More load-bearing here than for the archives: the artifact is directly
+    // executable, so a wrong one placed on PATH can simply be run.
+    expect(() =>
+      assertPinned({
+        name: "jq",
+        install: RELEASE_BINARY,
+        url: "https://example.invalid/jq-linux-amd64",
+      })
+    ).toThrow(/needs both url and sha256/);
+  });
+
+  it("names release-binary among the supported methods", () => {
+    expect(() => assertPinned({ name: "x", install: "nonsense" })).toThrow(
+      /release-binary/
+    );
+  });
+});
+
+describe("installTool with release-binary", () => {
+  it("installs an executable that actually runs", () => {
+    const artifact = bareBinary();
+    const binDir = path.join(artifact.root, "bin");
+    mkdirSync(binDir, { recursive: true });
+
+    installTool(
+      { name: "toy", version: "1.0.0", install: RELEASE_BINARY, ...artifact },
+      binDir
+    );
+
+    const installed = path.join(binDir, "toy");
+    expect(statSync(installed).mode & 0o777).toBe(0o755);
+    expect(execFileSync(installed, { encoding: "utf8" }).trim()).toBe(OUTPUT);
+  });
+
+  it("refuses a mismatched checksum before anything reaches PATH", () => {
+    // Ordering is the assertion. Verifying after placement would leave a
+    // runnable wrong binary in the bin directory even on a failed install.
+    const artifact = bareBinary();
+    const binDir = path.join(artifact.root, "bin");
+    mkdirSync(binDir, { recursive: true });
+
+    expect(() =>
+      installTool(
+        {
+          name: "toy",
+          version: "1.0.0",
+          install: RELEASE_BINARY,
+          url: artifact.url,
+          sha256: "b".repeat(64),
+        },
+        binDir
+      )
+    ).toThrow(/checksum mismatch/);
+    expect(existsSync(path.join(binDir, "toy"))).toBe(false);
+  });
+
+  it("leaves no download scratch behind", () => {
+    const artifact = bareBinary();
+    const binDir = path.join(artifact.root, "bin");
+    mkdirSync(binDir, { recursive: true });
+
+    installTool(
+      { name: "toy", version: "1.0.0", install: RELEASE_BINARY, ...artifact },
+      binDir
+    );
+
+    expect(existsSync(path.join(binDir, ".toy-download"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## The gap

`remoteEnv.tools` could pin an archive but not a bare executable. `jq` publishes
`jq-linux-amd64` next to a `sha256sum.txt` — ideal pin material — and had no
expressible install kind, which is why three TunnlAI repos run a `.husky/post-checkout`
guarded by `command -v jq >/dev/null 2>&1 || return 0`: the hook silently
no-ops on any container without it.

The failure mode is the bad sort. Declaring such a tool `release-zip` **passes
`assertPinned`** and then dies at provisioning when `unzip` is handed a binary —
an entry that validates in review and cannot install.

## The fix

A `release-binary` kind: download, verify the digest, `chmod 0755`, place. No
`binary` field, because the download *is* the binary — `assertPinned` requires
url + sha256 and nothing else.

Verify happens **before** placement. That ordering is the point: verifying after
would leave a runnable wrong binary in the bin directory even on a failed
install, which is worse than no install at all.

## Evidence

Proved against the real jq 1.8.2 in a `linux/amd64` container, not a fixture:

```
assertPinned: ok (no `binary` field required)
mode: 755
runs: jq-1.8.2
filters: works          # jq -r .a  <<< {"a":"works"}
checksum: enforced      # poisoned sha256 -> throws
nothing placed: true
```

`--version` alone would not have proved much; the filter run exercises it the
way the hook actually uses it.

**Negative control:** the same `assertPinned` call against `origin/main` rejects
with `unknown install method "release-binary"` — the new tests fail without the
change rather than passing vacuously.

## Tests

6 new cases plus one updated: `remote-env-phases` pins the supported-kinds
string verbatim, so it correctly failed until the new kind was listed.

Full suite green: 8800 passed, 525 files.

🤖 Generated with Claude Code

---

Work-Item: CodySwannGT/lisa#2304
