### PR TITLE
fix(work-item): read the Linear lifecycle from the workflow state, not labels

### DIFF
--- a/all/copy-overwrite/scripts/lisa-work-item.mjs
+++ b/all/copy-overwrite/scripts/lisa-work-item.mjs
@@ -206,14 +206,21 @@ function values(value) {
 }
 
 function lifecycleContract(config, provider) {
+  // Linear's lifecycle is a workflow STATE, exactly like Jira's status, so it
+  // is configured under `linear.workflow` — NOT `linear.labels.build`. The
+  // label path is still honoured as a fallback for any config written against
+  // the old shape. Reading only the label path meant nothing resolved, the
+  // GitHub-shaped `status:*` defaults below took over, and no Linear state name
+  // could ever match them, so every correctly claimed Linear issue was
+  // rejected as "not claimed".
   const configured =
     provider === "jira"
       ? config.jira?.workflow
       : provider === "github"
         ? config.github?.labels?.build
-        : config.linear?.labels?.build;
+        : (config.linear?.workflow ?? config.linear?.labels?.build);
   const defaults =
-    provider === "jira"
+    provider === "jira" || provider === "linear"
       ? {
           ready: "Ready",
           claimed: "In Progress",
@@ -228,7 +235,6 @@ function lifecycleContract(config, provider) {
       : {
           ready: "status:ready",
           claimed: "status:in-progress",
-          ...(provider === "linear" ? { review: "status:code-review" } : {}),
           blocked: "status:blocked",
           done: {
             dev: "status:on-dev",
@@ -786,7 +792,7 @@ function linearIssue(ref, contract) {
       "Linear validation requires LINEAR_API_KEY or a lisa-linear keychain entry"
     );
   const query =
-    "query($id:String!){issue(id:$id){id identifier team{key} state{type} labels{nodes{name}} children{nodes{state{type}}} attachments{nodes{url}} comments{nodes{body}}}}";
+    "query($id:String!){issue(id:$id){id identifier team{key} state{name type} labels{nodes{name}} children{nodes{state{type}}} attachments{nodes{url}} comments{nodes{body}}}}";
   const payload = JSON.stringify({ query, variables: { id: ref } });
   const result = secureCurl(
     ["https://api.linear.app/graphql"],
@@ -827,7 +833,10 @@ function linearIssue(ref, contract) {
     );
   }
   assertRepoScope(ref, contract, issue.labels?.nodes);
-  assertClaimedLifecycle(ref, contract, issue.labels?.nodes);
+  // Lifecycle comes from the workflow STATE, the same shape the Jira path uses
+  // (`[issue.fields?.status?.name]`). Repo scope stays on labels above, because
+  // repo scoping genuinely IS a label.
+  assertClaimedLifecycle(ref, contract, [issue.state?.name]);
   assertLeaf(
     ref,
     typeFromLabels(issue.labels?.nodes),

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -21,7 +21,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh":
       "bf4132e49ba18e2f7e941520c299c15aeeacfd220e489f3d2eb8397f2048157b",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
-      "6a8be8577242588f14ab52b25b2a22b6def53aefa9513b4d3d7c49f4d8027079",
+      "2d9ca0841db9e75ddfd95e3a4d485fd01aa639a512ef648996f565b7991d8e2b",
     "all/create-only/.claude/rules/PROJECT_RULES.md":
       "6e1c7923ad2a15356babc60c97e7f97be728d790af285b6a7cd7d1b4d39cd97f",
     "all/create-only/.lisaignore":

--- a/tests/unit/scripts/lisa-work-item.test.ts
+++ b/tests/unit/scripts/lisa-work-item.test.ts
@@ -98,7 +98,7 @@ function createFixture(config: object = githubConfig()): Fixture {
     FAKE_ACLI_JSON:
       '{"key":"LAS-12","fields":{"project":{"key":"LAS"},"status":{"name":"In Progress","statusCategory":{"key":"indeterminate"}},"labels":["repo:widgets"],"issuetype":{"name":"Task"},"subtasks":[],"comment":{"comments":[]}}}',
     FAKE_CURL_JSON:
-      '{"data":{"issue":{"id":"id-12","identifier":"LIN-12","team":{"key":"LIN"},"state":{"type":"started"},"labels":{"nodes":[{"name":"repo:widgets"},{"name":"status:in-progress"},{"name":"type:Task"}]},"children":{"nodes":[]},"attachments":{"nodes":[]},"comments":{"nodes":[]}}}}',
+      '{"data":{"issue":{"id":"id-12","identifier":"LIN-12","team":{"key":"LIN"},"state":{"name":"In Progress","type":"started"},"labels":{"nodes":[{"name":"repo:widgets"},{"name":"type:Task"}]},"children":{"nodes":[]},"attachments":{"nodes":[]},"comments":{"nodes":[]}}}}',
     FAKE_GH_ISSUE_JSON:
       '{"number":42,"url":"https://github.com/acme/widgets/issues/42","state":"OPEN","labels":[{"name":"repo:identity"},{"name":"status:in-progress"},{"name":"type:Bug"}],"comments":[],"closedByPullRequestsReferences":[]}',
     FAKE_GH_HIERARCHY_JSON:
@@ -169,15 +169,26 @@ function githubConfig(repository = "widgets"): object {
   return { tracker: "github", github: { org: "acme", repo: repository } };
 }
 
-/** Build a claimed, leaf Linear issue payload carrying the given labels. */
-function linearIssueResponse(labels: string[]): string {
+/**
+ * Build a leaf Linear issue payload carrying the given labels.
+ *
+ * Lifecycle lives in the workflow STATE, not in a label — the same shape the
+ * Jira path uses — so the state name is what decides claimed vs unclaimed.
+ * Labels still carry repo scope and issue type.
+ * @param labels - Label names on the issue.
+ * @param stateName - Workflow state name; defaults to the claimed state.
+ */
+function linearIssueResponse(
+  labels: string[],
+  stateName = "In Progress"
+): string {
   return JSON.stringify({
     data: {
       issue: {
         id: "id-12",
         identifier: "LIN-12",
         team: { key: "LIN" },
-        state: { type: "started" },
+        state: { name: stateName, type: "started" },
         labels: { nodes: labels.map(name => ({ name })) },
         children: { nodes: [] },
         attachments: { nodes: [] },
@@ -893,14 +904,18 @@ describe("provider liveness", () => {
       repo: "widgets",
       linear: { workspace: "acme", teamKey: "LIN" },
     });
-    const response = (labels: string[], children: object[] = []) =>
+    const response = (
+      labels: string[],
+      children: object[] = [],
+      stateName = "In Progress"
+    ) =>
       JSON.stringify({
         data: {
           issue: {
             id: "id-12",
             identifier: "LIN-12",
             team: { key: "LIN" },
-            state: { type: "started" },
+            state: { name: stateName, type: "started" },
             labels: { nodes: labels.map(name => ({ name })) },
             children: { nodes: children },
             attachments: { nodes: [] },
@@ -923,7 +938,7 @@ describe("provider liveness", () => {
 
     const unclaimed = command(fixture, ["bind", "LIN-12"], {
       env: {
-        FAKE_CURL_JSON: response(["repo:widgets", "status:ready", "type:Task"]),
+        FAKE_CURL_JSON: response(["repo:widgets", "type:Task"], [], "Ready"),
       },
     });
     expect(unclaimed.status).toBe(1);


### PR DESCRIPTION
Closes #2379

Work-Item: CodySwannGT/lisa#2379

## The problem

`lisa-work-item.mjs` rejects **every** correctly-claimed Linear issue, so the local commit gate is unusable in any repo whose tracker is `linear`.

Two defects, both survivors of the label → state sweep (#2271, #2277) that migrated the queue resolver, the sync and the agent artifacts onto `linear.workflow` — this file was missed.

**1. `lifecycleContract()` read the wrong config path.** It looked at `config.linear?.labels?.build`, but repos configure Linear's lifecycle under `linear.workflow`, mirroring `jira.workflow` — because a Linear lifecycle *is* a workflow state exactly as Jira's is a status. Nothing resolved there, so the GitHub-shaped `status:*` defaults took over, and no Linear state name could ever match them.

**2. `linearIssue()` checked labels where the Jira path checks status.** It passed `issue.labels?.nodes` to `assertClaimedLifecycle`, i.e. it wanted a *label* named "In Progress". The Jira path correctly passes `[issue.fields?.status?.name]`.

## Reproduction

`geminisportsai/frontend-v2` sets `tracker: "linear"` with a full `linear.workflow` block. Its SE-6812 — state **In Progress** (type `started`), label `repo:frontend-v2` — was rejected as "not claimed" on every single commit.

There was no honest way to satisfy the gate: the only workaround was adding a bogus "In Progress" **label**, which pollutes the tracker with metadata that duplicates the state it already has.

## The fix

- `lifecycleContract`: read `config.linear?.workflow`, keeping the label path as a fallback for any config written against the old shape, and give `linear` the same state-name defaults `jira` uses.
- `linearIssue`: query `state{name type}` and pass `[issue.state?.name]`.
- Repo scope stays on labels — repo scoping genuinely *is* a label, and `assertRepoScope` is untouched.

## On the test changes

The Linear fixtures encoded the bug. They expressed lifecycle as a `status:in-progress` **label** and gave the state only a `type`, so they would have passed against either implementation — which is exactly why this survived the sweep.

They now carry a workflow state name, and the unclaimed case expresses "not claimed" as a state (`"Ready"`) rather than as a label, so the fixtures assert what the code actually reads. Labels still carry repo scope and issue type in every fixture, and the repo-scope tests are unchanged.

`tests/unit/scripts/lisa-work-item.test.ts`: **33 passed**.

## Verified end to end

With this change applied, `frontend-v2` binds `SE-6812` and commits normally for the first time — the gate accepts a Linear issue whose workflow state is the claimed state, and still rejects unclaimed, terminal, wrong-repo and container issues.

🤖 Generated with Claude Code
