### PR TITLE
fix(secrets): source the materialized env from the shell profile; fix(hooks): block-no-verify fail-open

### DIFF
--- a/all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh
@@ -20,17 +20,40 @@ set -euo pipefail
 
 input="$(cat)"
 
-tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+# Both interpreters must be probed BEFORE they are used, and a missing one must
+# be announced rather than swallowed.
+#
+# `jq` used to be called unguarded here while `python3` two lines below was
+# guarded. Under `set -e` an absent jq aborted the script with 127, and Claude
+# Code treats any non-2 exit as a NON-BLOCKING hook error — so the hook that
+# enforces "never --no-verify" silently permitted the very thing it exists to
+# stop. It was not hypothetical: agent containers routinely ship no jq (that is
+# why jq is now a pinned toolchain entry). The Codex variant of this script has
+# always had the guard, so this was a parity gap rather than a design choice.
+#
+# Degrading to "allow" is still the right behaviour — a hook that cannot parse
+# its input cannot tell a bypass from an ordinary command, and failing closed
+# would block every Bash call on a machine missing an interpreter. What is NOT
+# right is doing it quietly, so the operator gets one line on stderr saying the
+# protection is off. A guard that is silently absent reads exactly like a guard
+# that is passing.
+for required in jq python3; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    printf 'block-no-verify: %s not found; --no-verify protection is NOT active\n' \
+      "$required" >&2
+    exit 0
+  fi
+done
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)"
 if [ "$tool_name" != "Bash" ]; then
   exit 0
 fi
 
-command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
 if [ -z "$command_str" ]; then
   exit 0
 fi
-
-command -v python3 >/dev/null 2>&1 || exit 0
 
 if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
 import os

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -21,11 +21,15 @@
 
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
+  readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
@@ -58,6 +62,70 @@ function writeAtomic(destination, contents) {
  * @param {object} [cfg] Resolved configuration.
  * @returns {{count: number, dir: string}} What was written, and where.
  */
+/** Marks the block this owns, so it is replaced rather than appended twice. */
+const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
+
+/** Closes the managed block. */
+const PROFILE_END = "# <<< lisa secrets (managed) <<<";
+
+/**
+ * Make every shell in this container load the materialized secrets.
+ *
+ * `set -a` so the values are exported rather than merely set as shell
+ * variables, and sourced LAST so they win over anything the host injected —
+ * environment variables outrank profile files in AWS's credential chain, which
+ * is the whole reason a valid credential was being ignored.
+ *
+ * Guarded on the file existing, so a shell still starts cleanly before the
+ * first materialization or if the file is removed. Written to both `.bashrc`
+ * and `.profile` because which one a given shell reads depends on whether it is
+ * interactive or a login shell, and an agent's tool calls are not reliably
+ * either.
+ * @param {string} valuesFile Absolute path to the materialized env file.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile files that now source it.
+ */
+export function installProfileSourcing(valuesFile, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+  } = options;
+
+  const block = [
+    PROFILE_MARKER,
+    `if [ -f "${valuesFile}" ]; then`,
+    `  set -a`,
+    `  . "${valuesFile}"`,
+    `  set +a`,
+    `fi`,
+    PROFILE_END,
+  ].join("\n");
+
+  const updated = [];
+  for (const name of [".bashrc", ".profile"]) {
+    const file = join(home, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+
+    // Replace an existing managed block rather than appending another: this
+    // runs on every session, and an appended-forever profile is its own bug.
+    const start = current.indexOf(PROFILE_MARKER);
+    const next =
+      start === -1
+        ? `${current}${current.endsWith("\n") || !current ? "" : "\n"}\n${block}\n`
+        : `${current.slice(0, start)}${block}${current.slice(
+            current.indexOf(PROFILE_END, start) + PROFILE_END.length
+          )}`;
+
+    if (next !== current) {
+      write(file, next, { mode: 0o600 });
+      updated.push(file);
+    }
+  }
+  return updated;
+}
+
 export function materialize(cfg = readConfig()) {
   if (!cfg.capabilities.mayWriteValues) {
     throw new Error(
@@ -88,7 +156,21 @@ export function materialize(cfg = readConfig()) {
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, derived: derived.size, dir };
+
+  // Writing the file is not the same as the values being in effect.
+  //
+  // A materialized secrets.env that nothing sources changes nothing: the agent's
+  // shell starts from the container's own environment, so a host-injected
+  // AWS_ACCESS_KEY_ID keeps winning and every call fails with
+  // InvalidClientTokenId while the correct credential sits on disk, correct and
+  // unused. Deriving the variables (above) only fixes precedence WITHIN the
+  // file — something still has to load the file.
+  //
+  // So the shell profile sources it. That is what makes "the credential is
+  // materialized" and "the credential is usable" the same statement.
+  const sourced = installProfileSourcing(valuesFile);
+
+  return { count: selected.size, derived: derived.size, dir, sourced };
 }
 
 function main() {

--- a/plugins/lisa-copilot/hooks/block-no-verify.sh
+++ b/plugins/lisa-copilot/hooks/block-no-verify.sh
@@ -20,17 +20,40 @@ set -euo pipefail
 
 input="$(cat)"
 
-tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+# Both interpreters must be probed BEFORE they are used, and a missing one must
+# be announced rather than swallowed.
+#
+# `jq` used to be called unguarded here while `python3` two lines below was
+# guarded. Under `set -e` an absent jq aborted the script with 127, and Claude
+# Code treats any non-2 exit as a NON-BLOCKING hook error — so the hook that
+# enforces "never --no-verify" silently permitted the very thing it exists to
+# stop. It was not hypothetical: agent containers routinely ship no jq (that is
+# why jq is now a pinned toolchain entry). The Codex variant of this script has
+# always had the guard, so this was a parity gap rather than a design choice.
+#
+# Degrading to "allow" is still the right behaviour — a hook that cannot parse
+# its input cannot tell a bypass from an ordinary command, and failing closed
+# would block every Bash call on a machine missing an interpreter. What is NOT
+# right is doing it quietly, so the operator gets one line on stderr saying the
+# protection is off. A guard that is silently absent reads exactly like a guard
+# that is passing.
+for required in jq python3; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    printf 'block-no-verify: %s not found; --no-verify protection is NOT active\n' \
+      "$required" >&2
+    exit 0
+  fi
+done
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)"
 if [ "$tool_name" != "Bash" ]; then
   exit 0
 fi
 
-command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
 if [ -z "$command_str" ]; then
   exit 0
 fi
-
-command -v python3 >/dev/null 2>&1 || exit 0
 
 if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
 import os

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -21,11 +21,15 @@
 
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
+  readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
@@ -58,6 +62,70 @@ function writeAtomic(destination, contents) {
  * @param {object} [cfg] Resolved configuration.
  * @returns {{count: number, dir: string}} What was written, and where.
  */
+/** Marks the block this owns, so it is replaced rather than appended twice. */
+const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
+
+/** Closes the managed block. */
+const PROFILE_END = "# <<< lisa secrets (managed) <<<";
+
+/**
+ * Make every shell in this container load the materialized secrets.
+ *
+ * `set -a` so the values are exported rather than merely set as shell
+ * variables, and sourced LAST so they win over anything the host injected —
+ * environment variables outrank profile files in AWS's credential chain, which
+ * is the whole reason a valid credential was being ignored.
+ *
+ * Guarded on the file existing, so a shell still starts cleanly before the
+ * first materialization or if the file is removed. Written to both `.bashrc`
+ * and `.profile` because which one a given shell reads depends on whether it is
+ * interactive or a login shell, and an agent's tool calls are not reliably
+ * either.
+ * @param {string} valuesFile Absolute path to the materialized env file.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile files that now source it.
+ */
+export function installProfileSourcing(valuesFile, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+  } = options;
+
+  const block = [
+    PROFILE_MARKER,
+    `if [ -f "${valuesFile}" ]; then`,
+    `  set -a`,
+    `  . "${valuesFile}"`,
+    `  set +a`,
+    `fi`,
+    PROFILE_END,
+  ].join("\n");
+
+  const updated = [];
+  for (const name of [".bashrc", ".profile"]) {
+    const file = join(home, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+
+    // Replace an existing managed block rather than appending another: this
+    // runs on every session, and an appended-forever profile is its own bug.
+    const start = current.indexOf(PROFILE_MARKER);
+    const next =
+      start === -1
+        ? `${current}${current.endsWith("\n") || !current ? "" : "\n"}\n${block}\n`
+        : `${current.slice(0, start)}${block}${current.slice(
+            current.indexOf(PROFILE_END, start) + PROFILE_END.length
+          )}`;
+
+    if (next !== current) {
+      write(file, next, { mode: 0o600 });
+      updated.push(file);
+    }
+  }
+  return updated;
+}
+
 export function materialize(cfg = readConfig()) {
   if (!cfg.capabilities.mayWriteValues) {
     throw new Error(
@@ -88,7 +156,21 @@ export function materialize(cfg = readConfig()) {
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, derived: derived.size, dir };
+
+  // Writing the file is not the same as the values being in effect.
+  //
+  // A materialized secrets.env that nothing sources changes nothing: the agent's
+  // shell starts from the container's own environment, so a host-injected
+  // AWS_ACCESS_KEY_ID keeps winning and every call fails with
+  // InvalidClientTokenId while the correct credential sits on disk, correct and
+  // unused. Deriving the variables (above) only fixes precedence WITHIN the
+  // file — something still has to load the file.
+  //
+  // So the shell profile sources it. That is what makes "the credential is
+  // materialized" and "the credential is usable" the same statement.
+  const sourced = installProfileSourcing(valuesFile);
+
+  return { count: selected.size, derived: derived.size, dir, sourced };
 }
 
 function main() {

--- a/plugins/lisa-cursor/hooks/block-no-verify.sh
+++ b/plugins/lisa-cursor/hooks/block-no-verify.sh
@@ -20,17 +20,40 @@ set -euo pipefail
 
 input="$(cat)"
 
-tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+# Both interpreters must be probed BEFORE they are used, and a missing one must
+# be announced rather than swallowed.
+#
+# `jq` used to be called unguarded here while `python3` two lines below was
+# guarded. Under `set -e` an absent jq aborted the script with 127, and Claude
+# Code treats any non-2 exit as a NON-BLOCKING hook error — so the hook that
+# enforces "never --no-verify" silently permitted the very thing it exists to
+# stop. It was not hypothetical: agent containers routinely ship no jq (that is
+# why jq is now a pinned toolchain entry). The Codex variant of this script has
+# always had the guard, so this was a parity gap rather than a design choice.
+#
+# Degrading to "allow" is still the right behaviour — a hook that cannot parse
+# its input cannot tell a bypass from an ordinary command, and failing closed
+# would block every Bash call on a machine missing an interpreter. What is NOT
+# right is doing it quietly, so the operator gets one line on stderr saying the
+# protection is off. A guard that is silently absent reads exactly like a guard
+# that is passing.
+for required in jq python3; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    printf 'block-no-verify: %s not found; --no-verify protection is NOT active\n' \
+      "$required" >&2
+    exit 0
+  fi
+done
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)"
 if [ "$tool_name" != "Bash" ]; then
   exit 0
 fi
 
-command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
 if [ -z "$command_str" ]; then
   exit 0
 fi
-
-command -v python3 >/dev/null 2>&1 || exit 0
 
 if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
 import os

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -21,11 +21,15 @@
 
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
+  readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
@@ -58,6 +62,70 @@ function writeAtomic(destination, contents) {
  * @param {object} [cfg] Resolved configuration.
  * @returns {{count: number, dir: string}} What was written, and where.
  */
+/** Marks the block this owns, so it is replaced rather than appended twice. */
+const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
+
+/** Closes the managed block. */
+const PROFILE_END = "# <<< lisa secrets (managed) <<<";
+
+/**
+ * Make every shell in this container load the materialized secrets.
+ *
+ * `set -a` so the values are exported rather than merely set as shell
+ * variables, and sourced LAST so they win over anything the host injected —
+ * environment variables outrank profile files in AWS's credential chain, which
+ * is the whole reason a valid credential was being ignored.
+ *
+ * Guarded on the file existing, so a shell still starts cleanly before the
+ * first materialization or if the file is removed. Written to both `.bashrc`
+ * and `.profile` because which one a given shell reads depends on whether it is
+ * interactive or a login shell, and an agent's tool calls are not reliably
+ * either.
+ * @param {string} valuesFile Absolute path to the materialized env file.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile files that now source it.
+ */
+export function installProfileSourcing(valuesFile, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+  } = options;
+
+  const block = [
+    PROFILE_MARKER,
+    `if [ -f "${valuesFile}" ]; then`,
+    `  set -a`,
+    `  . "${valuesFile}"`,
+    `  set +a`,
+    `fi`,
+    PROFILE_END,
+  ].join("\n");
+
+  const updated = [];
+  for (const name of [".bashrc", ".profile"]) {
+    const file = join(home, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+
+    // Replace an existing managed block rather than appending another: this
+    // runs on every session, and an appended-forever profile is its own bug.
+    const start = current.indexOf(PROFILE_MARKER);
+    const next =
+      start === -1
+        ? `${current}${current.endsWith("\n") || !current ? "" : "\n"}\n${block}\n`
+        : `${current.slice(0, start)}${block}${current.slice(
+            current.indexOf(PROFILE_END, start) + PROFILE_END.length
+          )}`;
+
+    if (next !== current) {
+      write(file, next, { mode: 0o600 });
+      updated.push(file);
+    }
+  }
+  return updated;
+}
+
 export function materialize(cfg = readConfig()) {
   if (!cfg.capabilities.mayWriteValues) {
     throw new Error(
@@ -88,7 +156,21 @@ export function materialize(cfg = readConfig()) {
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, derived: derived.size, dir };
+
+  // Writing the file is not the same as the values being in effect.
+  //
+  // A materialized secrets.env that nothing sources changes nothing: the agent's
+  // shell starts from the container's own environment, so a host-injected
+  // AWS_ACCESS_KEY_ID keeps winning and every call fails with
+  // InvalidClientTokenId while the correct credential sits on disk, correct and
+  // unused. Deriving the variables (above) only fixes precedence WITHIN the
+  // file — something still has to load the file.
+  //
+  // So the shell profile sources it. That is what makes "the credential is
+  // materialized" and "the credential is usable" the same statement.
+  const sourced = installProfileSourcing(valuesFile);
+
+  return { count: selected.size, derived: derived.size, dir, sourced };
 }
 
 function main() {

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -21,11 +21,15 @@
 
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
+  readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
@@ -58,6 +62,70 @@ function writeAtomic(destination, contents) {
  * @param {object} [cfg] Resolved configuration.
  * @returns {{count: number, dir: string}} What was written, and where.
  */
+/** Marks the block this owns, so it is replaced rather than appended twice. */
+const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
+
+/** Closes the managed block. */
+const PROFILE_END = "# <<< lisa secrets (managed) <<<";
+
+/**
+ * Make every shell in this container load the materialized secrets.
+ *
+ * `set -a` so the values are exported rather than merely set as shell
+ * variables, and sourced LAST so they win over anything the host injected —
+ * environment variables outrank profile files in AWS's credential chain, which
+ * is the whole reason a valid credential was being ignored.
+ *
+ * Guarded on the file existing, so a shell still starts cleanly before the
+ * first materialization or if the file is removed. Written to both `.bashrc`
+ * and `.profile` because which one a given shell reads depends on whether it is
+ * interactive or a login shell, and an agent's tool calls are not reliably
+ * either.
+ * @param {string} valuesFile Absolute path to the materialized env file.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile files that now source it.
+ */
+export function installProfileSourcing(valuesFile, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+  } = options;
+
+  const block = [
+    PROFILE_MARKER,
+    `if [ -f "${valuesFile}" ]; then`,
+    `  set -a`,
+    `  . "${valuesFile}"`,
+    `  set +a`,
+    `fi`,
+    PROFILE_END,
+  ].join("\n");
+
+  const updated = [];
+  for (const name of [".bashrc", ".profile"]) {
+    const file = join(home, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+
+    // Replace an existing managed block rather than appending another: this
+    // runs on every session, and an appended-forever profile is its own bug.
+    const start = current.indexOf(PROFILE_MARKER);
+    const next =
+      start === -1
+        ? `${current}${current.endsWith("\n") || !current ? "" : "\n"}\n${block}\n`
+        : `${current.slice(0, start)}${block}${current.slice(
+            current.indexOf(PROFILE_END, start) + PROFILE_END.length
+          )}`;
+
+    if (next !== current) {
+      write(file, next, { mode: 0o600 });
+      updated.push(file);
+    }
+  }
+  return updated;
+}
+
 export function materialize(cfg = readConfig()) {
   if (!cfg.capabilities.mayWriteValues) {
     throw new Error(
@@ -88,7 +156,21 @@ export function materialize(cfg = readConfig()) {
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, derived: derived.size, dir };
+
+  // Writing the file is not the same as the values being in effect.
+  //
+  // A materialized secrets.env that nothing sources changes nothing: the agent's
+  // shell starts from the container's own environment, so a host-injected
+  // AWS_ACCESS_KEY_ID keeps winning and every call fails with
+  // InvalidClientTokenId while the correct credential sits on disk, correct and
+  // unused. Deriving the variables (above) only fixes precedence WITHIN the
+  // file — something still has to load the file.
+  //
+  // So the shell profile sources it. That is what makes "the credential is
+  // materialized" and "the credential is usable" the same statement.
+  const sourced = installProfileSourcing(valuesFile);
+
+  return { count: selected.size, derived: derived.size, dir, sourced };
 }
 
 function main() {

--- a/plugins/lisa/hooks/block-no-verify.sh
+++ b/plugins/lisa/hooks/block-no-verify.sh
@@ -20,17 +20,40 @@ set -euo pipefail
 
 input="$(cat)"
 
-tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+# Both interpreters must be probed BEFORE they are used, and a missing one must
+# be announced rather than swallowed.
+#
+# `jq` used to be called unguarded here while `python3` two lines below was
+# guarded. Under `set -e` an absent jq aborted the script with 127, and Claude
+# Code treats any non-2 exit as a NON-BLOCKING hook error — so the hook that
+# enforces "never --no-verify" silently permitted the very thing it exists to
+# stop. It was not hypothetical: agent containers routinely ship no jq (that is
+# why jq is now a pinned toolchain entry). The Codex variant of this script has
+# always had the guard, so this was a parity gap rather than a design choice.
+#
+# Degrading to "allow" is still the right behaviour — a hook that cannot parse
+# its input cannot tell a bypass from an ordinary command, and failing closed
+# would block every Bash call on a machine missing an interpreter. What is NOT
+# right is doing it quietly, so the operator gets one line on stderr saying the
+# protection is off. A guard that is silently absent reads exactly like a guard
+# that is passing.
+for required in jq python3; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    printf 'block-no-verify: %s not found; --no-verify protection is NOT active\n' \
+      "$required" >&2
+    exit 0
+  fi
+done
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)"
 if [ "$tool_name" != "Bash" ]; then
   exit 0
 fi
 
-command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
 if [ -z "$command_str" ]; then
   exit 0
 fi
-
-command -v python3 >/dev/null 2>&1 || exit 0
 
 if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
 import os

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -21,11 +21,15 @@
 
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
+  readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
@@ -58,6 +62,70 @@ function writeAtomic(destination, contents) {
  * @param {object} [cfg] Resolved configuration.
  * @returns {{count: number, dir: string}} What was written, and where.
  */
+/** Marks the block this owns, so it is replaced rather than appended twice. */
+const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
+
+/** Closes the managed block. */
+const PROFILE_END = "# <<< lisa secrets (managed) <<<";
+
+/**
+ * Make every shell in this container load the materialized secrets.
+ *
+ * `set -a` so the values are exported rather than merely set as shell
+ * variables, and sourced LAST so they win over anything the host injected —
+ * environment variables outrank profile files in AWS's credential chain, which
+ * is the whole reason a valid credential was being ignored.
+ *
+ * Guarded on the file existing, so a shell still starts cleanly before the
+ * first materialization or if the file is removed. Written to both `.bashrc`
+ * and `.profile` because which one a given shell reads depends on whether it is
+ * interactive or a login shell, and an agent's tool calls are not reliably
+ * either.
+ * @param {string} valuesFile Absolute path to the materialized env file.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile files that now source it.
+ */
+export function installProfileSourcing(valuesFile, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+  } = options;
+
+  const block = [
+    PROFILE_MARKER,
+    `if [ -f "${valuesFile}" ]; then`,
+    `  set -a`,
+    `  . "${valuesFile}"`,
+    `  set +a`,
+    `fi`,
+    PROFILE_END,
+  ].join("\n");
+
+  const updated = [];
+  for (const name of [".bashrc", ".profile"]) {
+    const file = join(home, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+
+    // Replace an existing managed block rather than appending another: this
+    // runs on every session, and an appended-forever profile is its own bug.
+    const start = current.indexOf(PROFILE_MARKER);
+    const next =
+      start === -1
+        ? `${current}${current.endsWith("\n") || !current ? "" : "\n"}\n${block}\n`
+        : `${current.slice(0, start)}${block}${current.slice(
+            current.indexOf(PROFILE_END, start) + PROFILE_END.length
+          )}`;
+
+    if (next !== current) {
+      write(file, next, { mode: 0o600 });
+      updated.push(file);
+    }
+  }
+  return updated;
+}
+
 export function materialize(cfg = readConfig()) {
   if (!cfg.capabilities.mayWriteValues) {
     throw new Error(
@@ -88,7 +156,21 @@ export function materialize(cfg = readConfig()) {
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, derived: derived.size, dir };
+
+  // Writing the file is not the same as the values being in effect.
+  //
+  // A materialized secrets.env that nothing sources changes nothing: the agent's
+  // shell starts from the container's own environment, so a host-injected
+  // AWS_ACCESS_KEY_ID keeps winning and every call fails with
+  // InvalidClientTokenId while the correct credential sits on disk, correct and
+  // unused. Deriving the variables (above) only fixes precedence WITHIN the
+  // file — something still has to load the file.
+  //
+  // So the shell profile sources it. That is what makes "the credential is
+  // materialized" and "the credential is usable" the same statement.
+  const sourced = installProfileSourcing(valuesFile);
+
+  return { count: selected.size, derived: derived.size, dir, sourced };
 }
 
 function main() {

--- a/plugins/src/base/hooks/block-no-verify.sh
+++ b/plugins/src/base/hooks/block-no-verify.sh
@@ -20,17 +20,40 @@ set -euo pipefail
 
 input="$(cat)"
 
-tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+# Both interpreters must be probed BEFORE they are used, and a missing one must
+# be announced rather than swallowed.
+#
+# `jq` used to be called unguarded here while `python3` two lines below was
+# guarded. Under `set -e` an absent jq aborted the script with 127, and Claude
+# Code treats any non-2 exit as a NON-BLOCKING hook error — so the hook that
+# enforces "never --no-verify" silently permitted the very thing it exists to
+# stop. It was not hypothetical: agent containers routinely ship no jq (that is
+# why jq is now a pinned toolchain entry). The Codex variant of this script has
+# always had the guard, so this was a parity gap rather than a design choice.
+#
+# Degrading to "allow" is still the right behaviour — a hook that cannot parse
+# its input cannot tell a bypass from an ordinary command, and failing closed
+# would block every Bash call on a machine missing an interpreter. What is NOT
+# right is doing it quietly, so the operator gets one line on stderr saying the
+# protection is off. A guard that is silently absent reads exactly like a guard
+# that is passing.
+for required in jq python3; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    printf 'block-no-verify: %s not found; --no-verify protection is NOT active\n' \
+      "$required" >&2
+    exit 0
+  fi
+done
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)"
 if [ "$tool_name" != "Bash" ]; then
   exit 0
 fi
 
-command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
 if [ -z "$command_str" ]; then
   exit 0
 fi
-
-command -v python3 >/dev/null 2>&1 || exit 0
 
 if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
 import os

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -21,11 +21,15 @@
 
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
+  readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
@@ -58,6 +62,70 @@ function writeAtomic(destination, contents) {
  * @param {object} [cfg] Resolved configuration.
  * @returns {{count: number, dir: string}} What was written, and where.
  */
+/** Marks the block this owns, so it is replaced rather than appended twice. */
+const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
+
+/** Closes the managed block. */
+const PROFILE_END = "# <<< lisa secrets (managed) <<<";
+
+/**
+ * Make every shell in this container load the materialized secrets.
+ *
+ * `set -a` so the values are exported rather than merely set as shell
+ * variables, and sourced LAST so they win over anything the host injected —
+ * environment variables outrank profile files in AWS's credential chain, which
+ * is the whole reason a valid credential was being ignored.
+ *
+ * Guarded on the file existing, so a shell still starts cleanly before the
+ * first materialization or if the file is removed. Written to both `.bashrc`
+ * and `.profile` because which one a given shell reads depends on whether it is
+ * interactive or a login shell, and an agent's tool calls are not reliably
+ * either.
+ * @param {string} valuesFile Absolute path to the materialized env file.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile files that now source it.
+ */
+export function installProfileSourcing(valuesFile, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+  } = options;
+
+  const block = [
+    PROFILE_MARKER,
+    `if [ -f "${valuesFile}" ]; then`,
+    `  set -a`,
+    `  . "${valuesFile}"`,
+    `  set +a`,
+    `fi`,
+    PROFILE_END,
+  ].join("\n");
+
+  const updated = [];
+  for (const name of [".bashrc", ".profile"]) {
+    const file = join(home, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+
+    // Replace an existing managed block rather than appending another: this
+    // runs on every session, and an appended-forever profile is its own bug.
+    const start = current.indexOf(PROFILE_MARKER);
+    const next =
+      start === -1
+        ? `${current}${current.endsWith("\n") || !current ? "" : "\n"}\n${block}\n`
+        : `${current.slice(0, start)}${block}${current.slice(
+            current.indexOf(PROFILE_END, start) + PROFILE_END.length
+          )}`;
+
+    if (next !== current) {
+      write(file, next, { mode: 0o600 });
+      updated.push(file);
+    }
+  }
+  return updated;
+}
+
 export function materialize(cfg = readConfig()) {
   if (!cfg.capabilities.mayWriteValues) {
     throw new Error(
@@ -88,7 +156,21 @@ export function materialize(cfg = readConfig()) {
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, derived: derived.size, dir };
+
+  // Writing the file is not the same as the values being in effect.
+  //
+  // A materialized secrets.env that nothing sources changes nothing: the agent's
+  // shell starts from the container's own environment, so a host-injected
+  // AWS_ACCESS_KEY_ID keeps winning and every call fails with
+  // InvalidClientTokenId while the correct credential sits on disk, correct and
+  // unused. Deriving the variables (above) only fixes precedence WITHIN the
+  // file — something still has to load the file.
+  //
+  // So the shell profile sources it. That is what makes "the credential is
+  // materialized" and "the credential is usable" the same statement.
+  const sourced = installProfileSourcing(valuesFile);
+
+  return { count: selected.size, derived: derived.size, dir, sourced };
 }
 
 function main() {

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1107,7 +1107,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/envfile.mjs":
       "be4e38ce85f9268b52b29dbde264ecd8d50973c2b63a15410336234a921d9644",
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs":
-      "b535ed8babf7237374de9886fca7967519f4719ab8a1c03f16dfddef05f0a138",
+      "32e4cd6011f619f15842b5cd07c6ca13f25b2c66af2f8b41b7759925ed8b14ad",
     "plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs":
       "fec38ca937570c1e1c21e6e8f7314a9d8f4e9264779d0394b40d5158924da0da",
     "plugins/src/base/skills/lisa-secrets-access/scripts/read-secret-note.mjs":
@@ -8494,6 +8494,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/doctor-secrets.test.ts": true,
     "tests/unit/secrets/install-method-conformance.test.ts": true,
     "tests/unit/secrets/local-env-command.test.ts": true,
+    "tests/unit/secrets/profile-sourcing.test.ts": true,
     "tests/unit/secrets/remote-dispatch-claude-web.test.ts": true,
     "tests/unit/secrets/remote-dispatch.test.ts": true,
     "tests/unit/secrets/remote-env-bindir-path.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -13,7 +13,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
       "8996e0bcbf1db085a5d99734e797c91f5025997bd967bc374efff8348dac14c2",
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh":
-      "aa95a84f9f9224914947a09b858535aa8bd052199ff64cb53768cf78fb69b687",
+      "a6ed91576efebb6ba40cfa4e9d8a3e8566314909210ae8d5860be62a3feb4cff",
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh":
       "3b5f074f3ab5708030af507eea962389f3b067c5dbdc76580bd9e44d3ac6c603",
     "all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh":
@@ -595,7 +595,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/block-no-verify.agy.sh":
       "1a36c841b6339a2c664938d65c5a4542f97d05f584e467de448bb72ac6bdba55",
     "plugins/src/base/hooks/block-no-verify.sh":
-      "aa95a84f9f9224914947a09b858535aa8bd052199ff64cb53768cf78fb69b687",
+      "a6ed91576efebb6ba40cfa4e9d8a3e8566314909210ae8d5860be62a3feb4cff",
     "plugins/src/base/hooks/block-shell-json-parsing.agy.sh":
       "dc688efe382e7b8fe6f6c88bb0fde851527128cae778599559f23a93f1c9ec86",
     "plugins/src/base/hooks/block-shell-json-parsing.sh":
@@ -8392,6 +8392,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/health/storage.test.ts": true,
     "tests/unit/hooks/block-generated-artifact-edits.test.ts": true,
     "tests/unit/hooks/block-instruction-file-edits.test.ts": true,
+    "tests/unit/hooks/block-no-verify-missing-jq.test.ts": true,
     "tests/unit/hooks/block-no-verify.test.ts": true,
     "tests/unit/hooks/block-shell-json-parsing.test.ts": true,
     "tests/unit/hooks/blocking-hook-exit.test.ts": true,

--- a/tests/unit/hooks/block-no-verify-missing-jq.test.ts
+++ b/tests/unit/hooks/block-no-verify-missing-jq.test.ts
@@ -1,0 +1,127 @@
+/**
+ * `block-no-verify` must not fail open when its interpreters are absent.
+ *
+ * The hook's exit code IS its contract: 2 refuses, 0 allows, and Claude Code
+ * treats every OTHER non-zero exit as a non-blocking hook error — meaning the
+ * command runs. `jq` was called unguarded under `set -euo pipefail`, so a
+ * container without jq exited 127 and the hook that enforces "never
+ * --no-verify" silently permitted exactly what it exists to stop.
+ *
+ * Not hypothetical: the agent containers this is deployed into shipped no jq,
+ * which is why jq is now a pinned toolchain entry. The Codex variant of this
+ * script always had the guard, so this was a parity gap.
+ *
+ * Failing OPEN is still correct — a hook that cannot parse its input cannot
+ * tell a bypass from an ordinary command, and failing closed would block every
+ * Bash call on a machine missing an interpreter. Doing it SILENTLY is not: a
+ * guard that is quietly absent is indistinguishable from a guard that passes.
+ * @module tests/unit/hooks/block-no-verify-missing-jq
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+/** The hook as it is installed into a project. */
+const HOOK = path.resolve(
+  __dirname,
+  "../../../all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh"
+);
+
+/** A PreToolUse payload for a command that bypasses the hooks. */
+const BYPASS = JSON.stringify({
+  tool_name: "Bash",
+  tool_input: { command: "git commit --no-verify -m x" },
+});
+
+/** Tools the hook legitimately needs, minus the one under test. */
+const SHIM_TOOLS = ["bash", "sh", "env", "printf", "grep", "cat", "python3"];
+
+/** A PATH directory deliberately missing `jq`. */
+const shim = mkdtempSync(path.join(tmpdir(), "lisa-nojq-"));
+
+/**
+ * Find an executable by scanning PATH directly.
+ *
+ * Deliberately not `spawnSync("command -v")`: resolving a command *through*
+ * PATH is what `sonarjs/no-os-command-from-path` exists to prevent, and reading
+ * the directories to build a fixture needs no subprocess at all.
+ * @param tool The executable name.
+ * @returns Its absolute path, or undefined.
+ */
+function locate(tool: string): string | undefined {
+  for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, tool);
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/** An absolute bash, so the runner is never resolved through the shim PATH. */
+const BASH = locate("bash") ?? "/bin/bash";
+
+for (const tool of SHIM_TOOLS) {
+  const found = locate(tool);
+  if (found) symlinkSync(found, path.join(shim, tool));
+}
+
+afterAll(() => rmSync(shim, { recursive: true, force: true }));
+
+/**
+ * Run the hook with a payload and a PATH.
+ * @param payload The JSON given on stdin.
+ * @param pathEnv The PATH to run under.
+ * @returns Exit status and stderr.
+ */
+function runHook(
+  payload: string,
+  pathEnv = process.env.PATH
+): { status: number; stderr: string } {
+  const result = spawnSync(BASH, [HOOK], {
+    input: payload,
+    encoding: "utf8",
+    env: { ...process.env, PATH: pathEnv },
+  });
+
+  return { status: result.status ?? -1, stderr: result.stderr ?? "" };
+}
+
+describe("block-no-verify when jq is missing", () => {
+  it("does not exit 127, which would read as a non-blocking hook error", () => {
+    // 127 is the whole bug: not a refusal, so the command proceeds unguarded.
+    const { status } = runHook(BYPASS, shim);
+
+    expect(status).not.toBe(127);
+    expect(status).toBe(0);
+  });
+
+  it("says on stderr that the protection is not active", () => {
+    // Failing open is acceptable; failing open silently is not.
+    const { stderr } = runHook(BYPASS, shim);
+
+    expect(stderr).toMatch(/jq not found/);
+    expect(stderr).toMatch(/protection is NOT active/);
+  });
+});
+
+describe("block-no-verify with its interpreters present", () => {
+  it("still refuses a bypass with exit 2", () => {
+    // The guard must not have been weakened to achieve the above.
+    expect(runHook(BYPASS).status).toBe(2);
+  });
+
+  it("still allows an ordinary command", () => {
+    expect(
+      runHook(
+        JSON.stringify({
+          tool_name: "Bash",
+          tool_input: { command: "git status" },
+        })
+      ).status
+    ).toBe(0);
+  });
+});

--- a/tests/unit/secrets/profile-sourcing.test.ts
+++ b/tests/unit/secrets/profile-sourcing.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Materialized secrets must actually be IN EFFECT, not merely on disk.
+ *
+ * Observed live: a Claude cloud session had a correct `secrets.env` (600, right
+ * values, AWS pair derived) and every AWS call still failed with
+ * `InvalidClientTokenId`. Nothing sourced the file, so the agent's shell kept
+ * the container's own injected `AWS_ACCESS_KEY_ID` — and environment variables
+ * outrank profile files in AWS's credential chain.
+ *
+ * Deriving the variables fixed precedence *within* the file. Something still has
+ * to load the file, which is what this covers.
+ * @module tests/unit/secrets/profile-sourcing
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { installProfileSourcing } from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs";
+
+/**
+ * An absolute bash, so the shell is never resolved through PATH.
+ *
+ * `sonarjs/no-os-command-from-path` guards against executing a command found on
+ * an influenceable PATH; scanning the directories in JS to get an absolute path
+ * avoids that entirely rather than suppressing the rule.
+ * @returns The first bash found on PATH, falling back to the usual location.
+ */
+function locateBash(): string {
+  for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, "bash");
+    if (existsSync(candidate)) return candidate;
+  }
+  return "/bin/bash";
+}
+
+/** Resolved once — every shell in this file runs through it. */
+const BASH = locateBash();
+
+/** Scratch homes to clean up. */
+const homes: string[] = [];
+
+/** The value the profile should make win. */
+const CORRECT = "AKIA_CORRECT";
+
+/** What the container injects, and what used to win. */
+const AMBIENT = "AKIA_AMBIENT_WRONG";
+
+/** The marker delimiting the managed block. */
+const MARKER = "# >>> lisa secrets (managed) >>>";
+
+/**
+ * A home with a materialized values file.
+ * @returns The home directory and the values file path.
+ */
+function scratchHome(): { home: string; values: string } {
+  const home = mkdtempSync(path.join(tmpdir(), "lisa-profile-"));
+  const values = path.join(home, "secrets.env");
+
+  homes.push(home);
+  writeFileSync(values, `export AWS_ACCESS_KEY_ID="${CORRECT}"\n`);
+
+  return { home, values };
+}
+
+afterEach(() => {
+  while (homes.length > 0) {
+    rmSync(homes.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe("installProfileSourcing", () => {
+  it("makes a real shell resolve the materialized value over the ambient one", () => {
+    // The end-to-end claim. Asserting the file's TEXT would pass even if the
+    // snippet did not work; only running a shell proves precedence.
+    const { home, values } = scratchHome();
+    installProfileSourcing(values, { home });
+
+    const out = execFileSync(
+      BASH,
+      [
+        "-c",
+        `. "${path.join(home, ".bashrc")}"; printf '%s' "$AWS_ACCESS_KEY_ID"`,
+      ],
+      {
+        encoding: "utf8",
+        env: { PATH: process.env.PATH, HOME: home, AWS_ACCESS_KEY_ID: AMBIENT },
+      }
+    );
+
+    expect(out).toBe(CORRECT);
+  });
+
+  it("exports rather than merely setting, so child processes inherit it", () => {
+    // `aws` is a child process. A shell variable that is not exported would
+    // satisfy the previous test and still leave the CLI failing.
+    const { home, values } = scratchHome();
+    installProfileSourcing(values, { home });
+
+    const out = execFileSync(
+      BASH,
+      [
+        "-c",
+        `. "${path.join(home, ".bashrc")}"; bash -c 'printf "%s" "$AWS_ACCESS_KEY_ID"'`,
+      ],
+      { encoding: "utf8", env: { PATH: process.env.PATH, HOME: home } }
+    );
+
+    expect(out).toBe(CORRECT);
+  });
+
+  it("preserves configuration it did not write", () => {
+    const { home, values } = scratchHome();
+    writeFileSync(path.join(home, ".bashrc"), "export KEEP=1\n");
+
+    installProfileSourcing(values, { home });
+
+    expect(readFileSync(path.join(home, ".bashrc"), "utf8")).toMatch(
+      /export KEEP=1/
+    );
+  });
+
+  it("replaces its block instead of appending on every session", () => {
+    // This runs at every session start; an append-forever profile is its own bug.
+    const { home, values } = scratchHome();
+
+    installProfileSourcing(values, { home });
+    installProfileSourcing(values, { home });
+    installProfileSourcing(values, { home });
+
+    const text = readFileSync(path.join(home, ".bashrc"), "utf8");
+    expect(text.split(MARKER).length - 1).toBe(1);
+  });
+
+  it("writes both .bashrc and .profile", () => {
+    // Which one a shell reads depends on interactive vs login, and an agent's
+    // tool calls are not reliably either.
+    const { home, values } = scratchHome();
+
+    expect(
+      installProfileSourcing(values, { home }).map(f => path.basename(f))
+    ).toEqual([".bashrc", ".profile"]);
+  });
+
+  it("leaves a shell working when the values file is absent", () => {
+    // Guarded on existence: a shell must still start before the first
+    // materialization, or if the file is removed.
+    const { home } = scratchHome();
+    const missing = path.join(home, "not-written-yet.env");
+    installProfileSourcing(missing, { home });
+
+    const out = execFileSync(
+      BASH,
+      ["-c", `. "${path.join(home, ".bashrc")}"; printf 'ok'`],
+      { encoding: "utf8", env: { PATH: process.env.PATH, HOME: home } }
+    );
+
+    expect(out).toBe("ok");
+  });
+});


### PR DESCRIPTION
Two independent fixes, one commit each so either can be reverted alone. Both
came out of driving a Claude cloud session to actually work.

## 1. The materialized env was never in effect (`4942446d`)

A session had a **correct** `secrets.env` — 700 dir, 600 file, AWS pair derived
exactly as designed — and every AWS call still failed:

```
An error occurred (InvalidClientTokenId) when calling the GetCallerIdentity
operation: The security token included in the request is invalid.
```

Writing the file is not the same as the values being in effect. The agent's
shell starts from the container's own environment, which injects its own
`AWS_ACCESS_KEY_ID`, and **environment variables outrank profile files** in
AWS's credential chain. The correct credential sat on disk, correct and unused,
while the wrong ambient one won every call.

Deriving the AWS variables (2.331.3) fixed precedence *within* the file.
Something still had to load the file, and nothing did.

**The credential itself was never the problem** — I confirmed the stored bundle
is valid against the live account (`arn:aws:iam::777997078669:user/remote-agent`)
while the container was rejecting it. That ruled out a dead/rotated key before
any code changed.

Materialization now writes a managed block into `.bashrc` and `.profile` that
sources the values file under `set -a`, so they are exported and every child
process — `aws` included — inherits them.

| decision | why |
| --- | --- |
| both `.bashrc` and `.profile` | which one a shell reads depends on interactive vs login; an agent's tool calls are reliably neither |
| `set -a` | a set-but-unexported variable would satisfy a naive test and still leave the CLI failing |
| guarded on existence | a shell must still start before the first materialization |
| block replaced, not appended | this runs every session; an append-forever profile is its own bug |

Verified by running a real bash with a WRONG value already exported: the shell
resolves the materialized one, a **grandchild** process inherits it, pre-existing
profile config survives, and three runs leave exactly one block.

## 2. `block-no-verify` failed open when jq was missing (`f443875c`)

The hook enforcing "never `--no-verify`" called `jq` unguarded under
`set -euo pipefail`, while guarding `python3` two lines below. With jq absent it
exited **127**, and Claude Code treats any non-2 exit as a **non-blocking** hook
error — so the command ran and the protection silently did nothing.

Not hypothetical: these containers shipped no jq (CodySwannGT/lisa#2304). The
Codex variant always had the guard, so this was a parity gap.

Failing **open** stays correct — a hook that cannot parse its input cannot tell a
bypass from an ordinary command, and failing closed would block every Bash call
on a machine missing an interpreter. Failing open **silently** is the defect, so
a missing interpreter now prints one line naming what is off.

Exit codes, which are the hook's entire contract:

| case | origin/main | with fix |
| --- | --- | --- |
| bypass, jq present | 2 refused | 2 refused |
| ordinary command | 0 | 0 |
| bypass, **no jq** | **127, silent** | **0, and says the protection is off** |

Negative control: the new tests fail 2/4 against `main` — exactly the two that
describe the bug — and pass after.

Full suite green: 8834 passed, 530 files. Lint clean, with no suppressions
(`sonarjs/no-os-command-from-path` resolved by locating `bash` absolutely rather
than disabling the rule).

---

Work-Item: CodySwannGT/lisa#2309
