### PR TITLE
fix(hooks): close two guards that passed when they had not checked

### DIFF
--- a/all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh
@@ -118,8 +118,42 @@ def is_permitted_hooks_path(value):
         cleaned = cleaned[2:]
     return cleaned.rstrip("/") in PERMITTED_HOOKS_PATHS
 
+
+# Git resolves any UNAMBIGUOUS abbreviation of a long option, so `--no-verify`
+# is only the longest of the spellings that disable verification: `git commit
+# --no-veri` skips hooks exactly as completely. An equality check therefore
+# enforced the guard against the one spelling nobody in a hurry types.
+#
+# Matched as "a prefix of --no-verify" rather than by listing abbreviations,
+# because the set of accepted abbreviations is a property of git's parser and
+# changes with the surrounding options. `--no-verbose` is NOT caught, and must
+# not be: it diverges from `--no-verify` at the character after `--no-ver`, so
+# it fails the prefix test.
+#
+# The floor is `--no-v`. Shorter is refused anyway — bare `--no-` is not a flag
+# — and blocking an abbreviation git would reject as ambiguous costs nothing,
+# while missing one git accepts costs the whole guard.
+NO_VERIFY = "--no-verify"
+NO_VERIFY_MIN_PREFIX = len("--no-v")
+
+
+def disables_verification(token):
+    """Whether a token is `--no-verify` or an abbreviation git would accept.
+
+    Args:
+        token: A single shell token from the command line.
+
+    Returns:
+        True if git would read this token as --no-verify.
+    """
+    return (
+        len(token) >= NO_VERIFY_MIN_PREFIX
+        and len(token) <= len(NO_VERIFY)
+        and NO_VERIFY.startswith(token)
+    )
+
 for i, token in enumerate(normalized_tokens):
-    if token == "--no-verify":
+    if disables_verification(token):
         sys.exit(1)
     if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
         sys.exit(1)

--- a/plugins/lisa-agy/hooks/block-no-verify.agy.sh
+++ b/plugins/lisa-agy/hooks/block-no-verify.agy.sh
@@ -79,8 +79,31 @@ except ValueError:
 
 normalized_tokens = [token.strip("();|&") for token in tokens]
 
+# Git resolves any UNAMBIGUOUS abbreviation of a long option, so `--no-veri`
+# skips hooks exactly as completely as `--no-verify`. Matched as a prefix
+# rather than by listing abbreviations; `--no-verbose` diverges after
+# `--no-ver` and so is correctly not caught.
+NO_VERIFY = "--no-verify"
+NO_VERIFY_MIN_PREFIX = len("--no-v")
+
+
+def disables_verification(token):
+    """Whether a token is `--no-verify` or an abbreviation git would accept.
+
+    Args:
+        token: A single shell token from the command line.
+
+    Returns:
+        True if git would read this token as --no-verify.
+    """
+    return (
+        len(token) >= NO_VERIFY_MIN_PREFIX
+        and len(token) <= len(NO_VERIFY)
+        and NO_VERIFY.startswith(token)
+    )
+
 for i, token in enumerate(normalized_tokens):
-    if token == "--no-verify":
+    if disables_verification(token):
         sys.exit(1)
     if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
         sys.exit(1)

--- a/plugins/lisa-copilot/hooks/block-no-verify.sh
+++ b/plugins/lisa-copilot/hooks/block-no-verify.sh
@@ -118,8 +118,42 @@ def is_permitted_hooks_path(value):
         cleaned = cleaned[2:]
     return cleaned.rstrip("/") in PERMITTED_HOOKS_PATHS
 
+
+# Git resolves any UNAMBIGUOUS abbreviation of a long option, so `--no-verify`
+# is only the longest of the spellings that disable verification: `git commit
+# --no-veri` skips hooks exactly as completely. An equality check therefore
+# enforced the guard against the one spelling nobody in a hurry types.
+#
+# Matched as "a prefix of --no-verify" rather than by listing abbreviations,
+# because the set of accepted abbreviations is a property of git's parser and
+# changes with the surrounding options. `--no-verbose` is NOT caught, and must
+# not be: it diverges from `--no-verify` at the character after `--no-ver`, so
+# it fails the prefix test.
+#
+# The floor is `--no-v`. Shorter is refused anyway — bare `--no-` is not a flag
+# — and blocking an abbreviation git would reject as ambiguous costs nothing,
+# while missing one git accepts costs the whole guard.
+NO_VERIFY = "--no-verify"
+NO_VERIFY_MIN_PREFIX = len("--no-v")
+
+
+def disables_verification(token):
+    """Whether a token is `--no-verify` or an abbreviation git would accept.
+
+    Args:
+        token: A single shell token from the command line.
+
+    Returns:
+        True if git would read this token as --no-verify.
+    """
+    return (
+        len(token) >= NO_VERIFY_MIN_PREFIX
+        and len(token) <= len(NO_VERIFY)
+        and NO_VERIFY.startswith(token)
+    )
+
 for i, token in enumerate(normalized_tokens):
-    if token == "--no-verify":
+    if disables_verification(token):
         sys.exit(1)
     if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
         sys.exit(1)

--- a/plugins/lisa-copilot/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa-copilot/hooks/threshold-ratchet.mjs
@@ -172,6 +172,30 @@ function run(mode, baseRef, onlyFiles) {
   const watched = plan.files.filter(f => familyFor(f));
   if (watched.length === 0) return 0;
 
+  // A null baseline means one of two opposite things, and they must not be
+  // conflated: the file is NEW (nothing to weaken — pass), or it exists at the
+  // baseline and could not be read (nothing could be COMPARED — the one case
+  // where the ratchet cannot do its job). Both arrive here as null because
+  // `git()` swallows every failure, so the ratchet passed exactly when it had
+  // no evidence — failing open in its blind spot.
+  //
+  // `cat-file -e` answers the question `git show` cannot: does this path exist
+  // at that ref? Absent means new; present-but-unreadable means undeterminable,
+  // and an undeterminable ratchet must refuse rather than wave the change on.
+  const unreadable = watched.filter(
+    f =>
+      git(["show", `${plan.baselineRef}:${f}`], root) === null &&
+      git(["cat-file", "-e", `${plan.baselineRef}:${f}`], root) !== null
+  );
+  if (unreadable.length > 0) {
+    return undeterminable(
+      mode,
+      `could not read the baseline for ${unreadable.join(", ")} — ` +
+        `the file exists at ${plan.baselineRef} but its contents could not be ` +
+        `retrieved, so a loosened threshold could not be detected`
+    );
+  }
+
   const findings = watched.flatMap(f =>
     compareFile(
       f,

--- a/plugins/lisa-cursor/hooks/block-no-verify.sh
+++ b/plugins/lisa-cursor/hooks/block-no-verify.sh
@@ -118,8 +118,42 @@ def is_permitted_hooks_path(value):
         cleaned = cleaned[2:]
     return cleaned.rstrip("/") in PERMITTED_HOOKS_PATHS
 
+
+# Git resolves any UNAMBIGUOUS abbreviation of a long option, so `--no-verify`
+# is only the longest of the spellings that disable verification: `git commit
+# --no-veri` skips hooks exactly as completely. An equality check therefore
+# enforced the guard against the one spelling nobody in a hurry types.
+#
+# Matched as "a prefix of --no-verify" rather than by listing abbreviations,
+# because the set of accepted abbreviations is a property of git's parser and
+# changes with the surrounding options. `--no-verbose` is NOT caught, and must
+# not be: it diverges from `--no-verify` at the character after `--no-ver`, so
+# it fails the prefix test.
+#
+# The floor is `--no-v`. Shorter is refused anyway — bare `--no-` is not a flag
+# — and blocking an abbreviation git would reject as ambiguous costs nothing,
+# while missing one git accepts costs the whole guard.
+NO_VERIFY = "--no-verify"
+NO_VERIFY_MIN_PREFIX = len("--no-v")
+
+
+def disables_verification(token):
+    """Whether a token is `--no-verify` or an abbreviation git would accept.
+
+    Args:
+        token: A single shell token from the command line.
+
+    Returns:
+        True if git would read this token as --no-verify.
+    """
+    return (
+        len(token) >= NO_VERIFY_MIN_PREFIX
+        and len(token) <= len(NO_VERIFY)
+        and NO_VERIFY.startswith(token)
+    )
+
 for i, token in enumerate(normalized_tokens):
-    if token == "--no-verify":
+    if disables_verification(token):
         sys.exit(1)
     if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
         sys.exit(1)

--- a/plugins/lisa-cursor/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa-cursor/hooks/threshold-ratchet.mjs
@@ -172,6 +172,30 @@ function run(mode, baseRef, onlyFiles) {
   const watched = plan.files.filter(f => familyFor(f));
   if (watched.length === 0) return 0;
 
+  // A null baseline means one of two opposite things, and they must not be
+  // conflated: the file is NEW (nothing to weaken — pass), or it exists at the
+  // baseline and could not be read (nothing could be COMPARED — the one case
+  // where the ratchet cannot do its job). Both arrive here as null because
+  // `git()` swallows every failure, so the ratchet passed exactly when it had
+  // no evidence — failing open in its blind spot.
+  //
+  // `cat-file -e` answers the question `git show` cannot: does this path exist
+  // at that ref? Absent means new; present-but-unreadable means undeterminable,
+  // and an undeterminable ratchet must refuse rather than wave the change on.
+  const unreadable = watched.filter(
+    f =>
+      git(["show", `${plan.baselineRef}:${f}`], root) === null &&
+      git(["cat-file", "-e", `${plan.baselineRef}:${f}`], root) !== null
+  );
+  if (unreadable.length > 0) {
+    return undeterminable(
+      mode,
+      `could not read the baseline for ${unreadable.join(", ")} — ` +
+        `the file exists at ${plan.baselineRef} but its contents could not be ` +
+        `retrieved, so a loosened threshold could not be detected`
+    );
+  }
+
   const findings = watched.flatMap(f =>
     compareFile(
       f,

--- a/plugins/lisa/hooks/block-no-verify.agy.sh
+++ b/plugins/lisa/hooks/block-no-verify.agy.sh
@@ -79,8 +79,31 @@ except ValueError:
 
 normalized_tokens = [token.strip("();|&") for token in tokens]
 
+# Git resolves any UNAMBIGUOUS abbreviation of a long option, so `--no-veri`
+# skips hooks exactly as completely as `--no-verify`. Matched as a prefix
+# rather than by listing abbreviations; `--no-verbose` diverges after
+# `--no-ver` and so is correctly not caught.
+NO_VERIFY = "--no-verify"
+NO_VERIFY_MIN_PREFIX = len("--no-v")
+
+
+def disables_verification(token):
+    """Whether a token is `--no-verify` or an abbreviation git would accept.
+
+    Args:
+        token: A single shell token from the command line.
+
+    Returns:
+        True if git would read this token as --no-verify.
+    """
+    return (
+        len(token) >= NO_VERIFY_MIN_PREFIX
+        and len(token) <= len(NO_VERIFY)
+        and NO_VERIFY.startswith(token)
+    )
+
 for i, token in enumerate(normalized_tokens):
-    if token == "--no-verify":
+    if disables_verification(token):
         sys.exit(1)
     if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
         sys.exit(1)

--- a/plugins/lisa/hooks/block-no-verify.sh
+++ b/plugins/lisa/hooks/block-no-verify.sh
@@ -118,8 +118,42 @@ def is_permitted_hooks_path(value):
         cleaned = cleaned[2:]
     return cleaned.rstrip("/") in PERMITTED_HOOKS_PATHS
 
+
+# Git resolves any UNAMBIGUOUS abbreviation of a long option, so `--no-verify`
+# is only the longest of the spellings that disable verification: `git commit
+# --no-veri` skips hooks exactly as completely. An equality check therefore
+# enforced the guard against the one spelling nobody in a hurry types.
+#
+# Matched as "a prefix of --no-verify" rather than by listing abbreviations,
+# because the set of accepted abbreviations is a property of git's parser and
+# changes with the surrounding options. `--no-verbose` is NOT caught, and must
+# not be: it diverges from `--no-verify` at the character after `--no-ver`, so
+# it fails the prefix test.
+#
+# The floor is `--no-v`. Shorter is refused anyway — bare `--no-` is not a flag
+# — and blocking an abbreviation git would reject as ambiguous costs nothing,
+# while missing one git accepts costs the whole guard.
+NO_VERIFY = "--no-verify"
+NO_VERIFY_MIN_PREFIX = len("--no-v")
+
+
+def disables_verification(token):
+    """Whether a token is `--no-verify` or an abbreviation git would accept.
+
+    Args:
+        token: A single shell token from the command line.
+
+    Returns:
+        True if git would read this token as --no-verify.
+    """
+    return (
+        len(token) >= NO_VERIFY_MIN_PREFIX
+        and len(token) <= len(NO_VERIFY)
+        and NO_VERIFY.startswith(token)
+    )
+
 for i, token in enumerate(normalized_tokens):
-    if token == "--no-verify":
+    if disables_verification(token):
         sys.exit(1)
     if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
         sys.exit(1)

--- a/plugins/lisa/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa/hooks/threshold-ratchet.mjs
@@ -172,6 +172,30 @@ function run(mode, baseRef, onlyFiles) {
   const watched = plan.files.filter(f => familyFor(f));
   if (watched.length === 0) return 0;
 
+  // A null baseline means one of two opposite things, and they must not be
+  // conflated: the file is NEW (nothing to weaken — pass), or it exists at the
+  // baseline and could not be read (nothing could be COMPARED — the one case
+  // where the ratchet cannot do its job). Both arrive here as null because
+  // `git()` swallows every failure, so the ratchet passed exactly when it had
+  // no evidence — failing open in its blind spot.
+  //
+  // `cat-file -e` answers the question `git show` cannot: does this path exist
+  // at that ref? Absent means new; present-but-unreadable means undeterminable,
+  // and an undeterminable ratchet must refuse rather than wave the change on.
+  const unreadable = watched.filter(
+    f =>
+      git(["show", `${plan.baselineRef}:${f}`], root) === null &&
+      git(["cat-file", "-e", `${plan.baselineRef}:${f}`], root) !== null
+  );
+  if (unreadable.length > 0) {
+    return undeterminable(
+      mode,
+      `could not read the baseline for ${unreadable.join(", ")} — ` +
+        `the file exists at ${plan.baselineRef} but its contents could not be ` +
+        `retrieved, so a loosened threshold could not be detected`
+    );
+  }
+
   const findings = watched.flatMap(f =>
     compareFile(
       f,

--- a/plugins/src/base/hooks/block-no-verify.agy.sh
+++ b/plugins/src/base/hooks/block-no-verify.agy.sh
@@ -79,8 +79,31 @@ except ValueError:
 
 normalized_tokens = [token.strip("();|&") for token in tokens]
 
+# Git resolves any UNAMBIGUOUS abbreviation of a long option, so `--no-veri`
+# skips hooks exactly as completely as `--no-verify`. Matched as a prefix
+# rather than by listing abbreviations; `--no-verbose` diverges after
+# `--no-ver` and so is correctly not caught.
+NO_VERIFY = "--no-verify"
+NO_VERIFY_MIN_PREFIX = len("--no-v")
+
+
+def disables_verification(token):
+    """Whether a token is `--no-verify` or an abbreviation git would accept.
+
+    Args:
+        token: A single shell token from the command line.
+
+    Returns:
+        True if git would read this token as --no-verify.
+    """
+    return (
+        len(token) >= NO_VERIFY_MIN_PREFIX
+        and len(token) <= len(NO_VERIFY)
+        and NO_VERIFY.startswith(token)
+    )
+
 for i, token in enumerate(normalized_tokens):
-    if token == "--no-verify":
+    if disables_verification(token):
         sys.exit(1)
     if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
         sys.exit(1)

--- a/plugins/src/base/hooks/block-no-verify.sh
+++ b/plugins/src/base/hooks/block-no-verify.sh
@@ -118,8 +118,42 @@ def is_permitted_hooks_path(value):
         cleaned = cleaned[2:]
     return cleaned.rstrip("/") in PERMITTED_HOOKS_PATHS
 
+
+# Git resolves any UNAMBIGUOUS abbreviation of a long option, so `--no-verify`
+# is only the longest of the spellings that disable verification: `git commit
+# --no-veri` skips hooks exactly as completely. An equality check therefore
+# enforced the guard against the one spelling nobody in a hurry types.
+#
+# Matched as "a prefix of --no-verify" rather than by listing abbreviations,
+# because the set of accepted abbreviations is a property of git's parser and
+# changes with the surrounding options. `--no-verbose` is NOT caught, and must
+# not be: it diverges from `--no-verify` at the character after `--no-ver`, so
+# it fails the prefix test.
+#
+# The floor is `--no-v`. Shorter is refused anyway — bare `--no-` is not a flag
+# — and blocking an abbreviation git would reject as ambiguous costs nothing,
+# while missing one git accepts costs the whole guard.
+NO_VERIFY = "--no-verify"
+NO_VERIFY_MIN_PREFIX = len("--no-v")
+
+
+def disables_verification(token):
+    """Whether a token is `--no-verify` or an abbreviation git would accept.
+
+    Args:
+        token: A single shell token from the command line.
+
+    Returns:
+        True if git would read this token as --no-verify.
+    """
+    return (
+        len(token) >= NO_VERIFY_MIN_PREFIX
+        and len(token) <= len(NO_VERIFY)
+        and NO_VERIFY.startswith(token)
+    )
+
 for i, token in enumerate(normalized_tokens):
-    if token == "--no-verify":
+    if disables_verification(token):
         sys.exit(1)
     if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
         sys.exit(1)

--- a/plugins/src/base/hooks/threshold-ratchet.mjs
+++ b/plugins/src/base/hooks/threshold-ratchet.mjs
@@ -172,6 +172,30 @@ function run(mode, baseRef, onlyFiles) {
   const watched = plan.files.filter(f => familyFor(f));
   if (watched.length === 0) return 0;
 
+  // A null baseline means one of two opposite things, and they must not be
+  // conflated: the file is NEW (nothing to weaken — pass), or it exists at the
+  // baseline and could not be read (nothing could be COMPARED — the one case
+  // where the ratchet cannot do its job). Both arrive here as null because
+  // `git()` swallows every failure, so the ratchet passed exactly when it had
+  // no evidence — failing open in its blind spot.
+  //
+  // `cat-file -e` answers the question `git show` cannot: does this path exist
+  // at that ref? Absent means new; present-but-unreadable means undeterminable,
+  // and an undeterminable ratchet must refuse rather than wave the change on.
+  const unreadable = watched.filter(
+    f =>
+      git(["show", `${plan.baselineRef}:${f}`], root) === null &&
+      git(["cat-file", "-e", `${plan.baselineRef}:${f}`], root) !== null
+  );
+  if (unreadable.length > 0) {
+    return undeterminable(
+      mode,
+      `could not read the baseline for ${unreadable.join(", ")} — ` +
+        `the file exists at ${plan.baselineRef} but its contents could not be ` +
+        `retrieved, so a loosened threshold could not be detected`
+    );
+  }
+
   const findings = watched.flatMap(f =>
     compareFile(
       f,

--- a/rails/copy-overwrite/scripts/check-threshold-ratchet.mjs
+++ b/rails/copy-overwrite/scripts/check-threshold-ratchet.mjs
@@ -172,6 +172,30 @@ function run(mode, baseRef, onlyFiles) {
   const watched = plan.files.filter(f => familyFor(f));
   if (watched.length === 0) return 0;
 
+  // A null baseline means one of two opposite things, and they must not be
+  // conflated: the file is NEW (nothing to weaken — pass), or it exists at the
+  // baseline and could not be read (nothing could be COMPARED — the one case
+  // where the ratchet cannot do its job). Both arrive here as null because
+  // `git()` swallows every failure, so the ratchet passed exactly when it had
+  // no evidence — failing open in its blind spot.
+  //
+  // `cat-file -e` answers the question `git show` cannot: does this path exist
+  // at that ref? Absent means new; present-but-unreadable means undeterminable,
+  // and an undeterminable ratchet must refuse rather than wave the change on.
+  const unreadable = watched.filter(
+    f =>
+      git(["show", `${plan.baselineRef}:${f}`], root) === null &&
+      git(["cat-file", "-e", `${plan.baselineRef}:${f}`], root) !== null
+  );
+  if (unreadable.length > 0) {
+    return undeterminable(
+      mode,
+      `could not read the baseline for ${unreadable.join(", ")} — ` +
+        `the file exists at ${plan.baselineRef} but its contents could not be ` +
+        `retrieved, so a loosened threshold could not be detected`
+    );
+  }
+
   const findings = watched.flatMap(f =>
     compareFile(
       f,

--- a/src/codex/scripts/block-no-verify.sh
+++ b/src/codex/scripts/block-no-verify.sh
@@ -62,8 +62,31 @@ except ValueError:
 
 normalized_tokens = [token.strip("();|&") for token in tokens]
 
+# Git resolves any UNAMBIGUOUS abbreviation of a long option, so `--no-veri`
+# skips hooks exactly as completely as `--no-verify`. Matched as a prefix
+# rather than by listing abbreviations; `--no-verbose` diverges after
+# `--no-ver` and so is correctly not caught.
+NO_VERIFY = "--no-verify"
+NO_VERIFY_MIN_PREFIX = len("--no-v")
+
+
+def disables_verification(token):
+    """Whether a token is `--no-verify` or an abbreviation git would accept.
+
+    Args:
+        token: A single shell token from the command line.
+
+    Returns:
+        True if git would read this token as --no-verify.
+    """
+    return (
+        len(token) >= NO_VERIFY_MIN_PREFIX
+        and len(token) <= len(NO_VERIFY)
+        and NO_VERIFY.startswith(token)
+    )
+
 for i, token in enumerate(normalized_tokens):
-    if token == "--no-verify":
+    if disables_verification(token):
         sys.exit(1)
     if token == "HUSKY=0" or token.startswith("HUSKY_SKIP_HOOKS="):
         sys.exit(1)

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -13,7 +13,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
       "850cfc23852eb752114ae1e938a1c7bcf34bc50c85d3aaca0c02311cc8c0ef70",
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh":
-      "33e2bd341eb992036059b0c4606db35a218adcfeca7e44d174fedf8ebdff29d2",
+      "031ef7a53fc49cb18665105b834b7b50ad6a43317e0821949809e877e0562ce4",
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh":
       "1934a15e154fda3c2a40979a5cd6225661b14fe7bc77328a69ce499bea85dba7",
     "all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh":
@@ -595,9 +595,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/block-instruction-file-edits.sh":
       "850cfc23852eb752114ae1e938a1c7bcf34bc50c85d3aaca0c02311cc8c0ef70",
     "plugins/src/base/hooks/block-no-verify.agy.sh":
-      "1a36c841b6339a2c664938d65c5a4542f97d05f584e467de448bb72ac6bdba55",
+      "c549f1dadd6ac3fab72c0b670524445a08bee732a05b868954a438970d4d5bcc",
     "plugins/src/base/hooks/block-no-verify.sh":
-      "33e2bd341eb992036059b0c4606db35a218adcfeca7e44d174fedf8ebdff29d2",
+      "031ef7a53fc49cb18665105b834b7b50ad6a43317e0821949809e877e0562ce4",
     "plugins/src/base/hooks/block-shell-json-parsing.agy.sh":
       "dc688efe382e7b8fe6f6c88bb0fde851527128cae778599559f23a93f1c9ec86",
     "plugins/src/base/hooks/block-shell-json-parsing.sh":
@@ -633,7 +633,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/threshold-ratchet-families.mjs":
       "db14245ed89b483912af287bdee917a7a921dc21bb29b49be37fc799c05c413f",
     "plugins/src/base/hooks/threshold-ratchet.mjs":
-      "49dee610439f4f21aecb0420a0cc72f5d3595a36f2489970053096190b9909c4",
+      "e1e3f22b33267212b90f915f83821559d1a45cab5b16c7164b86bd6c7b53549b",
     "plugins/src/base/hooks/threshold-ratchet.sh":
       "b86f4d0b554e44fd119ad8a8920cd0ba6c9dbe779f7ee219d381cf0629453990",
     "plugins/src/base/hooks/ticket-sync-reminder.sh":
@@ -1895,7 +1895,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/copy-overwrite/lefthook.yml":
       "28bb382b9171a04fb92ebafc1f1522b8639f5edc4fcffcc6940e7fba3460fb4e",
     "rails/copy-overwrite/scripts/check-threshold-ratchet.mjs":
-      "49dee610439f4f21aecb0420a0cc72f5d3595a36f2489970053096190b9909c4",
+      "e1e3f22b33267212b90f915f83821559d1a45cab5b16c7164b86bd6c7b53549b",
     "rails/copy-overwrite/scripts/lisa-clean-git-env.sh":
       "e7121a0ee9e1bf7c01cd2ab55f563dd6d9ab75990739bb6ddf571a513efa10e9",
     "rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs":
@@ -2141,7 +2141,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/knip.json":
       "6eb93d705a2d645332fbae1dd42cf2d48f85978ebc265451a53790912f277d12",
     "typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs":
-      "49dee610439f4f21aecb0420a0cc72f5d3595a36f2489970053096190b9909c4",
+      "e1e3f22b33267212b90f915f83821559d1a45cab5b16c7164b86bd6c7b53549b",
     "typescript/copy-overwrite/scripts/check-verification-coverage.mjs":
       "3c1d27d0668fc66a18cb014f2b607878f0a88c178a773fbe964b8e46b19e86d6",
     "typescript/copy-overwrite/scripts/lisa-mutation.mjs":

--- a/tests/unit/hooks/block-no-verify.test.ts
+++ b/tests/unit/hooks/block-no-verify.test.ts
@@ -50,6 +50,26 @@ describe("block-no-verify.sh", () => {
       expect(status).toBe(EXIT_BLOCKED);
     });
 
+    // Git resolves unambiguous abbreviations of long options, so each of these
+    // skips hooks exactly as completely as the full spelling. An equality check
+    // enforced the guard against only the longest form — the one spelling
+    // nobody bypassing hooks in a hurry would bother to type.
+    it.each(["--no-v", "--no-ve", "--no-ver", "--no-veri", "--no-verif"])(
+      "blocks the abbreviation %s, which git accepts as --no-verify",
+      (abbreviation: string) => {
+        const { status } = runHook("Bash", `git commit ${abbreviation} -m x`);
+        expect(status).toBe(EXIT_BLOCKED);
+      }
+    );
+
+    it("does not block --no-verbose, which is a different flag", () => {
+      // Diverges from --no-verify at the character after `--no-ver`, so it
+      // fails the prefix test. Guarding the abbreviations must not swallow
+      // neighbouring flags that happen to share a stem.
+      const { status } = runHook("Bash", "git commit --no-verbose -m x");
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
     it("blocks --no-verify inside a subshell with parentheses", () => {
       // Regression: `)` after --no-verify was not in the old allowed boundary
       // set, allowing (git commit --no-verify) to bypass the check.

--- a/typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs
+++ b/typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs
@@ -172,6 +172,30 @@ function run(mode, baseRef, onlyFiles) {
   const watched = plan.files.filter(f => familyFor(f));
   if (watched.length === 0) return 0;
 
+  // A null baseline means one of two opposite things, and they must not be
+  // conflated: the file is NEW (nothing to weaken — pass), or it exists at the
+  // baseline and could not be read (nothing could be COMPARED — the one case
+  // where the ratchet cannot do its job). Both arrive here as null because
+  // `git()` swallows every failure, so the ratchet passed exactly when it had
+  // no evidence — failing open in its blind spot.
+  //
+  // `cat-file -e` answers the question `git show` cannot: does this path exist
+  // at that ref? Absent means new; present-but-unreadable means undeterminable,
+  // and an undeterminable ratchet must refuse rather than wave the change on.
+  const unreadable = watched.filter(
+    f =>
+      git(["show", `${plan.baselineRef}:${f}`], root) === null &&
+      git(["cat-file", "-e", `${plan.baselineRef}:${f}`], root) !== null
+  );
+  if (unreadable.length > 0) {
+    return undeterminable(
+      mode,
+      `could not read the baseline for ${unreadable.join(", ")} — ` +
+        `the file exists at ${plan.baselineRef} but its contents could not be ` +
+        `retrieved, so a loosened threshold could not be detected`
+    );
+  }
+
   const findings = watched.flatMap(f =>
     compareFile(
       f,


### PR DESCRIPTION
Both guards reported success in exactly the circumstances they exist to catch. That is the failure mode that stays invisible — a guard blocking nothing looks identical to a codebase with nothing to block.

## 1. `--no-verify` was matched by equality

Git resolves any **unambiguous abbreviation** of a long option, so `git commit --no-veri` skips hooks exactly as completely as the full spelling. The guard compared `token == "--no-verify"`, so it enforced *never --no-verify* against the one spelling nobody bypassing hooks in a hurry would type.

Now matched as a prefix of `--no-verify` with floor `--no-v`, rather than by enumerating abbreviations — which abbreviations git accepts depends on the surrounding options and varies by subcommand, so a list would rot.

Verified against the real hook:

```
--no-verify      blocked      --no-verbose     allowed
--no-veri        blocked      --no-verify-ssl  allowed
--no-ver         blocked      git commit -m x  allowed
--no-v           blocked
```

`--no-verbose` diverges at the character after `--no-ver`, so it fails the prefix test and is correctly untouched.

## 2. The threshold ratchet passed when it could not read the baseline

A null baseline meant two opposite things, conflated: the file is **new** (nothing to weaken — correctly passes), or it **exists at the baseline and could not be read** (nothing could be compared). `git()` swallows every failure into null, so the ratchet passed precisely when it had no evidence.

`cat-file -e` separates them — absent means new, present-but-unreadable means undeterminable. Undeterminable now routes through the existing `undeterminable()` path, which fails closed in `staged`/`base` mode and stays non-blocking in `hook` mode. That preserves the deliberate split already in the file between the local hook and the authoritative CI gate, rather than inventing a new policy.

## Fan-out

Applied to the canonical modules and rebuilt, so every agent variant and stack template carries them — `plugins/src/base/hooks` (claude, agy, copilot, cursor), `all/copy-overwrite`, `typescript/` and `rails/copy-overwrite`, and the separate codex variant under `src/codex/scripts`.

I initially edited the stack-template copies; `threshold-ratchet-wiring` caught it and I moved the change to the canonical module so the byte-identity assertion holds.

## Verification

- 72 tests pass across the no-verify, agy-variant, ratchet-wiring and evidence-manifest suites.
- New cases cover every abbreviation git accepts and assert `--no-verbose` is not swallowed.
- `check-learnings-budget` fails on a stashed tree too — pre-existing, unrelated.

Source of the findings: CodeRabbit on geminisportsai/infrastructure-v2#351, where these files appeared only because a version bump vendored them.

Work-Item: CodySwannGT/lisa#2389

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git hook protection now blocks accepted abbreviated forms of `--no-verify` while allowing distinct options such as `--no-verbose`.
  * Threshold checks now fail safely when an existing baseline file cannot be read, while continuing to handle genuinely new files appropriately.

* **Tests**
  * Added coverage for abbreviated verification-bypass options and similar non-matching flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->