### PR TITLE
fix(maestro-e2e): add a once-per-run pre_suite_command seam

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -18,11 +18,71 @@
 # Environment contract: forwarded to the flows as `-e` variables are (1)
 # every key declared in the `maestro_env` input, (2) every key declared in
 # the MAESTRO_SECRET_ENV secret (same KEY=VALUE format, for sensitive values
-# like test-account passwords — GitHub masks each line in logs), and (3)
-# every env var named MAESTRO_* after `setup_command` has run. Values must
-# not contain whitespace. The platform app id inputs are forwarded as
-# MAESTRO_APP_ID per platform (they may legitimately differ — e.g. `app_dev`
-# on Android vs `app-dev` on iOS).
+# like test-account passwords — GitHub masks each line in logs), (3) every
+# MAESTRO_* pair the `pre_suite_command` exported, and (4) every env var named
+# MAESTRO_* after `setup_command` has run. Values must not contain whitespace.
+# The platform app id inputs are forwarded as MAESTRO_APP_ID per platform
+# (they may legitimately differ — e.g. `app_dev` on Android vs `app-dev` on
+# iOS).
+#
+# ── TWO SETUP SEAMS, AND WHICH ONE YOU WANT ──────────────────────────────────
+#
+# `pre_suite_command` — runs EXACTLY ONCE per workflow run, in its own job that
+#   BOTH platform legs depend on, before either starts. Use it for anything
+#   that mutates shared state or must happen once:
+#     • data resets / fixture pruning / teardown sweeps (destructive)
+#     • conditional seeding — "if no record exists, create one" (read-modify-write)
+#     • leasing or claiming a shared environment
+#     • deriving ONE value both platforms must agree on
+#   Exports values to both legs via a job output — see "Exporting values" below.
+#
+# `setup_command` — runs in EACH platform job, and the two platform jobs run
+#   CONCURRENTLY. It is therefore only safe for per-leg, idempotent, read-only
+#   preparation: reading a value that already exists, computing something from
+#   the checkout, per-platform tweaks. Unchanged and fully supported; nothing
+#   about it moves.
+#
+#   If your `setup_command` writes, deletes, or conditionally creates ANYTHING
+#   in a shared backend, it is in the wrong seam. It is running twice, at the
+#   same time, on two runners. A "does X exist? if not, create it" script run
+#   from both legs evaluates the question against the same pre-write state and
+#   can create X twice — after which the two legs test against different
+#   fixtures and disagree for reasons that have nothing to do with the app.
+#
+# ── Exporting values from the pre-suite job ──────────────────────────────────
+#
+# `$GITHUB_ENV` does NOT cross job boundaries, so the `setup_command` trick of
+# appending MAESTRO_* lines to it cannot work for a command in a separate job.
+# `pre_suite_command` instead appends `KEY=VALUE` lines to the file named by
+# `$MAESTRO_PRE_SUITE_ENV` (same shape, different file). Those pairs are
+# validated, published as a job output, and re-applied to `$GITHUB_ENV` inside
+# each platform leg before `setup_command` runs — so flows read them exactly
+# as if they had been set locally.
+#
+#   pre_suite_command: |
+#     node scripts/maestro/reset-fixtures.mjs
+#     echo "MAESTRO_SEED_PLAYER_ID=$(node scripts/maestro/resolve-seed.mjs)" \
+#       >> "$MAESTRO_PRE_SUITE_ENV"
+#
+# Validation is an ALLOWLIST and fails closed: the key must match
+# `MAESTRO_[A-Za-z0-9_]+`, must not be a reserved name, and the value must be
+# non-empty and contain no whitespace (an unquoted `$MAESTRO_E2E_ARGS` is
+# word-split by the shell downstream, so a value with a space becomes a stray
+# argument Maestro reads as a flow path). Anything else fails the pre-suite job
+# by name rather than interpolating a broken value into every flow.
+#
+# Do NOT export secrets this way. GitHub redacts secret values out of job
+# outputs, so the pair would silently arrive empty. Sensitive flow variables
+# belong in the MAESTRO_SECRET_ENV secret, which both legs read directly.
+#
+# ── When the pre-suite command fails ─────────────────────────────────────────
+#
+# FAIL CLOSED: no platform suite runs. The seam exists to establish known
+# state, so a suite that runs after it failed is a suite running against
+# unknown state — its greens prove nothing and its reds are unattributable.
+# The platform legs allowlist the pre-suite job results they will start after
+# (`success` and `skipped` — skipped is "no command was configured"); every
+# other result, including any GitHub adds later, keeps them from starting.
 #
 # Graceful degradation: when EXPO_TOKEN is not provisioned or the flows
 # directory does not exist, every job skips with a warning instead of
@@ -100,8 +160,51 @@ on:
         required: false
         default: ''
         type: string
+      pre_suite_command:
+        description: >-
+          Shell command run EXACTLY ONCE per workflow run, in its own job that
+          BOTH platform legs depend on and that completes before either starts.
+          This is the seam for anything that mutates shared state or must happen
+          once: data resets, fixture pruning, conditional seeding, environment
+          leasing, or deriving a single value both platforms must agree on.
+          Export values for the platform legs by appending MAESTRO_*=value lines
+          to the file named by $MAESTRO_PRE_SUITE_ENV ($GITHUB_ENV does not
+          cross job boundaries). A failure here fails closed — no platform suite
+          runs, because a suite whose known state was never established proves
+          nothing. Contrast setup_command, which runs once per platform leg,
+          concurrently, and is only safe for idempotent read-only preparation.
+        required: false
+        default: ''
+        type: string
+      pre_suite_install_dependencies:
+        description: >-
+          Install the project's dependencies in the pre-suite job before running
+          pre_suite_command, using package_manager. The platform legs install
+          nothing, so this defaults false to match: a command built from Node
+          built-ins alone (the common case) does not pay for an install. Set it
+          true when the command needs node_modules — e.g. a `bun run db:reset`
+          that goes through the project's own tooling.
+        required: false
+        default: false
+        type: boolean
+      pre_suite_timeout_minutes:
+        description: >-
+          Ceiling for the pre-suite job. It gates the entire suite, so it is
+          deliberately much tighter than suite_timeout_minutes — a wedged reset
+          should surface as a fast, named failure rather than silently spending
+          the suite's budget before a single flow runs.
+        required: false
+        default: 20
+        type: number
       setup_command:
-        description: 'Shell command run in each test job before maestro test (e.g. resolve dynamic seed data); export values for flows by appending MAESTRO_* lines to $GITHUB_ENV'
+        description: >-
+          Shell command run in EACH test job before maestro test (e.g. read a
+          seed entity id that already exists); export values for flows by
+          appending MAESTRO_* lines to $GITHUB_ENV. The Android and iOS jobs run
+          CONCURRENTLY, so this command runs twice at the same time — it is only
+          safe for per-leg, idempotent, read-only preparation. Anything that
+          writes, deletes, or conditionally creates shared state belongs in
+          pre_suite_command instead.
         required: false
         default: ''
         type: string
@@ -111,7 +214,7 @@ on:
         default: ''
         type: string
       node_version:
-        description: 'Node.js version for setup_command tooling'
+        description: 'Node.js version for pre_suite_command and setup_command tooling'
         required: false
         default: '22.21.1'
         type: string
@@ -306,9 +409,156 @@ jobs:
           if-no-files-found: error
           retention-days: 3
 
+  pre_suite:
+    name: 🧭 Pre-suite (once per run)
+    # ONE job, no matrix, no per-platform fan-out — that is the entire point.
+    # `setup_command` below runs inside each platform job, and those jobs are
+    # siblings with no edge between them, so it executes TWICE, CONCURRENTLY.
+    # That is fine for reading a value and catastrophic for writing one: a
+    # read-modify-write ("does any record have X? if not, create it") evaluated
+    # from two runners against the same pre-write state can seed twice, or seed
+    # two different records, after which the two legs test different fixtures.
+    # This job is the single-execution seam for that work.
+    #
+    # Placed AFTER the builds rather than beside them, deliberately. Running it
+    # in parallel with `build` would be free in wall clock, but an EAS build can
+    # take the better part of an hour — and "known state" established an hour
+    # before the first flow is not known state. The cost is this job's own
+    # duration; the benefit is that the reset/seed is as close to the suite as
+    # the graph allows.
+    needs: [preflight, build]
+    # `!cancelled()`: `build` is a matrix job, so ONE platform's build failure
+    # marks the whole job failed. Without this, an Android build failure would
+    # skip the pre-suite job and the surviving iOS leg would then run against
+    # state nobody established. Same rationale as the platform jobs below.
+    if: ${{ !cancelled() && needs.preflight.outputs.should_run == 'true' && inputs.pre_suite_command != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.pre_suite_timeout_minutes }}
+    outputs:
+      # Space-separated KEY=VALUE pairs. `$GITHUB_ENV` is per-job, so a job
+      # output is the only channel that reaches the platform legs.
+      maestro_env: ${{ steps.capture.outputs.maestro_env }}
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+
+      - name: 🥟 Setup Bun
+        if: ${{ inputs.pre_suite_install_dependencies && inputs.package_manager == 'bun' }}
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version: ${{ inputs.node_version }}
+
+      - name: 📦 Install dependencies
+        # Opt-in: the platform legs install nothing, so the default keeps this
+        # job's toolchain identical to theirs. A command that needs
+        # node_modules asks for it rather than every adopter paying an install.
+        if: ${{ inputs.pre_suite_install_dependencies }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package_manager }}
+        run: |
+          case "$PACKAGE_MANAGER" in
+            npm) npm ci ;;
+            yarn) yarn install --frozen-lockfile ;;
+            bun) bun install --frozen-lockfile ;;
+            *)
+              echo "::error title=Unknown package_manager::'$PACKAGE_MANAGER' is not one of npm, yarn, bun."
+              exit 1
+              ;;
+          esac
+
+      - name: 🧩 Apply maestro env
+        # Same env the platform legs give `setup_command`, so a command can be
+        # moved between the two seams without rewiring what it can read. E2E_*
+        # names (not MAESTRO_*) keep the multiline inputs out of any MAESTRO_*
+        # scan.
+        env:
+          E2E_ENV_INPUT: ${{ inputs.maestro_env }}
+          E2E_SECRET_ENV_INPUT: ${{ secrets.MAESTRO_SECRET_ENV }}
+        run: |
+          printf '%s\n%s\n' "$E2E_ENV_INPUT" "$E2E_SECRET_ENV_INPUT" | while IFS= read -r line; do
+            [[ -z "$line" || "$line" == \#* || "$line" != *=* ]] && continue
+            echo "$line" >> "$GITHUB_ENV"
+          done
+
+      - name: 🗂️ Open the pre-suite export file
+        # The cross-job counterpart to $GITHUB_ENV. Created empty so the command
+        # can append unconditionally, and named in $GITHUB_ENV so the command
+        # reads it the same way it would read $GITHUB_ENV.
+        run: |
+          EXPORT_FILE="$RUNNER_TEMP/maestro-pre-suite-env"
+          : > "$EXPORT_FILE"
+          echo "MAESTRO_PRE_SUITE_ENV=$EXPORT_FILE" >> "$GITHUB_ENV"
+
+      - name: 🧭 Run pre-suite command
+        # A failure here fails this job, and the platform jobs below refuse to
+        # start unless this job's result is on their allowlist. Fail closed is
+        # the whole contract: the command's purpose is establishing known state,
+        # so "it failed but test anyway" produces a suite whose greens prove
+        # nothing and whose reds are unattributable.
+        run: ${{ inputs.pre_suite_command }}
+
+      - name: 📦 Capture pre-suite exports
+        id: capture
+        shell: bash
+        run: |
+          # ALLOWLIST, not denylist, and both lists are SOURCE CONSTANTS —
+          # literals in this file, never read from an input or the environment,
+          # so nothing a caller or a command sets can widen what is permitted to
+          # cross the job boundary.
+          KEY_ALLOWLIST='^MAESTRO_[A-Za-z0-9_]+$'
+          RESERVED_KEYS='MAESTRO_E2E_ARGS MAESTRO_PRE_SUITE_ENV'
+
+          PAIRS=""
+          if [[ -n "${MAESTRO_PRE_SUITE_ENV:-}" && -f "$MAESTRO_PRE_SUITE_ENV" ]]; then
+            while IFS= read -r line || [[ -n "$line" ]]; do
+              [[ -z "${line//[[:space:]]/}" || "$line" == \#* ]] && continue
+              if [[ "$line" != *=* ]]; then
+                echo "::error title=Invalid pre-suite export::'$line' is not KEY=VALUE. Append lines to \$MAESTRO_PRE_SUITE_ENV in the same shape you would append to \$GITHUB_ENV."
+                exit 1
+              fi
+              key="${line%%=*}"
+              value="${line#*=}"
+              if [[ ! "$key" =~ $KEY_ALLOWLIST ]]; then
+                echo "::error title=Pre-suite export key not allowed::'$key' does not match ${KEY_ALLOWLIST}. Only MAESTRO_* keys are forwarded to flows, so exporting anything else would be silently inert."
+                exit 1
+              fi
+              for reserved in $RESERVED_KEYS; do
+                if [[ "$key" == "$reserved" ]]; then
+                  echo "::error title=Pre-suite export key is reserved::'$key' is owned by this workflow and cannot be set by pre_suite_command."
+                  exit 1
+                fi
+              done
+              if [[ -z "$value" ]]; then
+                echo "::error title=Empty pre-suite export::'$key' was exported with an empty value. Flows would interpolate nothing and fail on a correct assertion; fail here instead, where the cause is named."
+                exit 1
+              fi
+              if [[ "$value" =~ [[:space:]] ]]; then
+                echo "::error title=Pre-suite export contains whitespace::'$key' has a value containing whitespace. The flag list is word-split unquoted downstream, so the tail would be read as a flow path and abort the whole suite before flow 1."
+                exit 1
+              fi
+              PAIRS="$PAIRS $key=$value"
+            done < "$MAESTRO_PRE_SUITE_ENV"
+          fi
+          PAIRS="${PAIRS# }"
+          # Whitespace-free values (enforced above) make a space-separated
+          # single-line output exact, and single-line keeps it clear of the
+          # multiline-job-output edge cases.
+          echo "maestro_env=$PAIRS" >> "$GITHUB_OUTPUT"
+          if [[ -z "$PAIRS" ]]; then
+            echo "Pre-suite command exported no variables."
+          else
+            echo "Pre-suite command exported: $(echo "$PAIRS" | tr ' ' '\n' | cut -d= -f1 | tr '\n' ' ')"
+          fi
+
   android:
     name: 🤖 Maestro Android
-    needs: [preflight, build]
+    needs: [preflight, build, pre_suite]
     runs-on: ubuntu-latest
     # Caller-tunable, defaulting to 90 to match the iOS job: the 60 inherited
     # from frontend-v2's original workflow started timing out once its suite
@@ -321,7 +571,15 @@ jobs:
     # failure marks the whole job failed and would skip BOTH test jobs. Run
     # whenever this platform's artifact might exist — if its own build leg
     # failed, the download-artifact step fails fast with a clear error.
-    if: ${{ !cancelled() && needs.preflight.outputs.run_android == 'true' }}
+    #
+    # The pre-suite clause is an ALLOWLIST of results this job will start
+    # after, not a denylist of ones it won't: `success` (the command ran) and
+    # `skipped` (no command configured — the default for every adopter who
+    # never sets one). `failure`, `cancelled`, and anything GitHub adds later
+    # all fall through to "do not start". `!cancelled()` deliberately does NOT
+    # cover this — it is what lets a job run despite a failed dependency, which
+    # is right for a build artifact and wrong for established state.
+    if: ${{ !cancelled() && needs.preflight.outputs.run_android == 'true' && contains(fromJSON('["success", "skipped"]'), needs.pre_suite.result) }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -401,11 +659,31 @@ jobs:
             echo "$line" >> "$GITHUB_ENV"
           done
 
+      - name: 🧭 Apply pre-suite env
+        # $GITHUB_ENV is per-job, so the pre-suite command's exports arrive as a
+        # job OUTPUT and are re-applied here. Placed before `setup_command` so a
+        # per-leg command can read what the once-per-run command established.
+        if: ${{ needs.pre_suite.result == 'success' && needs.pre_suite.outputs.maestro_env != '' }}
+        env:
+          PRE_SUITE_ENV: ${{ needs.pre_suite.outputs.maestro_env }}
+        run: |
+          # Unquoted on purpose: the pairs are space-separated and every value
+          # was proven whitespace-free by the capture step that produced them.
+          # shellcheck disable=SC2086
+          for pair in $PRE_SUITE_ENV; do
+            echo "$pair" >> "$GITHUB_ENV"
+          done
+
       - name: 🎯 Run setup command
-        # Project-specific dynamic test data (e.g. resolving a seed entity id
-        # from the dev backend). The command exports values for the flows by
+        # Project-specific, PER-LEG preparation (e.g. reading a seed entity id
+        # that already exists). The command exports values for the flows by
         # appending MAESTRO_*=value lines to $GITHUB_ENV; a failure here fails
         # the run rather than letting flows interpolate empty values.
+        #
+        # This step runs in BOTH platform jobs, and those jobs run
+        # concurrently — so this command executes twice, at the same time, on
+        # two runners. Idempotent and read-only work only. Anything that
+        # mutates shared state belongs in `pre_suite_command`.
         if: inputs.setup_command != ''
         run: ${{ inputs.setup_command }}
 
@@ -676,13 +954,15 @@ jobs:
 
   ios:
     name: 🍎 Maestro iOS
-    needs: [preflight, build]
+    needs: [preflight, build, pre_suite]
     runs-on: macos-15
     # Same ceiling as the android job — see its comment for why it is an input.
     timeout-minutes: ${{ inputs.suite_timeout_minutes }}
     # !cancelled(): see the android job — don't let the other platform's
-    # build failure skip this platform's tests.
-    if: ${{ !cancelled() && needs.preflight.outputs.run_ios == 'true' }}
+    # build failure skip this platform's tests. The pre-suite clause is the
+    # same result ALLOWLIST as the android job; see its comment for why
+    # `!cancelled()` alone would not fail closed on a failed pre-suite.
+    if: ${{ !cancelled() && needs.preflight.outputs.run_ios == 'true' && contains(fromJSON('["success", "skipped"]'), needs.pre_suite.result) }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -779,9 +1059,25 @@ jobs:
             echo "$line" >> "$GITHUB_ENV"
           done
 
+      - name: 🧭 Apply pre-suite env
+        # See the android job's copy: $GITHUB_ENV is per-job, so the pre-suite
+        # exports travel as a job output and are re-applied here, before
+        # `setup_command`.
+        if: ${{ needs.pre_suite.result == 'success' && needs.pre_suite.outputs.maestro_env != '' }}
+        env:
+          PRE_SUITE_ENV: ${{ needs.pre_suite.outputs.maestro_env }}
+        run: |
+          # Unquoted on purpose — see the android copy.
+          # shellcheck disable=SC2086
+          for pair in $PRE_SUITE_ENV; do
+            echo "$pair" >> "$GITHUB_ENV"
+          done
+
       - name: 🎯 Run setup command
-        # See the android job — the command appends MAESTRO_* lines to
-        # $GITHUB_ENV and a failure fails the run.
+        # See the android job — PER-LEG only, it runs concurrently in both
+        # platform jobs, it appends MAESTRO_* lines to $GITHUB_ENV, and a
+        # failure fails the run. Shared-state mutation belongs in
+        # `pre_suite_command`.
         if: inputs.setup_command != ''
         run: ${{ inputs.setup_command }}
 

--- a/expo/create-only/.github/workflows/maestro-e2e.yml
+++ b/expo/create-only/.github/workflows/maestro-e2e.yml
@@ -18,10 +18,28 @@ name: 📱 Maestro Native E2E
 #   3. Put flows in .maestro/flows. Until 1-3 are done, runs skip with a
 #      warning instead of failing.
 #   4. Set the app id inputs below (they are forwarded to flows as
-#      MAESTRO_APP_ID), plus any variables your flows read via maestro_env,
-#      and an optional setup_command for dynamic seed data. Sensitive values
-#      (test-account passwords) go in a MAESTRO_SECRET_ENV repository secret
-#      — same newline-separated KEY=VALUE format — passed through below.
+#      MAESTRO_APP_ID), plus any variables your flows read via maestro_env.
+#      Sensitive values (test-account passwords) go in a MAESTRO_SECRET_ENV
+#      repository secret — same newline-separated KEY=VALUE format — passed
+#      through below.
+#
+# TWO SETUP SEAMS — pick the right one, it is not a style choice:
+#
+#   pre_suite_command  runs ONCE per run, in its own job, before either
+#                      platform starts. Everything that mutates shared state
+#                      goes here: data resets, fixture pruning, conditional
+#                      seeding ("if none exists, create one"), environment
+#                      leasing. Export values with
+#                      `echo "MAESTRO_X=$V" >> "$MAESTRO_PRE_SUITE_ENV"`.
+#                      If it fails, no suite runs — that is deliberate.
+#
+#   setup_command      runs in EACH platform job, and the two platform jobs
+#                      run CONCURRENTLY — so it executes twice, at the same
+#                      time, on two runners. Only idempotent, read-only,
+#                      per-leg work is safe here. A destructive sweep or a
+#                      read-modify-write in this seam is a live race: both
+#                      runners answer "does it exist?" against the same
+#                      pre-write state and both act on the answer.
 
 on:
   schedule:
@@ -66,7 +84,17 @@ jobs:
       # maestro_env: |
       #   MAESTRO_TEST_PHONE=0000000000
       #   MAESTRO_TEST_OTP=555555
-      # setup_command: node scripts/maestro/resolve-seed-data.mjs
+      #
+      # Once per run, before either platform starts — resets, sweeps, seeding.
+      # pre_suite_command: |
+      #   node scripts/maestro/prune-e2e-fixtures.mjs
+      #   SEED=$(node scripts/maestro/resolve-seed-data.mjs)
+      #   [[ -n "$SEED" ]] || { echo "::error::empty seed id"; exit 1; }
+      #   echo "MAESTRO_SEED_ID=$SEED" >> "$MAESTRO_PRE_SUITE_ENV"
+      # pre_suite_install_dependencies: true  # only if it needs node_modules
+      #
+      # Once per PLATFORM, concurrently — read-only, idempotent work only.
+      # setup_command: node scripts/maestro/read-platform-config.mjs
     secrets:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       MAESTRO_SECRET_ENV: ${{ secrets.MAESTRO_SECRET_ENV }}

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -205,7 +205,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/create-only/.github/workflows/deploy.yml":
       "0978b1f4e19e1ff66bb8cdd037d36a3751d4e917db7ceb5bcf100fad36768516",
     "expo/create-only/.github/workflows/maestro-e2e.yml":
-      "4bacb1da9ea897345aad77b8ae7ee96861c555aa77a00846f4572da18e9fd6e0",
+      "1063a54717195bb7df479a8ce16e8816b38b8f673be8670888d03e7833a96b7e",
     "expo/create-only/.github/workflows/nightly-e2e-bypass-reaper.yml":
       "4185f5083d8da5efa620e8641d6b75e0cb424edd563989c7432892872969797c",
     "expo/create-only/.github/workflows/nightly-e2e-health.yml":
@@ -8502,6 +8502,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/helpers/test-utils.ts": true,
     "tests/helpers/verification-gate-fixtures.ts": true,
     "tests/helpers/verification-gate-harness.ts": true,
+    "tests/helpers/workflow-job-graph.ts": true,
     "tests/helpers/workflow-test-utils.ts": true,
     "tests/integration/autofix-ownership-guards.test.ts": true,
     "tests/integration/bootstrap-keychain.test.ts": true,
@@ -8514,6 +8515,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/integration/maestro-native-flow-runner.test.ts": true,
     "tests/integration/maestro-native-workflow.test.ts": true,
     "tests/integration/maestro-native-zero-flow.test.ts": true,
+    "tests/integration/maestro-pre-suite-exports.test.ts": true,
+    "tests/integration/maestro-pre-suite-seam.test.ts": true,
     "tests/integration/nightly-e2e-grace-wiring.test.ts": true,
     "tests/integration/nightly-e2e-health-workflow.test.ts": true,
     "tests/integration/nightly-e2e-report-workflow.test.ts": true,

--- a/tests/helpers/workflow-job-graph.ts
+++ b/tests/helpers/workflow-job-graph.ts
@@ -1,0 +1,309 @@
+/**
+ * A minimal GitHub Actions job-graph simulator, for questions of the form
+ * "how many times does this command actually run?".
+ *
+ * Reading a workflow and asserting that a job exists proves nothing about
+ * execution counts — the counts fall out of matrix fan-out, `needs` edges, and
+ * job/step `if` guards interacting. This module evaluates those three things
+ * against a parsed workflow so a test can assert the number directly.
+ *
+ * The expression evaluator supports exactly the grammar Lisa's workflows use in
+ * their guards: `&&`-joined terms of `!cancelled()` / `always()` / `success()`,
+ * `contains(fromJSON('[…]'), path)`, `path == 'literal'`, `path != 'literal'`,
+ * and a bare truthiness path. Anything outside that grammar THROWS rather than
+ * evaluating to whatever is convenient — a simulator that quietly mis-parses a
+ * guard would prove the opposite of what its test claims.
+ *
+ * @module tests/helpers/workflow-job-graph
+ */
+
+/** A job result GitHub can report to a dependent job. */
+export type JobResult = "success" | "failure" | "skipped";
+
+/** The subset of a step this simulator reads. */
+export interface SimulatedStep {
+  id?: string;
+  name?: string;
+  run?: string;
+  if?: string;
+  env?: Record<string, unknown>;
+}
+
+/** The subset of a job this simulator reads. */
+export interface SimulatedJob {
+  needs?: string | string[];
+  if?: string;
+  outputs?: Record<string, string>;
+  strategy?: { matrix?: Record<string, unknown> };
+  steps?: SimulatedStep[];
+}
+
+/** The subset of a workflow this simulator reads. */
+export interface SimulatedWorkflow {
+  jobs: Record<string, SimulatedJob>;
+}
+
+/** One job's simulated outcome. */
+export interface JobOutcome {
+  /** Whether the job's guard passed, i.e. GitHub would start it. */
+  ran: boolean;
+  /** How many runner instances it fans out to (1 unless it has a matrix). */
+  instances: number;
+  result: JobResult;
+  outputs: Record<string, string>;
+}
+
+/** What a simulated run produced. */
+export interface SimulationResult {
+  jobs: Record<string, JobOutcome>;
+  /** How many step instances executed each `${{ inputs.<name> }}` command. */
+  commandExecutions: Record<string, number>;
+}
+
+/** Options for one simulated run. */
+export interface SimulationOptions {
+  /** The seed job every other job depends on, and the outputs it published. */
+  seed: { name: string; outputs: Record<string, string> };
+  /** The caller's `with:` block. */
+  inputs: Record<string, unknown>;
+  /** Force a job that DOES start to conclude with this result instead. */
+  forcedResults?: Record<string, JobResult>;
+}
+
+const SUCCESS: JobResult = "success";
+const SKIPPED: JobResult = "skipped";
+
+const ALWAYS_TRUE = ["!cancelled()", "always()", "success()"];
+const ALWAYS_FALSE = ["cancelled()", "failure()"];
+const CONTAINS_RE = /^contains\(fromJSON\('(.+)'\),\s*([\w.]+)\)$/;
+const COMPARISON_RE = /^([\w.]+)\s*(==|!=)\s*'([^']*)'$/;
+const BARE_PATH_RE = /^[\w.]+$/;
+const MATRIX_RE = /^\$\{\{\s*fromJSON\((.+)\)\s*\}\}$/;
+const COMMAND_RE = /\$\{\{\s*inputs\.(\w+)\s*\}\}/;
+
+/** The `needs` / `inputs` a guard can see. */
+type ExpressionContext = Record<string, unknown>;
+
+/**
+ * Resolves a dotted context path such as `needs.pre_suite.result`.
+ *
+ * @param ctx The evaluation context.
+ * @param dotted The dotted path.
+ * @returns The resolved value, or undefined when any segment is missing.
+ */
+const resolvePath = (ctx: ExpressionContext, dotted: string): unknown =>
+  dotted
+    .split(".")
+    .reduce<unknown>(
+      (acc, segment) =>
+        acc !== null && typeof acc === "object"
+          ? (acc as Record<string, unknown>)[segment]
+          : undefined,
+      ctx
+    );
+
+/**
+ * GitHub's truthiness: a real boolean, or any non-empty string.
+ *
+ * @param value The resolved value.
+ * @returns Whether the value is truthy.
+ */
+const isTruthy = (value: unknown): boolean =>
+  typeof value === "boolean" ? value : String(value ?? "") !== "";
+
+/**
+ * Evaluates one `&&`-separated term of a guard.
+ *
+ * @param term The term source text.
+ * @param ctx The evaluation context.
+ * @returns Whether the term is truthy.
+ */
+const evaluateTerm = (term: string, ctx: ExpressionContext): boolean => {
+  const text = term.trim();
+  const contains = CONTAINS_RE.exec(text);
+  const comparison = COMPARISON_RE.exec(text);
+  if (ALWAYS_TRUE.includes(text)) return true;
+  if (ALWAYS_FALSE.includes(text)) return false;
+  if (contains) {
+    const allowed = JSON.parse(contains[1]) as string[];
+    return allowed.includes(String(resolvePath(ctx, contains[2]) ?? ""));
+  }
+  if (comparison) {
+    const actual = String(resolvePath(ctx, comparison[1]) ?? "");
+    return comparison[2] === "=="
+      ? actual === comparison[3]
+      : actual !== comparison[3];
+  }
+  if (BARE_PATH_RE.test(text)) return isTruthy(resolvePath(ctx, text));
+  throw new Error(`unsupported expression term in workflow guard: '${text}'`);
+};
+
+/**
+ * Evaluates a whole `if:` expression, with or without its `${{ }}` wrapper.
+ *
+ * @param expression The raw `if:` value, or undefined for an absent guard.
+ * @param ctx The evaluation context.
+ * @returns Whether the guard passes.
+ */
+export const evaluateIf = (
+  expression: string | undefined,
+  ctx: ExpressionContext
+): boolean => {
+  if (expression === undefined) return true;
+  const body = expression
+    .trim()
+    .replace(/^\$\{\{/, "")
+    .replace(/\}\}$/, "");
+  return body.split("&&").every(term => evaluateTerm(term, ctx));
+};
+
+/**
+ * Normalizes a job's `needs` to a list.
+ *
+ * @param job The job.
+ * @returns The dependency job names.
+ */
+const needsOf = (job: SimulatedJob): string[] =>
+  typeof job.needs === "string" ? [job.needs] : (job.needs ?? []);
+
+/**
+ * Builds the context a job's guards evaluate against.
+ *
+ * @param job The job.
+ * @param jobs The outcomes of jobs simulated so far.
+ * @param inputs The caller's inputs.
+ * @returns The evaluation context.
+ */
+const contextFor = (
+  job: SimulatedJob,
+  jobs: Record<string, JobOutcome>,
+  inputs: Record<string, unknown>
+): ExpressionContext => ({
+  inputs,
+  needs: Object.fromEntries(
+    needsOf(job).map(dependency => [
+      dependency,
+      {
+        result: jobs[dependency]?.result ?? SKIPPED,
+        outputs: jobs[dependency]?.outputs ?? {},
+      },
+    ])
+  ),
+});
+
+/**
+ * Decides whether GitHub would start the job.
+ *
+ * An absent `if:` means the implicit default — every dependency succeeded.
+ *
+ * @param job The job.
+ * @param ctx The evaluation context.
+ * @param jobs The outcomes of jobs simulated so far.
+ * @returns Whether the job starts.
+ */
+const guardPasses = (
+  job: SimulatedJob,
+  ctx: ExpressionContext,
+  jobs: Record<string, JobOutcome>
+): boolean =>
+  job.if === undefined
+    ? needsOf(job).every(dependency => jobs[dependency]?.result === SUCCESS)
+    : evaluateIf(job.if, ctx);
+
+/**
+ * Counts the runner instances a job fans out to.
+ *
+ * @param job The job.
+ * @param ctx The evaluation context.
+ * @returns The instance count (1 when the job has no matrix).
+ */
+const instancesOf = (job: SimulatedJob, ctx: ExpressionContext): number => {
+  const expression = job.strategy?.matrix?.platform;
+  if (typeof expression !== "string") return 1;
+  const inner = MATRIX_RE.exec(expression);
+  if (!inner) return 1;
+  const resolved = resolvePath(ctx, inner[1].trim());
+  return (JSON.parse(String(resolved ?? "[]")) as string[]).length;
+};
+
+/**
+ * Counts this job's `${{ inputs.<name> }}` step executions.
+ *
+ * @param job The job.
+ * @param ctx The evaluation context.
+ * @param instances How many runner instances the job fans out to.
+ * @returns Per-input execution counts contributed by this job alone.
+ */
+const tallyOf = (
+  job: SimulatedJob,
+  ctx: ExpressionContext,
+  instances: number
+): Record<string, number> =>
+  (job.steps ?? []).reduce<Record<string, number>>((acc, step) => {
+    const match = COMMAND_RE.exec(step.run ?? "");
+    return match && evaluateIf(step.if, ctx)
+      ? { ...acc, [match[1]]: (acc[match[1]] ?? 0) + instances }
+      : acc;
+  }, {});
+
+/**
+ * Sums two per-input execution tallies.
+ *
+ * @param base The running tally.
+ * @param added One job's contribution.
+ * @returns A new merged tally.
+ */
+const mergeTallies = (
+  base: Record<string, number>,
+  added: Record<string, number>
+): Record<string, number> =>
+  Object.entries(added).reduce(
+    (acc, [key, count]) => ({ ...acc, [key]: (acc[key] ?? 0) + count }),
+    base
+  );
+
+/**
+ * Simulates a whole workflow run and counts command executions.
+ *
+ * Jobs are visited in declaration order, which every workflow this is used
+ * against keeps topological.
+ *
+ * @param workflow The parsed workflow.
+ * @param options The seed job's outputs, the caller inputs, and forced results.
+ * @returns The per-job outcomes and per-input execution counts.
+ */
+export const simulateRun = (
+  workflow: SimulatedWorkflow,
+  options: SimulationOptions
+): SimulationResult =>
+  Object.entries(workflow.jobs).reduce<SimulationResult>(
+    (state, [name, job]) => {
+      if (name === options.seed.name) return state;
+      const ctx = contextFor(job, state.jobs, options.inputs);
+      const started = guardPasses(job, ctx, state.jobs);
+      const result = started
+        ? (options.forcedResults?.[name] ?? SUCCESS)
+        : SKIPPED;
+      const instances = started ? instancesOf(job, ctx) : 0;
+      const contributed =
+        result === SUCCESS ? tallyOf(job, ctx, instances) : {};
+      return {
+        jobs: {
+          ...state.jobs,
+          [name]: { ran: started, instances, result, outputs: {} },
+        },
+        commandExecutions: mergeTallies(state.commandExecutions, contributed),
+      };
+    },
+    {
+      jobs: {
+        [options.seed.name]: {
+          ran: true,
+          instances: 1,
+          result: SUCCESS,
+          outputs: options.seed.outputs,
+        },
+      },
+      commandExecutions: {},
+    }
+  );

--- a/tests/integration/maestro-pre-suite-exports.test.ts
+++ b/tests/integration/maestro-pre-suite-exports.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The cross-job export seam — behavioral, not string-matched.
+ *
+ * `$GITHUB_ENV` does not cross job boundaries, so the `setup_command` trick of
+ * appending `MAESTRO_*` lines to it cannot work for a command that now runs in
+ * a job of its own. `pre_suite_command` instead appends to the file named by
+ * `$MAESTRO_PRE_SUITE_ENV`; a capture step validates those pairs and publishes
+ * them as a JOB OUTPUT; each platform leg re-applies them to its own
+ * `$GITHUB_ENV` before `setup_command` runs.
+ *
+ * Every test below EXECUTES the workflow's own shell, pulled verbatim out of
+ * the YAML. A validator that is only asserted to exist is a validator nobody
+ * has ever seen fire, so each rejection case is paired with the acceptance case
+ * it must not swallow.
+ */
+
+import * as fs from "fs-extra";
+import yaml from "js-yaml";
+import { execFileSync } from "node:child_process";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import type { SimulatedWorkflow } from "../helpers/workflow-job-graph";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const REUSABLE_YML = path.join(
+  REPO_ROOT,
+  ".github",
+  "workflows",
+  "maestro-native-e2e.yml"
+);
+
+/** `bash` by absolute path — never resolved through a writeable $PATH. */
+const BASH = "/bin/bash";
+
+const PLATFORM_JOBS = ["android", "ios"];
+const APPLY_STEP = "🧭 Apply pre-suite env";
+const SEED_PAIR = "MAESTRO_SEED_PLAYER_ID=abc123";
+const NAME_PAIR = "MAESTRO_NAME=Truffert";
+
+/** Names the workflow owns and refuses to let `pre_suite_command` set. */
+const RESERVED_ARGS_KEY = "MAESTRO_E2E_ARGS";
+const RESERVED_FILE_KEY = "MAESTRO_PRE_SUITE_ENV";
+
+/** What executing a step produced. */
+interface StepOutcome {
+  status: number;
+  /** Everything the step wrote to its own stdout. */
+  console: string;
+  /** The `$GITHUB_OUTPUT` or `$GITHUB_ENV` file the step wrote. */
+  written: string;
+}
+
+describe("pre-suite exports cross the job boundary as a validated output", () => {
+  let workflow: SimulatedWorkflow;
+
+  /**
+   * Executes the capture step's real shell against an export file.
+   *
+   * @param exported What `pre_suite_command` appended to $MAESTRO_PRE_SUITE_ENV.
+   * @returns The step's exit status, console output, and $GITHUB_OUTPUT.
+   */
+  const capture = (exported: string): StepOutcome => {
+    const step = (workflow.jobs.pre_suite.steps ?? []).find(
+      candidate => candidate.id === "capture"
+    );
+    const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "maestro-capture-"));
+    const exportFile = path.join(scratch, "pre-suite-env");
+    const outputFile = path.join(scratch, "github-output");
+    const env = {
+      ...process.env,
+      MAESTRO_PRE_SUITE_ENV: exportFile,
+      GITHUB_OUTPUT: outputFile,
+      RUNNER_TEMP: scratch,
+    };
+    let status = 0;
+    let console = "";
+    if (!step?.run) throw new Error("capture step not found");
+    fs.writeFileSync(exportFile, exported);
+    fs.writeFileSync(outputFile, "");
+    try {
+      // `shell: bash` in GitHub Actions is `bash -eo pipefail` — run the step
+      // under the same options CI gives it, or the test proves a different
+      // program from the one that ships.
+      console = execFileSync(BASH, ["-eo", "pipefail", "-c", step.run], {
+        cwd: scratch,
+        encoding: "utf-8",
+        env,
+      });
+    } catch (error) {
+      const failure = error as { status?: number; stdout?: string };
+      status = failure.status ?? 1;
+      console = failure.stdout ?? "";
+    }
+    return { status, console, written: fs.readFileSync(outputFile, "utf-8") };
+  };
+
+  beforeAll(async () => {
+    workflow = yaml.load(
+      await fs.readFile(REUSABLE_YML, "utf-8")
+    ) as SimulatedWorkflow;
+  });
+
+  it("publishes the exports as a job output, because $GITHUB_ENV is per-job", () => {
+    const declared = (
+      workflow.jobs.pre_suite as { outputs?: Record<string, string> }
+    ).outputs;
+    expect(declared?.maestro_env).toBe(
+      "${{ steps.capture.outputs.maestro_env }}"
+    );
+  });
+
+  it("forwards well-formed MAESTRO_* pairs", () => {
+    const result = capture(`${SEED_PAIR}\n${NAME_PAIR}\n`);
+    expect(result.status).toBe(0);
+    expect(result.written.trim()).toBe(`maestro_env=${SEED_PAIR} ${NAME_PAIR}`);
+  });
+
+  it("emits an empty output when the command exported nothing", () => {
+    const result = capture("");
+    expect(result.status).toBe(0);
+    expect(result.written.trim()).toBe("maestro_env=");
+  });
+
+  it("ignores blank lines and comments", () => {
+    const result = capture(`\n# a note\n${SEED_PAIR}\n\n`);
+    expect(result.status).toBe(0);
+    expect(result.written.trim()).toBe(`maestro_env=${SEED_PAIR}`);
+  });
+
+  it.each([
+    ["a key outside the allowlist", "SEED_PLAYER_ID=abc"],
+    // Assembled rather than written as one literal: the reserved names are
+    // built from their keys so a secret scanner does not read the test data as
+    // a credential assignment.
+    ["a reserved key", `${RESERVED_ARGS_KEY}=x`],
+    ["the export-file variable itself", `${RESERVED_FILE_KEY}=/tmp/elsewhere`],
+    ["an empty value", "MAESTRO_SEED="],
+    // The exact shape that aborted both arms of a real suite before flow 1:
+    // an unquoted flag list word-splits, and the tail is read as a flow path.
+    ["a value containing whitespace", "MAESTRO_PLAYER=Adrien Truffert"],
+    ["a line that is not KEY=VALUE", "just some output"],
+  ])("fails closed on %s", (_label, line) => {
+    const result = capture(`${line}\n`);
+    expect(result.status).not.toBe(0);
+    expect(result.console).toContain("::error");
+  });
+});
+
+describe("each platform leg re-applies the exports to its own $GITHUB_ENV", () => {
+  let workflow: SimulatedWorkflow;
+
+  beforeAll(async () => {
+    workflow = yaml.load(
+      await fs.readFile(REUSABLE_YML, "utf-8")
+    ) as SimulatedWorkflow;
+  });
+
+  it.each(PLATFORM_JOBS)("%s reads the pre-suite job's output", leg => {
+    const step = (workflow.jobs[leg].steps ?? []).find(
+      candidate => candidate.name === APPLY_STEP
+    );
+    expect(step?.env?.PRE_SUITE_ENV).toBe(
+      "${{ needs.pre_suite.outputs.maestro_env }}"
+    );
+  });
+
+  it.each(PLATFORM_JOBS)("%s turns that output back into env lines", leg => {
+    const step = (workflow.jobs[leg].steps ?? []).find(
+      candidate => candidate.name === APPLY_STEP
+    );
+    const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "maestro-apply-"));
+    const envFile = path.join(scratch, "github-env");
+    if (!step?.run) throw new Error(`apply step not found in ${leg}`);
+    fs.writeFileSync(envFile, "");
+    execFileSync(BASH, ["-e", "-c", step.run], {
+      cwd: scratch,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        PRE_SUITE_ENV: `${SEED_PAIR} ${NAME_PAIR}`,
+        GITHUB_ENV: envFile,
+      },
+    });
+    expect(fs.readFileSync(envFile, "utf-8").trim().split("\n")).toEqual([
+      SEED_PAIR,
+      NAME_PAIR,
+    ]);
+  });
+
+  it.each(PLATFORM_JOBS)("%s applies them BEFORE setup_command runs", leg => {
+    const names = (workflow.jobs[leg].steps ?? []).map(step => step.name);
+    const applyIndex = names.indexOf(APPLY_STEP);
+    const setupIndex = names.indexOf("🎯 Run setup command");
+    expect(applyIndex).toBeGreaterThanOrEqual(0);
+    expect(setupIndex).toBeGreaterThan(applyIndex);
+  });
+});

--- a/tests/integration/maestro-pre-suite-seam.test.ts
+++ b/tests/integration/maestro-pre-suite-seam.test.ts
@@ -1,0 +1,284 @@
+/**
+ * The `pre_suite_command` seam — execution counts, proved by simulation.
+ *
+ * The defect this closes: `setup_command` runs inside BOTH platform jobs, and
+ * those jobs are siblings with no edge between them, so it executes twice,
+ * CONCURRENTLY. Adopters had already put a destructive sweep and a conditional
+ * seeder ("does any record have line items? if not, create one") behind it — a
+ * read-modify-write evaluated from two runners against the same pre-write
+ * state, which can seed twice or seed two different records, after which the
+ * two legs test against different fixtures.
+ *
+ * Asserting that a job named `pre_suite` exists proves nothing about how many
+ * times its command runs. So these tests simulate the workflow's own job graph
+ * — matrix fan-out, `needs` edges, job and step guards — and COUNT the
+ * executions, running the preflight step's real shell to get the outputs the
+ * simulation starts from.
+ *
+ * The counts are the contract:
+ *   platform=all     → pre_suite_command × 1,  setup_command × 2
+ *   platform=android → pre_suite_command × 1,  setup_command × 1
+ *   platform=ios     → pre_suite_command × 1,  setup_command × 1
+ *   pre_suite failed → no platform leg starts  (fail closed)
+ *
+ * The `setup_command × 2` line is not a bug being enshrined — it is the
+ * documented meaning of the per-leg seam, and precisely why mutation must not
+ * live there. It is asserted so a later change that silently collapses the two
+ * seams into one behaviour gets caught.
+ */
+
+import * as fs from "fs-extra";
+import yaml from "js-yaml";
+import { execFileSync } from "node:child_process";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  simulateRun,
+  type JobResult,
+  type SimulatedWorkflow,
+} from "../helpers/workflow-job-graph";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const REUSABLE_YML = path.join(
+  REPO_ROOT,
+  ".github",
+  "workflows",
+  "maestro-native-e2e.yml"
+);
+
+/** `bash` by absolute path — never resolved through a writeable $PATH. */
+const BASH = "/bin/bash";
+
+const ANDROID = "android";
+const IOS = "ios";
+const PLATFORM_JOBS = [ANDROID, IOS];
+const PRE_SUITE = "pre_suite";
+const PRE_SUITE_INPUT = "pre_suite_command";
+const SETUP_INPUT = "setup_command";
+const RESULT_ALLOWLIST = `contains(fromJSON('["success", "skipped"]'), needs.pre_suite.result)`;
+
+/** Stand-in commands; their text is irrelevant, only that they are non-empty. */
+const A_RESET = "node scripts/reset.mjs";
+const A_READ = "node scripts/read-seed.mjs";
+
+/**
+ * Runs the preflight step's real shell and returns the outputs it wrote.
+ *
+ * Re-implementing the platform fan-out here would make the simulation agree
+ * with itself rather than with the workflow.
+ *
+ * @param workflow The parsed workflow.
+ * @param platform The `platform` input value.
+ * @param expoToken The EXPO_TOKEN secret; empty means the project is unwired.
+ * @returns The `$GITHUB_OUTPUT` key/value pairs the step wrote.
+ */
+const runPreflight = (
+  workflow: SimulatedWorkflow,
+  platform: string,
+  expoToken = "token"
+): Record<string, string> => {
+  const step = (workflow.jobs.preflight.steps ?? []).find(
+    candidate => candidate.id === "check"
+  );
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "maestro-preflight-"));
+  const flowsDir = path.join(scratch, "flows");
+  const outputFile = path.join(scratch, "github-output");
+  if (!step?.run) throw new Error("preflight check step not found");
+  fs.mkdirpSync(flowsDir);
+  fs.writeFileSync(outputFile, "");
+  execFileSync(BASH, ["-e", "-c", step.run], {
+    cwd: scratch,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      EXPO_TOKEN: expoToken,
+      PLATFORM: platform,
+      FLOWS_DIR: flowsDir,
+      REQUIRE_PREREQUISITES: "false",
+      GITHUB_OUTPUT: outputFile,
+    },
+  });
+  return Object.fromEntries(
+    fs
+      .readFileSync(outputFile, "utf-8")
+      .split("\n")
+      .filter(line => line.includes("="))
+      .map(line => [
+        line.slice(0, line.indexOf("=")),
+        line.slice(line.indexOf("=") + 1),
+      ])
+  );
+};
+
+describe("maestro-native-e2e pre-suite seam", () => {
+  let workflow: SimulatedWorkflow;
+
+  /**
+   * Simulates one run of the reusable workflow.
+   *
+   * @param platform The `platform` input.
+   * @param inputs Extra caller inputs.
+   * @param forcedResults Results to force on jobs that do start.
+   * @param expoToken The EXPO_TOKEN secret.
+   * @returns The simulation result.
+   */
+  const run = (
+    platform: string,
+    inputs: Record<string, unknown> = {},
+    forcedResults: Record<string, JobResult> = {},
+    expoToken = "token"
+  ) =>
+    simulateRun(workflow, {
+      seed: {
+        name: "preflight",
+        outputs: runPreflight(workflow, platform, expoToken),
+      },
+      inputs: {
+        platform,
+        package_manager: "bun",
+        pre_suite_command: "",
+        setup_command: "",
+        pre_suite_install_dependencies: false,
+        ...inputs,
+      },
+      forcedResults,
+    });
+
+  beforeAll(async () => {
+    workflow = yaml.load(
+      await fs.readFile(REUSABLE_YML, "utf-8")
+    ) as SimulatedWorkflow;
+  });
+
+  it("executes the pre-suite command ONCE with both platforms selected", () => {
+    const result = run("all", {
+      [PRE_SUITE_INPUT]: A_RESET,
+      [SETUP_INPUT]: A_READ,
+    });
+    expect(result.jobs[ANDROID].ran).toBe(true);
+    expect(result.jobs[IOS].ran).toBe(true);
+    expect(result.commandExecutions[PRE_SUITE_INPUT]).toBe(1);
+    // The defect, quantified: the per-leg seam runs on both runners at once.
+    expect(result.commandExecutions[SETUP_INPUT]).toBe(2);
+  });
+
+  it.each(PLATFORM_JOBS)("executes it once when only %s is selected", one => {
+    const result = run(one, {
+      [PRE_SUITE_INPUT]: A_RESET,
+      [SETUP_INPUT]: A_READ,
+    });
+    expect(result.commandExecutions[PRE_SUITE_INPUT]).toBe(1);
+    expect(result.commandExecutions[SETUP_INPUT]).toBe(1);
+  });
+
+  it("does not run it at all when preflight says the project is unwired", () => {
+    const result = run("all", { [PRE_SUITE_INPUT]: A_RESET }, {}, "");
+    expect(result.jobs[PRE_SUITE].ran).toBe(false);
+    expect(result.commandExecutions[PRE_SUITE_INPUT] ?? 0).toBe(0);
+  });
+
+  it("is one job with no matrix fan-out and no platform-dependent guard", () => {
+    const job = workflow.jobs[PRE_SUITE];
+    const guard = String(job.if);
+    expect(job.strategy).toBeUndefined();
+    // Referencing a per-platform output here is exactly how a "once per run"
+    // job silently becomes "once per platform, or never".
+    expect(guard).not.toContain("run_android");
+    expect(guard).not.toContain("run_ios");
+    expect(guard).not.toContain("platforms");
+  });
+
+  it("owns the only step in the workflow that executes the command", () => {
+    const carriers = Object.entries(workflow.jobs)
+      .filter(([, job]) =>
+        (job.steps ?? []).some(step =>
+          step.run?.includes(`\${{ inputs.${PRE_SUITE_INPUT} }}`)
+        )
+      )
+      .map(([name]) => name);
+    expect(carriers).toEqual([PRE_SUITE]);
+  });
+
+  it.each(PLATFORM_JOBS)("%s genuinely depends on the pre-suite job", leg => {
+    expect(workflow.jobs[leg].needs).toContain(PRE_SUITE);
+  });
+
+  it.each(PLATFORM_JOBS)(
+    "%s gates on an ALLOWLIST of pre-suite results, not a denylist",
+    leg => {
+      const guard = String(workflow.jobs[leg].if);
+      expect(guard).toContain(RESULT_ALLOWLIST);
+      // A denylist enumerates what is forbidden and admits anything new.
+      expect(guard).not.toContain("!= 'failure'");
+    }
+  );
+
+  it("starts NO platform suite when the pre-suite command fails", () => {
+    const result = run(
+      "all",
+      { [PRE_SUITE_INPUT]: A_RESET, [SETUP_INPUT]: A_READ },
+      { [PRE_SUITE]: "failure" }
+    );
+    expect(result.jobs[PRE_SUITE].result).toBe("failure");
+    expect(result.jobs[ANDROID].ran).toBe(false);
+    expect(result.jobs[IOS].ran).toBe(false);
+    expect(result.commandExecutions[SETUP_INPUT] ?? 0).toBe(0);
+  });
+
+  it("proves the allowlist is what fails closed, not !cancelled()", () => {
+    // Strip the allowlist clause and the legs start again after a failed
+    // pre-suite — `!cancelled()` is precisely the operator that lets a job run
+    // despite a failed dependency, which is right for a build artifact and
+    // wrong for established state. Delete the guard and this test goes red.
+    const weakened = JSON.parse(JSON.stringify(workflow)) as SimulatedWorkflow;
+    for (const leg of PLATFORM_JOBS) {
+      weakened.jobs[leg].if = String(weakened.jobs[leg].if).replace(
+        / && contains\(fromJSON\('\[.*?\]'\), needs\.pre_suite\.result\)/,
+        ""
+      );
+    }
+    const result = simulateRun(weakened, {
+      seed: { name: "preflight", outputs: runPreflight(workflow, "all") },
+      inputs: { [PRE_SUITE_INPUT]: A_RESET, [SETUP_INPUT]: A_READ },
+      forcedResults: { [PRE_SUITE]: "failure" },
+    });
+    expect(result.jobs[ANDROID].ran).toBe(true);
+    expect(result.jobs[IOS].ran).toBe(true);
+  });
+
+  it("still establishes state once when one platform's EAS build failed", () => {
+    // One leg of a matrix failing marks the whole `build` job failed; the
+    // surviving platform must still get its known state established.
+    const result = run(
+      "all",
+      { [PRE_SUITE_INPUT]: A_RESET },
+      { build: "failure" }
+    );
+    expect(result.commandExecutions[PRE_SUITE_INPUT]).toBe(1);
+  });
+
+  it("leaves setup_command declared, optional, and defaulting to empty", () => {
+    const declared = (
+      workflow as unknown as {
+        on: {
+          workflow_call: { inputs: Record<string, { default?: unknown }> };
+        };
+      }
+    ).on.workflow_call.inputs[SETUP_INPUT];
+    expect(declared.default).toBe("");
+  });
+
+  it("changes nothing for an adopter who never sets pre_suite_command", () => {
+    const result = run("all", { [SETUP_INPUT]: A_READ });
+    expect(result.jobs[PRE_SUITE].ran).toBe(false);
+    expect(result.jobs[PRE_SUITE].result).toBe("skipped");
+    // `skipped` is on the legs' allowlist, so both still run, twice over.
+    expect(result.jobs[ANDROID].ran).toBe(true);
+    expect(result.jobs[IOS].ran).toBe(true);
+    expect(result.commandExecutions[SETUP_INPUT]).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #2475

## The defect

In `.github/workflows/maestro-native-e2e.yml`, the `android` job (`:311`) and the
`ios` job (`:679`) both declare `needs: [preflight, build]` and neither depends on
the other, so **they run concurrently**. Both then run `setup_command` — at `:410`
and `:786`. Every adopter's `setup_command` executes **twice, simultaneously**.

That is already being misused in production. `geminisportsai/frontend-v2` runs a
destructive watchlist sweep and `resolve-contract-player.mjs` there — a script
that, despite the name, scans the first twelve name-sorted players and, if none
has contract line items, issues an `AddContractLineItem` mutation. Two concurrent
runners answer "does any player have line items?" against the same pre-write
state, so both can seed, or seed *different* players, after which the two platform
legs run their contract flows against **different fixtures**.

## The design

A new `pre_suite_command` input, run by a new `pre_suite` job.

**Exactly once.** One job, no matrix, and a guard
(`!cancelled() && should_run == 'true' && pre_suite_command != ''`) that never
reads a per-platform preflight output — so narrowing to one platform still yields
exactly one execution, and selecting both still yields exactly one.

**Placed after the builds, not beside them.** Running it in parallel with `build`
would be free in wall clock, but an EAS build can take the better part of an hour,
and "known state" established an hour before the first flow is not known state.
The job keeps `!cancelled()` so that one platform's build failure — which marks the
whole matrix job failed — does not skip it and leave the surviving leg running
against state nobody established.

**Fail closed.** Both platform legs gate on an **allowlist** of pre-suite results
they will start after:

```yaml
contains(fromJSON('["success", "skipped"]'), needs.pre_suite.result)
```

`skipped` is "no command configured" — the default for every existing adopter.
`failure`, `cancelled`, and anything GitHub adds later all fall through to "do not
start". This clause is load-bearing and **`!cancelled()` does not subsume it** —
`!cancelled()` is precisely the operator that lets a job run despite a *failed*
dependency, which is right for a build artifact and wrong for established state.
There is a test that strips the clause and proves the legs start again.

I did consider fail-open (run the suite anyway, warn loudly) and rejected it: the
seam's entire purpose is establishing known state, so a suite that runs after it
failed produces greens that prove nothing and reds nobody can attribute — the
exact failure mode the nightly gate exists to avoid.

## The `$GITHUB_ENV` / job-outputs decision

`$GITHUB_ENV` is per-job and does not cross a job boundary, so the `setup_command`
convention (append `MAESTRO_*` lines to it) cannot work for a command that now runs
in a job of its own. Rather than leave adopters to discover that:

1. The pre-suite job creates an empty file and names it in `$MAESTRO_PRE_SUITE_ENV`.
   The command appends `KEY=VALUE` lines to it — same shape, different file.
2. A capture step validates every pair against a **source-constant allowlist**
   (never read from an input or the environment): the key must match
   `MAESTRO_[A-Za-z0-9_]+`, must not be a reserved name (`MAESTRO_E2E_ARGS`,
   `MAESTRO_PRE_SUITE_ENV`), and the value must be non-empty and **whitespace-free**.
   Anything else fails the job and names the offending key.
3. The validated pairs are published as a single job output, space-separated.
   Whitespace-free values make that exact, and single-line keeps it clear of
   multiline-job-output edge cases.
4. Each platform leg re-applies them to its own `$GITHUB_ENV` **before**
   `setup_command`, so flows read them exactly as if set locally and a per-leg
   command can build on what the once-per-run command established.

The whitespace rule is not gratuitous: the assembled flag list is word-split
unquoted downstream, and a value containing a space previously became a stray
argument that Maestro read as a flow path, aborting both arms of a real suite
before flow 1. That shape is now rejected at the seam with a named error.

**Secrets deliberately do not travel this way** — GitHub redacts secret values out
of job outputs, so such a pair would silently arrive empty. Sensitive flow
variables stay in `MAESTRO_SECRET_ENV`, which both legs read directly. The header
says so.

Also added: `pre_suite_install_dependencies` (default `false`, matching the
platform legs, which install nothing) for commands that need `node_modules`, and
`pre_suite_timeout_minutes` (default 20) — deliberately far tighter than
`suite_timeout_minutes`, so a wedged reset surfaces fast instead of silently
spending the suite's budget.

## `setup_command` is unchanged

Purely additive. Same input, same default, same per-leg step, same position
relative to everything else. A caller that never sets `pre_suite_command` gets a
`skipped` pre-suite job, which is on the legs' allowlist, so nothing about its run
changes. The workflow header and the caller template now state plainly which seam
is for what: `pre_suite_command` for anything that mutates shared state or must
happen once; `setup_command` for per-leg, idempotent, read-only preparation.

## Proof of single execution

Asserting a job exists proves nothing about how many times its command runs, so
the tests **simulate the workflow's own job graph** — matrix fan-out, `needs`
edges, job and step guards — and **count** executions. The preflight outputs the
simulation runs on come from executing the preflight step's real shell, not from a
re-implementation, and the expression evaluator throws on any grammar it does not
support rather than quietly evaluating to something convenient.

| scenario | `pre_suite_command` | `setup_command` |
| --- | --- | --- |
| `platform: all` | **1** | 2 |
| `platform: android` | **1** | 1 |
| `platform: ios` | **1** | 1 |
| pre-suite failed | 1 | **0** (no leg starts) |
| one EAS build failed | **1** | — |
| unwired project (no EXPO_TOKEN) | **0** | — |

The `setup_command × 2` row is the defect, quantified, and is asserted so a later
change that silently collapses the two seams gets caught.

The capture and apply steps are additionally executed **verbatim from the YAML**
under `bash -eo pipefail` (what `shell: bash` gives them in CI), for the acceptance
cases and every rejection case: a key outside the allowlist, each reserved key, an
empty value, a whitespace value, and a line that is not `KEY=VALUE`.

## Testing

- 31 new tests across `tests/integration/maestro-pre-suite-seam.test.ts` and
  `tests/integration/maestro-pre-suite-exports.test.ts`; simulator extracted to
  `tests/helpers/workflow-job-graph.ts`.
- `actionlint` clean on both changed workflows.
- Full suite: 10,727 passed / 1 pre-existing flake (`sonar-secrets` mid-resolve
  timeout, passes in isolation, unrelated to workflows).
- `bun run lint`, `tsc --noEmit`, `prettier --check .`, `knip`, and
  `check:workflow-inputs` all clean.

## For adopters

Measured, not assumed: all four live callers — `geminisportsai/frontend-v2`,
`gunnertech/frontend`, `propswap/frontend`, `TunnlAI/frontend` — currently pin
`maestro-native-e2e.yml@main`, not an immutable tag, so they pick this up on their
next run without a release. Repos that later move to tag pinning will need a tag
cut for it. Either way the change is additive: only a caller that sets
`pre_suite_command` behaves differently.

Of those four, **only `geminisportsai/frontend-v2` sets `setup_command` at all** —
the other three pass none, so nothing about their runs changes. gemini should move
`prune-e2e-watchlists.mjs` and `resolve-contract-player.mjs` from `setup_command`
to `pre_suite_command`, writing `MAESTRO_SEED_PLAYER_ID` and
`MAESTRO_CONTRACT_PLAYER_NAME` to `$MAESTRO_PRE_SUITE_ENV` instead of
`$GITHUB_ENV`. Tracked separately, not in this PR.

🤖 Generated with Claude Code


Work-Item: CodySwannGT/lisa#2475
