### PR TITLE
fix(apply): report managed templates a non-interactive apply cannot update

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -205,6 +205,16 @@ export interface FileOperationResult {
   readonly action:
     | "copied"
     | "skipped"
+    /**
+     * The managed template differs from the installed file and this apply
+     * could not update it, because a non-interactive apply cannot prompt
+     * before replacing a file a project may have customised.
+     *
+     * Distinct from "skipped" on purpose. Folding the two together is what
+     * let template changes — including fixes to the enforcement guards —
+     * go undelivered while the summary read exactly like a clean no-op.
+     */
+    | "stale"
     | "overwritten"
     | "appended"
     | "merged"
@@ -218,6 +228,8 @@ export interface FileOperationResult {
 export interface OperationCounters {
   copied: number;
   skipped: number;
+  /** Managed files left out of date because this apply could not overwrite them. */
+  stale: number;
   overwritten: number;
   appended: number;
   merged: number;
@@ -256,6 +268,7 @@ export function createInitialCounters(): OperationCounters {
   return {
     copied: 0,
     skipped: 0,
+    stale: 0,
     overwritten: 0,
     appended: 0,
     merged: 0,

--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -130,6 +130,15 @@ type PluginExecAsync = (
  */
 export class Lisa {
   private counters: OperationCounters = createInitialCounters();
+
+  /**
+   * Managed files this apply found out of date but could not update.
+   *
+   * Named so the summary can list them: a count alone tells an operator that
+   * something did not land without telling them what, which is most of the way
+   * back to the silence this exists to end.
+   */
+  private readonly stalePaths: string[] = [];
   private detectedTypes: ProjectType[] = [];
   private ignorePatterns: IgnorePatterns = {
     patterns: [],
@@ -1890,6 +1899,10 @@ export class Lisa {
       case "skipped":
         this.counters.skipped++;
         break;
+      case "stale":
+        this.counters.stale++;
+        this.stalePaths.push(result.relativePath);
+        break;
       case "overwritten":
         this.counters.overwritten++;
         break;
@@ -1932,6 +1945,11 @@ export class Lisa {
         break;
       case "skipped":
         // Silent for skipped files
+        break;
+      case "stale":
+        this.deps.logger.warn(
+          `Out of date, not updated: ${result.relativePath}`
+        );
         break;
       case "overwritten":
         this.logMessage(
@@ -2109,6 +2127,12 @@ export class Lisa {
     );
     this.printStatLine("Would prompt:   ", overwritten, pc.yellow, "(differ)");
     this.printStatLine(
+      "Out of date:    ",
+      this.counters.stale,
+      pc.yellow,
+      "(managed templates changed; would NOT be updated)"
+    );
+    this.printStatLine(
       "Would append:   ",
       appended,
       pc.blue,
@@ -2145,6 +2169,12 @@ export class Lisa {
       pc.yellow,
       "(user approved)"
     );
+    this.printStatLine(
+      "Out of date:",
+      this.counters.stale,
+      pc.yellow,
+      "(managed templates changed; NOT updated)"
+    );
     this.printStatLine("Appended:   ", appended, pc.blue, "(copy-contents)");
     this.printStatLine("Merged:     ", merged, pc.green, "(JSON merged)");
     this.printStatLine("Deleted:    ", deleted, pc.red);
@@ -2156,6 +2186,33 @@ export class Lisa {
         this.lisaignoreSuffix
       );
     }
+    this.printStaleDetail();
+  }
+
+  /**
+   * Name the out-of-date managed files and say how to update them.
+   *
+   * A bare count is not enough to act on. An operator taking an upgrade needs
+   * to see WHICH managed files the release changed and did not deliver —
+   * particularly the enforcement guards, where the gap is a security control
+   * that stayed on its old version while the release notes said otherwise.
+   */
+  private printStaleDetail(): void {
+    if (this.counters.stale === 0) return;
+    const { logger } = this.deps;
+
+    logger.warn(
+      `${this.counters.stale} managed file(s) changed upstream but were left as-is:`
+    );
+    for (const relativePath of this.stalePaths) {
+      logger.warn(`  ${relativePath}`);
+    }
+    logger.info(
+      "A non-interactive apply will not replace a file your project may have customised."
+    );
+    logger.info(
+      "Review the differences and run `lisa apply .` interactively to take them, or add paths to .lisaignore to keep yours."
+    );
   }
 
   /**

--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -1948,7 +1948,9 @@ export class Lisa {
         break;
       case "stale":
         this.deps.logger.warn(
-          `Out of date, not updated: ${result.relativePath}`
+          this.config.dryRun
+            ? `Out of date, would not be updated: ${result.relativePath}`
+            : `Out of date, not updated: ${result.relativePath}`
         );
         break;
       case "overwritten":
@@ -2148,6 +2150,7 @@ export class Lisa {
         this.lisaignoreSuffix
       );
     }
+    this.printStaleDetail();
   }
 
   /**
@@ -2202,7 +2205,9 @@ export class Lisa {
     const { logger } = this.deps;
 
     logger.warn(
-      `${this.counters.stale} managed file(s) changed upstream but were left as-is:`
+      this.config.dryRun
+        ? `${this.counters.stale} managed file(s) changed upstream and would be left as-is:`
+        : `${this.counters.stale} managed file(s) changed upstream but were left as-is:`
     );
     for (const relativePath of this.stalePaths) {
       logger.warn(`  ${relativePath}`);

--- a/src/strategies/copy-contents.ts
+++ b/src/strategies/copy-contents.ts
@@ -175,11 +175,13 @@ export class CopyContentsStrategy implements ICopyStrategy {
       };
     }
 
+    // Same reasoning as copy-overwrite: a non-interactive apply leaves the file
+    // alone, but must say so. `stale`, never `skipped`.
     if (context.config.skipGitCheck) {
       return {
         relativePath: realRelativePath,
         strategy: this.name,
-        action: "skipped",
+        action: "stale",
       };
     }
 

--- a/src/strategies/copy-overwrite.ts
+++ b/src/strategies/copy-overwrite.ts
@@ -43,8 +43,19 @@ export class CopyOverwriteStrategy implements ICopyStrategy {
       return { relativePath, strategy: this.name, action: "skipped" };
     }
 
+    // A non-interactive apply (postinstall / `--skip-git-check`) cannot prompt,
+    // and replacing a file the project may have customised without asking is
+    // not a decision this path gets to make. So the file is left alone — but
+    // reported as `stale`, never as `skipped`.
+    //
+    // Reporting it as `skipped` is what made template changes undeliverable in
+    // practice: the postinstall bootstrap is how downstream projects take an
+    // upgrade, so every changed template landed here, and the summary counted
+    // it beside genuinely-identical files under "identical or create-only".
+    // A fix to an enforcement guard could ship in a release and reach nobody,
+    // with nothing in the output to say so.
     if (config.skipGitCheck) {
-      return { relativePath, strategy: this.name, action: "skipped" };
+      return { relativePath, strategy: this.name, action: "stale" };
     }
 
     if (config.dryRun) {

--- a/tests/unit/strategies/copy-overwrite.test.ts
+++ b/tests/unit/strategies/copy-overwrite.test.ts
@@ -10,6 +10,8 @@ const NEW_CONTENT = "new content";
 const OLD_CONTENT = "old content";
 const KNIP_JSON = "knip.json";
 const TSCONFIG_JSON = "tsconfig.json";
+const IDENTICAL_TXT = "identical.txt";
+const CHANGED_TXT = "changed.txt";
 
 describe("CopyOverwriteStrategy", () => {
   let strategy: CopyOverwriteStrategy;
@@ -163,7 +165,10 @@ describe("CopyOverwriteStrategy", () => {
       createContext({ skipGitCheck: true })
     );
 
-    expect(result.action).toBe("skipped");
+    // Preserved, as before — but reported as `stale`, not `skipped`. The file
+    // is out of date with the packaged template and the operator has to be
+    // able to see that.
+    expect(result.action).toBe("stale");
     expect(await fs.readJson(destFile)).toEqual({
       ignoreDependencies: ["shell-quote"],
     });
@@ -182,8 +187,65 @@ describe("CopyOverwriteStrategy", () => {
       createContext({ skipGitCheck: true })
     );
 
-    expect(result.action).toBe("skipped");
+    expect(result.action).toBe("stale");
     expect(await fs.readJson(destFile)).toEqual({});
+  });
+
+  it("distinguishes an out-of-date file from an identical one", async () => {
+    // The regression this exists to stop. Both cases leave the file untouched,
+    // so folding them into one `skipped` count made an undelivered template
+    // change indistinguishable from a clean no-op. A guard fix could ship in a
+    // release and reach nobody, with nothing in the summary to say so.
+    const identicalSrc = path.join(srcDir, IDENTICAL_TXT);
+    const identicalDest = path.join(destDir, IDENTICAL_TXT);
+    await fs.writeFile(identicalSrc, NEW_CONTENT);
+    await fs.writeFile(identicalDest, NEW_CONTENT);
+
+    const changedSrc = path.join(srcDir, CHANGED_TXT);
+    const changedDest = path.join(destDir, CHANGED_TXT);
+    await fs.writeFile(changedSrc, NEW_CONTENT);
+    await fs.writeFile(changedDest, OLD_CONTENT);
+
+    const context = createContext({ skipGitCheck: true });
+
+    expect(
+      (
+        await strategy.apply(
+          identicalSrc,
+          identicalDest,
+          IDENTICAL_TXT,
+          context
+        )
+      ).action
+    ).toBe("skipped");
+    expect(
+      (await strategy.apply(changedSrc, changedDest, CHANGED_TXT, context))
+        .action
+    ).toBe("stale");
+  });
+
+  it("reports an out-of-date enforcement guard rather than swallowing it", async () => {
+    // The concrete case: a released fix to a PreToolUse guard reaching a
+    // project that already has the old one. It is still not overwritten
+    // without a prompt, but it can no longer be invisible.
+    const rel = "scripts/lisa-hooks/block-no-verify.sh";
+    const srcFile = path.join(srcDir, rel);
+    const destFile = path.join(destDir, rel);
+    await fs.ensureDir(path.dirname(srcFile));
+    await fs.ensureDir(path.dirname(destFile));
+    await fs.writeFile(srcFile, "#!/usr/bin/env bash\n# fixed\n");
+    await fs.writeFile(destFile, "#!/usr/bin/env bash\n# vulnerable\n");
+
+    const result = await strategy.apply(
+      srcFile,
+      destFile,
+      rel,
+      createContext({ skipGitCheck: true })
+    );
+
+    expect(result.action).toBe("stale");
+    expect(result.relativePath).toBe(rel);
+    expect(await fs.readFile(destFile, "utf-8")).toContain("vulnerable");
   });
 
   it("creates parent directories when needed", async () => {

--- a/tests/unit/strategies/copy-overwrite.test.ts
+++ b/tests/unit/strategies/copy-overwrite.test.ts
@@ -12,6 +12,7 @@ const KNIP_JSON = "knip.json";
 const TSCONFIG_JSON = "tsconfig.json";
 const IDENTICAL_TXT = "identical.txt";
 const CHANGED_TXT = "changed.txt";
+const VULNERABLE_GUARD = "#!/usr/bin/env bash\n# vulnerable\n";
 
 describe("CopyOverwriteStrategy", () => {
   let strategy: CopyOverwriteStrategy;
@@ -234,7 +235,7 @@ describe("CopyOverwriteStrategy", () => {
     await fs.ensureDir(path.dirname(srcFile));
     await fs.ensureDir(path.dirname(destFile));
     await fs.writeFile(srcFile, "#!/usr/bin/env bash\n# fixed\n");
-    await fs.writeFile(destFile, "#!/usr/bin/env bash\n# vulnerable\n");
+    await fs.writeFile(destFile, VULNERABLE_GUARD);
 
     const result = await strategy.apply(
       srcFile,
@@ -245,7 +246,10 @@ describe("CopyOverwriteStrategy", () => {
 
     expect(result.action).toBe("stale");
     expect(result.relativePath).toBe(rel);
-    expect(await fs.readFile(destFile, "utf-8")).toContain("vulnerable");
+    // Exact content, not a substring: the contract is that the host file is
+    // untouched, and a substring match would still pass if it had been rewritten
+    // around that word.
+    expect(await fs.readFile(destFile, "utf-8")).toBe(VULNERABLE_GUARD);
   });
 
   it("creates parent directories when needed", async () => {


### PR DESCRIPTION
Closes #2377.

## The problem

A non-interactive apply — `--skip-git-check`, which the postinstall bootstrap **always** passes — leaves every changed managed template in place and reported it as `skipped`, counted under **"identical or create-only"**. Since the postinstall bootstrap is how downstream projects take an upgrade, a template change never reached an already-installed project and nothing in the output said so.

Found while propagating #2374. Four repos were bumped to the release carrying six enforcement-guard fail-open fixes, the bootstrap ran, and every repo still had the vulnerable guards:

```
Copied:        0 files
Skipped:      97 files (identical or create-only)
```

The installed package had the fix. The repo copy did not. They differed. Nothing was copied and nothing was reported. **A security fix shipped in a release and reached nobody.**

## Root cause

The flag is documented as skipping the dirty-working-directory prompt:

> `--skip-git-check  Skip dirty git working directory check (for postinstall use)`

But `copy-overwrite.ts` and `copy-contents.ts` overload it to mean "never modify an existing file", returning `skipped` for anything that differs.

## What this changes — and what it does not

**Behaviour is unchanged.** Not prompting is the right call on a non-interactive path, and silently replacing a file a project has customised would be worse. No file is clobbered that was not clobbered before.

**The silence is what changes:**

- a `stale` action distinct from `skipped`, in both strategies
- `[WARN] Out of date, not updated: <path>` per file
- an `Out of date: N files (managed templates changed; NOT updated)` summary line, in apply and dry-run
- a closing block naming every stale path and stating the remedy

Against a fixture with an outdated `block-no-verify.sh`:

```
  Out of date:   1 files (managed templates changed; NOT updated)
[WARN] 1 managed file(s) changed upstream but were left as-is:
[WARN]   scripts/lisa-hooks/block-no-verify.sh
[INFO] A non-interactive apply will not replace a file your project may have customised.
[INFO] Review the differences and run `lisa apply .` interactively to take them, or add paths to .lisaignore to keep yours.
```

## Two existing tests changed, not just added

`preserves host-owned config during skip-git-check applies` and `preserves any existing host file during skip-git-check applies` asserted `action === "skipped"`. Their real contract — the host file is preserved byte-for-byte — is asserted unchanged; only the reported action differs, which is precisely what this PR changes. Calling it out because editing a test to make a change pass is normally the wrong move.

## Verification

- End-to-end against a real fixture, before and after
- 4,707 strategy/unit tests green, `tsc` and `eslint` clean
- New tests pin the distinction directly, including the guard case

## Not in scope

An opt-in force flag for non-interactive applies. That would give releases a supported delivery path for guard fixes instead of the delete-and-recreate workaround downstream repos need today — but it is a behaviour change rather than a reporting one, and belongs in its own PR.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2377


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stale-file reporting for managed files that differ from their templates but are intentionally not overwritten.
  * Dry-run and apply summaries now show stale file counts and affected paths.
  * Apply results include guidance for reviewing or accepting stale changes.

* **Bug Fixes**
  * Differing files are now correctly reported as “stale” instead of “skipped” when overwrite checks are bypassed.
  * Identical files continue to be recognized separately from outdated files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->