### PR TITLE
feat(secrets): add lisa environment <surface> --tenant=<name>

### DIFF
--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/bootstrap-store.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/bootstrap-store.mjs
@@ -184,6 +184,39 @@ export function clearBootstrap(key, deps = {}) {
 }
 
 /**
+ * Whether this machine already holds a bootstrap under that name.
+ *
+ * Asked so `environment local` can re-materialize after a rotation in the vault
+ * without demanding the token again — that is the common case, and prompting
+ * every time would make it the tedious one.
+ *
+ * Presence only. The value is never read here, because nothing about deciding
+ * whether to prompt needs it.
+ * @param {string} key Bootstrap variable name.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {boolean} True when a value is stored.
+ */
+export function hasBootstrap(key, deps = {}) {
+  const kind = deps.kind ?? storeKind();
+  const env = deps.env ?? process.env;
+
+  if (kind === "keychain") {
+    const run = deps.run ?? execFileSync;
+    try {
+      run(
+        "security",
+        ["find-generic-password", "-s", assertKey(key), "-a", env.USER ?? ""],
+        { stdio: "ignore" }
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return (deps.exists ?? existsSync)(deps.path ?? bootstrapFile(key, env));
+}
+
+/**
  * Read a file-backed bootstrap, treating absence as empty.
  *
  * The keychain reader lives beside the other provider concerns in

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -299,12 +299,28 @@ export function installAwsProfiles(bundle, options = {}) {
   return rendered.profiles;
 }
 
-export function materialize(cfg = readConfig()) {
-  if (!cfg.capabilities.mayWriteValues) {
+export function materialize(cfg = readConfig(), options = {}) {
+  // `requested` distinguishes an OPERATOR asking from a flow deciding.
+  //
+  // The capability governs automated behaviour: a session-start hook on a
+  // laptop must not write credentials to disk, because the provider CLI is
+  // authenticated there and a copy would add drift and exposure without adding
+  // capability. That reasoning holds, and the guard below still enforces it.
+  //
+  // It does not hold for `lisa environment local`, where the operator typed the
+  // command whose entire purpose is to put credentials on this machine — the
+  // AWS `-static` profiles reference variables that exist only once the env
+  // file is materialized, so refusing there means the profiles never work.
+  //
+  // Two different questions, so two different answers, rather than flipping
+  // `local` to `materialized: true` and silently starting to write on every
+  // machine that upgrades.
+  if (!cfg.capabilities.mayWriteValues && !options.requested) {
     throw new Error(
       `surface "${cfg.surface}" may not write secret values to disk.\n` +
         `It can read through to the provider, so a copy on disk would add drift ` +
-        `and exposure without adding capability.`
+        `and exposure without adding capability.\n` +
+        `Run 'lisa environment local --tenant=<name>' to ask for it explicitly.`
     );
   }
 

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -253,6 +253,33 @@ function resolveBootstrap(bootstrap, provider, namespace) {
 }
 
 /**
+ * Build a configuration for a tenant the operator named outright.
+ *
+ * Deliberately ignores any `.lisa.config.json` in the working directory. The
+ * flag is the more specific statement — someone who typed `--tenant=acme` means
+ * acme, whichever repository they happen to be standing in — and silently
+ * preferring the file would materialize a different tenant than the one on the
+ * command line.
+ *
+ * Getting this wrong is not a cosmetic error. Every namespace is a directory
+ * under `$XDG_CONFIG_HOME`, so resolving to the wrong one writes one tenant's
+ * credentials where another tenant's sessions read, and on a machine serving
+ * several the two would share a store.
+ * @param {{tenant: string, provider?: string}} options Named identity.
+ * @param {Record<string, string|undefined>} [env] Environment to inherit.
+ * @returns {object} A resolved configuration.
+ */
+export function configForTenant({ tenant, provider }, env = process.env) {
+  return withSurface(
+    fromEnvironment({
+      ...env,
+      LISA_TENANT: tenant,
+      ...(provider ? { LISA_PROVIDER: provider } : {}),
+    })
+  );
+}
+
+/**
  * Build a configuration from the environment, for sessions with no checkout.
  *
  * `LISA_SECRETS_NAMESPACE` is the one value with no safe default: it names the

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/environment.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/environment.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * Configure one surface for one tenant.
+ *
+ * One verb, one axis — *which surface* — and the only difference between them
+ * is whether Lisa can execute there or has to hand an operator text to paste.
+ *
+ *     environment local        runs it here
+ *     environment container    emits an image definition and a run command
+ *     environment claude-web   emits, because the dialog has no API
+ *     environment codex-cloud  emits, same reason
+ *
+ * This replaces `remote-env --emit=<surface>`, whose name described the
+ * machinery rather than the task: from a laptop, `remote-env` reads as
+ * "prepare the remote environment I am currently in", which is the opposite of
+ * what an operator configuring a cloud environment is doing. The old spelling
+ * still works so nothing in flight breaks.
+ *
+ * `workstation` remains a separate command and a separate concern: it answers
+ * "what binaries does this machine have", with no tenant and no credentials. So
+ * **rotating a token is `environment local` again**, not re-running an
+ * installer that wants to reinstall six coding agents.
+ * @module environment
+ */
+
+import { pathToFileURL } from "node:url";
+
+/** Surfaces this command can configure, and how each is delivered. */
+export const TARGETS = {
+  local: { mode: "run", label: "this machine" },
+  container: { mode: "emit", label: "a container image you build" },
+  "claude-web": { mode: "emit", label: "a Claude cloud environment" },
+  "codex-cloud": { mode: "emit", label: "a Codex Cloud environment" },
+};
+
+/**
+ * Resolve the surface name an operator asked for.
+ *
+ * An unknown name is an error rather than a default, because defaulting would
+ * configure something other than what they typed — and on this command the
+ * difference between surfaces is where a credential ends up.
+ * @param {string|undefined} name Requested surface.
+ * @returns {string} A key of {@link TARGETS}.
+ */
+export function assertTarget(name) {
+  if (!name || !TARGETS[name]) {
+    throw new Error(
+      `unknown environment "${name ?? ""}".\n` +
+        `Known: ${Object.keys(TARGETS).join(", ")}`
+    );
+  }
+  return name;
+}
+
+/**
+ * Prepare THIS machine: store the bootstrap, then materialize.
+ *
+ * The prompt is skipped rather than blocked when nothing can answer it, and
+ * skipped rather than repeated when the machine already holds a bootstrap —
+ * `environment local` is also how an operator re-materializes after rotating a
+ * secret in the vault, and demanding the token again every time would make the
+ * common case the tedious one. `--rotate` is how you say you mean to replace it.
+ * @param {object} options Resolved tenant, provider and flags.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {Promise<string[]>} Lines to report.
+ */
+export async function configureLocal(options, deps = {}) {
+  const { tenant, provider, bootstrapKey: key, rotate = false } = options;
+  const lines = [];
+
+  // A tenant is required here, unlike the emit paths, because this one WRITES.
+  // Without it the config falls back to the default namespace and materializes
+  // one tenant's credentials into another's directory — and on a machine
+  // serving several, the two would then share a store.
+  if (!tenant) {
+    throw new Error(
+      "environment local needs --tenant=<name>.\n" +
+        "It writes credentials into a per-tenant directory, so guessing the " +
+        "name would put one tenant's secrets where another's sessions read."
+    );
+  }
+
+  const wired = deps.prompt
+    ? deps
+    : { ...(await localDeps({ tenant, provider })), ...deps };
+  const { canPrompt, promptSecret } = wired.prompt;
+  const { storeBootstrap, hasBootstrap } = wired.store;
+  const materialize = wired.materialize;
+
+  if (!key) {
+    lines.push(
+      `${provider} has no environment-variable bootstrap, so there is nothing`,
+      `to store. Authenticate it the way its own CLI expects.`
+    );
+  } else if (hasBootstrap(key) && !rotate) {
+    lines.push(`${key} is already stored; pass --rotate to replace it.`);
+  } else if (!canPrompt()) {
+    // Not fatal. A non-interactive caller can legitimately have supplied the
+    // bootstrap through the environment, and refusing would break that.
+    lines.push(
+      `No terminal to prompt on, so ${key} was not stored.`,
+      `Set it in the environment, or re-run where a human can type.`
+    );
+  } else {
+    const value = promptSecret(`Paste the access token for ${tenant}: `);
+    if (!value) {
+      lines.push(`Nothing entered, so ${key} was not stored.`);
+    } else {
+      const { where } = storeBootstrap(key, value);
+      lines.push(`Stored ${key} in ${where}.`);
+    }
+  }
+
+  const result = await materialize();
+  lines.push(...result);
+  return lines;
+}
+
+/**
+ * Run the command.
+ * @param {string[]} argv Arguments after the command name.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {Promise<number>} Exit code.
+ */
+export async function run(argv, deps = {}) {
+  const out = deps.log ?? console.log;
+  const err = deps.error ?? console.error;
+
+  try {
+    const target = assertTarget(argv.find(a => !a.startsWith("-")));
+    const resolve = deps.resolveTarget ?? (await defaultResolver());
+    const identity = await resolve(argv);
+
+    if (TARGETS[target].mode === "run") {
+      const lines = await (deps.configureLocal ?? configureLocal)(
+        { ...identity, rotate: argv.includes("--rotate") },
+        deps
+      );
+      out(lines.join("\n"));
+      return 0;
+    }
+
+    out((deps.emit ?? (await defaultEmitter()))(target, identity));
+    return 0;
+  } catch (error) {
+    err(String(error.message));
+    return 1;
+  }
+}
+
+// Executed directly by the CLI, imported by tests. Without this the module
+// exported a `run` nobody called and the command printed nothing at all.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  run(process.argv.slice(2)).then(code => {
+    process.exitCode = code;
+  });
+}
+
+/**
+ * Wire the local path to the real prompt, store and materializer.
+ *
+ * Loaded lazily so the emit paths — which need none of it — do not pay for it,
+ * and so tests can substitute the lot without touching a keychain or a vault.
+ *
+ * `materialize` is called with `requested: true`: the operator typed the
+ * command whose purpose is to put credentials on this machine, which is a
+ * different question from whether an automated flow may write here. The
+ * capability guard still refuses the automated case.
+ * @returns {Promise<object>} Default dependencies for `configureLocal`.
+ */
+async function localDeps(identity) {
+  const at = name =>
+    new URL(`../../lisa-secrets-access/scripts/${name}`, import.meta.url).href;
+  const prompt = await import(at("prompt-secret.mjs"));
+  const store = await import(at("bootstrap-store.mjs"));
+  const secrets = await import(at("materialize-secrets.mjs"));
+  const surfaces = await import(at("surfaces.mjs"));
+
+  return {
+    prompt,
+    store,
+    materialize: () => {
+      // The NAMED tenant, not whatever config the working directory holds.
+      // Reading the directory materialized the default namespace instead of the
+      // one on the command line — observed writing 49 secrets of the wrong
+      // tenant into the wrong directory.
+      const { count, derived, dir, profiles } = secrets.materialize(
+        surfaces.configForTenant(identity),
+        { requested: true }
+      );
+      return [
+        `Materialized ${count} secret(s) into ${dir}.`,
+        ...(derived ? [`${derived} variable(s) derived from the bundle.`] : []),
+        ...(profiles?.length
+          ? [`AWS profiles installed: ${profiles.join(", ")}`]
+          : []),
+      ];
+    },
+  };
+}
+
+/**
+ * Load the identity resolver from the sibling runner.
+ * @returns {Promise<Function>} The resolver.
+ */
+async function defaultResolver() {
+  // Already a URL — passing it through pathToFileURL again throws.
+  const mod = await import(
+    new URL("./setup-remote-env.mjs", import.meta.url).href
+  );
+  return argv => mod.resolveEmitTarget(argv);
+}
+
+/**
+ * Load the emitter from the sibling runner.
+ * @returns {Promise<Function>} The emitter.
+ */
+async function defaultEmitter() {
+  // Already a URL — passing it through pathToFileURL again throws.
+  const mod = await import(
+    new URL("./setup-remote-env.mjs", import.meta.url).href
+  );
+  return (target, identity) => mod.emitFor(target, identity);
+}

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -1031,6 +1031,142 @@ export function emitClaudeWeb({
 }
 
 /**
+ * Emit the configuration for a surface Lisa cannot reach.
+ *
+ * Dispatch rather than four call sites, so `environment` names a surface and
+ * nothing downstream has to know which of them has an API and which does not.
+ * @param {string} target Surface name.
+ * @param {object} identity Resolved tenant, provider and bootstrap key.
+ * @returns {string} Text to show the operator.
+ */
+export function emitFor(target, identity) {
+  if (target === "claude-web") return emitClaudeWeb(identity);
+  if (target === "codex-cloud") return emitCodexCloud(identity);
+  if (target === "container") return emitContainer(identity);
+  throw new Error(`no emit template for surface "${target}".`);
+}
+
+/**
+ * Produce the configuration a human pastes into a Codex Cloud environment.
+ *
+ * Differs from Claude's in three ways that are properties of the vendor rather
+ * than of Lisa, and each has cost someone a debugging session.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitCodexCloud({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
+  return [
+    "Provisioning tier: EMIT — Codex Cloud exposes no environment API.",
+    "  `codex cloud` offers exec, status and list; nothing that writes an",
+    "  environment. So this is text for the settings page.",
+    "",
+    "Paste into the environment settings",
+    "-----------------------------------",
+    "  Repository:        the DEFAULT checkout for this environment",
+    "",
+    "  Environment variables — NOT task secrets:",
+    // Written as name=value, not as `export name='value'`. This is a settings
+    // form, not a shell: the quotes would be stored as part of the value, and
+    // the surface named must be this one rather than the shell block's.
+    `    LISA_TENANT=${namespace}`,
+    ...(bootstrapKey
+      ? [`    ${key}=<read this from your credential manager>`]
+      : [`    (${provider} has no environment-variable bootstrap)`]),
+    ...(provider ? [`    LISA_PROVIDER=${provider}`] : []),
+    "    LISA_SECRETS_SURFACE=codex-cloud",
+    "",
+    "    Setup and cache-resume maintenance both run BEFORE task secrets",
+    "    exist, so a bootstrap placed in the secrets box is invisible to the",
+    "    only two steps that need it.",
+    "",
+    "  Setup script:",
+    `    ${SETUP_FIELD}`,
+    "",
+    "  Maintenance script:",
+    "    The SAME line. It runs when a container resumes from cache, and every",
+    "    step is idempotent and version-aware — so running it again is how a",
+    "    rotated value, an edited note, or a changed pin gets picked up.",
+    "",
+    "Watch for",
+    "---------",
+    "  CODEX_ENV_NODE_VERSION overrides the repository's own .nvmrc and",
+    "  engines. An environment left on an older major breaks setup for a repo",
+    "  that requires a newer one, and the error blames the package manager.",
+    "",
+    "  Codex clones `main`, not the repository's default branch. If those",
+    "  differ here, that is where the confusion starts.",
+    "",
+    "  Setup logs are visible only in the Codex UI; no CLI retrieves them.",
+  ].join("\n");
+}
+
+/**
+ * Produce an image definition and a run command for a container.
+ *
+ * Split across build and run on purpose: the binaries are baked once, and the
+ * credential arrives at `docker run`. Baking it would put it in an image layer,
+ * readable by anyone who can pull the image and surviving every
+ * `docker history` — so the Dockerfile deliberately contains no secret.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitContainer({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
+  return [
+    "Provisioning tier: EMIT — an image is built from a file you own.",
+    "",
+    "Dockerfile",
+    "----------",
+    "  Generate it with the bootstrap's own emitter, so the image and this",
+    "  machine install the identical set:",
+    "",
+    "    npx -y @codyswann/lisa@latest workstation --print-dockerfile \\",
+    `      --provider=${provider ?? "bitwarden"} > Dockerfile.lisa`,
+    "    docker build -f Dockerfile.lisa -t lisa-workstation .",
+    "",
+    "  Nothing secret belongs in it. An image layer is readable by anyone who",
+    "  can pull the image and survives every `docker history`, so the",
+    "  credential arrives at run time instead.",
+    "",
+    "docker run",
+    "----------",
+    "  docker run --rm -it \\",
+    `    -e LISA_TENANT=${namespace} \\`,
+    `    -e ${key}="<this image's own access token>" \\`,
+    ...(provider ? [`    -e LISA_PROVIDER=${provider} \\`] : []),
+    "    -e LISA_SECRETS_SURFACE=container \\",
+    '    -v "$PWD:/work" -w /work \\',
+    "    lisa-workstation",
+    "",
+    "  LISA_SECRETS_SURFACE=container is what makes credentials materialize.",
+    "  Left to detection a container reads as `local`, which is",
+    "  materialized:false — right for a human at a keyboard whose provider CLI",
+    "  is authenticated, wrong for a container that has no keychain and dies",
+    "  with its filesystem.",
+    "",
+    "  Give the image its own access token rather than reusing this machine's.",
+    "  If the image is shared, so is anything its token can read.",
+    "",
+    "Mounted repositories need nothing further",
+    "-----------------------------------------",
+    "  A checkout you have already run `apply` and `sync` on carries its",
+    "  .lisa.config.json with it. Cloning INSIDE the container instead means",
+    "  running those there.",
+  ].join("\n");
+}
+
+/**
  * Report tooling the project appears to need but has not declared.
  *
  * Called before the toolchain is applied, because the manifest is the only

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/bootstrap-store.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/bootstrap-store.mjs
@@ -184,6 +184,39 @@ export function clearBootstrap(key, deps = {}) {
 }
 
 /**
+ * Whether this machine already holds a bootstrap under that name.
+ *
+ * Asked so `environment local` can re-materialize after a rotation in the vault
+ * without demanding the token again — that is the common case, and prompting
+ * every time would make it the tedious one.
+ *
+ * Presence only. The value is never read here, because nothing about deciding
+ * whether to prompt needs it.
+ * @param {string} key Bootstrap variable name.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {boolean} True when a value is stored.
+ */
+export function hasBootstrap(key, deps = {}) {
+  const kind = deps.kind ?? storeKind();
+  const env = deps.env ?? process.env;
+
+  if (kind === "keychain") {
+    const run = deps.run ?? execFileSync;
+    try {
+      run(
+        "security",
+        ["find-generic-password", "-s", assertKey(key), "-a", env.USER ?? ""],
+        { stdio: "ignore" }
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return (deps.exists ?? existsSync)(deps.path ?? bootstrapFile(key, env));
+}
+
+/**
  * Read a file-backed bootstrap, treating absence as empty.
  *
  * The keychain reader lives beside the other provider concerns in

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -299,12 +299,28 @@ export function installAwsProfiles(bundle, options = {}) {
   return rendered.profiles;
 }
 
-export function materialize(cfg = readConfig()) {
-  if (!cfg.capabilities.mayWriteValues) {
+export function materialize(cfg = readConfig(), options = {}) {
+  // `requested` distinguishes an OPERATOR asking from a flow deciding.
+  //
+  // The capability governs automated behaviour: a session-start hook on a
+  // laptop must not write credentials to disk, because the provider CLI is
+  // authenticated there and a copy would add drift and exposure without adding
+  // capability. That reasoning holds, and the guard below still enforces it.
+  //
+  // It does not hold for `lisa environment local`, where the operator typed the
+  // command whose entire purpose is to put credentials on this machine — the
+  // AWS `-static` profiles reference variables that exist only once the env
+  // file is materialized, so refusing there means the profiles never work.
+  //
+  // Two different questions, so two different answers, rather than flipping
+  // `local` to `materialized: true` and silently starting to write on every
+  // machine that upgrades.
+  if (!cfg.capabilities.mayWriteValues && !options.requested) {
     throw new Error(
       `surface "${cfg.surface}" may not write secret values to disk.\n` +
         `It can read through to the provider, so a copy on disk would add drift ` +
-        `and exposure without adding capability.`
+        `and exposure without adding capability.\n` +
+        `Run 'lisa environment local --tenant=<name>' to ask for it explicitly.`
     );
   }
 

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -253,6 +253,33 @@ function resolveBootstrap(bootstrap, provider, namespace) {
 }
 
 /**
+ * Build a configuration for a tenant the operator named outright.
+ *
+ * Deliberately ignores any `.lisa.config.json` in the working directory. The
+ * flag is the more specific statement — someone who typed `--tenant=acme` means
+ * acme, whichever repository they happen to be standing in — and silently
+ * preferring the file would materialize a different tenant than the one on the
+ * command line.
+ *
+ * Getting this wrong is not a cosmetic error. Every namespace is a directory
+ * under `$XDG_CONFIG_HOME`, so resolving to the wrong one writes one tenant's
+ * credentials where another tenant's sessions read, and on a machine serving
+ * several the two would share a store.
+ * @param {{tenant: string, provider?: string}} options Named identity.
+ * @param {Record<string, string|undefined>} [env] Environment to inherit.
+ * @returns {object} A resolved configuration.
+ */
+export function configForTenant({ tenant, provider }, env = process.env) {
+  return withSurface(
+    fromEnvironment({
+      ...env,
+      LISA_TENANT: tenant,
+      ...(provider ? { LISA_PROVIDER: provider } : {}),
+    })
+  );
+}
+
+/**
  * Build a configuration from the environment, for sessions with no checkout.
  *
  * `LISA_SECRETS_NAMESPACE` is the one value with no safe default: it names the

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/environment.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/environment.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * Configure one surface for one tenant.
+ *
+ * One verb, one axis — *which surface* — and the only difference between them
+ * is whether Lisa can execute there or has to hand an operator text to paste.
+ *
+ *     environment local        runs it here
+ *     environment container    emits an image definition and a run command
+ *     environment claude-web   emits, because the dialog has no API
+ *     environment codex-cloud  emits, same reason
+ *
+ * This replaces `remote-env --emit=<surface>`, whose name described the
+ * machinery rather than the task: from a laptop, `remote-env` reads as
+ * "prepare the remote environment I am currently in", which is the opposite of
+ * what an operator configuring a cloud environment is doing. The old spelling
+ * still works so nothing in flight breaks.
+ *
+ * `workstation` remains a separate command and a separate concern: it answers
+ * "what binaries does this machine have", with no tenant and no credentials. So
+ * **rotating a token is `environment local` again**, not re-running an
+ * installer that wants to reinstall six coding agents.
+ * @module environment
+ */
+
+import { pathToFileURL } from "node:url";
+
+/** Surfaces this command can configure, and how each is delivered. */
+export const TARGETS = {
+  local: { mode: "run", label: "this machine" },
+  container: { mode: "emit", label: "a container image you build" },
+  "claude-web": { mode: "emit", label: "a Claude cloud environment" },
+  "codex-cloud": { mode: "emit", label: "a Codex Cloud environment" },
+};
+
+/**
+ * Resolve the surface name an operator asked for.
+ *
+ * An unknown name is an error rather than a default, because defaulting would
+ * configure something other than what they typed — and on this command the
+ * difference between surfaces is where a credential ends up.
+ * @param {string|undefined} name Requested surface.
+ * @returns {string} A key of {@link TARGETS}.
+ */
+export function assertTarget(name) {
+  if (!name || !TARGETS[name]) {
+    throw new Error(
+      `unknown environment "${name ?? ""}".\n` +
+        `Known: ${Object.keys(TARGETS).join(", ")}`
+    );
+  }
+  return name;
+}
+
+/**
+ * Prepare THIS machine: store the bootstrap, then materialize.
+ *
+ * The prompt is skipped rather than blocked when nothing can answer it, and
+ * skipped rather than repeated when the machine already holds a bootstrap —
+ * `environment local` is also how an operator re-materializes after rotating a
+ * secret in the vault, and demanding the token again every time would make the
+ * common case the tedious one. `--rotate` is how you say you mean to replace it.
+ * @param {object} options Resolved tenant, provider and flags.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {Promise<string[]>} Lines to report.
+ */
+export async function configureLocal(options, deps = {}) {
+  const { tenant, provider, bootstrapKey: key, rotate = false } = options;
+  const lines = [];
+
+  // A tenant is required here, unlike the emit paths, because this one WRITES.
+  // Without it the config falls back to the default namespace and materializes
+  // one tenant's credentials into another's directory — and on a machine
+  // serving several, the two would then share a store.
+  if (!tenant) {
+    throw new Error(
+      "environment local needs --tenant=<name>.\n" +
+        "It writes credentials into a per-tenant directory, so guessing the " +
+        "name would put one tenant's secrets where another's sessions read."
+    );
+  }
+
+  const wired = deps.prompt
+    ? deps
+    : { ...(await localDeps({ tenant, provider })), ...deps };
+  const { canPrompt, promptSecret } = wired.prompt;
+  const { storeBootstrap, hasBootstrap } = wired.store;
+  const materialize = wired.materialize;
+
+  if (!key) {
+    lines.push(
+      `${provider} has no environment-variable bootstrap, so there is nothing`,
+      `to store. Authenticate it the way its own CLI expects.`
+    );
+  } else if (hasBootstrap(key) && !rotate) {
+    lines.push(`${key} is already stored; pass --rotate to replace it.`);
+  } else if (!canPrompt()) {
+    // Not fatal. A non-interactive caller can legitimately have supplied the
+    // bootstrap through the environment, and refusing would break that.
+    lines.push(
+      `No terminal to prompt on, so ${key} was not stored.`,
+      `Set it in the environment, or re-run where a human can type.`
+    );
+  } else {
+    const value = promptSecret(`Paste the access token for ${tenant}: `);
+    if (!value) {
+      lines.push(`Nothing entered, so ${key} was not stored.`);
+    } else {
+      const { where } = storeBootstrap(key, value);
+      lines.push(`Stored ${key} in ${where}.`);
+    }
+  }
+
+  const result = await materialize();
+  lines.push(...result);
+  return lines;
+}
+
+/**
+ * Run the command.
+ * @param {string[]} argv Arguments after the command name.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {Promise<number>} Exit code.
+ */
+export async function run(argv, deps = {}) {
+  const out = deps.log ?? console.log;
+  const err = deps.error ?? console.error;
+
+  try {
+    const target = assertTarget(argv.find(a => !a.startsWith("-")));
+    const resolve = deps.resolveTarget ?? (await defaultResolver());
+    const identity = await resolve(argv);
+
+    if (TARGETS[target].mode === "run") {
+      const lines = await (deps.configureLocal ?? configureLocal)(
+        { ...identity, rotate: argv.includes("--rotate") },
+        deps
+      );
+      out(lines.join("\n"));
+      return 0;
+    }
+
+    out((deps.emit ?? (await defaultEmitter()))(target, identity));
+    return 0;
+  } catch (error) {
+    err(String(error.message));
+    return 1;
+  }
+}
+
+// Executed directly by the CLI, imported by tests. Without this the module
+// exported a `run` nobody called and the command printed nothing at all.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  run(process.argv.slice(2)).then(code => {
+    process.exitCode = code;
+  });
+}
+
+/**
+ * Wire the local path to the real prompt, store and materializer.
+ *
+ * Loaded lazily so the emit paths — which need none of it — do not pay for it,
+ * and so tests can substitute the lot without touching a keychain or a vault.
+ *
+ * `materialize` is called with `requested: true`: the operator typed the
+ * command whose purpose is to put credentials on this machine, which is a
+ * different question from whether an automated flow may write here. The
+ * capability guard still refuses the automated case.
+ * @returns {Promise<object>} Default dependencies for `configureLocal`.
+ */
+async function localDeps(identity) {
+  const at = name =>
+    new URL(`../../lisa-secrets-access/scripts/${name}`, import.meta.url).href;
+  const prompt = await import(at("prompt-secret.mjs"));
+  const store = await import(at("bootstrap-store.mjs"));
+  const secrets = await import(at("materialize-secrets.mjs"));
+  const surfaces = await import(at("surfaces.mjs"));
+
+  return {
+    prompt,
+    store,
+    materialize: () => {
+      // The NAMED tenant, not whatever config the working directory holds.
+      // Reading the directory materialized the default namespace instead of the
+      // one on the command line — observed writing 49 secrets of the wrong
+      // tenant into the wrong directory.
+      const { count, derived, dir, profiles } = secrets.materialize(
+        surfaces.configForTenant(identity),
+        { requested: true }
+      );
+      return [
+        `Materialized ${count} secret(s) into ${dir}.`,
+        ...(derived ? [`${derived} variable(s) derived from the bundle.`] : []),
+        ...(profiles?.length
+          ? [`AWS profiles installed: ${profiles.join(", ")}`]
+          : []),
+      ];
+    },
+  };
+}
+
+/**
+ * Load the identity resolver from the sibling runner.
+ * @returns {Promise<Function>} The resolver.
+ */
+async function defaultResolver() {
+  // Already a URL — passing it through pathToFileURL again throws.
+  const mod = await import(
+    new URL("./setup-remote-env.mjs", import.meta.url).href
+  );
+  return argv => mod.resolveEmitTarget(argv);
+}
+
+/**
+ * Load the emitter from the sibling runner.
+ * @returns {Promise<Function>} The emitter.
+ */
+async function defaultEmitter() {
+  // Already a URL — passing it through pathToFileURL again throws.
+  const mod = await import(
+    new URL("./setup-remote-env.mjs", import.meta.url).href
+  );
+  return (target, identity) => mod.emitFor(target, identity);
+}

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -1031,6 +1031,142 @@ export function emitClaudeWeb({
 }
 
 /**
+ * Emit the configuration for a surface Lisa cannot reach.
+ *
+ * Dispatch rather than four call sites, so `environment` names a surface and
+ * nothing downstream has to know which of them has an API and which does not.
+ * @param {string} target Surface name.
+ * @param {object} identity Resolved tenant, provider and bootstrap key.
+ * @returns {string} Text to show the operator.
+ */
+export function emitFor(target, identity) {
+  if (target === "claude-web") return emitClaudeWeb(identity);
+  if (target === "codex-cloud") return emitCodexCloud(identity);
+  if (target === "container") return emitContainer(identity);
+  throw new Error(`no emit template for surface "${target}".`);
+}
+
+/**
+ * Produce the configuration a human pastes into a Codex Cloud environment.
+ *
+ * Differs from Claude's in three ways that are properties of the vendor rather
+ * than of Lisa, and each has cost someone a debugging session.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitCodexCloud({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
+  return [
+    "Provisioning tier: EMIT — Codex Cloud exposes no environment API.",
+    "  `codex cloud` offers exec, status and list; nothing that writes an",
+    "  environment. So this is text for the settings page.",
+    "",
+    "Paste into the environment settings",
+    "-----------------------------------",
+    "  Repository:        the DEFAULT checkout for this environment",
+    "",
+    "  Environment variables — NOT task secrets:",
+    // Written as name=value, not as `export name='value'`. This is a settings
+    // form, not a shell: the quotes would be stored as part of the value, and
+    // the surface named must be this one rather than the shell block's.
+    `    LISA_TENANT=${namespace}`,
+    ...(bootstrapKey
+      ? [`    ${key}=<read this from your credential manager>`]
+      : [`    (${provider} has no environment-variable bootstrap)`]),
+    ...(provider ? [`    LISA_PROVIDER=${provider}`] : []),
+    "    LISA_SECRETS_SURFACE=codex-cloud",
+    "",
+    "    Setup and cache-resume maintenance both run BEFORE task secrets",
+    "    exist, so a bootstrap placed in the secrets box is invisible to the",
+    "    only two steps that need it.",
+    "",
+    "  Setup script:",
+    `    ${SETUP_FIELD}`,
+    "",
+    "  Maintenance script:",
+    "    The SAME line. It runs when a container resumes from cache, and every",
+    "    step is idempotent and version-aware — so running it again is how a",
+    "    rotated value, an edited note, or a changed pin gets picked up.",
+    "",
+    "Watch for",
+    "---------",
+    "  CODEX_ENV_NODE_VERSION overrides the repository's own .nvmrc and",
+    "  engines. An environment left on an older major breaks setup for a repo",
+    "  that requires a newer one, and the error blames the package manager.",
+    "",
+    "  Codex clones `main`, not the repository's default branch. If those",
+    "  differ here, that is where the confusion starts.",
+    "",
+    "  Setup logs are visible only in the Codex UI; no CLI retrieves them.",
+  ].join("\n");
+}
+
+/**
+ * Produce an image definition and a run command for a container.
+ *
+ * Split across build and run on purpose: the binaries are baked once, and the
+ * credential arrives at `docker run`. Baking it would put it in an image layer,
+ * readable by anyone who can pull the image and surviving every
+ * `docker history` — so the Dockerfile deliberately contains no secret.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitContainer({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
+  return [
+    "Provisioning tier: EMIT — an image is built from a file you own.",
+    "",
+    "Dockerfile",
+    "----------",
+    "  Generate it with the bootstrap's own emitter, so the image and this",
+    "  machine install the identical set:",
+    "",
+    "    npx -y @codyswann/lisa@latest workstation --print-dockerfile \\",
+    `      --provider=${provider ?? "bitwarden"} > Dockerfile.lisa`,
+    "    docker build -f Dockerfile.lisa -t lisa-workstation .",
+    "",
+    "  Nothing secret belongs in it. An image layer is readable by anyone who",
+    "  can pull the image and survives every `docker history`, so the",
+    "  credential arrives at run time instead.",
+    "",
+    "docker run",
+    "----------",
+    "  docker run --rm -it \\",
+    `    -e LISA_TENANT=${namespace} \\`,
+    `    -e ${key}="<this image's own access token>" \\`,
+    ...(provider ? [`    -e LISA_PROVIDER=${provider} \\`] : []),
+    "    -e LISA_SECRETS_SURFACE=container \\",
+    '    -v "$PWD:/work" -w /work \\',
+    "    lisa-workstation",
+    "",
+    "  LISA_SECRETS_SURFACE=container is what makes credentials materialize.",
+    "  Left to detection a container reads as `local`, which is",
+    "  materialized:false — right for a human at a keyboard whose provider CLI",
+    "  is authenticated, wrong for a container that has no keychain and dies",
+    "  with its filesystem.",
+    "",
+    "  Give the image its own access token rather than reusing this machine's.",
+    "  If the image is shared, so is anything its token can read.",
+    "",
+    "Mounted repositories need nothing further",
+    "-----------------------------------------",
+    "  A checkout you have already run `apply` and `sync` on carries its",
+    "  .lisa.config.json with it. Cloning INSIDE the container instead means",
+    "  running those there.",
+  ].join("\n");
+}
+
+/**
  * Report tooling the project appears to need but has not declared.
  *
  * Called before the toolchain is applied, because the manifest is the only

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/bootstrap-store.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/bootstrap-store.mjs
@@ -184,6 +184,39 @@ export function clearBootstrap(key, deps = {}) {
 }
 
 /**
+ * Whether this machine already holds a bootstrap under that name.
+ *
+ * Asked so `environment local` can re-materialize after a rotation in the vault
+ * without demanding the token again — that is the common case, and prompting
+ * every time would make it the tedious one.
+ *
+ * Presence only. The value is never read here, because nothing about deciding
+ * whether to prompt needs it.
+ * @param {string} key Bootstrap variable name.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {boolean} True when a value is stored.
+ */
+export function hasBootstrap(key, deps = {}) {
+  const kind = deps.kind ?? storeKind();
+  const env = deps.env ?? process.env;
+
+  if (kind === "keychain") {
+    const run = deps.run ?? execFileSync;
+    try {
+      run(
+        "security",
+        ["find-generic-password", "-s", assertKey(key), "-a", env.USER ?? ""],
+        { stdio: "ignore" }
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return (deps.exists ?? existsSync)(deps.path ?? bootstrapFile(key, env));
+}
+
+/**
  * Read a file-backed bootstrap, treating absence as empty.
  *
  * The keychain reader lives beside the other provider concerns in

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -299,12 +299,28 @@ export function installAwsProfiles(bundle, options = {}) {
   return rendered.profiles;
 }
 
-export function materialize(cfg = readConfig()) {
-  if (!cfg.capabilities.mayWriteValues) {
+export function materialize(cfg = readConfig(), options = {}) {
+  // `requested` distinguishes an OPERATOR asking from a flow deciding.
+  //
+  // The capability governs automated behaviour: a session-start hook on a
+  // laptop must not write credentials to disk, because the provider CLI is
+  // authenticated there and a copy would add drift and exposure without adding
+  // capability. That reasoning holds, and the guard below still enforces it.
+  //
+  // It does not hold for `lisa environment local`, where the operator typed the
+  // command whose entire purpose is to put credentials on this machine — the
+  // AWS `-static` profiles reference variables that exist only once the env
+  // file is materialized, so refusing there means the profiles never work.
+  //
+  // Two different questions, so two different answers, rather than flipping
+  // `local` to `materialized: true` and silently starting to write on every
+  // machine that upgrades.
+  if (!cfg.capabilities.mayWriteValues && !options.requested) {
     throw new Error(
       `surface "${cfg.surface}" may not write secret values to disk.\n` +
         `It can read through to the provider, so a copy on disk would add drift ` +
-        `and exposure without adding capability.`
+        `and exposure without adding capability.\n` +
+        `Run 'lisa environment local --tenant=<name>' to ask for it explicitly.`
     );
   }
 

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -253,6 +253,33 @@ function resolveBootstrap(bootstrap, provider, namespace) {
 }
 
 /**
+ * Build a configuration for a tenant the operator named outright.
+ *
+ * Deliberately ignores any `.lisa.config.json` in the working directory. The
+ * flag is the more specific statement — someone who typed `--tenant=acme` means
+ * acme, whichever repository they happen to be standing in — and silently
+ * preferring the file would materialize a different tenant than the one on the
+ * command line.
+ *
+ * Getting this wrong is not a cosmetic error. Every namespace is a directory
+ * under `$XDG_CONFIG_HOME`, so resolving to the wrong one writes one tenant's
+ * credentials where another tenant's sessions read, and on a machine serving
+ * several the two would share a store.
+ * @param {{tenant: string, provider?: string}} options Named identity.
+ * @param {Record<string, string|undefined>} [env] Environment to inherit.
+ * @returns {object} A resolved configuration.
+ */
+export function configForTenant({ tenant, provider }, env = process.env) {
+  return withSurface(
+    fromEnvironment({
+      ...env,
+      LISA_TENANT: tenant,
+      ...(provider ? { LISA_PROVIDER: provider } : {}),
+    })
+  );
+}
+
+/**
  * Build a configuration from the environment, for sessions with no checkout.
  *
  * `LISA_SECRETS_NAMESPACE` is the one value with no safe default: it names the

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/environment.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/environment.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * Configure one surface for one tenant.
+ *
+ * One verb, one axis — *which surface* — and the only difference between them
+ * is whether Lisa can execute there or has to hand an operator text to paste.
+ *
+ *     environment local        runs it here
+ *     environment container    emits an image definition and a run command
+ *     environment claude-web   emits, because the dialog has no API
+ *     environment codex-cloud  emits, same reason
+ *
+ * This replaces `remote-env --emit=<surface>`, whose name described the
+ * machinery rather than the task: from a laptop, `remote-env` reads as
+ * "prepare the remote environment I am currently in", which is the opposite of
+ * what an operator configuring a cloud environment is doing. The old spelling
+ * still works so nothing in flight breaks.
+ *
+ * `workstation` remains a separate command and a separate concern: it answers
+ * "what binaries does this machine have", with no tenant and no credentials. So
+ * **rotating a token is `environment local` again**, not re-running an
+ * installer that wants to reinstall six coding agents.
+ * @module environment
+ */
+
+import { pathToFileURL } from "node:url";
+
+/** Surfaces this command can configure, and how each is delivered. */
+export const TARGETS = {
+  local: { mode: "run", label: "this machine" },
+  container: { mode: "emit", label: "a container image you build" },
+  "claude-web": { mode: "emit", label: "a Claude cloud environment" },
+  "codex-cloud": { mode: "emit", label: "a Codex Cloud environment" },
+};
+
+/**
+ * Resolve the surface name an operator asked for.
+ *
+ * An unknown name is an error rather than a default, because defaulting would
+ * configure something other than what they typed — and on this command the
+ * difference between surfaces is where a credential ends up.
+ * @param {string|undefined} name Requested surface.
+ * @returns {string} A key of {@link TARGETS}.
+ */
+export function assertTarget(name) {
+  if (!name || !TARGETS[name]) {
+    throw new Error(
+      `unknown environment "${name ?? ""}".\n` +
+        `Known: ${Object.keys(TARGETS).join(", ")}`
+    );
+  }
+  return name;
+}
+
+/**
+ * Prepare THIS machine: store the bootstrap, then materialize.
+ *
+ * The prompt is skipped rather than blocked when nothing can answer it, and
+ * skipped rather than repeated when the machine already holds a bootstrap —
+ * `environment local` is also how an operator re-materializes after rotating a
+ * secret in the vault, and demanding the token again every time would make the
+ * common case the tedious one. `--rotate` is how you say you mean to replace it.
+ * @param {object} options Resolved tenant, provider and flags.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {Promise<string[]>} Lines to report.
+ */
+export async function configureLocal(options, deps = {}) {
+  const { tenant, provider, bootstrapKey: key, rotate = false } = options;
+  const lines = [];
+
+  // A tenant is required here, unlike the emit paths, because this one WRITES.
+  // Without it the config falls back to the default namespace and materializes
+  // one tenant's credentials into another's directory — and on a machine
+  // serving several, the two would then share a store.
+  if (!tenant) {
+    throw new Error(
+      "environment local needs --tenant=<name>.\n" +
+        "It writes credentials into a per-tenant directory, so guessing the " +
+        "name would put one tenant's secrets where another's sessions read."
+    );
+  }
+
+  const wired = deps.prompt
+    ? deps
+    : { ...(await localDeps({ tenant, provider })), ...deps };
+  const { canPrompt, promptSecret } = wired.prompt;
+  const { storeBootstrap, hasBootstrap } = wired.store;
+  const materialize = wired.materialize;
+
+  if (!key) {
+    lines.push(
+      `${provider} has no environment-variable bootstrap, so there is nothing`,
+      `to store. Authenticate it the way its own CLI expects.`
+    );
+  } else if (hasBootstrap(key) && !rotate) {
+    lines.push(`${key} is already stored; pass --rotate to replace it.`);
+  } else if (!canPrompt()) {
+    // Not fatal. A non-interactive caller can legitimately have supplied the
+    // bootstrap through the environment, and refusing would break that.
+    lines.push(
+      `No terminal to prompt on, so ${key} was not stored.`,
+      `Set it in the environment, or re-run where a human can type.`
+    );
+  } else {
+    const value = promptSecret(`Paste the access token for ${tenant}: `);
+    if (!value) {
+      lines.push(`Nothing entered, so ${key} was not stored.`);
+    } else {
+      const { where } = storeBootstrap(key, value);
+      lines.push(`Stored ${key} in ${where}.`);
+    }
+  }
+
+  const result = await materialize();
+  lines.push(...result);
+  return lines;
+}
+
+/**
+ * Run the command.
+ * @param {string[]} argv Arguments after the command name.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {Promise<number>} Exit code.
+ */
+export async function run(argv, deps = {}) {
+  const out = deps.log ?? console.log;
+  const err = deps.error ?? console.error;
+
+  try {
+    const target = assertTarget(argv.find(a => !a.startsWith("-")));
+    const resolve = deps.resolveTarget ?? (await defaultResolver());
+    const identity = await resolve(argv);
+
+    if (TARGETS[target].mode === "run") {
+      const lines = await (deps.configureLocal ?? configureLocal)(
+        { ...identity, rotate: argv.includes("--rotate") },
+        deps
+      );
+      out(lines.join("\n"));
+      return 0;
+    }
+
+    out((deps.emit ?? (await defaultEmitter()))(target, identity));
+    return 0;
+  } catch (error) {
+    err(String(error.message));
+    return 1;
+  }
+}
+
+// Executed directly by the CLI, imported by tests. Without this the module
+// exported a `run` nobody called and the command printed nothing at all.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  run(process.argv.slice(2)).then(code => {
+    process.exitCode = code;
+  });
+}
+
+/**
+ * Wire the local path to the real prompt, store and materializer.
+ *
+ * Loaded lazily so the emit paths — which need none of it — do not pay for it,
+ * and so tests can substitute the lot without touching a keychain or a vault.
+ *
+ * `materialize` is called with `requested: true`: the operator typed the
+ * command whose purpose is to put credentials on this machine, which is a
+ * different question from whether an automated flow may write here. The
+ * capability guard still refuses the automated case.
+ * @returns {Promise<object>} Default dependencies for `configureLocal`.
+ */
+async function localDeps(identity) {
+  const at = name =>
+    new URL(`../../lisa-secrets-access/scripts/${name}`, import.meta.url).href;
+  const prompt = await import(at("prompt-secret.mjs"));
+  const store = await import(at("bootstrap-store.mjs"));
+  const secrets = await import(at("materialize-secrets.mjs"));
+  const surfaces = await import(at("surfaces.mjs"));
+
+  return {
+    prompt,
+    store,
+    materialize: () => {
+      // The NAMED tenant, not whatever config the working directory holds.
+      // Reading the directory materialized the default namespace instead of the
+      // one on the command line — observed writing 49 secrets of the wrong
+      // tenant into the wrong directory.
+      const { count, derived, dir, profiles } = secrets.materialize(
+        surfaces.configForTenant(identity),
+        { requested: true }
+      );
+      return [
+        `Materialized ${count} secret(s) into ${dir}.`,
+        ...(derived ? [`${derived} variable(s) derived from the bundle.`] : []),
+        ...(profiles?.length
+          ? [`AWS profiles installed: ${profiles.join(", ")}`]
+          : []),
+      ];
+    },
+  };
+}
+
+/**
+ * Load the identity resolver from the sibling runner.
+ * @returns {Promise<Function>} The resolver.
+ */
+async function defaultResolver() {
+  // Already a URL — passing it through pathToFileURL again throws.
+  const mod = await import(
+    new URL("./setup-remote-env.mjs", import.meta.url).href
+  );
+  return argv => mod.resolveEmitTarget(argv);
+}
+
+/**
+ * Load the emitter from the sibling runner.
+ * @returns {Promise<Function>} The emitter.
+ */
+async function defaultEmitter() {
+  // Already a URL — passing it through pathToFileURL again throws.
+  const mod = await import(
+    new URL("./setup-remote-env.mjs", import.meta.url).href
+  );
+  return (target, identity) => mod.emitFor(target, identity);
+}

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -1031,6 +1031,142 @@ export function emitClaudeWeb({
 }
 
 /**
+ * Emit the configuration for a surface Lisa cannot reach.
+ *
+ * Dispatch rather than four call sites, so `environment` names a surface and
+ * nothing downstream has to know which of them has an API and which does not.
+ * @param {string} target Surface name.
+ * @param {object} identity Resolved tenant, provider and bootstrap key.
+ * @returns {string} Text to show the operator.
+ */
+export function emitFor(target, identity) {
+  if (target === "claude-web") return emitClaudeWeb(identity);
+  if (target === "codex-cloud") return emitCodexCloud(identity);
+  if (target === "container") return emitContainer(identity);
+  throw new Error(`no emit template for surface "${target}".`);
+}
+
+/**
+ * Produce the configuration a human pastes into a Codex Cloud environment.
+ *
+ * Differs from Claude's in three ways that are properties of the vendor rather
+ * than of Lisa, and each has cost someone a debugging session.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitCodexCloud({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
+  return [
+    "Provisioning tier: EMIT — Codex Cloud exposes no environment API.",
+    "  `codex cloud` offers exec, status and list; nothing that writes an",
+    "  environment. So this is text for the settings page.",
+    "",
+    "Paste into the environment settings",
+    "-----------------------------------",
+    "  Repository:        the DEFAULT checkout for this environment",
+    "",
+    "  Environment variables — NOT task secrets:",
+    // Written as name=value, not as `export name='value'`. This is a settings
+    // form, not a shell: the quotes would be stored as part of the value, and
+    // the surface named must be this one rather than the shell block's.
+    `    LISA_TENANT=${namespace}`,
+    ...(bootstrapKey
+      ? [`    ${key}=<read this from your credential manager>`]
+      : [`    (${provider} has no environment-variable bootstrap)`]),
+    ...(provider ? [`    LISA_PROVIDER=${provider}`] : []),
+    "    LISA_SECRETS_SURFACE=codex-cloud",
+    "",
+    "    Setup and cache-resume maintenance both run BEFORE task secrets",
+    "    exist, so a bootstrap placed in the secrets box is invisible to the",
+    "    only two steps that need it.",
+    "",
+    "  Setup script:",
+    `    ${SETUP_FIELD}`,
+    "",
+    "  Maintenance script:",
+    "    The SAME line. It runs when a container resumes from cache, and every",
+    "    step is idempotent and version-aware — so running it again is how a",
+    "    rotated value, an edited note, or a changed pin gets picked up.",
+    "",
+    "Watch for",
+    "---------",
+    "  CODEX_ENV_NODE_VERSION overrides the repository's own .nvmrc and",
+    "  engines. An environment left on an older major breaks setup for a repo",
+    "  that requires a newer one, and the error blames the package manager.",
+    "",
+    "  Codex clones `main`, not the repository's default branch. If those",
+    "  differ here, that is where the confusion starts.",
+    "",
+    "  Setup logs are visible only in the Codex UI; no CLI retrieves them.",
+  ].join("\n");
+}
+
+/**
+ * Produce an image definition and a run command for a container.
+ *
+ * Split across build and run on purpose: the binaries are baked once, and the
+ * credential arrives at `docker run`. Baking it would put it in an image layer,
+ * readable by anyone who can pull the image and surviving every
+ * `docker history` — so the Dockerfile deliberately contains no secret.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitContainer({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
+  return [
+    "Provisioning tier: EMIT — an image is built from a file you own.",
+    "",
+    "Dockerfile",
+    "----------",
+    "  Generate it with the bootstrap's own emitter, so the image and this",
+    "  machine install the identical set:",
+    "",
+    "    npx -y @codyswann/lisa@latest workstation --print-dockerfile \\",
+    `      --provider=${provider ?? "bitwarden"} > Dockerfile.lisa`,
+    "    docker build -f Dockerfile.lisa -t lisa-workstation .",
+    "",
+    "  Nothing secret belongs in it. An image layer is readable by anyone who",
+    "  can pull the image and survives every `docker history`, so the",
+    "  credential arrives at run time instead.",
+    "",
+    "docker run",
+    "----------",
+    "  docker run --rm -it \\",
+    `    -e LISA_TENANT=${namespace} \\`,
+    `    -e ${key}="<this image's own access token>" \\`,
+    ...(provider ? [`    -e LISA_PROVIDER=${provider} \\`] : []),
+    "    -e LISA_SECRETS_SURFACE=container \\",
+    '    -v "$PWD:/work" -w /work \\',
+    "    lisa-workstation",
+    "",
+    "  LISA_SECRETS_SURFACE=container is what makes credentials materialize.",
+    "  Left to detection a container reads as `local`, which is",
+    "  materialized:false — right for a human at a keyboard whose provider CLI",
+    "  is authenticated, wrong for a container that has no keychain and dies",
+    "  with its filesystem.",
+    "",
+    "  Give the image its own access token rather than reusing this machine's.",
+    "  If the image is shared, so is anything its token can read.",
+    "",
+    "Mounted repositories need nothing further",
+    "-----------------------------------------",
+    "  A checkout you have already run `apply` and `sync` on carries its",
+    "  .lisa.config.json with it. Cloning INSIDE the container instead means",
+    "  running those there.",
+  ].join("\n");
+}
+
+/**
  * Report tooling the project appears to need but has not declared.
  *
  * Called before the toolchain is applied, because the manifest is the only

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/bootstrap-store.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/bootstrap-store.mjs
@@ -184,6 +184,39 @@ export function clearBootstrap(key, deps = {}) {
 }
 
 /**
+ * Whether this machine already holds a bootstrap under that name.
+ *
+ * Asked so `environment local` can re-materialize after a rotation in the vault
+ * without demanding the token again — that is the common case, and prompting
+ * every time would make it the tedious one.
+ *
+ * Presence only. The value is never read here, because nothing about deciding
+ * whether to prompt needs it.
+ * @param {string} key Bootstrap variable name.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {boolean} True when a value is stored.
+ */
+export function hasBootstrap(key, deps = {}) {
+  const kind = deps.kind ?? storeKind();
+  const env = deps.env ?? process.env;
+
+  if (kind === "keychain") {
+    const run = deps.run ?? execFileSync;
+    try {
+      run(
+        "security",
+        ["find-generic-password", "-s", assertKey(key), "-a", env.USER ?? ""],
+        { stdio: "ignore" }
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return (deps.exists ?? existsSync)(deps.path ?? bootstrapFile(key, env));
+}
+
+/**
  * Read a file-backed bootstrap, treating absence as empty.
  *
  * The keychain reader lives beside the other provider concerns in

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -299,12 +299,28 @@ export function installAwsProfiles(bundle, options = {}) {
   return rendered.profiles;
 }
 
-export function materialize(cfg = readConfig()) {
-  if (!cfg.capabilities.mayWriteValues) {
+export function materialize(cfg = readConfig(), options = {}) {
+  // `requested` distinguishes an OPERATOR asking from a flow deciding.
+  //
+  // The capability governs automated behaviour: a session-start hook on a
+  // laptop must not write credentials to disk, because the provider CLI is
+  // authenticated there and a copy would add drift and exposure without adding
+  // capability. That reasoning holds, and the guard below still enforces it.
+  //
+  // It does not hold for `lisa environment local`, where the operator typed the
+  // command whose entire purpose is to put credentials on this machine — the
+  // AWS `-static` profiles reference variables that exist only once the env
+  // file is materialized, so refusing there means the profiles never work.
+  //
+  // Two different questions, so two different answers, rather than flipping
+  // `local` to `materialized: true` and silently starting to write on every
+  // machine that upgrades.
+  if (!cfg.capabilities.mayWriteValues && !options.requested) {
     throw new Error(
       `surface "${cfg.surface}" may not write secret values to disk.\n` +
         `It can read through to the provider, so a copy on disk would add drift ` +
-        `and exposure without adding capability.`
+        `and exposure without adding capability.\n` +
+        `Run 'lisa environment local --tenant=<name>' to ask for it explicitly.`
     );
   }
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -253,6 +253,33 @@ function resolveBootstrap(bootstrap, provider, namespace) {
 }
 
 /**
+ * Build a configuration for a tenant the operator named outright.
+ *
+ * Deliberately ignores any `.lisa.config.json` in the working directory. The
+ * flag is the more specific statement — someone who typed `--tenant=acme` means
+ * acme, whichever repository they happen to be standing in — and silently
+ * preferring the file would materialize a different tenant than the one on the
+ * command line.
+ *
+ * Getting this wrong is not a cosmetic error. Every namespace is a directory
+ * under `$XDG_CONFIG_HOME`, so resolving to the wrong one writes one tenant's
+ * credentials where another tenant's sessions read, and on a machine serving
+ * several the two would share a store.
+ * @param {{tenant: string, provider?: string}} options Named identity.
+ * @param {Record<string, string|undefined>} [env] Environment to inherit.
+ * @returns {object} A resolved configuration.
+ */
+export function configForTenant({ tenant, provider }, env = process.env) {
+  return withSurface(
+    fromEnvironment({
+      ...env,
+      LISA_TENANT: tenant,
+      ...(provider ? { LISA_PROVIDER: provider } : {}),
+    })
+  );
+}
+
+/**
  * Build a configuration from the environment, for sessions with no checkout.
  *
  * `LISA_SECRETS_NAMESPACE` is the one value with no safe default: it names the

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/environment.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/environment.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * Configure one surface for one tenant.
+ *
+ * One verb, one axis — *which surface* — and the only difference between them
+ * is whether Lisa can execute there or has to hand an operator text to paste.
+ *
+ *     environment local        runs it here
+ *     environment container    emits an image definition and a run command
+ *     environment claude-web   emits, because the dialog has no API
+ *     environment codex-cloud  emits, same reason
+ *
+ * This replaces `remote-env --emit=<surface>`, whose name described the
+ * machinery rather than the task: from a laptop, `remote-env` reads as
+ * "prepare the remote environment I am currently in", which is the opposite of
+ * what an operator configuring a cloud environment is doing. The old spelling
+ * still works so nothing in flight breaks.
+ *
+ * `workstation` remains a separate command and a separate concern: it answers
+ * "what binaries does this machine have", with no tenant and no credentials. So
+ * **rotating a token is `environment local` again**, not re-running an
+ * installer that wants to reinstall six coding agents.
+ * @module environment
+ */
+
+import { pathToFileURL } from "node:url";
+
+/** Surfaces this command can configure, and how each is delivered. */
+export const TARGETS = {
+  local: { mode: "run", label: "this machine" },
+  container: { mode: "emit", label: "a container image you build" },
+  "claude-web": { mode: "emit", label: "a Claude cloud environment" },
+  "codex-cloud": { mode: "emit", label: "a Codex Cloud environment" },
+};
+
+/**
+ * Resolve the surface name an operator asked for.
+ *
+ * An unknown name is an error rather than a default, because defaulting would
+ * configure something other than what they typed — and on this command the
+ * difference between surfaces is where a credential ends up.
+ * @param {string|undefined} name Requested surface.
+ * @returns {string} A key of {@link TARGETS}.
+ */
+export function assertTarget(name) {
+  if (!name || !TARGETS[name]) {
+    throw new Error(
+      `unknown environment "${name ?? ""}".\n` +
+        `Known: ${Object.keys(TARGETS).join(", ")}`
+    );
+  }
+  return name;
+}
+
+/**
+ * Prepare THIS machine: store the bootstrap, then materialize.
+ *
+ * The prompt is skipped rather than blocked when nothing can answer it, and
+ * skipped rather than repeated when the machine already holds a bootstrap —
+ * `environment local` is also how an operator re-materializes after rotating a
+ * secret in the vault, and demanding the token again every time would make the
+ * common case the tedious one. `--rotate` is how you say you mean to replace it.
+ * @param {object} options Resolved tenant, provider and flags.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {Promise<string[]>} Lines to report.
+ */
+export async function configureLocal(options, deps = {}) {
+  const { tenant, provider, bootstrapKey: key, rotate = false } = options;
+  const lines = [];
+
+  // A tenant is required here, unlike the emit paths, because this one WRITES.
+  // Without it the config falls back to the default namespace and materializes
+  // one tenant's credentials into another's directory — and on a machine
+  // serving several, the two would then share a store.
+  if (!tenant) {
+    throw new Error(
+      "environment local needs --tenant=<name>.\n" +
+        "It writes credentials into a per-tenant directory, so guessing the " +
+        "name would put one tenant's secrets where another's sessions read."
+    );
+  }
+
+  const wired = deps.prompt
+    ? deps
+    : { ...(await localDeps({ tenant, provider })), ...deps };
+  const { canPrompt, promptSecret } = wired.prompt;
+  const { storeBootstrap, hasBootstrap } = wired.store;
+  const materialize = wired.materialize;
+
+  if (!key) {
+    lines.push(
+      `${provider} has no environment-variable bootstrap, so there is nothing`,
+      `to store. Authenticate it the way its own CLI expects.`
+    );
+  } else if (hasBootstrap(key) && !rotate) {
+    lines.push(`${key} is already stored; pass --rotate to replace it.`);
+  } else if (!canPrompt()) {
+    // Not fatal. A non-interactive caller can legitimately have supplied the
+    // bootstrap through the environment, and refusing would break that.
+    lines.push(
+      `No terminal to prompt on, so ${key} was not stored.`,
+      `Set it in the environment, or re-run where a human can type.`
+    );
+  } else {
+    const value = promptSecret(`Paste the access token for ${tenant}: `);
+    if (!value) {
+      lines.push(`Nothing entered, so ${key} was not stored.`);
+    } else {
+      const { where } = storeBootstrap(key, value);
+      lines.push(`Stored ${key} in ${where}.`);
+    }
+  }
+
+  const result = await materialize();
+  lines.push(...result);
+  return lines;
+}
+
+/**
+ * Run the command.
+ * @param {string[]} argv Arguments after the command name.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {Promise<number>} Exit code.
+ */
+export async function run(argv, deps = {}) {
+  const out = deps.log ?? console.log;
+  const err = deps.error ?? console.error;
+
+  try {
+    const target = assertTarget(argv.find(a => !a.startsWith("-")));
+    const resolve = deps.resolveTarget ?? (await defaultResolver());
+    const identity = await resolve(argv);
+
+    if (TARGETS[target].mode === "run") {
+      const lines = await (deps.configureLocal ?? configureLocal)(
+        { ...identity, rotate: argv.includes("--rotate") },
+        deps
+      );
+      out(lines.join("\n"));
+      return 0;
+    }
+
+    out((deps.emit ?? (await defaultEmitter()))(target, identity));
+    return 0;
+  } catch (error) {
+    err(String(error.message));
+    return 1;
+  }
+}
+
+// Executed directly by the CLI, imported by tests. Without this the module
+// exported a `run` nobody called and the command printed nothing at all.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  run(process.argv.slice(2)).then(code => {
+    process.exitCode = code;
+  });
+}
+
+/**
+ * Wire the local path to the real prompt, store and materializer.
+ *
+ * Loaded lazily so the emit paths — which need none of it — do not pay for it,
+ * and so tests can substitute the lot without touching a keychain or a vault.
+ *
+ * `materialize` is called with `requested: true`: the operator typed the
+ * command whose purpose is to put credentials on this machine, which is a
+ * different question from whether an automated flow may write here. The
+ * capability guard still refuses the automated case.
+ * @returns {Promise<object>} Default dependencies for `configureLocal`.
+ */
+async function localDeps(identity) {
+  const at = name =>
+    new URL(`../../lisa-secrets-access/scripts/${name}`, import.meta.url).href;
+  const prompt = await import(at("prompt-secret.mjs"));
+  const store = await import(at("bootstrap-store.mjs"));
+  const secrets = await import(at("materialize-secrets.mjs"));
+  const surfaces = await import(at("surfaces.mjs"));
+
+  return {
+    prompt,
+    store,
+    materialize: () => {
+      // The NAMED tenant, not whatever config the working directory holds.
+      // Reading the directory materialized the default namespace instead of the
+      // one on the command line — observed writing 49 secrets of the wrong
+      // tenant into the wrong directory.
+      const { count, derived, dir, profiles } = secrets.materialize(
+        surfaces.configForTenant(identity),
+        { requested: true }
+      );
+      return [
+        `Materialized ${count} secret(s) into ${dir}.`,
+        ...(derived ? [`${derived} variable(s) derived from the bundle.`] : []),
+        ...(profiles?.length
+          ? [`AWS profiles installed: ${profiles.join(", ")}`]
+          : []),
+      ];
+    },
+  };
+}
+
+/**
+ * Load the identity resolver from the sibling runner.
+ * @returns {Promise<Function>} The resolver.
+ */
+async function defaultResolver() {
+  // Already a URL — passing it through pathToFileURL again throws.
+  const mod = await import(
+    new URL("./setup-remote-env.mjs", import.meta.url).href
+  );
+  return argv => mod.resolveEmitTarget(argv);
+}
+
+/**
+ * Load the emitter from the sibling runner.
+ * @returns {Promise<Function>} The emitter.
+ */
+async function defaultEmitter() {
+  // Already a URL — passing it through pathToFileURL again throws.
+  const mod = await import(
+    new URL("./setup-remote-env.mjs", import.meta.url).href
+  );
+  return (target, identity) => mod.emitFor(target, identity);
+}

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -1031,6 +1031,142 @@ export function emitClaudeWeb({
 }
 
 /**
+ * Emit the configuration for a surface Lisa cannot reach.
+ *
+ * Dispatch rather than four call sites, so `environment` names a surface and
+ * nothing downstream has to know which of them has an API and which does not.
+ * @param {string} target Surface name.
+ * @param {object} identity Resolved tenant, provider and bootstrap key.
+ * @returns {string} Text to show the operator.
+ */
+export function emitFor(target, identity) {
+  if (target === "claude-web") return emitClaudeWeb(identity);
+  if (target === "codex-cloud") return emitCodexCloud(identity);
+  if (target === "container") return emitContainer(identity);
+  throw new Error(`no emit template for surface "${target}".`);
+}
+
+/**
+ * Produce the configuration a human pastes into a Codex Cloud environment.
+ *
+ * Differs from Claude's in three ways that are properties of the vendor rather
+ * than of Lisa, and each has cost someone a debugging session.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitCodexCloud({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
+  return [
+    "Provisioning tier: EMIT — Codex Cloud exposes no environment API.",
+    "  `codex cloud` offers exec, status and list; nothing that writes an",
+    "  environment. So this is text for the settings page.",
+    "",
+    "Paste into the environment settings",
+    "-----------------------------------",
+    "  Repository:        the DEFAULT checkout for this environment",
+    "",
+    "  Environment variables — NOT task secrets:",
+    // Written as name=value, not as `export name='value'`. This is a settings
+    // form, not a shell: the quotes would be stored as part of the value, and
+    // the surface named must be this one rather than the shell block's.
+    `    LISA_TENANT=${namespace}`,
+    ...(bootstrapKey
+      ? [`    ${key}=<read this from your credential manager>`]
+      : [`    (${provider} has no environment-variable bootstrap)`]),
+    ...(provider ? [`    LISA_PROVIDER=${provider}`] : []),
+    "    LISA_SECRETS_SURFACE=codex-cloud",
+    "",
+    "    Setup and cache-resume maintenance both run BEFORE task secrets",
+    "    exist, so a bootstrap placed in the secrets box is invisible to the",
+    "    only two steps that need it.",
+    "",
+    "  Setup script:",
+    `    ${SETUP_FIELD}`,
+    "",
+    "  Maintenance script:",
+    "    The SAME line. It runs when a container resumes from cache, and every",
+    "    step is idempotent and version-aware — so running it again is how a",
+    "    rotated value, an edited note, or a changed pin gets picked up.",
+    "",
+    "Watch for",
+    "---------",
+    "  CODEX_ENV_NODE_VERSION overrides the repository's own .nvmrc and",
+    "  engines. An environment left on an older major breaks setup for a repo",
+    "  that requires a newer one, and the error blames the package manager.",
+    "",
+    "  Codex clones `main`, not the repository's default branch. If those",
+    "  differ here, that is where the confusion starts.",
+    "",
+    "  Setup logs are visible only in the Codex UI; no CLI retrieves them.",
+  ].join("\n");
+}
+
+/**
+ * Produce an image definition and a run command for a container.
+ *
+ * Split across build and run on purpose: the binaries are baked once, and the
+ * credential arrives at `docker run`. Baking it would put it in an image layer,
+ * readable by anyone who can pull the image and surviving every
+ * `docker history` — so the Dockerfile deliberately contains no secret.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitContainer({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
+  return [
+    "Provisioning tier: EMIT — an image is built from a file you own.",
+    "",
+    "Dockerfile",
+    "----------",
+    "  Generate it with the bootstrap's own emitter, so the image and this",
+    "  machine install the identical set:",
+    "",
+    "    npx -y @codyswann/lisa@latest workstation --print-dockerfile \\",
+    `      --provider=${provider ?? "bitwarden"} > Dockerfile.lisa`,
+    "    docker build -f Dockerfile.lisa -t lisa-workstation .",
+    "",
+    "  Nothing secret belongs in it. An image layer is readable by anyone who",
+    "  can pull the image and survives every `docker history`, so the",
+    "  credential arrives at run time instead.",
+    "",
+    "docker run",
+    "----------",
+    "  docker run --rm -it \\",
+    `    -e LISA_TENANT=${namespace} \\`,
+    `    -e ${key}="<this image's own access token>" \\`,
+    ...(provider ? [`    -e LISA_PROVIDER=${provider} \\`] : []),
+    "    -e LISA_SECRETS_SURFACE=container \\",
+    '    -v "$PWD:/work" -w /work \\',
+    "    lisa-workstation",
+    "",
+    "  LISA_SECRETS_SURFACE=container is what makes credentials materialize.",
+    "  Left to detection a container reads as `local`, which is",
+    "  materialized:false — right for a human at a keyboard whose provider CLI",
+    "  is authenticated, wrong for a container that has no keychain and dies",
+    "  with its filesystem.",
+    "",
+    "  Give the image its own access token rather than reusing this machine's.",
+    "  If the image is shared, so is anything its token can read.",
+    "",
+    "Mounted repositories need nothing further",
+    "-----------------------------------------",
+    "  A checkout you have already run `apply` and `sync` on carries its",
+    "  .lisa.config.json with it. Cloning INSIDE the container instead means",
+    "  running those there.",
+  ].join("\n");
+}
+
+/**
  * Report tooling the project appears to need but has not declared.
  *
  * Called before the toolchain is applied, because the manifest is the only

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/bootstrap-store.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/bootstrap-store.mjs
@@ -184,6 +184,39 @@ export function clearBootstrap(key, deps = {}) {
 }
 
 /**
+ * Whether this machine already holds a bootstrap under that name.
+ *
+ * Asked so `environment local` can re-materialize after a rotation in the vault
+ * without demanding the token again — that is the common case, and prompting
+ * every time would make it the tedious one.
+ *
+ * Presence only. The value is never read here, because nothing about deciding
+ * whether to prompt needs it.
+ * @param {string} key Bootstrap variable name.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {boolean} True when a value is stored.
+ */
+export function hasBootstrap(key, deps = {}) {
+  const kind = deps.kind ?? storeKind();
+  const env = deps.env ?? process.env;
+
+  if (kind === "keychain") {
+    const run = deps.run ?? execFileSync;
+    try {
+      run(
+        "security",
+        ["find-generic-password", "-s", assertKey(key), "-a", env.USER ?? ""],
+        { stdio: "ignore" }
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return (deps.exists ?? existsSync)(deps.path ?? bootstrapFile(key, env));
+}
+
+/**
  * Read a file-backed bootstrap, treating absence as empty.
  *
  * The keychain reader lives beside the other provider concerns in

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -299,12 +299,28 @@ export function installAwsProfiles(bundle, options = {}) {
   return rendered.profiles;
 }
 
-export function materialize(cfg = readConfig()) {
-  if (!cfg.capabilities.mayWriteValues) {
+export function materialize(cfg = readConfig(), options = {}) {
+  // `requested` distinguishes an OPERATOR asking from a flow deciding.
+  //
+  // The capability governs automated behaviour: a session-start hook on a
+  // laptop must not write credentials to disk, because the provider CLI is
+  // authenticated there and a copy would add drift and exposure without adding
+  // capability. That reasoning holds, and the guard below still enforces it.
+  //
+  // It does not hold for `lisa environment local`, where the operator typed the
+  // command whose entire purpose is to put credentials on this machine — the
+  // AWS `-static` profiles reference variables that exist only once the env
+  // file is materialized, so refusing there means the profiles never work.
+  //
+  // Two different questions, so two different answers, rather than flipping
+  // `local` to `materialized: true` and silently starting to write on every
+  // machine that upgrades.
+  if (!cfg.capabilities.mayWriteValues && !options.requested) {
     throw new Error(
       `surface "${cfg.surface}" may not write secret values to disk.\n` +
         `It can read through to the provider, so a copy on disk would add drift ` +
-        `and exposure without adding capability.`
+        `and exposure without adding capability.\n` +
+        `Run 'lisa environment local --tenant=<name>' to ask for it explicitly.`
     );
   }
 

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -253,6 +253,33 @@ function resolveBootstrap(bootstrap, provider, namespace) {
 }
 
 /**
+ * Build a configuration for a tenant the operator named outright.
+ *
+ * Deliberately ignores any `.lisa.config.json` in the working directory. The
+ * flag is the more specific statement — someone who typed `--tenant=acme` means
+ * acme, whichever repository they happen to be standing in — and silently
+ * preferring the file would materialize a different tenant than the one on the
+ * command line.
+ *
+ * Getting this wrong is not a cosmetic error. Every namespace is a directory
+ * under `$XDG_CONFIG_HOME`, so resolving to the wrong one writes one tenant's
+ * credentials where another tenant's sessions read, and on a machine serving
+ * several the two would share a store.
+ * @param {{tenant: string, provider?: string}} options Named identity.
+ * @param {Record<string, string|undefined>} [env] Environment to inherit.
+ * @returns {object} A resolved configuration.
+ */
+export function configForTenant({ tenant, provider }, env = process.env) {
+  return withSurface(
+    fromEnvironment({
+      ...env,
+      LISA_TENANT: tenant,
+      ...(provider ? { LISA_PROVIDER: provider } : {}),
+    })
+  );
+}
+
+/**
  * Build a configuration from the environment, for sessions with no checkout.
  *
  * `LISA_SECRETS_NAMESPACE` is the one value with no safe default: it names the

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/environment.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/environment.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * Configure one surface for one tenant.
+ *
+ * One verb, one axis — *which surface* — and the only difference between them
+ * is whether Lisa can execute there or has to hand an operator text to paste.
+ *
+ *     environment local        runs it here
+ *     environment container    emits an image definition and a run command
+ *     environment claude-web   emits, because the dialog has no API
+ *     environment codex-cloud  emits, same reason
+ *
+ * This replaces `remote-env --emit=<surface>`, whose name described the
+ * machinery rather than the task: from a laptop, `remote-env` reads as
+ * "prepare the remote environment I am currently in", which is the opposite of
+ * what an operator configuring a cloud environment is doing. The old spelling
+ * still works so nothing in flight breaks.
+ *
+ * `workstation` remains a separate command and a separate concern: it answers
+ * "what binaries does this machine have", with no tenant and no credentials. So
+ * **rotating a token is `environment local` again**, not re-running an
+ * installer that wants to reinstall six coding agents.
+ * @module environment
+ */
+
+import { pathToFileURL } from "node:url";
+
+/** Surfaces this command can configure, and how each is delivered. */
+export const TARGETS = {
+  local: { mode: "run", label: "this machine" },
+  container: { mode: "emit", label: "a container image you build" },
+  "claude-web": { mode: "emit", label: "a Claude cloud environment" },
+  "codex-cloud": { mode: "emit", label: "a Codex Cloud environment" },
+};
+
+/**
+ * Resolve the surface name an operator asked for.
+ *
+ * An unknown name is an error rather than a default, because defaulting would
+ * configure something other than what they typed — and on this command the
+ * difference between surfaces is where a credential ends up.
+ * @param {string|undefined} name Requested surface.
+ * @returns {string} A key of {@link TARGETS}.
+ */
+export function assertTarget(name) {
+  if (!name || !TARGETS[name]) {
+    throw new Error(
+      `unknown environment "${name ?? ""}".\n` +
+        `Known: ${Object.keys(TARGETS).join(", ")}`
+    );
+  }
+  return name;
+}
+
+/**
+ * Prepare THIS machine: store the bootstrap, then materialize.
+ *
+ * The prompt is skipped rather than blocked when nothing can answer it, and
+ * skipped rather than repeated when the machine already holds a bootstrap —
+ * `environment local` is also how an operator re-materializes after rotating a
+ * secret in the vault, and demanding the token again every time would make the
+ * common case the tedious one. `--rotate` is how you say you mean to replace it.
+ * @param {object} options Resolved tenant, provider and flags.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {Promise<string[]>} Lines to report.
+ */
+export async function configureLocal(options, deps = {}) {
+  const { tenant, provider, bootstrapKey: key, rotate = false } = options;
+  const lines = [];
+
+  // A tenant is required here, unlike the emit paths, because this one WRITES.
+  // Without it the config falls back to the default namespace and materializes
+  // one tenant's credentials into another's directory — and on a machine
+  // serving several, the two would then share a store.
+  if (!tenant) {
+    throw new Error(
+      "environment local needs --tenant=<name>.\n" +
+        "It writes credentials into a per-tenant directory, so guessing the " +
+        "name would put one tenant's secrets where another's sessions read."
+    );
+  }
+
+  const wired = deps.prompt
+    ? deps
+    : { ...(await localDeps({ tenant, provider })), ...deps };
+  const { canPrompt, promptSecret } = wired.prompt;
+  const { storeBootstrap, hasBootstrap } = wired.store;
+  const materialize = wired.materialize;
+
+  if (!key) {
+    lines.push(
+      `${provider} has no environment-variable bootstrap, so there is nothing`,
+      `to store. Authenticate it the way its own CLI expects.`
+    );
+  } else if (hasBootstrap(key) && !rotate) {
+    lines.push(`${key} is already stored; pass --rotate to replace it.`);
+  } else if (!canPrompt()) {
+    // Not fatal. A non-interactive caller can legitimately have supplied the
+    // bootstrap through the environment, and refusing would break that.
+    lines.push(
+      `No terminal to prompt on, so ${key} was not stored.`,
+      `Set it in the environment, or re-run where a human can type.`
+    );
+  } else {
+    const value = promptSecret(`Paste the access token for ${tenant}: `);
+    if (!value) {
+      lines.push(`Nothing entered, so ${key} was not stored.`);
+    } else {
+      const { where } = storeBootstrap(key, value);
+      lines.push(`Stored ${key} in ${where}.`);
+    }
+  }
+
+  const result = await materialize();
+  lines.push(...result);
+  return lines;
+}
+
+/**
+ * Run the command.
+ * @param {string[]} argv Arguments after the command name.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {Promise<number>} Exit code.
+ */
+export async function run(argv, deps = {}) {
+  const out = deps.log ?? console.log;
+  const err = deps.error ?? console.error;
+
+  try {
+    const target = assertTarget(argv.find(a => !a.startsWith("-")));
+    const resolve = deps.resolveTarget ?? (await defaultResolver());
+    const identity = await resolve(argv);
+
+    if (TARGETS[target].mode === "run") {
+      const lines = await (deps.configureLocal ?? configureLocal)(
+        { ...identity, rotate: argv.includes("--rotate") },
+        deps
+      );
+      out(lines.join("\n"));
+      return 0;
+    }
+
+    out((deps.emit ?? (await defaultEmitter()))(target, identity));
+    return 0;
+  } catch (error) {
+    err(String(error.message));
+    return 1;
+  }
+}
+
+// Executed directly by the CLI, imported by tests. Without this the module
+// exported a `run` nobody called and the command printed nothing at all.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  run(process.argv.slice(2)).then(code => {
+    process.exitCode = code;
+  });
+}
+
+/**
+ * Wire the local path to the real prompt, store and materializer.
+ *
+ * Loaded lazily so the emit paths — which need none of it — do not pay for it,
+ * and so tests can substitute the lot without touching a keychain or a vault.
+ *
+ * `materialize` is called with `requested: true`: the operator typed the
+ * command whose purpose is to put credentials on this machine, which is a
+ * different question from whether an automated flow may write here. The
+ * capability guard still refuses the automated case.
+ * @returns {Promise<object>} Default dependencies for `configureLocal`.
+ */
+async function localDeps(identity) {
+  const at = name =>
+    new URL(`../../lisa-secrets-access/scripts/${name}`, import.meta.url).href;
+  const prompt = await import(at("prompt-secret.mjs"));
+  const store = await import(at("bootstrap-store.mjs"));
+  const secrets = await import(at("materialize-secrets.mjs"));
+  const surfaces = await import(at("surfaces.mjs"));
+
+  return {
+    prompt,
+    store,
+    materialize: () => {
+      // The NAMED tenant, not whatever config the working directory holds.
+      // Reading the directory materialized the default namespace instead of the
+      // one on the command line — observed writing 49 secrets of the wrong
+      // tenant into the wrong directory.
+      const { count, derived, dir, profiles } = secrets.materialize(
+        surfaces.configForTenant(identity),
+        { requested: true }
+      );
+      return [
+        `Materialized ${count} secret(s) into ${dir}.`,
+        ...(derived ? [`${derived} variable(s) derived from the bundle.`] : []),
+        ...(profiles?.length
+          ? [`AWS profiles installed: ${profiles.join(", ")}`]
+          : []),
+      ];
+    },
+  };
+}
+
+/**
+ * Load the identity resolver from the sibling runner.
+ * @returns {Promise<Function>} The resolver.
+ */
+async function defaultResolver() {
+  // Already a URL — passing it through pathToFileURL again throws.
+  const mod = await import(
+    new URL("./setup-remote-env.mjs", import.meta.url).href
+  );
+  return argv => mod.resolveEmitTarget(argv);
+}
+
+/**
+ * Load the emitter from the sibling runner.
+ * @returns {Promise<Function>} The emitter.
+ */
+async function defaultEmitter() {
+  // Already a URL — passing it through pathToFileURL again throws.
+  const mod = await import(
+    new URL("./setup-remote-env.mjs", import.meta.url).href
+  );
+  return (target, identity) => mod.emitFor(target, identity);
+}

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -1031,6 +1031,142 @@ export function emitClaudeWeb({
 }
 
 /**
+ * Emit the configuration for a surface Lisa cannot reach.
+ *
+ * Dispatch rather than four call sites, so `environment` names a surface and
+ * nothing downstream has to know which of them has an API and which does not.
+ * @param {string} target Surface name.
+ * @param {object} identity Resolved tenant, provider and bootstrap key.
+ * @returns {string} Text to show the operator.
+ */
+export function emitFor(target, identity) {
+  if (target === "claude-web") return emitClaudeWeb(identity);
+  if (target === "codex-cloud") return emitCodexCloud(identity);
+  if (target === "container") return emitContainer(identity);
+  throw new Error(`no emit template for surface "${target}".`);
+}
+
+/**
+ * Produce the configuration a human pastes into a Codex Cloud environment.
+ *
+ * Differs from Claude's in three ways that are properties of the vendor rather
+ * than of Lisa, and each has cost someone a debugging session.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitCodexCloud({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
+  return [
+    "Provisioning tier: EMIT — Codex Cloud exposes no environment API.",
+    "  `codex cloud` offers exec, status and list; nothing that writes an",
+    "  environment. So this is text for the settings page.",
+    "",
+    "Paste into the environment settings",
+    "-----------------------------------",
+    "  Repository:        the DEFAULT checkout for this environment",
+    "",
+    "  Environment variables — NOT task secrets:",
+    // Written as name=value, not as `export name='value'`. This is a settings
+    // form, not a shell: the quotes would be stored as part of the value, and
+    // the surface named must be this one rather than the shell block's.
+    `    LISA_TENANT=${namespace}`,
+    ...(bootstrapKey
+      ? [`    ${key}=<read this from your credential manager>`]
+      : [`    (${provider} has no environment-variable bootstrap)`]),
+    ...(provider ? [`    LISA_PROVIDER=${provider}`] : []),
+    "    LISA_SECRETS_SURFACE=codex-cloud",
+    "",
+    "    Setup and cache-resume maintenance both run BEFORE task secrets",
+    "    exist, so a bootstrap placed in the secrets box is invisible to the",
+    "    only two steps that need it.",
+    "",
+    "  Setup script:",
+    `    ${SETUP_FIELD}`,
+    "",
+    "  Maintenance script:",
+    "    The SAME line. It runs when a container resumes from cache, and every",
+    "    step is idempotent and version-aware — so running it again is how a",
+    "    rotated value, an edited note, or a changed pin gets picked up.",
+    "",
+    "Watch for",
+    "---------",
+    "  CODEX_ENV_NODE_VERSION overrides the repository's own .nvmrc and",
+    "  engines. An environment left on an older major breaks setup for a repo",
+    "  that requires a newer one, and the error blames the package manager.",
+    "",
+    "  Codex clones `main`, not the repository's default branch. If those",
+    "  differ here, that is where the confusion starts.",
+    "",
+    "  Setup logs are visible only in the Codex UI; no CLI retrieves them.",
+  ].join("\n");
+}
+
+/**
+ * Produce an image definition and a run command for a container.
+ *
+ * Split across build and run on purpose: the binaries are baked once, and the
+ * credential arrives at `docker run`. Baking it would put it in an image layer,
+ * readable by anyone who can pull the image and surviving every
+ * `docker history` — so the Dockerfile deliberately contains no secret.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitContainer({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
+  return [
+    "Provisioning tier: EMIT — an image is built from a file you own.",
+    "",
+    "Dockerfile",
+    "----------",
+    "  Generate it with the bootstrap's own emitter, so the image and this",
+    "  machine install the identical set:",
+    "",
+    "    npx -y @codyswann/lisa@latest workstation --print-dockerfile \\",
+    `      --provider=${provider ?? "bitwarden"} > Dockerfile.lisa`,
+    "    docker build -f Dockerfile.lisa -t lisa-workstation .",
+    "",
+    "  Nothing secret belongs in it. An image layer is readable by anyone who",
+    "  can pull the image and survives every `docker history`, so the",
+    "  credential arrives at run time instead.",
+    "",
+    "docker run",
+    "----------",
+    "  docker run --rm -it \\",
+    `    -e LISA_TENANT=${namespace} \\`,
+    `    -e ${key}="<this image's own access token>" \\`,
+    ...(provider ? [`    -e LISA_PROVIDER=${provider} \\`] : []),
+    "    -e LISA_SECRETS_SURFACE=container \\",
+    '    -v "$PWD:/work" -w /work \\',
+    "    lisa-workstation",
+    "",
+    "  LISA_SECRETS_SURFACE=container is what makes credentials materialize.",
+    "  Left to detection a container reads as `local`, which is",
+    "  materialized:false — right for a human at a keyboard whose provider CLI",
+    "  is authenticated, wrong for a container that has no keychain and dies",
+    "  with its filesystem.",
+    "",
+    "  Give the image its own access token rather than reusing this machine's.",
+    "  If the image is shared, so is anything its token can read.",
+    "",
+    "Mounted repositories need nothing further",
+    "-----------------------------------------",
+    "  A checkout you have already run `apply` and `sync` on carries its",
+    "  .lisa.config.json with it. Cloning INSIDE the container instead means",
+    "  running those there.",
+  ].join("\n");
+}
+
+/**
  * Report tooling the project appears to need but has not declared.
  *
  * Called before the toolchain is applied, because the manifest is the only

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/bootstrap-store.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/bootstrap-store.mjs
@@ -184,6 +184,39 @@ export function clearBootstrap(key, deps = {}) {
 }
 
 /**
+ * Whether this machine already holds a bootstrap under that name.
+ *
+ * Asked so `environment local` can re-materialize after a rotation in the vault
+ * without demanding the token again — that is the common case, and prompting
+ * every time would make it the tedious one.
+ *
+ * Presence only. The value is never read here, because nothing about deciding
+ * whether to prompt needs it.
+ * @param {string} key Bootstrap variable name.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {boolean} True when a value is stored.
+ */
+export function hasBootstrap(key, deps = {}) {
+  const kind = deps.kind ?? storeKind();
+  const env = deps.env ?? process.env;
+
+  if (kind === "keychain") {
+    const run = deps.run ?? execFileSync;
+    try {
+      run(
+        "security",
+        ["find-generic-password", "-s", assertKey(key), "-a", env.USER ?? ""],
+        { stdio: "ignore" }
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return (deps.exists ?? existsSync)(deps.path ?? bootstrapFile(key, env));
+}
+
+/**
  * Read a file-backed bootstrap, treating absence as empty.
  *
  * The keychain reader lives beside the other provider concerns in

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -299,12 +299,28 @@ export function installAwsProfiles(bundle, options = {}) {
   return rendered.profiles;
 }
 
-export function materialize(cfg = readConfig()) {
-  if (!cfg.capabilities.mayWriteValues) {
+export function materialize(cfg = readConfig(), options = {}) {
+  // `requested` distinguishes an OPERATOR asking from a flow deciding.
+  //
+  // The capability governs automated behaviour: a session-start hook on a
+  // laptop must not write credentials to disk, because the provider CLI is
+  // authenticated there and a copy would add drift and exposure without adding
+  // capability. That reasoning holds, and the guard below still enforces it.
+  //
+  // It does not hold for `lisa environment local`, where the operator typed the
+  // command whose entire purpose is to put credentials on this machine — the
+  // AWS `-static` profiles reference variables that exist only once the env
+  // file is materialized, so refusing there means the profiles never work.
+  //
+  // Two different questions, so two different answers, rather than flipping
+  // `local` to `materialized: true` and silently starting to write on every
+  // machine that upgrades.
+  if (!cfg.capabilities.mayWriteValues && !options.requested) {
     throw new Error(
       `surface "${cfg.surface}" may not write secret values to disk.\n` +
         `It can read through to the provider, so a copy on disk would add drift ` +
-        `and exposure without adding capability.`
+        `and exposure without adding capability.\n` +
+        `Run 'lisa environment local --tenant=<name>' to ask for it explicitly.`
     );
   }
 

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -253,6 +253,33 @@ function resolveBootstrap(bootstrap, provider, namespace) {
 }
 
 /**
+ * Build a configuration for a tenant the operator named outright.
+ *
+ * Deliberately ignores any `.lisa.config.json` in the working directory. The
+ * flag is the more specific statement — someone who typed `--tenant=acme` means
+ * acme, whichever repository they happen to be standing in — and silently
+ * preferring the file would materialize a different tenant than the one on the
+ * command line.
+ *
+ * Getting this wrong is not a cosmetic error. Every namespace is a directory
+ * under `$XDG_CONFIG_HOME`, so resolving to the wrong one writes one tenant's
+ * credentials where another tenant's sessions read, and on a machine serving
+ * several the two would share a store.
+ * @param {{tenant: string, provider?: string}} options Named identity.
+ * @param {Record<string, string|undefined>} [env] Environment to inherit.
+ * @returns {object} A resolved configuration.
+ */
+export function configForTenant({ tenant, provider }, env = process.env) {
+  return withSurface(
+    fromEnvironment({
+      ...env,
+      LISA_TENANT: tenant,
+      ...(provider ? { LISA_PROVIDER: provider } : {}),
+    })
+  );
+}
+
+/**
  * Build a configuration from the environment, for sessions with no checkout.
  *
  * `LISA_SECRETS_NAMESPACE` is the one value with no safe default: it names the

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/environment.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/environment.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * Configure one surface for one tenant.
+ *
+ * One verb, one axis — *which surface* — and the only difference between them
+ * is whether Lisa can execute there or has to hand an operator text to paste.
+ *
+ *     environment local        runs it here
+ *     environment container    emits an image definition and a run command
+ *     environment claude-web   emits, because the dialog has no API
+ *     environment codex-cloud  emits, same reason
+ *
+ * This replaces `remote-env --emit=<surface>`, whose name described the
+ * machinery rather than the task: from a laptop, `remote-env` reads as
+ * "prepare the remote environment I am currently in", which is the opposite of
+ * what an operator configuring a cloud environment is doing. The old spelling
+ * still works so nothing in flight breaks.
+ *
+ * `workstation` remains a separate command and a separate concern: it answers
+ * "what binaries does this machine have", with no tenant and no credentials. So
+ * **rotating a token is `environment local` again**, not re-running an
+ * installer that wants to reinstall six coding agents.
+ * @module environment
+ */
+
+import { pathToFileURL } from "node:url";
+
+/** Surfaces this command can configure, and how each is delivered. */
+export const TARGETS = {
+  local: { mode: "run", label: "this machine" },
+  container: { mode: "emit", label: "a container image you build" },
+  "claude-web": { mode: "emit", label: "a Claude cloud environment" },
+  "codex-cloud": { mode: "emit", label: "a Codex Cloud environment" },
+};
+
+/**
+ * Resolve the surface name an operator asked for.
+ *
+ * An unknown name is an error rather than a default, because defaulting would
+ * configure something other than what they typed — and on this command the
+ * difference between surfaces is where a credential ends up.
+ * @param {string|undefined} name Requested surface.
+ * @returns {string} A key of {@link TARGETS}.
+ */
+export function assertTarget(name) {
+  if (!name || !TARGETS[name]) {
+    throw new Error(
+      `unknown environment "${name ?? ""}".\n` +
+        `Known: ${Object.keys(TARGETS).join(", ")}`
+    );
+  }
+  return name;
+}
+
+/**
+ * Prepare THIS machine: store the bootstrap, then materialize.
+ *
+ * The prompt is skipped rather than blocked when nothing can answer it, and
+ * skipped rather than repeated when the machine already holds a bootstrap —
+ * `environment local` is also how an operator re-materializes after rotating a
+ * secret in the vault, and demanding the token again every time would make the
+ * common case the tedious one. `--rotate` is how you say you mean to replace it.
+ * @param {object} options Resolved tenant, provider and flags.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {Promise<string[]>} Lines to report.
+ */
+export async function configureLocal(options, deps = {}) {
+  const { tenant, provider, bootstrapKey: key, rotate = false } = options;
+  const lines = [];
+
+  // A tenant is required here, unlike the emit paths, because this one WRITES.
+  // Without it the config falls back to the default namespace and materializes
+  // one tenant's credentials into another's directory — and on a machine
+  // serving several, the two would then share a store.
+  if (!tenant) {
+    throw new Error(
+      "environment local needs --tenant=<name>.\n" +
+        "It writes credentials into a per-tenant directory, so guessing the " +
+        "name would put one tenant's secrets where another's sessions read."
+    );
+  }
+
+  const wired = deps.prompt
+    ? deps
+    : { ...(await localDeps({ tenant, provider })), ...deps };
+  const { canPrompt, promptSecret } = wired.prompt;
+  const { storeBootstrap, hasBootstrap } = wired.store;
+  const materialize = wired.materialize;
+
+  if (!key) {
+    lines.push(
+      `${provider} has no environment-variable bootstrap, so there is nothing`,
+      `to store. Authenticate it the way its own CLI expects.`
+    );
+  } else if (hasBootstrap(key) && !rotate) {
+    lines.push(`${key} is already stored; pass --rotate to replace it.`);
+  } else if (!canPrompt()) {
+    // Not fatal. A non-interactive caller can legitimately have supplied the
+    // bootstrap through the environment, and refusing would break that.
+    lines.push(
+      `No terminal to prompt on, so ${key} was not stored.`,
+      `Set it in the environment, or re-run where a human can type.`
+    );
+  } else {
+    const value = promptSecret(`Paste the access token for ${tenant}: `);
+    if (!value) {
+      lines.push(`Nothing entered, so ${key} was not stored.`);
+    } else {
+      const { where } = storeBootstrap(key, value);
+      lines.push(`Stored ${key} in ${where}.`);
+    }
+  }
+
+  const result = await materialize();
+  lines.push(...result);
+  return lines;
+}
+
+/**
+ * Run the command.
+ * @param {string[]} argv Arguments after the command name.
+ * @param {object} [deps] Injected seams, for tests.
+ * @returns {Promise<number>} Exit code.
+ */
+export async function run(argv, deps = {}) {
+  const out = deps.log ?? console.log;
+  const err = deps.error ?? console.error;
+
+  try {
+    const target = assertTarget(argv.find(a => !a.startsWith("-")));
+    const resolve = deps.resolveTarget ?? (await defaultResolver());
+    const identity = await resolve(argv);
+
+    if (TARGETS[target].mode === "run") {
+      const lines = await (deps.configureLocal ?? configureLocal)(
+        { ...identity, rotate: argv.includes("--rotate") },
+        deps
+      );
+      out(lines.join("\n"));
+      return 0;
+    }
+
+    out((deps.emit ?? (await defaultEmitter()))(target, identity));
+    return 0;
+  } catch (error) {
+    err(String(error.message));
+    return 1;
+  }
+}
+
+// Executed directly by the CLI, imported by tests. Without this the module
+// exported a `run` nobody called and the command printed nothing at all.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  run(process.argv.slice(2)).then(code => {
+    process.exitCode = code;
+  });
+}
+
+/**
+ * Wire the local path to the real prompt, store and materializer.
+ *
+ * Loaded lazily so the emit paths — which need none of it — do not pay for it,
+ * and so tests can substitute the lot without touching a keychain or a vault.
+ *
+ * `materialize` is called with `requested: true`: the operator typed the
+ * command whose purpose is to put credentials on this machine, which is a
+ * different question from whether an automated flow may write here. The
+ * capability guard still refuses the automated case.
+ * @returns {Promise<object>} Default dependencies for `configureLocal`.
+ */
+async function localDeps(identity) {
+  const at = name =>
+    new URL(`../../lisa-secrets-access/scripts/${name}`, import.meta.url).href;
+  const prompt = await import(at("prompt-secret.mjs"));
+  const store = await import(at("bootstrap-store.mjs"));
+  const secrets = await import(at("materialize-secrets.mjs"));
+  const surfaces = await import(at("surfaces.mjs"));
+
+  return {
+    prompt,
+    store,
+    materialize: () => {
+      // The NAMED tenant, not whatever config the working directory holds.
+      // Reading the directory materialized the default namespace instead of the
+      // one on the command line — observed writing 49 secrets of the wrong
+      // tenant into the wrong directory.
+      const { count, derived, dir, profiles } = secrets.materialize(
+        surfaces.configForTenant(identity),
+        { requested: true }
+      );
+      return [
+        `Materialized ${count} secret(s) into ${dir}.`,
+        ...(derived ? [`${derived} variable(s) derived from the bundle.`] : []),
+        ...(profiles?.length
+          ? [`AWS profiles installed: ${profiles.join(", ")}`]
+          : []),
+      ];
+    },
+  };
+}
+
+/**
+ * Load the identity resolver from the sibling runner.
+ * @returns {Promise<Function>} The resolver.
+ */
+async function defaultResolver() {
+  // Already a URL — passing it through pathToFileURL again throws.
+  const mod = await import(
+    new URL("./setup-remote-env.mjs", import.meta.url).href
+  );
+  return argv => mod.resolveEmitTarget(argv);
+}
+
+/**
+ * Load the emitter from the sibling runner.
+ * @returns {Promise<Function>} The emitter.
+ */
+async function defaultEmitter() {
+  // Already a URL — passing it through pathToFileURL again throws.
+  const mod = await import(
+    new URL("./setup-remote-env.mjs", import.meta.url).href
+  );
+  return (target, identity) => mod.emitFor(target, identity);
+}

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -1031,6 +1031,142 @@ export function emitClaudeWeb({
 }
 
 /**
+ * Emit the configuration for a surface Lisa cannot reach.
+ *
+ * Dispatch rather than four call sites, so `environment` names a surface and
+ * nothing downstream has to know which of them has an API and which does not.
+ * @param {string} target Surface name.
+ * @param {object} identity Resolved tenant, provider and bootstrap key.
+ * @returns {string} Text to show the operator.
+ */
+export function emitFor(target, identity) {
+  if (target === "claude-web") return emitClaudeWeb(identity);
+  if (target === "codex-cloud") return emitCodexCloud(identity);
+  if (target === "container") return emitContainer(identity);
+  throw new Error(`no emit template for surface "${target}".`);
+}
+
+/**
+ * Produce the configuration a human pastes into a Codex Cloud environment.
+ *
+ * Differs from Claude's in three ways that are properties of the vendor rather
+ * than of Lisa, and each has cost someone a debugging session.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitCodexCloud({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
+  return [
+    "Provisioning tier: EMIT — Codex Cloud exposes no environment API.",
+    "  `codex cloud` offers exec, status and list; nothing that writes an",
+    "  environment. So this is text for the settings page.",
+    "",
+    "Paste into the environment settings",
+    "-----------------------------------",
+    "  Repository:        the DEFAULT checkout for this environment",
+    "",
+    "  Environment variables — NOT task secrets:",
+    // Written as name=value, not as `export name='value'`. This is a settings
+    // form, not a shell: the quotes would be stored as part of the value, and
+    // the surface named must be this one rather than the shell block's.
+    `    LISA_TENANT=${namespace}`,
+    ...(bootstrapKey
+      ? [`    ${key}=<read this from your credential manager>`]
+      : [`    (${provider} has no environment-variable bootstrap)`]),
+    ...(provider ? [`    LISA_PROVIDER=${provider}`] : []),
+    "    LISA_SECRETS_SURFACE=codex-cloud",
+    "",
+    "    Setup and cache-resume maintenance both run BEFORE task secrets",
+    "    exist, so a bootstrap placed in the secrets box is invisible to the",
+    "    only two steps that need it.",
+    "",
+    "  Setup script:",
+    `    ${SETUP_FIELD}`,
+    "",
+    "  Maintenance script:",
+    "    The SAME line. It runs when a container resumes from cache, and every",
+    "    step is idempotent and version-aware — so running it again is how a",
+    "    rotated value, an edited note, or a changed pin gets picked up.",
+    "",
+    "Watch for",
+    "---------",
+    "  CODEX_ENV_NODE_VERSION overrides the repository's own .nvmrc and",
+    "  engines. An environment left on an older major breaks setup for a repo",
+    "  that requires a newer one, and the error blames the package manager.",
+    "",
+    "  Codex clones `main`, not the repository's default branch. If those",
+    "  differ here, that is where the confusion starts.",
+    "",
+    "  Setup logs are visible only in the Codex UI; no CLI retrieves them.",
+  ].join("\n");
+}
+
+/**
+ * Produce an image definition and a run command for a container.
+ *
+ * Split across build and run on purpose: the binaries are baked once, and the
+ * credential arrives at `docker run`. Baking it would put it in an image layer,
+ * readable by anyone who can pull the image and surviving every
+ * `docker history` — so the Dockerfile deliberately contains no secret.
+ * @param {{bootstrapKey: string|null, tenant?: string|null, provider?: string}} options Project details.
+ * @returns {string} Text to show the operator.
+ */
+export function emitContainer({
+  bootstrapKey,
+  tenant = null,
+  provider = null,
+}) {
+  const key = bootstrapKey ?? "<not resolved>";
+  const namespace = tenant ?? "<your namespace>";
+  return [
+    "Provisioning tier: EMIT — an image is built from a file you own.",
+    "",
+    "Dockerfile",
+    "----------",
+    "  Generate it with the bootstrap's own emitter, so the image and this",
+    "  machine install the identical set:",
+    "",
+    "    npx -y @codyswann/lisa@latest workstation --print-dockerfile \\",
+    `      --provider=${provider ?? "bitwarden"} > Dockerfile.lisa`,
+    "    docker build -f Dockerfile.lisa -t lisa-workstation .",
+    "",
+    "  Nothing secret belongs in it. An image layer is readable by anyone who",
+    "  can pull the image and survives every `docker history`, so the",
+    "  credential arrives at run time instead.",
+    "",
+    "docker run",
+    "----------",
+    "  docker run --rm -it \\",
+    `    -e LISA_TENANT=${namespace} \\`,
+    `    -e ${key}="<this image's own access token>" \\`,
+    ...(provider ? [`    -e LISA_PROVIDER=${provider} \\`] : []),
+    "    -e LISA_SECRETS_SURFACE=container \\",
+    '    -v "$PWD:/work" -w /work \\',
+    "    lisa-workstation",
+    "",
+    "  LISA_SECRETS_SURFACE=container is what makes credentials materialize.",
+    "  Left to detection a container reads as `local`, which is",
+    "  materialized:false — right for a human at a keyboard whose provider CLI",
+    "  is authenticated, wrong for a container that has no keychain and dies",
+    "  with its filesystem.",
+    "",
+    "  Give the image its own access token rather than reusing this machine's.",
+    "  If the image is shared, so is anything its token can read.",
+    "",
+    "Mounted repositories need nothing further",
+    "-----------------------------------------",
+    "  A checkout you have already run `apply` and `sync` on carries its",
+    "  .lisa.config.json with it. Cloning INSIDE the container instead means",
+    "  running those there.",
+  ].join("\n");
+}
+
+/**
  * Report tooling the project appears to need but has not declared.
  *
  * Called before the toolchain is applied, because the manifest is the only

--- a/src/cli/environment-cmd.ts
+++ b/src/cli/environment-cmd.ts
@@ -1,0 +1,127 @@
+/**
+ * CLI entry point for `lisa environment <surface>`.
+ *
+ * One verb, one axis — which surface — and the only difference between them is
+ * whether Lisa can execute there or has to hand an operator text to paste.
+ *
+ * It replaces `remote-env --emit=<surface>`, whose name described the machinery
+ * rather than the task. From a laptop, `remote-env` reads as "prepare the
+ * remote environment I am currently in", which is the opposite of what an
+ * operator configuring a cloud environment is doing. The old spelling still
+ * works, so nothing in flight breaks.
+ * @module cli/environment-cmd
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import type { Command } from "commander";
+
+import { flagsAfterCommand } from "./workstation-cmd.js";
+import { getCliInstallPath } from "./version-cmd.js";
+
+/** Where the runner sits inside the published package. */
+const SCRIPT_RELATIVE = path.join(
+  "plugins",
+  "src",
+  "base",
+  "skills",
+  "lisa-setup-remote-env",
+  "scripts",
+  "environment.mjs"
+);
+
+/** Injectable seams so the command is testable without provisioning anything. */
+export interface EnvironmentDeps {
+  /** Resolve the installed package root. */
+  readonly installPath?: () => string;
+  /** Run the script. */
+  readonly run?: (command: string, args: string[]) => { status: number | null };
+  /** Report a problem. */
+  readonly error?: (message: string) => void;
+}
+
+/**
+ * Locate the runner inside the installed package.
+ *
+ * Resolved from the module's own location rather than the working directory:
+ * this command's whole point is that it works without a checkout, so the cwd is
+ * frequently not a project at all.
+ * @param installPath Package root resolver.
+ * @returns Absolute path to the runner.
+ * @throws {Error} When the package is incomplete.
+ */
+export function resolveEnvironmentScript(
+  installPath: () => string = getCliInstallPath
+): string {
+  const script = path.join(installPath(), SCRIPT_RELATIVE);
+  if (!existsSync(script)) {
+    throw new Error(
+      `environment runner not found at ${script}.\n` +
+        `The installed @codyswann/lisa looks incomplete; reinstall it.`
+    );
+  }
+  return script;
+}
+
+/**
+ * Run the environment runner with the given arguments.
+ * @param args Surface and flags, forwarded verbatim.
+ * @param deps Injectable seams.
+ * @returns The runner's exit code.
+ */
+export function runEnvironment(
+  args: readonly string[] = [],
+  deps: EnvironmentDeps = {}
+): number {
+  const {
+    installPath = getCliInstallPath,
+    run = (command: string, spawnArgs: string[]) =>
+      spawnSync(command, spawnArgs, { stdio: "inherit" }),
+    error = (message: string) => process.stderr.write(`${message}\n`),
+  } = deps;
+
+  try {
+    const script = resolveEnvironmentScript(installPath);
+    // process.execPath rather than "node": under npx the runner must be run by
+    // the interpreter already running, not whichever node a PATH lookup finds.
+    return run(process.execPath, [script, ...args]).status ?? 1;
+  } catch (err) {
+    error((err as Error).message);
+    return 1;
+  }
+}
+
+/**
+ * Register `lisa environment`.
+ * @param program Commander program to mutate.
+ * @param deps Program dependencies.
+ * @param deps.runEnvironment Runs the runner and returns its exit code.
+ */
+export function addEnvironmentCommand(
+  program: Command,
+  deps: { readonly runEnvironment: (args: readonly string[]) => number } = {
+    runEnvironment,
+  }
+): void {
+  program
+    .command("environment")
+    .description(
+      "Configure one surface for one tenant: 'local' prepares this machine, " +
+        "'container', 'claude-web' and 'codex-cloud' print what to paste. " +
+        "Needs no checkout: " +
+        "'npx -y @codyswann/lisa@latest environment local --tenant=<name>'."
+    )
+    // The arguments belong to the runner, not to commander. Re-declaring them
+    // would give the CLI and the skill two vocabularies to keep in step.
+    .allowUnknownOption(true)
+    .argument("[args...]", "surface and flags forwarded to the runner")
+    .action(() => {
+      const code = deps.runEnvironment(
+        flagsAfterCommand(process.argv, "environment")
+      );
+      if (code !== 0) {
+        process.exitCode = code;
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,6 +33,7 @@ import { runUpdate } from "./update-cmd.js";
 import { runUpdateCheck } from "./update-check.js";
 import { addUpdateCheckHook } from "./update-check-hook.js";
 import { runVersion } from "./version-cmd.js";
+import { addEnvironmentCommand } from "./environment-cmd.js";
 import { addRemoteEnvCommand } from "./remote-env-cmd.js";
 import { addWorkstationCommand } from "./workstation-cmd.js";
 import { getPackageVersion } from "./version.js";
@@ -241,6 +242,7 @@ function addMaintenanceCommands(
 
   addWorkstationCommand(program);
   addRemoteEnvCommand(program);
+  addEnvironmentCommand(program);
   addDoctorCommand(program, deps);
   addHealthCommand(program, deps);
   addStandardsProofCommand(program, deps);

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1107,13 +1107,13 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/aws-bootstrap.mjs":
       "a06c212d45442a0a2daaefda1a7255e299f82704ca3637243b778d8268a5ce65",
     "plugins/src/base/skills/lisa-secrets-access/scripts/bootstrap-store.mjs":
-      "6b59accef9d1899a5154fc504932e7bf24613bdd65f31d6d4e30cb1311c1e597",
+      "8dd5ca2c99394ead696093dd10caf664ce2609d39fb8d8ae8f4d4f236dbddbe6",
     "plugins/src/base/skills/lisa-secrets-access/scripts/doctor-secrets.mjs":
       "f203c71457da958cdb49637c87e4a9c43e964f98ecef3dd0e933b419d565f98e",
     "plugins/src/base/skills/lisa-secrets-access/scripts/envfile.mjs":
       "be4e38ce85f9268b52b29dbde264ecd8d50973c2b63a15410336234a921d9644",
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs":
-      "3b598675cee9d5235a3d12b82ab969effb0b47be263edf41474f8427105e3ce4",
+      "694f2660df23871d470701d1fb9fc7e24fcf7be137d9c275059ae7f7383340e9",
     "plugins/src/base/skills/lisa-secrets-access/scripts/prompt-secret.mjs":
       "22b28bcdf49b9b0fcd1b15639e031655efacc028b74d48d57e2275f3e1557508",
     "plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs":
@@ -1125,7 +1125,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/rotate-secret.mjs":
       "546dc1c2f279cee6db56c0f55c01aabae0c316842f32d3219c5af6d638936a9c",
     "plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs":
-      "284c0634b64d6c2b24d388cf3a74a6275588c592fdf60a525ba5aa3c7cc569b7",
+      "ad4df3007572f6dba5086633b8238e51a14e5ef163216aea899800441f56cd02",
     "plugins/src/base/skills/lisa-secrets-access/scripts/tools-from-notes.mjs":
       "07d183d8325341feea0db82c5f48f403981d0642999ce9b6462b6f89642e93c6",
     "plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs":
@@ -1168,8 +1168,10 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "cb63d08b14ab7aa2d405e6770e0cf7db5d6588ae1dcb924ea6224b026fcff496",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
       "c30d98a5645f033fc1d3a723043691b9ad997ae5666df539ff6aa19c563431b2",
+    "plugins/src/base/skills/lisa-setup-remote-env/scripts/environment.mjs":
+      "3b9be11691d81a896fc779c37fb6d69e8e7222f95e23f84aa03d4e590f9d9108",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "d17e71d7073e76d2301db26b57003cfc66eefe4ee4f7ac4b6649e3a028569946",
+      "b4b831f8900360bbb36922edcddaef6bbe4b3730cb21cf0a365d76b914bcbe4e",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
       "496de5aed034692fee421dc3a1fbad9f85ed9e1d0c83a1080f781a486d0274e6",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
@@ -3341,6 +3343,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-setup-remote-env/assets/session-start.sh": true,
     "plugins/lisa-agy/skills/lisa-setup-remote-env/assets/setup.sh": true,
+    "plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/environment.mjs": true,
     "plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs": true,
     "plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/toolchain.mjs": true,
     "plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs": true,
@@ -3774,6 +3777,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-setup-remote-env/assets/session-start.sh": true,
     "plugins/lisa-copilot/skills/lisa-setup-remote-env/assets/setup.sh": true,
+    "plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/environment.mjs": true,
     "plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs": true,
     "plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/toolchain.mjs": true,
     "plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs": true,
@@ -4193,6 +4197,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-setup-remote-env/assets/session-start.sh": true,
     "plugins/lisa-cursor/skills/lisa-setup-remote-env/assets/setup.sh": true,
+    "plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/environment.mjs": true,
     "plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs": true,
     "plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/toolchain.mjs": true,
     "plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs": true,
@@ -6241,6 +6246,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/agents/openai.yaml": true,
     "plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/assets/session-start.sh": true,
     "plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/assets/setup.sh": true,
+    "plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/environment.mjs": true,
     "plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs": true,
     "plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/toolchain.mjs": true,
     "plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs": true,
@@ -6840,6 +6846,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/skills/lisa-setup-remote-env/agents/openai.yaml": true,
     "plugins/lisa/skills/lisa-setup-remote-env/assets/session-start.sh": true,
     "plugins/lisa/skills/lisa-setup-remote-env/assets/setup.sh": true,
+    "plugins/lisa/skills/lisa-setup-remote-env/scripts/environment.mjs": true,
     "plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs": true,
     "plugins/lisa/skills/lisa-setup-remote-env/scripts/toolchain.mjs": true,
     "plugins/lisa/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs": true,
@@ -7300,6 +7307,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md": true,
     "plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh": true,
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh": true,
+    "plugins/src/base/skills/lisa-setup-remote-env/scripts/environment.mjs": true,
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs": true,
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs": true,
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs": true,
@@ -7871,6 +7879,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/cli/doctor-worker-epoch.ts": true,
     "src/cli/doctor-worker-journey.ts": true,
     "src/cli/doctor.ts": true,
+    "src/cli/environment-cmd.ts": true,
     "src/cli/file-upstream-cmd.ts": true,
     "src/cli/gate-commands.ts": true,
     "src/cli/health-cmd.ts": true,
@@ -8536,6 +8545,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/doctor-secrets.test.ts": true,
     "tests/unit/secrets/emit-claude-web-exports.test.ts": true,
     "tests/unit/secrets/emit-tenant-provider.test.ts": true,
+    "tests/unit/secrets/environment-command.test.ts": true,
     "tests/unit/secrets/install-method-conformance.test.ts": true,
     "tests/unit/secrets/local-aws-profiles.test.ts": true,
     "tests/unit/secrets/local-env-command.test.ts": true,

--- a/tests/unit/secrets/environment-command.test.ts
+++ b/tests/unit/secrets/environment-command.test.ts
@@ -1,0 +1,174 @@
+/**
+ * `environment <surface> --tenant=<name>`: one verb, one axis.
+ *
+ * The tenant guard is the one that matters. Every namespace is a directory
+ * under `$XDG_CONFIG_HOME`, so resolving the wrong one writes one tenant's
+ * credentials where another tenant's sessions read — and on a machine serving
+ * several, the two would share a store. An early version fell back to the
+ * default namespace and materialized 49 secrets of the wrong tenant before
+ * anyone noticed.
+ * @module tests/unit/secrets/environment-command
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  TARGETS,
+  assertTarget,
+  configureLocal,
+} from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/environment.mjs";
+
+/**
+ * Seams standing in for the prompt, the store and the materializer.
+ * @param over Overrides for a specific case.
+ * @returns Dependencies plus the log they fill.
+ */
+function deps(over: Record<string, unknown> = {}): {
+  d: Record<string, unknown>;
+  stored: { key: string; value: string }[];
+  materializedFor: unknown[];
+} {
+  const stored: { key: string; value: string }[] = [];
+  const materializedFor: unknown[] = [];
+  return {
+    stored,
+    materializedFor,
+    d: {
+      prompt: {
+        canPrompt: () => true,
+        promptSecret: () => "typed-value",
+        ...((over.prompt as object) ?? {}),
+      },
+      store: {
+        hasBootstrap: () => false,
+        storeBootstrap: (key: string, value: string) => {
+          stored.push({ key, value });
+          return { kind: "keychain", where: "keychain" };
+        },
+        ...((over.store as object) ?? {}),
+      },
+      materialize: () => {
+        materializedFor.push(true);
+        return ["Materialized 3 secret(s)."];
+      },
+    },
+  };
+}
+
+/** A resolved identity, as the resolver returns it. */
+const IDENTITY = {
+  tenant: "tunnl",
+  provider: "bitwarden",
+  bootstrapKey: "BWS_ACCESS_TOKEN_tunnl",
+};
+
+describe("assertTarget", () => {
+  it("names every surface it can configure", () => {
+    expect(Object.keys(TARGETS)).toEqual([
+      "local",
+      "container",
+      "claude-web",
+      "codex-cloud",
+    ]);
+  });
+
+  it("runs local and emits the rest", () => {
+    // The only difference between surfaces is whether Lisa can execute there.
+    expect(TARGETS.local.mode).toBe("run");
+    for (const name of ["container", "claude-web", "codex-cloud"]) {
+      expect(TARGETS[name as keyof typeof TARGETS].mode).toBe("emit");
+    }
+  });
+
+  it("refuses an unknown surface rather than defaulting", () => {
+    // Defaulting would configure something other than what was typed, and on
+    // this command the difference is where a credential ends up.
+    expect(() => assertTarget("claude-cloud")).toThrow(/unknown environment/);
+    expect(() => assertTarget(undefined)).toThrow(/unknown environment/);
+  });
+});
+
+describe("configureLocal", () => {
+  it("REFUSES without a tenant, because it writes", () => {
+    // The bug that shipped in an early draft: no tenant meant the default
+    // namespace, so it materialized the wrong tenant into the wrong directory.
+    const { d } = deps();
+
+    return expect(
+      configureLocal({ ...IDENTITY, tenant: null }, d)
+    ).rejects.toThrow(/needs --tenant/);
+  });
+
+  it("stores what was typed, then materializes", async () => {
+    const { d, stored, materializedFor } = deps();
+
+    await configureLocal(IDENTITY, d);
+
+    expect(stored).toEqual([
+      { key: "BWS_ACCESS_TOKEN_tunnl", value: "typed-value" },
+    ]);
+    expect(materializedFor).toHaveLength(1);
+  });
+
+  it("does not re-prompt when a bootstrap is already stored", async () => {
+    // This command is also how an operator re-materializes after rotating a
+    // secret in the vault. Demanding the token every time would make the common
+    // case the tedious one.
+    const { d, stored, materializedFor } = deps({
+      store: { hasBootstrap: () => true },
+    });
+
+    const lines = await configureLocal(IDENTITY, d);
+
+    expect(stored).toEqual([]);
+    expect(lines.join("\n")).toMatch(/already stored; pass --rotate/);
+    expect(materializedFor).toHaveLength(1);
+  });
+
+  it("re-prompts when --rotate says so", async () => {
+    const { d, stored } = deps({ store: { hasBootstrap: () => true } });
+
+    await configureLocal({ ...IDENTITY, rotate: true }, d);
+
+    expect(stored).toHaveLength(1);
+  });
+
+  it("SKIPS the prompt without a terminal, and still materializes", async () => {
+    // Hanging on a read nobody will answer looks like a slow install. And a
+    // non-interactive caller can legitimately supply the bootstrap through the
+    // environment, so this is not fatal.
+    const { d, stored, materializedFor } = deps({
+      prompt: { canPrompt: () => false },
+    });
+
+    const lines = await configureLocal(IDENTITY, d);
+
+    expect(stored).toEqual([]);
+    expect(lines.join("\n")).toMatch(/No terminal to prompt on/);
+    expect(materializedFor).toHaveLength(1);
+  });
+
+  it("says so and stores nothing when the operator enters nothing", async () => {
+    const { d, stored } = deps({ prompt: { promptSecret: () => "" } });
+
+    const lines = await configureLocal(IDENTITY, d);
+
+    expect(stored).toEqual([]);
+    expect(lines.join("\n")).toMatch(/Nothing entered/);
+  });
+
+  it("explains a provider that has no such variable, and still materializes", async () => {
+    // 1Password, Vault and AWS authenticate by other means; there is nothing to
+    // store, which is different from having failed to store it.
+    const { d, stored, materializedFor } = deps();
+
+    const lines = await configureLocal(
+      { tenant: "acme", provider: "1password", bootstrapKey: null },
+      d
+    );
+
+    expect(stored).toEqual([]);
+    expect(lines.join("\n")).toMatch(/1password has no environment-variable/);
+    expect(materializedFor).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Third of four, on top of #2362 and #2364.

## One verb, one axis

```
environment local        runs it here
environment container    emits an image definition and a run command
environment claude-web   emits, because the dialog has no API
environment codex-cloud  emits, same reason
```

The only difference between surfaces is whether Lisa can execute there. This replaces `remote-env --emit=<surface>`, which named the machinery rather than the task — from a laptop, `remote-env` reads as *"prepare the remote environment I am currently in"*, the opposite of configuring a cloud environment. The old spelling still works.

`workstation` stays a separate concern: what binaries this machine has, no tenant, no credentials. Which also means **rotating a token is `environment local` again**, not re-running an installer that wants to reinstall six coding agents.

## `--tenant` is required on `local`, and that is the point

Every namespace is a directory under `$XDG_CONFIG_HOME`. Resolving the wrong one writes one tenant's credentials where another tenant's sessions read — and on a machine serving several, the two share a store.

An early draft of this fell back to the default namespace and **materialized 49 secrets of the wrong tenant into the wrong directory on a real machine.** So `configForTenant` resolves from the named tenant and deliberately ignores any `.lisa.config.json` in the working directory: someone who typed `--tenant=acme` means acme, whichever repository they happen to be standing in.

## `materialize` gains a `requested` flag

`local` is `materialized: false`, and that reasoning holds for automated flows — a session-start hook on a laptop must not write credentials to disk when the provider CLI is authenticated and can be read through.

It does not hold for an operator typing the command whose entire purpose is to put credentials on this machine. The AWS `-static` profiles reference variables that exist only once the env file is materialized, so refusing there means the profiles never work.

Two different questions, two different answers — rather than flipping `local` to `materialized: true` and silently starting to write on every machine that upgrades. The capability guard still refuses the automated case, and now names the command that asks explicitly.

## Verification

Run, not asserted on shapes — that is how the last two defects in this area got through:

```
$ environment local
environment local needs --tenant=<name>.

$ environment local --tenant=tunnl
BWS_ACCESS_TOKEN_tunnl is already stored; pass --rotate to replace it.
Materialized 17 secret(s) into /Users/cody/.config/tunnl.
1 variable(s) derived from the bundle.
AWS profiles installed: tunnl-dev-static, tunnl-staging-static, tunnl-production-static, tunnl-shared-static
```

All three emit paths exercised; an unknown surface exits 1. `bun run lint` clean, `bun run test` green (9052), 10 new tests covering the tenant guard, the already-stored and `--rotate` paths, the no-TTY skip, an empty entry, and a provider with no bootstrap variable.

Two bugs the first real invocation caught and unit tests had not: a field-name mismatch that reported "bitwarden has no environment-variable bootstrap", and the wrong-tenant materialization above.

Work-Item: CodySwannGT/lisa#2365
