### PR TITLE
docs: write down the onboarding order, and test it against the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,101 @@ native Playwright/Maestro regression authority.
 
 ## Getting started
 
+Setup has three layers, and conflating them is the usual mistake:
+
+```
+vault  →  machine  →  each repo  →  each other surface
+```
+
+Two commands do the machine-and-surface work, and **neither needs a checkout** —
+that matters, because the surfaces most in need of setup are the ones with no
+repository attached.
+
+| Command | Answers | Scope |
+| --- | --- | --- |
+| `workstation` | what binaries does this machine have | once per machine |
+| `environment <surface>` | which tenant, and where do its credentials go | once per machine, and once per other surface |
+
+`environment` runs where Lisa can execute and prints what to paste where it
+cannot:
+
+```
+environment local        prepares this machine
+environment container    an image definition and a run command
+environment claude-web   text for the Claude environment dialog
+environment codex-cloud  text for the Codex environment settings
+```
+
+### 1. The vault, once per tenant
+
+Create the secrets, then a **machine account** granted only the projects agents
+may read — that grant is what scopes every headless session. Annotate a secret's
+note with `tool: <name>` where a CLI is implied (`sonar`, `aws`, `gh`); a session
+with no checkout installs exactly what the notes name, and the whole catalogue
+if they name nothing.
+
+Issue each place its own access token, at the moment you set that place up. One
+token shared across five places makes any compromise a five-place outage, and
+makes every access in the audit log anonymous.
+
+### 2. The machine
+
+```bash
+npx -y @codyswann/lisa@latest workstation --install --provider=bitwarden
+exec $SHELL -l                                   # ~/.local/bin on PATH
+npx -y @codyswann/lisa@latest environment local --tenant=<name>
+```
+
+Node is the only prerequisite. `workstation` is the one entry point that works
+before any agent or repository exists — invoking a *skill* needs an installed
+agent, and Lisa is a devDependency so it needs a clone; both are what this
+creates.
+
+`environment local` prompts for the token, stores it in the OS keychain (a
+`0600` file where there is no keychain), materializes the credentials, and
+installs the per-environment AWS profiles. **Re-run it to rotate** — it is not
+an installer, so it will not reinstall six coding agents to replace one token.
+
+`--tenant` is required because every namespace is a directory: guessing would
+put one tenant's credentials where another tenant's sessions read.
+
+Then authenticate the things that are *you* rather than the machine account —
+`gh auth login`, `aws configure sso`, and each agent's own login.
+
+### 3. Each repository
+
+```bash
+git clone … && cd …
+npx -y @codyswann/lisa@latest apply    # lint, hooks, workflows, agent surfaces
+bun install                            # postinstall installs the agent plugins
+npx -y @codyswann/lisa@latest sync     # then set secrets.namespace
+```
+
+A repository only needs to say *which tenant it belongs to*. The credentials are
+already on the machine.
+
+Brownfield repositories then converge — see below.
+
+### 4. Each other surface
+
+Cloud environments are account-scoped and shared across every repository, so
+this is once per environment rather than once per repository:
+
+```bash
+npx -y @codyswann/lisa@latest environment claude-web --tenant=<name>
+```
+
+Paste what it prints. Give that environment its **own** access token: those
+dialogs store values in plain text, readable by everyone who can use the
+environment.
+
+A repository becomes usable *from* a cloud surface with
+`lisa remote-env --install`, which writes two entrypoints to commit. They are
+inert locally — a container that has just cloned the repository has never seen
+the plugin they came from, so they have to be part of the clone.
+
+---
+
 Install Lisa as a development dependency in each project that uses it:
 
 ```bash

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/SKILL.md
@@ -236,6 +236,41 @@ What the detector produces is a proposal with `<pin>`, `<release url>` and `<sha
 
 The other objections stay true and stay unfixed: most tooling has no credential and most credentials imply no tool, so notes are one signal among four and the weakest of them. They are read *after* npm scripts and MCP servers, and a note alone should be the least persuasive reason to add anything.
 
+## One command, four surfaces
+
+`lisa environment <surface> --tenant=<name>` configures one surface for one
+tenant. The only difference between them is whether Lisa can execute there:
+
+| Surface | What happens | Materializes |
+| --- | --- | --- |
+| `local` | runs here: stores the bootstrap, materializes, installs AWS profiles | on request |
+| `container` | emits an image definition and a `docker run` line | at container start |
+| `claude-web` | emits text for the environment dialog | at setup **and** session start |
+| `codex-cloud` | emits text for the environment settings | at setup |
+
+None of it needs a checkout, which is the point: the surfaces most in need of
+configuration are the ones with no repository attached.
+
+`--tenant` is required on `local` because that path **writes**. Every namespace
+is a directory under `$XDG_CONFIG_HOME`, so resolving the wrong one puts one
+tenant's credentials where another tenant's sessions read — and on a machine
+serving several, the two would share a store. The named tenant also outranks any
+`.lisa.config.json` in the working directory: someone who typed `--tenant=acme`
+means acme, whichever repository they happen to be standing in.
+
+Re-running `environment local` is how a token is **rotated**. It is not an
+installer, so it does not reinstall agents to replace one credential; it reports
+that a bootstrap is already stored and leaves it alone unless `--rotate` says
+otherwise.
+
+`workstation` remains the separate question — what binaries does this machine
+have — with no tenant and no credentials.
+
+`remote-env --emit=<surface>` still works, and is the older spelling of the same
+thing. It named the machinery rather than the task: from a laptop it reads as
+"prepare the remote environment I am currently in", which is the opposite of
+configuring a cloud environment.
+
 ## Provisioning tiers
 
 Preference order, falling back:

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/SKILL.md
@@ -236,6 +236,41 @@ What the detector produces is a proposal with `<pin>`, `<release url>` and `<sha
 
 The other objections stay true and stay unfixed: most tooling has no credential and most credentials imply no tool, so notes are one signal among four and the weakest of them. They are read *after* npm scripts and MCP servers, and a note alone should be the least persuasive reason to add anything.
 
+## One command, four surfaces
+
+`lisa environment <surface> --tenant=<name>` configures one surface for one
+tenant. The only difference between them is whether Lisa can execute there:
+
+| Surface | What happens | Materializes |
+| --- | --- | --- |
+| `local` | runs here: stores the bootstrap, materializes, installs AWS profiles | on request |
+| `container` | emits an image definition and a `docker run` line | at container start |
+| `claude-web` | emits text for the environment dialog | at setup **and** session start |
+| `codex-cloud` | emits text for the environment settings | at setup |
+
+None of it needs a checkout, which is the point: the surfaces most in need of
+configuration are the ones with no repository attached.
+
+`--tenant` is required on `local` because that path **writes**. Every namespace
+is a directory under `$XDG_CONFIG_HOME`, so resolving the wrong one puts one
+tenant's credentials where another tenant's sessions read — and on a machine
+serving several, the two would share a store. The named tenant also outranks any
+`.lisa.config.json` in the working directory: someone who typed `--tenant=acme`
+means acme, whichever repository they happen to be standing in.
+
+Re-running `environment local` is how a token is **rotated**. It is not an
+installer, so it does not reinstall agents to replace one credential; it reports
+that a bootstrap is already stored and leaves it alone unless `--rotate` says
+otherwise.
+
+`workstation` remains the separate question — what binaries does this machine
+have — with no tenant and no credentials.
+
+`remote-env --emit=<surface>` still works, and is the older spelling of the same
+thing. It named the machinery rather than the task: from a laptop it reads as
+"prepare the remote environment I am currently in", which is the opposite of
+configuring a cloud environment.
+
 ## Provisioning tiers
 
 Preference order, falling back:

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/SKILL.md
@@ -236,6 +236,41 @@ What the detector produces is a proposal with `<pin>`, `<release url>` and `<sha
 
 The other objections stay true and stay unfixed: most tooling has no credential and most credentials imply no tool, so notes are one signal among four and the weakest of them. They are read *after* npm scripts and MCP servers, and a note alone should be the least persuasive reason to add anything.
 
+## One command, four surfaces
+
+`lisa environment <surface> --tenant=<name>` configures one surface for one
+tenant. The only difference between them is whether Lisa can execute there:
+
+| Surface | What happens | Materializes |
+| --- | --- | --- |
+| `local` | runs here: stores the bootstrap, materializes, installs AWS profiles | on request |
+| `container` | emits an image definition and a `docker run` line | at container start |
+| `claude-web` | emits text for the environment dialog | at setup **and** session start |
+| `codex-cloud` | emits text for the environment settings | at setup |
+
+None of it needs a checkout, which is the point: the surfaces most in need of
+configuration are the ones with no repository attached.
+
+`--tenant` is required on `local` because that path **writes**. Every namespace
+is a directory under `$XDG_CONFIG_HOME`, so resolving the wrong one puts one
+tenant's credentials where another tenant's sessions read — and on a machine
+serving several, the two would share a store. The named tenant also outranks any
+`.lisa.config.json` in the working directory: someone who typed `--tenant=acme`
+means acme, whichever repository they happen to be standing in.
+
+Re-running `environment local` is how a token is **rotated**. It is not an
+installer, so it does not reinstall agents to replace one credential; it reports
+that a bootstrap is already stored and leaves it alone unless `--rotate` says
+otherwise.
+
+`workstation` remains the separate question — what binaries does this machine
+have — with no tenant and no credentials.
+
+`remote-env --emit=<surface>` still works, and is the older spelling of the same
+thing. It named the machinery rather than the task: from a laptop it reads as
+"prepare the remote environment I am currently in", which is the opposite of
+configuring a cloud environment.
+
 ## Provisioning tiers
 
 Preference order, falling back:

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/SKILL.md
@@ -236,6 +236,41 @@ What the detector produces is a proposal with `<pin>`, `<release url>` and `<sha
 
 The other objections stay true and stay unfixed: most tooling has no credential and most credentials imply no tool, so notes are one signal among four and the weakest of them. They are read *after* npm scripts and MCP servers, and a note alone should be the least persuasive reason to add anything.
 
+## One command, four surfaces
+
+`lisa environment <surface> --tenant=<name>` configures one surface for one
+tenant. The only difference between them is whether Lisa can execute there:
+
+| Surface | What happens | Materializes |
+| --- | --- | --- |
+| `local` | runs here: stores the bootstrap, materializes, installs AWS profiles | on request |
+| `container` | emits an image definition and a `docker run` line | at container start |
+| `claude-web` | emits text for the environment dialog | at setup **and** session start |
+| `codex-cloud` | emits text for the environment settings | at setup |
+
+None of it needs a checkout, which is the point: the surfaces most in need of
+configuration are the ones with no repository attached.
+
+`--tenant` is required on `local` because that path **writes**. Every namespace
+is a directory under `$XDG_CONFIG_HOME`, so resolving the wrong one puts one
+tenant's credentials where another tenant's sessions read — and on a machine
+serving several, the two would share a store. The named tenant also outranks any
+`.lisa.config.json` in the working directory: someone who typed `--tenant=acme`
+means acme, whichever repository they happen to be standing in.
+
+Re-running `environment local` is how a token is **rotated**. It is not an
+installer, so it does not reinstall agents to replace one credential; it reports
+that a bootstrap is already stored and leaves it alone unless `--rotate` says
+otherwise.
+
+`workstation` remains the separate question — what binaries does this machine
+have — with no tenant and no credentials.
+
+`remote-env --emit=<surface>` still works, and is the older spelling of the same
+thing. It named the machinery rather than the task: from a laptop it reads as
+"prepare the remote environment I am currently in", which is the opposite of
+configuring a cloud environment.
+
 ## Provisioning tiers
 
 Preference order, falling back:

--- a/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-remote-env/SKILL.md
@@ -236,6 +236,41 @@ What the detector produces is a proposal with `<pin>`, `<release url>` and `<sha
 
 The other objections stay true and stay unfixed: most tooling has no credential and most credentials imply no tool, so notes are one signal among four and the weakest of them. They are read *after* npm scripts and MCP servers, and a note alone should be the least persuasive reason to add anything.
 
+## One command, four surfaces
+
+`lisa environment <surface> --tenant=<name>` configures one surface for one
+tenant. The only difference between them is whether Lisa can execute there:
+
+| Surface | What happens | Materializes |
+| --- | --- | --- |
+| `local` | runs here: stores the bootstrap, materializes, installs AWS profiles | on request |
+| `container` | emits an image definition and a `docker run` line | at container start |
+| `claude-web` | emits text for the environment dialog | at setup **and** session start |
+| `codex-cloud` | emits text for the environment settings | at setup |
+
+None of it needs a checkout, which is the point: the surfaces most in need of
+configuration are the ones with no repository attached.
+
+`--tenant` is required on `local` because that path **writes**. Every namespace
+is a directory under `$XDG_CONFIG_HOME`, so resolving the wrong one puts one
+tenant's credentials where another tenant's sessions read — and on a machine
+serving several, the two would share a store. The named tenant also outranks any
+`.lisa.config.json` in the working directory: someone who typed `--tenant=acme`
+means acme, whichever repository they happen to be standing in.
+
+Re-running `environment local` is how a token is **rotated**. It is not an
+installer, so it does not reinstall agents to replace one credential; it reports
+that a bootstrap is already stored and leaves it alone unless `--rotate` says
+otherwise.
+
+`workstation` remains the separate question — what binaries does this machine
+have — with no tenant and no credentials.
+
+`remote-env --emit=<surface>` still works, and is the older spelling of the same
+thing. It named the machinery rather than the task: from a laptop it reads as
+"prepare the remote environment I am currently in", which is the opposite of
+configuring a cloud environment.
+
 ## Provisioning tiers
 
 Preference order, falling back:

--- a/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-remote-env/SKILL.md
@@ -236,6 +236,41 @@ What the detector produces is a proposal with `<pin>`, `<release url>` and `<sha
 
 The other objections stay true and stay unfixed: most tooling has no credential and most credentials imply no tool, so notes are one signal among four and the weakest of them. They are read *after* npm scripts and MCP servers, and a note alone should be the least persuasive reason to add anything.
 
+## One command, four surfaces
+
+`lisa environment <surface> --tenant=<name>` configures one surface for one
+tenant. The only difference between them is whether Lisa can execute there:
+
+| Surface | What happens | Materializes |
+| --- | --- | --- |
+| `local` | runs here: stores the bootstrap, materializes, installs AWS profiles | on request |
+| `container` | emits an image definition and a `docker run` line | at container start |
+| `claude-web` | emits text for the environment dialog | at setup **and** session start |
+| `codex-cloud` | emits text for the environment settings | at setup |
+
+None of it needs a checkout, which is the point: the surfaces most in need of
+configuration are the ones with no repository attached.
+
+`--tenant` is required on `local` because that path **writes**. Every namespace
+is a directory under `$XDG_CONFIG_HOME`, so resolving the wrong one puts one
+tenant's credentials where another tenant's sessions read — and on a machine
+serving several, the two would share a store. The named tenant also outranks any
+`.lisa.config.json` in the working directory: someone who typed `--tenant=acme`
+means acme, whichever repository they happen to be standing in.
+
+Re-running `environment local` is how a token is **rotated**. It is not an
+installer, so it does not reinstall agents to replace one credential; it reports
+that a bootstrap is already stored and leaves it alone unless `--rotate` says
+otherwise.
+
+`workstation` remains the separate question — what binaries does this machine
+have — with no tenant and no credentials.
+
+`remote-env --emit=<surface>` still works, and is the older spelling of the same
+thing. It named the machinery rather than the task: from a laptop it reads as
+"prepare the remote environment I am currently in", which is the opposite of
+configuring a cloud environment.
+
 ## Provisioning tiers
 
 Preference order, falling back:

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1163,7 +1163,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md":
       "80fbf157f9c562c033886c25a99b37356602edd9e61cd2d492f339769ddcf97e",
     "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md":
-      "79c5572dfa4c5d37b1fcfbc75a38ca7d1d708258cca761ec946fb7070bc727f4",
+      "7aa1f616440cb262e47881e8b37b701ebd11ad1ea619412aa04c33324770904c",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/session-start.sh":
       "cb63d08b14ab7aa2d405e6770e0cf7db5d6588ae1dcb924ea6224b026fcff496",
     "plugins/src/base/skills/lisa-setup-remote-env/assets/setup.sh":
@@ -8425,6 +8425,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/core/upstream-attribution-file-safety.test.ts": true,
     "tests/unit/core/upstream-attribution-integrity.test.ts": true,
     "tests/unit/detection/detectors.test.ts": true,
+    "tests/unit/docs/onboarding-walkthrough.test.ts": true,
     "tests/unit/governance-contracts.test.ts": true,
     "tests/unit/health/agentic.test.ts": true,
     "tests/unit/health/consumer.test.ts": true,

--- a/tests/unit/docs/onboarding-walkthrough.test.ts
+++ b/tests/unit/docs/onboarding-walkthrough.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The onboarding walkthrough has to describe the commands that exist.
+ *
+ * Documentation is where this area has repeatedly gone wrong: a copy of a shell
+ * one-liner pinned a release behind, a `cd` was documented to work around a bug
+ * rather than the bug being fixed, and an emit template went years without
+ * mentioning the three exports a repo-less session cannot run without.
+ *
+ * So these assert the walkthrough against the surfaces registry and the command
+ * table, rather than against a copy of what someone meant to write.
+ * @module tests/unit/docs/onboarding-walkthrough
+ */
+
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { TARGETS } from "../../../plugins/src/base/skills/lisa-setup-remote-env/scripts/environment.mjs";
+import { SURFACES } from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs";
+
+const README = readFileSync("README.md", "utf8");
+const SKILL = readFileSync(
+  "plugins/src/base/skills/lisa-setup-remote-env/SKILL.md",
+  "utf8"
+);
+
+describe("the README walkthrough", () => {
+  it("names every surface `environment` can configure", () => {
+    // Derived from the command's own table, so a surface added without a line
+    // in the walkthrough fails here rather than going undocumented.
+    for (const surface of Object.keys(TARGETS)) {
+      expect(README).toContain(`environment ${surface}`);
+    }
+  });
+
+  it("says the machine commands need no checkout", () => {
+    // The property that makes the ordering work at all, and the one every
+    // earlier version of this documentation got wrong.
+    expect(README).toMatch(/neither needs a checkout|needs no checkout/i);
+  });
+
+  it("requires --tenant where the command requires it", () => {
+    expect(README).toMatch(/environment local --tenant=/);
+  });
+
+  it("tells operators to give each place its own token", () => {
+    // A shared token makes any compromise a multi-place outage and every audit
+    // entry anonymous.
+    expect(README).toMatch(/own access token/i);
+  });
+
+  it("keeps the layers in order: machine, then repo", () => {
+    expect(README.indexOf("### 2. The machine")).toBeLessThan(
+      README.indexOf("### 3. Each repository")
+    );
+  });
+});
+
+describe("the skill's surface table", () => {
+  it("lists every surface that materializes", () => {
+    // A surface that writes credentials and is not described is one nobody
+    // knows to configure.
+    for (const [name, capability] of Object.entries(SURFACES)) {
+      if (!capability.materialized) continue;
+      expect(SKILL).toContain(name);
+    }
+  });
+
+  it("explains why --tenant is mandatory rather than only stating it", () => {
+    expect(SKILL).toMatch(/another tenant's sessions read/);
+  });
+
+  it("records that the old spelling still works", () => {
+    expect(SKILL).toContain("remote-env --emit=");
+  });
+});


### PR DESCRIPTION
Last of four, completing `environment <surface> --tenant=<name>` (#2362, #2364, #2366).

## The gap

The pieces were documented individually; the **sequence** was not. So the order got reconstructed from first principles each time, and reconstructed wrong — `workstation` never reads a repository, `apply` only reads a repository, and neither can bootstrap the other. The commands that explicitly need no checkout were being run from inside one, and the surfaces most in need of configuration — the ones with no repository attached — were the ones nobody knew how to set up.

## What lands

A `Getting started` walkthrough over the three layers:

```
vault  →  machine  →  each repo  →  each other surface
```

and a surface table in the skill covering all four: `local`, `container`, `claude-web`, `codex-cloud` — with *why* `--tenant` is mandatory on `local`, not merely that it is.

## Tested against the code, not against prose

This is the area where documentation has repeatedly been the defect, not a description of one:

- a copy of a shell one-liner that pinned a release behind (#2352)
- a `cd` documented to work around a bug rather than the bug being fixed (#2359)
- an emit template that never mentioned the three exports a repo-less session cannot run without

So the tests derive from `TARGETS` and `SURFACES` rather than restating them. **A surface added without a line in the walkthrough fails. A surface that materializes credentials without being described fails.** Plus assertions that the layers stay in order, that the no-checkout property is stated, and that the own-token guidance survives — that last one is the difference between one compromise and a five-place outage.

## Verification

`bun run lint` clean; `bun run test` green (9060). Eight new tests.

Work-Item: CodySwannGT/lisa#2367
