### PR TITLE
fix(ci): pair the Playwright blob reporter with a streaming one

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1283,9 +1283,21 @@ jobs:
       # distinct from the aggregator's unsuffixed context. `--shard=1/1` is
       # a no-op split (runs every test) and keeps a single command shape
       # regardless of `playwright_shards` value.
+      #
+      # `line` is paired with `blob` so a shard that never finishes still says
+      # what it was doing. `blob` writes its file only when the run ENDS and
+      # prints nothing to the console meanwhile, so a shard killed by the job
+      # timeout produces no artifact AND no console output — the aggregator has
+      # nothing to merge and the log names no test. Observed on
+      # geminisportsai/frontend-v2, where shard 2 hit the 60-minute timeout on
+      # three consecutive nightlies having printed only "Running 136 tests using
+      # 2 workers, shard 2 of 4"; the hang could not be attributed to a test at
+      # all, in any run. `line` streams progress to the console without
+      # displacing the blob artifact the aggregator needs, so the next timeout
+      # is self-diagnosing.
       - name: 🎭 Run Playwright tests
         if: steps.check_playwright.outputs.has_config == 'true'
-        run: npx playwright test --shard=${{ matrix.shard }}/${{ inputs.playwright_shards }} --reporter=blob
+        run: npx playwright test --shard=${{ matrix.shard }}/${{ inputs.playwright_shards }} --reporter=blob,line
         working-directory: ${{ inputs.working_directory || '.' }}
 
       # Every shard uploads its blob report. The aggregator (below) always

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -286,6 +286,23 @@ describe("quality.yml reusable workflow", () => {
         "playwright-blob-${{ github.run_id }}-shard-${{ matrix.shard }}"
       );
     });
+
+    it("pairs blob with a streaming reporter so a timed-out shard names its tests", () => {
+      const steps = workflow.jobs.playwright_e2e.steps ?? [];
+      const run = steps.find(s => s.name === "🎭 Run Playwright tests")?.run;
+      expect(run).toContain("--reporter=");
+      const reporters =
+        /--reporter=(\S+)/.exec(run ?? "")?.[1].split(",") ?? [];
+      // `blob` must stay — the aggregator merges those artifacts.
+      expect(reporters).toContain("blob");
+      // …but `blob` alone writes only at the END of the run and prints nothing
+      // meanwhile, so a shard killed by the 60-minute job timeout leaves no
+      // artifact AND no console output, naming no test. A streaming reporter
+      // alongside it is what makes such a timeout diagnosable at all.
+      expect(reporters.some(r => ["line", "list", "dot"].includes(r))).toBe(
+        true
+      );
+    });
   });
 
   describe("playwright_e2e_aggregate job (ruleset anchor)", () => {


### PR DESCRIPTION
## What

Runs sharded Playwright with `--reporter=blob,line` instead of `--reporter=blob`, and adds an integration assertion pinning the pairing.

## Why

`blob` writes its file only when the run **ends** and prints nothing to the console meanwhile. A shard killed by the 60-minute job timeout therefore produces **no artifact and no output** — the aggregator has nothing to merge for it, and the log names no test. The one shard that dies is the one shard guaranteed to tell you nothing.

Seen on `geminisportsai/frontend-v2`, where shard 2 timed out on three consecutive nightlies having printed only `Running 136 tests using 2 workers, shard 2 of 4`:

```
shard 1  success    17m
shard 3  success    20m
shard 4  success    21m
shard 2  CANCELLED  60m exactly
```

Siblings finish in 17–21m on the same backend, so the hang is real and shard-local — but across three runs it could not be attributed to a test. The first occurrence was read as an ordinary failure and the second as fail-fast cancellation from a sibling; what actually identified it was both durations being exactly 60 minutes, not anything in the logs.

## How

`blob` stays — `playwright_e2e_aggregate` merges those artifacts, and dropping it would break the merged HTML report. `line` is added alongside so progress reaches the console as it happens. Playwright accepts comma-separated reporters (`--reporter` help: *"Reporter to use, comma-separated…"*), and a console reporter does not displace the blob artifact.

## Verification

- `tests/integration/quality-workflow.test.ts` — new case asserts `blob` is present **and** at least one of `line`/`list`/`dot` accompanies it.
- Confirmed it genuinely gates: reverting the workflow to bare `--reporter=blob` fails the test (`expected false to be true`), and restoring it passes. A green test on an unchanged file proves nothing, so this was checked in both directions.
- The assertion allows any streaming reporter rather than pinning `line` exactly, so a repo preferring `list` or `dot` isn't forced into a specific choice — the contract is "something speaks before the end", not a particular reporter.

## Out of scope

Diagnosing the `frontend-v2` shard-2 hang. That repo's e2e debt is being worked separately; this only makes such a timeout diagnosable, for every repo on the shared workflow.

Work-Item: CodySwannGT/lisa#2384

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify end-to-end test reporting includes both aggregated test artifacts and live progress output.

* **Chores**
  * Improved automated test runs by displaying progress in the console while preserving reports for later aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->