### PR TITLE
PROOF (do not merge): an unswept persistent entity fails the state-classification gate

### DIFF
--- a/state/demo-project/state/inventory.json
+++ b/state/demo-project/state/inventory.json
@@ -11,11 +11,37 @@
   ],
   "notEnumerated": [],
   "entities": [
-    { "id": "app.notes", "kind": "table" },
-    { "id": "app.catalog_items", "kind": "table" },
-    { "id": "analytics.item_rollup", "kind": "materialized-view" },
-    { "id": "ledger.payments", "kind": "table" },
-    { "id": "identity://user-pool/e2e-personas", "kind": "identity-group" },
-    { "id": "object-store://uploads/e2e/", "kind": "object-prefix" }
+    {
+      "id": "app.notes",
+      "kind": "table"
+    },
+    {
+      "id": "app.catalog_items",
+      "kind": "table"
+    },
+    {
+      "id": "analytics.item_rollup",
+      "kind": "materialized-view"
+    },
+    {
+      "id": "ledger.payments",
+      "kind": "table"
+    },
+    {
+      "id": "identity://user-pool/e2e-personas",
+      "kind": "identity-group"
+    },
+    {
+      "id": "object-store://uploads/e2e/",
+      "kind": "object-prefix"
+    },
+    {
+      "id": "app.saved_searches",
+      "kind": "table"
+    },
+    {
+      "id": "app.share_links",
+      "kind": "table"
+    }
   ]
 }

--- a/state/demo-project/state/state-contract.json
+++ b/state/demo-project/state/state-contract.json
@@ -18,7 +18,10 @@
   "fixtureIdentity": {
     "description": "Reserved fixture ids and reserved persona principals; anything else in a fixture-owned entity belongs to someone real.",
     "idPattern": "^e2e[0-9a-f]{5}-0000-4000-8[0-9a-f]{3}-[0-9a-f]{12}$",
-    "reservedPrincipals": ["persona-owner", "persona-member"]
+    "reservedPrincipals": [
+      "persona-owner",
+      "persona-member"
+    ]
   },
   "entities": [
     {
@@ -72,6 +75,14 @@
       "owner": "lisa-maintainers",
       "ownership": "objects under the reserved e2e prefix only",
       "sweptBy": "reset:object-store-routine"
+    },
+    {
+      "id": "app.share_links",
+      "kind": "table",
+      "policy": "fixture-owned",
+      "reason": "Share links the sharing flow creates; the flow deletes them as its last step.",
+      "owner": "lisa-maintainers",
+      "ownership": "rows created by a reserved persona"
     }
   ],
   "assurances": {


### PR DESCRIPTION
> **DO NOT MERGE.** This PR exists to be red. It is the WS-1c proof that the drift check fails on the exact condition that has repeatedly leaked state silently.

Base: `feat/ws1c-reset-seed-governance` (#2413).

## What it simulates

A feature lands and adds two persistent entities. The running system now holds them.

- **`app.saved_searches`** — nobody thought about it at all.
- **`app.share_links`** — the author remembered the entity but only halfway. The flow creates share links and deletes them **as its last step**, so nobody wrote a sweep. That is per-flow self-cleanup: it runs on the happy path and leaks on every failure that happens in between.

That second shape is not hypothetical. It is precisely how leaked records accumulate unnoticed until a list view, a uniqueness constraint, or an exact-count assertion finally breaks — months after the change that caused it.

## What the gate does about it

`🧬 State Classification` fails on this pull request, naming both:

```
ERROR unclassified-entity: app.saved_searches exists in the running system but no
policy classifies it — fail closed: an unclassified entity is neither safe to keep
nor safe to delete. Classify it fixture-owned / preserve / derived-rebuild /
forbidden in the state contract.

ERROR policy-obligation-unmet: app.share_links is "fixture-owned" with no `sweptBy`
routine — an entity the suite creates but nothing removes is exactly the leak this
contract exists to catch.

exit=1
```

The failure arrives **on the pull request that introduces the gap**, not later as an unreproducible flake. That is the whole deliverable.

## What deliberately did NOT happen

The check never inferred a policy for the entity it had not seen. Under a "new entities are cleared by default" model, `app.saved_searches` would have been **deleted** on the next reset run in whatever non-production environment happened to run first — a shared dev database holding hand-built scenarios, support reproductions, or a partner sandbox. Failing closed asks instead of guessing. This PR is as much a demonstration of that restraint as of the failure.

## Everything else is green

Only the classification job is red. Lint, typecheck, format, the full unit suite (565 files / 9550 tests), plugin sync, rules pairing and the upstream evidence manifest all pass — so the red is unambiguously the gate doing its job, not collateral damage.

## Context

Portfolio E2E Standards plan revision `2026-08-12-r2`, workstream WS-1c definition of done: *"a proof PR that adds an unswept persistent entity FAILS the drift check rather than leaking silently."*

🤖 Generated with Claude Code


Work-Item: CodySwannGT/lisa#2411
