### PR TITLE
fix(ci): stop the build-cache key from hashing node_modules

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1293,12 +1293,55 @@ jobs:
           fi
         working-directory: ${{ inputs.working_directory || '.' }}
 
+      # Fingerprint of the inputs the build below depends on. Deliberately
+      # ungated: the cache steps interpolate this output, and a skipped step
+      # yields an empty string, which would silently collapse the cache key to
+      # a constant rather than fail. It costs ~10ms, so it always runs.
+      #
+      # This replaces `hashFiles('**/src/**', '**/app/**', ...)`. Those patterns
+      # are unanchored, so they also matched `node_modules/**/src/**`: measured
+      # on PropSwapLLC/frontend, the glob enumerated 116,353 paths and hashed
+      # 26,955 files out of node_modules against 1,305 real source files. The
+      # runner caps one hashFiles call at 120 seconds, and on a slow runner it
+      # blew through that — failing the job in the cache's POST step, AFTER
+      # every test had already passed. Playwright nightly run 31574583191 went
+      # red exactly that way, with 73/73 specs green and zero test failures.
+      #
+      # git only tracks checked-in files, so gitignored node_modules can never
+      # enter the key, and the walk is O(tracked files) — 0.012s on the same
+      # repo. `ls-files -s` emits each file's mode and blob SHA, so the digest
+      # stays content-addressed exactly as hashFiles was, and `hash-object`
+      # keeps it portable across runner OSes (no sha256sum/shasum split).
+      #
+      # Pathspecs are relative to the working directory, which is what the
+      # `**/`-prefixed globs were approximating — and gets it right for a
+      # nested working_directory instead of hashing every package in a monorepo.
+      #
+      # app.config.{js,ts} are included here but were absent from the old glob,
+      # even though 🔍 Detect Expo project treats them as Expo config: changing
+      # one used to restore a stale export.
+      - name: 🔑 Fingerprint build inputs
+        id: build_fingerprint
+        run: |
+          set -euo pipefail
+          fingerprint=$(git ls-files -s -- \
+            'bun.lock' 'bun.lockb' 'package-lock.json' 'yarn.lock' \
+            'src' 'app' 'components' 'features' \
+            'app.json' 'app.config.js' 'app.config.ts' 'package.json' \
+            'babel.config.js' 'babel.config.ts' \
+            'metro.config.js' 'metro.config.ts' 'tsconfig.json' \
+            | git hash-object --stdin)
+          echo "hash=$fingerprint" >> "$GITHUB_OUTPUT"
+          echo "Build input fingerprint: $fingerprint"
+        working-directory: ${{ inputs.working_directory || '.' }}
+
       # Expo build cache — opt-in via `cache_build: true`.
       #
       # Cache invalidation contract:
-      #   Key hashes (in order): lockfiles → source directories → config files.
-      #   Any change to a lockfile, src/app/components/features source, or
-      #   Expo/Metro/Babel/TS config will miss the cache and force a rebuild.
+      #   Key is the build-input fingerprint computed above: lockfiles → source
+      #   directories → config files. Any change to a lockfile, to
+      #   src/app/components/features source, or to Expo/Metro/Babel/TS config
+      #   misses the cache and forces a rebuild.
       #   Runner OS is part of the key to prevent cross-OS cache reuse.
       # Cached paths:
       #   - dist/             Expo web export output (consumed by Playwright)
@@ -1313,7 +1356,7 @@ jobs:
             ${{ inputs.working_directory || '.' }}/dist
             ${{ inputs.working_directory || '.' }}/.expo
             ${{ inputs.working_directory || '.' }}/node_modules/.cache
-          key: ${{ runner.os }}-expo-build-${{ hashFiles('**/bun.lock', '**/bun.lockb', '**/package-lock.json', '**/yarn.lock', '**/src/**', '**/app/**', '**/components/**', '**/features/**', '**/app.json', '**/package.json', '**/babel.config.js', '**/babel.config.ts', '**/metro.config.js', '**/metro.config.ts', '**/tsconfig.json') }}
+          key: ${{ runner.os }}-expo-build-${{ steps.build_fingerprint.outputs.hash }}
           restore-keys: |
             ${{ runner.os }}-expo-build-
 
@@ -1560,11 +1603,31 @@ jobs:
           fi
         working-directory: ${{ inputs.working_directory || '.' }}
 
+      # Same build-input fingerprint the playwright_e2e job uses, and for the
+      # same reason — the `**/src/**`-style globs this replaces walked
+      # node_modules and could exceed the runner's 120s hashFiles cap. See the
+      # 🔑 Fingerprint build inputs step in playwright_e2e for the measurements.
+      - name: 🔑 Fingerprint build inputs
+        id: build_fingerprint
+        run: |
+          set -euo pipefail
+          fingerprint=$(git ls-files -s -- \
+            'bun.lock' 'bun.lockb' 'package-lock.json' 'yarn.lock' \
+            'src' 'app' 'components' 'features' \
+            'app.json' 'app.config.js' 'app.config.ts' 'package.json' \
+            'babel.config.js' 'babel.config.ts' \
+            'metro.config.js' 'metro.config.ts' 'tsconfig.json' \
+            | git hash-object --stdin)
+          echo "hash=$fingerprint" >> "$GITHUB_OUTPUT"
+          echo "Build input fingerprint: $fingerprint"
+        working-directory: ${{ inputs.working_directory || '.' }}
+
       # Build output cache — opt-in via `cache_build: true`.
       #
       # Cache invalidation contract (same as playwright_e2e):
-      #   Key hashes lockfiles → src/app/components/features sources →
-      #   Expo/Metro/Babel/TS configs. Any change forces a rebuild.
+      #   Key is the build-input fingerprint above: lockfiles →
+      #   src/app/components/features sources → Expo/Metro/Babel/TS configs.
+      #   Any change forces a rebuild.
       # Cached paths cover common build output directories (dist, build,
       # .next, out) plus bundler caches. Default false = unchanged behavior.
       - name: 💾 Restore build cache
@@ -1579,7 +1642,7 @@ jobs:
             ${{ inputs.working_directory || '.' }}/out
             ${{ inputs.working_directory || '.' }}/.expo
             ${{ inputs.working_directory || '.' }}/node_modules/.cache
-          key: ${{ runner.os }}-build-${{ hashFiles('**/bun.lock', '**/bun.lockb', '**/package-lock.json', '**/yarn.lock', '**/src/**', '**/app/**', '**/components/**', '**/features/**', '**/app.json', '**/package.json', '**/babel.config.js', '**/babel.config.ts', '**/metro.config.js', '**/metro.config.ts', '**/tsconfig.json') }}
+          key: ${{ runner.os }}-build-${{ steps.build_fingerprint.outputs.hash }}
           restore-keys: |
             ${{ runner.os }}-build-
 

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -220,8 +220,66 @@ describe("quality.yml reusable workflow", () => {
         step => step.id === "build_cache"
       );
 
-      expect(playwrightExpoCache?.with?.key).toContain("'**/src/**'");
-      expect(buildCache?.with?.key).toContain("'**/src/**'");
+      // Both keys derive from the git-based fingerprint step rather than
+      // inlining a hashFiles glob — see the node_modules regression test below.
+      expect(playwrightExpoCache?.with?.key).toContain(
+        "steps.build_fingerprint.outputs.hash"
+      );
+      expect(buildCache?.with?.key).toContain(
+        "steps.build_fingerprint.outputs.hash"
+      );
+
+      for (const job of ["playwright_e2e", "build"] as const) {
+        const fingerprint = workflow.jobs[job].steps?.find(
+          step => step.id === "build_fingerprint"
+        );
+        expect(
+          fingerprint,
+          `${job} must compute a build fingerprint`
+        ).toBeDefined();
+        // The source roots and the lockfiles still drive invalidation.
+        expect(fingerprint?.run).toContain("git ls-files");
+        for (const path of ["'src'", "'bun.lock'", "'package.json'"]) {
+          expect(fingerprint?.run).toContain(path);
+        }
+      }
+    });
+
+    // Regression guard for CodySwannGT/lisa#2418.
+    //
+    // `hashFiles('**/src/**')` is unanchored, so it also matches
+    // `node_modules/**/src/**`. On PropSwapLLC/frontend that walked 116,353
+    // paths and hashed 26,955 node_modules files, blowing past the runner's
+    // 120-second hashFiles ceiling and failing the job in the cache's POST
+    // step — after every test had already passed. A green Playwright nightly
+    // (73/73) was reported as red, blocking merges repo-wide.
+    it("never derives a build cache key from an unanchored source glob", () => {
+      const fingerprintSteps = [
+        ...(workflow.jobs.playwright_e2e.steps ?? []),
+        ...(workflow.jobs.build.steps ?? []),
+      ].filter(
+        step =>
+          step.id === "build_fingerprint" ||
+          step.id === "expo_cache" ||
+          step.id === "build_cache"
+      );
+
+      expect(fingerprintSteps.length).toBe(4);
+
+      for (const step of fingerprintSteps) {
+        const text = `${step.run ?? ""}${step.with?.key ?? ""}`;
+        for (const glob of [
+          "**/src/**",
+          "**/app/**",
+          "**/components/**",
+          "**/features/**",
+        ]) {
+          expect(
+            text,
+            `${step.id} must not hash ${glob} — it traverses node_modules`
+          ).not.toContain(glob);
+        }
+      }
     });
   });
 


### PR DESCRIPTION
Fixes CodySwannGT/lisa#2418

## What went wrong

PropSwapLLC/frontend's nightly Playwright run [31574583191](https://github.com/PropSwapLLC/frontend/actions/runs/31574583191) concluded `failure` and reddened the `🌙 Nightly E2E Health` gate on every open propswap PR.

**No test failed.** The merged blob report says `{"total": 82, "expected": 73, "unexpected": 0, "flaky": 0, "skipped": 9, "ok": true}` across all four shards. Shard 3's `🎭 Run Playwright tests` step succeeded and uploaded its blob; the job then died in the **post** step of `actions/cache`:

```
The template is not valid. CodySwannGT/lisa/.github/workflows/quality.yml@main (Line: 1261, Col: 16):
hashFiles('**/bun.lock, …, **/src/**, **/app/**, **/components/**, **/features/**, …')
couldn't finish within 120 seconds.
```

The three sibling shards evaluated the identical key fine — this is a timing cliff, not a deterministic break, which is why the Aug 10 and Aug 11 nightlies were green and Aug 12 was not.

## Why

`'**/src/**'` and friends are unanchored, so they also match `node_modules/**/src/**`. Measured against PropSwapLLC/frontend:

| Approach | Paths enumerated | Wall time |
| --- | --- | --- |
| Current globs | 116,353 | 64.2s *(before hashing a single byte)* |
| `+ '!**/node_modules/**'` | 11,767 | 42.0s |
| `git ls-files -s` over the same paths | 1,311 | **0.012s** |

node_modules holds 216,628 files there, 26,955 of them under a directory named `src`/`app`/`components`/`features` — all read and SHA-256'd on every run, against 1,305 real source files. On a warm Apple-silicon machine that is 64s of enumeration alone; a GitHub-hosted runner is slower, and 120s is the ceiling.

I measured the obvious one-line fix too: adding `'!**/node_modules/**'` is **not** sufficient. `@actions/glob` applies exclude patterns as a result filter, not as a traversal prune, so the walk still costs 42s — it would have moved the cliff, not removed it.

## The fix

Both call sites (`playwright_e2e` and `build`) now derive the key from a git fingerprint:

```sh
git ls-files -s -- 'bun.lock' … 'tsconfig.json' | git hash-object --stdin
```

- git only tracks checked-in files, so gitignored `node_modules` can never enter the key.
- `ls-files -s` emits mode + blob SHA per file, so the digest stays content-addressed exactly as `hashFiles` was.
- `git hash-object` avoids the `sha256sum` / `shasum` split across runner OSes.
- Pathspecs are relative to the working directory — what the `**/` prefix was approximating, and more correct for a nested `working_directory` in a monorepo.
- The step is deliberately ungated: a skipped step yields an empty output, which would silently collapse the cache key to a constant rather than fail loudly. It costs ~10ms.

Also folds in `app.config.js` / `app.config.ts`, which `🔍 Detect Expo project` treats as Expo config but the old glob never hashed — changing one restored a stale web export.

## Tests

The existing assertion pinned the literal `'**/src/**'` in both keys — the very glob at fault — so it is re-pointed at the invariant it was protecting (the key still invalidates on source and lockfile changes), now via the fingerprint step.

Added a regression guard: no cache key or fingerprint step may reference an unanchored `**/src/**`-style glob. **Verified non-vacuous** — run against the pre-fix workflow it reports 8 violations (4 globs x 2 cache steps); against the fixed workflow, 0.

`tests/integration/quality-workflow.test.ts`: 49 passed.

## Blast radius

Cache-hit *rates* are otherwise unchanged, but the key format changes, so every consumer takes a one-time miss and one rebuild.

## Verification on the affected repo

Independently of this PR, re-running the nightly on propswap dev ([31641292394](https://github.com/PropSwapLLC/frontend/actions/runs/31641292394), head SHA `64304309` = `refs/heads/dev`) put all four shards and the `🎭 Playwright E2E Tests` aggregator green, confirming the product was never broken. This PR is what stops the cliff from being rolled again nightly.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2418
