### PR TITLE
fix(postinstall): surface failed applies instead of discarding them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,6 +234,13 @@ expo-env.d.ts
 # /lisa:automation-status. Runbooks are project knowledge; run records are not.
 .lisa/automations/runs/
 
+# Proof that `lisa apply` completed in THIS checkout, read by `lisa doctor` to
+# report a repo that has silently stopped receiving templates. Machine-local by
+# construction: committing it would churn on every version bump, conflict
+# between developers on different Lisa versions, and lie about a fresh clone
+# that has never installed.
+.lisa/apply-receipt.json
+
 # Built Claude Code plugins are committed so the GitHub marketplace works.
 # Regenerate with: bun run build:plugins
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,28 @@ bun add --dev --trust @codyswann/lisa
 
 Lisa's dependency `postinstall` runs `lisa apply` for that project. A later
 `bun update @codyswann/lisa` reapplies the updated project-scoped artifacts.
+
+That bootstrap is **loud but non-fatal**: a failed apply prints the real error
+plus a warning naming the consequence, and still exits 0, because a postinstall
+that aborts would break `bun install` in every environment where apply
+legitimately cannot run. The durable signal is
+`lisa doctor` — a successful apply writes `.lisa/apply-receipt.json`, and doctor
+reports any repo whose receipt is missing or older than the installed Lisa
+("this repo has not successfully applied templates since `<version>`"). Run it
+whenever a project seems to have stopped tracking upstream changes; a repo can
+otherwise sit silently stale for months.
+
+The same check covers a second, quieter gap. A package install runs apply in
+**postinstall-safe** mode (`--skip-git-check`), which deliberately skips every
+agent emit — Codex, Claude, agy, Copilot, OpenCode — and the Sonar integration,
+because those rewrite host-owned files. So no `bun install` at any version can
+reconcile `.codex/config.toml`; only a full `lisa apply .` does. Doctor now says
+so instead of reporting such a repo as current.
+
+Lisa drives `js-yaml` through one interop shim and works with the 3.x, 4.x, and
+5.x lines, so a host `overrides`/`resolutions` pin that collapses Lisa's own
+copy is fine. A pin Lisa genuinely cannot drive is reported by `lisa doctor` as
+a named incompatibility rather than a crash.
 Lisa does not register user-wide Codex plugins, skills, hooks, rules, MCP
 servers, or configuration. Other harnesses retain their existing delivery
 behavior. For a new project, run the CLI ephemerally with

--- a/all/copy-contents/gitignore
+++ b/all/copy-contents/gitignore
@@ -238,6 +238,13 @@ expo-env.d.ts
 # /lisa:automation-status. Runbooks are project knowledge; run records are not.
 .lisa/automations/runs/
 
+# Proof that `lisa apply` completed in THIS checkout, read by `lisa doctor` to
+# report a repo that has silently stopped receiving templates. Machine-local by
+# construction: committing it would churn on every version bump, conflict
+# between developers on different Lisa versions, and lie about a fresh clone
+# that has never installed.
+.lisa/apply-receipt.json
+
 # Remote-dispatch ledger. Records the sessions this machine started so a later
 # run can find them. Per developer by construction — each fires their own
 # routine under their own account — so committing it would collide on every

--- a/scripts/install-claude-plugins.sh
+++ b/scripts/install-claude-plugins.sh
@@ -177,7 +177,11 @@ if [ "$IS_LISA_SELF" != "true" ] && [ -z "${CI:-}" ]; then
   if [ "$HOST_HAS_LISA_POSTINSTALL" = "true" ]; then
     echo "Lisa apply deferred to the host project's own postinstall script."
   elif ! LISA_BOOTSTRAP=1 node "$LISA_DIR/dist/index.js" --yes --skip-git-check "$PROJECT_ROOT"; then
-    echo "⚠️  Warning: Lisa template application failed. Migration may be incomplete." >&2
+    # Loud but non-fatal, for the same reason as the host-side bootstrap: a
+    # postinstall that exits non-zero aborts the whole install. The durable
+    # signal is the apply receipt this failed run did NOT write, which
+    # `lisa doctor` reports (CodySwannGT/lisa#2467).
+    echo "⚠️  lisa: TEMPLATE APPLY FAILED (error above) - this project is NOT receiving Lisa template or guardrail updates. Diagnose with: node $LISA_DIR/dist/index.js doctor" >&2
   fi
 fi
 

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Harness, LisaConfig, RefreshTemplates } from "../core/config.js";
+import { recordSuccessfulApply } from "../core/apply-receipt.js";
 import { getBootstrapApplySkipNotice } from "../core/bootstrap-environment.js";
 import { ACCEPTED_HARNESS_INPUTS } from "../core/config.js";
 import { Lisa } from "../core/lisa.js";
@@ -20,6 +21,7 @@ import {
   createDependencies,
   parseRefreshTemplates,
 } from "./shared-options.js";
+import { getPackageVersion } from "./version.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -179,6 +181,48 @@ function buildApplyConfig(parts: {
 }
 
 /**
+ * Persist everything a completed, real (non-validate, non-dry-run) apply owes
+ * the project: its `.lisa.config.json`, any legacy harness migration, and the
+ * receipt proving the apply finished.
+ * @param parts - Resolved state for this invocation
+ * @param parts.destDir - Project directory that was applied to
+ * @param parts.logger - Logger for migration notices
+ * @param parts.config - The config this apply ran with
+ * @param parts.harness - Resolved harness for this invocation
+ * @param parts.persistence - Inputs deciding whether config must be written
+ */
+async function finalizeSuccessfulApply(parts: {
+  destDir: string;
+  logger: ConsoleLogger;
+  config: LisaConfig;
+  harness: Harness;
+  persistence: ProjectConfigPersistenceInput;
+}): Promise<void> {
+  const { destDir, logger, config, harness, persistence } = parts;
+  // Ensure every applied project carries a .lisa.config.json. A missing file is
+  // always backfilled with the resolved harness (the default when no --harness
+  // was passed) so no project is left config-less; an existing file is only
+  // rewritten when --harness actually changes the persisted value.
+  await persistProjectConfigIfNeeded(destDir, persistence);
+  // Rewrite retired legacy harness values (e.g. "both") in place so the
+  // committed config stops carrying a value newer Lisa versions reject.
+  await migrateLegacyHarnessIfNeeded(destDir, logger);
+  // Record that an apply actually completed here. The postinstall bootstrap is
+  // non-fatal by design, so absence of this receipt is the only reliable
+  // evidence that a repo has silently stopped receiving templates — which is
+  // what `lisa doctor` reports (CodySwannGT/lisa#2467).
+  await recordSuccessfulApply(destDir, {
+    lisaVersion: getPackageVersion(),
+    harness,
+    // `--skip-git-check` IS postinstall-safe mode: it skips every agent emit,
+    // so a bump alone can never reconcile `.codex/config.toml` and friends.
+    // Recording which mode ran is what lets doctor say that work is still
+    // outstanding rather than reporting the repo as current.
+    applyMode: config.skipGitCheck ? "postinstall-safe" : "full",
+  });
+}
+
+/**
  * Apply Lisa to the given destination with the given options.
  *
  * This is the relocated action that previously lived inline in
@@ -234,21 +278,19 @@ export async function runApply(
       process.exit(1);
     }
 
-    // Ensure every applied project carries a .lisa.config.json (not on
-    // validate / dry-run). A missing file is always backfilled with the
-    // resolved harness (the default when no --harness was passed) so no
-    // project is left config-less; an existing file is only rewritten when
-    // --harness actually changes the persisted value, avoiding churn.
     if (!options.validate && !dryRun) {
-      await persistProjectConfigIfNeeded(destDir, {
-        fileExists: configFileExists,
-        flagHarness: options.harness,
-        existingHarness: projectConfig.harness,
-        resolvedHarness: harness,
+      await finalizeSuccessfulApply({
+        destDir,
+        logger,
+        config,
+        harness,
+        persistence: {
+          fileExists: configFileExists,
+          flagHarness: options.harness,
+          existingHarness: projectConfig.harness,
+          resolvedHarness: harness,
+        },
       });
-      // Rewrite retired legacy harness values (e.g. "both") in place so the
-      // committed config stops carrying a value newer Lisa versions reject.
-      await migrateLegacyHarnessIfNeeded(destDir, logger);
     }
 
     // After a real apply, surface (read-only) whether any locally-authored

--- a/src/cli/doctor-apply-freshness.ts
+++ b/src/cli/doctor-apply-freshness.ts
@@ -1,0 +1,234 @@
+/**
+ * Doctor check: has `lisa apply` ever actually succeeded here, and did it
+ * succeed on the Lisa version this project now has installed?
+ *
+ * This is the arm that would have caught geminisportsai/frontend-v2
+ * (CodySwannGT/lisa#2467). That repo's `lisa apply` had been failing outright
+ * for months — an incompatible js-yaml pin killed the CLI before it could print
+ * anything — while the postinstall bootstrap discarded the error. Nothing
+ * anywhere said the repo had stopped receiving templates, guardrails, or
+ * security floors. The only way to find out was for a human to run apply by
+ * hand and read the crash.
+ *
+ * The signal is the apply receipt (`core/apply-receipt`), written only by a
+ * completed apply. Missing receipt means no apply has ever finished; an older
+ * version stamp means none has finished since that version. Both are reported
+ * with the version and date, and with the command that reproduces the failure.
+ *
+ * A third silence lives in the same subsystem: postinstall-safe mode
+ * (`--skip-git-check`, which is what a package manager runs) skips every agent
+ * emit. That is deliberate — those emits rewrite host-owned files — but it
+ * means no `bun install` at any version can reconcile `.codex/config.toml`, so
+ * repos on the newest Lisa still carry a deprecated `codex_hooks` key and an
+ * audit reasonably but wrongly concluded "apply just hasn't re-run". Same shape
+ * as #2436: postinstall-safe mode skipping work callers assume a bump performs.
+ * A receipt whose only recorded apply was postinstall-safe warns for that too.
+ *
+ * Warn, not fail: the remedy is one command, and a project mid-upgrade — or one
+ * freshly cloned and not yet installed — is legitimately in this state for a
+ * few minutes. Reddening doctor's exit code there would train operators to
+ * ignore it, which is how the original silence took hold.
+ * @module cli/doctor-apply-freshness
+ */
+import * as path from "node:path";
+import { lt, valid } from "semver";
+import {
+  APPLY_RECEIPT_DISPLAY_PATH,
+  readApplyReceipt,
+} from "../core/apply-receipt.js";
+import { LISA_PACKAGE_NAME, isLisaSourceRepo } from "../core/self-apply.js";
+import { readJsonOrNull } from "../utils/json-utils.js";
+import { probeYamlRuntime } from "../utils/yaml.js";
+import { getPackageVersion } from "./version.js";
+
+const CHECK_NAME = "Templates applied by this Lisa version?";
+const YAML_CHECK_NAME = "YAML runtime usable?";
+const REAPPLY_COMMAND =
+  "node node_modules/@codyswann/lisa/dist/index.js --yes --skip-git-check .";
+/** No `--skip-git-check`: the only form that performs the agent emits. */
+const FULL_APPLY_COMMAND = "node node_modules/@codyswann/lisa/dist/index.js .";
+
+/** One doctor check result, structurally identical to `DoctorCheck`. */
+interface FreshnessCheck {
+  name: string;
+  status: "ok" | "warn" | "fail";
+  detail: string;
+}
+
+/** Dependency sections that can declare Lisa. */
+interface ManifestShape {
+  readonly dependencies?: Readonly<Record<string, string>>;
+  readonly devDependencies?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Resolve Lisa's version without throwing when package metadata is unreadable.
+ * @returns Version string, or null when it cannot be determined
+ */
+function installedLisaVersion(): string | null {
+  try {
+    return getPackageVersion();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decide whether this project is one Lisa is supposed to be applying to.
+ *
+ * Deliberately based on the manifest rather than on `.lisa.config.json`: a
+ * project that has *never* applied successfully may not have a config yet, and
+ * that is exactly the case this check exists to report.
+ * @param targetPath - Project path
+ * @returns True when the project declares Lisa as a dependency
+ */
+async function declaresLisa(targetPath: string): Promise<boolean> {
+  const manifest = await readJsonOrNull<ManifestShape>(
+    path.join(targetPath, "package.json")
+  );
+  if (!manifest) return false;
+  return (
+    manifest.dependencies?.[LISA_PACKAGE_NAME] !== undefined ||
+    manifest.devDependencies?.[LISA_PACKAGE_NAME] !== undefined
+  );
+}
+
+/**
+ * Render an ISO timestamp as a plain calendar date, degrading to the raw value.
+ * @param isoTimestamp - Timestamp from the receipt
+ * @returns `YYYY-MM-DD`, or the input when it is not a real date
+ */
+function toCalendarDate(isoTimestamp: string): string {
+  const parsed = new Date(isoTimestamp);
+  return Number.isNaN(parsed.getTime())
+    ? isoTimestamp
+    : parsed.toISOString().slice(0, 10);
+}
+
+/**
+ * Build the "never applied" warning.
+ * @param installed - Installed Lisa version
+ * @returns Doctor check result
+ */
+function neverApplied(installed: string): FreshnessCheck {
+  return {
+    name: CHECK_NAME,
+    status: "warn",
+    detail:
+      `No successful Lisa apply has ever been recorded here (installed Lisa ${installed}; ` +
+      `no ${APPLY_RECEIPT_DISPLAY_PATH}). This repo is not receiving template, guardrail, ` +
+      `or dependency-floor updates. Run \`${REAPPLY_COMMAND}\` and read the output — ` +
+      "the postinstall bootstrap is non-fatal, so an apply that crashes every time " +
+      "will not stop an install.",
+  };
+}
+
+/**
+ * Compare the receipt against the installed version.
+ * @param targetPath - Project path
+ * @param installed - Installed Lisa version
+ * @returns Doctor check result
+ */
+async function compareReceipt(
+  targetPath: string,
+  installed: string
+): Promise<FreshnessCheck> {
+  const receipt = await readApplyReceipt(targetPath);
+  if (receipt === null) {
+    return neverApplied(installed);
+  }
+
+  const recorded = receipt.lisa_version;
+  const appliedOn = toCalendarDate(receipt.applied_at);
+  const bothParse = valid(recorded) !== null && valid(installed) !== null;
+  const isStale = bothParse ? lt(recorded, installed) : recorded !== installed;
+
+  if (!isStale) {
+    return receipt.apply_mode === "postinstall-safe"
+      ? {
+          name: CHECK_NAME,
+          status: "warn",
+          detail:
+            `Templates are current (Lisa ${recorded} on ${appliedOn}), but the only apply ` +
+            "recorded here ran in postinstall-safe mode, which skips every agent emit — " +
+            "Codex, Claude, agy, Copilot, OpenCode — and the Sonar integration. No package " +
+            "install at any version performs that work, so artifacts like `.codex/config.toml` " +
+            `are still unreconciled. Run \`${FULL_APPLY_COMMAND}\` to complete it.`,
+        }
+      : {
+          name: CHECK_NAME,
+          status: "ok",
+          detail: `Last successful apply: Lisa ${recorded} on ${appliedOn}`,
+        };
+  }
+
+  return {
+    name: CHECK_NAME,
+    status: "warn",
+    detail:
+      `This repo has not successfully applied templates since Lisa ${recorded} ` +
+      `(${appliedOn}); installed Lisa is ${installed}. Everything shipped between ` +
+      `those versions is missing here. Run \`${REAPPLY_COMMAND}\` and read the output.`,
+  };
+}
+
+/**
+ * Report whether template application is current for this checkout.
+ * @param targetPath - Project path to inspect
+ * @returns Doctor check result
+ */
+export async function checkApplyFreshness(
+  targetPath: string
+): Promise<FreshnessCheck> {
+  if (await isLisaSourceRepo(targetPath)) {
+    return {
+      name: CHECK_NAME,
+      status: "ok",
+      detail:
+        "Lisa source repo; apply is self-restricted and records no receipt",
+    };
+  }
+  if (!(await declaresLisa(targetPath))) {
+    return {
+      name: CHECK_NAME,
+      status: "ok",
+      detail: `${LISA_PACKAGE_NAME} is not a dependency here; skipped`,
+    };
+  }
+
+  const installed = installedLisaVersion();
+  if (installed === null) {
+    return {
+      name: CHECK_NAME,
+      status: "warn",
+      detail:
+        "Could not determine the installed Lisa version to compare against",
+    };
+  }
+  return compareReceipt(targetPath, installed);
+}
+
+/**
+ * Report whether the js-yaml this install resolved can actually be driven.
+ *
+ * Separate from the freshness check because it answers the follow-up question:
+ * *why* has nothing applied? A host `overrides`/`resolutions` entry collapses
+ * Lisa's own js-yaml onto the host's pin, and an incompatible pin used to kill
+ * the CLI at module-load time with a bare stack trace. Lisa now links against
+ * any js-yaml shape and reports the incompatibility in plain language here.
+ *
+ * `fail`, not `warn`: nothing that parses YAML works in this state — Codex and
+ * OpenCode artifact generation, CI workflow readiness, and the console's deploy
+ * pipeline all stop — and the remedy is a one-line manifest edit.
+ * @returns Doctor check result
+ */
+export function checkYamlRuntime(): FreshnessCheck {
+  const problem = probeYamlRuntime();
+  return problem === null
+    ? {
+        name: YAML_CHECK_NAME,
+        status: "ok",
+        detail: "Resolved js-yaml exposes a usable load()",
+      }
+    : { name: YAML_CHECK_NAME, status: "fail", detail: problem };
+}

--- a/src/cli/doctor-readiness-workflows.ts
+++ b/src/cli/doctor-readiness-workflows.ts
@@ -16,8 +16,8 @@
  */
 import { readdir, readFile } from "node:fs/promises";
 import * as path from "node:path";
-import yaml from "js-yaml";
 import { isJsonObject } from "../sync/json-path.js";
+import { loadYaml } from "../utils/yaml.js";
 
 /** The workflows directory every GitHub repository declares its CI in. */
 const WORKFLOWS_DIR = path.join(".github", "workflows");
@@ -303,7 +303,7 @@ async function parseOneWorkflow(
       path.join(root, WORKFLOWS_DIR, fileName),
       "utf8"
     );
-    const document: unknown = yaml.load(source);
+    const document: unknown = loadYaml(source);
     if (!isJsonObject(document)) {
       return null;
     }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -7,6 +7,10 @@ import { migrateInstructionFiles } from "../core/instruction-files-migration.js"
 import { probeKaneReadiness } from "../core/kane-cli.js";
 import { probeSonarReadiness } from "../core/sonar-integration.js";
 import { createDetectorRegistry } from "../detection/index.js";
+import {
+  checkApplyFreshness,
+  checkYamlRuntime,
+} from "./doctor-apply-freshness.js";
 import { checkKaneProvider } from "./doctor-kane.js";
 import { checkLearningsLedger } from "./doctor-learnings-ledger.js";
 import { checkSonarProvider } from "./doctor-sonar.js";
@@ -327,6 +331,11 @@ export async function runDoctor(
   const resolvedTarget = path.resolve(targetPath ?? process.cwd());
   const checks = [
     await checkVersion(deps, options.offline === true),
+    // Runs early and unconditionally: a repo that has silently stopped applying
+    // templates fails every other check's premise, and the two lines below are
+    // the ones that name the cause (CodySwannGT/lisa#2467).
+    await checkApplyFreshness(resolvedTarget),
+    checkYamlRuntime(),
     await checkProjectConfig(resolvedTarget),
     await checkKaneProvider(resolvedTarget, deps),
     await checkSonarProvider(resolvedTarget, deps),

--- a/src/cli/ui-ci-quality-jobs-parse.ts
+++ b/src/cli/ui-ci-quality-jobs-parse.ts
@@ -4,8 +4,8 @@
  */
 import { readFile } from "node:fs/promises";
 import * as path from "node:path";
-import yaml from "js-yaml";
 import { isJsonObject } from "../sync/json-path.js";
+import { loadYaml } from "../utils/yaml.js";
 import type { CiWorkflowInputs } from "./ui-ci-quality-jobs-compute.js";
 
 /**
@@ -110,7 +110,7 @@ export async function parseCiWorkflowInputs(
   readCiYml: (projectRoot: string) => Promise<string> = readCiYmlFile
 ): Promise<CiWorkflowInputs> {
   const source = await readCiYml(cwd);
-  const document: unknown = yaml.load(source);
+  const document: unknown = loadYaml(source);
   const withBlock = qualityWithBlock(document);
   if (withBlock === undefined) {
     throw new Error(

--- a/src/cli/ui-deploy-pipeline-model.ts
+++ b/src/cli/ui-deploy-pipeline-model.ts
@@ -2,8 +2,8 @@
  * Pure model for Deploy pipeline stages — parse deploy.yml, map holds, assemble.
  * @module cli/ui-deploy-pipeline-model
  */
-import yaml from "js-yaml";
 import { isJsonObject, type JsonValue } from "../sync/json-path.js";
+import { loadYaml } from "../utils/yaml.js";
 import type { ProbeResult } from "./ui-status.js";
 
 /** Stable probe id consumed by the Deploy section hydration. */
@@ -62,7 +62,7 @@ export function parseDeployWorkflowStages(
   contents: string
 ): readonly DeployPipelineStage[] {
   try {
-    const loaded = yaml.load(contents) as unknown;
+    const loaded = loadYaml(contents) as unknown;
     if (!isJsonObject(loaded)) {
       return [];
     }

--- a/src/codex/agent-transformer.ts
+++ b/src/codex/agent-transformer.ts
@@ -29,7 +29,7 @@
  * Codex's loader accepts.
  * @module codex/agent-transformer
  */
-import yaml from "js-yaml";
+import { loadYaml } from "../utils/yaml.js";
 
 /**
  * Prefix applied to every Lisa-owned Codex agent name. Provides
@@ -80,7 +80,7 @@ export function parseAgentMarkdown(source: string): ParsedAgent {
   }
   const rawFrontmatter = match[1];
   const rawBody = match[2];
-  const parsed = yaml.load(rawFrontmatter) as unknown;
+  const parsed = loadYaml(rawFrontmatter) as unknown;
   const frontmatter = validateFrontmatter(parsed);
   return { frontmatter, body: rawBody.trimStart() };
 }

--- a/src/codex/command-skill-transformer.ts
+++ b/src/codex/command-skill-transformer.ts
@@ -1,7 +1,7 @@
 /**
  * Convert Claude slash-command markdown into Codex skill markdown.
  */
-import yaml from "js-yaml";
+import { loadYaml } from "../utils/yaml.js";
 
 /** Parsed Claude command frontmatter fields relevant to Codex compatibility */
 interface CommandFrontmatter {
@@ -42,7 +42,7 @@ export function convertCommandToSkill(
   const rawBody = match[2];
 
   const parsedFrontmatter = parseCommandFrontmatter(
-    yaml.load(rawFrontmatter),
+    loadYaml(rawFrontmatter),
     displayName
   );
   const body = rawBody
@@ -71,7 +71,7 @@ export function convertCommandToSkill(
 
 /**
  * Parse the subset of Claude command frontmatter that Codex should preserve.
- * @param parsed - Output of `yaml.load(rawFrontmatter)` (untrusted shape)
+ * @param parsed - Output of `loadYaml(rawFrontmatter)` (untrusted shape)
  * @param displayName - Fallback used when no description is available
  * @returns Command frontmatter relevant to Codex skill conversion
  */

--- a/src/core/apply-receipt.ts
+++ b/src/core/apply-receipt.ts
@@ -1,0 +1,154 @@
+/**
+ * The durable record that `lisa apply` actually succeeded here.
+ *
+ * The postinstall bootstrap is loud but non-fatal by design (see
+ * `migrations/ensure-lisa-postinstall`), and the detached reconciliation
+ * trampoline runs with `stdio: "ignore"` because it outlives the terminal that
+ * started it. Both are correct, and both mean a failed apply can leave no trace
+ * anyone will ever read. geminisportsai/frontend-v2 went months that way
+ * (CodySwannGT/lisa#2467).
+ *
+ * So success — not failure — is what gets recorded. A receipt is written only
+ * on a completed, non-dry-run apply, which makes absence and staleness both
+ * self-evident: no receipt means no apply has ever finished here, and an old
+ * version stamp means none has finished since that version. `lisa doctor` reads
+ * it (see `cli/doctor-apply-freshness`), so the failure is findable long after
+ * the install output has scrolled away, without anyone re-running apply by hand.
+ *
+ * The receipt is machine-local and gitignored: it describes this checkout, not
+ * the project. Committing it would churn on every version bump and conflict
+ * between developers on different Lisa versions, and a committed receipt would
+ * lie about a fresh clone that has never installed.
+ * @module core/apply-receipt
+ */
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+import { readJsonOrNull } from "../utils/json-utils.js";
+
+/** Directory-relative location of the receipt, for messages and gitignores. */
+export const APPLY_RECEIPT_DISPLAY_PATH = ".lisa/apply-receipt.json";
+
+/**
+ * Receipt schema version. Bump only alongside a reader change — an unknown
+ * version is treated as no receipt at all rather than being misread.
+ */
+export const APPLY_RECEIPT_SCHEMA_VERSION = 1;
+
+/**
+ * How complete the recorded apply was.
+ *
+ * `postinstall-safe` is the `--skip-git-check` path a package manager runs. It
+ * deliberately skips every agent emit (Codex, Claude, agy, Copilot, OpenCode)
+ * and the Sonar integration, because those rewrite host-owned files that must
+ * not change under an install. That is the right behaviour and the wrong
+ * silence: it means no `bun install` at any version can migrate `.codex/config.toml`
+ * — including the deprecated `codex_hooks` key — so a repo can sit on the
+ * newest Lisa and still be missing work only a full `lisa apply` performs.
+ * Recording the mode is what lets doctor say so.
+ *
+ * `unknown` covers receipts written before this field existed.
+ */
+export type ApplyMode = "full" | "postinstall-safe" | "unknown";
+
+/** The persisted `.lisa/apply-receipt.json` shape. */
+export interface ApplyReceipt {
+  readonly schema_version: number;
+  /** Lisa version that completed the apply. */
+  readonly lisa_version: string;
+  /** ISO timestamp of that apply. */
+  readonly applied_at: string;
+  /** Harness the apply emitted artifacts for. */
+  readonly harness: string;
+  /** Whether that apply was a full one or the postinstall-safe subset. */
+  readonly apply_mode: ApplyMode;
+}
+
+/**
+ * Narrow a persisted mode value, treating anything unrecognised — including a
+ * receipt written before the field existed — as `unknown` rather than guessing.
+ * @param value - Raw value from the receipt
+ * @returns A known apply mode
+ */
+function toApplyMode(value: unknown): ApplyMode {
+  return value === "full" || value === "postinstall-safe" ? value : "unknown";
+}
+
+/**
+ * Resolve the single path every reader and writer uses.
+ * @param root - Project root
+ * @returns Absolute path to the receipt
+ */
+export function resolveApplyReceiptPath(root: string): string {
+  return path.join(root, ".lisa", "apply-receipt.json");
+}
+
+/**
+ * Read the receipt, returning null when it is missing, unparseable, or written
+ * by a schema this build does not understand.
+ * @param root - Project root
+ * @returns The receipt, or null when there is no usable one
+ */
+export async function readApplyReceipt(
+  root: string
+): Promise<ApplyReceipt | null> {
+  const parsed = await readJsonOrNull<Partial<ApplyReceipt>>(
+    resolveApplyReceiptPath(root)
+  );
+  if (
+    parsed?.schema_version !== APPLY_RECEIPT_SCHEMA_VERSION ||
+    typeof parsed.lisa_version !== "string" ||
+    typeof parsed.applied_at !== "string"
+  ) {
+    return null;
+  }
+  return {
+    schema_version: parsed.schema_version,
+    lisa_version: parsed.lisa_version,
+    applied_at: parsed.applied_at,
+    harness: typeof parsed.harness === "string" ? parsed.harness : "unknown",
+    apply_mode: toApplyMode(parsed.apply_mode),
+  };
+}
+
+/**
+ * Record that an apply completed successfully.
+ *
+ * Written atomically (temp file plus rename) so a reader never sees a partial
+ * document, and never throws: a receipt that could not be written must not turn
+ * a successful apply into a failed one. The cost of a silently missing receipt
+ * is one spurious doctor warning; the cost of throwing here is breaking installs.
+ * @param root - Project root that was applied to
+ * @param details - What completed
+ * @param details.lisaVersion - Lisa version that ran the apply
+ * @param details.harness - Harness the apply emitted for
+ * @param details.applyMode - Whether this was a full or postinstall-safe apply
+ * @param now - Clock, injectable for tests
+ * @returns True when the receipt was persisted
+ */
+export async function recordSuccessfulApply(
+  root: string,
+  details: {
+    readonly lisaVersion: string;
+    readonly harness: string;
+    readonly applyMode: ApplyMode;
+  },
+  now: () => Date = () => new Date()
+): Promise<boolean> {
+  const receipt: ApplyReceipt = {
+    schema_version: APPLY_RECEIPT_SCHEMA_VERSION,
+    lisa_version: details.lisaVersion,
+    applied_at: now().toISOString(),
+    harness: details.harness,
+    apply_mode: details.applyMode,
+  };
+  const receiptPath = resolveApplyReceiptPath(root);
+  try {
+    await mkdir(path.dirname(receiptPath), { recursive: true });
+    const tempPath = `${receiptPath}.tmp`;
+    await writeFile(tempPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+    await rename(tempPath, receiptPath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -5,7 +5,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-contents/.gitattributes":
       "9d3831007e681186a3673e1037ef3fc82980cab2fc04e27c0868e562912c9e9f",
     "all/copy-contents/gitignore":
-      "2dbf7fd2f2020fc7824c432342002d9ca3ebb57b2872e761b14e942b23479a11",
+      "8104ccd32d7e6137cae706511c5037d11d6b6045b8e2a9bb7b3a48a81c053cfa",
     "all/copy-overwrite/scripts/check-state-classification.mjs":
       "94dc98e0bbfcf8d43cba035d4805a1c5d61a3a0db88faa791e8e06e34e741f46",
     "all/copy-overwrite/scripts/lisa-command-envelope.mjs":
@@ -2109,7 +2109,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/github-status-check.sh":
       "c6a4a13ff5cf689fcbd7a6aca718f9e7d46d54ccb6687f662b055c1ca20e792f",
     "scripts/install-claude-plugins.sh":
-      "ed60ed3afc25175b81439330dbf26ff639f55fabec54223df4c7266805c84f22",
+      "0e96ebbae1e59304bb432286eccba38900a6008b80f2c53a1ec2c95801d4087c",
     "scripts/internal-agy-skill-policy.json":
       "c2ce87d2eeebfdc9f24d6486425c010cf9289376f8a459f4767ca22d2bf8670d",
     "scripts/internal-codex-skill-policy.json":
@@ -8096,6 +8096,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/cli/check-learnings-budget-cmd.ts": true,
     "src/cli/cross-pollinate-cmd.ts": true,
     "src/cli/cross-pollinate-nudge.ts": true,
+    "src/cli/doctor-apply-freshness.ts": true,
     "src/cli/doctor-kane.ts": true,
     "src/cli/doctor-learnings-ledger.ts": true,
     "src/cli/doctor-legacy-overlay.ts": true,
@@ -8245,6 +8246,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/configs/worktrees.ts": true,
     "src/copilot/copilot-instructions-installer.ts": true,
     "src/copilot/plugin-installer.ts": true,
+    "src/core/apply-receipt.ts": true,
     "src/core/bootstrap-environment.ts": true,
     "src/core/config.ts": true,
     "src/core/git-service.ts": true,
@@ -8398,6 +8400,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/utils/postinstall-trampoline.ts": true,
     "src/utils/usage-accounting-rollup.ts": true,
     "src/utils/usage-accounting.ts": true,
+    "src/utils/yaml.ts": true,
     "state/demo-project/README.md": true,
     "state/demo-project/state/inventory.json": true,
     "state/demo-project/state/state-contract.json": true,
@@ -8533,6 +8536,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/claude/claude-md-installer.test.ts": true,
     "tests/unit/cli/apply.test.ts": true,
     "tests/unit/cli/check-learnings-budget-cmd.test.ts": true,
+    "tests/unit/cli/doctor-apply-freshness.test.ts": true,
     "tests/unit/cli/doctor-kane.test.ts": true,
     "tests/unit/cli/doctor-learnings-ledger.test.ts": true,
     "tests/unit/cli/doctor-lisa-owned-artifacts.test.ts": true,
@@ -8782,6 +8786,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/migrations/ensure-tsconfig-local-includes.test.ts": true,
     "tests/unit/migrations/ensure-wiki-source-declared.test.ts": true,
     "tests/unit/migrations/migration-registry.test.ts": true,
+    "tests/unit/migrations/postinstall-failure-surfacing.test.ts": true,
     "tests/unit/migrations/reconcile-claude-stack-plugins.test.ts": true,
     "tests/unit/migrations/untrack-codex-marketplace.test.ts": true,
     "tests/unit/opencode/agent-installer.test.ts": true,
@@ -9128,6 +9133,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/utils/usage-accounting-table-normalization.test.ts": true,
     "tests/unit/utils/usage-accounting-token-serialization.test.ts": true,
     "tests/unit/utils/usage-accounting.test.ts": true,
+    "tests/unit/utils/yaml-interop.test.ts": true,
     "tests/unit/workstation/fixtures.ts": true,
     "tests/unit/workstation/link-into-bin-dir.test.ts": true,
     "tests/unit/workstation/workstation-install.test.ts": true,

--- a/src/migrations/ensure-lisa-postinstall.ts
+++ b/src/migrations/ensure-lisa-postinstall.ts
@@ -11,8 +11,46 @@ import type {
 const PACKAGE_JSON = "package.json";
 const CI_GUARD_PREFIX = '[ -n "$CI" ] || ';
 const BOOTSTRAP_PREFIX = "LISA_BOOTSTRAP=1 ";
-const LISA_INVOCATION = `${CI_GUARD_PREFIX}${BOOTSTRAP_PREFIX}node node_modules/@codyswann/lisa/dist/index.js --yes --skip-git-check . 2>/dev/null || true`;
 const LISA_MARKER = "node_modules/@codyswann/lisa/dist/index.js";
+const LISA_APPLY_COMMAND = `node ${LISA_MARKER} --yes --skip-git-check .`;
+
+/**
+ * What the operator sees on stderr when the bootstrap apply fails.
+ *
+ * Written for someone scrolling past a wall of install output who may not know
+ * what Lisa is: it says what stopped working (templates and guardrails are no
+ * longer arriving), that the real error is directly above, and the two commands
+ * that reproduce and diagnose it. ASCII and free of `"`, `$`, and backticks so
+ * it survives being embedded in a JSON string inside a `sh -c` command.
+ */
+export const APPLY_FAILURE_NOTICE =
+  "lisa: TEMPLATE APPLY FAILED - this project is NOT receiving Lisa template " +
+  `or guardrail updates. The error is above. Reproduce it with: ${LISA_APPLY_COMMAND} ` +
+  `- then run: node ${LISA_MARKER} doctor`;
+
+/**
+ * The bootstrap invocation chained into a host project's `postinstall`.
+ *
+ * Shape: **loud but non-fatal**. It used to end in `2>/dev/null || true`, which
+ * discarded the apply's stderr and its exit code, so a totally failed apply was
+ * indistinguishable from success and a repo could silently stop receiving
+ * template updates (CodySwannGT/lisa#2467). Stderr now flows through and a
+ * failure adds an explicit warning line.
+ *
+ * It deliberately still exits 0. A postinstall runs inside `npm install` /
+ * `bun install`; exiting non-zero aborts the install and leaves `node_modules`
+ * half-built. Apply legitimately cannot run in plenty of environments (no git
+ * repo, no project config, sandboxed or non-interactive shells), so a hard
+ * failure would convert a template-sync problem into an install outage across
+ * the fleet. The durable signal instead lives in the apply receipt that a
+ * successful apply writes — `lisa doctor` reports a repo whose receipt is
+ * missing or older than the installed Lisa, so the failure is still findable
+ * long after the install output has scrolled away.
+ *
+ * Exported so tests can execute the real script under `sh` rather than assert
+ * on a string.
+ */
+export const LISA_INVOCATION = `${CI_GUARD_PREFIX}${BOOTSTRAP_PREFIX}${LISA_APPLY_COMMAND} || echo "${APPLY_FAILURE_NOTICE}" >&2`;
 
 /**
  * Project types that do not use Node.js postinstall hooks (e.g. Rails).
@@ -40,12 +78,20 @@ async function readPackageJson(
 }
 
 /**
- * Legacy Lisa invocation pattern (without CI guard). Existing projects may
- * have this form chained with other commands; we detect and replace it so
- * the CI guard is introduced without duplicating the invocation.
+ * Every historical spelling of the Lisa invocation, so an in-place upgrade
+ * replaces it rather than chaining a second copy in front of it.
+ *
+ * The optional tail covers, in order: the failure-swallowing legacy form
+ * (`2>/dev/null || true`), the current loud-but-non-fatal form
+ * (`|| echo "..." >&2`), and a bare invocation with no tail at all. Guard
+ * prefixes are optional and repeatable because older Lisa versions introduced
+ * them one at a time.
  */
-const LISA_INVOCATION_RE =
-  /(?:(?:\[ -n "\$CI" \] \|\| )|(?:LISA_BOOTSTRAP=1 ))*node node_modules\/@codyswann\/lisa\/dist\/index\.js --yes --skip-git-check \. 2>\/dev\/null \|\| true/;
+const LISA_INVOCATION_RE = new RegExp(
+  '(?:(?:\\[ -n "\\$CI" \\] \\|\\| )|(?:LISA_BOOTSTRAP=1 ))*' +
+    "node node_modules/@codyswann/lisa/dist/index\\.js --yes --skip-git-check \\." +
+    '(?: 2>/dev/null \\|\\| true| \\|\\| echo "[^"]*" >&2)?'
+);
 
 /**
  * Compose the new postinstall, prepending the Lisa invocation to any existing command.

--- a/src/opencode/command-transformer.ts
+++ b/src/opencode/command-transformer.ts
@@ -31,7 +31,7 @@
  * passed through unchanged.
  * @module opencode/command-transformer
  */
-import yaml from "js-yaml";
+import { loadYaml } from "../utils/yaml.js";
 
 /**
  * Pure transform: convert a Lisa command Markdown into an OpenCode command
@@ -53,7 +53,7 @@ export function transformCommandToOpencode(
       `Command source is missing YAML frontmatter for ${displayName}`
     );
   }
-  const description = parseDescription(yaml.load(match[1]), displayName);
+  const description = parseDescription(loadYaml(match[1]), displayName);
   const body = match[2].trimStart().trimEnd();
 
   const frontmatter = [
@@ -69,7 +69,7 @@ export function transformCommandToOpencode(
 /**
  * Extract the command description from parsed frontmatter, falling back to the
  * display name when none is present.
- * @param parsed - Output of `yaml.load(rawFrontmatter)` (untrusted shape)
+ * @param parsed - Output of `loadYaml(rawFrontmatter)` (untrusted shape)
  * @param displayName - Fallback used when no description is available
  * @returns The description string
  */

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -1,0 +1,145 @@
+/**
+ * The single js-yaml entry point for all of Lisa.
+ *
+ * Why this exists rather than `import yaml from "js-yaml"` at each call site:
+ * Lisa is `"type": "module"`, so a default import compiles to a real ESM
+ * default import. js-yaml 5.x ships an ESM build that exports `load`/`dump`
+ * as *named* exports and no `default`, so the default import is a link-time
+ * `SyntaxError: The requested module 'js-yaml' does not provide an export
+ * named 'default'`. That error fires while the module graph is being
+ * instantiated — before any Lisa code runs — so the whole CLI is dead,
+ * including `lisa doctor`. Lisa declares js-yaml `^4.3.1` for itself, but a
+ * host project's `overrides`/`resolutions` collapse Lisa's nested copy onto
+ * whatever the host pinned, which is exactly how geminisportsai/frontend-v2
+ * ended up running Lisa against js-yaml 5 (CodySwannGT/lisa#2467).
+ *
+ * A namespace import links against any module shape, so the incompatibility
+ * becomes a *runtime* condition this module can inspect and report in plain
+ * language instead of a link-time crash with a stack trace.
+ *
+ * Compatibility is deliberately shape-based, not version-based: js-yaml 3, 4
+ * and 5 all expose a `load(source)` that Lisa uses identically, and Lisa uses
+ * nothing else from the package. Anything exposing that function works; a
+ * future major that renames it fails with a message naming the problem.
+ * @module utils/yaml
+ */
+import * as jsYaml from "js-yaml";
+import { LisaError } from "../errors/index.js";
+
+/** The only js-yaml surface Lisa consumes. */
+export interface YamlApi {
+  /**
+   * Parse a single YAML document.
+   * @param source - YAML text
+   * @returns The parsed document
+   */
+  readonly load: (source: string) => unknown;
+}
+
+/** Human-readable statement of what Lisa can drive. */
+export const SUPPORTED_JS_YAML_DESCRIPTION =
+  "js-yaml 3.x, 4.x and 5.x (any build exposing a load() function)";
+
+/**
+ * Raised when the resolved js-yaml cannot be driven by Lisa.
+ *
+ * Carries the remediation inline: the operator reading this in a postinstall
+ * warning has no other context to work from.
+ */
+export class IncompatibleYamlError extends LisaError {
+  /**
+   * Build the operator-facing incompatibility message.
+   * @param shape - Short description of what the resolved module did expose
+   */
+  constructor(shape: string) {
+    super(
+      "Lisa cannot use the installed js-yaml: the resolved package exposes no " +
+        `load() function (${shape}). Lisa supports ${SUPPORTED_JS_YAML_DESCRIPTION}. ` +
+        "This usually means a js-yaml pin, override, or resolution in your " +
+        "package.json forced Lisa onto an incompatible copy. Remove or widen " +
+        "that js-yaml entry, reinstall, and re-run `lisa doctor`.",
+      "INCOMPATIBLE_JS_YAML"
+    );
+    this.name = "IncompatibleYamlError";
+  }
+}
+
+/**
+ * Pull a callable `load` off a candidate object.
+ * @param candidate - Namespace object, interop default, or anything else
+ * @returns The `load` function when present and callable
+ */
+function pickLoad(candidate: unknown): YamlApi["load"] | undefined {
+  if (typeof candidate !== "object" || candidate === null) {
+    return undefined;
+  }
+  const { load } = candidate as { readonly load?: unknown };
+  return typeof load === "function" ? (load as YamlApi["load"]) : undefined;
+}
+
+/**
+ * Describe what a resolved module actually exposed, for the failure message.
+ * @param moduleNamespace - The resolved js-yaml module namespace
+ * @returns A short, bounded description of its exports
+ */
+function describeShape(moduleNamespace: unknown): string {
+  if (typeof moduleNamespace !== "object" || moduleNamespace === null) {
+    return `resolved to ${typeof moduleNamespace}`;
+  }
+  const keys = Object.keys(moduleNamespace);
+  return keys.length === 0
+    ? "no exports"
+    : `exports: ${keys.slice(0, 8).join(", ")}${keys.length > 8 ? ", ..." : ""}`;
+}
+
+/**
+ * Resolve Lisa's YAML surface from a js-yaml module namespace, tolerating both
+ * the named-export shape (3.x/4.x/5.x ESM) and the CJS interop shape where the
+ * whole module hangs off `default`.
+ *
+ * Exported so `lisa doctor` can probe compatibility without parsing anything,
+ * and so the failure path is directly testable.
+ * @param moduleNamespace - The resolved js-yaml module namespace
+ * @returns The YAML surface Lisa uses
+ * @throws IncompatibleYamlError when no callable `load` can be found
+ */
+export function resolveYamlApi(moduleNamespace: unknown): YamlApi {
+  const named = pickLoad(moduleNamespace);
+  if (named) {
+    return { load: named };
+  }
+  const interop = pickLoad(
+    (moduleNamespace as { readonly default?: unknown } | null)?.default
+  );
+  if (interop) {
+    return { load: interop };
+  }
+  throw new IncompatibleYamlError(describeShape(moduleNamespace));
+}
+
+/**
+ * Parse a single YAML document using whichever js-yaml the install resolved.
+ * @param source - YAML text
+ * @returns The parsed document
+ * @throws IncompatibleYamlError when the resolved js-yaml is unusable
+ */
+export function loadYaml(source: string): unknown {
+  return resolveYamlApi(jsYaml).load(source);
+}
+
+/**
+ * Probe the js-yaml this process actually resolved.
+ *
+ * Never throws: `lisa doctor` turns the result into a check line, and a doctor
+ * that crashed on the very incompatibility it is meant to report would be the
+ * silent-failure bug all over again.
+ * @returns The incompatibility message, or null when the resolved js-yaml works
+ */
+export function probeYamlRuntime(): string | null {
+  try {
+    resolveYamlApi(jsYaml);
+    return null;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}

--- a/tests/integration/lisa.test.ts
+++ b/tests/integration/lisa.test.ts
@@ -8,6 +8,7 @@ import { AutoAcceptPrompter } from "../../src/cli/prompts.js";
 import { DetectorRegistry } from "../../src/detection/index.js";
 import { SilentLogger } from "../../src/logging/silent-logger.js";
 import { MigrationRegistry } from "../../src/migrations/index.js";
+import { LISA_INVOCATION } from "../../src/migrations/ensure-lisa-postinstall.js";
 import { StrategyRegistry } from "../../src/strategies/index.js";
 import {
   parseLearningsFile,
@@ -454,9 +455,13 @@ describe("Lisa Integration Tests", () => {
 
     it("preserves host-owned config during postinstall-safe apply", async () => {
       await createTypeScriptProject(destDir);
-      const guardedPostinstall =
+      // The duplicated form is the pre-#2467 spelling that still sits in
+      // installed projects; apply must collapse it to the current invocation,
+      // which surfaces failures instead of discarding them.
+      const swallowingPostinstall =
         '[ -n "$CI" ] || LISA_BOOTSTRAP=1 node node_modules/@codyswann/lisa/dist/index.js --yes --skip-git-check . 2>/dev/null || true';
-      const duplicatedPostinstall = `[ -n "$CI" ] || LISA_BOOTSTRAP=1 ${guardedPostinstall}`;
+      const guardedPostinstall = LISA_INVOCATION;
+      const duplicatedPostinstall = `[ -n "$CI" ] || LISA_BOOTSTRAP=1 ${swallowingPostinstall}`;
       const hostPackageJson = {
         name: "host-project",
         dependencies: { typescript: "^5.0.0" },

--- a/tests/unit/cli/doctor-apply-freshness.test.ts
+++ b/tests/unit/cli/doctor-apply-freshness.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Regression tests for CodySwannGT/lisa#2467.
+ *
+ * geminisportsai/frontend-v2 received no template updates for months because
+ * every `lisa apply` crashed and the postinstall bootstrap threw the error
+ * away. Nothing in the toolchain could say so. These tests pin the check that
+ * can: a repo whose apply receipt is missing or older than the installed Lisa
+ * is reported by `lisa doctor` without anyone running apply by hand.
+ */
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  checkApplyFreshness,
+  checkYamlRuntime,
+} from "../../../src/cli/doctor-apply-freshness.js";
+import { getPackageVersion } from "../../../src/cli/version.js";
+import type { ApplyMode } from "../../../src/core/apply-receipt.js";
+import {
+  APPLY_RECEIPT_SCHEMA_VERSION,
+  readApplyReceipt,
+  recordSuccessfulApply,
+  resolveApplyReceiptPath,
+} from "../../../src/core/apply-receipt.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const CHECK_NAME = "Templates applied by this Lisa version?";
+const MANIFEST = "package.json";
+const LISA_DEP = "@codyswann/lisa";
+const FULL: ApplyMode = "full";
+const POSTINSTALL_SAFE: ApplyMode = "postinstall-safe";
+const APPLIED_AT = "2026-01-15T10:00:00.000Z";
+
+describe("apply freshness doctor check", () => {
+  let tempDir: string;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    projectDir = path.join(tempDir, "project");
+    await fs.ensureDir(projectDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  /**
+   * Write a host manifest declaring Lisa as a devDependency.
+   * @param extra - Extra manifest fields
+   */
+  async function writeHostManifest(extra: object = {}): Promise<void> {
+    await fs.writeJson(path.join(projectDir, MANIFEST), {
+      name: "host-project",
+      devDependencies: { [LISA_DEP]: "^3.0.0" },
+      ...extra,
+    });
+  }
+
+  /**
+   * Write a receipt claiming an apply completed at the given version.
+   * @param version - Lisa version to stamp
+   * @param applyMode - Whether that apply was full or postinstall-safe
+   * @param appliedAt - ISO timestamp
+   */
+  async function writeReceipt(
+    version: string,
+    applyMode: ApplyMode = FULL,
+    appliedAt = APPLIED_AT
+  ): Promise<void> {
+    const receiptPath = resolveApplyReceiptPath(projectDir);
+    await fs.ensureDir(path.dirname(receiptPath));
+    await fs.writeJson(receiptPath, {
+      schema_version: APPLY_RECEIPT_SCHEMA_VERSION,
+      lisa_version: version,
+      applied_at: appliedAt,
+      harness: "fleet",
+      apply_mode: applyMode,
+    });
+  }
+
+  it("reports a repo that has never successfully applied", async () => {
+    await writeHostManifest();
+
+    const check = await checkApplyFreshness(projectDir);
+
+    expect(check.name).toBe(CHECK_NAME);
+    expect(check.status).toBe("warn");
+    expect(check.detail).toContain("No successful Lisa apply has ever been");
+    // Must name the installed version and the command that reproduces it.
+    expect(check.detail).toContain(getPackageVersion());
+    expect(check.detail).toContain("--skip-git-check");
+  });
+
+  it("names the version a stale repo last applied at", async () => {
+    await writeHostManifest();
+    await writeReceipt("2.342.2");
+
+    const check = await checkApplyFreshness(projectDir);
+
+    expect(check.status).toBe("warn");
+    expect(check.detail).toContain(
+      "has not successfully applied templates since Lisa 2.342.2"
+    );
+    expect(check.detail).toContain("2026-01-15");
+    expect(check.detail).toContain(getPackageVersion());
+  });
+
+  it("passes when the receipt matches the installed version", async () => {
+    await writeHostManifest();
+    await writeReceipt(getPackageVersion());
+
+    const check = await checkApplyFreshness(projectDir);
+
+    expect(check.status).toBe("ok");
+    expect(check.detail).toContain(getPackageVersion());
+  });
+
+  it("does not warn about a repo that is newer than the installed Lisa", async () => {
+    await writeHostManifest();
+    await writeReceipt("999.0.0");
+
+    expect((await checkApplyFreshness(projectDir)).status).toBe("ok");
+  });
+
+  it("reports work postinstall-safe mode skipped even when the version is current", async () => {
+    // The second silent-staleness class: a package install can never run the
+    // agent emits, so `.codex/config.toml` stays unreconciled on the newest
+    // Lisa and nothing said so (ask-gemini#734, same shape as #2436).
+    await writeHostManifest();
+    await writeReceipt(getPackageVersion(), POSTINSTALL_SAFE);
+
+    const check = await checkApplyFreshness(projectDir);
+
+    expect(check.status).toBe("warn");
+    expect(check.detail).toContain(POSTINSTALL_SAFE);
+    expect(check.detail).toContain("agent emit");
+    expect(check.detail).toContain(".codex/config.toml");
+    // Must point at a FULL apply, not the postinstall-safe one that caused it.
+    expect(check.detail).toContain(
+      "node node_modules/@codyswann/lisa/dist/index.js ."
+    );
+  });
+
+  it("stays quiet when a receipt predates the apply-mode field", async () => {
+    await writeHostManifest();
+    const receiptPath = resolveApplyReceiptPath(projectDir);
+    await fs.ensureDir(path.dirname(receiptPath));
+    await fs.writeJson(receiptPath, {
+      schema_version: APPLY_RECEIPT_SCHEMA_VERSION,
+      lisa_version: getPackageVersion(),
+      applied_at: APPLIED_AT,
+      harness: "fleet",
+    });
+
+    expect((await checkApplyFreshness(projectDir)).status).toBe("ok");
+  });
+
+  it("treats an unreadable or wrong-schema receipt as no receipt", async () => {
+    await writeHostManifest();
+    const receiptPath = resolveApplyReceiptPath(projectDir);
+    await fs.ensureDir(path.dirname(receiptPath));
+    await fs.writeFile(receiptPath, "{ not json");
+
+    expect((await checkApplyFreshness(projectDir)).status).toBe("warn");
+
+    await fs.writeJson(receiptPath, {
+      schema_version: 99,
+      lisa_version: "3.0.0",
+      applied_at: APPLIED_AT,
+    });
+
+    expect((await checkApplyFreshness(projectDir)).status).toBe("warn");
+  });
+
+  it("stays silent for projects that do not depend on Lisa", async () => {
+    await fs.writeJson(path.join(projectDir, MANIFEST), {
+      name: "unrelated",
+    });
+
+    expect((await checkApplyFreshness(projectDir)).status).toBe("ok");
+  });
+
+  it("stays silent for the Lisa source repo, which never self-applies", async () => {
+    await fs.writeJson(path.join(projectDir, MANIFEST), {
+      name: LISA_DEP,
+      devDependencies: { [LISA_DEP]: "^3.0.0" },
+    });
+
+    const check = await checkApplyFreshness(projectDir);
+
+    expect(check.status).toBe("ok");
+    expect(check.detail).toContain("source repo");
+  });
+});
+
+describe("apply receipt", () => {
+  let tempDir: string;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    projectDir = path.join(tempDir, "project");
+    await fs.ensureDir(projectDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  it("records the version, harness and timestamp of a completed apply", async () => {
+    const written = await recordSuccessfulApply(
+      projectDir,
+      { lisaVersion: "3.4.0", harness: "fleet", applyMode: FULL },
+      () => new Date("2026-08-12T09:30:00.000Z")
+    );
+
+    expect(written).toBe(true);
+    expect(await readApplyReceipt(projectDir)).toEqual({
+      schema_version: APPLY_RECEIPT_SCHEMA_VERSION,
+      lisa_version: "3.4.0",
+      applied_at: "2026-08-12T09:30:00.000Z",
+      harness: "fleet",
+      apply_mode: FULL,
+    });
+  });
+
+  it("never throws when the receipt cannot be written", async () => {
+    // A file where the .lisa directory needs to be: mkdir fails, apply must not.
+    await fs.writeFile(path.join(projectDir, ".lisa"), "not a directory");
+
+    await expect(
+      recordSuccessfulApply(projectDir, {
+        lisaVersion: "3.4.0",
+        harness: "fleet",
+        applyMode: POSTINSTALL_SAFE,
+      })
+    ).resolves.toBe(false);
+  });
+
+  it("reports no receipt for a project that has never applied", async () => {
+    expect(await readApplyReceipt(projectDir)).toBeNull();
+  });
+});
+
+describe("yaml runtime doctor check", () => {
+  it("passes on the js-yaml this build resolved", () => {
+    const check = checkYamlRuntime();
+
+    expect(check.status).toBe("ok");
+    expect(check.name).toBe("YAML runtime usable?");
+  });
+});

--- a/tests/unit/migrations/ensure-lisa-postinstall.test.ts
+++ b/tests/unit/migrations/ensure-lisa-postinstall.test.ts
@@ -2,15 +2,22 @@ import * as fs from "fs-extra";
 import * as path from "node:path";
 import type { ProjectType } from "../../../src/core/config.js";
 import { SilentLogger } from "../../../src/logging/silent-logger.js";
-import { EnsureLisaPostinstallMigration } from "../../../src/migrations/ensure-lisa-postinstall.js";
+import {
+  EnsureLisaPostinstallMigration,
+  LISA_INVOCATION,
+} from "../../../src/migrations/ensure-lisa-postinstall.js";
 import type { MigrationContext } from "../../../src/migrations/migration.interface.js";
 import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
 
+// Historical spellings that still sit in installed projects' package.json,
+// written verbatim rather than derived: recognising what is actually on disk
+// out there is the whole job of the migration. `SWALLOWING_LISA_INVOCATION` is
+// the pre-#2467 form that discarded the apply's stderr and exit code.
 const LEGACY_LISA_INVOCATION =
   "node node_modules/@codyswann/lisa/dist/index.js --yes --skip-git-check . 2>/dev/null || true";
 const OLD_GUARDED_LISA_INVOCATION = `[ -n "$CI" ] || ${LEGACY_LISA_INVOCATION}`;
-const LISA_INVOCATION = `[ -n "$CI" ] || LISA_BOOTSTRAP=1 ${LEGACY_LISA_INVOCATION}`;
-const DUPLICATED_GUARD_INVOCATION = `[ -n "$CI" ] || LISA_BOOTSTRAP=1 ${LISA_INVOCATION}`;
+const SWALLOWING_LISA_INVOCATION = `[ -n "$CI" ] || LISA_BOOTSTRAP=1 ${LEGACY_LISA_INVOCATION}`;
+const DUPLICATED_GUARD_INVOCATION = `[ -n "$CI" ] || LISA_BOOTSTRAP=1 ${SWALLOWING_LISA_INVOCATION}`;
 const PACKAGE_JSON = "package.json";
 const PATCH_PACKAGE = "patch-package";
 

--- a/tests/unit/migrations/postinstall-failure-surfacing.test.ts
+++ b/tests/unit/migrations/postinstall-failure-surfacing.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Behavioural regression tests for CodySwannGT/lisa#2467.
+ *
+ * The shipped postinstall bootstrap redirected the apply's stderr to
+ * `/dev/null` and then `|| true`d the exit code, so a completely failed apply
+ * was byte-for-byte indistinguishable from a successful one. geminisportsai
+ * ran that way for months and received no template updates.
+ *
+ * These tests execute the real composed script under `sh` — the same way a
+ * package manager runs it — instead of asserting on the string, because the
+ * property that matters is observable behaviour: a failure must be visible and
+ * must not break `npm install` / `bun install`.
+ */
+import { spawnSync } from "node:child_process";
+import * as path from "node:path";
+import * as fs from "fs-extra";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ProjectType } from "../../../src/core/config.js";
+import { SilentLogger } from "../../../src/logging/silent-logger.js";
+import {
+  EnsureLisaPostinstallMigration,
+  LISA_INVOCATION,
+} from "../../../src/migrations/ensure-lisa-postinstall.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const LISA_ENTRY_RELATIVE = "node_modules/@codyswann/lisa/dist/index.js";
+const REAL_ERROR = "SyntaxError: does not provide an export named 'default'";
+/** Stub entry point that fails the way a crashing apply does. */
+const FAILING_ENTRY = "process.exit(1);";
+/** Absolute interpreter path: never resolve the shell through PATH. */
+const SHELL = "/bin/sh";
+/** The pre-fix invocation that discarded both stderr and the exit code. */
+const SWALLOWING_INVOCATION = `[ -n "$CI" ] || LISA_BOOTSTRAP=1 node ${LISA_ENTRY_RELATIVE} --yes --skip-git-check . 2>/dev/null || true`;
+
+describe("postinstall bootstrap surfaces a failed apply", () => {
+  let tempDir: string;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    projectDir = path.join(tempDir, "project");
+    await fs.ensureDir(
+      path.join(projectDir, path.dirname(LISA_ENTRY_RELATIVE))
+    );
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  /**
+   * Install a stub Lisa entry point with the given behaviour.
+   * @param body - Node source for the stub
+   */
+  async function writeLisaEntry(body: string): Promise<void> {
+    await fs.writeFile(path.join(projectDir, LISA_ENTRY_RELATIVE), body);
+  }
+
+  /**
+   * Run a postinstall script the way a package manager does.
+   * @param script - The composed postinstall command
+   * @param ci - Value for the CI env var, or undefined to unset it
+   * @returns Captured status and streams
+   */
+  function runPostinstall(
+    script: string,
+    ci?: string
+  ): {
+    readonly status: number | null;
+    readonly stdout: string;
+    readonly stderr: string;
+  } {
+    const env = { ...process.env };
+    if (ci === undefined) {
+      delete env.CI;
+    } else {
+      env.CI = ci;
+    }
+    const result = spawnSync(SHELL, ["-c", script], {
+      cwd: projectDir,
+      encoding: "utf8",
+      env,
+    });
+    return {
+      status: result.status,
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+    };
+  }
+
+  it("lets the real error reach stderr instead of /dev/null", async () => {
+    await writeLisaEntry(
+      `console.error(${JSON.stringify(REAL_ERROR)}); process.exit(1);`
+    );
+
+    expect(runPostinstall(LISA_INVOCATION).stderr).toContain(REAL_ERROR);
+  });
+
+  it("adds a warning naming the failure and how to reproduce it", async () => {
+    await writeLisaEntry(FAILING_ENTRY);
+
+    const { stderr } = runPostinstall(LISA_INVOCATION);
+
+    // The operator sees only this line in a wall of install output: it must say
+    // that templates are not being applied, and give the command to re-run.
+    expect(stderr).toContain("lisa");
+    expect(stderr.toUpperCase()).toContain("FAILED");
+    expect(stderr).toContain(LISA_ENTRY_RELATIVE);
+    expect(stderr).toContain("doctor");
+  });
+
+  it("stays non-fatal so a failed apply never breaks the install", async () => {
+    await writeLisaEntry(FAILING_ENTRY);
+
+    expect(runPostinstall(LISA_INVOCATION).status).toBe(0);
+  });
+
+  it("stays quiet when the apply succeeds", async () => {
+    await writeLisaEntry("process.exit(0);");
+
+    const { status, stderr } = runPostinstall(LISA_INVOCATION);
+
+    expect(status).toBe(0);
+    expect(stderr).toBe("");
+  });
+
+  it("still runs the host's own chained postinstall after a failed apply", async () => {
+    await writeLisaEntry(FAILING_ENTRY);
+
+    const { status, stdout } = runPostinstall(
+      `${LISA_INVOCATION} && echo host-postinstall-ran`
+    );
+
+    expect(status).toBe(0);
+    expect(stdout).toContain("host-postinstall-ran");
+  });
+
+  it("short-circuits entirely when CI is set", async () => {
+    await writeLisaEntry("console.error('should not run'); process.exit(1);");
+
+    const { status, stderr } = runPostinstall(LISA_INVOCATION, "true");
+
+    expect(status).toBe(0);
+    expect(stderr).toBe("");
+  });
+
+  it("proves the pre-fix shape was silent on the same failure", async () => {
+    await writeLisaEntry(
+      `console.error(${JSON.stringify(REAL_ERROR)}); process.exit(1);`
+    );
+
+    const { status, stdout, stderr } = runPostinstall(SWALLOWING_INVOCATION);
+
+    // This is the bug, pinned: a total failure produced nothing at all.
+    expect(status).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+  });
+
+  it("upgrades an installed project off the swallowing shape", async () => {
+    await fs.writeJson(path.join(projectDir, "package.json"), {
+      scripts: { postinstall: SWALLOWING_INVOCATION },
+    });
+    const detectedTypes: readonly ProjectType[] = ["typescript"];
+
+    await new EnsureLisaPostinstallMigration().apply({
+      projectDir,
+      lisaDir: tempDir,
+      detectedTypes,
+      dryRun: false,
+      logger: new SilentLogger(),
+    });
+
+    const pkg = await fs.readJson(path.join(projectDir, "package.json"));
+    expect(pkg.scripts.postinstall).toBe(LISA_INVOCATION);
+    expect(pkg.scripts.postinstall).not.toContain("2>/dev/null");
+  });
+});

--- a/tests/unit/utils/yaml-interop.test.ts
+++ b/tests/unit/utils/yaml-interop.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression tests for CodySwannGT/lisa#2467.
+ *
+ * A host project pinned js-yaml 5, whose ESM build has no default export. Every
+ * Lisa module did `import yaml from "js-yaml"`, so the entire CLI died at link
+ * time with a SyntaxError — and the postinstall bootstrap threw that stack
+ * trace away, so the repo silently stopped receiving template updates.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  IncompatibleYamlError,
+  loadYaml,
+  probeYamlRuntime,
+  resolveYamlApi,
+} from "../../../src/utils/yaml.js";
+
+/** The js-yaml 5.x ESM shape: named exports only, no `default`. */
+const V5_NAMESPACE = {
+  load: (source: string): unknown => ({ v5: source }),
+  dump: (): string => "",
+  loadAll: (): unknown[] => [],
+};
+
+/** The js-yaml 4.x shape as Node presents it: named exports plus interop default. */
+const V4_NAMESPACE = {
+  load: (source: string): unknown => ({ v4: source }),
+  safeLoad: (): unknown => undefined,
+  default: { load: (source: string): unknown => ({ v4default: source }) },
+};
+
+/** A CJS-only build where everything hangs off the interop default. */
+const CJS_INTEROP_NAMESPACE = {
+  default: { load: (source: string): unknown => ({ cjs: source }) },
+};
+
+describe("resolveYamlApi", () => {
+  it("drives the js-yaml 5.x named-export shape", () => {
+    expect(resolveYamlApi(V5_NAMESPACE).load("a")).toEqual({ v5: "a" });
+  });
+
+  it("prefers the named export over the interop default on js-yaml 4.x", () => {
+    expect(resolveYamlApi(V4_NAMESPACE).load("a")).toEqual({ v4: "a" });
+  });
+
+  it("falls back to the interop default for a CJS-only build", () => {
+    expect(resolveYamlApi(CJS_INTEROP_NAMESPACE).load("a")).toEqual({
+      cjs: "a",
+    });
+  });
+
+  it("rejects a module exposing no callable load", () => {
+    expect(() => resolveYamlApi({ dump: (): string => "" })).toThrow(
+      IncompatibleYamlError
+    );
+  });
+
+  it("names the problem in plain language instead of a stack trace", () => {
+    let message = "";
+    try {
+      resolveYamlApi({ parse: (): unknown => undefined });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    // An operator with no other context must learn: what broke, that it is a
+    // pin, and what to do next.
+    expect(message).toContain("js-yaml");
+    expect(message).toContain("load()");
+    expect(message).toContain("package.json");
+    expect(message).toContain("lisa doctor");
+    expect(message).toContain("parse");
+  });
+
+  it("reports a non-object resolution rather than throwing a TypeError", () => {
+    expect(() => resolveYamlApi(undefined)).toThrow(IncompatibleYamlError);
+    expect(() => resolveYamlApi("js-yaml")).toThrow(IncompatibleYamlError);
+  });
+});
+
+describe("loadYaml", () => {
+  it("parses YAML through whichever js-yaml the install resolved", () => {
+    expect(loadYaml("name: lisa\ncount: 2\n")).toEqual({
+      name: "lisa",
+      count: 2,
+    });
+  });
+});
+
+describe("probeYamlRuntime", () => {
+  it("returns null when the resolved js-yaml is usable", () => {
+    expect(probeYamlRuntime()).toBeNull();
+  });
+});


### PR DESCRIPTION
## What was silently broken

The bootstrap chained into every host project's `postinstall` ended in
`2>/dev/null || true`. A `lisa apply` that failed outright was byte-for-byte
indistinguishable from one that succeeded: no output, exit 0.

`geminisportsai/frontend-v2` ran that way for months. Its `js-yaml@^5.2.3` pin
killed the CLI at module-load time, so it received no template, guardrail, or
dependency-floor updates and nothing anywhere said so. `propswap/infrastructure`
`c373ba1` was the same class of bug, so the pattern was systemic.

## The shape chosen: loud but non-fatal

Stderr now flows through, and a failed apply adds an explicit warning naming the
consequence and the command that reproduces it. **It still exits 0 deliberately.**
A postinstall that exits non-zero aborts `npm install` / `bun install` and leaves
`node_modules` half-built, and apply legitimately cannot run in plenty of
environments (no git repo, no project config, sandboxed or non-interactive
shells). Making a template-sync problem break dependency installation would turn
one silent repo into a fleet outage.

Because a warning nobody was watching is still lost, **success is recorded**: a
completed apply writes `.lisa/apply-receipt.json`, and `lisa doctor` reports a
repo whose receipt is missing or older than the installed Lisa. That also covers
the detached reconciliation trampoline, which runs `stdio: "ignore"` and can
never report anything itself. The receipt is gitignored — it describes this
checkout, not the project.

## Arms

1. **`postinstall` surfaces failures** — `src/migrations/ensure-lisa-postinstall.ts`.
   The migration upgrades the swallowing form in place in installed repos.
2. **`lisa doctor` makes staleness discoverable** — `src/cli/doctor-apply-freshness.ts`:
   - "No successful Lisa apply has ever been recorded here (installed Lisa X)"
   - "This repo has not successfully applied templates since Lisa 2.342.2 (2026-02-11); installed Lisa is 3.4.0"
3. **js-yaml is fixed, not just documented** — `src/utils/yaml.ts`. Lisa is
   `"type": "module"`, so `import yaml from "js-yaml"` was a real ESM default
   import; js-yaml 5's ESM build has named exports only, giving a **link-time**
   `SyntaxError` that killed the whole CLI — `lisa doctor` included — before any
   Lisa code ran. One namespace-import shim links against any module shape, so
   3.x/4.x/5.x all work and a genuinely undriveable pin becomes a named doctor
   failure instead of a stack trace.
4. **Postinstall-safe mode's skipped work is now visible** (widened after
   `geminisportsai/ask-gemini#734`). `--skip-git-check` skips every agent emit,
   so **no package install at any version can reconcile `.codex/config.toml`** —
   the real reason host repos still carry the deprecated `codex_hooks` key, not
   "apply hasn't re-run". Same shape as #2436. The receipt records the apply
   mode and doctor reports it. Postinstall still skips those emits (correct);
   only the silence is fixed.

## Empirical verification

Scratch project with `js-yaml@5.2.3` forced over Lisa's own copy, running the
shipped postinstall.

**Before** — same failing apply, pre-fix postinstall:

```
everything the operator sees: []
exit status seen by the package manager: 0
```

**After** — same failing apply, the postinstall this PR writes:

```
SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:226:21)
lisa: TEMPLATE APPLY FAILED - this project is NOT receiving Lisa template or guardrail
updates. The error is above. Reproduce it with: node node_modules/@codyswann/lisa/dist/index.js
--yes --skip-git-check . - then run: node node_modules/@codyswann/lisa/dist/index.js doctor
exit status seen by the package manager: 0
```

With the interop fix, apply runs to completion under js-yaml 5 and the migration
upgrades the swallowing postinstall in place. Doctor, in the same scratch repo:

```
WARN Templates applied by this Lisa version?: No successful Lisa apply has ever been recorded here (installed Lisa 3.4.0; no .lisa/apply-receipt.json) ...
WARN Templates applied by this Lisa version?: This repo has not successfully applied templates since Lisa 2.342.2 (2026-02-11); installed Lisa is 3.4.0 ...
WARN Templates applied by this Lisa version?: Templates are current (Lisa 3.4.0 on 2026-08-13), but the only apply recorded here ran in postinstall-safe mode, which skips every agent emit ... Run `node node_modules/@codyswann/lisa/dist/index.js .` to complete it.
OK   Templates applied by this Lisa version?: Last successful apply: Lisa 3.4.0 on 2026-08-13
FAIL YAML runtime usable?: Lisa cannot use the installed js-yaml: the resolved package exposes no load() function (exports: dump) ...
```

## Tests

TDD per arm. `tests/unit/migrations/postinstall-failure-surfacing.test.ts`
executes the real composed script under `sh` the way a package manager does, and
pins the pre-fix shape's silence as a regression guard. Full suite: 10,726 pass.

Work-Item: CodySwannGT/lisa#2467

🤖 Generated with Claude Code
