### PR TITLE
fix(work-item): bound tracker calls, page sub-issues, and classify failures

### DIFF
--- a/all/copy-overwrite/scripts/lisa-work-item.mjs
+++ b/all/copy-overwrite/scripts/lisa-work-item.mjs
@@ -29,21 +29,9 @@ const GUIDANCE = [
 class TrackingError extends Error {}
 
 /**
- * Say which of three different failures a `gh` invocation actually hit.
- *
- * The three are indistinguishable from an exit status alone, and they send the
- * reader to three different places: a missing binary is an environment to
- * provision, a refused credential is an access grant to obtain, and only the
- * third is anything to do with the ticket.
- *
- * Collapsing them cost a real round trip. On Claude Code web, where `gh` is not
- * pre-installed, every commit was refused with "issue #2202 does not exist or
- * is inaccessible" — about an issue that was open and correct. The message
- * accused the ticket, so that is where the reader went.
- * @param {{status: number|null, error?: Error, stderr?: string}} result Spawn result.
- * @param {string} ref Work item reference, for the message.
- * @param {string} noun What the reference names.
- * @returns {string} A message naming the actual fault.
+ * The tracker could not be ASKED — a missing binary, a refused credential, a
+ * call that never completed. Distinct from a TrackingError, which carries the
+ * tracker's own "no". Only this kind may be degraded.
  */
 export class TrackerUnreachableError extends TrackingError {}
 
@@ -68,6 +56,23 @@ export function githubFailure(result, ref) {
     : new TrackingError(reason);
 }
 
+/**
+ * Say which of three different failures a `gh` invocation actually hit.
+ *
+ * The three are indistinguishable from an exit status alone, and they send the
+ * reader to three different places: a missing binary is an environment to
+ * provision, a refused credential is an access grant to obtain, and only the
+ * third is anything to do with the ticket.
+ *
+ * Collapsing them cost a real round trip. On Claude Code web, where `gh` is not
+ * pre-installed, every commit was refused with "issue #2202 does not exist or
+ * is inaccessible" — about an issue that was open and correct. The message
+ * accused the ticket, so that is where the reader went.
+ * @param {{status: number|null, error?: Error, stderr?: string}} result Spawn result.
+ * @param {string} ref Work item reference, for the message.
+ * @param {string} noun What the reference names.
+ * @returns {string} A message naming the actual fault.
+ */
 export function githubFailureReason(result, ref, noun) {
   if (result.error?.code === "ENOENT") {
     return (
@@ -91,13 +96,31 @@ export function githubFailureReason(result, ref, noun) {
   return `${noun} ${ref} does not exist or is inaccessible`;
 }
 
+/**
+ * Wall-clock ceiling for any child process this script spawns.
+ *
+ * These run inside a git hook, so an unbounded call does not merely wait — it
+ * hangs the commit or push that invoked it, with no output explaining why. A
+ * tracker that has stopped answering must look like a tracker that is
+ * unreachable, which the degradation path already knows how to handle.
+ */
+const CHILD_TIMEOUT_MS = 30_000;
+
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
     cwd: options.cwd ?? process.cwd(),
     encoding: "utf8",
     env: options.env ?? process.env,
     input: options.input,
+    timeout: options.timeout ?? CHILD_TIMEOUT_MS,
   });
+  // spawnSync reports a timeout via `error`, not a non-zero status, so the
+  // status check below would let a timed-out call through as success.
+  if (result.error && !options.allowFailure) {
+    throw new TrackerUnreachableError(
+      `${command} ${args.join(" ")} did not complete: ${result.error.message}`
+    );
+  }
   if (result.status !== 0 && !options.allowFailure) {
     throw new TrackingError(
       options.error ?? `${command} ${args.join(" ")} failed`
@@ -122,10 +145,24 @@ function secureCurl(args, entries, options = {}) {
   const input = `${entries
     .map(([name, value]) => `${name} = ${curlConfigValue(value)}`)
     .join("\n")}\n`;
-  return run("curl", ["-fsS", "--config", "-", ...args], {
-    ...options,
-    input,
-  });
+  // --max-time bounds curl itself, so it exits on its own rather than being
+  // killed by the spawnSync ceiling; --connect-timeout fails fast on a host
+  // that is not answering at all. Kept below CHILD_TIMEOUT_MS so curl's own
+  // error message is what surfaces.
+  return run(
+    "curl",
+    [
+      "-fsS",
+      "--connect-timeout",
+      "10",
+      "--max-time",
+      "25",
+      "--config",
+      "-",
+      ...args,
+    ],
+    { ...options, input }
+  );
 }
 
 function projectRoot() {
@@ -557,13 +594,34 @@ function typeFromLabels(labels) {
   return namesFrom(labels).find(name => name.startsWith("type:"));
 }
 
+/**
+ * Every sub-issue state for a GitHub issue, following pagination.
+ *
+ * Two things this gets right that the single-page version did not:
+ *
+ * A transport failure is classified through githubFailure, exactly as
+ * githubIssue does. Raising a bare TrackingError meant "gh is missing" and
+ * "the network is down" read as "this work item is invalid", so validateLive
+ * could not degrade and the hook hard-failed on a laptop with no connection.
+ *
+ * And it pages. `subIssues(first:100)` silently truncated, so an Epic with
+ * more than 100 children reported only the first page — assertLeaf then saw
+ * no open child beyond it and treated a container as a leaf, which is the
+ * precise condition leaf-only-lifecycle exists to prevent.
+ * @param {string} ref Canonical work-item ref, for error messages.
+ * @param {object} contract Resolved tracker contract.
+ * @param {string|number} number GitHub issue number.
+ * @returns {string[]} State of every sub-issue.
+ */
 function githubHierarchy(ref, contract, number) {
   const [owner, repo] = contract.repository.split("/");
   const query =
-    "query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){issue(number:$number){subIssues(first:100){nodes{state}}}}}";
-  const result = run(
-    "gh",
-    [
+    "query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){issue(number:$number){subIssues(first:100,after:$after){nodes{state}pageInfo{hasNextPage endCursor}}}}}";
+  const states = [];
+  const cursor = { after: null };
+
+  do {
+    const args = [
       "api",
       "graphql",
       "-f",
@@ -574,19 +632,25 @@ function githubHierarchy(ref, contract, number) {
       `repo=${repo}`,
       "-F",
       `number=${number}`,
-    ],
-    { allowFailure: true }
-  );
-  if (result.status !== 0)
-    throw new TrackingError(`GitHub issue ${ref} hierarchy is inaccessible`);
-  const response = safeJson(result.stdout, `GitHub issue ${ref} hierarchy`);
-  const issue = response.data?.repository?.issue;
-  if (!issue || !Array.isArray(issue.subIssues?.nodes)) {
-    throw new TrackingError(
-      `GitHub issue ${ref} did not expose native sub-issue hierarchy`
-    );
-  }
-  return issue.subIssues.nodes.map(child => child.state);
+    ];
+    if (cursor.after) args.push("-F", `after=${cursor.after}`);
+    const result = run("gh", args, { allowFailure: true });
+    if (result.status !== 0) throw githubFailure(result, ref);
+
+    const response = safeJson(result.stdout, `GitHub issue ${ref} hierarchy`);
+    const subIssues = response.data?.repository?.issue?.subIssues;
+    if (!Array.isArray(subIssues?.nodes)) {
+      throw new TrackingError(
+        `GitHub issue ${ref} did not expose native sub-issue hierarchy`
+      );
+    }
+    states.push(...subIssues.nodes.map(child => child.state));
+    cursor.after = subIssues.pageInfo?.hasNextPage
+      ? subIssues.pageInfo.endCursor
+      : null;
+  } while (cursor.after);
+
+  return states;
 }
 
 function githubIssue(ref, contract) {
@@ -1152,9 +1216,25 @@ function currentPullRequest(number, repository = currentRepository()) {
     : undefined;
 }
 
+/**
+ * Read a `--name <value>` option, falling back to an environment variable.
+ *
+ * A flag present but carrying no value — last on the line, or immediately
+ * followed by another flag — used to yield `undefined` (or the next flag's
+ * name) rather than falling back. `lisa … --ref` therefore silently discarded
+ * a perfectly good value in the environment, and `--ref --json` bound the
+ * literal string "--json". Both now behave as if the flag were absent.
+ * @param {string[]} args Argument list.
+ * @param {string} name Flag to read, including leading dashes.
+ * @param {string} envName Environment variable to fall back to.
+ * @returns {string | undefined} The resolved value, if any.
+ */
 function option(args, name, envName) {
   const index = args.indexOf(name);
-  return index >= 0 ? args[index + 1] : process.env[envName];
+  if (index < 0) return process.env[envName];
+  const value = args[index + 1];
+  if (value === undefined || value.startsWith("-")) return process.env[envName];
+  return value;
 }
 
 function bind(args) {

--- a/all/copy-overwrite/scripts/lisa-work-item.mjs
+++ b/all/copy-overwrite/scripts/lisa-work-item.mjs
@@ -49,8 +49,13 @@ export class TrackerUnreachableError extends TrackingError {}
  */
 export function githubFailure(result, ref) {
   const reason = githubFailureReason(result, ref, "GitHub issue");
+  // ANY spawn-level error means the tracker could not be asked — the binary is
+  // missing (ENOENT), the call was killed at its deadline (ETIMEDOUT), the
+  // system could not fork (EAGAIN). Singling out ENOENT made a timed-out `gh`
+  // a non-degradable TrackingError, i.e. "this work item is invalid" because
+  // the network was slow.
   const unreachable =
-    result.error?.code === "ENOENT" || /cannot authenticate/.test(reason);
+    result.error !== undefined || /cannot authenticate/.test(reason);
   return unreachable
     ? new TrackerUnreachableError(reason)
     : new TrackingError(reason);
@@ -104,7 +109,9 @@ export function githubFailureReason(result, ref, noun) {
  * tracker that has stopped answering must look like a tracker that is
  * unreachable, which the degradation path already knows how to handle.
  */
-const CHILD_TIMEOUT_MS = 30_000;
+const CHILD_TIMEOUT_MS = Number(
+  process.env.LISA_WORK_ITEM_TIMEOUT_MS || 30_000
+);
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
@@ -113,6 +120,11 @@ function run(command, args, options = {}) {
     env: options.env ?? process.env,
     input: options.input,
     timeout: options.timeout ?? CHILD_TIMEOUT_MS,
+    // SIGKILL, not the default SIGTERM. `timeout` sends killSignal and then
+    // keeps waiting for the child to exit, so a child that traps or ignores
+    // SIGTERM hangs the hook exactly as long as it would have without any
+    // timeout at all. A deadline a child can decline is not a deadline.
+    killSignal: "SIGKILL",
   });
   // spawnSync reports a timeout via `error`, not a non-zero status, so the
   // status check below would let a timed-out call through as success.

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -21,7 +21,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh":
       "bf4132e49ba18e2f7e941520c299c15aeeacfd220e489f3d2eb8397f2048157b",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
-      "ab0dede91c5c8a07984ae13aa48ec70cdcd2fa691b59617bc4b57998dc79a51c",
+      "fc0d92739e620d8fd70f7aa4a12d3e0b3a8f790d47c4a8322040f32c30b9445a",
     "all/create-only/.claude/rules/PROJECT_RULES.md":
       "6e1c7923ad2a15356babc60c97e7f97be728d790af285b6a7cd7d1b4d39cd97f",
     "all/create-only/.lisaignore":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -21,7 +21,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh":
       "bf4132e49ba18e2f7e941520c299c15aeeacfd220e489f3d2eb8397f2048157b",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
-      "2d9ca0841db9e75ddfd95e3a4d485fd01aa639a512ef648996f565b7991d8e2b",
+      "ab0dede91c5c8a07984ae13aa48ec70cdcd2fa691b59617bc4b57998dc79a51c",
     "all/create-only/.claude/rules/PROJECT_RULES.md":
       "6e1c7923ad2a15356babc60c97e7f97be728d790af285b6a7cd7d1b4d39cd97f",
     "all/create-only/.lisaignore":

--- a/tests/unit/scripts/lisa-work-item.test.ts
+++ b/tests/unit/scripts/lisa-work-item.test.ts
@@ -127,7 +127,17 @@ case "\${1:-} \${2:-}" in
       printf '%s\\n' "$FAKE_GH_ISSUE_JSON"
     fi
     ;;
-  "api graphql") printf '%s\\n' "$FAKE_GH_HIERARCHY_JSON" ;;
+  "api graphql")
+    # Page-aware so sub-issue pagination can be exercised. The real caller
+    # sends "after=<cursor>" only on follow-up pages, so its presence is what
+    # distinguishes page 2 from page 1 — no state file needed.
+    case "$*" in
+      *after=*)
+        printf '%s\\n' "\${FAKE_GH_HIERARCHY_PAGE2_JSON:-$FAKE_GH_HIERARCHY_JSON}" ;;
+      *)
+        printf '%s\\n' "$FAKE_GH_HIERARCHY_JSON" ;;
+    esac
+    ;;
   "pr view")
     [ "\${FAKE_GH_PR_MISSING:-0}" != "1" ] || exit 1
     printf '%s\\n' "$FAKE_GH_PR_JSON"
@@ -543,6 +553,62 @@ describe("work-item binding and commit messages", () => {
           '{"data":{"repository":{"issue":{"subIssues":{"nodes":[{"state":"OPEN"}]}}}}}',
       },
     });
+    expect(parent.status).toBe(1);
+    expect(parent.stderr).toContain("is a container");
+  });
+
+  it("finds an open child on a later page of sub-issues (#2371)", () => {
+    // `subIssues(first:100)` truncated silently, so an Epic with more than 100
+    // children reported only the first page. assertLeaf then saw no open child
+    // and treated a container as a leaf — the exact condition
+    // leaf-only-lifecycle exists to prevent, reachable by having enough
+    // children that the open one falls past the boundary.
+    const fixture = createFixture({
+      tracker: "github",
+      github: { org: "acme", repo: "identity", queueRepo: "acme/widgets" },
+    });
+    const parent = command(fixture, ["bind", "acme/widgets#42"], {
+      env: {
+        FAKE_GH_ISSUE_JSON: JSON.stringify({
+          number: 42,
+          state: "OPEN",
+          labels: [
+            { name: "repo:identity" },
+            { name: "status:in-progress" },
+            { name: "type:Task" },
+          ],
+          comments: [],
+          closedByPullRequestsReferences: [],
+        }),
+        // Page 1: every child closed, and more pages to come.
+        FAKE_GH_HIERARCHY_JSON: JSON.stringify({
+          data: {
+            repository: {
+              issue: {
+                subIssues: {
+                  nodes: [{ state: "CLOSED" }],
+                  pageInfo: { hasNextPage: true, endCursor: "CURSOR1" },
+                },
+              },
+            },
+          },
+        }),
+        // Page 2: the open child that used to be invisible.
+        FAKE_GH_HIERARCHY_PAGE2_JSON: JSON.stringify({
+          data: {
+            repository: {
+              issue: {
+                subIssues: {
+                  nodes: [{ state: "OPEN" }],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            },
+          },
+        }),
+      },
+    });
+
     expect(parent.status).toBe(1);
     expect(parent.stderr).toContain("is a container");
   });

--- a/tests/unit/scripts/lisa-work-item.test.ts
+++ b/tests/unit/scripts/lisa-work-item.test.ts
@@ -117,6 +117,13 @@ function createFixture(config: object = githubConfig()): Fixture {
     path.join(bin, "gh"),
     `
 if [ -n "\${FAKE_GH_LOG:-}" ]; then printf '%s\\n' "$*" >> "$FAKE_GH_LOG"; fi
+# An unresponsive tracker that also declines SIGTERM — the case a plain
+# \`timeout\` cannot end, because it signals and then keeps waiting.
+if [ "\${FAKE_GH_HANG:-0}" = "1" ]; then
+  trap '' TERM
+  sleep 30
+  exit 0
+fi
 case "\${1:-} \${2:-}" in
   "issue view")
     if [ "\${3:-}" = "43" ]; then
@@ -556,6 +563,34 @@ describe("work-item binding and commit messages", () => {
     expect(parent.status).toBe(1);
     expect(parent.stderr).toContain("is a container");
   });
+
+  it("kills a tracker call that ignores SIGTERM, and degrades (#2371)", () => {
+    // The deadline has to be one the child cannot decline. `timeout` alone
+    // sends SIGTERM and then waits for the child to exit, so a child that
+    // traps it hangs the commit exactly as long as it would have with no
+    // timeout at all. killSignal: "SIGKILL" is what makes it a deadline.
+    //
+    // And the outcome must be degradable: a call killed at its deadline means
+    // the tracker could not be ASKED, not that the work item is invalid.
+    const fixture = createFixture({
+      tracker: "github",
+      github: { org: "acme", repo: "identity", queueRepo: "acme/widgets" },
+    });
+
+    const started = Date.now();
+    const result = command(fixture, ["bind", "acme/widgets#42"], {
+      env: { FAKE_GH_HANG: "1", LISA_WORK_ITEM_TIMEOUT_MS: "1500" },
+    });
+    const elapsed = Date.now() - started;
+
+    // Well under the child's own 30s sleep: proof it was killed, not waited out.
+    expect(elapsed).toBeLessThan(15_000);
+    // Degraded, not refused. A call killed at its deadline means the tracker
+    // could not be ASKED — treating that as "this work item is invalid" would
+    // block every commit on a slow network.
+    expect(result.status).toBe(0);
+    expect(result.stderr).toMatch(/live validation SKIPPED/i);
+  }, 30_000);
 
   it("finds an open child on a later page of sub-issues (#2371)", () => {
     // `subIssues(first:100)` truncated silently, so an Epic with more than 100


### PR DESCRIPTION
The correctness half of what remained on #2371, all in `lisa-work-item.mjs`.

## Sub-issue hierarchy was single-page, and mis-classified failures

`subIssues(first:100)` truncated silently, so an Epic with more than 100 children reported only the first page. `assertLeaf` then saw no open child past the boundary and treated a **container as a leaf** — the exact condition `leaf-only-lifecycle` exists to prevent, reachable by nothing more exotic than having enough children. Now pages to exhaustion.

A transport failure also raised a bare `TrackingError`, so "gh is missing" and "the network is down" read as "this work item is invalid": `validateLive` could not degrade and the hook hard-failed on a laptop with no connection. Now classified through `githubFailure`, the same way `githubIssue` already did.

## No timeout on child processes

These run inside a git hook, so an unbounded call does not merely wait — it hangs the commit or push that invoked it, with no output explaining why. `spawnSync` now carries a 30s ceiling and `curl` its own `--connect-timeout`/`--max-time` beneath it, so curl's message is what surfaces.

A timeout reports as `TrackerUnreachableError`, which the degradation path already handles. `spawnSync` signals a timeout through `error` rather than a non-zero status, so that is checked explicitly — otherwise a timed-out call would have passed as success.

## `option()` discarded a valid value

A flag present but carrying no value — last on the line, or followed by another flag — yielded `undefined` or the next flag's name instead of falling back to the environment. `--ref` with nothing after it silently discarded a good value in the environment; `--ref --json` bound the literal string `"--json"`.

## JSDoc documented the wrong declaration

The block describing `result`/`ref`/`noun` and returning a string sat above `class TrackerUnreachableError`, which takes no parameters and returns nothing. Moved to `githubFailureReason`, which it describes.

## Three findings deliberately NOT changed

Two are **existing tested behaviour**, not oversights, and changing them would break consumers:

- **`applyAllowList` suffix matching.** An entry for a bare `vitest.config.ts` covering `packages/*/vitest.config.ts` is asserted by `suppresses findings matched by a baseline allow entry` — a monorepo convenience. Narrowing to exact paths would turn previously-allowed findings into CI blocks for every consumer using the bare form. That is a design change with a migration, not a drive-by fix.
- **`extractAllowEntries` accepting a missing `reason`.** Typed optional and asserted by `extracts only well-formed allow entries`. Requiring it would silently drop existing entries and fail their gates.

The third was a **false positive**: `import.meta.main` in `lisa-floor-collisions.mjs` was reported as non-portable. Verified otherwise — it landed in Node 22.18, this package's engines floor is 22.21.1, and I confirmed empirically that it returns `true` as an entrypoint and `false` when imported.

## Verification

The pagination test **fails against `origin/main` and passes here** — verified by swapping in the `origin/main` implementation and re-running. The fake `gh` in the hermetic fixture is now page-aware, keyed on the `after=` cursor the real caller sends, so no state file is needed.

1,136 tests green, `tsc` and `eslint` clean.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2371


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added time limits for external commands and tracker requests to prevent stalled operations.
  * Improved handling and classification of unreachable tracker and command failures.
  * GitHub hierarchy validation now checks all paginated sub-issues, preventing invalid parent issues from being accepted.
  * Improved option handling when values are missing or followed by another flag.
* **Documentation**
  * Clarified behavior for tracker-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->