### PR TITLE
fix(nightly-e2e): refuse a green run that only tested half the fleet

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -33,9 +33,17 @@
 # true` inverts warn-and-skip into a hard red. Leaving it false forever is a
 # false-green generator — the run concludes `success` having tested nothing, so
 # a deleted flows directory or an expired EXPO_TOKEN is indistinguishable from a
-# passing suite to anything reading this workflow's conclusion (the
-# `nightly-e2e-health.yml` gate reads exactly that). Adopters were hand-rolling
-# their own preflight jobs to get this; use the input instead.
+# passing suite to anything reading this workflow's conclusion. Adopters were
+# hand-rolling their own preflight jobs to get this; use the input instead.
+#
+# What this workflow's SKIPS mean to the health gate: a skipped job does not
+# redden the run that contains it, so `platform: android` (iOS job skipped) and
+# an unwired preflight (every job skipped) both conclude `success`. The
+# `nightly-e2e-health.yml` gate therefore reads the JOBS behind a `success` run,
+# not just its conclusion — see truth-table row 26 and §2.4 of
+# `docs/nightly-e2e-gate.md`. Renaming or removing the per-platform test jobs
+# below is fine; making one of them conclude something other than `success`
+# while the run stays green is what the gate is watching for.
 
 name: 📱 Maestro Native E2E
 

--- a/docs/nightly-e2e-gate.md
+++ b/docs/nightly-e2e-gate.md
@@ -5,7 +5,8 @@
 > `typescript/copy-overwrite/scripts/check-nightly-e2e-health.mjs` implement.
 > Every row of §2 is proven by a named case in Lisa's
 > `tests/unit/scripts/nightly-e2e-health.test.ts` (rows 1-16),
-> `…-api.test.ts` (rows 17-20) and `…-bypass.test.ts` (rows 21-25).
+> `…-api.test.ts` (rows 17-20), `…-bypass.test.ts` (rows 21-25) and
+> `…-completeness.test.ts` (row 26).
 > Changing a row without changing its test is a contract violation.
 >
 > **Plan revision followed:** `2026-08-12-r3` (Portfolio E2E Standards Plan,
@@ -44,9 +45,14 @@ listed here in the order you should prefer them.
 
 | Mode | What it reads | Use when |
 |---|---|---|
-| `run` | the run's own `conclusion` | the whole workflow **is** the suite (e.g. a dedicated `maestro-e2e.yml`) |
+| `run` | the run's own `conclusion` **and** the conclusion of every job behind it | the whole workflow **is** the suite (e.g. a dedicated `maestro-e2e.yml`) |
 | `job` | the `conclusion` of the job whose name is **exactly** the declared string | the suite is one job inside a larger workflow |
 | `job_pattern` | the `conclusion` of every job whose name matches an **anchored** regex | last resort only |
+
+`run` reads the jobs as well as the run because **GitHub concludes a run
+`success` when its jobs were skipped**. "The whole workflow is the suite" has to
+mean the whole workflow actually ran, or a suite narrowed to one arm reports
+green about the arm it never touched — see row 26 and §2.4.
 
 **`run` and `job` are the machine-readable contract; `job_pattern` is not.** A
 job name is a string the suite publishes on purpose and a repo can pin with a
@@ -94,6 +100,8 @@ applied last (§6).
 | 23 | Bootstrap window declared but already expired, and evidence still missing | — | — | **`fail`** |
 | 24 | Bootstrap window declared beyond `bootstrap_max_days` from the workflow run date | **fail** | **fail** | **`fail`** (invalid configuration) |
 | 25 | Bootstrap window active and evidence missing | non-blocking | — | **`bootstrap`**, summary states the UTC expiry timestamp |
+| 26 | `mode: "run"` and the run concluded `success`, but a job behind it did **not**: skipped, `cancelled`, `neutral`, or unreadable (empty job list) | non-blocking | **fail** | `bootstrap` / **`fail`** |
+| 26 | `mode: "run"` and the run concluded `success`, but a job behind it concluded `failure` / `timed_out` / `action_required` / `startup_failure` (a `continue-on-error` job) | fail | fail | **`fail`** |
 
 ### 2.1 Rows 17–19 in one sentence
 
@@ -129,6 +137,78 @@ value GitHub adds later) is **indecisive** → state `unknown` → row 8.
 
 The set is closed on purpose: a conclusion GitHub introduces after this file was
 written is unknown to us, and an unknown conclusion is not evidence of health.
+
+### 2.4 Row 26 — why a `success` run is not automatically evidence
+
+**GitHub concludes a run `success` when its jobs were skipped.** A skipped job
+does not redden the run that contains it. So a suite that narrowed itself —
+because a dispatch input filtered it, or because its prerequisites were absent —
+finishes green having tested nothing it was asked about, and a gate reading the
+run conclusion alone reports that as last night's verdict.
+
+This is not hypothetical. The nightly caller Lisa ships,
+`expo/create-only/.github/workflows/maestro-e2e.yml`, exposes a `platform`
+dispatch picker (`all` | `android` | `ios`). Dispatching it with
+`platform: android` makes the reusable suite's preflight emit `run_ios=false`,
+which skips the `🍎 Maestro iOS` job — and the run still concludes `success`.
+Read through `{"mode":"run"}`, that one dispatch cleared a **required merge
+gate** for the platform it deliberately did not test. It is propswap's trap
+verbatim (`91874b83`): *the suite declaring itself green on evidence it never
+gathered.*
+
+The **cron** path has the same shape. `maestro-native-e2e.yml` defaults to
+`require_prerequisites: false`, so a missing `EXPO_TOKEN` or a deleted flows
+directory warns and skips every job — and concludes `success`. Nothing about
+that run distinguishes it from a passing suite to a reader of run conclusions.
+
+**The discriminator is "was this run PARTIAL?", never "was this a dispatch?".**
+Two independent reasons, and both are load-bearing:
+
+1. **A dispatch must keep counting.** A full, unfiltered `workflow_dispatch` is
+   the documented unblock path (§7): it is what makes this gate escapable by
+   *fixing* rather than by waiting for tomorrow's cron. A rule of the form
+   "dispatch runs do not count" would delete the only non-bypass escape and turn
+   every red nightly into a day-long merge freeze.
+2. **The filter is unreadable anyway.** The Actions runs API returns no `inputs`
+   field on a workflow run — the object carries `event`, `display_title`,
+   `actor`, `triggering_actor` and so on, and nothing about what the dispatcher
+   typed. Recovering the inputs would mean parsing run *logs*, which are
+   artifacts by another name and are refused for the reasons in §1.
+
+Completeness is readable, and it is the property that actually matters: the
+gate asks the jobs list whether every job behind a `success` run also succeeded.
+That answer covers the filtered dispatch, the prerequisite-skipped cron run, and
+a `continue-on-error` job that failed inside a green run — three different
+causes of one false green, closed by one condition.
+
+Row 26 splits on **what kind** of shortfall it found, because bootstrap must
+keep telling absence apart from failure (§4):
+
+- a **skipped / cancelled / neutral / unreadable** job is *absence of evidence*
+  → `unknown`, which bootstrap may forgive and which blocks once the window
+  closes;
+- a job that **actually failed** inside a green run is *evidence of failure*
+  → `fail`, which bootstrap never forgives.
+
+An **empty** job list lands in the first case rather than passing: a completed
+run always has at least one job, so an empty list means the gate could not read
+them, and "we could not check" never renders as "it is fine" (§2.1).
+
+Row 26 is scoped to `mode: "run"` on purpose. A `job`- or `job_pattern`-scoped
+suite has already declared *which* jobs are the suite, and holding it to the
+skips of jobs it never claimed — a lint job, a Lighthouse job — would redden
+gates that are working correctly.
+
+**If a workflow you declared as `mode: "run"` skips a job on every single run,
+it is not a run-scoped suite.** Row 26 is not misfiring on it; the declaration
+is wrong. `mode: "run"` asserts *the whole workflow is the suite*, and a
+workflow with a permanently-dormant arm has some other job doing the testing.
+Name the jobs that are the suite with `mode: "job"` (best) or an anchored
+`mode: "job_pattern"` (matrix arms), which is the more precise gate in any case.
+The one skip that is *supposed* to redden a run-scoped suite is the dormant
+harness itself — a `maestro-native-e2e.yml` whose preflight skipped everything
+because `EXPO_TOKEN` is missing tested nothing, and `bootstrap_until` (§4), not
+a pass, is how a repo gets breathing room while wiring that up.
 
 ## 3. The `suites` input — structured JSON, schema-validated
 
@@ -198,11 +278,13 @@ window here is mandatory and bounded.
   `⚠️ bootstrap — not blocking; this window expires <timestamp> (in N days)`,
   in the job summary and in the job's `verdict` output. The expiry is always
   visible; there is no quiet bootstrap.
-- **Genuinely red evidence still fails during bootstrap.** Rows 2–5, 11, 14 and
-  17–20 are red inside the window as well as outside it. Bootstrap forgives
-  *absence of evidence*, never *evidence of failure*.
-- The moment the window lapses, rows 6–10, 12–13, 15–16 flip to `fail` with no
-  further action (row 23). Nothing needs to be turned on.
+- **Genuinely red evidence still fails during bootstrap.** Rows 2–5, 11, 14,
+  17–20 and the failed-job half of row 26 are red inside the window as well as
+  outside it. Bootstrap forgives *absence of evidence*, never *evidence of
+  failure*.
+- The moment the window lapses, rows 6–10, 12–13, 15–16 and the skipped-job half
+  of row 26 flip to `fail` with no further action (row 23). Nothing needs to be
+  turned on.
 
 ## 5. The context-name identity — two strings that disarm the gate silently
 
@@ -374,14 +456,16 @@ Job listing (`/runs/{id}/jobs?filter=latest`) **does** paginate, to exhaustion
 up to `api_max_pages` (default 5), because a matrix suite routinely exceeds one
 page and a truncated job list turns "the failing shard is on page 2" into a
 false green. Exhausting the page cap while pages are still full is **red**, not
-a partial read.
+a partial read. Jobs are listed for **every** match mode, `run` included — row
+26 needs them to tell a complete run from one that skipped half of itself.
 
 **Rate limits.** A 403/429 carrying `x-ratelimit-remaining: 0` is retried after
 `x-ratelimit-reset` (bounded by `api_retry_max_seconds`, default 60) up to
 `api_max_attempts` (default 3), then **fails** (row 18). Secondary rate limits
 (`retry-after`) are honoured the same way. The gate issues at most
-`1 + suites × 2` requests on the happy path, which is negligible against the
-5 000/hour installation limit even with every PR re-running it.
+`1 + suites × 3` requests on the happy path (two run lookups plus one job page),
+which is negligible against the 5 000/hour installation limit even with every PR
+re-running it.
 
 **Reruns.** A re-run of the *gate* re-reads history and can legitimately change
 verdict — that is the unblock path working (re-dispatch the suite, re-run the
@@ -392,7 +476,11 @@ conclusion rather than a cached one, a rerun-to-green is picked up immediately.
 `workflow_dispatch` runs count exactly like `schedule` runs, by design: that is
 what makes the gate escapable by *fixing* rather than by *waiting*. Dispatch
 runs are still branch-filtered — a dispatch from someone's feature branch must
-never clear the gate for everybody.
+never clear the gate for everybody — and, since row 26, they must still be
+**whole**: a dispatch that narrowed the suite with a platform / tag / shard
+picker leaves a skipped job and does not clear the gate. Leave the picker on its
+`all` default when dispatching to unblock. Nothing about *being* a dispatch
+disqualifies a run; being a partial one does (§2.4).
 
 **Concurrency.** Gate evaluations are idempotent reads with no shared state, so
 the caller template uses a per-PR `concurrency` group with
@@ -425,7 +513,16 @@ repo last applied. Both are per-repo adoption events.
     rejected.
   - *Minor* — adding an optional input with a fail-closed-safe default, adding
     an output field, adding a match mode, adding a `DECISIVE_CONCLUSIONS`
-    member.
+    member, or **adding a §2 row that can only turn a previously-*passing*
+    observation into a blocking one, never the reverse**.
+  - The last clause is what row 26 shipped under, and it is narrow on purpose.
+    The major-mismatch assertion exists to stop the two halves running *a
+    contract neither agrees on*; the workflow half carries **no** §2 logic at
+    all — every row lives in the guard — so a strictly-tightening row cannot
+    make a skewed pair looser than either half intends, only stricter. Anything
+    that could turn a *blocking* observation into a passing one is still major,
+    because that skew direction fails **open**, which is the one outcome the
+    version check exists to prevent.
   - *Patch* — message wording, docs, internal refactors, test-only changes.
   - **Inputs are never repurposed.** A removed input keeps its name reserved and
     is rejected with a pointer to its replacement, rather than being silently

--- a/expo/create-only/.github/workflows/maestro-e2e.yml
+++ b/expo/create-only/.github/workflows/maestro-e2e.yml
@@ -31,7 +31,16 @@ on:
   workflow_dispatch:
     inputs:
       platform:
-        description: 'Platform(s) to run'
+        # NARROWING THIS DOES NOT CLEAR THE NIGHTLY GATE. Picking `android` or
+        # `ios` skips the other platform's job, and GitHub still concludes the
+        # run `success` — a skipped job does not redden its run. The
+        # nightly-e2e-health gate reads the jobs behind a `success` run for
+        # exactly this reason (truth-table row 26 in Lisa's
+        # `docs/nightly-e2e-gate.md`), so a narrowed run reports
+        # `incomplete_run` and keeps blocking. Use these options to iterate on
+        # one platform; dispatch with `all` when the point is to clear a red
+        # nightly.
+        description: 'Platform(s) to run — use `all` when dispatching to clear the nightly gate'
         type: choice
         default: all
         options:

--- a/expo/create-only/.github/workflows/nightly-e2e-health.yml
+++ b/expo/create-only/.github/workflows/nightly-e2e-health.yml
@@ -102,6 +102,11 @@ jobs:
       # `{"mode":"job_pattern","pattern":"^…$"}` only for matrix job names that
       # no single string can cover.
       #
+      # `{"mode":"run"}` reads the run's conclusion AND every job behind it,
+      # because GitHub concludes a run `success` when jobs were skipped — a
+      # suite dispatched for one platform only would otherwise report green
+      # about the platform it never tested (row 26 / §2.4 of the contract).
+      #
       # ONLY `maestro-e2e.yml` by default, because that is the only nightly
       # suite this template actually ships. Naming a workflow file that does not
       # exist is truth-table row 11 — a HARD failure, not missing evidence —

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -201,11 +201,11 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/create-only/.github/workflows/deploy.yml":
       "0978b1f4e19e1ff66bb8cdd037d36a3751d4e917db7ceb5bcf100fad36768516",
     "expo/create-only/.github/workflows/maestro-e2e.yml":
-      "444367a8cefaa81b484bc6eff5923c34177e10f6a67cbf1befec00c9d0d1d36b",
+      "4bacb1da9ea897345aad77b8ae7ee96861c555aa77a00846f4572da18e9fd6e0",
     "expo/create-only/.github/workflows/nightly-e2e-bypass-reaper.yml":
       "4185f5083d8da5efa620e8641d6b75e0cb424edd563989c7432892872969797c",
     "expo/create-only/.github/workflows/nightly-e2e-health.yml":
-      "f0ca0b9ed28f565e60de14e0fb949d335b308243e108948cd1f7cb1472d30724",
+      "009f43bf5a07574adcad11c09c947d54e1a5877ff4ba51128dd4721ad6877a70",
     "expo/create-only/.zap/baseline.conf":
       "ab18d74ba5270dd5d795e740cd6b1292bb78dc36c79a20c1e7b752d14c0c55f5",
     "expo/create-only/babel.config.js":
@@ -2197,7 +2197,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/knip.json":
       "6eb93d705a2d645332fbae1dd42cf2d48f85978ebc265451a53790912f277d12",
     "typescript/copy-overwrite/scripts/check-nightly-e2e-health.mjs":
-      "c1e4bf2287982c9814f168a13f66792c013f557a6028adbc8110ee4214cecf15",
+      "1c79ec49e5f4a3bba700bc1d97e9fc0f4f1799dec3acdf2bed5e3e5b866a0efd",
     "typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs":
       "86e9df17ea11fe0cd11d54f7fd60f016338e7fe28cdd4b07fab3b0b064b64ffb",
     "typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs":
@@ -8661,6 +8661,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/lisa-work-item.test.ts": true,
     "tests/unit/scripts/nightly-e2e-health-api.test.ts": true,
     "tests/unit/scripts/nightly-e2e-health-bypass.test.ts": true,
+    "tests/unit/scripts/nightly-e2e-health-completeness.test.ts": true,
     "tests/unit/scripts/nightly-e2e-health-label-attribution.test.ts": true,
     "tests/unit/scripts/nightly-e2e-health.test.ts": true,
     "tests/unit/scripts/per-agent-hook-filter.test.ts": true,

--- a/tests/helpers/nightly-e2e-gate-harness.ts
+++ b/tests/helpers/nightly-e2e-gate-harness.ts
@@ -117,6 +117,18 @@ export interface GateModule {
     runId: number,
     wait?: () => Promise<void>
   ): Promise<readonly Job[]>;
+  observe(
+    api: Record<string, unknown>,
+    suites: readonly Record<string, unknown>[],
+    branch: string,
+    wait?: () => Promise<void>
+  ): Promise<
+    readonly {
+      workflowMissing: boolean;
+      run: Run | null;
+      jobs: readonly Job[];
+    }[]
+  >;
   retryDelayMs(
     response: { headers: { get(name: string): string | null } | null },
     attempt: number,
@@ -150,6 +162,22 @@ export const REASON = Object.freeze({
   indecisive: "indecisive_conclusion",
   noRun: "no_run",
   staleRun: "stale_run",
+  incompleteRun: "incomplete_run",
+});
+
+/**
+ * A job every `mode: "run"` fixture carries unless it is testing completeness.
+ *
+ * A completed run always has at least one job, and since row 26 a run-scoped
+ * suite reads them: the run's own `success` is only evidence when every job
+ * behind it succeeded. A fixture with no jobs is therefore not "a green run
+ * with the job list omitted for brevity" — it is row 26's unreadable-job-list
+ * case, which is exactly why it lives here rather than being defaulted away
+ * inside each suite.
+ */
+export const GREEN_JOB: Job = Object.freeze({
+  name: "🧪 e2e",
+  conclusion: "success",
 });
 
 /** Suite states. */

--- a/tests/integration/nightly-e2e-health-workflow.test.ts
+++ b/tests/integration/nightly-e2e-health-workflow.test.ts
@@ -407,4 +407,25 @@ describe("the contract document and its proof stay together", () => {
     expect(doc).toContain("NIGHTLY_E2E_CONTRACT_VERSION");
     expect(doc).toContain("Rollback is");
   });
+
+  it("row 26: doc, guard and caller agree on the completeness rule", () => {
+    // A row that lives only in code is a row the next reader will "simplify"
+    // away — and the unblock path must survive the tightening, or a red nightly
+    // becomes a day-long merge freeze with no escape but the bypass.
+    expect(doc).toContain(
+      "GitHub concludes a run `success` when its jobs were skipped"
+    );
+    expect(doc).toContain(
+      'The discriminator is "was this run PARTIAL?", never "was this a dispatch?"'
+    );
+    expect(doc).toContain(
+      "Nothing about *being* a dispatch disqualifies a run; being a partial one does"
+    );
+    expect(read(GUARD_REL)).toContain("incomplete_run");
+    // The platform picker is the surface that produced the false green, so the
+    // warning belongs where the operator chooses the value.
+    expect(
+      read("expo/create-only/.github/workflows/maestro-e2e.yml")
+    ).toContain("NARROWING THIS DOES NOT CLEAR THE NIGHTLY GATE");
+  });
 });

--- a/tests/unit/scripts/nightly-e2e-health-completeness.test.ts
+++ b/tests/unit/scripts/nightly-e2e-health-completeness.test.ts
@@ -1,0 +1,229 @@
+/**
+ * The nightly e2e gate's truth table, row 26: a run-scoped green must be a
+ * COMPLETE run.
+ *
+ * **GitHub concludes a run `success` when its jobs were skipped.** So a suite
+ * that narrowed itself finishes green having tested nothing it was asked about,
+ * and a gate reading the run conclusion alone reports that as last night's
+ * verdict. The shipped `maestro-e2e.yml` caller exposes a `platform` dispatch
+ * picker (all | android | ios); `platform: android` makes the reusable suite's
+ * preflight emit `run_ios=false`, the iOS job is SKIPPED, and the run still
+ * concludes `success`. Read through `{"mode":"run"}`, that one dispatch cleared
+ * a required merge gate for the platform it deliberately did not test —
+ * propswap's trap (91874b83), a suite declaring itself green on evidence it
+ * never gathered.
+ *
+ * The discriminator these cases pin is **"was this run PARTIAL?"**, never "was
+ * this a dispatch?". Twice deliberately: a full unfiltered dispatch is the
+ * documented unblock path (§7) and must keep counting, and the Actions runs API
+ * exposes no `inputs` field at all, so the filter itself is unreadable without
+ * parsing run logs — artifacts by another name, refused by §1.
+ *
+ * Sibling of `nightly-e2e-health.test.ts` (rows 1-16),
+ * `…-api.test.ts` (rows 17-20) and `…-bypass.test.ts` (rows 21-25).
+ * Specification: `docs/nightly-e2e-gate.md` §2 row 26 and §2.4.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  BRANCH,
+  FRESH,
+  type Finding,
+  type GateModule,
+  type Job,
+  NOW,
+  REASON,
+  type Run,
+  STATE,
+  TEST_API,
+  fakeResponse,
+  loadGateModule,
+  noWait,
+  runWith,
+} from "../../helpers/nightly-e2e-gate-harness";
+
+/** The Android arm, green. */
+const ANDROID: Job = Object.freeze({
+  name: "🤖 Maestro Android",
+  conclusion: "success",
+});
+/** The iOS arm's job name — the arm a `platform: android` dispatch skips. */
+const IOS = "🍎 Maestro iOS";
+/** The iOS arm as a filtered dispatch leaves it. */
+const IOS_SKIPPED: Job = Object.freeze({
+  name: IOS,
+  conclusion: "skipped",
+  html_url: "u/ios",
+});
+/** The iOS arm as a full run leaves it. */
+const IOS_GREEN: Job = Object.freeze({ name: IOS, conclusion: "success" });
+/** The iOS arm failing under `continue-on-error` inside a green run. */
+const IOS_FAILED: Job = Object.freeze({ name: IOS, conclusion: "failure" });
+/** A bootstrap window that is closed. */
+const NO_BOOTSTRAP = Object.freeze({
+  active: false,
+  until: null,
+  expiresInDays: null,
+});
+
+describe("nightly e2e gate — truth table row 26", () => {
+  let mod: GateModule;
+
+  beforeAll(async () => {
+    mod = await loadGateModule();
+  });
+
+  /**
+   * Assesses a run-scoped suite against one observation.
+   *
+   * @param run - The newest completed run
+   * @param jobs - The run's jobs, as the API reports them
+   * @param suite - Suite overrides; run-scoped unless replaced
+   * @returns The finding
+   */
+  function assess(
+    run: Run,
+    jobs: readonly Job[],
+    suite: Record<string, unknown> = { match: { mode: "run" } }
+  ): Finding {
+    return mod.assessSuite(
+      { label: "suite", workflow: "maestro-e2e.yml", ...suite },
+      { run, jobs, workflowMissing: false },
+      { branch: BRANCH, freshnessHours: 36, now: NOW }
+    );
+  }
+
+  it("row 26: a platform-filtered dispatch does NOT satisfy the gate", () => {
+    const finding = assess(runWith("success", { event: "workflow_dispatch" }), [
+      ANDROID,
+      IOS_SKIPPED,
+    ]);
+    expect(finding.state).toBe(STATE.unknown);
+    expect(finding.reason).toBe(REASON.incompleteRun);
+    // The offending job is named by its conclusion and its url, so the report
+    // points at the arm that did not run rather than at the run's summary.
+    expect(finding.conclusion).toBe("skipped");
+    expect(finding.url).toBe("u/ios");
+  });
+
+  it("row 26: that filtered dispatch BLOCKS once it reaches the verdict", () => {
+    const finding = assess(runWith("success", { event: "workflow_dispatch" }), [
+      ANDROID,
+      IOS_SKIPPED,
+    ]);
+    const verdict = mod.decide([finding], { bootstrap: NO_BOOTSTRAP });
+    expect(verdict.blocked).toBe(true);
+    expect(verdict.verdict).toBe("fail");
+  });
+
+  it("row 26: a FULL unfiltered dispatch still counts — the unblock path holds", () => {
+    // §7: a dispatch counts exactly like a schedule, which is what makes the
+    // gate escapable by FIXING rather than by waiting for tomorrow's cron.
+    // Narrowing that to "dispatches never count" would delete the escape.
+    const finding = assess(runWith("success", { event: "workflow_dispatch" }), [
+      ANDROID,
+      IOS_GREEN,
+    ]);
+    expect(finding.state).toBe(STATE.pass);
+    expect(finding.reason).toBe(REASON.runConclusion);
+  });
+
+  it("row 26: a full scheduled run still counts", () => {
+    const finding = assess(runWith("success", { event: "schedule" }), [
+      ANDROID,
+      IOS_GREEN,
+    ]);
+    expect(finding.state).toBe(STATE.pass);
+  });
+
+  it("row 26: a run whose jobs are unreadable is not a pass either", () => {
+    // A completed run always has at least one job, so an empty list means the
+    // gate could not read them — "we could not check" never renders as "it is
+    // fine" (§2.1). The finding also withholds the RUN's `success`, because
+    // "⚪ … [success]" is the gate contradicting itself.
+    const finding = assess(runWith("success"), []);
+    expect(finding.state).toBe(STATE.unknown);
+    expect(finding.reason).toBe(REASON.incompleteRun);
+    expect(finding.conclusion).toBeNull();
+  });
+
+  it("row 26: a job that FAILED inside a `success` run is red, not merely unknown", () => {
+    // `continue-on-error: true` on a job leaves the run green while the job
+    // failed. That is evidence of failure, so bootstrap must never forgive it.
+    const finding = assess(runWith("success"), [ANDROID, IOS_FAILED]);
+    expect(finding.state).toBe(STATE.fail);
+    expect(finding.reason).toBe(REASON.incompleteRun);
+  });
+
+  it("row 26: bootstrap forgives a SKIPPED arm and never a FAILED one", () => {
+    const bootstrap = {
+      active: true,
+      until: "2026-08-26T00:00:00Z",
+      expiresInDays: 14,
+    };
+    const skipped = assess(runWith("success"), [ANDROID, IOS_SKIPPED]);
+    const failed = assess(runWith("success"), [ANDROID, IOS_FAILED]);
+    expect(mod.decide([skipped], { bootstrap }).blocked).toBe(false);
+    expect(mod.decide([failed], { bootstrap }).blocked).toBe(true);
+  });
+
+  it("row 26 leaves the job-scoped modes alone", () => {
+    // A `mode: "job"` suite has already declared WHICH jobs are the suite, so
+    // holding it to the skips of jobs it never claimed — a lint job, a
+    // Lighthouse job — would redden gates that are working correctly.
+    const watched = "🎭 Playwright E2E Tests";
+    const finding = assess(
+      runWith("success"),
+      [
+        { name: watched, conclusion: "success" },
+        { name: "🧹 Lint", conclusion: "skipped" },
+      ],
+      { match: { mode: "job", name: watched } }
+    );
+    expect(finding.state).toBe(STATE.pass);
+  });
+
+  it("row 26: the observation step gathers jobs for a run-scoped suite", async () => {
+    // The pure classifier can only judge completeness from jobs it was given,
+    // so `observe` has to gather them for `mode: "run"` too. Before row 26 it
+    // deliberately did not, which is what made the filtered dispatch read green.
+    const paths: string[] = [];
+    let calls = 0;
+    (globalThis as { fetch: unknown }).fetch = async (
+      url: string
+    ): Promise<unknown> => {
+      calls += 1;
+      paths.push(url);
+      if (url.includes("/jobs")) {
+        return fakeResponse(200, {}, { jobs: [IOS_SKIPPED] });
+      }
+      return fakeResponse(
+        200,
+        {},
+        {
+          workflow_runs:
+            calls === 1
+              ? [
+                  {
+                    id: 42,
+                    conclusion: "success",
+                    created_at: FRESH,
+                    event: "schedule",
+                    head_branch: BRANCH,
+                  },
+                ]
+              : [],
+        }
+      );
+    };
+
+    const observed = await mod.observe(
+      TEST_API,
+      [{ label: "one", workflow: "maestro-e2e.yml", match: { mode: "run" } }],
+      BRANCH,
+      noWait
+    );
+    expect(paths.some(url => url.includes("/actions/runs/42/jobs"))).toBe(true);
+    expect(observed[0]?.jobs).toEqual([IOS_SKIPPED]);
+  });
+});

--- a/tests/unit/scripts/nightly-e2e-health.test.ts
+++ b/tests/unit/scripts/nightly-e2e-health.test.ts
@@ -3,8 +3,9 @@
  *
  * `docs/nightly-e2e-gate.md` §2 is the specification; this file and its
  * siblings `nightly-e2e-health-api.test.ts` (rows 17-20, the gate's own failure
- * modes) and `nightly-e2e-health-bypass.test.ts` (rows 21-25, bootstrap and
- * bypass) are the proof. Every `row N` case corresponds to the numbered row of
+ * modes), `nightly-e2e-health-bypass.test.ts` (rows 21-25, bootstrap and
+ * bypass) and `nightly-e2e-health-completeness.test.ts` (row 26, a run-scoped
+ * green must be a COMPLETE run) are the proof. Every `row N` case corresponds to the numbered row of
  * that table, so a behaviour change that is not also a documentation change
  * fails here. That pairing is the point: a gate's contract written only in
  * prose is a contract until the next refactor.
@@ -14,6 +15,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 import {
   BRANCH,
   type Finding,
+  GREEN_JOB,
   type GateModule,
   type Job,
   NOW,
@@ -45,6 +47,11 @@ describe("nightly e2e gate — truth table rows 1-16", () => {
    * @param observation.jobs - The run's jobs, for the job match modes
    * @param observation.workflowMissing - True when the API 404s the workflow file
    * @returns The finding
+   *
+   * The default job list is ONE GREEN JOB rather than an empty array: a
+   * completed run always has jobs, and since row 26 a run-scoped suite reads
+   * them. Defaulting to `[]` would make every row below assert against an
+   * observation the API cannot produce.
    */
   function assess(
     suite: Record<string, unknown>,
@@ -56,7 +63,7 @@ describe("nightly e2e gate — truth table rows 1-16", () => {
   ): Finding {
     return mod.assessSuite(
       { label: "suite", workflow: "e2e.yml", ...suite },
-      { run: null, jobs: [], workflowMissing: false, ...observation },
+      { run: null, jobs: [GREEN_JOB], workflowMissing: false, ...observation },
       { branch: BRANCH, freshnessHours: 36, now: NOW }
     );
   }

--- a/typescript/copy-overwrite/scripts/check-nightly-e2e-health.mjs
+++ b/typescript/copy-overwrite/scripts/check-nightly-e2e-health.mjs
@@ -6,7 +6,7 @@
  * `CodySwannGT/lisa/.github/workflows/nightly-e2e-health.yml`; the contract both
  * halves implement is `docs/nightly-e2e-gate.md` in Lisa, whose §2 truth table
  * is proven row-by-row by `tests/unit/scripts/nightly-e2e-health*.test.ts`
- * (rows 1-16, `-api` rows 17-20, `-bypass` rows 21-25).
+ * (rows 1-16, `-api` rows 17-20, `-bypass` rows 21-25, `-completeness` row 26).
  *
  * Usage:
  *   node scripts/check-nightly-e2e-health.mjs          # human report, exit 1 when blocked
@@ -38,6 +38,12 @@
  * An unreachable or rate-limited API is a HARD failure after a bounded retry;
  * there is no configuration that renders "we could not check" as "it is fine".
  *
+ * A `success` run is not automatically a fresh `success`, and since row 26 it is
+ * not automatically a COMPLETE one either: GitHub concludes a run `success` when
+ * jobs were skipped, so a suite narrowed to one platform — or one whose
+ * prerequisites were absent — reports green having tested nothing it was asked
+ * about. A run-scoped suite therefore reads the run's jobs as well.
+ *
  * The one forgiving state is the TIME-BOXED bootstrap window (`bootstrap_until`),
  * during which MISSING evidence is reported but does not block, always with its
  * expiry timestamp on screen. Bootstrap forgives absence of evidence, never
@@ -65,7 +71,7 @@ import { pathToFileURL } from "node:url";
  * rather than running a contract neither half agrees on. See §8 of
  * `docs/nightly-e2e-gate.md` for what counts as major / minor / patch.
  */
-export const NIGHTLY_E2E_CONTRACT_VERSION = "1.0.0";
+export const NIGHTLY_E2E_CONTRACT_VERSION = "1.1.0";
 
 /**
  * The conclusions that constitute a verdict about the code.
@@ -565,20 +571,75 @@ export function assessSuite(suite, observation, context) {
     };
   }
 
+  const jobs = observation.jobs ?? [];
+
   if (suite.match.mode === "run") {
     const state = stateForConclusion(run.conclusion);
+    if (state !== SUITE_STATES.pass) {
+      return {
+        ...base,
+        ...seen,
+        state,
+        reason:
+          state === SUITE_STATES.unknown
+            ? "indecisive_conclusion"
+            : "run_conclusion",
+      };
+    }
+
+    // Row 26 — COMPLETENESS. `mode: "run"` means the whole workflow IS the
+    // suite, so the run's own `success` is evidence only when every job behind
+    // it also succeeded.
+    //
+    // GitHub concludes a run `success` when jobs were SKIPPED. That is how a
+    // suite reports green having tested half of itself: the shipped
+    // `maestro-e2e.yml` caller exposes a `platform` dispatch picker, and
+    // `platform: android` leaves the iOS job skipped while the run still
+    // concludes `success`. Read as a run conclusion alone, that filtered
+    // dispatch cleared a required merge gate for an arm that never executed —
+    // propswap's trap, a suite declaring itself green on evidence it never
+    // gathered. The same shape reaches the CRON path: with
+    // `require_prerequisites: false` and no EXPO_TOKEN, every job skips and the
+    // run is still `success`.
+    //
+    // The discriminator is "was this run PARTIAL?", never "was this a
+    // dispatch?" — twice deliberately. The runs API exposes no `inputs` field,
+    // so the filter itself is unreadable; and a full unfiltered dispatch is the
+    // documented unblock path (§7), which must keep counting or the gate stops
+    // being escapable by FIXING.
+    //
+    // An EMPTY job list lands here too: a completed run always has at least one
+    // job, so an empty list is an unread job list, and "we could not check"
+    // never renders as "it is fine".
+    const shortfall = jobs.find(job => job.conclusion !== GREEN_CONCLUSION);
+    if (jobs.length === 0 || shortfall) {
+      const conclusion = shortfall?.conclusion ?? null;
+      return {
+        ...base,
+        ...seen,
+        // The RUN's `success` must not be printed beside a blocked state — the
+        // same self-contradiction the job-scoped modes refuse below.
+        conclusion,
+        url: shortfall?.html_url ?? seen.url,
+        // A skipped arm is ABSENCE of evidence, which bootstrap may forgive; a
+        // job that failed under `continue-on-error` inside a green run is
+        // EVIDENCE OF FAILURE, which it never may.
+        state:
+          stateForConclusion(conclusion) === SUITE_STATES.fail
+            ? SUITE_STATES.fail
+            : SUITE_STATES.unknown,
+        reason: "incomplete_run",
+      };
+    }
+
     return {
       ...base,
       ...seen,
-      state,
-      reason:
-        state === SUITE_STATES.unknown
-          ? "indecisive_conclusion"
-          : "run_conclusion",
+      state: SUITE_STATES.pass,
+      reason: "run_conclusion",
     };
   }
 
-  const jobs = observation.jobs ?? [];
   const matches =
     suite.match.mode === "job"
       ? jobs.filter(job => job.name === suite.match.name)
@@ -903,6 +964,8 @@ const REASON_TEXT = Object.freeze({
     "the run completed without ever producing the job this gate reads. The job was renamed, which silently disarms the gate.",
   pattern_matched_nothing:
     "the job pattern matched zero jobs in the newest run. Zero matches is the signature of a renamed job.",
+  incomplete_run:
+    "the run reported `success`, but it did not run everything: at least one job was skipped, failed under `continue-on-error`, or could not be read. A run that skipped part of itself did not gather the evidence its green claims — a suite re-run for one platform only is not a verdict about the other one. Re-run the suite WITHOUT narrowing it.",
   run_conclusion: "",
   job_conclusion: "",
 });
@@ -979,7 +1042,7 @@ export function formatReport(verdict, context) {
     lines.push(
       `Merges into \`${context.branch}\` are blocked until the nightly e2e suites are green again. To unblock:`,
       "  1. Fix the failure (open the run above — it names the failing spec or flow).",
-      `  2. Re-run the suite from the Actions tab against \`${context.branch}\`. A \`workflow_dispatch\` run counts exactly like a scheduled one, so a green dispatch clears this gate immediately — no waiting for tomorrow.`,
+      `  2. Re-run the suite from the Actions tab against \`${context.branch}\`, running the WHOLE suite. A \`workflow_dispatch\` run counts exactly like a scheduled one, so a green dispatch clears this gate immediately — no waiting for tomorrow. What does not count is a NARROWED re-run: leave any platform / tag / shard picker on its "all" default, because a run that skipped an arm says nothing about that arm.`,
       "  3. Re-run this check on your PR.",
       "",
       `If the failure is in the harness rather than the app — or this IS the PR that fixes the red nightly — a maintainer (not you) can apply the \`${context.bypassLabel}\` label after you add a \`Nightly-E2E-Bypass: <TICKET> <reason>\` line to the PR body. There is no admin-merge-past-red: the audited bypass is the only sanctioned path.`
@@ -1182,7 +1245,10 @@ export async function observe(api, suites, branch, wait) {
               : newest,
           null
         );
-      if (!run || suite.match.mode === "run") {
+      // Jobs are read for EVERY match mode, `run` included. A run-scoped suite
+      // needs them to prove the run was complete (row 26) — a `success` run
+      // that skipped half its jobs is not evidence about the half it skipped.
+      if (!run) {
         return { workflowMissing: false, run, jobs: [] };
       }
       return {


### PR DESCRIPTION
## The exposure — real, and live

**GitHub concludes a run `success` when its jobs were SKIPPED.** The nightly e2e health gate (shipped in #2416) read the run conclusion alone for `match.mode: "run"`, so a suite that narrowed itself reported green about the arm it never touched.

The chain, end to end:

1. `expo/create-only/.github/workflows/maestro-e2e.yml` exposes a `platform` dispatch picker (`all` | `android` | `ios`).
2. `platform: android` makes the reusable suite's preflight emit `run_ios=false` (`.github/workflows/maestro-native-e2e.yml:461`), so the `🍎 Maestro iOS` job is skipped.
3. A skipped job does not redden its run — the run concludes **`success`**.
4. The default suites table reads that run with `{"mode":"run"}`, and `assessSuite` accepted the run's own `success` as the verdict.

Net: one filtered dispatch cleared a **required merge gate** for the platform it deliberately did not test. propswap's documented trap (`91874b83`) — *the suite declaring itself green on evidence it never gathered*.

Confirmed against live run history rather than by reading code alone: run [31656882283](https://github.com/CodySwannGT/lisa/actions/runs/31656882283) in this repo concludes `success` with a `skipped` job behind it. Fed through the patched guard it now reports `state: unknown, reason: incomplete_run, blocked: true`.

The **cron** path had the same hole independently: `require_prerequisites: false` plus a missing `EXPO_TOKEN` skips every job and still concludes `success` — which the reusable workflow's own header already called a false-green generator, without anything downstream acting on it.

## The fix — truth-table row 26

A run-scoped suite whose run concluded `success` is a pass only when **every job behind it also succeeded**.

| Shortfall | State | Bootstrap |
|---|---|---|
| a job `skipped` / `cancelled` / `neutral`, or an unreadable (empty) job list | `unknown` | may forgive; blocks once the window closes |
| a job that concluded `failure` / `timed_out` / … inside a green run (`continue-on-error`) | `fail` | never forgiven |

An empty job list lands in the first case rather than passing: a completed run always has at least one job, so an empty list is an unread one, and "we could not check" never renders as "it is fine".

### Why the discriminator is "was this run PARTIAL?", not "was this a dispatch?"

Two independent reasons, both load-bearing:

1. **A full unfiltered dispatch must keep counting.** It is the documented unblock path (§7) — what makes the gate escapable by *fixing* rather than by waiting for tomorrow's cron. A rule of the form "dispatch runs do not count" would delete the only non-bypass escape from a red nightly and turn every failure into a day-long merge freeze. There are explicit regression tests for the full-dispatch and cron cases.
2. **The filter is unreadable anyway.** The Actions runs API returns **no `inputs` field** on a workflow run — verified against the live API, the object carries `event`, `display_title`, `actor`, `triggering_actor` and nothing about what the dispatcher typed. Recovering it would mean parsing run *logs*, which are artifacts by another name and are refused by §1 of the contract.

Completeness is readable, and it is the property that actually matters. One condition closes three different causes of one false green: the filtered dispatch, the prerequisite-skipped cron run, and a `continue-on-error` job that failed inside a green run.

Row 26 stays scoped to `mode: "run"`. A `job`- or `job_pattern`-scoped suite has already declared *which* jobs are the suite; reddening it for a skipped lint job would break gates that are working correctly.

## Contract and versioning

`docs/nightly-e2e-gate.md` is normative, so the row ships in the doc as well as the code: row 26 in the §2 table, a new §2.4 explaining the mechanism, updated §1.1 match-mode semantics, §4 bootstrap row lists, §7 request accounting (`1 + suites × 3`) and the dispatch caveat.

`NIGHTLY_E2E_CONTRACT_VERSION` 1.0.0 → **1.1.0**, MINOR under a clause this PR adds to §8: *a §2 row that can only turn a previously-passing observation into a blocking one, never the reverse*. The major-mismatch assertion exists to stop the two halves running a contract neither agrees on, and the workflow half carries **no** §2 logic — every row lives in the guard — so a strictly-tightening row cannot make a skewed pair looser, only stricter. Anything that could turn a *blocking* observation into a passing one stays major, because that skew direction fails open. Keeping it minor also means the create-only caller template's existing `@v2.345.1` pin does not hard-fail for adopters mid-upgrade.

## Operator-facing wording

The gate's unblock instructions now say to re-run the **whole** suite and leave any platform / tag / shard picker on its `all` default, and the `platform` input in the caller template says outright that narrowing it does not clear the gate.

## Test evidence

TDD, red leg first: 7 new row-26 cases failed against the unpatched guard while all 49 existing cases (including every one of the 25 truth-table rows) passed — proving the new cases fail for the bug and nothing else regressed.

- New `tests/unit/scripts/nightly-e2e-health-completeness.test.ts` (9 cases): filtered dispatch does not satisfy the gate and blocks at the verdict; full unfiltered dispatch does; cron does; unreadable job list does not; a green run's `success` is never printed beside a blocked state; a `continue-on-error` failure is red not merely unknown; bootstrap forgives a skipped arm and never a failed one; job-scoped modes are untouched; `observe` gathers jobs for run-scoped suites.
- Integration: doc, guard and caller template pinned to agree on the rule and on the preserved unblock path.
- Full local verification green: `lint`, `typecheck`, unit + coverage (85.61% statements), 17 integration files / 198 tests, plugin parity.

## Out of scope

Zero-coverage-as-a-state, tracking-issue filing, per-suite bootstrap grace, and flake classification — other work units own these.

**Natural seams this opens for them:** `incomplete_run` is a distinct reason token on the finding, so zero-coverage-as-a-state can specialise it (empty job list vs. skipped arm) without re-deriving the observation; and since `observe` now returns the job list for every match mode, per-arm reporting and flake classification have the per-job conclusions already in hand.

One residual, deliberately not closed here: a filter that only *shrinks a matrix* leaves no skipped job to detect (the missing leg simply never exists). It does not apply to `maestro-native-e2e.yml`, whose per-platform test jobs are plain `if:`-gated jobs, so the exposure this PR fixes is fully closed. A suite that filters its matrix instead would need to publish its expected arms — a job-mode suites table already does that today.

Work-Item: CodySwannGT/lisa#2432

🤖 Generated with Claude Code
