### PR TITLE
fix(ci): run the skipped-required-check guard, and report a spaced skip_jobs token

### DIFF
--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -43,7 +43,22 @@ on:
         type: string
         default: 'test'
       skip_jobs:
-        description: 'Comma-separated list of jobs to skip (lint, security, test, mutation, code_quality, secret_scanning, sg_scan, learnings_budget, threshold_ratchet, work_item_traceability, license_compliance, zap_baseline)'
+        # ⚠️ NO SPACES. Each token is matched exactly, as `,<token>,` inside
+        # `format(',{0},', inputs.skip_jobs)`. GitHub Actions expression syntax
+        # has no string-replace function — the available string functions are
+        # contains/startsWith/endsWith/format/join/toJSON/fromJSON/hashFiles —
+        # so this workflow cannot trim for you. `'test, mutation'` yields the
+        # token `" mutation"`, which matches nothing, and the job RUNS. That
+        # fails closed, so nothing unverified ships; it just silently does not
+        # do what you asked.
+        #
+        # The list below was itself written with spaces until #2427, which is
+        # how easy this is to get wrong. Rails projects do not ship
+        # `scripts/check-skipped-required-checks.mjs` (it is a TypeScript-stack
+        # copy-overwrite file), so unlike quality.yml there is no
+        # `🔒 Skipped Required Checks` job here to report a spaced token — on
+        # this workflow the constraint is documentation only.
+        description: 'Comma-separated list of jobs to skip, with NO SPACES — tokens are matched exactly, so `test, mutation` silently skips nothing. (lint,security,test,mutation,code_quality,secret_scanning,sg_scan,learnings_budget,threshold_ratchet,work_item_traceability,license_compliance,zap_baseline)'
         required: false
         type: string
         default: ''

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -55,7 +55,17 @@ on:
         default: 'npm'
         type: string
       skip_jobs:
-        description: 'Jobs to skip (comma-separated: lint,lint_slow,typecheck,test,test:unit,test:mutation,test:integration,test:e2e,maestro_e2e,playwright_e2e,e2e_coverage,bdd_coverage,state_classification,learnings_budget,threshold_ratchet,work_item_traceability,format,build,dead_code,sg_scan,floor_collisions,npm_security_scan,zap_baseline,github_issue)'
+        # ⚠️ NO SPACES. Each token is matched exactly, as `,<token>,` inside
+        # `format(',{0},', inputs.skip_jobs)`. GitHub Actions expression syntax
+        # has no string-replace function — the available string functions are
+        # contains/startsWith/endsWith/format/join/toJSON/fromJSON/hashFiles —
+        # so this workflow cannot trim for you. `'test, test:e2e'` yields the
+        # token `" test:e2e"`, which matches nothing, and the job RUNS. That
+        # fails closed, so nothing unverified ships; it just silently does not
+        # do what you asked. `scripts/check-skipped-required-checks.mjs` reports
+        # exactly this as `whitespace_in_skip_token`, and the
+        # `🔒 Skipped Required Checks` job below runs it on every pull request.
+        description: 'Jobs to skip. Comma-separated with NO SPACES — tokens are matched exactly, so `test, test:e2e` silently skips nothing. (lint,lint_slow,typecheck,test,test:unit,test:mutation,test:integration,test:e2e,maestro_e2e,playwright_e2e,e2e_coverage,bdd_coverage,state_classification,learnings_budget,threshold_ratchet,work_item_traceability,skipped_required_checks,format,build,dead_code,sg_scan,floor_collisions,npm_security_scan,zap_baseline,github_issue)'
         required: false
         default: ''
         type: string
@@ -1815,6 +1825,65 @@ jobs:
           include-hidden-files: true
           retention-days: 1
           if-no-files-found: ignore
+
+  # ---------------------------------------------------------------------------
+  # Skipped required checks (#2426)
+  # ---------------------------------------------------------------------------
+  # GitHub counts a SKIPPED required status check as SATISFIED. A job named in
+  # `skip_jobs` still reports a green checkmark against its required context
+  # having run zero steps in zero seconds, so that merge gate can never be red
+  # and therefore can never block anything. Measured twice in this portfolio:
+  # tunnl (TUN-402) and gemini, whose ruleset required
+  # `🔍 Quality Checks / 🎭 Playwright E2E Tests` while its ci.yml skipped it.
+  #
+  # Lisa shipped the guard, the npm scripts and the seeded declaration, but no
+  # workflow ran it — so adopters had to wire it by hand and none did. This job
+  # is that wiring.
+  #
+  # OFFLINE arm on purpose. The `:remote` arm reads the live ruleset over the
+  # network with `gh`, and the enforced pull-request path may not depend on
+  # network or auth: a flaky gate gets skipped, and a skipped gate is the exact
+  # false-green class this check exists to refuse. Two snapshots in one repo
+  # cannot see a ruleset edited in the admin console, so the remote arm runs on
+  # a schedule instead — `.github/workflows/required-checks-drift.yml`, shipped
+  # create-only beside this workflow's caller.
+  #
+  # Both `[ ! -f ]` guards below are load-bearing, and they are why this cannot
+  # redden a repository for a reason unrelated to skipped checks: a project
+  # without the script (non-TypeScript stacks, anything not yet re-applied) or
+  # without the declaration reports a notice and passes. What it will not do is
+  # read nothing and call that a clean bill of health — it says which piece is
+  # missing. Seeded-but-unreviewed repositories are handled a level down, by the
+  # seed's `"enforcement": "warn"`.
+  skipped_required_checks:
+    name: 🔒 Skipped Required Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',skipped_required_checks,') }}
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version: ${{ inputs.node_version }}
+
+      - name: 🔒 Refuse a skip that silences a required check
+        run: |
+          if [ ! -f scripts/check-skipped-required-checks.mjs ]; then
+            echo "scripts/check-skipped-required-checks.mjs not present — project not yet on this template; skipping."
+            exit 0
+          fi
+          if [ ! -f .github/required-checks.json ]; then
+            echo "No .github/required-checks.json — this guard rests on a reviewed snapshot that cannot be derived from the repository. Lisa ships a seed; run \`lisa apply\` to get it. Skipping."
+            exit 0
+          fi
+          node scripts/check-skipped-required-checks.mjs
 
   # Threshold ratchet: quality thresholds may tighten, never weaken. Compares
   # every watched gate file (coverage/e2e/eslint thresholds, stryker break,

--- a/nestjs/create-only/.github/required-checks.json
+++ b/nestjs/create-only/.github/required-checks.json
@@ -1,9 +1,8 @@
 {
   "_readme": [
     "See typescript/create-only/.github/required-checks.json in Lisa for the full rationale. In short: GitHub counts a SKIPPED required status check as SATISFIED, so a `skip_jobs` token that silences a required context makes the merge gate decorative.",
-    "This expo seed declares the three tokens the shipped ci.yml skips. Every one of them is currently NOT ruleset-required, so nothing here is a false green — but the declaration exists so that the day one of them BECOMES required, the guard says so instead of the gate quietly going hollow.",
+    "This nestjs seed declares the three tokens the shipped ci.yml skips. Every one of them is currently NOT ruleset-required, so nothing here is a false green — but the declaration exists so that the day one of them BECOMES required, the guard says so instead of the gate quietly going hollow.",
     "Transcribe `required_contexts` byte for byte from your ruleset and keep it current with `--remote`.",
-    "The nightly-gate context is listed because Lisa ships expo/github-rulesets/nightly-e2e-health.json requiring it on dev. No skip_jobs token silences it today, so nothing is a false green — it is here so that the day one does, the guard says so instead of staying quiet.",
     "Lisa's quality.yml runs the offline arm of this guard on every pull request. This seed ships `\"enforcement\": \"warn\"` because Lisa cannot know which contexts YOUR ruleset requires: findings are reported in the job summary and the build still passes, EXCEPT a proven false green (`skipped_required_check`), which blocks in every mode. Review the findings, then DELETE the `enforcement` key so the guard can block.",
     "`skip_jobs` is matched as an exact comma-delimited token and GitHub Actions expression syntax has no string-replace, so write the list with no spaces: `skip_jobs: 'a,b'`, never `skip_jobs: 'a, b'`. A spaced token matches nothing and the job runs — this guard reports that as `whitespace_in_skip_token`."
   ],
@@ -25,8 +24,7 @@
     "🔍 Quality Checks / 🔒 Security Scan",
     "🔍 Quality Checks / 🧪 Run Unit Tests",
     "🔍 Quality Checks / 🧪 Run Integration Tests",
-    "🔍 Quality Checks / 🔗 Work-Item Traceability",
-    "🌙 Nightly E2E Health / 🌙 Gate"
+    "🔍 Quality Checks / 🔗 Work-Item Traceability"
   ],
   "skip_job_declarations": {
     "test:e2e": {
@@ -34,7 +32,7 @@
         "🔍 Quality Checks / 🧪 Run E2E Tests"
       ],
       "ruleset_required": false,
-      "reason": "A fresh Expo project has no `test:e2e` script. Lisa's quality callee guards each job on script existence, so un-skipping it would produce a real run that succeeds having tested nothing — a worse false green than the skip. Not a required context, so skipping removes a check rather than faking one."
+      "reason": "A NestJS API's end-to-end suite needs a database and a booted app, which the shipped ci.yml does not provision. Lisa's quality callee guards each job on script existence, so un-skipping it without that scaffolding would produce a run that succeeds having tested nothing — a worse false green than the skip. Not a required context, so skipping removes a check rather than faking one."
     },
     "playwright_e2e": {
       "suppressed_contexts": [
@@ -42,14 +40,14 @@
         "🔍 Quality Checks / 🎭 Playwright E2E Tests"
       ],
       "ruleset_required": false,
-      "reason": "Note this ONE token silences TWO jobs. Neither is a required context. Browser e2e is gated by the nightly suite plus `🌙 Nightly E2E Health`, not by a PR-time Playwright run — which is exactly why the old `playwright` ruleset template was deleted: it required a context PRs skip, and GitHub counts skipped as satisfied."
+      "reason": "Note this ONE token silences TWO jobs — the mapping is not a mechanical transform, which is why this file is a reviewed snapshot rather than something derived. Neither is a required context: a headless API has no browser surface for Playwright to drive."
     },
     "zap_baseline": {
       "suppressed_contexts": [
         "🔍 Quality Checks / 🕷️ OWASP ZAP Baseline"
       ],
       "ruleset_required": false,
-      "reason": "DAST needs a deployed target and is run against staging, not on every PR. Not a required context."
+      "reason": "The shipped ci.yml runs ZAP as its own `zap` job against a deployed target after quality passes, not inside the quality callee. Not a required context."
     }
   }
 }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -199,7 +199,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/copy-overwrite/tsconfig.json":
       "c92e2c2c109e8794ee351f634361ef46297f5a0cd606aaf5c19911da836df307",
     "expo/create-only/.github/required-checks.json":
-      "fb2f03ba0c595fab1fdf59b018a38acce0f9b25ba15705bf8af498135eb148b4",
+      "d69d4b9cf275f5e07a090f5763f80bb946435c33627dfe21d261650cfe88851a",
     "expo/create-only/.github/workflows/ci.yml":
       "bf75c9d3b4f4a2cb24c2214d9fc27a9cb2247a6694b0cf02c40032b4d3e87cd9",
     "expo/create-only/.github/workflows/deploy.yml":
@@ -362,6 +362,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "350c18b2c588fd628db8a6e82fc5c0b3ffc8a09f1c89b64d1f530350bc64a9ca",
     "nestjs/create-only/.github/k6/thresholds/strict.json":
       "e121ec72de4596b95c013a8c71f03653bcdf057cf7f8d1fec6f0e13c1381867f",
+    "nestjs/create-only/.github/required-checks.json":
+      "6bbbe6976ec39c516608f69b02a431187d948d63b0b28ab7ad32a052e87ea171",
     "nestjs/create-only/.github/workflows/ci.yml":
       "0985668e6d0478f1993bed8ccd398601d8e73376afd8775e1269ae129418152e",
     "nestjs/create-only/.github/workflows/deploy.yml":
@@ -2251,7 +2253,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/scripts/check-nightly-e2e-health.mjs":
       "c9dd6f6816b35d4d8f684892878d4181b9cb5266a7f2e2814970aa49dc04a001",
     "typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs":
-      "86e9df17ea11fe0cd11d54f7fd60f016338e7fe28cdd4b07fab3b0b064b64ffb",
+      "e4a9d255c74a7ddeac3db5fdf47b5c5f8110f49f63576983d7e4ffe23e4a631b",
     "typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs":
       "e1e3f22b33267212b90f915f83821559d1a45cab5b16c7164b86bd6c7b53549b",
     "typescript/copy-overwrite/scripts/check-verification-coverage.mjs":
@@ -2273,7 +2275,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/vitest.config.ts":
       "da92f06cc3ce68462c6f2f3d95adb1b1464591ce383a24e3334dc986e0c1e0fb",
     "typescript/create-only/.github/required-checks.json":
-      "a490d9d4344bafe8178c6b0b4a9a8a6fff8548ef9cff76ba0562c50040b174ae",
+      "86718597f15cd23527ba32e6490ba2269457a78e18abb257f97bde5076d3dc7d",
     "typescript/create-only/.github/workflows/auto-update-pr-branches-dispatch.yml":
       "347f8a3830efdc3ad701fae0858994f4e45df8100844e91948b017b98115a28c",
     "typescript/create-only/.github/workflows/auto-update-pr-branches.yml":
@@ -2296,6 +2298,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "072cc8290eec15ef6d55c2583e94ae49cda4a56a0fea252556a8fce8170cc540",
     "typescript/create-only/.github/workflows/claude.yml":
       "fd230bf19769a12b1b3afeeeb1d5f51c44338db974c26ff05dc381f0e1ba2382",
+    "typescript/create-only/.github/workflows/required-checks-drift.yml":
+      "ec0d93396043b3d9fe0263a3ffbdc4721b1890020886bd97a09afe779c703adf",
     "typescript/create-only/.gitleaksignore":
       "6927d376648675331801c798a4390b652a22a3e5d350cd26f36d42c10af02d67",
     "typescript/create-only/audit.ignore.local.json":
@@ -2724,6 +2728,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "nestjs/create-only/.github/k6/thresholds/normal.json": true,
     "nestjs/create-only/.github/k6/thresholds/relaxed.json": true,
     "nestjs/create-only/.github/k6/thresholds/strict.json": true,
+    "nestjs/create-only/.github/required-checks.json": true,
     "nestjs/create-only/.github/workflows/ci.yml": true,
     "nestjs/create-only/.github/workflows/deploy.yml": true,
     "nestjs/create-only/.zap/baseline.conf": true,
@@ -8852,6 +8857,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/plugin-sync-workflow.test.ts": true,
     "tests/unit/scripts/security-floors.test.ts": true,
     "tests/unit/scripts/setup-jira-cli-config.test.ts": true,
+    "tests/unit/scripts/skipped-required-checks-wiring.test.ts": true,
     "tests/unit/scripts/skipped-required-checks.test.ts": true,
     "tests/unit/scripts/state-classification.test.ts": true,
     "tests/unit/scripts/threshold-ratchet-gates.test.ts": true,
@@ -9195,6 +9201,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "typescript/create-only/.github/workflows/claude-nightly-test-improvement.yml": true,
     "typescript/create-only/.github/workflows/claude-sync-down-branches.yml": true,
     "typescript/create-only/.github/workflows/claude.yml": true,
+    "typescript/create-only/.github/workflows/required-checks-drift.yml": true,
     "typescript/create-only/.gitleaksignore": true,
     "typescript/create-only/audit.ignore.local.json": true,
     "typescript/create-only/eslint.config.local.ts": true,

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -181,6 +181,118 @@ describe("quality.yml reusable workflow", () => {
         "${{ !contains(format(',{0},', inputs.skip_jobs), ',test:e2e,') }}"
       );
     });
+
+    // #2427: the sentinel-comma idiom matches EXACT bytes, and GitHub Actions
+    // expression syntax has no string-replace function to trim with — the
+    // available string functions are contains/startsWith/endsWith/format/join/
+    // toJSON/fromJSON/hashFiles. So a spaced list cannot be normalized in the
+    // workflow, and the constraint is documented at the input instead. These
+    // cases pin which way the resulting mistake falls: CLOSED, meaning the job
+    // runs and nothing unverified ships. If a future change makes a spaced
+    // token skip MORE than an unspaced one, that is a hole and this fails.
+    describe("whitespace in the skip list (#2427)", () => {
+      const SENTINEL =
+        /!contains\(format\(',\{0\},', inputs\.skip_jobs\), '(?<needle>[^']*)'\)/u;
+
+      /**
+       * Evaluates a job's shipped `if:` the way GitHub Actions would.
+       *
+       * Derived from the workflow's own expression rather than re-implemented,
+       * so the test cannot drift away from what actually ships.
+       *
+       * @param job Parsed workflow job.
+       * @param skipJobs The `skip_jobs` input value a caller passed.
+       * @returns True when the job would RUN.
+       */
+      function jobRuns(
+        job: WorkflowJob | undefined,
+        skipJobs: string
+      ): boolean {
+        const needle = SENTINEL.exec(job?.if ?? "")?.groups?.needle;
+        if (needle === undefined) {
+          throw new Error(`no sentinel-comma guard in: ${String(job?.if)}`);
+        }
+        return !`,${skipJobs},`.includes(needle);
+      }
+
+      it("'test,test:e2e' — written correctly, skips both", () => {
+        expect(jobRuns(workflow.jobs.test, "test,test:e2e")).toBe(false);
+        expect(jobRuns(workflow.jobs.test_e2e, "test,test:e2e")).toBe(false);
+      });
+
+      it("'test, test:e2e' — the space makes test:e2e RUN anyway (fails closed)", () => {
+        expect(jobRuns(workflow.jobs.test, "test, test:e2e")).toBe(false);
+        expect(jobRuns(workflow.jobs.test_e2e, "test, test:e2e")).toBe(true);
+      });
+
+      it("' test ' — padded on both sides, skips nothing at all", () => {
+        expect(jobRuns(workflow.jobs.test, " test ")).toBe(true);
+        expect(jobRuns(workflow.jobs.lint, " test ")).toBe(true);
+      });
+
+      it("documents the constraint at the input, in both workflows", () => {
+        // The fix that cannot be written in expression syntax has to be
+        // written where the operator types the value.
+        for (const parsed of [workflow, railsWorkflow]) {
+          expect(
+            parsed.on.workflow_call?.inputs?.skip_jobs?.description
+          ).toMatch(/NO SPACES/u);
+        }
+      });
+    });
+  });
+
+  // #2426: Lisa shipped the guard, the npm scripts and a seeded declaration,
+  // but no workflow ran it — so adopters had to wire it by hand and none did.
+  describe("the skipped-required-check guard is actually invoked", () => {
+    it("runs the OFFLINE arm as a job on every pull request", () => {
+      const job = workflow.jobs.skipped_required_checks;
+      expect(job).toBeDefined();
+      expect(job?.if).toBe(
+        "${{ !contains(format(',{0},', inputs.skip_jobs), ',skipped_required_checks,') }}"
+      );
+      const run = job?.steps?.map(step => step.run ?? "").join("\n") ?? "";
+      expect(run).toContain("node scripts/check-skipped-required-checks.mjs");
+      // The enforced pull-request path may not depend on network or `gh` auth:
+      // a flaky gate gets skipped, and a skipped gate is the false-green class
+      // this guard exists to refuse. The remote arm runs on a schedule instead.
+      expect(run).not.toContain("--remote");
+    });
+
+    it("passes rather than reddens when the script or the snapshot is absent", () => {
+      const run =
+        workflow.jobs.skipped_required_checks?.steps
+          ?.map(step => step.run ?? "")
+          .join("\n") ?? "";
+      expect(run).toContain(
+        "[ ! -f scripts/check-skipped-required-checks.mjs ]"
+      );
+      expect(run).toContain("[ ! -f .github/required-checks.json ]");
+    });
+
+    it("runs the REMOTE arm on a schedule, because offline snapshots rot", () => {
+      const drift = yaml.load(
+        fs.readFileSync(
+          path.join(
+            REPO_ROOT,
+            "typescript",
+            CREATE_ONLY_DIR,
+            ...GITHUB_WORKFLOWS_PARTS,
+            "required-checks-drift.yml"
+          ),
+          "utf8"
+        )
+      ) as { on?: Record<string, unknown>; jobs?: Record<string, WorkflowJob> };
+      expect(drift.on).toHaveProperty("schedule");
+      // Never on pull_request: a network-dependent check must not be able to
+      // wedge a merge.
+      expect(drift.on).not.toHaveProperty("pull_request");
+      const run =
+        drift.jobs?.drift?.steps?.map(step => step.run ?? "").join("\n") ?? "";
+      expect(run).toContain(
+        "node scripts/check-skipped-required-checks.mjs --remote"
+      );
+    });
   });
 
   describe("template skip_jobs defaults", () => {

--- a/tests/unit/scripts/skipped-required-checks-wiring.test.ts
+++ b/tests/unit/scripts/skipped-required-checks-wiring.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for the two properties that let the skipped-required-check guard be
+ * WIRED INTO A SHIPPED WORKFLOW rather than left for adopters to invoke by hand.
+ *
+ * Sibling of `skipped-required-checks.test.ts`, which covers the guard's
+ * coherence rules; these cover what changes once it runs unattended in every
+ * repository:
+ *
+ *  - `enforcement` (#2426) — the adoption ramp. A seed cannot know which
+ *    contexts a given repository's ruleset requires, so a seeded-but-unreviewed
+ *    repo must be able to report findings without going red on the day Lisa
+ *    installs the job. A gate that reddens a repository on arrival gets
+ *    deleted, not fixed.
+ *  - `whitespace_in_skip_token` (#2427) — GitHub Actions expression syntax has
+ *    no string-replace, so `skip_jobs: 'test, test:e2e'` cannot be normalized
+ *    in the workflow. It fails CLOSED (the job runs), so nothing unverified
+ *    ships — but the skip silently did not happen, and until the guard ran in
+ *    CI nothing anywhere could say so.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SCRIPT_REL =
+  "typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs";
+const CI_WORKFLOW = ".github/workflows/ci.yml";
+const REQUIRED = "🔍 Quality Checks / 🧪 Run E2E Tests";
+
+/** One violation. */
+interface Violation {
+  readonly kind: string;
+  readonly token: string | null;
+  readonly message: string;
+}
+
+/** What the guard exports, as this suite consumes it. */
+interface GuardModule {
+  readonly VIOLATIONS: Record<string, string>;
+  readSkipJobs(
+    contents: string,
+    sourcePath: string,
+    options?: { preserveWhitespace?: boolean }
+  ): string[];
+  loadDeclaration(rootDir: string): Record<string, unknown>;
+  collectSkipJobTokens(
+    rootDir: string,
+    workflows: readonly string[]
+  ): { tokens: string[]; violations: Violation[] };
+  runGuard(argv: readonly string[]): {
+    violations: Violation[];
+    enforcement: string;
+  };
+}
+
+/**
+ * Creates a throwaway repository with a `.github/workflows` directory.
+ *
+ * @param prefix - Temp-directory prefix
+ * @returns The repository root
+ */
+function emptyRepo(prefix: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  fs.mkdirSync(path.join(root, ".github", "workflows"), { recursive: true });
+  return root;
+}
+
+describe("check-skipped-required-checks, as a shipped CI job", () => {
+  let mod: GuardModule;
+
+  beforeAll(async () => {
+    mod = (await import(
+      pathToFileURL(path.join(REPO_ROOT, SCRIPT_REL)).href
+    )) as unknown as GuardModule;
+  });
+
+  describe("a skip token written with whitespace (#2427)", () => {
+    /**
+     * Builds a repo whose ci.yml carries one `skip_jobs` value.
+     *
+     * @param value - The raw scalar to write after `skip_jobs:`
+     * @returns The repo root
+     */
+    const repoSkipping = (value: string): string => {
+      const root = emptyRepo("skipreq-ws-");
+      fs.writeFileSync(
+        path.join(root, CI_WORKFLOW.replace(/\//gu, path.sep)),
+        ["jobs:", "  quality:", "    with:", `      skip_jobs: ${value}`].join(
+          "\n"
+        )
+      );
+      return root;
+    };
+
+    it("reads tokens EXACTLY as written when asked to preserve whitespace", () => {
+      // Trimming is what erases the evidence: once normalized, a spaced token
+      // looks identical to a correctly written one.
+      expect(
+        mod.readSkipJobs("      skip_jobs: 'test, test:e2e'", "w.yml", {
+          preserveWhitespace: true,
+        })
+      ).toEqual(["test", " test:e2e"]);
+    });
+
+    it("reports `test, test:e2e` — the space makes the token match NOTHING", () => {
+      const collected = mod.collectSkipJobTokens(
+        repoSkipping("'test, test:e2e'"),
+        [CI_WORKFLOW]
+      );
+      expect(collected.violations.map(violation => violation.kind)).toEqual([
+        mod.VIOLATIONS.whitespace,
+      ]);
+      expect(collected.violations[0].token).toBe("test:e2e");
+      expect(collected.violations[0].message).toContain("fails closed");
+    });
+
+    it("reports a lone ` test ` padded on both sides", () => {
+      const collected = mod.collectSkipJobTokens(repoSkipping("' test '"), [
+        CI_WORKFLOW,
+      ]);
+      expect(collected.violations.map(violation => violation.kind)).toEqual([
+        mod.VIOLATIONS.whitespace,
+      ]);
+      expect(collected.violations[0].token).toBe("test");
+    });
+
+    it("still carries the TRIMMED token forward — over-report, never under-report", () => {
+      // The job is not actually skipped, so this over-reports. That is the safe
+      // direction, and the whitespace violation beside it explains why the
+      // token showed up at all.
+      expect(
+        mod.collectSkipJobTokens(repoSkipping("'test, test:e2e'"), [
+          CI_WORKFLOW,
+        ]).tokens
+      ).toEqual(["test", "test:e2e"]);
+    });
+
+    it("says nothing about a correctly written list", () => {
+      const collected = mod.collectSkipJobTokens(
+        repoSkipping("'test,test:e2e'"),
+        [CI_WORKFLOW]
+      );
+      expect(collected.violations).toEqual([]);
+      expect(collected.tokens).toEqual(["test", "test:e2e"]);
+    });
+  });
+
+  describe("`enforcement`, the adoption ramp (#2426)", () => {
+    /**
+     * Writes a declaration carrying one `enforcement` value.
+     *
+     * @param enforcement - The value to write, or undefined to omit the key
+     * @returns The repo root
+     */
+    const repoDeclaring = (enforcement?: unknown): string => {
+      const root = emptyRepo("skipreq-mode-");
+      fs.writeFileSync(
+        path.join(root, CI_WORKFLOW.replace(/\//gu, path.sep)),
+        "      skip_jobs: ''"
+      );
+      fs.writeFileSync(
+        path.join(root, ".github", "required-checks.json"),
+        JSON.stringify({
+          ...(enforcement === undefined ? {} : { enforcement }),
+          required_contexts: [REQUIRED],
+          workflows: [CI_WORKFLOW],
+          skip_job_declarations: {},
+        })
+      );
+      return root;
+    };
+
+    it("ENFORCES when the key is absent — a hand-written declaration is an opt-in", () => {
+      expect(mod.runGuard([repoDeclaring()]).enforcement).toBe("error");
+    });
+
+    it("carries `warn` through so the caller can downgrade its findings", () => {
+      expect(mod.runGuard([repoDeclaring("warn")]).enforcement).toBe("warn");
+    });
+
+    it("REFUSES an unrecognised mode rather than silently enforcing or not", () => {
+      // A typo that quietly downgrades this guard to advice is the fail-open
+      // shape the whole file exists to refuse.
+      expect(() => mod.loadDeclaration(repoDeclaring("warning"))).toThrow(
+        /`enforcement` must be one of/u
+      );
+    });
+  });
+});

--- a/tests/unit/scripts/skipped-required-checks.test.ts
+++ b/tests/unit/scripts/skipped-required-checks.test.ts
@@ -49,7 +49,6 @@ interface GuardModule {
     snapshot: readonly string[],
     live: readonly string[]
   ): Violation[];
-  runGuard(argv: readonly string[]): { violations: Violation[] };
 }
 
 const REQUIRED = "🔍 Quality Checks / 🧪 Run E2E Tests";
@@ -336,6 +335,7 @@ describe("check-skipped-required-checks", () => {
   describe("the shipped seeds are coherent against the shipped ci.yml templates", () => {
     it.each([
       ["expo", "expo/create-only", "expo/create-only"],
+      ["nestjs", "nestjs/create-only", "nestjs/create-only"],
       ["typescript", "typescript/create-only", "typescript/create-only"],
     ])(
       "%s: its required-checks.json declares every token its ci.yml skips",

--- a/typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs
+++ b/typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs
@@ -11,6 +11,28 @@
  * Usage:
  *   node scripts/check-skipped-required-checks.mjs [rootDir] [--remote] [--json]
  *
+ * ## Where this runs
+ *
+ * Lisa's `quality.yml` runs the OFFLINE arm on every pull request, and the
+ * shipped `required-checks-drift.yml` runs `--remote` on a weekly schedule.
+ * That split is deliberate and is argued under "Why this is a DECLARATION
+ * guard" below: the enforced PR path may not depend on network or `gh` auth,
+ * and the snapshot it enforces may not be allowed to rot unwatched.
+ *
+ * ## `enforcement`
+ *
+ * A declaration may set `"enforcement": "warn"` to report violations without
+ * failing the build. The seeds Lisa ships start there ON PURPOSE: a seed cannot
+ * know which contexts a given repository's ruleset requires, so a seeded repo
+ * that has never been reviewed would otherwise go red on its first Lisa update
+ * for skips that may be entirely legitimate — and a gate that reddens a
+ * repository the day it arrives gets deleted, not fixed. Absent the key the
+ * guard ENFORCES: a declaration somebody hand-wrote is an opt-in.
+ *
+ * `warn` is a ramp, not a licence: `skipped_required_check` — the repository's
+ * own declaration stating that a token it really skips silences a context its
+ * ruleset really requires — blocks in every mode.
+ *
  * ## Why this exists
  *
  * **GitHub counts a `skipped` required status check as SATISFIED.** A job named
@@ -110,7 +132,31 @@ export const VIOLATIONS = Object.freeze({
   orphaned: "orphaned_exemption",
   badExemption: "exemption_without_valid_ticket",
   remoteDrift: "ruleset_snapshot_drift",
+  whitespace: "whitespace_in_skip_token",
 });
+
+/** Enforcement modes a declaration may select. */
+const ENFORCEMENT_MODES = Object.freeze(["error", "warn"]);
+
+/**
+ * Violation kinds that block even under `"enforcement": "warn"`.
+ *
+ * `warn` is an ADOPTION RAMP for hygiene findings — an undeclared token, a
+ * snapshot that has drifted from the code — in a repository nobody has reviewed
+ * yet. It is not a licence for a PROVEN false green. Reaching
+ * `skipped_required_check` requires the repository's own declaration to say
+ * both that a context is ruleset-required AND that a token it actually skips
+ * silences it; that is a reviewed state, and shipping past it is the exact
+ * defect this file exists to refuse.
+ *
+ * `ruleset_snapshot_drift` blocks for the same reason: it only fires under an
+ * explicit `--remote` on a repository that filled in its ruleset ids, and it is
+ * measured against live truth rather than inferred from a seed.
+ */
+const ALWAYS_BLOCKING = Object.freeze([
+  VIOLATIONS.suppressesRequired,
+  VIOLATIONS.remoteDrift,
+]);
 
 /**
  * True when a line is a whole-line YAML comment.
@@ -170,13 +216,25 @@ export function unquoteScalar(rawValue) {
 /**
  * Splits a comma list into unique, non-empty tokens.
  *
+ * `preserveWhitespace` keeps each token EXACTLY as written, which is the only
+ * way to see the defect in `skip_jobs: 'test, test:e2e'`. GitHub Actions has no
+ * string-replace in expression syntax, so the sentinel-comma idiom
+ * (`contains(format(',{0},', inputs.skip_jobs), ',test:e2e,')`) compares raw
+ * bytes: the token there is `" test:e2e"`, which never matches `,test:e2e,` and
+ * the job runs. That fails CLOSED, so it is a papercut rather than a hole — but
+ * it silently does not do what the operator asked, and nothing else in the
+ * pipeline can see it, because by the time the guard has trimmed it looks
+ * identical to a correctly written skip.
+ *
  * @param {string} commaList - Tokens joined by commas
+ * @param {boolean} [preserveWhitespace] - Return tokens exactly as written
  * @returns {string[]} Unique tokens in first-seen order
  */
-function tokenize(commaList) {
+function tokenize(commaList, preserveWhitespace = false) {
   const out = [];
-  for (const token of commaList.split(",").map(part => part.trim())) {
-    if (token !== "" && !out.includes(token)) out.push(token);
+  for (const part of commaList.split(",")) {
+    const token = preserveWhitespace ? part : part.trim();
+    if (token.trim() !== "" && !out.includes(token)) out.push(token);
   }
   return out;
 }
@@ -195,10 +253,12 @@ function tokenize(commaList) {
  * @param {string} contents - Full text of a workflow file
  * @param {string} sourcePath - Repo-relative path, used only to name the file in
  *   a throw. Never an absolute path.
+ * @param {{preserveWhitespace?: boolean}} [options] - `preserveWhitespace`
+ *   returns each token exactly as written instead of trimmed
  * @returns {string[]} Every declared skip token, de-duplicated
  * @throws {Error} When a `skip_jobs` key is not an inline scalar
  */
-export function readSkipJobs(contents, sourcePath) {
+export function readSkipJobs(contents, sourcePath, options = {}) {
   const all = [];
   contents.split("\n").forEach((line, index) => {
     if (isCommentLine(line)) return;
@@ -224,7 +284,7 @@ export function readSkipJobs(contents, sourcePath) {
             .map(found => found[1])
             .join(",");
 
-    for (const token of tokenize(source)) {
+    for (const token of tokenize(source, options.preserveWhitespace === true)) {
       if (!all.includes(token)) all.push(token);
     }
   });
@@ -270,6 +330,14 @@ export function loadDeclaration(rootDir) {
       `check-skipped-required-checks: \`workflows\` must list at least one workflow file whose \`skip_jobs\` this guard reads.`
     );
   }
+  if (
+    declaration.enforcement !== undefined &&
+    !ENFORCEMENT_MODES.includes(declaration.enforcement)
+  ) {
+    throw new Error(
+      `check-skipped-required-checks: \`enforcement\` must be one of ${ENFORCEMENT_MODES.map(mode => `"${mode}"`).join(", ")}, not ${JSON.stringify(declaration.enforcement)}. Omit it to enforce — a typo silently downgrading this guard to advice is the fail-open shape it exists to refuse.`
+    );
+  }
 
   // Validate the SHAPE of every declaration, not just its presence. A truthy
   // non-object entry (`"test:e2e": true`, or a string) reads as "declared" at
@@ -308,14 +376,21 @@ export function loadDeclaration(rootDir) {
  * guard that silently reads nothing reports a clean bill of health for a
  * repository it never looked at.
  *
+ * A token written with surrounding whitespace is reported HERE rather than
+ * downstream, because trimming has already erased the evidence by the time the
+ * coherence rules run. The trimmed form is still carried into the evaluation:
+ * over-reporting a skip that does not actually happen is the safe direction,
+ * and the whitespace violation beside it explains why the token appeared.
+ *
  * @param {string} rootDir - Repository root
  * @param {ReadonlyArray<string>} workflows - Repo-relative workflow paths
- * @returns {{tokens: string[], sources: Record<string, string[]>}} Tokens and where each came from
+ * @returns {{tokens: string[], sources: Record<string, string[]>, violations: object[]}} Tokens, where each came from, and how each was written
  */
 export function collectSkipJobTokens(rootDir, workflows) {
   const tokens = [];
   /** @type {Record<string, string[]>} */
   const sources = {};
+  const violations = [];
   for (const relative of workflows) {
     const path = resolve(rootDir, relative);
     if (!existsSync(path)) {
@@ -323,12 +398,23 @@ export function collectSkipJobTokens(rootDir, workflows) {
         `check-skipped-required-checks: \`workflows\` names ${relative}, which does not exist. A guard that reads nothing reports a clean bill of health for a repository it never looked at.`
       );
     }
-    for (const token of readSkipJobs(readFileSync(path, "utf8"), relative)) {
+    const contents = readFileSync(path, "utf8");
+    for (const token of readSkipJobs(contents, relative)) {
       if (!tokens.includes(token)) tokens.push(token);
       sources[token] = [...(sources[token] ?? []), relative];
     }
+    for (const raw of readSkipJobs(contents, relative, {
+      preserveWhitespace: true,
+    })) {
+      if (raw === raw.trim()) continue;
+      violations.push({
+        kind: VIOLATIONS.whitespace,
+        token: raw.trim(),
+        message: `\`skip_jobs\` in ${relative} lists ${JSON.stringify(raw)} — the token carries whitespace. GitHub Actions expression syntax has no string-replace, so \`skip_jobs\` is matched as an exact comma-delimited token and the surrounding space makes it match NOTHING: the job runs as if you had never listed it. That fails closed, so nothing unverified ships — but the skip you asked for silently did not happen. Write the list with no spaces: \`skip_jobs: 'a,b'\`, never \`skip_jobs: 'a, b'\`.`,
+      });
+    }
   }
-  return { tokens, sources };
+  return { tokens, sources, violations };
 }
 
 /**
@@ -491,15 +577,15 @@ export function compareRulesetBaseline(snapshot, live) {
  * Runs the guard.
  *
  * @param {ReadonlyArray<string>} argv - CLI arguments
- * @returns {{violations: object[], checked: number, tokens: string[]}} The result
+ * @returns {{violations: object[], checked: number, tokens: string[], enforcement: string}} The result
  */
 export function runGuard(argv) {
   const positional = argv.filter(arg => !arg.startsWith("--"));
   const rootDir = positional[0] ?? process.cwd();
   const declaration = loadDeclaration(rootDir);
-  const { tokens } = collectSkipJobTokens(rootDir, declaration.workflows);
-  const result = evaluateSkippedRequiredChecks(declaration, tokens);
-  const violations = [...result.violations];
+  const collected = collectSkipJobTokens(rootDir, declaration.workflows);
+  const result = evaluateSkippedRequiredChecks(declaration, collected.tokens);
+  const violations = [...collected.violations, ...result.violations];
   if (argv.includes("--remote")) {
     violations.push(
       ...compareRulesetBaseline(
@@ -508,7 +594,12 @@ export function runGuard(argv) {
       )
     );
   }
-  return { violations, checked: result.checked, tokens };
+  return {
+    violations,
+    checked: result.checked,
+    tokens: collected.tokens,
+    enforcement: declaration.enforcement ?? "error",
+  };
 }
 
 /**
@@ -518,7 +609,7 @@ export function runGuard(argv) {
  * @returns {void}
  */
 function main(argv) {
-  /** @type {{violations: object[], checked: number, tokens: string[]}} */
+  /** @type {{violations: object[], checked: number, tokens: string[], enforcement: string}} */
   let result;
   try {
     result = runGuard(argv);
@@ -545,6 +636,16 @@ function main(argv) {
     return;
   }
 
+  const warnOnly = result.enforcement === "warn";
+  /**
+   * True when a violation still fails the build under the active mode.
+   *
+   * @param {{kind: string}} violation - One violation
+   * @returns {boolean} True when it blocks
+   */
+  const blocks = violation =>
+    !warnOnly || ALWAYS_BLOCKING.includes(violation.kind);
+  const blocking = result.violations.filter(blocks);
   const lines = ["## 🔒 Skipped required checks", ""];
   if (result.violations.length === 0) {
     lines.push(
@@ -552,13 +653,19 @@ function main(argv) {
     );
   } else {
     lines.push(
-      `❌ ${result.violations.length} violation(s) across ${result.checked} \`skip_jobs\` token(s):`,
+      `${blocking.length > 0 ? "❌" : "⚠️"} ${result.violations.length} violation(s) across ${result.checked} \`skip_jobs\` token(s):`,
       ""
     );
     for (const violation of result.violations) {
       lines.push(`- **${violation.kind}** — ${violation.message}`);
       process.stderr.write(
-        `::error title=${violation.kind}::${violation.message.split("\n")[0]}\n`
+        `::${blocks(violation) ? "error" : "warning"} title=${violation.kind}::${violation.message.split("\n")[0]}\n`
+      );
+    }
+    if (warnOnly) {
+      lines.push(
+        "",
+        `This declaration sets \`"enforcement": "warn"\`, so everything above except a proven false green (\`${VIOLATIONS.suppressesRequired}\`) is reported without failing the build. Review each finding, fix or declare it, then delete the \`enforcement\` key so this guard can block.`
       );
     }
   }
@@ -569,7 +676,7 @@ function main(argv) {
       appendFileSync(process.env.GITHUB_STEP_SUMMARY, report);
     });
   }
-  if (result.violations.length > 0) process.exitCode = 1;
+  if (blocking.length > 0) process.exitCode = 1;
 }
 
 if (

--- a/typescript/create-only/.github/required-checks.json
+++ b/typescript/create-only/.github/required-checks.json
@@ -5,8 +5,11 @@
     "Why it matters: GitHub counts a SKIPPED required status check as SATISFIED. A job named in `skip_jobs` still reports green against its required context having run zero steps, so the merge gate can never be red and therefore can never block anything.",
     "Transcribe `required_contexts` BYTE FOR BYTE from the ruleset, emoji and the ' / ' separator included. The guard compares with exact string equality on purpose: a repo routinely carries confusable pairs (an external app's required `SonarCloud Code Analysis` beside a skippable, not-required `SonarCloud SAST`; `Run Tests` beside `Run Unit Tests`), and a fuzzy match would raise a false alarm whose obvious fix is to delete the guard.",
     "Run `node scripts/check-skipped-required-checks.mjs --remote` periodically: two snapshots in one repo can only catch each other drifting from the CODE, never from a ruleset edited in the console.",
-    "Fill in `ruleset.repo` / `ruleset.ids` before --remote can work. Find the ids with: gh api repos/OWNER/NAME/rulesets --jq '.[] | \"\\(.id) \\(.name)\"'"
+    "Fill in `ruleset.repo` / `ruleset.ids` before --remote can work. Find the ids with: gh api repos/OWNER/NAME/rulesets --jq '.[] | \"\\(.id) \\(.name)\"'. Once they are filled in, the shipped `.github/workflows/required-checks-drift.yml` runs --remote weekly; until then it reports UNCONFIGURED and passes.",
+    "Lisa's quality.yml runs the offline arm of this guard on every pull request. This seed ships `\"enforcement\": \"warn\"` because Lisa cannot know which contexts YOUR ruleset requires: findings are reported in the job summary and the build still passes, EXCEPT a proven false green (`skipped_required_check`), which blocks in every mode. Review the findings, then DELETE the `enforcement` key so the guard can block.",
+    "`skip_jobs` is matched as an exact comma-delimited token and GitHub Actions expression syntax has no string-replace, so write the list with no spaces: `skip_jobs: 'a,b'`, never `skip_jobs: 'a, b'`. A spaced token matches nothing and the job runs — this guard reports that as `whitespace_in_skip_token`."
   ],
+  "enforcement": "warn",
   "ruleset": {
     "repo": "",
     "ids": [],

--- a/typescript/create-only/.github/workflows/required-checks-drift.yml
+++ b/typescript/create-only/.github/workflows/required-checks-drift.yml
@@ -1,0 +1,77 @@
+# This file was created by Lisa and is yours to edit.
+# -----------------------------------------------------------------------------
+# Required-checks snapshot drift — the REMOTE arm (#2426)
+# -----------------------------------------------------------------------------
+# `.github/required-checks.json` holds two reviewed snapshots that police each
+# other: the contexts your ruleset requires, and what each `skip_jobs` token
+# silences. Two snapshots inside one repository can only catch each other
+# drifting from the CODE. Neither can see the RULESET change, because rulesets
+# are edited in an admin console — which is exactly how one repo's list went
+# from ten required contexts to eleven with every test still green for a day.
+#
+# So this runs the `--remote` arm on a schedule, and the pull-request path stays
+# offline. That split is the whole design: an enforced gate that needed network
+# and `gh` auth on every run would flake, and a flaky gate gets skipped — which
+# reintroduces the false-green class the guard exists to refuse. This workflow
+# never runs on `pull_request`, so it cannot wedge a merge.
+#
+# Reading a repository ruleset needs a token with administration:read. The
+# default GITHUB_TOKEN generally does not have it, so provide a PAT as the
+# repository secret RULESET_READ_TOKEN. Without it this job goes red rather
+# than reporting a clean bill of health it never checked.
+#
+# Until `ruleset.repo` / `ruleset.ids` are filled in, this reports UNCONFIGURED
+# and passes. Find the ids with:
+#   gh api repos/OWNER/NAME/rulesets --jq '.[] | "\(.id) \(.name)"'
+
+name: 🔒 Required-Checks Drift
+
+on:
+  schedule:
+    # Weekly. A ruleset can be edited in the admin console on a day nobody
+    # touched the repository, so change-triggered checking alone would miss it.
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    name: 🔒 Ruleset snapshot vs live ruleset
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version: '22.21.1'
+
+      - name: 🔒 Compare the committed snapshot against the live ruleset
+        env:
+          GH_TOKEN: ${{ secrets.RULESET_READ_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          if [ ! -f scripts/check-skipped-required-checks.mjs ]; then
+            echo "scripts/check-skipped-required-checks.mjs not present — project not yet on this template; skipping."
+            exit 0
+          fi
+          if [ ! -f .github/required-checks.json ]; then
+            echo "No .github/required-checks.json — nothing to compare. Lisa ships a seed; run \`lisa apply\` to get it."
+            exit 0
+          fi
+          configured="$(node -e "const d=require('./.github/required-checks.json');process.stdout.write(String(Boolean(d.ruleset&&d.ruleset.repo&&Array.isArray(d.ruleset.ids)&&d.ruleset.ids.length)))")"
+          if [ "$configured" != "true" ]; then
+            echo "UNCONFIGURED: .github/required-checks.json has no \`ruleset.repo\` / \`ruleset.ids\`, so drift cannot be checked."
+            echo "Fill them in to arm this: gh api repos/OWNER/NAME/rulesets --jq '.[] | \"\\(.id) \\(.name)\"'"
+            echo "::warning title=Required-checks drift UNCHECKED::Fill in ruleset.repo and ruleset.ids in .github/required-checks.json to arm the remote drift check."
+            exit 0
+          fi
+          node scripts/check-skipped-required-checks.mjs --remote


### PR DESCRIPTION
Fixes two related CI-gate defects. Work-Item: CodySwannGT/lisa#2426 (and CodySwannGT/lisa#2427).

## #2426 — a shipped guard that nothing invoked

`typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs`, its npm scripts, its seeded declaration and its test suite all shipped — and no workflow ran any of it. Adopters had to wire it by hand, and none did; tunnlai built its own equivalent (TUN-402) because nothing surfaced the class.

**Wiring: `quality.yml` gains `🔒 Skipped Required Checks`, running the OFFLINE arm on every pull request.**

Offline is the deliberate choice for the enforced path. The `:remote` arm reads the live ruleset over the network with `gh`; a gate that needs network and auth on every run flakes, a flaky gate gets skipped, and a skipped gate is *precisely* the false-green class this guard exists to refuse. The script's own header already argued this — the wiring now honours it.

**Rot is handled separately, on a schedule.** Two snapshots inside one repository can only catch each other drifting from the *code*; neither can see a ruleset edited in an admin console, which is how one repo's list went from ten required contexts to eleven with every test green for a day. So `--remote` ships as a new create-only `required-checks-drift.yml`: weekly cron plus `workflow_dispatch`, **never `pull_request`**, so a network-dependent check can never wedge a merge.

### What it does in an unseeded or stale repo

It must not redden repositories for unrelated reasons, so there are three layers, and none of them ever calls an unchecked repo clean — each says which piece is missing:

| State | Behaviour |
|---|---|
| No `scripts/check-skipped-required-checks.mjs` (non-TS stack, not yet re-applied) | notice, **pass** — same `[ ! -f ]` shape `threshold_ratchet` already uses |
| No `.github/required-checks.json` | notice naming the seed, **pass** |
| Seeded but never reviewed | seeds now ship `"enforcement": "warn"`: findings annotate + land in the job summary, build **passes** |
| Hand-written declaration (no `enforcement` key) | **enforces** — writing one is the opt-in |
| Drift workflow with empty `ruleset.ids` | `::warning` UNCONFIGURED, **pass** |

`warn` is a ramp, not a licence: a **proven false green** (`skipped_required_check` — the repo's own declaration saying a token it really skips silences a context its ruleset really requires) and **measured ruleset drift** block in *every* mode. A typo'd `enforcement` value throws rather than silently downgrading the guard to advice.

Also seeds `nestjs/create-only/.github/required-checks.json`, which was missing while nestjs's `ci.yml` skips three tokens.

## #2427 — `skip_jobs` does not trim whitespace

`skip_jobs: 'test, test:e2e'` yields the token `" test:e2e"`, which never matches `,test:e2e,`, so the job runs. Fails closed — nothing unverified ships — but it silently does not do what the operator asked.

**The `replace()` fix is not available.** GitHub Actions expression syntax has no string-replace; the complete string-function set is `contains`/`startsWith`/`endsWith`/`format`/`join`/`toJSON`/`fromJSON`/`hashFiles`. The only in-platform normalizer is a job emitting a normalized output that every other job `needs:` — which is *worse than the papercut*: if that job ever failed, all ~45 jobs would report **skipped**, and GitHub counts a skipped required check as satisfied. The fix for a UX papercut would manufacture the exact false green #2426 is about.

So the constraint is documented where the operator types the value — both input definitions now lead with **NO SPACES** (`quality-rails.yml` listed its own tokens *with* spaces until now, which is how easy this is to get wrong) — **and it is no longer silent**: the guard reports `whitespace_in_skip_token`, which it can only do because it now actually runs. The trimmed token is still carried into the evaluation: over-reporting a skip that did not happen is the safe direction.

## Tests

Extends the existing suites rather than forking them (the substring bug was already fixed in `1ced328b7`; `tests/integration/quality-workflow.test.ts` still pins it).

- `quality-workflow.test.ts` — a `jobRuns()` helper derived from the workflow's **own shipped `if:`** (not re-implemented) evaluates `'test,test:e2e'` (both skip), `'test, test:e2e'` (`test:e2e` **runs** — fails closed), `' test '` (skips nothing); plus NO-SPACES documentation in both workflows, and the guard's offline/scheduled wiring.
- `skipped-required-checks-wiring.test.ts` (new sibling; the original file was at the 300-line ceiling) — whitespace detection and `enforcement`.
- Seed-coherence `it.each` now covers nestjs.

Evidence: `test:unit` 10450 tests, `test:integration` 249/249, typecheck and eslint clean. Pre-existing/environmental only: `check-learnings-budget` (needs Bun runner) and one flaky `learnings-writer` lock-contention timeout that passes in isolation.

## ⚠️ Workflow permissions

**No `permissions:` block was added or changed on any job.** `quality.yml`'s new job needs no scopes — it reads two files from the checkout. The drift workflow is standalone (`contents: read`) and takes an optional `RULESET_READ_TOKEN` secret because the default `GITHUB_TOKEN` generally cannot read rulesets; absent it, the run goes red rather than reporting a clean bill of health it never checked.

🤖 Generated with Claude Code



Work-Item: CodySwannGT/lisa#2426
