### PR TITLE
feat(bdd): discover e2e specs and enforce exclusions in the v2 coverage gate

### DIFF
--- a/docs/bdd-coverage-schema.md
+++ b/docs/bdd-coverage-schema.md
@@ -12,7 +12,7 @@ Shipped artifacts (copy-overwrite, so `lisa apply` replaces local edits):
 |---|---|
 | `scripts/check-bdd-coverage.mjs` | The gate. Validates the contract, evaluates the ratchet, emits the envelope. |
 | `scripts/bdd-matrix.mjs` | The per-scenario traceability matrix. |
-| `scripts/bdd/*.mjs` | Shared modules: grammar, parser, validators, report, renderer, baseline. |
+| `scripts/bdd/*.mjs` | Shared modules: grammar, parser, validators, discovery, report, renderer, baseline. |
 
 Seeded once, never overwritten (create-only): `bdd/coverage-map.json`, `bdd/features/.keep`.
 
@@ -28,6 +28,7 @@ report never merges them and the burndown never prints one without the others.
 | `execution.executed` | How many mapped tests actually ran in a supplied run. | Whether they passed. |
 | `execution.passed/failed/skipped` | What those runs returned. | Anything about unmapped behavior. |
 | `waived.*` | What is deliberately outside the denominator, with owner, reason, ticket, expiry. | That the behavior works. A waiver is an IOU. |
+| `testInventory.*` | Which test files exist under the declared roots, and how many of them the contract never mentions. | Anything about behaviors nobody wrote a test for — that is `gaps`. |
 
 `traceability` is **traceability coverage**. It is not execution coverage and it is
 not a pass rate — a mapped test that fails on every run still counts as traced. When
@@ -85,9 +86,9 @@ Exit codes come from the envelope contract: `0` for `completed`, `no-op` and
 prose: `adoptionState`, `findingsError`, `findingsWarning`,
 `scenariosDeclared`, `scenariosRequired`, `scenariosExcluded`,
 `traceabilityCovered`, `traceabilityTotal`, `traceabilityPercentage`,
-`executionEvidenceSupplied`, `mappedTests`, `waivedObligations`, `floorOk`, and
-— **only when run evidence was supplied** — `executed`, `passed`, `failed`,
-`skipped`, `notRun`.
+`executionEvidenceSupplied`, `mappedTests`, `testsDiscovered`,
+`testsUndisclosed`, `waivedObligations`, `floorOk`, and — **only when run
+evidence was supplied** — `executed`, `passed`, `failed`, `skipped`, `notRun`.
 
 **Human narration goes to stderr**, so stdout holds exactly one machine-readable
 document.
@@ -118,6 +119,11 @@ carrying two shapes has no schema at all. The same document is written to
     "executed": 0, "passed": 0, "failed": 0, "skipped": 0, "notRun": 0,
     "notRunTests": []
   },
+  "testInventory": {
+    "note": "", "runners": [], "roots": [], "discovered": 0, "disclosed": 0, "dynamicTitles": 0,
+    "undisclosed": [{ "runner": "", "platforms": [], "file": "", "evidence": null }],
+    "exclusions": [{ "file": "", "evidence": null, "reason": "" }]
+  },
   "waived": { "note": "", "count": 0, "entries": [{ "scenario": "", "platforms": [], "runner": null, "owner": null, "reason": null, "ticket": null, "recordedAt": null, "expiresAt": null }] },
   "floor": { "byPlatform": { "<platform>": { "floor": 0, "actual": 0, "ok": true } }, "unset": [], "ok": true },
   "trackers": { "scenariosWithTag": 0, "scenariosWithoutTag": 0, "tags": [{ "tag": "", "url": null, "scenarios": [] }] },
@@ -147,6 +153,95 @@ The gate never invokes a runner and never parses a vendor report format.
 
 Results join to mappings on `runner|file|evidence`. A mapped test with no matching
 result is `notRun` and named in `notRunTests` — never quietly counted as passing.
+
+## Test discovery — the other direction
+
+Validating what the manifest DECLARES can only find defects in the declarations. A
+spec file nobody declared is invisible to that check, which is exactly how undeclared
+end-to-end specs came to sit on default branches under a green gate. The gate
+therefore also walks the project's own roots and requires every test it finds to be
+**named by a mapping or excused by an exclusion**.
+
+Roots, extensions, and the evidence grammar are per-runner **contract data**, not
+source constants — a gate with `e2e/` compiled into it cannot see a project that keeps
+its flows elsewhere, and a hardcoded flow directory is what made a subflow directory
+structurally invisible in the fork this replaces. Keys must be runners declared in
+`runnerPlatforms`; the runner→platform pairing is derived from there, never restated.
+
+```json
+"testDiscovery": {
+  "<runner>": {
+    "roots": ["e2e"],
+    "extensions": [".spec.ts", ".spec.tsx"],
+    "ignore": ["e2e/fixtures"],
+    "evidence": { "kind": "call-title", "functions": ["test", "it"] }
+  },
+  "<flow-runner>": {
+    "roots": [".maestro/flows", ".maestro/subflows"],
+    "extensions": [".yaml", ".yml"],
+    "evidence": { "kind": "line-field", "field": "name" }
+  }
+}
+```
+
+`evidence.kind` is an **allowlist of two grammars**, never a project-supplied regular
+expression — the coverage map is repo data an author edits, and compiling a pattern
+out of it would hand that author the gate's own execution:
+
+| Kind | Reads | Evidence string |
+|---|---|---|
+| `call-title` | `test("…")`, `it.skip('…')`, any declared function name with any member chain | The title, **verbatim from the source** |
+| `line-field` | The first `<field>: …` line in a document | The field value, verbatim. No field ⇒ the file is the unit and carries no title |
+
+**A template-literal title is kept exactly as written** — `` test(`handles ${error.name} failures`) `` yields the evidence `handles ${error.name} failures`. It is never
+interpolated, truncated, or rewritten: the verbatim text is a real substring of the
+file, so a mapping or exclusion naming it stays falsifiable like any other evidence
+string. `testInventory.dynamicTitles` counts them, because an execution result cannot
+be joined to a computed title.
+
+**Disclosure rule.** A mapping or exclusion accounts for a discovered test when it
+names the same `file` **and** its `evidence` string *contains* that test's title.
+Containment in that direction is deliberate: an author may write either the bare title
+or `test("title"`, but one short string can never come to account for every test in a
+file. An exclusion with **no** `evidence` excuses the whole file.
+
+### Exclusion record
+
+```json
+"exclusions": [{ "file": "<path>", "evidence": "<optional exact title>", "reason": "<why this test aligns to no product behavior>" }]
+```
+
+`reason` is required — an exclusion with no stated reason is an undisclosed test with
+extra steps. An exclusion is a standing claim, so it expires by falsification rather
+than by date: `exclusion-stale` fires when its file is gone, when its `evidence`
+matches nothing discovered in that file, or when no configured discovery root covers
+it at all.
+
+### Discovery defect codes
+
+| Code | Fires when | Warnable in bootstrap |
+|---|---|---|
+| `spec-undisclosed` | A discovered test is named by no mapping and no exclusion. | Yes |
+| `exclusion-metadata` | An exclusion names no file, or states no reason. | Yes |
+| `exclusion-stale` | An exclusion no longer excuses anything. | Yes |
+| `discovery-missing` | *(enforced only)* A declared runner has no `testDiscovery` block, so none of its tests can ever be found. | Yes |
+| `discovery-invalid` | The `testDiscovery` block is malformed, names an undeclared runner, escapes the repo, or asks for an unknown evidence kind. | **No** |
+
+`discovery-invalid` is deliberately off the warnable allowlist, on the same reasoning
+as `floor-invalid`: one edit there would silently switch off the only check that can
+see an undeclared test, and a switched-off discovery looks exactly like a clean repo.
+
+## A defect never wedges the artifacts that document it
+
+`--write` regenerates `bdd/coverage-report.json` and `docs/e2e-bdd-coverage.md`
+whenever a report could be built **at all**, no matter how many defects the run found.
+The fleet hit the opposite behavior in a fork that returned no report once it had any
+error: one renamed test title made regeneration refuse to run, so a new waiver could
+not even be recorded until an unrelated string was repaired.
+
+Stale evidence remains a defect and still loses its coverage credit — it simply does
+not hold the paperwork hostage. The only runs that write nothing are the ones with no
+report to write: an absent, malformed, or unsupported coverage map.
 
 ## Compatibility policy
 

--- a/expo/copy-overwrite/scripts/bdd/discover.mjs
+++ b/expo/copy-overwrite/scripts/bdd/discover.mjs
@@ -1,0 +1,502 @@
+/**
+ * Test-file DISCOVERY for the BDD gate.
+ *
+ * Validating what a manifest DECLARES can only ever find defects in the
+ * declarations. A test file nobody declared is invisible to that check, which
+ * is precisely how undeclared end-to-end specs came to sit on default branches
+ * with a green gate above them. This module walks the project's own declared
+ * roots, extracts each test's evidence string, and hands the caller the specs
+ * that no mapping and no exclusion accounts for.
+ *
+ * Nothing here names a runner, a directory, or a file extension: roots,
+ * extensions and the evidence grammar are per-runner CONTRACT DATA
+ * (`testDiscovery` in the coverage map), and the runner→platform pairing is
+ * derived from `runnerPlatforms`. A gate with `e2e/` compiled into it cannot
+ * see a project that keeps its flows anywhere else — the exact reason a
+ * subflow directory was structurally invisible to the fork this replaces.
+ *
+ * @module scripts/bdd/discover
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { listFiles, posix, resolveInsideRepo } from "./parse.mjs";
+
+/**
+ * Build one defect record, always naming the entity it is about.
+ * @param {string} code - Stable machine-readable defect code.
+ * @param {string} message - Operator-readable description.
+ * @param {string} subject - The entity the finding is about.
+ * @returns {{code: string, message: string, subject: string}} The defect.
+ */
+const defect = (code, message, subject) => ({ code, message, subject });
+
+/**
+ * The evidence grammars a project may choose from, as SOURCE CONSTANTS.
+ *
+ * An allowlist, never a project-supplied regular expression: the coverage map
+ * is repo data an author edits, and compiling a pattern out of it would hand
+ * that author the gate's own execution. `call-title` reads a titled test call
+ * (`test("...")`, `it.skip('...')`); `line-field` reads a leading document
+ * field (`name: ...`), which is how flow-style runners title a file.
+ */
+export const EVIDENCE_KINDS = Object.freeze(["call-title", "line-field"]);
+
+/** A JavaScript identifier, the only shape a declared function name may take. */
+const IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/** A document field name, the only shape a declared field may take. */
+const FIELD_NAME = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+
+/**
+ * True for a plain JSON object.
+ * @param {unknown} value - Candidate.
+ * @returns {boolean} Whether it is a non-array object.
+ */
+const isObject = value =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * True for a non-empty array whose every entry passes a test.
+ * @param {unknown} value - Candidate.
+ * @param {(entry: unknown) => boolean} predicate - Entry test.
+ * @returns {boolean} Whether the array is usable.
+ */
+const isListOf = (value, predicate) =>
+  Array.isArray(value) && value.length > 0 && value.every(predicate);
+
+/**
+ * The problems that make one runner's discovery block unusable.
+ *
+ * Every one of these is refused rather than skipped. Skipping a malformed
+ * block would silently disable discovery for that runner — the same
+ * one-character fail-open the coverage floor already refuses.
+ * @param {string} runner - Runner name the block is keyed under.
+ * @param {unknown} config - The raw block.
+ * @param {object} contract - Parsed coverage map.
+ * @returns {string[]} Reasons, empty when the block is usable.
+ */
+function configProblems(runner, config, contract) {
+  if (!contract.runnerPlatforms?.[runner]) {
+    return [`names runner ${runner}, which runnerPlatforms does not declare`];
+  }
+  if (!isObject(config)) return ["is not a JSON object"];
+  return [
+    ...rootProblems(config.roots),
+    ...(isListOf(config.extensions, entry => isExtension(entry))
+      ? []
+      : ['extensions must be a non-empty array of suffixes like ".spec.ts"']),
+    ...(config.ignore === undefined ||
+    (Array.isArray(config.ignore) &&
+      config.ignore.every(entry => typeof entry === "string"))
+      ? []
+      : ["ignore must be an array of repo-relative path prefixes"]),
+    ...evidenceProblems(config.evidence),
+  ];
+}
+
+/**
+ * Whether a declared extension is a usable suffix.
+ * @param {unknown} entry - Candidate extension.
+ * @returns {boolean} Whether it is a dot-prefixed suffix.
+ */
+function isExtension(entry) {
+  return typeof entry === "string" && entry.startsWith(".") && entry.length > 1;
+}
+
+/**
+ * Reject unusable or escaping roots.
+ * @param {unknown} roots - Declared roots.
+ * @returns {string[]} Reasons, empty when usable.
+ */
+function rootProblems(roots) {
+  if (
+    !isListOf(roots, entry => typeof entry === "string" && entry.length > 0)
+  ) {
+    return ["roots must be a non-empty array of repo-relative directories"];
+  }
+  return roots
+    .filter(
+      root =>
+        path.isAbsolute(root) ||
+        /^[a-zA-Z]:/.test(root) ||
+        root.split(/[\\/]/).includes("..")
+    )
+    .map(root => `root ${root} must be repo-relative and must not traverse up`);
+}
+
+/**
+ * Reject an evidence grammar the gate does not implement, or one whose
+ * parameters would end up inside a regular expression unvalidated.
+ * @param {unknown} evidence - Declared evidence grammar.
+ * @returns {string[]} Reasons, empty when usable.
+ */
+function evidenceProblems(evidence) {
+  if (!isObject(evidence)) return ["evidence must be a JSON object"];
+  if (!EVIDENCE_KINDS.includes(evidence.kind)) {
+    return [
+      `evidence.kind ${JSON.stringify(evidence.kind)} is not one of ${EVIDENCE_KINDS.join(", ")}`,
+    ];
+  }
+  if (evidence.kind === "call-title") {
+    return isListOf(
+      evidence.functions,
+      entry => typeof entry === "string" && IDENTIFIER.test(entry)
+    )
+      ? []
+      : ["evidence.functions must be a non-empty array of function names"];
+  }
+  return typeof evidence.field === "string" && FIELD_NAME.test(evidence.field)
+    ? []
+    : ["evidence.field must be a document field name"];
+}
+
+/**
+ * Read and validate the whole `testDiscovery` block.
+ * @param {object} contract - Parsed coverage map.
+ * @returns {{configs: Map<string, object>, defects: object[]}} Usable configs and refusals.
+ */
+function readDiscovery(contract) {
+  const raw = contract.testDiscovery;
+  const configs = new Map();
+  const subject = "coverage-map.testDiscovery";
+  if (raw === undefined) return { configs, defects: [] };
+  if (!isObject(raw)) {
+    return {
+      configs,
+      defects: [
+        defect(
+          "discovery-invalid",
+          `${subject} must be a JSON object keyed by runner`,
+          subject
+        ),
+      ],
+    };
+  }
+  const defects = [];
+  for (const [runner, config] of Object.entries(raw)) {
+    if (runner.startsWith("_")) continue;
+    const problems = configProblems(runner, config, contract);
+    for (const problem of problems) {
+      defects.push(
+        defect(
+          "discovery-invalid",
+          `${subject}.${runner} ${problem}`,
+          `${subject}.${runner}`
+        )
+      );
+    }
+    if (problems.length === 0) configs.set(runner, config);
+  }
+  return { configs, defects };
+}
+
+/**
+ * Every titled test call in a source file, with the title taken VERBATIM from
+ * the source.
+ *
+ * A template-literal title is kept exactly as written — `${error.name}` and
+ * all. Rewriting or truncating it is how the fork this replaces produced
+ * evidence strings that matched nothing, which authors then had to paper over
+ * with exclusions for artifacts of the parser rather than of the repo. The
+ * verbatim text is a real substring of the file, so a mapping or exclusion
+ * naming it stays falsifiable exactly like any other evidence string.
+ * @param {string} source - File contents.
+ * @param {readonly string[]} functions - Declared test-function names.
+ * @returns {{evidence: string, dynamic: boolean}[]} Discovered titles in source order.
+ */
+function callTitles(source, functions) {
+  const pattern = new RegExp(
+    String.raw`\b(?:${functions.join("|")})(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*\s*\(\s*` +
+      String.raw`(?:"((?:[^"\\\n]|\\.)*)"|'((?:[^'\\\n]|\\.)*)'|\x60([^\x60]*)\x60)`,
+    "g"
+  );
+  const found = [];
+  for (const match of source.matchAll(pattern)) {
+    const template = match[3];
+    const evidence = match[1] ?? match[2] ?? template;
+    if (evidence === undefined || evidence.length === 0) continue;
+    found.push({
+      evidence,
+      dynamic: template !== undefined && template.includes("${"),
+    });
+  }
+  return found;
+}
+
+/**
+ * The leading document field a flow-style runner titles a file with.
+ *
+ * When the field is absent the file itself is the discovered unit and carries
+ * NO evidence — inventing a title from the filename would fabricate a string
+ * that appears nowhere in the file, which is the opposite of falsifiable.
+ * @param {string} source - File contents.
+ * @param {string} field - Declared field name.
+ * @returns {{evidence: string|null, dynamic: boolean}[]} Exactly one entry.
+ */
+function lineField(source, field) {
+  const match = new RegExp(String.raw`^\s*${field}:\s*(\S.*?)\s*$`, "m").exec(
+    source
+  );
+  return [{ evidence: match ? match[1] : null, dynamic: false }];
+}
+
+/**
+ * Walk one runner's declared roots and extract its tests.
+ * @param {object} input - Root, runner, its config, and the contract.
+ * @returns {object[]} Discovered specs.
+ */
+function discoverRunner({ root, runner, config, contract }) {
+  const platforms = [...(contract.runnerPlatforms?.[runner] ?? [])].sort();
+  const ignore = config.ignore ?? [];
+  const specs = [];
+  for (const declaredRoot of config.roots) {
+    for (const file of filesUnder(root, declaredRoot, config)) {
+      const relative = posix(path.relative(root, file));
+      if (ignore.some(prefix => relative.startsWith(prefix))) continue;
+      const source = fs.readFileSync(file, "utf8");
+      for (const found of extract(source, config.evidence)) {
+        specs.push({ runner, platforms, file: relative, ...found });
+      }
+    }
+  }
+  return specs;
+}
+
+/**
+ * Extract evidence from one file under the declared grammar.
+ * @param {string} source - File contents.
+ * @param {object} evidence - The declared evidence grammar.
+ * @returns {{evidence: string|null, dynamic: boolean}[]} Discovered entries.
+ */
+function extract(source, evidence) {
+  return evidence.kind === "call-title"
+    ? callTitles(source, evidence.functions)
+    : lineField(source, evidence.field);
+}
+
+/**
+ * List candidate files under one declared root.
+ *
+ * A root that does not exist yet is not an error — a project may declare where
+ * its flows WILL live. A root that resolves outside the repo is refused, on
+ * the same reasoning as a mapping path: repo data must never be able to read
+ * the runner's filesystem.
+ * @param {string} root - Repo root.
+ * @param {string} declaredRoot - One declared root.
+ * @param {object} config - The runner's discovery config.
+ * @returns {string[]} Absolute paths.
+ */
+function filesUnder(root, declaredRoot, config) {
+  const directory = path.join(root, declaredRoot);
+  if (!fs.existsSync(directory)) return [];
+  if (!resolveInsideRepo(root, declaredRoot).path) return [];
+  return listFiles(directory, file =>
+    config.extensions.some(extension => file.endsWith(extension))
+  );
+}
+
+/**
+ * Discover every test file the project's own configuration points at.
+ * @param {object} input - Repo root and the parsed contract.
+ * @returns {object} Specs, configured runners, declared roots, and refusals.
+ */
+export function discoverSpecs({ root, contract }) {
+  const { configs, defects } = readDiscovery(contract);
+  const specs = [];
+  const roots = [];
+  for (const [runner, config] of configs) {
+    roots.push(...config.roots.map(entry => posix(entry).replace(/\/+$/, "")));
+    specs.push(...discoverRunner({ root, runner, config, contract }));
+  }
+  return {
+    specs: specs.sort((a, b) =>
+      `${a.file}${a.evidence ?? ""}`.localeCompare(
+        `${b.file}${b.evidence ?? ""}`
+      )
+    ),
+    runners: [...configs.keys()].sort(),
+    roots: [...new Set(roots)].sort(),
+    defects,
+  };
+}
+
+/**
+ * Whether one map entry accounts for one discovered spec.
+ *
+ * An entry accounts for a spec when it names the same file AND its evidence
+ * string CONTAINS that spec's title. Containment in that direction is
+ * deliberate: an author may map `test("title"` or the bare title, but one
+ * short string can never come to account for every test in a file — which
+ * would rebuild the fail-open this check exists to close. A file-level entry
+ * (an exclusion with no evidence) accounts for the whole file, and so does any
+ * entry naming a file whose discovered unit has no title of its own.
+ * @param {object} entry - A mapping or exclusion.
+ * @param {object} spec - A discovered spec.
+ * @param {boolean} fileLevelAllowed - Whether a missing evidence string covers the file.
+ * @returns {boolean} Whether the spec is accounted for.
+ */
+function accountsFor(entry, spec, fileLevelAllowed) {
+  if (entry.file !== spec.file) return false;
+  if (typeof entry.evidence !== "string" || entry.evidence.length === 0) {
+    return fileLevelAllowed;
+  }
+  return spec.evidence === null || entry.evidence.includes(spec.evidence);
+}
+
+/**
+ * Whether any mapping or exclusion discloses a discovered spec.
+ * @param {object} spec - A discovered spec.
+ * @param {object} contract - Parsed coverage map.
+ * @returns {boolean} Whether it is disclosed.
+ */
+export function isDisclosed(spec, contract) {
+  return (
+    (contract.mappings ?? []).some(mapping =>
+      accountsFor(mapping, spec, false)
+    ) ||
+    (contract.exclusions ?? []).some(exclusion =>
+      accountsFor(exclusion, spec, true)
+    )
+  );
+}
+
+/**
+ * Defects for every discovered spec the contract never mentions.
+ * @param {readonly object[]} specs - Discovered specs.
+ * @param {object} contract - Parsed coverage map.
+ * @returns {object[]} Defects found.
+ */
+function undisclosedDefects(specs, contract) {
+  return specs
+    .filter(spec => !isDisclosed(spec, contract))
+    .map(spec =>
+      defect(
+        "spec-undisclosed",
+        `${spec.file}${spec.evidence === null ? "" : ` :: ${JSON.stringify(spec.evidence)}`} is discovered by runner ${spec.runner} but named by no mapping and no exclusion. Map it to a scenario, or record an exclusion with a reason.`,
+        spec.file
+      )
+    );
+}
+
+/**
+ * Defects for exclusions that no longer excuse anything.
+ *
+ * An exclusion is a standing claim that a real test aligns to no product
+ * behavior. Once its file is gone, its title has been renamed, or no
+ * configured root even covers it, the claim is about nothing — and a pile of
+ * such claims is how "unmapped test" stops meaning anything.
+ * @param {object} input - Root, contract, and the discovery result.
+ * @returns {object[]} Defects found.
+ */
+function exclusionDefects({ root, contract, discovery }) {
+  const defects = [];
+  for (const [index, exclusion] of (contract.exclusions ?? []).entries()) {
+    const at = `coverage-map.exclusions[${index}]`;
+    const subject = typeof exclusion.file === "string" ? exclusion.file : at;
+    defects.push(...exclusionMetadata(exclusion, at, subject));
+    if (typeof exclusion.file !== "string" || exclusion.file.length === 0) {
+      continue;
+    }
+    defects.push(
+      ...exclusionStale({ root, exclusion, discovery, at, subject })
+    );
+  }
+  return defects;
+}
+
+/**
+ * The bookkeeping an exclusion owes whoever has to re-litigate it.
+ * @param {object} exclusion - Raw exclusion entry.
+ * @param {string} at - Location label.
+ * @param {string} subject - Finding subject.
+ * @returns {object[]} Defects found.
+ */
+function exclusionMetadata(exclusion, at, subject) {
+  const defects = [];
+  if (typeof exclusion.file !== "string" || exclusion.file.length === 0) {
+    defects.push(defect("exclusion-metadata", `${at}: names no file`, subject));
+  }
+  if (typeof exclusion.reason !== "string" || exclusion.reason.trim() === "") {
+    defects.push(
+      defect(
+        "exclusion-metadata",
+        `${at}: has no reason; an exclusion with no stated reason is an undisclosed test with extra steps`,
+        subject
+      )
+    );
+  }
+  return defects;
+}
+
+/**
+ * The three ways an exclusion outlives what it excused.
+ * @param {object} input - Root, the exclusion, discovery, and labels.
+ * @returns {object[]} Defects found.
+ */
+function exclusionStale({ root, exclusion, discovery, at, subject }) {
+  const resolved = resolveInsideRepo(root, exclusion.file);
+  if (!resolved.path) {
+    return [
+      defect(
+        "exclusion-stale",
+        `${at}: ${exclusion.file} — ${resolved.error}; retire the exclusion or restore the file`,
+        subject
+      ),
+    ];
+  }
+  if (!discovery.roots.some(entry => exclusion.file.startsWith(`${entry}/`))) {
+    return [
+      defect(
+        "exclusion-stale",
+        `${at}: ${exclusion.file} is covered by no configured discovery root (${discovery.roots.join(", ") || "none declared"}), so the exclusion suppresses nothing`,
+        subject
+      ),
+    ];
+  }
+  return discovery.specs.some(spec => accountsFor(exclusion, spec, true))
+    ? []
+    : [
+        defect(
+          "exclusion-stale",
+          `${at}: no discovered test in ${exclusion.file} matches ${JSON.stringify(exclusion.evidence)}`,
+          subject
+        ),
+      ];
+}
+
+/**
+ * Every disclosure defect: undeclared specs and dead exclusions.
+ * @param {object} input - Root, contract, and the discovery result.
+ * @returns {object[]} Defects found.
+ */
+export function disclosureDefects({ root, contract, discovery }) {
+  return [
+    ...undisclosedDefects(discovery.specs, contract),
+    ...exclusionDefects({ root, contract, discovery }),
+  ];
+}
+
+/**
+ * The runners that declared a platform but no way to find their tests.
+ *
+ * Reported only where absence must fail, exactly like a missing coverage
+ * floor: a runner with no discovery block contributes nothing to the
+ * inventory, and a silent zero there is indistinguishable from a clean repo.
+ * @param {object} contract - Parsed coverage map.
+ * @param {object} discovery - The discovery result.
+ * @returns {object[]} Defects found.
+ */
+export function missingDiscoveryDefects(contract, discovery) {
+  return Object.keys(contract.runnerPlatforms ?? {})
+    .filter(runner => !runner.startsWith("_"))
+    .filter(runner => !discovery.runners.includes(runner))
+    .sort()
+    .map(runner =>
+      defect(
+        "discovery-missing",
+        `enforced mode: runner ${runner} declares platforms but testDiscovery says nothing about where its tests live, so no undeclared test of that runner can ever be found`,
+        `coverage-map.testDiscovery.${runner}`
+      )
+    );
+}

--- a/expo/copy-overwrite/scripts/bdd/envelope.mjs
+++ b/expo/copy-overwrite/scripts/bdd/envelope.mjs
@@ -39,11 +39,17 @@ const ENVELOPE_MODULE_PATHS = Object.freeze([
  * Everything here is a contract-QUALITY defect: the manifest is legible and
  * the adoption state is coherent, the contract just is not clean yet. Codes
  * about adoption integrity itself (bootstrap-metadata, bootstrap-expired,
- * adoption-drift, config-*) are deliberately absent, so they always fail.
+ * adoption-drift, config-*, discovery-invalid) are deliberately absent, so
+ * they always fail: a malformed discovery block would silently switch off the
+ * only check that can see an undeclared test, exactly as a quoted coverage
+ * floor silently switches off the ratchet.
  */
 export const WARNABLE_DEFECT_CODES = Object.freeze([
   "baseline",
+  "discovery-missing",
   "empty-contract",
+  "exclusion-metadata",
+  "exclusion-stale",
   "execution-results",
   "floor-missing",
   "floor-ratchet",
@@ -61,6 +67,7 @@ export const WARNABLE_DEFECT_CODES = Object.freeze([
   "scenario-platform",
   "scenario-provenance",
   "scenario-steps",
+  "spec-undisclosed",
   "tracker-missing",
   "tracker-orphan",
   "waiver-duplicate",
@@ -205,6 +212,8 @@ export function buildSummary({ adoptionState, report, defects, filesWritten }) {
     traceabilityPercentage: report.traceability.overall.percentage,
     executionEvidenceSupplied: report.execution.supplied,
     mappedTests: report.execution.mappedTests,
+    testsDiscovered: report.testInventory.discovered,
+    testsUndisclosed: report.testInventory.undisclosed.length,
     ...executionCounts(report.execution),
     waivedObligations: report.waived.count,
     floorOk: report.floor.ok,

--- a/expo/copy-overwrite/scripts/bdd/render.mjs
+++ b/expo/copy-overwrite/scripts/bdd/render.mjs
@@ -112,6 +112,47 @@ function floorTable(report) {
 }
 
 /**
+ * Render the discovered-test inventory: what the roots hold, and what of it
+ * the contract never mentions.
+ *
+ * The undisclosed list is printed in full rather than counted. A count is a
+ * number somebody can grow accustomed to; a named file with a named test is a
+ * thing somebody has to either map or excuse.
+ * @param {object} report - The coverage report.
+ * @returns {string} Markdown section body.
+ */
+function inventorySection(report) {
+  const inventory = report.testInventory;
+  if (inventory.runners.length === 0) {
+    return "**No `testDiscovery` roots are declared**, so no test file was walked and an undeclared test cannot be found here. In enforced mode this is a `discovery-missing` defect.";
+  }
+  const rows =
+    inventory.undisclosed
+      .map(
+        item =>
+          `| ${cell(item.runner)} | \`${cell(item.file)}\` | ${item.evidence === null ? "*(file has no title)*" : cell(item.evidence)} |`
+      )
+      .join("\n") || "| — | — | None |";
+  return `${inventory.discovered} tests discovered under ${inventory.roots.map(root => `\`${cell(root)}\``).join(", ")}; ${inventory.disclosed} are named by a mapping or an exclusion. ${inventory.dynamicTitles} carry a computed (template-literal) title, taken verbatim from the source — a runner result cannot be joined to those by title.\n\n| Runner | File | Test not named by the contract |\n|---|---|---|\n${rows}`;
+}
+
+/**
+ * Render the exclusion ledger: tests deliberately aligned to no behavior.
+ * @param {object} report - The coverage report.
+ * @returns {string} Markdown table.
+ */
+function exclusionTable(report) {
+  const rows =
+    report.testInventory.exclusions
+      .map(
+        entry =>
+          `| \`${cell(entry.file)}\` | ${entry.evidence === null ? "*(whole file)*" : cell(entry.evidence)} | ${cell(entry.reason ?? "**unstated**")} |`
+      )
+      .join("\n") || "| — | — | None |";
+  return `| File | Test | Reason it aligns to no product behavior |\n|---|---|---|\n${rows}`;
+}
+
+/**
  * Group the remaining gaps by feature.
  * @param {object} report - The coverage report.
  * @returns {string} Markdown sections.
@@ -185,6 +226,18 @@ ${floorTable(report)}
 ${report.waived.note}
 
 ${waiverTable(report)}
+
+## Discovered tests the contract does not mention
+
+${report.testInventory.note}
+
+${inventorySection(report)}
+
+## Tests deliberately aligned to no behavior
+
+Every row here is a standing claim that a real test proves nothing about product behavior. An exclusion whose file is gone, whose title was renamed, or that no discovery root covers is a defect, not a permanent excuse.
+
+${exclusionTable(report)}
 
 ## Traceability to work items
 

--- a/expo/copy-overwrite/scripts/bdd/report.mjs
+++ b/expo/copy-overwrite/scripts/bdd/report.mjs
@@ -21,6 +21,50 @@ import {
   runnersByPlatform,
   trackerUrl,
 } from "./contract.mjs";
+import { isDisclosed } from "./discover.mjs";
+
+/** An empty discovery result, for callers that do not walk the tree. */
+const NO_DISCOVERY = Object.freeze({ specs: [], runners: [], roots: [] });
+
+/**
+ * Summarize what walking the project's declared roots actually found.
+ *
+ * Traceability answers "is every declared behavior automated". This answers
+ * the other direction — "is every automated test accounted for" — and the two
+ * are not the same question: a repo can be at 100% traceability while carrying
+ * end-to-end tests nobody has ever mapped to a behavior.
+ * @param {object} discovery - The discovery result.
+ * @param {object} contract - Parsed coverage map.
+ * @returns {object} The report's `testInventory` block.
+ */
+function buildTestInventory(discovery, contract) {
+  const undisclosed = discovery.specs.filter(
+    spec => !isDisclosed(spec, contract)
+  );
+  return {
+    note: "Tests found by walking the roots declared in testDiscovery. A discovered test must be named by a mapping or by an exclusion carrying a reason; anything else is an undisclosed test, not a clean repo.",
+    runners: discovery.runners,
+    roots: discovery.roots,
+    discovered: discovery.specs.length,
+    disclosed: discovery.specs.length - undisclosed.length,
+    dynamicTitles: discovery.specs.filter(spec => spec.dynamic).length,
+    undisclosed: undisclosed.map(spec => ({
+      runner: spec.runner,
+      platforms: spec.platforms,
+      file: spec.file,
+      evidence: spec.evidence,
+    })),
+    exclusions: (contract.exclusions ?? [])
+      .map(exclusion => ({
+        file: exclusion.file ?? null,
+        evidence: exclusion.evidence ?? null,
+        reason: exclusion.reason ?? null,
+      }))
+      .sort((a, b) =>
+        `${a.file}${a.evidence}`.localeCompare(`${b.file}${b.evidence}`)
+      ),
+  };
+}
 
 /**
  * Summarize a subset of obligations against the covered set.
@@ -310,6 +354,7 @@ export function buildReport({
   runs,
   platforms,
   unresolved = new Set(),
+  discovery = NO_DISCOVERY,
 }) {
   const platformRunners = runnersByPlatform(contract.runnerPlatforms);
   const declared = declaredObligations(scenarios, platformRunners);
@@ -340,6 +385,7 @@ export function buildReport({
       byRunner: byRunnerSummary(contract, obligations, coveredKeys),
     },
     execution: buildExecution(contract.mappings ?? [], runs),
+    testInventory: buildTestInventory(discovery, contract),
     waived: waivedSummary(contract, scenarios, declared, waivedKeys),
     floor: evaluateFloor(contract, byPlatform, platforms),
     trackers: buildTrackerIndex(scenarios, contract.trackers),

--- a/expo/copy-overwrite/scripts/check-bdd-coverage.mjs
+++ b/expo/copy-overwrite/scripts/check-bdd-coverage.mjs
@@ -50,6 +50,11 @@ import {
   subjectFor,
 } from "./bdd/envelope.mjs";
 import { checkDeletions, checkRatchet, loadBaseline } from "./bdd/baseline.mjs";
+import {
+  disclosureDefects,
+  discoverSpecs,
+  missingDiscoveryDefects,
+} from "./bdd/discover.mjs";
 import { loadScenarios } from "./bdd/parse.mjs";
 import { buildReport } from "./bdd/report.mjs";
 import { renderBurndown } from "./bdd/render.mjs";
@@ -236,12 +241,22 @@ export function loadExecutionResults(root, files) {
  * @param {object} input - Root, contract, scenarios, platforms, and options.
  * @returns {object[]} Defects found.
  */
-function validateAll({ root, contract, scenarios, platforms, options, cache }) {
+function validateAll({
+  root,
+  contract,
+  scenarios,
+  platforms,
+  options,
+  cache,
+  discovery,
+}) {
   const defects = [
     ...validateScenarios(scenarios, platforms),
     ...validateTrackerTags(scenarios, contract.trackers),
     ...validateMappings({ root, scenarios, contract, cache }),
     ...validateWaivers({ scenarios, contract, today: options.today }),
+    ...discovery.defects,
+    ...disclosureDefects({ root, contract, discovery }),
   ];
   if (!options.baseSha) return defects;
   const baseline = loadBaseline(root, options.baseSha);
@@ -294,7 +309,13 @@ function floorIntegrityDefects(report) {
  * @param {object} input - Contract, scenarios, report, and platforms.
  * @returns {object[]} Defects found.
  */
-function enforcedDefects({ contract, scenarios, report, platforms }) {
+function enforcedDefects({
+  contract,
+  scenarios,
+  report,
+  platforms,
+  discovery,
+}) {
   const defects = [];
   if (scenarios.length === 0) {
     defects.push(
@@ -320,6 +341,7 @@ function enforcedDefects({ contract, scenarios, report, platforms }) {
       )
     );
   }
+  defects.push(...missingDiscoveryDefects(contract, discovery));
   for (const platform of report.floor.unset) {
     defects.push(
       defect(
@@ -366,21 +388,34 @@ export function run(root, options) {
   // so each mapped file is read once no matter how large the manifest.
   const cache = new Map();
   const unresolved = unresolvedEvidenceKeys({ root, contract, cache });
+  // Discovery answers the question the declared half cannot: which tests exist
+  // that the manifest never mentions. It runs before the report so the report
+  // can carry the inventory it produced.
+  const discovery = discoverSpecs({ root, contract });
   const report = buildReport({
     scenarios,
     contract,
     runs: execution.runs,
     platforms,
     unresolved,
+    discovery,
   });
   const defects = [
     ...(versionDefect ? [versionDefect] : []),
     ...validateAdoption(contract, mode, options.today),
     ...execution.defects,
     ...floorIntegrityDefects(report),
-    ...validateAll({ root, contract, scenarios, platforms, options, cache }),
+    ...validateAll({
+      root,
+      contract,
+      scenarios,
+      platforms,
+      options,
+      cache,
+      discovery,
+    }),
     ...(mode === "enforced"
-      ? enforcedDefects({ contract, scenarios, report, platforms })
+      ? enforcedDefects({ contract, scenarios, report, platforms, discovery })
       : []),
   ];
   return result({ mode, defects, report, contract });

--- a/expo/create-only/bdd/coverage-map.json
+++ b/expo/create-only/bdd/coverage-map.json
@@ -13,6 +13,21 @@
     "playwright": ["web"],
     "maestro": ["ios", "android"]
   },
+  "testDiscovery": {
+    "_comment": "Where each runner's tests live, so the gate can find a test NOBODY DECLARED. Keys must be runners declared in runnerPlatforms. `roots` are repo-relative directories (list every one — a subflow or helper directory omitted here is structurally invisible to the gate), `extensions` are filename suffixes, optional `ignore` holds repo-relative path prefixes to skip, and `evidence` says how a test is titled: {\"kind\": \"call-title\", \"functions\": [...]} reads test(\"...\") style declarations, {\"kind\": \"line-field\", \"field\": \"name\"} reads a leading document field. Edit these to match this project; a malformed block is refused rather than ignored, because silently discovering nothing looks exactly like a clean repo.",
+    "playwright": {
+      "roots": ["e2e"],
+      "extensions": [".spec.ts", ".spec.tsx", ".spec.js", ".spec.jsx"],
+      "ignore": [],
+      "evidence": { "kind": "call-title", "functions": ["test", "it"] }
+    },
+    "maestro": {
+      "roots": [".maestro/flows", ".maestro/subflows"],
+      "extensions": [".yaml", ".yml"],
+      "ignore": [],
+      "evidence": { "kind": "line-field", "field": "name" }
+    }
+  },
   "coverageFloor": {
     "_comment": "Committed traceability floor per platform. A ratchet: may rise, may never fall. Seeded at 0 so adopting on a brownfield app never red-gates CI before any scenario exists. Lowering one requires a coverageFloorBaseline record naming the exact change AND the maintainer-applied `bdd-floor-baseline` pull-request label.",
     "web": 0,
@@ -34,5 +49,6 @@
   },
   "platformWaivers": [],
   "mappings": [],
+  "_exclusionsComment": "A discovered test must be named by a mapping or by an exclusion. Each entry is {\"file\": \"<path>\", \"evidence\": \"<optional exact title; omit to excuse the whole file>\", \"reason\": \"<why this test aligns to no product behavior>\"} — an exclusion whose file is gone, whose title was renamed, or that no discovery root covers is a defect, never a permanent excuse.",
   "exclusions": []
 }

--- a/plugins/lisa-copilot/rules/eager/bdd-e2e-coverage.md
+++ b/plugins/lisa-copilot/rules/eager/bdd-e2e-coverage.md
@@ -15,7 +15,7 @@ Default locations (a project that already has an equivalent contract keeps its o
 | Artifact | Default path | What it is |
 |---|---|---|
 | Scenarios | `bdd/features/*.feature` | Gherkin, the product-level behavior contract |
-| Coverage map | `bdd/coverage-map.json` | scenario → runner/platform/file/evidence mappings, plus waivers |
+| Coverage map | `bdd/coverage-map.json` | scenario → runner/platform/file/evidence mappings, plus waivers, per-runner test-discovery roots, and exclusions |
 | Generated matrix | `docs/bdd-scenario-matrix.md` | regenerated, never hand-edited |
 | Burndown | `docs/e2e-bdd-coverage.md` | current coverage per platform |
 
@@ -35,6 +35,8 @@ The last three are out of the denominator. Deleting a committed capability to ma
 ## What seals a scenario
 
 Coverage is counted per **required scenario-platform obligation**, and an obligation is sealed only by **aligned e2e automation in the project's configured runner for that platform** — the runner→platform mapping is project configuration (e.g. a web runner covering `web`, a device runner covering `ios`/`android`), never named by this contract. A unit test, a route boot, a screenshot, a fixture, an API test, or a passing test on a *different* platform never seals an obligation: they prove something else. Each mapping names the runner, the platforms, the file, and the evidence string inside it, so the gate can prove the mapping still resolves.
+
+**The gate reads in both directions.** It also walks the test roots the project declares per runner, so an e2e test that exists but that the contract never mentions is a violation — map it to a scenario, or record an exclusion stating why it aligns to no product behavior. Roots are configuration: a subflow or helper directory left undeclared is structurally invisible, which is the same failure as having no gate for it.
 
 **Waivers are dated IOUs, never coverage.** An obligation whose runner genuinely cannot decide it today (no camera on the simulator, no request interception, no provisioned provider credential) is recorded with scenario, platforms, reason, and `recordedAt`. It leaves the denominator; it never counts as covered, and nothing about it asserts the behavior works. A waiver is invalid — and fails the gate — when it names a nonexistent scenario or an undeclared platform, covers an already-excluded scenario, or masks a scenario-platform that already has a mapping. Revisit a waiver when its reason dies.
 

--- a/plugins/lisa-copilot/rules/reference/bdd-e2e-coverage.md
+++ b/plugins/lisa-copilot/rules/reference/bdd-e2e-coverage.md
@@ -68,16 +68,43 @@ platforms it requires and that each named platform has a configured runner.
       "level": "behavioral"
     }
   ],
+  "testDiscovery": {
+    "<runner>": {
+      "roots": ["<repo-relative directory>", "..."],
+      "extensions": [".<suffix>", "..."],
+      "ignore": ["<optional repo-relative path prefix>"],
+      "evidence": { "kind": "call-title", "functions": ["test", "it"] }
+    }
+  },
   "exclusions": [
-    { "file": "<path>", "reason": "why this test aligns to no product behavior" }
+    {
+      "file": "<path>",
+      "evidence": "<optional exact title; omit to excuse the whole file>",
+      "reason": "why this test aligns to no product behavior"
+    }
   ]
 }
 ```
 
 `evidence` is what makes a mapping falsifiable: the gate reads the mapped file and confirms the
 string is still there, so renaming or deleting a test breaks the map loudly instead of leaving a
-scenario silently unguarded. `exclusions` records tests that deliberately map to nothing — starter
-templates, source-level corroboration — so "unmapped test" stays a meaningful signal.
+scenario silently unguarded.
+
+`testDiscovery` closes the other direction. Validating only what the map DECLARES can never see a
+test file nobody declared, so the gate walks the project's own roots and requires **every test it
+finds to be named by a mapping or excused by an exclusion**. Roots and the evidence grammar are
+per-runner configuration — list every directory, including subflow and helper directories, because
+a directory omitted here is structurally invisible to the gate. Evidence grammars are an allowlist
+of two (`call-title` reads `test("…")`-style declarations; `line-field` reads a leading `name:`
+field), never a project-supplied regular expression, and a template-literal title is used verbatim
+from the source rather than rewritten. A missing block is a defect in enforced mode
+(`discovery-missing`); a malformed one is refused in **every** state (`discovery-invalid`), because
+discovery that silently finds nothing looks exactly like a clean repo.
+
+`exclusions` records tests that deliberately map to nothing — starter templates, source-level
+corroboration — so "unmapped test" stays a meaningful signal. Each entry states a `reason`, and an
+exclusion whose file is gone, whose title was renamed, or that no discovery root covers is
+`exclusion-stale`: a standing claim about nothing, never a permanent excuse.
 
 ## The gate
 
@@ -94,7 +121,13 @@ Two commands, wired into the project's script surface and into CI:
    - an invalid waiver (nonexistent scenario, undeclared platform, already-excluded scenario, a
      `runner` that does not cover the waived platform under `runnerPlatforms`, or one that masks an
      existing mapping);
+   - a discovered test named by no mapping and no exclusion, or an exclusion that no longer excuses
+     anything;
    - a regression against the project's committed `coverageFloor` per platform.
+
+   Regeneration is never blocked by the check: `--write` rewrites the report and burndown whenever a
+   report can be built at all, so a stale evidence string can never hold hostage the paperwork that
+   documents it.
 
 The percentage measures **aligned automation inventory, not the latest run result**. A mapped test
 that currently fails is a red CI check, a separate signal; the map only asserts the automation
@@ -157,9 +190,12 @@ A repo with no contract yet, taking its first frontend work item:
 
 1. **Detect runners.** Find the e2e harnesses the project actually has, per the Tool Discovery
    Process in `verification-lifecycle`. Record which platforms each covers.
-2. **Scaffold the minimum** — `bdd/features/`, `bdd/coverage-map.json` (with `runnerPlatforms` from
-   step 1 and a coverage floor of the current, honest number), the regenerate + check scripts wired
-   into the project's script surface, and the CI invocation of the check.
+2. **Scaffold the minimum** — `bdd/features/`, `bdd/coverage-map.json` (with `runnerPlatforms` and
+   `testDiscovery` from step 1 — every root each runner's tests actually live in, subflow and helper
+   directories included — and a coverage floor of the current, honest number), the regenerate +
+   check scripts wired into the project's script surface, and the CI invocation of the check.
+   Pre-existing tests that align to no product behavior are recorded as `exclusions` with reasons
+   during this step, never left undisclosed.
 3. **Write only this item's scenarios.** The first item is not a backfill project. Pre-existing
    uncovered behavior becomes burndown in `docs/e2e-bdd-coverage.md`, and the floor starts where the
    repo actually is.

--- a/plugins/lisa-cursor/rules/bdd-e2e-coverage-reference.mdc
+++ b/plugins/lisa-cursor/rules/bdd-e2e-coverage-reference.mdc
@@ -73,16 +73,43 @@ platforms it requires and that each named platform has a configured runner.
       "level": "behavioral"
     }
   ],
+  "testDiscovery": {
+    "<runner>": {
+      "roots": ["<repo-relative directory>", "..."],
+      "extensions": [".<suffix>", "..."],
+      "ignore": ["<optional repo-relative path prefix>"],
+      "evidence": { "kind": "call-title", "functions": ["test", "it"] }
+    }
+  },
   "exclusions": [
-    { "file": "<path>", "reason": "why this test aligns to no product behavior" }
+    {
+      "file": "<path>",
+      "evidence": "<optional exact title; omit to excuse the whole file>",
+      "reason": "why this test aligns to no product behavior"
+    }
   ]
 }
 ```
 
 `evidence` is what makes a mapping falsifiable: the gate reads the mapped file and confirms the
 string is still there, so renaming or deleting a test breaks the map loudly instead of leaving a
-scenario silently unguarded. `exclusions` records tests that deliberately map to nothing — starter
-templates, source-level corroboration — so "unmapped test" stays a meaningful signal.
+scenario silently unguarded.
+
+`testDiscovery` closes the other direction. Validating only what the map DECLARES can never see a
+test file nobody declared, so the gate walks the project's own roots and requires **every test it
+finds to be named by a mapping or excused by an exclusion**. Roots and the evidence grammar are
+per-runner configuration — list every directory, including subflow and helper directories, because
+a directory omitted here is structurally invisible to the gate. Evidence grammars are an allowlist
+of two (`call-title` reads `test("…")`-style declarations; `line-field` reads a leading `name:`
+field), never a project-supplied regular expression, and a template-literal title is used verbatim
+from the source rather than rewritten. A missing block is a defect in enforced mode
+(`discovery-missing`); a malformed one is refused in **every** state (`discovery-invalid`), because
+discovery that silently finds nothing looks exactly like a clean repo.
+
+`exclusions` records tests that deliberately map to nothing — starter templates, source-level
+corroboration — so "unmapped test" stays a meaningful signal. Each entry states a `reason`, and an
+exclusion whose file is gone, whose title was renamed, or that no discovery root covers is
+`exclusion-stale`: a standing claim about nothing, never a permanent excuse.
 
 ## The gate
 
@@ -99,7 +126,13 @@ Two commands, wired into the project's script surface and into CI:
    - an invalid waiver (nonexistent scenario, undeclared platform, already-excluded scenario, a
      `runner` that does not cover the waived platform under `runnerPlatforms`, or one that masks an
      existing mapping);
+   - a discovered test named by no mapping and no exclusion, or an exclusion that no longer excuses
+     anything;
    - a regression against the project's committed `coverageFloor` per platform.
+
+   Regeneration is never blocked by the check: `--write` rewrites the report and burndown whenever a
+   report can be built at all, so a stale evidence string can never hold hostage the paperwork that
+   documents it.
 
 The percentage measures **aligned automation inventory, not the latest run result**. A mapped test
 that currently fails is a red CI check, a separate signal; the map only asserts the automation
@@ -162,9 +195,12 @@ A repo with no contract yet, taking its first frontend work item:
 
 1. **Detect runners.** Find the e2e harnesses the project actually has, per the Tool Discovery
    Process in `verification-lifecycle`. Record which platforms each covers.
-2. **Scaffold the minimum** — `bdd/features/`, `bdd/coverage-map.json` (with `runnerPlatforms` from
-   step 1 and a coverage floor of the current, honest number), the regenerate + check scripts wired
-   into the project's script surface, and the CI invocation of the check.
+2. **Scaffold the minimum** — `bdd/features/`, `bdd/coverage-map.json` (with `runnerPlatforms` and
+   `testDiscovery` from step 1 — every root each runner's tests actually live in, subflow and helper
+   directories included — and a coverage floor of the current, honest number), the regenerate +
+   check scripts wired into the project's script surface, and the CI invocation of the check.
+   Pre-existing tests that align to no product behavior are recorded as `exclusions` with reasons
+   during this step, never left undisclosed.
 3. **Write only this item's scenarios.** The first item is not a backfill project. Pre-existing
    uncovered behavior becomes burndown in `docs/e2e-bdd-coverage.md`, and the floor starts where the
    repo actually is.

--- a/plugins/lisa-cursor/rules/bdd-e2e-coverage.mdc
+++ b/plugins/lisa-cursor/rules/bdd-e2e-coverage.mdc
@@ -20,7 +20,7 @@ Default locations (a project that already has an equivalent contract keeps its o
 | Artifact | Default path | What it is |
 |---|---|---|
 | Scenarios | `bdd/features/*.feature` | Gherkin, the product-level behavior contract |
-| Coverage map | `bdd/coverage-map.json` | scenario → runner/platform/file/evidence mappings, plus waivers |
+| Coverage map | `bdd/coverage-map.json` | scenario → runner/platform/file/evidence mappings, plus waivers, per-runner test-discovery roots, and exclusions |
 | Generated matrix | `docs/bdd-scenario-matrix.md` | regenerated, never hand-edited |
 | Burndown | `docs/e2e-bdd-coverage.md` | current coverage per platform |
 
@@ -40,6 +40,8 @@ The last three are out of the denominator. Deleting a committed capability to ma
 ## What seals a scenario
 
 Coverage is counted per **required scenario-platform obligation**, and an obligation is sealed only by **aligned e2e automation in the project's configured runner for that platform** — the runner→platform mapping is project configuration (e.g. a web runner covering `web`, a device runner covering `ios`/`android`), never named by this contract. A unit test, a route boot, a screenshot, a fixture, an API test, or a passing test on a *different* platform never seals an obligation: they prove something else. Each mapping names the runner, the platforms, the file, and the evidence string inside it, so the gate can prove the mapping still resolves.
+
+**The gate reads in both directions.** It also walks the test roots the project declares per runner, so an e2e test that exists but that the contract never mentions is a violation — map it to a scenario, or record an exclusion stating why it aligns to no product behavior. Roots are configuration: a subflow or helper directory left undeclared is structurally invisible, which is the same failure as having no gate for it.
 
 **Waivers are dated IOUs, never coverage.** An obligation whose runner genuinely cannot decide it today (no camera on the simulator, no request interception, no provisioned provider credential) is recorded with scenario, platforms, reason, and `recordedAt`. It leaves the denominator; it never counts as covered, and nothing about it asserts the behavior works. A waiver is invalid — and fails the gate — when it names a nonexistent scenario or an undeclared platform, covers an already-excluded scenario, or masks a scenario-platform that already has a mapping. Revisit a waiver when its reason dies.
 

--- a/plugins/lisa/rules/eager/bdd-e2e-coverage.md
+++ b/plugins/lisa/rules/eager/bdd-e2e-coverage.md
@@ -15,7 +15,7 @@ Default locations (a project that already has an equivalent contract keeps its o
 | Artifact | Default path | What it is |
 |---|---|---|
 | Scenarios | `bdd/features/*.feature` | Gherkin, the product-level behavior contract |
-| Coverage map | `bdd/coverage-map.json` | scenario → runner/platform/file/evidence mappings, plus waivers |
+| Coverage map | `bdd/coverage-map.json` | scenario → runner/platform/file/evidence mappings, plus waivers, per-runner test-discovery roots, and exclusions |
 | Generated matrix | `docs/bdd-scenario-matrix.md` | regenerated, never hand-edited |
 | Burndown | `docs/e2e-bdd-coverage.md` | current coverage per platform |
 
@@ -35,6 +35,8 @@ The last three are out of the denominator. Deleting a committed capability to ma
 ## What seals a scenario
 
 Coverage is counted per **required scenario-platform obligation**, and an obligation is sealed only by **aligned e2e automation in the project's configured runner for that platform** — the runner→platform mapping is project configuration (e.g. a web runner covering `web`, a device runner covering `ios`/`android`), never named by this contract. A unit test, a route boot, a screenshot, a fixture, an API test, or a passing test on a *different* platform never seals an obligation: they prove something else. Each mapping names the runner, the platforms, the file, and the evidence string inside it, so the gate can prove the mapping still resolves.
+
+**The gate reads in both directions.** It also walks the test roots the project declares per runner, so an e2e test that exists but that the contract never mentions is a violation — map it to a scenario, or record an exclusion stating why it aligns to no product behavior. Roots are configuration: a subflow or helper directory left undeclared is structurally invisible, which is the same failure as having no gate for it.
 
 **Waivers are dated IOUs, never coverage.** An obligation whose runner genuinely cannot decide it today (no camera on the simulator, no request interception, no provisioned provider credential) is recorded with scenario, platforms, reason, and `recordedAt`. It leaves the denominator; it never counts as covered, and nothing about it asserts the behavior works. A waiver is invalid — and fails the gate — when it names a nonexistent scenario or an undeclared platform, covers an already-excluded scenario, or masks a scenario-platform that already has a mapping. Revisit a waiver when its reason dies.
 

--- a/plugins/lisa/rules/reference/bdd-e2e-coverage.md
+++ b/plugins/lisa/rules/reference/bdd-e2e-coverage.md
@@ -68,16 +68,43 @@ platforms it requires and that each named platform has a configured runner.
       "level": "behavioral"
     }
   ],
+  "testDiscovery": {
+    "<runner>": {
+      "roots": ["<repo-relative directory>", "..."],
+      "extensions": [".<suffix>", "..."],
+      "ignore": ["<optional repo-relative path prefix>"],
+      "evidence": { "kind": "call-title", "functions": ["test", "it"] }
+    }
+  },
   "exclusions": [
-    { "file": "<path>", "reason": "why this test aligns to no product behavior" }
+    {
+      "file": "<path>",
+      "evidence": "<optional exact title; omit to excuse the whole file>",
+      "reason": "why this test aligns to no product behavior"
+    }
   ]
 }
 ```
 
 `evidence` is what makes a mapping falsifiable: the gate reads the mapped file and confirms the
 string is still there, so renaming or deleting a test breaks the map loudly instead of leaving a
-scenario silently unguarded. `exclusions` records tests that deliberately map to nothing — starter
-templates, source-level corroboration — so "unmapped test" stays a meaningful signal.
+scenario silently unguarded.
+
+`testDiscovery` closes the other direction. Validating only what the map DECLARES can never see a
+test file nobody declared, so the gate walks the project's own roots and requires **every test it
+finds to be named by a mapping or excused by an exclusion**. Roots and the evidence grammar are
+per-runner configuration — list every directory, including subflow and helper directories, because
+a directory omitted here is structurally invisible to the gate. Evidence grammars are an allowlist
+of two (`call-title` reads `test("…")`-style declarations; `line-field` reads a leading `name:`
+field), never a project-supplied regular expression, and a template-literal title is used verbatim
+from the source rather than rewritten. A missing block is a defect in enforced mode
+(`discovery-missing`); a malformed one is refused in **every** state (`discovery-invalid`), because
+discovery that silently finds nothing looks exactly like a clean repo.
+
+`exclusions` records tests that deliberately map to nothing — starter templates, source-level
+corroboration — so "unmapped test" stays a meaningful signal. Each entry states a `reason`, and an
+exclusion whose file is gone, whose title was renamed, or that no discovery root covers is
+`exclusion-stale`: a standing claim about nothing, never a permanent excuse.
 
 ## The gate
 
@@ -94,7 +121,13 @@ Two commands, wired into the project's script surface and into CI:
    - an invalid waiver (nonexistent scenario, undeclared platform, already-excluded scenario, a
      `runner` that does not cover the waived platform under `runnerPlatforms`, or one that masks an
      existing mapping);
+   - a discovered test named by no mapping and no exclusion, or an exclusion that no longer excuses
+     anything;
    - a regression against the project's committed `coverageFloor` per platform.
+
+   Regeneration is never blocked by the check: `--write` rewrites the report and burndown whenever a
+   report can be built at all, so a stale evidence string can never hold hostage the paperwork that
+   documents it.
 
 The percentage measures **aligned automation inventory, not the latest run result**. A mapped test
 that currently fails is a red CI check, a separate signal; the map only asserts the automation
@@ -157,9 +190,12 @@ A repo with no contract yet, taking its first frontend work item:
 
 1. **Detect runners.** Find the e2e harnesses the project actually has, per the Tool Discovery
    Process in `verification-lifecycle`. Record which platforms each covers.
-2. **Scaffold the minimum** — `bdd/features/`, `bdd/coverage-map.json` (with `runnerPlatforms` from
-   step 1 and a coverage floor of the current, honest number), the regenerate + check scripts wired
-   into the project's script surface, and the CI invocation of the check.
+2. **Scaffold the minimum** — `bdd/features/`, `bdd/coverage-map.json` (with `runnerPlatforms` and
+   `testDiscovery` from step 1 — every root each runner's tests actually live in, subflow and helper
+   directories included — and a coverage floor of the current, honest number), the regenerate +
+   check scripts wired into the project's script surface, and the CI invocation of the check.
+   Pre-existing tests that align to no product behavior are recorded as `exclusions` with reasons
+   during this step, never left undisclosed.
 3. **Write only this item's scenarios.** The first item is not a backfill project. Pre-existing
    uncovered behavior becomes burndown in `docs/e2e-bdd-coverage.md`, and the floor starts where the
    repo actually is.

--- a/plugins/src/base/rules/eager/bdd-e2e-coverage.md
+++ b/plugins/src/base/rules/eager/bdd-e2e-coverage.md
@@ -15,7 +15,7 @@ Default locations (a project that already has an equivalent contract keeps its o
 | Artifact | Default path | What it is |
 |---|---|---|
 | Scenarios | `bdd/features/*.feature` | Gherkin, the product-level behavior contract |
-| Coverage map | `bdd/coverage-map.json` | scenario → runner/platform/file/evidence mappings, plus waivers |
+| Coverage map | `bdd/coverage-map.json` | scenario → runner/platform/file/evidence mappings, plus waivers, per-runner test-discovery roots, and exclusions |
 | Generated matrix | `docs/bdd-scenario-matrix.md` | regenerated, never hand-edited |
 | Burndown | `docs/e2e-bdd-coverage.md` | current coverage per platform |
 
@@ -35,6 +35,8 @@ The last three are out of the denominator. Deleting a committed capability to ma
 ## What seals a scenario
 
 Coverage is counted per **required scenario-platform obligation**, and an obligation is sealed only by **aligned e2e automation in the project's configured runner for that platform** — the runner→platform mapping is project configuration (e.g. a web runner covering `web`, a device runner covering `ios`/`android`), never named by this contract. A unit test, a route boot, a screenshot, a fixture, an API test, or a passing test on a *different* platform never seals an obligation: they prove something else. Each mapping names the runner, the platforms, the file, and the evidence string inside it, so the gate can prove the mapping still resolves.
+
+**The gate reads in both directions.** It also walks the test roots the project declares per runner, so an e2e test that exists but that the contract never mentions is a violation — map it to a scenario, or record an exclusion stating why it aligns to no product behavior. Roots are configuration: a subflow or helper directory left undeclared is structurally invisible, which is the same failure as having no gate for it.
 
 **Waivers are dated IOUs, never coverage.** An obligation whose runner genuinely cannot decide it today (no camera on the simulator, no request interception, no provisioned provider credential) is recorded with scenario, platforms, reason, and `recordedAt`. It leaves the denominator; it never counts as covered, and nothing about it asserts the behavior works. A waiver is invalid — and fails the gate — when it names a nonexistent scenario or an undeclared platform, covers an already-excluded scenario, or masks a scenario-platform that already has a mapping. Revisit a waiver when its reason dies.
 

--- a/plugins/src/base/rules/reference/bdd-e2e-coverage.md
+++ b/plugins/src/base/rules/reference/bdd-e2e-coverage.md
@@ -68,16 +68,43 @@ platforms it requires and that each named platform has a configured runner.
       "level": "behavioral"
     }
   ],
+  "testDiscovery": {
+    "<runner>": {
+      "roots": ["<repo-relative directory>", "..."],
+      "extensions": [".<suffix>", "..."],
+      "ignore": ["<optional repo-relative path prefix>"],
+      "evidence": { "kind": "call-title", "functions": ["test", "it"] }
+    }
+  },
   "exclusions": [
-    { "file": "<path>", "reason": "why this test aligns to no product behavior" }
+    {
+      "file": "<path>",
+      "evidence": "<optional exact title; omit to excuse the whole file>",
+      "reason": "why this test aligns to no product behavior"
+    }
   ]
 }
 ```
 
 `evidence` is what makes a mapping falsifiable: the gate reads the mapped file and confirms the
 string is still there, so renaming or deleting a test breaks the map loudly instead of leaving a
-scenario silently unguarded. `exclusions` records tests that deliberately map to nothing — starter
-templates, source-level corroboration — so "unmapped test" stays a meaningful signal.
+scenario silently unguarded.
+
+`testDiscovery` closes the other direction. Validating only what the map DECLARES can never see a
+test file nobody declared, so the gate walks the project's own roots and requires **every test it
+finds to be named by a mapping or excused by an exclusion**. Roots and the evidence grammar are
+per-runner configuration — list every directory, including subflow and helper directories, because
+a directory omitted here is structurally invisible to the gate. Evidence grammars are an allowlist
+of two (`call-title` reads `test("…")`-style declarations; `line-field` reads a leading `name:`
+field), never a project-supplied regular expression, and a template-literal title is used verbatim
+from the source rather than rewritten. A missing block is a defect in enforced mode
+(`discovery-missing`); a malformed one is refused in **every** state (`discovery-invalid`), because
+discovery that silently finds nothing looks exactly like a clean repo.
+
+`exclusions` records tests that deliberately map to nothing — starter templates, source-level
+corroboration — so "unmapped test" stays a meaningful signal. Each entry states a `reason`, and an
+exclusion whose file is gone, whose title was renamed, or that no discovery root covers is
+`exclusion-stale`: a standing claim about nothing, never a permanent excuse.
 
 ## The gate
 
@@ -94,7 +121,13 @@ Two commands, wired into the project's script surface and into CI:
    - an invalid waiver (nonexistent scenario, undeclared platform, already-excluded scenario, a
      `runner` that does not cover the waived platform under `runnerPlatforms`, or one that masks an
      existing mapping);
+   - a discovered test named by no mapping and no exclusion, or an exclusion that no longer excuses
+     anything;
    - a regression against the project's committed `coverageFloor` per platform.
+
+   Regeneration is never blocked by the check: `--write` rewrites the report and burndown whenever a
+   report can be built at all, so a stale evidence string can never hold hostage the paperwork that
+   documents it.
 
 The percentage measures **aligned automation inventory, not the latest run result**. A mapped test
 that currently fails is a red CI check, a separate signal; the map only asserts the automation
@@ -157,9 +190,12 @@ A repo with no contract yet, taking its first frontend work item:
 
 1. **Detect runners.** Find the e2e harnesses the project actually has, per the Tool Discovery
    Process in `verification-lifecycle`. Record which platforms each covers.
-2. **Scaffold the minimum** — `bdd/features/`, `bdd/coverage-map.json` (with `runnerPlatforms` from
-   step 1 and a coverage floor of the current, honest number), the regenerate + check scripts wired
-   into the project's script surface, and the CI invocation of the check.
+2. **Scaffold the minimum** — `bdd/features/`, `bdd/coverage-map.json` (with `runnerPlatforms` and
+   `testDiscovery` from step 1 — every root each runner's tests actually live in, subflow and helper
+   directories included — and a coverage floor of the current, honest number), the regenerate +
+   check scripts wired into the project's script surface, and the CI invocation of the check.
+   Pre-existing tests that align to no product behavior are recorded as `exclusions` with reasons
+   during this step, never left undisclosed.
 3. **Write only this item's scenarios.** The first item is not a backfill project. Pre-existing
    uncovered behavior becomes burndown in `docs/e2e-bdd-coverage.md`, and the floor starts where the
    repo actually is.

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -172,20 +172,22 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "96f6a295bad34c0b52f7f667640243a462cb745998768c21a192c74d1a96dd34",
     "expo/copy-overwrite/scripts/bdd/contract.mjs":
       "d8a418d655d4a14d4d3287518b8d678cb410b7f08e38a60cf0dbf30b2e796973",
+    "expo/copy-overwrite/scripts/bdd/discover.mjs":
+      "820e8a869a0b46fc11461a655bb82f0c8c60f5b46005fbff48e5d19930d7d25a",
     "expo/copy-overwrite/scripts/bdd/envelope.mjs":
-      "7bb2aa5dbe49fa97d3f14e5400fef3f76e0fd99ab74e88d568a3d037c94c601d",
+      "ab3c9520be5c4c630ec3b6c8489015f24f97888c8687dde108865bbcff93efdb",
     "expo/copy-overwrite/scripts/bdd/parse.mjs":
       "d1bf74b01388d107e6869b90a3d1e1d2c03da8124cb2cc14f9cf6d64e2b00ce8",
     "expo/copy-overwrite/scripts/bdd/render.mjs":
-      "47a5adb9fc607e5d330c246218d0b043be14a8527c7ba198b222df03fd96672a",
+      "fa4f51fbb3a0517c4813c4a0dc9edde26d402efa115420cc251aaed7b5dfd5f3",
     "expo/copy-overwrite/scripts/bdd/report.mjs":
-      "4a07425197ddbcc53052a334354325c5d6b1880d586a02c176362bfb5c826a2a",
+      "30a7c3471611e740f62f544e613a2ecf095946e7f70c752f62fa51ac58949822",
     "expo/copy-overwrite/scripts/bdd/validate.mjs":
       "afb8dd052733a5f83e6d004eac3437783a707c08810ba9cc65138d898aff83e2",
     "expo/copy-overwrite/scripts/bdd/waivers.mjs":
       "4b9ebf80100f478cc5e06d50b4d672ad08ec77a3746a7a109a74e1daf71a55b7",
     "expo/copy-overwrite/scripts/check-bdd-coverage.mjs":
-      "98fa86e5987e7384c7fd23baa435f86830fb432424134bb7d8141c005af9167b",
+      "d8448a5ad476eb8ad51aa3a6ee5ff90aded974a0ea426682f25df5482d2b279d",
     "expo/copy-overwrite/scripts/check-e2e-coverage.mjs":
       "30cf7d860ecd3b838b8608f38da10fcddb4e7e90a0867438f411d68346a5f129",
     "expo/copy-overwrite/tsconfig.eslint.json":
@@ -211,7 +213,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/create-only/babel.config.js":
       "faaf96f0d43c724a240a7892584de54ae384eee9ef9d76430d081f37d9f92924",
     "expo/create-only/bdd/coverage-map.json":
-      "7aecd1aca01b73eb20e311281a5e63137bd92d86d49c02fb48bcee9fdc94e07d",
+      "fcf9de0a802341ef8f879f2f9e20db11fc0e25c7caab465ea537c58c22e87fbd",
     "expo/create-only/bdd/features/.keep":
       "b807c9c94a3b00b93d2463a9b098dac41db227ac1f5b0b1cb746e5e6f68de15d",
     "expo/create-only/e2e.thresholds.json":
@@ -691,7 +693,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/eager/base-rules.md":
       "d3a4bd518acf2c6f4e866042542f9155fdbf5b2fdad5747e1afd097bdef15351",
     "plugins/src/base/rules/eager/bdd-e2e-coverage.md":
-      "2d5afe505153afc32d7bfb835e8e176a418c2485bdfbe811191116809bdf635b",
+      "379c0fcbf69be3f536d99a0034a3fe1548cfd05d37af6c6504a7e921401eb88b",
     "plugins/src/base/rules/eager/claim-archaeology.md":
       "96afa034075593dfb7433c5c990b472a6b6f7320332da42ef54b1f01fa45664b",
     "plugins/src/base/rules/eager/claim-evidence-mapping.md":
@@ -771,7 +773,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/reference/base-rules.md":
       "487ea1764c4b636ca4a33b78a90e925f028bb9a54182c0795cd1bbdc437a262d",
     "plugins/src/base/rules/reference/bdd-e2e-coverage.md":
-      "9bfd9f1ebc37cf23a5594552c330adccd3d4dba9ddf7f697f7e2e315294a9117",
+      "16e8f868f9a1dee19a950bdb6619c0985524995c770621ff85458229f5b8926f",
     "plugins/src/base/rules/reference/claim-archaeology.md":
       "fff025d47848c768d5b2c7047de744b7151eb2e44148d2df058c87310859457b",
     "plugins/src/base/rules/reference/claim-evidence-mapping.md":
@@ -2573,6 +2575,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "expo/copy-overwrite/scripts/bdd-matrix.mjs": true,
     "expo/copy-overwrite/scripts/bdd/baseline.mjs": true,
     "expo/copy-overwrite/scripts/bdd/contract.mjs": true,
+    "expo/copy-overwrite/scripts/bdd/discover.mjs": true,
     "expo/copy-overwrite/scripts/bdd/envelope.mjs": true,
     "expo/copy-overwrite/scripts/bdd/parse.mjs": true,
     "expo/copy-overwrite/scripts/bdd/render.mjs": true,
@@ -8626,7 +8629,9 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/opencode/settings-installer.test.ts": true,
     "tests/unit/opencode/skills-installer.test.ts": true,
     "tests/unit/scripts/bdd-adoption.test.ts": true,
+    "tests/unit/scripts/bdd-discovery.test.ts": true,
     "tests/unit/scripts/bdd-envelope.test.ts": true,
+    "tests/unit/scripts/bdd-exclusions.test.ts": true,
     "tests/unit/scripts/bdd-failopen.test.ts": true,
     "tests/unit/scripts/bdd-grammar.test.ts": true,
     "tests/unit/scripts/bdd-ratchet.test.ts": true,

--- a/tests/unit/scripts/bdd-discovery.test.ts
+++ b/tests/unit/scripts/bdd-discovery.test.ts
@@ -1,0 +1,282 @@
+/**
+ * The other direction: tests the gate DISCOVERS, rather than tests the map
+ * declares.
+ *
+ * Validating declarations can only ever find defects in the declarations. A
+ * spec file nobody declared is invisible to that check — which is how six
+ * undeclared end-to-end specs came to sit on a fleet default branch under a
+ * green gate. Every case here proves the gate now walks the project's own
+ * declared roots and refuses a test the contract never mentions.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  BOOTSTRAP,
+  COMPLETED,
+  ENFORCED,
+  HEALTHY_FILES,
+  HEALTHY_MAP,
+  HOME_EVIDENCE,
+  HOME_FEATURE_FILE,
+  HOME_ID,
+  HOME_SPEC,
+  MAESTRO,
+  PLAYWRIGHT,
+  PLAYWRIGHT_DISCOVERY,
+  RATIFIED,
+  WEB,
+  codes,
+  featureSource,
+  healthyProject,
+  makeProject,
+  messages,
+  runGate,
+  runReport,
+} from "./bdd/support";
+
+const UNDISCLOSED = "spec-undisclosed";
+const EXCLUSION_STALE = "exclusion-stale";
+const EXCLUSION_METADATA = "exclusion-metadata";
+const DISCOVERY_INVALID = "discovery-invalid";
+const DISCOVERY_MISSING = "discovery-missing";
+const STRAY_SPEC = "e2e/stray.spec.ts";
+const STRAY_TITLE = "a test nobody declared";
+const STRAY_SOURCE = `test("${STRAY_TITLE}", async () => {});\n`;
+const SMOKE_REASON = "starter template kept as a runner smoke check";
+const DYNAMIC_REASON = "error-path smoke check with a computed title";
+const LIVE_BOOTSTRAP = {
+  state: BOOTSTRAP,
+  owner: "o@example.test",
+  expiresAt: "2099-01-01",
+};
+
+describe("a discovered spec must be declared or excluded", () => {
+  it("fails enforced on a spec no mapping and no exclusion names", () => {
+    // The fleet's actual bug: six undeclared Playwright specs sat invisible on
+    // a default branch because the gate only ever read what the map DECLARED.
+    const run = runGate(
+      healthyProject({}, { files: { [STRAY_SPEC]: STRAY_SOURCE } }),
+      { BDD_MODE: ENFORCED }
+    );
+    expect(run.status).toBe(1);
+    expect(messages(run, UNDISCLOSED)[0]).toContain(STRAY_TITLE);
+    expect(messages(run, UNDISCLOSED)[0]).toContain(PLAYWRIGHT);
+  });
+
+  it("reports it as a visible warning in bootstrap rather than a blocker", () => {
+    const run = runGate(
+      healthyProject(
+        {
+          adoption: LIVE_BOOTSTRAP,
+          coverageFloor: { [WEB]: 0 },
+        },
+        { files: { [STRAY_SPEC]: STRAY_SOURCE } }
+      ),
+      { BDD_MODE: BOOTSTRAP }
+    );
+    expect(run.status).toBe(0);
+    expect(run.envelope.status).toBe(COMPLETED);
+    expect(
+      run.envelope.findings.find(item => item.code === UNDISCLOSED)?.severity
+    ).toBe("warning");
+  });
+
+  it("only credits the titles a mapping actually names", () => {
+    // A second test added to an already-mapped file is the common way an
+    // undeclared behavior arrives; the mapping's evidence names one title.
+    const run = runGate(
+      healthyProject(
+        {},
+        {
+          files: {
+            [HOME_SPEC]:
+              `test("${HOME_EVIDENCE}", async () => {});\n` +
+              `test("${STRAY_TITLE}", async () => {});\n`,
+          },
+        }
+      ),
+      { BDD_MODE: ENFORCED }
+    );
+    expect(messages(run, UNDISCLOSED)).toHaveLength(1);
+    expect(messages(run, UNDISCLOSED)[0]).toContain(STRAY_TITLE);
+  });
+
+  it("passes once an exclusion names it with a reason", () => {
+    const run = runGate(
+      healthyProject(
+        {
+          exclusions: [
+            {
+              file: STRAY_SPEC,
+              evidence: STRAY_TITLE,
+              reason: SMOKE_REASON,
+            },
+          ],
+        },
+        { files: { [STRAY_SPEC]: STRAY_SOURCE } }
+      ),
+      { BDD_MODE: ENFORCED }
+    );
+    expect(codes(run)).not.toContain(UNDISCLOSED);
+    expect(run.status).toBe(0);
+  });
+
+  it("treats an exclusion with no evidence as covering the whole file", () => {
+    const run = runGate(
+      healthyProject(
+        {
+          exclusions: [
+            {
+              file: STRAY_SPEC,
+              reason: "vendor smoke suite, not product behavior",
+            },
+          ],
+        },
+        {
+          files: {
+            [STRAY_SPEC]: `${STRAY_SOURCE}test("and another", async () => {});\n`,
+          },
+        }
+      ),
+      { BDD_MODE: ENFORCED }
+    );
+    expect(run.status).toBe(0);
+  });
+
+  it("refuses an exclusion with no reason", () => {
+    const run = runGate(
+      healthyProject(
+        { exclusions: [{ file: STRAY_SPEC, evidence: STRAY_TITLE }] },
+        { files: { [STRAY_SPEC]: STRAY_SOURCE } }
+      ),
+      { BDD_MODE: ENFORCED }
+    );
+    expect(messages(run, EXCLUSION_METADATA)[0]).toContain("reason");
+  });
+});
+
+describe("discovery configuration is contract data, not a source constant", () => {
+  it("refuses a malformed discovery block in bootstrap too", () => {
+    // Same reasoning as a quoted coverage floor: one edit here would silently
+    // switch discovery off, and a switched-off discovery finds nothing.
+    const run = runGate(
+      healthyProject({
+        adoption: LIVE_BOOTSTRAP,
+        coverageFloor: { [WEB]: 0 },
+        testDiscovery: {
+          [PLAYWRIGHT]: { ...PLAYWRIGHT_DISCOVERY, roots: "e2e" },
+        },
+      }),
+      { BDD_MODE: BOOTSTRAP }
+    );
+    expect(run.status).toBe(1);
+    expect(codes(run)).toContain(DISCOVERY_INVALID);
+  });
+
+  it("refuses an unknown evidence kind rather than skipping the runner", () => {
+    const run = runGate(
+      healthyProject({
+        testDiscovery: {
+          [PLAYWRIGHT]: {
+            ...PLAYWRIGHT_DISCOVERY,
+            evidence: { kind: "guess-from-filename" },
+          },
+        },
+      }),
+      { BDD_MODE: ENFORCED }
+    );
+    expect(codes(run)).toContain(DISCOVERY_INVALID);
+  });
+
+  it("requires a discovery block for every declared runner in enforced mode", () => {
+    const run = runGate(healthyProject({ testDiscovery: undefined }), {
+      BDD_MODE: ENFORCED,
+    });
+    expect(run.status).toBe(1);
+    expect(messages(run, DISCOVERY_MISSING)[0]).toContain(PLAYWRIGHT);
+  });
+
+  it("walks every declared root, including the subflow directory", () => {
+    // Hardcoded roots downstream made `.maestro/subflows` structurally
+    // invisible. Roots are per-runner configuration precisely so a project can
+    // say where its tests live.
+    const map = {
+      ...HEALTHY_MAP,
+      runnerPlatforms: { [PLAYWRIGHT]: [WEB], [MAESTRO]: ["ios"] },
+      coverageFloor: { [WEB]: 100, ios: 0 },
+      testDiscovery: {
+        [PLAYWRIGHT]: PLAYWRIGHT_DISCOVERY,
+        [MAESTRO]: {
+          roots: [".maestro/flows", ".maestro/subflows"],
+          extensions: [".yaml"],
+          evidence: { kind: "line-field", field: "name" },
+        },
+      },
+    };
+    const run = runGate(
+      makeProject({
+        map,
+        features: {
+          [HOME_FEATURE_FILE]: featureSource("Home", [
+            { id: HOME_ID, tags: [WEB, RATIFIED] },
+          ]),
+        },
+        files: {
+          ...HEALTHY_FILES,
+          ".maestro/subflows/login.yaml": "appId: com.example\nname: Log in\n",
+        },
+      }),
+      { BDD_MODE: ENFORCED }
+    );
+    expect(messages(run, UNDISCLOSED)[0]).toContain(
+      ".maestro/subflows/login.yaml"
+    );
+    expect(messages(run, UNDISCLOSED)[0]).toContain("Log in");
+  });
+});
+
+describe("a template-literal title is used verbatim, never mangled", () => {
+  const DYNAMIC_SPEC = "e2e/dynamic.spec.ts";
+  const DYNAMIC_TITLE = "handles ${error.name} failures";
+  const DYNAMIC_SOURCE = `test(\`${DYNAMIC_TITLE}\`, async () => {});\n`;
+
+  it("discloses it against the source text exactly as written", () => {
+    const run = runGate(
+      healthyProject(
+        {
+          exclusions: [
+            {
+              file: DYNAMIC_SPEC,
+              evidence: DYNAMIC_TITLE,
+              reason: DYNAMIC_REASON,
+            },
+          ],
+        },
+        { files: { [DYNAMIC_SPEC]: DYNAMIC_SOURCE } }
+      ),
+      { BDD_MODE: ENFORCED }
+    );
+    expect(codes(run)).not.toContain(UNDISCLOSED);
+    expect(codes(run)).not.toContain(EXCLUSION_STALE);
+    expect(run.status).toBe(0);
+  });
+
+  it("counts it as a dynamic title so the limitation is visible", () => {
+    const report = runReport(
+      healthyProject(
+        {
+          exclusions: [
+            {
+              file: DYNAMIC_SPEC,
+              evidence: DYNAMIC_TITLE,
+              reason: DYNAMIC_REASON,
+            },
+          ],
+        },
+        { files: { [DYNAMIC_SPEC]: DYNAMIC_SOURCE } }
+      ),
+      { BDD_MODE: ENFORCED }
+    );
+    expect(report.testInventory.dynamicTitles).toBe(1);
+  });
+});

--- a/tests/unit/scripts/bdd-exclusions.test.ts
+++ b/tests/unit/scripts/bdd-exclusions.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The exclusion ledger, and the rule that a red run still writes its paperwork.
+ *
+ * An exclusion is a standing claim that a real test proves nothing about
+ * product behavior. Left unchecked those claims outlive what they excused, and
+ * "unmapped test" stops meaning anything — so a dead exclusion is a defect in
+ * its own right. The last case guards the opposite failure: a fleet fork let
+ * one renamed title wedge regeneration entirely, so the artifacts documenting
+ * a defect could not be produced until the defect was gone.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  ENFORCED,
+  HOME_SPEC,
+  type Report,
+  codes,
+  healthyProject,
+  messages,
+  readProjectFile,
+  runGate,
+  runGateWrite,
+} from "./bdd/support";
+
+const UNDISCLOSED = "spec-undisclosed";
+const EXCLUSION_STALE = "exclusion-stale";
+const STRAY_SPEC = "e2e/stray.spec.ts";
+const STRAY_TITLE = "a test nobody declared";
+const STRAY_SOURCE = `test("${STRAY_TITLE}", async () => {});\n`;
+const SMOKE_REASON = "starter template kept as a runner smoke check";
+
+describe("an exclusion cannot outlive what it excused", () => {
+  it("fails when the excluded file no longer exists", () => {
+    const run = runGate(
+      healthyProject({
+        exclusions: [
+          { file: "e2e/deleted.spec.ts", reason: "deleted last quarter" },
+        ],
+      }),
+      { BDD_MODE: ENFORCED }
+    );
+    expect(run.status).toBe(1);
+    expect(messages(run, EXCLUSION_STALE)[0]).toContain("e2e/deleted.spec.ts");
+  });
+
+  it("fails when its evidence matches nothing in the file", () => {
+    const run = runGate(
+      healthyProject(
+        {
+          exclusions: [
+            {
+              file: STRAY_SPEC,
+              evidence: "a title that was renamed away",
+              reason: SMOKE_REASON,
+            },
+          ],
+        },
+        { files: { [STRAY_SPEC]: STRAY_SOURCE } }
+      ),
+      { BDD_MODE: ENFORCED }
+    );
+    expect(messages(run, EXCLUSION_STALE)[0]).toContain("renamed away");
+    expect(codes(run)).toContain(UNDISCLOSED);
+  });
+
+  it("fails when no configured discovery root covers the excluded file", () => {
+    const run = runGate(
+      healthyProject(
+        {
+          exclusions: [{ file: "src/util.ts", reason: "not a test at all" }],
+        },
+        { files: { "src/util.ts": "export const x = 1;\n" } }
+      ),
+      { BDD_MODE: ENFORCED }
+    );
+    expect(messages(run, EXCLUSION_STALE)[0]).toContain("discovery root");
+  });
+});
+
+describe("a defect never wedges the artifacts that document it", () => {
+  it("regenerates the burndown and report while the run is red", () => {
+    // The fleet hit this exactly: one renamed test title made `--write` refuse
+    // to run, so a new waiver could not be recorded until an unrelated string
+    // was repaired. A defect must stay a defect and keep losing coverage
+    // credit — without holding the paperwork hostage.
+    const root = healthyProject(
+      {},
+      { files: { [HOME_SPEC]: STRAY_SOURCE, [STRAY_SPEC]: STRAY_SOURCE } }
+    );
+    const burndown = runGateWrite(root, { BDD_MODE: ENFORCED });
+    const report = JSON.parse(
+      readProjectFile(root, "bdd/coverage-report.json")
+    ) as Report;
+    expect(burndown).toContain(STRAY_TITLE);
+    expect(report.testInventory.undisclosed).toHaveLength(2);
+    expect(report.traceability.overall.covered).toBe(0);
+    expect(runGate(root, { BDD_MODE: ENFORCED }).status).toBe(1);
+  });
+});

--- a/tests/unit/scripts/bdd-failopen.test.ts
+++ b/tests/unit/scripts/bdd-failopen.test.ts
@@ -29,12 +29,15 @@ import {
   messages,
   readMap,
   runGate,
+  runGateWrite,
   runReport,
   writeMap,
 } from "./bdd/support";
 
 const RESULTS_FILE = "results.json";
 const FLOOR_INVALID = "floor-invalid";
+const STALE_TITLE = "renamed away";
+const STALE_SOURCE = `test("${STALE_TITLE}", async () => {});\n`;
 
 describe("a malformed coverage floor cannot disable the floor", () => {
   it("refuses a floor quoted as a string, in enforced mode", () => {
@@ -137,6 +140,14 @@ describe("a stale mapping stops counting as covered", () => {
       { BDD_MODE: BOOTSTRAP }
     );
     expect(report.gaps.map(gap => gap.scenario)).toContain(HOME_ID);
+  });
+
+  it("still lets --write regenerate the artifacts that document it", () => {
+    // A renamed title once wedged regeneration entirely in a fleet fork, so a
+    // waiver could not be recorded until an unrelated string was repaired.
+    const root = healthyProject({}, { files: { [HOME_SPEC]: STALE_SOURCE } });
+    expect(runGateWrite(root, { BDD_MODE: ENFORCED })).toContain(STALE_TITLE);
+    expect(runGate(root, { BDD_MODE: ENFORCED }).status).toBe(1);
   });
 });
 

--- a/tests/unit/scripts/bdd-wiring.test.ts
+++ b/tests/unit/scripts/bdd-wiring.test.ts
@@ -31,6 +31,7 @@ describe("shipped wiring", () => {
       "expo/copy-overwrite/scripts/bdd/report.mjs",
       "expo/copy-overwrite/scripts/bdd/render.mjs",
       "expo/copy-overwrite/scripts/bdd/baseline.mjs",
+      "expo/copy-overwrite/scripts/bdd/discover.mjs",
       "expo/copy-overwrite/scripts/bdd/envelope.mjs",
     ]) {
       expect(fs.existsSync(path.join(REPO_ROOT, relative)), relative).toBe(
@@ -53,6 +54,40 @@ describe("shipped wiring", () => {
     expect(
       fs.existsSync(path.join(REPO_ROOT, "expo/create-only/bdd/features/.keep"))
     ).toBe(true);
+  });
+
+  it("seeds a discovery block for every runner it seeds a platform for", () => {
+    // A seeded runner with no roots can never find an undeclared test, and the
+    // seed is create-only — whatever ships here is what most repos will run.
+    const seed = JSON.parse(read(SEED_MAP_REL)) as {
+      runnerPlatforms: Record<string, unknown>;
+      testDiscovery: Record<string, { roots: string[]; evidence: unknown }>;
+    };
+    const runners = Object.keys(seed.runnerPlatforms).filter(
+      key => !key.startsWith("_")
+    );
+    expect(runners.length).toBeGreaterThan(0);
+    for (const runner of runners) {
+      expect(seed.testDiscovery[runner]?.roots.length, runner).toBeGreaterThan(
+        0
+      );
+      expect(seed.testDiscovery[runner]?.evidence, runner).toBeTruthy();
+    }
+    // The subflow directory the fleet's hardcoded roots could not see.
+    expect(seed.testDiscovery.maestro.roots).toContain(".maestro/subflows");
+  });
+
+  it("documents discovery and exclusions in the versioned schema doc", () => {
+    const doc = read(DOC_REL);
+    for (const needle of [
+      "testDiscovery",
+      "spec-undisclosed",
+      "exclusion-stale",
+      "discovery-invalid",
+      "never wedges the artifacts",
+    ]) {
+      expect(doc, needle).toContain(needle);
+    }
   });
 
   it("exposes the gate and matrix on the standard package script surface", () => {

--- a/tests/unit/scripts/bdd/support.ts
+++ b/tests/unit/scripts/bdd/support.ts
@@ -39,6 +39,23 @@ export const RATIFIED = "ratified-shipped-behavior";
 export const HOME_FEATURE_FILE = "home.feature";
 export const MAP_REL = "bdd/coverage-map.json";
 
+/** Discovery vocabulary, so no test repeats a runner or root literal. */
+export const MAESTRO = "maestro";
+export const E2E_ROOT = "e2e";
+export const SPEC_EXTENSION = ".spec.ts";
+
+/**
+ * The playwright discovery block used by every healthy fixture.
+ *
+ * Declared per runner in the map, never hardcoded in the gate — that is the
+ * whole point of making roots configuration rather than a source constant.
+ */
+export const PLAYWRIGHT_DISCOVERY: Record<string, unknown> = {
+  roots: [E2E_ROOT],
+  extensions: [SPEC_EXTENSION],
+  evidence: { kind: "call-title", functions: ["test"] },
+};
+
 /** Defect codes asserted across more than one case. */
 export const FLOOR_RATCHET = "floor-ratchet";
 export const SCENARIO_DELETED = "scenario-deleted";
@@ -118,6 +135,24 @@ export interface Report {
   readonly floor: { ok: boolean; unset: readonly string[] };
   readonly trackers: { tags: readonly { tag: string; url: string | null }[] };
   readonly gaps: readonly Record<string, unknown>[];
+  readonly testInventory: {
+    readonly runners: readonly string[];
+    readonly discovered: number;
+    readonly disclosed: number;
+    readonly dynamicTitles: number;
+    readonly undisclosed: readonly Record<string, unknown>[];
+    readonly exclusions: readonly Record<string, unknown>[];
+  };
+}
+
+/**
+ * Read a file from inside a fixture project.
+ * @param root - Project root.
+ * @param relativePath - Project-relative path.
+ * @returns File contents.
+ */
+export function readProjectFile(root: string, relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), "utf-8");
 }
 
 /**
@@ -313,6 +348,7 @@ export const HEALTHY_MAP: Record<string, unknown> = {
   asOf: TODAY,
   adoption: { state: ENFORCED },
   runnerPlatforms: { [PLAYWRIGHT]: [WEB] },
+  testDiscovery: { [PLAYWRIGHT]: PLAYWRIGHT_DISCOVERY },
   coverageFloor: { [WEB]: 100 },
   trackers: {
     keys: ["TUN"],


### PR DESCRIPTION
## What

Lisa's v2 BDD gate validated what `bdd/coverage-map.json` **declared** and never walked the tree, so an e2e spec nobody declared was invisible to it. `exclusions` shipped in the contract doc and in the create-only template while being read by **zero** gate code.

This upstreams the discovery every downstream fork still carries (tunnlai, geminisportsai, propswap all run a ~567-line schemaVersion-1 monolith that *has* working discovery — the v2 generalization dropped it), and fixes the four weaknesses a 2026-08-12 fleet audit found in that design.

## Why it matters

Six undeclared Playwright specs sit on geminisportsai/frontend-v2's default branch today, and one at propswap/frontend, invisible under a green gate — because downstream only *reports* unmapped specs into a burndown doc and never fails on them.

## How

**New config — `testDiscovery`, per runner, in the coverage map (project-editable, create-only):**

```json
"testDiscovery": {
  "playwright": { "roots": ["e2e"], "extensions": [".spec.ts"], "ignore": [],
                  "evidence": { "kind": "call-title", "functions": ["test", "it"] } },
  "maestro":    { "roots": [".maestro/flows", ".maestro/subflows"], "extensions": [".yaml"],
                  "evidence": { "kind": "line-field", "field": "name" } }
}
```

**Weaknesses fixed while upstreaming:**

| Downstream weakness | Fix here |
|---|---|
| Hardcoded `e2e/` + `.maestro/flows/` (subflows structurally invisible) | Roots/extensions/ignore are per-runner contract data; the seed declares `.maestro/subflows` |
| Hardcoded `RUNNER_FOR_PLATFORM` | Runner→platform pairing derived from `runnerPlatforms`; an unknown runner key is `discovery-invalid` |
| Template-literal titles mangled (gemini carries `${error.name}` exclusions as parser workarounds) | Titles are taken **verbatim from the source**, so they stay real file substrings and remain mappable/excusable; counted in `testInventory.dynamicTitles` |
| Unmapped specs only reported, never failed | New enforced defect `spec-undisclosed` |

**New defect codes:** `spec-undisclosed`, `exclusion-metadata`, `exclusion-stale`, `discovery-missing` (all warnable in bootstrap), and `discovery-invalid` — deliberately **not** warnable, on the same reasoning as `floor-invalid`: a malformed block would silently switch off the only check that can see an undeclared test, and switched-off discovery looks exactly like a clean repo.

**Evidence grammars are an allowlist of two**, never a project-supplied regular expression — the coverage map is repo data an author edits, and compiling a pattern out of it would hand that author the gate's own execution. Declared function names and field names are validated against identifier shapes before they reach a regex.

**Disclosure rule:** a mapping or exclusion accounts for a discovered test when it names the same file **and** its `evidence` contains that test's title; an exclusion with no `evidence` excuses the whole file. Containment in that direction means one short string can never come to account for every test in a file.

**Stale-evidence wedge fixed and locked:** `--write` regenerates the report and burndown whenever a report can be built at all. At geminisportsai one renamed title made `--write` refuse to run, so a new waiver could not be recorded until an unrelated string was repaired. Stale evidence stays a defect and still loses coverage credit — it just no longer holds the paperwork hostage.

## Acceptance criteria

```gherkin
Scenario: an undisclosed spec fails the gate
  Given a repo in enforced mode with a discovered e2e spec
  When the spec is named by no mapping and no exclusion
  Then the gate reports spec-undisclosed and exits 1

Scenario: a deliberate non-product test passes through an exclusion
  Given a discovered spec covered by an exclusion carrying a reason
  When the gate runs in enforced mode
  Then the gate passes

Scenario: a stale exclusion fails
  Given an exclusion naming a file that no longer exists
  When the gate runs
  Then the gate reports exclusion-stale

Scenario: defects never wedge regeneration
  Given a repo with stale evidence and an undisclosed spec
  When the gate runs with --write
  Then the burndown and machine report are still regenerated
```

## Test evidence

- 120 BDD gate tests green (was 117): 15 new cases across `bdd-discovery.test.ts`, `bdd-exclusions.test.ts`, plus one added to the existing `bdd-failopen.test.ts` stale-mapping suite. Red-leg first: 13 failing before implementation.
- `b71e494`'s hardening is intact and unforked — mapping→existing scenario, stale evidence losing coverage credit, and floor non-regression all still run in `bdd-failopen.test.ts`.
- Full `test:cov` + integration suites green on pre-push (9591 unit / 197 integration).
- End-to-end smoke against a scratch project: discovery found both `e2e/home.spec.ts` and `.maestro/subflows/login.yaml` (the structurally-invisible case), and both artifacts were written despite 3 errors in the run.

## Notes

- The new cases live in two sibling files rather than all inside `bdd-failopen.test.ts` because that file would exceed the repo's 300-line `max-lines` threshold (thresholds may only tighten). The existing suite is extended, never forked.
- No Rails copy of the gate exists to mirror to — `check-bdd-coverage.mjs` and `scripts/bdd/` ship only from `expo/`.
- Out of scope, as planned: obligation-coverage promotion (WU-G part 2), floor mechanics, downstream repo migration (WU-L).

Work-Item: CodySwannGT/lisa#2440

🤖 Generated with Claude Code
