### PR TITLE
feat(secrets): assume a role per environment instead of exporting the bootstrap pair

### DIFF
--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -33,8 +33,98 @@ const ACCESS_KEY = "AWS_ACCESS_KEY_ID";
 const SECRET_KEY = "AWS_SECRET_ACCESS_KEY";
 const REGION = "AWS_DEFAULT_REGION";
 
+/** Selects which environment's role a session assumes. */
+const PROFILE = "AWS_PROFILE";
+
 /** The bundle that carries the agent's identity. */
 export const BOOTSTRAP_KEY = "LISA_AWS_BOOTSTRAP_JSON";
+
+/**
+ * The profile that holds the bootstrap key pair and is assumed FROM.
+ *
+ * Named rather than `default` so it can never be picked up by accident: this
+ * identity can assume roles and do nothing else, so a call that silently ran as
+ * it would fail with a permissions error far from its cause.
+ */
+export const SOURCE_PROFILE = "lisa-bootstrap";
+
+/**
+ * Read the bundle's `profiles`, which may be an object OR a JSON string.
+ *
+ * The real bundle stores it double-encoded — a string containing JSON — so a
+ * plain `typeof === "object"` check silently yields zero profiles and every
+ * environment quietly disappears. Failing that way is worse than throwing:
+ * everything still "works", as the assume-only identity, with no permissions.
+ * @param {object|null} bundle Parsed bootstrap bundle.
+ * @returns {Record<string, {roleArn?: string, region?: string}>} Profiles by name.
+ */
+export function readProfiles(bundle) {
+  const raw = bundle?.profiles;
+  if (!raw) return {};
+  if (typeof raw === "object") return raw;
+  if (typeof raw !== "string") return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Render `~/.aws/credentials` and `~/.aws/config` from the bundle.
+ *
+ * The bundle carries a `profiles` map — one entry per environment, each a
+ * `roleArn` in a DIFFERENT account — plus the `externalId` those roles require.
+ * Nothing consumed any of it, so `--profile agent-dev` failed with "profile not
+ * found" and every call fell back to the bootstrap identity in the shared
+ * account. That identity can assume roles and nothing else, which is why
+ * `aws sts get-caller-identity` could succeed while real work had no
+ * permissions anywhere: a green check that proved only the first link.
+ *
+ * Writing the pair here rather than exporting it is deliberate. Exported
+ * environment credentials OUTRANK `AWS_PROFILE`, so a session that exports them
+ * ignores whichever profile it selects — the profiles would exist and never be
+ * used.
+ * @param {object} bundle Parsed bootstrap bundle.
+ * @returns {{credentials: string, config: string, profiles: string[]}|null}
+ *   Rendered file contents and the profile names, or null when unusable.
+ */
+export function renderAwsProfiles(bundle) {
+  if (!bundle) return null;
+
+  const accessKeyId = bundle.accessKeyId ?? bundle.aws_access_key_id;
+  const secretAccessKey =
+    bundle.secretAccessKey ?? bundle.aws_secret_access_key;
+  if (!accessKeyId || !secretAccessKey) return null;
+
+  const profiles = readProfiles(bundle);
+
+  const credentials = [
+    `[${SOURCE_PROFILE}]`,
+    `aws_access_key_id = ${accessKeyId}`,
+    `aws_secret_access_key = ${secretAccessKey}`,
+    "",
+  ].join("\n");
+
+  const sections = [];
+  for (const [name, entry] of Object.entries(profiles)) {
+    const roleArn = entry?.roleArn ?? entry?.role_arn;
+    if (!roleArn) continue;
+
+    const lines = [`[profile ${name}]`, `role_arn = ${roleArn}`];
+    lines.push(`source_profile = ${SOURCE_PROFILE}`);
+    if (bundle.externalId) lines.push(`external_id = ${bundle.externalId}`);
+    if (entry.region) lines.push(`region = ${entry.region}`);
+    sections.push(`${lines.join("\n")}\n`);
+  }
+
+  return {
+    credentials,
+    config: sections.join("\n"),
+    profiles: sections.map(s => s.slice(9, s.indexOf("]"))),
+  };
+}
 
 /**
  * Read the bootstrap bundle, treating anything malformed as absent.
@@ -80,16 +170,41 @@ export function deriveAwsEnvironment(selected) {
   // explicit. Overriding that would be this module guessing against an operator.
   if (selected.has(ACCESS_KEY) || selected.has(SECRET_KEY)) return derived;
 
-  const note =
-    `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Exported ` +
-    `deliberately so it overrides any ambient ${ACCESS_KEY} the host injects — ` +
-    `environment variables outrank profile files in the AWS credential chain, ` +
-    `so without this a stale host value wins and every call fails with ` +
-    `InvalidClientTokenId. This is the assume-only bootstrap identity; real ` +
-    `work assumes a role from it.`;
+  // The key pair is deliberately NOT exported.
+  //
+  // It used to be, to out-shout the ambient pair a cloud container injects. That
+  // worked and cost more than it bought: exported environment credentials
+  // outrank `AWS_PROFILE`, so every call ran as the bootstrap identity — which
+  // can assume roles and do nothing else. `aws sts get-caller-identity`
+  // succeeded while real work had no permissions in any environment account,
+  // because each environment is a SEPARATE account reached by assuming a role.
+  //
+  // The pair now lives in ~/.aws/credentials as the source profile, and the
+  // session selects an environment instead. The ambient pair is unset by the
+  // shell profile rather than overridden — removing the poison beats out-
+  // shouting it, and it is what makes `--profile agent-staging` behave exactly
+  // as it does on a developer's machine.
+  const names = Object.keys(readProfiles(bundle));
+  if (names.length > 0 && !selected.has(PROFILE)) {
+    // Never production by default. An implicit production profile is one
+    // careless command away from a bad afternoon; that one must be typed.
+    const preferred =
+      names.find(name => /dev/i.test(name)) ??
+      names.find(name => !/prod/i.test(name)) ??
+      names[0];
 
-  derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
-  derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+    derived.set(PROFILE, {
+      value: preferred,
+      note:
+        `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Selects the ` +
+        `environment whose role this session assumes, via ~/.aws/config. ` +
+        `Defaults to a non-production profile deliberately — reach production ` +
+        `by naming it (\`--profile ${names.find(n => /prod/i.test(n)) ?? "…"}\`). ` +
+        `The bootstrap key pair is NOT exported: environment credentials ` +
+        `outrank AWS_PROFILE, so exporting them would ignore this selection ` +
+        `and run everything as the assume-only identity.`,
+    });
+  }
 
   const region = bundle.region ?? bundle.defaultRegion;
   if (region && !selected.has(REGION)) {

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -108,22 +108,29 @@ export function renderAwsProfiles(bundle) {
   ].join("\n");
 
   const sections = [];
+  const names = [];
   for (const [name, entry] of Object.entries(profiles)) {
     const roleArn = entry?.roleArn ?? entry?.role_arn;
     if (!roleArn) continue;
+
+    // A name is only usable if it can be written as an ini section header and
+    // read back as the same string. Anything with a bracket or newline would
+    // either truncate or inject extra lines into ~/.aws/config, and a config
+    // file this corrupts is worse than one it never wrote.
+    if (!/^[\w.@-]+$/.test(name)) continue;
 
     const lines = [`[profile ${name}]`, `role_arn = ${roleArn}`];
     lines.push(`source_profile = ${SOURCE_PROFILE}`);
     if (bundle.externalId) lines.push(`external_id = ${bundle.externalId}`);
     if (entry.region) lines.push(`region = ${entry.region}`);
     sections.push(`${lines.join("\n")}\n`);
+    // Collected here, where the name is already in scope. Recovering it by
+    // re-parsing the rendered text made the header format load-bearing: a
+    // change to it would silently corrupt every returned name.
+    names.push(name);
   }
 
-  return {
-    credentials,
-    config: sections.join("\n"),
-    profiles: sections.map(s => s.slice(9, s.indexOf("]"))),
-  };
+  return { credentials, config: sections.join("\n"), profiles: names };
 }
 
 /**
@@ -184,7 +191,30 @@ export function deriveAwsEnvironment(selected) {
   // shell profile rather than overridden — removing the poison beats out-
   // shouting it, and it is what makes `--profile agent-staging` behave exactly
   // as it does on a developer's machine.
-  const names = Object.keys(readProfiles(bundle));
+  // Only profiles that actually get WRITTEN are candidates. Selecting a name
+  // that ~/.aws/config never contains — an entry with no roleArn, or a name too
+  // exotic to be an ini header — fails with "profile not found", which is the
+  // exact failure this whole change removes.
+  const names = renderAwsProfiles(bundle)?.profiles ?? [];
+
+  // No usable profiles is not a reason to hand back a session with NOTHING.
+  //
+  // The pair stops being exported only because a profile supersedes it. With no
+  // profile to select, exporting it is the difference between a degraded
+  // session (the assume-only identity, which at least authenticates) and a dead
+  // one — and the managed shell block unsets the ambient pair, so nothing would
+  // fill the gap.
+  if (names.length === 0) {
+    const note =
+      `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. The bundle ` +
+      `declares no usable per-environment profile, so this falls back to the ` +
+      `bootstrap identity. It can assume roles and little else — if AWS calls ` +
+      `fail with permission errors, the bundle's "profiles" map is the thing ` +
+      `to check.`;
+    derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
+    derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+  }
+
   if (names.length > 0 && !selected.has(PROFILE)) {
     // Never production by default. An implicit production profile is one
     // careless command away from a bad afternoon; that one must be typed.

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -74,6 +74,15 @@ const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
 const PROFILE_END = "# <<< lisa secrets (managed) <<<";
 
 /**
+ * Identifies an `~/.aws` file as one this wrote, and may therefore replace.
+ *
+ * `#` is a comment in the AWS shared-config format, so this is inert to every
+ * consumer while still being the thing that distinguishes "our file, refresh
+ * it" from "someone else's file, leave it alone".
+ */
+const MANAGED_MARKER = "# managed by lisa-secrets-access";
+
+/**
  * Make every shell in this container load the materialized secrets.
  *
  * `set -a` so the values are exported rather than merely set as shell
@@ -153,6 +162,8 @@ export function installAwsProfiles(bundle, options = {}) {
     home = process.env.HOME || homedir(),
     mkdir = mkdirSync,
     write = writeFileSync,
+    read = readFileSync,
+    exists = existsSync,
     chmod = chmodSync,
   } = options;
 
@@ -160,10 +171,34 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
+
+  // Never overwrite an ~/.aws this did not write.
+  //
+  // These are whole-file writes, so a pre-existing credentials file — a
+  // developer's own profiles, or something another tool set up — would be
+  // destroyed rather than merged. This only runs on a surface allowed to write
+  // secrets to disk (a disposable container), but "usually disposable" is not a
+  // reason to be able to delete someone's credentials. The marker makes our own
+  // file re-writable while anything else is left alone and reported.
+  for (const name of ["credentials", "config"]) {
+    const file = join(dir, name);
+    if (exists(file) && !String(read(file, "utf8")).includes(MANAGED_MARKER)) {
+      return [];
+    }
+  }
+
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
-  write(join(dir, "credentials"), rendered.credentials, { mode: 0o600 });
-  write(join(dir, "config"), rendered.config, { mode: 0o600 });
+  write(
+    join(dir, "credentials"),
+    `${MANAGED_MARKER}\n${rendered.credentials}`,
+    {
+      mode: 0o600,
+    }
+  );
+  write(join(dir, "config"), `${MANAGED_MARKER}\n${rendered.config}`, {
+    mode: 0o600,
+  });
 
   return rendered.profiles;
 }

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -31,7 +31,12 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
+import {
+  BOOTSTRAP_KEY,
+  deriveAwsEnvironment,
+  parseBootstrap,
+  renderAwsProfiles,
+} from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
 import { fetchAll } from "./providers.mjs";
 import { materializedPaths, readConfig } from "./surfaces.mjs";
@@ -95,6 +100,14 @@ export function installProfileSourcing(valuesFile, options = {}) {
 
   const block = [
     PROFILE_MARKER,
+    // Unset BEFORE sourcing. A cloud container injects its own AWS key pair,
+    // and environment credentials outrank both ~/.aws profiles and AWS_PROFILE
+    // — so leaving them set means the session ignores whichever environment it
+    // selected and runs as whatever the host injected. That is how a perfectly
+    // valid credential produced InvalidClientTokenId for a day. Removing the
+    // poison beats out-shouting it, and it is what lets `--profile agent-dev`
+    // behave here exactly as it does on a developer's machine.
+    `unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN`,
     `if [ -f "${valuesFile}" ]; then`,
     `  set -a`,
     `  . "${valuesFile}"`,
@@ -124,6 +137,35 @@ export function installProfileSourcing(valuesFile, options = {}) {
     }
   }
   return updated;
+}
+
+/**
+ * Write `~/.aws/credentials` and `~/.aws/config` from the bootstrap bundle.
+ *
+ * Both at 0600 inside a 0700 directory, matching how the materialized secrets
+ * themselves are protected — the credentials file holds the source key pair.
+ * @param {object|null} bundle Parsed bootstrap bundle.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile names written.
+ */
+export function installAwsProfiles(bundle, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    mkdir = mkdirSync,
+    write = writeFileSync,
+    chmod = chmodSync,
+  } = options;
+
+  const rendered = renderAwsProfiles(bundle);
+  if (!rendered) return [];
+
+  const dir = join(home, ".aws");
+  mkdir(dir, { recursive: true, mode: 0o700 });
+  chmod(dir, 0o700);
+  write(join(dir, "credentials"), rendered.credentials, { mode: 0o600 });
+  write(join(dir, "config"), rendered.config, { mode: 0o600 });
+
+  return rendered.profiles;
 }
 
 export function materialize(cfg = readConfig()) {
@@ -170,7 +212,21 @@ export function materialize(cfg = readConfig()) {
   // materialized" and "the credential is usable" the same statement.
   const sourced = installProfileSourcing(valuesFile);
 
-  return { count: selected.size, derived: derived.size, dir, sourced };
+  // The environments live in separate AWS accounts, reached by assuming a role
+  // per environment. Without these files `--profile agent-dev` fails with
+  // "profile not found" and everything silently falls back to the bootstrap
+  // identity, which can assume roles and do nothing else.
+  const profiles = installAwsProfiles(
+    parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value)
+  );
+
+  return {
+    count: selected.size,
+    derived: derived.size,
+    dir,
+    sourced,
+    profiles,
+  };
 }
 
 function main() {

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -33,8 +33,98 @@ const ACCESS_KEY = "AWS_ACCESS_KEY_ID";
 const SECRET_KEY = "AWS_SECRET_ACCESS_KEY";
 const REGION = "AWS_DEFAULT_REGION";
 
+/** Selects which environment's role a session assumes. */
+const PROFILE = "AWS_PROFILE";
+
 /** The bundle that carries the agent's identity. */
 export const BOOTSTRAP_KEY = "LISA_AWS_BOOTSTRAP_JSON";
+
+/**
+ * The profile that holds the bootstrap key pair and is assumed FROM.
+ *
+ * Named rather than `default` so it can never be picked up by accident: this
+ * identity can assume roles and do nothing else, so a call that silently ran as
+ * it would fail with a permissions error far from its cause.
+ */
+export const SOURCE_PROFILE = "lisa-bootstrap";
+
+/**
+ * Read the bundle's `profiles`, which may be an object OR a JSON string.
+ *
+ * The real bundle stores it double-encoded — a string containing JSON — so a
+ * plain `typeof === "object"` check silently yields zero profiles and every
+ * environment quietly disappears. Failing that way is worse than throwing:
+ * everything still "works", as the assume-only identity, with no permissions.
+ * @param {object|null} bundle Parsed bootstrap bundle.
+ * @returns {Record<string, {roleArn?: string, region?: string}>} Profiles by name.
+ */
+export function readProfiles(bundle) {
+  const raw = bundle?.profiles;
+  if (!raw) return {};
+  if (typeof raw === "object") return raw;
+  if (typeof raw !== "string") return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Render `~/.aws/credentials` and `~/.aws/config` from the bundle.
+ *
+ * The bundle carries a `profiles` map — one entry per environment, each a
+ * `roleArn` in a DIFFERENT account — plus the `externalId` those roles require.
+ * Nothing consumed any of it, so `--profile agent-dev` failed with "profile not
+ * found" and every call fell back to the bootstrap identity in the shared
+ * account. That identity can assume roles and nothing else, which is why
+ * `aws sts get-caller-identity` could succeed while real work had no
+ * permissions anywhere: a green check that proved only the first link.
+ *
+ * Writing the pair here rather than exporting it is deliberate. Exported
+ * environment credentials OUTRANK `AWS_PROFILE`, so a session that exports them
+ * ignores whichever profile it selects — the profiles would exist and never be
+ * used.
+ * @param {object} bundle Parsed bootstrap bundle.
+ * @returns {{credentials: string, config: string, profiles: string[]}|null}
+ *   Rendered file contents and the profile names, or null when unusable.
+ */
+export function renderAwsProfiles(bundle) {
+  if (!bundle) return null;
+
+  const accessKeyId = bundle.accessKeyId ?? bundle.aws_access_key_id;
+  const secretAccessKey =
+    bundle.secretAccessKey ?? bundle.aws_secret_access_key;
+  if (!accessKeyId || !secretAccessKey) return null;
+
+  const profiles = readProfiles(bundle);
+
+  const credentials = [
+    `[${SOURCE_PROFILE}]`,
+    `aws_access_key_id = ${accessKeyId}`,
+    `aws_secret_access_key = ${secretAccessKey}`,
+    "",
+  ].join("\n");
+
+  const sections = [];
+  for (const [name, entry] of Object.entries(profiles)) {
+    const roleArn = entry?.roleArn ?? entry?.role_arn;
+    if (!roleArn) continue;
+
+    const lines = [`[profile ${name}]`, `role_arn = ${roleArn}`];
+    lines.push(`source_profile = ${SOURCE_PROFILE}`);
+    if (bundle.externalId) lines.push(`external_id = ${bundle.externalId}`);
+    if (entry.region) lines.push(`region = ${entry.region}`);
+    sections.push(`${lines.join("\n")}\n`);
+  }
+
+  return {
+    credentials,
+    config: sections.join("\n"),
+    profiles: sections.map(s => s.slice(9, s.indexOf("]"))),
+  };
+}
 
 /**
  * Read the bootstrap bundle, treating anything malformed as absent.
@@ -80,16 +170,41 @@ export function deriveAwsEnvironment(selected) {
   // explicit. Overriding that would be this module guessing against an operator.
   if (selected.has(ACCESS_KEY) || selected.has(SECRET_KEY)) return derived;
 
-  const note =
-    `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Exported ` +
-    `deliberately so it overrides any ambient ${ACCESS_KEY} the host injects — ` +
-    `environment variables outrank profile files in the AWS credential chain, ` +
-    `so without this a stale host value wins and every call fails with ` +
-    `InvalidClientTokenId. This is the assume-only bootstrap identity; real ` +
-    `work assumes a role from it.`;
+  // The key pair is deliberately NOT exported.
+  //
+  // It used to be, to out-shout the ambient pair a cloud container injects. That
+  // worked and cost more than it bought: exported environment credentials
+  // outrank `AWS_PROFILE`, so every call ran as the bootstrap identity — which
+  // can assume roles and do nothing else. `aws sts get-caller-identity`
+  // succeeded while real work had no permissions in any environment account,
+  // because each environment is a SEPARATE account reached by assuming a role.
+  //
+  // The pair now lives in ~/.aws/credentials as the source profile, and the
+  // session selects an environment instead. The ambient pair is unset by the
+  // shell profile rather than overridden — removing the poison beats out-
+  // shouting it, and it is what makes `--profile agent-staging` behave exactly
+  // as it does on a developer's machine.
+  const names = Object.keys(readProfiles(bundle));
+  if (names.length > 0 && !selected.has(PROFILE)) {
+    // Never production by default. An implicit production profile is one
+    // careless command away from a bad afternoon; that one must be typed.
+    const preferred =
+      names.find(name => /dev/i.test(name)) ??
+      names.find(name => !/prod/i.test(name)) ??
+      names[0];
 
-  derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
-  derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+    derived.set(PROFILE, {
+      value: preferred,
+      note:
+        `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Selects the ` +
+        `environment whose role this session assumes, via ~/.aws/config. ` +
+        `Defaults to a non-production profile deliberately — reach production ` +
+        `by naming it (\`--profile ${names.find(n => /prod/i.test(n)) ?? "…"}\`). ` +
+        `The bootstrap key pair is NOT exported: environment credentials ` +
+        `outrank AWS_PROFILE, so exporting them would ignore this selection ` +
+        `and run everything as the assume-only identity.`,
+    });
+  }
 
   const region = bundle.region ?? bundle.defaultRegion;
   if (region && !selected.has(REGION)) {

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -108,22 +108,29 @@ export function renderAwsProfiles(bundle) {
   ].join("\n");
 
   const sections = [];
+  const names = [];
   for (const [name, entry] of Object.entries(profiles)) {
     const roleArn = entry?.roleArn ?? entry?.role_arn;
     if (!roleArn) continue;
+
+    // A name is only usable if it can be written as an ini section header and
+    // read back as the same string. Anything with a bracket or newline would
+    // either truncate or inject extra lines into ~/.aws/config, and a config
+    // file this corrupts is worse than one it never wrote.
+    if (!/^[\w.@-]+$/.test(name)) continue;
 
     const lines = [`[profile ${name}]`, `role_arn = ${roleArn}`];
     lines.push(`source_profile = ${SOURCE_PROFILE}`);
     if (bundle.externalId) lines.push(`external_id = ${bundle.externalId}`);
     if (entry.region) lines.push(`region = ${entry.region}`);
     sections.push(`${lines.join("\n")}\n`);
+    // Collected here, where the name is already in scope. Recovering it by
+    // re-parsing the rendered text made the header format load-bearing: a
+    // change to it would silently corrupt every returned name.
+    names.push(name);
   }
 
-  return {
-    credentials,
-    config: sections.join("\n"),
-    profiles: sections.map(s => s.slice(9, s.indexOf("]"))),
-  };
+  return { credentials, config: sections.join("\n"), profiles: names };
 }
 
 /**
@@ -184,7 +191,30 @@ export function deriveAwsEnvironment(selected) {
   // shell profile rather than overridden — removing the poison beats out-
   // shouting it, and it is what makes `--profile agent-staging` behave exactly
   // as it does on a developer's machine.
-  const names = Object.keys(readProfiles(bundle));
+  // Only profiles that actually get WRITTEN are candidates. Selecting a name
+  // that ~/.aws/config never contains — an entry with no roleArn, or a name too
+  // exotic to be an ini header — fails with "profile not found", which is the
+  // exact failure this whole change removes.
+  const names = renderAwsProfiles(bundle)?.profiles ?? [];
+
+  // No usable profiles is not a reason to hand back a session with NOTHING.
+  //
+  // The pair stops being exported only because a profile supersedes it. With no
+  // profile to select, exporting it is the difference between a degraded
+  // session (the assume-only identity, which at least authenticates) and a dead
+  // one — and the managed shell block unsets the ambient pair, so nothing would
+  // fill the gap.
+  if (names.length === 0) {
+    const note =
+      `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. The bundle ` +
+      `declares no usable per-environment profile, so this falls back to the ` +
+      `bootstrap identity. It can assume roles and little else — if AWS calls ` +
+      `fail with permission errors, the bundle's "profiles" map is the thing ` +
+      `to check.`;
+    derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
+    derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+  }
+
   if (names.length > 0 && !selected.has(PROFILE)) {
     // Never production by default. An implicit production profile is one
     // careless command away from a bad afternoon; that one must be typed.

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -74,6 +74,15 @@ const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
 const PROFILE_END = "# <<< lisa secrets (managed) <<<";
 
 /**
+ * Identifies an `~/.aws` file as one this wrote, and may therefore replace.
+ *
+ * `#` is a comment in the AWS shared-config format, so this is inert to every
+ * consumer while still being the thing that distinguishes "our file, refresh
+ * it" from "someone else's file, leave it alone".
+ */
+const MANAGED_MARKER = "# managed by lisa-secrets-access";
+
+/**
  * Make every shell in this container load the materialized secrets.
  *
  * `set -a` so the values are exported rather than merely set as shell
@@ -153,6 +162,8 @@ export function installAwsProfiles(bundle, options = {}) {
     home = process.env.HOME || homedir(),
     mkdir = mkdirSync,
     write = writeFileSync,
+    read = readFileSync,
+    exists = existsSync,
     chmod = chmodSync,
   } = options;
 
@@ -160,10 +171,34 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
+
+  // Never overwrite an ~/.aws this did not write.
+  //
+  // These are whole-file writes, so a pre-existing credentials file — a
+  // developer's own profiles, or something another tool set up — would be
+  // destroyed rather than merged. This only runs on a surface allowed to write
+  // secrets to disk (a disposable container), but "usually disposable" is not a
+  // reason to be able to delete someone's credentials. The marker makes our own
+  // file re-writable while anything else is left alone and reported.
+  for (const name of ["credentials", "config"]) {
+    const file = join(dir, name);
+    if (exists(file) && !String(read(file, "utf8")).includes(MANAGED_MARKER)) {
+      return [];
+    }
+  }
+
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
-  write(join(dir, "credentials"), rendered.credentials, { mode: 0o600 });
-  write(join(dir, "config"), rendered.config, { mode: 0o600 });
+  write(
+    join(dir, "credentials"),
+    `${MANAGED_MARKER}\n${rendered.credentials}`,
+    {
+      mode: 0o600,
+    }
+  );
+  write(join(dir, "config"), `${MANAGED_MARKER}\n${rendered.config}`, {
+    mode: 0o600,
+  });
 
   return rendered.profiles;
 }

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -31,7 +31,12 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
+import {
+  BOOTSTRAP_KEY,
+  deriveAwsEnvironment,
+  parseBootstrap,
+  renderAwsProfiles,
+} from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
 import { fetchAll } from "./providers.mjs";
 import { materializedPaths, readConfig } from "./surfaces.mjs";
@@ -95,6 +100,14 @@ export function installProfileSourcing(valuesFile, options = {}) {
 
   const block = [
     PROFILE_MARKER,
+    // Unset BEFORE sourcing. A cloud container injects its own AWS key pair,
+    // and environment credentials outrank both ~/.aws profiles and AWS_PROFILE
+    // — so leaving them set means the session ignores whichever environment it
+    // selected and runs as whatever the host injected. That is how a perfectly
+    // valid credential produced InvalidClientTokenId for a day. Removing the
+    // poison beats out-shouting it, and it is what lets `--profile agent-dev`
+    // behave here exactly as it does on a developer's machine.
+    `unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN`,
     `if [ -f "${valuesFile}" ]; then`,
     `  set -a`,
     `  . "${valuesFile}"`,
@@ -124,6 +137,35 @@ export function installProfileSourcing(valuesFile, options = {}) {
     }
   }
   return updated;
+}
+
+/**
+ * Write `~/.aws/credentials` and `~/.aws/config` from the bootstrap bundle.
+ *
+ * Both at 0600 inside a 0700 directory, matching how the materialized secrets
+ * themselves are protected — the credentials file holds the source key pair.
+ * @param {object|null} bundle Parsed bootstrap bundle.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile names written.
+ */
+export function installAwsProfiles(bundle, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    mkdir = mkdirSync,
+    write = writeFileSync,
+    chmod = chmodSync,
+  } = options;
+
+  const rendered = renderAwsProfiles(bundle);
+  if (!rendered) return [];
+
+  const dir = join(home, ".aws");
+  mkdir(dir, { recursive: true, mode: 0o700 });
+  chmod(dir, 0o700);
+  write(join(dir, "credentials"), rendered.credentials, { mode: 0o600 });
+  write(join(dir, "config"), rendered.config, { mode: 0o600 });
+
+  return rendered.profiles;
 }
 
 export function materialize(cfg = readConfig()) {
@@ -170,7 +212,21 @@ export function materialize(cfg = readConfig()) {
   // materialized" and "the credential is usable" the same statement.
   const sourced = installProfileSourcing(valuesFile);
 
-  return { count: selected.size, derived: derived.size, dir, sourced };
+  // The environments live in separate AWS accounts, reached by assuming a role
+  // per environment. Without these files `--profile agent-dev` fails with
+  // "profile not found" and everything silently falls back to the bootstrap
+  // identity, which can assume roles and do nothing else.
+  const profiles = installAwsProfiles(
+    parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value)
+  );
+
+  return {
+    count: selected.size,
+    derived: derived.size,
+    dir,
+    sourced,
+    profiles,
+  };
 }
 
 function main() {

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -33,8 +33,98 @@ const ACCESS_KEY = "AWS_ACCESS_KEY_ID";
 const SECRET_KEY = "AWS_SECRET_ACCESS_KEY";
 const REGION = "AWS_DEFAULT_REGION";
 
+/** Selects which environment's role a session assumes. */
+const PROFILE = "AWS_PROFILE";
+
 /** The bundle that carries the agent's identity. */
 export const BOOTSTRAP_KEY = "LISA_AWS_BOOTSTRAP_JSON";
+
+/**
+ * The profile that holds the bootstrap key pair and is assumed FROM.
+ *
+ * Named rather than `default` so it can never be picked up by accident: this
+ * identity can assume roles and do nothing else, so a call that silently ran as
+ * it would fail with a permissions error far from its cause.
+ */
+export const SOURCE_PROFILE = "lisa-bootstrap";
+
+/**
+ * Read the bundle's `profiles`, which may be an object OR a JSON string.
+ *
+ * The real bundle stores it double-encoded — a string containing JSON — so a
+ * plain `typeof === "object"` check silently yields zero profiles and every
+ * environment quietly disappears. Failing that way is worse than throwing:
+ * everything still "works", as the assume-only identity, with no permissions.
+ * @param {object|null} bundle Parsed bootstrap bundle.
+ * @returns {Record<string, {roleArn?: string, region?: string}>} Profiles by name.
+ */
+export function readProfiles(bundle) {
+  const raw = bundle?.profiles;
+  if (!raw) return {};
+  if (typeof raw === "object") return raw;
+  if (typeof raw !== "string") return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Render `~/.aws/credentials` and `~/.aws/config` from the bundle.
+ *
+ * The bundle carries a `profiles` map — one entry per environment, each a
+ * `roleArn` in a DIFFERENT account — plus the `externalId` those roles require.
+ * Nothing consumed any of it, so `--profile agent-dev` failed with "profile not
+ * found" and every call fell back to the bootstrap identity in the shared
+ * account. That identity can assume roles and nothing else, which is why
+ * `aws sts get-caller-identity` could succeed while real work had no
+ * permissions anywhere: a green check that proved only the first link.
+ *
+ * Writing the pair here rather than exporting it is deliberate. Exported
+ * environment credentials OUTRANK `AWS_PROFILE`, so a session that exports them
+ * ignores whichever profile it selects — the profiles would exist and never be
+ * used.
+ * @param {object} bundle Parsed bootstrap bundle.
+ * @returns {{credentials: string, config: string, profiles: string[]}|null}
+ *   Rendered file contents and the profile names, or null when unusable.
+ */
+export function renderAwsProfiles(bundle) {
+  if (!bundle) return null;
+
+  const accessKeyId = bundle.accessKeyId ?? bundle.aws_access_key_id;
+  const secretAccessKey =
+    bundle.secretAccessKey ?? bundle.aws_secret_access_key;
+  if (!accessKeyId || !secretAccessKey) return null;
+
+  const profiles = readProfiles(bundle);
+
+  const credentials = [
+    `[${SOURCE_PROFILE}]`,
+    `aws_access_key_id = ${accessKeyId}`,
+    `aws_secret_access_key = ${secretAccessKey}`,
+    "",
+  ].join("\n");
+
+  const sections = [];
+  for (const [name, entry] of Object.entries(profiles)) {
+    const roleArn = entry?.roleArn ?? entry?.role_arn;
+    if (!roleArn) continue;
+
+    const lines = [`[profile ${name}]`, `role_arn = ${roleArn}`];
+    lines.push(`source_profile = ${SOURCE_PROFILE}`);
+    if (bundle.externalId) lines.push(`external_id = ${bundle.externalId}`);
+    if (entry.region) lines.push(`region = ${entry.region}`);
+    sections.push(`${lines.join("\n")}\n`);
+  }
+
+  return {
+    credentials,
+    config: sections.join("\n"),
+    profiles: sections.map(s => s.slice(9, s.indexOf("]"))),
+  };
+}
 
 /**
  * Read the bootstrap bundle, treating anything malformed as absent.
@@ -80,16 +170,41 @@ export function deriveAwsEnvironment(selected) {
   // explicit. Overriding that would be this module guessing against an operator.
   if (selected.has(ACCESS_KEY) || selected.has(SECRET_KEY)) return derived;
 
-  const note =
-    `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Exported ` +
-    `deliberately so it overrides any ambient ${ACCESS_KEY} the host injects — ` +
-    `environment variables outrank profile files in the AWS credential chain, ` +
-    `so without this a stale host value wins and every call fails with ` +
-    `InvalidClientTokenId. This is the assume-only bootstrap identity; real ` +
-    `work assumes a role from it.`;
+  // The key pair is deliberately NOT exported.
+  //
+  // It used to be, to out-shout the ambient pair a cloud container injects. That
+  // worked and cost more than it bought: exported environment credentials
+  // outrank `AWS_PROFILE`, so every call ran as the bootstrap identity — which
+  // can assume roles and do nothing else. `aws sts get-caller-identity`
+  // succeeded while real work had no permissions in any environment account,
+  // because each environment is a SEPARATE account reached by assuming a role.
+  //
+  // The pair now lives in ~/.aws/credentials as the source profile, and the
+  // session selects an environment instead. The ambient pair is unset by the
+  // shell profile rather than overridden — removing the poison beats out-
+  // shouting it, and it is what makes `--profile agent-staging` behave exactly
+  // as it does on a developer's machine.
+  const names = Object.keys(readProfiles(bundle));
+  if (names.length > 0 && !selected.has(PROFILE)) {
+    // Never production by default. An implicit production profile is one
+    // careless command away from a bad afternoon; that one must be typed.
+    const preferred =
+      names.find(name => /dev/i.test(name)) ??
+      names.find(name => !/prod/i.test(name)) ??
+      names[0];
 
-  derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
-  derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+    derived.set(PROFILE, {
+      value: preferred,
+      note:
+        `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Selects the ` +
+        `environment whose role this session assumes, via ~/.aws/config. ` +
+        `Defaults to a non-production profile deliberately — reach production ` +
+        `by naming it (\`--profile ${names.find(n => /prod/i.test(n)) ?? "…"}\`). ` +
+        `The bootstrap key pair is NOT exported: environment credentials ` +
+        `outrank AWS_PROFILE, so exporting them would ignore this selection ` +
+        `and run everything as the assume-only identity.`,
+    });
+  }
 
   const region = bundle.region ?? bundle.defaultRegion;
   if (region && !selected.has(REGION)) {

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -108,22 +108,29 @@ export function renderAwsProfiles(bundle) {
   ].join("\n");
 
   const sections = [];
+  const names = [];
   for (const [name, entry] of Object.entries(profiles)) {
     const roleArn = entry?.roleArn ?? entry?.role_arn;
     if (!roleArn) continue;
+
+    // A name is only usable if it can be written as an ini section header and
+    // read back as the same string. Anything with a bracket or newline would
+    // either truncate or inject extra lines into ~/.aws/config, and a config
+    // file this corrupts is worse than one it never wrote.
+    if (!/^[\w.@-]+$/.test(name)) continue;
 
     const lines = [`[profile ${name}]`, `role_arn = ${roleArn}`];
     lines.push(`source_profile = ${SOURCE_PROFILE}`);
     if (bundle.externalId) lines.push(`external_id = ${bundle.externalId}`);
     if (entry.region) lines.push(`region = ${entry.region}`);
     sections.push(`${lines.join("\n")}\n`);
+    // Collected here, where the name is already in scope. Recovering it by
+    // re-parsing the rendered text made the header format load-bearing: a
+    // change to it would silently corrupt every returned name.
+    names.push(name);
   }
 
-  return {
-    credentials,
-    config: sections.join("\n"),
-    profiles: sections.map(s => s.slice(9, s.indexOf("]"))),
-  };
+  return { credentials, config: sections.join("\n"), profiles: names };
 }
 
 /**
@@ -184,7 +191,30 @@ export function deriveAwsEnvironment(selected) {
   // shell profile rather than overridden — removing the poison beats out-
   // shouting it, and it is what makes `--profile agent-staging` behave exactly
   // as it does on a developer's machine.
-  const names = Object.keys(readProfiles(bundle));
+  // Only profiles that actually get WRITTEN are candidates. Selecting a name
+  // that ~/.aws/config never contains — an entry with no roleArn, or a name too
+  // exotic to be an ini header — fails with "profile not found", which is the
+  // exact failure this whole change removes.
+  const names = renderAwsProfiles(bundle)?.profiles ?? [];
+
+  // No usable profiles is not a reason to hand back a session with NOTHING.
+  //
+  // The pair stops being exported only because a profile supersedes it. With no
+  // profile to select, exporting it is the difference between a degraded
+  // session (the assume-only identity, which at least authenticates) and a dead
+  // one — and the managed shell block unsets the ambient pair, so nothing would
+  // fill the gap.
+  if (names.length === 0) {
+    const note =
+      `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. The bundle ` +
+      `declares no usable per-environment profile, so this falls back to the ` +
+      `bootstrap identity. It can assume roles and little else — if AWS calls ` +
+      `fail with permission errors, the bundle's "profiles" map is the thing ` +
+      `to check.`;
+    derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
+    derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+  }
+
   if (names.length > 0 && !selected.has(PROFILE)) {
     // Never production by default. An implicit production profile is one
     // careless command away from a bad afternoon; that one must be typed.

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -74,6 +74,15 @@ const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
 const PROFILE_END = "# <<< lisa secrets (managed) <<<";
 
 /**
+ * Identifies an `~/.aws` file as one this wrote, and may therefore replace.
+ *
+ * `#` is a comment in the AWS shared-config format, so this is inert to every
+ * consumer while still being the thing that distinguishes "our file, refresh
+ * it" from "someone else's file, leave it alone".
+ */
+const MANAGED_MARKER = "# managed by lisa-secrets-access";
+
+/**
  * Make every shell in this container load the materialized secrets.
  *
  * `set -a` so the values are exported rather than merely set as shell
@@ -153,6 +162,8 @@ export function installAwsProfiles(bundle, options = {}) {
     home = process.env.HOME || homedir(),
     mkdir = mkdirSync,
     write = writeFileSync,
+    read = readFileSync,
+    exists = existsSync,
     chmod = chmodSync,
   } = options;
 
@@ -160,10 +171,34 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
+
+  // Never overwrite an ~/.aws this did not write.
+  //
+  // These are whole-file writes, so a pre-existing credentials file — a
+  // developer's own profiles, or something another tool set up — would be
+  // destroyed rather than merged. This only runs on a surface allowed to write
+  // secrets to disk (a disposable container), but "usually disposable" is not a
+  // reason to be able to delete someone's credentials. The marker makes our own
+  // file re-writable while anything else is left alone and reported.
+  for (const name of ["credentials", "config"]) {
+    const file = join(dir, name);
+    if (exists(file) && !String(read(file, "utf8")).includes(MANAGED_MARKER)) {
+      return [];
+    }
+  }
+
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
-  write(join(dir, "credentials"), rendered.credentials, { mode: 0o600 });
-  write(join(dir, "config"), rendered.config, { mode: 0o600 });
+  write(
+    join(dir, "credentials"),
+    `${MANAGED_MARKER}\n${rendered.credentials}`,
+    {
+      mode: 0o600,
+    }
+  );
+  write(join(dir, "config"), `${MANAGED_MARKER}\n${rendered.config}`, {
+    mode: 0o600,
+  });
 
   return rendered.profiles;
 }

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -31,7 +31,12 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
+import {
+  BOOTSTRAP_KEY,
+  deriveAwsEnvironment,
+  parseBootstrap,
+  renderAwsProfiles,
+} from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
 import { fetchAll } from "./providers.mjs";
 import { materializedPaths, readConfig } from "./surfaces.mjs";
@@ -95,6 +100,14 @@ export function installProfileSourcing(valuesFile, options = {}) {
 
   const block = [
     PROFILE_MARKER,
+    // Unset BEFORE sourcing. A cloud container injects its own AWS key pair,
+    // and environment credentials outrank both ~/.aws profiles and AWS_PROFILE
+    // — so leaving them set means the session ignores whichever environment it
+    // selected and runs as whatever the host injected. That is how a perfectly
+    // valid credential produced InvalidClientTokenId for a day. Removing the
+    // poison beats out-shouting it, and it is what lets `--profile agent-dev`
+    // behave here exactly as it does on a developer's machine.
+    `unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN`,
     `if [ -f "${valuesFile}" ]; then`,
     `  set -a`,
     `  . "${valuesFile}"`,
@@ -124,6 +137,35 @@ export function installProfileSourcing(valuesFile, options = {}) {
     }
   }
   return updated;
+}
+
+/**
+ * Write `~/.aws/credentials` and `~/.aws/config` from the bootstrap bundle.
+ *
+ * Both at 0600 inside a 0700 directory, matching how the materialized secrets
+ * themselves are protected — the credentials file holds the source key pair.
+ * @param {object|null} bundle Parsed bootstrap bundle.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile names written.
+ */
+export function installAwsProfiles(bundle, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    mkdir = mkdirSync,
+    write = writeFileSync,
+    chmod = chmodSync,
+  } = options;
+
+  const rendered = renderAwsProfiles(bundle);
+  if (!rendered) return [];
+
+  const dir = join(home, ".aws");
+  mkdir(dir, { recursive: true, mode: 0o700 });
+  chmod(dir, 0o700);
+  write(join(dir, "credentials"), rendered.credentials, { mode: 0o600 });
+  write(join(dir, "config"), rendered.config, { mode: 0o600 });
+
+  return rendered.profiles;
 }
 
 export function materialize(cfg = readConfig()) {
@@ -170,7 +212,21 @@ export function materialize(cfg = readConfig()) {
   // materialized" and "the credential is usable" the same statement.
   const sourced = installProfileSourcing(valuesFile);
 
-  return { count: selected.size, derived: derived.size, dir, sourced };
+  // The environments live in separate AWS accounts, reached by assuming a role
+  // per environment. Without these files `--profile agent-dev` fails with
+  // "profile not found" and everything silently falls back to the bootstrap
+  // identity, which can assume roles and do nothing else.
+  const profiles = installAwsProfiles(
+    parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value)
+  );
+
+  return {
+    count: selected.size,
+    derived: derived.size,
+    dir,
+    sourced,
+    profiles,
+  };
 }
 
 function main() {

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -33,8 +33,98 @@ const ACCESS_KEY = "AWS_ACCESS_KEY_ID";
 const SECRET_KEY = "AWS_SECRET_ACCESS_KEY";
 const REGION = "AWS_DEFAULT_REGION";
 
+/** Selects which environment's role a session assumes. */
+const PROFILE = "AWS_PROFILE";
+
 /** The bundle that carries the agent's identity. */
 export const BOOTSTRAP_KEY = "LISA_AWS_BOOTSTRAP_JSON";
+
+/**
+ * The profile that holds the bootstrap key pair and is assumed FROM.
+ *
+ * Named rather than `default` so it can never be picked up by accident: this
+ * identity can assume roles and do nothing else, so a call that silently ran as
+ * it would fail with a permissions error far from its cause.
+ */
+export const SOURCE_PROFILE = "lisa-bootstrap";
+
+/**
+ * Read the bundle's `profiles`, which may be an object OR a JSON string.
+ *
+ * The real bundle stores it double-encoded — a string containing JSON — so a
+ * plain `typeof === "object"` check silently yields zero profiles and every
+ * environment quietly disappears. Failing that way is worse than throwing:
+ * everything still "works", as the assume-only identity, with no permissions.
+ * @param {object|null} bundle Parsed bootstrap bundle.
+ * @returns {Record<string, {roleArn?: string, region?: string}>} Profiles by name.
+ */
+export function readProfiles(bundle) {
+  const raw = bundle?.profiles;
+  if (!raw) return {};
+  if (typeof raw === "object") return raw;
+  if (typeof raw !== "string") return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Render `~/.aws/credentials` and `~/.aws/config` from the bundle.
+ *
+ * The bundle carries a `profiles` map — one entry per environment, each a
+ * `roleArn` in a DIFFERENT account — plus the `externalId` those roles require.
+ * Nothing consumed any of it, so `--profile agent-dev` failed with "profile not
+ * found" and every call fell back to the bootstrap identity in the shared
+ * account. That identity can assume roles and nothing else, which is why
+ * `aws sts get-caller-identity` could succeed while real work had no
+ * permissions anywhere: a green check that proved only the first link.
+ *
+ * Writing the pair here rather than exporting it is deliberate. Exported
+ * environment credentials OUTRANK `AWS_PROFILE`, so a session that exports them
+ * ignores whichever profile it selects — the profiles would exist and never be
+ * used.
+ * @param {object} bundle Parsed bootstrap bundle.
+ * @returns {{credentials: string, config: string, profiles: string[]}|null}
+ *   Rendered file contents and the profile names, or null when unusable.
+ */
+export function renderAwsProfiles(bundle) {
+  if (!bundle) return null;
+
+  const accessKeyId = bundle.accessKeyId ?? bundle.aws_access_key_id;
+  const secretAccessKey =
+    bundle.secretAccessKey ?? bundle.aws_secret_access_key;
+  if (!accessKeyId || !secretAccessKey) return null;
+
+  const profiles = readProfiles(bundle);
+
+  const credentials = [
+    `[${SOURCE_PROFILE}]`,
+    `aws_access_key_id = ${accessKeyId}`,
+    `aws_secret_access_key = ${secretAccessKey}`,
+    "",
+  ].join("\n");
+
+  const sections = [];
+  for (const [name, entry] of Object.entries(profiles)) {
+    const roleArn = entry?.roleArn ?? entry?.role_arn;
+    if (!roleArn) continue;
+
+    const lines = [`[profile ${name}]`, `role_arn = ${roleArn}`];
+    lines.push(`source_profile = ${SOURCE_PROFILE}`);
+    if (bundle.externalId) lines.push(`external_id = ${bundle.externalId}`);
+    if (entry.region) lines.push(`region = ${entry.region}`);
+    sections.push(`${lines.join("\n")}\n`);
+  }
+
+  return {
+    credentials,
+    config: sections.join("\n"),
+    profiles: sections.map(s => s.slice(9, s.indexOf("]"))),
+  };
+}
 
 /**
  * Read the bootstrap bundle, treating anything malformed as absent.
@@ -80,16 +170,41 @@ export function deriveAwsEnvironment(selected) {
   // explicit. Overriding that would be this module guessing against an operator.
   if (selected.has(ACCESS_KEY) || selected.has(SECRET_KEY)) return derived;
 
-  const note =
-    `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Exported ` +
-    `deliberately so it overrides any ambient ${ACCESS_KEY} the host injects — ` +
-    `environment variables outrank profile files in the AWS credential chain, ` +
-    `so without this a stale host value wins and every call fails with ` +
-    `InvalidClientTokenId. This is the assume-only bootstrap identity; real ` +
-    `work assumes a role from it.`;
+  // The key pair is deliberately NOT exported.
+  //
+  // It used to be, to out-shout the ambient pair a cloud container injects. That
+  // worked and cost more than it bought: exported environment credentials
+  // outrank `AWS_PROFILE`, so every call ran as the bootstrap identity — which
+  // can assume roles and do nothing else. `aws sts get-caller-identity`
+  // succeeded while real work had no permissions in any environment account,
+  // because each environment is a SEPARATE account reached by assuming a role.
+  //
+  // The pair now lives in ~/.aws/credentials as the source profile, and the
+  // session selects an environment instead. The ambient pair is unset by the
+  // shell profile rather than overridden — removing the poison beats out-
+  // shouting it, and it is what makes `--profile agent-staging` behave exactly
+  // as it does on a developer's machine.
+  const names = Object.keys(readProfiles(bundle));
+  if (names.length > 0 && !selected.has(PROFILE)) {
+    // Never production by default. An implicit production profile is one
+    // careless command away from a bad afternoon; that one must be typed.
+    const preferred =
+      names.find(name => /dev/i.test(name)) ??
+      names.find(name => !/prod/i.test(name)) ??
+      names[0];
 
-  derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
-  derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+    derived.set(PROFILE, {
+      value: preferred,
+      note:
+        `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Selects the ` +
+        `environment whose role this session assumes, via ~/.aws/config. ` +
+        `Defaults to a non-production profile deliberately — reach production ` +
+        `by naming it (\`--profile ${names.find(n => /prod/i.test(n)) ?? "…"}\`). ` +
+        `The bootstrap key pair is NOT exported: environment credentials ` +
+        `outrank AWS_PROFILE, so exporting them would ignore this selection ` +
+        `and run everything as the assume-only identity.`,
+    });
+  }
 
   const region = bundle.region ?? bundle.defaultRegion;
   if (region && !selected.has(REGION)) {

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -108,22 +108,29 @@ export function renderAwsProfiles(bundle) {
   ].join("\n");
 
   const sections = [];
+  const names = [];
   for (const [name, entry] of Object.entries(profiles)) {
     const roleArn = entry?.roleArn ?? entry?.role_arn;
     if (!roleArn) continue;
+
+    // A name is only usable if it can be written as an ini section header and
+    // read back as the same string. Anything with a bracket or newline would
+    // either truncate or inject extra lines into ~/.aws/config, and a config
+    // file this corrupts is worse than one it never wrote.
+    if (!/^[\w.@-]+$/.test(name)) continue;
 
     const lines = [`[profile ${name}]`, `role_arn = ${roleArn}`];
     lines.push(`source_profile = ${SOURCE_PROFILE}`);
     if (bundle.externalId) lines.push(`external_id = ${bundle.externalId}`);
     if (entry.region) lines.push(`region = ${entry.region}`);
     sections.push(`${lines.join("\n")}\n`);
+    // Collected here, where the name is already in scope. Recovering it by
+    // re-parsing the rendered text made the header format load-bearing: a
+    // change to it would silently corrupt every returned name.
+    names.push(name);
   }
 
-  return {
-    credentials,
-    config: sections.join("\n"),
-    profiles: sections.map(s => s.slice(9, s.indexOf("]"))),
-  };
+  return { credentials, config: sections.join("\n"), profiles: names };
 }
 
 /**
@@ -184,7 +191,30 @@ export function deriveAwsEnvironment(selected) {
   // shell profile rather than overridden — removing the poison beats out-
   // shouting it, and it is what makes `--profile agent-staging` behave exactly
   // as it does on a developer's machine.
-  const names = Object.keys(readProfiles(bundle));
+  // Only profiles that actually get WRITTEN are candidates. Selecting a name
+  // that ~/.aws/config never contains — an entry with no roleArn, or a name too
+  // exotic to be an ini header — fails with "profile not found", which is the
+  // exact failure this whole change removes.
+  const names = renderAwsProfiles(bundle)?.profiles ?? [];
+
+  // No usable profiles is not a reason to hand back a session with NOTHING.
+  //
+  // The pair stops being exported only because a profile supersedes it. With no
+  // profile to select, exporting it is the difference between a degraded
+  // session (the assume-only identity, which at least authenticates) and a dead
+  // one — and the managed shell block unsets the ambient pair, so nothing would
+  // fill the gap.
+  if (names.length === 0) {
+    const note =
+      `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. The bundle ` +
+      `declares no usable per-environment profile, so this falls back to the ` +
+      `bootstrap identity. It can assume roles and little else — if AWS calls ` +
+      `fail with permission errors, the bundle's "profiles" map is the thing ` +
+      `to check.`;
+    derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
+    derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+  }
+
   if (names.length > 0 && !selected.has(PROFILE)) {
     // Never production by default. An implicit production profile is one
     // careless command away from a bad afternoon; that one must be typed.

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -74,6 +74,15 @@ const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
 const PROFILE_END = "# <<< lisa secrets (managed) <<<";
 
 /**
+ * Identifies an `~/.aws` file as one this wrote, and may therefore replace.
+ *
+ * `#` is a comment in the AWS shared-config format, so this is inert to every
+ * consumer while still being the thing that distinguishes "our file, refresh
+ * it" from "someone else's file, leave it alone".
+ */
+const MANAGED_MARKER = "# managed by lisa-secrets-access";
+
+/**
  * Make every shell in this container load the materialized secrets.
  *
  * `set -a` so the values are exported rather than merely set as shell
@@ -153,6 +162,8 @@ export function installAwsProfiles(bundle, options = {}) {
     home = process.env.HOME || homedir(),
     mkdir = mkdirSync,
     write = writeFileSync,
+    read = readFileSync,
+    exists = existsSync,
     chmod = chmodSync,
   } = options;
 
@@ -160,10 +171,34 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
+
+  // Never overwrite an ~/.aws this did not write.
+  //
+  // These are whole-file writes, so a pre-existing credentials file — a
+  // developer's own profiles, or something another tool set up — would be
+  // destroyed rather than merged. This only runs on a surface allowed to write
+  // secrets to disk (a disposable container), but "usually disposable" is not a
+  // reason to be able to delete someone's credentials. The marker makes our own
+  // file re-writable while anything else is left alone and reported.
+  for (const name of ["credentials", "config"]) {
+    const file = join(dir, name);
+    if (exists(file) && !String(read(file, "utf8")).includes(MANAGED_MARKER)) {
+      return [];
+    }
+  }
+
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
-  write(join(dir, "credentials"), rendered.credentials, { mode: 0o600 });
-  write(join(dir, "config"), rendered.config, { mode: 0o600 });
+  write(
+    join(dir, "credentials"),
+    `${MANAGED_MARKER}\n${rendered.credentials}`,
+    {
+      mode: 0o600,
+    }
+  );
+  write(join(dir, "config"), `${MANAGED_MARKER}\n${rendered.config}`, {
+    mode: 0o600,
+  });
 
   return rendered.profiles;
 }

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -31,7 +31,12 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
+import {
+  BOOTSTRAP_KEY,
+  deriveAwsEnvironment,
+  parseBootstrap,
+  renderAwsProfiles,
+} from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
 import { fetchAll } from "./providers.mjs";
 import { materializedPaths, readConfig } from "./surfaces.mjs";
@@ -95,6 +100,14 @@ export function installProfileSourcing(valuesFile, options = {}) {
 
   const block = [
     PROFILE_MARKER,
+    // Unset BEFORE sourcing. A cloud container injects its own AWS key pair,
+    // and environment credentials outrank both ~/.aws profiles and AWS_PROFILE
+    // — so leaving them set means the session ignores whichever environment it
+    // selected and runs as whatever the host injected. That is how a perfectly
+    // valid credential produced InvalidClientTokenId for a day. Removing the
+    // poison beats out-shouting it, and it is what lets `--profile agent-dev`
+    // behave here exactly as it does on a developer's machine.
+    `unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN`,
     `if [ -f "${valuesFile}" ]; then`,
     `  set -a`,
     `  . "${valuesFile}"`,
@@ -124,6 +137,35 @@ export function installProfileSourcing(valuesFile, options = {}) {
     }
   }
   return updated;
+}
+
+/**
+ * Write `~/.aws/credentials` and `~/.aws/config` from the bootstrap bundle.
+ *
+ * Both at 0600 inside a 0700 directory, matching how the materialized secrets
+ * themselves are protected — the credentials file holds the source key pair.
+ * @param {object|null} bundle Parsed bootstrap bundle.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile names written.
+ */
+export function installAwsProfiles(bundle, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    mkdir = mkdirSync,
+    write = writeFileSync,
+    chmod = chmodSync,
+  } = options;
+
+  const rendered = renderAwsProfiles(bundle);
+  if (!rendered) return [];
+
+  const dir = join(home, ".aws");
+  mkdir(dir, { recursive: true, mode: 0o700 });
+  chmod(dir, 0o700);
+  write(join(dir, "credentials"), rendered.credentials, { mode: 0o600 });
+  write(join(dir, "config"), rendered.config, { mode: 0o600 });
+
+  return rendered.profiles;
 }
 
 export function materialize(cfg = readConfig()) {
@@ -170,7 +212,21 @@ export function materialize(cfg = readConfig()) {
   // materialized" and "the credential is usable" the same statement.
   const sourced = installProfileSourcing(valuesFile);
 
-  return { count: selected.size, derived: derived.size, dir, sourced };
+  // The environments live in separate AWS accounts, reached by assuming a role
+  // per environment. Without these files `--profile agent-dev` fails with
+  // "profile not found" and everything silently falls back to the bootstrap
+  // identity, which can assume roles and do nothing else.
+  const profiles = installAwsProfiles(
+    parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value)
+  );
+
+  return {
+    count: selected.size,
+    derived: derived.size,
+    dir,
+    sourced,
+    profiles,
+  };
 }
 
 function main() {

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -33,8 +33,98 @@ const ACCESS_KEY = "AWS_ACCESS_KEY_ID";
 const SECRET_KEY = "AWS_SECRET_ACCESS_KEY";
 const REGION = "AWS_DEFAULT_REGION";
 
+/** Selects which environment's role a session assumes. */
+const PROFILE = "AWS_PROFILE";
+
 /** The bundle that carries the agent's identity. */
 export const BOOTSTRAP_KEY = "LISA_AWS_BOOTSTRAP_JSON";
+
+/**
+ * The profile that holds the bootstrap key pair and is assumed FROM.
+ *
+ * Named rather than `default` so it can never be picked up by accident: this
+ * identity can assume roles and do nothing else, so a call that silently ran as
+ * it would fail with a permissions error far from its cause.
+ */
+export const SOURCE_PROFILE = "lisa-bootstrap";
+
+/**
+ * Read the bundle's `profiles`, which may be an object OR a JSON string.
+ *
+ * The real bundle stores it double-encoded — a string containing JSON — so a
+ * plain `typeof === "object"` check silently yields zero profiles and every
+ * environment quietly disappears. Failing that way is worse than throwing:
+ * everything still "works", as the assume-only identity, with no permissions.
+ * @param {object|null} bundle Parsed bootstrap bundle.
+ * @returns {Record<string, {roleArn?: string, region?: string}>} Profiles by name.
+ */
+export function readProfiles(bundle) {
+  const raw = bundle?.profiles;
+  if (!raw) return {};
+  if (typeof raw === "object") return raw;
+  if (typeof raw !== "string") return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Render `~/.aws/credentials` and `~/.aws/config` from the bundle.
+ *
+ * The bundle carries a `profiles` map — one entry per environment, each a
+ * `roleArn` in a DIFFERENT account — plus the `externalId` those roles require.
+ * Nothing consumed any of it, so `--profile agent-dev` failed with "profile not
+ * found" and every call fell back to the bootstrap identity in the shared
+ * account. That identity can assume roles and nothing else, which is why
+ * `aws sts get-caller-identity` could succeed while real work had no
+ * permissions anywhere: a green check that proved only the first link.
+ *
+ * Writing the pair here rather than exporting it is deliberate. Exported
+ * environment credentials OUTRANK `AWS_PROFILE`, so a session that exports them
+ * ignores whichever profile it selects — the profiles would exist and never be
+ * used.
+ * @param {object} bundle Parsed bootstrap bundle.
+ * @returns {{credentials: string, config: string, profiles: string[]}|null}
+ *   Rendered file contents and the profile names, or null when unusable.
+ */
+export function renderAwsProfiles(bundle) {
+  if (!bundle) return null;
+
+  const accessKeyId = bundle.accessKeyId ?? bundle.aws_access_key_id;
+  const secretAccessKey =
+    bundle.secretAccessKey ?? bundle.aws_secret_access_key;
+  if (!accessKeyId || !secretAccessKey) return null;
+
+  const profiles = readProfiles(bundle);
+
+  const credentials = [
+    `[${SOURCE_PROFILE}]`,
+    `aws_access_key_id = ${accessKeyId}`,
+    `aws_secret_access_key = ${secretAccessKey}`,
+    "",
+  ].join("\n");
+
+  const sections = [];
+  for (const [name, entry] of Object.entries(profiles)) {
+    const roleArn = entry?.roleArn ?? entry?.role_arn;
+    if (!roleArn) continue;
+
+    const lines = [`[profile ${name}]`, `role_arn = ${roleArn}`];
+    lines.push(`source_profile = ${SOURCE_PROFILE}`);
+    if (bundle.externalId) lines.push(`external_id = ${bundle.externalId}`);
+    if (entry.region) lines.push(`region = ${entry.region}`);
+    sections.push(`${lines.join("\n")}\n`);
+  }
+
+  return {
+    credentials,
+    config: sections.join("\n"),
+    profiles: sections.map(s => s.slice(9, s.indexOf("]"))),
+  };
+}
 
 /**
  * Read the bootstrap bundle, treating anything malformed as absent.
@@ -80,16 +170,41 @@ export function deriveAwsEnvironment(selected) {
   // explicit. Overriding that would be this module guessing against an operator.
   if (selected.has(ACCESS_KEY) || selected.has(SECRET_KEY)) return derived;
 
-  const note =
-    `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Exported ` +
-    `deliberately so it overrides any ambient ${ACCESS_KEY} the host injects — ` +
-    `environment variables outrank profile files in the AWS credential chain, ` +
-    `so without this a stale host value wins and every call fails with ` +
-    `InvalidClientTokenId. This is the assume-only bootstrap identity; real ` +
-    `work assumes a role from it.`;
+  // The key pair is deliberately NOT exported.
+  //
+  // It used to be, to out-shout the ambient pair a cloud container injects. That
+  // worked and cost more than it bought: exported environment credentials
+  // outrank `AWS_PROFILE`, so every call ran as the bootstrap identity — which
+  // can assume roles and do nothing else. `aws sts get-caller-identity`
+  // succeeded while real work had no permissions in any environment account,
+  // because each environment is a SEPARATE account reached by assuming a role.
+  //
+  // The pair now lives in ~/.aws/credentials as the source profile, and the
+  // session selects an environment instead. The ambient pair is unset by the
+  // shell profile rather than overridden — removing the poison beats out-
+  // shouting it, and it is what makes `--profile agent-staging` behave exactly
+  // as it does on a developer's machine.
+  const names = Object.keys(readProfiles(bundle));
+  if (names.length > 0 && !selected.has(PROFILE)) {
+    // Never production by default. An implicit production profile is one
+    // careless command away from a bad afternoon; that one must be typed.
+    const preferred =
+      names.find(name => /dev/i.test(name)) ??
+      names.find(name => !/prod/i.test(name)) ??
+      names[0];
 
-  derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
-  derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+    derived.set(PROFILE, {
+      value: preferred,
+      note:
+        `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Selects the ` +
+        `environment whose role this session assumes, via ~/.aws/config. ` +
+        `Defaults to a non-production profile deliberately — reach production ` +
+        `by naming it (\`--profile ${names.find(n => /prod/i.test(n)) ?? "…"}\`). ` +
+        `The bootstrap key pair is NOT exported: environment credentials ` +
+        `outrank AWS_PROFILE, so exporting them would ignore this selection ` +
+        `and run everything as the assume-only identity.`,
+    });
+  }
 
   const region = bundle.region ?? bundle.defaultRegion;
   if (region && !selected.has(REGION)) {

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -108,22 +108,29 @@ export function renderAwsProfiles(bundle) {
   ].join("\n");
 
   const sections = [];
+  const names = [];
   for (const [name, entry] of Object.entries(profiles)) {
     const roleArn = entry?.roleArn ?? entry?.role_arn;
     if (!roleArn) continue;
+
+    // A name is only usable if it can be written as an ini section header and
+    // read back as the same string. Anything with a bracket or newline would
+    // either truncate or inject extra lines into ~/.aws/config, and a config
+    // file this corrupts is worse than one it never wrote.
+    if (!/^[\w.@-]+$/.test(name)) continue;
 
     const lines = [`[profile ${name}]`, `role_arn = ${roleArn}`];
     lines.push(`source_profile = ${SOURCE_PROFILE}`);
     if (bundle.externalId) lines.push(`external_id = ${bundle.externalId}`);
     if (entry.region) lines.push(`region = ${entry.region}`);
     sections.push(`${lines.join("\n")}\n`);
+    // Collected here, where the name is already in scope. Recovering it by
+    // re-parsing the rendered text made the header format load-bearing: a
+    // change to it would silently corrupt every returned name.
+    names.push(name);
   }
 
-  return {
-    credentials,
-    config: sections.join("\n"),
-    profiles: sections.map(s => s.slice(9, s.indexOf("]"))),
-  };
+  return { credentials, config: sections.join("\n"), profiles: names };
 }
 
 /**
@@ -184,7 +191,30 @@ export function deriveAwsEnvironment(selected) {
   // shell profile rather than overridden — removing the poison beats out-
   // shouting it, and it is what makes `--profile agent-staging` behave exactly
   // as it does on a developer's machine.
-  const names = Object.keys(readProfiles(bundle));
+  // Only profiles that actually get WRITTEN are candidates. Selecting a name
+  // that ~/.aws/config never contains — an entry with no roleArn, or a name too
+  // exotic to be an ini header — fails with "profile not found", which is the
+  // exact failure this whole change removes.
+  const names = renderAwsProfiles(bundle)?.profiles ?? [];
+
+  // No usable profiles is not a reason to hand back a session with NOTHING.
+  //
+  // The pair stops being exported only because a profile supersedes it. With no
+  // profile to select, exporting it is the difference between a degraded
+  // session (the assume-only identity, which at least authenticates) and a dead
+  // one — and the managed shell block unsets the ambient pair, so nothing would
+  // fill the gap.
+  if (names.length === 0) {
+    const note =
+      `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. The bundle ` +
+      `declares no usable per-environment profile, so this falls back to the ` +
+      `bootstrap identity. It can assume roles and little else — if AWS calls ` +
+      `fail with permission errors, the bundle's "profiles" map is the thing ` +
+      `to check.`;
+    derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
+    derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+  }
+
   if (names.length > 0 && !selected.has(PROFILE)) {
     // Never production by default. An implicit production profile is one
     // careless command away from a bad afternoon; that one must be typed.

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -74,6 +74,15 @@ const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
 const PROFILE_END = "# <<< lisa secrets (managed) <<<";
 
 /**
+ * Identifies an `~/.aws` file as one this wrote, and may therefore replace.
+ *
+ * `#` is a comment in the AWS shared-config format, so this is inert to every
+ * consumer while still being the thing that distinguishes "our file, refresh
+ * it" from "someone else's file, leave it alone".
+ */
+const MANAGED_MARKER = "# managed by lisa-secrets-access";
+
+/**
  * Make every shell in this container load the materialized secrets.
  *
  * `set -a` so the values are exported rather than merely set as shell
@@ -153,6 +162,8 @@ export function installAwsProfiles(bundle, options = {}) {
     home = process.env.HOME || homedir(),
     mkdir = mkdirSync,
     write = writeFileSync,
+    read = readFileSync,
+    exists = existsSync,
     chmod = chmodSync,
   } = options;
 
@@ -160,10 +171,34 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
+
+  // Never overwrite an ~/.aws this did not write.
+  //
+  // These are whole-file writes, so a pre-existing credentials file — a
+  // developer's own profiles, or something another tool set up — would be
+  // destroyed rather than merged. This only runs on a surface allowed to write
+  // secrets to disk (a disposable container), but "usually disposable" is not a
+  // reason to be able to delete someone's credentials. The marker makes our own
+  // file re-writable while anything else is left alone and reported.
+  for (const name of ["credentials", "config"]) {
+    const file = join(dir, name);
+    if (exists(file) && !String(read(file, "utf8")).includes(MANAGED_MARKER)) {
+      return [];
+    }
+  }
+
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
-  write(join(dir, "credentials"), rendered.credentials, { mode: 0o600 });
-  write(join(dir, "config"), rendered.config, { mode: 0o600 });
+  write(
+    join(dir, "credentials"),
+    `${MANAGED_MARKER}\n${rendered.credentials}`,
+    {
+      mode: 0o600,
+    }
+  );
+  write(join(dir, "config"), `${MANAGED_MARKER}\n${rendered.config}`, {
+    mode: 0o600,
+  });
 
   return rendered.profiles;
 }

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -31,7 +31,12 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
+import {
+  BOOTSTRAP_KEY,
+  deriveAwsEnvironment,
+  parseBootstrap,
+  renderAwsProfiles,
+} from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
 import { fetchAll } from "./providers.mjs";
 import { materializedPaths, readConfig } from "./surfaces.mjs";
@@ -95,6 +100,14 @@ export function installProfileSourcing(valuesFile, options = {}) {
 
   const block = [
     PROFILE_MARKER,
+    // Unset BEFORE sourcing. A cloud container injects its own AWS key pair,
+    // and environment credentials outrank both ~/.aws profiles and AWS_PROFILE
+    // — so leaving them set means the session ignores whichever environment it
+    // selected and runs as whatever the host injected. That is how a perfectly
+    // valid credential produced InvalidClientTokenId for a day. Removing the
+    // poison beats out-shouting it, and it is what lets `--profile agent-dev`
+    // behave here exactly as it does on a developer's machine.
+    `unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN`,
     `if [ -f "${valuesFile}" ]; then`,
     `  set -a`,
     `  . "${valuesFile}"`,
@@ -124,6 +137,35 @@ export function installProfileSourcing(valuesFile, options = {}) {
     }
   }
   return updated;
+}
+
+/**
+ * Write `~/.aws/credentials` and `~/.aws/config` from the bootstrap bundle.
+ *
+ * Both at 0600 inside a 0700 directory, matching how the materialized secrets
+ * themselves are protected — the credentials file holds the source key pair.
+ * @param {object|null} bundle Parsed bootstrap bundle.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile names written.
+ */
+export function installAwsProfiles(bundle, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    mkdir = mkdirSync,
+    write = writeFileSync,
+    chmod = chmodSync,
+  } = options;
+
+  const rendered = renderAwsProfiles(bundle);
+  if (!rendered) return [];
+
+  const dir = join(home, ".aws");
+  mkdir(dir, { recursive: true, mode: 0o700 });
+  chmod(dir, 0o700);
+  write(join(dir, "credentials"), rendered.credentials, { mode: 0o600 });
+  write(join(dir, "config"), rendered.config, { mode: 0o600 });
+
+  return rendered.profiles;
 }
 
 export function materialize(cfg = readConfig()) {
@@ -170,7 +212,21 @@ export function materialize(cfg = readConfig()) {
   // materialized" and "the credential is usable" the same statement.
   const sourced = installProfileSourcing(valuesFile);
 
-  return { count: selected.size, derived: derived.size, dir, sourced };
+  // The environments live in separate AWS accounts, reached by assuming a role
+  // per environment. Without these files `--profile agent-dev` fails with
+  // "profile not found" and everything silently falls back to the bootstrap
+  // identity, which can assume roles and do nothing else.
+  const profiles = installAwsProfiles(
+    parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value)
+  );
+
+  return {
+    count: selected.size,
+    derived: derived.size,
+    dir,
+    sourced,
+    profiles,
+  };
 }
 
 function main() {

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -33,8 +33,98 @@ const ACCESS_KEY = "AWS_ACCESS_KEY_ID";
 const SECRET_KEY = "AWS_SECRET_ACCESS_KEY";
 const REGION = "AWS_DEFAULT_REGION";
 
+/** Selects which environment's role a session assumes. */
+const PROFILE = "AWS_PROFILE";
+
 /** The bundle that carries the agent's identity. */
 export const BOOTSTRAP_KEY = "LISA_AWS_BOOTSTRAP_JSON";
+
+/**
+ * The profile that holds the bootstrap key pair and is assumed FROM.
+ *
+ * Named rather than `default` so it can never be picked up by accident: this
+ * identity can assume roles and do nothing else, so a call that silently ran as
+ * it would fail with a permissions error far from its cause.
+ */
+export const SOURCE_PROFILE = "lisa-bootstrap";
+
+/**
+ * Read the bundle's `profiles`, which may be an object OR a JSON string.
+ *
+ * The real bundle stores it double-encoded — a string containing JSON — so a
+ * plain `typeof === "object"` check silently yields zero profiles and every
+ * environment quietly disappears. Failing that way is worse than throwing:
+ * everything still "works", as the assume-only identity, with no permissions.
+ * @param {object|null} bundle Parsed bootstrap bundle.
+ * @returns {Record<string, {roleArn?: string, region?: string}>} Profiles by name.
+ */
+export function readProfiles(bundle) {
+  const raw = bundle?.profiles;
+  if (!raw) return {};
+  if (typeof raw === "object") return raw;
+  if (typeof raw !== "string") return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Render `~/.aws/credentials` and `~/.aws/config` from the bundle.
+ *
+ * The bundle carries a `profiles` map — one entry per environment, each a
+ * `roleArn` in a DIFFERENT account — plus the `externalId` those roles require.
+ * Nothing consumed any of it, so `--profile agent-dev` failed with "profile not
+ * found" and every call fell back to the bootstrap identity in the shared
+ * account. That identity can assume roles and nothing else, which is why
+ * `aws sts get-caller-identity` could succeed while real work had no
+ * permissions anywhere: a green check that proved only the first link.
+ *
+ * Writing the pair here rather than exporting it is deliberate. Exported
+ * environment credentials OUTRANK `AWS_PROFILE`, so a session that exports them
+ * ignores whichever profile it selects — the profiles would exist and never be
+ * used.
+ * @param {object} bundle Parsed bootstrap bundle.
+ * @returns {{credentials: string, config: string, profiles: string[]}|null}
+ *   Rendered file contents and the profile names, or null when unusable.
+ */
+export function renderAwsProfiles(bundle) {
+  if (!bundle) return null;
+
+  const accessKeyId = bundle.accessKeyId ?? bundle.aws_access_key_id;
+  const secretAccessKey =
+    bundle.secretAccessKey ?? bundle.aws_secret_access_key;
+  if (!accessKeyId || !secretAccessKey) return null;
+
+  const profiles = readProfiles(bundle);
+
+  const credentials = [
+    `[${SOURCE_PROFILE}]`,
+    `aws_access_key_id = ${accessKeyId}`,
+    `aws_secret_access_key = ${secretAccessKey}`,
+    "",
+  ].join("\n");
+
+  const sections = [];
+  for (const [name, entry] of Object.entries(profiles)) {
+    const roleArn = entry?.roleArn ?? entry?.role_arn;
+    if (!roleArn) continue;
+
+    const lines = [`[profile ${name}]`, `role_arn = ${roleArn}`];
+    lines.push(`source_profile = ${SOURCE_PROFILE}`);
+    if (bundle.externalId) lines.push(`external_id = ${bundle.externalId}`);
+    if (entry.region) lines.push(`region = ${entry.region}`);
+    sections.push(`${lines.join("\n")}\n`);
+  }
+
+  return {
+    credentials,
+    config: sections.join("\n"),
+    profiles: sections.map(s => s.slice(9, s.indexOf("]"))),
+  };
+}
 
 /**
  * Read the bootstrap bundle, treating anything malformed as absent.
@@ -80,16 +170,41 @@ export function deriveAwsEnvironment(selected) {
   // explicit. Overriding that would be this module guessing against an operator.
   if (selected.has(ACCESS_KEY) || selected.has(SECRET_KEY)) return derived;
 
-  const note =
-    `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Exported ` +
-    `deliberately so it overrides any ambient ${ACCESS_KEY} the host injects — ` +
-    `environment variables outrank profile files in the AWS credential chain, ` +
-    `so without this a stale host value wins and every call fails with ` +
-    `InvalidClientTokenId. This is the assume-only bootstrap identity; real ` +
-    `work assumes a role from it.`;
+  // The key pair is deliberately NOT exported.
+  //
+  // It used to be, to out-shout the ambient pair a cloud container injects. That
+  // worked and cost more than it bought: exported environment credentials
+  // outrank `AWS_PROFILE`, so every call ran as the bootstrap identity — which
+  // can assume roles and do nothing else. `aws sts get-caller-identity`
+  // succeeded while real work had no permissions in any environment account,
+  // because each environment is a SEPARATE account reached by assuming a role.
+  //
+  // The pair now lives in ~/.aws/credentials as the source profile, and the
+  // session selects an environment instead. The ambient pair is unset by the
+  // shell profile rather than overridden — removing the poison beats out-
+  // shouting it, and it is what makes `--profile agent-staging` behave exactly
+  // as it does on a developer's machine.
+  const names = Object.keys(readProfiles(bundle));
+  if (names.length > 0 && !selected.has(PROFILE)) {
+    // Never production by default. An implicit production profile is one
+    // careless command away from a bad afternoon; that one must be typed.
+    const preferred =
+      names.find(name => /dev/i.test(name)) ??
+      names.find(name => !/prod/i.test(name)) ??
+      names[0];
 
-  derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
-  derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+    derived.set(PROFILE, {
+      value: preferred,
+      note:
+        `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. Selects the ` +
+        `environment whose role this session assumes, via ~/.aws/config. ` +
+        `Defaults to a non-production profile deliberately — reach production ` +
+        `by naming it (\`--profile ${names.find(n => /prod/i.test(n)) ?? "…"}\`). ` +
+        `The bootstrap key pair is NOT exported: environment credentials ` +
+        `outrank AWS_PROFILE, so exporting them would ignore this selection ` +
+        `and run everything as the assume-only identity.`,
+    });
+  }
 
   const region = bundle.region ?? bundle.defaultRegion;
   if (region && !selected.has(REGION)) {

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs
@@ -108,22 +108,29 @@ export function renderAwsProfiles(bundle) {
   ].join("\n");
 
   const sections = [];
+  const names = [];
   for (const [name, entry] of Object.entries(profiles)) {
     const roleArn = entry?.roleArn ?? entry?.role_arn;
     if (!roleArn) continue;
+
+    // A name is only usable if it can be written as an ini section header and
+    // read back as the same string. Anything with a bracket or newline would
+    // either truncate or inject extra lines into ~/.aws/config, and a config
+    // file this corrupts is worse than one it never wrote.
+    if (!/^[\w.@-]+$/.test(name)) continue;
 
     const lines = [`[profile ${name}]`, `role_arn = ${roleArn}`];
     lines.push(`source_profile = ${SOURCE_PROFILE}`);
     if (bundle.externalId) lines.push(`external_id = ${bundle.externalId}`);
     if (entry.region) lines.push(`region = ${entry.region}`);
     sections.push(`${lines.join("\n")}\n`);
+    // Collected here, where the name is already in scope. Recovering it by
+    // re-parsing the rendered text made the header format load-bearing: a
+    // change to it would silently corrupt every returned name.
+    names.push(name);
   }
 
-  return {
-    credentials,
-    config: sections.join("\n"),
-    profiles: sections.map(s => s.slice(9, s.indexOf("]"))),
-  };
+  return { credentials, config: sections.join("\n"), profiles: names };
 }
 
 /**
@@ -184,7 +191,30 @@ export function deriveAwsEnvironment(selected) {
   // shell profile rather than overridden — removing the poison beats out-
   // shouting it, and it is what makes `--profile agent-staging` behave exactly
   // as it does on a developer's machine.
-  const names = Object.keys(readProfiles(bundle));
+  // Only profiles that actually get WRITTEN are candidates. Selecting a name
+  // that ~/.aws/config never contains — an entry with no roleArn, or a name too
+  // exotic to be an ini header — fails with "profile not found", which is the
+  // exact failure this whole change removes.
+  const names = renderAwsProfiles(bundle)?.profiles ?? [];
+
+  // No usable profiles is not a reason to hand back a session with NOTHING.
+  //
+  // The pair stops being exported only because a profile supersedes it. With no
+  // profile to select, exporting it is the difference between a degraded
+  // session (the assume-only identity, which at least authenticates) and a dead
+  // one — and the managed shell block unsets the ambient pair, so nothing would
+  // fill the gap.
+  if (names.length === 0) {
+    const note =
+      `Derived from ${BOOTSTRAP_KEY} by lisa-secrets-access. The bundle ` +
+      `declares no usable per-environment profile, so this falls back to the ` +
+      `bootstrap identity. It can assume roles and little else — if AWS calls ` +
+      `fail with permission errors, the bundle's "profiles" map is the thing ` +
+      `to check.`;
+    derived.set(ACCESS_KEY, { value: String(accessKeyId), note });
+    derived.set(SECRET_KEY, { value: String(secretAccessKey), note });
+  }
+
   if (names.length > 0 && !selected.has(PROFILE)) {
     // Never production by default. An implicit production profile is one
     // careless command away from a bad afternoon; that one must be typed.

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -74,6 +74,15 @@ const PROFILE_MARKER = "# >>> lisa secrets (managed) >>>";
 const PROFILE_END = "# <<< lisa secrets (managed) <<<";
 
 /**
+ * Identifies an `~/.aws` file as one this wrote, and may therefore replace.
+ *
+ * `#` is a comment in the AWS shared-config format, so this is inert to every
+ * consumer while still being the thing that distinguishes "our file, refresh
+ * it" from "someone else's file, leave it alone".
+ */
+const MANAGED_MARKER = "# managed by lisa-secrets-access";
+
+/**
  * Make every shell in this container load the materialized secrets.
  *
  * `set -a` so the values are exported rather than merely set as shell
@@ -153,6 +162,8 @@ export function installAwsProfiles(bundle, options = {}) {
     home = process.env.HOME || homedir(),
     mkdir = mkdirSync,
     write = writeFileSync,
+    read = readFileSync,
+    exists = existsSync,
     chmod = chmodSync,
   } = options;
 
@@ -160,10 +171,34 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
+
+  // Never overwrite an ~/.aws this did not write.
+  //
+  // These are whole-file writes, so a pre-existing credentials file — a
+  // developer's own profiles, or something another tool set up — would be
+  // destroyed rather than merged. This only runs on a surface allowed to write
+  // secrets to disk (a disposable container), but "usually disposable" is not a
+  // reason to be able to delete someone's credentials. The marker makes our own
+  // file re-writable while anything else is left alone and reported.
+  for (const name of ["credentials", "config"]) {
+    const file = join(dir, name);
+    if (exists(file) && !String(read(file, "utf8")).includes(MANAGED_MARKER)) {
+      return [];
+    }
+  }
+
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
-  write(join(dir, "credentials"), rendered.credentials, { mode: 0o600 });
-  write(join(dir, "config"), rendered.config, { mode: 0o600 });
+  write(
+    join(dir, "credentials"),
+    `${MANAGED_MARKER}\n${rendered.credentials}`,
+    {
+      mode: 0o600,
+    }
+  );
+  write(join(dir, "config"), `${MANAGED_MARKER}\n${rendered.config}`, {
+    mode: 0o600,
+  });
 
   return rendered.profiles;
 }

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -31,7 +31,12 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { deriveAwsEnvironment } from "./aws-bootstrap.mjs";
+import {
+  BOOTSTRAP_KEY,
+  deriveAwsEnvironment,
+  parseBootstrap,
+  renderAwsProfiles,
+} from "./aws-bootstrap.mjs";
 import { renderEnv, renderNotes } from "./envfile.mjs";
 import { fetchAll } from "./providers.mjs";
 import { materializedPaths, readConfig } from "./surfaces.mjs";
@@ -95,6 +100,14 @@ export function installProfileSourcing(valuesFile, options = {}) {
 
   const block = [
     PROFILE_MARKER,
+    // Unset BEFORE sourcing. A cloud container injects its own AWS key pair,
+    // and environment credentials outrank both ~/.aws profiles and AWS_PROFILE
+    // — so leaving them set means the session ignores whichever environment it
+    // selected and runs as whatever the host injected. That is how a perfectly
+    // valid credential produced InvalidClientTokenId for a day. Removing the
+    // poison beats out-shouting it, and it is what lets `--profile agent-dev`
+    // behave here exactly as it does on a developer's machine.
+    `unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN`,
     `if [ -f "${valuesFile}" ]; then`,
     `  set -a`,
     `  . "${valuesFile}"`,
@@ -124,6 +137,35 @@ export function installProfileSourcing(valuesFile, options = {}) {
     }
   }
   return updated;
+}
+
+/**
+ * Write `~/.aws/credentials` and `~/.aws/config` from the bootstrap bundle.
+ *
+ * Both at 0600 inside a 0700 directory, matching how the materialized secrets
+ * themselves are protected — the credentials file holds the source key pair.
+ * @param {object|null} bundle Parsed bootstrap bundle.
+ * @param {object} [options] Home directory and file seams, for tests.
+ * @returns {string[]} The profile names written.
+ */
+export function installAwsProfiles(bundle, options = {}) {
+  const {
+    home = process.env.HOME || homedir(),
+    mkdir = mkdirSync,
+    write = writeFileSync,
+    chmod = chmodSync,
+  } = options;
+
+  const rendered = renderAwsProfiles(bundle);
+  if (!rendered) return [];
+
+  const dir = join(home, ".aws");
+  mkdir(dir, { recursive: true, mode: 0o700 });
+  chmod(dir, 0o700);
+  write(join(dir, "credentials"), rendered.credentials, { mode: 0o600 });
+  write(join(dir, "config"), rendered.config, { mode: 0o600 });
+
+  return rendered.profiles;
 }
 
 export function materialize(cfg = readConfig()) {
@@ -170,7 +212,21 @@ export function materialize(cfg = readConfig()) {
   // materialized" and "the credential is usable" the same statement.
   const sourced = installProfileSourcing(valuesFile);
 
-  return { count: selected.size, derived: derived.size, dir, sourced };
+  // The environments live in separate AWS accounts, reached by assuming a role
+  // per environment. Without these files `--profile agent-dev` fails with
+  // "profile not found" and everything silently falls back to the bootstrap
+  // identity, which can assume roles and do nothing else.
+  const profiles = installAwsProfiles(
+    parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value)
+  );
+
+  return {
+    count: selected.size,
+    derived: derived.size,
+    dir,
+    sourced,
+    profiles,
+  };
 }
 
 function main() {

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1101,13 +1101,13 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/SKILL.md":
       "9d7346864b04304e5b4bbb90512c7f2e701d69ab012b4fcf3b7b687221fc76bd",
     "plugins/src/base/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs":
-      "5403ddeec18b670d10257beb3859cd220d92fab5d4768535a35a56a7d8a280da",
+      "91fb457376f48333f5a6ca701a2fe1886904d2417d4de62fc3b205827b501ba9",
     "plugins/src/base/skills/lisa-secrets-access/scripts/doctor-secrets.mjs":
       "f203c71457da958cdb49637c87e4a9c43e964f98ecef3dd0e933b419d565f98e",
     "plugins/src/base/skills/lisa-secrets-access/scripts/envfile.mjs":
       "be4e38ce85f9268b52b29dbde264ecd8d50973c2b63a15410336234a921d9644",
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs":
-      "32e4cd6011f619f15842b5cd07c6ca13f25b2c66af2f8b41b7759925ed8b14ad",
+      "999237529ec806d5e27b12252bc57e3e57c809fcf7e10ebc9c1ee599e35a191b",
     "plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs":
       "fec38ca937570c1e1c21e6e8f7314a9d8f4e9264779d0394b40d5158924da0da",
     "plugins/src/base/skills/lisa-secrets-access/scripts/read-secret-note.mjs":
@@ -8488,6 +8488,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/work-item-tracker-unreachable.test.ts": true,
     "tests/unit/secrets/automation-workflow.test.ts": true,
     "tests/unit/secrets/aws-bootstrap-derivation.test.ts": true,
+    "tests/unit/secrets/aws-profiles.test.ts": true,
     "tests/unit/secrets/bootstrap-key-naming.test.ts": true,
     "tests/unit/secrets/detect-tooling-discovery.test.ts": true,
     "tests/unit/secrets/detect-tooling.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1101,13 +1101,13 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/SKILL.md":
       "9d7346864b04304e5b4bbb90512c7f2e701d69ab012b4fcf3b7b687221fc76bd",
     "plugins/src/base/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs":
-      "91fb457376f48333f5a6ca701a2fe1886904d2417d4de62fc3b205827b501ba9",
+      "a06c212d45442a0a2daaefda1a7255e299f82704ca3637243b778d8268a5ce65",
     "plugins/src/base/skills/lisa-secrets-access/scripts/doctor-secrets.mjs":
       "f203c71457da958cdb49637c87e4a9c43e964f98ecef3dd0e933b419d565f98e",
     "plugins/src/base/skills/lisa-secrets-access/scripts/envfile.mjs":
       "be4e38ce85f9268b52b29dbde264ecd8d50973c2b63a15410336234a921d9644",
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs":
-      "999237529ec806d5e27b12252bc57e3e57c809fcf7e10ebc9c1ee599e35a191b",
+      "a8d025e56bf6ca292e2fcfa6ba81f80283f0b9419b2661e68455b3a765b3ec0e",
     "plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs":
       "fec38ca937570c1e1c21e6e8f7314a9d8f4e9264779d0394b40d5158924da0da",
     "plugins/src/base/skills/lisa-secrets-access/scripts/read-secret-note.mjs":
@@ -8488,6 +8488,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/work-item-tracker-unreachable.test.ts": true,
     "tests/unit/secrets/automation-workflow.test.ts": true,
     "tests/unit/secrets/aws-bootstrap-derivation.test.ts": true,
+    "tests/unit/secrets/aws-profiles-install.test.ts": true,
     "tests/unit/secrets/aws-profiles.test.ts": true,
     "tests/unit/secrets/bootstrap-key-naming.test.ts": true,
     "tests/unit/secrets/detect-tooling-discovery.test.ts": true,

--- a/tests/unit/secrets/aws-bootstrap-derivation.test.ts
+++ b/tests/unit/secrets/aws-bootstrap-derivation.test.ts
@@ -32,7 +32,25 @@ const BUNDLE = JSON.stringify({
   secretAccessKey: SECRET,
   roleName: "RemoteAgent",
   externalId: "example-external-id",
-  profiles: { dev: "111111111111", production: "222222222222" },
+  // Shaped as the real bundle stores it: each entry names a role to assume in
+  // that environment's own account. An earlier fixture mapped names to bare
+  // account-id strings, which no code path can turn into a profile — so it
+  // silently exercised the no-usable-profiles branch while claiming to cover
+  // the normal one.
+  profiles: {
+    dev: {
+      roleArn: "arn:aws:iam::111111111111:role/RemoteAgent",
+      region: "us-east-1",
+    },
+    production: { roleArn: "arn:aws:iam::222222222222:role/RemoteAgent" },
+  },
+});
+
+/** A bundle whose profiles cannot produce a single usable entry. */
+const BUNDLE_NO_PROFILES = JSON.stringify({
+  accessKeyId: KEY_ID,
+  secretAccessKey: SECRET,
+  roleName: "RemoteAgent",
 });
 
 /**
@@ -75,6 +93,22 @@ describe("deriveAwsEnvironment", () => {
 
     expect(derived.has("AWS_ACCESS_KEY_ID")).toBe(false);
     expect(derived.has("AWS_SECRET_ACCESS_KEY")).toBe(false);
+  });
+
+  it("falls back to the pair when no usable profile exists", () => {
+    // Withholding the pair is only safe because a profile supersedes it. With
+    // no profile to select — and the managed shell block unsetting the ambient
+    // pair — withholding it too would leave the session with NO credentials at
+    // all. A degraded session beats a dead one.
+    const derived = deriveAwsEnvironment(
+      selection({ [BOOTSTRAP_KEY]: BUNDLE_NO_PROFILES })
+    );
+
+    expect(derived.get("AWS_ACCESS_KEY_ID")?.value).toBe(KEY_ID);
+    expect(derived.get("AWS_SECRET_ACCESS_KEY")?.value).toBe(SECRET);
+    expect(derived.has("AWS_PROFILE")).toBe(false);
+    // And it must say why, so the empty `profiles` map is findable.
+    expect(derived.get("AWS_ACCESS_KEY_ID")?.note ?? "").toContain("profiles");
   });
 
   it("yields nothing when the bundle is absent", () => {

--- a/tests/unit/secrets/aws-bootstrap-derivation.test.ts
+++ b/tests/unit/secrets/aws-bootstrap-derivation.test.ts
@@ -63,24 +63,18 @@ describe("parseBootstrap", () => {
 });
 
 describe("deriveAwsEnvironment", () => {
-  it("derives the pair the SDKs actually read", () => {
+  it("does NOT export the raw key pair", () => {
+    // It used to, to out-shout the ambient pair a container injects. That made
+    // every call run as the bootstrap identity, because exported environment
+    // credentials outrank AWS_PROFILE — so the per-environment profiles existed
+    // and were never used. The pair now lives in ~/.aws/credentials as the
+    // source profile, and the ambient one is unset rather than overridden.
     const derived = deriveAwsEnvironment(
       selection({ [BOOTSTRAP_KEY]: BUNDLE })
     );
-    expect(derived.get("AWS_ACCESS_KEY_ID")?.value).toBe(KEY_ID);
-    expect(derived.get("AWS_SECRET_ACCESS_KEY")?.value).toBe(SECRET);
-  });
 
-  it("explains in the note why it overrides an ambient value", () => {
-    // The override is an intrusion — this project exporting over a variable it
-    // did not set. It has to be discoverable through the same read-the-note
-    // path as any other credential, not buried in a commit message.
-    const derived = deriveAwsEnvironment(
-      selection({ [BOOTSTRAP_KEY]: BUNDLE })
-    );
-    const note = derived.get("AWS_ACCESS_KEY_ID")?.note ?? "";
-    expect(note).toContain("outrank profile files");
-    expect(note).toContain("InvalidClientTokenId");
+    expect(derived.has("AWS_ACCESS_KEY_ID")).toBe(false);
+    expect(derived.has("AWS_SECRET_ACCESS_KEY")).toBe(false);
   });
 
   it("yields nothing when the bundle is absent", () => {

--- a/tests/unit/secrets/aws-profiles-install.test.ts
+++ b/tests/unit/secrets/aws-profiles-install.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Writing `~/.aws` must never destroy credentials this did not write.
+ *
+ * These are whole-file writes, so a pre-existing `credentials` file — a
+ * developer's own profiles, or another tool's setup — would be replaced rather
+ * than merged. This only runs on a surface allowed to write secrets to disk,
+ * which is normally a disposable container, but "normally disposable" is not a
+ * reason to be able to delete someone's credentials.
+ * @module tests/unit/secrets/aws-profiles-install
+ */
+
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { installAwsProfiles } from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs";
+
+/** Where the written credentials live, relative to home. */
+const CREDENTIALS = ".aws/credentials";
+
+/** Scratch homes to remove. */
+const homes: string[] = [];
+
+/** A bundle that renders one usable profile. */
+const BUNDLE = {
+  accessKeyId: "AKIAEXAMPLE",
+  secretAccessKey: "s3cret",
+  externalId: "ext-1",
+  profiles: {
+    "agent-dev": {
+      roleArn: "arn:aws:iam::905179307867:role/RemoteAgent",
+      region: "us-east-1",
+    },
+  },
+};
+
+/**
+ * A scratch home directory.
+ * @returns Its path.
+ */
+function scratchHome(): string {
+  const home = mkdtempSync(path.join(tmpdir(), "lisa-awsinstall-"));
+  homes.push(home);
+  return home;
+}
+
+afterEach(() => {
+  while (homes.length > 0) {
+    rmSync(homes.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe("installAwsProfiles", () => {
+  it("writes the profiles and reports their names", () => {
+    const home = scratchHome();
+
+    expect(installAwsProfiles(BUNDLE, { home })).toEqual(["agent-dev"]);
+    expect(readFileSync(path.join(home, ".aws/config"), "utf8")).toContain(
+      "[profile agent-dev]"
+    );
+  });
+
+  it("refuses to overwrite an ~/.aws it did not write", () => {
+    // The failure this prevents is silent and unrecoverable: someone's own
+    // credentials replaced by ours, with no copy kept.
+    const home = scratchHome();
+    const existing = "[default]\naws_access_key_id = THEIRS\n";
+    mkdirSync(path.join(home, ".aws"), { recursive: true });
+    writeFileSync(path.join(home, CREDENTIALS), existing);
+
+    expect(installAwsProfiles(BUNDLE, { home })).toEqual([]);
+    expect(readFileSync(path.join(home, CREDENTIALS), "utf8")).toBe(existing);
+  });
+
+  it("refreshes a file it wrote previously", () => {
+    // Materialization runs every session; its own output must stay updatable,
+    // or a rotated credential would never reach the file.
+    const home = scratchHome();
+    installAwsProfiles(BUNDLE, { home });
+
+    expect(
+      installAwsProfiles({ ...BUNDLE, accessKeyId: "AKIAROTATED" }, { home })
+    ).toEqual(["agent-dev"]);
+    expect(readFileSync(path.join(home, CREDENTIALS), "utf8")).toContain(
+      "AKIAROTATED"
+    );
+  });
+
+  it("writes nothing when the bundle has no usable key pair", () => {
+    const home = scratchHome();
+
+    expect(installAwsProfiles({ profiles: BUNDLE.profiles }, { home })).toEqual(
+      []
+    );
+  });
+});

--- a/tests/unit/secrets/aws-profiles.test.ts
+++ b/tests/unit/secrets/aws-profiles.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Each environment is a SEPARATE AWS account, reached by assuming a role.
+ *
+ * The bootstrap bundle has always carried a `profiles` map — one `roleArn` per
+ * environment — plus the `externalId` those roles require. Nothing consumed any
+ * of it, so `--profile agent-dev` failed with "profile not found" and every call
+ * fell back to the bootstrap identity in the shared account. That identity can
+ * assume roles and nothing else, which is why `aws sts get-caller-identity`
+ * could succeed while real work had no permissions anywhere.
+ * @module tests/unit/secrets/aws-profiles
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveAwsEnvironment,
+  BOOTSTRAP_KEY,
+  readProfiles,
+  renderAwsProfiles,
+  SOURCE_PROFILE,
+} from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs";
+
+/** The four environments, shaped as the real bundle stores them. */
+const PROFILES = {
+  "agent-dev": {
+    roleArn: "arn:aws:iam::905179307867:role/RemoteAgent",
+    region: "us-east-1",
+  },
+  "agent-staging": {
+    roleArn: "arn:aws:iam::362324310783:role/RemoteAgent",
+    region: "us-east-1",
+  },
+  "agent-production": {
+    roleArn: "arn:aws:iam::002889194405:role/RemoteAgent",
+    region: "us-east-1",
+  },
+  "agent-shared": {
+    roleArn: "arn:aws:iam::777997078669:role/RemoteAgent",
+    region: "us-east-1",
+  },
+};
+
+/** A bundle whose `profiles` is an object. */
+const BUNDLE = {
+  accessKeyId: "AKIAEXAMPLE",
+  secretAccessKey: "s3cret",
+  roleName: "RemoteAgent",
+  externalId: "ext-123",
+  profiles: PROFILES,
+};
+
+/**
+ * Wrap a bundle the way a selected secret set carries it.
+ * @param bundle The bundle object.
+ * @returns A selection map.
+ */
+function selection(bundle: unknown): Map<string, { value: string }> {
+  return new Map([[BOOTSTRAP_KEY, { value: JSON.stringify(bundle) }]]);
+}
+
+describe("readProfiles", () => {
+  it("accepts a profiles map stored as a JSON STRING", () => {
+    // The real bundle double-encodes it. A plain `typeof === "object"` check
+    // yields zero profiles and every environment silently disappears — which is
+    // worse than throwing, because everything still "works" as the assume-only
+    // identity with no permissions.
+    expect(
+      readProfiles({ ...BUNDLE, profiles: JSON.stringify(PROFILES) })
+    ).toEqual(PROFILES);
+  });
+
+  it("accepts a profiles map stored as an object", () => {
+    expect(readProfiles(BUNDLE)).toEqual(PROFILES);
+  });
+
+  it("treats unparseable or absent profiles as none", () => {
+    expect(readProfiles({ profiles: "{not json" })).toEqual({});
+    expect(readProfiles({})).toEqual({});
+    expect(readProfiles(null)).toEqual({});
+  });
+});
+
+describe("renderAwsProfiles", () => {
+  it("writes one profile per environment, each assuming from the source", () => {
+    const rendered = renderAwsProfiles(BUNDLE);
+
+    expect(rendered?.profiles).toEqual([
+      "agent-dev",
+      "agent-staging",
+      "agent-production",
+      "agent-shared",
+    ]);
+    expect(rendered?.config).toContain("[profile agent-dev]");
+    expect(rendered?.config).toContain(
+      "role_arn = arn:aws:iam::905179307867:role/RemoteAgent"
+    );
+    expect(rendered?.config).toContain(`source_profile = ${SOURCE_PROFILE}`);
+  });
+
+  it("carries the external id the roles require", () => {
+    // Without it every assume-role call is denied, and the error names trust
+    // policy rather than a missing field — expensive to diagnose.
+    expect(renderAwsProfiles(BUNDLE)?.config).toContain(
+      "external_id = ext-123"
+    );
+  });
+
+  it("puts the key pair in the source profile, not a default one", () => {
+    // `default` would be picked up by any call that names no profile, silently
+    // running as an identity that can only assume roles.
+    const rendered = renderAwsProfiles(BUNDLE);
+
+    expect(rendered?.credentials).toContain(`[${SOURCE_PROFILE}]`);
+    expect(rendered?.credentials).not.toContain("[default]");
+  });
+
+  it("refuses a bundle with no usable key pair", () => {
+    expect(renderAwsProfiles({ profiles: PROFILES })).toBeNull();
+    expect(renderAwsProfiles(null)).toBeNull();
+  });
+
+  it("skips a profile entry with no role", () => {
+    const rendered = renderAwsProfiles({
+      ...BUNDLE,
+      profiles: {
+        broken: { region: "us-east-1" },
+        "agent-dev": PROFILES["agent-dev"],
+      },
+    });
+
+    expect(rendered?.profiles).toEqual(["agent-dev"]);
+  });
+});
+
+describe("the default profile a session selects", () => {
+  it("defaults to a dev profile", () => {
+    expect(
+      deriveAwsEnvironment(selection(BUNDLE)).get("AWS_PROFILE")?.value
+    ).toBe("agent-dev");
+  });
+
+  it("never defaults to production", () => {
+    // An implicit production profile is one careless command away from a bad
+    // afternoon. Production must be named deliberately.
+    const noDev = {
+      ...BUNDLE,
+      profiles: {
+        "agent-production": PROFILES["agent-production"],
+        "agent-staging": PROFILES["agent-staging"],
+      },
+    };
+
+    expect(
+      deriveAwsEnvironment(selection(noDev)).get("AWS_PROFILE")?.value
+    ).toBe("agent-staging");
+  });
+
+  it("selects nothing when the bundle declares no profiles", () => {
+    expect(
+      deriveAwsEnvironment(selection({ ...BUNDLE, profiles: undefined })).has(
+        "AWS_PROFILE"
+      )
+    ).toBe(false);
+  });
+
+  it("never overrides a profile the store itself supplies", () => {
+    const selected = selection(BUNDLE);
+    selected.set("AWS_PROFILE", { value: "chosen-by-operator" });
+
+    expect(deriveAwsEnvironment(selected).has("AWS_PROFILE")).toBe(false);
+  });
+});

--- a/tests/unit/secrets/aws-profiles.test.ts
+++ b/tests/unit/secrets/aws-profiles.test.ts
@@ -119,6 +119,34 @@ describe("renderAwsProfiles", () => {
     expect(renderAwsProfiles(null)).toBeNull();
   });
 
+  it("skips a name that cannot round-trip as an ini header", () => {
+    // A `]` truncates the header and a newline injects extra lines, so the
+    // written config would not mean what it appears to. Names were also being
+    // recovered by re-parsing the rendered text, which made this corrupting
+    // rather than merely wrong.
+    const rendered = renderAwsProfiles({
+      ...BUNDLE,
+      profiles: {
+        "bad]name": { roleArn: "arn:aws:iam::1:role/X" },
+        "with\nnewline": { roleArn: "arn:aws:iam::2:role/X" },
+        "agent-dev": PROFILES["agent-dev"],
+      },
+    });
+
+    expect(rendered?.profiles).toEqual(["agent-dev"]);
+    expect(rendered?.config).not.toContain("bad]name");
+  });
+
+  it("returns names collected in the loop, not re-parsed from its output", () => {
+    // Guards the specific regression: if the header format changes, the names
+    // must still be right.
+    const rendered = renderAwsProfiles(BUNDLE);
+
+    for (const name of rendered?.profiles ?? []) {
+      expect(rendered?.config).toContain(`[profile ${name}]`);
+    }
+  });
+
   it("skips a profile entry with no role", () => {
     const rendered = renderAwsProfiles({
       ...BUNDLE,


### PR DESCRIPTION
The AWS bootstrap bundle has always carried a `profiles` map — one `roleArn` per
environment, each in a **different AWS account** — plus the `externalId` those
roles require:

```
agent-dev         → arn:aws:iam::905179307867:role/RemoteAgent
agent-staging     → arn:aws:iam::362324310783:role/RemoteAgent
agent-production  → arn:aws:iam::002889194405:role/RemoteAgent
agent-shared      → arn:aws:iam::777997078669:role/RemoteAgent
```

**Nothing consumes any of it.** Neither Lisa nor the project scripts write
`~/.aws/config` or `~/.aws/credentials`, so `--profile agent-dev` fails with
"profile not found" and every call falls back to the bootstrap identity in the
shared account — an identity that can assume roles and do nothing else.

That is why `aws sts get-caller-identity` returning
`arn:aws:iam::777997078669:user/remote-agent` looked like success while real work
had no permissions anywhere. It proves the first link in the chain and was read
as proof of the whole thing.

Compounding it: 2.331.3 exports the bootstrap key pair into the environment to
out-shout the ambient pair a container injects. Exported environment credentials
**outrank `AWS_PROFILE`**, so even once profiles exist, they would be ignored.

## Fix

- write `~/.aws/credentials` with the key pair under a **named** source profile
  (never `default`, which any profile-less call would silently pick up)
- write `~/.aws/config` with one profile per environment: `role_arn`,
  `source_profile`, `external_id`, `region`
- select a default environment with `AWS_PROFILE`, and stop exporting the raw
  pair
- have the managed shell block **unset** the ambient pair rather than override
  it — removing the poison beats out-shouting it

Default must never be production; that one gets named deliberately.

Raised by the operator, who pointed out that local work already uses
`--profile <env>` and asked whether the container should do the same. It should.

## Evidence

Against the LIVE accounts, with no ambient credentials present at all:

```
profiles written: agent-dev, agent-staging, agent-production, agent-shared
default AWS_PROFILE: agent-dev
raw key pair exported? no

agent-dev:        arn:aws:sts::905179307867:assumed-role/RemoteAgent/...
agent-staging:    arn:aws:sts::362324310783:assumed-role/RemoteAgent/...
agent-production: arn:aws:sts::002889194405:assumed-role/RemoteAgent/...
agent-shared:     arn:aws:sts::777997078669:assumed-role/RemoteAgent/...
```

Each lands in its own account as `assumed-role/RemoteAgent` — not the bootstrap
user. That distinction is the whole point: the old green check only ever proved
the first link.

## Two silent bugs found while building it

1. **`profiles` is double-encoded** — a JSON *string*, not an object. A plain
   `typeof === "object"` check yields zero profiles and every environment
   disappears while everything still appears to work, as the assume-only
   identity. My first run printed `profiles written:` (empty) and passed.
2. **`default` as the source profile name** would be picked up by any call that
   names no profile, silently running as the identity that can only assume
   roles. It is named `lisa-bootstrap` instead.

Full suite green: 8869 passed, 531 files. Lint clean.

---

Work-Item: CodySwannGT/lisa#2317


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AWS CLI profile generation from bootstrap credentials, including role-based profiles, regions, source credentials, and external IDs.
  * Automatically selects a suitable non-production AWS profile when none is specified.
  * Installs protected AWS credentials and configuration files for easier profile-based access.

* **Security**
  * Prevents ambient AWS credential variables from overriding materialized credentials.
  * Preserves explicitly supplied credentials and profile selections.

* **Tests**
  * Added coverage for profile parsing, rendering, validation, and safe default selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->