### PR TITLE
fix(ci): let callers raise the Maestro per-suite timeout

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -99,6 +99,11 @@ on:
         required: false
         default: 'bun'
         type: string
+      suite_timeout_minutes:
+        description: 'Ceiling for EACH platform suite job (Android and iOS separately), not the whole workflow. Raise it when the flow count outgrows the default — a suite cancelled mid-run reports as a failure with no usable result.'
+        required: false
+        default: 90
+        type: number
     secrets:
       EXPO_TOKEN:
         description: 'Expo token for EAS builds. When absent, the whole suite skips with a warning.'
@@ -244,11 +249,13 @@ jobs:
     name: 🤖 Maestro Android
     needs: [preflight, build]
     runs-on: ubuntu-latest
-    # 90 to match the iOS job: the 60 inherited from frontend-v2's original
-    # workflow started timing out once its suite grew (nightly 29322073759 —
-    # the Android leg was cancelled mid-suite at exactly 60:00). Jobs end when
-    # the suite ends, so fast suites pay nothing for the headroom.
-    timeout-minutes: 90
+    # Caller-tunable, defaulting to 90 to match the iOS job: the 60 inherited
+    # from frontend-v2's original workflow started timing out once its suite
+    # grew (nightly 29322073759 — the Android leg was cancelled mid-suite at
+    # exactly 60:00). Jobs end when the suite ends, so fast suites pay nothing
+    # for the headroom, and a project whose suite outgrows 90 raises
+    # suite_timeout_minutes rather than waiting on a Lisa release.
+    timeout-minutes: ${{ inputs.suite_timeout_minutes }}
     # !cancelled(): `needs: build` is a matrix job, so one platform's build
     # failure marks the whole job failed and would skip BOTH test jobs. Run
     # whenever this platform's artifact might exist — if its own build leg
@@ -393,7 +400,8 @@ jobs:
     name: 🍎 Maestro iOS
     needs: [preflight, build]
     runs-on: macos-15
-    timeout-minutes: 90
+    # Same ceiling as the android job — see its comment for why it is an input.
+    timeout-minutes: ${{ inputs.suite_timeout_minutes }}
     # !cancelled(): see the android job — don't let the other platform's
     # build failure skip this platform's tests.
     if: ${{ !cancelled() && needs.preflight.outputs.run_ios == 'true' }}

--- a/tests/integration/maestro-native-workflow.test.ts
+++ b/tests/integration/maestro-native-workflow.test.ts
@@ -52,7 +52,8 @@ interface WorkflowStep {
 interface WorkflowJob {
   name?: string;
   "runs-on"?: string;
-  "timeout-minutes"?: number;
+  // A string when the ceiling is wired to a workflow_call input expression.
+  "timeout-minutes"?: number | string;
   needs?: string | string[];
   if?: string;
   uses?: string;
@@ -134,6 +135,26 @@ describe("maestro-native-e2e reusable workflow", () => {
     expect(inputs.setup_command).toBeDefined();
     expect(inputs.android_app_id).toBeDefined();
     expect(inputs.ios_app_id).toBeDefined();
+  });
+
+  it("lets a caller raise the per-suite timeout without changing its 90-minute default", () => {
+    const suiteTimeout =
+      workflow.on.workflow_call?.inputs?.suite_timeout_minutes;
+    expect(suiteTimeout?.type).toBe("number");
+    expect(suiteTimeout?.required ?? false).toBe(false);
+    // Callers that pass nothing must keep the ceiling they have today.
+    expect(suiteTimeout?.default).toBe(90);
+
+    // The input caps EACH platform suite job...
+    expect(workflow.jobs.android["timeout-minutes"]).toBe(
+      "${{ inputs.suite_timeout_minutes }}"
+    );
+    expect(workflow.jobs.ios["timeout-minutes"]).toBe(
+      "${{ inputs.suite_timeout_minutes }}"
+    );
+    // ...and only those: the EAS build job is a separate, fixed ceiling, so
+    // raising the suite budget must not also loosen a hung build.
+    expect(workflow.jobs.build["timeout-minutes"]).toBe(90);
   });
 
   it("gates build and test jobs behind the preflight prerequisite check", () => {


### PR DESCRIPTION
Closes #2386

## Problem

`maestro-native-e2e.yml` hardcoded `timeout-minutes: 90` on both platform suite jobs, so a project whose Maestro suite outgrows 90 minutes had no way to say so — it had to wait on a Lisa change plus a release, or accept a nightly cancelled mid-suite every night.

A cancelled suite is worse than a failing one: no JUnit report is written, so the run reports a failure that names no flow, and every flow after the cut-off is never exercised at all.

`TunnlAI/frontend` run [31289218029](https://github.com/TunnlAI/frontend/actions/runs/31289218029) shows both legs cancelled at exactly 90:00, having completed **34/107** flows on Android and **58/107** on iOS. That suite is not hanging — it is genuinely long. Each flow pays JIT emulator/simulator provisioning, and the full 107 flows estimate at 3–4 hours on GitHub-hosted runners.

## Change

Adds a `suite_timeout_minutes` `workflow_call` input (type `number`, default `90`) and wires it to the `android` and `ios` jobs:

```yaml
timeout-minutes: ${{ inputs.suite_timeout_minutes }}
```

The `build` job's `timeout-minutes: 90` stays hardcoded on purpose — it caps the EAS build, a separate concern. A project with a long suite should not thereby loosen the ceiling on a hung build.

## Backward compatibility

The default reproduces today's behavior exactly. `geminisportsai/frontend-v2` and the `expo/create-only` caller template pass nothing and keep their 90-minute ceiling with no change on their side. Callers reference `@main`, so a merge here takes effect immediately without a release.

`bun run check:workflow-inputs` is green (31 ok / 0 stale) — adding an input can never strand a caller, only removing one can.

## Verification

- `tests/integration/maestro-native-workflow.test.ts` gains an assertion covering the default (`90`), the type (`number`), the wiring on both suite jobs, and the build job's separate fixed ceiling.
- **Red-state proven**: with the workflow reverted to `origin/main` and the new test in place, the suite fails `1 failed | 15 passed` on `expected undefined to be 'number'`. With the change, `16 passed`.
- `actionlint` clean on the modified workflow.
- Full pre-push gate green (unit + coverage + all 15 integration files, 162 tests).

## Out of scope

Making the Tunnl suite faster — per-flow provisioning cost, sharding, and flow trimming are tracked in that repo. This PR only removes the hardcoded ceiling so a long suite can finish and report at all.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2386
