### PR TITLE
fix(skills): refuse merge_method=rebase instead of verifying it wrongly

### DIFF
--- a/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -14,9 +14,18 @@ merges" loop. Other skills delegate here instead of re-implementing it. Runs
 
 - `pr=<number|url>` — the PR to drive. Default: the PR for the current branch
   (`gh pr view --json number,url,baseRefName,headRefName,state`).
-- `merge_method=<merge|rebase>` — strategy for both auto-merge and the direct-merge
-  fallback. Default `merge`. **Never squash** — squashing flattens
-  `chore(release): X.Y.Z [skip ci]` commits and breaks release promotion detection.
+- `merge_method=<merge>` — strategy for both auto-merge and the direct-merge
+  fallback. Default and only accepted value: `merge`.
+  - **Never squash** — squashing flattens `chore(release): X.Y.Z [skip ci]`
+    commits and breaks release promotion detection.
+  - **Never rebase.** REJECT `merge_method=rebase` up front with a clear message
+    rather than accepting it and verifying it wrongly. GitHub's rebase-and-merge
+    rewrites the commits — new SHAs — and creates no merge commit, so the
+    shipped-verification in section 3 cannot succeed: `verify_commit` is the
+    pre-rebase SHA and is not an ancestor of the base branch afterwards, and the
+    merge-parent assertion has nothing to assert against. A successful merge
+    would then report as a FAILED verification and drive a false fix-forward,
+    which is worse than refusing the input. See CodySwannGT/lisa#2316.
 - `verify_commit=<sha>` — the commit that MUST end up in the merged base (for the
   ancestry check). Default: the PR head at the time this skill starts.
 - `auto_merge=<true|false>` — whether this skill is allowed to merge the PR at

--- a/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -14,9 +14,18 @@ merges" loop. Other skills delegate here instead of re-implementing it. Runs
 
 - `pr=<number|url>` — the PR to drive. Default: the PR for the current branch
   (`gh pr view --json number,url,baseRefName,headRefName,state`).
-- `merge_method=<merge|rebase>` — strategy for both auto-merge and the direct-merge
-  fallback. Default `merge`. **Never squash** — squashing flattens
-  `chore(release): X.Y.Z [skip ci]` commits and breaks release promotion detection.
+- `merge_method=<merge>` — strategy for both auto-merge and the direct-merge
+  fallback. Default and only accepted value: `merge`.
+  - **Never squash** — squashing flattens `chore(release): X.Y.Z [skip ci]`
+    commits and breaks release promotion detection.
+  - **Never rebase.** REJECT `merge_method=rebase` up front with a clear message
+    rather than accepting it and verifying it wrongly. GitHub's rebase-and-merge
+    rewrites the commits — new SHAs — and creates no merge commit, so the
+    shipped-verification in section 3 cannot succeed: `verify_commit` is the
+    pre-rebase SHA and is not an ancestor of the base branch afterwards, and the
+    merge-parent assertion has nothing to assert against. A successful merge
+    would then report as a FAILED verification and drive a false fix-forward,
+    which is worse than refusing the input. See CodySwannGT/lisa#2316.
 - `verify_commit=<sha>` — the commit that MUST end up in the merged base (for the
   ancestry check). Default: the PR head at the time this skill starts.
 - `auto_merge=<true|false>` — whether this skill is allowed to merge the PR at

--- a/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -14,9 +14,18 @@ merges" loop. Other skills delegate here instead of re-implementing it. Runs
 
 - `pr=<number|url>` — the PR to drive. Default: the PR for the current branch
   (`gh pr view --json number,url,baseRefName,headRefName,state`).
-- `merge_method=<merge|rebase>` — strategy for both auto-merge and the direct-merge
-  fallback. Default `merge`. **Never squash** — squashing flattens
-  `chore(release): X.Y.Z [skip ci]` commits and breaks release promotion detection.
+- `merge_method=<merge>` — strategy for both auto-merge and the direct-merge
+  fallback. Default and only accepted value: `merge`.
+  - **Never squash** — squashing flattens `chore(release): X.Y.Z [skip ci]`
+    commits and breaks release promotion detection.
+  - **Never rebase.** REJECT `merge_method=rebase` up front with a clear message
+    rather than accepting it and verifying it wrongly. GitHub's rebase-and-merge
+    rewrites the commits — new SHAs — and creates no merge commit, so the
+    shipped-verification in section 3 cannot succeed: `verify_commit` is the
+    pre-rebase SHA and is not an ancestor of the base branch afterwards, and the
+    merge-parent assertion has nothing to assert against. A successful merge
+    would then report as a FAILED verification and drive a false fix-forward,
+    which is worse than refusing the input. See CodySwannGT/lisa#2316.
 - `verify_commit=<sha>` — the commit that MUST end up in the merged base (for the
   ancestry check). Default: the PR head at the time this skill starts.
 - `auto_merge=<true|false>` — whether this skill is allowed to merge the PR at

--- a/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -14,9 +14,18 @@ merges" loop. Other skills delegate here instead of re-implementing it. Runs
 
 - `pr=<number|url>` — the PR to drive. Default: the PR for the current branch
   (`gh pr view --json number,url,baseRefName,headRefName,state`).
-- `merge_method=<merge|rebase>` — strategy for both auto-merge and the direct-merge
-  fallback. Default `merge`. **Never squash** — squashing flattens
-  `chore(release): X.Y.Z [skip ci]` commits and breaks release promotion detection.
+- `merge_method=<merge>` — strategy for both auto-merge and the direct-merge
+  fallback. Default and only accepted value: `merge`.
+  - **Never squash** — squashing flattens `chore(release): X.Y.Z [skip ci]`
+    commits and breaks release promotion detection.
+  - **Never rebase.** REJECT `merge_method=rebase` up front with a clear message
+    rather than accepting it and verifying it wrongly. GitHub's rebase-and-merge
+    rewrites the commits — new SHAs — and creates no merge commit, so the
+    shipped-verification in section 3 cannot succeed: `verify_commit` is the
+    pre-rebase SHA and is not an ancestor of the base branch afterwards, and the
+    merge-parent assertion has nothing to assert against. A successful merge
+    would then report as a FAILED verification and drive a false fix-forward,
+    which is worse than refusing the input. See CodySwannGT/lisa#2316.
 - `verify_commit=<sha>` — the commit that MUST end up in the merged base (for the
   ancestry check). Default: the PR head at the time this skill starts.
 - `auto_merge=<true|false>` — whether this skill is allowed to merge the PR at

--- a/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -14,9 +14,18 @@ merges" loop. Other skills delegate here instead of re-implementing it. Runs
 
 - `pr=<number|url>` — the PR to drive. Default: the PR for the current branch
   (`gh pr view --json number,url,baseRefName,headRefName,state`).
-- `merge_method=<merge|rebase>` — strategy for both auto-merge and the direct-merge
-  fallback. Default `merge`. **Never squash** — squashing flattens
-  `chore(release): X.Y.Z [skip ci]` commits and breaks release promotion detection.
+- `merge_method=<merge>` — strategy for both auto-merge and the direct-merge
+  fallback. Default and only accepted value: `merge`.
+  - **Never squash** — squashing flattens `chore(release): X.Y.Z [skip ci]`
+    commits and breaks release promotion detection.
+  - **Never rebase.** REJECT `merge_method=rebase` up front with a clear message
+    rather than accepting it and verifying it wrongly. GitHub's rebase-and-merge
+    rewrites the commits — new SHAs — and creates no merge commit, so the
+    shipped-verification in section 3 cannot succeed: `verify_commit` is the
+    pre-rebase SHA and is not an ancestor of the base branch afterwards, and the
+    merge-parent assertion has nothing to assert against. A successful merge
+    would then report as a FAILED verification and drive a false fix-forward,
+    which is worse than refusing the input. See CodySwannGT/lisa#2316.
 - `verify_commit=<sha>` — the commit that MUST end up in the merged base (for the
   ancestry check). Default: the PR head at the time this skill starts.
 - `auto_merge=<true|false>` — whether this skill is allowed to merge the PR at

--- a/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -14,9 +14,18 @@ merges" loop. Other skills delegate here instead of re-implementing it. Runs
 
 - `pr=<number|url>` — the PR to drive. Default: the PR for the current branch
   (`gh pr view --json number,url,baseRefName,headRefName,state`).
-- `merge_method=<merge|rebase>` — strategy for both auto-merge and the direct-merge
-  fallback. Default `merge`. **Never squash** — squashing flattens
-  `chore(release): X.Y.Z [skip ci]` commits and breaks release promotion detection.
+- `merge_method=<merge>` — strategy for both auto-merge and the direct-merge
+  fallback. Default and only accepted value: `merge`.
+  - **Never squash** — squashing flattens `chore(release): X.Y.Z [skip ci]`
+    commits and breaks release promotion detection.
+  - **Never rebase.** REJECT `merge_method=rebase` up front with a clear message
+    rather than accepting it and verifying it wrongly. GitHub's rebase-and-merge
+    rewrites the commits — new SHAs — and creates no merge commit, so the
+    shipped-verification in section 3 cannot succeed: `verify_commit` is the
+    pre-rebase SHA and is not an ancestor of the base branch afterwards, and the
+    merge-parent assertion has nothing to assert against. A successful merge
+    would then report as a FAILED verification and drive a false fix-forward,
+    which is worse than refusing the input. See CodySwannGT/lisa#2316.
 - `verify_commit=<sha>` — the commit that MUST end up in the merged base (for the
   ancestry check). Default: the PR head at the time this skill starts.
 - `auto_merge=<true|false>` — whether this skill is allowed to merge the PR at

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -869,7 +869,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
       "fb41a1e63c5332d47a46e715aff52551f3df867033b5e4f37dfaeee30019b891",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
-      "0317e029316be19682bbc689c397275e7bcab5a6215f644755d4aebbe956bacf",
+      "55de8bb44a958f5afd97deca410423b86a3c6d79bf571119304cf497c5a7a653",
     "plugins/src/base/skills/lisa-epic-triage/SKILL.md":
       "d02760411249bddbd396f283191fe3e82bb7b95bf9393a19a7025dc5a57c3ab7",
     "plugins/src/base/skills/lisa-evaluation-suite/SKILL.md":

--- a/tests/unit/strategies/drive-pr-auto-merge-race.test.ts
+++ b/tests/unit/strategies/drive-pr-auto-merge-race.test.ts
@@ -117,6 +117,21 @@ describe.each(ROOTS)("drive-pr-to-merge auto-merge race guard (%s)", root => {
     expect(offenders).toEqual([]);
   });
 
+  it("refuses merge_method=rebase rather than verifying it wrongly", () => {
+    // GitHub's rebase-and-merge rewrites the commits and creates no merge
+    // commit, so section 3's ancestry + merge-parent verification cannot
+    // succeed: a SUCCESSFUL merge reports as a failed verification and drives a
+    // false fix-forward. Refusing the input beats accepting it and being wrong
+    // about the outcome (CodySwannGT/lisa#2316).
+    expect(content).toMatch(/Never rebase/i);
+    expect(content).toMatch(/merge_method=<merge>/);
+    // The reasoning travels with the rule, so nobody re-adds `rebase` to the
+    // accepted set without meeting the argument first.
+    expect(content).toMatch(/rewrites the commits/i);
+    // ...and the old permissive signature is gone, not merely contradicted.
+    expect(content).not.toMatch(/merge_method=<merge\|rebase>/);
+  });
+
   it("scopes the armed-latch rule to auto_merge=true", () => {
     // An unqualified "never disable auto-merge" contradicts the auto_merge=false
     // contract, which disarms a pre-existing latch on purpose so the PR stays

--- a/tests/unit/strategies/drive-pr-auto-merge-race.test.ts
+++ b/tests/unit/strategies/drive-pr-auto-merge-race.test.ts
@@ -118,18 +118,29 @@ describe.each(ROOTS)("drive-pr-to-merge auto-merge race guard (%s)", root => {
   });
 
   it("refuses merge_method=rebase rather than verifying it wrongly", () => {
-    // GitHub's rebase-and-merge rewrites the commits and creates no merge
-    // commit, so section 3's ancestry + merge-parent verification cannot
-    // succeed: a SUCCESSFUL merge reports as a failed verification and drives a
-    // false fix-forward. Refusing the input beats accepting it and being wrong
-    // about the outcome (CodySwannGT/lisa#2316).
-    expect(content).toMatch(/Never rebase/i);
+    // The REFUSAL itself, not merely a mention of the word. "Never rebase"
+    // alone would pass against a document that named rebase and then went on
+    // to accept it.
+    expect(content).toMatch(/REJECT `merge_method=rebase`/);
     expect(content).toMatch(/merge_method=<merge>/);
-    // The reasoning travels with the rule, so nobody re-adds `rebase` to the
-    // accepted set without meeting the argument first.
-    expect(content).toMatch(/rewrites the commits/i);
     // ...and the old permissive signature is gone, not merely contradicted.
     expect(content).not.toMatch(/merge_method=<merge\|rebase>/);
+  });
+
+  it("says WHY rebase cannot be verified, in both its parts", () => {
+    // The reasoning travels with the rule, so nobody re-adds `rebase` without
+    // meeting the argument. Both halves matter and they fail differently:
+    // rewritten SHAs break the ancestry check, and the absent merge commit
+    // breaks the parent assertion. A document stating only one would leave the
+    // next reader thinking the other case is handled.
+    expect(content).toMatch(/rewrites the commits/i);
+    expect(content).toMatch(/creates no merge commit/i);
+    expect(content).toMatch(
+      /merge-parent assertion has nothing to assert against/i
+    );
+    // And the consequence, which is what makes refusing better than accepting:
+    // a successful merge reported as a failure drives a false fix-forward.
+    expect(content).toMatch(/false fix-forward/i);
   });
 
   it("scopes the armed-latch rule to auto_merge=true", () => {


### PR DESCRIPTION
Closes #2316.

## The change

`merge_method=rebase` is no longer an accepted input. The signature becomes `merge_method=<merge>`, and the skill refuses `rebase` up front with the reason.

## Why refuse rather than support it

Shipped-verification assumes a merge happened. GitHub's rebase-and-merge rewrites the commits — new SHAs — and creates no merge commit, so:

- `git merge-base --is-ancestor <verify_commit> origin/<baseRefName>` cannot pass: `verify_commit` is the pre-rebase SHA and is not on the base branch afterwards;
- the merge-commit parent assertion has nothing to assert against.

A **successful** merge therefore reported as a **failed** verification, which can drive a false fix-forward — the flow concluding the change did not ship when it did. Accepting an input and then being wrong about its outcome is worse than declining it.

## Why not make verification rebase-aware

Measured, not assumed:

```
gh api repos/CodySwannGT/lisa   --jq '.allow_rebase_merge'  → false
gh api repos/gunnertech/frontend --jq '.allow_rebase_merge'  → false
```

Both repos are merge-commit-only, so GitHub rejects a rebase merge regardless of what the skill asks for. Rebase-aware verification would buy a capability nothing here can exercise, and would add a second path through the one check that catches a raced merge — which #2312 just made more load-bearing by removing the auto-merge disarm.

If a downstream repo ever needs rebase merging, that is the moment to build it, with a repo that can actually test it.

## Guard

`drive-pr-auto-merge-race.test.ts` asserts, across all six plugin roots, that the refusal is stated, that the reasoning travels with it (so nobody re-adds `rebase` without meeting the argument), and that the old permissive `merge_method=<merge|rebase>` signature is **gone** rather than merely contradicted.

Verified by mutation: putting `rebase` back in the accepted set reddens it in all six roots.

## Verification

- `bun run check:plugins` — ✓ artifacts in sync, ✓ marketplace registers every plugin
- `drive-pr-auto-merge-race` — 84 passed
- Edited `plugins/src/base/`; the five variants are regenerated by `build:plugins`.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2316
