### PR TITLE
feat(maestro-e2e): add caller flow runner seam

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -89,6 +89,11 @@ on:
         required: false
         default: ''
         type: string
+      flow_runner:
+        description: 'Optional shell script path that runs Maestro flows and writes the supplied JUnit report/debug outputs'
+        required: false
+        default: ''
+        type: string
       node_version:
         description: 'Node.js version for setup_command tooling'
         required: false
@@ -345,6 +350,8 @@ jobs:
 
       - name: 📱 Run Maestro flows on emulator
         uses: reactivecircus/android-emulator-runner@v2
+        env:
+          FLOW_RUNNER: ${{ inputs.flow_runner }}
         with:
           api-level: 34
           arch: x86_64
@@ -383,7 +390,7 @@ jobs:
             adb shell input keyevent KEYCODE_HOME
             adb shell dumpsys power | grep -q 'mWakefulness=Awake'
             adb shell dumpsys window | grep -q 'isKeyguardShowing=false'
-            maestro test $MAESTRO_E2E_ARGS --format junit --output maestro-android-report.xml --debug-output maestro-debug ${{ inputs.flows_dir }}
+            if [ -n "$FLOW_RUNNER" ]; then bash "$FLOW_RUNNER" maestro-android-report.xml maestro-debug $MAESTRO_E2E_ARGS ${{ inputs.flows_dir }}; else maestro test $MAESTRO_E2E_ARGS --format junit --output maestro-android-report.xml --debug-output maestro-debug ${{ inputs.flows_dir }}; fi
 
       - name: 📤 Upload Maestro debug output
         if: always()
@@ -503,14 +510,20 @@ jobs:
           echo "MAESTRO_E2E_ARGS=$ARGS" >> "$GITHUB_ENV"
 
       - name: 📱 Run Maestro flows on simulator
+        env:
+          FLOW_RUNNER: ${{ inputs.flow_runner }}
         run: |
           # MAESTRO_E2E_ARGS is a flag list that needs word splitting.
           # shellcheck disable=SC2086
-          maestro test ${{ inputs.flows_dir }} \
-            $MAESTRO_E2E_ARGS \
-            --format junit \
-            --output maestro-ios-report.xml \
-            --debug-output maestro-debug
+          if [ -n "$FLOW_RUNNER" ]; then
+            bash "$FLOW_RUNNER" maestro-ios-report.xml maestro-debug $MAESTRO_E2E_ARGS ${{ inputs.flows_dir }}
+          else
+            maestro test ${{ inputs.flows_dir }} \
+              $MAESTRO_E2E_ARGS \
+              --format junit \
+              --output maestro-ios-report.xml \
+              --debug-output maestro-debug
+          fi
 
       - name: 📤 Upload Maestro debug output
         if: always()

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8238,6 +8238,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/integration/failure-issue-workflows.test.ts": true,
     "tests/integration/jest-expo-haste-pruning.test.ts": true,
     "tests/integration/lisa.test.ts": true,
+    "tests/integration/maestro-native-flow-runner.test.ts": true,
     "tests/integration/maestro-native-workflow.test.ts": true,
     "tests/integration/quality-workflow.test.ts": true,
     "tests/integration/release-changelog-entry.test.ts": true,

--- a/tests/integration/maestro-native-flow-runner.test.ts
+++ b/tests/integration/maestro-native-flow-runner.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Contract tests for the Maestro native reusable workflow's caller-owned flow
+ * runner seam.
+ */
+import * as fs from "fs-extra";
+import yaml from "js-yaml";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REUSABLE_YML = path.join(
+  __dirname,
+  "..",
+  "..",
+  ".github",
+  "workflows",
+  "maestro-native-e2e.yml"
+);
+
+/** Shape of a single `workflow_call` input declaration. */
+interface WorkflowInput {
+  default?: unknown;
+  required?: boolean;
+  type?: string;
+}
+
+/** Shape of a single step inside a workflow job's `steps:` list. */
+interface WorkflowStep {
+  run?: string;
+  uses?: string;
+  env?: Record<string, unknown>;
+  with?: Record<string, unknown>;
+}
+
+/** Shape of a single job inside a workflow's `jobs:` map. */
+interface WorkflowJob {
+  steps?: WorkflowStep[];
+}
+
+/** Root shape of the parsed reusable workflow. */
+interface ReusableWorkflow {
+  on: {
+    workflow_call?: {
+      inputs?: Record<string, WorkflowInput>;
+    };
+  };
+  jobs: Record<string, WorkflowJob>;
+}
+
+describe("maestro-native flow_runner seam", () => {
+  let workflow: ReusableWorkflow;
+
+  beforeAll(async () => {
+    workflow = yaml.load(
+      await fs.readFile(REUSABLE_YML, "utf-8")
+    ) as ReusableWorkflow;
+  });
+
+  it("exposes an opt-in runner input with today's default behavior", () => {
+    const flowRunner = workflow.on.workflow_call?.inputs?.flow_runner;
+    expect(flowRunner?.default).toBe("");
+    expect(flowRunner?.required ?? false).toBe(false);
+    expect(flowRunner?.type).toBe("string");
+  });
+
+  it("runs Android through the caller runner or the existing one-line Maestro command", () => {
+    const emulator = (workflow.jobs.android.steps ?? []).find(step =>
+      step.uses?.startsWith("reactivecircus/android-emulator-runner")
+    );
+    const script = String(emulator?.with?.script ?? "");
+    const runnerLine =
+      'if [ -n "$FLOW_RUNNER" ]; then bash "$FLOW_RUNNER" maestro-android-report.xml maestro-debug $MAESTRO_E2E_ARGS ${{ inputs.flows_dir }}; else maestro test $MAESTRO_E2E_ARGS --format junit --output maestro-android-report.xml --debug-output maestro-debug ${{ inputs.flows_dir }}; fi';
+
+    expect(emulator?.env?.FLOW_RUNNER).toBe("${{ inputs.flow_runner }}");
+    expect(script).toContain(runnerLine);
+    expect(
+      script.split("\n").filter(line => line.includes("maestro test"))
+    ).toHaveLength(1);
+  });
+
+  it("runs iOS through the caller runner or the existing Maestro command", () => {
+    const iosRun = (workflow.jobs.ios.steps ?? []).find(step =>
+      step.run?.includes("maestro-ios-report.xml")
+    );
+
+    expect(iosRun?.env?.FLOW_RUNNER).toBe("${{ inputs.flow_runner }}");
+    expect(iosRun?.run).toContain(
+      'bash "$FLOW_RUNNER" maestro-ios-report.xml maestro-debug $MAESTRO_E2E_ARGS ${{ inputs.flows_dir }}'
+    );
+    expect(iosRun?.run).toContain(
+      "maestro test ${{ inputs.flows_dir }} \\\n    $MAESTRO_E2E_ARGS"
+    );
+  });
+});

--- a/tests/integration/maestro-native-workflow.test.ts
+++ b/tests/integration/maestro-native-workflow.test.ts
@@ -133,6 +133,7 @@ describe("maestro-native-e2e reusable workflow", () => {
     expect(inputs.ios_include_tags?.default).toBe("");
     expect(inputs.maestro_env).toBeDefined();
     expect(inputs.setup_command).toBeDefined();
+    expect(inputs.flow_runner?.default).toBe("");
     expect(inputs.android_app_id).toBeDefined();
     expect(inputs.ios_app_id).toBeDefined();
   });

--- a/tests/unit/strategies/automation-status-claude-adapter.test.ts
+++ b/tests/unit/strategies/automation-status-claude-adapter.test.ts
@@ -7,6 +7,7 @@
  * @module tests/unit/strategies/automation-status-claude-adapter
  */
 import { describe, expect, it } from "vitest";
+import path from "node:path";
 
 import { resolveExpectedAutomationFleet } from "../../../plugins/src/base/scripts/automation-status-expected-fleet.mjs";
 import {
@@ -37,6 +38,7 @@ const FIXTURE_NOW = "2026-05-26T12:00:00Z";
 const RECENT_RUN_AT = "2026-05-26T11:55:00Z";
 const HOURLY_SCHEDULE = "hourly";
 const TEN_MINUTE_SCHEDULE = "every 10 minutes";
+const PROJECT_ROOT_WITHOUT_RUN_HISTORY = path.parse(process.cwd()).root;
 
 describe("automation-status Claude adapter (#802)", () => {
   it("maps structured Claude schedule metadata into shared health states", async () => {
@@ -83,6 +85,7 @@ describe("automation-status Claude adapter (#802)", () => {
           },
         ],
       },
+      projectRoot: PROJECT_ROOT_WITHOUT_RUN_HISTORY,
       now: FIXTURE_NOW,
     });
 
@@ -145,6 +148,7 @@ Command: ${BUILD_SCHEDULE_COMMAND}
 Status: ACTIVE
 Last result: No recent failures reported.
       `.trim(),
+      projectRoot: PROJECT_ROOT_WITHOUT_RUN_HISTORY,
       now: FIXTURE_NOW,
     });
 
@@ -179,6 +183,7 @@ ID: ${BUILD_AUTOMATION_ID}
 /schedule "hourly" /lisa:intake CodySwannGT/lisa intake_mode=build
 Status: ACTIVE
       `.trim(),
+      projectRoot: PROJECT_ROOT_WITHOUT_RUN_HISTORY,
       now: FIXTURE_NOW,
     });
 
@@ -234,6 +239,7 @@ Status: ACTIVE
           },
         ],
       },
+      projectRoot: PROJECT_ROOT_WITHOUT_RUN_HISTORY,
       now: FIXTURE_NOW,
     });
 
@@ -283,6 +289,7 @@ Status: ACTIVE
           detectedTypes: DETECTED_TYPES,
         }),
         scheduleListing,
+        projectRoot: PROJECT_ROOT_WITHOUT_RUN_HISTORY,
         now: FIXTURE_NOW,
       })
     ).resolves.toBeDefined();

--- a/tests/unit/strategies/automation-status-codex-adapter.test.ts
+++ b/tests/unit/strategies/automation-status-codex-adapter.test.ts
@@ -83,6 +83,7 @@ describe("automation-status Codex adapter (#801)", () => {
     const report = await inspectCodexAutomationFleet({
       expectedFleet,
       automationsDir,
+      projectRoot: automationsDir,
       now: RECENT_RUN_AT,
     });
 
@@ -152,6 +153,7 @@ describe("automation-status Codex adapter (#801)", () => {
         detectedTypes: ["typescript"],
       }),
       automationsDir,
+      projectRoot: automationsDir,
       now: "2026-05-26T12:00:00Z",
     });
 

--- a/tests/unit/strategies/automation-status-codex-cwd.test.ts
+++ b/tests/unit/strategies/automation-status-codex-cwd.test.ts
@@ -43,6 +43,7 @@ describe("automation-status Codex cwd health", () => {
         detectedTypes: ["typescript"],
       }),
       automationsDir,
+      projectRoot: automationsDir,
       now: RECENT_RUN_AT,
     });
 


### PR DESCRIPTION
## Summary

- Add an opt-in `flow_runner` input to `maestro-native-e2e.yml` so callers can wrap `maestro test` for per-flow retry without changing the default path.
- Preserve the existing Android one-line shell invocation and iOS default Maestro command when `flow_runner` is unset.
- Add contract coverage for both runner and default branches, and isolate automation-status fixture tests from live run-history state exposed during pre-push.

## Verification

- `bun test tests/integration/maestro-native-workflow.test.ts tests/integration/maestro-native-flow-runner.test.ts`
- `bun run lint -- .github/workflows/maestro-native-e2e.yml tests/integration/maestro-native-workflow.test.ts tests/integration/maestro-native-flow-runner.test.ts`
- `bun run check:upstream-evidence-manifest`
- `actionlint .github/workflows/maestro-native-e2e.yml`
- pre-push: typecheck, audit, slow lint, knip, coverage (`562 passed / 9486 tests`), integration (`16 passed / 165 tests`), plugin parity

Work-Item: CodySwannGT/lisa#2396

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional custom flow-runner support for native Maestro test workflows.
  * Preserved the default Maestro test execution when no custom runner is provided.

* **Tests**
  * Added integration coverage for custom runner configuration and platform-specific fallback behavior.
  * Improved automation status tests by providing consistent project-root context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->