### PR TITLE
feat(secrets): default the bootstrap block, and give containers a surface

### DIFF
--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -81,6 +81,28 @@ export const SURFACES = {
     // recoverable; an absent one means the environment does not work.
     materializeAt: "both",
   },
+  // A container an operator builds and runs themselves — locally, or anywhere
+  // Lisa is not the one provisioning the host.
+  //
+  // It exists because `local` was standing in for it, and `local` is
+  // `materialized: false`. That default is right for a human at a keyboard: the
+  // provider CLI is authenticated, secrets resolve live, and writing them to
+  // disk would be a second copy to keep honest. A container has no keychain and
+  // dies with its filesystem, so the same default leaves it with the CLIs
+  // installed and nothing to authenticate them.
+  //
+  // The workaround was to claim `claude-web`, which materializes correctly and
+  // is a lie — it made a local container indistinguishable from a cloud session
+  // in every diagnostic and log.
+  //
+  // `setup` rather than `both`: a container has no session-start hook to run,
+  // and it is started fresh rather than resumed from a vendor's cache, so the
+  // start of the container IS the refresh.
+  container: {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "setup",
+  },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */
@@ -187,15 +209,47 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
     throw new Error(`.lisa.config.json is not readable: ${err.message}`);
   }
   if (!cfg) return withSurface(DEFAULTS);
+  const provider = cfg.provider ?? DEFAULTS.provider;
+  const namespace = assertNamespace(cfg.namespace ?? DEFAULTS.namespace);
   return withSurface({
-    provider: cfg.provider ?? DEFAULTS.provider,
-    bootstrap: { ...DEFAULTS.bootstrap, ...(cfg.bootstrap ?? {}) },
+    provider,
+    bootstrap: resolveBootstrap(cfg.bootstrap, provider, namespace),
     require: cfg.require ?? null,
     rotating: cfg.rotating ?? [],
-    namespace: assertNamespace(cfg.namespace ?? DEFAULTS.namespace),
+    namespace,
     narrow: { ...DEFAULTS.narrow, ...(cfg.narrow ?? {}) },
     surface: cfg.surface ?? null,
   });
+}
+
+/**
+ * Fill in the bootstrap block a project did not spell out.
+ *
+ * Both defaults exist because a token stored on the machine was going unread.
+ *
+ * **The key** follows the same convention the repo-less path uses,
+ * `<PROVIDER_VAR>_<namespace>`, so a machine provisioned once serves every
+ * project of that tenant without each restating the name. A project that sets
+ * one keeps it: a name that is not derivable is a legitimate choice, and
+ * overriding it would point sessions at a variable nobody set.
+ *
+ * **The sources** gain `keychain` because `["env"]` alone meant a token in the
+ * OS keychain was never consulted — so the machine setup appeared to work and
+ * every project still failed until someone hand-edited its config. Env stays
+ * first, so a CI runner injecting the bootstrap never reaches for a local store.
+ * On a platform with no keychain the extra source reads as empty and costs
+ * nothing.
+ * @param {object|undefined} bootstrap The project's own block, if any.
+ * @param {string} provider Resolved provider name.
+ * @param {string} namespace Resolved namespace.
+ * @returns {{sources: string[], key: string|null}} The resolved block.
+ */
+function resolveBootstrap(bootstrap, provider, namespace) {
+  const given = bootstrap ?? {};
+  return {
+    sources: given.sources ?? ["env", "keychain"],
+    key: given.key ?? bootstrapKeyFor(provider, namespace),
+  };
 }
 
 /**
@@ -243,6 +297,10 @@ function fromEnvironment(env) {
       // name. Hardcoding it told a Doppler tenant to set BWS_ACCESS_TOKEN_<ns>,
       // which its CLI has never heard of — on the one surface that has no
       // config file to override the guess.
+      // Same two defaults as a project config gets, for the same reasons —
+      // see `resolveBootstrap`. Stated here too because this path never reads
+      // a file, so it cannot inherit them.
+      sources: ["env", "keychain"],
       key:
         env.LISA_BOOTSTRAP_KEY ??
         env.LISA_SECRETS_BOOTSTRAP_KEY ??

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -81,6 +81,28 @@ export const SURFACES = {
     // recoverable; an absent one means the environment does not work.
     materializeAt: "both",
   },
+  // A container an operator builds and runs themselves — locally, or anywhere
+  // Lisa is not the one provisioning the host.
+  //
+  // It exists because `local` was standing in for it, and `local` is
+  // `materialized: false`. That default is right for a human at a keyboard: the
+  // provider CLI is authenticated, secrets resolve live, and writing them to
+  // disk would be a second copy to keep honest. A container has no keychain and
+  // dies with its filesystem, so the same default leaves it with the CLIs
+  // installed and nothing to authenticate them.
+  //
+  // The workaround was to claim `claude-web`, which materializes correctly and
+  // is a lie — it made a local container indistinguishable from a cloud session
+  // in every diagnostic and log.
+  //
+  // `setup` rather than `both`: a container has no session-start hook to run,
+  // and it is started fresh rather than resumed from a vendor's cache, so the
+  // start of the container IS the refresh.
+  container: {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "setup",
+  },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */
@@ -187,15 +209,47 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
     throw new Error(`.lisa.config.json is not readable: ${err.message}`);
   }
   if (!cfg) return withSurface(DEFAULTS);
+  const provider = cfg.provider ?? DEFAULTS.provider;
+  const namespace = assertNamespace(cfg.namespace ?? DEFAULTS.namespace);
   return withSurface({
-    provider: cfg.provider ?? DEFAULTS.provider,
-    bootstrap: { ...DEFAULTS.bootstrap, ...(cfg.bootstrap ?? {}) },
+    provider,
+    bootstrap: resolveBootstrap(cfg.bootstrap, provider, namespace),
     require: cfg.require ?? null,
     rotating: cfg.rotating ?? [],
-    namespace: assertNamespace(cfg.namespace ?? DEFAULTS.namespace),
+    namespace,
     narrow: { ...DEFAULTS.narrow, ...(cfg.narrow ?? {}) },
     surface: cfg.surface ?? null,
   });
+}
+
+/**
+ * Fill in the bootstrap block a project did not spell out.
+ *
+ * Both defaults exist because a token stored on the machine was going unread.
+ *
+ * **The key** follows the same convention the repo-less path uses,
+ * `<PROVIDER_VAR>_<namespace>`, so a machine provisioned once serves every
+ * project of that tenant without each restating the name. A project that sets
+ * one keeps it: a name that is not derivable is a legitimate choice, and
+ * overriding it would point sessions at a variable nobody set.
+ *
+ * **The sources** gain `keychain` because `["env"]` alone meant a token in the
+ * OS keychain was never consulted — so the machine setup appeared to work and
+ * every project still failed until someone hand-edited its config. Env stays
+ * first, so a CI runner injecting the bootstrap never reaches for a local store.
+ * On a platform with no keychain the extra source reads as empty and costs
+ * nothing.
+ * @param {object|undefined} bootstrap The project's own block, if any.
+ * @param {string} provider Resolved provider name.
+ * @param {string} namespace Resolved namespace.
+ * @returns {{sources: string[], key: string|null}} The resolved block.
+ */
+function resolveBootstrap(bootstrap, provider, namespace) {
+  const given = bootstrap ?? {};
+  return {
+    sources: given.sources ?? ["env", "keychain"],
+    key: given.key ?? bootstrapKeyFor(provider, namespace),
+  };
 }
 
 /**
@@ -243,6 +297,10 @@ function fromEnvironment(env) {
       // name. Hardcoding it told a Doppler tenant to set BWS_ACCESS_TOKEN_<ns>,
       // which its CLI has never heard of — on the one surface that has no
       // config file to override the guess.
+      // Same two defaults as a project config gets, for the same reasons —
+      // see `resolveBootstrap`. Stated here too because this path never reads
+      // a file, so it cannot inherit them.
+      sources: ["env", "keychain"],
       key:
         env.LISA_BOOTSTRAP_KEY ??
         env.LISA_SECRETS_BOOTSTRAP_KEY ??

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -81,6 +81,28 @@ export const SURFACES = {
     // recoverable; an absent one means the environment does not work.
     materializeAt: "both",
   },
+  // A container an operator builds and runs themselves — locally, or anywhere
+  // Lisa is not the one provisioning the host.
+  //
+  // It exists because `local` was standing in for it, and `local` is
+  // `materialized: false`. That default is right for a human at a keyboard: the
+  // provider CLI is authenticated, secrets resolve live, and writing them to
+  // disk would be a second copy to keep honest. A container has no keychain and
+  // dies with its filesystem, so the same default leaves it with the CLIs
+  // installed and nothing to authenticate them.
+  //
+  // The workaround was to claim `claude-web`, which materializes correctly and
+  // is a lie — it made a local container indistinguishable from a cloud session
+  // in every diagnostic and log.
+  //
+  // `setup` rather than `both`: a container has no session-start hook to run,
+  // and it is started fresh rather than resumed from a vendor's cache, so the
+  // start of the container IS the refresh.
+  container: {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "setup",
+  },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */
@@ -187,15 +209,47 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
     throw new Error(`.lisa.config.json is not readable: ${err.message}`);
   }
   if (!cfg) return withSurface(DEFAULTS);
+  const provider = cfg.provider ?? DEFAULTS.provider;
+  const namespace = assertNamespace(cfg.namespace ?? DEFAULTS.namespace);
   return withSurface({
-    provider: cfg.provider ?? DEFAULTS.provider,
-    bootstrap: { ...DEFAULTS.bootstrap, ...(cfg.bootstrap ?? {}) },
+    provider,
+    bootstrap: resolveBootstrap(cfg.bootstrap, provider, namespace),
     require: cfg.require ?? null,
     rotating: cfg.rotating ?? [],
-    namespace: assertNamespace(cfg.namespace ?? DEFAULTS.namespace),
+    namespace,
     narrow: { ...DEFAULTS.narrow, ...(cfg.narrow ?? {}) },
     surface: cfg.surface ?? null,
   });
+}
+
+/**
+ * Fill in the bootstrap block a project did not spell out.
+ *
+ * Both defaults exist because a token stored on the machine was going unread.
+ *
+ * **The key** follows the same convention the repo-less path uses,
+ * `<PROVIDER_VAR>_<namespace>`, so a machine provisioned once serves every
+ * project of that tenant without each restating the name. A project that sets
+ * one keeps it: a name that is not derivable is a legitimate choice, and
+ * overriding it would point sessions at a variable nobody set.
+ *
+ * **The sources** gain `keychain` because `["env"]` alone meant a token in the
+ * OS keychain was never consulted — so the machine setup appeared to work and
+ * every project still failed until someone hand-edited its config. Env stays
+ * first, so a CI runner injecting the bootstrap never reaches for a local store.
+ * On a platform with no keychain the extra source reads as empty and costs
+ * nothing.
+ * @param {object|undefined} bootstrap The project's own block, if any.
+ * @param {string} provider Resolved provider name.
+ * @param {string} namespace Resolved namespace.
+ * @returns {{sources: string[], key: string|null}} The resolved block.
+ */
+function resolveBootstrap(bootstrap, provider, namespace) {
+  const given = bootstrap ?? {};
+  return {
+    sources: given.sources ?? ["env", "keychain"],
+    key: given.key ?? bootstrapKeyFor(provider, namespace),
+  };
 }
 
 /**
@@ -243,6 +297,10 @@ function fromEnvironment(env) {
       // name. Hardcoding it told a Doppler tenant to set BWS_ACCESS_TOKEN_<ns>,
       // which its CLI has never heard of — on the one surface that has no
       // config file to override the guess.
+      // Same two defaults as a project config gets, for the same reasons —
+      // see `resolveBootstrap`. Stated here too because this path never reads
+      // a file, so it cannot inherit them.
+      sources: ["env", "keychain"],
       key:
         env.LISA_BOOTSTRAP_KEY ??
         env.LISA_SECRETS_BOOTSTRAP_KEY ??

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -81,6 +81,28 @@ export const SURFACES = {
     // recoverable; an absent one means the environment does not work.
     materializeAt: "both",
   },
+  // A container an operator builds and runs themselves — locally, or anywhere
+  // Lisa is not the one provisioning the host.
+  //
+  // It exists because `local` was standing in for it, and `local` is
+  // `materialized: false`. That default is right for a human at a keyboard: the
+  // provider CLI is authenticated, secrets resolve live, and writing them to
+  // disk would be a second copy to keep honest. A container has no keychain and
+  // dies with its filesystem, so the same default leaves it with the CLIs
+  // installed and nothing to authenticate them.
+  //
+  // The workaround was to claim `claude-web`, which materializes correctly and
+  // is a lie — it made a local container indistinguishable from a cloud session
+  // in every diagnostic and log.
+  //
+  // `setup` rather than `both`: a container has no session-start hook to run,
+  // and it is started fresh rather than resumed from a vendor's cache, so the
+  // start of the container IS the refresh.
+  container: {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "setup",
+  },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */
@@ -187,15 +209,47 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
     throw new Error(`.lisa.config.json is not readable: ${err.message}`);
   }
   if (!cfg) return withSurface(DEFAULTS);
+  const provider = cfg.provider ?? DEFAULTS.provider;
+  const namespace = assertNamespace(cfg.namespace ?? DEFAULTS.namespace);
   return withSurface({
-    provider: cfg.provider ?? DEFAULTS.provider,
-    bootstrap: { ...DEFAULTS.bootstrap, ...(cfg.bootstrap ?? {}) },
+    provider,
+    bootstrap: resolveBootstrap(cfg.bootstrap, provider, namespace),
     require: cfg.require ?? null,
     rotating: cfg.rotating ?? [],
-    namespace: assertNamespace(cfg.namespace ?? DEFAULTS.namespace),
+    namespace,
     narrow: { ...DEFAULTS.narrow, ...(cfg.narrow ?? {}) },
     surface: cfg.surface ?? null,
   });
+}
+
+/**
+ * Fill in the bootstrap block a project did not spell out.
+ *
+ * Both defaults exist because a token stored on the machine was going unread.
+ *
+ * **The key** follows the same convention the repo-less path uses,
+ * `<PROVIDER_VAR>_<namespace>`, so a machine provisioned once serves every
+ * project of that tenant without each restating the name. A project that sets
+ * one keeps it: a name that is not derivable is a legitimate choice, and
+ * overriding it would point sessions at a variable nobody set.
+ *
+ * **The sources** gain `keychain` because `["env"]` alone meant a token in the
+ * OS keychain was never consulted — so the machine setup appeared to work and
+ * every project still failed until someone hand-edited its config. Env stays
+ * first, so a CI runner injecting the bootstrap never reaches for a local store.
+ * On a platform with no keychain the extra source reads as empty and costs
+ * nothing.
+ * @param {object|undefined} bootstrap The project's own block, if any.
+ * @param {string} provider Resolved provider name.
+ * @param {string} namespace Resolved namespace.
+ * @returns {{sources: string[], key: string|null}} The resolved block.
+ */
+function resolveBootstrap(bootstrap, provider, namespace) {
+  const given = bootstrap ?? {};
+  return {
+    sources: given.sources ?? ["env", "keychain"],
+    key: given.key ?? bootstrapKeyFor(provider, namespace),
+  };
 }
 
 /**
@@ -243,6 +297,10 @@ function fromEnvironment(env) {
       // name. Hardcoding it told a Doppler tenant to set BWS_ACCESS_TOKEN_<ns>,
       // which its CLI has never heard of — on the one surface that has no
       // config file to override the guess.
+      // Same two defaults as a project config gets, for the same reasons —
+      // see `resolveBootstrap`. Stated here too because this path never reads
+      // a file, so it cannot inherit them.
+      sources: ["env", "keychain"],
       key:
         env.LISA_BOOTSTRAP_KEY ??
         env.LISA_SECRETS_BOOTSTRAP_KEY ??

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -81,6 +81,28 @@ export const SURFACES = {
     // recoverable; an absent one means the environment does not work.
     materializeAt: "both",
   },
+  // A container an operator builds and runs themselves — locally, or anywhere
+  // Lisa is not the one provisioning the host.
+  //
+  // It exists because `local` was standing in for it, and `local` is
+  // `materialized: false`. That default is right for a human at a keyboard: the
+  // provider CLI is authenticated, secrets resolve live, and writing them to
+  // disk would be a second copy to keep honest. A container has no keychain and
+  // dies with its filesystem, so the same default leaves it with the CLIs
+  // installed and nothing to authenticate them.
+  //
+  // The workaround was to claim `claude-web`, which materializes correctly and
+  // is a lie — it made a local container indistinguishable from a cloud session
+  // in every diagnostic and log.
+  //
+  // `setup` rather than `both`: a container has no session-start hook to run,
+  // and it is started fresh rather than resumed from a vendor's cache, so the
+  // start of the container IS the refresh.
+  container: {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "setup",
+  },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */
@@ -187,15 +209,47 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
     throw new Error(`.lisa.config.json is not readable: ${err.message}`);
   }
   if (!cfg) return withSurface(DEFAULTS);
+  const provider = cfg.provider ?? DEFAULTS.provider;
+  const namespace = assertNamespace(cfg.namespace ?? DEFAULTS.namespace);
   return withSurface({
-    provider: cfg.provider ?? DEFAULTS.provider,
-    bootstrap: { ...DEFAULTS.bootstrap, ...(cfg.bootstrap ?? {}) },
+    provider,
+    bootstrap: resolveBootstrap(cfg.bootstrap, provider, namespace),
     require: cfg.require ?? null,
     rotating: cfg.rotating ?? [],
-    namespace: assertNamespace(cfg.namespace ?? DEFAULTS.namespace),
+    namespace,
     narrow: { ...DEFAULTS.narrow, ...(cfg.narrow ?? {}) },
     surface: cfg.surface ?? null,
   });
+}
+
+/**
+ * Fill in the bootstrap block a project did not spell out.
+ *
+ * Both defaults exist because a token stored on the machine was going unread.
+ *
+ * **The key** follows the same convention the repo-less path uses,
+ * `<PROVIDER_VAR>_<namespace>`, so a machine provisioned once serves every
+ * project of that tenant without each restating the name. A project that sets
+ * one keeps it: a name that is not derivable is a legitimate choice, and
+ * overriding it would point sessions at a variable nobody set.
+ *
+ * **The sources** gain `keychain` because `["env"]` alone meant a token in the
+ * OS keychain was never consulted — so the machine setup appeared to work and
+ * every project still failed until someone hand-edited its config. Env stays
+ * first, so a CI runner injecting the bootstrap never reaches for a local store.
+ * On a platform with no keychain the extra source reads as empty and costs
+ * nothing.
+ * @param {object|undefined} bootstrap The project's own block, if any.
+ * @param {string} provider Resolved provider name.
+ * @param {string} namespace Resolved namespace.
+ * @returns {{sources: string[], key: string|null}} The resolved block.
+ */
+function resolveBootstrap(bootstrap, provider, namespace) {
+  const given = bootstrap ?? {};
+  return {
+    sources: given.sources ?? ["env", "keychain"],
+    key: given.key ?? bootstrapKeyFor(provider, namespace),
+  };
 }
 
 /**
@@ -243,6 +297,10 @@ function fromEnvironment(env) {
       // name. Hardcoding it told a Doppler tenant to set BWS_ACCESS_TOKEN_<ns>,
       // which its CLI has never heard of — on the one surface that has no
       // config file to override the guess.
+      // Same two defaults as a project config gets, for the same reasons —
+      // see `resolveBootstrap`. Stated here too because this path never reads
+      // a file, so it cannot inherit them.
+      sources: ["env", "keychain"],
       key:
         env.LISA_BOOTSTRAP_KEY ??
         env.LISA_SECRETS_BOOTSTRAP_KEY ??

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -81,6 +81,28 @@ export const SURFACES = {
     // recoverable; an absent one means the environment does not work.
     materializeAt: "both",
   },
+  // A container an operator builds and runs themselves — locally, or anywhere
+  // Lisa is not the one provisioning the host.
+  //
+  // It exists because `local` was standing in for it, and `local` is
+  // `materialized: false`. That default is right for a human at a keyboard: the
+  // provider CLI is authenticated, secrets resolve live, and writing them to
+  // disk would be a second copy to keep honest. A container has no keychain and
+  // dies with its filesystem, so the same default leaves it with the CLIs
+  // installed and nothing to authenticate them.
+  //
+  // The workaround was to claim `claude-web`, which materializes correctly and
+  // is a lie — it made a local container indistinguishable from a cloud session
+  // in every diagnostic and log.
+  //
+  // `setup` rather than `both`: a container has no session-start hook to run,
+  // and it is started fresh rather than resumed from a vendor's cache, so the
+  // start of the container IS the refresh.
+  container: {
+    materialized: true,
+    mayWriteValues: true,
+    materializeAt: "setup",
+  },
 };
 
 /** Config defaults when `.lisa.config.json` carries no `secrets` block. */
@@ -187,15 +209,47 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
     throw new Error(`.lisa.config.json is not readable: ${err.message}`);
   }
   if (!cfg) return withSurface(DEFAULTS);
+  const provider = cfg.provider ?? DEFAULTS.provider;
+  const namespace = assertNamespace(cfg.namespace ?? DEFAULTS.namespace);
   return withSurface({
-    provider: cfg.provider ?? DEFAULTS.provider,
-    bootstrap: { ...DEFAULTS.bootstrap, ...(cfg.bootstrap ?? {}) },
+    provider,
+    bootstrap: resolveBootstrap(cfg.bootstrap, provider, namespace),
     require: cfg.require ?? null,
     rotating: cfg.rotating ?? [],
-    namespace: assertNamespace(cfg.namespace ?? DEFAULTS.namespace),
+    namespace,
     narrow: { ...DEFAULTS.narrow, ...(cfg.narrow ?? {}) },
     surface: cfg.surface ?? null,
   });
+}
+
+/**
+ * Fill in the bootstrap block a project did not spell out.
+ *
+ * Both defaults exist because a token stored on the machine was going unread.
+ *
+ * **The key** follows the same convention the repo-less path uses,
+ * `<PROVIDER_VAR>_<namespace>`, so a machine provisioned once serves every
+ * project of that tenant without each restating the name. A project that sets
+ * one keeps it: a name that is not derivable is a legitimate choice, and
+ * overriding it would point sessions at a variable nobody set.
+ *
+ * **The sources** gain `keychain` because `["env"]` alone meant a token in the
+ * OS keychain was never consulted — so the machine setup appeared to work and
+ * every project still failed until someone hand-edited its config. Env stays
+ * first, so a CI runner injecting the bootstrap never reaches for a local store.
+ * On a platform with no keychain the extra source reads as empty and costs
+ * nothing.
+ * @param {object|undefined} bootstrap The project's own block, if any.
+ * @param {string} provider Resolved provider name.
+ * @param {string} namespace Resolved namespace.
+ * @returns {{sources: string[], key: string|null}} The resolved block.
+ */
+function resolveBootstrap(bootstrap, provider, namespace) {
+  const given = bootstrap ?? {};
+  return {
+    sources: given.sources ?? ["env", "keychain"],
+    key: given.key ?? bootstrapKeyFor(provider, namespace),
+  };
 }
 
 /**
@@ -243,6 +297,10 @@ function fromEnvironment(env) {
       // name. Hardcoding it told a Doppler tenant to set BWS_ACCESS_TOKEN_<ns>,
       // which its CLI has never heard of — on the one surface that has no
       // config file to override the guess.
+      // Same two defaults as a project config gets, for the same reasons —
+      // see `resolveBootstrap`. Stated here too because this path never reads
+      // a file, so it cannot inherit them.
+      sources: ["env", "keychain"],
       key:
         env.LISA_BOOTSTRAP_KEY ??
         env.LISA_SECRETS_BOOTSTRAP_KEY ??

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1121,7 +1121,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/rotate-secret.mjs":
       "546dc1c2f279cee6db56c0f55c01aabae0c316842f32d3219c5af6d638936a9c",
     "plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs":
-      "2bbd7234626813d0458a7aecd68eb4d69dcacea2d3c907594e1619af9e15537f",
+      "284c0634b64d6c2b24d388cf3a74a6275588c592fdf60a525ba5aa3c7cc569b7",
     "plugins/src/base/skills/lisa-secrets-access/scripts/tools-from-notes.mjs":
       "07d183d8325341feea0db82c5f48f403981d0642999ce9b6462b6f89642e93c6",
     "plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs":
@@ -8511,6 +8511,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/aws-profiles-install.test.ts": true,
     "tests/unit/secrets/aws-profiles-permissions.test.ts": true,
     "tests/unit/secrets/aws-profiles.test.ts": true,
+    "tests/unit/secrets/bootstrap-defaults.test.ts": true,
     "tests/unit/secrets/bootstrap-key-naming.test.ts": true,
     "tests/unit/secrets/detect-tooling-discovery.test.ts": true,
     "tests/unit/secrets/detect-tooling.test.ts": true,

--- a/tests/unit/secrets/bootstrap-defaults.test.ts
+++ b/tests/unit/secrets/bootstrap-defaults.test.ts
@@ -1,0 +1,132 @@
+/**
+ * A bootstrap stored on the machine has to be one a project will actually read.
+ *
+ * Two defaults were missing, and together they made machine setup look like it
+ * worked while every project failed. `bootstrap.sources` defaulted to `["env"]`,
+ * so a token in the OS keychain was never consulted; and `bootstrap.key`
+ * defaulted to `null`, so each project had to restate a name that is derivable
+ * from its own namespace.
+ *
+ * Live projects hid it by setting both by hand. A fresh one would not have.
+ * @module tests/unit/secrets/bootstrap-defaults
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  SURFACES,
+  readConfig,
+} from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs";
+
+let project: string;
+
+/**
+ * Write a `.lisa.config.json` carrying the given secrets block.
+ * @param secrets The block to write.
+ */
+function config(secrets: unknown): void {
+  writeFileSync(
+    path.join(project, ".lisa.config.json"),
+    JSON.stringify({ secrets })
+  );
+}
+
+beforeEach(() => {
+  project = mkdtempSync(path.join(tmpdir(), "lisa-bootstrap-"));
+});
+
+afterEach(() => {
+  rmSync(project, { recursive: true, force: true });
+});
+
+describe("bootstrap defaults", () => {
+  it('consults the keychain, which `["env"]` alone never did', () => {
+    config({ provider: "bitwarden", namespace: "tunnl" });
+
+    expect(readConfig(project, {}).bootstrap.sources).toEqual([
+      "env",
+      "keychain",
+    ]);
+  });
+
+  it("keeps env FIRST, so CI never reaches for a local store", () => {
+    // A runner injects the bootstrap into the environment. Consulting a
+    // developer's keychain ahead of that would bind a job to whoever's machine
+    // happened to have one.
+    config({ provider: "bitwarden", namespace: "tunnl" });
+
+    expect(readConfig(project, {}).bootstrap.sources[0]).toBe("env");
+  });
+
+  it("derives the key from the provider and namespace", () => {
+    config({ provider: "bitwarden", namespace: "tunnl" });
+
+    expect(readConfig(project, {}).bootstrap.key).toBe(
+      "BWS_ACCESS_TOKEN_tunnl"
+    );
+  });
+
+  it("derives it from the CHOSEN provider, not Bitwarden's name", () => {
+    config({ provider: "doppler", namespace: "acme" });
+
+    expect(readConfig(project, {}).bootstrap.key).toBe("DOPPLER_TOKEN_acme");
+  });
+
+  it("leaves the key null for a provider with no such variable", () => {
+    // Inventing one produces a variable nothing reads. `providerEnv` already
+    // treats an unmapped provider as "inject nothing".
+    config({ provider: "1password", namespace: "acme" });
+
+    expect(readConfig(project, {}).bootstrap.key).toBeNull();
+  });
+
+  it("never overrides what a project spelled out", () => {
+    // A non-derivable name is a legitimate choice, and overriding it would
+    // point sessions at a variable nobody set.
+    config({
+      provider: "bitwarden",
+      namespace: "tunnl",
+      bootstrap: { sources: ["env"], key: "CUSTOM_NAME" },
+    });
+
+    expect(readConfig(project, {}).bootstrap).toEqual({
+      sources: ["env"],
+      key: "CUSTOM_NAME",
+    });
+  });
+
+  it("fills only the half a project left out", () => {
+    config({
+      provider: "bitwarden",
+      namespace: "tunnl",
+      bootstrap: { key: "CUSTOM_NAME" },
+    });
+
+    expect(readConfig(project, {}).bootstrap).toEqual({
+      sources: ["env", "keychain"],
+      key: "CUSTOM_NAME",
+    });
+  });
+});
+
+describe("the container surface", () => {
+  it("materializes, which `local` standing in for it did not", () => {
+    // A container has no keychain and dies with its filesystem, so secrets have
+    // to reach disk. `local` is materialized:false — right for a human at a
+    // keyboard, wrong for a container, and the reason `claude-web` was being
+    // claimed by containers that were not one.
+    expect(SURFACES.container).toEqual({
+      materialized: true,
+      mayWriteValues: true,
+      materializeAt: "setup",
+    });
+  });
+
+  it("does not disturb what `local` means", () => {
+    expect(SURFACES.local.materialized).toBe(false);
+  });
+});


### PR DESCRIPTION
First of four, building toward `environment <surface> --tenant=<name>`. This one is the foundation the rest sits on.

## A token stored on the machine was never read

`bootstrap.sources` defaulted to `["env"]`, so a keychain entry was not consulted. Every live project works only because someone hand-wrote `["env","keychain"]` into its `.lisa.config.json`. A fresh project would not have — which means machine setup could store a token, report success, and every project would still fail on "Missing access token."

`bootstrap.key` defaulted to `null`, so each project restated a name derivable from its own provider and namespace. The repo-less path already derives it; the config path did not.

Now:

| | |
|---|---|
| `sources` | `["env", "keychain"]` — **env first**, so a CI runner injecting the bootstrap never reaches for a local store |
| `key` | `bootstrapKeyFor(provider, namespace)` |

Neither overrides what a project spelled out, and a project that gave only one half keeps it. A non-derivable name is a legitimate choice, and overriding it would point sessions at a variable nobody set.

On a platform with no keychain the extra source reads as empty and costs nothing.

## Containers had no surface

The four were `local`, `github-actions`, `codex-cloud`, `claude-web`. `local` is `materialized: false` — right for a human at a keyboard, where the provider CLI is authenticated and secrets resolve live, and a copy on disk would be a second thing to keep honest. A container has no keychain and dies with its filesystem, so the same default leaves it with the CLIs installed and nothing to authenticate them.

The workaround was to claim `claude-web`. It materializes correctly and is a lie — it makes a container indistinguishable from a cloud session in every diagnostic and log.

`container` is `materialized: true`, `materializeAt: "setup"`. Not `both`: a container has no session-start hook to run, and is started fresh rather than resumed from a vendor's cache, so the start of the container *is* the refresh.

## Verification

- `bun run lint` clean; `bun run test` green (9010).
- Nine tests covering both defaults, the derivation per provider, `null` for a provider with no such variable, that a spelled-out block is untouched, that a half-specified one is only half-filled, and that `local` still means what it meant.

Work-Item: CodySwannGT/lisa#2361


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added container secret handling with setup-time materialization and disk writing.
  * Bootstrap configuration now defaults to environment and keychain sources.
  * Bootstrap keys are automatically derived from the provider and namespace when not specified.
  * Explicit project settings remain unchanged, with partial defaults filled automatically.

* **Bug Fixes**
  * Improved secret configuration for environments without a repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->