### PR TITLE
fix(secrets): emit a repo-less environment without a repo, and without assuming Bitwarden

### DIFF
--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/providers.mjs
@@ -52,6 +52,29 @@ const PROVIDER_BOOTSTRAP_ENV = {
 };
 
 /**
+ * The tenant-scoped bootstrap variable a provider expects, by convention.
+ *
+ * Exists so the repo-less path cannot invent one. It used to compose
+ * `BWS_ACCESS_TOKEN_<namespace>` literally, ignoring the provider it had just
+ * resolved — so a Doppler tenant with no checkout was told to set a Bitwarden
+ * variable, and its CLI failed with "Missing access token". That is precisely
+ * the confusion the two questions above are separated to prevent, reintroduced
+ * on the one surface with no config file to correct it.
+ *
+ * `null` for a provider with no env-var bootstrap — 1Password, Vault and AWS
+ * authenticate by other means — because a name invented for them would be a
+ * variable nothing reads, which is worse than admitting there is none.
+ * `providerEnv` already treats an unmapped provider as "inject nothing".
+ * @param {string} provider Provider name.
+ * @param {string} namespace Tenant namespace.
+ * @returns {string|null} The variable to set, or null when the provider has none.
+ */
+export function bootstrapKeyFor(provider, namespace) {
+  const canonical = PROVIDER_BOOTSTRAP_ENV[provider];
+  return canonical ? `${canonical}_${namespace}` : null;
+}
+
+/**
  * Build the child environment for a provider CLI, injecting the bootstrap under
  * the name that CLI actually reads.
  *

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -17,6 +17,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { bootstrapKeyFor } from "./providers.mjs";
+
 /**
  * Capabilities, per surface.
  *
@@ -237,10 +239,14 @@ function fromEnvironment(env) {
     namespace: assertNamespace(namespace),
     bootstrap: {
       ...DEFAULTS.bootstrap,
+      // Derived from the provider resolved just above, not from Bitwarden's
+      // name. Hardcoding it told a Doppler tenant to set BWS_ACCESS_TOKEN_<ns>,
+      // which its CLI has never heard of — on the one surface that has no
+      // config file to override the guess.
       key:
         env.LISA_BOOTSTRAP_KEY ??
         env.LISA_SECRETS_BOOTSTRAP_KEY ??
-        `BWS_ACCESS_TOKEN_${namespace}`,
+        bootstrapKeyFor(provider, namespace),
     },
   };
 }

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -886,17 +886,6 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
 }
 
 /**
- * Produce the configuration a human pastes to provision a Claude cloud surface.
- *
- * This surface has no API tier and no console tier to fall back to: a Claude
- * cloud environment is configured only in the environment dialog, which has no
- * settings page, no direct URL, and no endpoint. Emit is not a degraded option
- * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
- * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
- * @returns {string} Text to show the operator.
- */
-/**
  * The lines an operator puts above the field, for a session with no checkout.
  *
  * Emitted as shell that runs, not as a template with holes: every hole is a
@@ -942,6 +931,17 @@ function repoLessExports({ namespace, key, provider, bootstrapKey, tenant }) {
   ];
 }
 
+/**
+ * Produce the configuration a human pastes to provision a Claude cloud surface.
+ *
+ * This surface has no API tier and no console tier to fall back to: a Claude
+ * cloud environment is configured only in the environment dialog, which has no
+ * settings page, no direct URL, and no endpoint. Emit is not a degraded option
+ * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
+ * what makes the result trustworthy, exactly as it would be at any other tier.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
 export function emitClaudeWeb({
   bootstrapKey,
   tenant = null,
@@ -1179,6 +1179,18 @@ export async function resolveEmitTarget(
     flag("provider") ||
     (env.LISA_PROVIDER ?? env.LISA_SECRETS_PROVIDER ?? "").trim() ||
     "bitwarden";
+
+  // Validated before it can reach the output, by the same rule the runtime path
+  // applies. This one becomes `export LISA_TENANT=<value>` in a block an
+  // operator pastes verbatim, so `my tenant` or `has$var` would emit shell that
+  // breaks — or worse, expands — where nothing reviews it. Refusing here costs
+  // a re-run; emitting it costs a container nobody can explain.
+  if (tenant) {
+    const { assertNamespace } = await import(
+      pathToFileURL(siblingScript("lisa-secrets-access", "surfaces.mjs")).href
+    );
+    assertNamespace(tenant);
+  }
 
   // A configured key outranks the convention: a project may legitimately use a
   // name that is not derivable, and this command must not tell its operator to

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -893,11 +893,62 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
  * settings page, no direct URL, and no endpoint. Emit is not a degraded option
  * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
  * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null}} options Project details.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
  * @returns {string} Text to show the operator.
  */
-export function emitClaudeWeb({ bootstrapKey }) {
-  const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+/**
+ * The lines an operator puts above the field, for a session with no checkout.
+ *
+ * Emitted as shell that runs, not as a template with holes: every hole is a
+ * hand substitution in a settings box with no review, which is the failure this
+ * whole file exists to prevent. So a provider that cannot be bootstrapped by an
+ * environment variable gets a sentence explaining that, not an `export` of a
+ * placeholder — a line that would be a syntax error if pasted.
+ *
+ * `LISA_PROVIDER` is exported even though the field defaults it, because the
+ * field's default is Bitwarden. A Doppler tenant that omits it gets `bws`
+ * installed and its own CLI missing, having configured everything correctly.
+ * @param {object} options Resolved identity and display strings.
+ * @returns {string[]} Lines to include in the emitted guidance.
+ */
+function repoLessExports({ namespace, key, provider, bootstrapKey, tenant }) {
+  // Two different reasons the key can be missing, and telling them apart is the
+  // whole value of the message. "Nothing was named" is the operator's to fix by
+  // re-running; "this provider has no such variable" is not fixable at all and
+  // must not read as an omission.
+  if (!tenant) {
+    return [
+      "      # Re-run with --tenant=<name> and these are filled in for you.",
+      `      export LISA_TENANT=${namespace}`,
+      "      export <bootstrap variable>='<read from your credential manager>'",
+      "      export LISA_SECRETS_SURFACE=claude-web",
+    ];
+  }
+  if (!bootstrapKey) {
+    return [
+      `      # ${provider} has no environment-variable bootstrap, so there is`,
+      "      # nothing to export for it. Authenticate it the way its own CLI",
+      "      # expects, then set the three below.",
+      `      export LISA_TENANT=${namespace}`,
+      `      export LISA_PROVIDER=${provider}`,
+      "      export LISA_SECRETS_SURFACE=claude-web",
+    ];
+  }
+  return [
+    `      export LISA_TENANT=${namespace}`,
+    `      export ${key}='<the same value as above>'`,
+    ...(provider ? [`      export LISA_PROVIDER=${provider}`] : []),
+    "      export LISA_SECRETS_SURFACE=claude-web",
+  ];
+}
+
+export function emitClaudeWeb({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
   return [
     "Provisioning tier: EMIT — and for this surface that is the only tier.",
     "  A Claude cloud environment is account-scoped configuration edited in the",
@@ -924,11 +975,9 @@ export function emitClaudeWeb({ bootstrapKey }) {
     "    while the image is being built, before the environment exists. So a",
     "    session with no checkout has to be told its tenant inside the script",
     "    itself, or the field finds nothing to prepare and exits 0 looking like",
-    "    success. Put these three lines FIRST, then the line after them:",
+    "    success. Put the lines below FIRST, then the field after them:",
     "",
-    "      export LISA_TENANT=<your namespace>",
-    `      export ${key}='<the same value as above>'`,
-    "      export LISA_SECRETS_SURFACE=claude-web",
+    ...repoLessExports({ namespace, key, provider, bootstrapKey, tenant }),
     "",
     "    LISA_SECRETS_SURFACE is set explicitly rather than left to detection:",
     "    detection keys off CLAUDE_CODE_REMOTE, and a surface that does not set",
@@ -1096,6 +1145,54 @@ function readBootstrapKey(cwd = process.cwd()) {
   return JSON.parse(readFileSync(path, "utf8")).secrets?.bootstrap?.key ?? null;
 }
 
+/**
+ * Work out what to tell the operator to export, for a surface that has no repo.
+ *
+ * Emitting used to read the key out of `.lisa.config.json` in the working
+ * directory, which made the command that configures a REPO-LESS environment
+ * require a repository — so it was run from a checkout that happened to be
+ * nearby, or it printed a placeholder the operator substituted by hand.
+ *
+ * Explicit flags win, then the environment, then a checkout if the caller
+ * happens to be standing in one, then the convention. The provider matters
+ * because it decides the variable's name: `bws` reads `BWS_ACCESS_TOKEN` and
+ * `doppler` reads `DOPPLER_TOKEN`, so a tenant on one told to export the
+ * other's name gets "Missing access token" from a CLI it did configure.
+ * @param {string[]} argv Process arguments.
+ * @param {Record<string, string|undefined>} [env] Environment to read.
+ * @param {string} [cwd] Directory to look for a config in.
+ * @returns {Promise<{tenant: string|null, provider: string, bootstrapKey: string|null}>} Resolved identity.
+ */
+export async function resolveEmitTarget(
+  argv,
+  env = process.env,
+  cwd = process.cwd()
+) {
+  const flag = name =>
+    argv.find(a => a.startsWith(`--${name}=`))?.slice(name.length + 3) ?? null;
+
+  const tenant =
+    flag("tenant") ||
+    (env.LISA_TENANT ?? env.LISA_SECRETS_NAMESPACE ?? "").trim() ||
+    null;
+  const provider =
+    flag("provider") ||
+    (env.LISA_PROVIDER ?? env.LISA_SECRETS_PROVIDER ?? "").trim() ||
+    "bitwarden";
+
+  // A configured key outranks the convention: a project may legitimately use a
+  // name that is not derivable, and this command must not tell its operator to
+  // set a different one from the one their sessions actually read.
+  const configured = readBootstrapKey(cwd);
+  if (configured) return { tenant, provider, bootstrapKey: configured };
+  if (!tenant) return { tenant, provider, bootstrapKey: null };
+
+  const { bootstrapKeyFor } = await import(
+    pathToFileURL(siblingScript("lisa-secrets-access", "providers.mjs")).href
+  );
+  return { tenant, provider, bootstrapKey: bootstrapKeyFor(provider, tenant) };
+}
+
 async function main() {
   // `--print-tools` answers "which CLIs does this secret set imply", reading
   // the notes materialized alongside the values.
@@ -1170,7 +1267,7 @@ async function main() {
           `Emitting is implemented for claude-web, which has no other tier.`
       );
     }
-    console.log(emitClaudeWeb({ bootstrapKey: readBootstrapKey() }));
+    console.log(emitClaudeWeb(await resolveEmitTarget(process.argv)));
     return;
   }
 

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/providers.mjs
@@ -52,6 +52,29 @@ const PROVIDER_BOOTSTRAP_ENV = {
 };
 
 /**
+ * The tenant-scoped bootstrap variable a provider expects, by convention.
+ *
+ * Exists so the repo-less path cannot invent one. It used to compose
+ * `BWS_ACCESS_TOKEN_<namespace>` literally, ignoring the provider it had just
+ * resolved — so a Doppler tenant with no checkout was told to set a Bitwarden
+ * variable, and its CLI failed with "Missing access token". That is precisely
+ * the confusion the two questions above are separated to prevent, reintroduced
+ * on the one surface with no config file to correct it.
+ *
+ * `null` for a provider with no env-var bootstrap — 1Password, Vault and AWS
+ * authenticate by other means — because a name invented for them would be a
+ * variable nothing reads, which is worse than admitting there is none.
+ * `providerEnv` already treats an unmapped provider as "inject nothing".
+ * @param {string} provider Provider name.
+ * @param {string} namespace Tenant namespace.
+ * @returns {string|null} The variable to set, or null when the provider has none.
+ */
+export function bootstrapKeyFor(provider, namespace) {
+  const canonical = PROVIDER_BOOTSTRAP_ENV[provider];
+  return canonical ? `${canonical}_${namespace}` : null;
+}
+
+/**
  * Build the child environment for a provider CLI, injecting the bootstrap under
  * the name that CLI actually reads.
  *

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -17,6 +17,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { bootstrapKeyFor } from "./providers.mjs";
+
 /**
  * Capabilities, per surface.
  *
@@ -237,10 +239,14 @@ function fromEnvironment(env) {
     namespace: assertNamespace(namespace),
     bootstrap: {
       ...DEFAULTS.bootstrap,
+      // Derived from the provider resolved just above, not from Bitwarden's
+      // name. Hardcoding it told a Doppler tenant to set BWS_ACCESS_TOKEN_<ns>,
+      // which its CLI has never heard of — on the one surface that has no
+      // config file to override the guess.
       key:
         env.LISA_BOOTSTRAP_KEY ??
         env.LISA_SECRETS_BOOTSTRAP_KEY ??
-        `BWS_ACCESS_TOKEN_${namespace}`,
+        bootstrapKeyFor(provider, namespace),
     },
   };
 }

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -886,17 +886,6 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
 }
 
 /**
- * Produce the configuration a human pastes to provision a Claude cloud surface.
- *
- * This surface has no API tier and no console tier to fall back to: a Claude
- * cloud environment is configured only in the environment dialog, which has no
- * settings page, no direct URL, and no endpoint. Emit is not a degraded option
- * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
- * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
- * @returns {string} Text to show the operator.
- */
-/**
  * The lines an operator puts above the field, for a session with no checkout.
  *
  * Emitted as shell that runs, not as a template with holes: every hole is a
@@ -942,6 +931,17 @@ function repoLessExports({ namespace, key, provider, bootstrapKey, tenant }) {
   ];
 }
 
+/**
+ * Produce the configuration a human pastes to provision a Claude cloud surface.
+ *
+ * This surface has no API tier and no console tier to fall back to: a Claude
+ * cloud environment is configured only in the environment dialog, which has no
+ * settings page, no direct URL, and no endpoint. Emit is not a degraded option
+ * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
+ * what makes the result trustworthy, exactly as it would be at any other tier.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
 export function emitClaudeWeb({
   bootstrapKey,
   tenant = null,
@@ -1179,6 +1179,18 @@ export async function resolveEmitTarget(
     flag("provider") ||
     (env.LISA_PROVIDER ?? env.LISA_SECRETS_PROVIDER ?? "").trim() ||
     "bitwarden";
+
+  // Validated before it can reach the output, by the same rule the runtime path
+  // applies. This one becomes `export LISA_TENANT=<value>` in a block an
+  // operator pastes verbatim, so `my tenant` or `has$var` would emit shell that
+  // breaks — or worse, expands — where nothing reviews it. Refusing here costs
+  // a re-run; emitting it costs a container nobody can explain.
+  if (tenant) {
+    const { assertNamespace } = await import(
+      pathToFileURL(siblingScript("lisa-secrets-access", "surfaces.mjs")).href
+    );
+    assertNamespace(tenant);
+  }
 
   // A configured key outranks the convention: a project may legitimately use a
   // name that is not derivable, and this command must not tell its operator to

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -893,11 +893,62 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
  * settings page, no direct URL, and no endpoint. Emit is not a degraded option
  * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
  * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null}} options Project details.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
  * @returns {string} Text to show the operator.
  */
-export function emitClaudeWeb({ bootstrapKey }) {
-  const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+/**
+ * The lines an operator puts above the field, for a session with no checkout.
+ *
+ * Emitted as shell that runs, not as a template with holes: every hole is a
+ * hand substitution in a settings box with no review, which is the failure this
+ * whole file exists to prevent. So a provider that cannot be bootstrapped by an
+ * environment variable gets a sentence explaining that, not an `export` of a
+ * placeholder — a line that would be a syntax error if pasted.
+ *
+ * `LISA_PROVIDER` is exported even though the field defaults it, because the
+ * field's default is Bitwarden. A Doppler tenant that omits it gets `bws`
+ * installed and its own CLI missing, having configured everything correctly.
+ * @param {object} options Resolved identity and display strings.
+ * @returns {string[]} Lines to include in the emitted guidance.
+ */
+function repoLessExports({ namespace, key, provider, bootstrapKey, tenant }) {
+  // Two different reasons the key can be missing, and telling them apart is the
+  // whole value of the message. "Nothing was named" is the operator's to fix by
+  // re-running; "this provider has no such variable" is not fixable at all and
+  // must not read as an omission.
+  if (!tenant) {
+    return [
+      "      # Re-run with --tenant=<name> and these are filled in for you.",
+      `      export LISA_TENANT=${namespace}`,
+      "      export <bootstrap variable>='<read from your credential manager>'",
+      "      export LISA_SECRETS_SURFACE=claude-web",
+    ];
+  }
+  if (!bootstrapKey) {
+    return [
+      `      # ${provider} has no environment-variable bootstrap, so there is`,
+      "      # nothing to export for it. Authenticate it the way its own CLI",
+      "      # expects, then set the three below.",
+      `      export LISA_TENANT=${namespace}`,
+      `      export LISA_PROVIDER=${provider}`,
+      "      export LISA_SECRETS_SURFACE=claude-web",
+    ];
+  }
+  return [
+    `      export LISA_TENANT=${namespace}`,
+    `      export ${key}='<the same value as above>'`,
+    ...(provider ? [`      export LISA_PROVIDER=${provider}`] : []),
+    "      export LISA_SECRETS_SURFACE=claude-web",
+  ];
+}
+
+export function emitClaudeWeb({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
   return [
     "Provisioning tier: EMIT — and for this surface that is the only tier.",
     "  A Claude cloud environment is account-scoped configuration edited in the",
@@ -924,11 +975,9 @@ export function emitClaudeWeb({ bootstrapKey }) {
     "    while the image is being built, before the environment exists. So a",
     "    session with no checkout has to be told its tenant inside the script",
     "    itself, or the field finds nothing to prepare and exits 0 looking like",
-    "    success. Put these three lines FIRST, then the line after them:",
+    "    success. Put the lines below FIRST, then the field after them:",
     "",
-    "      export LISA_TENANT=<your namespace>",
-    `      export ${key}='<the same value as above>'`,
-    "      export LISA_SECRETS_SURFACE=claude-web",
+    ...repoLessExports({ namespace, key, provider, bootstrapKey, tenant }),
     "",
     "    LISA_SECRETS_SURFACE is set explicitly rather than left to detection:",
     "    detection keys off CLAUDE_CODE_REMOTE, and a surface that does not set",
@@ -1096,6 +1145,54 @@ function readBootstrapKey(cwd = process.cwd()) {
   return JSON.parse(readFileSync(path, "utf8")).secrets?.bootstrap?.key ?? null;
 }
 
+/**
+ * Work out what to tell the operator to export, for a surface that has no repo.
+ *
+ * Emitting used to read the key out of `.lisa.config.json` in the working
+ * directory, which made the command that configures a REPO-LESS environment
+ * require a repository — so it was run from a checkout that happened to be
+ * nearby, or it printed a placeholder the operator substituted by hand.
+ *
+ * Explicit flags win, then the environment, then a checkout if the caller
+ * happens to be standing in one, then the convention. The provider matters
+ * because it decides the variable's name: `bws` reads `BWS_ACCESS_TOKEN` and
+ * `doppler` reads `DOPPLER_TOKEN`, so a tenant on one told to export the
+ * other's name gets "Missing access token" from a CLI it did configure.
+ * @param {string[]} argv Process arguments.
+ * @param {Record<string, string|undefined>} [env] Environment to read.
+ * @param {string} [cwd] Directory to look for a config in.
+ * @returns {Promise<{tenant: string|null, provider: string, bootstrapKey: string|null}>} Resolved identity.
+ */
+export async function resolveEmitTarget(
+  argv,
+  env = process.env,
+  cwd = process.cwd()
+) {
+  const flag = name =>
+    argv.find(a => a.startsWith(`--${name}=`))?.slice(name.length + 3) ?? null;
+
+  const tenant =
+    flag("tenant") ||
+    (env.LISA_TENANT ?? env.LISA_SECRETS_NAMESPACE ?? "").trim() ||
+    null;
+  const provider =
+    flag("provider") ||
+    (env.LISA_PROVIDER ?? env.LISA_SECRETS_PROVIDER ?? "").trim() ||
+    "bitwarden";
+
+  // A configured key outranks the convention: a project may legitimately use a
+  // name that is not derivable, and this command must not tell its operator to
+  // set a different one from the one their sessions actually read.
+  const configured = readBootstrapKey(cwd);
+  if (configured) return { tenant, provider, bootstrapKey: configured };
+  if (!tenant) return { tenant, provider, bootstrapKey: null };
+
+  const { bootstrapKeyFor } = await import(
+    pathToFileURL(siblingScript("lisa-secrets-access", "providers.mjs")).href
+  );
+  return { tenant, provider, bootstrapKey: bootstrapKeyFor(provider, tenant) };
+}
+
 async function main() {
   // `--print-tools` answers "which CLIs does this secret set imply", reading
   // the notes materialized alongside the values.
@@ -1170,7 +1267,7 @@ async function main() {
           `Emitting is implemented for claude-web, which has no other tier.`
       );
     }
-    console.log(emitClaudeWeb({ bootstrapKey: readBootstrapKey() }));
+    console.log(emitClaudeWeb(await resolveEmitTarget(process.argv)));
     return;
   }
 

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/providers.mjs
@@ -52,6 +52,29 @@ const PROVIDER_BOOTSTRAP_ENV = {
 };
 
 /**
+ * The tenant-scoped bootstrap variable a provider expects, by convention.
+ *
+ * Exists so the repo-less path cannot invent one. It used to compose
+ * `BWS_ACCESS_TOKEN_<namespace>` literally, ignoring the provider it had just
+ * resolved — so a Doppler tenant with no checkout was told to set a Bitwarden
+ * variable, and its CLI failed with "Missing access token". That is precisely
+ * the confusion the two questions above are separated to prevent, reintroduced
+ * on the one surface with no config file to correct it.
+ *
+ * `null` for a provider with no env-var bootstrap — 1Password, Vault and AWS
+ * authenticate by other means — because a name invented for them would be a
+ * variable nothing reads, which is worse than admitting there is none.
+ * `providerEnv` already treats an unmapped provider as "inject nothing".
+ * @param {string} provider Provider name.
+ * @param {string} namespace Tenant namespace.
+ * @returns {string|null} The variable to set, or null when the provider has none.
+ */
+export function bootstrapKeyFor(provider, namespace) {
+  const canonical = PROVIDER_BOOTSTRAP_ENV[provider];
+  return canonical ? `${canonical}_${namespace}` : null;
+}
+
+/**
  * Build the child environment for a provider CLI, injecting the bootstrap under
  * the name that CLI actually reads.
  *

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -17,6 +17,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { bootstrapKeyFor } from "./providers.mjs";
+
 /**
  * Capabilities, per surface.
  *
@@ -237,10 +239,14 @@ function fromEnvironment(env) {
     namespace: assertNamespace(namespace),
     bootstrap: {
       ...DEFAULTS.bootstrap,
+      // Derived from the provider resolved just above, not from Bitwarden's
+      // name. Hardcoding it told a Doppler tenant to set BWS_ACCESS_TOKEN_<ns>,
+      // which its CLI has never heard of — on the one surface that has no
+      // config file to override the guess.
       key:
         env.LISA_BOOTSTRAP_KEY ??
         env.LISA_SECRETS_BOOTSTRAP_KEY ??
-        `BWS_ACCESS_TOKEN_${namespace}`,
+        bootstrapKeyFor(provider, namespace),
     },
   };
 }

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -886,17 +886,6 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
 }
 
 /**
- * Produce the configuration a human pastes to provision a Claude cloud surface.
- *
- * This surface has no API tier and no console tier to fall back to: a Claude
- * cloud environment is configured only in the environment dialog, which has no
- * settings page, no direct URL, and no endpoint. Emit is not a degraded option
- * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
- * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
- * @returns {string} Text to show the operator.
- */
-/**
  * The lines an operator puts above the field, for a session with no checkout.
  *
  * Emitted as shell that runs, not as a template with holes: every hole is a
@@ -942,6 +931,17 @@ function repoLessExports({ namespace, key, provider, bootstrapKey, tenant }) {
   ];
 }
 
+/**
+ * Produce the configuration a human pastes to provision a Claude cloud surface.
+ *
+ * This surface has no API tier and no console tier to fall back to: a Claude
+ * cloud environment is configured only in the environment dialog, which has no
+ * settings page, no direct URL, and no endpoint. Emit is not a degraded option
+ * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
+ * what makes the result trustworthy, exactly as it would be at any other tier.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
 export function emitClaudeWeb({
   bootstrapKey,
   tenant = null,
@@ -1179,6 +1179,18 @@ export async function resolveEmitTarget(
     flag("provider") ||
     (env.LISA_PROVIDER ?? env.LISA_SECRETS_PROVIDER ?? "").trim() ||
     "bitwarden";
+
+  // Validated before it can reach the output, by the same rule the runtime path
+  // applies. This one becomes `export LISA_TENANT=<value>` in a block an
+  // operator pastes verbatim, so `my tenant` or `has$var` would emit shell that
+  // breaks — or worse, expands — where nothing reviews it. Refusing here costs
+  // a re-run; emitting it costs a container nobody can explain.
+  if (tenant) {
+    const { assertNamespace } = await import(
+      pathToFileURL(siblingScript("lisa-secrets-access", "surfaces.mjs")).href
+    );
+    assertNamespace(tenant);
+  }
 
   // A configured key outranks the convention: a project may legitimately use a
   // name that is not derivable, and this command must not tell its operator to

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -893,11 +893,62 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
  * settings page, no direct URL, and no endpoint. Emit is not a degraded option
  * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
  * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null}} options Project details.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
  * @returns {string} Text to show the operator.
  */
-export function emitClaudeWeb({ bootstrapKey }) {
-  const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+/**
+ * The lines an operator puts above the field, for a session with no checkout.
+ *
+ * Emitted as shell that runs, not as a template with holes: every hole is a
+ * hand substitution in a settings box with no review, which is the failure this
+ * whole file exists to prevent. So a provider that cannot be bootstrapped by an
+ * environment variable gets a sentence explaining that, not an `export` of a
+ * placeholder — a line that would be a syntax error if pasted.
+ *
+ * `LISA_PROVIDER` is exported even though the field defaults it, because the
+ * field's default is Bitwarden. A Doppler tenant that omits it gets `bws`
+ * installed and its own CLI missing, having configured everything correctly.
+ * @param {object} options Resolved identity and display strings.
+ * @returns {string[]} Lines to include in the emitted guidance.
+ */
+function repoLessExports({ namespace, key, provider, bootstrapKey, tenant }) {
+  // Two different reasons the key can be missing, and telling them apart is the
+  // whole value of the message. "Nothing was named" is the operator's to fix by
+  // re-running; "this provider has no such variable" is not fixable at all and
+  // must not read as an omission.
+  if (!tenant) {
+    return [
+      "      # Re-run with --tenant=<name> and these are filled in for you.",
+      `      export LISA_TENANT=${namespace}`,
+      "      export <bootstrap variable>='<read from your credential manager>'",
+      "      export LISA_SECRETS_SURFACE=claude-web",
+    ];
+  }
+  if (!bootstrapKey) {
+    return [
+      `      # ${provider} has no environment-variable bootstrap, so there is`,
+      "      # nothing to export for it. Authenticate it the way its own CLI",
+      "      # expects, then set the three below.",
+      `      export LISA_TENANT=${namespace}`,
+      `      export LISA_PROVIDER=${provider}`,
+      "      export LISA_SECRETS_SURFACE=claude-web",
+    ];
+  }
+  return [
+    `      export LISA_TENANT=${namespace}`,
+    `      export ${key}='<the same value as above>'`,
+    ...(provider ? [`      export LISA_PROVIDER=${provider}`] : []),
+    "      export LISA_SECRETS_SURFACE=claude-web",
+  ];
+}
+
+export function emitClaudeWeb({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
   return [
     "Provisioning tier: EMIT — and for this surface that is the only tier.",
     "  A Claude cloud environment is account-scoped configuration edited in the",
@@ -924,11 +975,9 @@ export function emitClaudeWeb({ bootstrapKey }) {
     "    while the image is being built, before the environment exists. So a",
     "    session with no checkout has to be told its tenant inside the script",
     "    itself, or the field finds nothing to prepare and exits 0 looking like",
-    "    success. Put these three lines FIRST, then the line after them:",
+    "    success. Put the lines below FIRST, then the field after them:",
     "",
-    "      export LISA_TENANT=<your namespace>",
-    `      export ${key}='<the same value as above>'`,
-    "      export LISA_SECRETS_SURFACE=claude-web",
+    ...repoLessExports({ namespace, key, provider, bootstrapKey, tenant }),
     "",
     "    LISA_SECRETS_SURFACE is set explicitly rather than left to detection:",
     "    detection keys off CLAUDE_CODE_REMOTE, and a surface that does not set",
@@ -1096,6 +1145,54 @@ function readBootstrapKey(cwd = process.cwd()) {
   return JSON.parse(readFileSync(path, "utf8")).secrets?.bootstrap?.key ?? null;
 }
 
+/**
+ * Work out what to tell the operator to export, for a surface that has no repo.
+ *
+ * Emitting used to read the key out of `.lisa.config.json` in the working
+ * directory, which made the command that configures a REPO-LESS environment
+ * require a repository — so it was run from a checkout that happened to be
+ * nearby, or it printed a placeholder the operator substituted by hand.
+ *
+ * Explicit flags win, then the environment, then a checkout if the caller
+ * happens to be standing in one, then the convention. The provider matters
+ * because it decides the variable's name: `bws` reads `BWS_ACCESS_TOKEN` and
+ * `doppler` reads `DOPPLER_TOKEN`, so a tenant on one told to export the
+ * other's name gets "Missing access token" from a CLI it did configure.
+ * @param {string[]} argv Process arguments.
+ * @param {Record<string, string|undefined>} [env] Environment to read.
+ * @param {string} [cwd] Directory to look for a config in.
+ * @returns {Promise<{tenant: string|null, provider: string, bootstrapKey: string|null}>} Resolved identity.
+ */
+export async function resolveEmitTarget(
+  argv,
+  env = process.env,
+  cwd = process.cwd()
+) {
+  const flag = name =>
+    argv.find(a => a.startsWith(`--${name}=`))?.slice(name.length + 3) ?? null;
+
+  const tenant =
+    flag("tenant") ||
+    (env.LISA_TENANT ?? env.LISA_SECRETS_NAMESPACE ?? "").trim() ||
+    null;
+  const provider =
+    flag("provider") ||
+    (env.LISA_PROVIDER ?? env.LISA_SECRETS_PROVIDER ?? "").trim() ||
+    "bitwarden";
+
+  // A configured key outranks the convention: a project may legitimately use a
+  // name that is not derivable, and this command must not tell its operator to
+  // set a different one from the one their sessions actually read.
+  const configured = readBootstrapKey(cwd);
+  if (configured) return { tenant, provider, bootstrapKey: configured };
+  if (!tenant) return { tenant, provider, bootstrapKey: null };
+
+  const { bootstrapKeyFor } = await import(
+    pathToFileURL(siblingScript("lisa-secrets-access", "providers.mjs")).href
+  );
+  return { tenant, provider, bootstrapKey: bootstrapKeyFor(provider, tenant) };
+}
+
 async function main() {
   // `--print-tools` answers "which CLIs does this secret set imply", reading
   // the notes materialized alongside the values.
@@ -1170,7 +1267,7 @@ async function main() {
           `Emitting is implemented for claude-web, which has no other tier.`
       );
     }
-    console.log(emitClaudeWeb({ bootstrapKey: readBootstrapKey() }));
+    console.log(emitClaudeWeb(await resolveEmitTarget(process.argv)));
     return;
   }
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/providers.mjs
@@ -52,6 +52,29 @@ const PROVIDER_BOOTSTRAP_ENV = {
 };
 
 /**
+ * The tenant-scoped bootstrap variable a provider expects, by convention.
+ *
+ * Exists so the repo-less path cannot invent one. It used to compose
+ * `BWS_ACCESS_TOKEN_<namespace>` literally, ignoring the provider it had just
+ * resolved — so a Doppler tenant with no checkout was told to set a Bitwarden
+ * variable, and its CLI failed with "Missing access token". That is precisely
+ * the confusion the two questions above are separated to prevent, reintroduced
+ * on the one surface with no config file to correct it.
+ *
+ * `null` for a provider with no env-var bootstrap — 1Password, Vault and AWS
+ * authenticate by other means — because a name invented for them would be a
+ * variable nothing reads, which is worse than admitting there is none.
+ * `providerEnv` already treats an unmapped provider as "inject nothing".
+ * @param {string} provider Provider name.
+ * @param {string} namespace Tenant namespace.
+ * @returns {string|null} The variable to set, or null when the provider has none.
+ */
+export function bootstrapKeyFor(provider, namespace) {
+  const canonical = PROVIDER_BOOTSTRAP_ENV[provider];
+  return canonical ? `${canonical}_${namespace}` : null;
+}
+
+/**
  * Build the child environment for a provider CLI, injecting the bootstrap under
  * the name that CLI actually reads.
  *

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -17,6 +17,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { bootstrapKeyFor } from "./providers.mjs";
+
 /**
  * Capabilities, per surface.
  *
@@ -237,10 +239,14 @@ function fromEnvironment(env) {
     namespace: assertNamespace(namespace),
     bootstrap: {
       ...DEFAULTS.bootstrap,
+      // Derived from the provider resolved just above, not from Bitwarden's
+      // name. Hardcoding it told a Doppler tenant to set BWS_ACCESS_TOKEN_<ns>,
+      // which its CLI has never heard of — on the one surface that has no
+      // config file to override the guess.
       key:
         env.LISA_BOOTSTRAP_KEY ??
         env.LISA_SECRETS_BOOTSTRAP_KEY ??
-        `BWS_ACCESS_TOKEN_${namespace}`,
+        bootstrapKeyFor(provider, namespace),
     },
   };
 }

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -886,17 +886,6 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
 }
 
 /**
- * Produce the configuration a human pastes to provision a Claude cloud surface.
- *
- * This surface has no API tier and no console tier to fall back to: a Claude
- * cloud environment is configured only in the environment dialog, which has no
- * settings page, no direct URL, and no endpoint. Emit is not a degraded option
- * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
- * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
- * @returns {string} Text to show the operator.
- */
-/**
  * The lines an operator puts above the field, for a session with no checkout.
  *
  * Emitted as shell that runs, not as a template with holes: every hole is a
@@ -942,6 +931,17 @@ function repoLessExports({ namespace, key, provider, bootstrapKey, tenant }) {
   ];
 }
 
+/**
+ * Produce the configuration a human pastes to provision a Claude cloud surface.
+ *
+ * This surface has no API tier and no console tier to fall back to: a Claude
+ * cloud environment is configured only in the environment dialog, which has no
+ * settings page, no direct URL, and no endpoint. Emit is not a degraded option
+ * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
+ * what makes the result trustworthy, exactly as it would be at any other tier.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
 export function emitClaudeWeb({
   bootstrapKey,
   tenant = null,
@@ -1179,6 +1179,18 @@ export async function resolveEmitTarget(
     flag("provider") ||
     (env.LISA_PROVIDER ?? env.LISA_SECRETS_PROVIDER ?? "").trim() ||
     "bitwarden";
+
+  // Validated before it can reach the output, by the same rule the runtime path
+  // applies. This one becomes `export LISA_TENANT=<value>` in a block an
+  // operator pastes verbatim, so `my tenant` or `has$var` would emit shell that
+  // breaks — or worse, expands — where nothing reviews it. Refusing here costs
+  // a re-run; emitting it costs a container nobody can explain.
+  if (tenant) {
+    const { assertNamespace } = await import(
+      pathToFileURL(siblingScript("lisa-secrets-access", "surfaces.mjs")).href
+    );
+    assertNamespace(tenant);
+  }
 
   // A configured key outranks the convention: a project may legitimately use a
   // name that is not derivable, and this command must not tell its operator to

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -893,11 +893,62 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
  * settings page, no direct URL, and no endpoint. Emit is not a degraded option
  * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
  * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null}} options Project details.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
  * @returns {string} Text to show the operator.
  */
-export function emitClaudeWeb({ bootstrapKey }) {
-  const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+/**
+ * The lines an operator puts above the field, for a session with no checkout.
+ *
+ * Emitted as shell that runs, not as a template with holes: every hole is a
+ * hand substitution in a settings box with no review, which is the failure this
+ * whole file exists to prevent. So a provider that cannot be bootstrapped by an
+ * environment variable gets a sentence explaining that, not an `export` of a
+ * placeholder — a line that would be a syntax error if pasted.
+ *
+ * `LISA_PROVIDER` is exported even though the field defaults it, because the
+ * field's default is Bitwarden. A Doppler tenant that omits it gets `bws`
+ * installed and its own CLI missing, having configured everything correctly.
+ * @param {object} options Resolved identity and display strings.
+ * @returns {string[]} Lines to include in the emitted guidance.
+ */
+function repoLessExports({ namespace, key, provider, bootstrapKey, tenant }) {
+  // Two different reasons the key can be missing, and telling them apart is the
+  // whole value of the message. "Nothing was named" is the operator's to fix by
+  // re-running; "this provider has no such variable" is not fixable at all and
+  // must not read as an omission.
+  if (!tenant) {
+    return [
+      "      # Re-run with --tenant=<name> and these are filled in for you.",
+      `      export LISA_TENANT=${namespace}`,
+      "      export <bootstrap variable>='<read from your credential manager>'",
+      "      export LISA_SECRETS_SURFACE=claude-web",
+    ];
+  }
+  if (!bootstrapKey) {
+    return [
+      `      # ${provider} has no environment-variable bootstrap, so there is`,
+      "      # nothing to export for it. Authenticate it the way its own CLI",
+      "      # expects, then set the three below.",
+      `      export LISA_TENANT=${namespace}`,
+      `      export LISA_PROVIDER=${provider}`,
+      "      export LISA_SECRETS_SURFACE=claude-web",
+    ];
+  }
+  return [
+    `      export LISA_TENANT=${namespace}`,
+    `      export ${key}='<the same value as above>'`,
+    ...(provider ? [`      export LISA_PROVIDER=${provider}`] : []),
+    "      export LISA_SECRETS_SURFACE=claude-web",
+  ];
+}
+
+export function emitClaudeWeb({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
   return [
     "Provisioning tier: EMIT — and for this surface that is the only tier.",
     "  A Claude cloud environment is account-scoped configuration edited in the",
@@ -924,11 +975,9 @@ export function emitClaudeWeb({ bootstrapKey }) {
     "    while the image is being built, before the environment exists. So a",
     "    session with no checkout has to be told its tenant inside the script",
     "    itself, or the field finds nothing to prepare and exits 0 looking like",
-    "    success. Put these three lines FIRST, then the line after them:",
+    "    success. Put the lines below FIRST, then the field after them:",
     "",
-    "      export LISA_TENANT=<your namespace>",
-    `      export ${key}='<the same value as above>'`,
-    "      export LISA_SECRETS_SURFACE=claude-web",
+    ...repoLessExports({ namespace, key, provider, bootstrapKey, tenant }),
     "",
     "    LISA_SECRETS_SURFACE is set explicitly rather than left to detection:",
     "    detection keys off CLAUDE_CODE_REMOTE, and a surface that does not set",
@@ -1096,6 +1145,54 @@ function readBootstrapKey(cwd = process.cwd()) {
   return JSON.parse(readFileSync(path, "utf8")).secrets?.bootstrap?.key ?? null;
 }
 
+/**
+ * Work out what to tell the operator to export, for a surface that has no repo.
+ *
+ * Emitting used to read the key out of `.lisa.config.json` in the working
+ * directory, which made the command that configures a REPO-LESS environment
+ * require a repository — so it was run from a checkout that happened to be
+ * nearby, or it printed a placeholder the operator substituted by hand.
+ *
+ * Explicit flags win, then the environment, then a checkout if the caller
+ * happens to be standing in one, then the convention. The provider matters
+ * because it decides the variable's name: `bws` reads `BWS_ACCESS_TOKEN` and
+ * `doppler` reads `DOPPLER_TOKEN`, so a tenant on one told to export the
+ * other's name gets "Missing access token" from a CLI it did configure.
+ * @param {string[]} argv Process arguments.
+ * @param {Record<string, string|undefined>} [env] Environment to read.
+ * @param {string} [cwd] Directory to look for a config in.
+ * @returns {Promise<{tenant: string|null, provider: string, bootstrapKey: string|null}>} Resolved identity.
+ */
+export async function resolveEmitTarget(
+  argv,
+  env = process.env,
+  cwd = process.cwd()
+) {
+  const flag = name =>
+    argv.find(a => a.startsWith(`--${name}=`))?.slice(name.length + 3) ?? null;
+
+  const tenant =
+    flag("tenant") ||
+    (env.LISA_TENANT ?? env.LISA_SECRETS_NAMESPACE ?? "").trim() ||
+    null;
+  const provider =
+    flag("provider") ||
+    (env.LISA_PROVIDER ?? env.LISA_SECRETS_PROVIDER ?? "").trim() ||
+    "bitwarden";
+
+  // A configured key outranks the convention: a project may legitimately use a
+  // name that is not derivable, and this command must not tell its operator to
+  // set a different one from the one their sessions actually read.
+  const configured = readBootstrapKey(cwd);
+  if (configured) return { tenant, provider, bootstrapKey: configured };
+  if (!tenant) return { tenant, provider, bootstrapKey: null };
+
+  const { bootstrapKeyFor } = await import(
+    pathToFileURL(siblingScript("lisa-secrets-access", "providers.mjs")).href
+  );
+  return { tenant, provider, bootstrapKey: bootstrapKeyFor(provider, tenant) };
+}
+
 async function main() {
   // `--print-tools` answers "which CLIs does this secret set imply", reading
   // the notes materialized alongside the values.
@@ -1170,7 +1267,7 @@ async function main() {
           `Emitting is implemented for claude-web, which has no other tier.`
       );
     }
-    console.log(emitClaudeWeb({ bootstrapKey: readBootstrapKey() }));
+    console.log(emitClaudeWeb(await resolveEmitTarget(process.argv)));
     return;
   }
 

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/providers.mjs
@@ -52,6 +52,29 @@ const PROVIDER_BOOTSTRAP_ENV = {
 };
 
 /**
+ * The tenant-scoped bootstrap variable a provider expects, by convention.
+ *
+ * Exists so the repo-less path cannot invent one. It used to compose
+ * `BWS_ACCESS_TOKEN_<namespace>` literally, ignoring the provider it had just
+ * resolved — so a Doppler tenant with no checkout was told to set a Bitwarden
+ * variable, and its CLI failed with "Missing access token". That is precisely
+ * the confusion the two questions above are separated to prevent, reintroduced
+ * on the one surface with no config file to correct it.
+ *
+ * `null` for a provider with no env-var bootstrap — 1Password, Vault and AWS
+ * authenticate by other means — because a name invented for them would be a
+ * variable nothing reads, which is worse than admitting there is none.
+ * `providerEnv` already treats an unmapped provider as "inject nothing".
+ * @param {string} provider Provider name.
+ * @param {string} namespace Tenant namespace.
+ * @returns {string|null} The variable to set, or null when the provider has none.
+ */
+export function bootstrapKeyFor(provider, namespace) {
+  const canonical = PROVIDER_BOOTSTRAP_ENV[provider];
+  return canonical ? `${canonical}_${namespace}` : null;
+}
+
+/**
  * Build the child environment for a provider CLI, injecting the bootstrap under
  * the name that CLI actually reads.
  *

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -17,6 +17,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { bootstrapKeyFor } from "./providers.mjs";
+
 /**
  * Capabilities, per surface.
  *
@@ -237,10 +239,14 @@ function fromEnvironment(env) {
     namespace: assertNamespace(namespace),
     bootstrap: {
       ...DEFAULTS.bootstrap,
+      // Derived from the provider resolved just above, not from Bitwarden's
+      // name. Hardcoding it told a Doppler tenant to set BWS_ACCESS_TOKEN_<ns>,
+      // which its CLI has never heard of — on the one surface that has no
+      // config file to override the guess.
       key:
         env.LISA_BOOTSTRAP_KEY ??
         env.LISA_SECRETS_BOOTSTRAP_KEY ??
-        `BWS_ACCESS_TOKEN_${namespace}`,
+        bootstrapKeyFor(provider, namespace),
     },
   };
 }

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -886,17 +886,6 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
 }
 
 /**
- * Produce the configuration a human pastes to provision a Claude cloud surface.
- *
- * This surface has no API tier and no console tier to fall back to: a Claude
- * cloud environment is configured only in the environment dialog, which has no
- * settings page, no direct URL, and no endpoint. Emit is not a degraded option
- * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
- * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
- * @returns {string} Text to show the operator.
- */
-/**
  * The lines an operator puts above the field, for a session with no checkout.
  *
  * Emitted as shell that runs, not as a template with holes: every hole is a
@@ -942,6 +931,17 @@ function repoLessExports({ namespace, key, provider, bootstrapKey, tenant }) {
   ];
 }
 
+/**
+ * Produce the configuration a human pastes to provision a Claude cloud surface.
+ *
+ * This surface has no API tier and no console tier to fall back to: a Claude
+ * cloud environment is configured only in the environment dialog, which has no
+ * settings page, no direct URL, and no endpoint. Emit is not a degraded option
+ * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
+ * what makes the result trustworthy, exactly as it would be at any other tier.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
 export function emitClaudeWeb({
   bootstrapKey,
   tenant = null,
@@ -1179,6 +1179,18 @@ export async function resolveEmitTarget(
     flag("provider") ||
     (env.LISA_PROVIDER ?? env.LISA_SECRETS_PROVIDER ?? "").trim() ||
     "bitwarden";
+
+  // Validated before it can reach the output, by the same rule the runtime path
+  // applies. This one becomes `export LISA_TENANT=<value>` in a block an
+  // operator pastes verbatim, so `my tenant` or `has$var` would emit shell that
+  // breaks — or worse, expands — where nothing reviews it. Refusing here costs
+  // a re-run; emitting it costs a container nobody can explain.
+  if (tenant) {
+    const { assertNamespace } = await import(
+      pathToFileURL(siblingScript("lisa-secrets-access", "surfaces.mjs")).href
+    );
+    assertNamespace(tenant);
+  }
 
   // A configured key outranks the convention: a project may legitimately use a
   // name that is not derivable, and this command must not tell its operator to

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -893,11 +893,62 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
  * settings page, no direct URL, and no endpoint. Emit is not a degraded option
  * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
  * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null}} options Project details.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
  * @returns {string} Text to show the operator.
  */
-export function emitClaudeWeb({ bootstrapKey }) {
-  const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+/**
+ * The lines an operator puts above the field, for a session with no checkout.
+ *
+ * Emitted as shell that runs, not as a template with holes: every hole is a
+ * hand substitution in a settings box with no review, which is the failure this
+ * whole file exists to prevent. So a provider that cannot be bootstrapped by an
+ * environment variable gets a sentence explaining that, not an `export` of a
+ * placeholder — a line that would be a syntax error if pasted.
+ *
+ * `LISA_PROVIDER` is exported even though the field defaults it, because the
+ * field's default is Bitwarden. A Doppler tenant that omits it gets `bws`
+ * installed and its own CLI missing, having configured everything correctly.
+ * @param {object} options Resolved identity and display strings.
+ * @returns {string[]} Lines to include in the emitted guidance.
+ */
+function repoLessExports({ namespace, key, provider, bootstrapKey, tenant }) {
+  // Two different reasons the key can be missing, and telling them apart is the
+  // whole value of the message. "Nothing was named" is the operator's to fix by
+  // re-running; "this provider has no such variable" is not fixable at all and
+  // must not read as an omission.
+  if (!tenant) {
+    return [
+      "      # Re-run with --tenant=<name> and these are filled in for you.",
+      `      export LISA_TENANT=${namespace}`,
+      "      export <bootstrap variable>='<read from your credential manager>'",
+      "      export LISA_SECRETS_SURFACE=claude-web",
+    ];
+  }
+  if (!bootstrapKey) {
+    return [
+      `      # ${provider} has no environment-variable bootstrap, so there is`,
+      "      # nothing to export for it. Authenticate it the way its own CLI",
+      "      # expects, then set the three below.",
+      `      export LISA_TENANT=${namespace}`,
+      `      export LISA_PROVIDER=${provider}`,
+      "      export LISA_SECRETS_SURFACE=claude-web",
+    ];
+  }
+  return [
+    `      export LISA_TENANT=${namespace}`,
+    `      export ${key}='<the same value as above>'`,
+    ...(provider ? [`      export LISA_PROVIDER=${provider}`] : []),
+    "      export LISA_SECRETS_SURFACE=claude-web",
+  ];
+}
+
+export function emitClaudeWeb({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
   return [
     "Provisioning tier: EMIT — and for this surface that is the only tier.",
     "  A Claude cloud environment is account-scoped configuration edited in the",
@@ -924,11 +975,9 @@ export function emitClaudeWeb({ bootstrapKey }) {
     "    while the image is being built, before the environment exists. So a",
     "    session with no checkout has to be told its tenant inside the script",
     "    itself, or the field finds nothing to prepare and exits 0 looking like",
-    "    success. Put these three lines FIRST, then the line after them:",
+    "    success. Put the lines below FIRST, then the field after them:",
     "",
-    "      export LISA_TENANT=<your namespace>",
-    `      export ${key}='<the same value as above>'`,
-    "      export LISA_SECRETS_SURFACE=claude-web",
+    ...repoLessExports({ namespace, key, provider, bootstrapKey, tenant }),
     "",
     "    LISA_SECRETS_SURFACE is set explicitly rather than left to detection:",
     "    detection keys off CLAUDE_CODE_REMOTE, and a surface that does not set",
@@ -1096,6 +1145,54 @@ function readBootstrapKey(cwd = process.cwd()) {
   return JSON.parse(readFileSync(path, "utf8")).secrets?.bootstrap?.key ?? null;
 }
 
+/**
+ * Work out what to tell the operator to export, for a surface that has no repo.
+ *
+ * Emitting used to read the key out of `.lisa.config.json` in the working
+ * directory, which made the command that configures a REPO-LESS environment
+ * require a repository — so it was run from a checkout that happened to be
+ * nearby, or it printed a placeholder the operator substituted by hand.
+ *
+ * Explicit flags win, then the environment, then a checkout if the caller
+ * happens to be standing in one, then the convention. The provider matters
+ * because it decides the variable's name: `bws` reads `BWS_ACCESS_TOKEN` and
+ * `doppler` reads `DOPPLER_TOKEN`, so a tenant on one told to export the
+ * other's name gets "Missing access token" from a CLI it did configure.
+ * @param {string[]} argv Process arguments.
+ * @param {Record<string, string|undefined>} [env] Environment to read.
+ * @param {string} [cwd] Directory to look for a config in.
+ * @returns {Promise<{tenant: string|null, provider: string, bootstrapKey: string|null}>} Resolved identity.
+ */
+export async function resolveEmitTarget(
+  argv,
+  env = process.env,
+  cwd = process.cwd()
+) {
+  const flag = name =>
+    argv.find(a => a.startsWith(`--${name}=`))?.slice(name.length + 3) ?? null;
+
+  const tenant =
+    flag("tenant") ||
+    (env.LISA_TENANT ?? env.LISA_SECRETS_NAMESPACE ?? "").trim() ||
+    null;
+  const provider =
+    flag("provider") ||
+    (env.LISA_PROVIDER ?? env.LISA_SECRETS_PROVIDER ?? "").trim() ||
+    "bitwarden";
+
+  // A configured key outranks the convention: a project may legitimately use a
+  // name that is not derivable, and this command must not tell its operator to
+  // set a different one from the one their sessions actually read.
+  const configured = readBootstrapKey(cwd);
+  if (configured) return { tenant, provider, bootstrapKey: configured };
+  if (!tenant) return { tenant, provider, bootstrapKey: null };
+
+  const { bootstrapKeyFor } = await import(
+    pathToFileURL(siblingScript("lisa-secrets-access", "providers.mjs")).href
+  );
+  return { tenant, provider, bootstrapKey: bootstrapKeyFor(provider, tenant) };
+}
+
 async function main() {
   // `--print-tools` answers "which CLIs does this secret set imply", reading
   // the notes materialized alongside the values.
@@ -1170,7 +1267,7 @@ async function main() {
           `Emitting is implemented for claude-web, which has no other tier.`
       );
     }
-    console.log(emitClaudeWeb({ bootstrapKey: readBootstrapKey() }));
+    console.log(emitClaudeWeb(await resolveEmitTarget(process.argv)));
     return;
   }
 

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs
@@ -52,6 +52,29 @@ const PROVIDER_BOOTSTRAP_ENV = {
 };
 
 /**
+ * The tenant-scoped bootstrap variable a provider expects, by convention.
+ *
+ * Exists so the repo-less path cannot invent one. It used to compose
+ * `BWS_ACCESS_TOKEN_<namespace>` literally, ignoring the provider it had just
+ * resolved — so a Doppler tenant with no checkout was told to set a Bitwarden
+ * variable, and its CLI failed with "Missing access token". That is precisely
+ * the confusion the two questions above are separated to prevent, reintroduced
+ * on the one surface with no config file to correct it.
+ *
+ * `null` for a provider with no env-var bootstrap — 1Password, Vault and AWS
+ * authenticate by other means — because a name invented for them would be a
+ * variable nothing reads, which is worse than admitting there is none.
+ * `providerEnv` already treats an unmapped provider as "inject nothing".
+ * @param {string} provider Provider name.
+ * @param {string} namespace Tenant namespace.
+ * @returns {string|null} The variable to set, or null when the provider has none.
+ */
+export function bootstrapKeyFor(provider, namespace) {
+  const canonical = PROVIDER_BOOTSTRAP_ENV[provider];
+  return canonical ? `${canonical}_${namespace}` : null;
+}
+
+/**
  * Build the child environment for a provider CLI, injecting the bootstrap under
  * the name that CLI actually reads.
  *

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -17,6 +17,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { bootstrapKeyFor } from "./providers.mjs";
+
 /**
  * Capabilities, per surface.
  *
@@ -237,10 +239,14 @@ function fromEnvironment(env) {
     namespace: assertNamespace(namespace),
     bootstrap: {
       ...DEFAULTS.bootstrap,
+      // Derived from the provider resolved just above, not from Bitwarden's
+      // name. Hardcoding it told a Doppler tenant to set BWS_ACCESS_TOKEN_<ns>,
+      // which its CLI has never heard of — on the one surface that has no
+      // config file to override the guess.
       key:
         env.LISA_BOOTSTRAP_KEY ??
         env.LISA_SECRETS_BOOTSTRAP_KEY ??
-        `BWS_ACCESS_TOKEN_${namespace}`,
+        bootstrapKeyFor(provider, namespace),
     },
   };
 }

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -886,17 +886,6 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
 }
 
 /**
- * Produce the configuration a human pastes to provision a Claude cloud surface.
- *
- * This surface has no API tier and no console tier to fall back to: a Claude
- * cloud environment is configured only in the environment dialog, which has no
- * settings page, no direct URL, and no endpoint. Emit is not a degraded option
- * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
- * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
- * @returns {string} Text to show the operator.
- */
-/**
  * The lines an operator puts above the field, for a session with no checkout.
  *
  * Emitted as shell that runs, not as a template with holes: every hole is a
@@ -942,6 +931,17 @@ function repoLessExports({ namespace, key, provider, bootstrapKey, tenant }) {
   ];
 }
 
+/**
+ * Produce the configuration a human pastes to provision a Claude cloud surface.
+ *
+ * This surface has no API tier and no console tier to fall back to: a Claude
+ * cloud environment is configured only in the environment dialog, which has no
+ * settings page, no direct URL, and no endpoint. Emit is not a degraded option
+ * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
+ * what makes the result trustworthy, exactly as it would be at any other tier.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
 export function emitClaudeWeb({
   bootstrapKey,
   tenant = null,
@@ -1179,6 +1179,18 @@ export async function resolveEmitTarget(
     flag("provider") ||
     (env.LISA_PROVIDER ?? env.LISA_SECRETS_PROVIDER ?? "").trim() ||
     "bitwarden";
+
+  // Validated before it can reach the output, by the same rule the runtime path
+  // applies. This one becomes `export LISA_TENANT=<value>` in a block an
+  // operator pastes verbatim, so `my tenant` or `has$var` would emit shell that
+  // breaks — or worse, expands — where nothing reviews it. Refusing here costs
+  // a re-run; emitting it costs a container nobody can explain.
+  if (tenant) {
+    const { assertNamespace } = await import(
+      pathToFileURL(siblingScript("lisa-secrets-access", "surfaces.mjs")).href
+    );
+    assertNamespace(tenant);
+  }
 
   // A configured key outranks the convention: a project may legitimately use a
   // name that is not derivable, and this command must not tell its operator to

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -893,11 +893,62 @@ export function pinEnvironment(environmentId, cwd = process.cwd()) {
  * settings page, no direct URL, and no endpoint. Emit is not a degraded option
  * here, it is the only one — so the read-back in `verify-remote-env.mjs` is
  * what makes the result trustworthy, exactly as it would be at any other tier.
- * @param {{bootstrapKey: string|null}} options Project details.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
  * @returns {string} Text to show the operator.
  */
-export function emitClaudeWeb({ bootstrapKey }) {
-  const key = bootstrapKey ?? "<secrets.bootstrap.key is not configured>";
+/**
+ * The lines an operator puts above the field, for a session with no checkout.
+ *
+ * Emitted as shell that runs, not as a template with holes: every hole is a
+ * hand substitution in a settings box with no review, which is the failure this
+ * whole file exists to prevent. So a provider that cannot be bootstrapped by an
+ * environment variable gets a sentence explaining that, not an `export` of a
+ * placeholder — a line that would be a syntax error if pasted.
+ *
+ * `LISA_PROVIDER` is exported even though the field defaults it, because the
+ * field's default is Bitwarden. A Doppler tenant that omits it gets `bws`
+ * installed and its own CLI missing, having configured everything correctly.
+ * @param {object} options Resolved identity and display strings.
+ * @returns {string[]} Lines to include in the emitted guidance.
+ */
+function repoLessExports({ namespace, key, provider, bootstrapKey, tenant }) {
+  // Two different reasons the key can be missing, and telling them apart is the
+  // whole value of the message. "Nothing was named" is the operator's to fix by
+  // re-running; "this provider has no such variable" is not fixable at all and
+  // must not read as an omission.
+  if (!tenant) {
+    return [
+      "      # Re-run with --tenant=<name> and these are filled in for you.",
+      `      export LISA_TENANT=${namespace}`,
+      "      export <bootstrap variable>='<read from your credential manager>'",
+      "      export LISA_SECRETS_SURFACE=claude-web",
+    ];
+  }
+  if (!bootstrapKey) {
+    return [
+      `      # ${provider} has no environment-variable bootstrap, so there is`,
+      "      # nothing to export for it. Authenticate it the way its own CLI",
+      "      # expects, then set the three below.",
+      `      export LISA_TENANT=${namespace}`,
+      `      export LISA_PROVIDER=${provider}`,
+      "      export LISA_SECRETS_SURFACE=claude-web",
+    ];
+  }
+  return [
+    `      export LISA_TENANT=${namespace}`,
+    `      export ${key}='<the same value as above>'`,
+    ...(provider ? [`      export LISA_PROVIDER=${provider}`] : []),
+    "      export LISA_SECRETS_SURFACE=claude-web",
+  ];
+}
+
+export function emitClaudeWeb({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
   return [
     "Provisioning tier: EMIT — and for this surface that is the only tier.",
     "  A Claude cloud environment is account-scoped configuration edited in the",
@@ -924,11 +975,9 @@ export function emitClaudeWeb({ bootstrapKey }) {
     "    while the image is being built, before the environment exists. So a",
     "    session with no checkout has to be told its tenant inside the script",
     "    itself, or the field finds nothing to prepare and exits 0 looking like",
-    "    success. Put these three lines FIRST, then the line after them:",
+    "    success. Put the lines below FIRST, then the field after them:",
     "",
-    "      export LISA_TENANT=<your namespace>",
-    `      export ${key}='<the same value as above>'`,
-    "      export LISA_SECRETS_SURFACE=claude-web",
+    ...repoLessExports({ namespace, key, provider, bootstrapKey, tenant }),
     "",
     "    LISA_SECRETS_SURFACE is set explicitly rather than left to detection:",
     "    detection keys off CLAUDE_CODE_REMOTE, and a surface that does not set",
@@ -1096,6 +1145,54 @@ function readBootstrapKey(cwd = process.cwd()) {
   return JSON.parse(readFileSync(path, "utf8")).secrets?.bootstrap?.key ?? null;
 }
 
+/**
+ * Work out what to tell the operator to export, for a surface that has no repo.
+ *
+ * Emitting used to read the key out of `.lisa.config.json` in the working
+ * directory, which made the command that configures a REPO-LESS environment
+ * require a repository — so it was run from a checkout that happened to be
+ * nearby, or it printed a placeholder the operator substituted by hand.
+ *
+ * Explicit flags win, then the environment, then a checkout if the caller
+ * happens to be standing in one, then the convention. The provider matters
+ * because it decides the variable's name: `bws` reads `BWS_ACCESS_TOKEN` and
+ * `doppler` reads `DOPPLER_TOKEN`, so a tenant on one told to export the
+ * other's name gets "Missing access token" from a CLI it did configure.
+ * @param {string[]} argv Process arguments.
+ * @param {Record<string, string|undefined>} [env] Environment to read.
+ * @param {string} [cwd] Directory to look for a config in.
+ * @returns {Promise<{tenant: string|null, provider: string, bootstrapKey: string|null}>} Resolved identity.
+ */
+export async function resolveEmitTarget(
+  argv,
+  env = process.env,
+  cwd = process.cwd()
+) {
+  const flag = name =>
+    argv.find(a => a.startsWith(`--${name}=`))?.slice(name.length + 3) ?? null;
+
+  const tenant =
+    flag("tenant") ||
+    (env.LISA_TENANT ?? env.LISA_SECRETS_NAMESPACE ?? "").trim() ||
+    null;
+  const provider =
+    flag("provider") ||
+    (env.LISA_PROVIDER ?? env.LISA_SECRETS_PROVIDER ?? "").trim() ||
+    "bitwarden";
+
+  // A configured key outranks the convention: a project may legitimately use a
+  // name that is not derivable, and this command must not tell its operator to
+  // set a different one from the one their sessions actually read.
+  const configured = readBootstrapKey(cwd);
+  if (configured) return { tenant, provider, bootstrapKey: configured };
+  if (!tenant) return { tenant, provider, bootstrapKey: null };
+
+  const { bootstrapKeyFor } = await import(
+    pathToFileURL(siblingScript("lisa-secrets-access", "providers.mjs")).href
+  );
+  return { tenant, provider, bootstrapKey: bootstrapKeyFor(provider, tenant) };
+}
+
 async function main() {
   // `--print-tools` answers "which CLIs does this secret set imply", reading
   // the notes materialized alongside the values.
@@ -1170,7 +1267,7 @@ async function main() {
           `Emitting is implemented for claude-web, which has no other tier.`
       );
     }
-    console.log(emitClaudeWeb({ bootstrapKey: readBootstrapKey() }));
+    console.log(emitClaudeWeb(await resolveEmitTarget(process.argv)));
     return;
   }
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1165,7 +1165,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "c30d98a5645f033fc1d3a723043691b9ad997ae5666df539ff6aa19c563431b2",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "5de9b2987ab50e15bbbe24d025d79ef38e1ad1021df7b80ef71c0401b70917f4",
+      "d17e71d7073e76d2301db26b57003cfc66eefe4ee4f7ac4b6649e3a028569946",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
       "496de5aed034692fee421dc3a1fbad9f85ed9e1d0c83a1080f781a486d0274e6",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1113,7 +1113,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs":
       "3b598675cee9d5235a3d12b82ab969effb0b47be263edf41474f8427105e3ce4",
     "plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs":
-      "fec38ca937570c1e1c21e6e8f7314a9d8f4e9264779d0394b40d5158924da0da",
+      "af876989440fdf2ddb035a40829474c6a5c0c9c292c4d18d2447a16a3b67361d",
     "plugins/src/base/skills/lisa-secrets-access/scripts/read-secret-note.mjs":
       "1471d2108058f3059e242f9c71208c99fdbc212bde32de34b798eaa9a27ffbcc",
     "plugins/src/base/skills/lisa-secrets-access/scripts/resolve-secret.mjs":
@@ -1121,7 +1121,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/rotate-secret.mjs":
       "546dc1c2f279cee6db56c0f55c01aabae0c316842f32d3219c5af6d638936a9c",
     "plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs":
-      "a765822c43fe488a674683a820cd03e8a9cc2f4507391afc4d971a500f4d0d3e",
+      "2bbd7234626813d0458a7aecd68eb4d69dcacea2d3c907594e1619af9e15537f",
     "plugins/src/base/skills/lisa-secrets-access/scripts/tools-from-notes.mjs":
       "07d183d8325341feea0db82c5f48f403981d0642999ce9b6462b6f89642e93c6",
     "plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs":
@@ -1165,7 +1165,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "c30d98a5645f033fc1d3a723043691b9ad997ae5666df539ff6aa19c563431b2",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "4d4f3fa7d49a430bd30ab32876a9b8492dcb51f6693e924a5ae5f5d49f6b7463",
+      "5de9b2987ab50e15bbbe24d025d79ef38e1ad1021df7b80ef71c0401b70917f4",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
       "496de5aed034692fee421dc3a1fbad9f85ed9e1d0c83a1080f781a486d0274e6",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
@@ -8516,6 +8516,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/detect-tooling.test.ts": true,
     "tests/unit/secrets/doctor-secrets.test.ts": true,
     "tests/unit/secrets/emit-claude-web-exports.test.ts": true,
+    "tests/unit/secrets/emit-tenant-provider.test.ts": true,
     "tests/unit/secrets/install-method-conformance.test.ts": true,
     "tests/unit/secrets/local-aws-profiles.test.ts": true,
     "tests/unit/secrets/local-env-command.test.ts": true,

--- a/tests/unit/secrets/emit-claude-web-exports.test.ts
+++ b/tests/unit/secrets/emit-claude-web-exports.test.ts
@@ -18,7 +18,15 @@ import { describe, expect, it } from "vitest";
 
 import { emitClaudeWeb } from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs";
 
-const emitted = emitClaudeWeb({ bootstrapKey: "BWS_ACCESS_TOKEN_acme" });
+// The tenant is supplied because that is the case worth asserting: with one,
+// every placeholder is filled in and the block is shell that runs as pasted.
+// Without one the guidance switches to "re-run with --tenant=", which
+// `emit-tenant-provider` covers.
+const emitted = emitClaudeWeb({
+  bootstrapKey: "BWS_ACCESS_TOKEN_acme",
+  tenant: "acme",
+  provider: "bitwarden",
+});
 
 describe("the repo-less exports in the emitted configuration", () => {
   it("names all three", () => {

--- a/tests/unit/secrets/emit-tenant-provider.test.ts
+++ b/tests/unit/secrets/emit-tenant-provider.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Emitting a repo-less environment must not require a repository.
+ *
+ * The command that configures a surface defined by having no checkout used to
+ * read the bootstrap key out of `.lisa.config.json` in the working directory.
+ * So it was run from a checkout that happened to be nearby, or it printed a
+ * placeholder the operator substituted by hand — in a settings box with no
+ * review, which is the failure this whole area exists to prevent.
+ *
+ * The provider is part of the answer, not a detail: `bws` reads
+ * `BWS_ACCESS_TOKEN` and `doppler` reads `DOPPLER_TOKEN`, so a tenant told to
+ * export the other one's name gets "Missing access token" from a CLI it
+ * configured correctly.
+ * @module tests/unit/secrets/emit-tenant-provider
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  emitClaudeWeb,
+  resolveEmitTarget,
+} from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs";
+
+/** A directory with no Lisa config, standing in for "anywhere". */
+let nowhere: string;
+
+beforeEach(() => {
+  nowhere = mkdtempSync(path.join(tmpdir(), "lisa-emit-"));
+});
+
+afterEach(() => {
+  rmSync(nowhere, { recursive: true, force: true });
+});
+
+describe("resolveEmitTarget", () => {
+  it("derives the key from the tenant, with no repository anywhere", async () => {
+    // `await` is load-bearing: an unawaited `.resolves` is a floating promise
+    // and the assertion cannot fail the test.
+    await expect(
+      resolveEmitTarget(["--emit=claude-web", "--tenant=tunnl"], {}, nowhere)
+    ).resolves.toMatchObject({
+      tenant: "tunnl",
+      provider: "bitwarden",
+      bootstrapKey: "BWS_ACCESS_TOKEN_tunnl",
+    });
+  });
+
+  it("names the variable the CHOSEN provider's CLI reads", async () => {
+    // Not `BWS_ACCESS_TOKEN_acme`. That was the bug: the provider was resolved
+    // and then ignored when composing the name.
+    await expect(
+      resolveEmitTarget(["--tenant=acme", "--provider=doppler"], {}, nowhere)
+    ).resolves.toMatchObject({ bootstrapKey: "DOPPLER_TOKEN_acme" });
+  });
+
+  it("returns no key for a provider with no environment bootstrap", async () => {
+    // 1Password, Vault and AWS authenticate by other means. Inventing a name
+    // for them produces a variable nothing reads.
+    await expect(
+      resolveEmitTarget(["--tenant=acme", "--provider=1password"], {}, nowhere)
+    ).resolves.toMatchObject({ bootstrapKey: null });
+  });
+
+  it("honours LISA_TENANT and LISA_PROVIDER", async () => {
+    // The same variables the repo-less runtime path already reads. Emit
+    // ignoring them was the specific inconsistency.
+    await expect(
+      resolveEmitTarget(
+        [],
+        { LISA_TENANT: "acme", LISA_PROVIDER: "doppler" },
+        nowhere
+      )
+    ).resolves.toMatchObject({
+      tenant: "acme",
+      bootstrapKey: "DOPPLER_TOKEN_acme",
+    });
+  });
+
+  it("lets a flag beat the environment", async () => {
+    await expect(
+      resolveEmitTarget(
+        ["--tenant=flagged"],
+        { LISA_TENANT: "envvar" },
+        nowhere
+      )
+    ).resolves.toMatchObject({ tenant: "flagged" });
+  });
+
+  it("lets a CONFIGURED key beat the convention", async () => {
+    // A project may use a name that is not derivable. Telling its operator to
+    // set a different one from the one their sessions read would be worse than
+    // the placeholder this replaced.
+    writeFileSync(
+      path.join(nowhere, ".lisa.config.json"),
+      JSON.stringify({ secrets: { bootstrap: { key: "CUSTOM_NAME" } } })
+    );
+
+    await expect(
+      resolveEmitTarget(["--tenant=tunnl"], {}, nowhere)
+    ).resolves.toMatchObject({ bootstrapKey: "CUSTOM_NAME" });
+  });
+});
+
+describe("the emitted guidance", () => {
+  /**
+   * Emit for a tenant and provider.
+   * @param tenant Tenant name.
+   * @param provider Provider name.
+   * @returns The emitted text.
+   */
+  async function emit(
+    tenant: string | null,
+    provider: string
+  ): Promise<string> {
+    const argv = [
+      ...(tenant ? [`--tenant=${tenant}`] : []),
+      `--provider=${provider}`,
+    ];
+    return emitClaudeWeb(await resolveEmitTarget(argv, {}, nowhere));
+  }
+
+  it("fills both placeholders in when the tenant is known", async () => {
+    const out = await emit("tunnl", "bitwarden");
+
+    expect(out).toContain("export LISA_TENANT=tunnl");
+    expect(out).toContain("export BWS_ACCESS_TOKEN_tunnl=");
+    expect(out).not.toContain("<your namespace>");
+  });
+
+  it("exports LISA_PROVIDER, because the field defaults it to bitwarden", async () => {
+    // Without it a Doppler tenant gets `bws` installed and its own CLI absent,
+    // having configured everything else correctly.
+    expect(await emit("acme", "doppler")).toContain(
+      "export LISA_PROVIDER=doppler"
+    );
+  });
+
+  it("emits a COMMENT, not an export, when there is no such variable", async () => {
+    // `export <1password has no ...>=` is a syntax error where it is pasted.
+    const out = await emit("acme", "1password");
+
+    expect(out).toContain("# 1password has no environment-variable bootstrap");
+    expect(out).not.toMatch(/export <[^>]*1password/);
+  });
+
+  it("distinguishes 'nothing was named' from 'no such variable exists'", async () => {
+    // One is fixed by re-running; the other cannot be fixed at all, and must
+    // not read as an omission.
+    const out = await emit(null, "bitwarden");
+
+    expect(out).toContain("Re-run with --tenant=");
+    expect(out).not.toContain("has no environment-variable bootstrap");
+  });
+});

--- a/tests/unit/secrets/emit-tenant-provider.test.ts
+++ b/tests/unit/secrets/emit-tenant-provider.test.ts
@@ -90,6 +90,23 @@ describe("resolveEmitTarget", () => {
     ).resolves.toMatchObject({ tenant: "flagged" });
   });
 
+  it.each(["my tenant", "has$var", "../escape", "a;rm -rf /", ""])(
+    "refuses %j rather than emitting it as shell",
+    async bad => {
+      // The value lands in `export LISA_TENANT=<value>` inside a block pasted
+      // verbatim into a settings box. A space breaks the line, a `$` expands,
+      // and a `;` runs. Refusing costs a re-run; emitting costs a container
+      // nobody can explain. An empty string is simply not a tenant.
+      const call = resolveEmitTarget([`--tenant=${bad}`], {}, nowhere);
+
+      if (bad === "") {
+        await expect(call).resolves.toMatchObject({ tenant: null });
+        return;
+      }
+      await expect(call).rejects.toThrow(/one safe path segment/);
+    }
+  );
+
   it("lets a CONFIGURED key beat the convention", async () => {
     // A project may use a name that is not derivable. Telling its operator to
     // set a different one from the one their sessions read would be worse than

--- a/tests/unit/secrets/remote-env-phases.test.ts
+++ b/tests/unit/secrets/remote-env-phases.test.ts
@@ -322,13 +322,17 @@ describe("emitted Claude configuration", () => {
     expect(emitted).toContain("proxy-injected");
   });
 
-  it("says plainly when the bootstrap has not been configured", () => {
+  it("says how to fill the bootstrap in, rather than naming a config path", () => {
+    // It used to print `<secrets.bootstrap.key is not configured>`, which reads
+    // as an error in a file the operator of a repo-less surface does not have.
+    // The actionable version names the flag that resolves it.
     const missing = emitClaudeWeb({
       bootstrapKey: null,
       install: "npm ci",
       repoDir: "lisa",
     });
-    expect(missing).toMatch(/secrets\.bootstrap\.key is not configured/);
+
+    expect(missing).toMatch(/Re-run with --tenant=/);
   });
 });
 


### PR DESCRIPTION
## Two defects, one root

The emit path resolved the operator's identity from a checkout — on the one surface defined by not having one.

### 1. `--emit` required a repository it is configuring the absence of

It read `secrets.bootstrap.key` out of `.lisa.config.json` in the working directory. So the command that provisions a **repo-less** environment had to be run from a checkout that happened to be nearby, or it printed `<secrets.bootstrap.key is not configured>` for a human to substitute by hand — in a settings box with no review, which is the failure this whole area exists to prevent.

The rest of the skill already solved this: `readConfig()` falls back to `LISA_TENANT` precisely so repo-less callers work. Emit did not use it. Verified against the published 2.338.4 — `LISA_TENANT=tunnl … --emit=claude-web` still printed the placeholder.

### 2. The repo-less fallback hardcoded the Bitwarden variable

```js
key: env.LISA_BOOTSTRAP_KEY ?? env.LISA_SECRETS_BOOTSTRAP_KEY ?? `BWS_ACCESS_TOKEN_${namespace}`
```

The provider is resolved three lines above and then ignored. A Doppler tenant with no checkout was told to export `BWS_ACCESS_TOKEN_<ns>` when its CLI reads `DOPPLER_TOKEN` — the exact confusion the comment above `PROVIDER_BOOTSTRAP_ENV` documents ("the CLI was handed a variable it has never heard of and failed with *Missing access token*"), reintroduced on the surface with no config file to correct it.

It compounds: the field defaults `--provider=${LISA_PROVIDER:-…:-bitwarden}`, so that tenant also got the wrong provider CLI installed. Two wrong defaults, neither announced.

**No live tenant is affected** — every current one is Bitwarden throughout. This is a trap for the second.

## The fix

| | |
|---|---|
| `--emit` | takes `--tenant=` and `--provider=`; honours `LISA_TENANT`/`LISA_PROVIDER`; falls back to a config file when the caller is in one |
| a **configured** key | still outranks the convention — a project may use a name that is not derivable, and this must not tell its operator to set a different one from the one their sessions read |
| `bootstrapKeyFor(provider, ns)` | composes the name from the provider's own variable |
| a provider with no such variable | gets `null`, not an invented name — `providerEnv` already treats an unmapped provider as "inject nothing" |
| the emitted block | exports `LISA_PROVIDER` too, since the field's default is Bitwarden |

A provider with no environment bootstrap gets a **comment** explaining that, not an `export` of a placeholder — which would be a syntax error where it is pasted. And "nothing was named" is worded differently from "no such variable exists": one is fixed by re-running, the other cannot be fixed at all and must not read as an omission.

## Verification

- `bun run lint` clean; `bun run test` green (8996).
- Ten new tests; **verified four of them fail against the hardcoded name**, rather than assuming they cover it.
- All five emit paths exercised end to end: bitwarden, doppler, 1password, no-flags, and `LISA_TENANT` from the environment.

```
--tenant=tunnl                    → export BWS_ACCESS_TOKEN_tunnl / LISA_PROVIDER=bitwarden
--tenant=acme --provider=doppler  → export DOPPLER_TOKEN_acme     / LISA_PROVIDER=doppler
--tenant=acme --provider=1password→ # 1password has no environment-variable bootstrap
(no flags)                        → # Re-run with --tenant=<name> and these are filled in
```

One test of my own was unsound and is fixed here too: an unawaited `.resolves` is a floating promise whose assertion cannot fail the test.

Work-Item: CodySwannGT/lisa#2359


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-aware bootstrap configuration for Bitwarden, Doppler, and other supported providers.
  * Remote environment setup now resolves tenant, provider, and bootstrap settings from flags, environment variables, or repository configuration.
  * Added repository-free setup guidance, including actionable instructions for missing or unsupported bootstrap configuration.
* **Bug Fixes**
  * Explicit bootstrap-key overrides continue to take precedence over automatically derived values.
* **Tests**
  * Added coverage for tenant/provider resolution, provider-specific naming, overrides, and setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->