### PR TITLE
fix(hooks): close the remaining security findings from the guard review

### DIFF
--- a/all/copy-overwrite/scripts/lisa-floor-collisions.mjs
+++ b/all/copy-overwrite/scripts/lisa-floor-collisions.mjs
@@ -48,18 +48,50 @@ const DEPENDENCY_SECTIONS = [
 ];
 
 /**
+ * Lowest version a single disjunction branch permits.
+ *
+ * An upper-bound-only branch (`<2.0.0`, `<=2.0.0`) has no floor: it permits
+ * everything beneath the bound, so its lower bound is zero. Every other form
+ * used in practice (`>=1.2.3`, `^1.2.3`, `~1.2.3`, `1.2.3`, `>=1.2.3 <2`)
+ * leads with its lower bound.
+ * @param {string} branch One branch of a `||` range.
+ * @returns {number[]|null} [major, minor, patch], or null when there is none.
+ */
+function branchLowerBound(branch) {
+  const trimmed = branch.trim();
+  if (trimmed === "") return null;
+  if (/^<=?\s*\d/.test(trimmed)) return [0, 0, 0];
+  const match = /(\d+)\.(\d+)\.(\d+)/.exec(trimmed);
+  return match ? match.slice(1, 4).map(Number) : null;
+}
+
+/**
  * Lowest version a range permits, as a comparable tuple.
  *
- * Deliberately crude: it reads the first version in the spec, which is the
- * lower bound for every form used in practice (`>=1.2.3`, `^1.2.3`, `~1.2.3`,
- * `1.2.3`, `>=1.2.3 <2`). A spec carrying no version — `*`, `workspace:*`,
- * `latest` — has no floor to compare and returns null.
+ * Reading only the first version in the spec was wrong in a direction that
+ * matters: for `^2.0.0 || ^1.9.0` it reported 2.0.0, a floor HIGHER than the
+ * range actually permits, and the caller's `compare(target, floor) >= 0` then
+ * skipped a genuine collision. A floor read too high is a false negative in a
+ * security check, so every branch is measured and the lowest wins.
+ *
+ * An alias spec (`npm:other-pkg@^1.2.3`) versions a different package
+ * entirely; its number cannot be compared against a floor for this name, so it
+ * returns null rather than a misleading answer. A spec carrying no version —
+ * `*`, `workspace:*`, `latest` — has no floor either.
  * @param {string} spec A version range.
  * @returns {number[]|null} [major, minor, patch], or null when there is none.
  */
 export function lowestPermitted(spec) {
-  const match = /(\d+)\.(\d+)\.(\d+)/.exec(spec ?? "");
-  return match ? match.slice(1, 4).map(Number) : null;
+  const raw = spec ?? "";
+  if (/^\s*npm:/i.test(raw)) return null;
+  const bounds = raw
+    .split("||")
+    .map(branchLowerBound)
+    .filter(bound => bound !== null);
+  if (bounds.length === 0) return null;
+  return bounds.reduce((lowest, bound) =>
+    compare(bound, lowest) < 0 ? bound : lowest
+  );
 }
 
 /**

--- a/all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh
@@ -172,16 +172,6 @@ case "$command_str" in
     ;;
 esac
 
-# matches / matches_cs run an ERE against the guarded command text. matches is
-# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
-# for guards where flag case is meaningful (`git branch -d` vs `-D`).
-matches() {
-  printf '%s' "$command_for_guards" | grep -Eiq -- "$1"
-}
-matches_cs() {
-  printf '%s' "$command_for_guards" | grep -Eq -- "$1"
-}
-
 # Normalize bash line-continuations (a trailing backslash + newline → space)
 # before segmenting the command. Without this, "git push --force origin
 # \<newline>main" splits into a segment matching --force but not `main`, letting a
@@ -189,6 +179,28 @@ matches_cs() {
 # `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
 normalized_command_str="$(printf '%s' "$command_for_guards" \
   | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
+
+# matches / matches_cs run an ERE against the guarded command text. matches is
+# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
+# for guards where flag case is meaningful (`git branch -d` vs `-D`).
+#
+# Both read the NORMALIZED text. They used to read $command_for_guards, so only
+# the two segment-walking guards (rm, git push) were protected against line
+# continuations and every guard expressed through these helpers could be evaded
+# by breaking the command across lines:
+#
+#     git reset --hard \
+#       origin/main
+#
+# The patterns match on intermediate whitespace, and an embedded "\<newline>" is
+# not whitespace to grep -E, so the anchor failed to span the break. Defined
+# after the normalization above so the value exists when these are first called.
+matches() {
+  printf '%s' "$normalized_command_str" | grep -Eiq -- "$1"
+}
+matches_cs() {
+  printf '%s' "$normalized_command_str" | grep -Eq -- "$1"
+}
 
 # Shared ERE fragments. GIT_TOKENS walks over intermediate argv tokens without
 # crossing a statement separator, so a flag in a LATER statement can never be
@@ -553,9 +565,28 @@ if [ -f "$rules_file" ]; then
     case "$rule" in
       '' | '#'*) continue ;;
     esac
-    if printf '%s' "$command_for_guards" | grep -Eiq -- "$rule"; then
-      block "matched a project custom safety rule (${rules_file##*/}): $rule"
-    fi
+    # Normalized text, for the same reason every built-in guard uses it: a
+    # project rule must not be evadable by breaking the command across lines.
+    #
+    # `|| rule_status=$?` rather than a bare pipeline: this script runs under
+    # `set -e`, and a no-match grep exits 1, which would end the hook right
+    # here — before the remaining rules ran, and with an exit status that is
+    # not a refusal. The `||` puts the pipeline in a condition context, where
+    # a non-zero status is expected rather than fatal.
+    rule_status=0
+    printf '%s' "$normalized_command_str" | grep -Eiq -- "$rule" || rule_status=$?
+    case "$rule_status" in
+      0) block "matched a project custom safety rule (${rules_file##*/}): $rule" ;;
+      1) ;; # no match
+      # grep exits 2 on a malformed ERE. Treated as no-match before, so a typo
+      # in a project's rules file silently disabled that rule — a guard the
+      # project believed it had. Say so instead; still non-fatal, because one
+      # bad line must not take the other rules down with it.
+      *)
+        printf 'parity-safety-net: invalid regex in %s, rule NOT enforced: %s\n' \
+          "$rules_file" "$rule" >&2
+        ;;
+    esac
   done <"$rules_file"
 fi
 

--- a/all/create-only/scripts/remote-agent-aws-setup.sh
+++ b/all/create-only/scripts/remote-agent-aws-setup.sh
@@ -6,7 +6,14 @@ set -euo pipefail
 
 if NPM_ROOT="$(npm root 2>/dev/null)" && [ -n "$NPM_ROOT" ]; then
   LOCAL_LISA_SCRIPT="$NPM_ROOT/@codyswann/lisa/plugins/lisa/scripts/remote-agent-aws-setup.sh"
-  [ -x "$LOCAL_LISA_SCRIPT" ] && exec "$LOCAL_LISA_SCRIPT" "$@"
+  # Spelled as a full `if` rather than `[ -x … ] && exec …`. That form is the
+  # last command in this block, so when the file is absent its non-zero status
+  # is the block's status, and `set -e` exits (1) right here — before the
+  # diagnostic below can print. The operator saw a silent failure instead of
+  # being told to install the package.
+  if [ -x "$LOCAL_LISA_SCRIPT" ]; then
+    exec "$LOCAL_LISA_SCRIPT" "$@"
+  fi
 fi
 
 echo "remote-agent-aws-setup: install @codyswann/lisa before running this setup script" >&2

--- a/plugins/lisa-agy/hooks/parity-safety-net.sh
+++ b/plugins/lisa-agy/hooks/parity-safety-net.sh
@@ -172,16 +172,6 @@ case "$command_str" in
     ;;
 esac
 
-# matches / matches_cs run an ERE against the guarded command text. matches is
-# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
-# for guards where flag case is meaningful (`git branch -d` vs `-D`).
-matches() {
-  printf '%s' "$command_for_guards" | grep -Eiq -- "$1"
-}
-matches_cs() {
-  printf '%s' "$command_for_guards" | grep -Eq -- "$1"
-}
-
 # Normalize bash line-continuations (a trailing backslash + newline → space)
 # before segmenting the command. Without this, "git push --force origin
 # \<newline>main" splits into a segment matching --force but not `main`, letting a
@@ -189,6 +179,28 @@ matches_cs() {
 # `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
 normalized_command_str="$(printf '%s' "$command_for_guards" \
   | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
+
+# matches / matches_cs run an ERE against the guarded command text. matches is
+# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
+# for guards where flag case is meaningful (`git branch -d` vs `-D`).
+#
+# Both read the NORMALIZED text. They used to read $command_for_guards, so only
+# the two segment-walking guards (rm, git push) were protected against line
+# continuations and every guard expressed through these helpers could be evaded
+# by breaking the command across lines:
+#
+#     git reset --hard \
+#       origin/main
+#
+# The patterns match on intermediate whitespace, and an embedded "\<newline>" is
+# not whitespace to grep -E, so the anchor failed to span the break. Defined
+# after the normalization above so the value exists when these are first called.
+matches() {
+  printf '%s' "$normalized_command_str" | grep -Eiq -- "$1"
+}
+matches_cs() {
+  printf '%s' "$normalized_command_str" | grep -Eq -- "$1"
+}
 
 # Shared ERE fragments. GIT_TOKENS walks over intermediate argv tokens without
 # crossing a statement separator, so a flag in a LATER statement can never be
@@ -553,9 +565,28 @@ if [ -f "$rules_file" ]; then
     case "$rule" in
       '' | '#'*) continue ;;
     esac
-    if printf '%s' "$command_for_guards" | grep -Eiq -- "$rule"; then
-      block "matched a project custom safety rule (${rules_file##*/}): $rule"
-    fi
+    # Normalized text, for the same reason every built-in guard uses it: a
+    # project rule must not be evadable by breaking the command across lines.
+    #
+    # `|| rule_status=$?` rather than a bare pipeline: this script runs under
+    # `set -e`, and a no-match grep exits 1, which would end the hook right
+    # here — before the remaining rules ran, and with an exit status that is
+    # not a refusal. The `||` puts the pipeline in a condition context, where
+    # a non-zero status is expected rather than fatal.
+    rule_status=0
+    printf '%s' "$normalized_command_str" | grep -Eiq -- "$rule" || rule_status=$?
+    case "$rule_status" in
+      0) block "matched a project custom safety rule (${rules_file##*/}): $rule" ;;
+      1) ;; # no match
+      # grep exits 2 on a malformed ERE. Treated as no-match before, so a typo
+      # in a project's rules file silently disabled that rule — a guard the
+      # project believed it had. Say so instead; still non-fatal, because one
+      # bad line must not take the other rules down with it.
+      *)
+        printf 'parity-safety-net: invalid regex in %s, rule NOT enforced: %s\n' \
+          "$rules_file" "$rule" >&2
+        ;;
+    esac
   done <"$rules_file"
 fi
 

--- a/plugins/lisa-copilot/hooks/parity-safety-net.sh
+++ b/plugins/lisa-copilot/hooks/parity-safety-net.sh
@@ -172,16 +172,6 @@ case "$command_str" in
     ;;
 esac
 
-# matches / matches_cs run an ERE against the guarded command text. matches is
-# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
-# for guards where flag case is meaningful (`git branch -d` vs `-D`).
-matches() {
-  printf '%s' "$command_for_guards" | grep -Eiq -- "$1"
-}
-matches_cs() {
-  printf '%s' "$command_for_guards" | grep -Eq -- "$1"
-}
-
 # Normalize bash line-continuations (a trailing backslash + newline → space)
 # before segmenting the command. Without this, "git push --force origin
 # \<newline>main" splits into a segment matching --force but not `main`, letting a
@@ -189,6 +179,28 @@ matches_cs() {
 # `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
 normalized_command_str="$(printf '%s' "$command_for_guards" \
   | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
+
+# matches / matches_cs run an ERE against the guarded command text. matches is
+# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
+# for guards where flag case is meaningful (`git branch -d` vs `-D`).
+#
+# Both read the NORMALIZED text. They used to read $command_for_guards, so only
+# the two segment-walking guards (rm, git push) were protected against line
+# continuations and every guard expressed through these helpers could be evaded
+# by breaking the command across lines:
+#
+#     git reset --hard \
+#       origin/main
+#
+# The patterns match on intermediate whitespace, and an embedded "\<newline>" is
+# not whitespace to grep -E, so the anchor failed to span the break. Defined
+# after the normalization above so the value exists when these are first called.
+matches() {
+  printf '%s' "$normalized_command_str" | grep -Eiq -- "$1"
+}
+matches_cs() {
+  printf '%s' "$normalized_command_str" | grep -Eq -- "$1"
+}
 
 # Shared ERE fragments. GIT_TOKENS walks over intermediate argv tokens without
 # crossing a statement separator, so a flag in a LATER statement can never be
@@ -553,9 +565,28 @@ if [ -f "$rules_file" ]; then
     case "$rule" in
       '' | '#'*) continue ;;
     esac
-    if printf '%s' "$command_for_guards" | grep -Eiq -- "$rule"; then
-      block "matched a project custom safety rule (${rules_file##*/}): $rule"
-    fi
+    # Normalized text, for the same reason every built-in guard uses it: a
+    # project rule must not be evadable by breaking the command across lines.
+    #
+    # `|| rule_status=$?` rather than a bare pipeline: this script runs under
+    # `set -e`, and a no-match grep exits 1, which would end the hook right
+    # here — before the remaining rules ran, and with an exit status that is
+    # not a refusal. The `||` puts the pipeline in a condition context, where
+    # a non-zero status is expected rather than fatal.
+    rule_status=0
+    printf '%s' "$normalized_command_str" | grep -Eiq -- "$rule" || rule_status=$?
+    case "$rule_status" in
+      0) block "matched a project custom safety rule (${rules_file##*/}): $rule" ;;
+      1) ;; # no match
+      # grep exits 2 on a malformed ERE. Treated as no-match before, so a typo
+      # in a project's rules file silently disabled that rule — a guard the
+      # project believed it had. Say so instead; still non-fatal, because one
+      # bad line must not take the other rules down with it.
+      *)
+        printf 'parity-safety-net: invalid regex in %s, rule NOT enforced: %s\n' \
+          "$rules_file" "$rule" >&2
+        ;;
+    esac
   done <"$rules_file"
 fi
 

--- a/plugins/lisa-copilot/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa-copilot/hooks/threshold-ratchet.mjs
@@ -56,6 +56,15 @@ const GIT = GIT_LOCATIONS.find(candidate => fs.existsSync(candidate)) ?? "git";
 
 /** Git flag shared by every changed-file listing. */
 const NAME_ONLY = "--name-only";
+/**
+ * Suppress rename detection when discovering changed files.
+ *
+ * With it on, `git diff --name-only` reports a rename as the destination path
+ * only. Moving a watched threshold file to an unwatched path therefore lists
+ * one name the ratchet does not watch, and the loosening at the old path is
+ * never compared. Both sides have to be visible for the gate to mean anything.
+ */
+const NO_RENAMES = "--no-renames";
 
 /**
  * Run git, returning stdout or null on any failure.
@@ -87,7 +96,7 @@ function git(args, cwd) {
  */
 function resolvePlan(mode, root, baseRef, onlyFiles) {
   if (mode === "staged") {
-    const diff = git(["diff", "--cached", NAME_ONLY], root);
+    const diff = git(["diff", "--cached", NAME_ONLY, NO_RENAMES], root);
     if (diff === null) return null;
     return {
       files: diff.split("\n").filter(Boolean),
@@ -99,7 +108,7 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
     if (!baseRef) return null;
     const mergeBase = git(["merge-base", baseRef, "HEAD"], root)?.trim();
     if (!mergeBase) return null;
-    const diff = git(["diff", NAME_ONLY, mergeBase, "HEAD"], root);
+    const diff = git(["diff", NAME_ONLY, NO_RENAMES, mergeBase, "HEAD"], root);
     if (diff === null) return null;
     return {
       files: diff.split("\n").filter(Boolean),
@@ -107,7 +116,7 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
       readCurrent: f => git(["show", `HEAD:${f}`], root),
     };
   }
-  const diff = git(["diff", NAME_ONLY, "HEAD"], root);
+  const diff = git(["diff", NAME_ONLY, NO_RENAMES, "HEAD"], root);
   if (diff === null) return null;
   return {
     files: onlyFiles ?? diff.split("\n").filter(Boolean),
@@ -123,6 +132,31 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
 }
 
 /**
+ * Decide the exit code when the ratchet cannot determine what changed.
+ *
+ * `staged` and `base` are enforcement gates — pre-commit and CI. A gate that
+ * cannot see the change set has not found the change set clean, and returning 0
+ * reports exactly that. It fails closed, loudly.
+ *
+ * `hook` is advisory feedback to an agent mid-edit, fires on every tool call,
+ * and blocks nothing downstream. Failing it closed on a transient git hiccup
+ * would turn a hint into an outage, so it stays permissive — but still says so.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string} reason What could not be determined
+ * @returns {number} Process exit code
+ */
+function undeterminable(mode, reason) {
+  process.stderr.write(
+    `threshold-ratchet: ${reason}; the ratchet could not run in ${mode} mode\n`
+  );
+  if (mode === "hook") return 0;
+  process.stderr.write(
+    "threshold-ratchet: failing closed — an enforcement gate that cannot read the change set has not verified it\n"
+  );
+  return 1;
+}
+
+/**
  * Run the ratchet for a mode, print the report, and return the exit code.
  * @param {"hook"|"staged"|"base"} mode Comparison mode
  * @param {string | undefined} [baseRef] Base ref (base mode only)
@@ -131,9 +165,9 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
  */
 function run(mode, baseRef, onlyFiles) {
   const root = git(["rev-parse", "--show-toplevel"])?.trim();
-  if (!root) return 0;
+  if (!root) return undeterminable(mode, "not a git repository");
   const plan = resolvePlan(mode, root, baseRef, onlyFiles);
-  if (!plan) return 0;
+  if (!plan) return undeterminable(mode, "could not resolve the changed files");
 
   const watched = plan.files.filter(f => familyFor(f));
   if (watched.length === 0) return 0;

--- a/plugins/lisa-cursor/hooks/parity-safety-net.sh
+++ b/plugins/lisa-cursor/hooks/parity-safety-net.sh
@@ -172,16 +172,6 @@ case "$command_str" in
     ;;
 esac
 
-# matches / matches_cs run an ERE against the guarded command text. matches is
-# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
-# for guards where flag case is meaningful (`git branch -d` vs `-D`).
-matches() {
-  printf '%s' "$command_for_guards" | grep -Eiq -- "$1"
-}
-matches_cs() {
-  printf '%s' "$command_for_guards" | grep -Eq -- "$1"
-}
-
 # Normalize bash line-continuations (a trailing backslash + newline → space)
 # before segmenting the command. Without this, "git push --force origin
 # \<newline>main" splits into a segment matching --force but not `main`, letting a
@@ -189,6 +179,28 @@ matches_cs() {
 # `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
 normalized_command_str="$(printf '%s' "$command_for_guards" \
   | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
+
+# matches / matches_cs run an ERE against the guarded command text. matches is
+# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
+# for guards where flag case is meaningful (`git branch -d` vs `-D`).
+#
+# Both read the NORMALIZED text. They used to read $command_for_guards, so only
+# the two segment-walking guards (rm, git push) were protected against line
+# continuations and every guard expressed through these helpers could be evaded
+# by breaking the command across lines:
+#
+#     git reset --hard \
+#       origin/main
+#
+# The patterns match on intermediate whitespace, and an embedded "\<newline>" is
+# not whitespace to grep -E, so the anchor failed to span the break. Defined
+# after the normalization above so the value exists when these are first called.
+matches() {
+  printf '%s' "$normalized_command_str" | grep -Eiq -- "$1"
+}
+matches_cs() {
+  printf '%s' "$normalized_command_str" | grep -Eq -- "$1"
+}
 
 # Shared ERE fragments. GIT_TOKENS walks over intermediate argv tokens without
 # crossing a statement separator, so a flag in a LATER statement can never be
@@ -553,9 +565,28 @@ if [ -f "$rules_file" ]; then
     case "$rule" in
       '' | '#'*) continue ;;
     esac
-    if printf '%s' "$command_for_guards" | grep -Eiq -- "$rule"; then
-      block "matched a project custom safety rule (${rules_file##*/}): $rule"
-    fi
+    # Normalized text, for the same reason every built-in guard uses it: a
+    # project rule must not be evadable by breaking the command across lines.
+    #
+    # `|| rule_status=$?` rather than a bare pipeline: this script runs under
+    # `set -e`, and a no-match grep exits 1, which would end the hook right
+    # here — before the remaining rules ran, and with an exit status that is
+    # not a refusal. The `||` puts the pipeline in a condition context, where
+    # a non-zero status is expected rather than fatal.
+    rule_status=0
+    printf '%s' "$normalized_command_str" | grep -Eiq -- "$rule" || rule_status=$?
+    case "$rule_status" in
+      0) block "matched a project custom safety rule (${rules_file##*/}): $rule" ;;
+      1) ;; # no match
+      # grep exits 2 on a malformed ERE. Treated as no-match before, so a typo
+      # in a project's rules file silently disabled that rule — a guard the
+      # project believed it had. Say so instead; still non-fatal, because one
+      # bad line must not take the other rules down with it.
+      *)
+        printf 'parity-safety-net: invalid regex in %s, rule NOT enforced: %s\n' \
+          "$rules_file" "$rule" >&2
+        ;;
+    esac
   done <"$rules_file"
 fi
 

--- a/plugins/lisa-cursor/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa-cursor/hooks/threshold-ratchet.mjs
@@ -56,6 +56,15 @@ const GIT = GIT_LOCATIONS.find(candidate => fs.existsSync(candidate)) ?? "git";
 
 /** Git flag shared by every changed-file listing. */
 const NAME_ONLY = "--name-only";
+/**
+ * Suppress rename detection when discovering changed files.
+ *
+ * With it on, `git diff --name-only` reports a rename as the destination path
+ * only. Moving a watched threshold file to an unwatched path therefore lists
+ * one name the ratchet does not watch, and the loosening at the old path is
+ * never compared. Both sides have to be visible for the gate to mean anything.
+ */
+const NO_RENAMES = "--no-renames";
 
 /**
  * Run git, returning stdout or null on any failure.
@@ -87,7 +96,7 @@ function git(args, cwd) {
  */
 function resolvePlan(mode, root, baseRef, onlyFiles) {
   if (mode === "staged") {
-    const diff = git(["diff", "--cached", NAME_ONLY], root);
+    const diff = git(["diff", "--cached", NAME_ONLY, NO_RENAMES], root);
     if (diff === null) return null;
     return {
       files: diff.split("\n").filter(Boolean),
@@ -99,7 +108,7 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
     if (!baseRef) return null;
     const mergeBase = git(["merge-base", baseRef, "HEAD"], root)?.trim();
     if (!mergeBase) return null;
-    const diff = git(["diff", NAME_ONLY, mergeBase, "HEAD"], root);
+    const diff = git(["diff", NAME_ONLY, NO_RENAMES, mergeBase, "HEAD"], root);
     if (diff === null) return null;
     return {
       files: diff.split("\n").filter(Boolean),
@@ -107,7 +116,7 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
       readCurrent: f => git(["show", `HEAD:${f}`], root),
     };
   }
-  const diff = git(["diff", NAME_ONLY, "HEAD"], root);
+  const diff = git(["diff", NAME_ONLY, NO_RENAMES, "HEAD"], root);
   if (diff === null) return null;
   return {
     files: onlyFiles ?? diff.split("\n").filter(Boolean),
@@ -123,6 +132,31 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
 }
 
 /**
+ * Decide the exit code when the ratchet cannot determine what changed.
+ *
+ * `staged` and `base` are enforcement gates — pre-commit and CI. A gate that
+ * cannot see the change set has not found the change set clean, and returning 0
+ * reports exactly that. It fails closed, loudly.
+ *
+ * `hook` is advisory feedback to an agent mid-edit, fires on every tool call,
+ * and blocks nothing downstream. Failing it closed on a transient git hiccup
+ * would turn a hint into an outage, so it stays permissive — but still says so.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string} reason What could not be determined
+ * @returns {number} Process exit code
+ */
+function undeterminable(mode, reason) {
+  process.stderr.write(
+    `threshold-ratchet: ${reason}; the ratchet could not run in ${mode} mode\n`
+  );
+  if (mode === "hook") return 0;
+  process.stderr.write(
+    "threshold-ratchet: failing closed — an enforcement gate that cannot read the change set has not verified it\n"
+  );
+  return 1;
+}
+
+/**
  * Run the ratchet for a mode, print the report, and return the exit code.
  * @param {"hook"|"staged"|"base"} mode Comparison mode
  * @param {string | undefined} [baseRef] Base ref (base mode only)
@@ -131,9 +165,9 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
  */
 function run(mode, baseRef, onlyFiles) {
   const root = git(["rev-parse", "--show-toplevel"])?.trim();
-  if (!root) return 0;
+  if (!root) return undeterminable(mode, "not a git repository");
   const plan = resolvePlan(mode, root, baseRef, onlyFiles);
-  if (!plan) return 0;
+  if (!plan) return undeterminable(mode, "could not resolve the changed files");
 
   const watched = plan.files.filter(f => familyFor(f));
   if (watched.length === 0) return 0;

--- a/plugins/lisa/hooks/parity-safety-net.sh
+++ b/plugins/lisa/hooks/parity-safety-net.sh
@@ -172,16 +172,6 @@ case "$command_str" in
     ;;
 esac
 
-# matches / matches_cs run an ERE against the guarded command text. matches is
-# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
-# for guards where flag case is meaningful (`git branch -d` vs `-D`).
-matches() {
-  printf '%s' "$command_for_guards" | grep -Eiq -- "$1"
-}
-matches_cs() {
-  printf '%s' "$command_for_guards" | grep -Eq -- "$1"
-}
-
 # Normalize bash line-continuations (a trailing backslash + newline → space)
 # before segmenting the command. Without this, "git push --force origin
 # \<newline>main" splits into a segment matching --force but not `main`, letting a
@@ -189,6 +179,28 @@ matches_cs() {
 # `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
 normalized_command_str="$(printf '%s' "$command_for_guards" \
   | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
+
+# matches / matches_cs run an ERE against the guarded command text. matches is
+# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
+# for guards where flag case is meaningful (`git branch -d` vs `-D`).
+#
+# Both read the NORMALIZED text. They used to read $command_for_guards, so only
+# the two segment-walking guards (rm, git push) were protected against line
+# continuations and every guard expressed through these helpers could be evaded
+# by breaking the command across lines:
+#
+#     git reset --hard \
+#       origin/main
+#
+# The patterns match on intermediate whitespace, and an embedded "\<newline>" is
+# not whitespace to grep -E, so the anchor failed to span the break. Defined
+# after the normalization above so the value exists when these are first called.
+matches() {
+  printf '%s' "$normalized_command_str" | grep -Eiq -- "$1"
+}
+matches_cs() {
+  printf '%s' "$normalized_command_str" | grep -Eq -- "$1"
+}
 
 # Shared ERE fragments. GIT_TOKENS walks over intermediate argv tokens without
 # crossing a statement separator, so a flag in a LATER statement can never be
@@ -553,9 +565,28 @@ if [ -f "$rules_file" ]; then
     case "$rule" in
       '' | '#'*) continue ;;
     esac
-    if printf '%s' "$command_for_guards" | grep -Eiq -- "$rule"; then
-      block "matched a project custom safety rule (${rules_file##*/}): $rule"
-    fi
+    # Normalized text, for the same reason every built-in guard uses it: a
+    # project rule must not be evadable by breaking the command across lines.
+    #
+    # `|| rule_status=$?` rather than a bare pipeline: this script runs under
+    # `set -e`, and a no-match grep exits 1, which would end the hook right
+    # here — before the remaining rules ran, and with an exit status that is
+    # not a refusal. The `||` puts the pipeline in a condition context, where
+    # a non-zero status is expected rather than fatal.
+    rule_status=0
+    printf '%s' "$normalized_command_str" | grep -Eiq -- "$rule" || rule_status=$?
+    case "$rule_status" in
+      0) block "matched a project custom safety rule (${rules_file##*/}): $rule" ;;
+      1) ;; # no match
+      # grep exits 2 on a malformed ERE. Treated as no-match before, so a typo
+      # in a project's rules file silently disabled that rule — a guard the
+      # project believed it had. Say so instead; still non-fatal, because one
+      # bad line must not take the other rules down with it.
+      *)
+        printf 'parity-safety-net: invalid regex in %s, rule NOT enforced: %s\n' \
+          "$rules_file" "$rule" >&2
+        ;;
+    esac
   done <"$rules_file"
 fi
 

--- a/plugins/lisa/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa/hooks/threshold-ratchet.mjs
@@ -56,6 +56,15 @@ const GIT = GIT_LOCATIONS.find(candidate => fs.existsSync(candidate)) ?? "git";
 
 /** Git flag shared by every changed-file listing. */
 const NAME_ONLY = "--name-only";
+/**
+ * Suppress rename detection when discovering changed files.
+ *
+ * With it on, `git diff --name-only` reports a rename as the destination path
+ * only. Moving a watched threshold file to an unwatched path therefore lists
+ * one name the ratchet does not watch, and the loosening at the old path is
+ * never compared. Both sides have to be visible for the gate to mean anything.
+ */
+const NO_RENAMES = "--no-renames";
 
 /**
  * Run git, returning stdout or null on any failure.
@@ -87,7 +96,7 @@ function git(args, cwd) {
  */
 function resolvePlan(mode, root, baseRef, onlyFiles) {
   if (mode === "staged") {
-    const diff = git(["diff", "--cached", NAME_ONLY], root);
+    const diff = git(["diff", "--cached", NAME_ONLY, NO_RENAMES], root);
     if (diff === null) return null;
     return {
       files: diff.split("\n").filter(Boolean),
@@ -99,7 +108,7 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
     if (!baseRef) return null;
     const mergeBase = git(["merge-base", baseRef, "HEAD"], root)?.trim();
     if (!mergeBase) return null;
-    const diff = git(["diff", NAME_ONLY, mergeBase, "HEAD"], root);
+    const diff = git(["diff", NAME_ONLY, NO_RENAMES, mergeBase, "HEAD"], root);
     if (diff === null) return null;
     return {
       files: diff.split("\n").filter(Boolean),
@@ -107,7 +116,7 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
       readCurrent: f => git(["show", `HEAD:${f}`], root),
     };
   }
-  const diff = git(["diff", NAME_ONLY, "HEAD"], root);
+  const diff = git(["diff", NAME_ONLY, NO_RENAMES, "HEAD"], root);
   if (diff === null) return null;
   return {
     files: onlyFiles ?? diff.split("\n").filter(Boolean),
@@ -123,6 +132,31 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
 }
 
 /**
+ * Decide the exit code when the ratchet cannot determine what changed.
+ *
+ * `staged` and `base` are enforcement gates — pre-commit and CI. A gate that
+ * cannot see the change set has not found the change set clean, and returning 0
+ * reports exactly that. It fails closed, loudly.
+ *
+ * `hook` is advisory feedback to an agent mid-edit, fires on every tool call,
+ * and blocks nothing downstream. Failing it closed on a transient git hiccup
+ * would turn a hint into an outage, so it stays permissive — but still says so.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string} reason What could not be determined
+ * @returns {number} Process exit code
+ */
+function undeterminable(mode, reason) {
+  process.stderr.write(
+    `threshold-ratchet: ${reason}; the ratchet could not run in ${mode} mode\n`
+  );
+  if (mode === "hook") return 0;
+  process.stderr.write(
+    "threshold-ratchet: failing closed — an enforcement gate that cannot read the change set has not verified it\n"
+  );
+  return 1;
+}
+
+/**
  * Run the ratchet for a mode, print the report, and return the exit code.
  * @param {"hook"|"staged"|"base"} mode Comparison mode
  * @param {string | undefined} [baseRef] Base ref (base mode only)
@@ -131,9 +165,9 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
  */
 function run(mode, baseRef, onlyFiles) {
   const root = git(["rev-parse", "--show-toplevel"])?.trim();
-  if (!root) return 0;
+  if (!root) return undeterminable(mode, "not a git repository");
   const plan = resolvePlan(mode, root, baseRef, onlyFiles);
-  if (!plan) return 0;
+  if (!plan) return undeterminable(mode, "could not resolve the changed files");
 
   const watched = plan.files.filter(f => familyFor(f));
   if (watched.length === 0) return 0;

--- a/plugins/src/base/hooks/parity-safety-net.sh
+++ b/plugins/src/base/hooks/parity-safety-net.sh
@@ -172,16 +172,6 @@ case "$command_str" in
     ;;
 esac
 
-# matches / matches_cs run an ERE against the guarded command text. matches is
-# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
-# for guards where flag case is meaningful (`git branch -d` vs `-D`).
-matches() {
-  printf '%s' "$command_for_guards" | grep -Eiq -- "$1"
-}
-matches_cs() {
-  printf '%s' "$command_for_guards" | grep -Eq -- "$1"
-}
-
 # Normalize bash line-continuations (a trailing backslash + newline → space)
 # before segmenting the command. Without this, "git push --force origin
 # \<newline>main" splits into a segment matching --force but not `main`, letting a
@@ -189,6 +179,28 @@ matches_cs() {
 # `sed ':a;N;$!ba;…'`, which errors on BSD sed (macOS) and there silently no-ops.
 normalized_command_str="$(printf '%s' "$command_for_guards" \
   | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }')"
+
+# matches / matches_cs run an ERE against the guarded command text. matches is
+# case-insensitive (the default for these guards); matches_cs is case-SENSITIVE
+# for guards where flag case is meaningful (`git branch -d` vs `-D`).
+#
+# Both read the NORMALIZED text. They used to read $command_for_guards, so only
+# the two segment-walking guards (rm, git push) were protected against line
+# continuations and every guard expressed through these helpers could be evaded
+# by breaking the command across lines:
+#
+#     git reset --hard \
+#       origin/main
+#
+# The patterns match on intermediate whitespace, and an embedded "\<newline>" is
+# not whitespace to grep -E, so the anchor failed to span the break. Defined
+# after the normalization above so the value exists when these are first called.
+matches() {
+  printf '%s' "$normalized_command_str" | grep -Eiq -- "$1"
+}
+matches_cs() {
+  printf '%s' "$normalized_command_str" | grep -Eq -- "$1"
+}
 
 # Shared ERE fragments. GIT_TOKENS walks over intermediate argv tokens without
 # crossing a statement separator, so a flag in a LATER statement can never be
@@ -553,9 +565,28 @@ if [ -f "$rules_file" ]; then
     case "$rule" in
       '' | '#'*) continue ;;
     esac
-    if printf '%s' "$command_for_guards" | grep -Eiq -- "$rule"; then
-      block "matched a project custom safety rule (${rules_file##*/}): $rule"
-    fi
+    # Normalized text, for the same reason every built-in guard uses it: a
+    # project rule must not be evadable by breaking the command across lines.
+    #
+    # `|| rule_status=$?` rather than a bare pipeline: this script runs under
+    # `set -e`, and a no-match grep exits 1, which would end the hook right
+    # here — before the remaining rules ran, and with an exit status that is
+    # not a refusal. The `||` puts the pipeline in a condition context, where
+    # a non-zero status is expected rather than fatal.
+    rule_status=0
+    printf '%s' "$normalized_command_str" | grep -Eiq -- "$rule" || rule_status=$?
+    case "$rule_status" in
+      0) block "matched a project custom safety rule (${rules_file##*/}): $rule" ;;
+      1) ;; # no match
+      # grep exits 2 on a malformed ERE. Treated as no-match before, so a typo
+      # in a project's rules file silently disabled that rule — a guard the
+      # project believed it had. Say so instead; still non-fatal, because one
+      # bad line must not take the other rules down with it.
+      *)
+        printf 'parity-safety-net: invalid regex in %s, rule NOT enforced: %s\n' \
+          "$rules_file" "$rule" >&2
+        ;;
+    esac
   done <"$rules_file"
 fi
 

--- a/plugins/src/base/hooks/threshold-ratchet.mjs
+++ b/plugins/src/base/hooks/threshold-ratchet.mjs
@@ -56,6 +56,15 @@ const GIT = GIT_LOCATIONS.find(candidate => fs.existsSync(candidate)) ?? "git";
 
 /** Git flag shared by every changed-file listing. */
 const NAME_ONLY = "--name-only";
+/**
+ * Suppress rename detection when discovering changed files.
+ *
+ * With it on, `git diff --name-only` reports a rename as the destination path
+ * only. Moving a watched threshold file to an unwatched path therefore lists
+ * one name the ratchet does not watch, and the loosening at the old path is
+ * never compared. Both sides have to be visible for the gate to mean anything.
+ */
+const NO_RENAMES = "--no-renames";
 
 /**
  * Run git, returning stdout or null on any failure.
@@ -87,7 +96,7 @@ function git(args, cwd) {
  */
 function resolvePlan(mode, root, baseRef, onlyFiles) {
   if (mode === "staged") {
-    const diff = git(["diff", "--cached", NAME_ONLY], root);
+    const diff = git(["diff", "--cached", NAME_ONLY, NO_RENAMES], root);
     if (diff === null) return null;
     return {
       files: diff.split("\n").filter(Boolean),
@@ -99,7 +108,7 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
     if (!baseRef) return null;
     const mergeBase = git(["merge-base", baseRef, "HEAD"], root)?.trim();
     if (!mergeBase) return null;
-    const diff = git(["diff", NAME_ONLY, mergeBase, "HEAD"], root);
+    const diff = git(["diff", NAME_ONLY, NO_RENAMES, mergeBase, "HEAD"], root);
     if (diff === null) return null;
     return {
       files: diff.split("\n").filter(Boolean),
@@ -107,7 +116,7 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
       readCurrent: f => git(["show", `HEAD:${f}`], root),
     };
   }
-  const diff = git(["diff", NAME_ONLY, "HEAD"], root);
+  const diff = git(["diff", NAME_ONLY, NO_RENAMES, "HEAD"], root);
   if (diff === null) return null;
   return {
     files: onlyFiles ?? diff.split("\n").filter(Boolean),
@@ -123,6 +132,31 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
 }
 
 /**
+ * Decide the exit code when the ratchet cannot determine what changed.
+ *
+ * `staged` and `base` are enforcement gates — pre-commit and CI. A gate that
+ * cannot see the change set has not found the change set clean, and returning 0
+ * reports exactly that. It fails closed, loudly.
+ *
+ * `hook` is advisory feedback to an agent mid-edit, fires on every tool call,
+ * and blocks nothing downstream. Failing it closed on a transient git hiccup
+ * would turn a hint into an outage, so it stays permissive — but still says so.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string} reason What could not be determined
+ * @returns {number} Process exit code
+ */
+function undeterminable(mode, reason) {
+  process.stderr.write(
+    `threshold-ratchet: ${reason}; the ratchet could not run in ${mode} mode\n`
+  );
+  if (mode === "hook") return 0;
+  process.stderr.write(
+    "threshold-ratchet: failing closed — an enforcement gate that cannot read the change set has not verified it\n"
+  );
+  return 1;
+}
+
+/**
  * Run the ratchet for a mode, print the report, and return the exit code.
  * @param {"hook"|"staged"|"base"} mode Comparison mode
  * @param {string | undefined} [baseRef] Base ref (base mode only)
@@ -131,9 +165,9 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
  */
 function run(mode, baseRef, onlyFiles) {
   const root = git(["rev-parse", "--show-toplevel"])?.trim();
-  if (!root) return 0;
+  if (!root) return undeterminable(mode, "not a git repository");
   const plan = resolvePlan(mode, root, baseRef, onlyFiles);
-  if (!plan) return 0;
+  if (!plan) return undeterminable(mode, "could not resolve the changed files");
 
   const watched = plan.files.filter(f => familyFor(f));
   if (watched.length === 0) return 0;

--- a/rails/copy-overwrite/scripts/check-threshold-ratchet.mjs
+++ b/rails/copy-overwrite/scripts/check-threshold-ratchet.mjs
@@ -56,6 +56,15 @@ const GIT = GIT_LOCATIONS.find(candidate => fs.existsSync(candidate)) ?? "git";
 
 /** Git flag shared by every changed-file listing. */
 const NAME_ONLY = "--name-only";
+/**
+ * Suppress rename detection when discovering changed files.
+ *
+ * With it on, `git diff --name-only` reports a rename as the destination path
+ * only. Moving a watched threshold file to an unwatched path therefore lists
+ * one name the ratchet does not watch, and the loosening at the old path is
+ * never compared. Both sides have to be visible for the gate to mean anything.
+ */
+const NO_RENAMES = "--no-renames";
 
 /**
  * Run git, returning stdout or null on any failure.
@@ -87,7 +96,7 @@ function git(args, cwd) {
  */
 function resolvePlan(mode, root, baseRef, onlyFiles) {
   if (mode === "staged") {
-    const diff = git(["diff", "--cached", NAME_ONLY], root);
+    const diff = git(["diff", "--cached", NAME_ONLY, NO_RENAMES], root);
     if (diff === null) return null;
     return {
       files: diff.split("\n").filter(Boolean),
@@ -99,7 +108,7 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
     if (!baseRef) return null;
     const mergeBase = git(["merge-base", baseRef, "HEAD"], root)?.trim();
     if (!mergeBase) return null;
-    const diff = git(["diff", NAME_ONLY, mergeBase, "HEAD"], root);
+    const diff = git(["diff", NAME_ONLY, NO_RENAMES, mergeBase, "HEAD"], root);
     if (diff === null) return null;
     return {
       files: diff.split("\n").filter(Boolean),
@@ -107,7 +116,7 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
       readCurrent: f => git(["show", `HEAD:${f}`], root),
     };
   }
-  const diff = git(["diff", NAME_ONLY, "HEAD"], root);
+  const diff = git(["diff", NAME_ONLY, NO_RENAMES, "HEAD"], root);
   if (diff === null) return null;
   return {
     files: onlyFiles ?? diff.split("\n").filter(Boolean),
@@ -123,6 +132,31 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
 }
 
 /**
+ * Decide the exit code when the ratchet cannot determine what changed.
+ *
+ * `staged` and `base` are enforcement gates — pre-commit and CI. A gate that
+ * cannot see the change set has not found the change set clean, and returning 0
+ * reports exactly that. It fails closed, loudly.
+ *
+ * `hook` is advisory feedback to an agent mid-edit, fires on every tool call,
+ * and blocks nothing downstream. Failing it closed on a transient git hiccup
+ * would turn a hint into an outage, so it stays permissive — but still says so.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string} reason What could not be determined
+ * @returns {number} Process exit code
+ */
+function undeterminable(mode, reason) {
+  process.stderr.write(
+    `threshold-ratchet: ${reason}; the ratchet could not run in ${mode} mode\n`
+  );
+  if (mode === "hook") return 0;
+  process.stderr.write(
+    "threshold-ratchet: failing closed — an enforcement gate that cannot read the change set has not verified it\n"
+  );
+  return 1;
+}
+
+/**
  * Run the ratchet for a mode, print the report, and return the exit code.
  * @param {"hook"|"staged"|"base"} mode Comparison mode
  * @param {string | undefined} [baseRef] Base ref (base mode only)
@@ -131,9 +165,9 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
  */
 function run(mode, baseRef, onlyFiles) {
   const root = git(["rev-parse", "--show-toplevel"])?.trim();
-  if (!root) return 0;
+  if (!root) return undeterminable(mode, "not a git repository");
   const plan = resolvePlan(mode, root, baseRef, onlyFiles);
-  if (!plan) return 0;
+  if (!plan) return undeterminable(mode, "could not resolve the changed files");
 
   const watched = plan.files.filter(f => familyFor(f));
   if (watched.length === 0) return 0;

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -9,7 +9,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-enforcement-fallback.sh":
       "1bec5f3c284b3febdc471487ee6a23ffb72bd4e7b293f9e26b0188f32318c722",
     "all/copy-overwrite/scripts/lisa-floor-collisions.mjs":
-      "a612f172282d13ba9318fe5e03689d7c6ff42a0122d0c9d5d39051e1967b93dc",
+      "3c7a0234b4f5609fce49e44711d2ec86af8cf7fb82b0831e4450e3347ecefe45",
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
       "850cfc23852eb752114ae1e938a1c7bcf34bc50c85d3aaca0c02311cc8c0ef70",
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh":
@@ -17,7 +17,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh":
       "1934a15e154fda3c2a40979a5cd6225661b14fe7bc77328a69ce499bea85dba7",
     "all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh":
-      "062c69eea85157f1e941ec3626d8912aa9f182af6ccdbe19687588a6074db5ce",
+      "d9ea58150aa27e7f0aa9a4ef155ed446d30bdfc932d01c64e2b8ca211aa0de7b",
     "all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh":
       "bf4132e49ba18e2f7e941520c299c15aeeacfd220e489f3d2eb8397f2048157b",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
@@ -27,7 +27,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/create-only/.lisaignore":
       "3c9827e7e98daa46510b5357cd6dd9406da1821e64cc46d2eea9f311cd6d06b9",
     "all/create-only/scripts/remote-agent-aws-setup.sh":
-      "7677908a345891810d2104ba8b2fd1a8318bb29c408fb5ce0110d57beef9b556",
+      "12d2204d34195ad4f81082e90a25dbbf7d2493debcc50c1cd37b32dc4648fc17",
     "all/create-only/specs/.keep":
       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "all/deletions.json":
@@ -621,7 +621,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/parity-safety-net.agy.sh":
       "ce9bd2b4566ad9147e4ace56434cffbbe87edb4ccbb57549ab3fd9f4c671ced4",
     "plugins/src/base/hooks/parity-safety-net.sh":
-      "062c69eea85157f1e941ec3626d8912aa9f182af6ccdbe19687588a6074db5ce",
+      "d9ea58150aa27e7f0aa9a4ef155ed446d30bdfc932d01c64e2b8ca211aa0de7b",
     "plugins/src/base/hooks/setup-jira-cli.sh":
       "a675f6b17ce7f0d6b9fb7daeba6d2bc59bcb48ef79b034076ea73b2b1e72ee09",
     "plugins/src/base/hooks/shell-write-nudge.sh":
@@ -633,7 +633,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/threshold-ratchet-families.mjs":
       "db14245ed89b483912af287bdee917a7a921dc21bb29b49be37fc799c05c413f",
     "plugins/src/base/hooks/threshold-ratchet.mjs":
-      "04f660131bf50864239eb09cbf4d9555e53921254f6ab45ff2b85c173e160901",
+      "49dee610439f4f21aecb0420a0cc72f5d3595a36f2489970053096190b9909c4",
     "plugins/src/base/hooks/threshold-ratchet.sh":
       "b86f4d0b554e44fd119ad8a8920cd0ba6c9dbe779f7ee219d381cf0629453990",
     "plugins/src/base/hooks/ticket-sync-reminder.sh":
@@ -1895,7 +1895,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/copy-overwrite/lefthook.yml":
       "28bb382b9171a04fb92ebafc1f1522b8639f5edc4fcffcc6940e7fba3460fb4e",
     "rails/copy-overwrite/scripts/check-threshold-ratchet.mjs":
-      "04f660131bf50864239eb09cbf4d9555e53921254f6ab45ff2b85c173e160901",
+      "49dee610439f4f21aecb0420a0cc72f5d3595a36f2489970053096190b9909c4",
     "rails/copy-overwrite/scripts/lisa-clean-git-env.sh":
       "e7121a0ee9e1bf7c01cd2ab55f563dd6d9ab75990739bb6ddf571a513efa10e9",
     "rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs":
@@ -2141,7 +2141,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/knip.json":
       "6eb93d705a2d645332fbae1dd42cf2d48f85978ebc265451a53790912f277d12",
     "typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs":
-      "04f660131bf50864239eb09cbf4d9555e53921254f6ab45ff2b85c173e160901",
+      "49dee610439f4f21aecb0420a0cc72f5d3595a36f2489970053096190b9909c4",
     "typescript/copy-overwrite/scripts/check-verification-coverage.mjs":
       "3c1d27d0668fc66a18cb014f2b607878f0a88c178a773fbe964b8e46b19e86d6",
     "typescript/copy-overwrite/scripts/lisa-mutation.mjs":
@@ -8462,6 +8462,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/hooks/parity-safety-net-heredoc-continuation.test.ts": true,
     "tests/unit/hooks/parity-safety-net-heredoc-literal.test.ts": true,
     "tests/unit/hooks/parity-safety-net-heredoc.test.ts": true,
+    "tests/unit/hooks/parity-safety-net-line-continuation.test.ts": true,
     "tests/unit/hooks/parity-safety-net.test.ts": true,
     "tests/unit/hooks/post-checkout.test.ts": true,
     "tests/unit/hooks/pre-push-git-environment.test.ts": true,

--- a/tests/unit/hooks/parity-safety-net-line-continuation.test.ts
+++ b/tests/unit/hooks/parity-safety-net-line-continuation.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Every guard must see the same normalized command text.
+ *
+ * `parity-safety-net.sh` normalizes bash line-continuations (trailing backslash
+ * + newline → space) before matching, because the guard patterns rely on
+ * intermediate whitespace and an embedded `\<newline>` is not whitespace to
+ * `grep -E`. That normalization existed, but only the two segment-walking
+ * guards (`rm`, `git push`) consumed it: the shared `matches` / `matches_cs`
+ * helpers read the RAW text, so every guard expressed through them could be
+ * evaded by breaking the command across lines.
+ *
+ * Same shape as the force-push `+refspec` gap fixed in #2374 — a guard whose
+ * pattern is correct but whose input was not the text it was written against.
+ * @module tests/unit/hooks/parity-safety-net-line-continuation
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const HOOK_PATH = path.resolve("plugins/lisa/hooks/parity-safety-net.sh");
+const BASH_PATH = "/bin/bash";
+
+/** Claude's refusal code. Anything else lets the command through. */
+const EXIT_BLOCKED = 2;
+
+/**
+ * Run the hook against a Bash payload.
+ * @param command - The command Claude proposes to run.
+ * @returns Exit status and stderr.
+ */
+function runHook(command: string): { status: number | null; stderr: string } {
+  const result = spawnSync(BASH_PATH, [HOOK_PATH], {
+    input: JSON.stringify({ tool_name: "Bash", tool_input: { command } }),
+    encoding: "utf-8",
+  });
+  return { status: result.status, stderr: result.stderr ?? "" };
+}
+
+describe("parity-safety-net.sh — guards see normalized text", () => {
+  // Only unconditional guards belong here. `git reset --hard` is deliberately
+  // conditional — Lisa allows clean-tree resets and blocks only a dirty one —
+  // so asserting on it would pass or fail depending on whether the repo this
+  // suite happens to run in has uncommitted changes.
+  it.each([
+    ["git checkout --", "git checkout \\\n  -- src/index.ts"],
+    ["rm -rf", "rm -rf \\\n  /"],
+    ["destructive SQL", "psql -c 'DROP \\\n  TABLE users'"],
+    ["git branch -D", "git branch -D \\\n  main"],
+  ])("still blocks %s when split across lines", (_label, command) => {
+    // Each of these matched fine on one line and slipped straight through when
+    // the same command was wrapped — the whole point of the normalization.
+    expect(runHook(command).status).toBe(EXIT_BLOCKED);
+  });
+
+  it("blocks a protected force-push split across lines", () => {
+    // The case the normalization was originally written for; pinned here so the
+    // two segment-walking guards stay covered alongside the helper-based ones.
+    expect(runHook("git push --force origin \\\n  main").status).toBe(
+      EXIT_BLOCKED
+    );
+  });
+
+  it("still allows an ordinary wrapped command", () => {
+    // Normalizing must not turn every multi-line command into a refusal.
+    const { status } = runHook("echo hello \\\n  world");
+    expect(status).toBe(0);
+  });
+});

--- a/tests/unit/scripts/floor-collisions.test.ts
+++ b/tests/unit/scripts/floor-collisions.test.ts
@@ -36,6 +36,29 @@ describe("lowestPermitted", () => {
     expect(lowestPermitted("workspace:*")).toBeNull();
     expect(lowestPermitted("")).toBeNull();
   });
+
+  it("takes the lowest branch of a disjunction, not the first", () => {
+    // The false negative. Reading only the first triple reported 2.0.0 here —
+    // a floor HIGHER than the range permits — and the caller's
+    // `compare(target, floor) >= 0` then skipped a genuine collision.
+    expect(lowestPermitted("^2.0.0 || ^1.9.0")).toEqual([1, 9, 0]);
+    expect(lowestPermitted("^1.9.0 || ^2.0.0")).toEqual([1, 9, 0]);
+    expect(lowestPermitted(">=3.0.0 || >=1.0.0 || >=2.0.0")).toEqual([1, 0, 0]);
+  });
+
+  it("treats an upper-bound-only range as having no floor", () => {
+    // `<2.0.0` permits everything beneath it; reading 2.0.0 as its floor
+    // inverted the meaning of the bound entirely.
+    expect(lowestPermitted("<2.0.0")).toEqual([0, 0, 0]);
+    expect(lowestPermitted("<=2.0.0")).toEqual([0, 0, 0]);
+  });
+
+  it("returns null for an alias spec, which versions another package", () => {
+    // The number in `npm:other-pkg@^1.2.3` describes other-pkg, so comparing it
+    // against a floor recorded for THIS name answers a question nobody asked.
+    expect(lowestPermitted("npm:other-pkg@^1.2.3")).toBeNull();
+    expect(lowestPermitted("  npm:string-width@^4.2.3")).toBeNull();
+  });
 });
 
 describe("directDependencies", () => {

--- a/typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs
+++ b/typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs
@@ -56,6 +56,15 @@ const GIT = GIT_LOCATIONS.find(candidate => fs.existsSync(candidate)) ?? "git";
 
 /** Git flag shared by every changed-file listing. */
 const NAME_ONLY = "--name-only";
+/**
+ * Suppress rename detection when discovering changed files.
+ *
+ * With it on, `git diff --name-only` reports a rename as the destination path
+ * only. Moving a watched threshold file to an unwatched path therefore lists
+ * one name the ratchet does not watch, and the loosening at the old path is
+ * never compared. Both sides have to be visible for the gate to mean anything.
+ */
+const NO_RENAMES = "--no-renames";
 
 /**
  * Run git, returning stdout or null on any failure.
@@ -87,7 +96,7 @@ function git(args, cwd) {
  */
 function resolvePlan(mode, root, baseRef, onlyFiles) {
   if (mode === "staged") {
-    const diff = git(["diff", "--cached", NAME_ONLY], root);
+    const diff = git(["diff", "--cached", NAME_ONLY, NO_RENAMES], root);
     if (diff === null) return null;
     return {
       files: diff.split("\n").filter(Boolean),
@@ -99,7 +108,7 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
     if (!baseRef) return null;
     const mergeBase = git(["merge-base", baseRef, "HEAD"], root)?.trim();
     if (!mergeBase) return null;
-    const diff = git(["diff", NAME_ONLY, mergeBase, "HEAD"], root);
+    const diff = git(["diff", NAME_ONLY, NO_RENAMES, mergeBase, "HEAD"], root);
     if (diff === null) return null;
     return {
       files: diff.split("\n").filter(Boolean),
@@ -107,7 +116,7 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
       readCurrent: f => git(["show", `HEAD:${f}`], root),
     };
   }
-  const diff = git(["diff", NAME_ONLY, "HEAD"], root);
+  const diff = git(["diff", NAME_ONLY, NO_RENAMES, "HEAD"], root);
   if (diff === null) return null;
   return {
     files: onlyFiles ?? diff.split("\n").filter(Boolean),
@@ -123,6 +132,31 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
 }
 
 /**
+ * Decide the exit code when the ratchet cannot determine what changed.
+ *
+ * `staged` and `base` are enforcement gates — pre-commit and CI. A gate that
+ * cannot see the change set has not found the change set clean, and returning 0
+ * reports exactly that. It fails closed, loudly.
+ *
+ * `hook` is advisory feedback to an agent mid-edit, fires on every tool call,
+ * and blocks nothing downstream. Failing it closed on a transient git hiccup
+ * would turn a hint into an outage, so it stays permissive — but still says so.
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string} reason What could not be determined
+ * @returns {number} Process exit code
+ */
+function undeterminable(mode, reason) {
+  process.stderr.write(
+    `threshold-ratchet: ${reason}; the ratchet could not run in ${mode} mode\n`
+  );
+  if (mode === "hook") return 0;
+  process.stderr.write(
+    "threshold-ratchet: failing closed — an enforcement gate that cannot read the change set has not verified it\n"
+  );
+  return 1;
+}
+
+/**
  * Run the ratchet for a mode, print the report, and return the exit code.
  * @param {"hook"|"staged"|"base"} mode Comparison mode
  * @param {string | undefined} [baseRef] Base ref (base mode only)
@@ -131,9 +165,9 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
  */
 function run(mode, baseRef, onlyFiles) {
   const root = git(["rev-parse", "--show-toplevel"])?.trim();
-  if (!root) return 0;
+  if (!root) return undeterminable(mode, "not a git repository");
   const plan = resolvePlan(mode, root, baseRef, onlyFiles);
-  if (!plan) return 0;
+  if (!plan) return undeterminable(mode, "could not resolve the changed files");
 
   const watched = plan.files.filter(f => familyFor(f));
   if (watched.length === 0) return 0;


### PR DESCRIPTION
The security and correctness half of #2371. Each of these lets something through that the surrounding machinery exists to catch.

## `parity-safety-net.sh` — guards 3–14 matched un-normalized text

The script normalizes bash line-continuations before matching, because the patterns rely on intermediate whitespace and an embedded `\<newline>` is not whitespace to `grep -E`. Only the two segment-walking guards (`rm`, `git push`) consumed the normalized string — the shared `matches` / `matches_cs` helpers read the **raw** command, so every guard expressed through them was evadable by wrapping the line:

```bash
git checkout \
  -- src/index.ts
```

Same shape as the force-push `+refspec` gap in #2374: a correct pattern fed the wrong input. Helpers now read normalized text, and are defined after the normalization so the value exists when first called.

## `parity-safety-net.sh` — project rules scanned raw, and failed silently

Guard 14's custom-rule loop had the same raw-text problem, **and** treated `grep`'s exit 2 (malformed ERE) as no-match — so a typo in a project's rules file silently disabled a guard the project believed it had. Now matched against normalized text, with an invalid pattern reported on stderr and the remaining rules still enforced:

```
grep: repetition-operator operand invalid
parity-safety-net: invalid regex in rules.txt, rule NOT enforced: *[invalid
Blocked by safety-net: matched a project custom safety rule (rules.txt): terraform[[:space:]]+destroy
```

The status capture is `|| rule_status=$?` rather than a bare pipeline: under `set -e` a no-match `grep` exits 1, which would end the hook before the remaining rules ran. Three existing guard-matrix tests caught exactly that when I got it wrong first time.

## `threshold-ratchet.mjs` — enforcement gates failed open

`staged` and `base` are the pre-commit and CI gates. When git could not produce a change set they returned **0** — reporting the change clean when nothing had been compared. They now fail closed with a diagnostic.

`hook` mode stays permissive by design: it is advisory feedback on every tool call and blocks nothing downstream, so a transient git failure there must not become an outage. Both paths now say what happened.

## `threshold-ratchet.mjs` — rename detection hid moved thresholds

`git diff --name-only` reports a rename as the destination path only, so moving a watched threshold file to an unwatched path listed one name the ratchet ignores, and the loosening at the old path was never compared. Discovery now passes `--no-renames`.

## `lisa-floor-collisions.mjs` — `lowestPermitted` misread disjunctions

It took the first version triple in the spec. For `^2.0.0 || ^1.9.0` that is `2.0.0` — a floor **higher** than the range permits — and the caller's `compare(target, floor) >= 0` then skipped a genuine collision. A floor read too high is a false negative in a security check.

Every branch is now measured and the lowest wins; upper-bound-only branches (`<2.0.0`) contribute no floor rather than a spurious one; alias specs (`npm:other@^1.2.3`) return null, because their number versions a different package entirely.

## `remote-agent-aws-setup.sh` — `set -e` swallowed the diagnostic

`[ -x "$script" ] && exec "$script"` was the last command in its block, so when the file was absent its non-zero status ended the script there and the "install @codyswann/lisa" message never printed. The operator saw a bare `exit 1`. Spelled as a full `if` now — verified it prints and exits 1.

## Verification

- New tests **fail against `origin/main` and pass against this branch** — verified by swapping in the `origin/main` source, rebuilding the plugin artifacts, and re-running
- Invalid-rule path exercised end-to-end: bad rule reported, valid rule still blocks, harmless command still allowed
- 698 hook tests green, `tsc` and `eslint` clean, plugin artifacts regenerated and in sync

One test-authoring note worth recording: my first version asserted on `git reset --hard` split across lines. That guard is **deliberately conditional** — Lisa allows clean-tree resets and blocks only dirty ones — so the assertion passed or failed depending on whether the repo running the suite happened to have uncommitted changes. Replaced with unconditional guards and commented, so nobody re-adds it.

## Still open on #2371

The remaining items are quality nits with no security dimension: JSDoc placement, `replaceAll` / `String.raw` preferences, nested ternaries, cognitive complexity in `lisa-work-item.mjs`, and the `.lisa/*.md` scaffolding still shipping example rows. Left out to keep this reviewable as one security change; #2371 stays open for them.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2371
