### PR TITLE
fix(hooks): block-no-verify must not fail open when jq is missing

### DIFF
--- a/all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh
@@ -20,17 +20,40 @@ set -euo pipefail
 
 input="$(cat)"
 
-tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+# Both interpreters must be probed BEFORE they are used, and a missing one must
+# be announced rather than swallowed.
+#
+# `jq` used to be called unguarded here while `python3` two lines below was
+# guarded. Under `set -e` an absent jq aborted the script with 127, and Claude
+# Code treats any non-2 exit as a NON-BLOCKING hook error — so the hook that
+# enforces "never --no-verify" silently permitted the very thing it exists to
+# stop. It was not hypothetical: agent containers routinely ship no jq (that is
+# why jq is now a pinned toolchain entry). The Codex variant of this script has
+# always had the guard, so this was a parity gap rather than a design choice.
+#
+# Degrading to "allow" is still the right behaviour — a hook that cannot parse
+# its input cannot tell a bypass from an ordinary command, and failing closed
+# would block every Bash call on a machine missing an interpreter. What is NOT
+# right is doing it quietly, so the operator gets one line on stderr saying the
+# protection is off. A guard that is silently absent reads exactly like a guard
+# that is passing.
+for required in jq python3; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    printf 'block-no-verify: %s not found; --no-verify protection is NOT active\n' \
+      "$required" >&2
+    exit 0
+  fi
+done
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)"
 if [ "$tool_name" != "Bash" ]; then
   exit 0
 fi
 
-command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
 if [ -z "$command_str" ]; then
   exit 0
 fi
-
-command -v python3 >/dev/null 2>&1 || exit 0
 
 if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
 import os

--- a/plugins/lisa-copilot/hooks/block-no-verify.sh
+++ b/plugins/lisa-copilot/hooks/block-no-verify.sh
@@ -20,17 +20,40 @@ set -euo pipefail
 
 input="$(cat)"
 
-tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+# Both interpreters must be probed BEFORE they are used, and a missing one must
+# be announced rather than swallowed.
+#
+# `jq` used to be called unguarded here while `python3` two lines below was
+# guarded. Under `set -e` an absent jq aborted the script with 127, and Claude
+# Code treats any non-2 exit as a NON-BLOCKING hook error — so the hook that
+# enforces "never --no-verify" silently permitted the very thing it exists to
+# stop. It was not hypothetical: agent containers routinely ship no jq (that is
+# why jq is now a pinned toolchain entry). The Codex variant of this script has
+# always had the guard, so this was a parity gap rather than a design choice.
+#
+# Degrading to "allow" is still the right behaviour — a hook that cannot parse
+# its input cannot tell a bypass from an ordinary command, and failing closed
+# would block every Bash call on a machine missing an interpreter. What is NOT
+# right is doing it quietly, so the operator gets one line on stderr saying the
+# protection is off. A guard that is silently absent reads exactly like a guard
+# that is passing.
+for required in jq python3; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    printf 'block-no-verify: %s not found; --no-verify protection is NOT active\n' \
+      "$required" >&2
+    exit 0
+  fi
+done
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)"
 if [ "$tool_name" != "Bash" ]; then
   exit 0
 fi
 
-command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
 if [ -z "$command_str" ]; then
   exit 0
 fi
-
-command -v python3 >/dev/null 2>&1 || exit 0
 
 if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
 import os

--- a/plugins/lisa-cursor/hooks/block-no-verify.sh
+++ b/plugins/lisa-cursor/hooks/block-no-verify.sh
@@ -20,17 +20,40 @@ set -euo pipefail
 
 input="$(cat)"
 
-tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+# Both interpreters must be probed BEFORE they are used, and a missing one must
+# be announced rather than swallowed.
+#
+# `jq` used to be called unguarded here while `python3` two lines below was
+# guarded. Under `set -e` an absent jq aborted the script with 127, and Claude
+# Code treats any non-2 exit as a NON-BLOCKING hook error — so the hook that
+# enforces "never --no-verify" silently permitted the very thing it exists to
+# stop. It was not hypothetical: agent containers routinely ship no jq (that is
+# why jq is now a pinned toolchain entry). The Codex variant of this script has
+# always had the guard, so this was a parity gap rather than a design choice.
+#
+# Degrading to "allow" is still the right behaviour — a hook that cannot parse
+# its input cannot tell a bypass from an ordinary command, and failing closed
+# would block every Bash call on a machine missing an interpreter. What is NOT
+# right is doing it quietly, so the operator gets one line on stderr saying the
+# protection is off. A guard that is silently absent reads exactly like a guard
+# that is passing.
+for required in jq python3; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    printf 'block-no-verify: %s not found; --no-verify protection is NOT active\n' \
+      "$required" >&2
+    exit 0
+  fi
+done
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)"
 if [ "$tool_name" != "Bash" ]; then
   exit 0
 fi
 
-command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
 if [ -z "$command_str" ]; then
   exit 0
 fi
-
-command -v python3 >/dev/null 2>&1 || exit 0
 
 if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
 import os

--- a/plugins/lisa/hooks/block-no-verify.sh
+++ b/plugins/lisa/hooks/block-no-verify.sh
@@ -20,17 +20,40 @@ set -euo pipefail
 
 input="$(cat)"
 
-tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+# Both interpreters must be probed BEFORE they are used, and a missing one must
+# be announced rather than swallowed.
+#
+# `jq` used to be called unguarded here while `python3` two lines below was
+# guarded. Under `set -e` an absent jq aborted the script with 127, and Claude
+# Code treats any non-2 exit as a NON-BLOCKING hook error — so the hook that
+# enforces "never --no-verify" silently permitted the very thing it exists to
+# stop. It was not hypothetical: agent containers routinely ship no jq (that is
+# why jq is now a pinned toolchain entry). The Codex variant of this script has
+# always had the guard, so this was a parity gap rather than a design choice.
+#
+# Degrading to "allow" is still the right behaviour — a hook that cannot parse
+# its input cannot tell a bypass from an ordinary command, and failing closed
+# would block every Bash call on a machine missing an interpreter. What is NOT
+# right is doing it quietly, so the operator gets one line on stderr saying the
+# protection is off. A guard that is silently absent reads exactly like a guard
+# that is passing.
+for required in jq python3; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    printf 'block-no-verify: %s not found; --no-verify protection is NOT active\n' \
+      "$required" >&2
+    exit 0
+  fi
+done
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)"
 if [ "$tool_name" != "Bash" ]; then
   exit 0
 fi
 
-command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
 if [ -z "$command_str" ]; then
   exit 0
 fi
-
-command -v python3 >/dev/null 2>&1 || exit 0
 
 if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
 import os

--- a/plugins/src/base/hooks/block-no-verify.sh
+++ b/plugins/src/base/hooks/block-no-verify.sh
@@ -20,17 +20,40 @@ set -euo pipefail
 
 input="$(cat)"
 
-tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+# Both interpreters must be probed BEFORE they are used, and a missing one must
+# be announced rather than swallowed.
+#
+# `jq` used to be called unguarded here while `python3` two lines below was
+# guarded. Under `set -e` an absent jq aborted the script with 127, and Claude
+# Code treats any non-2 exit as a NON-BLOCKING hook error — so the hook that
+# enforces "never --no-verify" silently permitted the very thing it exists to
+# stop. It was not hypothetical: agent containers routinely ship no jq (that is
+# why jq is now a pinned toolchain entry). The Codex variant of this script has
+# always had the guard, so this was a parity gap rather than a design choice.
+#
+# Degrading to "allow" is still the right behaviour — a hook that cannot parse
+# its input cannot tell a bypass from an ordinary command, and failing closed
+# would block every Bash call on a machine missing an interpreter. What is NOT
+# right is doing it quietly, so the operator gets one line on stderr saying the
+# protection is off. A guard that is silently absent reads exactly like a guard
+# that is passing.
+for required in jq python3; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    printf 'block-no-verify: %s not found; --no-verify protection is NOT active\n' \
+      "$required" >&2
+    exit 0
+  fi
+done
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)"
 if [ "$tool_name" != "Bash" ]; then
   exit 0
 fi
 
-command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
 if [ -z "$command_str" ]; then
   exit 0
 fi
-
-command -v python3 >/dev/null 2>&1 || exit 0
 
 if ! BLOCK_NO_VERIFY_COMMAND="$command_str" python3 - <<'PY'
 import os

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -13,7 +13,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
       "8996e0bcbf1db085a5d99734e797c91f5025997bd967bc374efff8348dac14c2",
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh":
-      "aa95a84f9f9224914947a09b858535aa8bd052199ff64cb53768cf78fb69b687",
+      "a6ed91576efebb6ba40cfa4e9d8a3e8566314909210ae8d5860be62a3feb4cff",
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh":
       "3b5f074f3ab5708030af507eea962389f3b067c5dbdc76580bd9e44d3ac6c603",
     "all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh":
@@ -595,7 +595,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/block-no-verify.agy.sh":
       "1a36c841b6339a2c664938d65c5a4542f97d05f584e467de448bb72ac6bdba55",
     "plugins/src/base/hooks/block-no-verify.sh":
-      "aa95a84f9f9224914947a09b858535aa8bd052199ff64cb53768cf78fb69b687",
+      "a6ed91576efebb6ba40cfa4e9d8a3e8566314909210ae8d5860be62a3feb4cff",
     "plugins/src/base/hooks/block-shell-json-parsing.agy.sh":
       "dc688efe382e7b8fe6f6c88bb0fde851527128cae778599559f23a93f1c9ec86",
     "plugins/src/base/hooks/block-shell-json-parsing.sh":
@@ -8392,6 +8392,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/health/storage.test.ts": true,
     "tests/unit/hooks/block-generated-artifact-edits.test.ts": true,
     "tests/unit/hooks/block-instruction-file-edits.test.ts": true,
+    "tests/unit/hooks/block-no-verify-missing-jq.test.ts": true,
     "tests/unit/hooks/block-no-verify.test.ts": true,
     "tests/unit/hooks/block-shell-json-parsing.test.ts": true,
     "tests/unit/hooks/blocking-hook-exit.test.ts": true,

--- a/tests/unit/hooks/block-no-verify-missing-jq.test.ts
+++ b/tests/unit/hooks/block-no-verify-missing-jq.test.ts
@@ -1,0 +1,127 @@
+/**
+ * `block-no-verify` must not fail open when its interpreters are absent.
+ *
+ * The hook's exit code IS its contract: 2 refuses, 0 allows, and Claude Code
+ * treats every OTHER non-zero exit as a non-blocking hook error — meaning the
+ * command runs. `jq` was called unguarded under `set -euo pipefail`, so a
+ * container without jq exited 127 and the hook that enforces "never
+ * --no-verify" silently permitted exactly what it exists to stop.
+ *
+ * Not hypothetical: the agent containers this is deployed into shipped no jq,
+ * which is why jq is now a pinned toolchain entry. The Codex variant of this
+ * script always had the guard, so this was a parity gap.
+ *
+ * Failing OPEN is still correct — a hook that cannot parse its input cannot
+ * tell a bypass from an ordinary command, and failing closed would block every
+ * Bash call on a machine missing an interpreter. Doing it SILENTLY is not: a
+ * guard that is quietly absent is indistinguishable from a guard that passes.
+ * @module tests/unit/hooks/block-no-verify-missing-jq
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+/** The hook as it is installed into a project. */
+const HOOK = path.resolve(
+  __dirname,
+  "../../../all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh"
+);
+
+/** A PreToolUse payload for a command that bypasses the hooks. */
+const BYPASS = JSON.stringify({
+  tool_name: "Bash",
+  tool_input: { command: "git commit --no-verify -m x" },
+});
+
+/** Tools the hook legitimately needs, minus the one under test. */
+const SHIM_TOOLS = ["bash", "sh", "env", "printf", "grep", "cat", "python3"];
+
+/** A PATH directory deliberately missing `jq`. */
+const shim = mkdtempSync(path.join(tmpdir(), "lisa-nojq-"));
+
+/**
+ * Find an executable by scanning PATH directly.
+ *
+ * Deliberately not `spawnSync("command -v")`: resolving a command *through*
+ * PATH is what `sonarjs/no-os-command-from-path` exists to prevent, and reading
+ * the directories to build a fixture needs no subprocess at all.
+ * @param tool The executable name.
+ * @returns Its absolute path, or undefined.
+ */
+function locate(tool: string): string | undefined {
+  for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, tool);
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/** An absolute bash, so the runner is never resolved through the shim PATH. */
+const BASH = locate("bash") ?? "/bin/bash";
+
+for (const tool of SHIM_TOOLS) {
+  const found = locate(tool);
+  if (found) symlinkSync(found, path.join(shim, tool));
+}
+
+afterAll(() => rmSync(shim, { recursive: true, force: true }));
+
+/**
+ * Run the hook with a payload and a PATH.
+ * @param payload The JSON given on stdin.
+ * @param pathEnv The PATH to run under.
+ * @returns Exit status and stderr.
+ */
+function runHook(
+  payload: string,
+  pathEnv = process.env.PATH
+): { status: number; stderr: string } {
+  const result = spawnSync(BASH, [HOOK], {
+    input: payload,
+    encoding: "utf8",
+    env: { ...process.env, PATH: pathEnv },
+  });
+
+  return { status: result.status ?? -1, stderr: result.stderr ?? "" };
+}
+
+describe("block-no-verify when jq is missing", () => {
+  it("does not exit 127, which would read as a non-blocking hook error", () => {
+    // 127 is the whole bug: not a refusal, so the command proceeds unguarded.
+    const { status } = runHook(BYPASS, shim);
+
+    expect(status).not.toBe(127);
+    expect(status).toBe(0);
+  });
+
+  it("says on stderr that the protection is not active", () => {
+    // Failing open is acceptable; failing open silently is not.
+    const { stderr } = runHook(BYPASS, shim);
+
+    expect(stderr).toMatch(/jq not found/);
+    expect(stderr).toMatch(/protection is NOT active/);
+  });
+});
+
+describe("block-no-verify with its interpreters present", () => {
+  it("still refuses a bypass with exit 2", () => {
+    // The guard must not have been weakened to achieve the above.
+    expect(runHook(BYPASS).status).toBe(2);
+  });
+
+  it("still allows an ordinary command", () => {
+    expect(
+      runHook(
+        JSON.stringify({
+          tool_name: "Bash",
+          tool_input: { command: "git status" },
+        })
+      ).status
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## The guard against `--no-verify` was silently permitting it

`scripts/lisa-hooks/block-no-verify.sh` called `jq` **unguarded** under
`set -euo pipefail`, while guarding `python3` two lines below:

```sh
set -euo pipefail
tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"   # no guard
...
command -v python3 >/dev/null 2>&1 || exit 0                        # guarded
```

With jq absent the script aborts with **127**, and Claude Code treats any non-2
exit as a **non-blocking hook error** — so the command runs. The hook enforcing
"never `--no-verify`" permitted exactly what it exists to stop, and said nothing.

**Not hypothetical.** These agent containers shipped no jq, which is what
CodySwannGT/lisa#2304 was about. The asymmetry with `python3` shows the guard was
intended, and the Codex variant already had it
(`src/codex/scripts/block-no-verify.sh:13`) — a parity gap, not an open design
question.

## Fix

Probe both interpreters before use, in every variant, and **say so** when one is
missing.

Failing **open** stays correct: a hook that cannot parse its input cannot tell a
bypass from an ordinary command, and failing closed would block every Bash call
on a machine missing an interpreter. Failing open **silently** is the actual
defect — a guard that is quietly absent is indistinguishable from one that
passes.

## Evidence

Exit codes are the hook's entire contract:

| case | origin/main | with fix |
| --- | --- | --- |
| bypass, jq present | 2 refused | 2 refused |
| ordinary command | 0 allowed | 0 allowed |
| bypass, **no jq** | **127, silent** | **0, and announces the protection is off** |

Run against a PATH containing every interpreter except jq.

**Negative control:** the new tests fail 2 of 4 against `origin/main` — exactly
the two describing the bug — and all 4 pass after. The two "still works" cases
pass on both, proving the guard was not weakened to achieve the rest.

Lint clean with no suppressions: `sonarjs/no-os-command-from-path` was resolved
by resolving `bash` to an absolute path rather than disabling the rule.

---

Work-Item: CodySwannGT/lisa#2308
