### PR TITLE
fix(apply): deliver Lisa-owned enforcement guards on a version bump

### DIFF
--- a/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-doctor/SKILL.md
@@ -56,7 +56,10 @@ as applicable to the current repo:
    and `source` only. If a required CLI, MCP surface, or auth context is unavailable in the current
    runtime, report that explicitly instead of pretending the repo is ready.
 4. **Runtime distribution surfaces** — confirm the command, skill, hook, and related distribution
-   surfaces relevant to this repo are present where Lisa expects them on the active runtime.
+   surfaces relevant to this repo are present where Lisa expects them on the active runtime, and
+   that the Lisa-owned enforcement artifacts (`scripts/lisa-hooks/*`,
+   `scripts/lisa-enforcement-fallback.sh`) match the installed Lisa version rather than an older
+   copy. Present-but-stale is a finding: a guard whose fix never landed enforces the old behavior.
 5. **Automation readiness** — inspect whether the configured queue source/tracker and scheduling
    prerequisites are observable, but do **not** create, edit, or delete automations during doctor.
 6. **Optional GitHub Project coordination** — when `github.projects.v2` is configured, delegate

--- a/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-doctor/SKILL.md
@@ -56,7 +56,10 @@ as applicable to the current repo:
    and `source` only. If a required CLI, MCP surface, or auth context is unavailable in the current
    runtime, report that explicitly instead of pretending the repo is ready.
 4. **Runtime distribution surfaces** — confirm the command, skill, hook, and related distribution
-   surfaces relevant to this repo are present where Lisa expects them on the active runtime.
+   surfaces relevant to this repo are present where Lisa expects them on the active runtime, and
+   that the Lisa-owned enforcement artifacts (`scripts/lisa-hooks/*`,
+   `scripts/lisa-enforcement-fallback.sh`) match the installed Lisa version rather than an older
+   copy. Present-but-stale is a finding: a guard whose fix never landed enforces the old behavior.
 5. **Automation readiness** — inspect whether the configured queue source/tracker and scheduling
    prerequisites are observable, but do **not** create, edit, or delete automations during doctor.
 6. **Optional GitHub Project coordination** — when `github.projects.v2` is configured, delegate

--- a/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-doctor/SKILL.md
@@ -56,7 +56,10 @@ as applicable to the current repo:
    and `source` only. If a required CLI, MCP surface, or auth context is unavailable in the current
    runtime, report that explicitly instead of pretending the repo is ready.
 4. **Runtime distribution surfaces** — confirm the command, skill, hook, and related distribution
-   surfaces relevant to this repo are present where Lisa expects them on the active runtime.
+   surfaces relevant to this repo are present where Lisa expects them on the active runtime, and
+   that the Lisa-owned enforcement artifacts (`scripts/lisa-hooks/*`,
+   `scripts/lisa-enforcement-fallback.sh`) match the installed Lisa version rather than an older
+   copy. Present-but-stale is a finding: a guard whose fix never landed enforces the old behavior.
 5. **Automation readiness** — inspect whether the configured queue source/tracker and scheduling
    prerequisites are observable, but do **not** create, edit, or delete automations during doctor.
 6. **Optional GitHub Project coordination** — when `github.projects.v2` is configured, delegate

--- a/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-doctor/SKILL.md
@@ -56,7 +56,10 @@ as applicable to the current repo:
    and `source` only. If a required CLI, MCP surface, or auth context is unavailable in the current
    runtime, report that explicitly instead of pretending the repo is ready.
 4. **Runtime distribution surfaces** — confirm the command, skill, hook, and related distribution
-   surfaces relevant to this repo are present where Lisa expects them on the active runtime.
+   surfaces relevant to this repo are present where Lisa expects them on the active runtime, and
+   that the Lisa-owned enforcement artifacts (`scripts/lisa-hooks/*`,
+   `scripts/lisa-enforcement-fallback.sh`) match the installed Lisa version rather than an older
+   copy. Present-but-stale is a finding: a guard whose fix never landed enforces the old behavior.
 5. **Automation readiness** — inspect whether the configured queue source/tracker and scheduling
    prerequisites are observable, but do **not** create, edit, or delete automations during doctor.
 6. **Optional GitHub Project coordination** — when `github.projects.v2` is configured, delegate

--- a/plugins/lisa/skills/lisa-doctor/SKILL.md
+++ b/plugins/lisa/skills/lisa-doctor/SKILL.md
@@ -56,7 +56,10 @@ as applicable to the current repo:
    and `source` only. If a required CLI, MCP surface, or auth context is unavailable in the current
    runtime, report that explicitly instead of pretending the repo is ready.
 4. **Runtime distribution surfaces** — confirm the command, skill, hook, and related distribution
-   surfaces relevant to this repo are present where Lisa expects them on the active runtime.
+   surfaces relevant to this repo are present where Lisa expects them on the active runtime, and
+   that the Lisa-owned enforcement artifacts (`scripts/lisa-hooks/*`,
+   `scripts/lisa-enforcement-fallback.sh`) match the installed Lisa version rather than an older
+   copy. Present-but-stale is a finding: a guard whose fix never landed enforces the old behavior.
 5. **Automation readiness** — inspect whether the configured queue source/tracker and scheduling
    prerequisites are observable, but do **not** create, edit, or delete automations during doctor.
 6. **Optional GitHub Project coordination** — when `github.projects.v2` is configured, delegate

--- a/plugins/src/base/skills/lisa-doctor/SKILL.md
+++ b/plugins/src/base/skills/lisa-doctor/SKILL.md
@@ -56,7 +56,10 @@ as applicable to the current repo:
    and `source` only. If a required CLI, MCP surface, or auth context is unavailable in the current
    runtime, report that explicitly instead of pretending the repo is ready.
 4. **Runtime distribution surfaces** — confirm the command, skill, hook, and related distribution
-   surfaces relevant to this repo are present where Lisa expects them on the active runtime.
+   surfaces relevant to this repo are present where Lisa expects them on the active runtime, and
+   that the Lisa-owned enforcement artifacts (`scripts/lisa-hooks/*`,
+   `scripts/lisa-enforcement-fallback.sh`) match the installed Lisa version rather than an older
+   copy. Present-but-stale is a finding: a guard whose fix never landed enforces the old behavior.
 5. **Automation readiness** — inspect whether the configured queue source/tracker and scheduling
    prerequisites are observable, but do **not** create, edit, or delete automations during doctor.
 6. **Optional GitHub Project coordination** — when `github.projects.v2` is configured, delegate

--- a/src/cli/doctor-lisa-owned-artifacts.ts
+++ b/src/cli/doctor-lisa-owned-artifacts.ts
@@ -1,0 +1,179 @@
+/**
+ * Doctor check: is this project running the enforcement guards it shipped with,
+ * or an older copy?
+ *
+ * Apply now refreshes Lisa-owned artifacts on a version bump, so in the normal
+ * case this check is quiet. It exists because the fleet had no way to notice the
+ * abnormal case. Before the apply fix, a project could sit for months on a guard
+ * with a known fail-open hole and nothing anywhere said so — not the apply
+ * summary, not doctor, not CI. It can still happen: a project that pinned an old
+ * Lisa, or listed the path in `.lisaignore`, or never re-applied after upgrading,
+ * keeps whatever it has. This turns that silence into one warn line naming the
+ * files.
+ *
+ * Warn, not fail: a stale guard is a real hole, but the remedy is one command,
+ * and failing doctor would redden CI in every repo mid-upgrade.
+ * @module cli/doctor-lisa-owned-artifacts
+ */
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import * as fse from "fs-extra";
+
+import { PROJECT_TYPE_ORDER } from "../core/config.js";
+import { isLisaOwnedTemplate } from "../core/lisa-owned-templates.js";
+import { listFilesRecursive } from "../utils/file-operations.js";
+import {
+  matchesAnyPattern,
+  parseIgnorePatterns,
+} from "../utils/ignore-patterns.js";
+
+const CHECK_NAME = "Lisa enforcement artifacts current?";
+const COPY_OVERWRITE = "copy-overwrite";
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** One doctor check result, structurally identical to `DoctorCheck`. */
+interface ArtifactCheck {
+  name: string;
+  status: "ok" | "warn" | "fail";
+  detail: string;
+}
+
+/** One shipped Lisa-owned artifact and the destination it installs to. */
+type ShippedArtifact = readonly [destination: string, source: string];
+
+/**
+ * Resolve the installed Lisa package root, mirroring how apply resolves it.
+ * @returns Absolute path to the Lisa package root
+ */
+function defaultLisaRoot(): string {
+  return path.resolve(__dirname, "..", "..");
+}
+
+/**
+ * List the Lisa-owned artifacts one stack's copy-overwrite tree ships.
+ * @param lisaRoot - Installed Lisa package root
+ * @param type - Stack directory name
+ * @returns Destination/source pairs shipped by that stack
+ */
+async function shippedByStack(
+  lisaRoot: string,
+  type: string
+): Promise<readonly ShippedArtifact[]> {
+  const directory = path.join(lisaRoot, type, COPY_OVERWRITE);
+  if (!(await fse.pathExists(directory))) return [];
+  return (await listFilesRecursive(directory))
+    .map(
+      source =>
+        [
+          path.relative(directory, source).split(path.sep).join("/"),
+          source,
+        ] as const
+    )
+    .filter(([destination]) => isLisaOwnedTemplate(destination));
+}
+
+/**
+ * Collect every shipped Lisa-owned artifact, keyed by its destination path.
+ *
+ * A destination can be shipped by more than one stack; all shipped variants are
+ * kept so the comparison can accept whichever one the project actually has,
+ * rather than guessing which stack won at apply time.
+ * @param lisaRoot - Installed Lisa package root
+ * @returns Destination path to the shipped source files that produce it
+ */
+async function shippedArtifacts(
+  lisaRoot: string
+): Promise<ReadonlyMap<string, readonly string[]>> {
+  const shipped = (
+    await Promise.all(
+      ["all", ...PROJECT_TYPE_ORDER].map(async type =>
+        shippedByStack(lisaRoot, type)
+      )
+    )
+  ).flat();
+  const destinations = [
+    ...new Set(shipped.map(([destination]) => destination)),
+  ];
+  return new Map(
+    destinations.map(destination => [
+      destination,
+      shipped
+        .filter(([candidate]) => candidate === destination)
+        .map(([, source]) => source),
+    ])
+  );
+}
+
+/**
+ * Whether the installed file matches any shipped variant of that artifact.
+ * @param installed - Bytes currently installed in the project
+ * @param sources - Absolute paths of the shipped variants
+ * @returns True when the project is running a shipped version
+ */
+async function matchesAnyShipped(
+  installed: Buffer,
+  sources: readonly string[]
+): Promise<boolean> {
+  const shipped = await Promise.all(
+    sources.map(async source => readFile(source))
+  );
+  return shipped.some(candidate => installed.equals(candidate));
+}
+
+/**
+ * Report Lisa-owned enforcement artifacts the project has an outdated copy of.
+ *
+ * Only artifacts the project already has are considered: a missing one means
+ * the stack does not apply here, not that something drifted.
+ * @param targetPath - Project path to inspect
+ * @param lisaRoot - Installed Lisa package root (injected by tests)
+ * @returns Doctor check result
+ */
+export async function checkLisaOwnedArtifacts(
+  targetPath: string,
+  lisaRoot: string = defaultLisaRoot()
+): Promise<ArtifactCheck> {
+  const shipped = await shippedArtifacts(lisaRoot);
+  if (shipped.size === 0) {
+    return {
+      name: CHECK_NAME,
+      status: "ok",
+      detail: "No Lisa-owned enforcement artifacts are shipped",
+    };
+  }
+
+  const ignoreText = await readFile(
+    path.join(targetPath, ".lisaignore"),
+    "utf8"
+  ).catch(() => "");
+  const ignorePatterns = parseIgnorePatterns(ignoreText);
+
+  const results = await Promise.all(
+    [...shipped].map(async ([destination, sources]) => {
+      if (matchesAnyPattern(destination, ignorePatterns)) return undefined;
+      const installed = await readFile(
+        path.join(targetPath, destination)
+      ).catch(() => undefined);
+      if (installed === undefined) return undefined;
+      return (await matchesAnyShipped(installed, sources))
+        ? undefined
+        : destination;
+    })
+  );
+  const stale = results
+    .filter((item): item is string => item !== undefined)
+    .sort((left, right) => left.localeCompare(right));
+
+  return stale.length === 0
+    ? {
+        name: CHECK_NAME,
+        status: "ok",
+        detail: "Enforcement guards match the installed Lisa version",
+      }
+    : {
+        name: CHECK_NAME,
+        status: "warn",
+        detail: `Outdated Lisa-owned guards (run \`npx lisa apply .\` to refresh): ${stale.join(", ")}`,
+      };
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -11,6 +11,7 @@ import { checkKaneProvider } from "./doctor-kane.js";
 import { checkLearningsLedger } from "./doctor-learnings-ledger.js";
 import { checkSonarProvider } from "./doctor-sonar.js";
 import { checkLegacyCodexOverlay } from "./doctor-legacy-overlay.js";
+import { checkLisaOwnedArtifacts } from "./doctor-lisa-owned-artifacts.js";
 import { checkLegacyMonitorThresholds } from "./doctor-monitor-thresholds.js";
 import { checkRepositoryReadiness } from "./doctor-readiness.js";
 import { checkWorkerEpoch } from "./doctor-worker-epoch.js";
@@ -330,6 +331,7 @@ export async function runDoctor(
     await checkKaneProvider(resolvedTarget, deps),
     await checkSonarProvider(resolvedTarget, deps),
     await checkLegacyMonitorThresholds(resolvedTarget),
+    await checkLisaOwnedArtifacts(resolvedTarget),
     await checkProjectType(resolvedTarget),
     await checkInstructionFiles(resolvedTarget),
     // Runs AFTER the instruction-files check because that check performs the

--- a/src/core/lisa-owned-templates.ts
+++ b/src/core/lisa-owned-templates.ts
@@ -1,0 +1,42 @@
+/**
+ * Which managed files Lisa owns outright, as opposed to files a host project
+ * shares with Lisa and legitimately customises.
+ *
+ * The two populations sit side by side in the `copy-overwrite` trees and want
+ * opposite defaults. `tsconfig.json`, `knip.json`, and `eslint.config.ts` are
+ * seeded by Lisa and then edited downstream, so a non-interactive apply must
+ * never replace them without being asked. `scripts/lisa-hooks/*` and
+ * `scripts/lisa-enforcement-fallback.sh` are the enforcement itself — their
+ * content *is* the guard — and nobody edits them downstream. Treating those two
+ * populations the same is what made a released security fix undeliverable: the
+ * fail-open fixes in #2374 sat in the package while installed repos kept running
+ * the vulnerable guard, until someone deleted the files by hand so the create
+ * path would recreate them.
+ *
+ * The marker is the `lisa-` namespace in the path. Lisa names everything it owns
+ * outright that way — `lisa-hooks/`, `lisa-enforcement-fallback.sh`,
+ * `lisa-work-item.mjs`, `lisa-command-envelope.mjs` — and its own skills and
+ * hooks invoke those by exact path, which is precisely why a host cannot
+ * meaningfully fork one in place. Nothing a project customises carries the
+ * namespace.
+ *
+ * A project that genuinely wants to hold its own version of one of these still
+ * can: `.lisaignore` is filtered before any strategy runs, and an ignored path
+ * is never a candidate here.
+ * @module core/lisa-owned-templates
+ */
+
+/** Path-segment namespace Lisa reserves for artifacts it owns outright. */
+const LISA_NAMESPACE_PREFIX = "lisa-";
+
+/**
+ * Whether a managed file is Lisa's own artifact rather than shared host content.
+ * @param relativePath - Repo-relative destination path of the managed file
+ * @returns True when Lisa owns the file outright and may refresh it unprompted
+ */
+export function isLisaOwnedTemplate(relativePath: string): boolean {
+  return relativePath
+    .replaceAll("\\", "/")
+    .split("/")
+    .some(segment => segment.startsWith(LISA_NAMESPACE_PREFIX));
+}

--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -2166,11 +2166,15 @@ export class Lisa {
       pc.blue,
       "(identical or create-only)"
     );
+    // Not every overwrite is a human saying yes: Lisa's own artifacts refresh
+    // on any apply, which is how a released guard fix reaches installed
+    // projects. Saying "user approved" here would misreport that as consent
+    // nobody gave.
     this.printStatLine(
       "Overwritten:",
       overwritten,
       pc.yellow,
-      "(user approved)"
+      "(approved or Lisa-owned)"
     );
     this.printStatLine(
       "Out of date:",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -925,7 +925,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs":
       "9d06590e6b99cce33e5fb10bd5b9e7515318133e3635368ef47162abc123bdfa",
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
-      "fb41a1e63c5332d47a46e715aff52551f3df867033b5e4f37dfaeee30019b891",
+      "ed46df59bfd1097acad4a5ad960811ffb37b318c94e36e5f78ea3b96c2d76136",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
       "66a89df3976ddb17af5c31415eeb6192c4c9e0ebba7ab3ee38b4fa6ebadb4955",
     "plugins/src/base/skills/lisa-epic-triage/SKILL.md":
@@ -7948,6 +7948,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/cli/doctor-kane.ts": true,
     "src/cli/doctor-learnings-ledger.ts": true,
     "src/cli/doctor-legacy-overlay.ts": true,
+    "src/cli/doctor-lisa-owned-artifacts.ts": true,
     "src/cli/doctor-monitor-thresholds.ts": true,
     "src/cli/doctor-readiness-action-pins.ts": true,
     "src/cli/doctor-readiness-audit-allowlist.ts": true,
@@ -8122,6 +8123,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/core/learnings-stray-ledger.ts": true,
     "src/core/learnings-writer.ts": true,
     "src/core/learnings.ts": true,
+    "src/core/lisa-owned-templates.ts": true,
     "src/core/lisa-plugin-selection.ts": true,
     "src/core/lisa-rules-mirror.ts": true,
     "src/core/lisa-skill-sources.ts": true,
@@ -8376,6 +8378,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/check-learnings-budget-cmd.test.ts": true,
     "tests/unit/cli/doctor-kane.test.ts": true,
     "tests/unit/cli/doctor-learnings-ledger.test.ts": true,
+    "tests/unit/cli/doctor-lisa-owned-artifacts.test.ts": true,
     "tests/unit/cli/doctor-monitor-thresholds.test.ts": true,
     "tests/unit/cli/doctor-readiness-blockers.test.ts": true,
     "tests/unit/cli/doctor-readiness-capabilities.test.ts": true,
@@ -8546,6 +8549,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/core/learnings-supersede-race.test.ts": true,
     "tests/unit/core/learnings-unlocked-read.test.ts": true,
     "tests/unit/core/learnings-writer.test.ts": true,
+    "tests/unit/core/lisa-owned-templates.test.ts": true,
     "tests/unit/core/lisa-plugin-selection.test.ts": true,
     "tests/unit/core/lisa-skill-sources.test.ts": true,
     "tests/unit/core/project-config-harness-migration.test.ts": true,
@@ -8780,6 +8784,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/convergent-review-contract.test.ts": true,
     "tests/unit/strategies/copy-contents-gitignore.test.ts": true,
     "tests/unit/strategies/copy-contents.test.ts": true,
+    "tests/unit/strategies/copy-overwrite-lisa-owned-guards.test.ts": true,
     "tests/unit/strategies/copy-overwrite-refresh-templates.test.ts": true,
     "tests/unit/strategies/copy-overwrite.test.ts": true,
     "tests/unit/strategies/create-only.test.ts": true,

--- a/src/strategies/copy-overwrite.ts
+++ b/src/strategies/copy-overwrite.ts
@@ -2,6 +2,7 @@ import * as fse from "fs-extra";
 import { copyFile } from "node:fs/promises";
 import { mayRefreshTemplate } from "../core/config.js";
 import type { FileOperationResult } from "../core/config.js";
+import { isLisaOwnedTemplate } from "../core/lisa-owned-templates.js";
 import type { ICopyStrategy, StrategyContext } from "./strategy.interface.js";
 import { filesIdentical, ensureParentDir } from "../utils/file-operations.js";
 
@@ -86,12 +87,19 @@ export class CopyOverwriteStrategy implements ICopyStrategy {
   /**
    * Resolve a differing managed file on a non-interactive apply.
    *
-   * There is no prompt available here, so the file is left alone and reported
-   * as `stale` — unless `--refresh-templates` covers it, which is the operator
-   * deciding in advance to take upstream's version. That flag is the supported
-   * way to deliver a changed enforcement guard to an installed project; without
-   * it the only route is deleting the file so the create path picks it up,
-   * which is a workaround nobody should have to know.
+   * There is no prompt available here, so a file the project may have
+   * customised is left alone and reported as `stale` — unless
+   * `--refresh-templates` covers it, which is the operator deciding in advance
+   * to take upstream's version.
+   *
+   * Lisa's own artifacts are not in that category and never wait for the flag.
+   * A version bump is how the fleet takes an upgrade, and it passes no flags, so
+   * gating `scripts/lisa-hooks/*` behind one meant a released security fix
+   * reached nobody: the fail-open fixes in #2374 shipped while installed repos
+   * kept running the vulnerable guard, until someone deleted the files by hand
+   * so the create path would recreate them. Lisa owns those files outright —
+   * see `isLisaOwnedTemplate` — so they refresh here, backed up first, and a
+   * project that wants to keep its own copy says so in `.lisaignore`.
    * @param sourcePath - Packaged template path
    * @param destPath - Installed file path
    * @param relativePath - Repo-relative path for reporting
@@ -106,7 +114,10 @@ export class CopyOverwriteStrategy implements ICopyStrategy {
   ): Promise<FileOperationResult> {
     const { config, backupFile } = context;
 
-    if (!mayRefreshTemplate(relativePath, config.refreshTemplates)) {
+    if (
+      !isLisaOwnedTemplate(relativePath) &&
+      !mayRefreshTemplate(relativePath, config.refreshTemplates)
+    ) {
       return { relativePath, strategy: this.name, action: "stale" };
     }
 

--- a/tests/unit/cli/doctor-lisa-owned-artifacts.test.ts
+++ b/tests/unit/cli/doctor-lisa-owned-artifacts.test.ts
@@ -1,0 +1,93 @@
+/**
+ * The fleet's way to notice it is running an old enforcement guard.
+ *
+ * Apply delivers Lisa-owned artifacts on a version bump, so this check is
+ * normally quiet — but a project that pinned an old Lisa, or that never
+ * re-applied after upgrading, still runs whatever it has, and before this check
+ * nothing anywhere said so.
+ * @module tests/unit/cli/doctor-lisa-owned-artifacts
+ */
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { checkLisaOwnedArtifacts } from "../../../src/cli/doctor-lisa-owned-artifacts.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const GUARD = "scripts/lisa-hooks/block-no-verify.sh";
+const HOST_CONFIG = "tsconfig.json";
+const SHIPPED_GUARD = "#!/usr/bin/env bash\n# closed\n";
+const OLD_GUARD = "#!/usr/bin/env bash\n# fails open\n";
+
+describe("checkLisaOwnedArtifacts", () => {
+  let tempDir: string;
+  let lisaRoot: string;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    lisaRoot = path.join(tempDir, "lisa");
+    projectDir = path.join(tempDir, "project");
+    await fs.outputFile(
+      path.join(lisaRoot, "all", "copy-overwrite", GUARD),
+      SHIPPED_GUARD
+    );
+    await fs.outputFile(
+      path.join(lisaRoot, "all", "copy-overwrite", HOST_CONFIG),
+      '{"strict":true}'
+    );
+    await fs.ensureDir(projectDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  it("warns and names the guard when the project has an older copy", async () => {
+    await fs.outputFile(path.join(projectDir, GUARD), OLD_GUARD);
+
+    const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
+
+    expect(check.status).toBe("warn");
+    expect(check.detail).toContain(GUARD);
+  });
+
+  it("passes when the guard matches what Lisa ships", async () => {
+    await fs.outputFile(path.join(projectDir, GUARD), SHIPPED_GUARD);
+
+    const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
+
+    expect(check.status).toBe("ok");
+  });
+
+  it("passes when the project never installed the guard", async () => {
+    // A missing artifact means the stack does not apply here, not drift.
+    const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
+
+    expect(check.status).toBe("ok");
+  });
+
+  it("ignores drift in host-owned managed config", async () => {
+    // Customised build config is exactly what a project is allowed to do; this
+    // check is only about the files Lisa owns.
+    await fs.outputFile(path.join(projectDir, GUARD), SHIPPED_GUARD);
+    await fs.outputFile(path.join(projectDir, HOST_CONFIG), "{}");
+
+    const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
+
+    expect(check.status).toBe("ok");
+  });
+
+  it("respects .lisaignore", async () => {
+    // A project that deliberately holds its own copy said so already.
+    await fs.outputFile(path.join(projectDir, GUARD), OLD_GUARD);
+    await fs.outputFile(
+      path.join(projectDir, ".lisaignore"),
+      "scripts/lisa-hooks/\n"
+    );
+
+    const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
+
+    expect(check.status).toBe("ok");
+  });
+});

--- a/tests/unit/core/lisa-owned-templates.test.ts
+++ b/tests/unit/core/lisa-owned-templates.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Which managed files belong to Lisa rather than to the host project.
+ *
+ * The distinction decides whether a version bump may replace a file without
+ * asking. Getting it wrong in one direction leaves security fixes undelivered;
+ * getting it wrong in the other silently overwrites a project's build config.
+ * These tests pin the line: a `lisa-` namespaced path segment means Lisa owns
+ * the file, and nothing else does.
+ * @module tests/unit/core/lisa-owned-templates
+ */
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { isLisaOwnedTemplate } from "../../../src/core/lisa-owned-templates.js";
+import { listFilesRecursive } from "../../../src/utils/file-operations.js";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..", "..", "..");
+
+describe("isLisaOwnedTemplate", () => {
+  it("owns the enforcement guards", () => {
+    expect(isLisaOwnedTemplate("scripts/lisa-hooks/block-no-verify.sh")).toBe(
+      true
+    );
+    expect(isLisaOwnedTemplate("scripts/lisa-enforcement-fallback.sh")).toBe(
+      true
+    );
+  });
+
+  it("owns the other lisa-namespaced scripts Lisa's own skills invoke", () => {
+    expect(isLisaOwnedTemplate("scripts/lisa-work-item.mjs")).toBe(true);
+    expect(isLisaOwnedTemplate("scripts/lisa-command-envelope.mjs")).toBe(true);
+    expect(isLisaOwnedTemplate("scripts/lisa-mutation.mjs")).toBe(true);
+  });
+
+  it("normalises Windows separators", () => {
+    expect(isLisaOwnedTemplate("scripts\\lisa-hooks\\block-no-verify.sh")).toBe(
+      true
+    );
+  });
+
+  it("does not own files a project legitimately customises", () => {
+    for (const hostOwned of [
+      "tsconfig.json",
+      "knip.json",
+      "eslint.config.ts",
+      ".prettierrc.json",
+      "lefthook.yml",
+      ".github/workflows/ci.yml",
+      "scripts/check-threshold-ratchet.mjs",
+      ".lisa.config.json",
+      ".lisa/PROJECT_LEARNINGS.md",
+    ]) {
+      expect(isLisaOwnedTemplate(hostOwned), hostOwned).toBe(false);
+    }
+  });
+
+  it("classifies every shipped guard as Lisa-owned", async () => {
+    // Belt and braces against the guards moving: whatever is under a
+    // `lisa-hooks` directory in the shipped templates must be covered, or a
+    // future guard silently goes back to being undeliverable.
+    const guardDir = path.join(
+      REPO_ROOT,
+      "all",
+      "copy-overwrite",
+      "scripts",
+      "lisa-hooks"
+    );
+    expect(await fs.pathExists(guardDir)).toBe(true);
+    const guards = await listFilesRecursive(guardDir);
+    expect(guards.length).toBeGreaterThan(0);
+    for (const guard of guards) {
+      const relativePath = path
+        .relative(path.join(REPO_ROOT, "all", "copy-overwrite"), guard)
+        .split(path.sep)
+        .join("/");
+      expect(isLisaOwnedTemplate(relativePath), relativePath).toBe(true);
+    }
+  });
+});

--- a/tests/unit/strategies/copy-overwrite-lisa-owned-guards.test.ts
+++ b/tests/unit/strategies/copy-overwrite-lisa-owned-guards.test.ts
@@ -1,0 +1,203 @@
+/**
+ * A version bump has to deliver a fixed enforcement guard.
+ *
+ * How installed projects take an upgrade is `npm update @codyswann/lisa`, whose
+ * postinstall runs a non-interactive apply. That apply cannot prompt, so it used
+ * to leave every differing managed file alone — including Lisa's own guard
+ * scripts. The visible consequence was that the fail-open fixes in #2374 never
+ * reached the fleet: a downstream project had to delete `scripts/lisa-hooks/*`
+ * by hand so the create path would recreate them.
+ *
+ * Being conservative is right for files a project customises. It is wrong for
+ * files Lisa owns outright — nobody edits `scripts/lisa-hooks/block-no-verify.sh`
+ * downstream, and a stale copy of it is a hole in the enforcement. These tests
+ * pin both halves of that line.
+ * @module tests/unit/strategies/copy-overwrite-lisa-owned-guards
+ */
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { beforeEach, afterEach, describe, expect, it } from "vitest";
+
+import { CopyOverwriteStrategy } from "../../../src/strategies/copy-overwrite.js";
+import type { StrategyContext } from "../../../src/strategies/strategy.interface.js";
+import type { LisaConfig } from "../../../src/core/config.js";
+import { createTempDir, cleanupTempDir } from "../../helpers/test-utils.js";
+
+const GUARD = "scripts/lisa-hooks/block-no-verify.sh";
+const FALLBACK = "scripts/lisa-enforcement-fallback.sh";
+const HOST_CONFIG = "tsconfig.json";
+const FAIL_OPEN_GUARD = "#!/usr/bin/env bash\n# fails open\n";
+const FIXED_GUARD = "#!/usr/bin/env bash\n# closed\n";
+
+describe("CopyOverwriteStrategy: Lisa-owned artifacts on a version bump", () => {
+  let strategy: CopyOverwriteStrategy;
+  let tempDir: string;
+  let srcDir: string;
+  let destDir: string;
+
+  beforeEach(async () => {
+    strategy = new CopyOverwriteStrategy();
+    tempDir = await createTempDir();
+    srcDir = path.join(tempDir, "src");
+    destDir = path.join(tempDir, "dest");
+    await fs.ensureDir(srcDir);
+    await fs.ensureDir(destDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  /**
+   * Build the context a postinstall apply runs with: non-interactive, and with
+   * no `--refresh-templates` opt-in, because a version bump passes none.
+   * @param overrides - Configuration overrides
+   * @returns Strategy context representing a postinstall apply
+   */
+  function versionBumpContext(
+    overrides: Partial<LisaConfig> = {}
+  ): StrategyContext {
+    const config: LisaConfig = {
+      lisaDir: srcDir,
+      destDir,
+      dryRun: false,
+      yesMode: true,
+      validateOnly: false,
+      skipGitCheck: true,
+      harness: "claude",
+      ...overrides,
+    };
+    return {
+      config,
+      backupFile: async () => {},
+      promptOverwrite: async () => true,
+    };
+  }
+
+  /**
+   * Stage a differing managed file inside the temp project.
+   * @param rel - Repo-relative path to stage
+   * @param srcContent - Content of the packaged template
+   * @param destContent - Content already installed in the project
+   * @returns Absolute source and destination paths
+   */
+  async function stage(
+    rel: string,
+    srcContent: string,
+    destContent: string
+  ): Promise<{ srcFile: string; destFile: string }> {
+    const srcFile = path.join(srcDir, rel);
+    const destFile = path.join(destDir, rel);
+    await fs.ensureDir(path.dirname(srcFile));
+    await fs.ensureDir(path.dirname(destFile));
+    await fs.writeFile(srcFile, srcContent);
+    await fs.writeFile(destFile, destContent);
+    return { srcFile, destFile };
+  }
+
+  it("delivers a fixed guard to an already-installed project", async () => {
+    const { srcFile, destFile } = await stage(
+      GUARD,
+      FIXED_GUARD,
+      FAIL_OPEN_GUARD
+    );
+
+    const result = await strategy.apply(
+      srcFile,
+      destFile,
+      GUARD,
+      versionBumpContext()
+    );
+
+    expect(result.action).toBe("overwritten");
+    expect(await fs.readFile(destFile, "utf-8")).toBe(FIXED_GUARD);
+  });
+
+  it("delivers the enforcement fallback dispatcher too", async () => {
+    const { srcFile, destFile } = await stage(
+      FALLBACK,
+      FIXED_GUARD,
+      FAIL_OPEN_GUARD
+    );
+
+    const result = await strategy.apply(
+      srcFile,
+      destFile,
+      FALLBACK,
+      versionBumpContext()
+    );
+
+    expect(result.action).toBe("overwritten");
+    expect(await fs.readFile(destFile, "utf-8")).toBe(FIXED_GUARD);
+  });
+
+  it("backs the previous guard up before replacing it", async () => {
+    const { srcFile, destFile } = await stage(
+      GUARD,
+      FIXED_GUARD,
+      FAIL_OPEN_GUARD
+    );
+    let backedUp: string | null = null;
+
+    await strategy.apply(srcFile, destFile, GUARD, {
+      ...versionBumpContext(),
+      backupFile: async (target: string) => {
+        backedUp = target;
+      },
+    });
+
+    expect(backedUp).toBe(destFile);
+  });
+
+  it("still leaves host-owned managed config alone", async () => {
+    // The conservative default is what stops an upgrade quietly replacing a
+    // tsconfig.json a project has customised. Delivering guards must not cost
+    // a project that protection.
+    const { srcFile, destFile } = await stage(
+      HOST_CONFIG,
+      '{"strict":true}',
+      "{}"
+    );
+
+    const result = await strategy.apply(
+      srcFile,
+      destFile,
+      HOST_CONFIG,
+      versionBumpContext()
+    );
+
+    expect(result.action).toBe("stale");
+    expect(await fs.readFile(destFile, "utf-8")).toBe("{}");
+  });
+
+  it("writes nothing during a dry run", async () => {
+    const { srcFile, destFile } = await stage(
+      GUARD,
+      FIXED_GUARD,
+      FAIL_OPEN_GUARD
+    );
+
+    const result = await strategy.apply(
+      srcFile,
+      destFile,
+      GUARD,
+      versionBumpContext({ dryRun: true })
+    );
+
+    expect(result.action).toBe("overwritten");
+    expect(await fs.readFile(destFile, "utf-8")).toBe(FAIL_OPEN_GUARD);
+  });
+
+  it("leaves an identical guard untouched", async () => {
+    const { srcFile, destFile } = await stage(GUARD, FIXED_GUARD, FIXED_GUARD);
+
+    const result = await strategy.apply(
+      srcFile,
+      destFile,
+      GUARD,
+      versionBumpContext()
+    );
+
+    expect(result.action).toBe("skipped");
+  });
+});

--- a/tests/unit/strategies/copy-overwrite-refresh-templates.test.ts
+++ b/tests/unit/strategies/copy-overwrite-refresh-templates.test.ts
@@ -190,24 +190,28 @@ describe("CopyOverwriteStrategy", () => {
       expect(await fs.readFile(destFile, "utf-8")).toBe(VULNERABLE_GUARD);
     });
 
-    it("changes nothing when the flag is absent", async () => {
+    it("changes nothing host-owned when the flag is absent", async () => {
       // The default has to stay conservative — this is the behaviour that was
       // protecting customised host config all along.
+      //
+      // Lisa's own artifacts no longer need the flag: a version bump delivers
+      // them, which is what the flag was standing in for. The flag still exists
+      // for everything Lisa does not own, which is what this pins.
       const { srcFile, destFile } = await stage(
-        GUARD,
-        FIXED_GUARD,
-        VULNERABLE_GUARD
+        TSCONFIG_JSON,
+        '{"strict":true}',
+        "{}"
       );
 
       const result = await strategy.apply(
         srcFile,
         destFile,
-        GUARD,
+        TSCONFIG_JSON,
         createContext({ skipGitCheck: true })
       );
 
       expect(result.action).toBe("stale");
-      expect(await fs.readFile(destFile, "utf-8")).toBe(VULNERABLE_GUARD);
+      expect(await fs.readFile(destFile, "utf-8")).toBe("{}");
     });
   });
 });

--- a/tests/unit/strategies/copy-overwrite.test.ts
+++ b/tests/unit/strategies/copy-overwrite.test.ts
@@ -12,7 +12,7 @@ const KNIP_JSON = "knip.json";
 const TSCONFIG_JSON = "tsconfig.json";
 const IDENTICAL_TXT = "identical.txt";
 const CHANGED_TXT = "changed.txt";
-const VULNERABLE_GUARD = "#!/usr/bin/env bash\n# vulnerable\n";
+const HOST_CUSTOMISED_CONFIG = '{"strict":false}';
 
 describe("CopyOverwriteStrategy", () => {
   let strategy: CopyOverwriteStrategy;
@@ -225,17 +225,20 @@ describe("CopyOverwriteStrategy", () => {
     ).toBe("stale");
   });
 
-  it("reports an out-of-date enforcement guard rather than swallowing it", async () => {
-    // The concrete case: a released fix to a PreToolUse guard reaching a
-    // project that already has the old one. It is still not overwritten
-    // without a prompt, but it can no longer be invisible.
-    const rel = "scripts/lisa-hooks/block-no-verify.sh";
+  it("reports out-of-date host-owned config rather than swallowing it", async () => {
+    // A changed template reaching a project that already has an older, possibly
+    // customised copy. It is still not overwritten without a prompt, but it can
+    // no longer be invisible.
+    //
+    // Lisa's own artifacts take the opposite branch and are delivered here —
+    // see copy-overwrite-lisa-owned-guards.test.ts.
+    const rel = "tsconfig.json";
     const srcFile = path.join(srcDir, rel);
     const destFile = path.join(destDir, rel);
     await fs.ensureDir(path.dirname(srcFile));
     await fs.ensureDir(path.dirname(destFile));
-    await fs.writeFile(srcFile, "#!/usr/bin/env bash\n# fixed\n");
-    await fs.writeFile(destFile, VULNERABLE_GUARD);
+    await fs.writeFile(srcFile, '{"strict":true}');
+    await fs.writeFile(destFile, HOST_CUSTOMISED_CONFIG);
 
     const result = await strategy.apply(
       srcFile,
@@ -249,7 +252,7 @@ describe("CopyOverwriteStrategy", () => {
     // Exact content, not a substring: the contract is that the host file is
     // untouched, and a substring match would still pass if it had been rewritten
     // around that word.
-    expect(await fs.readFile(destFile, "utf-8")).toBe(VULNERABLE_GUARD);
+    expect(await fs.readFile(destFile, "utf-8")).toBe(HOST_CUSTOMISED_CONFIG);
   });
 
   it("creates parent directories when needed", async () => {

--- a/wiki/documentation/overview.md
+++ b/wiki/documentation/overview.md
@@ -521,10 +521,30 @@ Each project type directory contains these subdirectories:
 
 | Subdirectory | Behavior |
 |-------------|----------|
-| `copy-overwrite/` | Files are overwritten on every Lisa run |
+| `copy-overwrite/` | Lisa replaces the file (see ownership below) |
 | `create-only/` | Files are created only if they don't exist (safe to customize) |
 | `copy-contents/` | File contents are merged rather than replaced |
 | `package-lisa/` | Contains `package.lisa.json` for package.json governance |
+
+#### Who owns a `copy-overwrite` file
+
+The `copy-overwrite` trees hold two populations, and an apply that cannot prompt
+(the postinstall one a version bump runs) treats them differently:
+
+- **Lisa-owned artifacts** — anything with a `lisa-` path segment, such as
+  `scripts/lisa-hooks/*` and `scripts/lisa-enforcement-fallback.sh`. Their
+  content *is* the enforcement, and Lisa's own hooks invoke them by exact path,
+  so they are refreshed on every apply, backed up first. This is how a released
+  fix to a guard reaches an already-installed project; before it existed, such
+  fixes silently never shipped.
+- **Everything else** — `tsconfig.json`, `knip.json`, `eslint.config.ts` and
+  friends, which projects legitimately customize. A non-interactive apply leaves
+  those alone and reports them as `Out of date`. Take them with an interactive
+  `lisa apply .`, or in advance with `--refresh-templates[=paths]`.
+
+Either way, `.lisaignore` wins: an ignored path is never a candidate. `lisa
+doctor` reports any Lisa-owned artifact whose installed copy no longer matches
+the shipped one.
 
 ### Inheritance Chain
 
@@ -607,7 +627,7 @@ jest.config.ts            (copy-overwrite, per-stack entry point)
 ### Migration Notes
 
 When Lisa runs on existing projects:
-- **copy-overwrite files** (`tsconfig.json`, `jest.config.ts`) overwrite existing project files
+- **copy-overwrite files** (`tsconfig.json`, `jest.config.ts`) overwrite existing project files once approved — a non-interactive apply reports them as out of date instead (see [Who owns a `copy-overwrite` file](#who-owns-a-copy-overwrite-file))
 - **create-only files** (`tsconfig.local.json`, `jest.config.local.ts`, `jest.thresholds.json`) only created if absent
 - Projects move project-specific tsconfig settings (paths, includes, outDir) into `tsconfig.local.json`
 - Projects move project-specific jest settings (moduleNameMapper, setupFiles) into `jest.config.local.ts`


### PR DESCRIPTION
## The bug

A released fix to an enforcement guard reached nobody.

The fleet takes an upgrade with `npm update @codyswann/lisa`, whose postinstall runs a **non-interactive** apply (`--skip-git-check`). That apply cannot prompt, so `CopyOverwriteStrategy` left every differing managed file alone and reported it as `stale`. The six fail-open fixes in #2374 therefore sat in the published package while installed repos kept running the vulnerable guard. propswap `863ffbf3` documents the workaround they had to discover: delete `scripts/lisa-hooks/*` by hand so the create path recreates them.

`--refresh-templates` (added in #2374's follow-up) did not close this: a version bump passes no flags.

## Why the old behavior was half-right

The `copy-overwrite` trees hold two populations that want opposite defaults:

- Files a project legitimately customises — `tsconfig.json`, `knip.json`, `eslint.config.ts`. Never replace these without asking.
- Files Lisa owns outright — `scripts/lisa-hooks/*`, `scripts/lisa-enforcement-fallback.sh`. Their content *is* the enforcement, and Lisa's own hooks invoke them by exact path, which is why a host cannot meaningfully fork one in place.

Treating them the same is the bug. The fix is the distinction, not a blanket overwrite.

## What changed

- **`src/core/lisa-owned-templates.ts`** (new) — one pure predicate. A managed file is Lisa-owned when its path carries the `lisa-` namespace segment Lisa already uses for everything it owns (`lisa-hooks/`, `lisa-enforcement-fallback.sh`, `lisa-work-item.mjs`, `lisa-mutation.mjs`). Nothing a project customises carries it.
- **`src/strategies/copy-overwrite.ts`** — the non-interactive path refreshes Lisa-owned artifacts, backed up first. Everything else keeps the conservative `stale` behavior and the `--refresh-templates` opt-in. `.lisaignore` still wins: an ignored path is never a candidate.
- **`src/cli/doctor-lisa-owned-artifacts.ts`** (new) — a doctor check for the case apply cannot reach: a pinned old Lisa, an ignored path, a repo that never re-applied. Warn, not fail — the remedy is one command, and failing doctor would redden CI in every repo mid-upgrade.
- **Summary wording** — "Overwritten: N (user approved)" became "(approved or Lisa-owned)". An automatic refresh is not consent someone gave.
- Docs (`wiki/documentation/overview.md`) and the `lisa-doctor` skill contract, fanned out to all five agent copies via `build-plugins.sh`.

## Verification

TDD: the failing test (`copy-overwrite-lisa-owned-guards.test.ts`) reproduced the bug as `stale` before the fix.

Per repo convention, installer changes need a real apply. Against a scratch git project seeded as an already-installed repo with an outdated guard, an outdated fallback, and a customised `tsconfig.json`:

```
LISA_BOOTSTRAP=1 node dist/index.js apply "$SCRATCH" --yes --skip-git-check

  Overwritten:   2 files (approved or Lisa-owned)
  Out of date:   1 files (managed templates changed; NOT updated)
[WARN] 1 managed file(s) changed upstream but were left as-is:
[WARN]   tsconfig.json
```

- Both guards now byte-match the shipped templates (`md5` compared), and both were backed up under `.lisabak/`.
- `tsconfig.json` was untouched — host customisation preserved.
- Rolling one guard back and re-applying delivered it again.

Doctor, same project: `OK` when current → `WARN ... scripts/lisa-hooks/block-no-verify.sh` after rolling the guard back → `OK` again with the path in `.lisaignore`.

Full suite: 9798 tests passing, typecheck, lint, and prettier clean.

Work-Item: CodySwannGT/lisa#2424

🤖 Generated with Claude Code

