### PR TITLE
fix(ci): stop dropping hidden paths from the Lighthouse and build uploads

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -85,4 +85,11 @@ jobs:
         with:
           name: lighthouse-reports
           path: .lighthouseci/
+          # `.lighthouseci/` is a dot-directory and upload-artifact skips hidden
+          # paths by default, so this step found nothing, warned, and exited 0 —
+          # green on every run while never once producing an artifact. The
+          # 30-day retention configured here was doing nothing, leaving GCS
+          # report links (~14 days) as the only record, so a regression older
+          # than two weeks could not be bisected at all.
+          include-hidden-files: true
           retention-days: 30

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1550,6 +1550,11 @@ jobs:
             build
             .next
             out
+          # `.next` is hidden, so without this a Next.js project's build output
+          # is dropped from the artifact — and because the other three paths do
+          # not exist there either, `if-no-files-found: ignore` turns that into
+          # a silent no-op rather than a warning.
+          include-hidden-files: true
           retention-days: 1
           if-no-files-found: ignore
 


### PR DESCRIPTION
Closes #2398

Work-Item: CodySwannGT/lisa#2398

## The bug

`actions/upload-artifact` excludes hidden paths unless `include-hidden-files: true` is set, and it does so **quietly** — the step still exits 0. Two workflows upload dot-paths and have therefore been silently shipping nothing.

### `lighthouse.yml` — `.lighthouseci/`

The step has been green on every run in every consuming repo while never once producing an artifact: the glob matches nothing, the action warns, the job passes. From TunnlAI/frontend job `93722956621` — note the step is *green*:

```
##[warning]No files were found with the provided path: .lighthouseci/. No artifacts will be uploaded.
```

Artifacts actually attached to that run: `zap-report-expo`, `audit-log-…`, `node-modules-…`. No `lighthouse-reports`. Across every Lighthouse run in that repo the count is **zero**.

This removes the only durable record of Lighthouse results. Of **708** executed Lighthouse jobs in TunnlAI/frontend only **117** printed an `interactive` value — passing assertions print nothing. The numbers are otherwise reachable only via `upload.target: temporary-public-storage`, whose retention is ~14 days. The 30-day artifact configured here was doing nothing, so a regression older than two weeks could not be bisected at all — which is exactly what made the TUN-544 TTI investigation unrecoverable before 2026-07-28.

### `quality.yml` — `.next`

For a Next.js project the build output is dropped from `build-output-<run_id>`. Because `dist`/`build`/`out` do not exist there either, `if-no-files-found: ignore` turns the whole upload into a silent no-op rather than a warning.

## How these were found

#2398 asked for the broader check — "any other Lisa workflow uploading a dot-path has the same silent failure." I swept every `upload-artifact` step in the workflow set for a path with a dot-prefixed segment. **Four sites matched**: the two Maestro uploads (shipping separately under #2401) and these two. No other step in the workflow set uploads a hidden path.

## Scope note

The two Maestro upload steps have the identical defect but are **not** in this PR — the repo's work-item gate rejects a push whose commits reference more than one work item, so they ship under #2401. Together the two PRs close the class.

## Verification

`actionlint` reports the same 221 findings across the three touched workflows before and after, so this adds none.

A green upload step is not evidence — that is the whole bug. Assert the artifact **exists** on the next run:

```bash
gh api /repos/<owner>/<repo>/actions/runs/<run_id>/artifacts \
  --jq '[.artifacts[] | select(.name=="lighthouse-reports")] | length'
# must be 1, not 0
```

🤖 Generated with Claude Code
