### PR TITLE
fix(hooks): run the enforcement guards unconditionally

### DIFF
--- a/all/copy-overwrite/scripts/lisa-enforcement-fallback.sh
+++ b/all/copy-overwrite/scripts/lisa-enforcement-fallback.sh
@@ -24,16 +24,39 @@ payload="$(cat)"
 repo_root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
 [ -n "$repo_root" ] || exit 0
 
-# Skip when the plugin is installed, so a developer machine does not run every
-# guard twice and print every refusal twice. Absence is the interesting case and
-# the only one this exists for.
+# There is deliberately no skip here, and that is the whole point.
 #
-# Read from the plugin registry rather than from CLAUDE_PLUGIN_ROOT: that
-# variable is set for plugin hooks, and this hook is by definition not one.
-installed="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/installed_plugins.json"
-if [ -f "$installed" ] && grep -q '"lisa@lisa"' "$installed" 2>/dev/null; then
-  exit 0
-fi
+# This used to stand down when `installed_plugins.json` mentioned `lisa@lisa`,
+# to avoid running every guard twice on a developer machine. The question that
+# has to be answered is "are the plugin's guards running in this session?" and
+# the file being consulted answers "has this plugin ever been installed, for any
+# project, on this machine?". Those come apart three ways, and in each one both
+# layers were off:
+#
+#   - Project-blind. The registry is keyed by plugin with an array of per-project
+#     entries, so the grep matched the key. One project installing Lisa disabled
+#     the fallback for every other project on the machine.
+#   - Enablement-blind. `enabledPlugins` can set a plugin to false without
+#     removing its registry entry, so the plugin guards were off while this file
+#     believed they were on.
+#   - Session-blind. Hooks load at session start; the registry is written on any
+#     install or update. A plugin updated four minutes into a session leaves the
+#     registry saying "installed" for the rest of it, with no plugin hooks
+#     loaded. That is the one that was caught in the wild: a write to AGENTS.md
+#     went through in a session where both guard copies exit 2 for that exact
+#     payload.
+#
+# The first two are fixable with a better lookup. The third is not: plugin-hook
+# liveness is not observable from a repository hook. CLAUDE_PLUGIN_ROOT is set
+# only for plugin hooks, and nothing on disk distinguishes "registered" from
+# "loaded into this session". Any check against a file answers a different
+# question and will drift from the real one again.
+#
+# So the guards run unconditionally. On a machine where the plugin hooks are also
+# live that costs a duplicated sweep (~170ms) and a refusal printed twice, and
+# that is the correct trade against enforcement silently switching itself off.
+# Recovering it belongs in the guards — a marker keyed on session and payload, so
+# whichever layer fires first does the work — not in a liveness guess here.
 
 # Where the guards live depends on which repository this is.
 #

--- a/scripts/lisa-enforcement-fallback.sh
+++ b/scripts/lisa-enforcement-fallback.sh
@@ -24,16 +24,39 @@ payload="$(cat)"
 repo_root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
 [ -n "$repo_root" ] || exit 0
 
-# Skip when the plugin is installed, so a developer machine does not run every
-# guard twice and print every refusal twice. Absence is the interesting case and
-# the only one this exists for.
+# There is deliberately no skip here, and that is the whole point.
 #
-# Read from the plugin registry rather than from CLAUDE_PLUGIN_ROOT: that
-# variable is set for plugin hooks, and this hook is by definition not one.
-installed="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/installed_plugins.json"
-if [ -f "$installed" ] && grep -q '"lisa@lisa"' "$installed" 2>/dev/null; then
-  exit 0
-fi
+# This used to stand down when `installed_plugins.json` mentioned `lisa@lisa`,
+# to avoid running every guard twice on a developer machine. The question that
+# has to be answered is "are the plugin's guards running in this session?" and
+# the file being consulted answers "has this plugin ever been installed, for any
+# project, on this machine?". Those come apart three ways, and in each one both
+# layers were off:
+#
+#   - Project-blind. The registry is keyed by plugin with an array of per-project
+#     entries, so the grep matched the key. One project installing Lisa disabled
+#     the fallback for every other project on the machine.
+#   - Enablement-blind. `enabledPlugins` can set a plugin to false without
+#     removing its registry entry, so the plugin guards were off while this file
+#     believed they were on.
+#   - Session-blind. Hooks load at session start; the registry is written on any
+#     install or update. A plugin updated four minutes into a session leaves the
+#     registry saying "installed" for the rest of it, with no plugin hooks
+#     loaded. That is the one that was caught in the wild: a write to AGENTS.md
+#     went through in a session where both guard copies exit 2 for that exact
+#     payload.
+#
+# The first two are fixable with a better lookup. The third is not: plugin-hook
+# liveness is not observable from a repository hook. CLAUDE_PLUGIN_ROOT is set
+# only for plugin hooks, and nothing on disk distinguishes "registered" from
+# "loaded into this session". Any check against a file answers a different
+# question and will drift from the real one again.
+#
+# So the guards run unconditionally. On a machine where the plugin hooks are also
+# live that costs a duplicated sweep (~170ms) and a refusal printed twice, and
+# that is the correct trade against enforcement silently switching itself off.
+# Recovering it belongs in the guards — a marker keyed on session and payload, so
+# whichever layer fires first does the work — not in a liveness guess here.
 
 # Where the guards live depends on which repository this is.
 #

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7,7 +7,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-contents/gitignore":
       "2dbf7fd2f2020fc7824c432342002d9ca3ebb57b2872e761b14e942b23479a11",
     "all/copy-overwrite/scripts/lisa-enforcement-fallback.sh":
-      "e17c45f7cadf0fb55dd07270776caf211af99b7d4771a4fde75aafe5919e8dbe",
+      "d7d88e44763694bed5eae998cd3663922c957e49f9f9621d9201f0417a4128ad",
     "all/copy-overwrite/scripts/lisa-floor-collisions.mjs":
       "a612f172282d13ba9318fe5e03689d7c6ff42a0122d0c9d5d39051e1967b93dc",
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
@@ -2013,7 +2013,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/lisa-commit-and-pr-local.sh":
       "605409c3ce6ec38ad3275604291a1ceae98f7807a605654263bc14f811c03903",
     "scripts/lisa-enforcement-fallback.sh":
-      "e17c45f7cadf0fb55dd07270776caf211af99b7d4771a4fde75aafe5919e8dbe",
+      "d7d88e44763694bed5eae998cd3663922c957e49f9f9621d9201f0417a4128ad",
     "scripts/lisa-github-environments.sh":
       "0a76e92f108519abaf3e29991299ec3b0db20ea533e69e6d2a53d802dba9c370",
     "scripts/lisa-github-repo-settings.sh":

--- a/tests/unit/hooks/enforcement-fallback.test.ts
+++ b/tests/unit/hooks/enforcement-fallback.test.ts
@@ -96,17 +96,18 @@ describe("enforcement fallback when no plugin is installed", () => {
     expect(status).toBe(0);
   });
 
-  it("stays inert where the plugin already provides the guards", () => {
-    // Otherwise a developer machine runs every guard twice and prints every
-    // refusal twice, which teaches people to skim refusals.
+  it("fires even where the registry says the plugin is installed", () => {
+    // This used to assert the opposite — inert when registered — to spare a
+    // developer machine a duplicated sweep. The registry cannot support that
+    // conclusion. It answers "ever installed, for any project, on this machine";
+    // the question is "are the plugin's guards running in this session", and
+    // those come apart when another project registered it, when enabledPlugins
+    // turned it off, and when an install landed after the session's hooks were
+    // already loaded. The last one was observed: a write to AGENTS.md went
+    // through in a session where both guard copies refuse that exact payload.
     //
-    // The registry is BUILT here rather than read from `$HOME/.claude`. Pointing
-    // at the developer's real config made this assert machine state instead of
-    // behaviour: it passed locally because the plugin happens to be installed,
-    // and failed in CI — where it is not — because the fallback correctly fired.
-    // A test that only passes on a machine that already has the thing under
-    // test installed cannot tell "inert because registered" from "inert because
-    // broken".
+    // The registry is BUILT here rather than read from `$HOME/.claude`, so this
+    // asserts behaviour rather than machine state.
     const configDir = mkdtempSync(path.join(tmpdir(), "lisa-fallback-"));
     mkdirSync(path.join(configDir, "plugins"), { recursive: true });
     writeFileSync(
@@ -117,14 +118,12 @@ describe("enforcement fallback when no plugin is installed", () => {
     const { status } = runFallback(NO_VERIFY_COMMIT, configDir);
 
     rmSync(configDir, { recursive: true, force: true });
-    expect(status).toBe(0);
+    expect(status).toBe(BLOCKED);
   });
 
-  it("fires when the registry exists but does not carry the plugin", () => {
-    // The inert path keys on the plugin being REGISTERED, not on the registry
-    // file merely existing. Without this, a container that wrote an empty
-    // registry — precisely the failure this whole file exists for — would read
-    // as "plugin present" and silence the fallback.
+  it("fires when the registry exists but is empty", () => {
+    // A container that wrote an empty registry is precisely the failure this
+    // whole file exists for, and it must not read as "nothing to do".
     const configDir = mkdtempSync(path.join(tmpdir(), "lisa-fallback-"));
     mkdirSync(path.join(configDir, "plugins"), { recursive: true });
     writeFileSync(

--- a/tests/unit/hooks/host-enforcement-fallback.test.ts
+++ b/tests/unit/hooks/host-enforcement-fallback.test.ts
@@ -8,10 +8,11 @@
  * clone and reaches a cloud session whether or not a plugin ever installs.
  *
  * A host project has the identical hole and no `plugins/` directory to fall back
- * on, so `lisa apply` writes the same three guards into its checkout. These
- * tests cover the two halves that can rot independently: the shipped copies
- * drifting from the reviewed originals, and the dispatcher not finding them in
- * the layout a host project actually has.
+ * on, so `lisa apply` writes the same guards into its checkout. These tests
+ * cover the three parts that can rot independently: the shipped copies drifting
+ * from the reviewed originals, the dispatcher not finding them in the layout a
+ * host project actually has, and the dispatcher standing down on something that
+ * does not mean what it looks like it means.
  * @module tests/unit/hooks/host-enforcement-fallback
  */
 import { spawnSync } from "node:child_process";
@@ -22,6 +23,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -42,13 +44,16 @@ const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 /** The reviewed originals, which the plugin ships. */
 const PLUGIN_HOOKS = path.join(REPO_ROOT, "plugins", "src", "base", "hooks");
 
+/** The directory the guards sit in, under `scripts/`, in both trees. */
+const HOOKS_DIRNAME = "lisa-hooks";
+
 /** What `lisa apply` writes into a host checkout. */
 const SHIPPED_HOOKS = path.join(
   REPO_ROOT,
   "all",
   "copy-overwrite",
   SCRIPTS,
-  "lisa-hooks"
+  HOOKS_DIRNAME
 );
 
 const SHIPPED_FALLBACK = path.join(
@@ -96,27 +101,27 @@ describe("the guards a host project receives", () => {
   });
 });
 
+/**
+ * Build a host project as `lisa apply` leaves it: `scripts/` populated, and
+ * emphatically no `plugins/` directory to fall back on.
+ * @returns Path to the fake host checkout
+ */
+function hostProject(): string {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-host-"));
+  const scripts = path.join(root, SCRIPTS);
+  const fallback = path.join(scripts, FALLBACK_NAME);
+
+  temporaries.push(root);
+  mkdirSync(scripts, { recursive: true });
+  cpSync(SHIPPED_HOOKS, path.join(scripts, HOOKS_DIRNAME), {
+    recursive: true,
+  });
+  cpSync(SHIPPED_FALLBACK, fallback);
+  chmodSync(fallback, 0o755);
+  return root;
+}
+
 describe("enforcement in a host layout", () => {
-  /**
-   * Build a host project as `lisa apply` leaves it: `scripts/` populated, and
-   * emphatically no `plugins/` directory to fall back on.
-   * @returns Path to the fake host checkout
-   */
-  function hostProject(): string {
-    const root = mkdtempSync(path.join(tmpdir(), "lisa-host-"));
-    const scripts = path.join(root, SCRIPTS);
-    const fallback = path.join(scripts, FALLBACK_NAME);
-
-    temporaries.push(root);
-    mkdirSync(scripts, { recursive: true });
-    cpSync(SHIPPED_HOOKS, path.join(scripts, "lisa-hooks"), {
-      recursive: true,
-    });
-    cpSync(SHIPPED_FALLBACK, fallback);
-    chmodSync(fallback, 0o755);
-    return root;
-  }
-
   /**
    * Run the host's dispatcher against a proposed command.
    * @param root Host checkout
@@ -149,6 +154,75 @@ describe("enforcement in a host layout", () => {
   it("lets an ordinary command through", () => {
     // A fallback that blocks everything is not enforcement, it is an outage.
     expect(runInHost(hostProject(), "ls -la")).toBe(0);
+  });
+});
+
+describe("the plugin registry cannot switch enforcement off", () => {
+  /**
+   * A plugin registry shaped like the real one: keyed by plugin, with an array
+   * of per-project entries for other projects entirely.
+   * @returns Path to a directory usable as CLAUDE_CONFIG_DIR.
+   */
+  function registryListingLisa(): string {
+    const config = mkdtempSync(path.join(tmpdir(), "lisa-config-"));
+    const plugins = path.join(config, "plugins");
+
+    temporaries.push(config);
+    mkdirSync(plugins, { recursive: true });
+    writeFileSync(
+      path.join(plugins, "installed_plugins.json"),
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          "lisa@lisa": [
+            {
+              scope: "project",
+              projectPath: "/somewhere/else",
+              version: "9.9",
+            },
+          ],
+        },
+      })
+    );
+    return config;
+  }
+
+  /**
+   * Run the dispatcher with a registry that claims the plugin is installed.
+   * @param root Host checkout.
+   * @param command The Bash command Claude proposes.
+   * @returns Exit status.
+   */
+  function runWithRegistry(root: string, command: string): number | null {
+    return spawnSync(BASH, [path.join(root, SCRIPTS, FALLBACK_NAME)], {
+      input: JSON.stringify({ tool_name: "Bash", tool_input: { command } }),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CLAUDE_PROJECT_DIR: root,
+        CLAUDE_CONFIG_DIR: registryListingLisa(),
+      },
+    }).status;
+  }
+
+  it("still blocks the bypass when the registry lists lisa@lisa", () => {
+    // The registry answers "ever installed, for any project, on this machine".
+    // The question is "are the plugin's guards running in this session", which
+    // no file on disk can answer — so this file stopped asking. It stood down
+    // on a registry entry belonging to another project entirely, which is what
+    // this fixture reproduces.
+    expect(runWithRegistry(hostProject(), BYPASS)).toBe(BLOCKED);
+  });
+
+  it("still blocks a write to a session-instruction file", () => {
+    // Caught in the wild: a plugin updated four minutes into a session left the
+    // registry saying "installed" with no plugin hooks loaded, and this write
+    // went through even though both guard copies exit 2 for it.
+    expect(runWithRegistry(hostProject(), ": > AGENTS.md")).toBe(BLOCKED);
+  });
+
+  it("still lets an ordinary command through", () => {
+    expect(runWithRegistry(hostProject(), "ls -la")).toBe(0);
   });
 });
 


### PR DESCRIPTION
Closes CodySwannGT/lisa#2326

## The bug

`scripts/lisa-enforcement-fallback.sh` stood down like this:

```bash
if [ -f "$installed" ] && grep -q '"lisa@lisa"' "$installed" 2>/dev/null; then
  exit 0
fi
```

The question it has to answer is **"are the plugin's guards running in this
session?"** The file it consults answers **"has this plugin ever been installed,
for any project, on this machine?"** Those come apart three ways, and in each one
*both* layers are off — the exact silent fail-open the file's own header says it
exists to close.

| | How it fails | Evidence |
| --- | --- | --- |
| Project-blind | Registry is keyed by plugin with an array of per-project entries; the grep matches the key | 1282 entries under `lisa@lisa` on one machine — the first project to install Lisa disabled the fallback for all the others |
| Enablement-blind | `enabledPlugins` can set a plugin false without removing its registry entry | `safety-net@cc-marketplace` is `false` in a project's settings and still present in the registry |
| Session-blind | Hooks load at session start; the registry is written on any install/update | Session started ~20:18 UTC, `lisa@lisa` `lastUpdated` 20:24 UTC — registry said installed, no plugin hooks loaded for the rest of that session |

The third one was caught in the wild: `: > AGENTS.md` executed and emptied the
file, in a session where **both** guard copies exit 2 for that exact payload.

```
$ printf '{"tool_name":"Bash","tool_input":{"command":": > AGENTS.md"}}' \
    | bash plugins/src/base/hooks/block-instruction-file-edits.sh >/dev/null; echo $?
2
```

## Why the check is deleted rather than repaired

The first two are fixable with a project-scoped, enablement-aware lookup. The
third is not: **plugin-hook liveness is not observable from a repository hook.**
`CLAUDE_PLUGIN_ROOT` is set only for plugin hooks, and nothing on disk
distinguishes "registered" from "loaded into this session". Any check against a
file answers a different question and will drift from the real one again.

So the guards run unconditionally.

## The cost, measured

A full guard sweep is ~170 ms (5 sweeps in 847 ms). That is added to every Bash /
Write / Edit call on a machine where the plugin hooks are *also* live, plus a
refusal printed twice.

That is the price of the guards being on, and it is the right trade against
enforcement silently switching itself off. Recovering it belongs in the guards —
a marker keyed on session id plus a hash of the payload, so whichever layer fires
first does the work and the second short-circuits to the recorded status without
printing. That touches all four guards and their agy variants, so it is filed as
follow-up in #2326 rather than riding along here.

## Tests

`tests/unit/hooks/enforcement-fallback.test.ts` — the "stays inert where the
plugin already provides the guards" case is inverted, with the reasoning in the
comment so the next reader does not restore it as an optimization.

`tests/unit/hooks/host-enforcement-fallback.test.ts` — new block driving the host
dispatcher against a registry shaped like the real one, carrying a `lisa@lisa`
entry for *another project entirely*: the bypass is still blocked, the AGENTS.md
write is still blocked, an ordinary command still passes.

```
npx vitest run tests/unit/hooks     33 files, 658 tests passed
npm run typecheck                   clean
eslint                              clean
pre-push (audit, knip, coverage, integration, parity)   passed
```

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforcement fallback checks now remain active even when Lisa is listed as installed.
  * Commands that should be blocked are consistently prevented across plugin and host-project scenarios.
  * Enforcement behavior is no longer incorrectly disabled based on plugin registry entries.

* **Tests**
  * Expanded coverage for registered, empty, and cross-project plugin configurations.
  * Added validation for bypass handling and instruction-file updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Work-Item: CodySwannGT/lisa#2326
