### PR TITLE
fix(hooks): reject a threshold whose bound direction was flipped

### DIFF
--- a/plugins/lisa-copilot/hooks/threshold-ratchet-compare.mjs
+++ b/plugins/lisa-copilot/hooks/threshold-ratchet-compare.mjs
@@ -72,6 +72,29 @@ export function compareConstraints(relPath, base, current) {
       });
       continue;
     }
+    // A bound's DIRECTION carries as much of the gate as its number. Flipping
+    // `rate>=0.99` to `rate<=0.99` keeps the key and the value and inverts the
+    // meaning: "at least 99% success" becomes "at most 99% success", a gate
+    // that now passes when the system is broken. Comparing only values, that
+    // read as unchanged.
+    //
+    // Rejected rather than re-evaluated in the new direction, because the two
+    // bounds are not commensurable — there is no value at which `<=0.99` is
+    // "no weaker than" `>=0.99`. The honest verdict is that the change cannot
+    // be proven safe, so it belongs in the existing allow-list path where a
+    // human records why, not in a comparison that would have to invent an
+    // ordering between incomparable gates.
+    if (currentC.direction !== baseC.direction) {
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: baseC.value,
+        current: currentC.value,
+        message: `${relPath}: ${key} changed bound direction (${baseC.direction} → ${currentC.direction}) — the gate's meaning is inverted, so preserving it cannot be proven from the value alone.`,
+      });
+      continue;
+    }
     const weakened =
       baseC.direction === "min"
         ? currentC.value < baseC.value

--- a/plugins/lisa-cursor/hooks/threshold-ratchet-compare.mjs
+++ b/plugins/lisa-cursor/hooks/threshold-ratchet-compare.mjs
@@ -72,6 +72,29 @@ export function compareConstraints(relPath, base, current) {
       });
       continue;
     }
+    // A bound's DIRECTION carries as much of the gate as its number. Flipping
+    // `rate>=0.99` to `rate<=0.99` keeps the key and the value and inverts the
+    // meaning: "at least 99% success" becomes "at most 99% success", a gate
+    // that now passes when the system is broken. Comparing only values, that
+    // read as unchanged.
+    //
+    // Rejected rather than re-evaluated in the new direction, because the two
+    // bounds are not commensurable — there is no value at which `<=0.99` is
+    // "no weaker than" `>=0.99`. The honest verdict is that the change cannot
+    // be proven safe, so it belongs in the existing allow-list path where a
+    // human records why, not in a comparison that would have to invent an
+    // ordering between incomparable gates.
+    if (currentC.direction !== baseC.direction) {
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: baseC.value,
+        current: currentC.value,
+        message: `${relPath}: ${key} changed bound direction (${baseC.direction} → ${currentC.direction}) — the gate's meaning is inverted, so preserving it cannot be proven from the value alone.`,
+      });
+      continue;
+    }
     const weakened =
       baseC.direction === "min"
         ? currentC.value < baseC.value

--- a/plugins/lisa/hooks/threshold-ratchet-compare.mjs
+++ b/plugins/lisa/hooks/threshold-ratchet-compare.mjs
@@ -72,6 +72,29 @@ export function compareConstraints(relPath, base, current) {
       });
       continue;
     }
+    // A bound's DIRECTION carries as much of the gate as its number. Flipping
+    // `rate>=0.99` to `rate<=0.99` keeps the key and the value and inverts the
+    // meaning: "at least 99% success" becomes "at most 99% success", a gate
+    // that now passes when the system is broken. Comparing only values, that
+    // read as unchanged.
+    //
+    // Rejected rather than re-evaluated in the new direction, because the two
+    // bounds are not commensurable — there is no value at which `<=0.99` is
+    // "no weaker than" `>=0.99`. The honest verdict is that the change cannot
+    // be proven safe, so it belongs in the existing allow-list path where a
+    // human records why, not in a comparison that would have to invent an
+    // ordering between incomparable gates.
+    if (currentC.direction !== baseC.direction) {
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: baseC.value,
+        current: currentC.value,
+        message: `${relPath}: ${key} changed bound direction (${baseC.direction} → ${currentC.direction}) — the gate's meaning is inverted, so preserving it cannot be proven from the value alone.`,
+      });
+      continue;
+    }
     const weakened =
       baseC.direction === "min"
         ? currentC.value < baseC.value

--- a/plugins/src/base/hooks/threshold-ratchet-compare.mjs
+++ b/plugins/src/base/hooks/threshold-ratchet-compare.mjs
@@ -72,6 +72,29 @@ export function compareConstraints(relPath, base, current) {
       });
       continue;
     }
+    // A bound's DIRECTION carries as much of the gate as its number. Flipping
+    // `rate>=0.99` to `rate<=0.99` keeps the key and the value and inverts the
+    // meaning: "at least 99% success" becomes "at most 99% success", a gate
+    // that now passes when the system is broken. Comparing only values, that
+    // read as unchanged.
+    //
+    // Rejected rather than re-evaluated in the new direction, because the two
+    // bounds are not commensurable — there is no value at which `<=0.99` is
+    // "no weaker than" `>=0.99`. The honest verdict is that the change cannot
+    // be proven safe, so it belongs in the existing allow-list path where a
+    // human records why, not in a comparison that would have to invent an
+    // ordering between incomparable gates.
+    if (currentC.direction !== baseC.direction) {
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: baseC.value,
+        current: currentC.value,
+        message: `${relPath}: ${key} changed bound direction (${baseC.direction} → ${currentC.direction}) — the gate's meaning is inverted, so preserving it cannot be proven from the value alone.`,
+      });
+      continue;
+    }
     const weakened =
       baseC.direction === "min"
         ? currentC.value < baseC.value

--- a/rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs
+++ b/rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs
@@ -72,6 +72,29 @@ export function compareConstraints(relPath, base, current) {
       });
       continue;
     }
+    // A bound's DIRECTION carries as much of the gate as its number. Flipping
+    // `rate>=0.99` to `rate<=0.99` keeps the key and the value and inverts the
+    // meaning: "at least 99% success" becomes "at most 99% success", a gate
+    // that now passes when the system is broken. Comparing only values, that
+    // read as unchanged.
+    //
+    // Rejected rather than re-evaluated in the new direction, because the two
+    // bounds are not commensurable — there is no value at which `<=0.99` is
+    // "no weaker than" `>=0.99`. The honest verdict is that the change cannot
+    // be proven safe, so it belongs in the existing allow-list path where a
+    // human records why, not in a comparison that would have to invent an
+    // ordering between incomparable gates.
+    if (currentC.direction !== baseC.direction) {
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: baseC.value,
+        current: currentC.value,
+        message: `${relPath}: ${key} changed bound direction (${baseC.direction} → ${currentC.direction}) — the gate's meaning is inverted, so preserving it cannot be proven from the value alone.`,
+      });
+      continue;
+    }
     const weakened =
       baseC.direction === "min"
         ? currentC.value < baseC.value

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -629,7 +629,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/sonar-secrets.sh":
       "bf4132e49ba18e2f7e941520c299c15aeeacfd220e489f3d2eb8397f2048157b",
     "plugins/src/base/hooks/threshold-ratchet-compare.mjs":
-      "4535a145c5c5cbee13bdf970bc91d390a264043604e607288cdd6bf28de56192",
+      "90affbeaed0d65c032dccfc0bd4a4b26eda291f6b61aa8b12599f41842452e0a",
     "plugins/src/base/hooks/threshold-ratchet-families.mjs":
       "db14245ed89b483912af287bdee917a7a921dc21bb29b49be37fc799c05c413f",
     "plugins/src/base/hooks/threshold-ratchet.mjs":
@@ -1899,7 +1899,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/copy-overwrite/scripts/lisa-clean-git-env.sh":
       "e7121a0ee9e1bf7c01cd2ab55f563dd6d9ab75990739bb6ddf571a513efa10e9",
     "rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs":
-      "4535a145c5c5cbee13bdf970bc91d390a264043604e607288cdd6bf28de56192",
+      "90affbeaed0d65c032dccfc0bd4a4b26eda291f6b61aa8b12599f41842452e0a",
     "rails/copy-overwrite/scripts/threshold-ratchet-families.mjs":
       "db14245ed89b483912af287bdee917a7a921dc21bb29b49be37fc799c05c413f",
     "rails/copy-overwrite/sgconfig.yml":
@@ -2147,7 +2147,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/scripts/lisa-mutation.mjs":
       "7d8d24dea151ef2178807046e97aea7ebfadd9c88eb50347feb7bb4bb190227d",
     "typescript/copy-overwrite/scripts/threshold-ratchet-compare.mjs":
-      "4535a145c5c5cbee13bdf970bc91d390a264043604e607288cdd6bf28de56192",
+      "90affbeaed0d65c032dccfc0bd4a4b26eda291f6b61aa8b12599f41842452e0a",
     "typescript/copy-overwrite/scripts/threshold-ratchet-families.mjs":
       "db14245ed89b483912af287bdee917a7a921dc21bb29b49be37fc799c05c413f",
     "typescript/copy-overwrite/sgconfig.yml":

--- a/tests/unit/scripts/threshold-ratchet-gates.test.ts
+++ b/tests/unit/scripts/threshold-ratchet-gates.test.ts
@@ -134,6 +134,18 @@ describe("threshold-ratchet tiers 2 and 3", () => {
       expect(findings[0].type).toBe("weakened");
     });
 
+    it("blocks flipping a bound's direction at the same value", () => {
+      // `rate>=0.99` → `rate<=0.99` keeps the key and the number and inverts
+      // the gate: "at least 99% of checks pass" becomes "at most 99% pass",
+      // which succeeds when the system is broken. Comparing values alone, this
+      // read as no change at all.
+      const current = base.replace(RATE_LOWER, "rate<=0.99");
+      const findings = compareFile(K6_FILE, base, current);
+      expect(findings).toHaveLength(1);
+      expect(findings[0].type).toBe("weakened");
+      expect(findings[0].message).toContain("direction");
+    });
+
     it("blocks turning off abortOnFail", () => {
       const current = base.replace('"abortOnFail":true', '"abortOnFail":false');
       const findings = compareFile(K6_FILE, base, current);

--- a/typescript/copy-overwrite/scripts/threshold-ratchet-compare.mjs
+++ b/typescript/copy-overwrite/scripts/threshold-ratchet-compare.mjs
@@ -72,6 +72,29 @@ export function compareConstraints(relPath, base, current) {
       });
       continue;
     }
+    // A bound's DIRECTION carries as much of the gate as its number. Flipping
+    // `rate>=0.99` to `rate<=0.99` keeps the key and the value and inverts the
+    // meaning: "at least 99% success" becomes "at most 99% success", a gate
+    // that now passes when the system is broken. Comparing only values, that
+    // read as unchanged.
+    //
+    // Rejected rather than re-evaluated in the new direction, because the two
+    // bounds are not commensurable — there is no value at which `<=0.99` is
+    // "no weaker than" `>=0.99`. The honest verdict is that the change cannot
+    // be proven safe, so it belongs in the existing allow-list path where a
+    // human records why, not in a comparison that would have to invent an
+    // ordering between incomparable gates.
+    if (currentC.direction !== baseC.direction) {
+      findings.push({
+        file: relPath,
+        key,
+        type: TYPE_WEAKENED,
+        base: baseC.value,
+        current: currentC.value,
+        message: `${relPath}: ${key} changed bound direction (${baseC.direction} → ${currentC.direction}) — the gate's meaning is inverted, so preserving it cannot be proven from the value alone.`,
+      });
+      continue;
+    }
     const weakened =
       baseC.direction === "min"
         ? currentC.value < baseC.value


### PR DESCRIPTION
Third and last of the fail-open findings. The other two shipped in #2391 — this was going to be folded in, but #2391 auto-merged first, so it stands alone.

## The hole

A k6 threshold can change from `rate>=0.99` to `rate<=0.99` — same key, same number. "At least 99% of checks pass" becomes "at most 99% pass", a gate that now **succeeds when the system is broken**. The comparator only looked at values, so this read as no change at all.

## Why reject rather than re-evaluate

The two bounds are not commensurable: there is no value at which `<=0.99` is "no weaker than" `>=0.99`. The honest verdict is that the change cannot be proven safe from the value alone, so it routes to the existing allow-list path where a human records why — instead of forcing the comparator to invent an ordering between incomparable gates.

## Verification

Checked in both directions, because a passing test on already-correct code proves nothing:

- **Without** the fix, the new test fails with `expected [] to have a length of 1` — the direction flip produced *no findings whatsoever*, which is the fail-open stated plainly.
- **With** it, 42 tests pass across `threshold-ratchet`, `threshold-ratchet-gates` and `threshold-ratchet-wiring`.

Applied to the canonical module and fanned out, so the stack templates stay byte-identical — the wiring test enforces that and passes.

Work-Item: CodySwannGT/lisa#2389

🤖 Generated with Claude Code