### PR TITLE
fix(ci): stop auto-fix skipping every bot-authored branch

### DIFF
--- a/.github/workflows/reusable-claude-ci-auto-fix.yml
+++ b/.github/workflows/reusable-claude-ci-auto-fix.yml
@@ -132,10 +132,22 @@ jobs:
       - name: Check for previous auto-fix attempt
         id: loop-guard
         run: |
+          # Skip only when the head commit is a PREVIOUS auto-fix attempt —
+          # mirrors reusable-claude-deploy-auto-fix.yml, which fixed this
+          # same blanket check earlier. Branches routinely carry
+          # github-actions[bot] commits that are not fix attempts (release
+          # artifacts, content pipelines, any bot that opens a PR); treating
+          # every bot commit as a loop exempted those branches from auto-fix
+          # entirely, and bailed before the ownership guard below could apply
+          # the lease/quiet-period rules that enforce single-writer safety.
           AUTHOR=$(git log -1 --format='%an')
-          if [[ "$AUTHOR" == "github-actions[bot]" || "$AUTHOR" == "claude[bot]" ]]; then
+          SUBJECT=$(git log -1 --format='%s')
+          if [[ "$AUTHOR" == "claude[bot]" ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Last commit was by $AUTHOR — skipping to prevent loop."
+          elif [[ "$AUTHOR" == "github-actions[bot]" && "$SUBJECT" == *"claude-auto-fix-"* ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Last commit merges a previous auto-fix PR — skipping to prevent loop."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi

--- a/bun.lock
+++ b/bun.lock
@@ -116,6 +116,7 @@
     "handlebars": ">=4.7.9",
     "lodash": ">=4.18.1",
     "multer": ">=2.2.0",
+    "nanoid": "^3.3.18",
     "postcss": ">=8.5.18",
     "undici": "^6.27.0",
     "vite": "^8.0.16",
@@ -1590,7 +1591,7 @@
 
     "nano-spawn": ["nano-spawn@2.0.0", "", {}, "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@sentry/cli"
   ],
   "resolutions": {
+    "nanoid": "^3.3.18",
     "@isaacs/brace-expansion": "^5.0.1",
     "axios": ">=1.15.2",
     "esbuild": ">=0.28.1",
@@ -100,6 +101,7 @@
     "brace-expansion": ">=5.0.9"
   },
   "overrides": {
+    "nanoid": "^3.3.18",
     "@isaacs/brace-expansion": "^5.0.1",
     "axios": ">=1.15.2",
     "esbuild": ">=0.28.1",

--- a/package.lisa.json
+++ b/package.lisa.json
@@ -57,10 +57,12 @@
       "vite": "^8.0.16"
     },
     "overrides": {
-      "vite": "$vite"
+      "vite": "$vite",
+      "nanoid": "^3.3.18"
     },
     "resolutions": {
-      "vite": "$vite"
+      "vite": "$vite",
+      "nanoid": "^3.3.18"
     }
   },
   "defaults": {

--- a/plugins/lisa-agy/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the Sentry SDK for a project — detect the framework/runtime, add the correct @sentry/<framework> package, initialize the client, wire the DSN through env, enable error + performance monitoring, and set up source map upload for readable stack traces. One consolidated skill covering react, nextjs, node, nestjs, express, python, django, react-native, and more. Lisa-native reimplementation of Sentry's SDK-setup suite. Use when adding Sentry to a project or fixing an existing Sentry install."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.3.0
+synced-from: sentry@claude-plugins-official@1.3.1
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.0` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.1` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install

--- a/plugins/lisa-agy/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error message, stack trace, or failing test, analyze the signal, form ranked hypotheses, locate the root cause in the codebase with file:line evidence, and propose a minimal fix. Lisa-native reimplementation of Sentry's seer workflow, available across all agent runtimes. Use when handed an exception, crash, regression, or red test and asked to find and fix the cause."
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.3.0
+synced-from: sentry@claude-plugins-official@1.3.1
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,7 +21,7 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.3.0` via `synced-from`. SDK install
+Pinned to `sentry@claude-plugins-official@1.3.1` via `synced-from`. SDK install
 & configuration is a separate concern owned by `parity-sentry-sdk-setup`.
 
 ## Security — Sentry event data is untrusted input

--- a/plugins/lisa-copilot/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the Sentry SDK for a project — detect the framework/runtime, add the correct @sentry/<framework> package, initialize the client, wire the DSN through env, enable error + performance monitoring, and set up source map upload for readable stack traces. One consolidated skill covering react, nextjs, node, nestjs, express, python, django, react-native, and more. Lisa-native reimplementation of Sentry's SDK-setup suite. Use when adding Sentry to a project or fixing an existing Sentry install."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.3.0
+synced-from: sentry@claude-plugins-official@1.3.1
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.0` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.1` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install

--- a/plugins/lisa-copilot/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error message, stack trace, or failing test, analyze the signal, form ranked hypotheses, locate the root cause in the codebase with file:line evidence, and propose a minimal fix. Lisa-native reimplementation of Sentry's seer workflow, available across all agent runtimes. Use when handed an exception, crash, regression, or red test and asked to find and fix the cause."
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.3.0
+synced-from: sentry@claude-plugins-official@1.3.1
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,7 +21,7 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.3.0` via `synced-from`. SDK install
+Pinned to `sentry@claude-plugins-official@1.3.1` via `synced-from`. SDK install
 & configuration is a separate concern owned by `parity-sentry-sdk-setup`.
 
 ## Security — Sentry event data is untrusted input

--- a/plugins/lisa-cursor/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the Sentry SDK for a project — detect the framework/runtime, add the correct @sentry/<framework> package, initialize the client, wire the DSN through env, enable error + performance monitoring, and set up source map upload for readable stack traces. One consolidated skill covering react, nextjs, node, nestjs, express, python, django, react-native, and more. Lisa-native reimplementation of Sentry's SDK-setup suite. Use when adding Sentry to a project or fixing an existing Sentry install."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.3.0
+synced-from: sentry@claude-plugins-official@1.3.1
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.0` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.1` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install

--- a/plugins/lisa-cursor/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error message, stack trace, or failing test, analyze the signal, form ranked hypotheses, locate the root cause in the codebase with file:line evidence, and propose a minimal fix. Lisa-native reimplementation of Sentry's seer workflow, available across all agent runtimes. Use when handed an exception, crash, regression, or red test and asked to find and fix the cause."
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.3.0
+synced-from: sentry@claude-plugins-official@1.3.1
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,7 +21,7 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.3.0` via `synced-from`. SDK install
+Pinned to `sentry@claude-plugins-official@1.3.1` via `synced-from`. SDK install
 & configuration is a separate concern owned by `parity-sentry-sdk-setup`.
 
 ## Security — Sentry event data is untrusted input

--- a/plugins/lisa/.codex-plugin/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the…"
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.3.0
+synced-from: sentry@claude-plugins-official@1.3.1
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.0` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.1` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install

--- a/plugins/lisa/.codex-plugin/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error…"
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.3.0
+synced-from: sentry@claude-plugins-official@1.3.1
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,7 +21,7 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.3.0` via `synced-from`. SDK install
+Pinned to `sentry@claude-plugins-official@1.3.1` via `synced-from`. SDK install
 & configuration is a separate concern owned by `parity-sentry-sdk-setup`.
 
 ## Security — Sentry event data is untrusted input

--- a/plugins/lisa/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/lisa/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the Sentry SDK for a project — detect the framework/runtime, add the correct @sentry/<framework> package, initialize the client, wire the DSN through env, enable error + performance monitoring, and set up source map upload for readable stack traces. One consolidated skill covering react, nextjs, node, nestjs, express, python, django, react-native, and more. Lisa-native reimplementation of Sentry's SDK-setup suite. Use when adding Sentry to a project or fixing an existing Sentry install."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.3.0
+synced-from: sentry@claude-plugins-official@1.3.1
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.0` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.1` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install

--- a/plugins/lisa/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/lisa/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error message, stack trace, or failing test, analyze the signal, form ranked hypotheses, locate the root cause in the codebase with file:line evidence, and propose a minimal fix. Lisa-native reimplementation of Sentry's seer workflow, available across all agent runtimes. Use when handed an exception, crash, regression, or red test and asked to find and fix the cause."
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.3.0
+synced-from: sentry@claude-plugins-official@1.3.1
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,7 +21,7 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.3.0` via `synced-from`. SDK install
+Pinned to `sentry@claude-plugins-official@1.3.1` via `synced-from`. SDK install
 & configuration is a separate concern owned by `parity-sentry-sdk-setup`.
 
 ## Security — Sentry event data is untrusted input

--- a/plugins/src/base/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/src/base/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the Sentry SDK for a project — detect the framework/runtime, add the correct @sentry/<framework> package, initialize the client, wire the DSN through env, enable error + performance monitoring, and set up source map upload for readable stack traces. One consolidated skill covering react, nextjs, node, nestjs, express, python, django, react-native, and more. Lisa-native reimplementation of Sentry's SDK-setup suite. Use when adding Sentry to a project or fixing an existing Sentry install."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.3.0
+synced-from: sentry@claude-plugins-official@1.3.1
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.0` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.1` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install

--- a/plugins/src/base/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/src/base/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error message, stack trace, or failing test, analyze the signal, form ranked hypotheses, locate the root cause in the codebase with file:line evidence, and propose a minimal fix. Lisa-native reimplementation of Sentry's seer workflow, available across all agent runtimes. Use when handed an exception, crash, regression, or red test and asked to find and fix the cause."
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.3.0
+synced-from: sentry@claude-plugins-official@1.3.1
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,7 +21,7 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.3.0` via `synced-from`. SDK install
+Pinned to `sentry@claude-plugins-official@1.3.1` via `synced-from`. SDK install
 & configuration is a separate concern owned by `parity-sentry-sdk-setup`.
 
 ## Security — Sentry event data is untrusted input

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1033,9 +1033,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md":
       "8757ea8c83e9acaad1af59f7b46d5ac7efaba61da76f9df3fc94b258f9a16b2b",
     "plugins/src/base/skills/lisa-parity-sentry-sdk-setup/SKILL.md":
-      "25357629d6674c35e53279d4b20b62f1b76c3bcd0f724eee99593425365dd0d5",
+      "610890385568ae097b2a48c9d20e42104a1bf5a3ba06223a89086ef385542e3b",
     "plugins/src/base/skills/lisa-parity-sentry-seer/SKILL.md":
-      "583a288ef991ccbfb38ac3319b33bf9e8a158cb90fbc64a61993f51ac70ca657",
+      "d060d3171529cc228368e640d0ab813a79ec18440921602e7c720d53fdcabb67",
     "plugins/src/base/skills/lisa-parity-skill-creator/SKILL.md":
       "616e0493f75fe92c18137548d7c86a91a9b04d9844ca76fa3f14156e3e7814e5",
     "plugins/src/base/skills/lisa-performance-review/SKILL.md":

--- a/tests/integration/autofix-ownership-guards.test.ts
+++ b/tests/integration/autofix-ownership-guards.test.ts
@@ -1,6 +1,65 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadWorkflow } from "../helpers/workflow-test-utils.js";
+
+/** Step id of the loop guard in both auto-fix workflows. */
+const LOOP_GUARD_ID = "loop-guard";
+/** Absolute interpreter path; resolving `bash` via PATH is not permitted. */
+const BASH = "/bin/bash";
+/** Commit identity every CI automation shares; not auto-fix's own. */
+const BOT_AUTHOR = "github-actions[bot]";
+/** The commit identity auto-fix itself writes under. */
+const AUTOFIX_AUTHOR = "claude[bot]";
+
+/**
+ * A bash function declaration shadows the external command of the same name,
+ * so declaring `git` ahead of the step body makes the head commit's author
+ * and subject controllable without a PATH shim or an on-disk executable.
+ */
+const GIT_STUB = [
+  "git() {",
+  '  if [[ "$*" == *"%an"* ]]; then',
+  '    printf "%s\\n" "$STUB_AUTHOR"',
+  "  else",
+  '    printf "%s\\n" "$STUB_SUBJECT"',
+  "  fi",
+  "}",
+].join("\n");
+
+/**
+ * Execute a loop-guard step body against a synthetic head commit.
+ *
+ * Returns the `skip=` value the step wrote to GITHUB_OUTPUT, which is the
+ * only thing the downstream `if:` conditions consume.
+ * @param run The step's `run` script
+ * @param author Value `git log -1 --format='%an'` should report
+ * @param subject Value `git log -1 --format='%s'` should report
+ * @returns "true" or "false" as written to the step output, else "unset"
+ */
+function runLoopGuard(run: string, author: string, subject: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-loop-guard-"));
+  try {
+    const outFile = path.join(dir, "github-output");
+    fs.writeFileSync(outFile, "");
+    execFileSync(BASH, ["-c", `${GIT_STUB}\n${run}`], {
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: outFile,
+        STUB_AUTHOR: author,
+        STUB_SUBJECT: subject,
+      },
+      stdio: "pipe",
+    });
+    return (
+      /skip=(true|false)/.exec(fs.readFileSync(outFile, "utf8"))?.[1] ?? "unset"
+    );
+  } finally {
+    fs.rmSync(dir, { force: true, recursive: true });
+  }
+}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
@@ -30,7 +89,7 @@ describe("claude ci auto-fix ownership and fix detection", () => {
   const autoFixSteps = workflow.jobs["auto-fix"]?.steps ?? [];
 
   it("skips only previous fix attempts, not branches authored by github-actions[bot]", () => {
-    const guard = autoFixSteps.find(step => step.id === "loop-guard");
+    const guard = autoFixSteps.find(step => step.id === LOOP_GUARD_ID);
     // Parity with reusable-claude-deploy-auto-fix.yml: a merge of the
     // `claude-auto-fix-*` side branch is a loop; any other bot commit is not.
     expect(guard?.run).toContain('"$SUBJECT" == *"claude-auto-fix-"*');
@@ -39,6 +98,36 @@ describe("claude ci auto-fix ownership and fix detection", () => {
     // circuiting before the ownership guard could apply lease rules.
     expect(guard?.run).not.toContain(
       '"$AUTHOR" == "github-actions[bot]" || "$AUTHOR" == "claude[bot]"'
+    );
+  });
+
+  it("resolves every author/subject pair to the right loop-guard outcome", () => {
+    const run = autoFixSteps.find(step => step.id === LOOP_GUARD_ID)?.run ?? "";
+    expect(run).not.toBe("");
+
+    // Own identity: a previous auto-fix commit, whatever the subject.
+    expect(runLoopGuard(run, AUTOFIX_AUTHOR, "fix: repair failing lint")).toBe(
+      "true"
+    );
+    // A merge of the side branch is the other shape a previous attempt takes.
+    expect(
+      runLoopGuard(
+        run,
+        BOT_AUTHOR,
+        "Merge pull request #12 from o/claude-auto-fix-feature-x"
+      )
+    ).toBe("true");
+    // Unrelated bot commits must reach the ownership guard, not stand down.
+    // This is the case that regressed: a content pipeline authoring a branch.
+    expect(runLoopGuard(run, BOT_AUTHOR, "feat(blog): publish a post")).toBe(
+      "false"
+    );
+    expect(
+      runLoopGuard(run, BOT_AUTHOR, "chore(release): 1.2.3 [skip ci]")
+    ).toBe("false");
+    // Humans always proceed.
+    expect(runLoopGuard(run, "Cody Swann", "feat: add a feature")).toBe(
+      "false"
     );
   });
 
@@ -150,7 +239,7 @@ describe("deploy auto-fix escalation and loop guard", () => {
   const autoFixSteps = workflow.jobs["auto-fix"]?.steps ?? [];
 
   it("skips only previous fix attempts, not release commits by github-actions[bot]", () => {
-    const guard = autoFixSteps.find(step => step.id === "loop-guard");
+    const guard = autoFixSteps.find(step => step.id === LOOP_GUARD_ID);
     expect(guard?.run).toContain('"$SUBJECT" == *"claude/deploy-fix-"*');
     // The old blanket bot-author check disabled self-healing on every
     // deploy that followed a release commit.

--- a/tests/integration/autofix-ownership-guards.test.ts
+++ b/tests/integration/autofix-ownership-guards.test.ts
@@ -29,6 +29,19 @@ describe("claude ci auto-fix ownership and fix detection", () => {
   const workflow = loadWorkflow(CLAUDE_CI_AUTO_FIX_YML);
   const autoFixSteps = workflow.jobs["auto-fix"]?.steps ?? [];
 
+  it("skips only previous fix attempts, not branches authored by github-actions[bot]", () => {
+    const guard = autoFixSteps.find(step => step.id === "loop-guard");
+    // Parity with reusable-claude-deploy-auto-fix.yml: a merge of the
+    // `claude-auto-fix-*` side branch is a loop; any other bot commit is not.
+    expect(guard?.run).toContain('"$SUBJECT" == *"claude-auto-fix-"*');
+    // The old blanket bot-author check exempted every bot-authored branch
+    // (content pipelines, release bots) from auto-fix entirely, short-
+    // circuiting before the ownership guard could apply lease rules.
+    expect(guard?.run).not.toContain(
+      '"$AUTHOR" == "github-actions[bot]" || "$AUTHOR" == "claude[bot]"'
+    );
+  });
+
   it("captures the pre-fix SHA before Claude runs and compares the remote against it", () => {
     const claudeIndex = autoFixSteps.findIndex(
       step => step.id === "claude-fix"


### PR DESCRIPTION
Closes #2372

## The bug

The loop guard in `reusable-claude-ci-auto-fix.yml` skipped whenever the head commit's author was `github-actions[bot]` **or** `claude[bot]`. Only the second is this workflow's own commit identity (set two steps later in "Setup git identity"). `github-actions[bot]` is the generic identity of unrelated automation — release bots, content pipelines, anything that opens a PR.

So any branch whose head commit was bot-authored was exempt from auto-fix **from the moment it was created**, and bailed at the loop guard before the ownership guard could apply the lease / quiet-period rules that actually enforce single-writer safety.

## Evidence

Loop-guard outcomes over the last 15 auto-fix runs per repo, classified by step outcome (`Check branch ownership` skipped ⇒ guard tripped):

| repo | tripped | passed |
|---|---|---|
| gunnertech/frontend | **12** | 3 |
| gunnertech/thumbwar-frontend | 0 | 5 |
| gunnertech/backend | 0 | 3 |
| gunnertech/thumbwar-backend | 0 | 4 |

`frontend` is the outlier because its blog pipeline *creates the PR branch itself* and commits as `github-actions[bot]`. Repos with human-authored feature branches never trip it — which is why this stayed invisible despite the code being long-standing.

Concrete instance: gunnertech/frontend PR #320 failed its Security Scan; auto-fix run `31235086049` logged `Last commit was by github-actions[bot] — skipping to prevent loop.` and stopped. It was fixed by hand.

## The fix

`reusable-claude-deploy-auto-fix.yml` already fixed the identical blanket check — release commits on deploy branches hit the same false positive — and its behaviour is locked in by an existing test. This ports that logic to the CI variant, keyed to this workflow's own side-branch prefix:

- head authored by `claude[bot]` → skip (own identity; squash/rebase merges preserve it)
- head authored by `github-actions[bot]` **and** subject shows it merges a `claude-auto-fix-*` PR → skip
- otherwise → proceed to the ownership guard

That second arm matters: it preserves loop protection the bare author check was providing *by accident*. Once someone merges the `claude-auto-fix-*` PR, that PR is closed, so an "is there an open fix PR?" check would miss it and re-engage on every subsequent failure. Matching the merge subject catches it.

## Blast radius

All consumers track `@main` unpinned, so this ships immediately. Behaviour is **unchanged wherever the guard passes today**; it changes only on branches whose head is authored by `github-actions[bot]`, where auto-fix now proceeds to the ownership guard (fresh lease → stand down; no lease → quiet period, stand down if the head moved) instead of standing down unconditionally.

Repos where automation pushes to *feature* branches as `github-actions[bot]` will see auto-fix engage where it has been silent. That is the intended behaviour, but it is new spend — Claude runs plus quiet-period runner minutes.

## Incidental commits

Three unrelated repo-wide gates blocked every push; each is a prerequisite, not scope creep:

- `fix(deps): pin nanoid to ^3.3.18` — pre-push audit rejected all pushes on GHSA-2v37-7h3g-55p8. Capped to 3.x deliberately; unbounded `>=3.3.18` resolves to ESM-only nanoid 6.x and breaks the CJS consumers.
- `chore(plugins): bump sentry parity pins to 1.3.1` — pre-push parity gate rejected all pushes. Upstream 1.3.1 is version-number-only: diffing the cached 1.3.0 and 1.3.1 trees, the sole non-`.git` change is the `version` field in `plugin.json`, so the reimplementations needed no edits.
- `chore: resync upstream evidence manifest` — the SKILL.md edits above are tracked public sources; diff is exactly their two content hashes.

Happy to split any of these out if you would rather they land separately.

## Verification

`tests/integration/autofix-ownership-guards.test.ts` gains a CI-side assertion mirroring the existing deploy-side one. Full suite under Bun: **9345 passed**, 0 failed.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2372


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI auto-fix handling so only recognized Claude auto-fix commits are skipped.
  * Other automated commits now continue through ownership checks as expected.

* **Maintenance**
  * Updated Sentry skill synchronization references and verification records.
  * Added a required package version resolution.

* **Tests**
  * Added coverage confirming correct handling of automated commit authorship and auto-fix branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->