### PR TITLE
fix(secrets): source the materialized env from the shell profile

### DIFF
--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -21,11 +21,15 @@
 
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
+  readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
@@ -58,6 +62,70 @@ function writeAtomic(destination, contents) {
  * @param {object} [cfg] Resolved configuration.
  * @returns {{count: number, dir: string}} What was written, and where.
  */
+/** Marks the block this owns, so it is replaced rather than appended twice. */
+const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
+
+/** Closes the managed block. */
+const PROFILE_END = "# <<< lisa secrets (managed) <<<";
+
+/**
+ * Make every shell in this container load the materialized secrets.
+ *
+ * `set -a` so the values are exported rather than merely set as shell
+ * variables, and sourced LAST so they win over anything the host injected —
+ * environment variables outrank profile files in AWS's credential chain, which
+ * is the whole reason a valid credential was being ignored.
+ *
+ * Guarded on the file existing, so a shell still starts cleanly before the
+ * first materialization or if the file is removed. Written to both `.bashrc`
+ * and `.profile` because which one a given shell reads depends on whether it is
+ * interactive or a login shell, and an agent's tool calls are not reliably
+ * either.
+ * @param {string} valuesFile Absolute path to the materialized env file.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile files that now source it.
+ */
+export function installProfileSourcing(valuesFile, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+  } = options;
+
+  const block = [
+    PROFILE_MARKER,
+    `if [ -f "${valuesFile}" ]; then`,
+    `  set -a`,
+    `  . "${valuesFile}"`,
+    `  set +a`,
+    `fi`,
+    PROFILE_END,
+  ].join("\n");
+
+  const updated = [];
+  for (const name of [".bashrc", ".profile"]) {
+    const file = join(home, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+
+    // Replace an existing managed block rather than appending another: this
+    // runs on every session, and an appended-forever profile is its own bug.
+    const start = current.indexOf(PROFILE_MARKER);
+    const next =
+      start === -1
+        ? `${current}${current.endsWith("\n") || !current ? "" : "\n"}\n${block}\n`
+        : `${current.slice(0, start)}${block}${current.slice(
+            current.indexOf(PROFILE_END, start) + PROFILE_END.length
+          )}`;
+
+    if (next !== current) {
+      write(file, next, { mode: 0o600 });
+      updated.push(file);
+    }
+  }
+  return updated;
+}
+
 export function materialize(cfg = readConfig()) {
   if (!cfg.capabilities.mayWriteValues) {
     throw new Error(
@@ -88,7 +156,21 @@ export function materialize(cfg = readConfig()) {
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, derived: derived.size, dir };
+
+  // Writing the file is not the same as the values being in effect.
+  //
+  // A materialized secrets.env that nothing sources changes nothing: the agent's
+  // shell starts from the container's own environment, so a host-injected
+  // AWS_ACCESS_KEY_ID keeps winning and every call fails with
+  // InvalidClientTokenId while the correct credential sits on disk, correct and
+  // unused. Deriving the variables (above) only fixes precedence WITHIN the
+  // file — something still has to load the file.
+  //
+  // So the shell profile sources it. That is what makes "the credential is
+  // materialized" and "the credential is usable" the same statement.
+  const sourced = installProfileSourcing(valuesFile);
+
+  return { count: selected.size, derived: derived.size, dir, sourced };
 }
 
 function main() {

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -21,11 +21,15 @@
 
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
+  readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
@@ -58,6 +62,70 @@ function writeAtomic(destination, contents) {
  * @param {object} [cfg] Resolved configuration.
  * @returns {{count: number, dir: string}} What was written, and where.
  */
+/** Marks the block this owns, so it is replaced rather than appended twice. */
+const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
+
+/** Closes the managed block. */
+const PROFILE_END = "# <<< lisa secrets (managed) <<<";
+
+/**
+ * Make every shell in this container load the materialized secrets.
+ *
+ * `set -a` so the values are exported rather than merely set as shell
+ * variables, and sourced LAST so they win over anything the host injected —
+ * environment variables outrank profile files in AWS's credential chain, which
+ * is the whole reason a valid credential was being ignored.
+ *
+ * Guarded on the file existing, so a shell still starts cleanly before the
+ * first materialization or if the file is removed. Written to both `.bashrc`
+ * and `.profile` because which one a given shell reads depends on whether it is
+ * interactive or a login shell, and an agent's tool calls are not reliably
+ * either.
+ * @param {string} valuesFile Absolute path to the materialized env file.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile files that now source it.
+ */
+export function installProfileSourcing(valuesFile, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+  } = options;
+
+  const block = [
+    PROFILE_MARKER,
+    `if [ -f "${valuesFile}" ]; then`,
+    `  set -a`,
+    `  . "${valuesFile}"`,
+    `  set +a`,
+    `fi`,
+    PROFILE_END,
+  ].join("\n");
+
+  const updated = [];
+  for (const name of [".bashrc", ".profile"]) {
+    const file = join(home, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+
+    // Replace an existing managed block rather than appending another: this
+    // runs on every session, and an appended-forever profile is its own bug.
+    const start = current.indexOf(PROFILE_MARKER);
+    const next =
+      start === -1
+        ? `${current}${current.endsWith("\n") || !current ? "" : "\n"}\n${block}\n`
+        : `${current.slice(0, start)}${block}${current.slice(
+            current.indexOf(PROFILE_END, start) + PROFILE_END.length
+          )}`;
+
+    if (next !== current) {
+      write(file, next, { mode: 0o600 });
+      updated.push(file);
+    }
+  }
+  return updated;
+}
+
 export function materialize(cfg = readConfig()) {
   if (!cfg.capabilities.mayWriteValues) {
     throw new Error(
@@ -88,7 +156,21 @@ export function materialize(cfg = readConfig()) {
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, derived: derived.size, dir };
+
+  // Writing the file is not the same as the values being in effect.
+  //
+  // A materialized secrets.env that nothing sources changes nothing: the agent's
+  // shell starts from the container's own environment, so a host-injected
+  // AWS_ACCESS_KEY_ID keeps winning and every call fails with
+  // InvalidClientTokenId while the correct credential sits on disk, correct and
+  // unused. Deriving the variables (above) only fixes precedence WITHIN the
+  // file — something still has to load the file.
+  //
+  // So the shell profile sources it. That is what makes "the credential is
+  // materialized" and "the credential is usable" the same statement.
+  const sourced = installProfileSourcing(valuesFile);
+
+  return { count: selected.size, derived: derived.size, dir, sourced };
 }
 
 function main() {

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -21,11 +21,15 @@
 
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
+  readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
@@ -58,6 +62,70 @@ function writeAtomic(destination, contents) {
  * @param {object} [cfg] Resolved configuration.
  * @returns {{count: number, dir: string}} What was written, and where.
  */
+/** Marks the block this owns, so it is replaced rather than appended twice. */
+const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
+
+/** Closes the managed block. */
+const PROFILE_END = "# <<< lisa secrets (managed) <<<";
+
+/**
+ * Make every shell in this container load the materialized secrets.
+ *
+ * `set -a` so the values are exported rather than merely set as shell
+ * variables, and sourced LAST so they win over anything the host injected —
+ * environment variables outrank profile files in AWS's credential chain, which
+ * is the whole reason a valid credential was being ignored.
+ *
+ * Guarded on the file existing, so a shell still starts cleanly before the
+ * first materialization or if the file is removed. Written to both `.bashrc`
+ * and `.profile` because which one a given shell reads depends on whether it is
+ * interactive or a login shell, and an agent's tool calls are not reliably
+ * either.
+ * @param {string} valuesFile Absolute path to the materialized env file.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile files that now source it.
+ */
+export function installProfileSourcing(valuesFile, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+  } = options;
+
+  const block = [
+    PROFILE_MARKER,
+    `if [ -f "${valuesFile}" ]; then`,
+    `  set -a`,
+    `  . "${valuesFile}"`,
+    `  set +a`,
+    `fi`,
+    PROFILE_END,
+  ].join("\n");
+
+  const updated = [];
+  for (const name of [".bashrc", ".profile"]) {
+    const file = join(home, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+
+    // Replace an existing managed block rather than appending another: this
+    // runs on every session, and an appended-forever profile is its own bug.
+    const start = current.indexOf(PROFILE_MARKER);
+    const next =
+      start === -1
+        ? `${current}${current.endsWith("\n") || !current ? "" : "\n"}\n${block}\n`
+        : `${current.slice(0, start)}${block}${current.slice(
+            current.indexOf(PROFILE_END, start) + PROFILE_END.length
+          )}`;
+
+    if (next !== current) {
+      write(file, next, { mode: 0o600 });
+      updated.push(file);
+    }
+  }
+  return updated;
+}
+
 export function materialize(cfg = readConfig()) {
   if (!cfg.capabilities.mayWriteValues) {
     throw new Error(
@@ -88,7 +156,21 @@ export function materialize(cfg = readConfig()) {
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, derived: derived.size, dir };
+
+  // Writing the file is not the same as the values being in effect.
+  //
+  // A materialized secrets.env that nothing sources changes nothing: the agent's
+  // shell starts from the container's own environment, so a host-injected
+  // AWS_ACCESS_KEY_ID keeps winning and every call fails with
+  // InvalidClientTokenId while the correct credential sits on disk, correct and
+  // unused. Deriving the variables (above) only fixes precedence WITHIN the
+  // file — something still has to load the file.
+  //
+  // So the shell profile sources it. That is what makes "the credential is
+  // materialized" and "the credential is usable" the same statement.
+  const sourced = installProfileSourcing(valuesFile);
+
+  return { count: selected.size, derived: derived.size, dir, sourced };
 }
 
 function main() {

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -21,11 +21,15 @@
 
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
+  readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
@@ -58,6 +62,70 @@ function writeAtomic(destination, contents) {
  * @param {object} [cfg] Resolved configuration.
  * @returns {{count: number, dir: string}} What was written, and where.
  */
+/** Marks the block this owns, so it is replaced rather than appended twice. */
+const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
+
+/** Closes the managed block. */
+const PROFILE_END = "# <<< lisa secrets (managed) <<<";
+
+/**
+ * Make every shell in this container load the materialized secrets.
+ *
+ * `set -a` so the values are exported rather than merely set as shell
+ * variables, and sourced LAST so they win over anything the host injected —
+ * environment variables outrank profile files in AWS's credential chain, which
+ * is the whole reason a valid credential was being ignored.
+ *
+ * Guarded on the file existing, so a shell still starts cleanly before the
+ * first materialization or if the file is removed. Written to both `.bashrc`
+ * and `.profile` because which one a given shell reads depends on whether it is
+ * interactive or a login shell, and an agent's tool calls are not reliably
+ * either.
+ * @param {string} valuesFile Absolute path to the materialized env file.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile files that now source it.
+ */
+export function installProfileSourcing(valuesFile, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+  } = options;
+
+  const block = [
+    PROFILE_MARKER,
+    `if [ -f "${valuesFile}" ]; then`,
+    `  set -a`,
+    `  . "${valuesFile}"`,
+    `  set +a`,
+    `fi`,
+    PROFILE_END,
+  ].join("\n");
+
+  const updated = [];
+  for (const name of [".bashrc", ".profile"]) {
+    const file = join(home, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+
+    // Replace an existing managed block rather than appending another: this
+    // runs on every session, and an appended-forever profile is its own bug.
+    const start = current.indexOf(PROFILE_MARKER);
+    const next =
+      start === -1
+        ? `${current}${current.endsWith("\n") || !current ? "" : "\n"}\n${block}\n`
+        : `${current.slice(0, start)}${block}${current.slice(
+            current.indexOf(PROFILE_END, start) + PROFILE_END.length
+          )}`;
+
+    if (next !== current) {
+      write(file, next, { mode: 0o600 });
+      updated.push(file);
+    }
+  }
+  return updated;
+}
+
 export function materialize(cfg = readConfig()) {
   if (!cfg.capabilities.mayWriteValues) {
     throw new Error(
@@ -88,7 +156,21 @@ export function materialize(cfg = readConfig()) {
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, derived: derived.size, dir };
+
+  // Writing the file is not the same as the values being in effect.
+  //
+  // A materialized secrets.env that nothing sources changes nothing: the agent's
+  // shell starts from the container's own environment, so a host-injected
+  // AWS_ACCESS_KEY_ID keeps winning and every call fails with
+  // InvalidClientTokenId while the correct credential sits on disk, correct and
+  // unused. Deriving the variables (above) only fixes precedence WITHIN the
+  // file — something still has to load the file.
+  //
+  // So the shell profile sources it. That is what makes "the credential is
+  // materialized" and "the credential is usable" the same statement.
+  const sourced = installProfileSourcing(valuesFile);
+
+  return { count: selected.size, derived: derived.size, dir, sourced };
 }
 
 function main() {

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -21,11 +21,15 @@
 
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
+  readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
@@ -58,6 +62,70 @@ function writeAtomic(destination, contents) {
  * @param {object} [cfg] Resolved configuration.
  * @returns {{count: number, dir: string}} What was written, and where.
  */
+/** Marks the block this owns, so it is replaced rather than appended twice. */
+const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
+
+/** Closes the managed block. */
+const PROFILE_END = "# <<< lisa secrets (managed) <<<";
+
+/**
+ * Make every shell in this container load the materialized secrets.
+ *
+ * `set -a` so the values are exported rather than merely set as shell
+ * variables, and sourced LAST so they win over anything the host injected —
+ * environment variables outrank profile files in AWS's credential chain, which
+ * is the whole reason a valid credential was being ignored.
+ *
+ * Guarded on the file existing, so a shell still starts cleanly before the
+ * first materialization or if the file is removed. Written to both `.bashrc`
+ * and `.profile` because which one a given shell reads depends on whether it is
+ * interactive or a login shell, and an agent's tool calls are not reliably
+ * either.
+ * @param {string} valuesFile Absolute path to the materialized env file.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile files that now source it.
+ */
+export function installProfileSourcing(valuesFile, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+  } = options;
+
+  const block = [
+    PROFILE_MARKER,
+    `if [ -f "${valuesFile}" ]; then`,
+    `  set -a`,
+    `  . "${valuesFile}"`,
+    `  set +a`,
+    `fi`,
+    PROFILE_END,
+  ].join("\n");
+
+  const updated = [];
+  for (const name of [".bashrc", ".profile"]) {
+    const file = join(home, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+
+    // Replace an existing managed block rather than appending another: this
+    // runs on every session, and an appended-forever profile is its own bug.
+    const start = current.indexOf(PROFILE_MARKER);
+    const next =
+      start === -1
+        ? `${current}${current.endsWith("\n") || !current ? "" : "\n"}\n${block}\n`
+        : `${current.slice(0, start)}${block}${current.slice(
+            current.indexOf(PROFILE_END, start) + PROFILE_END.length
+          )}`;
+
+    if (next !== current) {
+      write(file, next, { mode: 0o600 });
+      updated.push(file);
+    }
+  }
+  return updated;
+}
+
 export function materialize(cfg = readConfig()) {
   if (!cfg.capabilities.mayWriteValues) {
     throw new Error(
@@ -88,7 +156,21 @@ export function materialize(cfg = readConfig()) {
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, derived: derived.size, dir };
+
+  // Writing the file is not the same as the values being in effect.
+  //
+  // A materialized secrets.env that nothing sources changes nothing: the agent's
+  // shell starts from the container's own environment, so a host-injected
+  // AWS_ACCESS_KEY_ID keeps winning and every call fails with
+  // InvalidClientTokenId while the correct credential sits on disk, correct and
+  // unused. Deriving the variables (above) only fixes precedence WITHIN the
+  // file — something still has to load the file.
+  //
+  // So the shell profile sources it. That is what makes "the credential is
+  // materialized" and "the credential is usable" the same statement.
+  const sourced = installProfileSourcing(valuesFile);
+
+  return { count: selected.size, derived: derived.size, dir, sourced };
 }
 
 function main() {

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -21,11 +21,15 @@
 
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
+  readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
@@ -58,6 +62,70 @@ function writeAtomic(destination, contents) {
  * @param {object} [cfg] Resolved configuration.
  * @returns {{count: number, dir: string}} What was written, and where.
  */
+/** Marks the block this owns, so it is replaced rather than appended twice. */
+const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
+
+/** Closes the managed block. */
+const PROFILE_END = "# <<< lisa secrets (managed) <<<";
+
+/**
+ * Make every shell in this container load the materialized secrets.
+ *
+ * `set -a` so the values are exported rather than merely set as shell
+ * variables, and sourced LAST so they win over anything the host injected —
+ * environment variables outrank profile files in AWS's credential chain, which
+ * is the whole reason a valid credential was being ignored.
+ *
+ * Guarded on the file existing, so a shell still starts cleanly before the
+ * first materialization or if the file is removed. Written to both `.bashrc`
+ * and `.profile` because which one a given shell reads depends on whether it is
+ * interactive or a login shell, and an agent's tool calls are not reliably
+ * either.
+ * @param {string} valuesFile Absolute path to the materialized env file.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile files that now source it.
+ */
+export function installProfileSourcing(valuesFile, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    exists = existsSync,
+    read = readFileSync,
+    write = writeFileSync,
+  } = options;
+
+  const block = [
+    PROFILE_MARKER,
+    `if [ -f "${valuesFile}" ]; then`,
+    `  set -a`,
+    `  . "${valuesFile}"`,
+    `  set +a`,
+    `fi`,
+    PROFILE_END,
+  ].join("\n");
+
+  const updated = [];
+  for (const name of [".bashrc", ".profile"]) {
+    const file = join(home, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+
+    // Replace an existing managed block rather than appending another: this
+    // runs on every session, and an appended-forever profile is its own bug.
+    const start = current.indexOf(PROFILE_MARKER);
+    const next =
+      start === -1
+        ? `${current}${current.endsWith("\n") || !current ? "" : "\n"}\n${block}\n`
+        : `${current.slice(0, start)}${block}${current.slice(
+            current.indexOf(PROFILE_END, start) + PROFILE_END.length
+          )}`;
+
+    if (next !== current) {
+      write(file, next, { mode: 0o600 });
+      updated.push(file);
+    }
+  }
+  return updated;
+}
+
 export function materialize(cfg = readConfig()) {
   if (!cfg.capabilities.mayWriteValues) {
     throw new Error(
@@ -88,7 +156,21 @@ export function materialize(cfg = readConfig()) {
   chmodSync(dir, 0o700);
   writeAtomic(valuesFile, renderEnv(selected));
   writeAtomic(notesFile, renderNotes(selected));
-  return { count: selected.size, derived: derived.size, dir };
+
+  // Writing the file is not the same as the values being in effect.
+  //
+  // A materialized secrets.env that nothing sources changes nothing: the agent's
+  // shell starts from the container's own environment, so a host-injected
+  // AWS_ACCESS_KEY_ID keeps winning and every call fails with
+  // InvalidClientTokenId while the correct credential sits on disk, correct and
+  // unused. Deriving the variables (above) only fixes precedence WITHIN the
+  // file — something still has to load the file.
+  //
+  // So the shell profile sources it. That is what makes "the credential is
+  // materialized" and "the credential is usable" the same statement.
+  const sourced = installProfileSourcing(valuesFile);
+
+  return { count: selected.size, derived: derived.size, dir, sourced };
 }
 
 function main() {

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1107,7 +1107,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/envfile.mjs":
       "be4e38ce85f9268b52b29dbde264ecd8d50973c2b63a15410336234a921d9644",
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs":
-      "b535ed8babf7237374de9886fca7967519f4719ab8a1c03f16dfddef05f0a138",
+      "32e4cd6011f619f15842b5cd07c6ca13f25b2c66af2f8b41b7759925ed8b14ad",
     "plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs":
       "fec38ca937570c1e1c21e6e8f7314a9d8f4e9264779d0394b40d5158924da0da",
     "plugins/src/base/skills/lisa-secrets-access/scripts/read-secret-note.mjs":
@@ -8493,6 +8493,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/doctor-secrets.test.ts": true,
     "tests/unit/secrets/install-method-conformance.test.ts": true,
     "tests/unit/secrets/local-env-command.test.ts": true,
+    "tests/unit/secrets/profile-sourcing.test.ts": true,
     "tests/unit/secrets/remote-dispatch-claude-web.test.ts": true,
     "tests/unit/secrets/remote-dispatch.test.ts": true,
     "tests/unit/secrets/remote-env-bindir-path.test.ts": true,

--- a/tests/unit/secrets/profile-sourcing.test.ts
+++ b/tests/unit/secrets/profile-sourcing.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Materialized secrets must actually be IN EFFECT, not merely on disk.
+ *
+ * Observed live: a Claude cloud session had a correct `secrets.env` (600, right
+ * values, AWS pair derived) and every AWS call still failed with
+ * `InvalidClientTokenId`. Nothing sourced the file, so the agent's shell kept
+ * the container's own injected `AWS_ACCESS_KEY_ID` — and environment variables
+ * outrank profile files in AWS's credential chain.
+ *
+ * Deriving the variables fixed precedence *within* the file. Something still has
+ * to load the file, which is what this covers.
+ * @module tests/unit/secrets/profile-sourcing
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { installProfileSourcing } from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs";
+
+/**
+ * An absolute bash, so the shell is never resolved through PATH.
+ *
+ * `sonarjs/no-os-command-from-path` guards against executing a command found on
+ * an influenceable PATH; scanning the directories in JS to get an absolute path
+ * avoids that entirely rather than suppressing the rule.
+ * @returns The first bash found on PATH, falling back to the usual location.
+ */
+function locateBash(): string {
+  for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, "bash");
+    if (existsSync(candidate)) return candidate;
+  }
+  return "/bin/bash";
+}
+
+/** Resolved once — every shell in this file runs through it. */
+const BASH = locateBash();
+
+/** Scratch homes to clean up. */
+const homes: string[] = [];
+
+/** The value the profile should make win. */
+const CORRECT = "AKIA_CORRECT";
+
+/** What the container injects, and what used to win. */
+const AMBIENT = "AKIA_AMBIENT_WRONG";
+
+/** The marker delimiting the managed block. */
+const MARKER = "# >>> lisa secrets (managed) >>>";
+
+/**
+ * A home with a materialized values file.
+ * @returns The home directory and the values file path.
+ */
+function scratchHome(): { home: string; values: string } {
+  const home = mkdtempSync(path.join(tmpdir(), "lisa-profile-"));
+  const values = path.join(home, "secrets.env");
+
+  homes.push(home);
+  writeFileSync(values, `export AWS_ACCESS_KEY_ID="${CORRECT}"\n`);
+
+  return { home, values };
+}
+
+afterEach(() => {
+  while (homes.length > 0) {
+    rmSync(homes.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe("installProfileSourcing", () => {
+  it("makes a real shell resolve the materialized value over the ambient one", () => {
+    // The end-to-end claim. Asserting the file's TEXT would pass even if the
+    // snippet did not work; only running a shell proves precedence.
+    const { home, values } = scratchHome();
+    installProfileSourcing(values, { home });
+
+    const out = execFileSync(
+      BASH,
+      [
+        "-c",
+        `. "${path.join(home, ".bashrc")}"; printf '%s' "$AWS_ACCESS_KEY_ID"`,
+      ],
+      {
+        encoding: "utf8",
+        env: { PATH: process.env.PATH, HOME: home, AWS_ACCESS_KEY_ID: AMBIENT },
+      }
+    );
+
+    expect(out).toBe(CORRECT);
+  });
+
+  it("exports rather than merely setting, so child processes inherit it", () => {
+    // `aws` is a child process. A shell variable that is not exported would
+    // satisfy the previous test and still leave the CLI failing.
+    const { home, values } = scratchHome();
+    installProfileSourcing(values, { home });
+
+    const out = execFileSync(
+      BASH,
+      [
+        "-c",
+        `. "${path.join(home, ".bashrc")}"; bash -c 'printf "%s" "$AWS_ACCESS_KEY_ID"'`,
+      ],
+      { encoding: "utf8", env: { PATH: process.env.PATH, HOME: home } }
+    );
+
+    expect(out).toBe(CORRECT);
+  });
+
+  it("preserves configuration it did not write", () => {
+    const { home, values } = scratchHome();
+    writeFileSync(path.join(home, ".bashrc"), "export KEEP=1\n");
+
+    installProfileSourcing(values, { home });
+
+    expect(readFileSync(path.join(home, ".bashrc"), "utf8")).toMatch(
+      /export KEEP=1/
+    );
+  });
+
+  it("replaces its block instead of appending on every session", () => {
+    // This runs at every session start; an append-forever profile is its own bug.
+    const { home, values } = scratchHome();
+
+    installProfileSourcing(values, { home });
+    installProfileSourcing(values, { home });
+    installProfileSourcing(values, { home });
+
+    const text = readFileSync(path.join(home, ".bashrc"), "utf8");
+    expect(text.split(MARKER).length - 1).toBe(1);
+  });
+
+  it("writes both .bashrc and .profile", () => {
+    // Which one a shell reads depends on interactive vs login, and an agent's
+    // tool calls are not reliably either.
+    const { home, values } = scratchHome();
+
+    expect(
+      installProfileSourcing(values, { home }).map(f => path.basename(f))
+    ).toEqual([".bashrc", ".profile"]);
+  });
+
+  it("leaves a shell working when the values file is absent", () => {
+    // Guarded on existence: a shell must still start before the first
+    // materialization, or if the file is removed.
+    const { home } = scratchHome();
+    const missing = path.join(home, "not-written-yet.env");
+    installProfileSourcing(missing, { home });
+
+    const out = execFileSync(
+      BASH,
+      ["-c", `. "${path.join(home, ".bashrc")}"; printf 'ok'`],
+      { encoding: "utf8", env: { PATH: process.env.PATH, HOME: home } }
+    );
+
+    expect(out).toBe("ok");
+  });
+});


### PR DESCRIPTION
## The materialized env was never in effect

A Claude cloud session had a **correct** `secrets.env` — 700 dir, 600 file, AWS
pair derived exactly as designed — and every AWS call still failed:

```
An error occurred (InvalidClientTokenId) when calling the GetCallerIdentity
operation: The security token included in the request is invalid.
```

Writing the file is not the same as the values being in effect. The agent's
shell starts from the container's own environment, which injects its own
`AWS_ACCESS_KEY_ID`, and **environment variables outrank profile files** in
AWS's credential chain. The correct credential sat on disk, correct and unused,
while the wrong ambient one won every call.

Deriving the AWS variables (2.331.3) fixed precedence *within* the file.
Something still had to load the file, and nothing did.

**The credential itself was never the problem.** I tested the stored bundle
against the live account before changing anything — valid, resolving to
`arn:aws:iam::777997078669:user/remote-agent`, unchanged since Aug 3. That ruled
out a dead or rotated key, which is where this would otherwise have been chased.

## Fix

Materialization writes a managed block into `.bashrc` and `.profile` that sources
the values file under `set -a`, so the values are exported and every child
process — `aws` included — inherits them.

| decision | why |
| --- | --- |
| both `.bashrc` and `.profile` | which one a shell reads depends on interactive vs login; an agent's tool calls are reliably neither |
| `set -a` | a set-but-unexported variable would satisfy a naive test and still leave the CLI failing |
| guarded on existence | a shell must still start before the first materialization, or if the file is removed |
| block replaced, not appended | this runs at every session start; an append-forever profile is its own bug |

## Evidence

A real bash, started with a **wrong** value already exported:

```
AWS_ACCESS_KEY_ID in shell: AKIA_CORRECT   ✅ correct wins over ambient
grandchild process inherits it             ✅ (proves `set -a`, not just set)
pre-existing profile config kept           ✅
managed blocks after 3 runs: 1             ✅
```

Asserting the file's *text* would have passed even if the snippet did not work;
only running a shell proves precedence.

## Known limitation

This works when the shell reads a profile — interactive or login. A bare
`bash -c` reads neither, and nothing in a hook can set environment variables for
a shell it does not spawn. If credentials are still absent in a session after
this, that is the thing to check; it is a different fix, not another credential
problem.

Full suite green: 8834 passed, 530 files. Lint clean, no suppressions
(`sonarjs/no-os-command-from-path` resolved by locating `bash` absolutely).

---

Work-Item: CodySwannGT/lisa#2309
