### PR TITLE
fix(secrets): register the session-start hook at user scope on remote surfaces

### DIFF
--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -38,6 +38,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -584,6 +585,101 @@ export const SETUP_FIELD =
   'exit "$rc"';
 
 /**
+ * Register the session-start hook at USER scope, so it fires wherever the
+ * session opens.
+ *
+ * The committed `.claude/settings.json` hook is *project*-scoped: it loads only
+ * when Claude Code's project directory is that repository. A cloud session does
+ * not reliably start there. With several repositories it starts in the shared
+ * parent, which is not a git repository at all; even with one, the checkout sits
+ * at `$HOME/<repo>` while the session may open at `$HOME`. In those sessions no
+ * project settings load, the hook never registers, and nothing materializes —
+ * the failure that `materializeAt: "both"` was introduced to paper over, and
+ * which it could not fix, because the setup phase cannot see the bootstrap
+ * credential in the first place.
+ *
+ * A user-scoped hook has neither problem: `~/.claude/settings.json` is read for
+ * every session regardless of project directory, and it runs in-session where
+ * the vendor's configured variables ARE present.
+ *
+ * Only ever on a remote surface. This writes machine state in an ephemeral
+ * container, which is fine there and would be an intrusion on a developer's
+ * laptop, where the project hook already works and the user owns that file.
+ *
+ * Merged, never clobbered, and idempotent on the exact command — an existing
+ * user settings file may carry hooks this knows nothing about.
+ * @param {string} repoRoot Absolute path to the checkout.
+ * @param {object} options Home directory, dry-run flag, and file seams.
+ * @returns {{action: string, path: string, reason?: string}} What was done.
+ */
+export function installUserSessionHook(repoRoot, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    dryRun = false,
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+    mkdir = mkdirSync,
+  } = options;
+
+  const script = join(repoRoot, "scripts/lisa-remote-env/session-start.sh");
+  if (!exists(script)) {
+    return { action: "skipped", path: script, reason: "no session-start.sh" };
+  }
+
+  const dir = join(home, ".claude");
+  const settingsPath = join(dir, "settings.json");
+  const command = `bash ${script}`;
+
+  let settings = {};
+  if (exists(settingsPath)) {
+    try {
+      settings = JSON.parse(String(read(settingsPath, "utf8"))) || {};
+    } catch {
+      // Refuse rather than overwrite. A settings file that does not parse is
+      // still someone's configuration, and replacing it would be the careless
+      // destruction this whole function is written to avoid.
+      return {
+        action: "failed",
+        path: settingsPath,
+        reason: "existing settings.json is not valid JSON; left untouched",
+      };
+    }
+  }
+
+  const hooks = settings.hooks ?? {};
+  const sessionStart = Array.isArray(hooks.SessionStart)
+    ? hooks.SessionStart
+    : [];
+  const already = sessionStart.some(entry =>
+    (entry?.hooks ?? []).some(hook => hook?.command === command)
+  );
+  if (already) {
+    return { action: "present", path: settingsPath };
+  }
+
+  const updated = {
+    ...settings,
+    hooks: {
+      ...hooks,
+      SessionStart: [
+        ...sessionStart,
+        {
+          matcher: "startup|resume",
+          hooks: [{ type: "command", command }],
+        },
+      ],
+    },
+  };
+
+  if (dryRun) return { action: "would-register", path: settingsPath };
+
+  mkdir(dir, { recursive: true });
+  write(settingsPath, `${JSON.stringify(updated, null, 2)}\n`);
+  return { action: "registered", path: settingsPath };
+}
+
+/**
  * The settings block that wires the session-start hook into a repository.
  *
  * Emitted rather than written, because `.claude/settings.json` belongs to the
@@ -936,6 +1032,19 @@ async function main() {
     // codex-cloud both have no second chance, so a silent pass there would
     // hand back a session with no credentials and call it ready.
     const retried = !requested && materializesAtSessionStart(materializeAt);
+
+    // If the hook is what will retry, make sure the hook can actually fire.
+    // Registering it at user scope is what makes the retry real rather than
+    // assumed: the committed project hook does not load when the session opens
+    // above the checkout, which is the norm in a cloud container.
+    // `materializeAt` being set is what "remote surface" means here. The
+    // toolchain phase derives a local `remote` from it, but that binding is
+    // scoped to its own block and is not in scope in this one.
+    if (retried && Boolean(materializeAt)) {
+      const hook = installUserSessionHook(process.cwd(), { dryRun });
+      console.log(`  session-start hook: ${hook.action} (${hook.path})`);
+      if (hook.reason) console.log(`    ${hook.reason}`);
+    }
     try {
       execFileSync(
         "node",

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -38,6 +38,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -584,6 +585,101 @@ export const SETUP_FIELD =
   'exit "$rc"';
 
 /**
+ * Register the session-start hook at USER scope, so it fires wherever the
+ * session opens.
+ *
+ * The committed `.claude/settings.json` hook is *project*-scoped: it loads only
+ * when Claude Code's project directory is that repository. A cloud session does
+ * not reliably start there. With several repositories it starts in the shared
+ * parent, which is not a git repository at all; even with one, the checkout sits
+ * at `$HOME/<repo>` while the session may open at `$HOME`. In those sessions no
+ * project settings load, the hook never registers, and nothing materializes —
+ * the failure that `materializeAt: "both"` was introduced to paper over, and
+ * which it could not fix, because the setup phase cannot see the bootstrap
+ * credential in the first place.
+ *
+ * A user-scoped hook has neither problem: `~/.claude/settings.json` is read for
+ * every session regardless of project directory, and it runs in-session where
+ * the vendor's configured variables ARE present.
+ *
+ * Only ever on a remote surface. This writes machine state in an ephemeral
+ * container, which is fine there and would be an intrusion on a developer's
+ * laptop, where the project hook already works and the user owns that file.
+ *
+ * Merged, never clobbered, and idempotent on the exact command — an existing
+ * user settings file may carry hooks this knows nothing about.
+ * @param {string} repoRoot Absolute path to the checkout.
+ * @param {object} options Home directory, dry-run flag, and file seams.
+ * @returns {{action: string, path: string, reason?: string}} What was done.
+ */
+export function installUserSessionHook(repoRoot, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    dryRun = false,
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+    mkdir = mkdirSync,
+  } = options;
+
+  const script = join(repoRoot, "scripts/lisa-remote-env/session-start.sh");
+  if (!exists(script)) {
+    return { action: "skipped", path: script, reason: "no session-start.sh" };
+  }
+
+  const dir = join(home, ".claude");
+  const settingsPath = join(dir, "settings.json");
+  const command = `bash ${script}`;
+
+  let settings = {};
+  if (exists(settingsPath)) {
+    try {
+      settings = JSON.parse(String(read(settingsPath, "utf8"))) || {};
+    } catch {
+      // Refuse rather than overwrite. A settings file that does not parse is
+      // still someone's configuration, and replacing it would be the careless
+      // destruction this whole function is written to avoid.
+      return {
+        action: "failed",
+        path: settingsPath,
+        reason: "existing settings.json is not valid JSON; left untouched",
+      };
+    }
+  }
+
+  const hooks = settings.hooks ?? {};
+  const sessionStart = Array.isArray(hooks.SessionStart)
+    ? hooks.SessionStart
+    : [];
+  const already = sessionStart.some(entry =>
+    (entry?.hooks ?? []).some(hook => hook?.command === command)
+  );
+  if (already) {
+    return { action: "present", path: settingsPath };
+  }
+
+  const updated = {
+    ...settings,
+    hooks: {
+      ...hooks,
+      SessionStart: [
+        ...sessionStart,
+        {
+          matcher: "startup|resume",
+          hooks: [{ type: "command", command }],
+        },
+      ],
+    },
+  };
+
+  if (dryRun) return { action: "would-register", path: settingsPath };
+
+  mkdir(dir, { recursive: true });
+  write(settingsPath, `${JSON.stringify(updated, null, 2)}\n`);
+  return { action: "registered", path: settingsPath };
+}
+
+/**
  * The settings block that wires the session-start hook into a repository.
  *
  * Emitted rather than written, because `.claude/settings.json` belongs to the
@@ -936,6 +1032,19 @@ async function main() {
     // codex-cloud both have no second chance, so a silent pass there would
     // hand back a session with no credentials and call it ready.
     const retried = !requested && materializesAtSessionStart(materializeAt);
+
+    // If the hook is what will retry, make sure the hook can actually fire.
+    // Registering it at user scope is what makes the retry real rather than
+    // assumed: the committed project hook does not load when the session opens
+    // above the checkout, which is the norm in a cloud container.
+    // `materializeAt` being set is what "remote surface" means here. The
+    // toolchain phase derives a local `remote` from it, but that binding is
+    // scoped to its own block and is not in scope in this one.
+    if (retried && Boolean(materializeAt)) {
+      const hook = installUserSessionHook(process.cwd(), { dryRun });
+      console.log(`  session-start hook: ${hook.action} (${hook.path})`);
+      if (hook.reason) console.log(`    ${hook.reason}`);
+    }
     try {
       execFileSync(
         "node",

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -38,6 +38,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -584,6 +585,101 @@ export const SETUP_FIELD =
   'exit "$rc"';
 
 /**
+ * Register the session-start hook at USER scope, so it fires wherever the
+ * session opens.
+ *
+ * The committed `.claude/settings.json` hook is *project*-scoped: it loads only
+ * when Claude Code's project directory is that repository. A cloud session does
+ * not reliably start there. With several repositories it starts in the shared
+ * parent, which is not a git repository at all; even with one, the checkout sits
+ * at `$HOME/<repo>` while the session may open at `$HOME`. In those sessions no
+ * project settings load, the hook never registers, and nothing materializes —
+ * the failure that `materializeAt: "both"` was introduced to paper over, and
+ * which it could not fix, because the setup phase cannot see the bootstrap
+ * credential in the first place.
+ *
+ * A user-scoped hook has neither problem: `~/.claude/settings.json` is read for
+ * every session regardless of project directory, and it runs in-session where
+ * the vendor's configured variables ARE present.
+ *
+ * Only ever on a remote surface. This writes machine state in an ephemeral
+ * container, which is fine there and would be an intrusion on a developer's
+ * laptop, where the project hook already works and the user owns that file.
+ *
+ * Merged, never clobbered, and idempotent on the exact command — an existing
+ * user settings file may carry hooks this knows nothing about.
+ * @param {string} repoRoot Absolute path to the checkout.
+ * @param {object} options Home directory, dry-run flag, and file seams.
+ * @returns {{action: string, path: string, reason?: string}} What was done.
+ */
+export function installUserSessionHook(repoRoot, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    dryRun = false,
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+    mkdir = mkdirSync,
+  } = options;
+
+  const script = join(repoRoot, "scripts/lisa-remote-env/session-start.sh");
+  if (!exists(script)) {
+    return { action: "skipped", path: script, reason: "no session-start.sh" };
+  }
+
+  const dir = join(home, ".claude");
+  const settingsPath = join(dir, "settings.json");
+  const command = `bash ${script}`;
+
+  let settings = {};
+  if (exists(settingsPath)) {
+    try {
+      settings = JSON.parse(String(read(settingsPath, "utf8"))) || {};
+    } catch {
+      // Refuse rather than overwrite. A settings file that does not parse is
+      // still someone's configuration, and replacing it would be the careless
+      // destruction this whole function is written to avoid.
+      return {
+        action: "failed",
+        path: settingsPath,
+        reason: "existing settings.json is not valid JSON; left untouched",
+      };
+    }
+  }
+
+  const hooks = settings.hooks ?? {};
+  const sessionStart = Array.isArray(hooks.SessionStart)
+    ? hooks.SessionStart
+    : [];
+  const already = sessionStart.some(entry =>
+    (entry?.hooks ?? []).some(hook => hook?.command === command)
+  );
+  if (already) {
+    return { action: "present", path: settingsPath };
+  }
+
+  const updated = {
+    ...settings,
+    hooks: {
+      ...hooks,
+      SessionStart: [
+        ...sessionStart,
+        {
+          matcher: "startup|resume",
+          hooks: [{ type: "command", command }],
+        },
+      ],
+    },
+  };
+
+  if (dryRun) return { action: "would-register", path: settingsPath };
+
+  mkdir(dir, { recursive: true });
+  write(settingsPath, `${JSON.stringify(updated, null, 2)}\n`);
+  return { action: "registered", path: settingsPath };
+}
+
+/**
  * The settings block that wires the session-start hook into a repository.
  *
  * Emitted rather than written, because `.claude/settings.json` belongs to the
@@ -936,6 +1032,19 @@ async function main() {
     // codex-cloud both have no second chance, so a silent pass there would
     // hand back a session with no credentials and call it ready.
     const retried = !requested && materializesAtSessionStart(materializeAt);
+
+    // If the hook is what will retry, make sure the hook can actually fire.
+    // Registering it at user scope is what makes the retry real rather than
+    // assumed: the committed project hook does not load when the session opens
+    // above the checkout, which is the norm in a cloud container.
+    // `materializeAt` being set is what "remote surface" means here. The
+    // toolchain phase derives a local `remote` from it, but that binding is
+    // scoped to its own block and is not in scope in this one.
+    if (retried && Boolean(materializeAt)) {
+      const hook = installUserSessionHook(process.cwd(), { dryRun });
+      console.log(`  session-start hook: ${hook.action} (${hook.path})`);
+      if (hook.reason) console.log(`    ${hook.reason}`);
+    }
     try {
       execFileSync(
         "node",

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -38,6 +38,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -584,6 +585,101 @@ export const SETUP_FIELD =
   'exit "$rc"';
 
 /**
+ * Register the session-start hook at USER scope, so it fires wherever the
+ * session opens.
+ *
+ * The committed `.claude/settings.json` hook is *project*-scoped: it loads only
+ * when Claude Code's project directory is that repository. A cloud session does
+ * not reliably start there. With several repositories it starts in the shared
+ * parent, which is not a git repository at all; even with one, the checkout sits
+ * at `$HOME/<repo>` while the session may open at `$HOME`. In those sessions no
+ * project settings load, the hook never registers, and nothing materializes —
+ * the failure that `materializeAt: "both"` was introduced to paper over, and
+ * which it could not fix, because the setup phase cannot see the bootstrap
+ * credential in the first place.
+ *
+ * A user-scoped hook has neither problem: `~/.claude/settings.json` is read for
+ * every session regardless of project directory, and it runs in-session where
+ * the vendor's configured variables ARE present.
+ *
+ * Only ever on a remote surface. This writes machine state in an ephemeral
+ * container, which is fine there and would be an intrusion on a developer's
+ * laptop, where the project hook already works and the user owns that file.
+ *
+ * Merged, never clobbered, and idempotent on the exact command — an existing
+ * user settings file may carry hooks this knows nothing about.
+ * @param {string} repoRoot Absolute path to the checkout.
+ * @param {object} options Home directory, dry-run flag, and file seams.
+ * @returns {{action: string, path: string, reason?: string}} What was done.
+ */
+export function installUserSessionHook(repoRoot, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    dryRun = false,
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+    mkdir = mkdirSync,
+  } = options;
+
+  const script = join(repoRoot, "scripts/lisa-remote-env/session-start.sh");
+  if (!exists(script)) {
+    return { action: "skipped", path: script, reason: "no session-start.sh" };
+  }
+
+  const dir = join(home, ".claude");
+  const settingsPath = join(dir, "settings.json");
+  const command = `bash ${script}`;
+
+  let settings = {};
+  if (exists(settingsPath)) {
+    try {
+      settings = JSON.parse(String(read(settingsPath, "utf8"))) || {};
+    } catch {
+      // Refuse rather than overwrite. A settings file that does not parse is
+      // still someone's configuration, and replacing it would be the careless
+      // destruction this whole function is written to avoid.
+      return {
+        action: "failed",
+        path: settingsPath,
+        reason: "existing settings.json is not valid JSON; left untouched",
+      };
+    }
+  }
+
+  const hooks = settings.hooks ?? {};
+  const sessionStart = Array.isArray(hooks.SessionStart)
+    ? hooks.SessionStart
+    : [];
+  const already = sessionStart.some(entry =>
+    (entry?.hooks ?? []).some(hook => hook?.command === command)
+  );
+  if (already) {
+    return { action: "present", path: settingsPath };
+  }
+
+  const updated = {
+    ...settings,
+    hooks: {
+      ...hooks,
+      SessionStart: [
+        ...sessionStart,
+        {
+          matcher: "startup|resume",
+          hooks: [{ type: "command", command }],
+        },
+      ],
+    },
+  };
+
+  if (dryRun) return { action: "would-register", path: settingsPath };
+
+  mkdir(dir, { recursive: true });
+  write(settingsPath, `${JSON.stringify(updated, null, 2)}\n`);
+  return { action: "registered", path: settingsPath };
+}
+
+/**
  * The settings block that wires the session-start hook into a repository.
  *
  * Emitted rather than written, because `.claude/settings.json` belongs to the
@@ -936,6 +1032,19 @@ async function main() {
     // codex-cloud both have no second chance, so a silent pass there would
     // hand back a session with no credentials and call it ready.
     const retried = !requested && materializesAtSessionStart(materializeAt);
+
+    // If the hook is what will retry, make sure the hook can actually fire.
+    // Registering it at user scope is what makes the retry real rather than
+    // assumed: the committed project hook does not load when the session opens
+    // above the checkout, which is the norm in a cloud container.
+    // `materializeAt` being set is what "remote surface" means here. The
+    // toolchain phase derives a local `remote` from it, but that binding is
+    // scoped to its own block and is not in scope in this one.
+    if (retried && Boolean(materializeAt)) {
+      const hook = installUserSessionHook(process.cwd(), { dryRun });
+      console.log(`  session-start hook: ${hook.action} (${hook.path})`);
+      if (hook.reason) console.log(`    ${hook.reason}`);
+    }
     try {
       execFileSync(
         "node",

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -38,6 +38,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -584,6 +585,101 @@ export const SETUP_FIELD =
   'exit "$rc"';
 
 /**
+ * Register the session-start hook at USER scope, so it fires wherever the
+ * session opens.
+ *
+ * The committed `.claude/settings.json` hook is *project*-scoped: it loads only
+ * when Claude Code's project directory is that repository. A cloud session does
+ * not reliably start there. With several repositories it starts in the shared
+ * parent, which is not a git repository at all; even with one, the checkout sits
+ * at `$HOME/<repo>` while the session may open at `$HOME`. In those sessions no
+ * project settings load, the hook never registers, and nothing materializes —
+ * the failure that `materializeAt: "both"` was introduced to paper over, and
+ * which it could not fix, because the setup phase cannot see the bootstrap
+ * credential in the first place.
+ *
+ * A user-scoped hook has neither problem: `~/.claude/settings.json` is read for
+ * every session regardless of project directory, and it runs in-session where
+ * the vendor's configured variables ARE present.
+ *
+ * Only ever on a remote surface. This writes machine state in an ephemeral
+ * container, which is fine there and would be an intrusion on a developer's
+ * laptop, where the project hook already works and the user owns that file.
+ *
+ * Merged, never clobbered, and idempotent on the exact command — an existing
+ * user settings file may carry hooks this knows nothing about.
+ * @param {string} repoRoot Absolute path to the checkout.
+ * @param {object} options Home directory, dry-run flag, and file seams.
+ * @returns {{action: string, path: string, reason?: string}} What was done.
+ */
+export function installUserSessionHook(repoRoot, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    dryRun = false,
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+    mkdir = mkdirSync,
+  } = options;
+
+  const script = join(repoRoot, "scripts/lisa-remote-env/session-start.sh");
+  if (!exists(script)) {
+    return { action: "skipped", path: script, reason: "no session-start.sh" };
+  }
+
+  const dir = join(home, ".claude");
+  const settingsPath = join(dir, "settings.json");
+  const command = `bash ${script}`;
+
+  let settings = {};
+  if (exists(settingsPath)) {
+    try {
+      settings = JSON.parse(String(read(settingsPath, "utf8"))) || {};
+    } catch {
+      // Refuse rather than overwrite. A settings file that does not parse is
+      // still someone's configuration, and replacing it would be the careless
+      // destruction this whole function is written to avoid.
+      return {
+        action: "failed",
+        path: settingsPath,
+        reason: "existing settings.json is not valid JSON; left untouched",
+      };
+    }
+  }
+
+  const hooks = settings.hooks ?? {};
+  const sessionStart = Array.isArray(hooks.SessionStart)
+    ? hooks.SessionStart
+    : [];
+  const already = sessionStart.some(entry =>
+    (entry?.hooks ?? []).some(hook => hook?.command === command)
+  );
+  if (already) {
+    return { action: "present", path: settingsPath };
+  }
+
+  const updated = {
+    ...settings,
+    hooks: {
+      ...hooks,
+      SessionStart: [
+        ...sessionStart,
+        {
+          matcher: "startup|resume",
+          hooks: [{ type: "command", command }],
+        },
+      ],
+    },
+  };
+
+  if (dryRun) return { action: "would-register", path: settingsPath };
+
+  mkdir(dir, { recursive: true });
+  write(settingsPath, `${JSON.stringify(updated, null, 2)}\n`);
+  return { action: "registered", path: settingsPath };
+}
+
+/**
  * The settings block that wires the session-start hook into a repository.
  *
  * Emitted rather than written, because `.claude/settings.json` belongs to the
@@ -936,6 +1032,19 @@ async function main() {
     // codex-cloud both have no second chance, so a silent pass there would
     // hand back a session with no credentials and call it ready.
     const retried = !requested && materializesAtSessionStart(materializeAt);
+
+    // If the hook is what will retry, make sure the hook can actually fire.
+    // Registering it at user scope is what makes the retry real rather than
+    // assumed: the committed project hook does not load when the session opens
+    // above the checkout, which is the norm in a cloud container.
+    // `materializeAt` being set is what "remote surface" means here. The
+    // toolchain phase derives a local `remote` from it, but that binding is
+    // scoped to its own block and is not in scope in this one.
+    if (retried && Boolean(materializeAt)) {
+      const hook = installUserSessionHook(process.cwd(), { dryRun });
+      console.log(`  session-start hook: ${hook.action} (${hook.path})`);
+      if (hook.reason) console.log(`    ${hook.reason}`);
+    }
     try {
       execFileSync(
         "node",

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -38,6 +38,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -584,6 +585,101 @@ export const SETUP_FIELD =
   'exit "$rc"';
 
 /**
+ * Register the session-start hook at USER scope, so it fires wherever the
+ * session opens.
+ *
+ * The committed `.claude/settings.json` hook is *project*-scoped: it loads only
+ * when Claude Code's project directory is that repository. A cloud session does
+ * not reliably start there. With several repositories it starts in the shared
+ * parent, which is not a git repository at all; even with one, the checkout sits
+ * at `$HOME/<repo>` while the session may open at `$HOME`. In those sessions no
+ * project settings load, the hook never registers, and nothing materializes —
+ * the failure that `materializeAt: "both"` was introduced to paper over, and
+ * which it could not fix, because the setup phase cannot see the bootstrap
+ * credential in the first place.
+ *
+ * A user-scoped hook has neither problem: `~/.claude/settings.json` is read for
+ * every session regardless of project directory, and it runs in-session where
+ * the vendor's configured variables ARE present.
+ *
+ * Only ever on a remote surface. This writes machine state in an ephemeral
+ * container, which is fine there and would be an intrusion on a developer's
+ * laptop, where the project hook already works and the user owns that file.
+ *
+ * Merged, never clobbered, and idempotent on the exact command — an existing
+ * user settings file may carry hooks this knows nothing about.
+ * @param {string} repoRoot Absolute path to the checkout.
+ * @param {object} options Home directory, dry-run flag, and file seams.
+ * @returns {{action: string, path: string, reason?: string}} What was done.
+ */
+export function installUserSessionHook(repoRoot, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    dryRun = false,
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+    mkdir = mkdirSync,
+  } = options;
+
+  const script = join(repoRoot, "scripts/lisa-remote-env/session-start.sh");
+  if (!exists(script)) {
+    return { action: "skipped", path: script, reason: "no session-start.sh" };
+  }
+
+  const dir = join(home, ".claude");
+  const settingsPath = join(dir, "settings.json");
+  const command = `bash ${script}`;
+
+  let settings = {};
+  if (exists(settingsPath)) {
+    try {
+      settings = JSON.parse(String(read(settingsPath, "utf8"))) || {};
+    } catch {
+      // Refuse rather than overwrite. A settings file that does not parse is
+      // still someone's configuration, and replacing it would be the careless
+      // destruction this whole function is written to avoid.
+      return {
+        action: "failed",
+        path: settingsPath,
+        reason: "existing settings.json is not valid JSON; left untouched",
+      };
+    }
+  }
+
+  const hooks = settings.hooks ?? {};
+  const sessionStart = Array.isArray(hooks.SessionStart)
+    ? hooks.SessionStart
+    : [];
+  const already = sessionStart.some(entry =>
+    (entry?.hooks ?? []).some(hook => hook?.command === command)
+  );
+  if (already) {
+    return { action: "present", path: settingsPath };
+  }
+
+  const updated = {
+    ...settings,
+    hooks: {
+      ...hooks,
+      SessionStart: [
+        ...sessionStart,
+        {
+          matcher: "startup|resume",
+          hooks: [{ type: "command", command }],
+        },
+      ],
+    },
+  };
+
+  if (dryRun) return { action: "would-register", path: settingsPath };
+
+  mkdir(dir, { recursive: true });
+  write(settingsPath, `${JSON.stringify(updated, null, 2)}\n`);
+  return { action: "registered", path: settingsPath };
+}
+
+/**
  * The settings block that wires the session-start hook into a repository.
  *
  * Emitted rather than written, because `.claude/settings.json` belongs to the
@@ -936,6 +1032,19 @@ async function main() {
     // codex-cloud both have no second chance, so a silent pass there would
     // hand back a session with no credentials and call it ready.
     const retried = !requested && materializesAtSessionStart(materializeAt);
+
+    // If the hook is what will retry, make sure the hook can actually fire.
+    // Registering it at user scope is what makes the retry real rather than
+    // assumed: the committed project hook does not load when the session opens
+    // above the checkout, which is the norm in a cloud container.
+    // `materializeAt` being set is what "remote surface" means here. The
+    // toolchain phase derives a local `remote` from it, but that binding is
+    // scoped to its own block and is not in scope in this one.
+    if (retried && Boolean(materializeAt)) {
+      const hook = installUserSessionHook(process.cwd(), { dryRun });
+      console.log(`  session-start hook: ${hook.action} (${hook.path})`);
+      if (hook.reason) console.log(`    ${hook.reason}`);
+    }
     try {
       execFileSync(
         "node",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1159,7 +1159,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "c30d98a5645f033fc1d3a723043691b9ad997ae5666df539ff6aa19c563431b2",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "1568756df16a7fbeee95e46112a3462e0cd803daae89835f4fde8c38cbb26095",
+      "aa703a3fcadd847594c694f458fc41edd39590dfabeddf4fed1546b73099f33f",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
       "496de5aed034692fee421dc3a1fbad9f85ed9e1d0c83a1080f781a486d0274e6",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
@@ -8510,6 +8510,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/toolchain-release-binary.test.ts": true,
     "tests/unit/secrets/toolchain-release-tree.test.ts": true,
     "tests/unit/secrets/toolchain-surfaces.test.ts": true,
+    "tests/unit/secrets/user-session-hook.test.ts": true,
     "tests/unit/secrets/validate-config.test.ts": true,
     "tests/unit/sonar/sonar-installer.test.ts": true,
     "tests/unit/standards/capture.test.ts": true,

--- a/tests/unit/secrets/user-session-hook.test.ts
+++ b/tests/unit/secrets/user-session-hook.test.ts
@@ -1,0 +1,168 @@
+/**
+ * The session-start hook must register at USER scope on a remote surface.
+ *
+ * The committed `.claude/settings.json` hook is project-scoped, so it loads only
+ * when Claude Code's project directory is that repository — which a cloud
+ * session does not reliably make true. With several repositories the session
+ * opens in the shared parent (not a git repository at all); with one, the
+ * checkout sits at `$HOME/<repo>` while the session may open at `$HOME`. Either
+ * way no project settings load, the hook never registers, and nothing
+ * materializes.
+ *
+ * `~/.claude/settings.json` is read for every session regardless of project
+ * directory, and runs in-session where the vendor's configured variables are
+ * present — unlike the setup phase, which cannot see them.
+ * @module tests/unit/secrets/user-session-hook
+ */
+
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { installUserSessionHook } from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs";
+
+/** Scratch roots to remove after each test. */
+const roots: string[] = [];
+
+/** The hook command's stable prefix. */
+const RUNNER = "scripts/lisa-remote-env/session-start.sh";
+
+/** Where user-scoped settings live, relative to home. */
+const SETTINGS = ".claude/settings.json";
+
+/**
+ * A checkout containing the session-start script, plus an empty home.
+ * @param withScript Whether the repo actually ships the script.
+ * @returns Repo root and home directory.
+ */
+function scratch(withScript = true): { repo: string; home: string } {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-userhook-"));
+  const repo = path.join(root, "repo");
+  const home = path.join(root, "home");
+
+  roots.push(root);
+  mkdirSync(path.join(repo, "scripts/lisa-remote-env"), { recursive: true });
+  mkdirSync(home, { recursive: true });
+  if (withScript)
+    writeFileSync(path.join(repo, RUNNER), "#!/usr/bin/env bash\n");
+
+  return { repo, home };
+}
+
+/**
+ * Read back the written user settings.
+ * @param home The home directory.
+ * @returns The parsed settings object.
+ */
+function settingsIn(home: string): Record<string, never> {
+  return JSON.parse(readFileSync(path.join(home, SETTINGS), "utf8"));
+}
+
+afterEach(() => {
+  while (roots.length > 0) {
+    rmSync(roots.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe("installUserSessionHook", () => {
+  it("registers a SessionStart hook pointing at the repo's script", () => {
+    const { repo, home } = scratch();
+
+    expect(installUserSessionHook(repo, { home }).action).toBe("registered");
+
+    const written = settingsIn(home) as never as {
+      hooks: {
+        SessionStart: { matcher: string; hooks: { command: string }[] }[];
+      };
+    };
+    const entry = written.hooks.SessionStart[0];
+    expect(entry.matcher).toBe("startup|resume");
+    // An ABSOLUTE path: the hook fires from whatever directory the session
+    // opens in, which is the entire reason this exists.
+    expect(entry.hooks[0].command).toBe(`bash ${path.join(repo, RUNNER)}`);
+  });
+
+  it("is idempotent — a second run does not duplicate the hook", () => {
+    // Setup can run more than once against one container.
+    const { repo, home } = scratch();
+
+    installUserSessionHook(repo, { home });
+    expect(installUserSessionHook(repo, { home }).action).toBe("present");
+
+    const written = settingsIn(home) as never as {
+      hooks: { SessionStart: unknown[] };
+    };
+    expect(written.hooks.SessionStart).toHaveLength(1);
+  });
+
+  it("preserves hooks and settings it did not write", () => {
+    // The container's settings may already carry configuration this knows
+    // nothing about. Clobbering it would be the careless destruction the
+    // project-scoped path deliberately avoids.
+    const { repo, home } = scratch();
+    mkdirSync(path.join(home, ".claude"), { recursive: true });
+    writeFileSync(
+      path.join(home, SETTINGS),
+      JSON.stringify({
+        model: "opus",
+        hooks: {
+          PreToolUse: [{ matcher: "Bash", hooks: [{ command: "guard.sh" }] }],
+          SessionStart: [
+            {
+              matcher: "startup",
+              hooks: [{ type: "command", command: "other.sh" }],
+            },
+          ],
+        },
+      })
+    );
+
+    installUserSessionHook(repo, { home });
+
+    const written = settingsIn(home) as never as {
+      model: string;
+      hooks: {
+        PreToolUse: unknown[];
+        SessionStart: { hooks: { command: string }[] }[];
+      };
+    };
+    expect(written.model).toBe("opus");
+    expect(written.hooks.PreToolUse).toHaveLength(1);
+    expect(written.hooks.SessionStart).toHaveLength(2);
+    expect(written.hooks.SessionStart[0].hooks[0].command).toBe("other.sh");
+  });
+
+  it("refuses to overwrite settings that do not parse", () => {
+    // Unparseable is still someone's configuration.
+    const { repo, home } = scratch();
+    mkdirSync(path.join(home, ".claude"), { recursive: true });
+    const file = path.join(home, SETTINGS);
+    writeFileSync(file, "{ not json");
+
+    expect(installUserSessionHook(repo, { home }).action).toBe("failed");
+    expect(readFileSync(file, "utf8")).toBe("{ not json");
+  });
+
+  it("skips a repo that ships no session-start script", () => {
+    const { repo, home } = scratch(false);
+
+    expect(installUserSessionHook(repo, { home }).action).toBe("skipped");
+  });
+
+  it("writes nothing on a dry run", () => {
+    const { repo, home } = scratch();
+
+    expect(installUserSessionHook(repo, { home, dryRun: true }).action).toBe(
+      "would-register"
+    );
+    expect(() => settingsIn(home)).toThrow();
+  });
+});


### PR DESCRIPTION
## The hook that was supposed to retry could not fire

`materializeAt: "both"` assumed the session-start hook would materialize secrets
when setup could not. It could not, and the two halves were failing for opposite
reasons:

- **setup** runs during image construction and cannot see the vendor's
  configured variables, so the bootstrap credential is absent exactly there
- **the hook** is registered in the repository's `.claude/settings.json`, which
  is **project-scoped** — it loads only when Claude Code's project directory is
  that repository

A cloud session does not reliably make that true. With several repositories it
opens in the shared parent, which is not a git repository at all. With one, the
checkout sits at `$HOME/<repo>` while the session may open at `$HOME`. Either
way no project settings load, the hook never registers, and nothing
materializes.

CodySwannGT/lisa#2310 stopped that from killing the container. This makes the
retry actually happen.

## Fix

Register the same hook at **user** scope during setup: `~/.claude/settings.json`
is read for every session regardless of project directory, and runs in-session
where the configured variables ARE present.

It writes machine state a container may share, so it is deliberate about it:

| guard | why |
| --- | --- |
| remote surfaces only | on a laptop the project hook already works and the user owns that file |
| merged, never clobbered | existing settings may carry hooks this knows nothing about |
| idempotent on the exact command | setup can run repeatedly against one container |
| refuses unparseable settings | an unreadable file is still someone's configuration — better to report than replace |
| absolute script path | the hook fires from an unknown cwd |

## Evidence

Real runner, stubbed failing materialize, home pre-seeded with unrelated hooks:

```
Secrets:
  session-start hook: registered (<home>/.claude/settings.json)
BWS_ACCESS_TOKEN_tunnl not found in: env, keychain.
  Secrets were not materialized during setup, and that is not fatal here.
  ... The session-start hook will retry.
Remote environment ready.
EXIT=0

registered command: bash <repo>/scripts/lisa-remote-env/session-start.sh
```

6 unit cases including the refusals (unparseable settings, no script, dry run)
and preservation of an unrelated `PreToolUse` hook and `model` key.

Full suite green: 8824 passed, 528 files.

## Note on provenance

The first commit of this branch merged as #2310 while this one was being pushed,
so the branch was recreated. Same auto-merge timing hazard as #2300; this repo
refuses `--disable-auto`, so it cannot be avoided by disarming.

---

Work-Item: CodySwannGT/lisa#2309
