### PR TITLE
fix(work-item): parse Work-Item trailers without a backtracking regex

### DIFF
--- a/all/copy-overwrite/scripts/lisa-work-item.mjs
+++ b/all/copy-overwrite/scripts/lisa-work-item.mjs
@@ -21,23 +21,34 @@ const RELEASE_SUBJECT =
   /^chore\(release\): \d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)? \[skip ci\]$/;
 const ZERO_OID = /^0+$/;
 const MARKER = "[lisa-pr-link]";
-const WORK_ITEM_PREFIX = "work-item:";
+/**
+ * The prefix only — an anchored, fixed-length literal with no quantifier, so
+ * it cannot backtrack. The ReDoS was never here; it was in the `\s*(.+?)\s*$`
+ * tail, which is now string work.
+ *
+ * Deliberately still a regex rather than `line.toLowerCase().startsWith(…)`.
+ * `toLowerCase()` applies FULL Unicode case mapping, so U+212A KELVIN SIGN
+ * folds to "k" and `WorK-Item:` written with it would be accepted — a format
+ * this has never accepted, because `/i` on a non-unicode pattern canonicalizes
+ * ASCII only.
+ */
+const WORK_ITEM_PREFIX = /^work-item:/i;
 
 /**
  * The value of a `Work-Item:` line, or null if this is not one.
  *
- * String operations rather than `/^Work-Item:\s*(.+?)\s*$/i`. That pattern
- * puts a lazy quantifier between two `\s*` groups, which backtracks
- * quadratically on a line that is mostly whitespace — and the lines it runs
- * over are commit messages and PR bodies, which are not this script's to
- * trust. Same acceptance: the prefix must start the line, the value must be
- * non-empty, surrounding whitespace is ignored.
+ * Replaces `/^Work-Item:\s*(.+?)\s*$/i`, which put a lazy quantifier between
+ * two `\s*` groups and backtracked super-linearly on a line that is mostly
+ * whitespace — over commit messages and PR bodies, which are not this
+ * script's to trust. Acceptance is unchanged: ASCII-case-insensitive prefix at
+ * the start of the line, non-empty value, surrounding whitespace ignored.
  * @param {string} line One line of a commit message or PR body.
  * @returns {string | null} The trimmed value, or null.
  */
 function workItemLineValue(line) {
-  if (!line.toLowerCase().startsWith(WORK_ITEM_PREFIX)) return null;
-  const value = line.slice(WORK_ITEM_PREFIX.length).trim();
+  const match = WORK_ITEM_PREFIX.exec(line);
+  if (!match) return null;
+  const value = line.slice(match[0].length).trim();
   return value === "" ? null : value;
 }
 const GUIDANCE = [

--- a/all/copy-overwrite/scripts/lisa-work-item.mjs
+++ b/all/copy-overwrite/scripts/lisa-work-item.mjs
@@ -21,6 +21,25 @@ const RELEASE_SUBJECT =
   /^chore\(release\): \d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)? \[skip ci\]$/;
 const ZERO_OID = /^0+$/;
 const MARKER = "[lisa-pr-link]";
+const WORK_ITEM_PREFIX = "work-item:";
+
+/**
+ * The value of a `Work-Item:` line, or null if this is not one.
+ *
+ * String operations rather than `/^Work-Item:\s*(.+?)\s*$/i`. That pattern
+ * puts a lazy quantifier between two `\s*` groups, which backtracks
+ * quadratically on a line that is mostly whitespace — and the lines it runs
+ * over are commit messages and PR bodies, which are not this script's to
+ * trust. Same acceptance: the prefix must start the line, the value must be
+ * non-empty, surrounding whitespace is ignored.
+ * @param {string} line One line of a commit message or PR body.
+ * @returns {string | null} The trimmed value, or null.
+ */
+function workItemLineValue(line) {
+  if (!line.toLowerCase().startsWith(WORK_ITEM_PREFIX)) return null;
+  const value = line.slice(WORK_ITEM_PREFIX.length).trim();
+  return value === "" ? null : value;
+}
 const GUIDANCE = [
   "Mention the ticket this work relates to, or ask Lisa to create one:",
   "  Work-Item: <configured-project-ticket>",
@@ -493,8 +512,8 @@ function parseTrailers(message) {
     .split("\n")
     .filter(Boolean)
     .flatMap(line => {
-      const match = /^Work-Item:\s*(.+?)\s*$/i.exec(line);
-      return match ? [match[1]] : [];
+      const value = workItemLineValue(line);
+      return value === null ? [] : [value];
     });
 }
 
@@ -1179,8 +1198,8 @@ function prWorkItem(body, contract) {
   const matches = String(body ?? "")
     .split(/\r?\n/)
     .flatMap(line => {
-      const match = /^Work-Item:\s*(.+?)\s*$/i.exec(line);
-      return match ? [match[1]] : [];
+      const value = workItemLineValue(line);
+      return value === null ? [] : [value];
     });
   if (matches.length !== 1)
     throw new TrackingError(

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -21,7 +21,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh":
       "bf4132e49ba18e2f7e941520c299c15aeeacfd220e489f3d2eb8397f2048157b",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
-      "fc0d92739e620d8fd70f7aa4a12d3e0b3a8f790d47c4a8322040f32c30b9445a",
+      "238dc2da29938edd92518c2b08192d14c6f2751ed175c07d6e882814829b7b7e",
     "all/create-only/.claude/rules/PROJECT_RULES.md":
       "6e1c7923ad2a15356babc60c97e7f97be728d790af285b6a7cd7d1b4d39cd97f",
     "all/create-only/.lisaignore":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -21,7 +21,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh":
       "bf4132e49ba18e2f7e941520c299c15aeeacfd220e489f3d2eb8397f2048157b",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
-      "238dc2da29938edd92518c2b08192d14c6f2751ed175c07d6e882814829b7b7e",
+      "e30016a49deff1c3cd3ae7951262aeb2ef3d472bce76bbbe2a177db6017c7cad",
     "all/create-only/.claude/rules/PROJECT_RULES.md":
       "6e1c7923ad2a15356babc60c97e7f97be728d790af285b6a7cd7d1b4d39cd97f",
     "all/create-only/.lisaignore":


### PR DESCRIPTION
Closes #2371 — the last substantive item, plus a documented disposition for everything else that remained.

## The fix

`/^Work-Item:\s*(.+?)\s*$/i` puts a lazy quantifier between two `\s*` groups, which backtracks super-linearly on a line that is mostly whitespace. It ran over **commit messages and pull-request bodies** — text this script does not get to trust — once per line, in two places.

Replaced with a shared `workItemLineValue()` doing string operations, which also removes the duplication. Acceptance is unchanged: the prefix must start the line, the value must be non-empty, surrounding whitespace is ignored.

Both `sonarjs/slow-regex` errors in this file are now clear under `eslint --no-ignore`. The file is excluded from the normal lint run as template content, which is why CI never surfaced them.

## Everything else on #2371, and why it is not here

**`.lisa/ACCOUNTABILITY.md` / `.lisa/DEPENDENCY_DECISIONS.md` "replace the example entries" — false positive at the template level.** The template already says, in a blockquote:

> **The two entries below are EXAMPLES.** They are here so you can see the shape

…and marks each one `### ESLint (EXAMPLE — a complete entry)` and `(example entry — never reviewed)`. `ACCOUNTABILITY.md` ships with empty rows and states `_(none recorded yet — this file ships blank on purpose)_`. What the review saw was a freshly-scaffolded downstream repo that had not filled its scaffolding in yet — true of that repo on day one, and the repo owner's job, not a template defect.

**`import.meta.main` "not portable" — false positive.** It landed in Node 22.18 and this package's engines floor is 22.21.1. Verified empirically: `true` as an entrypoint, `false` when imported.

**`applyAllowList` suffix matching and `extractAllowEntries` optional `reason` — declined.** Both are existing behaviour with tests asserting them (`suppresses findings matched by a baseline allow entry`, `extracts only well-formed allow entries`). Narrowing either would turn previously-allowed findings into CI blocks for every consumer whose config relies on the current shape. That is a design change with a migration, not a drive-by fix.

**Remaining style preferences — not taken.** `replaceAll` over `replace`, `String.raw`, nested-ternary extraction, `findLast` over `filter().at(-1)`, and cognitive-complexity refactors in `lisa-work-item.mjs`. This file is deliberately excluded from the repo's lint run as template content, so the project has already decided not to enforce style here; churning a 1,300-line security-relevant script for preferences its own linter does not check trades real regression risk for no signal. The two findings in that file that *were* enforceable — the ReDoS pair — are fixed above, found by running the linter explicitly.

## Verification

`lisa-work-item` (35) and `commit-msg` (4) suites pass — they cover the trailer forms this touches directly. Run with `--no-file-parallelism`: this machine is currently saturated by another workload (load average 35), which makes the full parallel suite flaky in unrelated places.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2371


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of `Work-Item:` entries in commit trailers and pull requests.
  * Matching is now case-insensitive and handles surrounding whitespace consistently.
  * Empty `Work-Item:` entries are ignored to prevent invalid values from being processed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->