### PR TITLE
fix(secrets): a setup-phase secrets failure must not kill the environment

### DIFF
--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -914,9 +914,45 @@ async function main() {
       "lisa-secrets-access",
       "materialize-secrets.mjs"
     );
-    execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
-      stdio: "inherit",
-    });
+    // A failure here is fatal only when nothing else will try again.
+    //
+    // On a surface that materializes at BOTH setup and session start, this run
+    // is the floor and the hook is the authority. The two run in different
+    // environments: a cloud vendor can expose its configured variables to the
+    // agent session while the setup phase — which runs earlier, during image
+    // construction — never sees them. That is not an error state, it is the
+    // normal shape of `materializeAt: "both"`, and the hook materializes
+    // correctly moments later.
+    //
+    // Treating it as fatal cost an entire environment: setup.sh `exec`s this
+    // script, so a non-zero exit fails the vendor's setup step and Claude Code
+    // never starts at all. Trading "secrets arrive one phase later" for "the
+    // container will not boot" is a bad trade, and it regressed a case that
+    // used to work — before this surface materialized at setup, setup simply
+    // never attempted it.
+    //
+    // Every other case keeps the hard failure: an explicit `--phase=secrets`
+    // (the hook's own authoritative run) and a setup-only surface such as
+    // codex-cloud both have no second chance, so a silent pass there would
+    // hand back a session with no credentials and call it ready.
+    const retried = !requested && materializesAtSessionStart(materializeAt);
+    try {
+      execFileSync(
+        "node",
+        dryRun ? [materialize, "--dry-run"] : [materialize],
+        { stdio: "inherit" }
+      );
+    } catch (err) {
+      if (!retried) throw err;
+      console.log(
+        `\n  Secrets were not materialized during setup, and that is not fatal ` +
+          `here.\n  This surface also materializes at session start, which runs ` +
+          `with the\n  session's own environment — the usual reason setup cannot ` +
+          `see the\n  bootstrap credential. The session-start hook will retry.\n` +
+          `  If secrets are still missing INSIDE a session, that run is the one ` +
+          `to debug.`
+      );
+    }
   } else if (!requested) {
     console.log(
       `\nSecrets: materialized from a session-start hook on "${surface}", ` +

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -914,9 +914,45 @@ async function main() {
       "lisa-secrets-access",
       "materialize-secrets.mjs"
     );
-    execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
-      stdio: "inherit",
-    });
+    // A failure here is fatal only when nothing else will try again.
+    //
+    // On a surface that materializes at BOTH setup and session start, this run
+    // is the floor and the hook is the authority. The two run in different
+    // environments: a cloud vendor can expose its configured variables to the
+    // agent session while the setup phase — which runs earlier, during image
+    // construction — never sees them. That is not an error state, it is the
+    // normal shape of `materializeAt: "both"`, and the hook materializes
+    // correctly moments later.
+    //
+    // Treating it as fatal cost an entire environment: setup.sh `exec`s this
+    // script, so a non-zero exit fails the vendor's setup step and Claude Code
+    // never starts at all. Trading "secrets arrive one phase later" for "the
+    // container will not boot" is a bad trade, and it regressed a case that
+    // used to work — before this surface materialized at setup, setup simply
+    // never attempted it.
+    //
+    // Every other case keeps the hard failure: an explicit `--phase=secrets`
+    // (the hook's own authoritative run) and a setup-only surface such as
+    // codex-cloud both have no second chance, so a silent pass there would
+    // hand back a session with no credentials and call it ready.
+    const retried = !requested && materializesAtSessionStart(materializeAt);
+    try {
+      execFileSync(
+        "node",
+        dryRun ? [materialize, "--dry-run"] : [materialize],
+        { stdio: "inherit" }
+      );
+    } catch (err) {
+      if (!retried) throw err;
+      console.log(
+        `\n  Secrets were not materialized during setup, and that is not fatal ` +
+          `here.\n  This surface also materializes at session start, which runs ` +
+          `with the\n  session's own environment — the usual reason setup cannot ` +
+          `see the\n  bootstrap credential. The session-start hook will retry.\n` +
+          `  If secrets are still missing INSIDE a session, that run is the one ` +
+          `to debug.`
+      );
+    }
   } else if (!requested) {
     console.log(
       `\nSecrets: materialized from a session-start hook on "${surface}", ` +

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -914,9 +914,45 @@ async function main() {
       "lisa-secrets-access",
       "materialize-secrets.mjs"
     );
-    execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
-      stdio: "inherit",
-    });
+    // A failure here is fatal only when nothing else will try again.
+    //
+    // On a surface that materializes at BOTH setup and session start, this run
+    // is the floor and the hook is the authority. The two run in different
+    // environments: a cloud vendor can expose its configured variables to the
+    // agent session while the setup phase — which runs earlier, during image
+    // construction — never sees them. That is not an error state, it is the
+    // normal shape of `materializeAt: "both"`, and the hook materializes
+    // correctly moments later.
+    //
+    // Treating it as fatal cost an entire environment: setup.sh `exec`s this
+    // script, so a non-zero exit fails the vendor's setup step and Claude Code
+    // never starts at all. Trading "secrets arrive one phase later" for "the
+    // container will not boot" is a bad trade, and it regressed a case that
+    // used to work — before this surface materialized at setup, setup simply
+    // never attempted it.
+    //
+    // Every other case keeps the hard failure: an explicit `--phase=secrets`
+    // (the hook's own authoritative run) and a setup-only surface such as
+    // codex-cloud both have no second chance, so a silent pass there would
+    // hand back a session with no credentials and call it ready.
+    const retried = !requested && materializesAtSessionStart(materializeAt);
+    try {
+      execFileSync(
+        "node",
+        dryRun ? [materialize, "--dry-run"] : [materialize],
+        { stdio: "inherit" }
+      );
+    } catch (err) {
+      if (!retried) throw err;
+      console.log(
+        `\n  Secrets were not materialized during setup, and that is not fatal ` +
+          `here.\n  This surface also materializes at session start, which runs ` +
+          `with the\n  session's own environment — the usual reason setup cannot ` +
+          `see the\n  bootstrap credential. The session-start hook will retry.\n` +
+          `  If secrets are still missing INSIDE a session, that run is the one ` +
+          `to debug.`
+      );
+    }
   } else if (!requested) {
     console.log(
       `\nSecrets: materialized from a session-start hook on "${surface}", ` +

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -914,9 +914,45 @@ async function main() {
       "lisa-secrets-access",
       "materialize-secrets.mjs"
     );
-    execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
-      stdio: "inherit",
-    });
+    // A failure here is fatal only when nothing else will try again.
+    //
+    // On a surface that materializes at BOTH setup and session start, this run
+    // is the floor and the hook is the authority. The two run in different
+    // environments: a cloud vendor can expose its configured variables to the
+    // agent session while the setup phase — which runs earlier, during image
+    // construction — never sees them. That is not an error state, it is the
+    // normal shape of `materializeAt: "both"`, and the hook materializes
+    // correctly moments later.
+    //
+    // Treating it as fatal cost an entire environment: setup.sh `exec`s this
+    // script, so a non-zero exit fails the vendor's setup step and Claude Code
+    // never starts at all. Trading "secrets arrive one phase later" for "the
+    // container will not boot" is a bad trade, and it regressed a case that
+    // used to work — before this surface materialized at setup, setup simply
+    // never attempted it.
+    //
+    // Every other case keeps the hard failure: an explicit `--phase=secrets`
+    // (the hook's own authoritative run) and a setup-only surface such as
+    // codex-cloud both have no second chance, so a silent pass there would
+    // hand back a session with no credentials and call it ready.
+    const retried = !requested && materializesAtSessionStart(materializeAt);
+    try {
+      execFileSync(
+        "node",
+        dryRun ? [materialize, "--dry-run"] : [materialize],
+        { stdio: "inherit" }
+      );
+    } catch (err) {
+      if (!retried) throw err;
+      console.log(
+        `\n  Secrets were not materialized during setup, and that is not fatal ` +
+          `here.\n  This surface also materializes at session start, which runs ` +
+          `with the\n  session's own environment — the usual reason setup cannot ` +
+          `see the\n  bootstrap credential. The session-start hook will retry.\n` +
+          `  If secrets are still missing INSIDE a session, that run is the one ` +
+          `to debug.`
+      );
+    }
   } else if (!requested) {
     console.log(
       `\nSecrets: materialized from a session-start hook on "${surface}", ` +

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -914,9 +914,45 @@ async function main() {
       "lisa-secrets-access",
       "materialize-secrets.mjs"
     );
-    execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
-      stdio: "inherit",
-    });
+    // A failure here is fatal only when nothing else will try again.
+    //
+    // On a surface that materializes at BOTH setup and session start, this run
+    // is the floor and the hook is the authority. The two run in different
+    // environments: a cloud vendor can expose its configured variables to the
+    // agent session while the setup phase — which runs earlier, during image
+    // construction — never sees them. That is not an error state, it is the
+    // normal shape of `materializeAt: "both"`, and the hook materializes
+    // correctly moments later.
+    //
+    // Treating it as fatal cost an entire environment: setup.sh `exec`s this
+    // script, so a non-zero exit fails the vendor's setup step and Claude Code
+    // never starts at all. Trading "secrets arrive one phase later" for "the
+    // container will not boot" is a bad trade, and it regressed a case that
+    // used to work — before this surface materialized at setup, setup simply
+    // never attempted it.
+    //
+    // Every other case keeps the hard failure: an explicit `--phase=secrets`
+    // (the hook's own authoritative run) and a setup-only surface such as
+    // codex-cloud both have no second chance, so a silent pass there would
+    // hand back a session with no credentials and call it ready.
+    const retried = !requested && materializesAtSessionStart(materializeAt);
+    try {
+      execFileSync(
+        "node",
+        dryRun ? [materialize, "--dry-run"] : [materialize],
+        { stdio: "inherit" }
+      );
+    } catch (err) {
+      if (!retried) throw err;
+      console.log(
+        `\n  Secrets were not materialized during setup, and that is not fatal ` +
+          `here.\n  This surface also materializes at session start, which runs ` +
+          `with the\n  session's own environment — the usual reason setup cannot ` +
+          `see the\n  bootstrap credential. The session-start hook will retry.\n` +
+          `  If secrets are still missing INSIDE a session, that run is the one ` +
+          `to debug.`
+      );
+    }
   } else if (!requested) {
     console.log(
       `\nSecrets: materialized from a session-start hook on "${surface}", ` +

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -914,9 +914,45 @@ async function main() {
       "lisa-secrets-access",
       "materialize-secrets.mjs"
     );
-    execFileSync("node", dryRun ? [materialize, "--dry-run"] : [materialize], {
-      stdio: "inherit",
-    });
+    // A failure here is fatal only when nothing else will try again.
+    //
+    // On a surface that materializes at BOTH setup and session start, this run
+    // is the floor and the hook is the authority. The two run in different
+    // environments: a cloud vendor can expose its configured variables to the
+    // agent session while the setup phase — which runs earlier, during image
+    // construction — never sees them. That is not an error state, it is the
+    // normal shape of `materializeAt: "both"`, and the hook materializes
+    // correctly moments later.
+    //
+    // Treating it as fatal cost an entire environment: setup.sh `exec`s this
+    // script, so a non-zero exit fails the vendor's setup step and Claude Code
+    // never starts at all. Trading "secrets arrive one phase later" for "the
+    // container will not boot" is a bad trade, and it regressed a case that
+    // used to work — before this surface materialized at setup, setup simply
+    // never attempted it.
+    //
+    // Every other case keeps the hard failure: an explicit `--phase=secrets`
+    // (the hook's own authoritative run) and a setup-only surface such as
+    // codex-cloud both have no second chance, so a silent pass there would
+    // hand back a session with no credentials and call it ready.
+    const retried = !requested && materializesAtSessionStart(materializeAt);
+    try {
+      execFileSync(
+        "node",
+        dryRun ? [materialize, "--dry-run"] : [materialize],
+        { stdio: "inherit" }
+      );
+    } catch (err) {
+      if (!retried) throw err;
+      console.log(
+        `\n  Secrets were not materialized during setup, and that is not fatal ` +
+          `here.\n  This surface also materializes at session start, which runs ` +
+          `with the\n  session's own environment — the usual reason setup cannot ` +
+          `see the\n  bootstrap credential. The session-start hook will retry.\n` +
+          `  If secrets are still missing INSIDE a session, that run is the one ` +
+          `to debug.`
+      );
+    }
   } else if (!requested) {
     console.log(
       `\nSecrets: materialized from a session-start hook on "${surface}", ` +

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1159,7 +1159,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "c30d98a5645f033fc1d3a723043691b9ad997ae5666df539ff6aa19c563431b2",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "2a91430fc2918f2e7df328d58d07feda35fcc0f11f1d9e29623e4f2552617d29",
+      "1568756df16a7fbeee95e46112a3462e0cd803daae89835f4fde8c38cbb26095",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
       "496de5aed034692fee421dc3a1fbad9f85ed9e1d0c83a1080f781a486d0274e6",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
@@ -8505,6 +8505,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/remote-env-toolchain.test.ts": true,
     "tests/unit/secrets/rotation-view.test.ts": true,
     "tests/unit/secrets/secrets-access-contract.test.ts": true,
+    "tests/unit/secrets/setup-secrets-nonfatal.test.ts": true,
     "tests/unit/secrets/toolchain-platforms.test.ts": true,
     "tests/unit/secrets/toolchain-release-binary.test.ts": true,
     "tests/unit/secrets/toolchain-release-tree.test.ts": true,

--- a/tests/unit/secrets/setup-secrets-nonfatal.test.ts
+++ b/tests/unit/secrets/setup-secrets-nonfatal.test.ts
@@ -1,0 +1,78 @@
+/**
+ * A setup-phase secrets failure must not kill the environment when the session
+ * start hook will retry.
+ *
+ * Regression of record: making `claude-web` materialize at BOTH setup and
+ * session start fixed the multi-repo case (the project-scoped hook never
+ * registers when the session opens in the parent directory) but introduced a
+ * worse failure. `setup.sh` ends in `exec node <this script>`, so a non-zero
+ * exit fails the vendor's setup step and Claude Code never starts — observed
+ * live on TunnlAI/frontend, where the configured bootstrap variable is visible
+ * to the session but not to the earlier setup phase.
+ *
+ * The distinction under test is "will anything try again", not "is this a
+ * cloud surface": a setup-only surface and the hook's own authoritative run
+ * must both still fail hard, because a silent pass there hands back a session
+ * with no credentials and reports it ready.
+ * @module tests/unit/secrets/setup-secrets-nonfatal
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  materializesAtSessionStart,
+  materializesAtSetup,
+} from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs";
+
+/**
+ * Whether a setup-phase failure is survivable, mirroring the runner's rule:
+ * fatal unless a later authoritative run will retry.
+ * @param requested The explicit `--phase` value, if the caller gave one.
+ * @param materializeAt The surface's declared materialization points.
+ * @returns True when the failure should be reported and tolerated.
+ */
+function survivesSetupFailure(
+  requested: string | undefined,
+  materializeAt: string | null
+): boolean {
+  return !requested && materializesAtSessionStart(materializeAt);
+}
+
+describe("materializeAt covers both phases", () => {
+  it('treats "both" as materializing at setup AND at session start', () => {
+    // The whole regression lives in this value, so it is asserted directly
+    // rather than inferred from the surfaces table.
+    expect(materializesAtSetup("both")).toBe(true);
+    expect(materializesAtSessionStart("both")).toBe(true);
+  });
+
+  it("keeps the single-phase values single-phase", () => {
+    expect(materializesAtSetup("setup")).toBe(true);
+    expect(materializesAtSessionStart("setup")).toBe(false);
+    expect(materializesAtSetup("session-start")).toBe(false);
+    expect(materializesAtSessionStart("session-start")).toBe(true);
+  });
+});
+
+describe("when a setup-phase secrets failure is survivable", () => {
+  it('survives on a "both" surface during the setup run', () => {
+    // claude-web: the hook runs moments later with the session's environment.
+    expect(survivesSetupFailure(undefined, "both")).toBe(true);
+  });
+
+  it("is fatal on a setup-only surface", () => {
+    // codex-cloud: nothing runs again, so tolerating this would hand back a
+    // credential-less session and call it ready.
+    expect(survivesSetupFailure(undefined, "setup")).toBe(false);
+  });
+
+  it("is fatal when the hook explicitly asks for the secrets phase", () => {
+    // `--phase=secrets` IS the authoritative run. If it cannot materialize,
+    // there is no later attempt to defer to.
+    expect(survivesSetupFailure("secrets", "both")).toBe(false);
+  });
+
+  it("is fatal when no materialization is declared at all", () => {
+    expect(survivesSetupFailure(undefined, null)).toBe(false);
+  });
+});


### PR DESCRIPTION
A Claude Code web environment for TunnlAI/frontend fails to build:

```
Secrets:
BWS_ACCESS_TOKEN_tunnl not found in: env, keychain.
Command failed: node .../materialize-secrets.mjs
Setup script failed with exit code 1.
```

`Start Claude Code` never runs — the environment is dead, not degraded. The
bootstrap variable **is** configured on the environment; the setup phase simply
cannot see it. Cloud vendors expose configured variables to the agent session
while the setup step runs earlier, during image construction.

## This is a regression from 2.331.2

Before `claude-web` became `materializeAt: "both"` (#2303-era fix for the
multi-repo case, where a project-scoped SessionStart hook never registers
because the session opens in the parent directory), setup never *attempted*
materialization, so it could not fail there. Making it attempt turned a
survivable condition into a fatal one, because `setup.sh` ends in
`exec node setup-remote-env.mjs` and the vendor reads that exit code.

Trading "secrets arrive one phase later" for "the container will not boot" is a
bad trade — and the hook materializes correctly moments later, which is the
whole point of `"both"`.

## Fix

A setup-phase secrets failure is fatal **only when nothing will retry**:
non-fatal when this is the setup run AND the surface also materializes at
session start. Everything else keeps failing hard — `codex-cloud` (setup-only,
no second chance) and an explicit `--phase=secrets` (the hook's own
authoritative run), because a silent pass there hands back a session with no
credentials and reports it ready.

## Evidence

Exit codes from the real runner (a stubbed failing materialize, one run per surface). Against `origin/main`:

```
claude-web  (both, setup run) -> exit 1 FATAL (environment would not boot)
codex-cloud (setup only)     -> exit 1 still fatal
claude-web  (--phase=secrets)-> exit 1 still fatal
```

With this change:

```
claude-web  (both, setup run) -> exit 0 SURVIVES, and says the hook will retry
codex-cloud (setup only)     -> exit 1 still fatal
claude-web  (--phase=secrets)-> exit 1 still fatal
```

Only the one case changes. My first harness set the surface in `.lisa.config.json`, which resolved to `local` and skipped the secrets phase entirely — every case passed while testing nothing. The surface is detected from the environment (`LISA_SECRETS_SURFACE`), which the corrected harness sets.

Full suite green: 8818 passed, 527 files.

---

Work-Item: CodySwannGT/lisa#2309


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Initial remote-environment setup no longer fails when secret materialization can be retried automatically at session start.
  * Explicit secret setup and configurations without a retry path continue to report failures immediately.
  * Retry notices now clarify that the session-start execution is authoritative.

* **Tests**
  * Added coverage for setup, session-start, combined, and setup-only secret handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->