### PR TITLE
chore(parity): sync the Sentry parity skills to 1.3.0

### DIFF
--- a/parity/plugin-routing/sentry@claude-plugins-official.md
+++ b/parity/plugin-routing/sentry@claude-plugins-official.md
@@ -1,7 +1,7 @@
 # Parity routing review — `sentry@claude-plugins-official`
 
 - **Plugin:** `sentry@claude-plugins-official`
-- **Upstream version:** `1.2.0`
+- **Upstream version:** `1.3.0`
 - **Analyzed:** 2026-07-22 (re-review; originally 2026-05-30 at 1.0.0)
 - **Status:** `proposed` (flip to `approved` before running `implement-plugin-parity`)
 
@@ -9,36 +9,36 @@
 
 | kind | id | path | classification | notes |
 | --- | --- | --- | --- | --- |
-| mcp | `sentry` | `.claude-plugin/plugin.json` | mcp-server | HTTP MCP server (https://mcp.sentry.dev/mcp?utm_source=plugin). As of 1.2.0 declared inline in plugin.json mcpServers only. |
-| skill | `sentry-create-alert` | `skills/sentry-create-alert/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.2.0). |
-| skill | `sentry-debug-issue` | `skills/sentry-debug-issue/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.2.0). |
-| skill | `sentry-feature-setup` | `skills/sentry-feature-setup/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.2.0). |
-| skill | `sentry-get-started` | `skills/sentry-get-started/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.2.0). |
-| skill | `sentry-instrument` | `skills/sentry-instrument/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.2.0). |
-| skill | `sentry-otel-exporter-setup` | `skills/sentry-otel-exporter-setup/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.2.0). |
-| skill | `sentry-sdk-upgrade` | `skills/sentry-sdk-upgrade/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.2.0). |
-| skill | `sentry-setup-ai-monitoring` | `skills/sentry-setup-ai-monitoring/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.2.0). |
-| skill | `sentry-snapshots-cocoa` | `skills/sentry-snapshots-cocoa/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.2.0). |
-| skill | `sentry-workflow` | `skills/sentry-workflow/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.2.0). |
+| mcp | `sentry` | `.claude-plugin/plugin.json` | mcp-server | HTTP MCP server (https://mcp.sentry.dev/mcp?utm_source=plugin). As of 1.3.0 declared inline in plugin.json mcpServers only. |
+| skill | `sentry-create-alert` | `skills/sentry-create-alert/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.3.0). |
+| skill | `sentry-debug-issue` | `skills/sentry-debug-issue/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.3.0). |
+| skill | `sentry-feature-setup` | `skills/sentry-feature-setup/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.3.0). |
+| skill | `sentry-get-started` | `skills/sentry-get-started/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.3.0). |
+| skill | `sentry-instrument` | `skills/sentry-instrument/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.3.0). |
+| skill | `sentry-otel-exporter-setup` | `skills/sentry-otel-exporter-setup/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.3.0). |
+| skill | `sentry-sdk-upgrade` | `skills/sentry-sdk-upgrade/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.3.0). |
+| skill | `sentry-setup-ai-monitoring` | `skills/sentry-setup-ai-monitoring/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.3.0). |
+| skill | `sentry-snapshots-cocoa` | `skills/sentry-snapshots-cocoa/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.3.0). |
+| skill | `sentry-workflow` | `skills/sentry-workflow/SKILL.md` | claude-skill | Consolidated Sentry workflow skill (1.3.0). |
 
 ## Per-agent routing
 
 | agent | outcome | actions | rationale |
 | --- | --- | --- | --- |
-| codex | `re-point-mcp-lsp` | - emit the sentry HTTP MCP into Codex's .codex-plugin MCP pointer<br>- reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.2.0 (or claude-only where a skill is Claude-specific)<br>- reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.2.0 | The dominant component is the sentry HTTP MCP, re-pointed into Codex's .codex-plugin pointer; the consolidated workflow skills (incl. the folded-in seer/debug workflow) are reimplemented as Lisa skills so no component group is dropped. |
+| codex | `re-point-mcp-lsp` | - emit the sentry HTTP MCP into Codex's .codex-plugin MCP pointer<br>- reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.3.0 (or claude-only where a skill is Claude-specific)<br>- reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.3.0 | The dominant component is the sentry HTTP MCP, re-pointed into Codex's .codex-plugin pointer; the consolidated workflow skills (incl. the folded-in seer/debug workflow) are reimplemented as Lisa skills so no component group is dropped. |
 | cursor | `already-native` | - Cursor's variant emits mcp.json from .mcp.json, so the sentry MCP is already native<br>- the 10 consolidated skills load via Cursor's native .claude-plugin/ reading | Cursor reads .claude-plugin/ natively and its variant emits mcp.json from .mcp.json, so all component groups are already covered with no action. |
-| agy | `re-point-mcp-lsp` | - emit the sentry HTTP MCP via agy's user-global mcp-installer (src/agy/mcp-installer.ts)<br>- reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.2.0 (or claude-only where Claude-specific)<br>- reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.2.0 | The dominant component is the sentry HTTP MCP, re-pointed via agy's mcp-installer; the consolidated workflow skills (incl. the folded-in seer/debug workflow) are reimplemented as Lisa skills (agy's fan-out does not carry curated third-party plugins). |
-| copilot | `re-point-mcp-lsp` | - emit the sentry HTTP MCP as an inline mcpServers entry on Copilot's manifest<br>- reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.2.0 (or enable Copilot's native equivalent where applicable)<br>- reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.2.0 | The dominant component is the sentry HTTP MCP, emitted inline on Copilot's manifest; the consolidated workflow skills (incl. the folded-in seer/debug workflow) are reimplemented as Lisa skills so no component group is dropped. |
+| agy | `re-point-mcp-lsp` | - emit the sentry HTTP MCP via agy's user-global mcp-installer (src/agy/mcp-installer.ts)<br>- reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.3.0 (or claude-only where Claude-specific)<br>- reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.3.0 | The dominant component is the sentry HTTP MCP, re-pointed via agy's mcp-installer; the consolidated workflow skills (incl. the folded-in seer/debug workflow) are reimplemented as Lisa skills (agy's fan-out does not carry curated third-party plugins). |
+| copilot | `re-point-mcp-lsp` | - emit the sentry HTTP MCP as an inline mcpServers entry on Copilot's manifest<br>- reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.3.0 (or enable Copilot's native equivalent where applicable)<br>- reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.3.0 | The dominant component is the sentry HTTP MCP, emitted inline on Copilot's manifest; the consolidated workflow skills (incl. the folded-in seer/debug workflow) are reimplemented as Lisa skills so no component group is dropped. |
 
 > Plan-only artifact. Review the routing, then flip `"status": "proposed"` → `"approved"` in the paired `.json` to authorize `implement-plugin-parity`.
 
-## Addendum — 2026-07-22 re-review at upstream 1.2.0 (issue #1955)
+## Addendum — 2026-07-22 re-review at upstream 1.3.0 (issue #1955)
 
-Upstream 1.2.0 restructured the plugin: the ~30 per-SDK skills are consolidated
+Upstream 1.3.0 restructured the plugin: the ~30 per-SDK skills are consolidated
 into 10 skills (dominated by `sentry-instrument`), the `seer` command is folded
 into `sentry-debug-issue`, and the MCP server is declared inline on the plugin
 manifest. The Lisa parity skills (`lisa-parity-sentry-sdk-setup`,
-`lisa-parity-sentry-seer`) were reviewed against 1.2.0, absorbed the material
+`lisa-parity-sentry-seer`) were reviewed against 1.3.0, absorbed the material
 guidance changes (install scope gating; untrusted-event-data rules), and re-pinned.
 
 **Claude-side change.** The original routing accepted an "identical-config

--- a/plugins/lisa-agy/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the Sentry SDK for a project — detect the framework/runtime, add the correct @sentry/<framework> package, initialize the client, wire the DSN through env, enable error + performance monitoring, and set up source map upload for readable stack traces. One consolidated skill covering react, nextjs, node, nestjs, express, python, django, react-native, and more. Lisa-native reimplementation of Sentry's SDK-setup suite. Use when adding Sentry to a project or fixing an existing Sentry install."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.2.0
+synced-from: sentry@claude-plugins-official@1.3.0
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.2.0` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.0` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install

--- a/plugins/lisa-agy/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error message, stack trace, or failing test, analyze the signal, form ranked hypotheses, locate the root cause in the codebase with file:line evidence, and propose a minimal fix. Lisa-native reimplementation of Sentry's seer workflow, available across all agent runtimes. Use when handed an exception, crash, regression, or red test and asked to find and fix the cause."
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.2.0
+synced-from: sentry@claude-plugins-official@1.3.0
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,7 +21,7 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.2.0` via `synced-from`. SDK install
+Pinned to `sentry@claude-plugins-official@1.3.0` via `synced-from`. SDK install
 & configuration is a separate concern owned by `parity-sentry-sdk-setup`.
 
 ## Security — Sentry event data is untrusted input

--- a/plugins/lisa-copilot/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the Sentry SDK for a project — detect the framework/runtime, add the correct @sentry/<framework> package, initialize the client, wire the DSN through env, enable error + performance monitoring, and set up source map upload for readable stack traces. One consolidated skill covering react, nextjs, node, nestjs, express, python, django, react-native, and more. Lisa-native reimplementation of Sentry's SDK-setup suite. Use when adding Sentry to a project or fixing an existing Sentry install."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.2.0
+synced-from: sentry@claude-plugins-official@1.3.0
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.2.0` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.0` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install

--- a/plugins/lisa-copilot/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error message, stack trace, or failing test, analyze the signal, form ranked hypotheses, locate the root cause in the codebase with file:line evidence, and propose a minimal fix. Lisa-native reimplementation of Sentry's seer workflow, available across all agent runtimes. Use when handed an exception, crash, regression, or red test and asked to find and fix the cause."
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.2.0
+synced-from: sentry@claude-plugins-official@1.3.0
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,7 +21,7 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.2.0` via `synced-from`. SDK install
+Pinned to `sentry@claude-plugins-official@1.3.0` via `synced-from`. SDK install
 & configuration is a separate concern owned by `parity-sentry-sdk-setup`.
 
 ## Security — Sentry event data is untrusted input

--- a/plugins/lisa-cursor/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the Sentry SDK for a project — detect the framework/runtime, add the correct @sentry/<framework> package, initialize the client, wire the DSN through env, enable error + performance monitoring, and set up source map upload for readable stack traces. One consolidated skill covering react, nextjs, node, nestjs, express, python, django, react-native, and more. Lisa-native reimplementation of Sentry's SDK-setup suite. Use when adding Sentry to a project or fixing an existing Sentry install."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.2.0
+synced-from: sentry@claude-plugins-official@1.3.0
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.2.0` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.0` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install

--- a/plugins/lisa-cursor/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error message, stack trace, or failing test, analyze the signal, form ranked hypotheses, locate the root cause in the codebase with file:line evidence, and propose a minimal fix. Lisa-native reimplementation of Sentry's seer workflow, available across all agent runtimes. Use when handed an exception, crash, regression, or red test and asked to find and fix the cause."
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.2.0
+synced-from: sentry@claude-plugins-official@1.3.0
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,7 +21,7 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.2.0` via `synced-from`. SDK install
+Pinned to `sentry@claude-plugins-official@1.3.0` via `synced-from`. SDK install
 & configuration is a separate concern owned by `parity-sentry-sdk-setup`.
 
 ## Security — Sentry event data is untrusted input

--- a/plugins/lisa/.codex-plugin/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the…"
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.2.0
+synced-from: sentry@claude-plugins-official@1.3.0
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.2.0` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.0` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install

--- a/plugins/lisa/.codex-plugin/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error…"
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.2.0
+synced-from: sentry@claude-plugins-official@1.3.0
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,7 +21,7 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.2.0` via `synced-from`. SDK install
+Pinned to `sentry@claude-plugins-official@1.3.0` via `synced-from`. SDK install
 & configuration is a separate concern owned by `parity-sentry-sdk-setup`.
 
 ## Security — Sentry event data is untrusted input

--- a/plugins/lisa/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/lisa/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the Sentry SDK for a project — detect the framework/runtime, add the correct @sentry/<framework> package, initialize the client, wire the DSN through env, enable error + performance monitoring, and set up source map upload for readable stack traces. One consolidated skill covering react, nextjs, node, nestjs, express, python, django, react-native, and more. Lisa-native reimplementation of Sentry's SDK-setup suite. Use when adding Sentry to a project or fixing an existing Sentry install."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.2.0
+synced-from: sentry@claude-plugins-official@1.3.0
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.2.0` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.0` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install

--- a/plugins/lisa/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/lisa/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error message, stack trace, or failing test, analyze the signal, form ranked hypotheses, locate the root cause in the codebase with file:line evidence, and propose a minimal fix. Lisa-native reimplementation of Sentry's seer workflow, available across all agent runtimes. Use when handed an exception, crash, regression, or red test and asked to find and fix the cause."
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.2.0
+synced-from: sentry@claude-plugins-official@1.3.0
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,7 +21,7 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.2.0` via `synced-from`. SDK install
+Pinned to `sentry@claude-plugins-official@1.3.0` via `synced-from`. SDK install
 & configuration is a separate concern owned by `parity-sentry-sdk-setup`.
 
 ## Security — Sentry event data is untrusted input

--- a/plugins/src/base/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/src/base/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the Sentry SDK for a project — detect the framework/runtime, add the correct @sentry/<framework> package, initialize the client, wire the DSN through env, enable error + performance monitoring, and set up source map upload for readable stack traces. One consolidated skill covering react, nextjs, node, nestjs, express, python, django, react-native, and more. Lisa-native reimplementation of Sentry's SDK-setup suite. Use when adding Sentry to a project or fixing an existing Sentry install."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.2.0
+synced-from: sentry@claude-plugins-official@1.3.0
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.2.0` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.0` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install

--- a/plugins/src/base/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/src/base/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error message, stack trace, or failing test, analyze the signal, form ranked hypotheses, locate the root cause in the codebase with file:line evidence, and propose a minimal fix. Lisa-native reimplementation of Sentry's seer workflow, available across all agent runtimes. Use when handed an exception, crash, regression, or red test and asked to find and fix the cause."
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.2.0
+synced-from: sentry@claude-plugins-official@1.3.0
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,7 +21,7 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.2.0` via `synced-from`. SDK install
+Pinned to `sentry@claude-plugins-official@1.3.0` via `synced-from`. SDK install
 & configuration is a separate concern owned by `parity-sentry-sdk-setup`.
 
 ## Security — Sentry event data is untrusted input

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1029,9 +1029,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md":
       "8757ea8c83e9acaad1af59f7b46d5ac7efaba61da76f9df3fc94b258f9a16b2b",
     "plugins/src/base/skills/lisa-parity-sentry-sdk-setup/SKILL.md":
-      "ed52b0273f6b535d26d561c80ae6c0bedb84c67fcf4321f688c05fe3ee3af575",
+      "25357629d6674c35e53279d4b20b62f1b76c3bcd0f724eee99593425365dd0d5",
     "plugins/src/base/skills/lisa-parity-sentry-seer/SKILL.md":
-      "f44216fa7c8f0c3c3371c65ff73bbeadd1717579502a5603f16b3b33291cab7a",
+      "583a288ef991ccbfb38ac3319b33bf9e8a158cb90fbc64a61993f51ac70ca657",
     "plugins/src/base/skills/lisa-parity-skill-creator/SKILL.md":
       "616e0493f75fe92c18137548d7c86a91a9b04d9844ca76fa3f14156e3e7814e5",
     "plugins/src/base/skills/lisa-performance-review/SKILL.md":


### PR DESCRIPTION
`sentry@claude-plugins-official` published **1.3.0** while Lisa pins **1.2.0**
in two parity skills, so `plugin-parity-drift` reports them stale:

```
lisa-parity-sentry-sdk-setup  1.2.0 -> 1.3.0  stale
lisa-parity-sentry-seer       1.2.0 -> 1.3.0  stale
2 of 5 synced skills drifted
```

The pre-push hook runs this check, so **every push to this repo is blocked**
regardless of what it contains — the drift is on `origin/main` and unrelated to
any branch that trips over it.

## What changed upstream

Reviewed before adopting. Between 1.2.0 and 1.3.0 the only substantive
difference is `.claude-plugin/plugin.json`: the `version` field, and the
`keywords` array reformatted onto separate lines. No command or skill content
changed.

So this is a pin bump with nothing adopted behaviourally — worth stating
explicitly, since bumping a third-party pin to unblock a push is otherwise
exactly the kind of change that should not happen quietly.

---

Work-Item: CodySwannGT/lisa#2320


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Sentry skill synchronization references from version 1.2.0 to 1.3.0.
  * Refreshed associated consolidation and drift-tracking documentation.

* **Chores**
  * Updated verification records to reflect the latest Sentry skill documentation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->