### PR TITLE
fix(skills): stop drive-pr-to-merge disabling auto-merge before a push

### DIFF
--- a/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,7 +126,10 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-**Leave the latch ARMED. Never disable auto-merge.**
+**With `auto_merge=true`, leave the latch ARMED — never disable auto-merge.**
+(Under `auto_merge=false` the deliberate disarm above still applies: that mode
+must leave the PR open for a human, so a pre-existing latch is removed on
+purpose. Everything below is the `auto_merge=true` path.)
 
 Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
 the PR's current head, so a new commit whose checks have not reported leaves the
@@ -249,10 +252,9 @@ registered you will instead see real conflict markers — run
 ### c. Failing CI / deploy checks (`statusCheckRollup` has FAILURE)
 Inspect the failing check's logs (`gh pr checks <pr>`, `gh run view <run> --log-failed`).
 Fix the underlying code inline — **never lower thresholds, skip tests, or disable
-checks** to force green. Before pushing the fix, disarm auto-merge or classify the
-run as race-prone, then after the push re-read the PR head, update `verify_commit`
-to that exact SHA, wait for checks on that head to start, and only then resume
-auto-merge. When the root cause is an upstream Lisa template/postinstall bug
+checks** to force green. Leave auto-merge armed across the push (section 1);
+after it, re-read the PR head and update `verify_commit` to that exact SHA so the
+shipped-verification checks what you pushed. When the root cause is an upstream Lisa template/postinstall bug
 rather than this project's code, fix it upstream and propagate down rather than
 patching only here.
 
@@ -261,10 +263,9 @@ Delegate to the `pull-request-review` skill with the PR number. It owns the whol
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. If that skill needs to push a commit, auto-merge
-must be disabled first when possible; when it returns, re-read `headRefOid`, reset
-`verify_commit` to the returned/pushed head, wait for that head's checks to start,
-then re-enable auto-merge and continue. Do not re-implement review handling here
+thread-resolution gate clears. If that skill needs to push a commit, leave
+auto-merge armed (section 1); when it returns, re-read `headRefOid` and reset
+`verify_commit` to the returned/pushed head, then continue. Do not re-implement review handling here
 — it is the single source of truth for review-thread handling.
 
 ### e. Review gate stall (`reviewDecision == CHANGES_REQUESTED`)
@@ -286,9 +287,9 @@ branch (the CI auto-fix workflow engaged before this session took the lease),
 adjudicate it: merge it into the head branch if the fix is correct and still
 needed, otherwise close it and delete the side branch. Never leave it dangling
 — it represents a competing writer's pending work. Merging it mutates the
-driven branch, so treat it like any other push: disarm auto-merge first,
-re-read `headRefOid`, reset `verify_commit` to the merged head, wait for that
-head's checks to start, then re-enable auto-merge (section 1). In
+driven branch, so treat it like any other push: leave auto-merge armed
+(section 1), then re-read `headRefOid` and reset `verify_commit` to the merged
+head. In
 `on_blocker=report` mode this whole step is off-limits (diagnose-only): do not
 merge, close, or delete anything — return `blocked:pending-auto-fix`.
 

--- a/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,13 +126,47 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-If any later step will push commits, temporarily remove the auto-merge latch
-before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
-or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
-reset `verify_commit` to the pushed head, wait until that head's checks have
-started, then re-enable auto-merge. Do not leave auto-merge armed while a
-required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
-still in flight.
+**Leave the latch ARMED. Never disable auto-merge.**
+
+Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
+the PR's current head, so a new commit whose checks have not reported leaves the
+PR blocked. Auto-merge cannot ship a commit nothing has verified.
+
+The only window a disarm ever protected is the gap between deciding to fix
+something and that fix landing — during which the PR is genuinely green and
+genuinely mergeable, and auto-merge firing is GitHub behaving correctly. Two
+merges in this repo's history are attributed to that window (#1392, and the
+release that shipped the `./hooks/` Cursor bug). Both were fixed forward within
+minutes; one was a one-line docs inconsistency.
+
+That evidence is also weaker than it looks: **auto-merge attributes the merge to
+whoever enabled it**, so an auto-merge and a human pressing Merge are
+indistinguishable in the timeline. The record cannot tell us those PRs were not
+simply merged by hand while the latch happened to be armed.
+
+Against that, disarming costs something certain. Disabling is a durable state
+change on GitHub; re-enabling is one more step the run has to reach. When a run
+ends in between — turns exhausted, job timeout, or you concluding the work while
+checks are still pending — the latch stays off and nothing restores it. The PR is
+left WORSE OFF THAN IF THIS SKILL HAD NEVER RUN: it has lost the mechanism that
+merges it while no agent is watching, and the run reports success. Measured on
+`gunnertech/frontend#282`, the latch went off 14s before the fix commit and the
+PR sat 26 minutes after going green, against ~3 minutes for PRs this skill never
+touched.
+
+So the trade is a rare, unproven miss that costs a fix-forward PR, against a
+frequent, silent stall on every PR this skill repairs. Take the rare one.
+
+What still applies on a push: immediately re-read `headRefOid` and reset
+`verify_commit` to the pushed head, so the shipped-verification in step 3 checks
+what you actually pushed rather than the commit you replaced. That ancestry check
+is what CATCHES a raced merge — it fails loudly when the fix SHA is not an
+ancestor of the base branch — so the rare miss is detected rather than silent.
+
+**Invariant:** never terminate having left auto-merge OFF on an open PR when
+`auto_merge=true`. If some future path does disable it, restoring it is a
+terminal obligation on EVERY exit — including give-up, budget-exhausted and error
+paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,7 +126,10 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-**Leave the latch ARMED. Never disable auto-merge.**
+**With `auto_merge=true`, leave the latch ARMED — never disable auto-merge.**
+(Under `auto_merge=false` the deliberate disarm above still applies: that mode
+must leave the PR open for a human, so a pre-existing latch is removed on
+purpose. Everything below is the `auto_merge=true` path.)
 
 Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
 the PR's current head, so a new commit whose checks have not reported leaves the
@@ -249,10 +252,9 @@ registered you will instead see real conflict markers — run
 ### c. Failing CI / deploy checks (`statusCheckRollup` has FAILURE)
 Inspect the failing check's logs (`gh pr checks <pr>`, `gh run view <run> --log-failed`).
 Fix the underlying code inline — **never lower thresholds, skip tests, or disable
-checks** to force green. Before pushing the fix, disarm auto-merge or classify the
-run as race-prone, then after the push re-read the PR head, update `verify_commit`
-to that exact SHA, wait for checks on that head to start, and only then resume
-auto-merge. When the root cause is an upstream Lisa template/postinstall bug
+checks** to force green. Leave auto-merge armed across the push (section 1);
+after it, re-read the PR head and update `verify_commit` to that exact SHA so the
+shipped-verification checks what you pushed. When the root cause is an upstream Lisa template/postinstall bug
 rather than this project's code, fix it upstream and propagate down rather than
 patching only here.
 
@@ -261,10 +263,9 @@ Delegate to the `pull-request-review` skill with the PR number. It owns the whol
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. If that skill needs to push a commit, auto-merge
-must be disabled first when possible; when it returns, re-read `headRefOid`, reset
-`verify_commit` to the returned/pushed head, wait for that head's checks to start,
-then re-enable auto-merge and continue. Do not re-implement review handling here
+thread-resolution gate clears. If that skill needs to push a commit, leave
+auto-merge armed (section 1); when it returns, re-read `headRefOid` and reset
+`verify_commit` to the returned/pushed head, then continue. Do not re-implement review handling here
 — it is the single source of truth for review-thread handling.
 
 ### e. Review gate stall (`reviewDecision == CHANGES_REQUESTED`)
@@ -286,9 +287,9 @@ branch (the CI auto-fix workflow engaged before this session took the lease),
 adjudicate it: merge it into the head branch if the fix is correct and still
 needed, otherwise close it and delete the side branch. Never leave it dangling
 — it represents a competing writer's pending work. Merging it mutates the
-driven branch, so treat it like any other push: disarm auto-merge first,
-re-read `headRefOid`, reset `verify_commit` to the merged head, wait for that
-head's checks to start, then re-enable auto-merge (section 1). In
+driven branch, so treat it like any other push: leave auto-merge armed
+(section 1), then re-read `headRefOid` and reset `verify_commit` to the merged
+head. In
 `on_blocker=report` mode this whole step is off-limits (diagnose-only): do not
 merge, close, or delete anything — return `blocked:pending-auto-fix`.
 

--- a/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,13 +126,47 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-If any later step will push commits, temporarily remove the auto-merge latch
-before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
-or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
-reset `verify_commit` to the pushed head, wait until that head's checks have
-started, then re-enable auto-merge. Do not leave auto-merge armed while a
-required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
-still in flight.
+**Leave the latch ARMED. Never disable auto-merge.**
+
+Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
+the PR's current head, so a new commit whose checks have not reported leaves the
+PR blocked. Auto-merge cannot ship a commit nothing has verified.
+
+The only window a disarm ever protected is the gap between deciding to fix
+something and that fix landing — during which the PR is genuinely green and
+genuinely mergeable, and auto-merge firing is GitHub behaving correctly. Two
+merges in this repo's history are attributed to that window (#1392, and the
+release that shipped the `./hooks/` Cursor bug). Both were fixed forward within
+minutes; one was a one-line docs inconsistency.
+
+That evidence is also weaker than it looks: **auto-merge attributes the merge to
+whoever enabled it**, so an auto-merge and a human pressing Merge are
+indistinguishable in the timeline. The record cannot tell us those PRs were not
+simply merged by hand while the latch happened to be armed.
+
+Against that, disarming costs something certain. Disabling is a durable state
+change on GitHub; re-enabling is one more step the run has to reach. When a run
+ends in between — turns exhausted, job timeout, or you concluding the work while
+checks are still pending — the latch stays off and nothing restores it. The PR is
+left WORSE OFF THAN IF THIS SKILL HAD NEVER RUN: it has lost the mechanism that
+merges it while no agent is watching, and the run reports success. Measured on
+`gunnertech/frontend#282`, the latch went off 14s before the fix commit and the
+PR sat 26 minutes after going green, against ~3 minutes for PRs this skill never
+touched.
+
+So the trade is a rare, unproven miss that costs a fix-forward PR, against a
+frequent, silent stall on every PR this skill repairs. Take the rare one.
+
+What still applies on a push: immediately re-read `headRefOid` and reset
+`verify_commit` to the pushed head, so the shipped-verification in step 3 checks
+what you actually pushed rather than the commit you replaced. That ancestry check
+is what CATCHES a raced merge — it fails loudly when the fix SHA is not an
+ancestor of the base branch — so the rare miss is detected rather than silent.
+
+**Invariant:** never terminate having left auto-merge OFF on an open PR when
+`auto_merge=true`. If some future path does disable it, restoring it is a
+terminal obligation on EVERY exit — including give-up, budget-exhausted and error
+paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,7 +126,10 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-**Leave the latch ARMED. Never disable auto-merge.**
+**With `auto_merge=true`, leave the latch ARMED — never disable auto-merge.**
+(Under `auto_merge=false` the deliberate disarm above still applies: that mode
+must leave the PR open for a human, so a pre-existing latch is removed on
+purpose. Everything below is the `auto_merge=true` path.)
 
 Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
 the PR's current head, so a new commit whose checks have not reported leaves the
@@ -249,10 +252,9 @@ registered you will instead see real conflict markers — run
 ### c. Failing CI / deploy checks (`statusCheckRollup` has FAILURE)
 Inspect the failing check's logs (`gh pr checks <pr>`, `gh run view <run> --log-failed`).
 Fix the underlying code inline — **never lower thresholds, skip tests, or disable
-checks** to force green. Before pushing the fix, disarm auto-merge or classify the
-run as race-prone, then after the push re-read the PR head, update `verify_commit`
-to that exact SHA, wait for checks on that head to start, and only then resume
-auto-merge. When the root cause is an upstream Lisa template/postinstall bug
+checks** to force green. Leave auto-merge armed across the push (section 1);
+after it, re-read the PR head and update `verify_commit` to that exact SHA so the
+shipped-verification checks what you pushed. When the root cause is an upstream Lisa template/postinstall bug
 rather than this project's code, fix it upstream and propagate down rather than
 patching only here.
 
@@ -261,10 +263,9 @@ Delegate to the `pull-request-review` skill with the PR number. It owns the whol
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. If that skill needs to push a commit, auto-merge
-must be disabled first when possible; when it returns, re-read `headRefOid`, reset
-`verify_commit` to the returned/pushed head, wait for that head's checks to start,
-then re-enable auto-merge and continue. Do not re-implement review handling here
+thread-resolution gate clears. If that skill needs to push a commit, leave
+auto-merge armed (section 1); when it returns, re-read `headRefOid` and reset
+`verify_commit` to the returned/pushed head, then continue. Do not re-implement review handling here
 — it is the single source of truth for review-thread handling.
 
 ### e. Review gate stall (`reviewDecision == CHANGES_REQUESTED`)
@@ -286,9 +287,9 @@ branch (the CI auto-fix workflow engaged before this session took the lease),
 adjudicate it: merge it into the head branch if the fix is correct and still
 needed, otherwise close it and delete the side branch. Never leave it dangling
 — it represents a competing writer's pending work. Merging it mutates the
-driven branch, so treat it like any other push: disarm auto-merge first,
-re-read `headRefOid`, reset `verify_commit` to the merged head, wait for that
-head's checks to start, then re-enable auto-merge (section 1). In
+driven branch, so treat it like any other push: leave auto-merge armed
+(section 1), then re-read `headRefOid` and reset `verify_commit` to the merged
+head. In
 `on_blocker=report` mode this whole step is off-limits (diagnose-only): do not
 merge, close, or delete anything — return `blocked:pending-auto-fix`.
 

--- a/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,13 +126,47 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-If any later step will push commits, temporarily remove the auto-merge latch
-before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
-or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
-reset `verify_commit` to the pushed head, wait until that head's checks have
-started, then re-enable auto-merge. Do not leave auto-merge armed while a
-required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
-still in flight.
+**Leave the latch ARMED. Never disable auto-merge.**
+
+Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
+the PR's current head, so a new commit whose checks have not reported leaves the
+PR blocked. Auto-merge cannot ship a commit nothing has verified.
+
+The only window a disarm ever protected is the gap between deciding to fix
+something and that fix landing — during which the PR is genuinely green and
+genuinely mergeable, and auto-merge firing is GitHub behaving correctly. Two
+merges in this repo's history are attributed to that window (#1392, and the
+release that shipped the `./hooks/` Cursor bug). Both were fixed forward within
+minutes; one was a one-line docs inconsistency.
+
+That evidence is also weaker than it looks: **auto-merge attributes the merge to
+whoever enabled it**, so an auto-merge and a human pressing Merge are
+indistinguishable in the timeline. The record cannot tell us those PRs were not
+simply merged by hand while the latch happened to be armed.
+
+Against that, disarming costs something certain. Disabling is a durable state
+change on GitHub; re-enabling is one more step the run has to reach. When a run
+ends in between — turns exhausted, job timeout, or you concluding the work while
+checks are still pending — the latch stays off and nothing restores it. The PR is
+left WORSE OFF THAN IF THIS SKILL HAD NEVER RUN: it has lost the mechanism that
+merges it while no agent is watching, and the run reports success. Measured on
+`gunnertech/frontend#282`, the latch went off 14s before the fix commit and the
+PR sat 26 minutes after going green, against ~3 minutes for PRs this skill never
+touched.
+
+So the trade is a rare, unproven miss that costs a fix-forward PR, against a
+frequent, silent stall on every PR this skill repairs. Take the rare one.
+
+What still applies on a push: immediately re-read `headRefOid` and reset
+`verify_commit` to the pushed head, so the shipped-verification in step 3 checks
+what you actually pushed rather than the commit you replaced. That ancestry check
+is what CATCHES a raced merge — it fails loudly when the fix SHA is not an
+ancestor of the base branch — so the rare miss is detected rather than silent.
+
+**Invariant:** never terminate having left auto-merge OFF on an open PR when
+`auto_merge=true`. If some future path does disable it, restoring it is a
+terminal obligation on EVERY exit — including give-up, budget-exhausted and error
+paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,7 +126,10 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-**Leave the latch ARMED. Never disable auto-merge.**
+**With `auto_merge=true`, leave the latch ARMED — never disable auto-merge.**
+(Under `auto_merge=false` the deliberate disarm above still applies: that mode
+must leave the PR open for a human, so a pre-existing latch is removed on
+purpose. Everything below is the `auto_merge=true` path.)
 
 Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
 the PR's current head, so a new commit whose checks have not reported leaves the
@@ -249,10 +252,9 @@ registered you will instead see real conflict markers — run
 ### c. Failing CI / deploy checks (`statusCheckRollup` has FAILURE)
 Inspect the failing check's logs (`gh pr checks <pr>`, `gh run view <run> --log-failed`).
 Fix the underlying code inline — **never lower thresholds, skip tests, or disable
-checks** to force green. Before pushing the fix, disarm auto-merge or classify the
-run as race-prone, then after the push re-read the PR head, update `verify_commit`
-to that exact SHA, wait for checks on that head to start, and only then resume
-auto-merge. When the root cause is an upstream Lisa template/postinstall bug
+checks** to force green. Leave auto-merge armed across the push (section 1);
+after it, re-read the PR head and update `verify_commit` to that exact SHA so the
+shipped-verification checks what you pushed. When the root cause is an upstream Lisa template/postinstall bug
 rather than this project's code, fix it upstream and propagate down rather than
 patching only here.
 
@@ -261,10 +263,9 @@ Delegate to the `pull-request-review` skill with the PR number. It owns the whol
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. If that skill needs to push a commit, auto-merge
-must be disabled first when possible; when it returns, re-read `headRefOid`, reset
-`verify_commit` to the returned/pushed head, wait for that head's checks to start,
-then re-enable auto-merge and continue. Do not re-implement review handling here
+thread-resolution gate clears. If that skill needs to push a commit, leave
+auto-merge armed (section 1); when it returns, re-read `headRefOid` and reset
+`verify_commit` to the returned/pushed head, then continue. Do not re-implement review handling here
 — it is the single source of truth for review-thread handling.
 
 ### e. Review gate stall (`reviewDecision == CHANGES_REQUESTED`)
@@ -286,9 +287,9 @@ branch (the CI auto-fix workflow engaged before this session took the lease),
 adjudicate it: merge it into the head branch if the fix is correct and still
 needed, otherwise close it and delete the side branch. Never leave it dangling
 — it represents a competing writer's pending work. Merging it mutates the
-driven branch, so treat it like any other push: disarm auto-merge first,
-re-read `headRefOid`, reset `verify_commit` to the merged head, wait for that
-head's checks to start, then re-enable auto-merge (section 1). In
+driven branch, so treat it like any other push: leave auto-merge armed
+(section 1), then re-read `headRefOid` and reset `verify_commit` to the merged
+head. In
 `on_blocker=report` mode this whole step is off-limits (diagnose-only): do not
 merge, close, or delete anything — return `blocked:pending-auto-fix`.
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,13 +126,47 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-If any later step will push commits, temporarily remove the auto-merge latch
-before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
-or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
-reset `verify_commit` to the pushed head, wait until that head's checks have
-started, then re-enable auto-merge. Do not leave auto-merge armed while a
-required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
-still in flight.
+**Leave the latch ARMED. Never disable auto-merge.**
+
+Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
+the PR's current head, so a new commit whose checks have not reported leaves the
+PR blocked. Auto-merge cannot ship a commit nothing has verified.
+
+The only window a disarm ever protected is the gap between deciding to fix
+something and that fix landing — during which the PR is genuinely green and
+genuinely mergeable, and auto-merge firing is GitHub behaving correctly. Two
+merges in this repo's history are attributed to that window (#1392, and the
+release that shipped the `./hooks/` Cursor bug). Both were fixed forward within
+minutes; one was a one-line docs inconsistency.
+
+That evidence is also weaker than it looks: **auto-merge attributes the merge to
+whoever enabled it**, so an auto-merge and a human pressing Merge are
+indistinguishable in the timeline. The record cannot tell us those PRs were not
+simply merged by hand while the latch happened to be armed.
+
+Against that, disarming costs something certain. Disabling is a durable state
+change on GitHub; re-enabling is one more step the run has to reach. When a run
+ends in between — turns exhausted, job timeout, or you concluding the work while
+checks are still pending — the latch stays off and nothing restores it. The PR is
+left WORSE OFF THAN IF THIS SKILL HAD NEVER RUN: it has lost the mechanism that
+merges it while no agent is watching, and the run reports success. Measured on
+`gunnertech/frontend#282`, the latch went off 14s before the fix commit and the
+PR sat 26 minutes after going green, against ~3 minutes for PRs this skill never
+touched.
+
+So the trade is a rare, unproven miss that costs a fix-forward PR, against a
+frequent, silent stall on every PR this skill repairs. Take the rare one.
+
+What still applies on a push: immediately re-read `headRefOid` and reset
+`verify_commit` to the pushed head, so the shipped-verification in step 3 checks
+what you actually pushed rather than the commit you replaced. That ancestry check
+is what CATCHES a raced merge — it fails loudly when the fix SHA is not an
+ancestor of the base branch — so the rare miss is detected rather than silent.
+
+**Invariant:** never terminate having left auto-merge OFF on an open PR when
+`auto_merge=true`. If some future path does disable it, restoring it is a
+terminal obligation on EVERY exit — including give-up, budget-exhausted and error
+paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,7 +126,10 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-**Leave the latch ARMED. Never disable auto-merge.**
+**With `auto_merge=true`, leave the latch ARMED — never disable auto-merge.**
+(Under `auto_merge=false` the deliberate disarm above still applies: that mode
+must leave the PR open for a human, so a pre-existing latch is removed on
+purpose. Everything below is the `auto_merge=true` path.)
 
 Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
 the PR's current head, so a new commit whose checks have not reported leaves the
@@ -249,10 +252,9 @@ registered you will instead see real conflict markers — run
 ### c. Failing CI / deploy checks (`statusCheckRollup` has FAILURE)
 Inspect the failing check's logs (`gh pr checks <pr>`, `gh run view <run> --log-failed`).
 Fix the underlying code inline — **never lower thresholds, skip tests, or disable
-checks** to force green. Before pushing the fix, disarm auto-merge or classify the
-run as race-prone, then after the push re-read the PR head, update `verify_commit`
-to that exact SHA, wait for checks on that head to start, and only then resume
-auto-merge. When the root cause is an upstream Lisa template/postinstall bug
+checks** to force green. Leave auto-merge armed across the push (section 1);
+after it, re-read the PR head and update `verify_commit` to that exact SHA so the
+shipped-verification checks what you pushed. When the root cause is an upstream Lisa template/postinstall bug
 rather than this project's code, fix it upstream and propagate down rather than
 patching only here.
 
@@ -261,10 +263,9 @@ Delegate to the `pull-request-review` skill with the PR number. It owns the whol
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. If that skill needs to push a commit, auto-merge
-must be disabled first when possible; when it returns, re-read `headRefOid`, reset
-`verify_commit` to the returned/pushed head, wait for that head's checks to start,
-then re-enable auto-merge and continue. Do not re-implement review handling here
+thread-resolution gate clears. If that skill needs to push a commit, leave
+auto-merge armed (section 1); when it returns, re-read `headRefOid` and reset
+`verify_commit` to the returned/pushed head, then continue. Do not re-implement review handling here
 — it is the single source of truth for review-thread handling.
 
 ### e. Review gate stall (`reviewDecision == CHANGES_REQUESTED`)
@@ -286,9 +287,9 @@ branch (the CI auto-fix workflow engaged before this session took the lease),
 adjudicate it: merge it into the head branch if the fix is correct and still
 needed, otherwise close it and delete the side branch. Never leave it dangling
 — it represents a competing writer's pending work. Merging it mutates the
-driven branch, so treat it like any other push: disarm auto-merge first,
-re-read `headRefOid`, reset `verify_commit` to the merged head, wait for that
-head's checks to start, then re-enable auto-merge (section 1). In
+driven branch, so treat it like any other push: leave auto-merge armed
+(section 1), then re-read `headRefOid` and reset `verify_commit` to the merged
+head. In
 `on_blocker=report` mode this whole step is off-limits (diagnose-only): do not
 merge, close, or delete anything — return `blocked:pending-auto-fix`.
 

--- a/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,13 +126,47 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-If any later step will push commits, temporarily remove the auto-merge latch
-before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
-or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
-reset `verify_commit` to the pushed head, wait until that head's checks have
-started, then re-enable auto-merge. Do not leave auto-merge armed while a
-required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
-still in flight.
+**Leave the latch ARMED. Never disable auto-merge.**
+
+Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
+the PR's current head, so a new commit whose checks have not reported leaves the
+PR blocked. Auto-merge cannot ship a commit nothing has verified.
+
+The only window a disarm ever protected is the gap between deciding to fix
+something and that fix landing — during which the PR is genuinely green and
+genuinely mergeable, and auto-merge firing is GitHub behaving correctly. Two
+merges in this repo's history are attributed to that window (#1392, and the
+release that shipped the `./hooks/` Cursor bug). Both were fixed forward within
+minutes; one was a one-line docs inconsistency.
+
+That evidence is also weaker than it looks: **auto-merge attributes the merge to
+whoever enabled it**, so an auto-merge and a human pressing Merge are
+indistinguishable in the timeline. The record cannot tell us those PRs were not
+simply merged by hand while the latch happened to be armed.
+
+Against that, disarming costs something certain. Disabling is a durable state
+change on GitHub; re-enabling is one more step the run has to reach. When a run
+ends in between — turns exhausted, job timeout, or you concluding the work while
+checks are still pending — the latch stays off and nothing restores it. The PR is
+left WORSE OFF THAN IF THIS SKILL HAD NEVER RUN: it has lost the mechanism that
+merges it while no agent is watching, and the run reports success. Measured on
+`gunnertech/frontend#282`, the latch went off 14s before the fix commit and the
+PR sat 26 minutes after going green, against ~3 minutes for PRs this skill never
+touched.
+
+So the trade is a rare, unproven miss that costs a fix-forward PR, against a
+frequent, silent stall on every PR this skill repairs. Take the rare one.
+
+What still applies on a push: immediately re-read `headRefOid` and reset
+`verify_commit` to the pushed head, so the shipped-verification in step 3 checks
+what you actually pushed rather than the commit you replaced. That ancestry check
+is what CATCHES a raced merge — it fails loudly when the fix SHA is not an
+ancestor of the base branch — so the rare miss is detected rather than silent.
+
+**Invariant:** never terminate having left auto-merge OFF on an open PR when
+`auto_merge=true`. If some future path does disable it, restoring it is a
+terminal obligation on EVERY exit — including give-up, budget-exhausted and error
+paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,7 +126,10 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-**Leave the latch ARMED. Never disable auto-merge.**
+**With `auto_merge=true`, leave the latch ARMED — never disable auto-merge.**
+(Under `auto_merge=false` the deliberate disarm above still applies: that mode
+must leave the PR open for a human, so a pre-existing latch is removed on
+purpose. Everything below is the `auto_merge=true` path.)
 
 Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
 the PR's current head, so a new commit whose checks have not reported leaves the
@@ -249,10 +252,9 @@ registered you will instead see real conflict markers — run
 ### c. Failing CI / deploy checks (`statusCheckRollup` has FAILURE)
 Inspect the failing check's logs (`gh pr checks <pr>`, `gh run view <run> --log-failed`).
 Fix the underlying code inline — **never lower thresholds, skip tests, or disable
-checks** to force green. Before pushing the fix, disarm auto-merge or classify the
-run as race-prone, then after the push re-read the PR head, update `verify_commit`
-to that exact SHA, wait for checks on that head to start, and only then resume
-auto-merge. When the root cause is an upstream Lisa template/postinstall bug
+checks** to force green. Leave auto-merge armed across the push (section 1);
+after it, re-read the PR head and update `verify_commit` to that exact SHA so the
+shipped-verification checks what you pushed. When the root cause is an upstream Lisa template/postinstall bug
 rather than this project's code, fix it upstream and propagate down rather than
 patching only here.
 
@@ -261,10 +263,9 @@ Delegate to the `pull-request-review` skill with the PR number. It owns the whol
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. If that skill needs to push a commit, auto-merge
-must be disabled first when possible; when it returns, re-read `headRefOid`, reset
-`verify_commit` to the returned/pushed head, wait for that head's checks to start,
-then re-enable auto-merge and continue. Do not re-implement review handling here
+thread-resolution gate clears. If that skill needs to push a commit, leave
+auto-merge armed (section 1); when it returns, re-read `headRefOid` and reset
+`verify_commit` to the returned/pushed head, then continue. Do not re-implement review handling here
 — it is the single source of truth for review-thread handling.
 
 ### e. Review gate stall (`reviewDecision == CHANGES_REQUESTED`)
@@ -286,9 +287,9 @@ branch (the CI auto-fix workflow engaged before this session took the lease),
 adjudicate it: merge it into the head branch if the fix is correct and still
 needed, otherwise close it and delete the side branch. Never leave it dangling
 — it represents a competing writer's pending work. Merging it mutates the
-driven branch, so treat it like any other push: disarm auto-merge first,
-re-read `headRefOid`, reset `verify_commit` to the merged head, wait for that
-head's checks to start, then re-enable auto-merge (section 1). In
+driven branch, so treat it like any other push: leave auto-merge armed
+(section 1), then re-read `headRefOid` and reset `verify_commit` to the merged
+head. In
 `on_blocker=report` mode this whole step is off-limits (diagnose-only): do not
 merge, close, or delete anything — return `blocked:pending-auto-fix`.
 

--- a/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -126,13 +126,47 @@ auto-merge against a stale head you have not verified.
 `gh pr merge <pr> --auto --<merge_method>`. Enabling auto-merge is **not terminal**
 — continue the loop below until the PR is actually `MERGED` or `CLOSED`.
 
-If any later step will push commits, temporarily remove the auto-merge latch
-before the push when GitHub exposes that mutation (`disablePullRequestAutoMerge`),
-or otherwise treat the push as a merge race: immediately re-read `headRefOid`,
-reset `verify_commit` to the pushed head, wait until that head's checks have
-started, then re-enable auto-merge. Do not leave auto-merge armed while a
-required fix, CodeRabbit follow-up, generated artifact update, or CI auto-fix is
-still in flight.
+**Leave the latch ARMED. Never disable auto-merge.**
+
+Once a fix is PUSHED the latch is safe: GitHub evaluates required checks against
+the PR's current head, so a new commit whose checks have not reported leaves the
+PR blocked. Auto-merge cannot ship a commit nothing has verified.
+
+The only window a disarm ever protected is the gap between deciding to fix
+something and that fix landing — during which the PR is genuinely green and
+genuinely mergeable, and auto-merge firing is GitHub behaving correctly. Two
+merges in this repo's history are attributed to that window (#1392, and the
+release that shipped the `./hooks/` Cursor bug). Both were fixed forward within
+minutes; one was a one-line docs inconsistency.
+
+That evidence is also weaker than it looks: **auto-merge attributes the merge to
+whoever enabled it**, so an auto-merge and a human pressing Merge are
+indistinguishable in the timeline. The record cannot tell us those PRs were not
+simply merged by hand while the latch happened to be armed.
+
+Against that, disarming costs something certain. Disabling is a durable state
+change on GitHub; re-enabling is one more step the run has to reach. When a run
+ends in between — turns exhausted, job timeout, or you concluding the work while
+checks are still pending — the latch stays off and nothing restores it. The PR is
+left WORSE OFF THAN IF THIS SKILL HAD NEVER RUN: it has lost the mechanism that
+merges it while no agent is watching, and the run reports success. Measured on
+`gunnertech/frontend#282`, the latch went off 14s before the fix commit and the
+PR sat 26 minutes after going green, against ~3 minutes for PRs this skill never
+touched.
+
+So the trade is a rare, unproven miss that costs a fix-forward PR, against a
+frequent, silent stall on every PR this skill repairs. Take the rare one.
+
+What still applies on a push: immediately re-read `headRefOid` and reset
+`verify_commit` to the pushed head, so the shipped-verification in step 3 checks
+what you actually pushed rather than the commit you replaced. That ancestry check
+is what CATCHES a raced merge — it fails loudly when the fix SHA is not an
+ancestor of the base branch — so the rare miss is detected rather than silent.
+
+**Invariant:** never terminate having left auto-merge OFF on an open PR when
+`auto_merge=true`. If some future path does disable it, restoring it is a
+terminal obligation on EVERY exit — including give-up, budget-exhausted and error
+paths — not a later step in a sequence.
 
 - **Capability fallback** (`auto_merge=true` only): if the repo disallows
   auto-merge, do not fail. Keep watching; once checks are green, the review gate

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -869,7 +869,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
       "fb41a1e63c5332d47a46e715aff52551f3df867033b5e4f37dfaeee30019b891",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
-      "c78ae2ba32c830d0b2cd7d24de91adf99e2b3cef4c7cab1c417580d86f41351f",
+      "84e42a50d46cc33b6218484da7510dda8888930b799b84a056ce080316722e13",
     "plugins/src/base/skills/lisa-epic-triage/SKILL.md":
       "d02760411249bddbd396f283191fe3e82bb7b95bf9393a19a7025dc5a57c3ab7",
     "plugins/src/base/skills/lisa-evaluation-suite/SKILL.md":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -869,7 +869,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
       "fb41a1e63c5332d47a46e715aff52551f3df867033b5e4f37dfaeee30019b891",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
-      "84e42a50d46cc33b6218484da7510dda8888930b799b84a056ce080316722e13",
+      "0317e029316be19682bbc689c397275e7bcab5a6215f644755d4aebbe956bacf",
     "plugins/src/base/skills/lisa-epic-triage/SKILL.md":
       "d02760411249bddbd396f283191fe3e82bb7b95bf9393a19a7025dc5a57c3ab7",
     "plugins/src/base/skills/lisa-evaluation-suite/SKILL.md":

--- a/tests/unit/strategies/drive-pr-auto-merge-race.test.ts
+++ b/tests/unit/strategies/drive-pr-auto-merge-race.test.ts
@@ -49,12 +49,37 @@ describe.each(ROOTS)("drive-pr-to-merge auto-merge race guard (%s)", root => {
     // window were fixed forward within minutes, one a docs typo — and are not
     // even distinguishable from a human pressing Merge, since auto-merge is
     // attributed to whoever enabled it.
-    expect(content).toMatch(/Leave the latch ARMED/i);
+    expect(content).toMatch(/leave the latch ARMED/i);
     expect(content).toMatch(/Never disable auto-merge/i);
     // The reasoning has to travel with the rule: an agent that finds only the
     // instruction and not the trade-off will re-add the disarm the first time a
     // race is suspected.
     expect(content).toMatch(/required checks against\s+the PR's current head/i);
+  });
+
+  it("leaves no disarm instruction in ANY auto_merge=true fix path", () => {
+    // The first version of this change only rewrote section 1 and left three
+    // later passages (failing checks, review threads, pending auto-fix) still
+    // telling the agent to disarm — a policy that contradicted itself, and a
+    // disarm that would still have happened. Scoping the check to section 1
+    // is what missed it, so this walks everything AFTER the auto_merge=false
+    // block instead.
+    const afterFalseMode = content.slice(content.indexOf("## 1. Enable auto-merge"));
+    expect(afterFalseMode.length).toBeGreaterThan(1000);
+
+    const offenders = afterFalseMode
+      .split("\n")
+      .filter(line => /disarm auto-merge|auto-merge\s+must be disabled|re-enable auto-merge/i.test(line));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("scopes the armed-latch rule to auto_merge=true", () => {
+    // An unqualified "never disable auto-merge" contradicts the auto_merge=false
+    // contract, which disarms a pre-existing latch on purpose so the PR stays
+    // open for a human.
+    expect(content).toMatch(/With `auto_merge=true`, leave the latch ARMED/);
+    expect(content).toMatch(/auto_merge=false` the deliberate disarm above still applies/);
   });
 
   it("never instructs disabling the latch on the happy path", () => {
@@ -71,11 +96,15 @@ describe.each(ROOTS)("drive-pr-to-merge auto-merge race guard (%s)", root => {
     expect(armSection).not.toMatch(/Do not leave auto-merge armed/i);
   });
 
-  it("resets verify_commit to the pushed head before re-enabling auto-merge", () => {
+  it("resets verify_commit to the pushed head after every push", () => {
+    // Retained from the original #1395 guard, minus the "before re-enabling"
+    // half — nothing is disabled now, so there is nothing to re-enable. What
+    // still matters, and matters MORE without a disarm, is that the
+    // shipped-verification in step 3 targets the commit actually pushed: that
+    // ancestry check is what catches a raced merge after the fact.
     expect(content).toMatch(
       /reset\s+`verify_commit` to the returned\/pushed head/i
     );
-    expect(content).toMatch(/wait for that head's checks to start/i);
     expect(content).toMatch(/failed drive-to-merge outcome/i);
   });
 

--- a/tests/unit/strategies/drive-pr-auto-merge-race.test.ts
+++ b/tests/unit/strategies/drive-pr-auto-merge-race.test.ts
@@ -57,19 +57,62 @@ describe.each(ROOTS)("drive-pr-to-merge auto-merge race guard (%s)", root => {
     expect(content).toMatch(/required checks against\s+the PR's current head/i);
   });
 
-  it("leaves no disarm instruction in ANY auto_merge=true fix path", () => {
-    // The first version of this change only rewrote section 1 and left three
-    // later passages (failing checks, review threads, pending auto-fix) still
-    // telling the agent to disarm — a policy that contradicted itself, and a
-    // disarm that would still have happened. Scoping the check to section 1
-    // is what missed it, so this walks everything AFTER the auto_merge=false
-    // block instead.
-    const afterFalseMode = content.slice(content.indexOf("## 1. Enable auto-merge"));
-    expect(afterFalseMode.length).toBeGreaterThan(1000);
+  // Where the auto_merge=false contract ends and the auto_merge=true path
+  // begins. Split on this rather than on the section header: the false-mode
+  // block lives INSIDE section 1 and legitimately contains a disarm, so a
+  // slice that starts at the header covers both modes and can only pass by
+  // having a regex too weak to notice — which is exactly how the first version
+  // of this test passed while three stale disarms sat further down the file.
+  const TRUE_MODE_ANCHOR =
+    "Before enabling auto-merge, capture the live PR head";
 
-    const offenders = afterFalseMode
+  /** Every spelling of "turn the latch off" that appears in this document. */
+  const DISARM_FORMS =
+    /--disable-auto|disarm|auto-merge\s+must be disabled|re-enable auto-merge/i;
+
+  it("keeps the auto_merge=false disarm, with its fail-closed re-read", () => {
+    const falseModeEnd = content.indexOf(TRUE_MODE_ANCHOR);
+    const sectionStart = content.indexOf("## 1. Enable auto-merge");
+    expect(sectionStart).toBeGreaterThanOrEqual(0);
+    expect(falseModeEnd).toBeGreaterThan(sectionStart);
+
+    const falseMode = content.slice(sectionStart, falseModeEnd);
+
+    // This mode must still disarm a pre-existing latch: skipping the enable
+    // step is not enough when a prior session already armed the PR, and an
+    // auto_merge=false PR must stay open for a human.
+    expect(falseMode).toMatch(/disarm any pre-existing auto-merge latch/i);
+    expect(falseMode).toMatch(/gh pr merge <pr> --disable-auto/);
+    // ...and the fail-closed re-read that proves the disarm actually took.
+    expect(falseMode).toMatch(/must print null/);
+    expect(falseMode).toMatch(/fail closed/i);
+  });
+
+  it("leaves no disarm instruction anywhere on the auto_merge=true path", () => {
+    const trueModeStart = content.indexOf(TRUE_MODE_ANCHOR);
+    expect(trueModeStart).toBeGreaterThanOrEqual(0);
+
+    // The rationale block necessarily says "disarm" — it exists to explain why
+    // the policy changed. Cut it by its own boundaries rather than pattern-
+    // matching the prose, so what remains is only INSTRUCTION text. (Filtering
+    // the explanation line-by-line is how this test first went red against the
+    // very paragraph documenting its own rule.)
+    const rationaleStart = content.indexOf(
+      "**With `auto_merge=true`, leave the latch ARMED"
+    );
+    const rationaleEnd = content.indexOf("What still applies on a push");
+    expect(rationaleStart).toBeGreaterThan(trueModeStart);
+    expect(rationaleEnd).toBeGreaterThan(rationaleStart);
+
+    const instructions =
+      content.slice(trueModeStart, rationaleStart) +
+      content.slice(rationaleEnd);
+    // Guard the guard: bad anchors would slice to nothing and pass vacuously.
+    expect(instructions.length).toBeGreaterThan(2000);
+
+    const offenders = instructions
       .split("\n")
-      .filter(line => /disarm auto-merge|auto-merge\s+must be disabled|re-enable auto-merge/i.test(line));
+      .filter(line => DISARM_FORMS.test(line));
 
     expect(offenders).toEqual([]);
   });
@@ -79,7 +122,9 @@ describe.each(ROOTS)("drive-pr-to-merge auto-merge race guard (%s)", root => {
     // contract, which disarms a pre-existing latch on purpose so the PR stays
     // open for a human.
     expect(content).toMatch(/With `auto_merge=true`, leave the latch ARMED/);
-    expect(content).toMatch(/auto_merge=false` the deliberate disarm above still applies/);
+    expect(content).toMatch(
+      /auto_merge=false` the deliberate disarm above still applies/
+    );
   });
 
   it("never instructs disabling the latch on the happy path", () => {

--- a/tests/unit/strategies/drive-pr-auto-merge-race.test.ts
+++ b/tests/unit/strategies/drive-pr-auto-merge-race.test.ts
@@ -36,10 +36,39 @@ describe.each(ROOTS)("drive-pr-to-merge auto-merge race guard (%s)", root => {
     expect(content).toMatch(/Never enable\s+auto-merge against a stale head/i);
   });
 
-  it("requires auto-merge to be disarmed or treated as race-prone before fix pushes", () => {
-    expect(content).toMatch(/disablePullRequestAutoMerge/);
-    expect(content).toMatch(/Do not leave auto-merge armed/i);
-    expect(content).toMatch(/required fix, CodeRabbit follow-up/i);
+  it("keeps auto-merge ARMED across fix pushes, and says why that is safe", () => {
+    // Reversed from the original #1395 guard, deliberately. That guard required
+    // the latch to be DISARMED before a fix push. Disarming is a durable change
+    // on GitHub while re-arming is one more step the run has to reach, so a run
+    // that ended in between left the PR unable to merge unattended — worse off
+    // than if the skill had never touched it, and reported as success.
+    //
+    // The window a disarm protected is only the gap between deciding to fix and
+    // the fix landing; once a commit is pushed, GitHub blocks on required checks
+    // that have not reported for the new head. The two merges attributed to that
+    // window were fixed forward within minutes, one a docs typo — and are not
+    // even distinguishable from a human pressing Merge, since auto-merge is
+    // attributed to whoever enabled it.
+    expect(content).toMatch(/Leave the latch ARMED/i);
+    expect(content).toMatch(/Never disable auto-merge/i);
+    // The reasoning has to travel with the rule: an agent that finds only the
+    // instruction and not the trade-off will re-add the disarm the first time a
+    // race is suspected.
+    expect(content).toMatch(/required checks against\s+the PR's current head/i);
+  });
+
+  it("never instructs disabling the latch on the happy path", () => {
+    // The mutation this file exists to catch, now pointing the other way: a
+    // reinstated disarm. `auto_merge=false` is a different thing — that mode
+    // deliberately disarms a pre-existing latch and must stay untouched — so
+    // this asserts on the section that runs when auto_merge=true.
+    const armSection = content.slice(
+      content.indexOf("## 1. Enable auto-merge"),
+      content.indexOf("## 2.")
+    );
+    expect(armSection.length).toBeGreaterThan(500);
+    expect(armSection).not.toMatch(/disablePullRequestAutoMerge/);
+    expect(armSection).not.toMatch(/Do not leave auto-merge armed/i);
   });
 
   it("resets verify_commit to the pushed head before re-enabling auto-merge", () => {


### PR DESCRIPTION
Closes #2299.

## The change

`drive-pr-to-merge` no longer disables auto-merge before pushing a fix. It keeps the latch armed and relies on required checks to hold the gate.

## Correcting my own first version of this

The initial commit argued that the race the disarm guarded was the seconds *after* a push, before GitHub registers checks for the new head. **That was wrong**, and the review — plus lisa's own #1395 regression test — caught it. GitHub evaluates required checks against the PR's current head, so a pushed commit whose checks have not reported leaves the PR blocked. The latch is already safe once a fix lands.

The window a disarm actually protects is narrower: the gap between **deciding** to fix something and the fix **landing**, during which the PR is genuinely green and auto-merge firing is GitHub behaving correctly. #1393 says exactly this:

> #1392 auto-merged on its prior head the instant the CodeRabbit status check went green, **before this fix commit could push**

## Why that window is not worth the guard

- **Two merges** in this repo are attributed to it. Both were fixed forward within minutes; one (#1392) was a one-line docs inconsistency between the lifecycle prompt and the stage list.
- **The attribution is not verifiable.** Auto-merge is recorded as a merge by whoever *enabled* it, so it is indistinguishable in the timeline from a human pressing Merge while the latch happened to be armed. Neither PR has an `auto_merge_disabled` event; that is all the record can tell us.
- **A raced merge is already caught.** The ancestry check from #1071 fails loudly when the fix SHA is not an ancestor of the base branch, so the rare miss is detected rather than silent.
- **Disarming costs something certain.** Disabling is durable on GitHub; re-enabling is one more step the run has to reach. A run that ends in between leaves the PR unable to merge unattended — worse off than if the skill had never run, and reported as success. On `gunnertech/frontend#282` the latch went off 14s before the fix commit and the PR sat 26 minutes after going green, against ~3 minutes for PRs the skill never touched.

So: a rare, unproven miss costing a fix-forward PR, against a frequent silent stall on every PR this skill repairs. This takes the rare one.

## The #1395 guard is flipped, not deleted

`drive-pr-auto-merge-race.test.ts` now asserts the opposite invariant across all six plugin roots:

- the latch stays **armed** (`Leave the latch ARMED`, `Never disable auto-merge`);
- the **reasoning travels with the rule**, so an agent finding only the instruction cannot re-add the disarm the first time a race is suspected;
- **no disarm is reinstated** anywhere in the `auto_merge=true` section.

`auto_merge=false` is untouched — that mode deliberately disarms a pre-existing latch and keeps its own assertions.

## Verification

- `bun run check:plugins` — ✓ artifacts in sync, ✓ marketplace registers every plugin
- `drive-pr-auto-merge-race` + `upstream-evidence-manifest` — 63 passed
- Remaining local failures (`ast-grep-template`, `enforcement-gates-e2e`) reproduce on the unmodified tree — pre-existing environment, not this change. `learnings-writer` passes 3/3 in isolation (parallel-load flake).

## Downstream

gunnertech/frontend#293 adds a re-arm step as a local mitigation; once this lands that step is unnecessary and should be deleted.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2299


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Auto-merge now remains enabled while fixes are pushed, allowing required checks to protect newly pushed commits.
  * Enhanced guidance verifies the latest commit and detects merges that occur during updates.
  * Added safeguards to prevent open pull requests from ending with auto-merge unintentionally disabled.

* **Tests**
  * Updated race-condition coverage to confirm auto-merge stays armed during fix pushes.
  * Added checks ensuring guidance does not instruct disabling auto-merge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

_Superseded by #2312 — same change, rebased onto current main and squashed into one commit carrying the required `Work-Item:` trailer (the traceability gate reads commit trailers, not the PR body)._
