### PR TITLE
feat(secrets): let agents use their own AWS identity on a laptop

### DIFF
--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -191,6 +191,38 @@ export function installProfileSourcing(valuesFile, options = {}) {
  * @param {object} [options] Home directory and file seams, for tests.
  * @returns {string[]} The profile names written.
  */
+/**
+ * Profile names already defined OUTSIDE this module's managed block.
+ *
+ * Only what lies outside the block counts: our own previous output is meant to
+ * be replaced, and treating it as a collision would make the second run fail.
+ * @param {string} dir The `.aws` directory.
+ * @param {string[]} names Profile names about to be written.
+ * @param {object} io `exists` and `read` seams.
+ * @returns {string[]} Colliding names, in the order given.
+ */
+export function collidingProfiles(dir, names, io = {}) {
+  const { exists = existsSync, read = readFileSync } = io;
+  const file = join(dir, "config");
+  if (!exists(file)) return [];
+
+  const text = String(read(file, "utf8"));
+  const start = text.indexOf(MANAGED_MARKER);
+  const endAt = start === -1 ? -1 : text.indexOf(MANAGED_END, start);
+  const outside =
+    start === -1
+      ? text
+      : text.slice(0, start) +
+        (endAt === -1 ? "" : text.slice(endAt + MANAGED_END.length));
+
+  return names.filter(name =>
+    new RegExp(
+      `^\\s*\\[profile\\s+${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\]`,
+      "m"
+    ).test(outside)
+  );
+}
+
 export function installAwsProfiles(bundle, options = {}) {
   const {
     home = process.env.HOME || homedir(),
@@ -205,6 +237,33 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
+
+  // Refuse to write a profile name the operator already uses outside our block.
+  //
+  // AWS does not error on a duplicate `[profile x]` — it resolves one and
+  // ignores the other. So writing `tunnl-dev` next to an operator's existing SSO
+  // `tunnl-dev` would silently run some calls as the wrong identity, which is
+  // worse than either winning outright. Merging protects their sections from
+  // being deleted; this protects them from being shadowed.
+  //
+  // Deliberately not resolved by renaming theirs: this module writes its own
+  // block and nothing else. The operator renames (conventionally to `-sso`) and
+  // re-runs.
+  const collisions = collidingProfiles(dir, rendered.profiles, {
+    exists,
+    read,
+  });
+  if (collisions.length > 0) {
+    throw new Error(
+      `~/.aws/config already defines ${collisions.map(n => `"${n}"`).join(", ")} ` +
+        `outside the lisa-managed block.\n` +
+        `Writing them would create duplicate sections, and AWS resolves only ` +
+        `one — some calls would silently use the wrong identity.\n` +
+        `Rename the existing entries (for example to "${collisions[0]}-sso") ` +
+        `and run this again.`
+    );
+  }
+
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
 
@@ -297,6 +356,47 @@ export function materialize(cfg = readConfig()) {
 
 function main() {
   const cfg = readConfig();
+
+  // `--aws-profiles-only` writes ~/.aws and NOTHING else, on any surface.
+  //
+  // A laptop refuses to materialize secrets to disk, deliberately: read-through
+  // to the provider adds no drift and leaves no copy. That rule is about the
+  // thirteen values in secrets.env, and it stays exactly as it was here.
+  //
+  // The AWS profiles are a different bargain, requested explicitly. Agents
+  // working on a developer's machine should act as RemoteAgent rather than
+  // borrowing the human's SSO identity — separate attribution in CloudTrail,
+  // the role's blast radius instead of a person's, and the same `agent-*`
+  // profile names as a container so a script does not need two vocabularies.
+  //
+  // The cost is real and belongs in the open: `source_profile` needs a
+  // long-lived key pair, so this writes one to a machine that is not
+  // disposable, which is the thing the local surface otherwise prevents. It is
+  // therefore opt-in per run, never automatic, and never part of a normal
+  // materialize.
+  if (process.argv.includes("--aws-profiles-only")) {
+    const selected = fetchAll(cfg);
+    const bundle = parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value);
+    const written = installAwsProfiles(bundle);
+
+    if (written.length === 0) {
+      console.log(
+        `no AWS profiles written — ${BOOTSTRAP_KEY} is absent, unparseable, ` +
+          `or declares no profile carrying a roleArn.`
+      );
+      return;
+    }
+    console.log(
+      `wrote ${written.length} AWS profile(s): ${written.join(", ")}`
+    );
+    console.log(
+      `  Sourced from a long-lived key pair in ~/.aws/credentials. Existing\n` +
+        `  sections were preserved — only the lisa-managed block was replaced.\n` +
+        `  Use them explicitly: aws --profile ${written[0]} ...`
+    );
+    return;
+  }
+
   if (process.argv.includes("--dry-run")) {
     const selected = fetchAll(cfg);
     // Derive here too, or the preview lies in the one place it matters most:
@@ -314,10 +414,20 @@ function main() {
   const { count, derived, dir } = materialize(cfg);
   console.log(`materialized ${count} secret(s) and their notes into ${dir}`);
   if (derived > 0) {
-    // Said out loud: this run exported variables the host may also have set.
+    // Do not claim an override this does not perform.
+    //
+    // This line used to end "overriding any ambient value". That was true when
+    // the key pair was exported and stopped being true when the pair moved into
+    // ~/.aws and AWS_PROFILE took its place — AWS_PROFILE loses to ambient
+    // environment credentials, it does not beat them. The stale sentence sent
+    // two separate investigations after a credential problem that did not
+    // exist, while the real fault was that nothing sourced the file. A message
+    // that overclaims costs more than no message.
     console.log(
-      `  ${derived} AWS variable(s) derived from the bootstrap bundle, ` +
-        `overriding any ambient value`
+      `  ${derived} AWS variable(s) derived from the bootstrap bundle. ` +
+        `These take\n  effect only in a shell that sourced the materialized ` +
+        `env file; ambient\n  credentials outrank AWS_PROFILE, so prefer an ` +
+        `explicit --profile.`
     );
   }
 }

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -191,6 +191,38 @@ export function installProfileSourcing(valuesFile, options = {}) {
  * @param {object} [options] Home directory and file seams, for tests.
  * @returns {string[]} The profile names written.
  */
+/**
+ * Profile names already defined OUTSIDE this module's managed block.
+ *
+ * Only what lies outside the block counts: our own previous output is meant to
+ * be replaced, and treating it as a collision would make the second run fail.
+ * @param {string} dir The `.aws` directory.
+ * @param {string[]} names Profile names about to be written.
+ * @param {object} io `exists` and `read` seams.
+ * @returns {string[]} Colliding names, in the order given.
+ */
+export function collidingProfiles(dir, names, io = {}) {
+  const { exists = existsSync, read = readFileSync } = io;
+  const file = join(dir, "config");
+  if (!exists(file)) return [];
+
+  const text = String(read(file, "utf8"));
+  const start = text.indexOf(MANAGED_MARKER);
+  const endAt = start === -1 ? -1 : text.indexOf(MANAGED_END, start);
+  const outside =
+    start === -1
+      ? text
+      : text.slice(0, start) +
+        (endAt === -1 ? "" : text.slice(endAt + MANAGED_END.length));
+
+  return names.filter(name =>
+    new RegExp(
+      `^\\s*\\[profile\\s+${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\]`,
+      "m"
+    ).test(outside)
+  );
+}
+
 export function installAwsProfiles(bundle, options = {}) {
   const {
     home = process.env.HOME || homedir(),
@@ -205,6 +237,33 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
+
+  // Refuse to write a profile name the operator already uses outside our block.
+  //
+  // AWS does not error on a duplicate `[profile x]` — it resolves one and
+  // ignores the other. So writing `tunnl-dev` next to an operator's existing SSO
+  // `tunnl-dev` would silently run some calls as the wrong identity, which is
+  // worse than either winning outright. Merging protects their sections from
+  // being deleted; this protects them from being shadowed.
+  //
+  // Deliberately not resolved by renaming theirs: this module writes its own
+  // block and nothing else. The operator renames (conventionally to `-sso`) and
+  // re-runs.
+  const collisions = collidingProfiles(dir, rendered.profiles, {
+    exists,
+    read,
+  });
+  if (collisions.length > 0) {
+    throw new Error(
+      `~/.aws/config already defines ${collisions.map(n => `"${n}"`).join(", ")} ` +
+        `outside the lisa-managed block.\n` +
+        `Writing them would create duplicate sections, and AWS resolves only ` +
+        `one — some calls would silently use the wrong identity.\n` +
+        `Rename the existing entries (for example to "${collisions[0]}-sso") ` +
+        `and run this again.`
+    );
+  }
+
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
 
@@ -297,6 +356,47 @@ export function materialize(cfg = readConfig()) {
 
 function main() {
   const cfg = readConfig();
+
+  // `--aws-profiles-only` writes ~/.aws and NOTHING else, on any surface.
+  //
+  // A laptop refuses to materialize secrets to disk, deliberately: read-through
+  // to the provider adds no drift and leaves no copy. That rule is about the
+  // thirteen values in secrets.env, and it stays exactly as it was here.
+  //
+  // The AWS profiles are a different bargain, requested explicitly. Agents
+  // working on a developer's machine should act as RemoteAgent rather than
+  // borrowing the human's SSO identity — separate attribution in CloudTrail,
+  // the role's blast radius instead of a person's, and the same `agent-*`
+  // profile names as a container so a script does not need two vocabularies.
+  //
+  // The cost is real and belongs in the open: `source_profile` needs a
+  // long-lived key pair, so this writes one to a machine that is not
+  // disposable, which is the thing the local surface otherwise prevents. It is
+  // therefore opt-in per run, never automatic, and never part of a normal
+  // materialize.
+  if (process.argv.includes("--aws-profiles-only")) {
+    const selected = fetchAll(cfg);
+    const bundle = parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value);
+    const written = installAwsProfiles(bundle);
+
+    if (written.length === 0) {
+      console.log(
+        `no AWS profiles written — ${BOOTSTRAP_KEY} is absent, unparseable, ` +
+          `or declares no profile carrying a roleArn.`
+      );
+      return;
+    }
+    console.log(
+      `wrote ${written.length} AWS profile(s): ${written.join(", ")}`
+    );
+    console.log(
+      `  Sourced from a long-lived key pair in ~/.aws/credentials. Existing\n` +
+        `  sections were preserved — only the lisa-managed block was replaced.\n` +
+        `  Use them explicitly: aws --profile ${written[0]} ...`
+    );
+    return;
+  }
+
   if (process.argv.includes("--dry-run")) {
     const selected = fetchAll(cfg);
     // Derive here too, or the preview lies in the one place it matters most:
@@ -314,10 +414,20 @@ function main() {
   const { count, derived, dir } = materialize(cfg);
   console.log(`materialized ${count} secret(s) and their notes into ${dir}`);
   if (derived > 0) {
-    // Said out loud: this run exported variables the host may also have set.
+    // Do not claim an override this does not perform.
+    //
+    // This line used to end "overriding any ambient value". That was true when
+    // the key pair was exported and stopped being true when the pair moved into
+    // ~/.aws and AWS_PROFILE took its place — AWS_PROFILE loses to ambient
+    // environment credentials, it does not beat them. The stale sentence sent
+    // two separate investigations after a credential problem that did not
+    // exist, while the real fault was that nothing sourced the file. A message
+    // that overclaims costs more than no message.
     console.log(
-      `  ${derived} AWS variable(s) derived from the bootstrap bundle, ` +
-        `overriding any ambient value`
+      `  ${derived} AWS variable(s) derived from the bootstrap bundle. ` +
+        `These take\n  effect only in a shell that sourced the materialized ` +
+        `env file; ambient\n  credentials outrank AWS_PROFILE, so prefer an ` +
+        `explicit --profile.`
     );
   }
 }

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -191,6 +191,38 @@ export function installProfileSourcing(valuesFile, options = {}) {
  * @param {object} [options] Home directory and file seams, for tests.
  * @returns {string[]} The profile names written.
  */
+/**
+ * Profile names already defined OUTSIDE this module's managed block.
+ *
+ * Only what lies outside the block counts: our own previous output is meant to
+ * be replaced, and treating it as a collision would make the second run fail.
+ * @param {string} dir The `.aws` directory.
+ * @param {string[]} names Profile names about to be written.
+ * @param {object} io `exists` and `read` seams.
+ * @returns {string[]} Colliding names, in the order given.
+ */
+export function collidingProfiles(dir, names, io = {}) {
+  const { exists = existsSync, read = readFileSync } = io;
+  const file = join(dir, "config");
+  if (!exists(file)) return [];
+
+  const text = String(read(file, "utf8"));
+  const start = text.indexOf(MANAGED_MARKER);
+  const endAt = start === -1 ? -1 : text.indexOf(MANAGED_END, start);
+  const outside =
+    start === -1
+      ? text
+      : text.slice(0, start) +
+        (endAt === -1 ? "" : text.slice(endAt + MANAGED_END.length));
+
+  return names.filter(name =>
+    new RegExp(
+      `^\\s*\\[profile\\s+${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\]`,
+      "m"
+    ).test(outside)
+  );
+}
+
 export function installAwsProfiles(bundle, options = {}) {
   const {
     home = process.env.HOME || homedir(),
@@ -205,6 +237,33 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
+
+  // Refuse to write a profile name the operator already uses outside our block.
+  //
+  // AWS does not error on a duplicate `[profile x]` — it resolves one and
+  // ignores the other. So writing `tunnl-dev` next to an operator's existing SSO
+  // `tunnl-dev` would silently run some calls as the wrong identity, which is
+  // worse than either winning outright. Merging protects their sections from
+  // being deleted; this protects them from being shadowed.
+  //
+  // Deliberately not resolved by renaming theirs: this module writes its own
+  // block and nothing else. The operator renames (conventionally to `-sso`) and
+  // re-runs.
+  const collisions = collidingProfiles(dir, rendered.profiles, {
+    exists,
+    read,
+  });
+  if (collisions.length > 0) {
+    throw new Error(
+      `~/.aws/config already defines ${collisions.map(n => `"${n}"`).join(", ")} ` +
+        `outside the lisa-managed block.\n` +
+        `Writing them would create duplicate sections, and AWS resolves only ` +
+        `one — some calls would silently use the wrong identity.\n` +
+        `Rename the existing entries (for example to "${collisions[0]}-sso") ` +
+        `and run this again.`
+    );
+  }
+
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
 
@@ -297,6 +356,47 @@ export function materialize(cfg = readConfig()) {
 
 function main() {
   const cfg = readConfig();
+
+  // `--aws-profiles-only` writes ~/.aws and NOTHING else, on any surface.
+  //
+  // A laptop refuses to materialize secrets to disk, deliberately: read-through
+  // to the provider adds no drift and leaves no copy. That rule is about the
+  // thirteen values in secrets.env, and it stays exactly as it was here.
+  //
+  // The AWS profiles are a different bargain, requested explicitly. Agents
+  // working on a developer's machine should act as RemoteAgent rather than
+  // borrowing the human's SSO identity — separate attribution in CloudTrail,
+  // the role's blast radius instead of a person's, and the same `agent-*`
+  // profile names as a container so a script does not need two vocabularies.
+  //
+  // The cost is real and belongs in the open: `source_profile` needs a
+  // long-lived key pair, so this writes one to a machine that is not
+  // disposable, which is the thing the local surface otherwise prevents. It is
+  // therefore opt-in per run, never automatic, and never part of a normal
+  // materialize.
+  if (process.argv.includes("--aws-profiles-only")) {
+    const selected = fetchAll(cfg);
+    const bundle = parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value);
+    const written = installAwsProfiles(bundle);
+
+    if (written.length === 0) {
+      console.log(
+        `no AWS profiles written — ${BOOTSTRAP_KEY} is absent, unparseable, ` +
+          `or declares no profile carrying a roleArn.`
+      );
+      return;
+    }
+    console.log(
+      `wrote ${written.length} AWS profile(s): ${written.join(", ")}`
+    );
+    console.log(
+      `  Sourced from a long-lived key pair in ~/.aws/credentials. Existing\n` +
+        `  sections were preserved — only the lisa-managed block was replaced.\n` +
+        `  Use them explicitly: aws --profile ${written[0]} ...`
+    );
+    return;
+  }
+
   if (process.argv.includes("--dry-run")) {
     const selected = fetchAll(cfg);
     // Derive here too, or the preview lies in the one place it matters most:
@@ -314,10 +414,20 @@ function main() {
   const { count, derived, dir } = materialize(cfg);
   console.log(`materialized ${count} secret(s) and their notes into ${dir}`);
   if (derived > 0) {
-    // Said out loud: this run exported variables the host may also have set.
+    // Do not claim an override this does not perform.
+    //
+    // This line used to end "overriding any ambient value". That was true when
+    // the key pair was exported and stopped being true when the pair moved into
+    // ~/.aws and AWS_PROFILE took its place — AWS_PROFILE loses to ambient
+    // environment credentials, it does not beat them. The stale sentence sent
+    // two separate investigations after a credential problem that did not
+    // exist, while the real fault was that nothing sourced the file. A message
+    // that overclaims costs more than no message.
     console.log(
-      `  ${derived} AWS variable(s) derived from the bootstrap bundle, ` +
-        `overriding any ambient value`
+      `  ${derived} AWS variable(s) derived from the bootstrap bundle. ` +
+        `These take\n  effect only in a shell that sourced the materialized ` +
+        `env file; ambient\n  credentials outrank AWS_PROFILE, so prefer an ` +
+        `explicit --profile.`
     );
   }
 }

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -191,6 +191,38 @@ export function installProfileSourcing(valuesFile, options = {}) {
  * @param {object} [options] Home directory and file seams, for tests.
  * @returns {string[]} The profile names written.
  */
+/**
+ * Profile names already defined OUTSIDE this module's managed block.
+ *
+ * Only what lies outside the block counts: our own previous output is meant to
+ * be replaced, and treating it as a collision would make the second run fail.
+ * @param {string} dir The `.aws` directory.
+ * @param {string[]} names Profile names about to be written.
+ * @param {object} io `exists` and `read` seams.
+ * @returns {string[]} Colliding names, in the order given.
+ */
+export function collidingProfiles(dir, names, io = {}) {
+  const { exists = existsSync, read = readFileSync } = io;
+  const file = join(dir, "config");
+  if (!exists(file)) return [];
+
+  const text = String(read(file, "utf8"));
+  const start = text.indexOf(MANAGED_MARKER);
+  const endAt = start === -1 ? -1 : text.indexOf(MANAGED_END, start);
+  const outside =
+    start === -1
+      ? text
+      : text.slice(0, start) +
+        (endAt === -1 ? "" : text.slice(endAt + MANAGED_END.length));
+
+  return names.filter(name =>
+    new RegExp(
+      `^\\s*\\[profile\\s+${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\]`,
+      "m"
+    ).test(outside)
+  );
+}
+
 export function installAwsProfiles(bundle, options = {}) {
   const {
     home = process.env.HOME || homedir(),
@@ -205,6 +237,33 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
+
+  // Refuse to write a profile name the operator already uses outside our block.
+  //
+  // AWS does not error on a duplicate `[profile x]` — it resolves one and
+  // ignores the other. So writing `tunnl-dev` next to an operator's existing SSO
+  // `tunnl-dev` would silently run some calls as the wrong identity, which is
+  // worse than either winning outright. Merging protects their sections from
+  // being deleted; this protects them from being shadowed.
+  //
+  // Deliberately not resolved by renaming theirs: this module writes its own
+  // block and nothing else. The operator renames (conventionally to `-sso`) and
+  // re-runs.
+  const collisions = collidingProfiles(dir, rendered.profiles, {
+    exists,
+    read,
+  });
+  if (collisions.length > 0) {
+    throw new Error(
+      `~/.aws/config already defines ${collisions.map(n => `"${n}"`).join(", ")} ` +
+        `outside the lisa-managed block.\n` +
+        `Writing them would create duplicate sections, and AWS resolves only ` +
+        `one — some calls would silently use the wrong identity.\n` +
+        `Rename the existing entries (for example to "${collisions[0]}-sso") ` +
+        `and run this again.`
+    );
+  }
+
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
 
@@ -297,6 +356,47 @@ export function materialize(cfg = readConfig()) {
 
 function main() {
   const cfg = readConfig();
+
+  // `--aws-profiles-only` writes ~/.aws and NOTHING else, on any surface.
+  //
+  // A laptop refuses to materialize secrets to disk, deliberately: read-through
+  // to the provider adds no drift and leaves no copy. That rule is about the
+  // thirteen values in secrets.env, and it stays exactly as it was here.
+  //
+  // The AWS profiles are a different bargain, requested explicitly. Agents
+  // working on a developer's machine should act as RemoteAgent rather than
+  // borrowing the human's SSO identity — separate attribution in CloudTrail,
+  // the role's blast radius instead of a person's, and the same `agent-*`
+  // profile names as a container so a script does not need two vocabularies.
+  //
+  // The cost is real and belongs in the open: `source_profile` needs a
+  // long-lived key pair, so this writes one to a machine that is not
+  // disposable, which is the thing the local surface otherwise prevents. It is
+  // therefore opt-in per run, never automatic, and never part of a normal
+  // materialize.
+  if (process.argv.includes("--aws-profiles-only")) {
+    const selected = fetchAll(cfg);
+    const bundle = parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value);
+    const written = installAwsProfiles(bundle);
+
+    if (written.length === 0) {
+      console.log(
+        `no AWS profiles written — ${BOOTSTRAP_KEY} is absent, unparseable, ` +
+          `or declares no profile carrying a roleArn.`
+      );
+      return;
+    }
+    console.log(
+      `wrote ${written.length} AWS profile(s): ${written.join(", ")}`
+    );
+    console.log(
+      `  Sourced from a long-lived key pair in ~/.aws/credentials. Existing\n` +
+        `  sections were preserved — only the lisa-managed block was replaced.\n` +
+        `  Use them explicitly: aws --profile ${written[0]} ...`
+    );
+    return;
+  }
+
   if (process.argv.includes("--dry-run")) {
     const selected = fetchAll(cfg);
     // Derive here too, or the preview lies in the one place it matters most:
@@ -314,10 +414,20 @@ function main() {
   const { count, derived, dir } = materialize(cfg);
   console.log(`materialized ${count} secret(s) and their notes into ${dir}`);
   if (derived > 0) {
-    // Said out loud: this run exported variables the host may also have set.
+    // Do not claim an override this does not perform.
+    //
+    // This line used to end "overriding any ambient value". That was true when
+    // the key pair was exported and stopped being true when the pair moved into
+    // ~/.aws and AWS_PROFILE took its place — AWS_PROFILE loses to ambient
+    // environment credentials, it does not beat them. The stale sentence sent
+    // two separate investigations after a credential problem that did not
+    // exist, while the real fault was that nothing sourced the file. A message
+    // that overclaims costs more than no message.
     console.log(
-      `  ${derived} AWS variable(s) derived from the bootstrap bundle, ` +
-        `overriding any ambient value`
+      `  ${derived} AWS variable(s) derived from the bootstrap bundle. ` +
+        `These take\n  effect only in a shell that sourced the materialized ` +
+        `env file; ambient\n  credentials outrank AWS_PROFILE, so prefer an ` +
+        `explicit --profile.`
     );
   }
 }

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -191,6 +191,38 @@ export function installProfileSourcing(valuesFile, options = {}) {
  * @param {object} [options] Home directory and file seams, for tests.
  * @returns {string[]} The profile names written.
  */
+/**
+ * Profile names already defined OUTSIDE this module's managed block.
+ *
+ * Only what lies outside the block counts: our own previous output is meant to
+ * be replaced, and treating it as a collision would make the second run fail.
+ * @param {string} dir The `.aws` directory.
+ * @param {string[]} names Profile names about to be written.
+ * @param {object} io `exists` and `read` seams.
+ * @returns {string[]} Colliding names, in the order given.
+ */
+export function collidingProfiles(dir, names, io = {}) {
+  const { exists = existsSync, read = readFileSync } = io;
+  const file = join(dir, "config");
+  if (!exists(file)) return [];
+
+  const text = String(read(file, "utf8"));
+  const start = text.indexOf(MANAGED_MARKER);
+  const endAt = start === -1 ? -1 : text.indexOf(MANAGED_END, start);
+  const outside =
+    start === -1
+      ? text
+      : text.slice(0, start) +
+        (endAt === -1 ? "" : text.slice(endAt + MANAGED_END.length));
+
+  return names.filter(name =>
+    new RegExp(
+      `^\\s*\\[profile\\s+${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\]`,
+      "m"
+    ).test(outside)
+  );
+}
+
 export function installAwsProfiles(bundle, options = {}) {
   const {
     home = process.env.HOME || homedir(),
@@ -205,6 +237,33 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
+
+  // Refuse to write a profile name the operator already uses outside our block.
+  //
+  // AWS does not error on a duplicate `[profile x]` — it resolves one and
+  // ignores the other. So writing `tunnl-dev` next to an operator's existing SSO
+  // `tunnl-dev` would silently run some calls as the wrong identity, which is
+  // worse than either winning outright. Merging protects their sections from
+  // being deleted; this protects them from being shadowed.
+  //
+  // Deliberately not resolved by renaming theirs: this module writes its own
+  // block and nothing else. The operator renames (conventionally to `-sso`) and
+  // re-runs.
+  const collisions = collidingProfiles(dir, rendered.profiles, {
+    exists,
+    read,
+  });
+  if (collisions.length > 0) {
+    throw new Error(
+      `~/.aws/config already defines ${collisions.map(n => `"${n}"`).join(", ")} ` +
+        `outside the lisa-managed block.\n` +
+        `Writing them would create duplicate sections, and AWS resolves only ` +
+        `one — some calls would silently use the wrong identity.\n` +
+        `Rename the existing entries (for example to "${collisions[0]}-sso") ` +
+        `and run this again.`
+    );
+  }
+
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
 
@@ -297,6 +356,47 @@ export function materialize(cfg = readConfig()) {
 
 function main() {
   const cfg = readConfig();
+
+  // `--aws-profiles-only` writes ~/.aws and NOTHING else, on any surface.
+  //
+  // A laptop refuses to materialize secrets to disk, deliberately: read-through
+  // to the provider adds no drift and leaves no copy. That rule is about the
+  // thirteen values in secrets.env, and it stays exactly as it was here.
+  //
+  // The AWS profiles are a different bargain, requested explicitly. Agents
+  // working on a developer's machine should act as RemoteAgent rather than
+  // borrowing the human's SSO identity — separate attribution in CloudTrail,
+  // the role's blast radius instead of a person's, and the same `agent-*`
+  // profile names as a container so a script does not need two vocabularies.
+  //
+  // The cost is real and belongs in the open: `source_profile` needs a
+  // long-lived key pair, so this writes one to a machine that is not
+  // disposable, which is the thing the local surface otherwise prevents. It is
+  // therefore opt-in per run, never automatic, and never part of a normal
+  // materialize.
+  if (process.argv.includes("--aws-profiles-only")) {
+    const selected = fetchAll(cfg);
+    const bundle = parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value);
+    const written = installAwsProfiles(bundle);
+
+    if (written.length === 0) {
+      console.log(
+        `no AWS profiles written — ${BOOTSTRAP_KEY} is absent, unparseable, ` +
+          `or declares no profile carrying a roleArn.`
+      );
+      return;
+    }
+    console.log(
+      `wrote ${written.length} AWS profile(s): ${written.join(", ")}`
+    );
+    console.log(
+      `  Sourced from a long-lived key pair in ~/.aws/credentials. Existing\n` +
+        `  sections were preserved — only the lisa-managed block was replaced.\n` +
+        `  Use them explicitly: aws --profile ${written[0]} ...`
+    );
+    return;
+  }
+
   if (process.argv.includes("--dry-run")) {
     const selected = fetchAll(cfg);
     // Derive here too, or the preview lies in the one place it matters most:
@@ -314,10 +414,20 @@ function main() {
   const { count, derived, dir } = materialize(cfg);
   console.log(`materialized ${count} secret(s) and their notes into ${dir}`);
   if (derived > 0) {
-    // Said out loud: this run exported variables the host may also have set.
+    // Do not claim an override this does not perform.
+    //
+    // This line used to end "overriding any ambient value". That was true when
+    // the key pair was exported and stopped being true when the pair moved into
+    // ~/.aws and AWS_PROFILE took its place — AWS_PROFILE loses to ambient
+    // environment credentials, it does not beat them. The stale sentence sent
+    // two separate investigations after a credential problem that did not
+    // exist, while the real fault was that nothing sourced the file. A message
+    // that overclaims costs more than no message.
     console.log(
-      `  ${derived} AWS variable(s) derived from the bootstrap bundle, ` +
-        `overriding any ambient value`
+      `  ${derived} AWS variable(s) derived from the bootstrap bundle. ` +
+        `These take\n  effect only in a shell that sourced the materialized ` +
+        `env file; ambient\n  credentials outrank AWS_PROFILE, so prefer an ` +
+        `explicit --profile.`
     );
   }
 }

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -191,6 +191,38 @@ export function installProfileSourcing(valuesFile, options = {}) {
  * @param {object} [options] Home directory and file seams, for tests.
  * @returns {string[]} The profile names written.
  */
+/**
+ * Profile names already defined OUTSIDE this module's managed block.
+ *
+ * Only what lies outside the block counts: our own previous output is meant to
+ * be replaced, and treating it as a collision would make the second run fail.
+ * @param {string} dir The `.aws` directory.
+ * @param {string[]} names Profile names about to be written.
+ * @param {object} io `exists` and `read` seams.
+ * @returns {string[]} Colliding names, in the order given.
+ */
+export function collidingProfiles(dir, names, io = {}) {
+  const { exists = existsSync, read = readFileSync } = io;
+  const file = join(dir, "config");
+  if (!exists(file)) return [];
+
+  const text = String(read(file, "utf8"));
+  const start = text.indexOf(MANAGED_MARKER);
+  const endAt = start === -1 ? -1 : text.indexOf(MANAGED_END, start);
+  const outside =
+    start === -1
+      ? text
+      : text.slice(0, start) +
+        (endAt === -1 ? "" : text.slice(endAt + MANAGED_END.length));
+
+  return names.filter(name =>
+    new RegExp(
+      `^\\s*\\[profile\\s+${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\]`,
+      "m"
+    ).test(outside)
+  );
+}
+
 export function installAwsProfiles(bundle, options = {}) {
   const {
     home = process.env.HOME || homedir(),
@@ -205,6 +237,33 @@ export function installAwsProfiles(bundle, options = {}) {
   if (!rendered) return [];
 
   const dir = join(home, ".aws");
+
+  // Refuse to write a profile name the operator already uses outside our block.
+  //
+  // AWS does not error on a duplicate `[profile x]` — it resolves one and
+  // ignores the other. So writing `tunnl-dev` next to an operator's existing SSO
+  // `tunnl-dev` would silently run some calls as the wrong identity, which is
+  // worse than either winning outright. Merging protects their sections from
+  // being deleted; this protects them from being shadowed.
+  //
+  // Deliberately not resolved by renaming theirs: this module writes its own
+  // block and nothing else. The operator renames (conventionally to `-sso`) and
+  // re-runs.
+  const collisions = collidingProfiles(dir, rendered.profiles, {
+    exists,
+    read,
+  });
+  if (collisions.length > 0) {
+    throw new Error(
+      `~/.aws/config already defines ${collisions.map(n => `"${n}"`).join(", ")} ` +
+        `outside the lisa-managed block.\n` +
+        `Writing them would create duplicate sections, and AWS resolves only ` +
+        `one — some calls would silently use the wrong identity.\n` +
+        `Rename the existing entries (for example to "${collisions[0]}-sso") ` +
+        `and run this again.`
+    );
+  }
+
   mkdir(dir, { recursive: true, mode: 0o700 });
   chmod(dir, 0o700);
 
@@ -297,6 +356,47 @@ export function materialize(cfg = readConfig()) {
 
 function main() {
   const cfg = readConfig();
+
+  // `--aws-profiles-only` writes ~/.aws and NOTHING else, on any surface.
+  //
+  // A laptop refuses to materialize secrets to disk, deliberately: read-through
+  // to the provider adds no drift and leaves no copy. That rule is about the
+  // thirteen values in secrets.env, and it stays exactly as it was here.
+  //
+  // The AWS profiles are a different bargain, requested explicitly. Agents
+  // working on a developer's machine should act as RemoteAgent rather than
+  // borrowing the human's SSO identity — separate attribution in CloudTrail,
+  // the role's blast radius instead of a person's, and the same `agent-*`
+  // profile names as a container so a script does not need two vocabularies.
+  //
+  // The cost is real and belongs in the open: `source_profile` needs a
+  // long-lived key pair, so this writes one to a machine that is not
+  // disposable, which is the thing the local surface otherwise prevents. It is
+  // therefore opt-in per run, never automatic, and never part of a normal
+  // materialize.
+  if (process.argv.includes("--aws-profiles-only")) {
+    const selected = fetchAll(cfg);
+    const bundle = parseBootstrap(selected.get(BOOTSTRAP_KEY)?.value);
+    const written = installAwsProfiles(bundle);
+
+    if (written.length === 0) {
+      console.log(
+        `no AWS profiles written — ${BOOTSTRAP_KEY} is absent, unparseable, ` +
+          `or declares no profile carrying a roleArn.`
+      );
+      return;
+    }
+    console.log(
+      `wrote ${written.length} AWS profile(s): ${written.join(", ")}`
+    );
+    console.log(
+      `  Sourced from a long-lived key pair in ~/.aws/credentials. Existing\n` +
+        `  sections were preserved — only the lisa-managed block was replaced.\n` +
+        `  Use them explicitly: aws --profile ${written[0]} ...`
+    );
+    return;
+  }
+
   if (process.argv.includes("--dry-run")) {
     const selected = fetchAll(cfg);
     // Derive here too, or the preview lies in the one place it matters most:
@@ -314,10 +414,20 @@ function main() {
   const { count, derived, dir } = materialize(cfg);
   console.log(`materialized ${count} secret(s) and their notes into ${dir}`);
   if (derived > 0) {
-    // Said out loud: this run exported variables the host may also have set.
+    // Do not claim an override this does not perform.
+    //
+    // This line used to end "overriding any ambient value". That was true when
+    // the key pair was exported and stopped being true when the pair moved into
+    // ~/.aws and AWS_PROFILE took its place — AWS_PROFILE loses to ambient
+    // environment credentials, it does not beat them. The stale sentence sent
+    // two separate investigations after a credential problem that did not
+    // exist, while the real fault was that nothing sourced the file. A message
+    // that overclaims costs more than no message.
     console.log(
-      `  ${derived} AWS variable(s) derived from the bootstrap bundle, ` +
-        `overriding any ambient value`
+      `  ${derived} AWS variable(s) derived from the bootstrap bundle. ` +
+        `These take\n  effect only in a shell that sourced the materialized ` +
+        `env file; ambient\n  credentials outrank AWS_PROFILE, so prefer an ` +
+        `explicit --profile.`
     );
   }
 }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1107,7 +1107,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/envfile.mjs":
       "be4e38ce85f9268b52b29dbde264ecd8d50973c2b63a15410336234a921d9644",
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs":
-      "0d214c16fa3e2d905e6ebd75c00710f9ec43449fd2337f2dca0b35833bb91f76",
+      "d74faf4f3d309f2bfb15c64386d2e28c811e958cd0d59fe24aa4b51e645a39ef",
     "plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs":
       "fec38ca937570c1e1c21e6e8f7314a9d8f4e9264779d0394b40d5158924da0da",
     "plugins/src/base/skills/lisa-secrets-access/scripts/read-secret-note.mjs":
@@ -8488,6 +8488,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/work-item-tracker-unreachable.test.ts": true,
     "tests/unit/secrets/automation-workflow.test.ts": true,
     "tests/unit/secrets/aws-bootstrap-derivation.test.ts": true,
+    "tests/unit/secrets/aws-profile-collisions.test.ts": true,
     "tests/unit/secrets/aws-profiles-install.test.ts": true,
     "tests/unit/secrets/aws-profiles-permissions.test.ts": true,
     "tests/unit/secrets/aws-profiles.test.ts": true,
@@ -8496,6 +8497,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/detect-tooling.test.ts": true,
     "tests/unit/secrets/doctor-secrets.test.ts": true,
     "tests/unit/secrets/install-method-conformance.test.ts": true,
+    "tests/unit/secrets/local-aws-profiles.test.ts": true,
     "tests/unit/secrets/local-env-command.test.ts": true,
     "tests/unit/secrets/profile-sourcing.test.ts": true,
     "tests/unit/secrets/remote-dispatch-claude-web.test.ts": true,

--- a/tests/unit/secrets/aws-profile-collisions.test.ts
+++ b/tests/unit/secrets/aws-profile-collisions.test.ts
@@ -1,0 +1,157 @@
+/**
+ * A profile name already used outside our block must stop the write.
+ *
+ * AWS does not error on a duplicate `[profile x]` — it resolves one and ignores
+ * the other. So writing a name an operator already uses would silently run some
+ * calls as the wrong identity, which is worse than either side winning
+ * outright: the file looks right and behaves wrongly.
+ *
+ * Merging protects the operator's sections from deletion; this protects them
+ * from being shadowed. The module never renames theirs — it writes its own block
+ * and nothing else, so the operator resolves the clash and re-runs.
+ * @module tests/unit/secrets/aws-profile-collisions
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  collidingProfiles,
+  installAwsProfiles,
+} from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs";
+
+/** The suffixed agent profile name, which cannot clash with SSO. */
+const STATIC_NAME = "tunnl-dev-static";
+
+/** Scratch homes to remove. */
+const homes: string[] = [];
+
+/** Where the config lands, relative to home. */
+const CONFIG = ".aws/config";
+
+/** An operator's own SSO profile, using a name the bundle also declares. */
+const THEIRS = [
+  "[sso-session tunnl]",
+  "sso_start_url = https://example.awsapps.com/start",
+  "",
+  "[profile tunnl-dev]",
+  "sso_session = tunnl",
+  "",
+].join("\n");
+
+/** A bundle whose profile names clash with the operator's. */
+const CLASHING = {
+  accessKeyId: "AKIAEXAMPLE",
+  secretAccessKey: "s3cret",
+  profiles: {
+    "tunnl-dev": { roleArn: "arn:aws:iam::905179307867:role/RemoteAgent" },
+  },
+};
+
+/** A bundle using the suffixed scheme, which cannot clash. */
+const SUFFIXED = {
+  accessKeyId: "AKIAEXAMPLE",
+  secretAccessKey: "s3cret",
+  profiles: {
+    [STATIC_NAME]: {
+      roleArn: "arn:aws:iam::905179307867:role/RemoteAgent",
+    },
+  },
+};
+
+afterEach(() => {
+  while (homes.length > 0) {
+    rmSync(homes.pop() as string, { recursive: true, force: true });
+  }
+});
+
+/**
+ * A home holding the operator's config.
+ * @returns Its path.
+ */
+function homeWithTheirs(): string {
+  const home = mkdtempSync(path.join(tmpdir(), "lisa-collide-"));
+  homes.push(home);
+  mkdirSync(path.join(home, ".aws"), { recursive: true });
+  writeFileSync(path.join(home, CONFIG), THEIRS);
+  return home;
+}
+
+describe("collidingProfiles", () => {
+  it("reports a name defined outside the managed block", () => {
+    const home = homeWithTheirs();
+
+    expect(collidingProfiles(path.join(home, ".aws"), ["tunnl-dev"])).toEqual([
+      "tunnl-dev",
+    ]);
+  });
+
+  it("ignores names that only exist INSIDE our own block", () => {
+    // Our previous output is meant to be replaced. Counting it would make the
+    // second run of an unchanged config fail.
+    const home = homeWithTheirs();
+    installAwsProfiles(SUFFIXED, { home });
+
+    expect(collidingProfiles(path.join(home, ".aws"), [STATIC_NAME])).toEqual(
+      []
+    );
+  });
+
+  it("does not match a different profile that merely shares a prefix", () => {
+    const home = homeWithTheirs();
+
+    expect(collidingProfiles(path.join(home, ".aws"), [STATIC_NAME])).toEqual(
+      []
+    );
+  });
+
+  it("returns nothing when no config exists yet", () => {
+    const home = mkdtempSync(path.join(tmpdir(), "lisa-collide-"));
+    homes.push(home);
+
+    expect(collidingProfiles(path.join(home, ".aws"), ["tunnl-dev"])).toEqual(
+      []
+    );
+  });
+});
+
+describe("installAwsProfiles refuses a colliding write", () => {
+  it("throws, names the collision, and suggests a rename", () => {
+    const home = homeWithTheirs();
+
+    expect(() => installAwsProfiles(CLASHING, { home })).toThrow(
+      /already defines "tunnl-dev"/
+    );
+  });
+
+  it("leaves the operator's file byte-identical when it refuses", () => {
+    // A guard that half-wrote would be worse than no guard.
+    const home = homeWithTheirs();
+
+    expect(() => installAwsProfiles(CLASHING, { home })).toThrow();
+    expect(readFileSync(path.join(home, CONFIG), "utf8")).toBe(THEIRS);
+  });
+
+  it("writes cleanly when the suffixed scheme avoids the clash", () => {
+    // The reason the `-static` naming exists: no rename, no collision, and the
+    // operator's SSO profiles are never touched.
+    const home = homeWithTheirs();
+
+    expect(installAwsProfiles(SUFFIXED, { home })).toEqual([
+      "tunnl-dev-static",
+    ]);
+
+    const config = readFileSync(path.join(home, CONFIG), "utf8");
+    expect(config).toContain("[profile tunnl-dev]");
+    expect(config).toContain("[profile tunnl-dev-static]");
+  });
+});

--- a/tests/unit/secrets/local-aws-profiles.test.ts
+++ b/tests/unit/secrets/local-aws-profiles.test.ts
@@ -1,0 +1,138 @@
+/**
+ * `--aws-profiles-only` writes `~/.aws` and nothing else, on any surface.
+ *
+ * A laptop refuses to materialize secrets to disk — read-through to the provider
+ * adds no drift and leaves no copy. That rule governs the values in
+ * `secrets.env` and is unchanged here.
+ *
+ * The AWS profiles are a separate, explicitly requested bargain: agents working
+ * on a developer's machine should act as `RemoteAgent` rather than borrow the
+ * human's SSO identity, giving separate CloudTrail attribution, the role's blast
+ * radius instead of a person's, and the same `agent-*` names a container uses.
+ *
+ * The cost is that `source_profile` needs a long-lived key pair on a machine
+ * that is not disposable. That is why this mode is per-run and never part of a
+ * normal materialize — the tests below pin exactly that boundary.
+ * @module tests/unit/secrets/local-aws-profiles
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { installAwsProfiles } from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs";
+
+/** Scratch homes to remove. */
+const homes: string[] = [];
+
+/** The developer's SSO session block, which must survive untouched. */
+const SSO_SECTION = "[sso-session tunnl]";
+
+/** Where the merged config lands, relative to home. */
+const CONFIG = ".aws/config";
+
+/** A developer's own SSO config, which must survive untouched. */
+const THEIRS = [
+  SSO_SECTION,
+  "sso_start_url = https://example.awsapps.com/start",
+  "",
+  "[profile tunnl-dev]",
+  "sso_session = tunnl",
+  "sso_account_id = 905179307867",
+  "",
+].join("\n");
+
+/** The bundle, shaped as the real one stores it. */
+const BUNDLE = {
+  accessKeyId: "AKIAEXAMPLE",
+  secretAccessKey: "s3cret",
+  externalId: "ext-1",
+  profiles: {
+    "agent-dev": {
+      roleArn: "arn:aws:iam::905179307867:role/RemoteAgent",
+      region: "us-east-1",
+    },
+    "agent-production": {
+      roleArn: "arn:aws:iam::002889194405:role/RemoteAgent",
+    },
+  },
+};
+
+afterEach(() => {
+  while (homes.length > 0) {
+    rmSync(homes.pop() as string, { recursive: true, force: true });
+  }
+});
+
+/**
+ * A home holding a developer's existing SSO config.
+ * @returns Its path.
+ */
+function homeWithSso(): string {
+  const home = mkdtempSync(path.join(tmpdir(), "lisa-localaws-"));
+  homes.push(home);
+  mkdirSync(path.join(home, ".aws"), { recursive: true });
+  writeFileSync(path.join(home, CONFIG), THEIRS);
+  return home;
+}
+
+describe("agent profiles alongside a developer's SSO config", () => {
+  it("adds the agent profiles without disturbing the SSO ones", () => {
+    // The laptop case that makes this dangerous: 20+ sections across several
+    // tenants, none of which this wrote.
+    const home = homeWithSso();
+
+    expect(installAwsProfiles(BUNDLE, { home })).toEqual([
+      "agent-dev",
+      "agent-production",
+    ]);
+
+    const config = readFileSync(path.join(home, CONFIG), "utf8");
+    expect(config).toContain(SSO_SECTION);
+    expect(config).toContain("[profile tunnl-dev]");
+    expect(config).toContain("sso_account_id = 905179307867");
+    expect(config).toContain("[profile agent-dev]");
+  });
+
+  it("never writes a [default] profile", () => {
+    // A `default` would be picked up by any call naming no profile, silently
+    // running as the assume-only identity instead of the human's SSO.
+    const home = homeWithSso();
+    installAwsProfiles(BUNDLE, { home });
+
+    const config = readFileSync(path.join(home, CONFIG), "utf8");
+    const credentials = readFileSync(
+      path.join(home, ".aws/credentials"),
+      "utf8"
+    );
+    expect(config).not.toContain("[default]");
+    expect(credentials).not.toContain("[default]");
+  });
+
+  it("does not write the materialized secrets file", () => {
+    // The local no-copy-on-disk rule is unchanged: this mode writes ~/.aws only.
+    const home = homeWithSso();
+    installAwsProfiles(BUNDLE, { home });
+
+    expect(existsSync(path.join(home, ".config"))).toBe(false);
+  });
+
+  it("re-running replaces its block rather than accumulating", () => {
+    const home = homeWithSso();
+    installAwsProfiles(BUNDLE, { home });
+    installAwsProfiles(BUNDLE, { home });
+
+    const config = readFileSync(path.join(home, CONFIG), "utf8");
+    expect(config.split("[profile agent-dev]").length - 1).toBe(1);
+    expect(config).toContain(SSO_SECTION);
+  });
+});


### PR DESCRIPTION
Agents working on a developer laptop currently have no AWS identity of their
own. The machine has SSO profiles (`tunnl-dev`, ...) that are the HUMAN, and
nothing writes the `agent-*` profiles a container gets.

So an agent either borrows the human SSO session — wrong attribution in
CloudTrail, a person blast radius instead of a role — or has no access at all.
Scripts also need two vocabularies, because container profiles are `agent-dev`
and laptop profiles are `tunnl-dev`.

## Requested behaviour

Write the same `agent-*` profiles locally, sourced from the bootstrap key pair,
so `aws --profile agent-dev` behaves identically on a laptop and in a container.

## The tradeoff, stated in the open

`source_profile` needs a long-lived key pair, so this writes one to a machine
that is not disposable — exactly what the local surface refuses to do for
`secrets.env`. That refusal is unchanged; this is a separate, explicit,
per-run action rather than part of any normal materialize.

The operator weighed this and chose it over sourcing from their SSO session
(which would need the RemoteAgent trust policy to accept an SSO principal).

## Scope

- `--aws-profiles-only` writes `~/.aws` and nothing else, on any surface
- merged into the managed block, so 20+ existing SSO sections survive
- never writes `[default]`, which a profile-less call would silently pick up
- never writes `secrets.env` locally

## Naming: the `-static` suffix

The agent profiles are named `<tenant>-<env>-static`, not `agent-<env>` and not
the operator's existing `<tenant>-<env>`.

Naming them the same as the SSO profiles would mean one name meaning two
identities depending on which machine you are on — the exact ambiguity that made
this whole area expensive to debug. `-static` names the credential TYPE (a
long-lived key pair assuming RemoteAgent, as opposed to SSO), reads explicitly
at every call site, and requires no rename of anything the operator owns.

## Collision guard

AWS does not error on a duplicate `[profile x]` — it resolves one and ignores
the other, so some calls would silently use the wrong identity. The writer now
refuses when a name already exists OUTSIDE the managed block, names the clashes,
and suggests a rename. Our own previous block is not a collision, or the second
run of an unchanged config would fail.

Proved against a copy of a real developer config (20+ sections, three tenants):
it refuses with `tunnl-dev`/`tunnl-staging` names and writes cleanly once those
are distinct.

Full suite green: 8903 passed, 535 files.

---

Work-Item: CodySwannGT/lisa#2328
