### PR TITLE
fix(oxlint): resolve extended config without node_modules so worktrees can commit

### DIFF
--- a/cdk/merge/.oxlintrc.json
+++ b/cdk/merge/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "extends": ["./node_modules/@codyswann/lisa/oxlint/cdk.json"],
+  "extends": ["./.lisa/lisa-oxlint/cdk.json"],
   "ignorePatterns": [
     "build/**",
     "dist/**",

--- a/expo/merge/.oxlintrc.json
+++ b/expo/merge/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "extends": ["./node_modules/@codyswann/lisa/oxlint/expo.json"],
+  "extends": ["./.lisa/lisa-oxlint/expo.json"],
   "ignorePatterns": [
     "build/**",
     "dist/**",

--- a/harper-fabric/merge/.oxlintrc.json
+++ b/harper-fabric/merge/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "extends": ["./node_modules/@codyswann/lisa/oxlint/harper-fabric.json"],
+  "extends": ["./.lisa/lisa-oxlint/harper-fabric.json"],
   "ignorePatterns": [
     "build/**",
     "dist/**",

--- a/nestjs/merge/.oxlintrc.json
+++ b/nestjs/merge/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "extends": ["./node_modules/@codyswann/lisa/oxlint/nestjs.json"],
+  "extends": ["./.lisa/lisa-oxlint/nestjs.json"],
   "ignorePatterns": [
     "build/**",
     "dist/**",

--- a/phaser/merge/.oxlintrc.json
+++ b/phaser/merge/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "extends": ["./node_modules/@codyswann/lisa/oxlint/phaser.json"],
+  "extends": ["./.lisa/lisa-oxlint/phaser.json"],
   "ignorePatterns": [
     "build/**",
     "dist/**",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -91,7 +91,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "cdk/merge/.claude/settings.json":
       "6f938fdc9c808ee4dda9d605815788dda384197065aac6793c7549d8811a6224",
     "cdk/merge/.oxlintrc.json":
-      "e74885a33fdb7b5d565e13ebd781a3dd2fd02409a2a059deed851645630a6985",
+      "f7d248cf8a89561374d7e68e24aa780f4a6a523938475ad685f034ce0194d75c",
     "cdk/package-lisa/package.lisa.json":
       "6eb9a4cea78747750d6efadb7a142a349bc8572ed5e5d109f8b71d862ed4e45d",
     "eslint-plugin-code-organization/README.md":
@@ -253,7 +253,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/merge/.claude/settings.json":
       "e97b33d7ad86b71abba94ab957d725e34c3cafca455e92fba0b29ebabc3b73d1",
     "expo/merge/.oxlintrc.json":
-      "2a0ea2191abd5b377aed4b525a4a97d3eefb1d9e41c845c02ee0daac75df6b1f",
+      "95b3069256c0040be0ef1a5adae46d14687ad56fb18f473a653ba2de45d106bb",
     "expo/package-lisa/package.lisa.json":
       "34c4a356db67fa55d715a7bb4dafac8249a3793cd330bc920cd1769b58fcdcd0",
     "harper-fabric/copy-contents/.prettierignore":
@@ -295,7 +295,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "harper-fabric/merge/.claude/settings.json":
       "278c48f1af3a6aa23b7f5dcf55aa0d2737baf809942b1d4ef6831cdfc144581a",
     "harper-fabric/merge/.oxlintrc.json":
-      "43bd2a48954e15fbd1fe89b1a4f7b84cf93706d7de7b84ec120d63906bfde31b",
+      "b41ea588eed47e0f1532aab5f6226b82586269b84edd1947bdde603e0a8513fa",
     "harper-fabric/package-lisa/package.lisa.json":
       "4672b147ff12d0af80516b9c824aa9419b05da1308531d978ea285ae4e3c2b23",
     "nestjs/copy-overwrite/eslint.config.ts":
@@ -381,7 +381,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "nestjs/merge/.claude/settings.json":
       "d0ce50361a1f3868d15728646e66b9e1cdb8373688eb22459adbdb176e342aca",
     "nestjs/merge/.oxlintrc.json":
-      "3743a1e2bcfc879f5250f35206f413b10815f34e20b1d0afce67824579813b5d",
+      "1de29d135744df0258e8659ee0b684acf84e687bbefade51db0576813e6ff097",
     "nestjs/package-lisa/package.lisa.json":
       "f54fbe079e12caa89f1b768a851e71cd1c30e37918ca309c50add4379102381d",
     "npm-package/create-only/.github/workflows/publish-to-npm.yml":
@@ -439,7 +439,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "phaser/merge/.claude/settings.json":
       "296b8d5e3c197cd4526a99454aee1dc7f5ce9a25a729a957f392b71be3e8cfb6",
     "phaser/merge/.oxlintrc.json":
-      "4ac4bca00bef4b32810f3759a914ab2b8148e6fad3e329417a497e36df9e810c",
+      "02c0d70e6e07bc0e981f94a1e2ccd01a2c295c4c66e8b8ea9b2f363d44fa5c06",
     "phaser/package-lisa/package.lisa.json":
       "2e01b1ec402f6804a54402e22d02d63f1aa96d3f698e171885b0fff6eb25b271",
     "plugins/src/base/agents/architecture-specialist.md":
@@ -2325,7 +2325,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/merge/.claude/settings.json":
       "834e6456cae81f45073bbbb08bf731fef043efb30cae2658cb4a59f17e66d165",
     "typescript/merge/.oxlintrc.json":
-      "4debc093acfd263eb81ae15894073ebf098513204f45f40b83fb8fa5353fa1f8",
+      "9504c20db80470c242c4ffe8cccad6951ed8141dfb5bf6503053e0b2712ab276",
     "typescript/package-lisa/package.lisa.json":
       "7f121eec2d022cad7e3cf960806fefe7f30ef626cc89f951d322b40f5a9bd5ca",
     "ui/README.md":
@@ -8325,6 +8325,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/migrations/ensure-learnings-gitattributes.ts": true,
     "src/migrations/ensure-learnings-merge-driver.ts": true,
     "src/migrations/ensure-lisa-postinstall.ts": true,
+    "src/migrations/ensure-oxlint-base-configs.ts": true,
     "src/migrations/ensure-quality-caller-scopes.ts": true,
     "src/migrations/ensure-sonar-excludes-lisa-harness.ts": true,
     "src/migrations/ensure-tsconfig-local-files-fallback.ts": true,
@@ -8517,6 +8518,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/integration/nightly-e2e-grace-wiring.test.ts": true,
     "tests/integration/nightly-e2e-health-workflow.test.ts": true,
     "tests/integration/nightly-e2e-report-workflow.test.ts": true,
+    "tests/integration/oxlint-worktree-resolution.test.ts": true,
     "tests/integration/quality-workflow.test.ts": true,
     "tests/integration/release-changelog-entry.test.ts": true,
     "tests/integration/release-changelog-push-recovery.test.ts": true,
@@ -8668,6 +8670,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/config/oxlint-expo.test.ts": true,
     "tests/unit/config/oxlint-jsdoc-parity.test.ts": true,
     "tests/unit/config/oxlint-typescript.test.ts": true,
+    "tests/unit/config/oxlint-worktree-safe-extends.test.ts": true,
     "tests/unit/config/phaser-template.test.ts": true,
     "tests/unit/config/postinstall-ci-guard.test.ts": true,
     "tests/unit/config/postinstall-cloud-session-guard.test.ts": true,
@@ -8776,6 +8779,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/migrations/ensure-learnings-gitattributes.test.ts": true,
     "tests/unit/migrations/ensure-learnings-merge-driver.test.ts": true,
     "tests/unit/migrations/ensure-lisa-postinstall.test.ts": true,
+    "tests/unit/migrations/ensure-oxlint-base-configs.test.ts": true,
     "tests/unit/migrations/ensure-quality-caller-scopes.test.ts": true,
     "tests/unit/migrations/ensure-sonar-excludes-lisa-harness.test.ts": true,
     "tests/unit/migrations/ensure-tsconfig-local-files-fallback.test.ts": true,

--- a/src/migrations/ensure-oxlint-base-configs.ts
+++ b/src/migrations/ensure-oxlint-base-configs.ts
@@ -1,0 +1,297 @@
+import * as path from "node:path";
+import * as fse from "fs-extra";
+import { readJsonOrNull } from "../utils/json-utils.js";
+import type {
+  Migration,
+  MigrationContext,
+  MigrationResult,
+} from "./migration.interface.js";
+
+const OXLINTRC = ".oxlintrc.json";
+
+/**
+ * Repo-relative home for the Lisa oxlint configs vendored into a host project.
+ *
+ * The `lisa-` path segment is deliberate: `isLisaOwnedTemplate()` keys on that
+ * namespace, and it is how Lisa marks files it owns outright and may refresh
+ * without asking. Hosts never hand-edit these — they layer their own rules in
+ * `.oxlintrc.json`, which stays host-owned.
+ */
+const VENDOR_DIR = ".lisa/lisa-oxlint";
+
+/** `extends` prefix that points at a vendored config. */
+const VENDOR_PREFIX = `./${VENDOR_DIR}/`;
+
+/** Directory inside the Lisa package holding the canonical oxlint configs. */
+const SOURCE_DIR = "oxlint";
+
+/**
+ * Legacy `extends` entry shape, pointing into the installed Lisa package.
+ * Captures the config's basename so it can be remapped to the vendored copy.
+ */
+const LEGACY_ENTRY =
+  /^\.?\/?node_modules\/@codyswann\/lisa\/oxlint\/([^/]+\.json)$/;
+
+/** Minimal shape of an oxlint config file. */
+interface OxlintConfigLike {
+  readonly extends?: readonly string[];
+  readonly $schema?: unknown;
+  readonly [key: string]: unknown;
+}
+
+/** What a run of this migration would change. */
+interface Plan {
+  /** Rewritten `extends` list for the host `.oxlintrc.json`. */
+  readonly nextExtends: readonly string[];
+  /** Whether `nextExtends` differs from what is on disk. */
+  readonly extendsChanged: boolean;
+  /** Vendored file basename to the exact content it should hold. */
+  readonly files: ReadonlyMap<string, string>;
+  /** Vendored files that are missing or stale on disk. */
+  readonly staleFiles: readonly string[];
+}
+
+/**
+ * Serialize a vendored oxlint config.
+ *
+ * `$schema` is dropped on the way in. It is an editor affordance that oxlint
+ * itself never reads, and every value Lisa ships is a `node_modules`-relative
+ * path — exactly the fragility this migration exists to remove. Leaving a
+ * dangling pointer inside the file that fixes dangling pointers would be
+ * self-defeating.
+ * @param config - Parsed source config
+ * @returns Canonical file content, newline-terminated
+ */
+function serialize(config: OxlintConfigLike): string {
+  const { $schema: _schema, ...rest } = config;
+  return `${JSON.stringify(rest, null, 2)}\n`;
+}
+
+/**
+ * Rewrite one `extends` entry, remapping a legacy package-relative path to its
+ * vendored equivalent and leaving anything else untouched.
+ * @param entry - Raw `extends` entry
+ * @returns Rewritten entry
+ */
+function remapEntry(entry: string): string {
+  const legacy = LEGACY_ENTRY.exec(entry);
+  return legacy ? `${VENDOR_PREFIX}${legacy[1]}` : entry;
+}
+
+/**
+ * Collect the vendored config basenames an `extends` list depends on.
+ * @param entries - Rewritten `extends` entries
+ * @returns Basenames such as `typescript.json`
+ */
+function vendoredNames(entries: readonly string[]): readonly string[] {
+  return entries
+    .filter(entry => entry.startsWith(VENDOR_PREFIX))
+    .map(entry => entry.slice(VENDOR_PREFIX.length))
+    .filter(name => name.length > 0 && !name.includes("/"));
+}
+
+/**
+ * Sibling config basenames a config inherits from.
+ * @param config - Parsed oxlint config
+ * @returns Basenames such as `base.json`
+ */
+function siblingParents(config: OxlintConfigLike): readonly string[] {
+  return (config.extends ?? [])
+    .filter(entry => entry.startsWith("./") && !entry.slice(2).includes("/"))
+    .map(entry => entry.slice(2));
+}
+
+/**
+ * Accumulate one config and everything it inherits from.
+ *
+ * Lisa's oxlint configs form a sibling chain (`expo.json` extends
+ * `./typescript.json` extends `./base.json`), so vendoring a leaf without its
+ * ancestors would leave a dangling reference — the very failure being fixed.
+ * A config Lisa does not ship contributes nothing rather than a partial chain.
+ * @param lisaDir - Lisa installation directory
+ * @param name - Config basename to collect
+ * @param seen - Already-collected basename to content
+ * @returns Updated basename to serialized content
+ */
+async function collectChain(
+  lisaDir: string,
+  name: string,
+  seen: ReadonlyMap<string, string>
+): Promise<ReadonlyMap<string, string>> {
+  if (seen.has(name)) {
+    return seen;
+  }
+  const config = await readJsonOrNull<OxlintConfigLike>(
+    path.join(lisaDir, SOURCE_DIR, name)
+  );
+  if (!config) {
+    return seen;
+  }
+  const withSelf: ReadonlyMap<string, string> = new Map([
+    ...seen,
+    [name, serialize(config)] as const,
+  ]);
+  return siblingParents(config).reduce<Promise<ReadonlyMap<string, string>>>(
+    async (acc, parent) => collectChain(lisaDir, parent, await acc),
+    Promise.resolve(withSelf)
+  );
+}
+
+/**
+ * Walk the `extends` chains of every config the host references.
+ * @param lisaDir - Lisa installation directory
+ * @param roots - Config basenames referenced by the host
+ * @returns Basename to serialized content for the whole closure
+ */
+async function resolveClosure(
+  lisaDir: string,
+  roots: readonly string[]
+): Promise<ReadonlyMap<string, string>> {
+  return roots.reduce<Promise<ReadonlyMap<string, string>>>(
+    async (acc, root) => collectChain(lisaDir, root, await acc),
+    Promise.resolve(new Map<string, string>())
+  );
+}
+
+/**
+ * Identify vendored configs whose on-disk content does not match what Lisa
+ * ships, including those not written yet.
+ * @param projectDir - Host project directory
+ * @param files - Basename to expected content
+ * @returns Basenames needing a write
+ */
+async function findStaleFiles(
+  projectDir: string,
+  files: ReadonlyMap<string, string>
+): Promise<readonly string[]> {
+  const checked = await Promise.all(
+    [...files].map(async ([name, content]) => {
+      const existing = await fse
+        .readFile(path.join(projectDir, VENDOR_DIR, name), "utf-8")
+        .catch(() => null as string | null);
+      return { name, stale: existing !== content };
+    })
+  );
+  return checked.filter(entry => entry.stale).map(entry => entry.name);
+}
+
+/**
+ * Compute what this migration would change for a project.
+ * @param ctx - Migration context
+ * @returns The plan, or null when the project has no managed oxlint config
+ */
+async function buildPlan(ctx: MigrationContext): Promise<Plan | null> {
+  const oxlintrcPath = path.join(ctx.projectDir, OXLINTRC);
+  const oxlintrc = await readJsonOrNull<OxlintConfigLike>(oxlintrcPath);
+  if (!oxlintrc || !Array.isArray(oxlintrc.extends)) {
+    return null;
+  }
+
+  const current = oxlintrc.extends;
+  const nextExtends = [...new Set(current.map(remapEntry))];
+  const names = vendoredNames(nextExtends);
+  if (names.length === 0) {
+    return null;
+  }
+
+  const files = await resolveClosure(ctx.lisaDir, names);
+  if (files.size === 0) {
+    return null;
+  }
+
+  const staleFiles = await findStaleFiles(ctx.projectDir, files);
+
+  const extendsChanged =
+    nextExtends.length !== current.length ||
+    nextExtends.some((entry, index) => entry !== current[index]);
+
+  return { nextExtends, extendsChanged, files, staleFiles };
+}
+
+/**
+ * Migration: vendor Lisa's oxlint configs into the host repository and point
+ * `.oxlintrc.json` at them, so linting works in a checkout without an install.
+ *
+ * oxlint resolves every `extends` entry as a plain path relative to the config
+ * file that declares it — its schema says so, and it performs no Node-style
+ * upward module resolution. A `./node_modules/@codyswann/lisa/oxlint/*.json`
+ * entry therefore dies in any checkout lacking its own `node_modules`, most
+ * commonly a fresh `git worktree`. Since `.lintstagedrc.json` runs
+ * `oxlint --fix` from the husky pre-commit hook, that blocked every commit in
+ * such a worktree, with the failure surfacing as a downstream prettier kill
+ * rather than as the config error it was (#2465).
+ *
+ * Vendoring is what makes it worktree-proof: git checks tracked files into
+ * every worktree, whereas `node_modules` is untracked by definition. The two
+ * layers are preserved — Lisa owns the vendored base, the host still owns
+ * `.oxlintrc.json` — so projects keep overriding rules exactly as before.
+ *
+ * Pruning the legacy entry is not cosmetic. The `merge` strategy unions arrays
+ * and can never drop an element, so an upgraded project would otherwise carry
+ * the new path *and* the old one; oxlint hard-fails on any unresolvable entry,
+ * so changing the templates alone would fix nothing for existing hosts.
+ */
+export class EnsureOxlintBaseConfigsMigration implements Migration {
+  readonly name = "ensure-oxlint-base-configs";
+  readonly description =
+    "Vendor Lisa oxlint configs into .lisa/lisa-oxlint/ so linting works without node_modules";
+
+  /**
+   * The migration applies when the vendored configs are missing or stale, or
+   * when `.oxlintrc.json` still carries a legacy package-relative entry.
+   * @param ctx - Migration context
+   * @returns True when there is work to do
+   */
+  async applies(ctx: MigrationContext): Promise<boolean> {
+    const plan = await buildPlan(ctx);
+    return plan !== null && (plan.extendsChanged || plan.staleFiles.length > 0);
+  }
+
+  /**
+   * Write the vendored configs and normalize the host `extends` list.
+   * @param ctx - Migration context
+   * @returns Result describing the action taken
+   */
+  async apply(ctx: MigrationContext): Promise<MigrationResult> {
+    const plan = await buildPlan(ctx);
+    if (!plan || (!plan.extendsChanged && plan.staleFiles.length === 0)) {
+      return { name: this.name, action: "noop" };
+    }
+
+    const changedFiles = [
+      ...plan.staleFiles.map(name => `${VENDOR_DIR}/${name}`),
+      ...(plan.extendsChanged ? [OXLINTRC] : []),
+    ];
+    const message = `vendored ${plan.files.size} oxlint config(s) into ${VENDOR_DIR}`;
+
+    if (ctx.dryRun) {
+      ctx.logger.dry(`Would ${message}`);
+      return { name: this.name, action: "applied", changedFiles, message };
+    }
+
+    const vendorDir = path.join(ctx.projectDir, VENDOR_DIR);
+    await fse.ensureDir(vendorDir);
+    await Promise.all(
+      plan.staleFiles.map(name =>
+        fse.writeFile(
+          path.join(vendorDir, name),
+          plan.files.get(name) as string
+        )
+      )
+    );
+
+    if (plan.extendsChanged) {
+      const oxlintrcPath = path.join(ctx.projectDir, OXLINTRC);
+      const oxlintrc = (await readJsonOrNull<OxlintConfigLike>(
+        oxlintrcPath
+      )) as OxlintConfigLike;
+      await fse.writeFile(
+        oxlintrcPath,
+        `${JSON.stringify({ ...oxlintrc, extends: plan.nextExtends }, null, 2)}\n`
+      );
+    }
+
+    ctx.logger.success(message);
+    return { name: this.name, action: "applied", changedFiles, message };
+  }
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -3,6 +3,7 @@ import { EnsureJestRnMockAccessibilityManagerMigration } from "./ensure-jest-rn-
 import { EnsureLearningsGitattributesMigration } from "./ensure-learnings-gitattributes.js";
 import { EnsureLearningsMergeDriverMigration } from "./ensure-learnings-merge-driver.js";
 import { EnsureLisaPostinstallMigration } from "./ensure-lisa-postinstall.js";
+import { EnsureOxlintBaseConfigsMigration } from "./ensure-oxlint-base-configs.js";
 import { EnsureQualityCallerScopesMigration } from "./ensure-quality-caller-scopes.js";
 import { EnsureSonarExcludesLisaHarnessMigration } from "./ensure-sonar-excludes-lisa-harness.js";
 import { EnsureTsconfigLocalFilesFallbackMigration } from "./ensure-tsconfig-local-files-fallback.js";
@@ -27,6 +28,7 @@ export { EnsureJestRnMockAccessibilityManagerMigration } from "./ensure-jest-rn-
 export { EnsureLearningsGitattributesMigration } from "./ensure-learnings-gitattributes.js";
 export { EnsureLearningsMergeDriverMigration } from "./ensure-learnings-merge-driver.js";
 export { EnsureLisaPostinstallMigration } from "./ensure-lisa-postinstall.js";
+export { EnsureOxlintBaseConfigsMigration } from "./ensure-oxlint-base-configs.js";
 export { EnsureQualityCallerScopesMigration } from "./ensure-quality-caller-scopes.js";
 export { EnsureSonarExcludesLisaHarnessMigration } from "./ensure-sonar-excludes-lisa-harness.js";
 export { EnsureTsconfigLocalFilesFallbackMigration } from "./ensure-tsconfig-local-files-fallback.js";
@@ -54,6 +56,7 @@ export class MigrationRegistry {
       new EnsureLearningsGitattributesMigration(),
       new EnsureLearningsMergeDriverMigration(),
       new EnsureLisaPostinstallMigration(),
+      new EnsureOxlintBaseConfigsMigration(),
       new EnsureQualityCallerScopesMigration(),
       new EnsureSonarExcludesLisaHarnessMigration(),
       new EnsureWikiSourceDeclaredMigration(),

--- a/tests/integration/oxlint-worktree-resolution.test.ts
+++ b/tests/integration/oxlint-worktree-resolution.test.ts
@@ -1,0 +1,187 @@
+/**
+ * End-to-end proof for issue #2465: a Lisa-managed project must be able to lint
+ * — and therefore commit — inside a fresh `git worktree` that has no
+ * worktree-local `node_modules`.
+ *
+ * This exercises the real path rather than a simulation: the real stack
+ * templates, the real vendoring migration, a real `git worktree`, and the real
+ * `oxlint` binary running the same `--fix` invocation `.lintstagedrc.json`
+ * issues from the husky pre-commit hook.
+ */
+import { execFileSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+
+import fs from "fs-extra";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ProjectType } from "../../src/core/config.js";
+import { SilentLogger } from "../../src/logging/silent-logger.js";
+import { EnsureOxlintBaseConfigsMigration } from "../../src/migrations/ensure-oxlint-base-configs.js";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const OXLINT_BIN = path.join(REPO_ROOT, "node_modules", ".bin", "oxlint");
+/** Pinned git binary — resolving `git` via $PATH trips no-os-command-from-path. */
+const GIT_BIN = "/usr/bin/git";
+
+/** Stacks that ship a managed `.oxlintrc.json`. */
+const STACKS = [
+  "typescript",
+  "cdk",
+  "expo",
+  "nestjs",
+  "phaser",
+  "harper-fabric",
+] as const;
+
+/** Outcome of running oxlint in a directory. */
+interface LintOutcome {
+  readonly code: number;
+  readonly output: string;
+}
+
+/**
+ * Run git with the ambient GIT_* environment stripped so an outer repository
+ * (or an outer worktree) cannot leak into the fixture.
+ * @param cwd - Directory to run in
+ * @param args - Git arguments
+ */
+function git(cwd: string, ...args: readonly string[]): void {
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_"))
+  );
+  execFileSync(GIT_BIN, args, { cwd, env, stdio: "pipe" });
+}
+
+/**
+ * Run oxlint exactly as lint-staged does from the pre-commit hook.
+ * @param cwd - Directory to lint in
+ * @returns Exit code and combined output
+ */
+function runOxlint(cwd: string): LintOutcome {
+  try {
+    const output = execFileSync(
+      OXLINT_BIN,
+      ["--fix", "--no-error-on-unmatched-pattern", "src.ts"],
+      { cwd, encoding: "utf8", stdio: "pipe" }
+    );
+    return { code: 0, output };
+  } catch (error) {
+    const failure = error as {
+      status?: number;
+      stdout?: string;
+      stderr?: string;
+    };
+    return {
+      code: failure.status ?? 1,
+      output: `${failure.stdout ?? ""}${failure.stderr ?? ""}`,
+    };
+  }
+}
+
+describe("oxlint resolves its config in a fresh git worktree (#2465)", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "lisa-oxlint-wt-"));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  /**
+   * Build a Lisa-managed host repo for a stack and add a worktree to it.
+   * @param stack - Stack template to apply
+   * @param legacyExtends - When set, override extends to the pre-fix path
+   * @returns Absolute paths of the host clone and its worktree
+   */
+  async function buildHostAndWorktree(
+    stack: string,
+    legacyExtends?: string
+  ): Promise<{ readonly host: string; readonly worktree: string }> {
+    const host = path.join(tempDir, `host-${stack}`);
+    const worktree = path.join(tempDir, `wt-${stack}`);
+    await fs.ensureDir(host);
+
+    // A Lisa-managed host has @codyswann/lisa installed in its node_modules.
+    await fs.ensureDir(path.join(host, "node_modules", "@codyswann"));
+    await fs.ensureSymlink(
+      REPO_ROOT,
+      path.join(host, "node_modules", "@codyswann", "lisa"),
+      "dir"
+    );
+    await fs.writeFile(path.join(host, ".gitignore"), "node_modules/\n");
+    await fs.writeFile(path.join(host, "src.ts"), "export const a = 1;\n");
+
+    // The exact `.oxlintrc.json` that `lisa apply` merges into the host.
+    const template = (await fs.readJson(
+      path.join(REPO_ROOT, stack, "merge", ".oxlintrc.json")
+    )) as Record<string, unknown>;
+    await fs.writeJson(
+      path.join(host, ".oxlintrc.json"),
+      legacyExtends ? { ...template, extends: [legacyExtends] } : template,
+      { spaces: 2 }
+    );
+
+    if (!legacyExtends) {
+      await new EnsureOxlintBaseConfigsMigration().apply({
+        projectDir: host,
+        lisaDir: REPO_ROOT,
+        detectedTypes: [stack as ProjectType],
+        dryRun: false,
+        logger: new SilentLogger(),
+      });
+    }
+
+    git(host, "init", "-q", ".");
+    git(host, "config", "user.email", "test@example.com");
+    git(host, "config", "user.name", "test");
+    git(host, "config", "commit.gpgsign", "false");
+    git(host, "add", "-A");
+    git(host, "commit", "-qm", "init");
+    git(host, "worktree", "add", "-q", "-b", "wt", worktree);
+
+    return { host, worktree };
+  }
+
+  it("control: the pre-fix node_modules extends path fails in a worktree", async () => {
+    const { host, worktree } = await buildHostAndWorktree(
+      "typescript",
+      "./node_modules/@codyswann/lisa/oxlint/typescript.json"
+    );
+
+    // The bug is invisible in the clone that has node_modules...
+    expect(runOxlint(host).code).toBe(0);
+
+    // ...and fatal in the worktree, which by construction has none.
+    expect(await fs.pathExists(path.join(worktree, "node_modules"))).toBe(
+      false
+    );
+    const result = runOxlint(worktree);
+    expect(result.code).not.toBe(0);
+    expect(result.output).toContain(
+      "Failed to parse oxlint configuration file"
+    );
+  });
+
+  it.each(STACKS)(
+    "%s: the shipped template lints cleanly in a worktree with no node_modules",
+    async stack => {
+      const { worktree } = await buildHostAndWorktree(stack);
+
+      expect(await fs.pathExists(path.join(worktree, "node_modules"))).toBe(
+        false
+      );
+      // The vendored configs are tracked, so the worktree checkout has them.
+      expect(
+        await fs.pathExists(path.join(worktree, ".lisa", "lisa-oxlint"))
+      ).toBe(true);
+
+      const result = runOxlint(worktree);
+      expect(result.output).not.toContain("Failed to parse oxlint");
+      expect(result.code).toBe(0);
+    },
+    30_000
+  );
+});

--- a/tests/unit/config/oxlint-worktree-safe-extends.test.ts
+++ b/tests/unit/config/oxlint-worktree-safe-extends.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression guards for issue #2465 — oxlint `extends` must resolve in a git
+ * worktree that has no worktree-local `node_modules`.
+ *
+ * oxlint resolves every `extends` entry as a plain path relative to the
+ * directory of the config file that declares it. It performs no Node-style
+ * upward module resolution, so a `./node_modules/...` entry is unresolvable in
+ * any checkout without its own installed dependencies — most importantly a
+ * fresh `git worktree`, where `node_modules` is untracked and therefore absent.
+ * Because lint-staged runs `oxlint --fix` from the husky pre-commit hook, an
+ * unresolvable entry blocks every commit in that worktree.
+ *
+ * The fix points `extends` at Lisa configs vendored into the repository itself,
+ * under the `.lisa/lisa-oxlint/` namespace. Tracked files are checked out into
+ * every worktree, so resolution no longer depends on an install.
+ */
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+
+/** Stacks that ship a managed `.oxlintrc.json` merge template. */
+const STACKS = [
+  "typescript",
+  "cdk",
+  "expo",
+  "nestjs",
+  "phaser",
+  "harper-fabric",
+] as const;
+
+/** Repository-relative directory holding the vendored Lisa oxlint configs. */
+const VENDOR_DIR = ".lisa/lisa-oxlint";
+
+/** Minimal shape of an oxlint config file. */
+interface OxlintConfigLike {
+  readonly extends?: readonly string[];
+}
+
+/**
+ * Read a JSON template from the Lisa repository.
+ * @param relativePath - Repo-relative JSON path
+ * @returns Parsed template content
+ */
+function readJson(relativePath: string): OxlintConfigLike {
+  return JSON.parse(
+    fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8")
+  ) as OxlintConfigLike;
+}
+
+describe("oxlint stack templates resolve without node_modules (#2465)", () => {
+  it.each(STACKS)(
+    "%s/merge/.oxlintrc.json extends nothing under node_modules",
+    stack => {
+      const config = readJson(`${stack}/merge/.oxlintrc.json`);
+      expect(config.extends ?? []).not.toContain(
+        expect.stringContaining("node_modules")
+      );
+      for (const entry of config.extends ?? []) {
+        expect(entry).not.toContain("node_modules");
+      }
+    }
+  );
+
+  it.each(STACKS)(
+    "%s/merge/.oxlintrc.json extends the vendored Lisa config for its stack",
+    stack => {
+      const config = readJson(`${stack}/merge/.oxlintrc.json`);
+      expect(config.extends).toEqual([`./${VENDOR_DIR}/${stack}.json`]);
+    }
+  );
+
+  it.each(STACKS)(
+    "the Lisa oxlint config backing %s exists and only extends siblings",
+    stack => {
+      // Vendoring copies `oxlint/*.json` verbatim, so the whole `extends`
+      // chain must be sibling-relative for it to survive relocation.
+      const seen = new Set<string>();
+      const queue = [`${stack}.json`];
+      while (queue.length > 0) {
+        const name = queue.pop() as string;
+        if (seen.has(name)) {
+          continue;
+        }
+        seen.add(name);
+        expect(fs.existsSync(path.join(REPO_ROOT, "oxlint", name))).toBe(true);
+        for (const entry of readJson(`oxlint/${name}`).extends ?? []) {
+          expect(entry).toMatch(/^\.\/[^/]+\.json$/);
+          queue.push(entry.replace("./", ""));
+        }
+      }
+      expect(seen.has("base.json")).toBe(true);
+    }
+  );
+});

--- a/tests/unit/migrations/ensure-oxlint-base-configs.test.ts
+++ b/tests/unit/migrations/ensure-oxlint-base-configs.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for the oxlint vendoring migration (issue #2465).
+ */
+import os from "node:os";
+import path from "node:path";
+
+import fs from "fs-extra";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ProjectType } from "../../../src/core/config.js";
+import { SilentLogger } from "../../../src/logging/silent-logger.js";
+import { EnsureOxlintBaseConfigsMigration } from "../../../src/migrations/ensure-oxlint-base-configs.js";
+import type { MigrationContext } from "../../../src/migrations/migration.interface.js";
+
+const OXLINTRC = ".oxlintrc.json";
+const VENDOR_DIR = path.join(".lisa", "lisa-oxlint");
+const LEGACY = "./node_modules/@codyswann/lisa/oxlint/typescript.json";
+const VENDORED = "./.lisa/lisa-oxlint/typescript.json";
+/** Basenames of the fixture configs, reused across assertions. */
+const BASE_JSON = "base.json";
+const TYPESCRIPT_JSON = "typescript.json";
+/** Exact content the fixture's typescript config must hold once vendored. */
+const TYPESCRIPT_CONFIG = {
+  extends: [`./${BASE_JSON}`],
+  plugins: ["typescript"],
+} as const;
+
+describe("EnsureOxlintBaseConfigsMigration", () => {
+  const migration = new EnsureOxlintBaseConfigsMigration();
+  let tempDir: string;
+  let projectDir: string;
+  let lisaDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "lisa-oxlint-"));
+    lisaDir = path.join(tempDir, "lisa");
+    projectDir = path.join(tempDir, "project");
+    await fs.ensureDir(projectDir);
+    // A miniature copy of Lisa's own `oxlint/` directory, chain included.
+    await fs.ensureDir(path.join(lisaDir, "oxlint"));
+    await fs.writeJson(path.join(lisaDir, "oxlint", BASE_JSON), {
+      rules: { "no-debugger": "error" },
+    });
+    await fs.writeJson(
+      path.join(lisaDir, "oxlint", TYPESCRIPT_JSON),
+      TYPESCRIPT_CONFIG
+    );
+    await fs.writeJson(path.join(lisaDir, "oxlint", "expo.json"), {
+      extends: [`./${TYPESCRIPT_JSON}`],
+      plugins: ["react"],
+    });
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  const ctx = (dryRun = false): MigrationContext => ({
+    projectDir,
+    lisaDir,
+    detectedTypes: ["typescript"] as ProjectType[],
+    dryRun,
+    logger: new SilentLogger(),
+  });
+
+  const writeOxlintrc = (config: unknown): Promise<void> =>
+    fs.writeJson(path.join(projectDir, OXLINTRC), config, { spaces: 2 });
+
+  const readOxlintrc = (): Promise<{ readonly extends?: readonly string[] }> =>
+    fs.readJson(path.join(projectDir, OXLINTRC));
+
+  const vendored = (name: string): string =>
+    path.join(projectDir, VENDOR_DIR, name);
+
+  it("is a noop when the project has no .oxlintrc.json", async () => {
+    expect(await migration.applies(ctx())).toBe(false);
+    expect((await migration.apply(ctx())).action).toBe("noop");
+  });
+
+  it("is a noop for Lisa's own repo, which extends its in-repo oxlint/", async () => {
+    await writeOxlintrc({ extends: ["./oxlint/typescript.json"] });
+    expect(await migration.applies(ctx())).toBe(false);
+  });
+
+  it("vendors the referenced config and its whole extends chain", async () => {
+    await writeOxlintrc({ extends: [VENDORED] });
+    expect(await migration.applies(ctx())).toBe(true);
+    await migration.apply(ctx());
+
+    expect(await fs.readJson(vendored(TYPESCRIPT_JSON))).toEqual(
+      TYPESCRIPT_CONFIG
+    );
+    // The transitive parent must come along or the chain dangles.
+    expect(await fs.readJson(vendored(BASE_JSON))).toEqual({
+      rules: { "no-debugger": "error" },
+    });
+  });
+
+  it("vendors the full chain for a child stack", async () => {
+    await writeOxlintrc({ extends: ["./.lisa/lisa-oxlint/expo.json"] });
+    await migration.apply(ctx());
+
+    for (const name of ["expo.json", TYPESCRIPT_JSON, BASE_JSON]) {
+      expect(await fs.pathExists(vendored(name))).toBe(true);
+    }
+  });
+
+  it("prunes the legacy node_modules extends entry left behind by array-union merge", async () => {
+    // The `merge` strategy unions arrays and never removes entries, so an
+    // upgraded host carries BOTH paths. oxlint hard-fails on the unresolvable
+    // one, so pruning is what actually fixes existing projects.
+    await writeOxlintrc({ extends: [LEGACY, VENDORED] });
+    expect(await migration.applies(ctx())).toBe(true);
+    await migration.apply(ctx());
+
+    expect((await readOxlintrc()).extends).toEqual([VENDORED]);
+  });
+
+  it("replaces a legacy-only extends with the vendored equivalent", async () => {
+    await writeOxlintrc({ extends: [LEGACY] });
+    expect(await migration.applies(ctx())).toBe(true);
+    await migration.apply(ctx());
+
+    expect((await readOxlintrc()).extends).toEqual([VENDORED]);
+    expect(await fs.pathExists(vendored(TYPESCRIPT_JSON))).toBe(true);
+  });
+
+  it("preserves host-authored extends entries and other keys", async () => {
+    await writeOxlintrc({
+      extends: [LEGACY, "./config/house-rules.json"],
+      rules: { "no-console": "off" },
+    });
+    await migration.apply(ctx());
+
+    const result = await readOxlintrc();
+    expect(result.extends).toEqual([VENDORED, "./config/house-rules.json"]);
+    expect(result).toMatchObject({ rules: { "no-console": "off" } });
+  });
+
+  it("is idempotent", async () => {
+    await writeOxlintrc({ extends: [VENDORED] });
+    await migration.apply(ctx());
+    const first = await readOxlintrc();
+
+    expect(await migration.applies(ctx())).toBe(false);
+    await migration.apply(ctx());
+    expect(await readOxlintrc()).toEqual(first);
+  });
+
+  it("refreshes a stale vendored config so hosts cannot pin old rules", async () => {
+    await writeOxlintrc({ extends: [VENDORED] });
+    await fs.ensureDir(path.join(projectDir, VENDOR_DIR));
+    await fs.writeJson(vendored(TYPESCRIPT_JSON), { plugins: ["stale"] });
+
+    expect(await migration.applies(ctx())).toBe(true);
+    await migration.apply(ctx());
+    expect(await fs.readJson(vendored(TYPESCRIPT_JSON))).toEqual(
+      TYPESCRIPT_CONFIG
+    );
+  });
+
+  it("writes nothing in dry-run mode", async () => {
+    await writeOxlintrc({ extends: [LEGACY, VENDORED] });
+    const result = await migration.apply(ctx(true));
+
+    expect(result.action).toBe("applied");
+    expect(await fs.pathExists(vendored(TYPESCRIPT_JSON))).toBe(false);
+    expect((await readOxlintrc()).extends).toEqual([LEGACY, VENDORED]);
+  });
+
+  it("leaves the host alone when Lisa ships no such config", async () => {
+    await writeOxlintrc({ extends: ["./.lisa/lisa-oxlint/rails.json"] });
+    const result = await migration.apply(ctx());
+
+    expect(result.action).toBe("noop");
+    expect(await fs.pathExists(vendored("rails.json"))).toBe(false);
+  });
+});

--- a/typescript/merge/.oxlintrc.json
+++ b/typescript/merge/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "extends": ["./node_modules/@codyswann/lisa/oxlint/typescript.json"],
+  "extends": ["./.lisa/lisa-oxlint/typescript.json"],
   "ignorePatterns": [
     "build/**",
     "dist/**",


### PR DESCRIPTION
Fixes the oxlint `extends` resolution failure that blocked every commit in a fresh git worktree, across all six stack templates.

## The defect

Every stack template shipped `.oxlintrc.json` with a relative
`extends: ["./node_modules/@codyswann/lisa/oxlint/<stack>.json"]`.

oxlint resolves each `extends` entry as a plain path relative to the config file that declares it, and performs no Node-style upward module resolution. Its own configuration schema says so:

> Paths of configuration files that this configuration file extends (inherits from). The files are resolved relative to the location of the configuration file that contains the `extends` property.

In any checkout without its own `node_modules` — most commonly a fresh `git worktree` — that path is unresolvable and oxlint dies. Because `.lintstagedrc.json` runs `oxlint --fix` from the husky pre-commit hook, this blocked **every commit** in such a worktree, with prettier then SIGKILLing further down the lint-staged cascade, so the symptom pointed at the formatter rather than at config resolution. `tsc` and `vitest` resolve fine in the same worktree because they *do* walk up, which masked the cause.

## Reproduction (before)

A real git worktree of a Lisa-managed host, running the exact lint-staged invocation:

```
typescript      worktree: BROKEN (config resolution failed)        EXIT=1
cdk             worktree: BROKEN (config resolution failed)        EXIT=1
expo            worktree: BROKEN (config resolution failed)        EXIT=1
nestjs          worktree: BROKEN (config resolution failed)        EXIT=1
phaser          worktree: BROKEN (config resolution failed)        EXIT=1
harper-fabric   worktree: BROKEN (config resolution failed)        EXIT=1
```

The same clone *with* `node_modules` exits 0 — which is exactly why this survived seven weeks after being reported downstream.

## The fix

Lisa's oxlint configs are vendored into the host repository under `.lisa/lisa-oxlint/`, and `extends` points there. Git checks tracked files out into every worktree, whereas `node_modules` is untracked by definition, so resolution no longer depends on an install.

The two-layer model is unchanged — Lisa owns the vendored base, the host still owns `.oxlintrc.json` — so projects override rules exactly as before. The `lisa-` path segment is what marks the vendored files Lisa-owned (`isLisaOwnedTemplate()`), so `lisa apply` refreshes them unprompted rather than leaving hosts pinned to stale rules. Filenames are unchanged, so the existing sibling chain (`expo.json` → `typescript.json` → `base.json`) survives relocation verbatim.

### Alternatives weighed

| Option | Verdict |
|---|---|
| Bare package specifier `@codyswann/lisa/oxlint/typescript.json` | **Out — empirically disproven.** oxlint treats it as a relative path and fails even when `node_modules` *is* present. |
| Absolute path generated at apply time | **Out.** Bakes a machine-specific path into a tracked file, breaking every other clone and CI. |
| Directive error + `lisa doctor` check | **Out.** Does not let a valid worktree commit, which is the actual requirement. |
| Inline the ruleset into `.oxlintrc.json` | **Out.** The `merge` strategy resolves scalar conflicts in Lisa's favour, so inlining would destroy the host's ability to override rules. |
| **Vendor into the repo** | **Chosen.** Robust in both a fresh worktree and a normal checkout, and requires no install before committing. |

### The pruning migration is load-bearing

`ensure-oxlint-base-configs` also removes the legacy entry. This is not cosmetic: the `merge` strategy unions arrays and can never drop an element, so an upgraded project would otherwise carry the new path **and** the old one — and oxlint hard-fails on *any* unresolvable entry. Changing the templates alone would have fixed nothing for existing hosts.

The migration runs in `processMigrations()`, after `processConfigurations()` has merged `.oxlintrc.json`. It is a no-op for Lisa's own repo, whose `.oxlintrc.json` already extends the in-repo `./oxlint/typescript.json`.

## Verification (after)

`tests/integration/oxlint-worktree-resolution.test.ts` proves it on the real path — a real `git worktree` with no `node_modules`, the real `oxlint` binary, the real stack templates, and the real migration:

```
typescript      worktree: ok    EXIT=0
cdk             worktree: ok    EXIT=0
expo            worktree: ok    EXIT=0
nestjs          worktree: ok    EXIT=0
phaser          worktree: ok    EXIT=0
harper-fabric   worktree: ok    EXIT=0
```

It includes a **control case** asserting the pre-fix path still fails in that worktree, so the harness is proven able to detect the bug it guards against.

Also added:
- `tests/unit/config/oxlint-worktree-safe-extends.test.ts` — invariant across all six templates: no `extends` entry may reference `node_modules`, and the chain must stay sibling-relative so vendoring survives.
- `tests/unit/migrations/ensure-oxlint-base-configs.test.ts` — chain closure, legacy pruning, host-entry preservation, idempotency, stale refresh, dry-run.

Full suite green (10,733 tests), lint and typecheck clean, upstream evidence manifest regenerated.

## Note on `$schema`

`$schema` in the six `.oxlintrc.json` templates still points into `node_modules`. It is editor metadata that oxlint never reads, so it is not part of the defect — the acceptance criteria concern `extends`. It is dropped from the *vendored* copies, since a dangling pointer inside the files that fix dangling pointers would be self-defeating.

Closes #2465

🤖 Generated with Claude Code



Work-Item: CodySwannGT/lisa#2465
