### PR TITLE
fix(doctor): stop doctor self-dirtying AGENTS.md and crying wolf on Lisa's own trampoline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,25 @@ If it is malformed, warn once and ignore it.
 
 Resolved path for this project: `.lisa/PROJECT_LEARNINGS.md`.
 <!-- LISA_PROJECT_LEARNINGS_END -->
+
+<!-- LISA_HOST_RULES_START -->
+## Host Rules
+
+This project's durable, host-authored operating rules live in `.agents/rules/`.
+Read those files when you need this project's standing rules. They are not
+injected at session start, so consult them on demand — which also means every
+agent reads them through this one pointer and no agent loads them twice.
+
+**Ownership.** The host owns every file in `.agents/rules/`. Lisa never writes
+rule bodies there; Lisa's own rules ship through its per-agent plugins. This
+marked block is the only Lisa-managed content in this file — everything outside
+the markers belongs to the host and is never touched.
+
+**Transition.** This project still has host rules at `.claude/rules/PROJECT_RULES.md`.
+They remain authoritative and are left exactly as written — Lisa does not
+move, rewrite, or delete them. Agents whose runtime auto-loads that path
+(Claude Code auto-loads `.claude/rules/`) already have that content and must
+not read it a second time; every other agent should read it alongside
+`.agents/rules/`. Reclassifying or relocating it is a human-gated
+decision, never an automated rewrite.
+<!-- LISA_HOST_RULES_END -->

--- a/src/cli/doctor-lisa-owned-artifacts.ts
+++ b/src/cli/doctor-lisa-owned-artifacts.ts
@@ -22,6 +22,7 @@ import * as fse from "fs-extra";
 
 import { PROJECT_TYPE_ORDER } from "../core/config.js";
 import { isLisaOwnedTemplate } from "../core/lisa-owned-templates.js";
+import { isLisaSourceRepo } from "../core/self-apply.js";
 import { listFilesRecursive } from "../utils/file-operations.js";
 import {
   matchesAnyPattern,
@@ -31,6 +32,13 @@ import {
 const CHECK_NAME = "Lisa enforcement artifacts current?";
 const COPY_OVERWRITE = "copy-overwrite";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Quoted relative module specifiers — `import`/`export from`, `require()`, and
+ * a shell `source`/`.` of a sibling path all spell the target the same way.
+ * Bounded quantifier keeps the scan linear on large files.
+ */
+const RELATIVE_SPECIFIER = /["'`](\.\.?\/[^"'`\n]{1,4096})["'`]/g;
 
 /** One doctor check result, structurally identical to `DoctorCheck`. */
 interface ArtifactCheck {
@@ -122,6 +130,36 @@ async function matchesAnyShipped(
 }
 
 /**
+ * Whether the installed file is a trampoline that re-exports the shipped
+ * template instead of copying it.
+ *
+ * Lisa's own repository is the one host that cannot hold a byte copy of a file
+ * it also ships: the working copy and the template would be two editable
+ * originals of the same guard, free to diverge. It keeps a few-line entrypoint
+ * that re-exports the template, so its hooks and CI run the exact bytes the
+ * fleet gets. Byte comparison necessarily calls that drift; it is the opposite.
+ *
+ * Proof, not pattern-match: the specifier is resolved against the installed
+ * file's own directory and must land exactly on a shipped variant of this same
+ * destination. A stub pointing anywhere else is still drift.
+ * @param installed - Bytes currently installed in the project
+ * @param installedPath - Absolute path of the installed file
+ * @param sources - Absolute paths of the shipped variants
+ * @returns True when the installed file defers to a shipped variant
+ */
+function reExportsShippedTemplate(
+  installed: Buffer,
+  installedPath: string,
+  sources: readonly string[]
+): boolean {
+  const shipped = new Set(sources.map(source => path.resolve(source)));
+  const directory = path.dirname(installedPath);
+  return [...installed.toString("utf8").matchAll(RELATIVE_SPECIFIER)].some(
+    match => shipped.has(path.resolve(directory, match[1] ?? ""))
+  );
+}
+
+/**
  * Report Lisa-owned enforcement artifacts the project has an outdated copy of.
  *
  * Only artifacts the project already has are considered: a missing one means
@@ -148,15 +186,21 @@ export async function checkLisaOwnedArtifacts(
     "utf8"
   ).catch(() => "");
   const ignorePatterns = parseIgnorePatterns(ignoreText);
+  // Gating the trampoline exemption on self-host keeps this check byte-for-byte
+  // unchanged for every real host project: the branch below is unreachable
+  // unless the target's package.json is Lisa itself. A host must not be able to
+  // swap a guard for a thin re-export and have doctor call it current.
+  const selfHost = await isLisaSourceRepo(targetPath);
 
   const results = await Promise.all(
     [...shipped].map(async ([destination, sources]) => {
       if (matchesAnyPattern(destination, ignorePatterns)) return undefined;
-      const installed = await readFile(
-        path.join(targetPath, destination)
-      ).catch(() => undefined);
+      const installedPath = path.join(targetPath, destination);
+      const installed = await readFile(installedPath).catch(() => undefined);
       if (installed === undefined) return undefined;
-      return (await matchesAnyShipped(installed, sources))
+      if (await matchesAnyShipped(installed, sources)) return undefined;
+      return selfHost &&
+        reExportsShippedTemplate(installed, installedPath, sources)
         ? undefined
         : destination;
     })

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8579,6 +8579,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/core/host-rules-parity.test.ts": true,
     "tests/unit/core/host-rules-pointer.test.ts": true,
     "tests/unit/core/instruction-files-migration.test.ts": true,
+    "tests/unit/core/instruction-files-self-host.test.ts": true,
     "tests/unit/core/kane-cli.test.ts": true,
     "tests/unit/core/kane-pilot.test.ts": true,
     "tests/unit/core/kane-readiness.test.ts": true,

--- a/tests/unit/cli/doctor-lisa-owned-artifacts.test.ts
+++ b/tests/unit/cli/doctor-lisa-owned-artifacts.test.ts
@@ -18,6 +18,54 @@ const GUARD = "scripts/lisa-hooks/block-no-verify.sh";
 const HOST_CONFIG = "tsconfig.json";
 const SHIPPED_GUARD = "#!/usr/bin/env bash\n# closed\n";
 const OLD_GUARD = "#!/usr/bin/env bash\n# fails open\n";
+const ENTRYPOINT = "scripts/lisa-work-item.mjs";
+const LISA_PACKAGE = '{"name":"@codyswann/lisa"}';
+const HOST_PACKAGE = '{"name":"some-host-app"}';
+const OK = "ok";
+const WARN = "warn";
+
+/**
+ * Absolute path of a destination as the `all` stack ships it.
+ * @param lisaRoot - Lisa package root shipping the template.
+ * @param destination - Project-relative destination path.
+ * @returns Absolute path to the shipped template.
+ */
+function shippedPath(lisaRoot: string, destination: string): string {
+  return path.join(lisaRoot, "all", "copy-overwrite", destination);
+}
+
+/**
+ * Write a project package.json so the check can tell Lisa's own repository from
+ * an ordinary host project.
+ * @param projectDir - Project root to write into.
+ * @param contents - package.json body.
+ */
+async function writePackageJson(
+  projectDir: string,
+  contents: string
+): Promise<void> {
+  await fs.outputFile(path.join(projectDir, "package.json"), contents);
+}
+
+/**
+ * Build the trampoline Lisa's own repository keeps at a Lisa-owned entrypoint:
+ * a few lines that re-export the shipped implementation instead of duplicating
+ * 50KB of it. The specifier is computed rather than written out so the test
+ * asserts on a path that genuinely resolves to the shipped file.
+ * @param projectDir - Project root the trampoline is installed into.
+ * @param lisaRoot - Lisa package root shipping the template.
+ * @returns Trampoline file contents.
+ */
+function trampolineFor(projectDir: string, lisaRoot: string): string {
+  const specifier = path
+    .relative(
+      path.dirname(path.join(projectDir, ENTRYPOINT)),
+      shippedPath(lisaRoot, ENTRYPOINT)
+    )
+    .split(path.sep)
+    .join("/");
+  return `#!/usr/bin/env node\n\n// The installed copy lives under all/copy-overwrite.\nimport { runCli } from "${specifier}";\n\nrunCli();\n`;
+}
 
 describe("checkLisaOwnedArtifacts", () => {
   let tempDir: string;
@@ -28,13 +76,11 @@ describe("checkLisaOwnedArtifacts", () => {
     tempDir = await createTempDir();
     lisaRoot = path.join(tempDir, "lisa");
     projectDir = path.join(tempDir, "project");
+    await fs.outputFile(shippedPath(lisaRoot, GUARD), SHIPPED_GUARD);
+    await fs.outputFile(shippedPath(lisaRoot, HOST_CONFIG), '{"strict":true}');
     await fs.outputFile(
-      path.join(lisaRoot, "all", "copy-overwrite", GUARD),
-      SHIPPED_GUARD
-    );
-    await fs.outputFile(
-      path.join(lisaRoot, "all", "copy-overwrite", HOST_CONFIG),
-      '{"strict":true}'
+      shippedPath(lisaRoot, ENTRYPOINT),
+      "export function runCli() {}\n"
     );
     await fs.ensureDir(projectDir);
   });
@@ -48,7 +94,7 @@ describe("checkLisaOwnedArtifacts", () => {
 
     const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
 
-    expect(check.status).toBe("warn");
+    expect(check.status).toBe(WARN);
     expect(check.detail).toContain(GUARD);
   });
 
@@ -57,14 +103,14 @@ describe("checkLisaOwnedArtifacts", () => {
 
     const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
 
-    expect(check.status).toBe("ok");
+    expect(check.status).toBe(OK);
   });
 
   it("passes when the project never installed the guard", async () => {
     // A missing artifact means the stack does not apply here, not drift.
     const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
 
-    expect(check.status).toBe("ok");
+    expect(check.status).toBe(OK);
   });
 
   it("ignores drift in host-owned managed config", async () => {
@@ -75,7 +121,7 @@ describe("checkLisaOwnedArtifacts", () => {
 
     const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
 
-    expect(check.status).toBe("ok");
+    expect(check.status).toBe(OK);
   });
 
   it("respects .lisaignore", async () => {
@@ -88,6 +134,65 @@ describe("checkLisaOwnedArtifacts", () => {
 
     const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
 
-    expect(check.status).toBe("ok");
+    expect(check.status).toBe(OK);
+  });
+
+  describe("when the project is Lisa's own repository", () => {
+    beforeEach(async () => {
+      await writePackageJson(projectDir, LISA_PACKAGE);
+    });
+
+    it("does not report a trampoline that re-exports the shipped template", async () => {
+      // Lisa's own repo cannot hold a byte copy of a file it also ships: the
+      // entrypoint is a re-export so its hooks and CI run the exact shipped
+      // implementation. That is the opposite of drift, and calling it drift in
+      // Lisa's own repo teaches everyone to ignore this check.
+      await fs.outputFile(
+        path.join(projectDir, ENTRYPOINT),
+        trampolineFor(projectDir, lisaRoot)
+      );
+
+      const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
+
+      expect(check.status).toBe(OK);
+    });
+
+    it("still reports a guard that genuinely drifted", async () => {
+      // The exemption is for re-exports, not for Lisa's repo wholesale.
+      await fs.outputFile(path.join(projectDir, GUARD), OLD_GUARD);
+
+      const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
+
+      expect(check.status).toBe(WARN);
+      expect(check.detail).toContain(GUARD);
+    });
+
+    it("still reports a stub that points somewhere other than the template", async () => {
+      await fs.outputFile(
+        path.join(projectDir, ENTRYPOINT),
+        'import { runCli } from "./somewhere-else.mjs";\n\nrunCli();\n'
+      );
+
+      const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
+
+      expect(check.status).toBe(WARN);
+      expect(check.detail).toContain(ENTRYPOINT);
+    });
+  });
+
+  it("does not exempt a trampoline in an ordinary host project", async () => {
+    // Load-bearing: drift detection is what makes Lisa's fixes reach installed
+    // repos. A host must never be able to swap a guard for a thin re-export and
+    // have doctor call it current.
+    await writePackageJson(projectDir, HOST_PACKAGE);
+    await fs.outputFile(
+      path.join(projectDir, ENTRYPOINT),
+      trampolineFor(projectDir, lisaRoot)
+    );
+
+    const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
+
+    expect(check.status).toBe(WARN);
+    expect(check.detail).toContain(ENTRYPOINT);
   });
 });

--- a/tests/unit/core/instruction-files-self-host.test.ts
+++ b/tests/unit/core/instruction-files-self-host.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Lisa's own `AGENTS.md` must already be what Lisa's own reconciler produces.
+ *
+ * `doctor` runs the instruction-files migration unconditionally and it is a
+ * mutating check — there is no dry-run mode. So if the committed `AGENTS.md`
+ * lacks a block the reconciler adds, every `doctor` run in this repository
+ * dirties the working tree, and `apply` then refuses to run because the tree is
+ * dirty. The tool blocks itself, in its own repository, for everyone.
+ *
+ * WU-A's stated contract was idempotence: reconciling an already-reconciled
+ * file writes nothing. That contract only holds for this repository if the
+ * committed bytes are the reconciled bytes, which is what this test pins.
+ *
+ * The migration runs against a faithful copy rather than the repository root so
+ * the test can never be the thing that dirties the tree it is defending.
+ * @module tests/unit/core/instruction-files-self-host
+ */
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { migrateInstructionFiles } from "../../../src/core/instruction-files-migration.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  ".."
+);
+
+/**
+ * Every repository file the migration reads when deciding what `AGENTS.md`
+ * should contain: the file itself, the config that names the harness and the
+ * learnings ledger, and the legacy rules document whose existence decides
+ * whether the pointer carries a transition paragraph.
+ */
+const INPUTS = [
+  "AGENTS.md",
+  "CLAUDE.md",
+  ".lisa.config.json",
+  ".claude/rules/PROJECT_RULES.md",
+];
+
+describe("Lisa's own instruction files", () => {
+  let tempDir: string;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    projectDir = path.join(tempDir, "lisa");
+    await Promise.all(
+      INPUTS.map(async relativePath => {
+        const source = path.join(REPO_ROOT, relativePath);
+        if (!(await fs.pathExists(source))) return;
+        await fs.copy(source, path.join(projectDir, relativePath));
+      })
+    );
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  it("reconciles to byte-identical AGENTS.md, so doctor leaves a clean tree clean", async () => {
+    const agentsMd = path.join(projectDir, "AGENTS.md");
+    const committed = await fs.readFile(agentsMd, "utf8");
+
+    // relocateLearnings is off for the same reason apply turns it off: it moves
+    // a ledger this copy does not have, and it is not what governs AGENTS.md.
+    const result = await migrateInstructionFiles(projectDir, {
+      relocateLearnings: false,
+    });
+
+    expect(await fs.readFile(agentsMd, "utf8")).toBe(committed);
+    expect(
+      result.actions.filter(action => action.includes("AGENTS.md"))
+    ).toEqual([]);
+  });
+
+  it("is a no-op on a repeat run", async () => {
+    await migrateInstructionFiles(projectDir, { relocateLearnings: false });
+
+    const second = await migrateInstructionFiles(projectDir, {
+      relocateLearnings: false,
+    });
+
+    expect(second.changed).toBe(false);
+  });
+});


### PR DESCRIPTION
Two "Lisa as its own host" defects found by integration verification of `main` at 2.353.0. Same class of bug: a Lisa check misbehaving when the host repo *is* the Lisa monorepo.

## Defect 1 (priority) — `doctor`/`apply` self-dirtied the tree, then `apply` refused to run

`doctor` runs the instruction-files migration unconditionally, and that check is mutating — there is no dry-run mode. Lisa's own committed `AGENTS.md` did not carry the `LISA_HOST_RULES` block #2444 added, so every `doctor` run here injected it and dirtied the tree. `apply` refuses to run on a dirty tree, so the tool blocked itself in its own repository, for everyone working here.

The reconciler was already idempotent — a second run wrote nothing. What was missing is that the committed bytes were not the reconciled bytes. This commits the block exactly as `reconcileManagedBlocks` produces it, generated by running `doctor` rather than hand-authored.

### Instruction-file write guard: override used, and why it is safe

#2444 could not land this itself. Lisa ships an instruction-file write guard (>= 2.330.0) that blocks agent writes to `AGENTS.md` / `CLAUDE.md` / `copilot-instructions.md`. **I used its documented escape hatch, `LISA_ALLOW_INSTRUCTION_FILE_WRITE=1`, deliberately and scoped to that single `git commit` invocation** — not exported into the session, not added to any config, and not used for the second commit.

That is safe here because the bytes are not agent prose. They are the output of Lisa's own reconciler, bounded by its own markers, with every byte outside the markers untouched — which is precisely the case the override exists for. The new test pins the committed bytes to the reconciler's output rather than to anything written by hand, so the two cannot silently diverge again.

## Defect 2 — false-positive drift WARN on a deliberate trampoline

`doctor` reported `Outdated Lisa-owned guards: scripts/lisa-work-item.mjs`. Not drift: that file is a deliberate twelve-line trampoline re-exporting `all/copy-overwrite/scripts/lisa-work-item.mjs`, so Lisa's own hooks and CI run the exact 50KB implementation the fleet gets rather than a second editable original free to diverge. The #2436 check compares bytes, so it necessarily called that stale.

WARN only, exit stayed 0 — cosmetic. But a check that cries wolf in its own repo trains people to ignore it, and this one is what makes Lisa's fixes reach installed repos.

### The exemption does not weaken host-repo drift detection

Two independent guards, deliberately belt-and-braces:

1. **Proof, not a filename blacklist.** The installed file's relative module specifiers are resolved against its own directory and must land *exactly* on a shipped variant of that same destination. A stub pointing anywhere else is still reported.
2. **Gated on `isLisaSourceRepo`.** This makes the no-weakening claim structural rather than argued: the exemption branch is **unreachable** unless the target's own `package.json` name is `@codyswann/lisa`. For every real host project, this check does the same byte comparison it did before — byte for byte unchanged.

Both halves are pinned by tests, including the adversarial one: a host repo carrying a byte-identical trampoline is **still** reported.

## Verification

Acceptance test for defect 1 (idempotence was WU-A's stated contract), on a clean tree at the head of this branch:

```
$ git status --porcelain            # clean
$ node dist/index.js doctor
OK Lisa enforcement artifacts current?: Enforcement guards match the installed Lisa version
OK Instruction files canonical?: Already canonical (AGENTS.md source of truth, CLAUDE.md imports it)
$ git status --porcelain            # still clean

$ node dist/index.js doctor         # second run: no-op
OK Lisa enforcement artifacts current?: Enforcement guards match the installed Lisa version
OK Instruction files canonical?: Already canonical (AGENTS.md source of truth, CLAUDE.md imports it)
$ git status --porcelain            # still clean
```

Before this branch, run 1 printed `Repaired: reconciled host-rules pointer in AGENTS.md` and left ` M AGENTS.md`, plus `WARN … Outdated Lisa-owned guards … scripts/lisa-work-item.mjs`. Both are gone.

- TDD red leg confirmed for both defects before any fix (2 failed; the AGENTS.md failure diff was exactly the missing block).
- `bun run test:unit` — 580 files, 10157 tests, all passing.
- `bun run lint`, `bun run typecheck`, `bun run check:upstream-evidence-manifest` — clean.
- `bun install` run in the worktree before pushing, so knip has `node_modules/.bin`.

## Notes for review

- The defect-1 test runs the migration against a faithful **copy** of the repository's instruction files rather than the repository root, so the test can never be the thing that dirties the tree it is defending.
- The work-item `bind` step could not run: the worktree-isolation hook false-positives on the literal token `bind` in the command string ("runs a string through bind"). Both commits instead carry a `Work-Item:` trailer, which `validate-commit` accepts when no binding state exists. Worth a separate look.

Work-Item: CodySwannGT/lisa#2458

🤖 Generated with Claude Code
