### PR TITLE
fix(bdd): close six ways the coverage gate could report what it had not proven

### DIFF
--- a/expo/copy-overwrite/scripts/bdd-matrix.mjs
+++ b/expo/copy-overwrite/scripts/bdd-matrix.mjs
@@ -22,6 +22,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { declaredPlatforms, trackerUrl } from "./bdd/contract.mjs";
 import { loadScenarios } from "./bdd/parse.mjs";
+import { indexResults } from "./bdd/report.mjs";
 import { loadExecutionResults } from "./check-bdd-coverage.mjs";
 
 const PACKAGE_ROOT = path.resolve(
@@ -44,37 +45,6 @@ function mappingsByScenario(contract) {
     ]);
   }
   return index;
-}
-
-/**
- * Index execution results by runner, file, and evidence.
- * @param {readonly object[]} runs - Parsed execution-result documents.
- * @returns {Map<string, object>} Lookup keyed by `runner|file|evidence`.
- */
-function resultsIndex(runs) {
-  const index = new Map();
-  for (const run of runs) {
-    for (const result of run.results ?? []) {
-      index.set(`${run.runner}|${result.file}|${result.evidence}`, result);
-    }
-  }
-  return index;
-}
-
-/**
- * Every `SCENARIO:platform` a waiver removes from the denominator.
- *
- * The matrix must know about waivers or it contradicts the burndown: a
- * waived obligation is not an uncovered one, it is a dated IOU.
- * @param {object} contract - Parsed coverage map.
- * @returns {Set<string>} Waived keys.
- */
-function waivedKeys(contract) {
-  return new Set(
-    (contract.platformWaivers ?? []).flatMap(waiver =>
-      (waiver.platforms ?? []).map(platform => `${waiver.scenario}:${platform}`)
-    )
-  );
 }
 
 /**
@@ -152,7 +122,10 @@ export function renderMatrix(root, resultFiles) {
   const platforms = declaredPlatforms(contract.runnerPlatforms);
   const scenarios = loadScenarios(root, platforms);
   const execution = loadExecutionResults(root, resultFiles);
-  const results = resultsIndex(execution.runs);
+  // Shared with the burndown so the two can never disagree about whether a
+  // test failed — including the retry precedence that keeps a `failed`
+  // attempt from being buried by a later `passed`.
+  const results = indexResults(execution.runs);
   const byScenario = mappingsByScenario(contract);
   const waived = waivedKeys(contract);
   const runners = Object.keys(contract.runnerPlatforms ?? {}).sort();

--- a/expo/copy-overwrite/scripts/bdd/baseline.mjs
+++ b/expo/copy-overwrite/scripts/bdd/baseline.mjs
@@ -91,15 +91,57 @@ export function loadBaseline(root, revision) {
 export function checkRatchet({ baseContract, contract, labels }) {
   const before = baseContract?.coverageFloor ?? {};
   const after = contract.coverageFloor ?? {};
+  // A head value that is not a finite number is treated as a REMOVAL, never
+  // as "unchanged". Quoting a floor as "19" would otherwise make the
+  // comparison `"19" < 19` false, recording no drop, while the report treats
+  // the same value as no floor at all — a one-character, single-file edit
+  // that disables enforcement and produces no defect. That is precisely what
+  // the ratchet exists to prevent, so an unusable value fails closed.
   const drops = Object.keys(before)
-    .filter(platform => typeof before[platform] === "number")
-    .filter(platform => (after[platform] ?? -Infinity) < before[platform])
+    .filter(platform => isUsableFloor(before[platform]))
+    .filter(
+      platform =>
+        !isUsableFloor(after[platform]) || after[platform] < before[platform]
+    )
     .map(platform => ({
       platform,
       from: before[platform],
-      to: typeof after[platform] === "number" ? after[platform] : null,
+      to: isUsableFloor(after[platform]) ? after[platform] : null,
+      malformed:
+        after[platform] !== undefined && !isUsableFloor(after[platform]),
     }));
   return drops.flatMap(drop => ratchetDefects(drop, contract, labels));
+}
+
+/**
+ * Whether a raw `coverageFloor` entry is a usable floor.
+ *
+ * Mirrors `classifyFloor` in report.mjs; a unit test asserts the two agree,
+ * because a disagreement is exactly the gap a quoted value slipped through.
+ * @param {unknown} value - The raw entry.
+ * @returns {boolean} True when it is a finite number in 0..100.
+ */
+export function isUsableFloor(value) {
+  return (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    value >= 0 &&
+    value <= 100
+  );
+}
+
+/**
+ * Describe one observed reduction for the operator.
+ * @param {object} drop - The observed reduction.
+ * @returns {string} A one-line description.
+ */
+function describeDrop(drop) {
+  if (drop.malformed) {
+    return `coverageFloor.${drop.platform} is no longer a number (was ${drop.from}); a non-numeric floor disables enforcement, so it counts as a removal`;
+  }
+  return drop.to === null
+    ? `coverageFloor.${drop.platform} was removed (was ${drop.from})`
+    : `coverageFloor.${drop.platform} lowered ${drop.from} → ${drop.to}`;
 }
 
 /**
@@ -110,10 +152,7 @@ export function checkRatchet({ baseContract, contract, labels }) {
  * @returns {object[]} Defects found.
  */
 function ratchetDefects(drop, contract, labels) {
-  const what =
-    drop.to === null
-      ? `coverageFloor.${drop.platform} was removed (was ${drop.from})`
-      : `coverageFloor.${drop.platform} lowered ${drop.from} → ${drop.to}`;
+  const what = describeDrop(drop);
   const record = (contract.coverageFloorBaseline ?? []).find(
     entry =>
       entry.platform === drop.platform &&

--- a/expo/copy-overwrite/scripts/bdd/parse.mjs
+++ b/expo/copy-overwrite/scripts/bdd/parse.mjs
@@ -139,6 +139,9 @@ export function parseFeatureSource(source, file, platforms) {
   const scenarios = [];
   const lines = source.split(/\r?\n/);
   let feature = null;
+  let featureTags = [];
+  let featureIdTags = [];
+  let featureLine = 0;
   let pending = [];
   let current = null;
   for (let index = 0; index < lines.length; index += 1) {
@@ -151,6 +154,15 @@ export function parseFeatureSource(source, file, platforms) {
     const featureMatch = /^Feature:\s*(.+)$/.exec(trimmed);
     if (featureMatch) {
       feature = featureMatch[1].trim();
+      // Gherkin inherits Feature-level tags down to every scenario in the
+      // file. Dropping them made an inherited @web or @ratified-* read as
+      // missing, so a conforming feature file failed on defects it did not
+      // have. Scenario IDs are deliberately NOT inherited — a feature-level
+      // @BDD-* would hand every scenario the same ID, which is a duplicate,
+      // so it is reported instead.
+      featureTags = pending.filter(tag => !ID_PATTERN.test(tag));
+      featureIdTags = pending.filter(tag => ID_PATTERN.test(tag));
+      featureLine = index + 1;
       pending = [];
       current = null;
       continue;
@@ -159,14 +171,22 @@ export function parseFeatureSource(source, file, platforms) {
       trimmed
     );
     if (scenarioMatch) {
-      const grouped = categorize(pending, platforms);
+      // Inherited tags come first so a scenario's own tags read last, and
+      // duplicates are collapsed: a scenario repeating an inherited @web must
+      // not look like it declared the platform twice.
+      const effective = [...new Set([...featureTags, ...pending])];
+      const grouped = categorize(effective, platforms);
       current = {
         id: grouped.ids[0] ?? null,
         name: scenarioMatch[1].trim(),
         feature: feature ?? "Unknown feature",
         file,
         line: index + 1,
-        tags: [...pending],
+        tags: effective,
+        ownTags: [...pending],
+        inheritedTags: [...featureTags],
+        featureIdTags,
+        featureLine,
         ...grouped,
         required: grouped.lifecycle.length === 0,
         primarySteps: [],

--- a/expo/copy-overwrite/scripts/bdd/render.mjs
+++ b/expo/copy-overwrite/scripts/bdd/render.mjs
@@ -17,9 +17,23 @@
  * @returns {string} Cell text.
  */
 const fmt = value =>
-  value.total === 0
+  value.total === 0 || value.percentage === null
     ? "n/a (no obligations)"
     : `${value.covered}/${value.total} (${value.percentage.toFixed(1)}%)`;
+
+/**
+ * Make author-supplied text safe inside a Markdown table cell.
+ *
+ * Waiver reasons and scenario titles are repo data. A single `|` ends the
+ * cell early and shifts every column after it, so the Ticket and Expires
+ * columns silently misreport — in a generated file nobody re-reads.
+ * @param {unknown} text - Arbitrary cell content.
+ * @returns {string} Text safe to interpolate into a table row.
+ */
+const cell = text =>
+  String(text ?? "")
+    .replace(/\|/g, "\\|")
+    .replace(/\r?\n/g, " ");
 
 /**
  * Render the per-platform traceability table.
@@ -28,7 +42,7 @@ const fmt = value =>
  */
 function platformTable(report) {
   const rows = Object.entries(report.traceability.byPlatform)
-    .map(([platform, value]) => `| ${platform} | ${fmt(value)} |`)
+    .map(([platform, value]) => `| ${cell(platform)} | ${fmt(value)} |`)
     .join("\n");
   return `| Platform | Obligations with mapped automation |\n|---|---:|\n${rows}\n| **Overall** | **${fmt(report.traceability.overall)}** |`;
 }
@@ -47,7 +61,7 @@ function executionSection(report) {
   const sources = execution.sources
     .map(
       source =>
-        `- \`${source.runner}\` run \`${source.runId ?? "unidentified"}\` (${source.resultCount} results, completed ${source.completedAt ?? "unknown"})`
+        `- \`${cell(source.runner)}\` run \`${cell(source.runId ?? "unidentified")}\` (${source.resultCount} results, completed ${cell(source.completedAt ?? "unknown")})`
     )
     .join("\n");
   return `| Mapped tests | Executed | Passed | Failed | Skipped | Not run |\n|---:|---:|---:|---:|---:|---:|\n| ${execution.mappedTests} | ${execution.executed} | ${execution.passed} | ${execution.failed} | ${execution.skipped} | ${execution.notRun} |\n\nSources:\n\n${sources}`;
@@ -63,10 +77,23 @@ function waiverTable(report) {
     report.waived.entries
       .map(
         entry =>
-          `| ${entry.scenario} | ${entry.platforms.join(", ")} | ${entry.runner ?? "—"} | ${entry.owner ?? "**unowned**"} | ${entry.reason ?? "—"} | ${entry.ticket ?? "**none**"} | ${entry.expiresAt ?? "**never**"} |`
+          `| ${cell(entry.scenario)} | ${cell(entry.platforms.join(", "))} | ${cell(entry.runner ?? "—")} | ${cell(entry.owner ?? "**unowned**")} | ${cell(entry.reason ?? "—")} | ${cell(entry.ticket ?? "**none**")} | ${cell(entry.expiresAt ?? "**never**")} |`
       )
       .join("\n") || "| — | — | — | — | None | — | — |";
   return `| Scenario | Platforms | Runner | Owner | Reason | Ticket | Expires |\n|---|---|---|---|---|---|---|\n${rows}`;
+}
+
+/**
+ * Render one platform's committed floor.
+ *
+ * An unusable value is called out as invalid rather than shown as absent —
+ * "no floor here" and "somebody broke the floor" need different reactions.
+ * @param {object} value - One platform's floor evaluation.
+ * @returns {string} Cell text.
+ */
+function floorCell(value) {
+  if (value.state === "invalid") return "**invalid**";
+  return value.floor === null ? "**unset**" : `${value.floor}%`;
 }
 
 /**
@@ -78,7 +105,7 @@ function floorTable(report) {
   const rows = Object.entries(report.floor.byPlatform)
     .map(
       ([platform, value]) =>
-        `| ${platform} | ${value.floor === null ? "**unset**" : `${value.floor}%`} | ${value.actual}% | ${value.ok ? "ok" : "**below floor**"} |`
+        `| ${cell(platform)} | ${floorCell(value)} | ${value.actual === null ? "n/a" : `${value.actual}%`} | ${value.ok ? "ok" : "**below floor**"} |`
     )
     .join("\n");
   return `| Platform | Committed floor | Current | Status |\n|---|---:|---:|---|\n${rows}`;
@@ -107,10 +134,10 @@ function gapSections(report) {
       const rows = [...entries.entries()]
         .map(
           ([id, value]) =>
-            `| ${id} | ${value.name} | ${value.platforms.sort().join(", ")} |`
+            `| ${cell(id)} | ${cell(value.name)} | ${cell(value.platforms.sort().join(", "))} |`
         )
         .join("\n");
-      return `### ${feature}\n\n| Scenario | Behavior with no mapped proof | Platforms |\n|---|---|---|\n${rows}`;
+      return `### ${cell(feature)}\n\n| Scenario | Behavior with no mapped proof | Platforms |\n|---|---|---|\n${rows}`;
     });
   return (
     sections.join("\n\n") ||

--- a/expo/copy-overwrite/scripts/bdd/report.mjs
+++ b/expo/copy-overwrite/scripts/bdd/report.mjs
@@ -22,11 +22,13 @@ import {
   trackerUrl,
 } from "./contract.mjs";
 
-const percentage = (covered, total) =>
-  total === 0 ? 100 : (covered / total) * 100;
-
 /**
  * Summarize a subset of obligations against the covered set.
+ *
+ * An empty denominator reports `percentage: null`, never 100. "Nothing was
+ * required here" and "everything required here is covered" are different
+ * claims, and printing the second for the first is how a platform with no
+ * obligations comes to look fully covered.
  * @param {readonly object[]} subset - Obligations to count.
  * @param {ReadonlySet<string>} coveredKeys - Keys with an aligned mapping.
  * @returns {object} Covered/total/percentage.
@@ -36,7 +38,10 @@ function summarize(subset, coveredKeys) {
   return {
     covered,
     total: subset.length,
-    percentage: Number(percentage(covered, subset.length).toFixed(1)),
+    percentage:
+      subset.length === 0
+        ? null
+        : Number(((covered / subset.length) * 100).toFixed(1)),
   };
 }
 
@@ -60,15 +65,54 @@ function declaredObligations(scenarios, platformRunners) {
 }
 
 /**
+ * Precedence when the same test reports more than once.
+ *
+ * Retries and sharded runs legitimately report a test twice. Last-write-wins
+ * would let a `passed` retry bury the `failed` attempt that preceded it, and
+ * the whole point of the execution block is that it cannot understate
+ * failures. Higher wins.
+ */
+const STATUS_PRECEDENCE = Object.freeze({
+  failed: 3,
+  skipped: 2,
+  passed: 1,
+});
+
+/**
+ * Rank a result status, treating anything unrecognized as the most severe.
+ *
+ * Unknown is ranked ABOVE failed on purpose: a status this gate does not
+ * understand must never be silently outranked by a `passed` from another
+ * shard (allowlist, never denylist).
+ * @param {string|undefined} status - A supplied result status.
+ * @returns {number} Its precedence.
+ */
+function statusRank(status) {
+  return STATUS_PRECEDENCE[status] ?? 4;
+}
+
+/**
  * Index supplied execution results by runner, file, and evidence.
+ *
+ * Exported so the matrix joins results exactly as the burndown does; two
+ * private copies of this rule would eventually disagree about whether a test
+ * failed.
  * @param {readonly object[]} runs - Parsed execution-result documents.
  * @returns {Map<string, object>} Lookup keyed by `runner|file|evidence`.
  */
-function indexResults(runs) {
+export function indexResults(runs) {
   const index = new Map();
   for (const run of runs) {
     for (const result of run.results ?? []) {
-      index.set(`${run.runner}|${result.file}|${result.evidence}`, {
+      const key = `${run.runner}|${result.file}|${result.evidence}`;
+      const existing = index.get(key);
+      if (
+        existing &&
+        statusRank(existing.status) >= statusRank(result.status)
+      ) {
+        continue;
+      }
+      index.set(key, {
         ...result,
         runner: run.runner,
         runId: run.runId ?? null,
@@ -153,33 +197,75 @@ function distinctTests(mappings) {
 }
 
 /**
+ * A declared floor value, or the reason it is not usable.
+ *
+ * Only a finite number in 0..100 is a floor. Anything else — a quoted
+ * `"19"`, a null, a NaN — is `invalid`, NOT "no floor": treating a bad value
+ * as absent is what let a one-character edit remove a platform from
+ * enforcement while producing no defect at all.
+ * @param {unknown} declared - The raw `coverageFloor` entry.
+ * @returns {{state: string, value: number|null}} The classified floor.
+ */
+function classifyFloor(declared) {
+  if (declared === undefined) return { state: "unset", value: null };
+  if (typeof declared !== "number" || !Number.isFinite(declared)) {
+    return { state: "invalid", value: null };
+  }
+  if (declared < 0 || declared > 100) return { state: "invalid", value: null };
+  return { state: "declared", value: declared };
+}
+
+/**
  * Evaluate the committed coverage floor per platform.
  * @param {object} contract - Parsed coverage map.
  * @param {object} byPlatform - Traceability summary per platform.
  * @param {ReadonlySet<string>} platforms - Declared platform vocabulary.
- * @returns {object} Floor evaluation, including which platforms declared none.
+ * @returns {object} Floor evaluation, naming unset and invalid platforms.
  */
 export function evaluateFloor(contract, byPlatform, platforms) {
   const floors = contract.coverageFloor ?? {};
   const entries = [...platforms].sort().map(platform => {
-    const declared = floors[platform];
-    const actual = byPlatform[platform]?.percentage ?? 100;
+    const declared = classifyFloor(floors[platform]);
+    // A platform with no obligations reports `null`, not 100. It cannot clear
+    // a positive floor by having nothing to measure.
+    const actual = byPlatform[platform]?.percentage ?? null;
     return [
       platform,
       {
-        floor: typeof declared === "number" ? declared : null,
+        floor: declared.value,
+        state: declared.state,
         actual,
-        ok: typeof declared !== "number" || actual + 1e-9 >= declared,
+        ok: isFloorMet(declared, actual),
       },
     ];
   });
   return {
     byPlatform: Object.fromEntries(entries),
     unset: entries
-      .filter(([, value]) => value.floor === null)
+      .filter(([, value]) => value.state === "unset")
+      .map(([name]) => name),
+    invalid: entries
+      .filter(([, value]) => value.state === "invalid")
       .map(([name]) => name),
     ok: entries.every(([, value]) => value.ok),
   };
+}
+
+/**
+ * Whether a platform clears its floor.
+ *
+ * An invalid floor is never "met" — a bad value must fail rather than quietly
+ * disable enforcement. An unset floor has nothing to clear here; the enforced
+ * mode reports its absence separately.
+ * @param {{state: string, value: number|null}} declared - The classified floor.
+ * @param {number|null} actual - Measured percentage, or null when there are no obligations.
+ * @returns {boolean} Whether the floor is satisfied.
+ */
+function isFloorMet(declared, actual) {
+  if (declared.state === "invalid") return false;
+  if (declared.state === "unset") return true;
+  if (actual === null) return declared.value === 0;
+  return actual + 1e-9 >= declared.value;
 }
 
 /**
@@ -218,7 +304,13 @@ export function buildTrackerIndex(scenarios, trackers) {
  * @param {object} input - Scenarios, contract, execution runs, and platforms.
  * @returns {object} The report envelope.
  */
-export function buildReport({ scenarios, contract, runs, platforms }) {
+export function buildReport({
+  scenarios,
+  contract,
+  runs,
+  platforms,
+  unresolved = new Set(),
+}) {
   const platformRunners = runnersByPlatform(contract.runnerPlatforms);
   const declared = declaredObligations(scenarios, platformRunners);
   const waivedKeys = new Set(
@@ -227,7 +319,7 @@ export function buildReport({ scenarios, contract, runs, platforms }) {
     )
   );
   const obligations = declared.filter(item => !waivedKeys.has(item.key));
-  const coveredKeys = coverageKeys(scenarios, contract);
+  const coveredKeys = coverageKeys(scenarios, contract, unresolved);
   const byPlatform = Object.fromEntries(
     [...platforms].sort().map(platform => [
       platform,
@@ -242,7 +334,7 @@ export function buildReport({ scenarios, contract, runs, platforms }) {
     asOf: contract.asOf ?? null,
     scenarios: countScenarios(scenarios),
     traceability: {
-      note: "Obligations whose aligned automation is mapped and whose evidence string still resolves. This is TRACEABILITY coverage, not execution coverage and not a pass rate.",
+      note: "Obligations whose aligned automation is mapped AND whose evidence string still resolves — a mapping whose test was renamed or deleted stops counting here immediately, even in bootstrap where the matching defect is only a warning. This is TRACEABILITY coverage, not execution coverage and not a pass rate.",
       overall: summarize(obligations, coveredKeys),
       byPlatform,
       byRunner: byRunnerSummary(contract, obligations, coveredKeys),
@@ -267,12 +359,19 @@ export function buildReport({ scenarios, contract, runs, platforms }) {
 }
 
 /**
- * Every scenario-platform key an existing mapping covers.
+ * Every scenario-platform key a mapping covers AND still proves.
+ *
+ * A mapping whose evidence string no longer resolves is excluded here, not
+ * merely reported. In bootstrap that defect is only a warning, so counting it
+ * as covered would let the headline keep claiming coverage the repo does not
+ * have — the precise "the manifest was lying" failure this gate exists to
+ * surface.
  * @param {readonly object[]} scenarios - Parsed scenarios.
  * @param {object} contract - Parsed coverage map.
+ * @param {ReadonlySet<string>} unresolved - Keys whose evidence no longer resolves.
  * @returns {Set<string>} Covered keys.
  */
-function coverageKeys(scenarios, contract) {
+function coverageKeys(scenarios, contract, unresolved) {
   const required = new Set(
     scenarios.filter(scenario => scenario.required).map(scenario => scenario.id)
   );
@@ -280,7 +379,8 @@ function coverageKeys(scenarios, contract) {
   for (const mapping of contract.mappings ?? []) {
     if (!required.has(mapping.scenario)) continue;
     for (const platform of mapping.platforms ?? []) {
-      covered.add(`${mapping.scenario}:${platform}`);
+      const key = `${mapping.scenario}:${platform}`;
+      if (!unresolved.has(key)) covered.add(key);
     }
   }
   return covered;

--- a/expo/copy-overwrite/scripts/bdd/validate.mjs
+++ b/expo/copy-overwrite/scripts/bdd/validate.mjs
@@ -64,9 +64,29 @@ export function validateScenarios(scenarios, platforms) {
       );
     }
     defects.push(...missingSteps(scenario, at));
+    defects.push(...featureLevelId(scenario));
     if (scenario.id) defects.push(...recordId(scenario, at, seen));
   }
-  return defects;
+  return [...new Map(defects.map(item => [item.message, item])).values()];
+}
+
+/**
+ * Reject a `@BDD-*` id placed on the Feature rather than a Scenario.
+ *
+ * Gherkin would inherit it into every scenario in the file, handing them all
+ * the same identity. IDs are per-behavior, so this is always a mistake — and
+ * inheriting it silently would produce a pile of duplicate-ID defects that
+ * never name the real cause.
+ * @param {object} scenario - Parsed scenario.
+ * @returns {object[]} Defects found.
+ */
+function featureLevelId(scenario) {
+  return (scenario.featureIdTags ?? []).map(tag =>
+    defect(
+      "scenario-id",
+      `${scenario.file}:${scenario.featureLine} declares @${tag} on the Feature; a scenario ID identifies one behavior and is never inherited`
+    )
+  );
 }
 
 /**
@@ -166,7 +186,12 @@ function orphanReason(reference, { keys, repos, defaultRepo }) {
  * @param {object} input - Root, scenarios, and the parsed contract.
  * @returns {object[]} Defects found.
  */
-export function validateMappings({ root, scenarios, contract }) {
+export function validateMappings({
+  root,
+  scenarios,
+  contract,
+  cache = new Map(),
+}) {
   const byId = new Map(scenarios.map(scenario => [scenario.id, scenario]));
   const platformRunners = runnersByPlatform(contract.runnerPlatforms);
   const defects = [];
@@ -188,7 +213,7 @@ export function validateMappings({ root, scenarios, contract }) {
     }
     defects.push(...mappingDuplicates(mapping, at, seen));
     defects.push(...mappingPlatforms(mapping, scenario, platformRunners, at));
-    defects.push(...mappingEvidence(root, mapping, at));
+    defects.push(...mappingEvidence(root, mapping, at, cache));
   }
   return defects;
 }
@@ -250,6 +275,69 @@ function mappingPlatforms(mapping, scenario, platformRunners, at) {
 }
 
 /**
+ * Whether a mapping's evidence string still resolves inside the repo.
+ *
+ * The single source of truth for "does this mapping still prove anything",
+ * shared by the defect check and by the coverage count. Two separate answers
+ * to that question is how a stale mapping comes to fail validation while
+ * still counting as covered.
+ * @param {string} root - Repo root.
+ * @param {object} mapping - Raw mapping entry.
+ * @param {Map<string, string>} [cache] - Optional file-content cache.
+ * @returns {{ok: boolean, code?: string, detail?: string}} The verdict.
+ */
+export function evidenceResolves(root, mapping, cache = new Map()) {
+  if (typeof mapping.evidence !== "string" || mapping.evidence.length === 0) {
+    return {
+      ok: false,
+      code: "mapping-evidence",
+      detail: "declares no evidence string",
+    };
+  }
+  const resolved = resolveInsideRepo(root, mapping.file);
+  if (!resolved.path) {
+    return {
+      ok: false,
+      code: "mapping-file",
+      detail: `${mapping.file} — ${resolved.error}`,
+    };
+  }
+  if (!cache.has(resolved.path)) {
+    cache.set(resolved.path, fs.readFileSync(resolved.path, "utf8"));
+  }
+  if (!cache.get(resolved.path).includes(mapping.evidence)) {
+    return {
+      ok: false,
+      code: "mapping-evidence",
+      detail: `${mapping.file} no longer contains ${JSON.stringify(mapping.evidence)}`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * The scenario-platform keys whose mapping no longer proves anything.
+ *
+ * Coverage is counted from mappings that PASS this check, so a mapping whose
+ * test was renamed stops counting the moment it stops resolving — including
+ * in bootstrap, where the matching defect is only a warning. Otherwise the
+ * headline would keep claiming coverage the repo does not have, which is
+ * exactly the "manifest was lying" failure this gate exists to surface.
+ * @param {object} input - Root, contract, and an optional file cache.
+ * @returns {Set<string>} Keys that must not be counted as covered.
+ */
+export function unresolvedEvidenceKeys({ root, contract, cache = new Map() }) {
+  const broken = new Set();
+  for (const mapping of contract.mappings ?? []) {
+    if (evidenceResolves(root, mapping, cache).ok) continue;
+    for (const platform of mapping.platforms ?? []) {
+      broken.add(`${mapping.scenario}:${platform}`);
+    }
+  }
+  return broken;
+}
+
+/**
  * Prove the mapped file still contains the exact evidence string.
  *
  * This is what makes a mapping falsifiable rather than an assertion: rename
@@ -258,25 +346,10 @@ function mappingPlatforms(mapping, scenario, platformRunners, at) {
  * @param {string} root - Repo root.
  * @param {object} mapping - Raw mapping entry.
  * @param {string} at - Location label.
+ * @param {Map<string, string>} cache - File-content cache.
  * @returns {object[]} Defects found.
  */
-function mappingEvidence(root, mapping, at) {
-  if (typeof mapping.evidence !== "string" || mapping.evidence.length === 0) {
-    return [defect("mapping-evidence", `${at}: declares no evidence string`)];
-  }
-  const resolved = resolveInsideRepo(root, mapping.file);
-  if (!resolved.path) {
-    return [
-      defect("mapping-file", `${at}: ${mapping.file} — ${resolved.error}`),
-    ];
-  }
-  if (!fs.readFileSync(resolved.path, "utf8").includes(mapping.evidence)) {
-    return [
-      defect(
-        "mapping-evidence",
-        `${at}: ${mapping.file} no longer contains ${JSON.stringify(mapping.evidence)}`
-      ),
-    ];
-  }
-  return [];
+function mappingEvidence(root, mapping, at, cache) {
+  const verdict = evidenceResolves(root, mapping, cache);
+  return verdict.ok ? [] : [defect(verdict.code, `${at}: ${verdict.detail}`)];
 }

--- a/expo/copy-overwrite/scripts/check-bdd-coverage.mjs
+++ b/expo/copy-overwrite/scripts/check-bdd-coverage.mjs
@@ -54,6 +54,7 @@ import { loadScenarios } from "./bdd/parse.mjs";
 import { buildReport } from "./bdd/report.mjs";
 import { renderBurndown } from "./bdd/render.mjs";
 import {
+  unresolvedEvidenceKeys,
   validateMappings,
   validateScenarios,
   validateTrackerTags,
@@ -235,11 +236,11 @@ export function loadExecutionResults(root, files) {
  * @param {object} input - Root, contract, scenarios, platforms, and options.
  * @returns {object[]} Defects found.
  */
-function validateAll({ root, contract, scenarios, platforms, options }) {
+function validateAll({ root, contract, scenarios, platforms, options, cache }) {
   const defects = [
     ...validateScenarios(scenarios, platforms),
     ...validateTrackerTags(scenarios, contract.trackers),
-    ...validateMappings({ root, scenarios, contract }),
+    ...validateMappings({ root, scenarios, contract, cache }),
     ...validateWaivers({ scenarios, contract, today: options.today }),
   ];
   if (!options.baseSha) return defects;
@@ -267,6 +268,25 @@ function validateAll({ root, contract, scenarios, platforms, options }) {
       labels: options.labels,
     }),
   ];
+}
+
+/**
+ * A malformed coverage floor, in EVERY adopted state.
+ *
+ * This is config integrity, not contract quality, so bootstrap does not
+ * downgrade it: a floor written as `"19"` rather than `19` disables the
+ * ratchet AND removes the platform from enforcement, in one character, in
+ * one file, with no other signal. It is refused rather than ignored.
+ * @param {object} report - The built report.
+ * @returns {object[]} Defects found.
+ */
+function floorIntegrityDefects(report) {
+  return (report.floor.invalid ?? []).map(platform =>
+    defect(
+      "floor-invalid",
+      `coverageFloor.${platform} is not a number between 0 and 100; a non-numeric floor silently disables enforcement, so it is refused rather than ignored`
+    )
+  );
 }
 
 /**
@@ -342,17 +362,23 @@ export function run(root, options) {
   const platforms = declaredPlatforms(contract.runnerPlatforms);
   const scenarios = loadScenarios(root, platforms);
   const execution = loadExecutionResults(root, options.resultFiles ?? []);
+  // One file cache serves both the evidence defects and the coverage count,
+  // so each mapped file is read once no matter how large the manifest.
+  const cache = new Map();
+  const unresolved = unresolvedEvidenceKeys({ root, contract, cache });
   const report = buildReport({
     scenarios,
     contract,
     runs: execution.runs,
     platforms,
+    unresolved,
   });
   const defects = [
     ...(versionDefect ? [versionDefect] : []),
     ...validateAdoption(contract, mode, options.today),
     ...execution.defects,
-    ...validateAll({ root, contract, scenarios, platforms, options }),
+    ...floorIntegrityDefects(report),
+    ...validateAll({ root, contract, scenarios, platforms, options, cache }),
     ...(mode === "enforced"
       ? enforcedDefects({ contract, scenarios, report, platforms })
       : []),

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -167,25 +167,25 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/copy-overwrite/knip.json":
       "b19d0c177d8d0460779e07043c92d37555e7721224b6b2134ac2f6d10ab44b33",
     "expo/copy-overwrite/scripts/bdd-matrix.mjs":
-      "f510e7e4484cd4f6182afab72f412ff9e8db458b18b96403ec1c0bd672f1dd51",
+      "519273668f08db7c14053ba1f25830e4cbb6e34ddf11f06264e72d0f7a80b98d",
     "expo/copy-overwrite/scripts/bdd/baseline.mjs":
-      "dd48f24536fd36c56e8e6dc3c192f8862f3aa7dfef0e46db4f55205c1ee2b1ec",
+      "96f6a295bad34c0b52f7f667640243a462cb745998768c21a192c74d1a96dd34",
     "expo/copy-overwrite/scripts/bdd/contract.mjs":
       "d8a418d655d4a14d4d3287518b8d678cb410b7f08e38a60cf0dbf30b2e796973",
     "expo/copy-overwrite/scripts/bdd/envelope.mjs":
       "7bb2aa5dbe49fa97d3f14e5400fef3f76e0fd99ab74e88d568a3d037c94c601d",
     "expo/copy-overwrite/scripts/bdd/parse.mjs":
-      "d6866a422d841cef291dea931424af4e0799be34d19f6817adba28e31972ac4f",
+      "d1bf74b01388d107e6869b90a3d1e1d2c03da8124cb2cc14f9cf6d64e2b00ce8",
     "expo/copy-overwrite/scripts/bdd/render.mjs":
-      "c900d5be3b4692bc7f2252f1461b0db987d300f99817ad83466428c530da4fce",
+      "47a5adb9fc607e5d330c246218d0b043be14a8527c7ba198b222df03fd96672a",
     "expo/copy-overwrite/scripts/bdd/report.mjs":
-      "effb76f834032e5a21e631134a1fb38a08382dcb1db5da2c57fc28aeebe6fb56",
+      "4a07425197ddbcc53052a334354325c5d6b1880d586a02c176362bfb5c826a2a",
     "expo/copy-overwrite/scripts/bdd/validate.mjs":
-      "564e128ba1fc804861598baf509e2e13ec688bb99df9612b1aea3434ed9412a6",
+      "afb8dd052733a5f83e6d004eac3437783a707c08810ba9cc65138d898aff83e2",
     "expo/copy-overwrite/scripts/bdd/waivers.mjs":
       "4b9ebf80100f478cc5e06d50b4d672ad08ec77a3746a7a109a74e1daf71a55b7",
     "expo/copy-overwrite/scripts/check-bdd-coverage.mjs":
-      "13db95d2ed8bce81acfb4fdfd9adb195a60818952393268f6a269dbaa6e62d66",
+      "98fa86e5987e7384c7fd23baa435f86830fb432424134bb7d8141c005af9167b",
     "expo/copy-overwrite/scripts/check-e2e-coverage.mjs":
       "30cf7d860ecd3b838b8608f38da10fcddb4e7e90a0867438f411d68346a5f129",
     "expo/copy-overwrite/tsconfig.eslint.json":
@@ -8627,8 +8627,10 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/opencode/skills-installer.test.ts": true,
     "tests/unit/scripts/bdd-adoption.test.ts": true,
     "tests/unit/scripts/bdd-envelope.test.ts": true,
+    "tests/unit/scripts/bdd-failopen.test.ts": true,
     "tests/unit/scripts/bdd-grammar.test.ts": true,
     "tests/unit/scripts/bdd-ratchet.test.ts": true,
+    "tests/unit/scripts/bdd-render.test.ts": true,
     "tests/unit/scripts/bdd-reporting.test.ts": true,
     "tests/unit/scripts/bdd-validation.test.ts": true,
     "tests/unit/scripts/bdd-wiring.test.ts": true,

--- a/tests/unit/scripts/bdd-failopen.test.ts
+++ b/tests/unit/scripts/bdd-failopen.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Regressions for six ways the gate could report something it had not proven.
+ *
+ * Every case here is a hole found by review AFTER the gate shipped, and each
+ * one failed in the same direction: the number looked better than the repo
+ * was. A gate whose whole purpose is to stop a manifest lying cannot itself
+ * round in the flattering direction.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  BOOTSTRAP,
+  COMPLETED,
+  ENFORCED,
+  HEALTHY_FILES,
+  HEALTHY_MAP,
+  HOME_EVIDENCE,
+  HOME_FEATURE_FILE,
+  HOME_ID,
+  HOME_SPEC,
+  PLAYWRIGHT,
+  RATIFIED,
+  WEB,
+  codes,
+  commitAll,
+  featureSource,
+  healthyProject,
+  makeProject,
+  messages,
+  readMap,
+  runGate,
+  runReport,
+  writeMap,
+} from "./bdd/support";
+
+const RESULTS_FILE = "results.json";
+const FLOOR_INVALID = "floor-invalid";
+
+describe("a malformed coverage floor cannot disable the floor", () => {
+  it("refuses a floor quoted as a string, in enforced mode", () => {
+    const run = runGate(healthyProject({ coverageFloor: { [WEB]: "100" } }), {
+      BDD_MODE: ENFORCED,
+    });
+    expect(run.status).toBe(1);
+    expect(messages(run, FLOOR_INVALID)[0]).toContain(
+      "silently disables enforcement"
+    );
+  });
+
+  it("refuses it in BOOTSTRAP too — this is config integrity, not contract quality", () => {
+    // The whole exploit is a one-character edit in one file. Downgrading it to
+    // a warning would leave the ratchet off with nothing red anywhere.
+    const run = runGate(healthyProject({ coverageFloor: { [WEB]: "100" } }), {
+      BDD_MODE: BOOTSTRAP,
+    });
+    expect(run.status).toBe(1);
+    expect(codes(run)).toContain(FLOOR_INVALID);
+  });
+
+  it("refuses NaN, null, and out-of-range floors", () => {
+    for (const bad of [null, Number.NaN, -1, 101, true]) {
+      const run = runGate(healthyProject({ coverageFloor: { [WEB]: bad } }), {
+        BDD_MODE: BOOTSTRAP,
+      });
+      expect(codes(run), String(bad)).toContain(FLOOR_INVALID);
+    }
+  });
+
+  it("treats quoting a floor as a RATCHET DROP, not as unchanged", () => {
+    const root = healthyProject({ coverageFloor: { [WEB]: 100 } });
+    const base = commitAll(root);
+    const map = readMap(root);
+    (map.coverageFloor as Record<string, unknown>)[WEB] = "100";
+    writeMap(root, map);
+    const run = runGate(root, { BDD_MODE: ENFORCED, BDD_BASE_SHA: base });
+    expect(run.status).toBe(1);
+    expect(messages(run, "floor-ratchet")[0]).toContain("no longer a number");
+  });
+
+  it("never reports a platform as clearing a floor it cannot evaluate", () => {
+    const report = runReport(
+      healthyProject({ coverageFloor: { [WEB]: "100" } }),
+      {
+        BDD_MODE: BOOTSTRAP,
+      }
+    );
+    expect(report.floor.byPlatform[WEB]).toMatchObject({
+      state: "invalid",
+      ok: false,
+    });
+    expect(report.floor.ok).toBe(false);
+  });
+});
+
+describe("a stale mapping stops counting as covered", () => {
+  it("excludes an unresolved evidence string from traceability, even in bootstrap", () => {
+    // In bootstrap `mapping-evidence` is only a warning. If the mapping still
+    // counted, the headline would keep claiming coverage for a test that no
+    // longer exists — the exact failure found live in another repo's manifest.
+    const root = makeProject({
+      map: {
+        ...HEALTHY_MAP,
+        adoption: {
+          state: BOOTSTRAP,
+          owner: "o@example.test",
+          expiresAt: "2099-01-01",
+        },
+        coverageFloor: { [WEB]: 0 },
+      },
+      features: {
+        [HOME_FEATURE_FILE]: featureSource("Home", [
+          { id: HOME_ID, tags: [WEB, RATIFIED] },
+        ]),
+      },
+      files: {
+        [HOME_SPEC]: `test("a completely different title", () => {});\n`,
+      },
+    });
+    const run = runGate(root, { BDD_MODE: BOOTSTRAP });
+    expect(codes(run)).toContain("mapping-evidence");
+    expect(run.envelope.status).toBe(COMPLETED);
+    expect(run.envelope.summary.traceabilityCovered).toBe(0);
+    expect(run.envelope.summary.traceabilityTotal).toBe(1);
+  });
+
+  it("still counts a mapping whose evidence resolves", () => {
+    const run = runGate(healthyProject(), { BDD_MODE: ENFORCED });
+    expect(run.envelope.summary.traceabilityCovered).toBe(1);
+  });
+
+  it("lists the now-uncovered obligation as a gap", () => {
+    const report = runReport(
+      healthyProject(
+        {},
+        { files: { [HOME_SPEC]: "test('renamed', () => {});\n" } }
+      ),
+      { BDD_MODE: BOOTSTRAP }
+    );
+    expect(report.gaps.map(gap => gap.scenario)).toContain(HOME_ID);
+  });
+});
+
+describe("Gherkin feature-level tags are inherited", () => {
+  /**
+   * Build a feature whose platform and provenance tags sit on `Feature:`.
+   * @returns Gherkin source.
+   */
+  function inheritedSource(): string {
+    return (
+      `@${WEB} @${RATIFIED}\nFeature: Home\n\n` +
+      `  @${HOME_ID}\n  Scenario: A visitor sees the hero\n` +
+      `    Given a visitor\n    When they act\n    Then something is true\n`
+    );
+  }
+
+  it("does not report inherited @web / @ratified-* as missing", () => {
+    const root = makeProject({
+      map: { ...HEALTHY_MAP, coverageFloor: { [WEB]: 0 } },
+      features: { [HOME_FEATURE_FILE]: inheritedSource() },
+      files: HEALTHY_FILES,
+    });
+    const run = runGate(root, { BDD_MODE: ENFORCED });
+    expect(codes(run)).not.toContain("scenario-platform");
+    expect(codes(run)).not.toContain("scenario-provenance");
+    expect(run.status).toBe(0);
+  });
+
+  it("counts the obligation the inherited platform creates", () => {
+    const root = makeProject({
+      map: { ...HEALTHY_MAP, coverageFloor: { [WEB]: 0 } },
+      features: { [HOME_FEATURE_FILE]: inheritedSource() },
+      files: HEALTHY_FILES,
+    });
+    expect(
+      runGate(root, { BDD_MODE: ENFORCED }).envelope.summary
+    ).toMatchObject({
+      traceabilityTotal: 1,
+      traceabilityCovered: 1,
+    });
+  });
+
+  it("refuses a scenario ID placed on the Feature", () => {
+    // Inheriting it would hand every scenario in the file the same identity.
+    const source =
+      `@${HOME_ID}\nFeature: Home\n\n` +
+      `  @${WEB} @${RATIFIED}\n  Scenario: One\n    Given a\n    When b\n    Then c\n\n` +
+      `  @${WEB} @${RATIFIED}\n  Scenario: Two\n    Given a\n    When b\n    Then c\n`;
+    const run = runGate(
+      makeProject({
+        map: { ...HEALTHY_MAP, mappings: [], coverageFloor: { [WEB]: 0 } },
+        features: { [HOME_FEATURE_FILE]: source },
+        files: HEALTHY_FILES,
+      }),
+      { BDD_MODE: BOOTSTRAP }
+    );
+    expect(messages(run, "scenario-id").join(" ")).toContain("on the Feature");
+  });
+
+  it("lets a scenario's own lifecycle tag apply alongside inherited tags", () => {
+    const source =
+      `@${WEB} @${RATIFIED}\nFeature: Home\n\n` +
+      `  @${HOME_ID} @blocked\n  Scenario: Not built yet\n    Given a\n    When b\n    Then c\n`;
+    const report = runReport(
+      makeProject({
+        map: { ...HEALTHY_MAP, mappings: [], coverageFloor: { [WEB]: 0 } },
+        features: { [HOME_FEATURE_FILE]: source },
+        files: HEALTHY_FILES,
+      }),
+      { BDD_MODE: BOOTSTRAP }
+    );
+    expect(report.scenarios).toMatchObject({
+      declared: 1,
+      required: 0,
+      blocked: 1,
+    });
+  });
+});
+
+describe("a duplicate execution result never buries a failure", () => {
+  /**
+   * Two runs reporting the same test with different statuses.
+   * @param first - Status reported by the first run.
+   * @param second - Status reported by the second run.
+   * @returns Serialized result documents.
+   */
+  function twoRuns(first: string, second: string): string {
+    return JSON.stringify([
+      {
+        schemaVersion: 1,
+        runner: PLAYWRIGHT,
+        runId: "shard-1",
+        results: [{ file: HOME_SPEC, evidence: HOME_EVIDENCE, status: first }],
+      },
+      {
+        schemaVersion: 1,
+        runner: PLAYWRIGHT,
+        runId: "shard-2",
+        results: [{ file: HOME_SPEC, evidence: HOME_EVIDENCE, status: second }],
+      },
+    ]);
+  }
+
+  it("keeps the failure whichever order the shards report in", () => {
+    for (const [first, second] of [
+      ["failed", "passed"],
+      ["passed", "failed"],
+    ] as const) {
+      const root = healthyProject(
+        {},
+        { files: { [RESULTS_FILE]: twoRuns(first, second) } }
+      );
+      const run = runGate(root, {
+        BDD_MODE: ENFORCED,
+        BDD_EXECUTION_RESULTS: RESULTS_FILE,
+      });
+      expect(run.envelope.summary, `${first}->${second}`).toMatchObject({
+        failed: 1,
+        passed: 0,
+        executed: 1,
+      });
+    }
+  });
+
+  it("ranks skipped above passed so a skip is not hidden either", () => {
+    const root = healthyProject(
+      {},
+      { files: { [RESULTS_FILE]: twoRuns("skipped", "passed") } }
+    );
+    expect(
+      runGate(root, { BDD_MODE: ENFORCED, BDD_EXECUTION_RESULTS: RESULTS_FILE })
+        .envelope.summary
+    ).toMatchObject({ skipped: 1, passed: 0 });
+  });
+
+  it("treats an unrecognized status as most severe rather than letting a pass win", () => {
+    const root = healthyProject(
+      {},
+      { files: { [RESULTS_FILE]: twoRuns("passed", "timed-out") } }
+    );
+    const summary = runGate(root, {
+      BDD_MODE: ENFORCED,
+      BDD_EXECUTION_RESULTS: RESULTS_FILE,
+    }).envelope.summary;
+    expect(summary.passed).toBe(0);
+    expect(summary.executed).toBe(1);
+  });
+});
+
+describe("an empty denominator is not 100%", () => {
+  it("reports percentage null rather than a fabricated 100", () => {
+    const report = runReport(
+      makeProject({
+        map: {
+          ...HEALTHY_MAP,
+          runnerPlatforms: { [PLAYWRIGHT]: [WEB], maestro: ["ios"] },
+          coverageFloor: { [WEB]: 0, ios: 0 },
+        },
+        features: {
+          [HOME_FEATURE_FILE]: featureSource("Home", [
+            { id: HOME_ID, tags: [WEB, RATIFIED] },
+          ]),
+        },
+        files: HEALTHY_FILES,
+      }),
+      { BDD_MODE: BOOTSTRAP }
+    );
+    expect(report.traceability.byPlatform.ios).toMatchObject({
+      total: 0,
+      percentage: null,
+    });
+  });
+
+  it("a positive floor is never cleared by having nothing to measure", () => {
+    const report = runReport(
+      makeProject({
+        map: {
+          ...HEALTHY_MAP,
+          runnerPlatforms: { [PLAYWRIGHT]: [WEB], maestro: ["ios"] },
+          coverageFloor: { [WEB]: 0, ios: 80 },
+        },
+        features: {
+          [HOME_FEATURE_FILE]: featureSource("Home", [
+            { id: HOME_ID, tags: [WEB, RATIFIED] },
+          ]),
+        },
+        files: HEALTHY_FILES,
+      }),
+      { BDD_MODE: BOOTSTRAP }
+    );
+    expect(report.floor.byPlatform.ios.ok).toBe(false);
+  });
+});

--- a/tests/unit/scripts/bdd-render.test.ts
+++ b/tests/unit/scripts/bdd-render.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The generated Markdown must survive author-supplied text.
+ *
+ * The burndown and matrix are generated files nobody re-reads line by line,
+ * so a table that silently shifts its columns misreports the Ticket and
+ * Expires cells forever.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  BOOTSTRAP,
+  HEALTHY_FILES,
+  HEALTHY_MAP,
+  HOME_FEATURE_FILE,
+  HOME_ID,
+  RATIFIED,
+  WEB,
+  featureSource,
+  makeProject,
+  runGateWrite,
+} from "./bdd/support";
+
+describe("author text cannot break the generated tables", () => {
+  it("escapes a pipe in a waiver reason", () => {
+    const root = makeProject({
+      map: {
+        ...HEALTHY_MAP,
+        mappings: [],
+        coverageFloor: { [WEB]: 0 },
+        platformWaivers: [
+          {
+            scenario: HOME_ID,
+            platforms: [WEB],
+            reason: "the runner pipes stdout | stderr and cannot decide it",
+            owner: "o@example.test",
+            ticket: "TUN-1",
+            recordedAt: "2026-08-01",
+            expiresAt: "2099-01-01",
+          },
+        ],
+      },
+      features: {
+        [HOME_FEATURE_FILE]: featureSource("Home", [
+          { id: HOME_ID, tags: [WEB, RATIFIED] },
+        ]),
+      },
+      files: HEALTHY_FILES,
+    });
+    const burndown = runGateWrite(root, { BDD_MODE: BOOTSTRAP });
+    const row = burndown
+      .split("\n")
+      .find(line => line.includes("stdout")) as string;
+    expect(row).toContain("stdout \\| stderr");
+    // Seven columns means the Ticket and Expires cells still line up.
+    expect(row.split(/(?<!\\)\|/).length - 2).toBe(7);
+  });
+});

--- a/tests/unit/scripts/bdd/support.ts
+++ b/tests/unit/scripts/bdd/support.ts
@@ -258,6 +258,35 @@ export function runReport(
 }
 
 /**
+ * Run the gate with `--write` and return the regenerated burndown.
+ * @param root - Project root.
+ * @param env - Extra environment.
+ * @returns The burndown Markdown.
+ */
+export function runGateWrite(
+  root: string,
+  env: Record<string, string> = {}
+): string {
+  spawnSync(process.execPath, [SCRIPT_ABS, "--write"], {
+    encoding: "utf-8",
+    env: {
+      ...hermeticEnv(root),
+      BDD_COVERAGE_ROOT: root,
+      BDD_TODAY: TODAY,
+      BDD_MODE: "",
+      BDD_BASE_SHA: "",
+      BDD_PR_LABELS: "",
+      BDD_EXECUTION_RESULTS: "",
+      ...env,
+    },
+  });
+  return fs.readFileSync(
+    path.join(root, "docs", "e2e-bdd-coverage.md"),
+    "utf-8"
+  );
+}
+
+/**
  * Collect the defect codes an envelope reported.
  * @param run - A gate run.
  * @returns The codes, in order.


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2421

Closes #2421 · Follow-up to #2414, from review on the adopter proof gunnertech/frontend#388.

## Summary

Review of the BDD coverage gate shipped in #2414 (adopter proof: gunnertech/frontend#388) found six ways the gate could report something it had not proven. **Every one fails in the same direction** — the number comes out better than the repo actually is. A gate whose entire purpose is to stop a manifest lying cannot round in the flattering direction itself.

### Three audiences

- **Product/founder:** the coverage number could be inflated — by a test that had been renamed, by a retry hiding a failure, or by a one-character edit that quietly switched the safety rail off. These close all of those.
- **Engineer:** a type-coercion hole in the ratchet, a coverage count taken from the wrong source of truth, dropped Gherkin tag inheritance, last-write-wins result indexing, `100%` for an empty denominator, and unescaped Markdown cells.
- **Operator:** one of these is already live — another repo's manifest claims coverage from three test titles that no longer exist.

## The six

| # | Hole | Direction of the lie |
|---|---|---|
| 1 | `coverageFloor: {web: "19"}` — `"19" < 19` is false so the ratchet sees no drop, while `evaluateFloor` requires `typeof === "number"` and reports `ok: true`. One character, one file, no defect. | Floor silently disabled |
| 2 | Coverage counted from a mapping's *presence*; the evidence check is separate and only a warning in bootstrap. A renamed test keeps its coverage. | Coverage overstated |
| 3 | Gherkin Feature-level tags are inherited by all scenarios; the parser dropped them, so an inherited `@web`/`@ratified-*` read as missing. | False defects, and lost obligations |
| 4 | Burndown and matrix each built their own result index with unconditional `set`; the last shard wins, so a `passed` retry erases the `failed` before it. | Failures hidden |
| 5 | `percentage: 100` when there are no obligations at all. | Empty reads as complete |
| 6 | A `|` in a waiver reason or scenario title ends its Markdown cell early and shifts every column after it. | Ticket/Expires misreported |

## Acceptance criteria

```gherkin
Scenario: A non-numeric floor is refused, not ignored
  Given a coverageFloor value that is not a finite number in 0..100
  When the gate runs in any adopted state
  Then it reports floor-invalid and fails
  And a base-revision comparison treats the change as a floor REMOVAL

Scenario: A stale mapping stops counting immediately
  Given a mapping whose evidence string no longer appears in its file
  When the gate runs in bootstrap, where that defect is only a warning
  Then the obligation is NOT counted as covered
  And it appears in the gaps list

Scenario: Feature-level tags are inherited
  Given @web and @ratified-* declared on the Feature
  When scenarios in that file are parsed
  Then they carry those tags and report no missing-platform defect
  And a @BDD-* id on the Feature is refused rather than inherited

Scenario: A retry never buries a failure
  Given two runs reporting the same test as failed and passed, in either order
  When results are joined
  Then the test counts as failed

Scenario: An empty denominator is not 100%
  Given a platform with no required obligations
  Then its percentage is null and a positive floor is not cleared

Scenario: Author text cannot break the generated tables
  Given a waiver reason containing a pipe character
  Then the rendered row still has its full column count
```

## Out of scope

Adopter-side regeneration (tracked on gunnertech/frontend#388) and any change to the three-state adoption contract, which is unaffected.

## Validation journey

1. `bun run test:unit` — 18 new regression cases across two suites, each named for the hole it closes.
2. Re-run the gate against all three portfolio contracts: gunnertech must stay at 306 declared / 91-247 obligations (fidelity to the canonical implementation), and gemini must DROP as its falsely-counted stale mapping stops counting.
3. Full CI.


## Portfolio effect

| Repo | Before | After | Reading |
|---|---|---|---|
| gunnertech | 306 declared, 91/247 | **unchanged** | Fidelity to the canonical implementation preserved |
| tunnl | 168 declared, 365/365 | **unchanged** | — |
| gemini | 348/517 | **347/517** | A falsely-counted stale mapping stops counting. The correction working. |

## Verification

- `bun run test:unit` — **557 files / 9472 tests pass** (the one file requiring Bun's runner passes under `bun run`).
- `eslint . --quiet`, `oxlint`, `tsc --noEmit`, `prettier --check .` — clean. No suppression directives added.
- `check:upstream-evidence-manifest` regenerated and passing.
- Re-ran the gate against all three portfolio contracts to confirm the table above.

🤖 Generated with Claude Code
