### PR TITLE
fix(secrets): stop the validator's install-method list drifting from the runner

### DIFF
--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -76,13 +76,37 @@ function bindingsFor(surface) {
 /**
  * Install methods the toolchain runner supports.
  *
- * `release-tar` was missing here while the runner had supported it for as long
- * as gh has been pinned — so this validator would have rejected the project's
- * own manifest, and the only reason nobody hit it is that nothing ran the two
- * against each other. Kept in step with `assertPinned` in `toolchain.mjs`,
- * which is the list that actually decides.
+ * This is a deliberate copy of `INSTALL_METHODS` in `toolchain.mjs`, which is
+ * the list that actually decides. Skills are distributed as self-contained
+ * directories and nothing imports across a skill boundary, so importing the
+ * authority here would couple two skills' distribution for one array.
+ *
+ * The copy has drifted twice. First `release-tar` was missing while the runner
+ * had supported it for as long as gh has been pinned. Then `release-tree` and
+ * `release-binary` were both missing, which rejected a valid `jq` pin. Each
+ * time the only safeguard was a comment asking the next author to remember.
+ * A conformance test now compares the two sets directly, so adding a kind on
+ * either side fails until both know it.
  */
-const INSTALL_METHODS = new Set(["release-zip", "release-tar", "npm-global"]);
+const INSTALL_METHODS = new Set([
+  "release-zip",
+  "release-tar",
+  "release-tree",
+  "release-binary",
+  "npm-global",
+]);
+
+/**
+ * Download kinds — every method that fetches a URL, so every one that needs a
+ * checksum. Spelled as "not npm-global" rather than as a list, because the next
+ * download kind should inherit the obligation by default; the drift above came
+ * from lists that had to be remembered.
+ * @param {string} method An install method.
+ * @returns {boolean} Whether the method fetches a pinned artifact.
+ */
+function isDownloadKind(method) {
+  return INSTALL_METHODS.has(method) && method !== "npm-global";
+}
 
 /**
  * Validate the `secrets` block.
@@ -171,17 +195,26 @@ function validateInstallArtifact(label, entry, problems) {
     );
     return;
   }
-  // Both archive kinds, not just zip. A tarball pinned without a checksum
-  // trusts whatever the URL serves today exactly as much as a zip does, and
-  // checking only one of them meant the tool Lisa's guardrails shell out to —
-  // gh, which ships a tarball on Linux — was the one going unverified.
-  if (
-    (entry.install === "release-zip" || entry.install === "release-tar") &&
-    !(entry.url && entry.sha256)
-  ) {
+  // Every download kind, not an enumerated few. A tarball pinned without a
+  // checksum trusts whatever the URL serves today exactly as much as a zip
+  // does, and checking only one of them meant the tool Lisa's guardrails shell
+  // out to — gh, which ships a tarball on Linux — was the one going unverified.
+  // A `release-binary` matters most of all: the artifact is directly
+  // executable, so a wrong one needs no unpacking step to run.
+  if (isDownloadKind(entry.install) && !(entry.url && entry.sha256)) {
     problems.push(
       `remoteEnv install ${label} needs both url and sha256. A pinned ` +
         `version with no checksum still trusts whatever the URL serves today.`
+    );
+  }
+  // A tree is the one kind with no sane default entry point: the archive root
+  // is a directory, so an omitted `binary` would install a directory as a
+  // command. The runner refuses it, and a validator that accepted it would just
+  // move the failure from review to provisioning.
+  if (entry.install === "release-tree" && !entry.binary) {
+    problems.push(
+      `remoteEnv install ${label} needs "binary" — the path to the entry ` +
+        `point INSIDE the archive, such as "maestro/bin/maestro".`
     );
   }
   if (entry.install === "npm-global" && !entry.package) {

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -302,6 +302,24 @@ export function planToolchain(
 }
 
 /**
+ * Every install method the runner can execute — the authoritative list.
+ *
+ * `validate-config.mjs` maintains its own copy because skills are distributed
+ * as self-contained directories and nothing else imports across a skill
+ * boundary. A comment saying "keep these in step" has now failed twice — first
+ * for `release-tar`, then for `release-tree` and `release-binary` together — so
+ * the pairing is enforced by a conformance test against this export instead.
+ * Adding a kind here fails that test until the validator learns it too.
+ */
+export const INSTALL_METHODS = Object.freeze([
+  "release-zip",
+  "release-tar",
+  "release-tree",
+  "release-binary",
+  "npm-global",
+]);
+
+/**
  * Reject a manifest entry that could install something unverifiable.
  *
  * A pinned version with no checksum still trusts whatever the URL serves today.
@@ -373,6 +391,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, release-tree, release-binary, npm-global.`
+      `Supported: ${INSTALL_METHODS.join(", ")}.`
   );
 }

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -76,13 +76,37 @@ function bindingsFor(surface) {
 /**
  * Install methods the toolchain runner supports.
  *
- * `release-tar` was missing here while the runner had supported it for as long
- * as gh has been pinned — so this validator would have rejected the project's
- * own manifest, and the only reason nobody hit it is that nothing ran the two
- * against each other. Kept in step with `assertPinned` in `toolchain.mjs`,
- * which is the list that actually decides.
+ * This is a deliberate copy of `INSTALL_METHODS` in `toolchain.mjs`, which is
+ * the list that actually decides. Skills are distributed as self-contained
+ * directories and nothing imports across a skill boundary, so importing the
+ * authority here would couple two skills' distribution for one array.
+ *
+ * The copy has drifted twice. First `release-tar` was missing while the runner
+ * had supported it for as long as gh has been pinned. Then `release-tree` and
+ * `release-binary` were both missing, which rejected a valid `jq` pin. Each
+ * time the only safeguard was a comment asking the next author to remember.
+ * A conformance test now compares the two sets directly, so adding a kind on
+ * either side fails until both know it.
  */
-const INSTALL_METHODS = new Set(["release-zip", "release-tar", "npm-global"]);
+const INSTALL_METHODS = new Set([
+  "release-zip",
+  "release-tar",
+  "release-tree",
+  "release-binary",
+  "npm-global",
+]);
+
+/**
+ * Download kinds — every method that fetches a URL, so every one that needs a
+ * checksum. Spelled as "not npm-global" rather than as a list, because the next
+ * download kind should inherit the obligation by default; the drift above came
+ * from lists that had to be remembered.
+ * @param {string} method An install method.
+ * @returns {boolean} Whether the method fetches a pinned artifact.
+ */
+function isDownloadKind(method) {
+  return INSTALL_METHODS.has(method) && method !== "npm-global";
+}
 
 /**
  * Validate the `secrets` block.
@@ -171,17 +195,26 @@ function validateInstallArtifact(label, entry, problems) {
     );
     return;
   }
-  // Both archive kinds, not just zip. A tarball pinned without a checksum
-  // trusts whatever the URL serves today exactly as much as a zip does, and
-  // checking only one of them meant the tool Lisa's guardrails shell out to —
-  // gh, which ships a tarball on Linux — was the one going unverified.
-  if (
-    (entry.install === "release-zip" || entry.install === "release-tar") &&
-    !(entry.url && entry.sha256)
-  ) {
+  // Every download kind, not an enumerated few. A tarball pinned without a
+  // checksum trusts whatever the URL serves today exactly as much as a zip
+  // does, and checking only one of them meant the tool Lisa's guardrails shell
+  // out to — gh, which ships a tarball on Linux — was the one going unverified.
+  // A `release-binary` matters most of all: the artifact is directly
+  // executable, so a wrong one needs no unpacking step to run.
+  if (isDownloadKind(entry.install) && !(entry.url && entry.sha256)) {
     problems.push(
       `remoteEnv install ${label} needs both url and sha256. A pinned ` +
         `version with no checksum still trusts whatever the URL serves today.`
+    );
+  }
+  // A tree is the one kind with no sane default entry point: the archive root
+  // is a directory, so an omitted `binary` would install a directory as a
+  // command. The runner refuses it, and a validator that accepted it would just
+  // move the failure from review to provisioning.
+  if (entry.install === "release-tree" && !entry.binary) {
+    problems.push(
+      `remoteEnv install ${label} needs "binary" — the path to the entry ` +
+        `point INSIDE the archive, such as "maestro/bin/maestro".`
     );
   }
   if (entry.install === "npm-global" && !entry.package) {

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -302,6 +302,24 @@ export function planToolchain(
 }
 
 /**
+ * Every install method the runner can execute — the authoritative list.
+ *
+ * `validate-config.mjs` maintains its own copy because skills are distributed
+ * as self-contained directories and nothing else imports across a skill
+ * boundary. A comment saying "keep these in step" has now failed twice — first
+ * for `release-tar`, then for `release-tree` and `release-binary` together — so
+ * the pairing is enforced by a conformance test against this export instead.
+ * Adding a kind here fails that test until the validator learns it too.
+ */
+export const INSTALL_METHODS = Object.freeze([
+  "release-zip",
+  "release-tar",
+  "release-tree",
+  "release-binary",
+  "npm-global",
+]);
+
+/**
  * Reject a manifest entry that could install something unverifiable.
  *
  * A pinned version with no checksum still trusts whatever the URL serves today.
@@ -373,6 +391,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, release-tree, release-binary, npm-global.`
+      `Supported: ${INSTALL_METHODS.join(", ")}.`
   );
 }

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -76,13 +76,37 @@ function bindingsFor(surface) {
 /**
  * Install methods the toolchain runner supports.
  *
- * `release-tar` was missing here while the runner had supported it for as long
- * as gh has been pinned — so this validator would have rejected the project's
- * own manifest, and the only reason nobody hit it is that nothing ran the two
- * against each other. Kept in step with `assertPinned` in `toolchain.mjs`,
- * which is the list that actually decides.
+ * This is a deliberate copy of `INSTALL_METHODS` in `toolchain.mjs`, which is
+ * the list that actually decides. Skills are distributed as self-contained
+ * directories and nothing imports across a skill boundary, so importing the
+ * authority here would couple two skills' distribution for one array.
+ *
+ * The copy has drifted twice. First `release-tar` was missing while the runner
+ * had supported it for as long as gh has been pinned. Then `release-tree` and
+ * `release-binary` were both missing, which rejected a valid `jq` pin. Each
+ * time the only safeguard was a comment asking the next author to remember.
+ * A conformance test now compares the two sets directly, so adding a kind on
+ * either side fails until both know it.
  */
-const INSTALL_METHODS = new Set(["release-zip", "release-tar", "npm-global"]);
+const INSTALL_METHODS = new Set([
+  "release-zip",
+  "release-tar",
+  "release-tree",
+  "release-binary",
+  "npm-global",
+]);
+
+/**
+ * Download kinds — every method that fetches a URL, so every one that needs a
+ * checksum. Spelled as "not npm-global" rather than as a list, because the next
+ * download kind should inherit the obligation by default; the drift above came
+ * from lists that had to be remembered.
+ * @param {string} method An install method.
+ * @returns {boolean} Whether the method fetches a pinned artifact.
+ */
+function isDownloadKind(method) {
+  return INSTALL_METHODS.has(method) && method !== "npm-global";
+}
 
 /**
  * Validate the `secrets` block.
@@ -171,17 +195,26 @@ function validateInstallArtifact(label, entry, problems) {
     );
     return;
   }
-  // Both archive kinds, not just zip. A tarball pinned without a checksum
-  // trusts whatever the URL serves today exactly as much as a zip does, and
-  // checking only one of them meant the tool Lisa's guardrails shell out to —
-  // gh, which ships a tarball on Linux — was the one going unverified.
-  if (
-    (entry.install === "release-zip" || entry.install === "release-tar") &&
-    !(entry.url && entry.sha256)
-  ) {
+  // Every download kind, not an enumerated few. A tarball pinned without a
+  // checksum trusts whatever the URL serves today exactly as much as a zip
+  // does, and checking only one of them meant the tool Lisa's guardrails shell
+  // out to — gh, which ships a tarball on Linux — was the one going unverified.
+  // A `release-binary` matters most of all: the artifact is directly
+  // executable, so a wrong one needs no unpacking step to run.
+  if (isDownloadKind(entry.install) && !(entry.url && entry.sha256)) {
     problems.push(
       `remoteEnv install ${label} needs both url and sha256. A pinned ` +
         `version with no checksum still trusts whatever the URL serves today.`
+    );
+  }
+  // A tree is the one kind with no sane default entry point: the archive root
+  // is a directory, so an omitted `binary` would install a directory as a
+  // command. The runner refuses it, and a validator that accepted it would just
+  // move the failure from review to provisioning.
+  if (entry.install === "release-tree" && !entry.binary) {
+    problems.push(
+      `remoteEnv install ${label} needs "binary" — the path to the entry ` +
+        `point INSIDE the archive, such as "maestro/bin/maestro".`
     );
   }
   if (entry.install === "npm-global" && !entry.package) {

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -302,6 +302,24 @@ export function planToolchain(
 }
 
 /**
+ * Every install method the runner can execute — the authoritative list.
+ *
+ * `validate-config.mjs` maintains its own copy because skills are distributed
+ * as self-contained directories and nothing else imports across a skill
+ * boundary. A comment saying "keep these in step" has now failed twice — first
+ * for `release-tar`, then for `release-tree` and `release-binary` together — so
+ * the pairing is enforced by a conformance test against this export instead.
+ * Adding a kind here fails that test until the validator learns it too.
+ */
+export const INSTALL_METHODS = Object.freeze([
+  "release-zip",
+  "release-tar",
+  "release-tree",
+  "release-binary",
+  "npm-global",
+]);
+
+/**
  * Reject a manifest entry that could install something unverifiable.
  *
  * A pinned version with no checksum still trusts whatever the URL serves today.
@@ -373,6 +391,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, release-tree, release-binary, npm-global.`
+      `Supported: ${INSTALL_METHODS.join(", ")}.`
   );
 }

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -76,13 +76,37 @@ function bindingsFor(surface) {
 /**
  * Install methods the toolchain runner supports.
  *
- * `release-tar` was missing here while the runner had supported it for as long
- * as gh has been pinned — so this validator would have rejected the project's
- * own manifest, and the only reason nobody hit it is that nothing ran the two
- * against each other. Kept in step with `assertPinned` in `toolchain.mjs`,
- * which is the list that actually decides.
+ * This is a deliberate copy of `INSTALL_METHODS` in `toolchain.mjs`, which is
+ * the list that actually decides. Skills are distributed as self-contained
+ * directories and nothing imports across a skill boundary, so importing the
+ * authority here would couple two skills' distribution for one array.
+ *
+ * The copy has drifted twice. First `release-tar` was missing while the runner
+ * had supported it for as long as gh has been pinned. Then `release-tree` and
+ * `release-binary` were both missing, which rejected a valid `jq` pin. Each
+ * time the only safeguard was a comment asking the next author to remember.
+ * A conformance test now compares the two sets directly, so adding a kind on
+ * either side fails until both know it.
  */
-const INSTALL_METHODS = new Set(["release-zip", "release-tar", "npm-global"]);
+const INSTALL_METHODS = new Set([
+  "release-zip",
+  "release-tar",
+  "release-tree",
+  "release-binary",
+  "npm-global",
+]);
+
+/**
+ * Download kinds — every method that fetches a URL, so every one that needs a
+ * checksum. Spelled as "not npm-global" rather than as a list, because the next
+ * download kind should inherit the obligation by default; the drift above came
+ * from lists that had to be remembered.
+ * @param {string} method An install method.
+ * @returns {boolean} Whether the method fetches a pinned artifact.
+ */
+function isDownloadKind(method) {
+  return INSTALL_METHODS.has(method) && method !== "npm-global";
+}
 
 /**
  * Validate the `secrets` block.
@@ -171,17 +195,26 @@ function validateInstallArtifact(label, entry, problems) {
     );
     return;
   }
-  // Both archive kinds, not just zip. A tarball pinned without a checksum
-  // trusts whatever the URL serves today exactly as much as a zip does, and
-  // checking only one of them meant the tool Lisa's guardrails shell out to —
-  // gh, which ships a tarball on Linux — was the one going unverified.
-  if (
-    (entry.install === "release-zip" || entry.install === "release-tar") &&
-    !(entry.url && entry.sha256)
-  ) {
+  // Every download kind, not an enumerated few. A tarball pinned without a
+  // checksum trusts whatever the URL serves today exactly as much as a zip
+  // does, and checking only one of them meant the tool Lisa's guardrails shell
+  // out to — gh, which ships a tarball on Linux — was the one going unverified.
+  // A `release-binary` matters most of all: the artifact is directly
+  // executable, so a wrong one needs no unpacking step to run.
+  if (isDownloadKind(entry.install) && !(entry.url && entry.sha256)) {
     problems.push(
       `remoteEnv install ${label} needs both url and sha256. A pinned ` +
         `version with no checksum still trusts whatever the URL serves today.`
+    );
+  }
+  // A tree is the one kind with no sane default entry point: the archive root
+  // is a directory, so an omitted `binary` would install a directory as a
+  // command. The runner refuses it, and a validator that accepted it would just
+  // move the failure from review to provisioning.
+  if (entry.install === "release-tree" && !entry.binary) {
+    problems.push(
+      `remoteEnv install ${label} needs "binary" — the path to the entry ` +
+        `point INSIDE the archive, such as "maestro/bin/maestro".`
     );
   }
   if (entry.install === "npm-global" && !entry.package) {

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -302,6 +302,24 @@ export function planToolchain(
 }
 
 /**
+ * Every install method the runner can execute — the authoritative list.
+ *
+ * `validate-config.mjs` maintains its own copy because skills are distributed
+ * as self-contained directories and nothing else imports across a skill
+ * boundary. A comment saying "keep these in step" has now failed twice — first
+ * for `release-tar`, then for `release-tree` and `release-binary` together — so
+ * the pairing is enforced by a conformance test against this export instead.
+ * Adding a kind here fails that test until the validator learns it too.
+ */
+export const INSTALL_METHODS = Object.freeze([
+  "release-zip",
+  "release-tar",
+  "release-tree",
+  "release-binary",
+  "npm-global",
+]);
+
+/**
  * Reject a manifest entry that could install something unverifiable.
  *
  * A pinned version with no checksum still trusts whatever the URL serves today.
@@ -373,6 +391,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, release-tree, release-binary, npm-global.`
+      `Supported: ${INSTALL_METHODS.join(", ")}.`
   );
 }

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -76,13 +76,37 @@ function bindingsFor(surface) {
 /**
  * Install methods the toolchain runner supports.
  *
- * `release-tar` was missing here while the runner had supported it for as long
- * as gh has been pinned — so this validator would have rejected the project's
- * own manifest, and the only reason nobody hit it is that nothing ran the two
- * against each other. Kept in step with `assertPinned` in `toolchain.mjs`,
- * which is the list that actually decides.
+ * This is a deliberate copy of `INSTALL_METHODS` in `toolchain.mjs`, which is
+ * the list that actually decides. Skills are distributed as self-contained
+ * directories and nothing imports across a skill boundary, so importing the
+ * authority here would couple two skills' distribution for one array.
+ *
+ * The copy has drifted twice. First `release-tar` was missing while the runner
+ * had supported it for as long as gh has been pinned. Then `release-tree` and
+ * `release-binary` were both missing, which rejected a valid `jq` pin. Each
+ * time the only safeguard was a comment asking the next author to remember.
+ * A conformance test now compares the two sets directly, so adding a kind on
+ * either side fails until both know it.
  */
-const INSTALL_METHODS = new Set(["release-zip", "release-tar", "npm-global"]);
+const INSTALL_METHODS = new Set([
+  "release-zip",
+  "release-tar",
+  "release-tree",
+  "release-binary",
+  "npm-global",
+]);
+
+/**
+ * Download kinds — every method that fetches a URL, so every one that needs a
+ * checksum. Spelled as "not npm-global" rather than as a list, because the next
+ * download kind should inherit the obligation by default; the drift above came
+ * from lists that had to be remembered.
+ * @param {string} method An install method.
+ * @returns {boolean} Whether the method fetches a pinned artifact.
+ */
+function isDownloadKind(method) {
+  return INSTALL_METHODS.has(method) && method !== "npm-global";
+}
 
 /**
  * Validate the `secrets` block.
@@ -171,17 +195,26 @@ function validateInstallArtifact(label, entry, problems) {
     );
     return;
   }
-  // Both archive kinds, not just zip. A tarball pinned without a checksum
-  // trusts whatever the URL serves today exactly as much as a zip does, and
-  // checking only one of them meant the tool Lisa's guardrails shell out to —
-  // gh, which ships a tarball on Linux — was the one going unverified.
-  if (
-    (entry.install === "release-zip" || entry.install === "release-tar") &&
-    !(entry.url && entry.sha256)
-  ) {
+  // Every download kind, not an enumerated few. A tarball pinned without a
+  // checksum trusts whatever the URL serves today exactly as much as a zip
+  // does, and checking only one of them meant the tool Lisa's guardrails shell
+  // out to — gh, which ships a tarball on Linux — was the one going unverified.
+  // A `release-binary` matters most of all: the artifact is directly
+  // executable, so a wrong one needs no unpacking step to run.
+  if (isDownloadKind(entry.install) && !(entry.url && entry.sha256)) {
     problems.push(
       `remoteEnv install ${label} needs both url and sha256. A pinned ` +
         `version with no checksum still trusts whatever the URL serves today.`
+    );
+  }
+  // A tree is the one kind with no sane default entry point: the archive root
+  // is a directory, so an omitted `binary` would install a directory as a
+  // command. The runner refuses it, and a validator that accepted it would just
+  // move the failure from review to provisioning.
+  if (entry.install === "release-tree" && !entry.binary) {
+    problems.push(
+      `remoteEnv install ${label} needs "binary" — the path to the entry ` +
+        `point INSIDE the archive, such as "maestro/bin/maestro".`
     );
   }
   if (entry.install === "npm-global" && !entry.package) {

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -302,6 +302,24 @@ export function planToolchain(
 }
 
 /**
+ * Every install method the runner can execute — the authoritative list.
+ *
+ * `validate-config.mjs` maintains its own copy because skills are distributed
+ * as self-contained directories and nothing else imports across a skill
+ * boundary. A comment saying "keep these in step" has now failed twice — first
+ * for `release-tar`, then for `release-tree` and `release-binary` together — so
+ * the pairing is enforced by a conformance test against this export instead.
+ * Adding a kind here fails that test until the validator learns it too.
+ */
+export const INSTALL_METHODS = Object.freeze([
+  "release-zip",
+  "release-tar",
+  "release-tree",
+  "release-binary",
+  "npm-global",
+]);
+
+/**
  * Reject a manifest entry that could install something unverifiable.
  *
  * A pinned version with no checksum still trusts whatever the URL serves today.
@@ -373,6 +391,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, release-tree, release-binary, npm-global.`
+      `Supported: ${INSTALL_METHODS.join(", ")}.`
   );
 }

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -76,13 +76,37 @@ function bindingsFor(surface) {
 /**
  * Install methods the toolchain runner supports.
  *
- * `release-tar` was missing here while the runner had supported it for as long
- * as gh has been pinned — so this validator would have rejected the project's
- * own manifest, and the only reason nobody hit it is that nothing ran the two
- * against each other. Kept in step with `assertPinned` in `toolchain.mjs`,
- * which is the list that actually decides.
+ * This is a deliberate copy of `INSTALL_METHODS` in `toolchain.mjs`, which is
+ * the list that actually decides. Skills are distributed as self-contained
+ * directories and nothing imports across a skill boundary, so importing the
+ * authority here would couple two skills' distribution for one array.
+ *
+ * The copy has drifted twice. First `release-tar` was missing while the runner
+ * had supported it for as long as gh has been pinned. Then `release-tree` and
+ * `release-binary` were both missing, which rejected a valid `jq` pin. Each
+ * time the only safeguard was a comment asking the next author to remember.
+ * A conformance test now compares the two sets directly, so adding a kind on
+ * either side fails until both know it.
  */
-const INSTALL_METHODS = new Set(["release-zip", "release-tar", "npm-global"]);
+const INSTALL_METHODS = new Set([
+  "release-zip",
+  "release-tar",
+  "release-tree",
+  "release-binary",
+  "npm-global",
+]);
+
+/**
+ * Download kinds — every method that fetches a URL, so every one that needs a
+ * checksum. Spelled as "not npm-global" rather than as a list, because the next
+ * download kind should inherit the obligation by default; the drift above came
+ * from lists that had to be remembered.
+ * @param {string} method An install method.
+ * @returns {boolean} Whether the method fetches a pinned artifact.
+ */
+function isDownloadKind(method) {
+  return INSTALL_METHODS.has(method) && method !== "npm-global";
+}
 
 /**
  * Validate the `secrets` block.
@@ -171,17 +195,26 @@ function validateInstallArtifact(label, entry, problems) {
     );
     return;
   }
-  // Both archive kinds, not just zip. A tarball pinned without a checksum
-  // trusts whatever the URL serves today exactly as much as a zip does, and
-  // checking only one of them meant the tool Lisa's guardrails shell out to —
-  // gh, which ships a tarball on Linux — was the one going unverified.
-  if (
-    (entry.install === "release-zip" || entry.install === "release-tar") &&
-    !(entry.url && entry.sha256)
-  ) {
+  // Every download kind, not an enumerated few. A tarball pinned without a
+  // checksum trusts whatever the URL serves today exactly as much as a zip
+  // does, and checking only one of them meant the tool Lisa's guardrails shell
+  // out to — gh, which ships a tarball on Linux — was the one going unverified.
+  // A `release-binary` matters most of all: the artifact is directly
+  // executable, so a wrong one needs no unpacking step to run.
+  if (isDownloadKind(entry.install) && !(entry.url && entry.sha256)) {
     problems.push(
       `remoteEnv install ${label} needs both url and sha256. A pinned ` +
         `version with no checksum still trusts whatever the URL serves today.`
+    );
+  }
+  // A tree is the one kind with no sane default entry point: the archive root
+  // is a directory, so an omitted `binary` would install a directory as a
+  // command. The runner refuses it, and a validator that accepted it would just
+  // move the failure from review to provisioning.
+  if (entry.install === "release-tree" && !entry.binary) {
+    problems.push(
+      `remoteEnv install ${label} needs "binary" — the path to the entry ` +
+        `point INSIDE the archive, such as "maestro/bin/maestro".`
     );
   }
   if (entry.install === "npm-global" && !entry.package) {

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs
@@ -302,6 +302,24 @@ export function planToolchain(
 }
 
 /**
+ * Every install method the runner can execute — the authoritative list.
+ *
+ * `validate-config.mjs` maintains its own copy because skills are distributed
+ * as self-contained directories and nothing else imports across a skill
+ * boundary. A comment saying "keep these in step" has now failed twice — first
+ * for `release-tar`, then for `release-tree` and `release-binary` together — so
+ * the pairing is enforced by a conformance test against this export instead.
+ * Adding a kind here fails that test until the validator learns it too.
+ */
+export const INSTALL_METHODS = Object.freeze([
+  "release-zip",
+  "release-tar",
+  "release-tree",
+  "release-binary",
+  "npm-global",
+]);
+
+/**
  * Reject a manifest entry that could install something unverifiable.
  *
  * A pinned version with no checksum still trusts whatever the URL serves today.
@@ -373,6 +391,6 @@ export function assertPinned(tool) {
   }
   throw new Error(
     `${tool.name}: unknown install method "${tool.install}".\n` +
-      `Supported: release-zip, release-tar, release-tree, release-binary, npm-global.`
+      `Supported: ${INSTALL_METHODS.join(", ")}.`
   );
 }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1119,7 +1119,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs":
       "f8d4404ab105284ee072a26319366a71333c89abb14f9d71aafe461e7ea0686a",
     "plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs":
-      "058d8cf474e05985a781e5575efcade371b20699c1dc5f6d4df156eeafba0831",
+      "62d1b87d1b852dc00c00ea9d132d9d6953f4ef77beb5fa4b93652c4424f33274",
     "plugins/src/base/skills/lisa-security-review/SKILL.md":
       "5a980eaf5efc4fcce66e75521ec5b1eda143a5b0d36e7157234a705dac94e3f5",
     "plugins/src/base/skills/lisa-security-zap-scan/SKILL.md":
@@ -1161,7 +1161,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
       "2a91430fc2918f2e7df328d58d07feda35fcc0f11f1d9e29623e4f2552617d29",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
-      "30695136eb4ae3ab92d26fe33b5eda60dd04d2e03f760dcf9d66df5d0144f5ae",
+      "496de5aed034692fee421dc3a1fbad9f85ed9e1d0c83a1080f781a486d0274e6",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
       "82bc2a27a0a5afb2ff413a88365c619fd7f0eaada5de3ccabf2000938f0607a4",
     "plugins/src/base/skills/lisa-setup-sonar/SKILL.md":
@@ -8491,6 +8491,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/detect-tooling-discovery.test.ts": true,
     "tests/unit/secrets/detect-tooling.test.ts": true,
     "tests/unit/secrets/doctor-secrets.test.ts": true,
+    "tests/unit/secrets/install-method-conformance.test.ts": true,
     "tests/unit/secrets/local-env-command.test.ts": true,
     "tests/unit/secrets/remote-dispatch-claude-web.test.ts": true,
     "tests/unit/secrets/remote-dispatch.test.ts": true,

--- a/tests/unit/secrets/install-method-conformance.test.ts
+++ b/tests/unit/secrets/install-method-conformance.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Conformance between the two install-method lists.
+ *
+ * `assertPinned` (lisa-setup-remote-env) decides what the runner installs.
+ * `validateRemoteEnv` (lisa-secrets-access) decides what config is accepted.
+ * They are separate skills, distributed as self-contained directories, so the
+ * second keeps a copy of the first's list rather than importing across a skill
+ * boundary.
+ *
+ * That copy has drifted twice, and both times a comment was the only safeguard:
+ *
+ * 1. `release-tar` was absent from the validator while the runner had supported
+ *    it for as long as gh had been pinned.
+ * 2. `release-tree` and `release-binary` were both absent, so a valid `jq` pin
+ *    was rejected by config validation while installing perfectly.
+ *
+ * Nothing had ever run the two against each other. This does. A kind added on
+ * one side fails here until the other side learns it, which is the difference
+ * between a convention and a mechanism.
+ * @module tests/unit/secrets/install-method-conformance
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { validateRemoteEnv } from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs";
+import {
+  assertPinned,
+  INSTALL_METHODS,
+} from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs";
+
+/** A well-formed digest, so only the method itself is under test. */
+const SHA = "a".repeat(64);
+
+/** The kind whose obligations differ from every other download kind. */
+const TREE = "release-tree";
+
+/** A plausible-but-unsupported kind — jq also ships a .deb, so this is the
+ * shape of a real mistake rather than a nonsense string. */
+const UNKNOWN_METHOD = "release-deb";
+
+/** A URL that is never fetched — validation must not need the network. */
+const URL = "https://example.invalid/a";
+
+/**
+ * A minimal entry that satisfies every obligation of the given method, so the
+ * only thing a rejection can be about is whether the method is recognised.
+ * @param {string} method The install method to build an entry for.
+ * @returns A complete manifest entry.
+ */
+function validEntryFor(method: string): Record<string, unknown> {
+  const base = { name: "probe", version: "1.0.0", install: method };
+
+  if (method === "npm-global") return { ...base, package: "probe-cli" };
+  if (method === TREE) {
+    return { ...base, url: URL, sha256: SHA, binary: "p/bin/p" };
+  }
+  return { ...base, url: URL, sha256: SHA };
+}
+
+/**
+ * Ask the validator about one entry.
+ * @param entry The manifest entry to validate.
+ * @returns Every problem reported.
+ */
+function validate(entry: Record<string, unknown>): string[] {
+  return validateRemoteEnv({ tools: { install: [entry] } });
+}
+
+describe("install-method conformance between runner and validator", () => {
+  it.each([...INSTALL_METHODS])(
+    "the validator accepts %s, which the runner can install",
+    method => {
+      const entry = validEntryFor(method);
+
+      // Both sides must agree this is installable. The runner is the authority;
+      // a validator that rejects it blocks a config the runner would honour.
+      expect(() => assertPinned(entry)).not.toThrow();
+      expect(validate(entry)).toEqual([]);
+    }
+  );
+
+  it("the validator rejects a method the runner cannot install", () => {
+    // The converse direction: a validator broader than the runner would pass
+    // config through to fail at provisioning instead of in review.
+    const unknown = { name: "probe", install: UNKNOWN_METHOD };
+
+    expect(() => assertPinned(unknown)).toThrow(/unknown install method/);
+    expect(validate(unknown)).not.toEqual([]);
+  });
+
+  it("names every supported kind when refusing an unknown one", () => {
+    // The error message is where an operator learns which kinds exist, so it is
+    // generated from the list rather than typed out beside it.
+    const unknown = { name: "probe", install: UNKNOWN_METHOD };
+
+    for (const method of INSTALL_METHODS) {
+      expect(() => assertPinned(unknown)).toThrow(new RegExp(method));
+    }
+  });
+});
+
+describe("obligations the validator must not be weaker about", () => {
+  // Derived, not listed: a new download kind inherits the checksum obligation
+  // here automatically. A hand-written list is what let release-tree and
+  // release-binary go unchecked in the first place.
+  it.each([...INSTALL_METHODS].filter(m => m !== "npm-global"))(
+    "requires a checksum for %s",
+    method => {
+      const unpinned = { ...validEntryFor(method), sha256: undefined };
+
+      expect(() => assertPinned(unpinned)).toThrow(/sha256/);
+      expect(validate(unpinned).join(" ")).toMatch(/needs both url and sha256/);
+    }
+  );
+
+  it("requires an entry point for release-tree", () => {
+    // The archive root is a directory; without this the install places one as
+    // if it were a command.
+    const noBinary = { ...validEntryFor("release-tree"), binary: undefined };
+
+    expect(() => assertPinned(noBinary)).toThrow(/needs "binary"/);
+    expect(validate(noBinary).join(" ")).toMatch(/needs "binary"/);
+  });
+});

--- a/tests/unit/secrets/validate-config.test.ts
+++ b/tests/unit/secrets/validate-config.test.ts
@@ -215,9 +215,11 @@ describe("remoteEnv block", () => {
       tools: { install: [{ name: "x", version: "1", install: "curl-bash" }] },
     });
     // The message is where an operator learns which methods exist at all, so
-    // it has to name the same three the runner accepts.
+    // it has to name the same set the runner accepts. That the two agree is
+    // enforced directly in install-method-conformance.test.ts; this only checks
+    // the message still enumerates them for whoever reads the failure.
     expect(problems[0]).toMatch(
-      /Supported: release-zip, release-tar, npm-global/
+      /Supported: release-zip, release-tar, release-tree, release-binary, npm-global/
     );
   });
 


### PR DESCRIPTION
## The bug

`validateRemoteEnv` (lisa-secrets-access) keeps its own copy of the install
methods `assertPinned` (lisa-setup-remote-env) actually enforces. The copy had
fallen two kinds behind:

```
validateRemoteEnv({tools:{install:[<a valid jq pin>]}})
-> remoteEnv install "jq" (linux-x64) has method "release-binary".
   Supported: release-zip, release-tar, npm-global.
```

Missing `release-tree` (2.330.x, the Maestro pin) **and** `release-binary`
(2.332.0). Either one installs perfectly and is rejected by config validation.

Two more places the validator was quietly weaker than the runner, neither
covered by a test:

- its checksum rule named only `release-zip` / `release-tar`, so a `release-tree`
  or `release-binary` could be declared with **no checksum at all**
- it never required `binary` for a `release-tree` — the one kind with no sane
  default entry point, since the archive root is a directory

## Why it happened, and what actually fixes it

This is the **second** drift. The file's own comment records the first:

> `release-tar` was missing here while the runner had supported it for as long as
> gh has been pinned — so this validator would have rejected the project's own
> manifest, and the only reason nobody hit it is that nothing ran the two against
> each other.

That last clause is the real defect. "Kept in step with `assertPinned`" is a
convention, and conventions do not fail builds. Adding the two kinds by hand
would fix today's symptom and leave the mechanism that produced it — so this
adds the missing mechanism:

- the runner exports `INSTALL_METHODS` as the authority and generates its own
  `Supported:` message from it
- a **conformance test** asserts both sides accept every kind in that list and
  reject what is not, plus the checksum and entry-point obligations
- the checksum rule is now expressed as "every download kind" rather than an
  enumeration, so the next kind inherits it by default

**The two lists stay physically separate on purpose.** Skills ship as
self-contained directories and nothing in the tree imports across a skill
boundary; single-sourcing would couple two skills' distribution for one array.
The test is what binds them, not an import.

## Evidence the test detects the real bug

Ran the new test against the **pre-fix** validator — it fails 5 of 12, and they
are exactly the five defects above, no more:

```
× the validator accepts release-tree, which the runner can install
× the validator accepts release-binary, which the runner can install
× requires a checksum for release-tree
× requires a checksum for release-binary
× requires an entry point for release-tree
Tests  5 failed | 7 passed (12)
```

Restored, all 12 pass, and the real jq entry validates with zero problems.

One pre-existing test asserted the old three-item `Supported:` string with the
comment "the same three the runner accepts" — updated, since that statement was
the bug written down as an assertion.

Full suite green: 8812 passed, 526 files. Lint clean.

## Impact

Blocks declaring `jq` in the three TunnlAI repos, which is what surfaced it.

🤖 Generated with Claude Code

---

Work-Item: CodySwannGT/lisa#2306


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `release-tree` and `release-binary` installation methods.
  * Added validation for download URLs, SHA-256 checksums, and required binary paths for tree-based releases.
  * Improved consistency of supported installation methods across setup and configuration validation.

* **Tests**
  * Added coverage ensuring installation methods remain consistent and required artifact fields are enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->