### PR TITLE
feat(parity): refresh the safety-net pin to 2.0.1 and correct its inventory

### DIFF
--- a/parity/FOLLOWUPS.md
+++ b/parity/FOLLOWUPS.md
@@ -64,9 +64,9 @@ maps to an upstream plugin publishing semver still carries its `synced-from` pin
 | ----------------------------------- | --------------------------------------------- |
 | `parity-code-simplifier`            | `code-simplifier@claude-plugins-official@1.0.0`     |
 | `parity-coderabbit`                 | `coderabbit@claude-plugins-official@1.1.1`          |
-| `parity-safety-net-rules`           | `safety-net@cc-marketplace@0.9.0`                   |
-| `parity-sentry-seer`                | `sentry@claude-plugins-official@1.0.0`              |
-| `parity-sentry-sdk-setup`           | `sentry@claude-plugins-official@1.0.0`              |
+| `parity-safety-net-rules`           | `safety-net@cc-marketplace@2.0.1`                   |
+| `parity-sentry-seer`                | `sentry@claude-plugins-official@1.3.1`              |
+| `parity-sentry-sdk-setup`           | `sentry@claude-plugins-official@1.3.1`              |
 | `parity-code-review`                | **no pin** — upstream has no semver → not drift-trackable (track manually) |
 | `parity-skill-creator`              | **no pin** — upstream has no semver → not drift-trackable (track manually) |
 
@@ -91,3 +91,40 @@ guard rules the hook enforces.
 - **All 7 routing artifacts approved** under `parity/plugin-routing/`:
   `code-review`, `code-simplifier`, `coderabbit`, `safety-net`, `sentry`,
   `skill-creator`, `typescript-lsp`.
+
+---
+
+## 5. `safety-net` 2.0 guard families NOT absorbed (deferred)
+
+The 2026-08-11 re-pin to `safety-net@cc-marketplace@2.0.1` refreshed the pin and the
+routing artifact but **did not absorb** the two guard families upstream introduced in
+2.0.0. Both gaps were measured, not assumed — the probe table (upstream `explain`
+verdicts beside live `parity-safety-net.sh` exit codes) is in
+`parity/plugin-routing/safety-net@cc-marketplace.md`.
+
+| upstream family | what it blocks | Lisa hook today |
+| --------------- | -------------- | --------------- |
+| `secret.*` | reading or copying SSH private keys, `.env` and `.env.*` files, AWS/gcloud credentials, coding-CLI credential stores, `.npmrc`, `*.key` | allows all |
+| `rm.git-metadata` | deleting the `.git` control plane (the directory itself, `.git/hooks/*`) | allows |
+
+**Why deferred rather than folded into the pin refresh.** This mirrors how the 1.0.6
+refresh was sequenced: the pin bump landed first and the guard absorption followed as
+its own tracked work (#1960) with a research audit and a fixture matrix. Two specifics
+make `secret.*` more than a pin-refresh change:
+
+- **It needs a new matcher surface.** `parity-safety-net.sh` is registered as a
+  `PreToolUse` matcher on `Bash` only. Upstream 2.0 screens file tools as well, so the
+  file-tool half of its coverage is unreachable from Lisa's hook without a registration
+  change that ships to **every** downstream project.
+- **It is a curated corpus, not a rule.** The family is a large path/basename/extension
+  pattern set (nine distinct rule ids observed in a twelve-case probe alone), and a
+  text-scan hook over-blocking on paths like `.env.example` would train users to work
+  around the safety net — the exact failure mode the skill warns against.
+
+`rm.git-metadata` is small and low-risk by comparison and is the natural first slice.
+
+**Not yet decided:** whether to absorb these into `parity-safety-net.sh` or to reverse
+#1960 and adopt upstream's native per-CLI integrations (2.0 ships an installer for
+twelve agent CLIs, including Codex, Antigravity, Cursor, and Copilot CLI). The second
+option would retire Lisa's own hook and is an owner-level standards call — see the
+flagged addendum in `parity/plugin-routing/safety-net@cc-marketplace.md`.

--- a/parity/FOLLOWUPS.md
+++ b/parity/FOLLOWUPS.md
@@ -45,9 +45,21 @@ and Lisa should prefer enabling those over reimplementing.
 | safety-net       | native hook runner (`cc-safety-net --copilot-cli`)          |
 
 There is **no Lisa mechanism** to enable a third-party vendor's plugin inside Copilot's
-marketplace from Lisa's side — these are **user-enabled native capabilities**. They are
-documented here and **not emitted by Lisa**. (Note: `coderabbit`'s `autofix` skill has no
-native Copilot equivalent, so it is reimplemented — see §3.)
+marketplace from Lisa's side — these are **user-enabled native capabilities** that Lisa
+itself never activates. (Note: `coderabbit`'s `autofix` skill has no native Copilot
+equivalent, so it is reimplemented — see §3.)
+
+**Correction for `safety-net` (2026-08-11 re-review).** "Not emitted by Lisa" does not
+hold for the `safety-net` row the way it was previously worded: the reimplemented
+`parity-safety-net.sh` hook and `lisa-parity-safety-net-rules` skill (see §3) ship into
+the generated Copilot plugin artifact via the same universal base-plugin fan-out every
+other agent gets — `generate-copilot-plugin-artifacts.mjs` has no safety-net-specific
+exclusion for them. What Lisa does not do is enable the *vendor's own* `cc-safety-net`
+runner inside Copilot's marketplace — a user who wants that installs
+`cc-safety-net --copilot-cli` themselves, and it then runs alongside Lisa's hook rather
+than replacing it. See `parity/plugin-routing/safety-net@cc-marketplace.md`'s "Flagged
+for owner review" addendum for the open question of whether to suppress the Lisa hook
+on Copilot instead.
 
 ---
 

--- a/parity/plugin-routing/safety-net@cc-marketplace.json
+++ b/parity/plugin-routing/safety-net@cc-marketplace.json
@@ -3,8 +3,8 @@
   "plugin": "safety-net@cc-marketplace",
   "pluginName": "safety-net",
   "marketplace": "cc-marketplace",
-  "upstreamVersion": "1.0.6",
-  "analyzedAt": "2026-07-22",
+  "upstreamVersion": "2.0.1",
+  "analyzedAt": "2026-08-11",
   "status": "approved",
   "components": [
     {
@@ -12,52 +12,45 @@
       "id": "pretooluse-bash-guard",
       "path": "hooks/hooks.json",
       "classification": "hook",
-      "notes": "PreToolUse Bash guard that runs dist/bin/cc-safety-net.js --claude-code to block destructive git/filesystem commands."
+      "notes": "PreToolUse guard that runs dist/bin/cc-safety-net.js hook --coding-cli. Byte-identical to 1.0.6; the engine behind it was rebuilt in 2.0.0 (canonical command IR, ordered guard pipeline, `explain` decision tracing) and grew two guard families Lisa does not mirror — secret-protection (secret.*) and rm.git-metadata. As of 2.0.0 the upstream matcher also screens file tools, not just Bash."
     },
     {
       "kind": "skill",
-      "id": "set-custom-rules",
-      "path": "skills/set-custom-rules/SKILL.md",
+      "id": "cc-safety-net",
+      "path": "skills/cc-safety-net/SKILL.md",
       "classification": "claude-skill",
-      "notes": "Configures custom safety-net rules."
-    },
-    {
-      "kind": "skill",
-      "id": "verify-custom-rules",
-      "path": "skills/verify-custom-rules/SKILL.md",
-      "classification": "claude-skill",
-      "notes": "Validates custom safety-net rules."
+      "notes": "Single consolidated rule-management skill, byte-identical between 1.0.6 and 2.0.1. Supersedes the 0.9.0-era set-custom-rules + verify-custom-rules pair that this artifact still listed through the 1.0.6 re-review (inventory corrected here). Drives the JSON rulebook via `cc-safety-net rule`."
     }
   ],
   "routing": {
     "codex": {
       "outcome": "reimplement",
       "actions": [
-        "scaffold a Lisa-native PreToolUse hook (fanned out via the per-agent hook generators from #1054–#1058) stamped synced-from: safety-net@cc-marketplace@0.9.0",
-        "reimplement the set-custom-rules and verify-custom-rules skills as Lisa-native skills stamped synced-from: safety-net@cc-marketplace@0.9.0"
+        "keep the Lisa-native PreToolUse hook (plugins/src/base/hooks/parity-safety-net.sh, fanned out via the per-agent hook generators from #1054–1058) as the canonical Bash guard, stamped synced-from: safety-net@cc-marketplace@2.0.1",
+        "keep the consolidated lisa-parity-safety-net-rules skill as the Lisa-native equivalent of the upstream cc-safety-net rule-management skill, stamped synced-from: safety-net@cc-marketplace@2.0.1"
       ],
-      "rationale": "A hook-bearing plugin has no MCP/LSP re-point; reimplement as a Lisa-native hook (via the existing per-agent hook generators) plus reimplement the two rule-management skills so no component group is dropped."
+      "rationale": "A hook-bearing plugin has no MCP/LSP re-point. Upstream 2.0 does now publish a native Codex integration (`cc-safety-net install --codex`), which would ordinarily outrank reimplement in the preference order — but it is an npx/Node installer that writes per-agent config outside Lisa's distribution model, and #1960 already made the Lisa hook canonical on every agent precisely so one audited guard set ships identically everywhere without an npx dependency. Keeping reimplement preserves that decision; the vendor-integration option is flagged for owner review in the addendum rather than taken unilaterally."
     },
     "cursor": {
       "outcome": "claude-only",
       "actions": [],
-      "rationale": "Cursor reads .claude-plugin/ natively; the hook and both skills load unchanged."
+      "rationale": "Cursor reads .claude-plugin/ natively, so Lisa's own hook and rules skill load unchanged. The upstream plugin itself stays uninstalled (retired in #1960) so a Cursor session is screened by one guard engine, not two."
     },
     "agy": {
       "outcome": "reimplement",
       "actions": [
-        "scaffold a Lisa-native PreToolUse hook (fanned out via the per-agent hook generators from #1054–#1058) stamped synced-from: safety-net@cc-marketplace@0.9.0",
-        "reimplement the set-custom-rules and verify-custom-rules skills as Lisa-native skills stamped synced-from: safety-net@cc-marketplace@0.9.0"
+        "keep the Lisa-native PreToolUse hook (plugins/src/base/hooks/parity-safety-net.sh, fanned out via the per-agent hook generators from #1054–1058) as the canonical Bash guard, stamped synced-from: safety-net@cc-marketplace@2.0.1",
+        "keep the consolidated lisa-parity-safety-net-rules skill as the Lisa-native equivalent of the upstream cc-safety-net rule-management skill, stamped synced-from: safety-net@cc-marketplace@2.0.1"
       ],
-      "rationale": "Curated third-party plugins are not in agy's fan-out; reimplement as a Lisa-native hook plus the two rule-management skills."
+      "rationale": "Curated third-party plugins are not in agy's fan-out, so agy receives nothing natively. Upstream 2.0 ships an Antigravity CLI installer, but the same npx-dependency and dual-engine objections as Codex apply; the Lisa hook stays canonical and the vendor option is flagged for owner review."
     },
     "copilot": {
       "outcome": "enable-vendor-equivalent",
       "actions": [
-        "enable safety-net's native Copilot CLI hook runner (cc-safety-net --copilot-cli) in the project-scoped marketplace",
-        "the set-custom-rules and verify-custom-rules skills are covered by cc-safety-net's native built-in commands for the Copilot CLI runner"
+        "the PreToolUse hook is covered by safety-net's native Copilot CLI hook runner (cc-safety-net install --copilot-cli), enabled by the user — Lisa emits nothing (see parity/FOLLOWUPS.md §2)",
+        "the cc-safety-net rule-management skill is covered by the same runner's built-in `cc-safety-net rule` commands"
       ],
-      "rationale": "safety-net ships a concrete Copilot CLI hook runner (cc-safety-net --copilot-cli) plus built-in rule-management commands, so enable the vendor's native Copilot support rather than reimplementing."
+      "rationale": "safety-net ships a concrete, named Copilot CLI hook runner plus built-in rule-management commands, so the vendor's native support is preferred over reimplementing. Unchanged from the 1.0.6 review; 2.0 keeps the Copilot CLI target."
     }
   }
 }

--- a/parity/plugin-routing/safety-net@cc-marketplace.json
+++ b/parity/plugin-routing/safety-net@cc-marketplace.json
@@ -47,10 +47,11 @@
     "copilot": {
       "outcome": "enable-vendor-equivalent",
       "actions": [
-        "the PreToolUse hook is covered by safety-net's native Copilot CLI hook runner (cc-safety-net install --copilot-cli), enabled by the user — Lisa emits nothing (see parity/FOLLOWUPS.md §2)",
-        "the cc-safety-net rule-management skill is covered by the same runner's built-in `cc-safety-net rule` commands"
+        "Correction (this re-review): the Lisa-native PreToolUse hook (parity-safety-net.sh) and the consolidated lisa-parity-safety-net-rules skill DO ship into the generated Copilot plugin artifact — they are part of the universal base-plugin fan-out (#1054-1058) that every agent variant receives, and the Copilot generator has no safety-net-specific exclusion for them. 'Lisa emits nothing' (the prior wording) was inaccurate.",
+        "safety-net's own native Copilot CLI hook runner (cc-safety-net install --copilot-cli) remains a separate, user-opt-in installation the user enables independently. If the user installs it, the vendor runner and the Lisa-native hook run side by side (both engines active) rather than Lisa emitting nothing — see parity/FOLLOWUPS.md §2",
+        "the same applies to rule management: Lisa's lisa-parity-safety-net-rules skill ships regardless of whether the user has the vendor runner's built-in `cc-safety-net rule` commands installed"
       ],
-      "rationale": "safety-net ships a concrete, named Copilot CLI hook runner plus built-in rule-management commands, so the vendor's native support is preferred over reimplementing. Unchanged from the 1.0.6 review; 2.0 keeps the Copilot CLI target."
+      "rationale": "safety-net ships a concrete, named Copilot CLI hook runner plus built-in rule-management commands, so the original 1.0.6 review preferred enabling that vendor runner over reimplementing specifically for Copilot. In practice, the universal reimplement fan-out landed in #1050 for every agent variant (Codex, cursor, agy, copilot) as the audited Lisa-native guard, so Copilot receives Lisa's own hook/skill regardless of this outcome label. The `enable-vendor-equivalent` outcome is kept because the vendor runner is still the preferred *additional* option when a user wants Copilot-CLI-native tooling, but the actions above now document the real dual-engine coexistence instead of a 'Lisa emits nothing' claim that the generated artifact contradicts. Whether to actively exclude the Lisa hook/skill from Copilot (making this outcome literally true) is an owner-level call — see the 'Flagged for owner review' addendum in parity/plugin-routing/safety-net@cc-marketplace.md."
     }
   }
 }

--- a/parity/plugin-routing/safety-net@cc-marketplace.md
+++ b/parity/plugin-routing/safety-net@cc-marketplace.md
@@ -25,7 +25,7 @@
 | codex | `reimplement` | - keep the Lisa-native PreToolUse hook (`parity-safety-net.sh`, fanned out via the #1054–1058 hook generators) as the canonical Bash guard, stamped synced-from: safety-net@cc-marketplace@2.0.1<br>- keep the consolidated `lisa-parity-safety-net-rules` skill as the Lisa-native equivalent of the upstream `cc-safety-net` skill, stamped synced-from: safety-net@cc-marketplace@2.0.1 | No MCP/LSP re-point exists for a hook plugin. Upstream 2.0 now publishes a native Codex integration, which would ordinarily outrank `reimplement` — see the flagged decision below. |
 | cursor | `claude-only` | _(none)_ | Cursor reads `.claude-plugin/` natively, so Lisa's hook and rules skill load unchanged. The upstream plugin stays uninstalled (retired in #1960) so a session is screened by one guard engine, not two. |
 | agy | `reimplement` | - keep the Lisa-native PreToolUse hook (`parity-safety-net.sh`, fanned out via the #1054–1058 hook generators) as the canonical Bash guard, stamped synced-from: safety-net@cc-marketplace@2.0.1<br>- keep the consolidated `lisa-parity-safety-net-rules` skill as the Lisa-native equivalent of the upstream `cc-safety-net` skill, stamped synced-from: safety-net@cc-marketplace@2.0.1 | Curated third-party plugins are not in agy's fan-out, so agy receives nothing natively. Same flagged decision as Codex. |
-| copilot | `enable-vendor-equivalent` | - the hook is covered by safety-net's native Copilot CLI hook runner (`cc-safety-net install --copilot-cli`), enabled by the user — Lisa emits nothing (see `parity/FOLLOWUPS.md` §2)<br>- the rule-management skill is covered by the same runner's built-in `cc-safety-net rule` commands | The vendor ships a concrete, named Copilot CLI runner plus built-in rule management. Unchanged from the 1.0.6 review. |
+| copilot | `enable-vendor-equivalent` | - **Correction (this re-review):** the Lisa-native `parity-safety-net.sh` hook and `lisa-parity-safety-net-rules` skill DO ship into the generated Copilot artifact via the universal base-plugin fan-out (#1054–1058); the Copilot generator has no safety-net-specific exclusion. The prior "Lisa emits nothing" wording was inaccurate.<br>- safety-net's native Copilot CLI hook runner (`cc-safety-net install --copilot-cli`) remains a separate, user-opt-in install; if enabled, it runs alongside the Lisa hook (dual engine), not instead of it (see `parity/FOLLOWUPS.md` §2)<br>- likewise the rule-management skill ships regardless of whether the user has the vendor runner's built-in `cc-safety-net rule` commands installed | The vendor ships a concrete, named Copilot CLI runner plus built-in rule management, which is why `enable-vendor-equivalent` was preferred over `reimplement` for Copilot in the 1.0.6 review. In practice the #1050 universal fan-out ships Lisa's own hook/skill to every agent variant including Copilot regardless of this outcome label, so the actions above now document the real dual-engine coexistence. Whether to actively exclude the Lisa hook/skill from Copilot (making the outcome literally true) is an owner-level call — see "Flagged for owner review" below. |
 
 > Review the routing, then flip `"status": "proposed"` → `"approved"` in the paired `.json` to authorize `implement-plugin-parity`.
 
@@ -46,8 +46,8 @@ twelve agent CLIs).
 Each case below was run through **both** engines — upstream via
 `node dist/bin/cc-safety-net.js explain --json <cmd>` (reading the `result` and
 `ruleId` fields) and Lisa's hook via a fake `PreToolUse` payload piped to
-`parity-safety-net.sh`, asserting the exit code. Two upstream guard families
-introduced in 2.0.0 have **no Lisa counterpart**:
+`parity-safety-net.sh`, asserting the exit code. The two comparable upstream
+guard families introduced in 2.0.0 have **no Lisa counterpart**:
 
 | upstream rule id | probe | upstream | Lisa hook |
 | --- | --- | --- | --- |
@@ -62,7 +62,7 @@ introduced in 2.0.0 have **no Lisa counterpart**:
 | `secret.ext-pattern.key` | `cat /etc/ssl/private/server.key` | BLOCK | allow |
 | `rm.git-metadata` | recursive delete of `.git` | BLOCK | allow |
 | `rm.git-metadata` | `rm .git/hooks/pre-commit` | BLOCK | allow |
-| `policy-protection` | delete of upstream's own policy file | BLOCK | allow (n/a — Lisa has no such file) |
+| `policy-protection` | delete of upstream's own policy file | BLOCK | n/a (non-comparable; Lisa has no such file) |
 
 Control cases (`ls -la`, `echo FOO=1 >> .env.example`) are allowed by both, and
 the README's broader "Git metadata mutation" claim is **narrower in practice**
@@ -98,5 +98,23 @@ dependency that writes per-agent config outside Lisa's distribution model;
 guard set ships identically everywhere; and `parity/FOLLOWUPS.md` §2 already
 records that Lisa has no mechanism to enable a third-party vendor plugin inside
 another agent's marketplace — `enable-vendor-equivalent` is documented as a
-user-enabled, manual outcome that Lisa never emits. Reversing #1960 is an
-owner-level standards call, so it is surfaced here rather than decided.
+user-enabled, manual outcome that Lisa itself never *activates*. Reversing
+#1960 is an owner-level standards call, so it is surfaced here rather than
+decided.
+
+**Correction (this re-review, addressing a review finding):** "Lisa itself
+never emits" was previously mis-stated as "Lisa emits nothing" for Copilot
+specifically. That is not true of the *hook and skill files* — the #1050
+universal base-plugin fan-out ships `parity-safety-net.sh` and
+`lisa-parity-safety-net-rules` into the generated Copilot artifact exactly as
+it does for every other agent, with no safety-net-specific carve-out in
+`generate-copilot-plugin-artifacts.mjs`. What Lisa does not do is *enable the
+vendor's own plugin/runner* inside Copilot's marketplace — that part of the
+claim holds. So today a Copilot user who also opts into
+`cc-safety-net install --copilot-cli` runs **both** engines side by side. The
+per-agent routing table above and `parity/FOLLOWUPS.md` §2 have been corrected
+to describe this dual-engine coexistence rather than "Lisa emits nothing."
+Deciding whether to suppress the Lisa hook/skill for Copilot specifically (so
+the vendor runner is the sole guard there) is the same owner-level call as the
+Codex/agy vendor-integration question above, and is left open pending that
+decision.

--- a/parity/plugin-routing/safety-net@cc-marketplace.md
+++ b/parity/plugin-routing/safety-net@cc-marketplace.md
@@ -1,56 +1,102 @@
 # Parity routing review — `safety-net@cc-marketplace`
 
 - **Plugin:** `safety-net@cc-marketplace`
-- **Upstream version:** `1.0.6`
-- **Analyzed:** 2026-07-22 (re-review; originally 2026-05-30 at 0.9.0)
+- **Upstream version:** `2.0.1`
+- **Analyzed:** 2026-08-11 (re-review; previously 2026-07-22 at 1.0.6, originally 2026-05-30 at 0.9.0)
 - **Status:** `approved`
 
 ## Components
 
 | kind | id | path | classification | notes |
 | --- | --- | --- | --- | --- |
-| hook | `pretooluse-bash-guard` | `hooks/hooks.json` | hook | PreToolUse Bash guard that runs dist/bin/cc-safety-net.js --claude-code to block destructive git/filesystem commands. |
-| skill | `set-custom-rules` | `skills/set-custom-rules/SKILL.md` | claude-skill | Configures custom safety-net rules. |
-| skill | `verify-custom-rules` | `skills/verify-custom-rules/SKILL.md` | claude-skill | Validates custom safety-net rules. |
+| hook | `pretooluse-bash-guard` | `hooks/hooks.json` | hook | PreToolUse guard running `dist/bin/cc-safety-net.js hook --coding-cli`. Byte-identical to 1.0.6; the engine behind it was rebuilt in 2.0.0 and grew two guard families Lisa does not mirror (`secret.*`, `rm.git-metadata`). As of 2.0.0 upstream also screens file tools, not just Bash. |
+| skill | `cc-safety-net` | `skills/cc-safety-net/SKILL.md` | claude-skill | Single consolidated rule-management skill, byte-identical between 1.0.6 and 2.0.1. Drives the JSON rulebook via `cc-safety-net rule`. |
+
+> **Inventory correction.** Through the 1.0.6 re-review this artifact still listed the
+> 0.9.0-era `set-custom-rules` + `verify-custom-rules` skill pair. Upstream had already
+> consolidated them into the single `cc-safety-net` skill by 1.0.6 — verified against the
+> cache tree, which contains only `skills/cc-safety-net/SKILL.md` at both 1.0.6 and 2.0.1.
+> The component list above is the corrected inventory.
 
 ## Per-agent routing
 
 | agent | outcome | actions | rationale |
 | --- | --- | --- | --- |
-| codex | `reimplement` | - scaffold a Lisa-native PreToolUse hook (fanned out via the per-agent hook generators from #1054–#1058) stamped synced-from: safety-net@cc-marketplace@0.9.0<br>- reimplement the set-custom-rules and verify-custom-rules skills as Lisa-native skills stamped synced-from: safety-net@cc-marketplace@0.9.0 | A hook-bearing plugin has no MCP/LSP re-point; reimplement as a Lisa-native hook (via the existing per-agent hook generators) plus reimplement the two rule-management skills so no component group is dropped. |
-| cursor | `claude-only` | _(none)_ | Cursor reads .claude-plugin/ natively; the hook and both skills load unchanged. |
-| agy | `reimplement` | - scaffold a Lisa-native PreToolUse hook (fanned out via the per-agent hook generators from #1054–#1058) stamped synced-from: safety-net@cc-marketplace@0.9.0<br>- reimplement the set-custom-rules and verify-custom-rules skills as Lisa-native skills stamped synced-from: safety-net@cc-marketplace@0.9.0 | Curated third-party plugins are not in agy's fan-out; reimplement as a Lisa-native hook plus the two rule-management skills. |
-| copilot | `enable-vendor-equivalent` | - enable safety-net's native Copilot CLI hook runner (cc-safety-net --copilot-cli) in the project-scoped marketplace<br>- the set-custom-rules and verify-custom-rules skills are covered by cc-safety-net's native built-in commands for the Copilot CLI runner | safety-net ships a concrete Copilot CLI hook runner (cc-safety-net --copilot-cli) plus built-in rule-management commands, so enable the vendor's native Copilot support rather than reimplementing. |
+| codex | `reimplement` | - keep the Lisa-native PreToolUse hook (`parity-safety-net.sh`, fanned out via the #1054–1058 hook generators) as the canonical Bash guard, stamped synced-from: safety-net@cc-marketplace@2.0.1<br>- keep the consolidated `lisa-parity-safety-net-rules` skill as the Lisa-native equivalent of the upstream `cc-safety-net` skill, stamped synced-from: safety-net@cc-marketplace@2.0.1 | No MCP/LSP re-point exists for a hook plugin. Upstream 2.0 now publishes a native Codex integration, which would ordinarily outrank `reimplement` — see the flagged decision below. |
+| cursor | `claude-only` | _(none)_ | Cursor reads `.claude-plugin/` natively, so Lisa's hook and rules skill load unchanged. The upstream plugin stays uninstalled (retired in #1960) so a session is screened by one guard engine, not two. |
+| agy | `reimplement` | - keep the Lisa-native PreToolUse hook (`parity-safety-net.sh`, fanned out via the #1054–1058 hook generators) as the canonical Bash guard, stamped synced-from: safety-net@cc-marketplace@2.0.1<br>- keep the consolidated `lisa-parity-safety-net-rules` skill as the Lisa-native equivalent of the upstream `cc-safety-net` skill, stamped synced-from: safety-net@cc-marketplace@2.0.1 | Curated third-party plugins are not in agy's fan-out, so agy receives nothing natively. Same flagged decision as Codex. |
+| copilot | `enable-vendor-equivalent` | - the hook is covered by safety-net's native Copilot CLI hook runner (`cc-safety-net install --copilot-cli`), enabled by the user — Lisa emits nothing (see `parity/FOLLOWUPS.md` §2)<br>- the rule-management skill is covered by the same runner's built-in `cc-safety-net rule` commands | The vendor ships a concrete, named Copilot CLI runner plus built-in rule management. Unchanged from the 1.0.6 review. |
 
-> Plan-only artifact. Review the routing, then flip `"status": "proposed"` → `"approved"` in the paired `.json` to authorize `implement-plugin-parity`.
+> Review the routing, then flip `"status": "proposed"` → `"approved"` in the paired `.json` to authorize `implement-plugin-parity`.
 
-## Addendum — 2026-07-22 re-review at upstream 1.0.6 (issue #1960)
+## Addendum — 2026-08-11 re-review at upstream 2.0.1
 
-Upstream 1.0.6 consolidated the two rule-management skills into a single
-`cc-safety-net` skill, moved custom rules to a JSON rulebook system driven by
-the `npx cc-safety-net rule` CLI, and grew the Bash-guard engine (semantic
-segment analysis, wrapper stripping, interpreter one-liner scanning). Lisa's
-`lisa-parity-safety-net-rules` skill deliberately keeps the flat ERE-lines-file
-design (auditable, no npx dependency, identical on every agent runtime) and is
-re-pinned at `1.0.6`.
+### What changed upstream (1.0.6 → 2.0.1)
 
-**Claude-side change.** The original routing left the upstream plugin installed
-on Claude/Cursor alongside Lisa's own `parity-safety-net.sh` PreToolUse hook,
-so every Bash command in a Claude session was screened twice by two different
-guard engines. As of issue #1960 the Lisa hook is canonical on every agent:
-its guard set was audited against upstream 1.0.6 (`.lisa/research-1960-guard-audit.md`)
-and every material default-mode guard was **reimplemented** (never ported) into
-`parity-safety-net.sh` — git discard family (checkout/switch/restore/stash/
-clean/branch -D/tag -d/reflog delete/worktree remove --force, reset --merge),
-rm target hardening (cwd `.`, `..`-traversal, out-of-project absolute paths
-with a /tmp+$TMPDIR allowance, `$VAR` targets, cwd=$HOME gate), quote-aware
-target boundaries (closing the `bash -c "rm -rf /"` / interpreter one-liner
-bypass), find/xargs deletion, always-on disk destroyers (dd/mkfs/shred), and a
-fail-closed exit-2 path for malformed hook input — proven by the 138-fixture
-matrix in `tests/unit/hooks/parity-safety-net-guards.test.ts`. Documented
-deliberate divergences kept: dirty-tree-only `reset --hard`,
-protected-branch-only force-push blocking, and Lisa-only guards upstream lacks
-(SQL DROP/TRUNCATE, bare `rm -rf *`, `git checkout .`). Mirroring the #1955
-sentry retirement, the upstream `safety-net@cc-marketplace` plugin is no longer
-installed (a version-gated uninstall retires existing installs) and the merge
-settings templates set its `enabledPlugins` entry to `false`.
+The **component surface did not change**: `hooks/hooks.json` and
+`skills/cc-safety-net/SKILL.md` are byte-identical between the two cached
+versions. What changed is entirely behind the hook — 2.0.0 was a major-version
+engine rebuild (canonical command IR, immutable policy snapshots, an ordered
+guard pipeline with `explain` decision tracing) plus new product surface
+(safety presets, a policy GUI, an audit log, and a universal installer covering
+twelve agent CLIs).
+
+### Guard-family gap (empirically measured, not inferred)
+
+Each case below was run through **both** engines — upstream via
+`node dist/bin/cc-safety-net.js explain --json <cmd>` (reading the `result` and
+`ruleId` fields) and Lisa's hook via a fake `PreToolUse` payload piped to
+`parity-safety-net.sh`, asserting the exit code. Two upstream guard families
+introduced in 2.0.0 have **no Lisa counterpart**:
+
+| upstream rule id | probe | upstream | Lisa hook |
+| --- | --- | --- | --- |
+| `secret.home.ssh` | `cat ~/.ssh/id_rsa` | BLOCK | allow |
+| `secret.home.ssh` | `cp ~/.ssh/id_ed25519 /tmp/x` | BLOCK | allow |
+| `secret.basename.env` | `cat .env` | BLOCK | allow |
+| `secret.pattern.env-variant` | `cat config/.env.production` | BLOCK | allow |
+| `secret.home.aws` | `cat ~/.aws/credentials` | BLOCK | allow |
+| `secret.home.gcloud-config` | `cat ~/.config/gcloud/credentials.db` | BLOCK | allow |
+| `secret.cli.claude-code` | `cat ~/.claude/.credentials.json` | BLOCK | allow |
+| `secret.basename.npmrc` | `cat ~/.npmrc` | BLOCK | allow |
+| `secret.ext-pattern.key` | `cat /etc/ssl/private/server.key` | BLOCK | allow |
+| `rm.git-metadata` | recursive delete of `.git` | BLOCK | allow |
+| `rm.git-metadata` | `rm .git/hooks/pre-commit` | BLOCK | allow |
+| `policy-protection` | delete of upstream's own policy file | BLOCK | allow (n/a — Lisa has no such file) |
+
+Control cases (`ls -la`, `echo FOO=1 >> .env.example`) are allowed by both, and
+the README's broader "Git metadata mutation" claim is **narrower in practice**
+than the prose suggests: upstream 2.0.1 allows `echo "x" > .git/config`,
+`git update-ref -d`, `git submodule deinit -f --all`, and recursive deletes of
+`.git/objects` and `.git/worktrees`.
+
+### Decision — re-pin now, absorb the gap under its own issue
+
+This re-review **re-pins to 2.0.1 and does not absorb the two new families**,
+matching how the 1.0.6 refresh was sequenced: the pin refresh landed first
+(`feat(parity): refresh drifted parity pins to current upstreams`) and the guard
+absorption followed as its own tracked work (#1960) with a research audit and a
+fixture matrix. Absorbing `secret.*` here would mean importing a large curated
+path/pattern corpus **and** registering the hook on file tools — today
+`parity-safety-net.sh` is a `Bash`-only `PreToolUse` matcher, so the file-tool
+half of upstream's coverage is not even reachable without a matcher change that
+ships to every downstream project. That is a behavioral change with
+cross-project blast radius and belongs behind its own review, not a pin refresh.
+Recorded as deferred work in `parity/FOLLOWUPS.md` §5.
+
+### Flagged for owner review — upstream now ships native multi-CLI integrations
+
+Upstream 2.0 added a universal installer covering **twelve** agent CLIs,
+including Codex, Antigravity, Cursor, and Copilot CLI. Under the locked
+preference order (`already-native > re-point-mcp-lsp > enable-vendor-equivalent
+> claude-only > reimplement`) a named vendor integration for Codex and agy would
+outrank `reimplement`, which would flip both cells and retire Lisa's own hook.
+
+That is **not** taken here, for three reasons: the installer is an npx/Node
+dependency that writes per-agent config outside Lisa's distribution model;
+#1960 deliberately made the Lisa hook canonical on every agent so one audited
+guard set ships identically everywhere; and `parity/FOLLOWUPS.md` §2 already
+records that Lisa has no mechanism to enable a third-party vendor plugin inside
+another agent's marketplace — `enable-vendor-equivalent` is documented as a
+user-enabled, manual outcome that Lisa never emits. Reversing #1960 is an
+owner-level standards call, so it is surfaced here rather than decided.

--- a/parity/plugin-routing/safety-net@cc-marketplace.md
+++ b/parity/plugin-routing/safety-net@cc-marketplace.md
@@ -43,11 +43,13 @@ twelve agent CLIs).
 
 ### Guard-family gap (empirically measured, not inferred)
 
-Each case below was run through **both** engines — upstream via
+Each comparable case below was run through **both** engines — upstream via
 `node dist/bin/cc-safety-net.js explain --json <cmd>` (reading the `result` and
 `ruleId` fields) and Lisa's hook via a fake `PreToolUse` payload piped to
-`parity-safety-net.sh`, asserting the exit code. The two comparable upstream
-guard families introduced in 2.0.0 have **no Lisa counterpart**:
+`parity-safety-net.sh`, asserting the exit code. The `policy-protection` row is
+non-comparable (Lisa has no policy file to probe) and is included only for
+completeness — see its `n/a` note. The two comparable upstream guard families
+introduced in 2.0.0 have **no Lisa counterpart**:
 
 | upstream rule id | probe | upstream | Lisa hook |
 | --- | --- | --- | --- |

--- a/parity/plugin-routing/sentry@claude-plugins-official.json
+++ b/parity/plugin-routing/sentry@claude-plugins-official.json
@@ -3,7 +3,7 @@
   "plugin": "sentry@claude-plugins-official",
   "pluginName": "sentry",
   "marketplace": "claude-plugins-official",
-  "upstreamVersion": "1.2.0",
+  "upstreamVersion": "1.3.1",
   "analyzedAt": "2026-07-22",
   "status": "approved",
   "components": [
@@ -90,8 +90,8 @@
       "outcome": "re-point-mcp-lsp",
       "actions": [
         "emit the sentry HTTP MCP into Codex's .codex-plugin MCP pointer",
-        "reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.2.0 (or claude-only where a skill is Claude-specific)",
-        "reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.2.0"
+        "reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.3.1 (or claude-only where a skill is Claude-specific)",
+        "reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.3.1"
       ],
       "rationale": "The dominant component is the sentry HTTP MCP, re-pointed into Codex's .codex-plugin pointer; the consolidated workflow skills (incl. the folded-in seer/debug workflow) are reimplemented as Lisa skills so no component group is dropped."
     },
@@ -107,8 +107,8 @@
       "outcome": "re-point-mcp-lsp",
       "actions": [
         "emit the sentry HTTP MCP via agy's user-global mcp-installer (src/agy/mcp-installer.ts)",
-        "reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.2.0 (or claude-only where Claude-specific)",
-        "reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.2.0"
+        "reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.3.1 (or claude-only where Claude-specific)",
+        "reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.3.1"
       ],
       "rationale": "The dominant component is the sentry HTTP MCP, re-pointed via agy's mcp-installer; the consolidated workflow skills (incl. the folded-in seer/debug workflow) are reimplemented as Lisa skills (agy's fan-out does not carry curated third-party plugins)."
     },
@@ -116,8 +116,8 @@
       "outcome": "re-point-mcp-lsp",
       "actions": [
         "emit the sentry HTTP MCP as an inline mcpServers entry on Copilot's manifest",
-        "reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.2.0 (or enable Copilot's native equivalent where applicable)",
-        "reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.2.0"
+        "reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.3.1 (or enable Copilot's native equivalent where applicable)",
+        "reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.3.1"
       ],
       "rationale": "The dominant component is the sentry HTTP MCP, emitted inline on Copilot's manifest; the consolidated workflow skills (incl. the folded-in seer/debug workflow) are reimplemented as Lisa skills so no component group is dropped."
     }

--- a/plugins/lisa-agy/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the custom guard rules enforced by Lisa's safety-net PreToolUse Bash hook (parity-safety-net.sh). The consolidated cross-agent equivalent of the upstream safety-net plugin's set-custom-rules + verify-custom-rules skills — manages a project-local list of extended-regex patterns that block destructive shell commands, on Codex, agy, Copilot, Cursor, and Claude."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@1.0.6
+synced-from: safety-net@cc-marketplace@2.0.1
 ---
 
 # Parity Safety-Net Rules
@@ -24,10 +24,21 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@1.0.6`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.1`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
+>
+> **Known gap at the 2.0.1 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> guard families this hook does **not** mirror: `secret.*` (blocks reading or
+> copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
+> stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both
+> were measured against this hook rather than assumed — see the probe table in
+> `parity/plugin-routing/safety-net@cc-marketplace.md`. Absorbing `secret.*` also
+> needs a matcher change, because this hook is registered on `Bash` only while
+> upstream also screens file tools. That work is tracked separately in
+> `parity/FOLLOWUPS.md` §5; **do not treat this skill's built-in guard list as
+> covering secret access.**
 
 ## How the rules work
 

--- a/plugins/lisa-copilot/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the custom guard rules enforced by Lisa's safety-net PreToolUse Bash hook (parity-safety-net.sh). The consolidated cross-agent equivalent of the upstream safety-net plugin's set-custom-rules + verify-custom-rules skills — manages a project-local list of extended-regex patterns that block destructive shell commands, on Codex, agy, Copilot, Cursor, and Claude."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@1.0.6
+synced-from: safety-net@cc-marketplace@2.0.1
 ---
 
 # Parity Safety-Net Rules
@@ -24,10 +24,21 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@1.0.6`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.1`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
+>
+> **Known gap at the 2.0.1 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> guard families this hook does **not** mirror: `secret.*` (blocks reading or
+> copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
+> stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both
+> were measured against this hook rather than assumed — see the probe table in
+> `parity/plugin-routing/safety-net@cc-marketplace.md`. Absorbing `secret.*` also
+> needs a matcher change, because this hook is registered on `Bash` only while
+> upstream also screens file tools. That work is tracked separately in
+> `parity/FOLLOWUPS.md` §5; **do not treat this skill's built-in guard list as
+> covering secret access.**
 
 ## How the rules work
 

--- a/plugins/lisa-cursor/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the custom guard rules enforced by Lisa's safety-net PreToolUse Bash hook (parity-safety-net.sh). The consolidated cross-agent equivalent of the upstream safety-net plugin's set-custom-rules + verify-custom-rules skills — manages a project-local list of extended-regex patterns that block destructive shell commands, on Codex, agy, Copilot, Cursor, and Claude."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@1.0.6
+synced-from: safety-net@cc-marketplace@2.0.1
 ---
 
 # Parity Safety-Net Rules
@@ -24,10 +24,21 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@1.0.6`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.1`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
+>
+> **Known gap at the 2.0.1 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> guard families this hook does **not** mirror: `secret.*` (blocks reading or
+> copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
+> stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both
+> were measured against this hook rather than assumed — see the probe table in
+> `parity/plugin-routing/safety-net@cc-marketplace.md`. Absorbing `secret.*` also
+> needs a matcher change, because this hook is registered on `Bash` only while
+> upstream also screens file tools. That work is tracked separately in
+> `parity/FOLLOWUPS.md` §5; **do not treat this skill's built-in guard list as
+> covering secret access.**
 
 ## How the rules work
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the…"
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@1.0.6
+synced-from: safety-net@cc-marketplace@2.0.1
 ---
 
 # Parity Safety-Net Rules
@@ -24,10 +24,21 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@1.0.6`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.1`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
+>
+> **Known gap at the 2.0.1 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> guard families this hook does **not** mirror: `secret.*` (blocks reading or
+> copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
+> stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both
+> were measured against this hook rather than assumed — see the probe table in
+> `parity/plugin-routing/safety-net@cc-marketplace.md`. Absorbing `secret.*` also
+> needs a matcher change, because this hook is registered on `Bash` only while
+> upstream also screens file tools. That work is tracked separately in
+> `parity/FOLLOWUPS.md` §5; **do not treat this skill's built-in guard list as
+> covering secret access.**
 
 ## How the rules work
 

--- a/plugins/lisa/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the custom guard rules enforced by Lisa's safety-net PreToolUse Bash hook (parity-safety-net.sh). The consolidated cross-agent equivalent of the upstream safety-net plugin's set-custom-rules + verify-custom-rules skills — manages a project-local list of extended-regex patterns that block destructive shell commands, on Codex, agy, Copilot, Cursor, and Claude."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@1.0.6
+synced-from: safety-net@cc-marketplace@2.0.1
 ---
 
 # Parity Safety-Net Rules
@@ -24,10 +24,21 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@1.0.6`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.1`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
+>
+> **Known gap at the 2.0.1 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> guard families this hook does **not** mirror: `secret.*` (blocks reading or
+> copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
+> stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both
+> were measured against this hook rather than assumed — see the probe table in
+> `parity/plugin-routing/safety-net@cc-marketplace.md`. Absorbing `secret.*` also
+> needs a matcher change, because this hook is registered on `Bash` only while
+> upstream also screens file tools. That work is tracked separately in
+> `parity/FOLLOWUPS.md` §5; **do not treat this skill's built-in guard list as
+> covering secret access.**
 
 ## How the rules work
 

--- a/plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the custom guard rules enforced by Lisa's safety-net PreToolUse Bash hook (parity-safety-net.sh). The consolidated cross-agent equivalent of the upstream safety-net plugin's set-custom-rules + verify-custom-rules skills — manages a project-local list of extended-regex patterns that block destructive shell commands, on Codex, agy, Copilot, Cursor, and Claude."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@1.0.6
+synced-from: safety-net@cc-marketplace@2.0.1
 ---
 
 # Parity Safety-Net Rules
@@ -24,10 +24,21 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@1.0.6`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.1`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
+>
+> **Known gap at the 2.0.1 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> guard families this hook does **not** mirror: `secret.*` (blocks reading or
+> copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
+> stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both
+> were measured against this hook rather than assumed — see the probe table in
+> `parity/plugin-routing/safety-net@cc-marketplace.md`. Absorbing `secret.*` also
+> needs a matcher change, because this hook is registered on `Bash` only while
+> upstream also screens file tools. That work is tracked separately in
+> `parity/FOLLOWUPS.md` §5; **do not treat this skill's built-in guard list as
+> covering secret access.**
 
 ## How the rules work
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1035,7 +1035,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-parity-coderabbit/SKILL.md":
       "ae882837d43741293d1b639c4516331fa6124fa1f5da234a74ecb31c5d7e52cd",
     "plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md":
-      "8757ea8c83e9acaad1af59f7b46d5ac7efaba61da76f9df3fc94b258f9a16b2b",
+      "35c4c9f5e77f73a0e33e2ec01a70198eeb6bf521ec793983c9e633cbcab7b69b",
     "plugins/src/base/skills/lisa-parity-sentry-sdk-setup/SKILL.md":
       "610890385568ae097b2a48c9d20e42104a1bf5a3ba06223a89086ef385542e3b",
     "plugins/src/base/skills/lisa-parity-sentry-seer/SKILL.md":


### PR DESCRIPTION
Closes #2402

Work-Item: CodySwannGT/lisa#2402

## Why

`plugin-parity-drift` reported `lisa-parity-safety-net-rules` **stale** (pinned `1.0.6`, cache holds `2.0.1`). `.husky/pre-push.local` treats `stale` as blocking, so **every push from a machine with the plugin cache was blocked**. This clears it.

Not a bare version bump — the analyze → approve → implement → rebuild path was followed, and the upstream delta was measured rather than assumed.

## What changed upstream (1.0.6 → 2.0.1)

The **component surface did not change**: `hooks/hooks.json` and `skills/cc-safety-net/SKILL.md` are byte-identical between the cached versions. 2.0.0 was an engine rebuild (canonical command IR, ordered guard pipeline, `explain` tracing) plus new product surface (presets, policy GUI, audit log, a twelve-CLI installer).

Two new guard families have **no counterpart** in `parity-safety-net.sh`. Each probe was run through upstream `explain --json` (reading `result` / `ruleId`) and through the live hook via a fake `PreToolUse` payload:

| upstream rule id | probe | upstream | Lisa hook |
| --- | --- | --- | --- |
| `secret.home.ssh` | `cat ~/.ssh/id_rsa` | BLOCK | allow |
| `secret.basename.env` | `cat .env` | BLOCK | allow |
| `secret.pattern.env-variant` | `cat config/.env.production` | BLOCK | allow |
| `secret.home.aws` | `cat ~/.aws/credentials` | BLOCK | allow |
| `secret.cli.claude-code` | `cat ~/.claude/.credentials.json` | BLOCK | allow |
| `secret.basename.npmrc` | `cat ~/.npmrc` | BLOCK | allow |
| `secret.ext-pattern.key` | `cat /etc/ssl/private/server.key` | BLOCK | allow |
| `rm.git-metadata` | recursive delete of `.git`; `rm .git/hooks/pre-commit` | BLOCK | allow |

Controls (`ls -la`, `echo FOO=1 >> .env.example`) allowed by both. Worth noting the README's "Git metadata mutation" claim is narrower in practice — 2.0.1 still allows `echo "x" > .git/config`, `git update-ref -d`, `git submodule deinit -f --all`, and recursive deletes of `.git/objects` and `.git/worktrees`.

## Why the gap is deferred, not absorbed

This mirrors how the 1.0.6 refresh was sequenced: the pin bump landed first, and the guard absorption followed as its own tracked work (#1960) with a research audit and a fixture matrix. Two specifics make `secret.*` more than a pin refresh:

- **It needs a new matcher surface.** `parity-safety-net.sh` is registered on `Bash` only; upstream 2.0 also screens file tools. The file-tool half is unreachable without a registration change that ships to **every** downstream project.
- **It is a curated corpus, not a rule** — nine distinct rule ids in a twelve-case probe alone. A text-scan hook over-blocking on paths like `.env.example` would train users to work around the safety net, the exact failure mode the skill warns against.

Recorded in `parity/FOLLOWUPS.md` §5, and called out in the skill itself so nobody reads the built-in guard list as covering secret access.

## Inventory correction

The artifact still listed the 0.9.0-era `set-custom-rules` + `verify-custom-rules` pair through the 1.0.6 re-review. Upstream had consolidated to the single `cc-safety-net` skill by 1.0.6 — the cache tree contains only `skills/cc-safety-net/SKILL.md` at both versions. Inventory corrected.

## Sentry artifact (drive-by, provably safe)

`plugin-routing-validate.mjs` was already failing on `sentry@claude-plugins-official.json` (`upstreamVersion 1.2.0 != cache max 1.3.1`) — its SKILL pins were refreshed to 1.3.1 earlier but the routing artifact was not. Verified pure bookkeeping lag: `diff -rq --exclude=.git 1.2.0 1.3.1` shows only the `version` field and JSON key formatting differ. Version and stamp strings corrected; the historical notes ("1.2.0 replaced the ~30 per-SDK skills") are true as written and left alone. All 7 artifacts now validate — this is the `implement-plugin-parity` pre-flight gate, so leaving it red would block the next parity run.

## Verification

```
node scripts/plugin-parity-drift.mjs      → 0 of 5 drifted, exit 0
node scripts/plugin-routing-validate.mjs  → 7/7 valid, 0 invalid
bun run check:plugins                     → artifacts in sync; marketplace complete
bun run check:upstream-evidence-manifest  → clean
vitest (parity drift + routing + guards)  → 3 files, 281 tests passed
pre-push (full unit + integration)        → passed; "✅ Plugin parity pins are current"
```

## Flagged for the owner — not decided here

Upstream 2.0 ships native integrations for twelve agent CLIs, including Codex, Antigravity, Cursor, and Copilot CLI. Under the locked preference order (`already-native > re-point-mcp-lsp > enable-vendor-equivalent > claude-only > reimplement`) a named vendor integration for Codex and agy would outrank `reimplement`, flip both cells, and retire Lisa's own hook.

Not taken, for three reasons: the installer is an npx/Node dependency writing per-agent config outside Lisa's distribution model; #1960 deliberately made the Lisa hook canonical on every agent so one audited guard set ships identically everywhere; and `parity/FOLLOWUPS.md` §2 already records that Lisa has no mechanism to enable a third-party vendor plugin inside another agent's marketplace. Reversing #1960 is a standards call, so it is surfaced in the artifact addendum rather than decided.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated safety-net guidance and parity records to version 2.0.1.
  * Clarified supported integrations, consolidated safety-net tooling, and Copilot setup details.
  * Documented known coverage gaps for secret-access and Git metadata protections, with follow-up tracking.

* **Updates**
  * Refreshed routing information across supported coding environments to reflect current safety-net integrations.
  * Updated Sentry workflow routing to version 1.3.1.
  * Refreshed synchronization and verification records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->