### PR TITLE
fix(sonar): make the resolver deadline stop the work, not just the waiting

### DIFF
--- a/all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh
@@ -81,11 +81,37 @@ is_inactive() {
 # `read -t` supplies the ceiling. `timeout` is absent on a stock macOS and
 # `coproc` needs Bash 4 (the hooks run under /bin/bash 3.2 there), so this is the
 # portable form. A timeout leaves `value` empty, which the caller treats as "the
-# provider had nothing" — the warn path, never a block. `|| true` because `read`
-# also reports failure at EOF on the resolver's deliberately unterminated output.
+# provider had nothing" — the warn path, never a block.
+#
+# Giving up on the read is not the same as stopping the work: a resolver blocked
+# on the network otherwise outlives the hook that started it, and this runs in
+# front of every prompt and every file read. So the child is killed and reaped,
+# which requires knowing its PID — and that is why the transport is a FIFO and
+# not the process substitution this function used to read from.
+#
+# On /bin/bash 3.2, `$!` after `< <(cmd)` is the SHELL'S OWN PID, not the
+# substitution's child (verified: the child's PPID is the shell, and `$!` equals
+# the shell). A `kill -9 "$!"` there tells the hook to kill itself. Backgrounding
+# the resolver explicitly is what makes `$!` mean the resolver.
+#
+# The FIFO is a rendezvous, not storage: a named pipe holds no data at rest, so
+# the value still never lands on disk (CWE-922) and a kill at any point leaves an
+# empty pipe behind rather than a readable token. The directory is `mktemp -d`,
+# which is 0700.
 resolve_secret() {
-  local resolver="$1" name="$2" value=""
-  IFS= read -r -t 10 value < <(node "$resolver" get "$name" 2>/dev/null) || true
+  local resolver="$1" name="$2" value="" child="" dir="" fifo=""
+  dir="$(mktemp -d)" || return 0
+  fifo="$dir/resolver"
+  if ! mkfifo -m 600 "$fifo" 2>/dev/null; then
+    rm -rf "$dir"
+    return 0
+  fi
+  node "$resolver" get "$name" >"$fifo" 2>/dev/null &
+  child=$!
+  IFS= read -r -t 10 value < "$fifo" || true
+  kill -9 "$child" 2>/dev/null
+  wait "$child" 2>/dev/null
+  rm -rf "$dir"
   printf '%s' "$value"
 }
 

--- a/plugins/lisa-copilot/hooks/sonar-secrets.sh
+++ b/plugins/lisa-copilot/hooks/sonar-secrets.sh
@@ -81,11 +81,37 @@ is_inactive() {
 # `read -t` supplies the ceiling. `timeout` is absent on a stock macOS and
 # `coproc` needs Bash 4 (the hooks run under /bin/bash 3.2 there), so this is the
 # portable form. A timeout leaves `value` empty, which the caller treats as "the
-# provider had nothing" — the warn path, never a block. `|| true` because `read`
-# also reports failure at EOF on the resolver's deliberately unterminated output.
+# provider had nothing" — the warn path, never a block.
+#
+# Giving up on the read is not the same as stopping the work: a resolver blocked
+# on the network otherwise outlives the hook that started it, and this runs in
+# front of every prompt and every file read. So the child is killed and reaped,
+# which requires knowing its PID — and that is why the transport is a FIFO and
+# not the process substitution this function used to read from.
+#
+# On /bin/bash 3.2, `$!` after `< <(cmd)` is the SHELL'S OWN PID, not the
+# substitution's child (verified: the child's PPID is the shell, and `$!` equals
+# the shell). A `kill -9 "$!"` there tells the hook to kill itself. Backgrounding
+# the resolver explicitly is what makes `$!` mean the resolver.
+#
+# The FIFO is a rendezvous, not storage: a named pipe holds no data at rest, so
+# the value still never lands on disk (CWE-922) and a kill at any point leaves an
+# empty pipe behind rather than a readable token. The directory is `mktemp -d`,
+# which is 0700.
 resolve_secret() {
-  local resolver="$1" name="$2" value=""
-  IFS= read -r -t 10 value < <(node "$resolver" get "$name" 2>/dev/null) || true
+  local resolver="$1" name="$2" value="" child="" dir="" fifo=""
+  dir="$(mktemp -d)" || return 0
+  fifo="$dir/resolver"
+  if ! mkfifo -m 600 "$fifo" 2>/dev/null; then
+    rm -rf "$dir"
+    return 0
+  fi
+  node "$resolver" get "$name" >"$fifo" 2>/dev/null &
+  child=$!
+  IFS= read -r -t 10 value < "$fifo" || true
+  kill -9 "$child" 2>/dev/null
+  wait "$child" 2>/dev/null
+  rm -rf "$dir"
   printf '%s' "$value"
 }
 

--- a/plugins/lisa-cursor/hooks/sonar-secrets.sh
+++ b/plugins/lisa-cursor/hooks/sonar-secrets.sh
@@ -81,11 +81,37 @@ is_inactive() {
 # `read -t` supplies the ceiling. `timeout` is absent on a stock macOS and
 # `coproc` needs Bash 4 (the hooks run under /bin/bash 3.2 there), so this is the
 # portable form. A timeout leaves `value` empty, which the caller treats as "the
-# provider had nothing" — the warn path, never a block. `|| true` because `read`
-# also reports failure at EOF on the resolver's deliberately unterminated output.
+# provider had nothing" — the warn path, never a block.
+#
+# Giving up on the read is not the same as stopping the work: a resolver blocked
+# on the network otherwise outlives the hook that started it, and this runs in
+# front of every prompt and every file read. So the child is killed and reaped,
+# which requires knowing its PID — and that is why the transport is a FIFO and
+# not the process substitution this function used to read from.
+#
+# On /bin/bash 3.2, `$!` after `< <(cmd)` is the SHELL'S OWN PID, not the
+# substitution's child (verified: the child's PPID is the shell, and `$!` equals
+# the shell). A `kill -9 "$!"` there tells the hook to kill itself. Backgrounding
+# the resolver explicitly is what makes `$!` mean the resolver.
+#
+# The FIFO is a rendezvous, not storage: a named pipe holds no data at rest, so
+# the value still never lands on disk (CWE-922) and a kill at any point leaves an
+# empty pipe behind rather than a readable token. The directory is `mktemp -d`,
+# which is 0700.
 resolve_secret() {
-  local resolver="$1" name="$2" value=""
-  IFS= read -r -t 10 value < <(node "$resolver" get "$name" 2>/dev/null) || true
+  local resolver="$1" name="$2" value="" child="" dir="" fifo=""
+  dir="$(mktemp -d)" || return 0
+  fifo="$dir/resolver"
+  if ! mkfifo -m 600 "$fifo" 2>/dev/null; then
+    rm -rf "$dir"
+    return 0
+  fi
+  node "$resolver" get "$name" >"$fifo" 2>/dev/null &
+  child=$!
+  IFS= read -r -t 10 value < "$fifo" || true
+  kill -9 "$child" 2>/dev/null
+  wait "$child" 2>/dev/null
+  rm -rf "$dir"
   printf '%s' "$value"
 }
 

--- a/plugins/lisa/hooks/sonar-secrets.sh
+++ b/plugins/lisa/hooks/sonar-secrets.sh
@@ -81,11 +81,37 @@ is_inactive() {
 # `read -t` supplies the ceiling. `timeout` is absent on a stock macOS and
 # `coproc` needs Bash 4 (the hooks run under /bin/bash 3.2 there), so this is the
 # portable form. A timeout leaves `value` empty, which the caller treats as "the
-# provider had nothing" — the warn path, never a block. `|| true` because `read`
-# also reports failure at EOF on the resolver's deliberately unterminated output.
+# provider had nothing" — the warn path, never a block.
+#
+# Giving up on the read is not the same as stopping the work: a resolver blocked
+# on the network otherwise outlives the hook that started it, and this runs in
+# front of every prompt and every file read. So the child is killed and reaped,
+# which requires knowing its PID — and that is why the transport is a FIFO and
+# not the process substitution this function used to read from.
+#
+# On /bin/bash 3.2, `$!` after `< <(cmd)` is the SHELL'S OWN PID, not the
+# substitution's child (verified: the child's PPID is the shell, and `$!` equals
+# the shell). A `kill -9 "$!"` there tells the hook to kill itself. Backgrounding
+# the resolver explicitly is what makes `$!` mean the resolver.
+#
+# The FIFO is a rendezvous, not storage: a named pipe holds no data at rest, so
+# the value still never lands on disk (CWE-922) and a kill at any point leaves an
+# empty pipe behind rather than a readable token. The directory is `mktemp -d`,
+# which is 0700.
 resolve_secret() {
-  local resolver="$1" name="$2" value=""
-  IFS= read -r -t 10 value < <(node "$resolver" get "$name" 2>/dev/null) || true
+  local resolver="$1" name="$2" value="" child="" dir="" fifo=""
+  dir="$(mktemp -d)" || return 0
+  fifo="$dir/resolver"
+  if ! mkfifo -m 600 "$fifo" 2>/dev/null; then
+    rm -rf "$dir"
+    return 0
+  fi
+  node "$resolver" get "$name" >"$fifo" 2>/dev/null &
+  child=$!
+  IFS= read -r -t 10 value < "$fifo" || true
+  kill -9 "$child" 2>/dev/null
+  wait "$child" 2>/dev/null
+  rm -rf "$dir"
   printf '%s' "$value"
 }
 

--- a/plugins/src/base/hooks/sonar-secrets.sh
+++ b/plugins/src/base/hooks/sonar-secrets.sh
@@ -81,11 +81,37 @@ is_inactive() {
 # `read -t` supplies the ceiling. `timeout` is absent on a stock macOS and
 # `coproc` needs Bash 4 (the hooks run under /bin/bash 3.2 there), so this is the
 # portable form. A timeout leaves `value` empty, which the caller treats as "the
-# provider had nothing" — the warn path, never a block. `|| true` because `read`
-# also reports failure at EOF on the resolver's deliberately unterminated output.
+# provider had nothing" — the warn path, never a block.
+#
+# Giving up on the read is not the same as stopping the work: a resolver blocked
+# on the network otherwise outlives the hook that started it, and this runs in
+# front of every prompt and every file read. So the child is killed and reaped,
+# which requires knowing its PID — and that is why the transport is a FIFO and
+# not the process substitution this function used to read from.
+#
+# On /bin/bash 3.2, `$!` after `< <(cmd)` is the SHELL'S OWN PID, not the
+# substitution's child (verified: the child's PPID is the shell, and `$!` equals
+# the shell). A `kill -9 "$!"` there tells the hook to kill itself. Backgrounding
+# the resolver explicitly is what makes `$!` mean the resolver.
+#
+# The FIFO is a rendezvous, not storage: a named pipe holds no data at rest, so
+# the value still never lands on disk (CWE-922) and a kill at any point leaves an
+# empty pipe behind rather than a readable token. The directory is `mktemp -d`,
+# which is 0700.
 resolve_secret() {
-  local resolver="$1" name="$2" value=""
-  IFS= read -r -t 10 value < <(node "$resolver" get "$name" 2>/dev/null) || true
+  local resolver="$1" name="$2" value="" child="" dir="" fifo=""
+  dir="$(mktemp -d)" || return 0
+  fifo="$dir/resolver"
+  if ! mkfifo -m 600 "$fifo" 2>/dev/null; then
+    rm -rf "$dir"
+    return 0
+  fi
+  node "$resolver" get "$name" >"$fifo" 2>/dev/null &
+  child=$!
+  IFS= read -r -t 10 value < "$fifo" || true
+  kill -9 "$child" 2>/dev/null
+  wait "$child" 2>/dev/null
+  rm -rf "$dir"
   printf '%s' "$value"
 }
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -19,7 +19,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh":
       "062c69eea85157f1e941ec3626d8912aa9f182af6ccdbe19687588a6074db5ce",
     "all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh":
-      "945453fb275a58aa7185e150e6b05e5810739750928ab5bd6edfbf87d1c8aa0d",
+      "bf4132e49ba18e2f7e941520c299c15aeeacfd220e489f3d2eb8397f2048157b",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
       "6a8be8577242588f14ab52b25b2a22b6def53aefa9513b4d3d7c49f4d8027079",
     "all/create-only/.claude/rules/PROJECT_RULES.md":
@@ -627,7 +627,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/shell-write-nudge.sh":
       "69839af423f8792b1e52c71097316c3264425553031627c0a2f9409a9d5becd0",
     "plugins/src/base/hooks/sonar-secrets.sh":
-      "945453fb275a58aa7185e150e6b05e5810739750928ab5bd6edfbf87d1c8aa0d",
+      "bf4132e49ba18e2f7e941520c299c15aeeacfd220e489f3d2eb8397f2048157b",
     "plugins/src/base/hooks/threshold-ratchet-compare.mjs":
       "4535a145c5c5cbee13bdf970bc91d390a264043604e607288cdd6bf28de56192",
     "plugins/src/base/hooks/threshold-ratchet-families.mjs":

--- a/tests/unit/hooks/sonar-secrets.test.ts
+++ b/tests/unit/hooks/sonar-secrets.test.ts
@@ -112,21 +112,41 @@ function stubSonar(whenAuthed: string): string {
  * @returns Path to the fake project root.
  */
 function projectWithResolver(token: string): string {
-  const root = mkdtempSync(path.join(tmpdir(), "lisa-sonar-proj-"));
-  const dir = path.join(
+  return checkoutWithResolver(
+    `process.stdout.write(${JSON.stringify(token)});\n`,
+    "lisa-sonar-proj-"
+  );
+}
+
+/**
+ * The first path the wrapper's resolver search checks, inside a fake checkout.
+ * @param root The fake checkout.
+ * @returns Absolute path to where `resolve-secret.mjs` must be planted.
+ */
+function resolverScriptPath(root: string): string {
+  return path.join(
     root,
     ".claude",
     "skills",
     "lisa-secrets-access",
-    "scripts"
+    "scripts",
+    "resolve-secret.mjs"
   );
+}
+
+/**
+ * A fresh checkout carrying a stub resolver with the given body.
+ * @param body Node source for the stub resolver.
+ * @param prefix Temp-directory prefix, so a failing run names itself.
+ * @returns Path to the fake checkout.
+ */
+function checkoutWithResolver(body: string, prefix: string): string {
+  const root = mkdtempSync(path.join(tmpdir(), prefix));
+  const script = resolverScriptPath(root);
 
   temporaries.push(root);
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(
-    path.join(dir, "resolve-secret.mjs"),
-    `process.stdout.write(${JSON.stringify(token)});\n`
-  );
+  mkdirSync(path.dirname(script), { recursive: true });
+  writeFileSync(script, body);
   return root;
 }
 
@@ -224,16 +244,21 @@ describe("the resolved value never reaches the filesystem", () => {
   // readable on disk. Process substitution has no path to leak, so this holds on
   // every exit path, signalled or not.
 
-  it("does not capture the resolver through a temp file at all", () => {
-    // The mechanism, pinned directly, because it is the whole guarantee: with
-    // no temp file there is no window between writing the token and deleting
-    // it, and therefore no termination for cleanup to lose a race against.
+  it("carries the value over a pipe, never a regular file", () => {
+    // The mechanism, pinned directly, because it is the whole guarantee. A FIFO
+    // holds no data at rest, so there is no window between writing the token
+    // and deleting it for a termination to land in. `mktemp -d` appears here —
+    // it makes the 0700 directory the FIFO lives in — so the pin is on the
+    // redirection target being a pipe, not on the absence of a temp path.
     const code = readFileSync(SOURCE, "utf8")
       .split("\n")
       .filter(line => !line.trimStart().startsWith("#"))
       .join("\n");
 
-    expect(code).not.toContain("mktemp");
+    expect(code).toContain("mkfifo");
+    expect(code).toContain('>"$fifo"');
+    // A bare `mktemp` (no -d) is the regular-file capture this replaced.
+    expect(code).not.toMatch(/mktemp(?!\s+-d)/u);
   });
 
   it("survives being killed mid-resolve without leaving the token behind", async () => {
@@ -244,23 +269,12 @@ describe("the resolved value never reaches the filesystem", () => {
     // implementation it exists to reject. Only files that appear during the run
     // are read, and only for a canary no other process emits.
     const before = new Set(readdirSync(tmpdir()));
-    const slow = mkdtempSync(path.join(tmpdir(), "lisa-sonar-slow-"));
-    const dir = path.join(
-      slow,
-      ".claude",
-      "skills",
-      "lisa-secrets-access",
-      "scripts"
-    );
-
-    temporaries.push(slow);
-    mkdirSync(dir, { recursive: true });
     // Emits the token, then holds the pipe open — so the kill lands squarely
-    // inside the window where a temp-file capture has already written it and
+    // inside the window where a regular-file capture has already written it and
     // not yet deleted it.
-    writeFileSync(
-      path.join(dir, "resolve-secret.mjs"),
-      'process.stdout.write("killed-run-token");\nsetTimeout(() => {}, 30000);\n'
+    const slow = checkoutWithResolver(
+      'process.stdout.write("killed-run-token");\nsetTimeout(() => {}, 30000);\n',
+      "lisa-sonar-slow-"
     );
 
     const child = spawn(BASH, [SOURCE, PROMPT_EVENT], {
@@ -295,6 +309,36 @@ describe("the resolved value never reaches the filesystem", () => {
 
     expect(leaked).toEqual([]);
   });
+});
+
+describe("the resolver deadline is enforced, not just declared", () => {
+  it("kills and reaps a resolver that outlives the ceiling", async () => {
+    // `read -t` bounds how long the hook WAITS; on its own it does not bound
+    // the work. A resolver blocked on the network otherwise outlives the hook
+    // that started it, and this runs in front of every prompt and file read —
+    // so the ceiling has to terminate the child, not merely stop listening.
+    // Never writes and never exits: the read times out with nothing, which is
+    // exactly the case where an unreaped child lingers.
+    const slow = checkoutWithResolver(
+      "setTimeout(() => {}, 600000);\n",
+      "lisa-sonar-hang-"
+    );
+
+    run({ bin: stubSonar(""), projectDir: slow });
+
+    // The hook has returned. Anything still running the stub resolver is a
+    // child it failed to reap.
+    const survivors = spawnSync(
+      "/bin/sh",
+      [
+        "-c",
+        `ps -eo pid,args | grep -F ${JSON.stringify(resolverScriptPath(slow))} | grep -v grep`,
+      ],
+      { encoding: "utf8" }
+    );
+
+    expect(survivors.stdout.trim()).toBe("");
+  }, 40_000);
 });
 
 describe("when the wrapper must stand aside", () => {


### PR DESCRIPTION
Closes CodySwannGT/lisa#2334

## The defect

`read -t 10` bounded how long the hook **waited** and nothing else. A resolver blocked on the network outlived the hook that started it, and this runs in front of every prompt and every file read — so the ceiling the comment advertised bounded nothing.

Raised by CodeRabbit on the downstream copy (TunnlAI/infrastructure#98).

## The trap in the obvious fix

Killing `$!` after reading from a process substitution is not merely unreliable on `/bin/bash` 3.2 — which is what the hooks run under on macOS — it is **actively dangerous**. `$!` there is the *shell's own PID*, not the substitution's child:

```
$! = 12615
  PID  PPID ARGS
12615 12614 /bin/bash -c ...          <- $! is the shell
12616 12615 node -e ...               <- the actual child
```

So `kill -9 "$!"` tells the hook to kill itself. That version was written, caught by this suite, and thrown away.

## The fix

Background the resolver explicitly — that is what makes `$!` mean the resolver — which needs a transport with a name, hence the FIFO:

```bash
node "$resolver" get "$name" >"$fifo" 2>/dev/null &
child=$!
IFS= read -r -t 10 value < "$fifo" || true
kill -9 "$child" 2>/dev/null
wait "$child" 2>/dev/null
```

A named pipe is a rendezvous, not storage: it holds no data at rest, so the CWE-922 property from #2333 is preserved. A kill at any point leaves an empty pipe rather than a readable token, and `mktemp -d` gives it a 0700 directory.

The mechanism pin moves with it. The invariant was never "no temp path" but "the value is never written to a regular file", so it now asserts the redirection target is a FIFO and rejects a bare `mktemp` without `-d`.

## Verification

New test, confirmed to **fail** against the un-reaped version before being kept:

```
× kills and reaps a resolver that outlives the ceiling
```

```
npx vitest run tests/unit/hooks/sonar-secrets.test.ts   11 passed
npm run typecheck / eslint                              clean
```

Re-checked end-to-end against the real SonarQube CLI v1.4.0 and a live Bitwarden project: a `ghp_…` prompt still returns `{"decision":"block"}`, a benign prompt passes silently, an inactive CLI recovers the token through the FIFO with no warning, and the hook returns normally rather than killing itself.

Work-Item: CodySwannGT/lisa#2334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret resolution reliability by preventing hangs during retrieval.
  * Added timeout handling and cleanup when secret resolvers fail or take too long.
  * Kept secret values from being stored in regular temporary files.

* **Tests**
  * Added coverage for resolver timeouts, process cleanup, and secure token transfer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->