### PR TITLE
Shard Playwright by default to fit hosted runners

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -125,9 +125,9 @@ on:
         default: ''
         type: string
       playwright_shards:
-        description: 'Number of parallel CI jobs (shards) to run Playwright tests across. Default 1 = single runner (unchanged behavior). Values >= 2 enable matrix sharding via `npx playwright test --shard=i/N`.'
+        description: 'Number of parallel CI jobs (shards) to run Playwright tests across. Default 2 keeps large suites within hosted-runner disk and time limits. Set 1 explicitly for a single runner.'
         required: false
-        default: 1
+        default: 2
         type: number
       cache_build:
         description: 'Cache build output between runs to skip `expo export` and `<pm> run build` when source unchanged. Default false = full rebuild every run (unchanged behavior). When true, cache key hashes lockfiles + src/app/components/features sources + Expo/Metro/Babel/TS configs; invalidates when any of those change.'
@@ -1130,7 +1130,7 @@ jobs:
           echo "To run Maestro tests, provide the maestro_app_file input with the path to your app binary"
 
   # Emits a JSON array consumed by playwright_e2e's matrix strategy.
-  # When playwright_shards <= 1 the array is [1] (single runner, behavior unchanged).
+  # When playwright_shards <= 1 the array is [1] (explicit single-runner mode).
   # When playwright_shards >= 2 the array is [1,2,...,N] and the test command
   # passes --shard=i/N so tests split across N parallel runners.
   playwright_e2e_setup:

--- a/plugins/lisa-agy/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the custom guard rules enforced by Lisa's safety-net PreToolUse Bash hook (parity-safety-net.sh). The consolidated cross-agent equivalent of the upstream safety-net plugin's set-custom-rules + verify-custom-rules skills — manages a project-local list of extended-regex patterns that block destructive shell commands, on Codex, agy, Copilot, Cursor, and Claude."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@2.0.1
+synced-from: safety-net@cc-marketplace@2.0.3
 ---
 
 # Parity Safety-Net Rules
@@ -24,12 +24,17 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.1`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.3`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
 >
-> **Known gap at the 2.0.1 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> **2.0.3 review.** Upstream 2.0.2–2.0.3 added Kimi Code and Amp installation
+> support and release tooling. Those changes do not alter the upstream
+> rule-management skill or Lisa's project-local ERE rule contract, and Lisa does
+> not currently ship hooks for those runtimes, so no behavior is absorbed here.
+>
+> **Known gap at the 2.0.3 pin.** Upstream 2.0.0 rebuilt its engine and added two
 > guard families this hook does **not** mirror: `secret.*` (blocks reading or
 > copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
 > stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both

--- a/plugins/lisa-agy/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the Sentry SDK for a project — detect the framework/runtime, add the correct @sentry/<framework> package, initialize the client, wire the DSN through env, enable error + performance monitoring, and set up source map upload for readable stack traces. One consolidated skill covering react, nextjs, node, nestjs, express, python, django, react-native, and more. Lisa-native reimplementation of Sentry's SDK-setup suite. Use when adding Sentry to a project or fixing an existing Sentry install."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.3.1
+synced-from: sentry@claude-plugins-official@1.3.2
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.1` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.2` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install
@@ -211,6 +211,16 @@ build time:
 - Tie uploads to a **release** identifier (commit SHA or version) and inject the
   same release into `Sentry.init({ release })` so traces map to the right build.
 
+## Step 6a — Name custom telemetry consistently
+
+When adding custom span or log attributes, use the current stable Sentry
+semantic-convention key for that domain when one exists. Sentry conventions are
+aligned with OpenTelemetry in many domains, but Sentry's current convention is
+authoritative for data sent to Sentry. Consult only the relevant domain in the
+official convention reference, omit deprecated keys, and do not invent a second
+name for an established attribute. Keep values low-cardinality and never attach
+secrets, credentials, request bodies, or unnecessary personal data.
+
 ## Step 7 — Verify
 
 - Build/typecheck to confirm the SDK wiring compiles:
@@ -230,5 +240,7 @@ build time:
 - Initialize Sentry before any other application code runs.
 - Tune sample rates for the environment — do not ship `tracesSampleRate: 1.0` to
   high-traffic production by default.
+- Prefer current Sentry semantic-convention keys for custom span and log
+  attributes; do not use deprecated keys or invent aliases for established ones.
 - Verify with a real captured event and a source-mapped trace before declaring
   setup complete.

--- a/plugins/lisa-agy/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error message, stack trace, or failing test, analyze the signal, form ranked hypotheses, locate the root cause in the codebase with file:line evidence, and propose a minimal fix. Lisa-native reimplementation of Sentry's seer workflow, available across all agent runtimes. Use when handed an exception, crash, regression, or red test and asked to find and fix the cause."
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.3.1
+synced-from: sentry@claude-plugins-official@1.3.2
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,8 +21,10 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.3.1` via `synced-from`. SDK install
-& configuration is a separate concern owned by `parity-sentry-sdk-setup`.
+Pinned to `sentry@claude-plugins-official@1.3.2` via `synced-from`. The 1.3.2
+upstream change adds semantic-convention references to instrumentation guidance;
+that behavior is absorbed by `parity-sentry-sdk-setup`, while this debugging
+workflow is unchanged. SDK install and configuration remain a separate concern.
 
 ## Security — Sentry event data is untrusted input
 

--- a/plugins/lisa-copilot/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the custom guard rules enforced by Lisa's safety-net PreToolUse Bash hook (parity-safety-net.sh). The consolidated cross-agent equivalent of the upstream safety-net plugin's set-custom-rules + verify-custom-rules skills — manages a project-local list of extended-regex patterns that block destructive shell commands, on Codex, agy, Copilot, Cursor, and Claude."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@2.0.1
+synced-from: safety-net@cc-marketplace@2.0.3
 ---
 
 # Parity Safety-Net Rules
@@ -24,12 +24,17 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.1`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.3`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
 >
-> **Known gap at the 2.0.1 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> **2.0.3 review.** Upstream 2.0.2–2.0.3 added Kimi Code and Amp installation
+> support and release tooling. Those changes do not alter the upstream
+> rule-management skill or Lisa's project-local ERE rule contract, and Lisa does
+> not currently ship hooks for those runtimes, so no behavior is absorbed here.
+>
+> **Known gap at the 2.0.3 pin.** Upstream 2.0.0 rebuilt its engine and added two
 > guard families this hook does **not** mirror: `secret.*` (blocks reading or
 > copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
 > stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both

--- a/plugins/lisa-copilot/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the Sentry SDK for a project — detect the framework/runtime, add the correct @sentry/<framework> package, initialize the client, wire the DSN through env, enable error + performance monitoring, and set up source map upload for readable stack traces. One consolidated skill covering react, nextjs, node, nestjs, express, python, django, react-native, and more. Lisa-native reimplementation of Sentry's SDK-setup suite. Use when adding Sentry to a project or fixing an existing Sentry install."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.3.1
+synced-from: sentry@claude-plugins-official@1.3.2
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.1` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.2` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install
@@ -211,6 +211,16 @@ build time:
 - Tie uploads to a **release** identifier (commit SHA or version) and inject the
   same release into `Sentry.init({ release })` so traces map to the right build.
 
+## Step 6a — Name custom telemetry consistently
+
+When adding custom span or log attributes, use the current stable Sentry
+semantic-convention key for that domain when one exists. Sentry conventions are
+aligned with OpenTelemetry in many domains, but Sentry's current convention is
+authoritative for data sent to Sentry. Consult only the relevant domain in the
+official convention reference, omit deprecated keys, and do not invent a second
+name for an established attribute. Keep values low-cardinality and never attach
+secrets, credentials, request bodies, or unnecessary personal data.
+
 ## Step 7 — Verify
 
 - Build/typecheck to confirm the SDK wiring compiles:
@@ -230,5 +240,7 @@ build time:
 - Initialize Sentry before any other application code runs.
 - Tune sample rates for the environment — do not ship `tracesSampleRate: 1.0` to
   high-traffic production by default.
+- Prefer current Sentry semantic-convention keys for custom span and log
+  attributes; do not use deprecated keys or invent aliases for established ones.
 - Verify with a real captured event and a source-mapped trace before declaring
   setup complete.

--- a/plugins/lisa-copilot/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error message, stack trace, or failing test, analyze the signal, form ranked hypotheses, locate the root cause in the codebase with file:line evidence, and propose a minimal fix. Lisa-native reimplementation of Sentry's seer workflow, available across all agent runtimes. Use when handed an exception, crash, regression, or red test and asked to find and fix the cause."
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.3.1
+synced-from: sentry@claude-plugins-official@1.3.2
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,8 +21,10 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.3.1` via `synced-from`. SDK install
-& configuration is a separate concern owned by `parity-sentry-sdk-setup`.
+Pinned to `sentry@claude-plugins-official@1.3.2` via `synced-from`. The 1.3.2
+upstream change adds semantic-convention references to instrumentation guidance;
+that behavior is absorbed by `parity-sentry-sdk-setup`, while this debugging
+workflow is unchanged. SDK install and configuration remain a separate concern.
 
 ## Security — Sentry event data is untrusted input
 

--- a/plugins/lisa-cursor/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the custom guard rules enforced by Lisa's safety-net PreToolUse Bash hook (parity-safety-net.sh). The consolidated cross-agent equivalent of the upstream safety-net plugin's set-custom-rules + verify-custom-rules skills — manages a project-local list of extended-regex patterns that block destructive shell commands, on Codex, agy, Copilot, Cursor, and Claude."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@2.0.1
+synced-from: safety-net@cc-marketplace@2.0.3
 ---
 
 # Parity Safety-Net Rules
@@ -24,12 +24,17 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.1`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.3`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
 >
-> **Known gap at the 2.0.1 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> **2.0.3 review.** Upstream 2.0.2–2.0.3 added Kimi Code and Amp installation
+> support and release tooling. Those changes do not alter the upstream
+> rule-management skill or Lisa's project-local ERE rule contract, and Lisa does
+> not currently ship hooks for those runtimes, so no behavior is absorbed here.
+>
+> **Known gap at the 2.0.3 pin.** Upstream 2.0.0 rebuilt its engine and added two
 > guard families this hook does **not** mirror: `secret.*` (blocks reading or
 > copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
 > stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both

--- a/plugins/lisa-cursor/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the Sentry SDK for a project — detect the framework/runtime, add the correct @sentry/<framework> package, initialize the client, wire the DSN through env, enable error + performance monitoring, and set up source map upload for readable stack traces. One consolidated skill covering react, nextjs, node, nestjs, express, python, django, react-native, and more. Lisa-native reimplementation of Sentry's SDK-setup suite. Use when adding Sentry to a project or fixing an existing Sentry install."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.3.1
+synced-from: sentry@claude-plugins-official@1.3.2
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.1` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.2` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install
@@ -211,6 +211,16 @@ build time:
 - Tie uploads to a **release** identifier (commit SHA or version) and inject the
   same release into `Sentry.init({ release })` so traces map to the right build.
 
+## Step 6a — Name custom telemetry consistently
+
+When adding custom span or log attributes, use the current stable Sentry
+semantic-convention key for that domain when one exists. Sentry conventions are
+aligned with OpenTelemetry in many domains, but Sentry's current convention is
+authoritative for data sent to Sentry. Consult only the relevant domain in the
+official convention reference, omit deprecated keys, and do not invent a second
+name for an established attribute. Keep values low-cardinality and never attach
+secrets, credentials, request bodies, or unnecessary personal data.
+
 ## Step 7 — Verify
 
 - Build/typecheck to confirm the SDK wiring compiles:
@@ -230,5 +240,7 @@ build time:
 - Initialize Sentry before any other application code runs.
 - Tune sample rates for the environment — do not ship `tracesSampleRate: 1.0` to
   high-traffic production by default.
+- Prefer current Sentry semantic-convention keys for custom span and log
+  attributes; do not use deprecated keys or invent aliases for established ones.
 - Verify with a real captured event and a source-mapped trace before declaring
   setup complete.

--- a/plugins/lisa-cursor/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error message, stack trace, or failing test, analyze the signal, form ranked hypotheses, locate the root cause in the codebase with file:line evidence, and propose a minimal fix. Lisa-native reimplementation of Sentry's seer workflow, available across all agent runtimes. Use when handed an exception, crash, regression, or red test and asked to find and fix the cause."
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.3.1
+synced-from: sentry@claude-plugins-official@1.3.2
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,8 +21,10 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.3.1` via `synced-from`. SDK install
-& configuration is a separate concern owned by `parity-sentry-sdk-setup`.
+Pinned to `sentry@claude-plugins-official@1.3.2` via `synced-from`. The 1.3.2
+upstream change adds semantic-convention references to instrumentation guidance;
+that behavior is absorbed by `parity-sentry-sdk-setup`, while this debugging
+workflow is unchanged. SDK install and configuration remain a separate concern.
 
 ## Security — Sentry event data is untrusted input
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the…"
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@2.0.1
+synced-from: safety-net@cc-marketplace@2.0.3
 ---
 
 # Parity Safety-Net Rules
@@ -24,12 +24,17 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.1`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.3`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
 >
-> **Known gap at the 2.0.1 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> **2.0.3 review.** Upstream 2.0.2–2.0.3 added Kimi Code and Amp installation
+> support and release tooling. Those changes do not alter the upstream
+> rule-management skill or Lisa's project-local ERE rule contract, and Lisa does
+> not currently ship hooks for those runtimes, so no behavior is absorbed here.
+>
+> **Known gap at the 2.0.3 pin.** Upstream 2.0.0 rebuilt its engine and added two
 > guard families this hook does **not** mirror: `secret.*` (blocks reading or
 > copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
 > stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both

--- a/plugins/lisa/.codex-plugin/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the…"
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.3.1
+synced-from: sentry@claude-plugins-official@1.3.2
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.1` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.2` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install
@@ -211,6 +211,16 @@ build time:
 - Tie uploads to a **release** identifier (commit SHA or version) and inject the
   same release into `Sentry.init({ release })` so traces map to the right build.
 
+## Step 6a — Name custom telemetry consistently
+
+When adding custom span or log attributes, use the current stable Sentry
+semantic-convention key for that domain when one exists. Sentry conventions are
+aligned with OpenTelemetry in many domains, but Sentry's current convention is
+authoritative for data sent to Sentry. Consult only the relevant domain in the
+official convention reference, omit deprecated keys, and do not invent a second
+name for an established attribute. Keep values low-cardinality and never attach
+secrets, credentials, request bodies, or unnecessary personal data.
+
 ## Step 7 — Verify
 
 - Build/typecheck to confirm the SDK wiring compiles:
@@ -230,5 +240,7 @@ build time:
 - Initialize Sentry before any other application code runs.
 - Tune sample rates for the environment — do not ship `tracesSampleRate: 1.0` to
   high-traffic production by default.
+- Prefer current Sentry semantic-convention keys for custom span and log
+  attributes; do not use deprecated keys or invent aliases for established ones.
 - Verify with a real captured event and a source-mapped trace before declaring
   setup complete.

--- a/plugins/lisa/.codex-plugin/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error…"
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.3.1
+synced-from: sentry@claude-plugins-official@1.3.2
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,8 +21,10 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.3.1` via `synced-from`. SDK install
-& configuration is a separate concern owned by `parity-sentry-sdk-setup`.
+Pinned to `sentry@claude-plugins-official@1.3.2` via `synced-from`. The 1.3.2
+upstream change adds semantic-convention references to instrumentation guidance;
+that behavior is absorbed by `parity-sentry-sdk-setup`, while this debugging
+workflow is unchanged. SDK install and configuration remain a separate concern.
 
 ## Security — Sentry event data is untrusted input
 

--- a/plugins/lisa/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the custom guard rules enforced by Lisa's safety-net PreToolUse Bash hook (parity-safety-net.sh). The consolidated cross-agent equivalent of the upstream safety-net plugin's set-custom-rules + verify-custom-rules skills — manages a project-local list of extended-regex patterns that block destructive shell commands, on Codex, agy, Copilot, Cursor, and Claude."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@2.0.1
+synced-from: safety-net@cc-marketplace@2.0.3
 ---
 
 # Parity Safety-Net Rules
@@ -24,12 +24,17 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.1`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.3`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
 >
-> **Known gap at the 2.0.1 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> **2.0.3 review.** Upstream 2.0.2–2.0.3 added Kimi Code and Amp installation
+> support and release tooling. Those changes do not alter the upstream
+> rule-management skill or Lisa's project-local ERE rule contract, and Lisa does
+> not currently ship hooks for those runtimes, so no behavior is absorbed here.
+>
+> **Known gap at the 2.0.3 pin.** Upstream 2.0.0 rebuilt its engine and added two
 > guard families this hook does **not** mirror: `secret.*` (blocks reading or
 > copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
 > stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both

--- a/plugins/lisa/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/lisa/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the Sentry SDK for a project — detect the framework/runtime, add the correct @sentry/<framework> package, initialize the client, wire the DSN through env, enable error + performance monitoring, and set up source map upload for readable stack traces. One consolidated skill covering react, nextjs, node, nestjs, express, python, django, react-native, and more. Lisa-native reimplementation of Sentry's SDK-setup suite. Use when adding Sentry to a project or fixing an existing Sentry install."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.3.1
+synced-from: sentry@claude-plugins-official@1.3.2
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.1` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.2` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install
@@ -211,6 +211,16 @@ build time:
 - Tie uploads to a **release** identifier (commit SHA or version) and inject the
   same release into `Sentry.init({ release })` so traces map to the right build.
 
+## Step 6a — Name custom telemetry consistently
+
+When adding custom span or log attributes, use the current stable Sentry
+semantic-convention key for that domain when one exists. Sentry conventions are
+aligned with OpenTelemetry in many domains, but Sentry's current convention is
+authoritative for data sent to Sentry. Consult only the relevant domain in the
+official convention reference, omit deprecated keys, and do not invent a second
+name for an established attribute. Keep values low-cardinality and never attach
+secrets, credentials, request bodies, or unnecessary personal data.
+
 ## Step 7 — Verify
 
 - Build/typecheck to confirm the SDK wiring compiles:
@@ -230,5 +240,7 @@ build time:
 - Initialize Sentry before any other application code runs.
 - Tune sample rates for the environment — do not ship `tracesSampleRate: 1.0` to
   high-traffic production by default.
+- Prefer current Sentry semantic-convention keys for custom span and log
+  attributes; do not use deprecated keys or invent aliases for established ones.
 - Verify with a real captured event and a source-mapped trace before declaring
   setup complete.

--- a/plugins/lisa/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/lisa/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error message, stack trace, or failing test, analyze the signal, form ranked hypotheses, locate the root cause in the codebase with file:line evidence, and propose a minimal fix. Lisa-native reimplementation of Sentry's seer workflow, available across all agent runtimes. Use when handed an exception, crash, regression, or red test and asked to find and fix the cause."
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.3.1
+synced-from: sentry@claude-plugins-official@1.3.2
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,8 +21,10 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.3.1` via `synced-from`. SDK install
-& configuration is a separate concern owned by `parity-sentry-sdk-setup`.
+Pinned to `sentry@claude-plugins-official@1.3.2` via `synced-from`. The 1.3.2
+upstream change adds semantic-convention references to instrumentation guidance;
+that behavior is absorbed by `parity-sentry-sdk-setup`, while this debugging
+workflow is unchanged. SDK install and configuration remain a separate concern.
 
 ## Security — Sentry event data is untrusted input
 

--- a/plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the custom guard rules enforced by Lisa's safety-net PreToolUse Bash hook (parity-safety-net.sh). The consolidated cross-agent equivalent of the upstream safety-net plugin's set-custom-rules + verify-custom-rules skills — manages a project-local list of extended-regex patterns that block destructive shell commands, on Codex, agy, Copilot, Cursor, and Claude."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@2.0.1
+synced-from: safety-net@cc-marketplace@2.0.3
 ---
 
 # Parity Safety-Net Rules
@@ -24,12 +24,17 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.1`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.3`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
 >
-> **Known gap at the 2.0.1 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> **2.0.3 review.** Upstream 2.0.2–2.0.3 added Kimi Code and Amp installation
+> support and release tooling. Those changes do not alter the upstream
+> rule-management skill or Lisa's project-local ERE rule contract, and Lisa does
+> not currently ship hooks for those runtimes, so no behavior is absorbed here.
+>
+> **Known gap at the 2.0.3 pin.** Upstream 2.0.0 rebuilt its engine and added two
 > guard families this hook does **not** mirror: `secret.*` (blocks reading or
 > copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
 > stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both

--- a/plugins/src/base/skills/lisa-parity-sentry-sdk-setup/SKILL.md
+++ b/plugins/src/base/skills/lisa-parity-sentry-sdk-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-sdk-setup
 description: "Install and configure the Sentry SDK for a project — detect the framework/runtime, add the correct @sentry/<framework> package, initialize the client, wire the DSN through env, enable error + performance monitoring, and set up source map upload for readable stack traces. One consolidated skill covering react, nextjs, node, nestjs, express, python, django, react-native, and more. Lisa-native reimplementation of Sentry's SDK-setup suite. Use when adding Sentry to a project or fixing an existing Sentry install."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: sentry@claude-plugins-official@1.3.1
+synced-from: sentry@claude-plugins-official@1.3.2
 ---
 
 # Sentry SDK Setup
@@ -19,7 +19,7 @@ setup skills**; this single Lisa-native skill consolidated all of them. As of
 upstream **1.2.0** Sentry itself consolidated the suite into one
 `sentry-instrument` playbook, so the shapes now match — but this skill remains a
 from-scratch reimplementation against Lisa conventions, **not** a translation of
-the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.1` via
+the upstream skill. Pinned to `sentry@claude-plugins-official@1.3.2` via
 `synced-from` so the parity drift detector tracks it as one unit.
 
 ## Step 0 — Scope the install
@@ -211,6 +211,16 @@ build time:
 - Tie uploads to a **release** identifier (commit SHA or version) and inject the
   same release into `Sentry.init({ release })` so traces map to the right build.
 
+## Step 6a — Name custom telemetry consistently
+
+When adding custom span or log attributes, use the current stable Sentry
+semantic-convention key for that domain when one exists. Sentry conventions are
+aligned with OpenTelemetry in many domains, but Sentry's current convention is
+authoritative for data sent to Sentry. Consult only the relevant domain in the
+official convention reference, omit deprecated keys, and do not invent a second
+name for an established attribute. Keep values low-cardinality and never attach
+secrets, credentials, request bodies, or unnecessary personal data.
+
 ## Step 7 — Verify
 
 - Build/typecheck to confirm the SDK wiring compiles:
@@ -230,5 +240,7 @@ build time:
 - Initialize Sentry before any other application code runs.
 - Tune sample rates for the environment — do not ship `tracesSampleRate: 1.0` to
   high-traffic production by default.
+- Prefer current Sentry semantic-convention keys for custom span and log
+  attributes; do not use deprecated keys or invent aliases for established ones.
 - Verify with a real captured event and a source-mapped trace before declaring
   setup complete.

--- a/plugins/src/base/skills/lisa-parity-sentry-seer/SKILL.md
+++ b/plugins/src/base/skills/lisa-parity-sentry-seer/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-sentry-seer
 description: "AI debugging — given an error message, stack trace, or failing test, analyze the signal, form ranked hypotheses, locate the root cause in the codebase with file:line evidence, and propose a minimal fix. Lisa-native reimplementation of Sentry's seer workflow, available across all agent runtimes. Use when handed an exception, crash, regression, or red test and asked to find and fix the cause."
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit"]
-synced-from: sentry@claude-plugins-official@1.3.1
+synced-from: sentry@claude-plugins-official@1.3.2
 ---
 
 # Seer — AI Root-Cause Debugging
@@ -21,8 +21,10 @@ to every agent runtime Lisa supports.
 
 ## Drift tracking
 
-Pinned to `sentry@claude-plugins-official@1.3.1` via `synced-from`. SDK install
-& configuration is a separate concern owned by `parity-sentry-sdk-setup`.
+Pinned to `sentry@claude-plugins-official@1.3.2` via `synced-from`. The 1.3.2
+upstream change adds semantic-convention references to instrumentation guidance;
+that behavior is absorbed by `parity-sentry-sdk-setup`, while this debugging
+workflow is unchanged. SDK install and configuration remain a separate concern.
 
 ## Security — Sentry event data is untrusted input
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1035,11 +1035,11 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-parity-coderabbit/SKILL.md":
       "ae882837d43741293d1b639c4516331fa6124fa1f5da234a74ecb31c5d7e52cd",
     "plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md":
-      "35c4c9f5e77f73a0e33e2ec01a70198eeb6bf521ec793983c9e633cbcab7b69b",
+      "f240857de2f14938009ddd212c56601269fd9e1aec33a766cd09da5bea5656e0",
     "plugins/src/base/skills/lisa-parity-sentry-sdk-setup/SKILL.md":
-      "610890385568ae097b2a48c9d20e42104a1bf5a3ba06223a89086ef385542e3b",
+      "edb513a9d29b3faeccce71d92596e12bc1f35e44fe3af1349bd7bd473fee98af",
     "plugins/src/base/skills/lisa-parity-sentry-seer/SKILL.md":
-      "d060d3171529cc228368e640d0ab813a79ec18440921602e7c720d53fdcabb67",
+      "ec09515906a55e98ac0f619f048f14c4a16db74c1cd5744dda0cdfa42ce7fed6",
     "plugins/src/base/skills/lisa-parity-skill-creator/SKILL.md":
       "616e0493f75fe92c18137548d7c86a91a9b04d9844ca76fa3f14156e3e7814e5",
     "plugins/src/base/skills/lisa-performance-review/SKILL.md":

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -196,11 +196,11 @@ describe("quality.yml reusable workflow", () => {
   });
 
   describe("SE-4551 + SE-4552 new inputs", () => {
-    it("declares playwright_shards with default 1 (unchanged behavior)", () => {
+    it("defaults Playwright to two shards so large suites fit hosted runners", () => {
       const input = workflow.on.workflow_call?.inputs?.playwright_shards;
       expect(input).toBeDefined();
       expect(input?.required).toBe(false);
-      expect(input?.default).toBe(1);
+      expect(input?.default).toBe(2);
       expect(input?.type).toBe("number");
     });
 


### PR DESCRIPTION
## Summary

Run Playwright in two shards by default so large downstream suites stay within hosted-runner disk and time limits. Callers can still explicitly request one shard. This also clears the mandatory local parity gate by reviewing the current Safety Net and Sentry releases, absorbing Sentry semantic-attribute guidance, and regenerating agent variants.

Closes #2407

## Work item

Work-Item: CodySwannGT/lisa#2407

## Verification

- 9,486 unit tests passed with coverage
- 165 integration tests passed
- Typecheck, slow lint, dead-code detection, and security audit passed
- Plugin artifacts regenerated and parity drift reports 0 of 5 stale
- Playwright workflow contract test asserts the default is 2 and explicit 1 remains supported

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quality checks now run across two parallel test runners by default, with an option to use one.
  * Added guidance for consistent Sentry telemetry naming, low-cardinality values, and sensitive-data protection.

* **Documentation**
  * Updated parity references and drift notes for the latest upstream safety and monitoring guidance.
  * Clarified which upstream installation and release-tooling changes are not adopted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->