### PR TITLE
fix(sonar): stop an unauthenticated scanner from blocking every prompt

### DIFF
--- a/all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Shared wrapper around `sonar hook <event>` for every agent surface.
+#
+# `sonar integrate <agent>` generates a five-line shim per surface: if `sonar` is
+# on PATH, pipe the hook payload to it and let whatever comes back stand. That is
+# correct for the thing the scanner exists to do — refusing a prompt or a file
+# read that genuinely contains a credential — and wrong for the thing it also
+# does, which is refusing *everything* when the CLI has no token yet:
+#
+#   {"decision":"block","reason":"SonarQube secret scanning is inactive:
+#    not authenticated. Run 'sonar auth login'."}
+#
+# At the shim level that reply is indistinguishable from a real finding, so a
+# workstation that had simply never run the browser login could not submit a
+# prompt at all. Two things are wrong with that, and this wrapper fixes both.
+#
+# 1. The credential is usually already provisioned. A project that declares
+#    SONARQUBE_CLI_TOKEN under `secrets.require` has it in its configured
+#    provider — and the CLI reads only the environment and the OS keychain, so on
+#    a local surface (which deliberately materializes nothing to disk) the value
+#    is present and unreachable at the same time. We resolve it through
+#    lisa-secrets-access, the one sanctioned reader, and only when the CLI says
+#    it needs it.
+#
+# 2. An unauthenticated scanner is a degraded gate, not a breach. This hook is
+#    one of several overlapping layers: secret scanning at commit time and in CI
+#    does not depend on it. Blocking every prompt to protect a redundant layer
+#    trades a certain outage for a hypothetical leak — and the outage lands on
+#    exactly the person least able to diagnose it, since the block fires before
+#    their first prompt is ever seen.
+#
+# A real finding still blocks. Only the "inactive" reply is downgraded, and the
+# distinction is drawn on the reason text the vendor emits, so a detection that
+# arrives while unauthenticated is impossible by construction — in that state the
+# scanner does not scan at all.
+#
+# Usage: sonar-secrets.sh <vendor-event-name>   # hook payload on stdin
+set -uo pipefail
+
+event="${1:-}"
+[ -n "$event" ] || exit 0
+
+# Nothing installed, nothing to enforce. Matches the vendor shim's own guard.
+command -v sonar >/dev/null 2>&1 || exit 0
+
+# An explicit off switch, for bisecting a session that is misbehaving. There is
+# deliberately no way to turn the *blocking* back on from the environment: the
+# decision that a missing token must not stop work belongs in this file, where it
+# is reviewable, not in whatever shell happened to launch the agent.
+[ "${LISA_SONAR_HOOK:-on}" = "off" ] && exit 0
+
+payload="$(cat)"
+
+# The vendor signals its verdict as JSON on stdout and always exits 0, so the
+# exit code carries no information and the reason text is the only channel.
+inactive_marker='secret scanning is inactive'
+
+run_scanner() {
+  printf '%s' "$payload" | sonar hook "$event" 2>/dev/null
+}
+
+is_inactive() {
+  case "$1" in
+    *"$inactive_marker"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Run the resolver with a ceiling, because the provider call crosses the network
+# and this sits in front of every prompt and every file read. `timeout` is not
+# present on a stock macOS, so this is the portable equivalent: start it, poll,
+# give up. Giving up is safe — the caller treats an empty value as "the provider
+# had nothing", which lands on the warn path rather than a block.
+resolve_secret() {
+  local resolver="$1" name="$2" out pid waited=0
+  out="$(mktemp)" || return 0
+  node "$resolver" get "$name" >"$out" 2>/dev/null &
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    [ "$waited" -ge 10 ] && { kill -9 "$pid" 2>/dev/null; break; }
+    sleep 1
+    waited=$((waited + 1))
+  done
+  wait "$pid" 2>/dev/null
+  cat "$out"
+  rm -f "$out"
+}
+
+out="$(run_scanner)"
+
+if is_inactive "$out"; then
+  # Where lisa-secrets-access lives depends on how the project receives Lisa.
+  # Claude and Codex get it as an installed plugin, which is not part of a clone;
+  # the agent skill directories and node_modules are what a fresh checkout
+  # actually has. Same search order as the remote-env setup script, including the
+  # `plugins/` rung that exists only in the Lisa monorepo itself.
+  repo_root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+  resolver=""
+  for candidate in \
+    "$repo_root/.claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/.agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/.codex/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/plugins/lisa/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-secrets-access/scripts/resolve-secret.mjs"; do
+    if [ -f "$candidate" ]; then
+      resolver="$candidate"
+      break
+    fi
+  done
+
+  if [ -n "$resolver" ] && command -v node >/dev/null 2>&1; then
+    token="$(resolve_secret "$resolver" SONARQUBE_CLI_TOKEN)"
+    if [ -n "$token" ]; then
+      # Exported into this process only. Writing it anywhere durable would create
+      # a second live copy of a credential whose single store is the provider —
+      # see the one-store rule in lisa-secrets-access.
+      export SONARQUBE_CLI_TOKEN="$token"
+      org="$(resolve_secret "$resolver" SONARQUBE_CLI_ORG)"
+      [ -n "$org" ] && export SONARQUBE_CLI_ORG="$org"
+      out="$(run_scanner)"
+    fi
+    unset token org
+  fi
+fi
+
+if is_inactive "$out"; then
+  # stderr on a zero exit is advisory in every agent's hook protocol: the user
+  # sees it, the operation proceeds.
+  echo "sonar: local secret scanning is inactive (no token in the environment," >&2
+  echo "  the OS keychain, or the configured secrets provider). Continuing —" >&2
+  echo "  commit-time and CI secret scanning still gate this repository." >&2
+  echo "  To restore it: 'sonar auth login', or store SONARQUBE_CLI_TOKEN in" >&2
+  echo "  the project's secrets provider." >&2
+  exit 0
+fi
+
+[ -n "$out" ] && printf '%s' "$out"
+exit 0

--- a/plugins/lisa-agy/skills/lisa-setup-sonar/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-sonar/SKILL.md
@@ -80,6 +80,51 @@ MCP config so it launches `sonar run mcp`, authenticated from the same env token
 
 Skip any agent whose CLI is not installed; never wire Kiro or Gemini.
 
+## 4a. Patch the generated shims — required, not optional
+
+Each integrate writes a five-line shim that pipes the hook payload to `sonar hook
+<event>` and passes the verdict through unchanged. That makes an
+**unauthenticated CLI refuse every prompt and every file read**, with a reason
+string that reads exactly like a real finding:
+
+```text
+SonarQube secret scanning is inactive: not authenticated. Run 'sonar auth login'.
+```
+
+The operator most likely to hit it is the one who just installed the CLI and has
+not logged in — so their very first prompt is rejected, before the session can
+say anything useful. Repoint every generated shim at Lisa's wrapper, which keeps
+real findings blocking, resolves `SONARQUBE_CLI_TOKEN` through
+`lisa-secrets-access` when the CLI reports it has none, and degrades the
+still-unauthenticated case to a warning:
+
+```bash
+if ! command -v sonar &> /dev/null; then
+  exit 0
+fi
+here="$(cd -- "$(dirname -- "$0")" && pwd)"
+exec bash "${here}/<relative-path>/scripts/lisa-hooks/sonar-secrets.sh" <vendor-event>
+```
+
+One wrapper serves every surface — it takes the vendor event name as its only
+argument. Known shim locations and their events:
+
+| Agent | Shim | Event |
+| --- | --- | --- |
+| Claude | `.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh` | `claude-prompt-submit` |
+| Claude | `.claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh` | `claude-pre-tool-use` |
+| Codex | `.codex/hooks/sonar-secrets/build-scripts/prompt-secrets.sh` | `codex-prompt-submit` |
+| Copilot | `.github/hooks/sonar-secrets/build-scripts/pretool-secrets.sh` | `copilot-pre-tool-use` |
+| Antigravity | `.agents/sonar/hooks/pretool-secrets.sh` | `antigravity-pre-tool-use` |
+
+Compute the relative path from each shim's own directory rather than assuming a
+depth — Antigravity's is three levels up, the rest are four.
+
+**Re-running an integrate overwrites the shim with the vendor's original**, so
+re-apply this patch whenever you re-run step 4, and say so in the summary. Leave
+a comment at the top of each patched shim naming the wrapper, so the next reader
+does not mistake the delegation for drift.
+
 ## 5. Write non-secret policy config
 
 Merge only non-secret identifiers into committed `.lisa.config.json`, preserving

--- a/plugins/lisa-copilot/hooks/sonar-secrets.sh
+++ b/plugins/lisa-copilot/hooks/sonar-secrets.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Shared wrapper around `sonar hook <event>` for every agent surface.
+#
+# `sonar integrate <agent>` generates a five-line shim per surface: if `sonar` is
+# on PATH, pipe the hook payload to it and let whatever comes back stand. That is
+# correct for the thing the scanner exists to do — refusing a prompt or a file
+# read that genuinely contains a credential — and wrong for the thing it also
+# does, which is refusing *everything* when the CLI has no token yet:
+#
+#   {"decision":"block","reason":"SonarQube secret scanning is inactive:
+#    not authenticated. Run 'sonar auth login'."}
+#
+# At the shim level that reply is indistinguishable from a real finding, so a
+# workstation that had simply never run the browser login could not submit a
+# prompt at all. Two things are wrong with that, and this wrapper fixes both.
+#
+# 1. The credential is usually already provisioned. A project that declares
+#    SONARQUBE_CLI_TOKEN under `secrets.require` has it in its configured
+#    provider — and the CLI reads only the environment and the OS keychain, so on
+#    a local surface (which deliberately materializes nothing to disk) the value
+#    is present and unreachable at the same time. We resolve it through
+#    lisa-secrets-access, the one sanctioned reader, and only when the CLI says
+#    it needs it.
+#
+# 2. An unauthenticated scanner is a degraded gate, not a breach. This hook is
+#    one of several overlapping layers: secret scanning at commit time and in CI
+#    does not depend on it. Blocking every prompt to protect a redundant layer
+#    trades a certain outage for a hypothetical leak — and the outage lands on
+#    exactly the person least able to diagnose it, since the block fires before
+#    their first prompt is ever seen.
+#
+# A real finding still blocks. Only the "inactive" reply is downgraded, and the
+# distinction is drawn on the reason text the vendor emits, so a detection that
+# arrives while unauthenticated is impossible by construction — in that state the
+# scanner does not scan at all.
+#
+# Usage: sonar-secrets.sh <vendor-event-name>   # hook payload on stdin
+set -uo pipefail
+
+event="${1:-}"
+[ -n "$event" ] || exit 0
+
+# Nothing installed, nothing to enforce. Matches the vendor shim's own guard.
+command -v sonar >/dev/null 2>&1 || exit 0
+
+# An explicit off switch, for bisecting a session that is misbehaving. There is
+# deliberately no way to turn the *blocking* back on from the environment: the
+# decision that a missing token must not stop work belongs in this file, where it
+# is reviewable, not in whatever shell happened to launch the agent.
+[ "${LISA_SONAR_HOOK:-on}" = "off" ] && exit 0
+
+payload="$(cat)"
+
+# The vendor signals its verdict as JSON on stdout and always exits 0, so the
+# exit code carries no information and the reason text is the only channel.
+inactive_marker='secret scanning is inactive'
+
+run_scanner() {
+  printf '%s' "$payload" | sonar hook "$event" 2>/dev/null
+}
+
+is_inactive() {
+  case "$1" in
+    *"$inactive_marker"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Run the resolver with a ceiling, because the provider call crosses the network
+# and this sits in front of every prompt and every file read. `timeout` is not
+# present on a stock macOS, so this is the portable equivalent: start it, poll,
+# give up. Giving up is safe — the caller treats an empty value as "the provider
+# had nothing", which lands on the warn path rather than a block.
+resolve_secret() {
+  local resolver="$1" name="$2" out pid waited=0
+  out="$(mktemp)" || return 0
+  node "$resolver" get "$name" >"$out" 2>/dev/null &
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    [ "$waited" -ge 10 ] && { kill -9 "$pid" 2>/dev/null; break; }
+    sleep 1
+    waited=$((waited + 1))
+  done
+  wait "$pid" 2>/dev/null
+  cat "$out"
+  rm -f "$out"
+}
+
+out="$(run_scanner)"
+
+if is_inactive "$out"; then
+  # Where lisa-secrets-access lives depends on how the project receives Lisa.
+  # Claude and Codex get it as an installed plugin, which is not part of a clone;
+  # the agent skill directories and node_modules are what a fresh checkout
+  # actually has. Same search order as the remote-env setup script, including the
+  # `plugins/` rung that exists only in the Lisa monorepo itself.
+  repo_root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+  resolver=""
+  for candidate in \
+    "$repo_root/.claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/.agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/.codex/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/plugins/lisa/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-secrets-access/scripts/resolve-secret.mjs"; do
+    if [ -f "$candidate" ]; then
+      resolver="$candidate"
+      break
+    fi
+  done
+
+  if [ -n "$resolver" ] && command -v node >/dev/null 2>&1; then
+    token="$(resolve_secret "$resolver" SONARQUBE_CLI_TOKEN)"
+    if [ -n "$token" ]; then
+      # Exported into this process only. Writing it anywhere durable would create
+      # a second live copy of a credential whose single store is the provider —
+      # see the one-store rule in lisa-secrets-access.
+      export SONARQUBE_CLI_TOKEN="$token"
+      org="$(resolve_secret "$resolver" SONARQUBE_CLI_ORG)"
+      [ -n "$org" ] && export SONARQUBE_CLI_ORG="$org"
+      out="$(run_scanner)"
+    fi
+    unset token org
+  fi
+fi
+
+if is_inactive "$out"; then
+  # stderr on a zero exit is advisory in every agent's hook protocol: the user
+  # sees it, the operation proceeds.
+  echo "sonar: local secret scanning is inactive (no token in the environment," >&2
+  echo "  the OS keychain, or the configured secrets provider). Continuing —" >&2
+  echo "  commit-time and CI secret scanning still gate this repository." >&2
+  echo "  To restore it: 'sonar auth login', or store SONARQUBE_CLI_TOKEN in" >&2
+  echo "  the project's secrets provider." >&2
+  exit 0
+fi
+
+[ -n "$out" ] && printf '%s' "$out"
+exit 0

--- a/plugins/lisa-copilot/skills/lisa-setup-sonar/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-sonar/SKILL.md
@@ -80,6 +80,51 @@ MCP config so it launches `sonar run mcp`, authenticated from the same env token
 
 Skip any agent whose CLI is not installed; never wire Kiro or Gemini.
 
+## 4a. Patch the generated shims — required, not optional
+
+Each integrate writes a five-line shim that pipes the hook payload to `sonar hook
+<event>` and passes the verdict through unchanged. That makes an
+**unauthenticated CLI refuse every prompt and every file read**, with a reason
+string that reads exactly like a real finding:
+
+```text
+SonarQube secret scanning is inactive: not authenticated. Run 'sonar auth login'.
+```
+
+The operator most likely to hit it is the one who just installed the CLI and has
+not logged in — so their very first prompt is rejected, before the session can
+say anything useful. Repoint every generated shim at Lisa's wrapper, which keeps
+real findings blocking, resolves `SONARQUBE_CLI_TOKEN` through
+`lisa-secrets-access` when the CLI reports it has none, and degrades the
+still-unauthenticated case to a warning:
+
+```bash
+if ! command -v sonar &> /dev/null; then
+  exit 0
+fi
+here="$(cd -- "$(dirname -- "$0")" && pwd)"
+exec bash "${here}/<relative-path>/scripts/lisa-hooks/sonar-secrets.sh" <vendor-event>
+```
+
+One wrapper serves every surface — it takes the vendor event name as its only
+argument. Known shim locations and their events:
+
+| Agent | Shim | Event |
+| --- | --- | --- |
+| Claude | `.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh` | `claude-prompt-submit` |
+| Claude | `.claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh` | `claude-pre-tool-use` |
+| Codex | `.codex/hooks/sonar-secrets/build-scripts/prompt-secrets.sh` | `codex-prompt-submit` |
+| Copilot | `.github/hooks/sonar-secrets/build-scripts/pretool-secrets.sh` | `copilot-pre-tool-use` |
+| Antigravity | `.agents/sonar/hooks/pretool-secrets.sh` | `antigravity-pre-tool-use` |
+
+Compute the relative path from each shim's own directory rather than assuming a
+depth — Antigravity's is three levels up, the rest are four.
+
+**Re-running an integrate overwrites the shim with the vendor's original**, so
+re-apply this patch whenever you re-run step 4, and say so in the summary. Leave
+a comment at the top of each patched shim naming the wrapper, so the next reader
+does not mistake the delegation for drift.
+
 ## 5. Write non-secret policy config
 
 Merge only non-secret identifiers into committed `.lisa.config.json`, preserving

--- a/plugins/lisa-cursor/hooks/sonar-secrets.sh
+++ b/plugins/lisa-cursor/hooks/sonar-secrets.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Shared wrapper around `sonar hook <event>` for every agent surface.
+#
+# `sonar integrate <agent>` generates a five-line shim per surface: if `sonar` is
+# on PATH, pipe the hook payload to it and let whatever comes back stand. That is
+# correct for the thing the scanner exists to do — refusing a prompt or a file
+# read that genuinely contains a credential — and wrong for the thing it also
+# does, which is refusing *everything* when the CLI has no token yet:
+#
+#   {"decision":"block","reason":"SonarQube secret scanning is inactive:
+#    not authenticated. Run 'sonar auth login'."}
+#
+# At the shim level that reply is indistinguishable from a real finding, so a
+# workstation that had simply never run the browser login could not submit a
+# prompt at all. Two things are wrong with that, and this wrapper fixes both.
+#
+# 1. The credential is usually already provisioned. A project that declares
+#    SONARQUBE_CLI_TOKEN under `secrets.require` has it in its configured
+#    provider — and the CLI reads only the environment and the OS keychain, so on
+#    a local surface (which deliberately materializes nothing to disk) the value
+#    is present and unreachable at the same time. We resolve it through
+#    lisa-secrets-access, the one sanctioned reader, and only when the CLI says
+#    it needs it.
+#
+# 2. An unauthenticated scanner is a degraded gate, not a breach. This hook is
+#    one of several overlapping layers: secret scanning at commit time and in CI
+#    does not depend on it. Blocking every prompt to protect a redundant layer
+#    trades a certain outage for a hypothetical leak — and the outage lands on
+#    exactly the person least able to diagnose it, since the block fires before
+#    their first prompt is ever seen.
+#
+# A real finding still blocks. Only the "inactive" reply is downgraded, and the
+# distinction is drawn on the reason text the vendor emits, so a detection that
+# arrives while unauthenticated is impossible by construction — in that state the
+# scanner does not scan at all.
+#
+# Usage: sonar-secrets.sh <vendor-event-name>   # hook payload on stdin
+set -uo pipefail
+
+event="${1:-}"
+[ -n "$event" ] || exit 0
+
+# Nothing installed, nothing to enforce. Matches the vendor shim's own guard.
+command -v sonar >/dev/null 2>&1 || exit 0
+
+# An explicit off switch, for bisecting a session that is misbehaving. There is
+# deliberately no way to turn the *blocking* back on from the environment: the
+# decision that a missing token must not stop work belongs in this file, where it
+# is reviewable, not in whatever shell happened to launch the agent.
+[ "${LISA_SONAR_HOOK:-on}" = "off" ] && exit 0
+
+payload="$(cat)"
+
+# The vendor signals its verdict as JSON on stdout and always exits 0, so the
+# exit code carries no information and the reason text is the only channel.
+inactive_marker='secret scanning is inactive'
+
+run_scanner() {
+  printf '%s' "$payload" | sonar hook "$event" 2>/dev/null
+}
+
+is_inactive() {
+  case "$1" in
+    *"$inactive_marker"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Run the resolver with a ceiling, because the provider call crosses the network
+# and this sits in front of every prompt and every file read. `timeout` is not
+# present on a stock macOS, so this is the portable equivalent: start it, poll,
+# give up. Giving up is safe — the caller treats an empty value as "the provider
+# had nothing", which lands on the warn path rather than a block.
+resolve_secret() {
+  local resolver="$1" name="$2" out pid waited=0
+  out="$(mktemp)" || return 0
+  node "$resolver" get "$name" >"$out" 2>/dev/null &
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    [ "$waited" -ge 10 ] && { kill -9 "$pid" 2>/dev/null; break; }
+    sleep 1
+    waited=$((waited + 1))
+  done
+  wait "$pid" 2>/dev/null
+  cat "$out"
+  rm -f "$out"
+}
+
+out="$(run_scanner)"
+
+if is_inactive "$out"; then
+  # Where lisa-secrets-access lives depends on how the project receives Lisa.
+  # Claude and Codex get it as an installed plugin, which is not part of a clone;
+  # the agent skill directories and node_modules are what a fresh checkout
+  # actually has. Same search order as the remote-env setup script, including the
+  # `plugins/` rung that exists only in the Lisa monorepo itself.
+  repo_root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+  resolver=""
+  for candidate in \
+    "$repo_root/.claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/.agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/.codex/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/plugins/lisa/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-secrets-access/scripts/resolve-secret.mjs"; do
+    if [ -f "$candidate" ]; then
+      resolver="$candidate"
+      break
+    fi
+  done
+
+  if [ -n "$resolver" ] && command -v node >/dev/null 2>&1; then
+    token="$(resolve_secret "$resolver" SONARQUBE_CLI_TOKEN)"
+    if [ -n "$token" ]; then
+      # Exported into this process only. Writing it anywhere durable would create
+      # a second live copy of a credential whose single store is the provider —
+      # see the one-store rule in lisa-secrets-access.
+      export SONARQUBE_CLI_TOKEN="$token"
+      org="$(resolve_secret "$resolver" SONARQUBE_CLI_ORG)"
+      [ -n "$org" ] && export SONARQUBE_CLI_ORG="$org"
+      out="$(run_scanner)"
+    fi
+    unset token org
+  fi
+fi
+
+if is_inactive "$out"; then
+  # stderr on a zero exit is advisory in every agent's hook protocol: the user
+  # sees it, the operation proceeds.
+  echo "sonar: local secret scanning is inactive (no token in the environment," >&2
+  echo "  the OS keychain, or the configured secrets provider). Continuing —" >&2
+  echo "  commit-time and CI secret scanning still gate this repository." >&2
+  echo "  To restore it: 'sonar auth login', or store SONARQUBE_CLI_TOKEN in" >&2
+  echo "  the project's secrets provider." >&2
+  exit 0
+fi
+
+[ -n "$out" ] && printf '%s' "$out"
+exit 0

--- a/plugins/lisa-cursor/skills/lisa-setup-sonar/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-sonar/SKILL.md
@@ -80,6 +80,51 @@ MCP config so it launches `sonar run mcp`, authenticated from the same env token
 
 Skip any agent whose CLI is not installed; never wire Kiro or Gemini.
 
+## 4a. Patch the generated shims — required, not optional
+
+Each integrate writes a five-line shim that pipes the hook payload to `sonar hook
+<event>` and passes the verdict through unchanged. That makes an
+**unauthenticated CLI refuse every prompt and every file read**, with a reason
+string that reads exactly like a real finding:
+
+```text
+SonarQube secret scanning is inactive: not authenticated. Run 'sonar auth login'.
+```
+
+The operator most likely to hit it is the one who just installed the CLI and has
+not logged in — so their very first prompt is rejected, before the session can
+say anything useful. Repoint every generated shim at Lisa's wrapper, which keeps
+real findings blocking, resolves `SONARQUBE_CLI_TOKEN` through
+`lisa-secrets-access` when the CLI reports it has none, and degrades the
+still-unauthenticated case to a warning:
+
+```bash
+if ! command -v sonar &> /dev/null; then
+  exit 0
+fi
+here="$(cd -- "$(dirname -- "$0")" && pwd)"
+exec bash "${here}/<relative-path>/scripts/lisa-hooks/sonar-secrets.sh" <vendor-event>
+```
+
+One wrapper serves every surface — it takes the vendor event name as its only
+argument. Known shim locations and their events:
+
+| Agent | Shim | Event |
+| --- | --- | --- |
+| Claude | `.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh` | `claude-prompt-submit` |
+| Claude | `.claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh` | `claude-pre-tool-use` |
+| Codex | `.codex/hooks/sonar-secrets/build-scripts/prompt-secrets.sh` | `codex-prompt-submit` |
+| Copilot | `.github/hooks/sonar-secrets/build-scripts/pretool-secrets.sh` | `copilot-pre-tool-use` |
+| Antigravity | `.agents/sonar/hooks/pretool-secrets.sh` | `antigravity-pre-tool-use` |
+
+Compute the relative path from each shim's own directory rather than assuming a
+depth — Antigravity's is three levels up, the rest are four.
+
+**Re-running an integrate overwrites the shim with the vendor's original**, so
+re-apply this patch whenever you re-run step 4, and say so in the summary. Leave
+a comment at the top of each patched shim naming the wrapper, so the next reader
+does not mistake the delegation for drift.
+
 ## 5. Write non-secret policy config
 
 Merge only non-secret identifiers into committed `.lisa.config.json`, preserving

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-sonar/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-sonar/SKILL.md
@@ -80,6 +80,51 @@ MCP config so it launches `sonar run mcp`, authenticated from the same env token
 
 Skip any agent whose CLI is not installed; never wire Kiro or Gemini.
 
+## 4a. Patch the generated shims — required, not optional
+
+Each integrate writes a five-line shim that pipes the hook payload to `sonar hook
+<event>` and passes the verdict through unchanged. That makes an
+**unauthenticated CLI refuse every prompt and every file read**, with a reason
+string that reads exactly like a real finding:
+
+```text
+SonarQube secret scanning is inactive: not authenticated. Run 'sonar auth login'.
+```
+
+The operator most likely to hit it is the one who just installed the CLI and has
+not logged in — so their very first prompt is rejected, before the session can
+say anything useful. Repoint every generated shim at Lisa's wrapper, which keeps
+real findings blocking, resolves `SONARQUBE_CLI_TOKEN` through
+`lisa-secrets-access` when the CLI reports it has none, and degrades the
+still-unauthenticated case to a warning:
+
+```bash
+if ! command -v sonar &> /dev/null; then
+  exit 0
+fi
+here="$(cd -- "$(dirname -- "$0")" && pwd)"
+exec bash "${here}/<relative-path>/scripts/lisa-hooks/sonar-secrets.sh" <vendor-event>
+```
+
+One wrapper serves every surface — it takes the vendor event name as its only
+argument. Known shim locations and their events:
+
+| Agent | Shim | Event |
+| --- | --- | --- |
+| Claude | `.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh` | `claude-prompt-submit` |
+| Claude | `.claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh` | `claude-pre-tool-use` |
+| Codex | `.codex/hooks/sonar-secrets/build-scripts/prompt-secrets.sh` | `codex-prompt-submit` |
+| Copilot | `.github/hooks/sonar-secrets/build-scripts/pretool-secrets.sh` | `copilot-pre-tool-use` |
+| Antigravity | `.agents/sonar/hooks/pretool-secrets.sh` | `antigravity-pre-tool-use` |
+
+Compute the relative path from each shim's own directory rather than assuming a
+depth — Antigravity's is three levels up, the rest are four.
+
+**Re-running an integrate overwrites the shim with the vendor's original**, so
+re-apply this patch whenever you re-run step 4, and say so in the summary. Leave
+a comment at the top of each patched shim naming the wrapper, so the next reader
+does not mistake the delegation for drift.
+
 ## 5. Write non-secret policy config
 
 Merge only non-secret identifiers into committed `.lisa.config.json`, preserving

--- a/plugins/lisa/hooks/sonar-secrets.sh
+++ b/plugins/lisa/hooks/sonar-secrets.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Shared wrapper around `sonar hook <event>` for every agent surface.
+#
+# `sonar integrate <agent>` generates a five-line shim per surface: if `sonar` is
+# on PATH, pipe the hook payload to it and let whatever comes back stand. That is
+# correct for the thing the scanner exists to do — refusing a prompt or a file
+# read that genuinely contains a credential — and wrong for the thing it also
+# does, which is refusing *everything* when the CLI has no token yet:
+#
+#   {"decision":"block","reason":"SonarQube secret scanning is inactive:
+#    not authenticated. Run 'sonar auth login'."}
+#
+# At the shim level that reply is indistinguishable from a real finding, so a
+# workstation that had simply never run the browser login could not submit a
+# prompt at all. Two things are wrong with that, and this wrapper fixes both.
+#
+# 1. The credential is usually already provisioned. A project that declares
+#    SONARQUBE_CLI_TOKEN under `secrets.require` has it in its configured
+#    provider — and the CLI reads only the environment and the OS keychain, so on
+#    a local surface (which deliberately materializes nothing to disk) the value
+#    is present and unreachable at the same time. We resolve it through
+#    lisa-secrets-access, the one sanctioned reader, and only when the CLI says
+#    it needs it.
+#
+# 2. An unauthenticated scanner is a degraded gate, not a breach. This hook is
+#    one of several overlapping layers: secret scanning at commit time and in CI
+#    does not depend on it. Blocking every prompt to protect a redundant layer
+#    trades a certain outage for a hypothetical leak — and the outage lands on
+#    exactly the person least able to diagnose it, since the block fires before
+#    their first prompt is ever seen.
+#
+# A real finding still blocks. Only the "inactive" reply is downgraded, and the
+# distinction is drawn on the reason text the vendor emits, so a detection that
+# arrives while unauthenticated is impossible by construction — in that state the
+# scanner does not scan at all.
+#
+# Usage: sonar-secrets.sh <vendor-event-name>   # hook payload on stdin
+set -uo pipefail
+
+event="${1:-}"
+[ -n "$event" ] || exit 0
+
+# Nothing installed, nothing to enforce. Matches the vendor shim's own guard.
+command -v sonar >/dev/null 2>&1 || exit 0
+
+# An explicit off switch, for bisecting a session that is misbehaving. There is
+# deliberately no way to turn the *blocking* back on from the environment: the
+# decision that a missing token must not stop work belongs in this file, where it
+# is reviewable, not in whatever shell happened to launch the agent.
+[ "${LISA_SONAR_HOOK:-on}" = "off" ] && exit 0
+
+payload="$(cat)"
+
+# The vendor signals its verdict as JSON on stdout and always exits 0, so the
+# exit code carries no information and the reason text is the only channel.
+inactive_marker='secret scanning is inactive'
+
+run_scanner() {
+  printf '%s' "$payload" | sonar hook "$event" 2>/dev/null
+}
+
+is_inactive() {
+  case "$1" in
+    *"$inactive_marker"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Run the resolver with a ceiling, because the provider call crosses the network
+# and this sits in front of every prompt and every file read. `timeout` is not
+# present on a stock macOS, so this is the portable equivalent: start it, poll,
+# give up. Giving up is safe — the caller treats an empty value as "the provider
+# had nothing", which lands on the warn path rather than a block.
+resolve_secret() {
+  local resolver="$1" name="$2" out pid waited=0
+  out="$(mktemp)" || return 0
+  node "$resolver" get "$name" >"$out" 2>/dev/null &
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    [ "$waited" -ge 10 ] && { kill -9 "$pid" 2>/dev/null; break; }
+    sleep 1
+    waited=$((waited + 1))
+  done
+  wait "$pid" 2>/dev/null
+  cat "$out"
+  rm -f "$out"
+}
+
+out="$(run_scanner)"
+
+if is_inactive "$out"; then
+  # Where lisa-secrets-access lives depends on how the project receives Lisa.
+  # Claude and Codex get it as an installed plugin, which is not part of a clone;
+  # the agent skill directories and node_modules are what a fresh checkout
+  # actually has. Same search order as the remote-env setup script, including the
+  # `plugins/` rung that exists only in the Lisa monorepo itself.
+  repo_root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+  resolver=""
+  for candidate in \
+    "$repo_root/.claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/.agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/.codex/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/plugins/lisa/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-secrets-access/scripts/resolve-secret.mjs"; do
+    if [ -f "$candidate" ]; then
+      resolver="$candidate"
+      break
+    fi
+  done
+
+  if [ -n "$resolver" ] && command -v node >/dev/null 2>&1; then
+    token="$(resolve_secret "$resolver" SONARQUBE_CLI_TOKEN)"
+    if [ -n "$token" ]; then
+      # Exported into this process only. Writing it anywhere durable would create
+      # a second live copy of a credential whose single store is the provider —
+      # see the one-store rule in lisa-secrets-access.
+      export SONARQUBE_CLI_TOKEN="$token"
+      org="$(resolve_secret "$resolver" SONARQUBE_CLI_ORG)"
+      [ -n "$org" ] && export SONARQUBE_CLI_ORG="$org"
+      out="$(run_scanner)"
+    fi
+    unset token org
+  fi
+fi
+
+if is_inactive "$out"; then
+  # stderr on a zero exit is advisory in every agent's hook protocol: the user
+  # sees it, the operation proceeds.
+  echo "sonar: local secret scanning is inactive (no token in the environment," >&2
+  echo "  the OS keychain, or the configured secrets provider). Continuing —" >&2
+  echo "  commit-time and CI secret scanning still gate this repository." >&2
+  echo "  To restore it: 'sonar auth login', or store SONARQUBE_CLI_TOKEN in" >&2
+  echo "  the project's secrets provider." >&2
+  exit 0
+fi
+
+[ -n "$out" ] && printf '%s' "$out"
+exit 0

--- a/plugins/lisa/skills/lisa-setup-sonar/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-sonar/SKILL.md
@@ -80,6 +80,51 @@ MCP config so it launches `sonar run mcp`, authenticated from the same env token
 
 Skip any agent whose CLI is not installed; never wire Kiro or Gemini.
 
+## 4a. Patch the generated shims — required, not optional
+
+Each integrate writes a five-line shim that pipes the hook payload to `sonar hook
+<event>` and passes the verdict through unchanged. That makes an
+**unauthenticated CLI refuse every prompt and every file read**, with a reason
+string that reads exactly like a real finding:
+
+```text
+SonarQube secret scanning is inactive: not authenticated. Run 'sonar auth login'.
+```
+
+The operator most likely to hit it is the one who just installed the CLI and has
+not logged in — so their very first prompt is rejected, before the session can
+say anything useful. Repoint every generated shim at Lisa's wrapper, which keeps
+real findings blocking, resolves `SONARQUBE_CLI_TOKEN` through
+`lisa-secrets-access` when the CLI reports it has none, and degrades the
+still-unauthenticated case to a warning:
+
+```bash
+if ! command -v sonar &> /dev/null; then
+  exit 0
+fi
+here="$(cd -- "$(dirname -- "$0")" && pwd)"
+exec bash "${here}/<relative-path>/scripts/lisa-hooks/sonar-secrets.sh" <vendor-event>
+```
+
+One wrapper serves every surface — it takes the vendor event name as its only
+argument. Known shim locations and their events:
+
+| Agent | Shim | Event |
+| --- | --- | --- |
+| Claude | `.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh` | `claude-prompt-submit` |
+| Claude | `.claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh` | `claude-pre-tool-use` |
+| Codex | `.codex/hooks/sonar-secrets/build-scripts/prompt-secrets.sh` | `codex-prompt-submit` |
+| Copilot | `.github/hooks/sonar-secrets/build-scripts/pretool-secrets.sh` | `copilot-pre-tool-use` |
+| Antigravity | `.agents/sonar/hooks/pretool-secrets.sh` | `antigravity-pre-tool-use` |
+
+Compute the relative path from each shim's own directory rather than assuming a
+depth — Antigravity's is three levels up, the rest are four.
+
+**Re-running an integrate overwrites the shim with the vendor's original**, so
+re-apply this patch whenever you re-run step 4, and say so in the summary. Leave
+a comment at the top of each patched shim naming the wrapper, so the next reader
+does not mistake the delegation for drift.
+
 ## 5. Write non-secret policy config
 
 Merge only non-secret identifiers into committed `.lisa.config.json`, preserving

--- a/plugins/src/base/hooks/sonar-secrets.sh
+++ b/plugins/src/base/hooks/sonar-secrets.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Shared wrapper around `sonar hook <event>` for every agent surface.
+#
+# `sonar integrate <agent>` generates a five-line shim per surface: if `sonar` is
+# on PATH, pipe the hook payload to it and let whatever comes back stand. That is
+# correct for the thing the scanner exists to do — refusing a prompt or a file
+# read that genuinely contains a credential — and wrong for the thing it also
+# does, which is refusing *everything* when the CLI has no token yet:
+#
+#   {"decision":"block","reason":"SonarQube secret scanning is inactive:
+#    not authenticated. Run 'sonar auth login'."}
+#
+# At the shim level that reply is indistinguishable from a real finding, so a
+# workstation that had simply never run the browser login could not submit a
+# prompt at all. Two things are wrong with that, and this wrapper fixes both.
+#
+# 1. The credential is usually already provisioned. A project that declares
+#    SONARQUBE_CLI_TOKEN under `secrets.require` has it in its configured
+#    provider — and the CLI reads only the environment and the OS keychain, so on
+#    a local surface (which deliberately materializes nothing to disk) the value
+#    is present and unreachable at the same time. We resolve it through
+#    lisa-secrets-access, the one sanctioned reader, and only when the CLI says
+#    it needs it.
+#
+# 2. An unauthenticated scanner is a degraded gate, not a breach. This hook is
+#    one of several overlapping layers: secret scanning at commit time and in CI
+#    does not depend on it. Blocking every prompt to protect a redundant layer
+#    trades a certain outage for a hypothetical leak — and the outage lands on
+#    exactly the person least able to diagnose it, since the block fires before
+#    their first prompt is ever seen.
+#
+# A real finding still blocks. Only the "inactive" reply is downgraded, and the
+# distinction is drawn on the reason text the vendor emits, so a detection that
+# arrives while unauthenticated is impossible by construction — in that state the
+# scanner does not scan at all.
+#
+# Usage: sonar-secrets.sh <vendor-event-name>   # hook payload on stdin
+set -uo pipefail
+
+event="${1:-}"
+[ -n "$event" ] || exit 0
+
+# Nothing installed, nothing to enforce. Matches the vendor shim's own guard.
+command -v sonar >/dev/null 2>&1 || exit 0
+
+# An explicit off switch, for bisecting a session that is misbehaving. There is
+# deliberately no way to turn the *blocking* back on from the environment: the
+# decision that a missing token must not stop work belongs in this file, where it
+# is reviewable, not in whatever shell happened to launch the agent.
+[ "${LISA_SONAR_HOOK:-on}" = "off" ] && exit 0
+
+payload="$(cat)"
+
+# The vendor signals its verdict as JSON on stdout and always exits 0, so the
+# exit code carries no information and the reason text is the only channel.
+inactive_marker='secret scanning is inactive'
+
+run_scanner() {
+  printf '%s' "$payload" | sonar hook "$event" 2>/dev/null
+}
+
+is_inactive() {
+  case "$1" in
+    *"$inactive_marker"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Run the resolver with a ceiling, because the provider call crosses the network
+# and this sits in front of every prompt and every file read. `timeout` is not
+# present on a stock macOS, so this is the portable equivalent: start it, poll,
+# give up. Giving up is safe — the caller treats an empty value as "the provider
+# had nothing", which lands on the warn path rather than a block.
+resolve_secret() {
+  local resolver="$1" name="$2" out pid waited=0
+  out="$(mktemp)" || return 0
+  node "$resolver" get "$name" >"$out" 2>/dev/null &
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    [ "$waited" -ge 10 ] && { kill -9 "$pid" 2>/dev/null; break; }
+    sleep 1
+    waited=$((waited + 1))
+  done
+  wait "$pid" 2>/dev/null
+  cat "$out"
+  rm -f "$out"
+}
+
+out="$(run_scanner)"
+
+if is_inactive "$out"; then
+  # Where lisa-secrets-access lives depends on how the project receives Lisa.
+  # Claude and Codex get it as an installed plugin, which is not part of a clone;
+  # the agent skill directories and node_modules are what a fresh checkout
+  # actually has. Same search order as the remote-env setup script, including the
+  # `plugins/` rung that exists only in the Lisa monorepo itself.
+  repo_root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+  resolver=""
+  for candidate in \
+    "$repo_root/.claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/.agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/.codex/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/plugins/lisa/skills/lisa-secrets-access/scripts/resolve-secret.mjs" \
+    "$repo_root/node_modules/@codyswann/lisa/plugins/lisa/skills/lisa-secrets-access/scripts/resolve-secret.mjs"; do
+    if [ -f "$candidate" ]; then
+      resolver="$candidate"
+      break
+    fi
+  done
+
+  if [ -n "$resolver" ] && command -v node >/dev/null 2>&1; then
+    token="$(resolve_secret "$resolver" SONARQUBE_CLI_TOKEN)"
+    if [ -n "$token" ]; then
+      # Exported into this process only. Writing it anywhere durable would create
+      # a second live copy of a credential whose single store is the provider —
+      # see the one-store rule in lisa-secrets-access.
+      export SONARQUBE_CLI_TOKEN="$token"
+      org="$(resolve_secret "$resolver" SONARQUBE_CLI_ORG)"
+      [ -n "$org" ] && export SONARQUBE_CLI_ORG="$org"
+      out="$(run_scanner)"
+    fi
+    unset token org
+  fi
+fi
+
+if is_inactive "$out"; then
+  # stderr on a zero exit is advisory in every agent's hook protocol: the user
+  # sees it, the operation proceeds.
+  echo "sonar: local secret scanning is inactive (no token in the environment," >&2
+  echo "  the OS keychain, or the configured secrets provider). Continuing —" >&2
+  echo "  commit-time and CI secret scanning still gate this repository." >&2
+  echo "  To restore it: 'sonar auth login', or store SONARQUBE_CLI_TOKEN in" >&2
+  echo "  the project's secrets provider." >&2
+  exit 0
+fi
+
+[ -n "$out" ] && printf '%s' "$out"
+exit 0

--- a/plugins/src/base/skills/lisa-setup-sonar/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-sonar/SKILL.md
@@ -80,6 +80,51 @@ MCP config so it launches `sonar run mcp`, authenticated from the same env token
 
 Skip any agent whose CLI is not installed; never wire Kiro or Gemini.
 
+## 4a. Patch the generated shims — required, not optional
+
+Each integrate writes a five-line shim that pipes the hook payload to `sonar hook
+<event>` and passes the verdict through unchanged. That makes an
+**unauthenticated CLI refuse every prompt and every file read**, with a reason
+string that reads exactly like a real finding:
+
+```text
+SonarQube secret scanning is inactive: not authenticated. Run 'sonar auth login'.
+```
+
+The operator most likely to hit it is the one who just installed the CLI and has
+not logged in — so their very first prompt is rejected, before the session can
+say anything useful. Repoint every generated shim at Lisa's wrapper, which keeps
+real findings blocking, resolves `SONARQUBE_CLI_TOKEN` through
+`lisa-secrets-access` when the CLI reports it has none, and degrades the
+still-unauthenticated case to a warning:
+
+```bash
+if ! command -v sonar &> /dev/null; then
+  exit 0
+fi
+here="$(cd -- "$(dirname -- "$0")" && pwd)"
+exec bash "${here}/<relative-path>/scripts/lisa-hooks/sonar-secrets.sh" <vendor-event>
+```
+
+One wrapper serves every surface — it takes the vendor event name as its only
+argument. Known shim locations and their events:
+
+| Agent | Shim | Event |
+| --- | --- | --- |
+| Claude | `.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh` | `claude-prompt-submit` |
+| Claude | `.claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh` | `claude-pre-tool-use` |
+| Codex | `.codex/hooks/sonar-secrets/build-scripts/prompt-secrets.sh` | `codex-prompt-submit` |
+| Copilot | `.github/hooks/sonar-secrets/build-scripts/pretool-secrets.sh` | `copilot-pre-tool-use` |
+| Antigravity | `.agents/sonar/hooks/pretool-secrets.sh` | `antigravity-pre-tool-use` |
+
+Compute the relative path from each shim's own directory rather than assuming a
+depth — Antigravity's is three levels up, the rest are four.
+
+**Re-running an integrate overwrites the shim with the vendor's original**, so
+re-apply this patch whenever you re-run step 4, and say so in the summary. Leave
+a comment at the top of each patched shim naming the wrapper, so the next reader
+does not mistake the delegation for drift.
+
 ## 5. Write non-secret policy config
 
 Merge only non-secret identifiers into committed `.lisa.config.json`, preserving

--- a/scripts/build-plugins.sh
+++ b/scripts/build-plugins.sh
@@ -112,6 +112,20 @@ for guard in block-no-verify parity-safety-net block-shell-json-parsing \
     chmod +x "$HOST_GUARD_DIR/$guard.sh"
   fi
 done
+# The Sonar hook wrapper, which ships alongside the guards but is not one.
+#
+# The guards above are dispatched by lisa-enforcement-fallback.sh and take a tool
+# payload with no arguments. This one is invoked by the shim that
+# `sonar integrate <agent>` generates, takes the vendor's event name as its only
+# argument, and must therefore stay out of that dispatcher's list — it is copied
+# here because a host project needs it in its checkout for the same reason the
+# guards are, not because it is dispatched the same way.
+if [ -f "$SRC_DIR/base/hooks/sonar-secrets.sh" ]; then
+  mkdir -p "$HOST_GUARD_DIR"
+  cp "$SRC_DIR/base/hooks/sonar-secrets.sh" "$HOST_GUARD_DIR/sonar-secrets.sh"
+  chmod +x "$HOST_GUARD_DIR/sonar-secrets.sh"
+fi
+
 # The dispatcher itself, so a host project gets the identical entry point.
 # Guarded like the ratchet above: this script is also run against isolated
 # fixtures that carry a source tree but none of the repository's own scripts,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -18,6 +18,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "3b5f074f3ab5708030af507eea962389f3b067c5dbdc76580bd9e44d3ac6c603",
     "all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh":
       "062c69eea85157f1e941ec3626d8912aa9f182af6ccdbe19687588a6074db5ce",
+    "all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh":
+      "7a408788975a6351d53e14aa32bb9a5d161f33df9dfea59ba32784ae33a62e67",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
       "6a8be8577242588f14ab52b25b2a22b6def53aefa9513b4d3d7c49f4d8027079",
     "all/create-only/.claude/rules/PROJECT_RULES.md":
@@ -624,6 +626,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "a675f6b17ce7f0d6b9fb7daeba6d2bc59bcb48ef79b034076ea73b2b1e72ee09",
     "plugins/src/base/hooks/shell-write-nudge.sh":
       "69839af423f8792b1e52c71097316c3264425553031627c0a2f9409a9d5becd0",
+    "plugins/src/base/hooks/sonar-secrets.sh":
+      "7a408788975a6351d53e14aa32bb9a5d161f33df9dfea59ba32784ae33a62e67",
     "plugins/src/base/hooks/threshold-ratchet-compare.mjs":
       "4535a145c5c5cbee13bdf970bc91d390a264043604e607288cdd6bf28de56192",
     "plugins/src/base/hooks/threshold-ratchet-families.mjs":
@@ -1165,7 +1169,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
       "82bc2a27a0a5afb2ff413a88365c619fd7f0eaada5de3ccabf2000938f0607a4",
     "plugins/src/base/skills/lisa-setup-sonar/SKILL.md":
-      "53fbd8acce4b5e47e88195a7b90d5be424fa6ef7ad872f52c50467c690664c3b",
+      "b18e07ae942f75aad5730c0535840ef5f7115072f1b6cc62afac83196b28d6a3",
     "plugins/src/base/skills/lisa-setup-workstation/SKILL.md":
       "e57e64083c292f0402b704eeb647244be0f33ab17394a688bce57a1efd59f169",
     "plugins/src/base/skills/lisa-setup-workstation/scripts/catalogue.mjs":
@@ -1941,7 +1945,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/merge/.claude/settings.json":
       "9c49f8c7c453f8749c90def3e22d412c3345c533d24b30dc7745ffa052ad6fa1",
     "scripts/build-plugins.sh":
-      "d4332a862d57798280e0d0c96826bbdc6b07855659dae529f8de32de994d2da9",
+      "c584fab4c77a77facf70c38c4699d4ed27d46ae667c1e1ef644efc2c4c5a14c7",
     "scripts/check-duplicate-versions.mjs":
       "84d97e94eb834522848ddce951bb54ae9da1e4be252e2c51fed0c01c4f4d6b72",
     "scripts/check-learnings-budget.ts":
@@ -2361,6 +2365,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh": true,
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh": true,
     "all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh": true,
+    "all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh": true,
     "all/copy-overwrite/scripts/lisa-work-item.mjs": true,
     "all/create-only/.claude/rules/PROJECT_RULES.md": true,
     "all/create-only/.lisaignore": true,
@@ -3492,6 +3497,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/hooks/parity-safety-net.sh": true,
     "plugins/lisa-copilot/hooks/setup-jira-cli.sh": true,
     "plugins/lisa-copilot/hooks/shell-write-nudge.sh": true,
+    "plugins/lisa-copilot/hooks/sonar-secrets.sh": true,
     "plugins/lisa-copilot/hooks/threshold-ratchet-compare.mjs": true,
     "plugins/lisa-copilot/hooks/threshold-ratchet-families.mjs": true,
     "plugins/lisa-copilot/hooks/threshold-ratchet.mjs": true,
@@ -3906,6 +3912,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/hooks/parity-safety-net.sh": true,
     "plugins/lisa-cursor/hooks/setup-jira-cli.sh": true,
     "plugins/lisa-cursor/hooks/shell-write-nudge.sh": true,
+    "plugins/lisa-cursor/hooks/sonar-secrets.sh": true,
     "plugins/lisa-cursor/hooks/threshold-ratchet-compare.mjs": true,
     "plugins/lisa-cursor/hooks/threshold-ratchet-families.mjs": true,
     "plugins/lisa-cursor/hooks/threshold-ratchet.mjs": true,
@@ -6405,6 +6412,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/hooks/parity-safety-net.sh": true,
     "plugins/lisa/hooks/setup-jira-cli.sh": true,
     "plugins/lisa/hooks/shell-write-nudge.sh": true,
+    "plugins/lisa/hooks/sonar-secrets.sh": true,
     "plugins/lisa/hooks/threshold-ratchet-compare.mjs": true,
     "plugins/lisa/hooks/threshold-ratchet-families.mjs": true,
     "plugins/lisa/hooks/threshold-ratchet.mjs": true,
@@ -7000,6 +7008,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/hooks/parity-safety-net.sh": true,
     "plugins/src/base/hooks/setup-jira-cli.sh": true,
     "plugins/src/base/hooks/shell-write-nudge.sh": true,
+    "plugins/src/base/hooks/sonar-secrets.sh": true,
     "plugins/src/base/hooks/threshold-ratchet-compare.mjs": true,
     "plugins/src/base/hooks/threshold-ratchet-families.mjs": true,
     "plugins/src/base/hooks/threshold-ratchet.mjs": true,
@@ -8417,6 +8426,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/hooks/parity-safety-net.test.ts": true,
     "tests/unit/hooks/post-checkout.test.ts": true,
     "tests/unit/hooks/pre-push-git-environment.test.ts": true,
+    "tests/unit/hooks/sonar-secrets.test.ts": true,
     "tests/unit/hooks/track-plan-sessions.test.ts": true,
     "tests/unit/hooks/typecheck-hook-placement.test.ts": true,
     "tests/unit/hooks/verification-failure-mode-fixtures.test.ts": true,

--- a/tests/unit/hooks/sonar-secrets.test.ts
+++ b/tests/unit/hooks/sonar-secrets.test.ts
@@ -1,0 +1,245 @@
+/**
+ * The Sonar hook wrapper must degrade, never blockade.
+ *
+ * `sonar integrate <agent>` generates a shim that passes the CLI's verdict
+ * through unchanged, and the CLI answers an unauthenticated invocation with a
+ * `decision: block` whose reason is "secret scanning is inactive". That is
+ * shaped exactly like a real finding, so the generated shim refuses every prompt
+ * and every file read on a workstation that has not logged in — the first prompt
+ * of the first session, before anything can explain why.
+ *
+ * These tests pin the three behaviours that fix has to keep straight: a real
+ * finding still blocks, an inactive scanner does not, and a token the project
+ * already provisioned is fetched before either conclusion is drawn.
+ * @module tests/unit/hooks/sonar-secrets
+ */
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+/** Absolute, so the interpreter is never resolved through a writeable PATH. */
+const BASH = "/bin/bash";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+
+/** The reviewed original, which the plugin ships. */
+const SOURCE = path.join(
+  REPO_ROOT,
+  "plugins",
+  "src",
+  "base",
+  "hooks",
+  "sonar-secrets.sh"
+);
+
+/** What `lisa apply` writes into a host checkout. */
+const SHIPPED = path.join(
+  REPO_ROOT,
+  "all",
+  "copy-overwrite",
+  "scripts",
+  "lisa-hooks",
+  "sonar-secrets.sh"
+);
+
+const INACTIVE = JSON.stringify({
+  decision: "block",
+  reason:
+    "SonarQube secret scanning is inactive: not authenticated. Run 'sonar auth login'.",
+});
+
+const FINDING = JSON.stringify({
+  decision: "block",
+  reason: "Sonar detected secrets in prompt",
+});
+
+const temporaries: string[] = [];
+
+afterEach(() => {
+  for (const dir of temporaries.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/**
+ * A directory holding a stub `sonar`, to be prepended to PATH.
+ *
+ * The stub models the one behaviour that matters: the real CLI is inactive
+ * until a token reaches it, and reports that inactivity as a block verdict
+ * rather than as an error or a non-zero exit.
+ * @param whenAuthed What the stub prints once a token is in its environment.
+ * @returns Path to the directory containing the stub.
+ */
+function stubSonar(whenAuthed: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "lisa-sonar-bin-"));
+  const stub = path.join(dir, "sonar");
+
+  temporaries.push(dir);
+  writeFileSync(
+    stub,
+    [
+      "#!/bin/bash",
+      "cat >/dev/null",
+      'if [ -n "${SONARQUBE_CLI_TOKEN:-}" ]; then',
+      `  printf '%s' ${JSON.stringify(whenAuthed)}`,
+      "else",
+      `  printf '%s' ${JSON.stringify(INACTIVE)}`,
+      "fi",
+      "exit 0",
+    ].join("\n")
+  );
+  chmodSync(stub, 0o755);
+  return dir;
+}
+
+/**
+ * A checkout carrying a stub secrets resolver at one of the searched paths.
+ * @param token What `resolve-secret.mjs get` should emit, or "" for nothing.
+ * @returns Path to the fake project root.
+ */
+function projectWithResolver(token: string): string {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-sonar-proj-"));
+  const dir = path.join(
+    root,
+    ".claude",
+    "skills",
+    "lisa-secrets-access",
+    "scripts"
+  );
+
+  temporaries.push(root);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    path.join(dir, "resolve-secret.mjs"),
+    `process.stdout.write(${JSON.stringify(token)});\n`
+  );
+  return root;
+}
+
+/**
+ * Run the wrapper the way a generated shim does.
+ * @param options How to stage the run.
+ * @param options.bin Directory holding a stub `sonar`, prepended to PATH.
+ * @param options.projectDir Checkout the resolver search starts from.
+ * @param options.env Extra environment variables for the run.
+ * @returns The completed process.
+ */
+function run(options: {
+  readonly bin?: string;
+  readonly projectDir?: string;
+  readonly env?: Readonly<Record<string, string>>;
+}): ReturnType<typeof spawnSync> {
+  const pathEntries = [options.bin, process.env.PATH].filter(Boolean);
+
+  return spawnSync(BASH, [SOURCE, "claude-prompt-submit"], {
+    input: JSON.stringify({ prompt: "hello" }),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: pathEntries.join(path.delimiter),
+      ...(options.projectDir === undefined
+        ? {}
+        : { CLAUDE_PROJECT_DIR: options.projectDir }),
+      ...options.env,
+    },
+  });
+}
+
+describe("the shipped wrapper", () => {
+  it("is byte-identical to the reviewed original", () => {
+    // Copies rot. The guards beside it get the same assertion for the same
+    // reason: synced by the build, pinned by a test.
+    expect(readFileSync(SHIPPED, "utf8")).toBe(readFileSync(SOURCE, "utf8"));
+  });
+});
+
+describe("what the wrapper does with the CLI's verdict", () => {
+  it("passes a real finding through, so it still blocks", () => {
+    const result = run({
+      bin: stubSonar(FINDING),
+      projectDir: projectWithResolver("a-token"),
+    });
+
+    expect(result.stdout).toBe(FINDING);
+    expect(result.status).toBe(0);
+  });
+
+  it("swallows an inactive scanner and warns instead", () => {
+    // The whole point: no token anywhere, and the prompt still goes through.
+    const result = run({
+      bin: stubSonar(""),
+      projectDir: projectWithResolver(""),
+    });
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("secret scanning is inactive");
+    expect(result.status).toBe(0);
+  });
+
+  it("resolves a provisioned token before giving up on the scanner", () => {
+    // A project that declares SONARQUBE_CLI_TOKEN has it in its provider; the
+    // CLI reads only the environment and the keychain, so on a local surface
+    // the value is present and unreachable at the same time. Reaching for it
+    // is what turns the warn path back into a working scanner — proven here by
+    // the finding the authenticated stub emits only once a token arrives.
+    const result = run({
+      bin: stubSonar(FINDING),
+      projectDir: projectWithResolver("resolved-from-provider"),
+    });
+
+    expect(result.stdout).toBe(FINDING);
+    expect(result.stderr).not.toContain("inactive");
+  });
+
+  it("never prints the value it resolved", () => {
+    const result = run({
+      bin: stubSonar(""),
+      projectDir: projectWithResolver("super-secret-value"),
+    });
+
+    expect(`${result.stdout}${result.stderr}`).not.toContain(
+      "super-secret-value"
+    );
+  });
+});
+
+describe("when the wrapper must stand aside", () => {
+  it("exits quietly when the CLI is not installed", () => {
+    // An empty PATH entry and nothing inherited: `command -v sonar` fails.
+    const result = spawnSync(BASH, [SOURCE, "claude-prompt-submit"], {
+      input: "{}",
+      encoding: "utf8",
+      env: { PATH: mkdtempSync(path.join(tmpdir(), "lisa-empty-bin-")) },
+    });
+
+    expect(result.stdout).toBe("");
+    expect(result.status).toBe(0);
+  });
+
+  it("exits quietly when switched off", () => {
+    const result = run({
+      bin: stubSonar(FINDING),
+      env: { LISA_SONAR_HOOK: "off" },
+    });
+
+    expect(result.stdout).toBe("");
+    expect(result.status).toBe(0);
+  });
+
+  it("exits quietly when given no event name", () => {
+    const result = spawnSync(BASH, [SOURCE], { input: "{}", encoding: "utf8" });
+
+    expect(result.stdout).toBe("");
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes CodySwannGT/lisa#2324

## The bug

`sonar integrate <agent>` generates a five-line shim that pipes the hook payload
to `sonar hook <event>` and passes the verdict through unchanged. The CLI answers
an **unauthenticated** invocation with a block verdict whose reason is
`SonarQube secret scanning is inactive: not authenticated` — shaped exactly like
a real finding. On `UserPromptSubmit` that rejects **every prompt** on a machine
where the CLI is installed but the browser login has never run, starting with the
first prompt of the first session, before anything can explain why.

## Why it is wrong twice

**The credential is usually already provisioned.** A project declaring
`SONARQUBE_CLI_TOKEN` under `secrets.require` has it in its configured provider.
The CLI reads only the environment and the OS keychain, and the `local` surface
deliberately materializes nothing to disk — so the value is present and
unreachable at the same time, and nothing in the path reached for it.

**An unauthenticated scanner is a degraded gate, not a breach.** Commit-time and
CI secret scanning do not depend on this hook. Blocking every prompt to protect a
redundant layer trades a certain outage for a hypothetical leak.

## What changed

- **`plugins/src/base/hooks/sonar-secrets.sh`** (new) — one wrapper for every
  surface, taking the vendor event name as its only argument. It runs the
  scanner; on the "inactive" reason *only* it resolves
  `SONARQUBE_CLI_TOKEN` / `SONARQUBE_CLI_ORG` through `lisa-secrets-access`
  (exported in-process, never written to disk — the one-store rule), re-runs,
  and if still inactive warns on stderr and exits 0. A real finding is passed
  through untouched. The resolver call is bounded by a hand-rolled ceiling
  because `timeout` is absent on a stock macOS and this sits in front of every
  prompt and file read.
- **`scripts/build-plugins.sh`** — syncs the wrapper into
  `all/copy-overwrite/scripts/lisa-hooks/` so a host checkout carries it, with a
  comment on why it stays *out* of the `lisa-enforcement-fallback.sh` guard list:
  the guards take a tool payload and no arguments, this takes an event name.
- **`lisa-setup-sonar`** — new required step 4a: repoint each generated shim at
  the wrapper, with a table of shim paths and event names, the note that
  Antigravity's shim is three levels deep while the rest are four, and the
  warning that re-running an integrate restores the vendor original.
- **`tests/unit/hooks/sonar-secrets.test.ts`** (new) — 8 tests.

## Distinguishing "inactive" from a finding

On the vendor's reason text. That is safe rather than fragile: in the inactive
state the scanner does not scan at all, so a real detection arriving with that
reason is impossible by construction.

## Verification

```
npx vitest run tests/unit/hooks     33 files, 655 tests passed
bash scripts/check-plugins-sync.sh  plugin artifacts in sync
generate-upstream-evidence-manifest.mjs --check   clean
npm run typecheck                   clean
pre-push (audit, knip, coverage, integration, parity)   passed
```

Manually confirmed against the real CLI (v1.4.0) in a host project: a prompt
containing a `ghp_…` token still returns `{"decision":"block"}`; an inactive CLI
warns and lets the prompt through; a stubbed inactive CLI plus a live Bitwarden
project resolves the token and scans normally.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2324



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sonar secret-scanning hooks across supported integrations.
  * Automatically retrieves configured credentials when scanning requires authentication.
  * Preserves blocking for genuine scanner findings while converting unavailable-scanner states into warnings.
  * Supports disabling hooks and safely skips enforcement when required tools or events are unavailable.

* **Documentation**
  * Added setup guidance for integrating Sonar hooks with supported agent environments.

* **Tests**
  * Added coverage for scanning behavior, credential handling, warnings, disabled hooks, and missing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
