### PR TITLE
feat: provider rungs for four access layers, plus a doctor check for an unregistered learnings merge driver

### DIFF
--- a/plugins/lisa-agy/skills/lisa-atlassian-access/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-atlassian-access/SKILL.md
@@ -69,6 +69,13 @@ read_atlassian_token() {
   # Legacy fallback: the OS keychain written by the guided /lisa:setup:atlassian
   # flow, for projects that have not adopted a credentials provider. Reached only
   # when the chokepoint is absent or has no entry.
+  #
+  # This rung is REMOVED ON 2026-11-01 — a dated migration ramp, not a standing
+  # exemption (see credential-substrate-precedence, "Legacy OS-keychain fallback
+  # — removal date"). A keychain entry is machine-local ambient state no headless
+  # surface can reach, so a project resting on it has no working tier 1 in cron,
+  # CI, or a cloud session. Re-run /lisa:setup:atlassian before that date to
+  # store ATLASSIAN_API_TOKEN through the chokepoint instead.
   case "$(uname -s)" in
     Darwin)  security find-generic-password -s lisa-atlassian -a "$email" -w 2>/dev/null ;;
     Linux)   command -v secret-tool >/dev/null && secret-tool lookup service lisa-atlassian account "$email" 2>/dev/null ;;

--- a/plugins/lisa-agy/skills/lisa-jam-access/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-jam-access/SKILL.md
@@ -39,20 +39,55 @@ headlessly — which is why it leads. The CLI tier uses:
 ```bash
 curl -fsSL https://native.jam.dev/install | bash
 export PATH="$HOME/.local/bin:$PATH"
-printf '%s' "$JAM_PAT" | jam auth login --token
+
+# Resolve the PAT through the chokepoint before giving up on the environment.
+# `$JAM_PAT` is the documented fallback, not the only rung: without this, a
+# project that keeps its credentials in Bitwarden, Doppler, or AWS has no tier 1
+# path at all and silently resolves through the interactive MCP — the exact
+# divergence `credential-substrate-precedence` exists to remove.
+read_jam_pat() {
+  [ -n "${JAM_PAT:-}" ] && { echo "$JAM_PAT"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get JAM_PAT 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
+# Piped, never written to disk and never passed as an argv token: a PAT on a
+# command line is readable from the process table by every user on the host.
+read_jam_pat | jam auth login --token
 jam skills install
 ```
 
 If neither tier works, fail with:
 
 ```text
-Error: no Jam access substrate available. Authenticate the Jam MCP or set JAM_PAT.
+Error: no Jam access substrate available. Authenticate the Jam MCP, set JAM_PAT, or store JAM_PAT in this project's secrets provider.
 ```
+
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — fetching a trace,
+a recording, or a bug report. So the `credential-substrate-precedence` guarded
+fallback for mutating operations (write, read back, assert the tenant from the
+response, roll back on mismatch) is not engaged here, and a failed tier is
+simply skipped. A future operation that mutates Jam state — commenting on or
+deleting a Jam — is a write and MUST reconcile by read-back before any retry.
 
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `JAM_PAT` CLI first, Jam MCP as
   a preserved first-class fallback. Do not retry a failed tier blindly.
+- The PAT is resolved through `lisa-secrets-access`, with the bare `JAM_PAT`
+  environment variable as the documented fallback. Never read a second
+  credential store directly.
 - Never commit a Jam PAT into `.mcp.json` or any generated setup artifact.
 - Headless Jam access requires `native.jam.dev` for the installer and
   `api.jam.dev` for CLI/API calls in any custom remote network allowlist.

--- a/plugins/lisa-agy/skills/lisa-notion-access/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-notion-access/SKILL.md
@@ -70,6 +70,13 @@ read_notion_token() {
   # Legacy fallback: the OS keychain written by the guided /lisa:setup:notion
   # flow, for projects that have not adopted a credentials provider. Reached only
   # when the chokepoint is absent or has no entry.
+  #
+  # This rung is REMOVED ON 2026-11-01 — a dated migration ramp, not a standing
+  # exemption (see credential-substrate-precedence, "Legacy OS-keychain fallback
+  # — removal date"). A keychain entry is machine-local ambient state no headless
+  # surface can reach, so a project resting on it has no working tier 1 in cron,
+  # CI, or a cloud session. Re-run /lisa:setup:notion before that date to store
+  # NOTION_API_TOKEN through the chokepoint instead.
   case "$(uname -s)" in
     Darwin)  security find-generic-password -s lisa-notion -a "$workspace" -w 2>/dev/null ;;
     Linux)   command -v secret-tool >/dev/null && \

--- a/plugins/lisa-agy/skills/lisa-posthog-access/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-posthog-access/SKILL.md
@@ -40,15 +40,38 @@ works interactively and headlessly — which is why it leads. The REST tier uses
 
 ```bash
 POSTHOG_HOST=${POSTHOG_HOST:-https://app.posthog.com}
+
+# Resolve the key through the chokepoint before giving up on the environment.
+# `$POSTHOG_PERSONAL_API_KEY` is the documented fallback, not the only rung:
+# without this, a project that keeps its credentials in Bitwarden, Doppler, or
+# AWS has no tier 1 path at all and silently resolves through the interactive
+# MCP — the exact divergence `credential-substrate-precedence` exists to remove.
+read_posthog_key() {
+  [ -n "${POSTHOG_PERSONAL_API_KEY:-}" ] && { echo "$POSTHOG_PERSONAL_API_KEY"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get POSTHOG_PERSONAL_API_KEY 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
 posthog_api() {
   local path="$1"
   local method="${2:-GET}"
   local body="${3:-}"
-  [ -n "$POSTHOG_PERSONAL_API_KEY" ] || {
-    echo "Error: POSTHOG_PERSONAL_API_KEY is not set." >&2
+  local key
+  key=$(read_posthog_key) || {
+    echo "Error: no PostHog key. Set POSTHOG_PERSONAL_API_KEY, or store it as" >&2
+    echo "POSTHOG_PERSONAL_API_KEY in this project's secrets provider." >&2
     return 1
   }
-  local args=(-sS -X "$method" -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY")
+  local args=(-sS -X "$method" -H "Authorization: Bearer $key")
   [ -n "$body" ] && args+=(-H "Content-Type: application/json" --data-binary "$body")
   curl "${args[@]}" "${POSTHOG_HOST%/}/api${path}"
 }
@@ -60,11 +83,25 @@ If neither tier works, fail with:
 Error: no PostHog access substrate available. Authenticate the PostHog MCP or set POSTHOG_PERSONAL_API_KEY.
 ```
 
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — analytics
+retrieval. `query` is an HTTP POST, but it reads: it submits a query body and
+changes no PostHog state. So the `credential-substrate-precedence` guarded
+fallback for mutating operations (write, read back, assert the tenant from the
+response, roll back on mismatch) is not engaged here, and a failed tier is
+simply skipped. Adding a genuinely mutating operation — creating an insight,
+editing a feature flag — pulls that protocol in: a write of unknown outcome MUST
+reconcile by read-back before any retry.
+
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `POSTHOG_PERSONAL_API_KEY`
   first, the PostHog MCP as a preserved first-class fallback. Identity-match
   against the configured project is mandatory on every tier.
+- The key is resolved through `lisa-secrets-access`, with the bare
+  `POSTHOG_PERSONAL_API_KEY` environment variable as the documented fallback.
+  Never read a second credential store directly.
 - `POSTHOG_HOST` defaults to PostHog Cloud but can point at a self-hosted
   deployment.
 - Consumer skills do not embed PostHog REST paths.

--- a/plugins/lisa-agy/skills/lisa-sentry-access/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-sentry-access/SKILL.md
@@ -39,16 +39,43 @@ Sentry documents API auth tokens for REST API calls, and the same token works
 interactively and headlessly — which is why it leads. The REST tier uses:
 
 ```bash
+# Resolve the token through the chokepoint before giving up on the environment.
+# `$SENTRY_AUTH_TOKEN` is the documented fallback, not the only rung: without
+# this, a project that keeps its credentials in Bitwarden, Doppler, or AWS has
+# no tier 1 path at all and silently resolves through the interactive MCP —
+# the exact divergence `credential-substrate-precedence` exists to remove.
+# Mirrors `linear-access`, `atlassian-access`, and `notion-access`.
+read_sentry_token() {
+  [ -n "${SENTRY_AUTH_TOKEN:-}" ] && { echo "$SENTRY_AUTH_TOKEN"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get SENTRY_AUTH_TOKEN 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
 sentry_api() {
   local path="$1"
-  [ -n "$SENTRY_AUTH_TOKEN" ] || {
-    echo "Error: SENTRY_AUTH_TOKEN is not set." >&2
+  local token
+  token=$(read_sentry_token) || {
+    echo "Error: no Sentry auth token. Set SENTRY_AUTH_TOKEN, or store it as" >&2
+    echo "SENTRY_AUTH_TOKEN in this project's secrets provider." >&2
     return 1
   }
   curl -sS "https://sentry.io/api/0${path}" \
-    -H "Authorization: Bearer $SENTRY_AUTH_TOKEN"
+    -H "Authorization: Bearer $token"
 }
 ```
+
+Tier 1a authenticates `sentry-cli` from the **same resolved token**
+(`SENTRY_AUTH_TOKEN=$(read_sentry_token) sentry-cli …`) — never from a second
+credential store, and never from an interactive `sentry-cli login` keychain.
 
 If neither tier works, fail with:
 
@@ -56,11 +83,25 @@ If neither tier works, fail with:
 Error: no Sentry access substrate available. Authenticate Sentry MCP/CLI or set SENTRY_AUTH_TOKEN.
 ```
 
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — issue, event, and
+release retrieval. So the `credential-substrate-precedence` guarded fallback for
+mutating operations (write, read back, assert the tenant from the response, roll
+back on mismatch) is not engaged here, and a failed tier is simply skipped. Any
+future operation that mutates Sentry state — resolving an issue, editing a
+release — is a write and MUST reconcile by read-back under that protocol before
+any retry; do not add one to the contract without it.
+
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `SENTRY_AUTH_TOKEN` first, the
   Sentry MCP as a preserved first-class fallback. Identity-match against the
   configured org/project is mandatory on every tier.
+- The token is resolved through `lisa-secrets-access`, with the bare
+  `SENTRY_AUTH_TOKEN` environment variable as the documented fallback. Never read
+  a second credential store (OS keychain, `~/.sentryclirc` token) directly — the
+  one-store rule lives at the chokepoint.
 - Org/project come from `.sentryclirc`, `.lisa.config.json`, or explicit
   operation args; never infer by searching all accessible orgs.
 - Consumer skills do not embed Sentry REST paths.

--- a/plugins/lisa-agy/skills/lisa-sonarcloud-access/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-sonarcloud-access/SKILL.md
@@ -34,6 +34,49 @@ SonarQube Cloud org. Do **not** substitute the raw MCP-image names
 running the Docker image directly, and the `sonar` CLI ignores them (auth exits
 non-zero). The CI scan gate's `SONAR_TOKEN` is a third, separate name.
 
+### Where those variables come from
+
+The `sonar` CLI reads them **from the environment only** — it has no provider
+integration of its own — so on a surface that deliberately materializes nothing
+to disk the credential can be provisioned and unreachable at the same time.
+Resolve it through `lisa-secrets-access` and export it into the launching
+process, exactly as the shared `sonar-secrets.sh` hook already does. The bare
+`$SONARQUBE_CLI_TOKEN` in the environment is the documented **fallback** rung,
+not the only one:
+
+```bash
+# Preferred: the one sanctioned reader. Without this rung a project keeping its
+# credentials in Bitwarden, Doppler, or AWS cannot authenticate the MCP at all,
+# and Sonar access degrades to "run `sonar auth login` in a browser" — dead in
+# cron, CI, and cloud sessions. See `credential-substrate-precedence`.
+read_sonar_secret() {
+  local name="$1"
+  [ -n "${!name:-}" ] && { echo "${!name}"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get "$name" 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
+# Exported into this process only. Writing it anywhere durable would create a
+# second live copy of a credential whose single store is the provider.
+SONARQUBE_CLI_TOKEN=$(read_sonar_secret SONARQUBE_CLI_TOKEN) && export SONARQUBE_CLI_TOKEN
+SONARQUBE_CLI_ORG=$(read_sonar_secret SONARQUBE_CLI_ORG) && export SONARQUBE_CLI_ORG
+```
+
+`sonar-secrets.sh` runs the same resolution with a longer search path (it also
+probes `.codex/skills/…` and `node_modules/@codyswann/lisa/plugins/lisa/…`,
+because a hook fires in checkouts that never installed an agent plugin) and with
+a timeout, because it sits in front of every prompt. Use its search order
+verbatim when this skill runs inside a hook.
+
 Wiring is performed once by `/lisa:setup:sonar` (which drives `sonar integrate
 <agent>`); this access layer assumes the MCP is already wired. This is distinct
 from the CI `SONAR_TOKEN` secret that authenticates the SonarCloud scan job in
@@ -79,9 +122,22 @@ Pass the project key through the tool's `projectKey` argument (or rely on a
 server-configured `SONARQUBE_PROJECT_KEY`); pass `branch` / `pullRequest` where the
 tool accepts them.
 
+## Mutation boundary
+
+Every operation in the map above is **read-only** — quality, coverage, and
+security data. So the `credential-substrate-precedence` guarded fallback for
+mutating operations (write, read back, assert the tenant from the response, roll
+back on mismatch) is not engaged here; with one substrate there is nothing to
+fall back to in any case. A future operation that mutates Sonar state — marking
+a hotspot safe, changing an issue's status — is a write and MUST reconcile by
+read-back before any retry.
+
 ## Invariants
 
 - The official SonarQube MCP is the only substrate; there is no REST fallback.
+- `SONARQUBE_CLI_*` values are resolved through `lisa-secrets-access` and
+  exported in-process, with the bare environment variables as the documented
+  fallback. Never write them to a dotfile or a `.env` on a local surface.
 - Auth is env-var only (`SONARQUBE_CLI_TOKEN` [+ `SONARQUBE_CLI_ORG` | `SONARQUBE_CLI_SERVER`]);
   never the interactive `sonar auth login` keychain flow inside a factory.
 - Sonar host access requires the host (`sonarcloud.io`, `sonarqube.us`, or the

--- a/plugins/lisa-copilot/rules/eager/credential-substrate-precedence.md
+++ b/plugins/lisa-copilot/rules/eager/credential-substrate-precedence.md
@@ -20,7 +20,9 @@ scope for that skill's work.
    `lisa-secrets-access`, chosen whenever its bootstrap credential is available **and**
    the resolved substrate identity-matches the configured tenant/workspace/site.
    `lisa-secrets-access` is the single chokepoint — never read an OS keychain a second
-   time.
+   time. The two legacy OS-keychain rungs that remain (`lisa-atlassian-access`,
+   `lisa-notion-access`) are a dated migration ramp with a **removal date of
+   2026-11-01**, not a standing exemption; no new access skill may add one.
 2. **Tier 2 — interactive MCP**, used only when tier 1 is *genuinely* unavailable:
    no bootstrap, no adapter for the operation (per-operation, not per-session), or a
    provider outage. "The MCP happens to be authenticated" and "tier 1 is slower" are

--- a/plugins/lisa-copilot/rules/reference/credential-substrate-precedence.md
+++ b/plugins/lisa-copilot/rules/reference/credential-substrate-precedence.md
@@ -139,6 +139,26 @@ operation, the fallback is guarded — never the normal path:
 A successful pre-flight switch is not sufficient for tenant safety — another process can
 mutate global state between the check and the write.
 
+## Legacy OS-keychain fallback — removal date 2026-11-01
+
+Two access skills (`lisa-atlassian-access`, `lisa-notion-access`) still read an
+OS keychain as a last rung below the chokepoint, because the guided
+`/lisa:setup:atlassian` and `/lisa:setup:notion` flows wrote credentials there
+before `lisa-secrets-access` existed. That rung is a **migration ramp with a
+removal date, not a standing exemption**: it is a second reader of the same
+credential, which is exactly how one credential ends up living in two places and
+drifting, and a keychain entry is machine-local ambient state that no headless
+surface can reach — so a project resting on it has no working tier 1 in cron, CI,
+or a cloud session.
+
+**Both rungs are deleted on 2026-11-01.** Before then, projects still on the
+keychain path move the credential into their configured provider — re-running
+`/lisa:setup:<vendor>` stores it through the chokepoint. After removal, a
+keychain-only project fails loudly with the exact variable named (tier 3), which
+is the intended outcome: it can never silently resolve through a substrate
+authenticated elsewhere. No new access skill may add a keychain rung; a credential
+the chokepoint cannot answer for is a setup gap to fix, not a store to add.
+
 ## Consequences to expect
 
 - **A stale or wrong token now fails identity-match instead of silently succeeding

--- a/plugins/lisa-copilot/skills/lisa-atlassian-access/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-atlassian-access/SKILL.md
@@ -69,6 +69,13 @@ read_atlassian_token() {
   # Legacy fallback: the OS keychain written by the guided /lisa:setup:atlassian
   # flow, for projects that have not adopted a credentials provider. Reached only
   # when the chokepoint is absent or has no entry.
+  #
+  # This rung is REMOVED ON 2026-11-01 — a dated migration ramp, not a standing
+  # exemption (see credential-substrate-precedence, "Legacy OS-keychain fallback
+  # — removal date"). A keychain entry is machine-local ambient state no headless
+  # surface can reach, so a project resting on it has no working tier 1 in cron,
+  # CI, or a cloud session. Re-run /lisa:setup:atlassian before that date to
+  # store ATLASSIAN_API_TOKEN through the chokepoint instead.
   case "$(uname -s)" in
     Darwin)  security find-generic-password -s lisa-atlassian -a "$email" -w 2>/dev/null ;;
     Linux)   command -v secret-tool >/dev/null && secret-tool lookup service lisa-atlassian account "$email" 2>/dev/null ;;

--- a/plugins/lisa-copilot/skills/lisa-jam-access/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-jam-access/SKILL.md
@@ -39,20 +39,55 @@ headlessly — which is why it leads. The CLI tier uses:
 ```bash
 curl -fsSL https://native.jam.dev/install | bash
 export PATH="$HOME/.local/bin:$PATH"
-printf '%s' "$JAM_PAT" | jam auth login --token
+
+# Resolve the PAT through the chokepoint before giving up on the environment.
+# `$JAM_PAT` is the documented fallback, not the only rung: without this, a
+# project that keeps its credentials in Bitwarden, Doppler, or AWS has no tier 1
+# path at all and silently resolves through the interactive MCP — the exact
+# divergence `credential-substrate-precedence` exists to remove.
+read_jam_pat() {
+  [ -n "${JAM_PAT:-}" ] && { echo "$JAM_PAT"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get JAM_PAT 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
+# Piped, never written to disk and never passed as an argv token: a PAT on a
+# command line is readable from the process table by every user on the host.
+read_jam_pat | jam auth login --token
 jam skills install
 ```
 
 If neither tier works, fail with:
 
 ```text
-Error: no Jam access substrate available. Authenticate the Jam MCP or set JAM_PAT.
+Error: no Jam access substrate available. Authenticate the Jam MCP, set JAM_PAT, or store JAM_PAT in this project's secrets provider.
 ```
+
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — fetching a trace,
+a recording, or a bug report. So the `credential-substrate-precedence` guarded
+fallback for mutating operations (write, read back, assert the tenant from the
+response, roll back on mismatch) is not engaged here, and a failed tier is
+simply skipped. A future operation that mutates Jam state — commenting on or
+deleting a Jam — is a write and MUST reconcile by read-back before any retry.
 
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `JAM_PAT` CLI first, Jam MCP as
   a preserved first-class fallback. Do not retry a failed tier blindly.
+- The PAT is resolved through `lisa-secrets-access`, with the bare `JAM_PAT`
+  environment variable as the documented fallback. Never read a second
+  credential store directly.
 - Never commit a Jam PAT into `.mcp.json` or any generated setup artifact.
 - Headless Jam access requires `native.jam.dev` for the installer and
   `api.jam.dev` for CLI/API calls in any custom remote network allowlist.

--- a/plugins/lisa-copilot/skills/lisa-notion-access/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-notion-access/SKILL.md
@@ -70,6 +70,13 @@ read_notion_token() {
   # Legacy fallback: the OS keychain written by the guided /lisa:setup:notion
   # flow, for projects that have not adopted a credentials provider. Reached only
   # when the chokepoint is absent or has no entry.
+  #
+  # This rung is REMOVED ON 2026-11-01 — a dated migration ramp, not a standing
+  # exemption (see credential-substrate-precedence, "Legacy OS-keychain fallback
+  # — removal date"). A keychain entry is machine-local ambient state no headless
+  # surface can reach, so a project resting on it has no working tier 1 in cron,
+  # CI, or a cloud session. Re-run /lisa:setup:notion before that date to store
+  # NOTION_API_TOKEN through the chokepoint instead.
   case "$(uname -s)" in
     Darwin)  security find-generic-password -s lisa-notion -a "$workspace" -w 2>/dev/null ;;
     Linux)   command -v secret-tool >/dev/null && \

--- a/plugins/lisa-copilot/skills/lisa-posthog-access/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-posthog-access/SKILL.md
@@ -40,15 +40,38 @@ works interactively and headlessly — which is why it leads. The REST tier uses
 
 ```bash
 POSTHOG_HOST=${POSTHOG_HOST:-https://app.posthog.com}
+
+# Resolve the key through the chokepoint before giving up on the environment.
+# `$POSTHOG_PERSONAL_API_KEY` is the documented fallback, not the only rung:
+# without this, a project that keeps its credentials in Bitwarden, Doppler, or
+# AWS has no tier 1 path at all and silently resolves through the interactive
+# MCP — the exact divergence `credential-substrate-precedence` exists to remove.
+read_posthog_key() {
+  [ -n "${POSTHOG_PERSONAL_API_KEY:-}" ] && { echo "$POSTHOG_PERSONAL_API_KEY"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get POSTHOG_PERSONAL_API_KEY 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
 posthog_api() {
   local path="$1"
   local method="${2:-GET}"
   local body="${3:-}"
-  [ -n "$POSTHOG_PERSONAL_API_KEY" ] || {
-    echo "Error: POSTHOG_PERSONAL_API_KEY is not set." >&2
+  local key
+  key=$(read_posthog_key) || {
+    echo "Error: no PostHog key. Set POSTHOG_PERSONAL_API_KEY, or store it as" >&2
+    echo "POSTHOG_PERSONAL_API_KEY in this project's secrets provider." >&2
     return 1
   }
-  local args=(-sS -X "$method" -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY")
+  local args=(-sS -X "$method" -H "Authorization: Bearer $key")
   [ -n "$body" ] && args+=(-H "Content-Type: application/json" --data-binary "$body")
   curl "${args[@]}" "${POSTHOG_HOST%/}/api${path}"
 }
@@ -60,11 +83,25 @@ If neither tier works, fail with:
 Error: no PostHog access substrate available. Authenticate the PostHog MCP or set POSTHOG_PERSONAL_API_KEY.
 ```
 
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — analytics
+retrieval. `query` is an HTTP POST, but it reads: it submits a query body and
+changes no PostHog state. So the `credential-substrate-precedence` guarded
+fallback for mutating operations (write, read back, assert the tenant from the
+response, roll back on mismatch) is not engaged here, and a failed tier is
+simply skipped. Adding a genuinely mutating operation — creating an insight,
+editing a feature flag — pulls that protocol in: a write of unknown outcome MUST
+reconcile by read-back before any retry.
+
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `POSTHOG_PERSONAL_API_KEY`
   first, the PostHog MCP as a preserved first-class fallback. Identity-match
   against the configured project is mandatory on every tier.
+- The key is resolved through `lisa-secrets-access`, with the bare
+  `POSTHOG_PERSONAL_API_KEY` environment variable as the documented fallback.
+  Never read a second credential store directly.
 - `POSTHOG_HOST` defaults to PostHog Cloud but can point at a self-hosted
   deployment.
 - Consumer skills do not embed PostHog REST paths.

--- a/plugins/lisa-copilot/skills/lisa-sentry-access/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-sentry-access/SKILL.md
@@ -39,16 +39,43 @@ Sentry documents API auth tokens for REST API calls, and the same token works
 interactively and headlessly — which is why it leads. The REST tier uses:
 
 ```bash
+# Resolve the token through the chokepoint before giving up on the environment.
+# `$SENTRY_AUTH_TOKEN` is the documented fallback, not the only rung: without
+# this, a project that keeps its credentials in Bitwarden, Doppler, or AWS has
+# no tier 1 path at all and silently resolves through the interactive MCP —
+# the exact divergence `credential-substrate-precedence` exists to remove.
+# Mirrors `linear-access`, `atlassian-access`, and `notion-access`.
+read_sentry_token() {
+  [ -n "${SENTRY_AUTH_TOKEN:-}" ] && { echo "$SENTRY_AUTH_TOKEN"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get SENTRY_AUTH_TOKEN 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
 sentry_api() {
   local path="$1"
-  [ -n "$SENTRY_AUTH_TOKEN" ] || {
-    echo "Error: SENTRY_AUTH_TOKEN is not set." >&2
+  local token
+  token=$(read_sentry_token) || {
+    echo "Error: no Sentry auth token. Set SENTRY_AUTH_TOKEN, or store it as" >&2
+    echo "SENTRY_AUTH_TOKEN in this project's secrets provider." >&2
     return 1
   }
   curl -sS "https://sentry.io/api/0${path}" \
-    -H "Authorization: Bearer $SENTRY_AUTH_TOKEN"
+    -H "Authorization: Bearer $token"
 }
 ```
+
+Tier 1a authenticates `sentry-cli` from the **same resolved token**
+(`SENTRY_AUTH_TOKEN=$(read_sentry_token) sentry-cli …`) — never from a second
+credential store, and never from an interactive `sentry-cli login` keychain.
 
 If neither tier works, fail with:
 
@@ -56,11 +83,25 @@ If neither tier works, fail with:
 Error: no Sentry access substrate available. Authenticate Sentry MCP/CLI or set SENTRY_AUTH_TOKEN.
 ```
 
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — issue, event, and
+release retrieval. So the `credential-substrate-precedence` guarded fallback for
+mutating operations (write, read back, assert the tenant from the response, roll
+back on mismatch) is not engaged here, and a failed tier is simply skipped. Any
+future operation that mutates Sentry state — resolving an issue, editing a
+release — is a write and MUST reconcile by read-back under that protocol before
+any retry; do not add one to the contract without it.
+
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `SENTRY_AUTH_TOKEN` first, the
   Sentry MCP as a preserved first-class fallback. Identity-match against the
   configured org/project is mandatory on every tier.
+- The token is resolved through `lisa-secrets-access`, with the bare
+  `SENTRY_AUTH_TOKEN` environment variable as the documented fallback. Never read
+  a second credential store (OS keychain, `~/.sentryclirc` token) directly — the
+  one-store rule lives at the chokepoint.
 - Org/project come from `.sentryclirc`, `.lisa.config.json`, or explicit
   operation args; never infer by searching all accessible orgs.
 - Consumer skills do not embed Sentry REST paths.

--- a/plugins/lisa-copilot/skills/lisa-sonarcloud-access/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-sonarcloud-access/SKILL.md
@@ -34,6 +34,49 @@ SonarQube Cloud org. Do **not** substitute the raw MCP-image names
 running the Docker image directly, and the `sonar` CLI ignores them (auth exits
 non-zero). The CI scan gate's `SONAR_TOKEN` is a third, separate name.
 
+### Where those variables come from
+
+The `sonar` CLI reads them **from the environment only** — it has no provider
+integration of its own — so on a surface that deliberately materializes nothing
+to disk the credential can be provisioned and unreachable at the same time.
+Resolve it through `lisa-secrets-access` and export it into the launching
+process, exactly as the shared `sonar-secrets.sh` hook already does. The bare
+`$SONARQUBE_CLI_TOKEN` in the environment is the documented **fallback** rung,
+not the only one:
+
+```bash
+# Preferred: the one sanctioned reader. Without this rung a project keeping its
+# credentials in Bitwarden, Doppler, or AWS cannot authenticate the MCP at all,
+# and Sonar access degrades to "run `sonar auth login` in a browser" — dead in
+# cron, CI, and cloud sessions. See `credential-substrate-precedence`.
+read_sonar_secret() {
+  local name="$1"
+  [ -n "${!name:-}" ] && { echo "${!name}"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get "$name" 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
+# Exported into this process only. Writing it anywhere durable would create a
+# second live copy of a credential whose single store is the provider.
+SONARQUBE_CLI_TOKEN=$(read_sonar_secret SONARQUBE_CLI_TOKEN) && export SONARQUBE_CLI_TOKEN
+SONARQUBE_CLI_ORG=$(read_sonar_secret SONARQUBE_CLI_ORG) && export SONARQUBE_CLI_ORG
+```
+
+`sonar-secrets.sh` runs the same resolution with a longer search path (it also
+probes `.codex/skills/…` and `node_modules/@codyswann/lisa/plugins/lisa/…`,
+because a hook fires in checkouts that never installed an agent plugin) and with
+a timeout, because it sits in front of every prompt. Use its search order
+verbatim when this skill runs inside a hook.
+
 Wiring is performed once by `/lisa:setup:sonar` (which drives `sonar integrate
 <agent>`); this access layer assumes the MCP is already wired. This is distinct
 from the CI `SONAR_TOKEN` secret that authenticates the SonarCloud scan job in
@@ -79,9 +122,22 @@ Pass the project key through the tool's `projectKey` argument (or rely on a
 server-configured `SONARQUBE_PROJECT_KEY`); pass `branch` / `pullRequest` where the
 tool accepts them.
 
+## Mutation boundary
+
+Every operation in the map above is **read-only** — quality, coverage, and
+security data. So the `credential-substrate-precedence` guarded fallback for
+mutating operations (write, read back, assert the tenant from the response, roll
+back on mismatch) is not engaged here; with one substrate there is nothing to
+fall back to in any case. A future operation that mutates Sonar state — marking
+a hotspot safe, changing an issue's status — is a write and MUST reconcile by
+read-back before any retry.
+
 ## Invariants
 
 - The official SonarQube MCP is the only substrate; there is no REST fallback.
+- `SONARQUBE_CLI_*` values are resolved through `lisa-secrets-access` and
+  exported in-process, with the bare environment variables as the documented
+  fallback. Never write them to a dotfile or a `.env` on a local surface.
 - Auth is env-var only (`SONARQUBE_CLI_TOKEN` [+ `SONARQUBE_CLI_ORG` | `SONARQUBE_CLI_SERVER`]);
   never the interactive `sonar auth login` keychain flow inside a factory.
 - Sonar host access requires the host (`sonarcloud.io`, `sonarqube.us`, or the

--- a/plugins/lisa-cursor/rules/credential-substrate-precedence-reference.mdc
+++ b/plugins/lisa-cursor/rules/credential-substrate-precedence-reference.mdc
@@ -144,6 +144,26 @@ operation, the fallback is guarded — never the normal path:
 A successful pre-flight switch is not sufficient for tenant safety — another process can
 mutate global state between the check and the write.
 
+## Legacy OS-keychain fallback — removal date 2026-11-01
+
+Two access skills (`lisa-atlassian-access`, `lisa-notion-access`) still read an
+OS keychain as a last rung below the chokepoint, because the guided
+`/lisa:setup:atlassian` and `/lisa:setup:notion` flows wrote credentials there
+before `lisa-secrets-access` existed. That rung is a **migration ramp with a
+removal date, not a standing exemption**: it is a second reader of the same
+credential, which is exactly how one credential ends up living in two places and
+drifting, and a keychain entry is machine-local ambient state that no headless
+surface can reach — so a project resting on it has no working tier 1 in cron, CI,
+or a cloud session.
+
+**Both rungs are deleted on 2026-11-01.** Before then, projects still on the
+keychain path move the credential into their configured provider — re-running
+`/lisa:setup:<vendor>` stores it through the chokepoint. After removal, a
+keychain-only project fails loudly with the exact variable named (tier 3), which
+is the intended outcome: it can never silently resolve through a substrate
+authenticated elsewhere. No new access skill may add a keychain rung; a credential
+the chokepoint cannot answer for is a setup gap to fix, not a store to add.
+
 ## Consequences to expect
 
 - **A stale or wrong token now fails identity-match instead of silently succeeding

--- a/plugins/lisa-cursor/rules/credential-substrate-precedence.mdc
+++ b/plugins/lisa-cursor/rules/credential-substrate-precedence.mdc
@@ -25,7 +25,9 @@ scope for that skill's work.
    `lisa-secrets-access`, chosen whenever its bootstrap credential is available **and**
    the resolved substrate identity-matches the configured tenant/workspace/site.
    `lisa-secrets-access` is the single chokepoint — never read an OS keychain a second
-   time.
+   time. The two legacy OS-keychain rungs that remain (`lisa-atlassian-access`,
+   `lisa-notion-access`) are a dated migration ramp with a **removal date of
+   2026-11-01**, not a standing exemption; no new access skill may add one.
 2. **Tier 2 — interactive MCP**, used only when tier 1 is *genuinely* unavailable:
    no bootstrap, no adapter for the operation (per-operation, not per-session), or a
    provider outage. "The MCP happens to be authenticated" and "tier 1 is slower" are

--- a/plugins/lisa-cursor/skills/lisa-atlassian-access/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-atlassian-access/SKILL.md
@@ -69,6 +69,13 @@ read_atlassian_token() {
   # Legacy fallback: the OS keychain written by the guided /lisa:setup:atlassian
   # flow, for projects that have not adopted a credentials provider. Reached only
   # when the chokepoint is absent or has no entry.
+  #
+  # This rung is REMOVED ON 2026-11-01 — a dated migration ramp, not a standing
+  # exemption (see credential-substrate-precedence, "Legacy OS-keychain fallback
+  # — removal date"). A keychain entry is machine-local ambient state no headless
+  # surface can reach, so a project resting on it has no working tier 1 in cron,
+  # CI, or a cloud session. Re-run /lisa:setup:atlassian before that date to
+  # store ATLASSIAN_API_TOKEN through the chokepoint instead.
   case "$(uname -s)" in
     Darwin)  security find-generic-password -s lisa-atlassian -a "$email" -w 2>/dev/null ;;
     Linux)   command -v secret-tool >/dev/null && secret-tool lookup service lisa-atlassian account "$email" 2>/dev/null ;;

--- a/plugins/lisa-cursor/skills/lisa-jam-access/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-jam-access/SKILL.md
@@ -39,20 +39,55 @@ headlessly — which is why it leads. The CLI tier uses:
 ```bash
 curl -fsSL https://native.jam.dev/install | bash
 export PATH="$HOME/.local/bin:$PATH"
-printf '%s' "$JAM_PAT" | jam auth login --token
+
+# Resolve the PAT through the chokepoint before giving up on the environment.
+# `$JAM_PAT` is the documented fallback, not the only rung: without this, a
+# project that keeps its credentials in Bitwarden, Doppler, or AWS has no tier 1
+# path at all and silently resolves through the interactive MCP — the exact
+# divergence `credential-substrate-precedence` exists to remove.
+read_jam_pat() {
+  [ -n "${JAM_PAT:-}" ] && { echo "$JAM_PAT"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get JAM_PAT 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
+# Piped, never written to disk and never passed as an argv token: a PAT on a
+# command line is readable from the process table by every user on the host.
+read_jam_pat | jam auth login --token
 jam skills install
 ```
 
 If neither tier works, fail with:
 
 ```text
-Error: no Jam access substrate available. Authenticate the Jam MCP or set JAM_PAT.
+Error: no Jam access substrate available. Authenticate the Jam MCP, set JAM_PAT, or store JAM_PAT in this project's secrets provider.
 ```
+
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — fetching a trace,
+a recording, or a bug report. So the `credential-substrate-precedence` guarded
+fallback for mutating operations (write, read back, assert the tenant from the
+response, roll back on mismatch) is not engaged here, and a failed tier is
+simply skipped. A future operation that mutates Jam state — commenting on or
+deleting a Jam — is a write and MUST reconcile by read-back before any retry.
 
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `JAM_PAT` CLI first, Jam MCP as
   a preserved first-class fallback. Do not retry a failed tier blindly.
+- The PAT is resolved through `lisa-secrets-access`, with the bare `JAM_PAT`
+  environment variable as the documented fallback. Never read a second
+  credential store directly.
 - Never commit a Jam PAT into `.mcp.json` or any generated setup artifact.
 - Headless Jam access requires `native.jam.dev` for the installer and
   `api.jam.dev` for CLI/API calls in any custom remote network allowlist.

--- a/plugins/lisa-cursor/skills/lisa-notion-access/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-notion-access/SKILL.md
@@ -70,6 +70,13 @@ read_notion_token() {
   # Legacy fallback: the OS keychain written by the guided /lisa:setup:notion
   # flow, for projects that have not adopted a credentials provider. Reached only
   # when the chokepoint is absent or has no entry.
+  #
+  # This rung is REMOVED ON 2026-11-01 — a dated migration ramp, not a standing
+  # exemption (see credential-substrate-precedence, "Legacy OS-keychain fallback
+  # — removal date"). A keychain entry is machine-local ambient state no headless
+  # surface can reach, so a project resting on it has no working tier 1 in cron,
+  # CI, or a cloud session. Re-run /lisa:setup:notion before that date to store
+  # NOTION_API_TOKEN through the chokepoint instead.
   case "$(uname -s)" in
     Darwin)  security find-generic-password -s lisa-notion -a "$workspace" -w 2>/dev/null ;;
     Linux)   command -v secret-tool >/dev/null && \

--- a/plugins/lisa-cursor/skills/lisa-posthog-access/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-posthog-access/SKILL.md
@@ -40,15 +40,38 @@ works interactively and headlessly — which is why it leads. The REST tier uses
 
 ```bash
 POSTHOG_HOST=${POSTHOG_HOST:-https://app.posthog.com}
+
+# Resolve the key through the chokepoint before giving up on the environment.
+# `$POSTHOG_PERSONAL_API_KEY` is the documented fallback, not the only rung:
+# without this, a project that keeps its credentials in Bitwarden, Doppler, or
+# AWS has no tier 1 path at all and silently resolves through the interactive
+# MCP — the exact divergence `credential-substrate-precedence` exists to remove.
+read_posthog_key() {
+  [ -n "${POSTHOG_PERSONAL_API_KEY:-}" ] && { echo "$POSTHOG_PERSONAL_API_KEY"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get POSTHOG_PERSONAL_API_KEY 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
 posthog_api() {
   local path="$1"
   local method="${2:-GET}"
   local body="${3:-}"
-  [ -n "$POSTHOG_PERSONAL_API_KEY" ] || {
-    echo "Error: POSTHOG_PERSONAL_API_KEY is not set." >&2
+  local key
+  key=$(read_posthog_key) || {
+    echo "Error: no PostHog key. Set POSTHOG_PERSONAL_API_KEY, or store it as" >&2
+    echo "POSTHOG_PERSONAL_API_KEY in this project's secrets provider." >&2
     return 1
   }
-  local args=(-sS -X "$method" -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY")
+  local args=(-sS -X "$method" -H "Authorization: Bearer $key")
   [ -n "$body" ] && args+=(-H "Content-Type: application/json" --data-binary "$body")
   curl "${args[@]}" "${POSTHOG_HOST%/}/api${path}"
 }
@@ -60,11 +83,25 @@ If neither tier works, fail with:
 Error: no PostHog access substrate available. Authenticate the PostHog MCP or set POSTHOG_PERSONAL_API_KEY.
 ```
 
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — analytics
+retrieval. `query` is an HTTP POST, but it reads: it submits a query body and
+changes no PostHog state. So the `credential-substrate-precedence` guarded
+fallback for mutating operations (write, read back, assert the tenant from the
+response, roll back on mismatch) is not engaged here, and a failed tier is
+simply skipped. Adding a genuinely mutating operation — creating an insight,
+editing a feature flag — pulls that protocol in: a write of unknown outcome MUST
+reconcile by read-back before any retry.
+
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `POSTHOG_PERSONAL_API_KEY`
   first, the PostHog MCP as a preserved first-class fallback. Identity-match
   against the configured project is mandatory on every tier.
+- The key is resolved through `lisa-secrets-access`, with the bare
+  `POSTHOG_PERSONAL_API_KEY` environment variable as the documented fallback.
+  Never read a second credential store directly.
 - `POSTHOG_HOST` defaults to PostHog Cloud but can point at a self-hosted
   deployment.
 - Consumer skills do not embed PostHog REST paths.

--- a/plugins/lisa-cursor/skills/lisa-sentry-access/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-sentry-access/SKILL.md
@@ -39,16 +39,43 @@ Sentry documents API auth tokens for REST API calls, and the same token works
 interactively and headlessly — which is why it leads. The REST tier uses:
 
 ```bash
+# Resolve the token through the chokepoint before giving up on the environment.
+# `$SENTRY_AUTH_TOKEN` is the documented fallback, not the only rung: without
+# this, a project that keeps its credentials in Bitwarden, Doppler, or AWS has
+# no tier 1 path at all and silently resolves through the interactive MCP —
+# the exact divergence `credential-substrate-precedence` exists to remove.
+# Mirrors `linear-access`, `atlassian-access`, and `notion-access`.
+read_sentry_token() {
+  [ -n "${SENTRY_AUTH_TOKEN:-}" ] && { echo "$SENTRY_AUTH_TOKEN"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get SENTRY_AUTH_TOKEN 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
 sentry_api() {
   local path="$1"
-  [ -n "$SENTRY_AUTH_TOKEN" ] || {
-    echo "Error: SENTRY_AUTH_TOKEN is not set." >&2
+  local token
+  token=$(read_sentry_token) || {
+    echo "Error: no Sentry auth token. Set SENTRY_AUTH_TOKEN, or store it as" >&2
+    echo "SENTRY_AUTH_TOKEN in this project's secrets provider." >&2
     return 1
   }
   curl -sS "https://sentry.io/api/0${path}" \
-    -H "Authorization: Bearer $SENTRY_AUTH_TOKEN"
+    -H "Authorization: Bearer $token"
 }
 ```
+
+Tier 1a authenticates `sentry-cli` from the **same resolved token**
+(`SENTRY_AUTH_TOKEN=$(read_sentry_token) sentry-cli …`) — never from a second
+credential store, and never from an interactive `sentry-cli login` keychain.
 
 If neither tier works, fail with:
 
@@ -56,11 +83,25 @@ If neither tier works, fail with:
 Error: no Sentry access substrate available. Authenticate Sentry MCP/CLI or set SENTRY_AUTH_TOKEN.
 ```
 
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — issue, event, and
+release retrieval. So the `credential-substrate-precedence` guarded fallback for
+mutating operations (write, read back, assert the tenant from the response, roll
+back on mismatch) is not engaged here, and a failed tier is simply skipped. Any
+future operation that mutates Sentry state — resolving an issue, editing a
+release — is a write and MUST reconcile by read-back under that protocol before
+any retry; do not add one to the contract without it.
+
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `SENTRY_AUTH_TOKEN` first, the
   Sentry MCP as a preserved first-class fallback. Identity-match against the
   configured org/project is mandatory on every tier.
+- The token is resolved through `lisa-secrets-access`, with the bare
+  `SENTRY_AUTH_TOKEN` environment variable as the documented fallback. Never read
+  a second credential store (OS keychain, `~/.sentryclirc` token) directly — the
+  one-store rule lives at the chokepoint.
 - Org/project come from `.sentryclirc`, `.lisa.config.json`, or explicit
   operation args; never infer by searching all accessible orgs.
 - Consumer skills do not embed Sentry REST paths.

--- a/plugins/lisa-cursor/skills/lisa-sonarcloud-access/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-sonarcloud-access/SKILL.md
@@ -34,6 +34,49 @@ SonarQube Cloud org. Do **not** substitute the raw MCP-image names
 running the Docker image directly, and the `sonar` CLI ignores them (auth exits
 non-zero). The CI scan gate's `SONAR_TOKEN` is a third, separate name.
 
+### Where those variables come from
+
+The `sonar` CLI reads them **from the environment only** — it has no provider
+integration of its own — so on a surface that deliberately materializes nothing
+to disk the credential can be provisioned and unreachable at the same time.
+Resolve it through `lisa-secrets-access` and export it into the launching
+process, exactly as the shared `sonar-secrets.sh` hook already does. The bare
+`$SONARQUBE_CLI_TOKEN` in the environment is the documented **fallback** rung,
+not the only one:
+
+```bash
+# Preferred: the one sanctioned reader. Without this rung a project keeping its
+# credentials in Bitwarden, Doppler, or AWS cannot authenticate the MCP at all,
+# and Sonar access degrades to "run `sonar auth login` in a browser" — dead in
+# cron, CI, and cloud sessions. See `credential-substrate-precedence`.
+read_sonar_secret() {
+  local name="$1"
+  [ -n "${!name:-}" ] && { echo "${!name}"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get "$name" 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
+# Exported into this process only. Writing it anywhere durable would create a
+# second live copy of a credential whose single store is the provider.
+SONARQUBE_CLI_TOKEN=$(read_sonar_secret SONARQUBE_CLI_TOKEN) && export SONARQUBE_CLI_TOKEN
+SONARQUBE_CLI_ORG=$(read_sonar_secret SONARQUBE_CLI_ORG) && export SONARQUBE_CLI_ORG
+```
+
+`sonar-secrets.sh` runs the same resolution with a longer search path (it also
+probes `.codex/skills/…` and `node_modules/@codyswann/lisa/plugins/lisa/…`,
+because a hook fires in checkouts that never installed an agent plugin) and with
+a timeout, because it sits in front of every prompt. Use its search order
+verbatim when this skill runs inside a hook.
+
 Wiring is performed once by `/lisa:setup:sonar` (which drives `sonar integrate
 <agent>`); this access layer assumes the MCP is already wired. This is distinct
 from the CI `SONAR_TOKEN` secret that authenticates the SonarCloud scan job in
@@ -79,9 +122,22 @@ Pass the project key through the tool's `projectKey` argument (or rely on a
 server-configured `SONARQUBE_PROJECT_KEY`); pass `branch` / `pullRequest` where the
 tool accepts them.
 
+## Mutation boundary
+
+Every operation in the map above is **read-only** — quality, coverage, and
+security data. So the `credential-substrate-precedence` guarded fallback for
+mutating operations (write, read back, assert the tenant from the response, roll
+back on mismatch) is not engaged here; with one substrate there is nothing to
+fall back to in any case. A future operation that mutates Sonar state — marking
+a hotspot safe, changing an issue's status — is a write and MUST reconcile by
+read-back before any retry.
+
 ## Invariants
 
 - The official SonarQube MCP is the only substrate; there is no REST fallback.
+- `SONARQUBE_CLI_*` values are resolved through `lisa-secrets-access` and
+  exported in-process, with the bare environment variables as the documented
+  fallback. Never write them to a dotfile or a `.env` on a local surface.
 - Auth is env-var only (`SONARQUBE_CLI_TOKEN` [+ `SONARQUBE_CLI_ORG` | `SONARQUBE_CLI_SERVER`]);
   never the interactive `sonar auth login` keychain flow inside a factory.
 - Sonar host access requires the host (`sonarcloud.io`, `sonarqube.us`, or the

--- a/plugins/lisa/.codex-plugin/skills/lisa-atlassian-access/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-atlassian-access/SKILL.md
@@ -69,6 +69,13 @@ read_atlassian_token() {
   # Legacy fallback: the OS keychain written by the guided /lisa:setup:atlassian
   # flow, for projects that have not adopted a credentials provider. Reached only
   # when the chokepoint is absent or has no entry.
+  #
+  # This rung is REMOVED ON 2026-11-01 — a dated migration ramp, not a standing
+  # exemption (see credential-substrate-precedence, "Legacy OS-keychain fallback
+  # — removal date"). A keychain entry is machine-local ambient state no headless
+  # surface can reach, so a project resting on it has no working tier 1 in cron,
+  # CI, or a cloud session. Re-run /lisa:setup:atlassian before that date to
+  # store ATLASSIAN_API_TOKEN through the chokepoint instead.
   case "$(uname -s)" in
     Darwin)  security find-generic-password -s lisa-atlassian -a "$email" -w 2>/dev/null ;;
     Linux)   command -v secret-tool >/dev/null && secret-tool lookup service lisa-atlassian account "$email" 2>/dev/null ;;

--- a/plugins/lisa/.codex-plugin/skills/lisa-jam-access/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-jam-access/SKILL.md
@@ -39,20 +39,55 @@ headlessly — which is why it leads. The CLI tier uses:
 ```bash
 curl -fsSL https://native.jam.dev/install | bash
 export PATH="$HOME/.local/bin:$PATH"
-printf '%s' "$JAM_PAT" | jam auth login --token
+
+# Resolve the PAT through the chokepoint before giving up on the environment.
+# `$JAM_PAT` is the documented fallback, not the only rung: without this, a
+# project that keeps its credentials in Bitwarden, Doppler, or AWS has no tier 1
+# path at all and silently resolves through the interactive MCP — the exact
+# divergence `credential-substrate-precedence` exists to remove.
+read_jam_pat() {
+  [ -n "${JAM_PAT:-}" ] && { echo "$JAM_PAT"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get JAM_PAT 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
+# Piped, never written to disk and never passed as an argv token: a PAT on a
+# command line is readable from the process table by every user on the host.
+read_jam_pat | jam auth login --token
 jam skills install
 ```
 
 If neither tier works, fail with:
 
 ```text
-Error: no Jam access substrate available. Authenticate the Jam MCP or set JAM_PAT.
+Error: no Jam access substrate available. Authenticate the Jam MCP, set JAM_PAT, or store JAM_PAT in this project's secrets provider.
 ```
+
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — fetching a trace,
+a recording, or a bug report. So the `credential-substrate-precedence` guarded
+fallback for mutating operations (write, read back, assert the tenant from the
+response, roll back on mismatch) is not engaged here, and a failed tier is
+simply skipped. A future operation that mutates Jam state — commenting on or
+deleting a Jam — is a write and MUST reconcile by read-back before any retry.
 
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `JAM_PAT` CLI first, Jam MCP as
   a preserved first-class fallback. Do not retry a failed tier blindly.
+- The PAT is resolved through `lisa-secrets-access`, with the bare `JAM_PAT`
+  environment variable as the documented fallback. Never read a second
+  credential store directly.
 - Never commit a Jam PAT into `.mcp.json` or any generated setup artifact.
 - Headless Jam access requires `native.jam.dev` for the installer and
   `api.jam.dev` for CLI/API calls in any custom remote network allowlist.

--- a/plugins/lisa/.codex-plugin/skills/lisa-notion-access/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-notion-access/SKILL.md
@@ -70,6 +70,13 @@ read_notion_token() {
   # Legacy fallback: the OS keychain written by the guided /lisa:setup:notion
   # flow, for projects that have not adopted a credentials provider. Reached only
   # when the chokepoint is absent or has no entry.
+  #
+  # This rung is REMOVED ON 2026-11-01 — a dated migration ramp, not a standing
+  # exemption (see credential-substrate-precedence, "Legacy OS-keychain fallback
+  # — removal date"). A keychain entry is machine-local ambient state no headless
+  # surface can reach, so a project resting on it has no working tier 1 in cron,
+  # CI, or a cloud session. Re-run /lisa:setup:notion before that date to store
+  # NOTION_API_TOKEN through the chokepoint instead.
   case "$(uname -s)" in
     Darwin)  security find-generic-password -s lisa-notion -a "$workspace" -w 2>/dev/null ;;
     Linux)   command -v secret-tool >/dev/null && \

--- a/plugins/lisa/.codex-plugin/skills/lisa-posthog-access/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-posthog-access/SKILL.md
@@ -40,15 +40,38 @@ works interactively and headlessly — which is why it leads. The REST tier uses
 
 ```bash
 POSTHOG_HOST=${POSTHOG_HOST:-https://app.posthog.com}
+
+# Resolve the key through the chokepoint before giving up on the environment.
+# `$POSTHOG_PERSONAL_API_KEY` is the documented fallback, not the only rung:
+# without this, a project that keeps its credentials in Bitwarden, Doppler, or
+# AWS has no tier 1 path at all and silently resolves through the interactive
+# MCP — the exact divergence `credential-substrate-precedence` exists to remove.
+read_posthog_key() {
+  [ -n "${POSTHOG_PERSONAL_API_KEY:-}" ] && { echo "$POSTHOG_PERSONAL_API_KEY"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get POSTHOG_PERSONAL_API_KEY 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
 posthog_api() {
   local path="$1"
   local method="${2:-GET}"
   local body="${3:-}"
-  [ -n "$POSTHOG_PERSONAL_API_KEY" ] || {
-    echo "Error: POSTHOG_PERSONAL_API_KEY is not set." >&2
+  local key
+  key=$(read_posthog_key) || {
+    echo "Error: no PostHog key. Set POSTHOG_PERSONAL_API_KEY, or store it as" >&2
+    echo "POSTHOG_PERSONAL_API_KEY in this project's secrets provider." >&2
     return 1
   }
-  local args=(-sS -X "$method" -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY")
+  local args=(-sS -X "$method" -H "Authorization: Bearer $key")
   [ -n "$body" ] && args+=(-H "Content-Type: application/json" --data-binary "$body")
   curl "${args[@]}" "${POSTHOG_HOST%/}/api${path}"
 }
@@ -60,11 +83,25 @@ If neither tier works, fail with:
 Error: no PostHog access substrate available. Authenticate the PostHog MCP or set POSTHOG_PERSONAL_API_KEY.
 ```
 
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — analytics
+retrieval. `query` is an HTTP POST, but it reads: it submits a query body and
+changes no PostHog state. So the `credential-substrate-precedence` guarded
+fallback for mutating operations (write, read back, assert the tenant from the
+response, roll back on mismatch) is not engaged here, and a failed tier is
+simply skipped. Adding a genuinely mutating operation — creating an insight,
+editing a feature flag — pulls that protocol in: a write of unknown outcome MUST
+reconcile by read-back before any retry.
+
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `POSTHOG_PERSONAL_API_KEY`
   first, the PostHog MCP as a preserved first-class fallback. Identity-match
   against the configured project is mandatory on every tier.
+- The key is resolved through `lisa-secrets-access`, with the bare
+  `POSTHOG_PERSONAL_API_KEY` environment variable as the documented fallback.
+  Never read a second credential store directly.
 - `POSTHOG_HOST` defaults to PostHog Cloud but can point at a self-hosted
   deployment.
 - Consumer skills do not embed PostHog REST paths.

--- a/plugins/lisa/.codex-plugin/skills/lisa-sentry-access/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-sentry-access/SKILL.md
@@ -39,16 +39,43 @@ Sentry documents API auth tokens for REST API calls, and the same token works
 interactively and headlessly — which is why it leads. The REST tier uses:
 
 ```bash
+# Resolve the token through the chokepoint before giving up on the environment.
+# `$SENTRY_AUTH_TOKEN` is the documented fallback, not the only rung: without
+# this, a project that keeps its credentials in Bitwarden, Doppler, or AWS has
+# no tier 1 path at all and silently resolves through the interactive MCP —
+# the exact divergence `credential-substrate-precedence` exists to remove.
+# Mirrors `linear-access`, `atlassian-access`, and `notion-access`.
+read_sentry_token() {
+  [ -n "${SENTRY_AUTH_TOKEN:-}" ] && { echo "$SENTRY_AUTH_TOKEN"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get SENTRY_AUTH_TOKEN 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
 sentry_api() {
   local path="$1"
-  [ -n "$SENTRY_AUTH_TOKEN" ] || {
-    echo "Error: SENTRY_AUTH_TOKEN is not set." >&2
+  local token
+  token=$(read_sentry_token) || {
+    echo "Error: no Sentry auth token. Set SENTRY_AUTH_TOKEN, or store it as" >&2
+    echo "SENTRY_AUTH_TOKEN in this project's secrets provider." >&2
     return 1
   }
   curl -sS "https://sentry.io/api/0${path}" \
-    -H "Authorization: Bearer $SENTRY_AUTH_TOKEN"
+    -H "Authorization: Bearer $token"
 }
 ```
+
+Tier 1a authenticates `sentry-cli` from the **same resolved token**
+(`SENTRY_AUTH_TOKEN=$(read_sentry_token) sentry-cli …`) — never from a second
+credential store, and never from an interactive `sentry-cli login` keychain.
 
 If neither tier works, fail with:
 
@@ -56,11 +83,25 @@ If neither tier works, fail with:
 Error: no Sentry access substrate available. Authenticate Sentry MCP/CLI or set SENTRY_AUTH_TOKEN.
 ```
 
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — issue, event, and
+release retrieval. So the `credential-substrate-precedence` guarded fallback for
+mutating operations (write, read back, assert the tenant from the response, roll
+back on mismatch) is not engaged here, and a failed tier is simply skipped. Any
+future operation that mutates Sentry state — resolving an issue, editing a
+release — is a write and MUST reconcile by read-back under that protocol before
+any retry; do not add one to the contract without it.
+
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `SENTRY_AUTH_TOKEN` first, the
   Sentry MCP as a preserved first-class fallback. Identity-match against the
   configured org/project is mandatory on every tier.
+- The token is resolved through `lisa-secrets-access`, with the bare
+  `SENTRY_AUTH_TOKEN` environment variable as the documented fallback. Never read
+  a second credential store (OS keychain, `~/.sentryclirc` token) directly — the
+  one-store rule lives at the chokepoint.
 - Org/project come from `.sentryclirc`, `.lisa.config.json`, or explicit
   operation args; never infer by searching all accessible orgs.
 - Consumer skills do not embed Sentry REST paths.

--- a/plugins/lisa/.codex-plugin/skills/lisa-sonarcloud-access/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-sonarcloud-access/SKILL.md
@@ -34,6 +34,49 @@ SonarQube Cloud org. Do **not** substitute the raw MCP-image names
 running the Docker image directly, and the `sonar` CLI ignores them (auth exits
 non-zero). The CI scan gate's `SONAR_TOKEN` is a third, separate name.
 
+### Where those variables come from
+
+The `sonar` CLI reads them **from the environment only** — it has no provider
+integration of its own — so on a surface that deliberately materializes nothing
+to disk the credential can be provisioned and unreachable at the same time.
+Resolve it through `lisa-secrets-access` and export it into the launching
+process, exactly as the shared `sonar-secrets.sh` hook already does. The bare
+`$SONARQUBE_CLI_TOKEN` in the environment is the documented **fallback** rung,
+not the only one:
+
+```bash
+# Preferred: the one sanctioned reader. Without this rung a project keeping its
+# credentials in Bitwarden, Doppler, or AWS cannot authenticate the MCP at all,
+# and Sonar access degrades to "run `sonar auth login` in a browser" — dead in
+# cron, CI, and cloud sessions. See `credential-substrate-precedence`.
+read_sonar_secret() {
+  local name="$1"
+  [ -n "${!name:-}" ] && { echo "${!name}"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get "$name" 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
+# Exported into this process only. Writing it anywhere durable would create a
+# second live copy of a credential whose single store is the provider.
+SONARQUBE_CLI_TOKEN=$(read_sonar_secret SONARQUBE_CLI_TOKEN) && export SONARQUBE_CLI_TOKEN
+SONARQUBE_CLI_ORG=$(read_sonar_secret SONARQUBE_CLI_ORG) && export SONARQUBE_CLI_ORG
+```
+
+`sonar-secrets.sh` runs the same resolution with a longer search path (it also
+probes `.codex/skills/…` and `node_modules/@codyswann/lisa/plugins/lisa/…`,
+because a hook fires in checkouts that never installed an agent plugin) and with
+a timeout, because it sits in front of every prompt. Use its search order
+verbatim when this skill runs inside a hook.
+
 Wiring is performed once by `/lisa:setup:sonar` (which drives `sonar integrate
 <agent>`); this access layer assumes the MCP is already wired. This is distinct
 from the CI `SONAR_TOKEN` secret that authenticates the SonarCloud scan job in
@@ -79,9 +122,22 @@ Pass the project key through the tool's `projectKey` argument (or rely on a
 server-configured `SONARQUBE_PROJECT_KEY`); pass `branch` / `pullRequest` where the
 tool accepts them.
 
+## Mutation boundary
+
+Every operation in the map above is **read-only** — quality, coverage, and
+security data. So the `credential-substrate-precedence` guarded fallback for
+mutating operations (write, read back, assert the tenant from the response, roll
+back on mismatch) is not engaged here; with one substrate there is nothing to
+fall back to in any case. A future operation that mutates Sonar state — marking
+a hotspot safe, changing an issue's status — is a write and MUST reconcile by
+read-back before any retry.
+
 ## Invariants
 
 - The official SonarQube MCP is the only substrate; there is no REST fallback.
+- `SONARQUBE_CLI_*` values are resolved through `lisa-secrets-access` and
+  exported in-process, with the bare environment variables as the documented
+  fallback. Never write them to a dotfile or a `.env` on a local surface.
 - Auth is env-var only (`SONARQUBE_CLI_TOKEN` [+ `SONARQUBE_CLI_ORG` | `SONARQUBE_CLI_SERVER`]);
   never the interactive `sonar auth login` keychain flow inside a factory.
 - Sonar host access requires the host (`sonarcloud.io`, `sonarqube.us`, or the

--- a/plugins/lisa/rules/eager/credential-substrate-precedence.md
+++ b/plugins/lisa/rules/eager/credential-substrate-precedence.md
@@ -20,7 +20,9 @@ scope for that skill's work.
    `lisa-secrets-access`, chosen whenever its bootstrap credential is available **and**
    the resolved substrate identity-matches the configured tenant/workspace/site.
    `lisa-secrets-access` is the single chokepoint — never read an OS keychain a second
-   time.
+   time. The two legacy OS-keychain rungs that remain (`lisa-atlassian-access`,
+   `lisa-notion-access`) are a dated migration ramp with a **removal date of
+   2026-11-01**, not a standing exemption; no new access skill may add one.
 2. **Tier 2 — interactive MCP**, used only when tier 1 is *genuinely* unavailable:
    no bootstrap, no adapter for the operation (per-operation, not per-session), or a
    provider outage. "The MCP happens to be authenticated" and "tier 1 is slower" are

--- a/plugins/lisa/rules/reference/credential-substrate-precedence.md
+++ b/plugins/lisa/rules/reference/credential-substrate-precedence.md
@@ -139,6 +139,26 @@ operation, the fallback is guarded — never the normal path:
 A successful pre-flight switch is not sufficient for tenant safety — another process can
 mutate global state between the check and the write.
 
+## Legacy OS-keychain fallback — removal date 2026-11-01
+
+Two access skills (`lisa-atlassian-access`, `lisa-notion-access`) still read an
+OS keychain as a last rung below the chokepoint, because the guided
+`/lisa:setup:atlassian` and `/lisa:setup:notion` flows wrote credentials there
+before `lisa-secrets-access` existed. That rung is a **migration ramp with a
+removal date, not a standing exemption**: it is a second reader of the same
+credential, which is exactly how one credential ends up living in two places and
+drifting, and a keychain entry is machine-local ambient state that no headless
+surface can reach — so a project resting on it has no working tier 1 in cron, CI,
+or a cloud session.
+
+**Both rungs are deleted on 2026-11-01.** Before then, projects still on the
+keychain path move the credential into their configured provider — re-running
+`/lisa:setup:<vendor>` stores it through the chokepoint. After removal, a
+keychain-only project fails loudly with the exact variable named (tier 3), which
+is the intended outcome: it can never silently resolve through a substrate
+authenticated elsewhere. No new access skill may add a keychain rung; a credential
+the chokepoint cannot answer for is a setup gap to fix, not a store to add.
+
 ## Consequences to expect
 
 - **A stale or wrong token now fails identity-match instead of silently succeeding

--- a/plugins/lisa/skills/lisa-atlassian-access/SKILL.md
+++ b/plugins/lisa/skills/lisa-atlassian-access/SKILL.md
@@ -69,6 +69,13 @@ read_atlassian_token() {
   # Legacy fallback: the OS keychain written by the guided /lisa:setup:atlassian
   # flow, for projects that have not adopted a credentials provider. Reached only
   # when the chokepoint is absent or has no entry.
+  #
+  # This rung is REMOVED ON 2026-11-01 — a dated migration ramp, not a standing
+  # exemption (see credential-substrate-precedence, "Legacy OS-keychain fallback
+  # — removal date"). A keychain entry is machine-local ambient state no headless
+  # surface can reach, so a project resting on it has no working tier 1 in cron,
+  # CI, or a cloud session. Re-run /lisa:setup:atlassian before that date to
+  # store ATLASSIAN_API_TOKEN through the chokepoint instead.
   case "$(uname -s)" in
     Darwin)  security find-generic-password -s lisa-atlassian -a "$email" -w 2>/dev/null ;;
     Linux)   command -v secret-tool >/dev/null && secret-tool lookup service lisa-atlassian account "$email" 2>/dev/null ;;

--- a/plugins/lisa/skills/lisa-jam-access/SKILL.md
+++ b/plugins/lisa/skills/lisa-jam-access/SKILL.md
@@ -39,20 +39,55 @@ headlessly — which is why it leads. The CLI tier uses:
 ```bash
 curl -fsSL https://native.jam.dev/install | bash
 export PATH="$HOME/.local/bin:$PATH"
-printf '%s' "$JAM_PAT" | jam auth login --token
+
+# Resolve the PAT through the chokepoint before giving up on the environment.
+# `$JAM_PAT` is the documented fallback, not the only rung: without this, a
+# project that keeps its credentials in Bitwarden, Doppler, or AWS has no tier 1
+# path at all and silently resolves through the interactive MCP — the exact
+# divergence `credential-substrate-precedence` exists to remove.
+read_jam_pat() {
+  [ -n "${JAM_PAT:-}" ] && { echo "$JAM_PAT"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get JAM_PAT 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
+# Piped, never written to disk and never passed as an argv token: a PAT on a
+# command line is readable from the process table by every user on the host.
+read_jam_pat | jam auth login --token
 jam skills install
 ```
 
 If neither tier works, fail with:
 
 ```text
-Error: no Jam access substrate available. Authenticate the Jam MCP or set JAM_PAT.
+Error: no Jam access substrate available. Authenticate the Jam MCP, set JAM_PAT, or store JAM_PAT in this project's secrets provider.
 ```
+
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — fetching a trace,
+a recording, or a bug report. So the `credential-substrate-precedence` guarded
+fallback for mutating operations (write, read back, assert the tenant from the
+response, roll back on mismatch) is not engaged here, and a failed tier is
+simply skipped. A future operation that mutates Jam state — commenting on or
+deleting a Jam — is a write and MUST reconcile by read-back before any retry.
 
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `JAM_PAT` CLI first, Jam MCP as
   a preserved first-class fallback. Do not retry a failed tier blindly.
+- The PAT is resolved through `lisa-secrets-access`, with the bare `JAM_PAT`
+  environment variable as the documented fallback. Never read a second
+  credential store directly.
 - Never commit a Jam PAT into `.mcp.json` or any generated setup artifact.
 - Headless Jam access requires `native.jam.dev` for the installer and
   `api.jam.dev` for CLI/API calls in any custom remote network allowlist.

--- a/plugins/lisa/skills/lisa-notion-access/SKILL.md
+++ b/plugins/lisa/skills/lisa-notion-access/SKILL.md
@@ -70,6 +70,13 @@ read_notion_token() {
   # Legacy fallback: the OS keychain written by the guided /lisa:setup:notion
   # flow, for projects that have not adopted a credentials provider. Reached only
   # when the chokepoint is absent or has no entry.
+  #
+  # This rung is REMOVED ON 2026-11-01 — a dated migration ramp, not a standing
+  # exemption (see credential-substrate-precedence, "Legacy OS-keychain fallback
+  # — removal date"). A keychain entry is machine-local ambient state no headless
+  # surface can reach, so a project resting on it has no working tier 1 in cron,
+  # CI, or a cloud session. Re-run /lisa:setup:notion before that date to store
+  # NOTION_API_TOKEN through the chokepoint instead.
   case "$(uname -s)" in
     Darwin)  security find-generic-password -s lisa-notion -a "$workspace" -w 2>/dev/null ;;
     Linux)   command -v secret-tool >/dev/null && \

--- a/plugins/lisa/skills/lisa-posthog-access/SKILL.md
+++ b/plugins/lisa/skills/lisa-posthog-access/SKILL.md
@@ -40,15 +40,38 @@ works interactively and headlessly — which is why it leads. The REST tier uses
 
 ```bash
 POSTHOG_HOST=${POSTHOG_HOST:-https://app.posthog.com}
+
+# Resolve the key through the chokepoint before giving up on the environment.
+# `$POSTHOG_PERSONAL_API_KEY` is the documented fallback, not the only rung:
+# without this, a project that keeps its credentials in Bitwarden, Doppler, or
+# AWS has no tier 1 path at all and silently resolves through the interactive
+# MCP — the exact divergence `credential-substrate-precedence` exists to remove.
+read_posthog_key() {
+  [ -n "${POSTHOG_PERSONAL_API_KEY:-}" ] && { echo "$POSTHOG_PERSONAL_API_KEY"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get POSTHOG_PERSONAL_API_KEY 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
 posthog_api() {
   local path="$1"
   local method="${2:-GET}"
   local body="${3:-}"
-  [ -n "$POSTHOG_PERSONAL_API_KEY" ] || {
-    echo "Error: POSTHOG_PERSONAL_API_KEY is not set." >&2
+  local key
+  key=$(read_posthog_key) || {
+    echo "Error: no PostHog key. Set POSTHOG_PERSONAL_API_KEY, or store it as" >&2
+    echo "POSTHOG_PERSONAL_API_KEY in this project's secrets provider." >&2
     return 1
   }
-  local args=(-sS -X "$method" -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY")
+  local args=(-sS -X "$method" -H "Authorization: Bearer $key")
   [ -n "$body" ] && args+=(-H "Content-Type: application/json" --data-binary "$body")
   curl "${args[@]}" "${POSTHOG_HOST%/}/api${path}"
 }
@@ -60,11 +83,25 @@ If neither tier works, fail with:
 Error: no PostHog access substrate available. Authenticate the PostHog MCP or set POSTHOG_PERSONAL_API_KEY.
 ```
 
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — analytics
+retrieval. `query` is an HTTP POST, but it reads: it submits a query body and
+changes no PostHog state. So the `credential-substrate-precedence` guarded
+fallback for mutating operations (write, read back, assert the tenant from the
+response, roll back on mismatch) is not engaged here, and a failed tier is
+simply skipped. Adding a genuinely mutating operation — creating an insight,
+editing a feature flag — pulls that protocol in: a write of unknown outcome MUST
+reconcile by read-back before any retry.
+
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `POSTHOG_PERSONAL_API_KEY`
   first, the PostHog MCP as a preserved first-class fallback. Identity-match
   against the configured project is mandatory on every tier.
+- The key is resolved through `lisa-secrets-access`, with the bare
+  `POSTHOG_PERSONAL_API_KEY` environment variable as the documented fallback.
+  Never read a second credential store directly.
 - `POSTHOG_HOST` defaults to PostHog Cloud but can point at a self-hosted
   deployment.
 - Consumer skills do not embed PostHog REST paths.

--- a/plugins/lisa/skills/lisa-sentry-access/SKILL.md
+++ b/plugins/lisa/skills/lisa-sentry-access/SKILL.md
@@ -39,16 +39,43 @@ Sentry documents API auth tokens for REST API calls, and the same token works
 interactively and headlessly — which is why it leads. The REST tier uses:
 
 ```bash
+# Resolve the token through the chokepoint before giving up on the environment.
+# `$SENTRY_AUTH_TOKEN` is the documented fallback, not the only rung: without
+# this, a project that keeps its credentials in Bitwarden, Doppler, or AWS has
+# no tier 1 path at all and silently resolves through the interactive MCP —
+# the exact divergence `credential-substrate-precedence` exists to remove.
+# Mirrors `linear-access`, `atlassian-access`, and `notion-access`.
+read_sentry_token() {
+  [ -n "${SENTRY_AUTH_TOKEN:-}" ] && { echo "$SENTRY_AUTH_TOKEN"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get SENTRY_AUTH_TOKEN 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
 sentry_api() {
   local path="$1"
-  [ -n "$SENTRY_AUTH_TOKEN" ] || {
-    echo "Error: SENTRY_AUTH_TOKEN is not set." >&2
+  local token
+  token=$(read_sentry_token) || {
+    echo "Error: no Sentry auth token. Set SENTRY_AUTH_TOKEN, or store it as" >&2
+    echo "SENTRY_AUTH_TOKEN in this project's secrets provider." >&2
     return 1
   }
   curl -sS "https://sentry.io/api/0${path}" \
-    -H "Authorization: Bearer $SENTRY_AUTH_TOKEN"
+    -H "Authorization: Bearer $token"
 }
 ```
+
+Tier 1a authenticates `sentry-cli` from the **same resolved token**
+(`SENTRY_AUTH_TOKEN=$(read_sentry_token) sentry-cli …`) — never from a second
+credential store, and never from an interactive `sentry-cli login` keychain.
 
 If neither tier works, fail with:
 
@@ -56,11 +83,25 @@ If neither tier works, fail with:
 Error: no Sentry access substrate available. Authenticate Sentry MCP/CLI or set SENTRY_AUTH_TOKEN.
 ```
 
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — issue, event, and
+release retrieval. So the `credential-substrate-precedence` guarded fallback for
+mutating operations (write, read back, assert the tenant from the response, roll
+back on mismatch) is not engaged here, and a failed tier is simply skipped. Any
+future operation that mutates Sentry state — resolving an issue, editing a
+release — is a write and MUST reconcile by read-back under that protocol before
+any retry; do not add one to the contract without it.
+
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `SENTRY_AUTH_TOKEN` first, the
   Sentry MCP as a preserved first-class fallback. Identity-match against the
   configured org/project is mandatory on every tier.
+- The token is resolved through `lisa-secrets-access`, with the bare
+  `SENTRY_AUTH_TOKEN` environment variable as the documented fallback. Never read
+  a second credential store (OS keychain, `~/.sentryclirc` token) directly — the
+  one-store rule lives at the chokepoint.
 - Org/project come from `.sentryclirc`, `.lisa.config.json`, or explicit
   operation args; never infer by searching all accessible orgs.
 - Consumer skills do not embed Sentry REST paths.

--- a/plugins/lisa/skills/lisa-sonarcloud-access/SKILL.md
+++ b/plugins/lisa/skills/lisa-sonarcloud-access/SKILL.md
@@ -34,6 +34,49 @@ SonarQube Cloud org. Do **not** substitute the raw MCP-image names
 running the Docker image directly, and the `sonar` CLI ignores them (auth exits
 non-zero). The CI scan gate's `SONAR_TOKEN` is a third, separate name.
 
+### Where those variables come from
+
+The `sonar` CLI reads them **from the environment only** — it has no provider
+integration of its own — so on a surface that deliberately materializes nothing
+to disk the credential can be provisioned and unreachable at the same time.
+Resolve it through `lisa-secrets-access` and export it into the launching
+process, exactly as the shared `sonar-secrets.sh` hook already does. The bare
+`$SONARQUBE_CLI_TOKEN` in the environment is the documented **fallback** rung,
+not the only one:
+
+```bash
+# Preferred: the one sanctioned reader. Without this rung a project keeping its
+# credentials in Bitwarden, Doppler, or AWS cannot authenticate the MCP at all,
+# and Sonar access degrades to "run `sonar auth login` in a browser" — dead in
+# cron, CI, and cloud sessions. See `credential-substrate-precedence`.
+read_sonar_secret() {
+  local name="$1"
+  [ -n "${!name:-}" ] && { echo "${!name}"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get "$name" 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
+# Exported into this process only. Writing it anywhere durable would create a
+# second live copy of a credential whose single store is the provider.
+SONARQUBE_CLI_TOKEN=$(read_sonar_secret SONARQUBE_CLI_TOKEN) && export SONARQUBE_CLI_TOKEN
+SONARQUBE_CLI_ORG=$(read_sonar_secret SONARQUBE_CLI_ORG) && export SONARQUBE_CLI_ORG
+```
+
+`sonar-secrets.sh` runs the same resolution with a longer search path (it also
+probes `.codex/skills/…` and `node_modules/@codyswann/lisa/plugins/lisa/…`,
+because a hook fires in checkouts that never installed an agent plugin) and with
+a timeout, because it sits in front of every prompt. Use its search order
+verbatim when this skill runs inside a hook.
+
 Wiring is performed once by `/lisa:setup:sonar` (which drives `sonar integrate
 <agent>`); this access layer assumes the MCP is already wired. This is distinct
 from the CI `SONAR_TOKEN` secret that authenticates the SonarCloud scan job in
@@ -79,9 +122,22 @@ Pass the project key through the tool's `projectKey` argument (or rely on a
 server-configured `SONARQUBE_PROJECT_KEY`); pass `branch` / `pullRequest` where the
 tool accepts them.
 
+## Mutation boundary
+
+Every operation in the map above is **read-only** — quality, coverage, and
+security data. So the `credential-substrate-precedence` guarded fallback for
+mutating operations (write, read back, assert the tenant from the response, roll
+back on mismatch) is not engaged here; with one substrate there is nothing to
+fall back to in any case. A future operation that mutates Sonar state — marking
+a hotspot safe, changing an issue's status — is a write and MUST reconcile by
+read-back before any retry.
+
 ## Invariants
 
 - The official SonarQube MCP is the only substrate; there is no REST fallback.
+- `SONARQUBE_CLI_*` values are resolved through `lisa-secrets-access` and
+  exported in-process, with the bare environment variables as the documented
+  fallback. Never write them to a dotfile or a `.env` on a local surface.
 - Auth is env-var only (`SONARQUBE_CLI_TOKEN` [+ `SONARQUBE_CLI_ORG` | `SONARQUBE_CLI_SERVER`]);
   never the interactive `sonar auth login` keychain flow inside a factory.
 - Sonar host access requires the host (`sonarcloud.io`, `sonarqube.us`, or the

--- a/plugins/src/base/rules/eager/credential-substrate-precedence.md
+++ b/plugins/src/base/rules/eager/credential-substrate-precedence.md
@@ -20,7 +20,9 @@ scope for that skill's work.
    `lisa-secrets-access`, chosen whenever its bootstrap credential is available **and**
    the resolved substrate identity-matches the configured tenant/workspace/site.
    `lisa-secrets-access` is the single chokepoint — never read an OS keychain a second
-   time.
+   time. The two legacy OS-keychain rungs that remain (`lisa-atlassian-access`,
+   `lisa-notion-access`) are a dated migration ramp with a **removal date of
+   2026-11-01**, not a standing exemption; no new access skill may add one.
 2. **Tier 2 — interactive MCP**, used only when tier 1 is *genuinely* unavailable:
    no bootstrap, no adapter for the operation (per-operation, not per-session), or a
    provider outage. "The MCP happens to be authenticated" and "tier 1 is slower" are

--- a/plugins/src/base/rules/reference/credential-substrate-precedence.md
+++ b/plugins/src/base/rules/reference/credential-substrate-precedence.md
@@ -139,6 +139,26 @@ operation, the fallback is guarded — never the normal path:
 A successful pre-flight switch is not sufficient for tenant safety — another process can
 mutate global state between the check and the write.
 
+## Legacy OS-keychain fallback — removal date 2026-11-01
+
+Two access skills (`lisa-atlassian-access`, `lisa-notion-access`) still read an
+OS keychain as a last rung below the chokepoint, because the guided
+`/lisa:setup:atlassian` and `/lisa:setup:notion` flows wrote credentials there
+before `lisa-secrets-access` existed. That rung is a **migration ramp with a
+removal date, not a standing exemption**: it is a second reader of the same
+credential, which is exactly how one credential ends up living in two places and
+drifting, and a keychain entry is machine-local ambient state that no headless
+surface can reach — so a project resting on it has no working tier 1 in cron, CI,
+or a cloud session.
+
+**Both rungs are deleted on 2026-11-01.** Before then, projects still on the
+keychain path move the credential into their configured provider — re-running
+`/lisa:setup:<vendor>` stores it through the chokepoint. After removal, a
+keychain-only project fails loudly with the exact variable named (tier 3), which
+is the intended outcome: it can never silently resolve through a substrate
+authenticated elsewhere. No new access skill may add a keychain rung; a credential
+the chokepoint cannot answer for is a setup gap to fix, not a store to add.
+
 ## Consequences to expect
 
 - **A stale or wrong token now fails identity-match instead of silently succeeding

--- a/plugins/src/base/skills/lisa-atlassian-access/SKILL.md
+++ b/plugins/src/base/skills/lisa-atlassian-access/SKILL.md
@@ -69,6 +69,13 @@ read_atlassian_token() {
   # Legacy fallback: the OS keychain written by the guided /lisa:setup:atlassian
   # flow, for projects that have not adopted a credentials provider. Reached only
   # when the chokepoint is absent or has no entry.
+  #
+  # This rung is REMOVED ON 2026-11-01 — a dated migration ramp, not a standing
+  # exemption (see credential-substrate-precedence, "Legacy OS-keychain fallback
+  # — removal date"). A keychain entry is machine-local ambient state no headless
+  # surface can reach, so a project resting on it has no working tier 1 in cron,
+  # CI, or a cloud session. Re-run /lisa:setup:atlassian before that date to
+  # store ATLASSIAN_API_TOKEN through the chokepoint instead.
   case "$(uname -s)" in
     Darwin)  security find-generic-password -s lisa-atlassian -a "$email" -w 2>/dev/null ;;
     Linux)   command -v secret-tool >/dev/null && secret-tool lookup service lisa-atlassian account "$email" 2>/dev/null ;;

--- a/plugins/src/base/skills/lisa-jam-access/SKILL.md
+++ b/plugins/src/base/skills/lisa-jam-access/SKILL.md
@@ -39,20 +39,55 @@ headlessly — which is why it leads. The CLI tier uses:
 ```bash
 curl -fsSL https://native.jam.dev/install | bash
 export PATH="$HOME/.local/bin:$PATH"
-printf '%s' "$JAM_PAT" | jam auth login --token
+
+# Resolve the PAT through the chokepoint before giving up on the environment.
+# `$JAM_PAT` is the documented fallback, not the only rung: without this, a
+# project that keeps its credentials in Bitwarden, Doppler, or AWS has no tier 1
+# path at all and silently resolves through the interactive MCP — the exact
+# divergence `credential-substrate-precedence` exists to remove.
+read_jam_pat() {
+  [ -n "${JAM_PAT:-}" ] && { echo "$JAM_PAT"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get JAM_PAT 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
+# Piped, never written to disk and never passed as an argv token: a PAT on a
+# command line is readable from the process table by every user on the host.
+read_jam_pat | jam auth login --token
 jam skills install
 ```
 
 If neither tier works, fail with:
 
 ```text
-Error: no Jam access substrate available. Authenticate the Jam MCP or set JAM_PAT.
+Error: no Jam access substrate available. Authenticate the Jam MCP, set JAM_PAT, or store JAM_PAT in this project's secrets provider.
 ```
+
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — fetching a trace,
+a recording, or a bug report. So the `credential-substrate-precedence` guarded
+fallback for mutating operations (write, read back, assert the tenant from the
+response, roll back on mismatch) is not engaged here, and a failed tier is
+simply skipped. A future operation that mutates Jam state — commenting on or
+deleting a Jam — is a write and MUST reconcile by read-back before any retry.
 
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `JAM_PAT` CLI first, Jam MCP as
   a preserved first-class fallback. Do not retry a failed tier blindly.
+- The PAT is resolved through `lisa-secrets-access`, with the bare `JAM_PAT`
+  environment variable as the documented fallback. Never read a second
+  credential store directly.
 - Never commit a Jam PAT into `.mcp.json` or any generated setup artifact.
 - Headless Jam access requires `native.jam.dev` for the installer and
   `api.jam.dev` for CLI/API calls in any custom remote network allowlist.

--- a/plugins/src/base/skills/lisa-notion-access/SKILL.md
+++ b/plugins/src/base/skills/lisa-notion-access/SKILL.md
@@ -70,6 +70,13 @@ read_notion_token() {
   # Legacy fallback: the OS keychain written by the guided /lisa:setup:notion
   # flow, for projects that have not adopted a credentials provider. Reached only
   # when the chokepoint is absent or has no entry.
+  #
+  # This rung is REMOVED ON 2026-11-01 — a dated migration ramp, not a standing
+  # exemption (see credential-substrate-precedence, "Legacy OS-keychain fallback
+  # — removal date"). A keychain entry is machine-local ambient state no headless
+  # surface can reach, so a project resting on it has no working tier 1 in cron,
+  # CI, or a cloud session. Re-run /lisa:setup:notion before that date to store
+  # NOTION_API_TOKEN through the chokepoint instead.
   case "$(uname -s)" in
     Darwin)  security find-generic-password -s lisa-notion -a "$workspace" -w 2>/dev/null ;;
     Linux)   command -v secret-tool >/dev/null && \

--- a/plugins/src/base/skills/lisa-posthog-access/SKILL.md
+++ b/plugins/src/base/skills/lisa-posthog-access/SKILL.md
@@ -40,15 +40,38 @@ works interactively and headlessly — which is why it leads. The REST tier uses
 
 ```bash
 POSTHOG_HOST=${POSTHOG_HOST:-https://app.posthog.com}
+
+# Resolve the key through the chokepoint before giving up on the environment.
+# `$POSTHOG_PERSONAL_API_KEY` is the documented fallback, not the only rung:
+# without this, a project that keeps its credentials in Bitwarden, Doppler, or
+# AWS has no tier 1 path at all and silently resolves through the interactive
+# MCP — the exact divergence `credential-substrate-precedence` exists to remove.
+read_posthog_key() {
+  [ -n "${POSTHOG_PERSONAL_API_KEY:-}" ] && { echo "$POSTHOG_PERSONAL_API_KEY"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get POSTHOG_PERSONAL_API_KEY 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
 posthog_api() {
   local path="$1"
   local method="${2:-GET}"
   local body="${3:-}"
-  [ -n "$POSTHOG_PERSONAL_API_KEY" ] || {
-    echo "Error: POSTHOG_PERSONAL_API_KEY is not set." >&2
+  local key
+  key=$(read_posthog_key) || {
+    echo "Error: no PostHog key. Set POSTHOG_PERSONAL_API_KEY, or store it as" >&2
+    echo "POSTHOG_PERSONAL_API_KEY in this project's secrets provider." >&2
     return 1
   }
-  local args=(-sS -X "$method" -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY")
+  local args=(-sS -X "$method" -H "Authorization: Bearer $key")
   [ -n "$body" ] && args+=(-H "Content-Type: application/json" --data-binary "$body")
   curl "${args[@]}" "${POSTHOG_HOST%/}/api${path}"
 }
@@ -60,11 +83,25 @@ If neither tier works, fail with:
 Error: no PostHog access substrate available. Authenticate the PostHog MCP or set POSTHOG_PERSONAL_API_KEY.
 ```
 
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — analytics
+retrieval. `query` is an HTTP POST, but it reads: it submits a query body and
+changes no PostHog state. So the `credential-substrate-precedence` guarded
+fallback for mutating operations (write, read back, assert the tenant from the
+response, roll back on mismatch) is not engaged here, and a failed tier is
+simply skipped. Adding a genuinely mutating operation — creating an insight,
+editing a feature flag — pulls that protocol in: a write of unknown outcome MUST
+reconcile by read-back before any retry.
+
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `POSTHOG_PERSONAL_API_KEY`
   first, the PostHog MCP as a preserved first-class fallback. Identity-match
   against the configured project is mandatory on every tier.
+- The key is resolved through `lisa-secrets-access`, with the bare
+  `POSTHOG_PERSONAL_API_KEY` environment variable as the documented fallback.
+  Never read a second credential store directly.
 - `POSTHOG_HOST` defaults to PostHog Cloud but can point at a self-hosted
   deployment.
 - Consumer skills do not embed PostHog REST paths.

--- a/plugins/src/base/skills/lisa-sentry-access/SKILL.md
+++ b/plugins/src/base/skills/lisa-sentry-access/SKILL.md
@@ -39,16 +39,43 @@ Sentry documents API auth tokens for REST API calls, and the same token works
 interactively and headlessly — which is why it leads. The REST tier uses:
 
 ```bash
+# Resolve the token through the chokepoint before giving up on the environment.
+# `$SENTRY_AUTH_TOKEN` is the documented fallback, not the only rung: without
+# this, a project that keeps its credentials in Bitwarden, Doppler, or AWS has
+# no tier 1 path at all and silently resolves through the interactive MCP —
+# the exact divergence `credential-substrate-precedence` exists to remove.
+# Mirrors `linear-access`, `atlassian-access`, and `notion-access`.
+read_sentry_token() {
+  [ -n "${SENTRY_AUTH_TOKEN:-}" ] && { echo "$SENTRY_AUTH_TOKEN"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get SENTRY_AUTH_TOKEN 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
 sentry_api() {
   local path="$1"
-  [ -n "$SENTRY_AUTH_TOKEN" ] || {
-    echo "Error: SENTRY_AUTH_TOKEN is not set." >&2
+  local token
+  token=$(read_sentry_token) || {
+    echo "Error: no Sentry auth token. Set SENTRY_AUTH_TOKEN, or store it as" >&2
+    echo "SENTRY_AUTH_TOKEN in this project's secrets provider." >&2
     return 1
   }
   curl -sS "https://sentry.io/api/0${path}" \
-    -H "Authorization: Bearer $SENTRY_AUTH_TOKEN"
+    -H "Authorization: Bearer $token"
 }
 ```
+
+Tier 1a authenticates `sentry-cli` from the **same resolved token**
+(`SENTRY_AUTH_TOKEN=$(read_sentry_token) sentry-cli …`) — never from a second
+credential store, and never from an interactive `sentry-cli login` keychain.
 
 If neither tier works, fail with:
 
@@ -56,11 +83,25 @@ If neither tier works, fail with:
 Error: no Sentry access substrate available. Authenticate Sentry MCP/CLI or set SENTRY_AUTH_TOKEN.
 ```
 
+## Mutation boundary
+
+Every operation in the Invocation Contract is **read-only** — issue, event, and
+release retrieval. So the `credential-substrate-precedence` guarded fallback for
+mutating operations (write, read back, assert the tenant from the response, roll
+back on mismatch) is not engaged here, and a failed tier is simply skipped. Any
+future operation that mutates Sentry state — resolving an issue, editing a
+release — is a write and MUST reconcile by read-back under that protocol before
+any retry; do not add one to the contract without it.
+
 ## Invariants
 
 - Tier order is `credential-substrate-precedence`: `SENTRY_AUTH_TOKEN` first, the
   Sentry MCP as a preserved first-class fallback. Identity-match against the
   configured org/project is mandatory on every tier.
+- The token is resolved through `lisa-secrets-access`, with the bare
+  `SENTRY_AUTH_TOKEN` environment variable as the documented fallback. Never read
+  a second credential store (OS keychain, `~/.sentryclirc` token) directly — the
+  one-store rule lives at the chokepoint.
 - Org/project come from `.sentryclirc`, `.lisa.config.json`, or explicit
   operation args; never infer by searching all accessible orgs.
 - Consumer skills do not embed Sentry REST paths.

--- a/plugins/src/base/skills/lisa-sonarcloud-access/SKILL.md
+++ b/plugins/src/base/skills/lisa-sonarcloud-access/SKILL.md
@@ -34,6 +34,49 @@ SonarQube Cloud org. Do **not** substitute the raw MCP-image names
 running the Docker image directly, and the `sonar` CLI ignores them (auth exits
 non-zero). The CI scan gate's `SONAR_TOKEN` is a third, separate name.
 
+### Where those variables come from
+
+The `sonar` CLI reads them **from the environment only** — it has no provider
+integration of its own — so on a surface that deliberately materializes nothing
+to disk the credential can be provisioned and unreachable at the same time.
+Resolve it through `lisa-secrets-access` and export it into the launching
+process, exactly as the shared `sonar-secrets.sh` hook already does. The bare
+`$SONARQUBE_CLI_TOKEN` in the environment is the documented **fallback** rung,
+not the only one:
+
+```bash
+# Preferred: the one sanctioned reader. Without this rung a project keeping its
+# credentials in Bitwarden, Doppler, or AWS cannot authenticate the MCP at all,
+# and Sonar access degrades to "run `sonar auth login` in a browser" — dead in
+# cron, CI, and cloud sessions. See `credential-substrate-precedence`.
+read_sonar_secret() {
+  local name="$1"
+  [ -n "${!name:-}" ] && { echo "${!name}"; return; }
+  local resolver
+  for resolver in .claude/skills/lisa-secrets-access/scripts/resolve-secret.mjs \
+                  .agents/skills/lisa-secrets-access/scripts/resolve-secret.mjs; do
+    if [ -f "$resolver" ]; then
+      local via_lisa
+      via_lisa=$(node "$resolver" get "$name" 2>/dev/null) \
+        && [ -n "$via_lisa" ] && { echo "$via_lisa"; return; }
+      break
+    fi
+  done
+  return 1
+}
+
+# Exported into this process only. Writing it anywhere durable would create a
+# second live copy of a credential whose single store is the provider.
+SONARQUBE_CLI_TOKEN=$(read_sonar_secret SONARQUBE_CLI_TOKEN) && export SONARQUBE_CLI_TOKEN
+SONARQUBE_CLI_ORG=$(read_sonar_secret SONARQUBE_CLI_ORG) && export SONARQUBE_CLI_ORG
+```
+
+`sonar-secrets.sh` runs the same resolution with a longer search path (it also
+probes `.codex/skills/…` and `node_modules/@codyswann/lisa/plugins/lisa/…`,
+because a hook fires in checkouts that never installed an agent plugin) and with
+a timeout, because it sits in front of every prompt. Use its search order
+verbatim when this skill runs inside a hook.
+
 Wiring is performed once by `/lisa:setup:sonar` (which drives `sonar integrate
 <agent>`); this access layer assumes the MCP is already wired. This is distinct
 from the CI `SONAR_TOKEN` secret that authenticates the SonarCloud scan job in
@@ -79,9 +122,22 @@ Pass the project key through the tool's `projectKey` argument (or rely on a
 server-configured `SONARQUBE_PROJECT_KEY`); pass `branch` / `pullRequest` where the
 tool accepts them.
 
+## Mutation boundary
+
+Every operation in the map above is **read-only** — quality, coverage, and
+security data. So the `credential-substrate-precedence` guarded fallback for
+mutating operations (write, read back, assert the tenant from the response, roll
+back on mismatch) is not engaged here; with one substrate there is nothing to
+fall back to in any case. A future operation that mutates Sonar state — marking
+a hotspot safe, changing an issue's status — is a write and MUST reconcile by
+read-back before any retry.
+
 ## Invariants
 
 - The official SonarQube MCP is the only substrate; there is no REST fallback.
+- `SONARQUBE_CLI_*` values are resolved through `lisa-secrets-access` and
+  exported in-process, with the bare environment variables as the documented
+  fallback. Never write them to a dotfile or a `.env` on a local surface.
 - Auth is env-var only (`SONARQUBE_CLI_TOKEN` [+ `SONARQUBE_CLI_ORG` | `SONARQUBE_CLI_SERVER`]);
   never the interactive `sonar auth login` keychain flow inside a factory.
 - Sonar host access requires the host (`sonarcloud.io`, `sonarqube.us`, or the

--- a/src/cli/doctor-learnings-merge-driver.ts
+++ b/src/cli/doctor-learnings-merge-driver.ts
@@ -1,0 +1,114 @@
+/**
+ * `lisa doctor` check: is the learnings union merge driver actually registered?
+ *
+ * A merge driver has two halves in two places. The `merge=lisa-learnings`
+ * mapping is committed in `.gitattributes`; the driver COMMAND is machine-local,
+ * because git refuses to run a command a repository supplied. So any clone that
+ * never ran `lisa apply` — a fresh CI checkout, a teammate who cloned without
+ * installing, a worktree created before the migration ran — silently falls back
+ * to git's built-in text merge for the ledger.
+ *
+ * That degradation is far less catastrophic than it sounds: the text merge
+ * leaves conflict markers, which the budget gate diagnoses, rather than
+ * resolving the ledger to empty. What it is not is visible. Nothing tells an
+ * operator that the union protecting the ledger is not registered here — and
+ * invisibility is precisely what let one fleet project lose 19 captured
+ * learnings. This check is the missing sentence.
+ * @module cli/doctor-learnings-merge-driver
+ */
+import { isLearningsMergeDriverEnabled } from "../core/learnings-merge-driver-config.js";
+import {
+  isLearningsPathMappedToDriver,
+  probeLearningsMergeDriverRegistration,
+} from "../core/learnings-merge-driver-install.js";
+import { LEARNINGS_MERGE_DRIVER_NAME } from "../core/learnings-merge-driver.js";
+import {
+  readProjectConfig,
+  resolveProjectLearningsFile,
+} from "../core/project-config.js";
+
+/** Name of the merge-driver check as doctor reports it. */
+export const LEARNINGS_MERGE_DRIVER_CHECK_NAME =
+  "Learnings merge driver registered?";
+
+/** Git config key holding the driver command. */
+const DRIVER_KEY = `merge.${LEARNINGS_MERGE_DRIVER_NAME}.driver`;
+
+/** Shape of one doctor check result (structurally identical to doctor's). */
+interface MergeDriverCheckResult {
+  name: string;
+  status: "ok" | "warn" | "fail";
+  detail: string;
+}
+
+/**
+ * Build one check result under this check's name.
+ * @param status - Reported status
+ * @param detail - Operator-readable explanation
+ * @returns Doctor check result
+ */
+function result(status: "ok" | "warn", detail: string): MergeDriverCheckResult {
+  return { name: LEARNINGS_MERGE_DRIVER_CHECK_NAME, status, detail };
+}
+
+/**
+ * Report whether this checkout can actually run the ledger's union merge.
+ *
+ * Warn, never fail: an unregistered driver degrades to a merge that conflicts
+ * loudly instead of one that loses content, so reddening a CI checkout over it
+ * would trade a real signal for noise. The states that are genuinely fine — a
+ * host that opted out, a directory that is not a git repository, a repository
+ * with nothing mapped to the driver — report ok and say which one they are,
+ * rather than sharing one indistinguishable "skipped".
+ * @param targetPath - Project path to inspect
+ * @returns Doctor check result
+ */
+export async function checkLearningsMergeDriver(
+  targetPath: string
+): Promise<MergeDriverCheckResult> {
+  try {
+    if (!(await isLearningsMergeDriverEnabled(targetPath))) {
+      return result(
+        "ok",
+        "Host opted out via learnings.mergeDriver: false; no driver expected"
+      );
+    }
+    const registration =
+      await probeLearningsMergeDriverRegistration(targetPath);
+    if (registration === "not-a-repository") {
+      return result(
+        "ok",
+        "Not a git repository, so merge-driver registration does not apply"
+      );
+    }
+    if (registration === "git-unavailable") {
+      return result(
+        "warn",
+        `git executable not found, so ${DRIVER_KEY} could not be verified — install git, then re-run \`lisa doctor\``
+      );
+    }
+    const ledger = resolveProjectLearningsFile(
+      await readProjectConfig(targetPath)
+    );
+    if (!(await isLearningsPathMappedToDriver(targetPath, ledger))) {
+      return result(
+        "ok",
+        `Nothing maps ${ledger} to the ${LEARNINGS_MERGE_DRIVER_NAME} driver, so there is nothing to register (run \`lisa apply\` to ship the .gitattributes mapping)`
+      );
+    }
+    if (registration === "registered") {
+      return result("ok", `${DRIVER_KEY} is registered for ${ledger}`);
+    }
+    return result(
+      "warn",
+      `.gitattributes maps ${ledger} to the ${LEARNINGS_MERGE_DRIVER_NAME} merge driver, but ${DRIVER_KEY} is not registered in this checkout — git silently falls back to its built-in text merge, which leaves conflict markers in the ledger instead of unioning entries by id. Fix it with \`lisa install-merge-driver\` (or any \`lisa apply\`) run here. Hosts that do not want the driver set learnings.mergeDriver: false in .lisa.config.json.`
+    );
+  } catch (error) {
+    return result(
+      "warn",
+      `Could not inspect the ${LEARNINGS_MERGE_DRIVER_NAME} merge driver: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -9,6 +9,7 @@ import { probeSonarReadiness } from "../core/sonar-integration.js";
 import { createDetectorRegistry } from "../detection/index.js";
 import { checkKaneProvider } from "./doctor-kane.js";
 import { checkLearningsLedger } from "./doctor-learnings-ledger.js";
+import { checkLearningsMergeDriver } from "./doctor-learnings-merge-driver.js";
 import { checkSonarProvider } from "./doctor-sonar.js";
 import { checkLegacyCodexOverlay } from "./doctor-legacy-overlay.js";
 import { checkLisaOwnedArtifacts } from "./doctor-lisa-owned-artifacts.js";
@@ -339,6 +340,12 @@ export async function runDoctor(
     // repaired first and passes here; only a genuine second ledger survives to
     // be reported.
     await checkLearningsLedger(resolvedTarget),
+    // Immediately after, and for the same reason that check runs late: both
+    // resolve the configured ledger path, which the instruction-files check may
+    // have just relocated. Reporting the merge arm second is also the order an
+    // operator can act in — which ledger is canonical, then whether this
+    // checkout can actually run the union merge that protects it.
+    await checkLearningsMergeDriver(resolvedTarget),
     await checkWorkerEpoch(resolvedTarget),
     checkLegacyCodexOverlay(resolvedTarget),
     await checkStarterHealth(deps, options.offline === true),

--- a/src/core/learnings-merge-driver-install.ts
+++ b/src/core/learnings-merge-driver-install.ts
@@ -158,6 +158,69 @@ export async function canInstallLearningsMergeDriver(
 }
 
 /**
+ * Registration state of the driver command for one checkout.
+ *
+ * `unregistered` is the state this whole module exists to make visible: the
+ * `.gitattributes` mapping is committed, so every clone believes the ledger is
+ * union-merged, while the command that performs the union lives only in local
+ * git config. A clone that never ran apply is degraded, not broken — and says
+ * nothing about it.
+ */
+export type MergeDriverRegistration =
+  | "registered"
+  | "unregistered"
+  | "not-a-repository"
+  | "git-unavailable";
+
+/**
+ * Report whether the driver command is registered for this checkout.
+ *
+ * Read-only, and deliberately scope-agnostic: registration is written to local
+ * config, but git resolves a merge driver from any config scope, so a global
+ * registration counts. Asking with `--local` would report a working driver as
+ * missing.
+ * @param projectRoot - Project directory to inspect
+ * @returns Closed registration state
+ */
+export async function probeLearningsMergeDriverRegistration(
+  projectRoot: string
+): Promise<MergeDriverRegistration> {
+  const probe = await probeRepository(projectRoot);
+  if (probe !== "repository") {
+    // Both non-repository outcomes are already registration states; narrowing
+    // hands them through unchanged rather than restating the literals.
+    return probe;
+  }
+  const current = await tryGit(["config", "--get", DRIVER_KEY], projectRoot);
+  return current.ok && current.stdout !== "" ? "registered" : "unregistered";
+}
+
+/**
+ * Report whether git resolves one path's `merge` attribute to this driver.
+ *
+ * Asks git rather than parsing `.gitattributes`, because the answer depends on
+ * pattern precedence and on every attributes source git consults (the working
+ * tree file, `.git/info/attributes`, a configured `core.attributesFile`).
+ * Reading the root file alone would claim a mapping the repository may not
+ * actually have — or miss one it does.
+ * @param projectRoot - Project directory to inspect
+ * @param ledgerPath - Project-relative path to the learnings ledger
+ * @returns True when the path is mapped to the learnings merge driver
+ */
+export async function isLearningsPathMappedToDriver(
+  projectRoot: string,
+  ledgerPath: string
+): Promise<boolean> {
+  const result = await tryGit(
+    ["check-attr", "merge", "--", ledgerPath],
+    projectRoot
+  );
+  return (
+    result.ok && result.stdout.endsWith(`merge: ${LEARNINGS_MERGE_DRIVER_NAME}`)
+  );
+}
+
+/**
  * Register the union merge driver in one project's local git config.
  *
  * Idempotent and safe outside a git repository: a non-repository directory is

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8098,6 +8098,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/cli/cross-pollinate-nudge.ts": true,
     "src/cli/doctor-kane.ts": true,
     "src/cli/doctor-learnings-ledger.ts": true,
+    "src/cli/doctor-learnings-merge-driver.ts": true,
     "src/cli/doctor-legacy-overlay.ts": true,
     "src/cli/doctor-lisa-owned-artifacts.ts": true,
     "src/cli/doctor-monitor-thresholds.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -713,7 +713,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/eager/convergent-review.md":
       "ba4ba53863ef99be353c07c01195fa4ae2923ef2b2a5ad4427072802c260d208",
     "plugins/src/base/rules/eager/credential-substrate-precedence.md":
-      "20fbbf6499b079105b5d749fed4da787a22a87c12851f1939572a7a5b2601800",
+      "f6013bc428294e6a1e3321e656dc74ad9ec44236b4e5d46d799c3467da1688bf",
     "plugins/src/base/rules/eager/dependency-decision-records.md":
       "e22888f107906992e863fca50f26c2c4b124da7132535cacfac71e4f3085728f",
     "plugins/src/base/rules/eager/dependency-internalization-kit.md":
@@ -813,7 +813,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/reference/convergent-review.md":
       "788a9d4dc2af7a928c3ccbb4d53a92856bb3544941ce512cfe38068d6b35850d",
     "plugins/src/base/rules/reference/credential-substrate-precedence.md":
-      "7c66b0a06792194a547b50bdb49df51923463f26f4f7a0356f0139c5a9385e4f",
+      "5420156ca98fff0d26d1537fbd54781e70cb801cdb8e770a6caa3cb8acd253c7",
     "plugins/src/base/rules/reference/dependency-decision-records.md":
       "84f9fb8fa0a606307e828ec355ccbf2258beeeb88795dd113abe9bb2c37db39f",
     "plugins/src/base/rules/reference/dependency-internalization-kit.md":
@@ -939,7 +939,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-analyze-claude-remote/SKILL.md":
       "a5863836b8fa9d67825d048e1c2fc086d3df95de33cf110129488959b83cb4b5",
     "plugins/src/base/skills/lisa-atlassian-access/SKILL.md":
-      "d516da35f973a94fedee141a2ae5f2d3bc82dda8263b44fd0bc0b03a8f5a5e08",
+      "6366ccce961217d1c7bcac4dad9c2293ee4dcc395b27c142a3b59c62f00b685c",
     "plugins/src/base/skills/lisa-atlassian-access/scripts/markdown-to-adf.mjs":
       "538e5a3d91482b9e2a055e133b7c1fcf809be51d4ae72a10776aaeeb8df4832a",
     "plugins/src/base/skills/lisa-attribute-failure/SKILL.md":
@@ -1045,7 +1045,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-intake/SKILL.md":
       "5ca35517fec4483c000466a4a2e7487b0f75ccec17053ad0b06ec4848027d1a1",
     "plugins/src/base/skills/lisa-jam-access/SKILL.md":
-      "c5adc2de7eb34bc021d95cf6de62033a6b1470741ce6e15d5af49ae196aec711",
+      "eb7255578a3ada2278a0437c4300fed3f28b9b1a4ef2fd4ceed63f3d9ab81ed3",
     "plugins/src/base/skills/lisa-jira-add-journey/SKILL.md":
       "92bc77aac50426b37f954ed24d95bd600ae1a429c2fecd6bbd4317053136bb03",
     "plugins/src/base/skills/lisa-jira-build-intake/SKILL.md":
@@ -1121,7 +1121,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-nightly-lower-code-complexity/SKILL.md":
       "1d070f368b8fb16e1ba60b13a5334a171287dfa0753bc3ad29554afd8fb7ae5b",
     "plugins/src/base/skills/lisa-notion-access/SKILL.md":
-      "2d1956560ef4ed3b8db9464b29c2a4f03030d27711d4cd6776d87cbeac505416",
+      "e0dc04a24c1ad49284e2f484fb59b46bf0b2876a1a2ef500c95444eda7fed05c",
     "plugins/src/base/skills/lisa-notion-prd-intake/SKILL.md":
       "cf9be0a2173782696e2c1d2fcbc2fc2ae29c0eefa3815ae951f5afef7d029c94",
     "plugins/src/base/skills/lisa-notion-to-tracker/SKILL.md":
@@ -1151,7 +1151,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-plugin-sync-explain/SKILL.md":
       "b41619f3d0d342af2438afd54cb97db7d2445e54e3fc7bb012292079acbc6a4f",
     "plugins/src/base/skills/lisa-posthog-access/SKILL.md":
-      "00c4bc302923930c93b1c32bdfe41b1ae2e5bdba4ca25678f5c9c3e2bff7ff6b",
+      "841f02d455e333edeb6dc859581fd0422101037281a9142ca4d6d77136a8817e",
     "plugins/src/base/skills/lisa-prd-backlink/SKILL.md":
       "31da3d266e461fe7aaa6a91fd03d68b8f2c0a5399f793606e1efc8a003c7b913",
     "plugins/src/base/skills/lisa-prd-source-write/SKILL.md":
@@ -1241,7 +1241,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-security-zap-scan/SKILL.md":
       "a5189442dbf970cc49fd089ab03c386c8a205b856e09501f6ad1966321e7e4b5",
     "plugins/src/base/skills/lisa-sentry-access/SKILL.md":
-      "937393a882f480fcbfe517fbaa0eb44ef557d8e0d567c1c66a17eceb6f6ac0a5",
+      "e8ea8e6e4288385202f88b04e258b6d86f304a05d6dc118ebde6e88a7e8b5f44",
     "plugins/src/base/skills/lisa-setup-atlassian/SKILL.md":
       "4fa7f9a83a9998951528c8ffffa930c61b5c316b510356a3e7a90ccb9d5ca123",
     "plugins/src/base/skills/lisa-setup-automations/SKILL.md":
@@ -1293,7 +1293,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-workstation/scripts/workstation.mjs":
       "6ab19c08aa9db7643aa49133ba1d0febf1c1dbdc9a503026a01b1ce0a83f68ab",
     "plugins/src/base/skills/lisa-sonarcloud-access/SKILL.md":
-      "011367d5e0337f3490e9c9bc1f90e04319593a3eae1ee7d32c19d2d9396dbea1",
+      "b98aba73d367a671395a08433a47034fce7ea701d31ef89b6aa866efc4dd3fcb",
     "plugins/src/base/skills/lisa-spec-conformance/SKILL.md":
       "50e79afcfabf16d36273325aabb58571c9a0e1cafe7a2865e2da10c6d46571eb",
     "plugins/src/base/skills/lisa-sync-down/SKILL.md":
@@ -8535,6 +8535,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/check-learnings-budget-cmd.test.ts": true,
     "tests/unit/cli/doctor-kane.test.ts": true,
     "tests/unit/cli/doctor-learnings-ledger.test.ts": true,
+    "tests/unit/cli/doctor-learnings-merge-driver.test.ts": true,
     "tests/unit/cli/doctor-lisa-owned-artifacts.test.ts": true,
     "tests/unit/cli/doctor-monitor-thresholds.test.ts": true,
     "tests/unit/cli/doctor-readiness-blockers.test.ts": true,

--- a/tests/unit/cli/doctor-learnings-merge-driver.test.ts
+++ b/tests/unit/cli/doctor-learnings-merge-driver.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Doctor coverage for an UNREGISTERED learnings union merge driver.
+ *
+ * `.gitattributes` ships the `merge=lisa-learnings` mapping, but git refuses to
+ * read a driver COMMAND from a repository — so a clone that never ran `lisa
+ * apply` silently falls back to git's built-in text merge for the ledger. That
+ * degradation is safe (it leaves conflict markers rather than resolving to
+ * empty) and completely invisible, which is the gap these tests close: doctor
+ * must say out loud that the union an operator believes is protecting the
+ * ledger is not registered here, and name the one command that fixes it.
+ * @module tests/unit/cli/doctor-learnings-merge-driver
+ */
+import * as fse from "fs-extra";
+import { execFileSync } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runDoctor } from "../../../src/cli/doctor.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const CHECK_NAME = "Learnings merge driver registered?";
+const LEDGER_CHECK_NAME = "Single learnings ledger?";
+const DRIVER_KEY = "merge.lisa-learnings.driver";
+const CANONICAL_LEDGER = ".lisa/PROJECT_LEARNINGS.md";
+const ATTRIBUTES = `${CANONICAL_LEDGER} merge=lisa-learnings\n`;
+
+/**
+ * Resolve git to an absolute executable path by scanning `PATH`.
+ * @returns Absolute path to the git executable
+ */
+function resolveGit(): string {
+  const found = (process.env.PATH ?? "")
+    .split(path.delimiter)
+    .filter(directory => directory !== "")
+    .map(directory => path.join(directory, "git"))
+    .find(candidate => {
+      try {
+        accessSync(candidate, constants.X_OK);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+  if (found === undefined) {
+    throw new Error("git executable not found on PATH");
+  }
+  return found;
+}
+
+const GIT = resolveGit();
+
+/**
+ * Environment without the outer repository's git state, so fixture repos are
+ * never contaminated by the worktree these tests run inside.
+ * @returns Environment safe for fixture git commands
+ */
+function cleanGitEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("GIT_")) {
+      delete env[key];
+    }
+  }
+  return env;
+}
+
+/**
+ * Run one git command inside a fixture repository.
+ * @param cwd - Fixture repository path
+ * @param args - Literal git arguments
+ */
+function git(cwd: string, args: readonly string[]): void {
+  execFileSync(GIT, [...args], {
+    cwd,
+    env: cleanGitEnv(),
+    stdio: "ignore",
+  });
+}
+
+/**
+ * Run doctor offline against a fixture and return every check.
+ * @param cwd - Fixture project path
+ * @returns Doctor check results
+ */
+async function doctorChecks(
+  cwd: string
+): Promise<readonly { name: string; status: string; detail: string }[]> {
+  const result = await runDoctor(
+    cwd,
+    { json: true, offline: true },
+    {
+      write: vi.fn(),
+      setExitCode: vi.fn(),
+      runUpdateCheck: vi.fn().mockResolvedValue({ updateAvailable: false }),
+    }
+  );
+  return result.checks;
+}
+
+/**
+ * Run doctor and return the merge-driver check.
+ * @param cwd - Fixture project path
+ * @returns The merge-driver check result
+ */
+async function driverCheck(
+  cwd: string
+): Promise<{ status: string; detail: string }> {
+  const check = (await doctorChecks(cwd)).find(
+    candidate => candidate.name === CHECK_NAME
+  );
+  if (check === undefined) {
+    throw new Error(`doctor did not run the "${CHECK_NAME}" check`);
+  }
+  return check;
+}
+
+describe("doctor learnings merge-driver check", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    await fse.writeJson(path.join(tempDir, ".lisa.config.json"), {
+      harness: "claude",
+    });
+    await fse.outputFile(path.join(tempDir, ".gitattributes"), ATTRIBUTES);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  it("warns when the ledger is mapped to a driver git cannot run", async () => {
+    git(tempDir, ["init"]);
+    const check = await driverCheck(tempDir);
+    expect(check.status).toBe("warn");
+    expect(check.detail).toContain(DRIVER_KEY);
+  });
+
+  it("names the repair command and the silent degradation it prevents", async () => {
+    git(tempDir, ["init"]);
+    const check = await driverCheck(tempDir);
+    expect(check.detail).toContain("lisa install-merge-driver");
+    expect(check.detail).toMatch(/text merge|conflict marker/iu);
+  });
+
+  it("passes once the driver command is registered locally", async () => {
+    git(tempDir, ["init"]);
+    git(tempDir, ["config", "--local", DRIVER_KEY, "lisa merge-learnings"]);
+    const check = await driverCheck(tempDir);
+    expect(check.status).toBe("ok");
+  });
+
+  it("passes when the host opted out with learnings.mergeDriver false", async () => {
+    git(tempDir, ["init"]);
+    await fse.writeJson(path.join(tempDir, ".lisa.config.json"), {
+      harness: "claude",
+      learnings: { mergeDriver: false },
+    });
+    const check = await driverCheck(tempDir);
+    expect(check.status).toBe("ok");
+    expect(check.detail).toMatch(/opted out|mergeDriver/iu);
+  });
+
+  it("passes when nothing maps the ledger to the driver", async () => {
+    git(tempDir, ["init"]);
+    await fse.outputFile(path.join(tempDir, ".gitattributes"), "*.md text\n");
+    const check = await driverCheck(tempDir);
+    expect(check.status).toBe("ok");
+  });
+
+  it("passes outside a git repository, where registration cannot apply", async () => {
+    const check = await driverCheck(tempDir);
+    expect(check.status).toBe("ok");
+    expect(check.detail).toMatch(/git repositor/iu);
+  });
+
+  it("reports the merge arm immediately after the single-ledger check", async () => {
+    git(tempDir, ["init"]);
+    const names = (await doctorChecks(tempDir)).map(check => check.name);
+    expect(names.indexOf(CHECK_NAME)).toBe(
+      names.indexOf(LEDGER_CHECK_NAME) + 1
+    );
+  });
+});

--- a/tests/unit/strategies/credential-substrate-precedence.test.ts
+++ b/tests/unit/strategies/credential-substrate-precedence.test.ts
@@ -245,6 +245,86 @@ describe("access skills conform to the precedence contract", () => {
   });
 });
 
+/**
+ * Every access skill whose tier 1 credential must be reachable through the
+ * `lisa-secrets-access` chokepoint, paired with the variable it resolves.
+ *
+ * Without this rung the ladder stops at rung one — a bare `$VAR` read — so a
+ * project keeping its credentials in Bitwarden, Doppler, or AWS has no tier 1
+ * path at all and silently resolves through the interactive MCP instead. That
+ * is the precise failure the precedence contract exists to remove, and it is
+ * why `/lisa:setup:linear` had nowhere to migrate its keychain read to.
+ */
+const RESOLVER_RUNG_SKILLS = [
+  [SENTRY, "SENTRY_AUTH_TOKEN"],
+  [POSTHOG, "POSTHOG_PERSONAL_API_KEY"],
+  [JAM, "JAM_PAT"],
+  ["lisa-sonarcloud-access", "SONARQUBE_CLI_TOKEN"],
+] as const;
+
+/** Date the legacy OS-keychain fallbacks stop being read. */
+const KEYCHAIN_REMOVAL_DATE = "2026-11-01";
+
+describe("access skills resolve tier 1 through lisa-secrets-access", () => {
+  describe.each(ROOTS)("%s", root => {
+    describe.each(RESOLVER_RUNG_SKILLS)("%s", (skillName, variable) => {
+      const skill = readSkill(root, skillName);
+
+      it("reads the credential through the resolve-secret chokepoint", () => {
+        expect(skill).toMatch(
+          /\.claude\/skills\/lisa-secrets-access\/scripts\/resolve-secret\.mjs/
+        );
+        expect(skill).toMatch(
+          /\.agents\/skills\/lisa-secrets-access\/scripts\/resolve-secret\.mjs/
+        );
+        expect(skill).toMatch(
+          new RegExp(
+            `resolve-secret[\\s\\S]{0,400}${variable}|${variable}[\\s\\S]{0,400}resolve-secret`,
+            "u"
+          )
+        );
+      });
+
+      it("keeps the bare environment variable as a documented fallback", () => {
+        expect(skill).toMatch(new RegExp(`\\$\\{?${variable}`, "u"));
+        expect(skill).toMatch(/fallback/i);
+      });
+
+      it("states the mutation boundary rather than leaving it implicit", () => {
+        // None of these four expose a mutating operation, so the contract's
+        // guarded-fallback / read-back reconciliation protocol is not engaged
+        // today — but that must be an asserted property, not an accident a
+        // future operation quietly breaks.
+        expect(skill).toMatch(/read-only/i);
+        expect(skill).toMatch(/guarded fallback|reconcil/i);
+      });
+    });
+  });
+});
+
+describe("legacy OS-keychain fallbacks carry a removal date", () => {
+  describe.each(ROOTS)("%s", root => {
+    const contract = read(root, CONTRACT);
+
+    it("publishes one shared removal date in the precedence contract", () => {
+      expect(contract).toMatch(/legacy OS-keychain fallback/i);
+      expect(contract).toContain(KEYCHAIN_REMOVAL_DATE);
+      expect(contract).toMatch(/removal date/i);
+    });
+
+    it.each([ATLASSIAN, NOTION])(
+      "dates the %s keychain fallback",
+      skillName => {
+        const skill = readSkill(root, skillName);
+        expect(skill).toContain(KEYCHAIN_REMOVAL_DATE);
+        expect(skill).toMatch(
+          /keychain[\s\S]{0,600}(removal date|removed on)|(removal date|removed on)[\s\S]{0,600}keychain/i
+        );
+      }
+    );
+  });
+});
+
 describe("integration-access-layer rule reflects the reversed ordering", () => {
   describe.each(ROOTS)("%s", root => {
     const eager = read(root, "rules/eager/integration-access-layer.md");

--- a/tests/unit/strategies/credential-substrate-precedence.test.ts
+++ b/tests/unit/strategies/credential-substrate-precedence.test.ts
@@ -312,6 +312,18 @@ describe("legacy OS-keychain fallbacks carry a removal date", () => {
       expect(contract).toMatch(/removal date/i);
     });
 
+    it("carries the date in the eager summary too, where the ban is stated", () => {
+      // An agent that loads only the eager rule reads "never read an OS keychain
+      // a second time"; the dated exception has to travel with it or the two
+      // surviving rungs look like a contradiction rather than a ramp.
+      const eager = read(
+        root,
+        "rules/eager/credential-substrate-precedence.md"
+      );
+      expect(eager).toContain(KEYCHAIN_REMOVAL_DATE);
+      expect(eager).toMatch(/removal date/i);
+    });
+
     it.each([ATLASSIAN, NOTION])(
       "dates the %s keychain fallback",
       skillName => {


### PR DESCRIPTION
Two follow-ups from the 2026-08-12 improvement-notes program, both closing gaps that were invisible rather than broken.

## #2438 — four access layers had no provider rung

`lisa-sentry-access`, `lisa-posthog-access`, `lisa-jam-access`, and `lisa-sonarcloud-access` each read a bare environment variable and stopped there. A project keeping its credentials in Bitwarden, Doppler, or AWS therefore had **no tier 1 path at all**: access silently resolved through the interactive MCP, which is dead in cron, CI, and cloud sessions — the exact divergence `credential-substrate-precedence` (PR #2451) exists to remove. Same shape as the `lisa-linear-access` gap fixed in #2437, which is why `/lisa:setup:linear` had nowhere to migrate its keychain read to.

Each now resolves through the `lisa-secrets-access` chokepoint first, with the bare variable as a documented fallback, and **cites** the shared contract for the ordering rather than restating it:

| Skill | Credential | Note |
|---|---|---|
| `lisa-sentry-access` | `SENTRY_AUTH_TOKEN` | tier 1a `sentry-cli` authenticates from the same resolved token |
| `lisa-posthog-access` | `POSTHOG_PERSONAL_API_KEY` | resolved once in `posthog_api` |
| `lisa-jam-access` | `JAM_PAT` | PAT moves off argv onto a pipe (process table exposure) |
| `lisa-sonarcloud-access` | `SONARQUBE_CLI_TOKEN` / `_ORG` | in-process export, reusing the search order `sonar-secrets.sh` already proved |

**Writes:** none of the four expose a mutating operation — all are reads (PostHog's `query` is a POST that reads). So the contract's guarded-fallback / read-back reconciliation boundary is **not engaged today**, and each skill now says so explicitly, with the rule that any future write must reconcile by read-back before any retry. That is asserted in the suite, so a mutating operation cannot inherit read semantics by accident.

**Keychain removal date:** the legacy OS-keychain rungs in `lisa-atlassian-access` and `lisa-notion-access` stop being permanent exemptions. One shared date — **2026-11-01** — published in the contract (eager + reference) and cited at both call sites, with the migration step named and a ban on new keychain rungs.

## #2435 — doctor now reports an unregistered merge driver

`.gitattributes` ships the `merge=lisa-learnings` mapping to every clone; the driver command is machine-local because git refuses to run a command a repository supplied. A clone that never ran apply therefore uses git's built-in text merge for the ledger — mild (it leaves conflict markers, which the budget gate diagnoses) but completely silent, and silence is what let the original incident destroy 19 captured learnings.

`lisa doctor` now **warns, never fails**, when the ledger is mapped and no command is registered, quoting `merge.lisa-learnings.driver`, the repair (`lisa install-merge-driver`), and the degradation prevented. The genuinely fine states each name themselves instead of sharing one opaque "skipped": opted out via `learnings.mergeDriver: false`, outside a git repository, or nothing mapped.

It sits **immediately after "Single learnings ledger?"** — deliberate on both sides: both resolve the configured ledger path the instruction-files check may have just relocated, and an operator wants to know which ledger is canonical before learning whether its union merge works here.

Registration is probed scope-agnostically (`git config --get`, not `--local`, since git honours any scope), and the mapping is resolved by asking `git check-attr` rather than parsing `.gitattributes`, whose answer depends on pattern precedence and on attribute sources outside that file.

## Evidence

- TDD: RED commit pins all assertions first (24 + 7 failures), GREEN commits close them.
- `bun run test` — 613 files, 10736 tests passed.
- `bun run typecheck`, `bun run lint` — clean.
- Pre-push integration suite — 22 files, 242 tests passed.
- Plugin fanout rebuilt (`build:plugins`) and `build:upstream-evidence-manifest` regenerated in the same commits.

Delivers CodySwannGT/lisa#2438 and CodySwannGT/lisa#2435 (both closed by hand after merge; the `Closes` keyword does not fire in this repo).

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2423
