### PR TITLE
fix(secrets): merge into ~/.aws instead of refusing when a file already exists

### DIFF
--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -195,7 +195,7 @@ export function installAwsProfiles(bundle, options = {}) {
   const {
     home = process.env.HOME || homedir(),
     mkdir = mkdirSync,
-    write = writeFileSync,
+    write = writeAtomic,
     read = readFileSync,
     exists = existsSync,
     chmod = chmodSync,
@@ -228,7 +228,7 @@ export function installAwsProfiles(bundle, options = {}) {
   ]) {
     const file = join(dir, name);
     const current = exists(file) ? String(read(file, "utf8")) : "";
-    write(file, upsertManagedBlock(current, body), { mode: 0o600 });
+    write(file, upsertManagedBlock(current, body));
   }
 
   return rendered.profiles;

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -80,7 +80,41 @@ const PROFILE_END = "# <<< lisa secrets (managed) <<<";
  * consumer while still being the thing that distinguishes "our file, refresh
  * it" from "someone else's file, leave it alone".
  */
-const MANAGED_MARKER = "# managed by lisa-secrets-access";
+const MANAGED_MARKER = "# >>> managed by lisa-secrets-access >>>";
+
+/** Closes the managed region of an `~/.aws` file. */
+const MANAGED_END = "# <<< managed by lisa-secrets-access <<<";
+
+/**
+ * Replace this module's delimited region in a file, preserving everything else.
+ *
+ * Written as a merge rather than a whole-file write because both `~/.aws` files
+ * routinely hold sections nobody here knows about — an operator's own profiles,
+ * or a container's bare `[default]`. Refusing on their account wrote nothing at
+ * all; overwriting would delete them. This does neither.
+ * @param {string} current Existing file contents, or "".
+ * @param {string} body The region this module owns.
+ * @returns {string} The merged file.
+ */
+export function upsertManagedBlock(current, body) {
+  const block = `${MANAGED_MARKER}\n${body.trimEnd()}\n${MANAGED_END}`;
+  const start = current.indexOf(MANAGED_MARKER);
+
+  if (start === -1) {
+    const prefix =
+      current && !current.endsWith("\n") ? `${current}\n` : current;
+    return `${prefix}${prefix ? "\n" : ""}${block}\n`;
+  }
+
+  const endAt = current.indexOf(MANAGED_END, start);
+  // A truncated block (marker opened, never closed) would otherwise swallow the
+  // rest of the file on every subsequent write.
+  const after =
+    endAt === -1
+      ? ""
+      : current.slice(endAt + MANAGED_END.length).replace(/^\n/, "");
+  return `${current.slice(0, start)}${block}\n${after}`;
+}
 
 /**
  * Make every shell in this container load the materialized secrets.
@@ -171,34 +205,31 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
-
-  // Never overwrite an ~/.aws this did not write.
-  //
-  // These are whole-file writes, so a pre-existing credentials file — a
-  // developer's own profiles, or something another tool set up — would be
-  // destroyed rather than merged. This only runs on a surface allowed to write
-  // secrets to disk (a disposable container), but "usually disposable" is not a
-  // reason to be able to delete someone's credentials. The marker makes our own
-  // file re-writable while anything else is left alone and reported.
-  for (const name of ["credentials", "config"]) {
-    const file = join(dir, name);
-    if (exists(file) && !String(read(file, "utf8")).includes(MANAGED_MARKER)) {
-      return [];
-    }
-  }
-
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
-  write(
-    join(dir, "credentials"),
-    `${MANAGED_MARKER}\n${rendered.credentials}`,
-    {
-      mode: 0o600,
-    }
-  );
-  write(join(dir, "config"), `${MANAGED_MARKER}\n${rendered.config}`, {
-    mode: 0o600,
-  });
+
+  // Merge into a delimited block; never replace the file.
+  //
+  // Refusing whole files whenever one already existed sounded safe and was
+  // worse than useless: a container ships `~/.aws/config` containing a bare
+  // `[default]`, so the guard fired every time, wrote nothing, and returned
+  // silently — while AWS_PROFILE was still derived from the bundle. The session
+  // got a pointer to a profile that did not exist:
+  //
+  //     The config profile (agent-dev) could not be found
+  //
+  // Merging keeps the operator's own sections intact AND writes ours, which is
+  // what the guard was actually for. Same delimited-block approach as the shell
+  // profile, and `#` is a comment in the shared-config format so the markers are
+  // inert to every consumer.
+  for (const [name, body] of [
+    ["credentials", rendered.credentials],
+    ["config", rendered.config],
+  ]) {
+    const file = join(dir, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+    write(file, upsertManagedBlock(current, body), { mode: 0o600 });
+  }
 
   return rendered.profiles;
 }

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -195,7 +195,7 @@ export function installAwsProfiles(bundle, options = {}) {
   const {
     home = process.env.HOME || homedir(),
     mkdir = mkdirSync,
-    write = writeFileSync,
+    write = writeAtomic,
     read = readFileSync,
     exists = existsSync,
     chmod = chmodSync,
@@ -228,7 +228,7 @@ export function installAwsProfiles(bundle, options = {}) {
   ]) {
     const file = join(dir, name);
     const current = exists(file) ? String(read(file, "utf8")) : "";
-    write(file, upsertManagedBlock(current, body), { mode: 0o600 });
+    write(file, upsertManagedBlock(current, body));
   }
 
   return rendered.profiles;

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -80,7 +80,41 @@ const PROFILE_END = "# <<< lisa secrets (managed) <<<";
  * consumer while still being the thing that distinguishes "our file, refresh
  * it" from "someone else's file, leave it alone".
  */
-const MANAGED_MARKER = "# managed by lisa-secrets-access";
+const MANAGED_MARKER = "# >>> managed by lisa-secrets-access >>>";
+
+/** Closes the managed region of an `~/.aws` file. */
+const MANAGED_END = "# <<< managed by lisa-secrets-access <<<";
+
+/**
+ * Replace this module's delimited region in a file, preserving everything else.
+ *
+ * Written as a merge rather than a whole-file write because both `~/.aws` files
+ * routinely hold sections nobody here knows about — an operator's own profiles,
+ * or a container's bare `[default]`. Refusing on their account wrote nothing at
+ * all; overwriting would delete them. This does neither.
+ * @param {string} current Existing file contents, or "".
+ * @param {string} body The region this module owns.
+ * @returns {string} The merged file.
+ */
+export function upsertManagedBlock(current, body) {
+  const block = `${MANAGED_MARKER}\n${body.trimEnd()}\n${MANAGED_END}`;
+  const start = current.indexOf(MANAGED_MARKER);
+
+  if (start === -1) {
+    const prefix =
+      current && !current.endsWith("\n") ? `${current}\n` : current;
+    return `${prefix}${prefix ? "\n" : ""}${block}\n`;
+  }
+
+  const endAt = current.indexOf(MANAGED_END, start);
+  // A truncated block (marker opened, never closed) would otherwise swallow the
+  // rest of the file on every subsequent write.
+  const after =
+    endAt === -1
+      ? ""
+      : current.slice(endAt + MANAGED_END.length).replace(/^\n/, "");
+  return `${current.slice(0, start)}${block}\n${after}`;
+}
 
 /**
  * Make every shell in this container load the materialized secrets.
@@ -171,34 +205,31 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
-
-  // Never overwrite an ~/.aws this did not write.
-  //
-  // These are whole-file writes, so a pre-existing credentials file — a
-  // developer's own profiles, or something another tool set up — would be
-  // destroyed rather than merged. This only runs on a surface allowed to write
-  // secrets to disk (a disposable container), but "usually disposable" is not a
-  // reason to be able to delete someone's credentials. The marker makes our own
-  // file re-writable while anything else is left alone and reported.
-  for (const name of ["credentials", "config"]) {
-    const file = join(dir, name);
-    if (exists(file) && !String(read(file, "utf8")).includes(MANAGED_MARKER)) {
-      return [];
-    }
-  }
-
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
-  write(
-    join(dir, "credentials"),
-    `${MANAGED_MARKER}\n${rendered.credentials}`,
-    {
-      mode: 0o600,
-    }
-  );
-  write(join(dir, "config"), `${MANAGED_MARKER}\n${rendered.config}`, {
-    mode: 0o600,
-  });
+
+  // Merge into a delimited block; never replace the file.
+  //
+  // Refusing whole files whenever one already existed sounded safe and was
+  // worse than useless: a container ships `~/.aws/config` containing a bare
+  // `[default]`, so the guard fired every time, wrote nothing, and returned
+  // silently — while AWS_PROFILE was still derived from the bundle. The session
+  // got a pointer to a profile that did not exist:
+  //
+  //     The config profile (agent-dev) could not be found
+  //
+  // Merging keeps the operator's own sections intact AND writes ours, which is
+  // what the guard was actually for. Same delimited-block approach as the shell
+  // profile, and `#` is a comment in the shared-config format so the markers are
+  // inert to every consumer.
+  for (const [name, body] of [
+    ["credentials", rendered.credentials],
+    ["config", rendered.config],
+  ]) {
+    const file = join(dir, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+    write(file, upsertManagedBlock(current, body), { mode: 0o600 });
+  }
 
   return rendered.profiles;
 }

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -195,7 +195,7 @@ export function installAwsProfiles(bundle, options = {}) {
   const {
     home = process.env.HOME || homedir(),
     mkdir = mkdirSync,
-    write = writeFileSync,
+    write = writeAtomic,
     read = readFileSync,
     exists = existsSync,
     chmod = chmodSync,
@@ -228,7 +228,7 @@ export function installAwsProfiles(bundle, options = {}) {
   ]) {
     const file = join(dir, name);
     const current = exists(file) ? String(read(file, "utf8")) : "";
-    write(file, upsertManagedBlock(current, body), { mode: 0o600 });
+    write(file, upsertManagedBlock(current, body));
   }
 
   return rendered.profiles;

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -80,7 +80,41 @@ const PROFILE_END = "# <<< lisa secrets (managed) <<<";
  * consumer while still being the thing that distinguishes "our file, refresh
  * it" from "someone else's file, leave it alone".
  */
-const MANAGED_MARKER = "# managed by lisa-secrets-access";
+const MANAGED_MARKER = "# >>> managed by lisa-secrets-access >>>";
+
+/** Closes the managed region of an `~/.aws` file. */
+const MANAGED_END = "# <<< managed by lisa-secrets-access <<<";
+
+/**
+ * Replace this module's delimited region in a file, preserving everything else.
+ *
+ * Written as a merge rather than a whole-file write because both `~/.aws` files
+ * routinely hold sections nobody here knows about — an operator's own profiles,
+ * or a container's bare `[default]`. Refusing on their account wrote nothing at
+ * all; overwriting would delete them. This does neither.
+ * @param {string} current Existing file contents, or "".
+ * @param {string} body The region this module owns.
+ * @returns {string} The merged file.
+ */
+export function upsertManagedBlock(current, body) {
+  const block = `${MANAGED_MARKER}\n${body.trimEnd()}\n${MANAGED_END}`;
+  const start = current.indexOf(MANAGED_MARKER);
+
+  if (start === -1) {
+    const prefix =
+      current && !current.endsWith("\n") ? `${current}\n` : current;
+    return `${prefix}${prefix ? "\n" : ""}${block}\n`;
+  }
+
+  const endAt = current.indexOf(MANAGED_END, start);
+  // A truncated block (marker opened, never closed) would otherwise swallow the
+  // rest of the file on every subsequent write.
+  const after =
+    endAt === -1
+      ? ""
+      : current.slice(endAt + MANAGED_END.length).replace(/^\n/, "");
+  return `${current.slice(0, start)}${block}\n${after}`;
+}
 
 /**
  * Make every shell in this container load the materialized secrets.
@@ -171,34 +205,31 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
-
-  // Never overwrite an ~/.aws this did not write.
-  //
-  // These are whole-file writes, so a pre-existing credentials file — a
-  // developer's own profiles, or something another tool set up — would be
-  // destroyed rather than merged. This only runs on a surface allowed to write
-  // secrets to disk (a disposable container), but "usually disposable" is not a
-  // reason to be able to delete someone's credentials. The marker makes our own
-  // file re-writable while anything else is left alone and reported.
-  for (const name of ["credentials", "config"]) {
-    const file = join(dir, name);
-    if (exists(file) && !String(read(file, "utf8")).includes(MANAGED_MARKER)) {
-      return [];
-    }
-  }
-
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
-  write(
-    join(dir, "credentials"),
-    `${MANAGED_MARKER}\n${rendered.credentials}`,
-    {
-      mode: 0o600,
-    }
-  );
-  write(join(dir, "config"), `${MANAGED_MARKER}\n${rendered.config}`, {
-    mode: 0o600,
-  });
+
+  // Merge into a delimited block; never replace the file.
+  //
+  // Refusing whole files whenever one already existed sounded safe and was
+  // worse than useless: a container ships `~/.aws/config` containing a bare
+  // `[default]`, so the guard fired every time, wrote nothing, and returned
+  // silently — while AWS_PROFILE was still derived from the bundle. The session
+  // got a pointer to a profile that did not exist:
+  //
+  //     The config profile (agent-dev) could not be found
+  //
+  // Merging keeps the operator's own sections intact AND writes ours, which is
+  // what the guard was actually for. Same delimited-block approach as the shell
+  // profile, and `#` is a comment in the shared-config format so the markers are
+  // inert to every consumer.
+  for (const [name, body] of [
+    ["credentials", rendered.credentials],
+    ["config", rendered.config],
+  ]) {
+    const file = join(dir, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+    write(file, upsertManagedBlock(current, body), { mode: 0o600 });
+  }
 
   return rendered.profiles;
 }

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -195,7 +195,7 @@ export function installAwsProfiles(bundle, options = {}) {
   const {
     home = process.env.HOME || homedir(),
     mkdir = mkdirSync,
-    write = writeFileSync,
+    write = writeAtomic,
     read = readFileSync,
     exists = existsSync,
     chmod = chmodSync,
@@ -228,7 +228,7 @@ export function installAwsProfiles(bundle, options = {}) {
   ]) {
     const file = join(dir, name);
     const current = exists(file) ? String(read(file, "utf8")) : "";
-    write(file, upsertManagedBlock(current, body), { mode: 0o600 });
+    write(file, upsertManagedBlock(current, body));
   }
 
   return rendered.profiles;

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -80,7 +80,41 @@ const PROFILE_END = "# <<< lisa secrets (managed) <<<";
  * consumer while still being the thing that distinguishes "our file, refresh
  * it" from "someone else's file, leave it alone".
  */
-const MANAGED_MARKER = "# managed by lisa-secrets-access";
+const MANAGED_MARKER = "# >>> managed by lisa-secrets-access >>>";
+
+/** Closes the managed region of an `~/.aws` file. */
+const MANAGED_END = "# <<< managed by lisa-secrets-access <<<";
+
+/**
+ * Replace this module's delimited region in a file, preserving everything else.
+ *
+ * Written as a merge rather than a whole-file write because both `~/.aws` files
+ * routinely hold sections nobody here knows about — an operator's own profiles,
+ * or a container's bare `[default]`. Refusing on their account wrote nothing at
+ * all; overwriting would delete them. This does neither.
+ * @param {string} current Existing file contents, or "".
+ * @param {string} body The region this module owns.
+ * @returns {string} The merged file.
+ */
+export function upsertManagedBlock(current, body) {
+  const block = `${MANAGED_MARKER}\n${body.trimEnd()}\n${MANAGED_END}`;
+  const start = current.indexOf(MANAGED_MARKER);
+
+  if (start === -1) {
+    const prefix =
+      current && !current.endsWith("\n") ? `${current}\n` : current;
+    return `${prefix}${prefix ? "\n" : ""}${block}\n`;
+  }
+
+  const endAt = current.indexOf(MANAGED_END, start);
+  // A truncated block (marker opened, never closed) would otherwise swallow the
+  // rest of the file on every subsequent write.
+  const after =
+    endAt === -1
+      ? ""
+      : current.slice(endAt + MANAGED_END.length).replace(/^\n/, "");
+  return `${current.slice(0, start)}${block}\n${after}`;
+}
 
 /**
  * Make every shell in this container load the materialized secrets.
@@ -171,34 +205,31 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
-
-  // Never overwrite an ~/.aws this did not write.
-  //
-  // These are whole-file writes, so a pre-existing credentials file — a
-  // developer's own profiles, or something another tool set up — would be
-  // destroyed rather than merged. This only runs on a surface allowed to write
-  // secrets to disk (a disposable container), but "usually disposable" is not a
-  // reason to be able to delete someone's credentials. The marker makes our own
-  // file re-writable while anything else is left alone and reported.
-  for (const name of ["credentials", "config"]) {
-    const file = join(dir, name);
-    if (exists(file) && !String(read(file, "utf8")).includes(MANAGED_MARKER)) {
-      return [];
-    }
-  }
-
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
-  write(
-    join(dir, "credentials"),
-    `${MANAGED_MARKER}\n${rendered.credentials}`,
-    {
-      mode: 0o600,
-    }
-  );
-  write(join(dir, "config"), `${MANAGED_MARKER}\n${rendered.config}`, {
-    mode: 0o600,
-  });
+
+  // Merge into a delimited block; never replace the file.
+  //
+  // Refusing whole files whenever one already existed sounded safe and was
+  // worse than useless: a container ships `~/.aws/config` containing a bare
+  // `[default]`, so the guard fired every time, wrote nothing, and returned
+  // silently — while AWS_PROFILE was still derived from the bundle. The session
+  // got a pointer to a profile that did not exist:
+  //
+  //     The config profile (agent-dev) could not be found
+  //
+  // Merging keeps the operator's own sections intact AND writes ours, which is
+  // what the guard was actually for. Same delimited-block approach as the shell
+  // profile, and `#` is a comment in the shared-config format so the markers are
+  // inert to every consumer.
+  for (const [name, body] of [
+    ["credentials", rendered.credentials],
+    ["config", rendered.config],
+  ]) {
+    const file = join(dir, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+    write(file, upsertManagedBlock(current, body), { mode: 0o600 });
+  }
 
   return rendered.profiles;
 }

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -195,7 +195,7 @@ export function installAwsProfiles(bundle, options = {}) {
   const {
     home = process.env.HOME || homedir(),
     mkdir = mkdirSync,
-    write = writeFileSync,
+    write = writeAtomic,
     read = readFileSync,
     exists = existsSync,
     chmod = chmodSync,
@@ -228,7 +228,7 @@ export function installAwsProfiles(bundle, options = {}) {
   ]) {
     const file = join(dir, name);
     const current = exists(file) ? String(read(file, "utf8")) : "";
-    write(file, upsertManagedBlock(current, body), { mode: 0o600 });
+    write(file, upsertManagedBlock(current, body));
   }
 
   return rendered.profiles;

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -80,7 +80,41 @@ const PROFILE_END = "# <<< lisa secrets (managed) <<<";
  * consumer while still being the thing that distinguishes "our file, refresh
  * it" from "someone else's file, leave it alone".
  */
-const MANAGED_MARKER = "# managed by lisa-secrets-access";
+const MANAGED_MARKER = "# >>> managed by lisa-secrets-access >>>";
+
+/** Closes the managed region of an `~/.aws` file. */
+const MANAGED_END = "# <<< managed by lisa-secrets-access <<<";
+
+/**
+ * Replace this module's delimited region in a file, preserving everything else.
+ *
+ * Written as a merge rather than a whole-file write because both `~/.aws` files
+ * routinely hold sections nobody here knows about — an operator's own profiles,
+ * or a container's bare `[default]`. Refusing on their account wrote nothing at
+ * all; overwriting would delete them. This does neither.
+ * @param {string} current Existing file contents, or "".
+ * @param {string} body The region this module owns.
+ * @returns {string} The merged file.
+ */
+export function upsertManagedBlock(current, body) {
+  const block = `${MANAGED_MARKER}\n${body.trimEnd()}\n${MANAGED_END}`;
+  const start = current.indexOf(MANAGED_MARKER);
+
+  if (start === -1) {
+    const prefix =
+      current && !current.endsWith("\n") ? `${current}\n` : current;
+    return `${prefix}${prefix ? "\n" : ""}${block}\n`;
+  }
+
+  const endAt = current.indexOf(MANAGED_END, start);
+  // A truncated block (marker opened, never closed) would otherwise swallow the
+  // rest of the file on every subsequent write.
+  const after =
+    endAt === -1
+      ? ""
+      : current.slice(endAt + MANAGED_END.length).replace(/^\n/, "");
+  return `${current.slice(0, start)}${block}\n${after}`;
+}
 
 /**
  * Make every shell in this container load the materialized secrets.
@@ -171,34 +205,31 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
-
-  // Never overwrite an ~/.aws this did not write.
-  //
-  // These are whole-file writes, so a pre-existing credentials file — a
-  // developer's own profiles, or something another tool set up — would be
-  // destroyed rather than merged. This only runs on a surface allowed to write
-  // secrets to disk (a disposable container), but "usually disposable" is not a
-  // reason to be able to delete someone's credentials. The marker makes our own
-  // file re-writable while anything else is left alone and reported.
-  for (const name of ["credentials", "config"]) {
-    const file = join(dir, name);
-    if (exists(file) && !String(read(file, "utf8")).includes(MANAGED_MARKER)) {
-      return [];
-    }
-  }
-
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
-  write(
-    join(dir, "credentials"),
-    `${MANAGED_MARKER}\n${rendered.credentials}`,
-    {
-      mode: 0o600,
-    }
-  );
-  write(join(dir, "config"), `${MANAGED_MARKER}\n${rendered.config}`, {
-    mode: 0o600,
-  });
+
+  // Merge into a delimited block; never replace the file.
+  //
+  // Refusing whole files whenever one already existed sounded safe and was
+  // worse than useless: a container ships `~/.aws/config` containing a bare
+  // `[default]`, so the guard fired every time, wrote nothing, and returned
+  // silently — while AWS_PROFILE was still derived from the bundle. The session
+  // got a pointer to a profile that did not exist:
+  //
+  //     The config profile (agent-dev) could not be found
+  //
+  // Merging keeps the operator's own sections intact AND writes ours, which is
+  // what the guard was actually for. Same delimited-block approach as the shell
+  // profile, and `#` is a comment in the shared-config format so the markers are
+  // inert to every consumer.
+  for (const [name, body] of [
+    ["credentials", rendered.credentials],
+    ["config", rendered.config],
+  ]) {
+    const file = join(dir, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+    write(file, upsertManagedBlock(current, body), { mode: 0o600 });
+  }
 
   return rendered.profiles;
 }

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -195,7 +195,7 @@ export function installAwsProfiles(bundle, options = {}) {
   const {
     home = process.env.HOME || homedir(),
     mkdir = mkdirSync,
-    write = writeFileSync,
+    write = writeAtomic,
     read = readFileSync,
     exists = existsSync,
     chmod = chmodSync,
@@ -228,7 +228,7 @@ export function installAwsProfiles(bundle, options = {}) {
   ]) {
     const file = join(dir, name);
     const current = exists(file) ? String(read(file, "utf8")) : "";
-    write(file, upsertManagedBlock(current, body), { mode: 0o600 });
+    write(file, upsertManagedBlock(current, body));
   }
 
   return rendered.profiles;

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -80,7 +80,41 @@ const PROFILE_END = "# <<< lisa secrets (managed) <<<";
  * consumer while still being the thing that distinguishes "our file, refresh
  * it" from "someone else's file, leave it alone".
  */
-const MANAGED_MARKER = "# managed by lisa-secrets-access";
+const MANAGED_MARKER = "# >>> managed by lisa-secrets-access >>>";
+
+/** Closes the managed region of an `~/.aws` file. */
+const MANAGED_END = "# <<< managed by lisa-secrets-access <<<";
+
+/**
+ * Replace this module's delimited region in a file, preserving everything else.
+ *
+ * Written as a merge rather than a whole-file write because both `~/.aws` files
+ * routinely hold sections nobody here knows about — an operator's own profiles,
+ * or a container's bare `[default]`. Refusing on their account wrote nothing at
+ * all; overwriting would delete them. This does neither.
+ * @param {string} current Existing file contents, or "".
+ * @param {string} body The region this module owns.
+ * @returns {string} The merged file.
+ */
+export function upsertManagedBlock(current, body) {
+  const block = `${MANAGED_MARKER}\n${body.trimEnd()}\n${MANAGED_END}`;
+  const start = current.indexOf(MANAGED_MARKER);
+
+  if (start === -1) {
+    const prefix =
+      current && !current.endsWith("\n") ? `${current}\n` : current;
+    return `${prefix}${prefix ? "\n" : ""}${block}\n`;
+  }
+
+  const endAt = current.indexOf(MANAGED_END, start);
+  // A truncated block (marker opened, never closed) would otherwise swallow the
+  // rest of the file on every subsequent write.
+  const after =
+    endAt === -1
+      ? ""
+      : current.slice(endAt + MANAGED_END.length).replace(/^\n/, "");
+  return `${current.slice(0, start)}${block}\n${after}`;
+}
 
 /**
  * Make every shell in this container load the materialized secrets.
@@ -171,34 +205,31 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
-
-  // Never overwrite an ~/.aws this did not write.
-  //
-  // These are whole-file writes, so a pre-existing credentials file — a
-  // developer's own profiles, or something another tool set up — would be
-  // destroyed rather than merged. This only runs on a surface allowed to write
-  // secrets to disk (a disposable container), but "usually disposable" is not a
-  // reason to be able to delete someone's credentials. The marker makes our own
-  // file re-writable while anything else is left alone and reported.
-  for (const name of ["credentials", "config"]) {
-    const file = join(dir, name);
-    if (exists(file) && !String(read(file, "utf8")).includes(MANAGED_MARKER)) {
-      return [];
-    }
-  }
-
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
-  write(
-    join(dir, "credentials"),
-    `${MANAGED_MARKER}\n${rendered.credentials}`,
-    {
-      mode: 0o600,
-    }
-  );
-  write(join(dir, "config"), `${MANAGED_MARKER}\n${rendered.config}`, {
-    mode: 0o600,
-  });
+
+  // Merge into a delimited block; never replace the file.
+  //
+  // Refusing whole files whenever one already existed sounded safe and was
+  // worse than useless: a container ships `~/.aws/config` containing a bare
+  // `[default]`, so the guard fired every time, wrote nothing, and returned
+  // silently — while AWS_PROFILE was still derived from the bundle. The session
+  // got a pointer to a profile that did not exist:
+  //
+  //     The config profile (agent-dev) could not be found
+  //
+  // Merging keeps the operator's own sections intact AND writes ours, which is
+  // what the guard was actually for. Same delimited-block approach as the shell
+  // profile, and `#` is a comment in the shared-config format so the markers are
+  // inert to every consumer.
+  for (const [name, body] of [
+    ["credentials", rendered.credentials],
+    ["config", rendered.config],
+  ]) {
+    const file = join(dir, name);
+    const current = exists(file) ? String(read(file, "utf8")) : "";
+    write(file, upsertManagedBlock(current, body), { mode: 0o600 });
+  }
 
   return rendered.profiles;
 }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1107,7 +1107,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/envfile.mjs":
       "be4e38ce85f9268b52b29dbde264ecd8d50973c2b63a15410336234a921d9644",
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs":
-      "a8d025e56bf6ca292e2fcfa6ba81f80283f0b9419b2661e68455b3a765b3ec0e",
+      "cbff6144fcdc5e1f0bcbe2f2e509ec4a572f7f387ec2dc3c03693ec9102fdede",
     "plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs":
       "fec38ca937570c1e1c21e6e8f7314a9d8f4e9264779d0394b40d5158924da0da",
     "plugins/src/base/skills/lisa-secrets-access/scripts/read-secret-note.mjs":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1107,7 +1107,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/envfile.mjs":
       "be4e38ce85f9268b52b29dbde264ecd8d50973c2b63a15410336234a921d9644",
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs":
-      "cbff6144fcdc5e1f0bcbe2f2e509ec4a572f7f387ec2dc3c03693ec9102fdede",
+      "0d214c16fa3e2d905e6ebd75c00710f9ec43449fd2337f2dca0b35833bb91f76",
     "plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs":
       "fec38ca937570c1e1c21e6e8f7314a9d8f4e9264779d0394b40d5158924da0da",
     "plugins/src/base/skills/lisa-secrets-access/scripts/read-secret-note.mjs":
@@ -8489,6 +8489,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/automation-workflow.test.ts": true,
     "tests/unit/secrets/aws-bootstrap-derivation.test.ts": true,
     "tests/unit/secrets/aws-profiles-install.test.ts": true,
+    "tests/unit/secrets/aws-profiles-permissions.test.ts": true,
     "tests/unit/secrets/aws-profiles.test.ts": true,
     "tests/unit/secrets/bootstrap-key-naming.test.ts": true,
     "tests/unit/secrets/detect-tooling-discovery.test.ts": true,

--- a/tests/unit/secrets/aws-profiles-install.test.ts
+++ b/tests/unit/secrets/aws-profiles-install.test.ts
@@ -23,6 +23,12 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { installAwsProfiles } from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs";
 
+/** The one environment this fixture declares. */
+const DEV = "agent-dev";
+
+/** Where the written config lives, relative to home. */
+const CONFIG = ".aws/config";
+
 /** Where the written credentials live, relative to home. */
 const CREDENTIALS = ".aws/credentials";
 
@@ -35,7 +41,7 @@ const BUNDLE = {
   secretAccessKey: "s3cret",
   externalId: "ext-1",
   profiles: {
-    "agent-dev": {
+    [DEV]: {
       roleArn: "arn:aws:iam::905179307867:role/RemoteAgent",
       region: "us-east-1",
     },
@@ -62,22 +68,47 @@ describe("installAwsProfiles", () => {
   it("writes the profiles and reports their names", () => {
     const home = scratchHome();
 
-    expect(installAwsProfiles(BUNDLE, { home })).toEqual(["agent-dev"]);
-    expect(readFileSync(path.join(home, ".aws/config"), "utf8")).toContain(
-      "[profile agent-dev]"
+    expect(installAwsProfiles(BUNDLE, { home })).toEqual([DEV]);
+    expect(readFileSync(path.join(home, CONFIG), "utf8")).toContain(
+      `[profile ${DEV}]`
     );
   });
 
-  it("refuses to overwrite an ~/.aws it did not write", () => {
-    // The failure this prevents is silent and unrecoverable: someone's own
-    // credentials replaced by ours, with no copy kept.
+  it("merges into an ~/.aws it did not write, keeping both", () => {
+    // Refusing outright was the first attempt and was worse than useless: a
+    // container ships `~/.aws/config` holding a bare `[default]`, so the guard
+    // fired every time and wrote nothing — while AWS_PROFILE was still derived
+    // from the bundle. The session got a pointer to a profile that did not
+    // exist: "The config profile (agent-dev) could not be found".
+    //
+    // Destroying their file and refusing to write ours are both wrong.
     const home = scratchHome();
-    const existing = "[default]\naws_access_key_id = THEIRS\n";
     mkdirSync(path.join(home, ".aws"), { recursive: true });
-    writeFileSync(path.join(home, CREDENTIALS), existing);
+    writeFileSync(
+      path.join(home, CREDENTIALS),
+      "[theirs]\naws_access_key_id = THEIRS\n"
+    );
+    writeFileSync(path.join(home, CONFIG), "[default]\nregion = us-east-1\n");
 
-    expect(installAwsProfiles(BUNDLE, { home })).toEqual([]);
-    expect(readFileSync(path.join(home, CREDENTIALS), "utf8")).toBe(existing);
+    expect(installAwsProfiles(BUNDLE, { home })).toEqual([DEV]);
+
+    const credentials = readFileSync(path.join(home, CREDENTIALS), "utf8");
+    const config = readFileSync(path.join(home, CONFIG), "utf8");
+    expect(credentials).toContain("aws_access_key_id = THEIRS");
+    expect(config).toContain("[default]");
+    expect(config).toContain(`[profile ${DEV}]`);
+  });
+
+  it("replaces its own block instead of stacking it every session", () => {
+    const home = scratchHome();
+    installAwsProfiles(BUNDLE, { home });
+    installAwsProfiles(BUNDLE, { home });
+    installAwsProfiles(BUNDLE, { home });
+
+    const config = readFileSync(path.join(home, CONFIG), "utf8");
+    expect(
+      config.split(">>> managed by lisa-secrets-access >>>").length - 1
+    ).toBe(1);
   });
 
   it("refreshes a file it wrote previously", () => {
@@ -88,7 +119,7 @@ describe("installAwsProfiles", () => {
 
     expect(
       installAwsProfiles({ ...BUNDLE, accessKeyId: "AKIAROTATED" }, { home })
-    ).toEqual(["agent-dev"]);
+    ).toEqual([DEV]);
     expect(readFileSync(path.join(home, CREDENTIALS), "utf8")).toContain(
       "AKIAROTATED"
     );

--- a/tests/unit/secrets/aws-profiles-permissions.test.ts
+++ b/tests/unit/secrets/aws-profiles-permissions.test.ts
@@ -1,0 +1,95 @@
+/**
+ * `~/.aws/credentials` must end up 0600 even when the file already existed.
+ *
+ * `fs.writeFileSync(path, data, { mode })` applies `mode` only when it CREATES
+ * the file. A container that ships its own `~/.aws/credentials` — or any run
+ * after the first — would therefore keep whatever permissions were already
+ * there, while the file now holds the bootstrap key pair. Writing through the
+ * atomic helper chmods before the rename, so the result is 0600 either way.
+ * @module tests/unit/secrets/aws-profiles-permissions
+ */
+
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { installAwsProfiles } from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs";
+
+/** Scratch homes to remove. */
+const homes: string[] = [];
+
+/** Where the credentials land, relative to home. */
+const CREDENTIALS = ".aws/credentials";
+
+/** A bundle rendering one usable profile. */
+const BUNDLE = {
+  accessKeyId: "AKIAEXAMPLE",
+  secretAccessKey: "s3cret",
+  profiles: {
+    "agent-dev": {
+      roleArn: "arn:aws:iam::1:role/RemoteAgent",
+      region: "us-east-1",
+    },
+  },
+};
+
+afterEach(() => {
+  while (homes.length > 0) {
+    rmSync(homes.pop() as string, { recursive: true, force: true });
+  }
+});
+
+/**
+ * A scratch home.
+ * @returns Its path.
+ */
+function scratchHome(): string {
+  const home = mkdtempSync(path.join(tmpdir(), "lisa-awsperm-"));
+  homes.push(home);
+  return home;
+}
+
+describe("~/.aws permissions", () => {
+  it("writes 0600 when creating the file", () => {
+    const home = scratchHome();
+    installAwsProfiles(BUNDLE, { home });
+
+    expect(statSync(path.join(home, CREDENTIALS)).mode & 0o777).toBe(0o600);
+  });
+
+  it("tightens a pre-existing world-readable file to 0600", () => {
+    // The case `mode` silently misses: the file already exists, so writeFileSync
+    // would leave 0644 on a file that now contains a key pair.
+    const home = scratchHome();
+    mkdirSync(path.join(home, ".aws"), { recursive: true });
+    const file = path.join(home, CREDENTIALS);
+    writeFileSync(file, "[theirs]\n");
+    chmodSync(file, 0o644);
+
+    installAwsProfiles(BUNDLE, { home });
+
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it("still preserves the foreign content it tightened", () => {
+    // Tightening must not become an excuse to replace the file.
+    const home = scratchHome();
+    mkdirSync(path.join(home, ".aws"), { recursive: true });
+    const file = path.join(home, CREDENTIALS);
+    writeFileSync(file, "[theirs]\naws_access_key_id = THEIRS\n");
+    chmodSync(file, 0o644);
+
+    installAwsProfiles(BUNDLE, { home });
+
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+  });
+});


### PR DESCRIPTION
The `~/.aws` clobber guard added during review of #2318 makes the feature it
guards do nothing.

A Claude cloud container ships an `~/.aws/config` holding a bare `[default]`.
That file carries no marker, so `installAwsProfiles` refuses on every run,
writes neither profiles nor credentials, and returns `[]` **silently** — while
`deriveAwsEnvironment` still derives `AWS_PROFILE=agent-dev` from the bundle and
writes it to the env file.

The session therefore holds a pointer to a profile that does not exist. Observed
live on lisa 2.333.0:

```
(login shell)  The config profile (agent-dev) could not be found
(tool shell)   InvalidClientTokenId: The security token ... is invalid
```

The two shells fail differently — the tool shell never reads a profile, so the
container's placeholder `AWS_ACCESS_KEY_ID` survives — and neither works.
`~/.aws/credentials` was never created at all, and `~/.aws/config` still held
only `[default]`.

## Fix

Merge into a delimited managed block instead of refusing whole files. Foreign
sections are preserved, ours is replaced rather than stacked, and a truncated
block cannot swallow the rest of the file. `#` is a comment in the AWS
shared-config format, so the markers are inert to every consumer.

Refusing to touch someone else's file and destroying it are both wrong; the
guard should have been a merge from the start.

## Measured precedence, which is why this is sufficient

```
--profile + ambient keys   -> profile wins
AWS_PROFILE + ambient keys -> ambient wins
AWS_PROFILE, no ambient    -> profile wins
```

A named profile therefore works in any shell, including one that never sourced
the managed block — which matters, because the agent's tool shell does not.

## Evidence

Reproducing the exact container condition — `~/.aws/config` pre-seeded with a bare `[default]`:

```
written: agent-dev, agent-staging, agent-production, agent-shared
kept pre-existing [default]: true
wrote [profile agent-dev]: true
managed blocks after 3 runs: 1
still has [default]: true
```

And a live call through the merged config, with the placeholder ambient
credentials still set:

```
arn:aws:sts::905179307867:assumed-role/RemoteAgent/...
```

Full suite green: 8877 passed, 532 files.

---

Work-Item: CodySwannGT/lisa#2319


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AWS profile installation now preserves unrelated content in existing credentials and configuration files.
  * Managed profile sections are safely added or replaced without overwriting entire files or creating duplicates.
  * Incomplete managed sections are handled safely during updates.

* **Tests**
  * Added coverage for preserving existing AWS settings and replacing managed sections during repeated installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->