### PR TITLE
fix(ci): upload the Maestro debug artifacts that were being silently dropped

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -393,6 +393,15 @@ jobs:
           path: |
             maestro-android-report.xml
             maestro-debug
+          # Maestro writes EVERY debug artifact under `maestro-debug/.maestro/`
+          # — a hidden directory — so the screenshots, view-hierarchy dumps and
+          # device logcat that name the cause of a failure all sit behind a dot.
+          # upload-artifact skips hidden files by default, which silently
+          # reduced this artifact to the junit XML alone: a failing run uploaded
+          # one file and told you an element was missing without a single frame
+          # showing what was on screen instead. Both native suites were
+          # undiagnosable after the fact for exactly this reason.
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 7
 
@@ -511,5 +520,8 @@ jobs:
           path: |
             maestro-ios-report.xml
             maestro-debug
+          # See the Android upload above: `maestro-debug/.maestro/` is hidden,
+          # and without this the artifact is the junit XML and nothing else.
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 7


### PR DESCRIPTION
Closes #2401

Work-Item: CodySwannGT/lisa#2401

## The bug

`maestro-native-e2e.yml` passes `--debug-output maestro-debug` on both platforms and uploads that directory — but every failing run, for as long as the workflow has existed, has produced an artifact containing the junit XML and nothing else.

Maestro writes its debug output under `maestro-debug/.maestro/tests/<ts>/`. That is a **hidden** directory, and `actions/upload-artifact` skips hidden files unless `include-hidden-files: true` is set. So the screenshots, view-hierarchy dumps and device logcat — the only things that say what was actually on screen when an assertion failed — were collected on the runner and thrown away at the upload step.

## Evidence

Measured locally against Maestro 2.7.0, a deliberately failing flow run with `--debug-output maestro-debug` produces:

```
maestro-debug/.maestro/tests/<ts>/<flow>/screenshots/step-NNN-*.png
maestro-debug/.maestro/tests/<ts>/<flow>/screen-hierarchy/step-NNN-*.json
maestro-debug/.maestro/tests/<ts>/<flow>/logs/device-logcat.txt
maestro-debug/.maestro/tests/<ts>/<flow>/{commands,manifest}.json
```

And the matching CI run (gunnertech/frontend run `31481576280`, Android job):

```
include-hidden-files: false
...
With the provided path, there will be 1 file uploaded
Uploaded bytes 602
```

602 bytes — the junit XML alone.

## Why it matters

gunnertech/frontend's Android nightly has two recurring failure signatures. One of them — all three flows failing their first `home:container` assertion (runs `31345038915` and `31481576280`) — **cannot be root-caused at all**: there is no frame, no hierarchy, no logcat from any run that exhibited it, so there is no way to tell a launcher popup from a blank render from a crashed app. The other was root-caused only because it happened to reproduce locally against the archived APK — luck, not process.

## Change

`include-hidden-files: true` on both `📤 Upload Maestro debug output` steps (Android and iOS).

Affects every project consuming `CodySwannGT/lisa/.github/workflows/maestro-native-e2e.yml@main`.

## Scope note

`.lighthouseci/` in `lighthouse.yml` and `.next` in `quality.yml` have the identical defect. They are **not** in this PR — the repo's work-item gate rejects a push whose commits reference more than one work item, so they ship separately under #2398. A sweep of every `upload-artifact` step in the workflow set found exactly those four sites and no others.

## Verification

`actionlint` reports the same 221 findings on this workflow before and after, so this adds none. A green upload step is not evidence for this class of bug — confirm the fix on the next failing native run by asserting the artifact actually carries the hidden tree:

```bash
gh api /repos/<owner>/<repo>/actions/runs/<run_id>/artifacts \
  --jq '.artifacts[] | select(.name|startswith("maestro-")) | .size_in_bytes'
# must be far larger than 602
```

🤖 Generated with Claude Code
