### PR TITLE
fix(bdd): repair the nine real defects in the vendored v2 gate sources

### DIFF
--- a/all/copy-overwrite/scripts/lisa-command-envelope.mjs
+++ b/all/copy-overwrite/scripts/lisa-command-envelope.mjs
@@ -33,10 +33,41 @@ const SCHEMA_PATH = path.join(
   "lisa-command-envelope.v1.schema.json"
 );
 
-/** The published envelope schema, read from the shipped JSON document. */
-export const COMMAND_ENVELOPE_SCHEMA = JSON.parse(
-  fs.readFileSync(SCHEMA_PATH, "utf8")
-);
+/**
+ * Read the shipped schema document, or explain why it could not be read.
+ *
+ * A throw at module scope happens before any handler runs, so an adopter with a
+ * partially-copied `scripts/` directory got a raw ENOENT stack from an import
+ * they never made directly — and any caller that merely wanted to VALIDATE
+ * something died on load. Reading it into a nullable value instead turns that
+ * into a first-class, fail-closed validation error with the missing path named
+ * in it.
+ * @returns {{schema: object|null, error: string|null}} The schema or the reason.
+ */
+function readSchemaDocument() {
+  try {
+    return {
+      schema: JSON.parse(fs.readFileSync(SCHEMA_PATH, "utf8")),
+      error: null,
+    };
+  } catch (error) {
+    return {
+      schema: null,
+      error: `the published envelope schema is not readable at ${SCHEMA_PATH} (${error.message}); scripts/schemas/ must be copied alongside scripts/`,
+    };
+  }
+}
+
+const SCHEMA_DOCUMENT = readSchemaDocument();
+
+/**
+ * The published envelope schema, read from the shipped JSON document.
+ *
+ * `null` when the document is missing — see {@link readSchemaDocument}. Every
+ * consumer must treat that as a validation FAILURE, never as "no schema to
+ * check against".
+ */
+export const COMMAND_ENVELOPE_SCHEMA = SCHEMA_DOCUMENT.schema;
 
 /**
  * Statuses that may exit 0.
@@ -67,6 +98,9 @@ export function exitCodeForStatus(status) {
  * @returns {{ valid: boolean, errors: string[] }} Validation outcome
  */
 export function validateEnvelope(envelope) {
+  if (!COMMAND_ENVELOPE_SCHEMA) {
+    return { valid: false, errors: [SCHEMA_DOCUMENT.error] };
+  }
   const base = validateAgainstSchema(envelope, COMMAND_ENVELOPE_SCHEMA);
   if (!base.valid) {
     return base;
@@ -154,6 +188,12 @@ export function emitEnvelope(envelope, io = {}) {
  */
 export function main(argv) {
   if (argv.includes("--print-schema")) {
+    if (!COMMAND_ENVELOPE_SCHEMA) {
+      process.stderr.write(
+        `[command-envelope] FAIL: ${SCHEMA_DOCUMENT.error}\n`
+      );
+      return 1;
+    }
     process.stdout.write(
       `${JSON.stringify(COMMAND_ENVELOPE_SCHEMA, null, 2)}\n`
     );

--- a/all/copy-overwrite/scripts/lisa-schema-validate.mjs
+++ b/all/copy-overwrite/scripts/lisa-schema-validate.mjs
@@ -9,7 +9,8 @@
  * keyword it does not implement**, so a schema can never silently validate less
  * than it claims: an unsupported keyword is a validator error, not a pass.
  *
- * Supported: `type`, `const`, `enum`, `required`, `properties`,
+ * Supported: `type` (a single name or an array of names), `const`, `enum`,
+ * `required`, `properties`,
  * `additionalProperties` (boolean), `items`, `minLength`, `minimum`, `pattern`,
  * `$ref` (local `#/$defs/<name>` only), `$defs`, plus the annotation-only
  * keywords `$schema`, `$id`, `title`, `description`.
@@ -79,15 +80,13 @@ function resolveRef(ref, root) {
 }
 
 /**
- * Validate one value against one subschema, appending human-readable errors.
- * @param {unknown} value - Value under validation
- * @param {object} schema - Subschema to apply
- * @param {object} root - Root schema document (for `$ref` resolution)
+ * Refuse any keyword this validator does not implement.
+ * @param {object} schema - Subschema to inspect
  * @param {string} instancePath - JSON-pointer-ish path for messages
- * @param {string[]} errors - Accumulator, mutated in place
  * @returns {void}
+ * @throws {Error} When the subschema uses an unimplemented keyword
  */
-function validateNode(value, schema, root, instancePath, errors) {
+function assertSupportedKeywords(schema, instancePath) {
   for (const keyword of Object.keys(schema)) {
     if (!SUPPORTED_KEYWORDS.has(keyword) && !ANNOTATION_KEYWORDS.has(keyword)) {
       throw new Error(
@@ -95,43 +94,76 @@ function validateNode(value, schema, root, instancePath, errors) {
       );
     }
   }
+}
 
-  if (typeof schema.$ref === "string") {
-    validateNode(
-      value,
-      resolveRef(schema.$ref, root),
-      root,
-      instancePath,
-      errors
+/**
+ * Whether one declared type name accepts an observed JSON type.
+ * @param {string} declared - A JSON Schema type name
+ * @param {string} actualType - The observed type
+ * @returns {boolean} Whether it matches
+ */
+function typeAccepts(declared, actualType) {
+  return (
+    declared === actualType ||
+    (declared === "number" && actualType === "integer")
+  );
+}
+
+/**
+ * The `type` mismatch message, or null when the value's type is acceptable.
+ *
+ * BOTH declared forms are handled. `type` may be a single name or an ARRAY of
+ * names (`["string", "null"]`), and the array form previously fell through the
+ * `typeof === "string"` test entirely: the keyword passed the allowlist, so the
+ * module's central promise — an unimplemented keyword is an error, never a
+ * silent pass — was broken for the one form nobody checked.
+ * @param {object} schema - Subschema to apply
+ * @param {string} actualType - The observed type
+ * @param {string} where - Location for the message
+ * @returns {string|null} The error, or null
+ */
+function typeError(schema, actualType, where) {
+  const declared = schema.type;
+  if (typeof declared === "string") {
+    return typeAccepts(declared, actualType)
+      ? null
+      : `${where}: expected type ${declared}, got ${actualType}`;
+  }
+  if (declared === undefined) return null;
+  if (
+    !Array.isArray(declared) ||
+    declared.length === 0 ||
+    !declared.every(entry => typeof entry === "string")
+  ) {
+    throw new Error(
+      `schema at ${where} declares a "type" that is neither a name nor an array of names`
     );
-    return;
   }
+  return declared.some(entry => typeAccepts(entry, actualType))
+    ? null
+    : `${where}: expected type ${declared.join(" or ")}, got ${actualType}`;
+}
 
-  const where = instancePath || "(root)";
-  const actualType = jsonTypeOf(value);
-
-  if (typeof schema.type === "string") {
-    const ok =
-      schema.type === actualType ||
-      (schema.type === "number" && actualType === "integer");
-    if (!ok) {
-      errors.push(`${where}: expected type ${schema.type}, got ${actualType}`);
-      return;
-    }
-  }
-
+/**
+ * Apply the value-level keywords: `const`, `enum`, and the string and number
+ * constraints.
+ * @param {unknown} value - Value under validation
+ * @param {object} schema - Subschema to apply
+ * @param {string} where - Location for messages
+ * @param {string[]} errors - Accumulator, mutated in place
+ * @returns {void}
+ */
+function checkValueKeywords(value, schema, where, errors) {
   if ("const" in schema && value !== schema.const) {
     errors.push(
       `${where}: expected constant ${JSON.stringify(schema.const)}, got ${JSON.stringify(value)}`
     );
   }
-
   if (Array.isArray(schema.enum) && !schema.enum.includes(value)) {
     errors.push(
       `${where}: ${JSON.stringify(value)} is not one of ${schema.enum.map(entry => JSON.stringify(entry)).join(", ")}`
     );
   }
-
   if (typeof value === "string") {
     if (
       typeof schema.minLength === "number" &&
@@ -146,29 +178,32 @@ function validateNode(value, schema, root, instancePath, errors) {
       errors.push(`${where}: does not match pattern ${schema.pattern}`);
     }
   }
-
-  if (typeof value === "number" && typeof schema.minimum === "number") {
-    if (value < schema.minimum) {
-      errors.push(`${where}: below minimum ${schema.minimum}`);
-    }
+  if (
+    typeof value === "number" &&
+    typeof schema.minimum === "number" &&
+    value < schema.minimum
+  ) {
+    errors.push(`${where}: below minimum ${schema.minimum}`);
   }
+}
 
-  if (actualType === "array" && schema.items) {
-    value.forEach((entry, index) => {
-      validateNode(entry, schema.items, root, `${where}[${index}]`, errors);
-    });
-  }
-
-  if (actualType !== "object") {
-    return;
-  }
-
+/**
+ * Apply the object-level keywords: `required`, `properties`, and
+ * `additionalProperties`.
+ * @param {object} value - Object under validation
+ * @param {object} schema - Subschema to apply
+ * @param {object} root - Root schema document (for `$ref` resolution)
+ * @param {string} instancePath - JSON-pointer-ish path for messages
+ * @param {string[]} errors - Accumulator, mutated in place
+ * @returns {void}
+ */
+function checkObjectKeywords(value, schema, root, instancePath, errors) {
+  const where = instancePath || "(root)";
   for (const key of schema.required ?? []) {
     if (!(key in value)) {
       errors.push(`${where}: missing required property "${key}"`);
     }
   }
-
   const properties = schema.properties ?? {};
   for (const [key, subschema] of Object.entries(properties)) {
     if (key in value) {
@@ -181,13 +216,56 @@ function validateNode(value, schema, root, instancePath, errors) {
       );
     }
   }
-
   if (schema.additionalProperties === false) {
     for (const key of Object.keys(value)) {
       if (!(key in properties)) {
         errors.push(`${where}: unexpected property "${key}"`);
       }
     }
+  }
+}
+
+/**
+ * Validate one value against one subschema, appending human-readable errors.
+ * @param {unknown} value - Value under validation
+ * @param {object} schema - Subschema to apply
+ * @param {object} root - Root schema document (for `$ref` resolution)
+ * @param {string} instancePath - JSON-pointer-ish path for messages
+ * @param {string[]} errors - Accumulator, mutated in place
+ * @returns {void}
+ */
+function validateNode(value, schema, root, instancePath, errors) {
+  assertSupportedKeywords(schema, instancePath);
+
+  if (typeof schema.$ref === "string") {
+    validateNode(
+      value,
+      resolveRef(schema.$ref, root),
+      root,
+      instancePath,
+      errors
+    );
+    return;
+  }
+
+  const where = instancePath || "(root)";
+  const actualType = jsonTypeOf(value);
+  const mismatch = typeError(schema, actualType, where);
+  if (mismatch) {
+    errors.push(mismatch);
+    return;
+  }
+
+  checkValueKeywords(value, schema, where, errors);
+
+  if (actualType === "array" && schema.items) {
+    value.forEach((entry, index) => {
+      validateNode(entry, schema.items, root, `${where}[${index}]`, errors);
+    });
+  }
+
+  if (actualType === "object") {
+    checkObjectKeywords(value, schema, root, instancePath, errors);
   }
 }
 

--- a/docs/bdd-coverage-schema.md
+++ b/docs/bdd-coverage-schema.md
@@ -107,9 +107,9 @@ carrying two shapes has no schema at all. The same document is written to
   "scenarios": { "declared": 0, "required": 0, "excluded": 0, "blocked": 0, "referenceOnly": 0, "superseded": 0 },
   "traceability": {
     "note": "<the traceability-is-not-execution disclaimer>",
-    "overall": { "covered": 0, "total": 0, "percentage": 0 },
-    "byPlatform": { "<platform>": { "covered": 0, "total": 0, "percentage": 0 } },
-    "byRunner":   { "<runner>":   { "covered": 0, "total": 0, "percentage": 0 } }
+    "overall": { "covered": 0, "total": 0, "percentage": 0, "exact": 0 },
+    "byPlatform": { "<platform>": { "covered": 0, "total": 0, "percentage": 0, "exact": 0 } },
+    "byRunner":   { "<runner>":   { "covered": 0, "total": 0, "percentage": 0, "exact": 0 } }
   },
   "execution": {
     "supplied": false,
@@ -125,16 +125,25 @@ carrying two shapes has no schema at all. The same document is written to
     "exclusions": [{ "file": "", "evidence": null, "reason": "" }]
   },
   "waived": { "note": "", "count": 0, "entries": [{ "scenario": "", "platforms": [], "runner": null, "owner": null, "reason": null, "ticket": null, "recordedAt": null, "expiresAt": null }] },
-  "floor": { "byPlatform": { "<platform>": { "floor": 0, "actual": 0, "ok": true } }, "unset": [], "ok": true },
+  "floor": { "byPlatform": { "<platform>": { "floor": 0, "actual": 0, "exact": 0, "ok": true } }, "unset": [], "ok": true },
   "trackers": { "scenariosWithTag": 0, "scenariosWithoutTag": 0, "tags": [{ "tag": "", "url": null, "scenarios": [] }] },
   "gaps": [{ "scenario": "", "name": "", "feature": "", "platform": "", "runners": [] }]
 }
 ```
 
-Output is **deterministic**: every array is sorted by a stable key, and the only date
-in the report comes from the coverage map's `asOf`, never from the clock. Two runs on
-the same tree produce byte-identical JSON. (`BDD_TODAY` overrides "now" for expiry
-evaluation, which is what makes expiry behavior testable.)
+Output is **deterministic**: every array is sorted by a stable key with an explicit
+comparator, and the only date in the report comes from the coverage map's `asOf`,
+never from the clock. Two runs on the same tree produce byte-identical JSON.
+(`BDD_TODAY` overrides "now" for expiry evaluation, which is what makes expiry
+behavior testable. A `BDD_TODAY` that is not an ISO date is a `waiver-metadata`
+defect — and a `bootstrap-metadata` defect in bootstrap — never a date comparison
+that quietly answers "not expired" for everything.)
+
+`percentage` is **rounded to one decimal for display**; `exact` is the unrounded
+value and is the only one a floor is ever compared against. 2000 of 2001
+obligations is 99.95002%, which displays as `100` — a platform must not clear a
+floor of 100 on a rounding convention. Both fields are present on every
+traceability summary and on each `floor.byPlatform` entry.
 
 ### Execution-result documents (`--results <file>`)
 
@@ -183,6 +192,11 @@ structurally invisible in the fork this replaces. Keys must be runners declared 
   }
 }
 ```
+
+`roots` and `ignore` are matched by **whole path segment**, not by character prefix:
+`e2e/live` covers `e2e/live` and `e2e/live/…` and does **not** swallow
+`e2e/live-personas/…`. A root of `.` (or `./`) means the repository root and covers
+every repo-relative path.
 
 `evidence.kind` is an **allowlist of two grammars**, never a project-supplied regular
 expression — the coverage map is repo data an author edits, and compiling a pattern

--- a/expo/copy-overwrite/scripts/bdd-matrix.mjs
+++ b/expo/copy-overwrite/scripts/bdd-matrix.mjs
@@ -20,7 +20,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { declaredPlatforms, trackerUrl } from "./bdd/contract.mjs";
+import { byCodeUnit, declaredPlatforms, trackerUrl } from "./bdd/contract.mjs";
 import { loadScenarios } from "./bdd/parse.mjs";
 import { indexResults } from "./bdd/report.mjs";
 import { loadExecutionResults } from "./check-bdd-coverage.mjs";
@@ -128,7 +128,7 @@ export function renderMatrix(root, resultFiles) {
   const results = indexResults(execution.runs);
   const byScenario = mappingsByScenario(contract);
   const waived = waivedKeys(contract);
-  const runners = Object.keys(contract.runnerPlatforms ?? {}).sort();
+  const runners = Object.keys(contract.runnerPlatforms ?? {}).sort(byCodeUnit);
   const byFeature = new Map();
   for (const scenario of scenarios) {
     byFeature.set(scenario.feature, [

--- a/expo/copy-overwrite/scripts/bdd/baseline.mjs
+++ b/expo/copy-overwrite/scripts/bdd/baseline.mjs
@@ -27,14 +27,87 @@
  * @module scripts/bdd/baseline
  */
 import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
 
-import { declaredPlatforms } from "./contract.mjs";
+import { byCodeUnit, declaredPlatforms } from "./contract.mjs";
 import { parseFeatureSource, scenarioIdsIn } from "./parse.mjs";
 
 const defect = (code, message) => ({ code, message });
 
 /** The maintainer-applied PR label that authorizes giving coverage back. */
 export const BASELINE_LABEL = "bdd-floor-baseline";
+
+/**
+ * Fixed absolute locations git is installed at, tried before anything on PATH.
+ *
+ * Handing a bare command name to the process spawner delegates the choice of
+ * binary to whatever `PATH` happens to say, so any writable directory earlier
+ * on it decides what this gate executes. The gate reads a base revision to
+ * decide whether a pull request may merge, which makes that a real
+ * substitution risk and not a theoretical one.
+ */
+const GIT_CANDIDATES = Object.freeze([
+  "/usr/bin/git",
+  "/usr/local/bin/git",
+  "/opt/homebrew/bin/git",
+  "/bin/git",
+  "C:\\Program Files\\Git\\cmd\\git.exe",
+]);
+
+/** Resolved git path, or null; computed once per process. */
+let gitBinary;
+
+/**
+ * Whether a path names a file that exists.
+ * @param {string} candidate - Absolute path.
+ * @returns {boolean} Whether it is a regular file.
+ */
+function isFile(candidate) {
+  try {
+    return fs.statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve git to an ABSOLUTE, verified path.
+ *
+ * Fixed system locations first, then each `PATH` entry resolved to an absolute
+ * path and confirmed to be a real file — a lookup, never a delegation, so the
+ * command actually executed is one this process chose and checked.
+ * @returns {string|null} The absolute path, or null when git is not installed.
+ */
+export function resolveGit() {
+  if (gitBinary !== undefined) return gitBinary;
+  const fromPath = (process.env.PATH ?? "")
+    .split(path.delimiter)
+    .filter(Boolean)
+    .flatMap(entry => ["git", "git.exe"].map(name => path.join(entry, name)))
+    .filter(candidate => path.isAbsolute(candidate));
+  gitBinary =
+    [...GIT_CANDIDATES, ...fromPath].find(candidate => isFile(candidate)) ??
+    null;
+  return gitBinary;
+}
+
+/**
+ * Run one git command at an absolute path, or report that git is unavailable.
+ * @param {string} root - Repo root.
+ * @param {readonly string[]} args - Arguments after the binary.
+ * @returns {{ok: boolean, stdout: string}} The verdict and its output.
+ */
+function git(root, args) {
+  const binary = resolveGit();
+  if (!binary) return { ok: false, stdout: "" };
+  const result = spawnSync(binary, [...args], {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return { ok: result.status === 0, stdout: result.stdout ?? "" };
+}
 
 /**
  * Read one path at a git revision.
@@ -44,12 +117,8 @@ export const BASELINE_LABEL = "bdd-floor-baseline";
  * @returns {string|null} File contents, or null when absent at that revision.
  */
 export function showAtRevision(root, revision, relative) {
-  const result = spawnSync("git", ["show", `${revision}:${relative}`], {
-    cwd: root,
-    encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
-  });
-  return result.status === 0 ? result.stdout : null;
+  const result = git(root, ["show", `${revision}:${relative}`]);
+  return result.ok ? result.stdout : null;
 }
 
 /**
@@ -59,12 +128,15 @@ export function showAtRevision(root, revision, relative) {
  * @returns {string[]} Repo-relative feature paths.
  */
 function featureFilesAt(root, revision) {
-  const result = spawnSync(
-    "git",
-    ["ls-tree", "-r", "--name-only", revision, "--", "bdd/features"],
-    { cwd: root, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 }
-  );
-  if (result.status !== 0) return [];
+  const result = git(root, [
+    "ls-tree",
+    "-r",
+    "--name-only",
+    revision,
+    "--",
+    "bdd/features",
+  ]);
+  if (!result.ok) return [];
   return result.stdout
     .split("\n")
     .map(line => line.trim())
@@ -79,20 +151,32 @@ function featureFilesAt(root, revision) {
  * an unknown tag the moment a pull request deleted the web runner from
  * `runnerPlatforms` — which would turn "I deleted the runner that proved this"
  * into an invisible change rather than the coverage loss it is.
+ *
+ * A base coverage map that EXISTS but does not parse makes the baseline
+ * UNAVAILABLE rather than empty. An empty `before` set produces no
+ * `coverage-regression` and no `scenario-deleted` finding at all, so treating
+ * an unreadable map as "nothing was covered before" would let one malformed
+ * character on the base revision switch off every non-regression check while
+ * the gate still reported that nothing regressed.
  * @param {string} root - Repo root.
  * @param {string} revision - Base commit-ish.
  * @param {ReadonlySet<string>} headPlatforms - The head contract's platforms.
- * @returns {{available: boolean, contract: object|null, scenarios: object[], scenarioIds: Set<string>}} Base state.
+ * @returns {{available: boolean, error: string|null, contract: object|null, scenarios: object[], scenarioIds: Set<string>}} Base state.
  */
 export function loadBaseline(root, revision, headPlatforms = new Set()) {
   const raw = showAtRevision(root, revision, "bdd/coverage-map.json");
   let contract = null;
+  let error = null;
   if (raw !== null) {
     try {
       contract = JSON.parse(raw);
-    } catch {
+    } catch (parseError) {
       contract = null;
+      error = `bdd/coverage-map.json at that revision is not valid JSON: ${parseError.message}`;
     }
+  }
+  if (raw === null && !resolveGit()) {
+    error = "git was not found, so no base revision could be read";
   }
   const documents = featureFilesAt(root, revision)
     .map(file => ({ file, source: showAtRevision(root, revision, file) }))
@@ -102,7 +186,8 @@ export function loadBaseline(root, revision, headPlatforms = new Set()) {
     ...headPlatforms,
   ]);
   return {
-    available: raw !== null || documents.length > 0,
+    available: error === null && (raw !== null || documents.length > 0),
+    error,
     contract,
     scenarios: documents.flatMap(document =>
       parseFeatureSource(document.source, document.file, platforms)
@@ -230,7 +315,7 @@ export function checkCoverageRegression({
   const waived = waivedKeys(contract);
   return [...before]
     .filter(key => !after.has(key) && present.has(partsOf(key).scenario))
-    .sort()
+    .sort(byCodeUnit)
     .flatMap(key => regressionDefect(key, { retired, waived, labels }));
 }
 
@@ -291,7 +376,7 @@ export function checkNewObligations({ baseline, contract, scenarios }) {
   const covered = acceptedKeys(scenarios, contract);
   return [...obligationKeys(scenarios, contract)]
     .filter(key => !before.has(key) && !covered.has(key))
-    .sort()
+    .sort(byCodeUnit)
     .map(key => {
       const { scenario, platform } = partsOf(key);
       return defect(
@@ -317,7 +402,7 @@ export function checkDeletions({ baseIds, scenarios, contract, labels }) {
   );
   return [...baseIds]
     .filter(id => !present.has(id))
-    .sort()
+    .sort(byCodeUnit)
     .flatMap(id => deletionDefects(id, retired.get(id), labels));
 }
 

--- a/expo/copy-overwrite/scripts/bdd/contract.mjs
+++ b/expo/copy-overwrite/scripts/bdd/contract.mjs
@@ -20,6 +20,25 @@
  */
 export const REPORT_SCHEMA_VERSION = 3;
 
+/**
+ * THE comparator every ordering in this gate uses.
+ *
+ * `Array.prototype.sort()` with no comparator coerces each element to a string
+ * and compares UTF-16 code units, which is right for the identifier lists this
+ * gate sorts and catastrophically wrong the first time someone sorts numbers
+ * (`[2, 10]` becomes `[10, 2]`). Stating the comparator makes that choice
+ * deliberate rather than inherited, and it reproduces the previous ordering
+ * exactly — deliberately NOT `localeCompare`, whose result depends on the
+ * runner's ICU data and would reorder committed report artifacts.
+ * @param {string} a - Left value.
+ * @param {string} b - Right value.
+ * @returns {number} Negative, zero, or positive.
+ */
+export const byCodeUnit = (a, b) => {
+  if (a < b) return -1;
+  return a > b ? 1 : 0;
+};
+
 /** Coverage-map schema versions this gate can read. */
 export const SUPPORTED_MAP_SCHEMA_VERSIONS = [1, 2];
 
@@ -115,7 +134,7 @@ export function runnersByPlatform(runnerPlatforms) {
       index.set(platform, [...(index.get(platform) ?? []), runner]);
     }
   }
-  for (const runners of index.values()) runners.sort();
+  for (const runners of index.values()) runners.sort(byCodeUnit);
   return index;
 }
 

--- a/expo/copy-overwrite/scripts/bdd/discover.mjs
+++ b/expo/copy-overwrite/scripts/bdd/discover.mjs
@@ -20,7 +20,42 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import { byCodeUnit } from "./contract.mjs";
 import { listFiles, posix, resolveInsideRepo } from "./parse.mjs";
+
+/**
+ * Normalize a repo-relative path or path prefix to one comparable spelling.
+ *
+ * `./e2e/`, `e2e`, and `e2e/` all name the same directory, and the repo root
+ * is spelled `.` in a `roots` list but never appears in a repo-relative file
+ * path at all. Comparing the raw strings made those spellings disagree.
+ * @param {string} value - A repo-relative path or prefix.
+ * @returns {string} Its canonical form; the empty string means the repo root.
+ */
+const canonicalPath = value =>
+  posix(String(value))
+    .replace(/^\.\/+/, "")
+    .replace(/\/+$/, "")
+    .replace(/^\.$/, "");
+
+/**
+ * Whether a repo-relative path lies at or under a path prefix, SEGMENT-WISE.
+ *
+ * A raw `startsWith` treats a prefix as a character prefix, so an ignore entry
+ * of `e2e/live` also swallowed `e2e/live-personas/…` — silently hiding a whole
+ * directory of undeclared tests, which is the one thing discovery exists to
+ * find. Matching is therefore on path segments: `e2e/live` covers `e2e/live`
+ * and `e2e/live/…` and nothing else.
+ * @param {string} relative - A repo-relative path.
+ * @param {string} prefix - A repo-relative path prefix.
+ * @returns {boolean} Whether the path is covered by the prefix.
+ */
+export function isUnderPrefix(relative, prefix) {
+  const target = canonicalPath(relative);
+  const root = canonicalPath(prefix);
+  if (root === "") return true;
+  return target === root || target.startsWith(`${root}/`);
+}
 
 /**
  * Build one defect record, always naming the entity it is about.
@@ -213,12 +248,18 @@ function callTitles(source, functions) {
   );
   const found = [];
   for (const match of source.matchAll(pattern)) {
+    // Exactly one of the three quoting alternatives participates in any match,
+    // so the others are genuinely `undefined` here. The tests are written by
+    // TYPE rather than against `undefined`: the intent is "did this call carry
+    // a usable title" and "did that title come from a template literal", and
+    // stating it that way is both what the code means and unambiguous to a
+    // static analyser reading the declared `string` element type.
     const template = match[3];
     const evidence = match[1] ?? match[2] ?? template;
-    if (evidence === undefined || evidence.length === 0) continue;
+    if (typeof evidence !== "string" || evidence.length === 0) continue;
     found.push({
       evidence,
-      dynamic: template !== undefined && template.includes("${"),
+      dynamic: typeof template === "string" && template.includes("${"),
     });
   }
   return found;
@@ -247,13 +288,15 @@ function lineField(source, field) {
  * @returns {object[]} Discovered specs.
  */
 function discoverRunner({ root, runner, config, contract }) {
-  const platforms = [...(contract.runnerPlatforms?.[runner] ?? [])].sort();
+  const platforms = [...(contract.runnerPlatforms?.[runner] ?? [])].sort(
+    byCodeUnit
+  );
   const ignore = config.ignore ?? [];
   const specs = [];
   for (const declaredRoot of config.roots) {
     for (const file of filesUnder(root, declaredRoot, config)) {
       const relative = posix(path.relative(root, file));
-      if (ignore.some(prefix => relative.startsWith(prefix))) continue;
+      if (ignore.some(prefix => isUnderPrefix(relative, prefix))) continue;
       const source = fs.readFileSync(file, "utf8");
       for (const found of extract(source, config.evidence)) {
         specs.push({ runner, platforms, file: relative, ...found });
@@ -306,7 +349,7 @@ export function discoverSpecs({ root, contract }) {
   const specs = [];
   const roots = [];
   for (const [runner, config] of configs) {
-    roots.push(...config.roots.map(entry => posix(entry).replace(/\/+$/, "")));
+    roots.push(...config.roots.map(canonicalPath));
     specs.push(...discoverRunner({ root, runner, config, contract }));
   }
   return {
@@ -315,8 +358,8 @@ export function discoverSpecs({ root, contract }) {
         `${b.file}${b.evidence ?? ""}`
       )
     ),
-    runners: [...configs.keys()].sort(),
-    roots: [...new Set(roots)].sort(),
+    runners: [...configs.keys()].sort(byCodeUnit),
+    roots: [...new Set(roots)].sort(byCodeUnit),
     defects,
   };
 }
@@ -445,11 +488,11 @@ function exclusionStale({ root, exclusion, discovery, at, subject }) {
       ),
     ];
   }
-  if (!discovery.roots.some(entry => exclusion.file.startsWith(`${entry}/`))) {
+  if (!discovery.roots.some(entry => isUnderPrefix(exclusion.file, entry))) {
     return [
       defect(
         "exclusion-stale",
-        `${at}: ${exclusion.file} is covered by no configured discovery root (${discovery.roots.join(", ") || "none declared"}), so the exclusion suppresses nothing`,
+        `${at}: ${exclusion.file} is covered by no configured discovery root (${discovery.roots.map(entry => entry || ".").join(", ") || "none declared"}), so the exclusion suppresses nothing`,
         subject
       ),
     ];
@@ -491,7 +534,7 @@ export function missingDiscoveryDefects(contract, discovery) {
   return Object.keys(contract.runnerPlatforms ?? {})
     .filter(runner => !runner.startsWith("_"))
     .filter(runner => !discovery.runners.includes(runner))
-    .sort()
+    .sort(byCodeUnit)
     .map(runner =>
       defect(
         "discovery-missing",

--- a/expo/copy-overwrite/scripts/bdd/parse.mjs
+++ b/expo/copy-overwrite/scripts/bdd/parse.mjs
@@ -14,6 +14,7 @@ import {
   ID_PATTERN,
   LIFECYCLE_TAGS,
   PROVENANCE_PATTERN,
+  byCodeUnit,
   parseTrackerTag,
 } from "./contract.mjs";
 
@@ -87,7 +88,7 @@ export function listFiles(directory, predicate) {
       else if (entry.isFile() && predicate(full)) found.push(full);
     }
   }
-  return found.sort();
+  return found.sort(byCodeUnit);
 }
 
 /**
@@ -130,6 +131,12 @@ function categorize(tags, platforms) {
  * Tags accumulate until a `Feature:` or `Scenario:` consumes them, matching
  * Gherkin's own tag scoping. `Scenario Outline` is treated as one scenario:
  * the contract counts behaviors, not example rows.
+ *
+ * `Background:` steps are Gherkin's way of saying "every scenario in this
+ * feature starts here", so they SEED each scenario's primary steps. Ignoring
+ * them made a conforming feature file — Given in the Background, When/Then in
+ * each scenario — report `scenario-steps` defects it did not have, which in
+ * enforced mode fails a repo for writing correct Gherkin.
  * @param {string} source - File contents.
  * @param {string} file - Repo-relative path, for error locations.
  * @param {ReadonlySet<string>} platforms - The project's declared platform vocabulary.
@@ -144,6 +151,8 @@ export function parseFeatureSource(source, file, platforms) {
   let featureLine = 0;
   let pending = [];
   let current = null;
+  let background = null;
+  let backgroundSteps = [];
   for (let index = 0; index < lines.length; index += 1) {
     const trimmed = lines[index].trim();
     if (trimmed.startsWith("#")) continue;
@@ -164,6 +173,16 @@ export function parseFeatureSource(source, file, platforms) {
       featureIdTags = pending.filter(tag => ID_PATTERN.test(tag));
       featureLine = index + 1;
       pending = [];
+      current = null;
+      background = null;
+      backgroundSteps = [];
+      continue;
+    }
+    if (/^Background:/.test(trimmed)) {
+      // Background is per-Feature, so it replaces any previous one rather than
+      // accumulating, and its steps are collected instead of a scenario's.
+      backgroundSteps = [];
+      background = backgroundSteps;
       current = null;
       continue;
     }
@@ -189,14 +208,17 @@ export function parseFeatureSource(source, file, platforms) {
         featureLine,
         ...grouped,
         required: grouped.lifecycle.length === 0,
-        primarySteps: [],
+        primarySteps: [...backgroundSteps],
       };
       scenarios.push(current);
+      background = null;
       pending = [];
       continue;
     }
     const step = /^(Given|When|Then)\b/.exec(trimmed);
-    if (step && current) current.primarySteps.push(step[1]);
+    if (!step) continue;
+    if (background) background.push(step[1]);
+    else if (current) current.primarySteps.push(step[1]);
   }
   return scenarios;
 }

--- a/expo/copy-overwrite/scripts/bdd/render.mjs
+++ b/expo/copy-overwrite/scripts/bdd/render.mjs
@@ -7,6 +7,7 @@
  *
  * @module scripts/bdd/render
  */
+import { byCodeUnit } from "./contract.mjs";
 
 /**
  * Format a coverage figure, refusing to print "100%" for an empty
@@ -175,7 +176,7 @@ function gapSections(report) {
       const rows = [...entries.entries()]
         .map(
           ([id, value]) =>
-            `| ${cell(id)} | ${cell(value.name)} | ${cell(value.platforms.sort().join(", "))} |`
+            `| ${cell(id)} | ${cell(value.name)} | ${cell([...value.platforms].sort(byCodeUnit).join(", "))} |`
         )
         .join("\n");
       return `### ${cell(feature)}\n\n| Scenario | Behavior with no mapped proof | Platforms |\n|---|---|---|\n${rows}`;

--- a/expo/copy-overwrite/scripts/bdd/report.mjs
+++ b/expo/copy-overwrite/scripts/bdd/report.mjs
@@ -18,6 +18,7 @@
  */
 import {
   REPORT_SCHEMA_VERSION,
+  byCodeUnit,
   runnersByPlatform,
   trackerUrl,
 } from "./contract.mjs";
@@ -73,19 +74,24 @@ function buildTestInventory(discovery, contract) {
  * required here" and "everything required here is covered" are different
  * claims, and printing the second for the first is how a platform with no
  * obligations comes to look fully covered.
+ *
+ * `percentage` is ROUNDED FOR DISPLAY and `exact` is not. Only `exact` is ever
+ * compared against a floor: 2000 of 2001 obligations is 99.95002%, which
+ * rounds to 100.0, and a genuinely-below-floor platform reporting `ok: true`
+ * because of a display convention is the same class of false headline this
+ * whole report is built to prevent.
  * @param {readonly object[]} subset - Obligations to count.
  * @param {ReadonlySet<string>} coveredKeys - Keys with an aligned mapping.
- * @returns {object} Covered/total/percentage.
+ * @returns {object} Covered/total/percentage/exact.
  */
 function summarize(subset, coveredKeys) {
   const covered = subset.filter(item => coveredKeys.has(item.key)).length;
+  const exact = subset.length === 0 ? null : (covered / subset.length) * 100;
   return {
     covered,
     total: subset.length,
-    percentage:
-      subset.length === 0
-        ? null
-        : Number(((covered / subset.length) * 100).toFixed(1)),
+    percentage: exact === null ? null : Number(exact.toFixed(1)),
+    exact,
   };
 }
 
@@ -212,7 +218,7 @@ export function buildExecution(mappings, runs) {
     notRunTests: outcomes
       .filter(item => item.result === null)
       .map(item => `${item.runner} ${item.file} :: ${item.evidence}`)
-      .sort(),
+      .sort(byCodeUnit),
   };
 }
 
@@ -268,18 +274,23 @@ function classifyFloor(declared) {
  */
 export function evaluateFloor(contract, byPlatform, platforms) {
   const floors = contract.coverageFloor ?? {};
-  const entries = [...platforms].sort().map(platform => {
+  const entries = [...platforms].sort(byCodeUnit).map(platform => {
     const declared = classifyFloor(floors[platform]);
     // A platform with no obligations reports `null`, not 100. It cannot clear
     // a positive floor by having nothing to measure.
     const actual = byPlatform[platform]?.percentage ?? null;
+    // The UNROUNDED value decides. `actual` above is the display figure and is
+    // kept only so the report and the operator message agree with the rest of
+    // the traceability block.
+    const exact = byPlatform[platform]?.exact ?? null;
     return [
       platform,
       {
         floor: declared.value,
         state: declared.state,
         actual,
-        ok: isFloorMet(declared, actual),
+        exact,
+        ok: isFloorMet(declared, exact),
       },
     ];
   });
@@ -302,7 +313,7 @@ export function evaluateFloor(contract, byPlatform, platforms) {
  * disable enforcement. An unset floor has nothing to clear here; the enforced
  * mode reports its absence separately.
  * @param {{state: string, value: number|null}} declared - The classified floor.
- * @param {number|null} actual - Measured percentage, or null when there are no obligations.
+ * @param {number|null} actual - Measured UNROUNDED percentage, or null when there are no obligations.
  * @returns {boolean} Whether the floor is satisfied.
  */
 function isFloorMet(declared, actual) {
@@ -338,7 +349,10 @@ export function buildTrackerIndex(scenarios, trackers) {
       scenario => scenario.trackers.length === 0
     ).length,
     tags: [...tags.values()]
-      .map(entry => ({ ...entry, scenarios: [...entry.scenarios].sort() }))
+      .map(entry => ({
+        ...entry,
+        scenarios: [...entry.scenarios].sort(byCodeUnit),
+      }))
       .sort((a, b) => a.tag.localeCompare(b.tag)),
   };
 }
@@ -366,7 +380,7 @@ export function buildReport({
   const obligations = declared.filter(item => !waivedKeys.has(item.key));
   const coveredKeys = coverageKeys(scenarios, contract, unresolved);
   const byPlatform = Object.fromEntries(
-    [...platforms].sort().map(platform => [
+    [...platforms].sort(byCodeUnit).map(platform => [
       platform,
       summarize(
         obligations.filter(item => item.platform === platform),
@@ -460,7 +474,7 @@ function countScenarios(scenarios) {
 function byRunnerSummary(contract, obligations, coveredKeys) {
   return Object.fromEntries(
     Object.keys(contract.runnerPlatforms ?? {})
-      .sort()
+      .sort(byCodeUnit)
       .map(runner => [
         runner,
         summarize(

--- a/expo/copy-overwrite/scripts/bdd/validate.mjs
+++ b/expo/copy-overwrite/scripts/bdd/validate.mjs
@@ -9,7 +9,7 @@
  */
 import * as fs from "node:fs";
 
-import { runnersByPlatform } from "./contract.mjs";
+import { byCodeUnit, runnersByPlatform } from "./contract.mjs";
 import { resolveInsideRepo } from "./parse.mjs";
 
 /**
@@ -43,7 +43,7 @@ export function validateScenarios(scenarios, platforms) {
       defects.push(
         defect(
           "scenario-platform",
-          `${at} declares no platform; expected one of ${[...platforms].sort().join(", ") || "(none configured)"}`
+          `${at} declares no platform; expected one of ${[...platforms].sort(byCodeUnit).join(", ") || "(none configured)"}`
         )
       );
     }

--- a/expo/copy-overwrite/scripts/bdd/waivers.mjs
+++ b/expo/copy-overwrite/scripts/bdd/waivers.mjs
@@ -22,10 +22,16 @@ const REQUIRED_FIELDS = [
 ];
 
 /** ISO calendar date, the only accepted date shape. */
-const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+export const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
  * Validate every waiver in the coverage map.
+ *
+ * The evaluation date is validated FIRST and reported as a defect of its own.
+ * Expiry is a lexical `<` comparison against an ISO date, and every comparison
+ * with a non-date string is false — so an unusable `BDD_TODAY` did not merely
+ * skip the expiry check, it silently passed EVERY expired waiver in the repo.
+ * A date the gate cannot read is a finding, never a free pass.
  * @param {object} input - Scenarios, contract, and the evaluation date.
  * @returns {object[]} Defects found.
  */
@@ -34,7 +40,15 @@ export function validateWaivers({ scenarios, contract, today }) {
   const platformRunners = runnersByPlatform(contract.runnerPlatforms);
   const mapped = mappedKeys(contract);
   const seen = new Set();
-  const defects = [];
+  const usableToday = typeof today === "string" && ISO_DATE.test(today);
+  const defects = usableToday
+    ? []
+    : [
+        defect(
+          "waiver-metadata",
+          `the evaluation date ${JSON.stringify(today ?? null)} is not an ISO date (YYYY-MM-DD), so no waiver expiry could be evaluated. Set BDD_TODAY to a calendar date or leave it unset.`
+        ),
+      ];
   for (const [index, waiver] of (contract.platformWaivers ?? []).entries()) {
     const at = `coverage-map.platformWaivers[${index}] ${waiver.scenario ?? "(no scenario)"}`;
     const scenario = byId.get(waiver.scenario);
@@ -43,7 +57,7 @@ export function validateWaivers({ scenarios, contract, today }) {
       defects.push(blocking);
       continue;
     }
-    defects.push(...metadataDefects(waiver, at, today));
+    defects.push(...metadataDefects(waiver, at, usableToday ? today : null));
     defects.push(...runnerDefects(waiver, platformRunners, at));
     defects.push(...platformDefects(waiver, scenario, { mapped, seen }, at));
   }
@@ -96,7 +110,7 @@ function blockingError(waiver, scenario, at) {
  * waiver — the time-box is what stops an IOU from becoming permanent.
  * @param {object} waiver - Raw waiver entry.
  * @param {string} at - Location label.
- * @param {string} today - ISO date the run is evaluated against.
+ * @param {string|null} today - ISO date the run is evaluated against, or null when unusable.
  * @returns {object[]} Defects found.
  */
 function metadataDefects(waiver, at, today) {
@@ -125,6 +139,7 @@ function metadataDefects(waiver, at, today) {
     );
   }
   if (
+    today !== null &&
     waiver.expiresAt &&
     ISO_DATE.test(waiver.expiresAt) &&
     waiver.expiresAt < today

--- a/expo/copy-overwrite/scripts/check-bdd-coverage.mjs
+++ b/expo/copy-overwrite/scripts/check-bdd-coverage.mjs
@@ -77,7 +77,7 @@ import {
   validateScenarios,
   validateTrackerTags,
 } from "./bdd/validate.mjs";
-import { validateWaivers } from "./bdd/waivers.mjs";
+import { ISO_DATE, validateWaivers } from "./bdd/waivers.mjs";
 
 const PACKAGE_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -178,6 +178,17 @@ export function validateAdoption(contract, mode, today) {
  */
 function bootstrapDefects(adoption, today) {
   const defects = [];
+  if (!ISO_DATE.test(String(today))) {
+    // The expiry is a lexical comparison against an ISO date, and every
+    // comparison with a non-date is false — so an unreadable evaluation date
+    // would make the time-box unreachable and bootstrap permanent.
+    defects.push(
+      defect(
+        "bootstrap-metadata",
+        `the evaluation date ${JSON.stringify(today ?? null)} is not an ISO date (YYYY-MM-DD), so the bootstrap expiry could not be evaluated`
+      )
+    );
+  }
   if (!adoption.owner) {
     defects.push(
       defect(
@@ -193,14 +204,14 @@ function bootstrapDefects(adoption, today) {
         "bootstrap requires adoption.expiresAt (an ISO date); a bootstrap with no time-box never ends"
       )
     );
-  } else if (!/^\d{4}-\d{2}-\d{2}$/.test(adoption.expiresAt)) {
+  } else if (!ISO_DATE.test(adoption.expiresAt)) {
     defects.push(
       defect(
         "bootstrap-metadata",
         "adoption.expiresAt must be an ISO date (YYYY-MM-DD)"
       )
     );
-  } else if (adoption.expiresAt < today) {
+  } else if (ISO_DATE.test(String(today)) && adoption.expiresAt < today) {
     defects.push(
       defect(
         "bootstrap-expired",
@@ -278,7 +289,7 @@ function validateAll({
       ...defects,
       defect(
         "baseline",
-        `base revision ${options.baseSha} is not readable, so the non-regression checks could not run. A gate that cannot compare against a base does not get to report that nothing regressed.`
+        `base revision ${options.baseSha} is not readable${baseline.error ? ` (${baseline.error})` : ""}, so the non-regression checks could not run. A gate that cannot compare against a base does not get to report that nothing regressed.`
       ),
     ];
   }
@@ -343,16 +354,16 @@ function floorIntegrityDefects(report) {
 
 /**
  * Defects that only exist in enforced mode, where absence must fail.
- * @param {object} input - Contract, scenarios, report, and platforms.
+ *
+ * The platform vocabulary is deliberately NOT a parameter: every platform this
+ * function cares about already reaches it through `report.floor`, which was
+ * built from that same vocabulary. It used to be passed and discarded behind a
+ * `void`, which reads as "unused for now" and hides whether an intended check
+ * was ever written.
+ * @param {object} input - Contract, scenarios, report, and discovery.
  * @returns {object[]} Defects found.
  */
-function enforcedDefects({
-  contract,
-  scenarios,
-  report,
-  platforms,
-  discovery,
-}) {
+function enforcedDefects({ contract, scenarios, report, discovery }) {
   const defects = [];
   if (scenarios.length === 0) {
     defects.push(
@@ -392,13 +403,26 @@ function enforcedDefects({
       defects.push(
         defect(
           "floor-regression",
-          `${platform} traceability coverage ${value.actual}% is below its committed floor of ${value.floor}%`
+          `${platform} traceability coverage ${measured(value)}% is below its committed floor of ${value.floor}%`
         )
       );
     }
   }
-  void platforms;
   return defects;
+}
+
+/**
+ * The measured percentage, printed at enough precision to explain the verdict.
+ *
+ * The floor is decided on the unrounded value, so a platform sitting at
+ * 99.95% must not be told it failed at "100%" — a message that contradicts
+ * its own finding is how an operator concludes the gate is broken.
+ * @param {{actual: number|null, exact: number|null}} value - A floor entry.
+ * @returns {string} The percentage to print.
+ */
+function measured(value) {
+  if (value.exact === null) return String(value.actual);
+  return String(Number(value.exact.toFixed(4)));
 }
 
 /**
@@ -452,7 +476,7 @@ export function run(root, options) {
       discovery,
     }),
     ...(mode === "enforced"
-      ? enforcedDefects({ contract, scenarios, report, platforms, discovery })
+      ? enforcedDefects({ contract, scenarios, report, discovery })
       : []),
   ];
   return result({ mode, defects, report, contract });
@@ -689,6 +713,14 @@ async function main() {
  * When the shared module is absent the same object is emitted unvalidated
  * rather than nothing: a gate that produces no result is indistinguishable
  * from one that passed.
+ *
+ * When the shared module is present but REFUSES the envelope — a schema this
+ * gate's fields no longer satisfy, or a half-copied `scripts/` directory whose
+ * schema document never arrived — that refusal is caught rather than thrown.
+ * An uncaught rejection here produced no envelope at all and a Node-supplied
+ * exit code, which is the one outcome this function exists to rule out. The
+ * fields are emitted with `status: "invalid"`, so the run is machine-readable,
+ * operator-readable, and NONZERO.
  * @param {object} input - The gate run, CLI options, and files written.
  * @returns {Promise<object>} The envelope.
  */
@@ -708,7 +740,17 @@ async function sealEnvelope({ gateRun, options, filesWritten }) {
     );
     return { schemaVersion: "lisa-command-envelope-v1", ...fields };
   }
-  return shared.buildEnvelope(fields);
+  try {
+    return shared.buildEnvelope(fields);
+  } catch (error) {
+    console.error(`[bdd-coverage] ${error.message}`);
+    return {
+      schemaVersion: "lisa-command-envelope-v1",
+      ...fields,
+      status: "invalid",
+      reason: `the result could not be sealed into a valid command envelope: ${error.message}`,
+    };
+  }
 }
 
 /**

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -9,7 +9,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/check-state-classification.mjs":
       "94dc98e0bbfcf8d43cba035d4805a1c5d61a3a0db88faa791e8e06e34e741f46",
     "all/copy-overwrite/scripts/lisa-command-envelope.mjs":
-      "2011331056b1c86bd181649713a395dbfd2768f9fcd7e37b521d6ad2a9318ea9",
+      "4f76bb7d466eb153a4e1414d06f12856a1242de2cfa4cb4b1b942cf29d8b7f37",
     "all/copy-overwrite/scripts/lisa-enforcement-fallback.sh":
       "1bec5f3c284b3febdc471487ee6a23ffb72bd4e7b293f9e26b0188f32318c722",
     "all/copy-overwrite/scripts/lisa-floor-collisions.mjs":
@@ -25,7 +25,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh":
       "bf4132e49ba18e2f7e941520c299c15aeeacfd220e489f3d2eb8397f2048157b",
     "all/copy-overwrite/scripts/lisa-schema-validate.mjs":
-      "9dd145c0f9dac6ed252b13d32e130dbab964da6cd357981b58541780ecb2f981",
+      "4a05a0ed70a274827fd2f0fd0c98890c66bee2fde70785b8379943ebe6650473",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
       "e30016a49deff1c3cd3ae7951262aeb2ef3d472bce76bbbe2a177db6017c7cad",
     "all/copy-overwrite/scripts/schemas/lisa-command-envelope.v1.schema.json":
@@ -167,27 +167,27 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/copy-overwrite/knip.json":
       "b19d0c177d8d0460779e07043c92d37555e7721224b6b2134ac2f6d10ab44b33",
     "expo/copy-overwrite/scripts/bdd-matrix.mjs":
-      "519273668f08db7c14053ba1f25830e4cbb6e34ddf11f06264e72d0f7a80b98d",
+      "4173a1c18d34285ab645314e0a99944f8baa02ae2632264b850c727347c8a836",
     "expo/copy-overwrite/scripts/bdd/baseline.mjs":
-      "630df2cbb6613534f755d3de1efbb6390a1c1dab5694d97f0ca09b8b7422881c",
+      "12503dd325bbfe95f4f4f7fc9d8284d78210d0f54fa75c9af774b42f20495fe0",
     "expo/copy-overwrite/scripts/bdd/contract.mjs":
-      "7366f56fb66f609b17438f3b2b89d0a45aaf012886278b38b0744e69955fa5cc",
+      "d4dd79f24f64d8bd29352582433356b2b67fcca4fcfc4e4b253efa70bccd08be",
     "expo/copy-overwrite/scripts/bdd/discover.mjs":
-      "820e8a869a0b46fc11461a655bb82f0c8c60f5b46005fbff48e5d19930d7d25a",
+      "d19b92e3f48bdc213c232175cd3021759080d635326e9675969976c0564d7676",
     "expo/copy-overwrite/scripts/bdd/envelope.mjs":
       "9f3c72316d4dd5b5c2e3fa7634f00fb203dfb9235ab9af7183c99105dad7645d",
     "expo/copy-overwrite/scripts/bdd/parse.mjs":
-      "d1bf74b01388d107e6869b90a3d1e1d2c03da8124cb2cc14f9cf6d64e2b00ce8",
+      "18afb534f85c904af5da32e4dc0b48e4d2a89895a2866b60a544a790ce8b7afb",
     "expo/copy-overwrite/scripts/bdd/render.mjs":
-      "35fa94358e979b223788d629fb95c3c72adff72a9af4dcd3a71febc317849187",
+      "c3cb36a6b3cf5771f5813cdd22f8273aa367c9de663ed1724c1fb3c59f2fbae9",
     "expo/copy-overwrite/scripts/bdd/report.mjs":
-      "30a7c3471611e740f62f544e613a2ecf095946e7f70c752f62fa51ac58949822",
+      "7c49bf1f430e32f7c2ac1fd90162293e928fe4fdf48db4cb5c8e3266187aac4e",
     "expo/copy-overwrite/scripts/bdd/validate.mjs":
-      "afb8dd052733a5f83e6d004eac3437783a707c08810ba9cc65138d898aff83e2",
+      "fa0c379c9ecab9ee2069f2ee41c1971f127b0a859647f911eaa707eb294a93e7",
     "expo/copy-overwrite/scripts/bdd/waivers.mjs":
-      "4b9ebf80100f478cc5e06d50b4d672ad08ec77a3746a7a109a74e1daf71a55b7",
+      "4a918db61b6bdf3a23cf14c5cebdee88259964c60e4c5869abfebb7d743b181c",
     "expo/copy-overwrite/scripts/check-bdd-coverage.mjs":
-      "cc6a200155889acff761b2eece1768577bc29e09dac417724d243d7f1d1ec9db",
+      "9ef2ef274602bf49ef5346b55ec95be575e3989e5c19e5c2b566d668ce0fd3ba",
     "expo/copy-overwrite/scripts/check-e2e-coverage.mjs":
       "30cf7d860ecd3b838b8608f38da10fcddb4e7e90a0867438f411d68346a5f129",
     "expo/copy-overwrite/scripts/classify-maestro-failures.mjs":
@@ -8800,6 +8800,9 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/bdd-envelope.test.ts": true,
     "tests/unit/scripts/bdd-exclusions.test.ts": true,
     "tests/unit/scripts/bdd-failopen.test.ts": true,
+    "tests/unit/scripts/bdd-gate-correctness.test.ts": true,
+    "tests/unit/scripts/bdd-gate-defects.test.ts": true,
+    "tests/unit/scripts/bdd-gate-paths.test.ts": true,
     "tests/unit/scripts/bdd-grammar.test.ts": true,
     "tests/unit/scripts/bdd-nonregression.test.ts": true,
     "tests/unit/scripts/bdd-ratchet-removal.test.ts": true,
@@ -8808,6 +8811,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/bdd-validation.test.ts": true,
     "tests/unit/scripts/bdd-wiring.test.ts": true,
     "tests/unit/scripts/bdd/regression-support.ts": true,
+    "tests/unit/scripts/bdd/sources.ts": true,
     "tests/unit/scripts/bdd/support.ts": true,
     "tests/unit/scripts/build-cursor-hooks-json.test.ts": true,
     "tests/unit/scripts/check-duplicate-versions-helpers.ts": true,

--- a/tests/unit/scripts/bdd-gate-correctness.test.ts
+++ b/tests/unit/scripts/bdd-gate-correctness.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Regression tests for the reported correctness findings that concern what the
+ * gate MEASURES and what it emits (CodySwannGT/lisa#2468, section A: #1, #2,
+ * #4, #5, #9, #10).
+ *
+ * The findings about how the gate reads paths and Gherkin live next door, in
+ * `bdd-gate-paths.test.ts`.
+ *
+ * @module tests/unit/scripts/bdd-gate-correctness
+ */
+import { spawnSync } from "node:child_process";
+import * as path from "node:path";
+
+import { GATE_DIR, SHARED_DIR, vendorGateWithoutSchemas } from "./bdd/sources";
+import {
+  BOOTSTRAP,
+  ENFORCED,
+  HEALTHY_MAP,
+  HOME_EVIDENCE,
+  HOME_ID,
+  HOME_SPEC,
+  PLAYWRIGHT,
+  PLAYWRIGHT_DISCOVERY,
+  RATIFIED,
+  REPO_ROOT,
+  TODAY,
+  WEB,
+  codes,
+  featureSource,
+  healthyProject,
+  hermeticEnv,
+  makeProject,
+  read,
+  runGate,
+} from "./bdd/support";
+
+/** A waiver whose expiry passed long ago. */
+const EXPIRED_WAIVER = {
+  scenario: HOME_ID,
+  platforms: [WEB],
+  reason: "the runner cannot decide it",
+  owner: "someone",
+  ticket: "TUN-1",
+  recordedAt: "2020-01-01",
+  expiresAt: "2020-06-01",
+};
+
+describe("bdd gate: measurement and output findings (lisa#2468)", () => {
+  describe("#1 the floor compares an unrounded percentage", () => {
+    it("fails a platform at 99.95% against a floor of 100", async () => {
+      const module = (await import(
+        path.join(REPO_ROOT, GATE_DIR, "bdd", "report.mjs")
+      )) as {
+        buildReport: (input: Record<string, unknown>) => {
+          traceability: { byPlatform: Record<string, { percentage: number }> };
+          floor: { byPlatform: Record<string, { ok: boolean }>; ok: boolean };
+        };
+      };
+      const total = 2001;
+      const scenarios = Array.from({ length: total }, (_unused, index) => ({
+        id: `BDD-BIG-${String(index).padStart(4, "0")}`,
+        name: `behavior ${index}`,
+        feature: "Big",
+        required: true,
+        platforms: [WEB],
+        lifecycle: [],
+        trackers: [],
+      }));
+      // One obligation short of complete: 2000/2001 is 99.95002%, which rounds
+      // to 100.0 for display and must still fail a floor of 100.
+      const contract = {
+        runnerPlatforms: { [PLAYWRIGHT]: [WEB] },
+        coverageFloor: { [WEB]: 100 },
+        mappings: scenarios.slice(0, total - 1).map(scenario => ({
+          scenario: scenario.id,
+          runner: PLAYWRIGHT,
+          platforms: [WEB],
+          file: HOME_SPEC,
+          evidence: HOME_EVIDENCE,
+        })),
+      };
+      const report = module.buildReport({
+        scenarios,
+        contract,
+        runs: [],
+        platforms: new Set([WEB]),
+      });
+      expect(report.traceability.byPlatform[WEB]?.percentage).toBe(100);
+      expect(report.floor.byPlatform[WEB]?.ok).toBe(false);
+      expect(report.floor.ok).toBe(false);
+    });
+  });
+
+  describe("#2 an unusable BDD_TODAY cannot excuse an expired waiver", () => {
+    it("reports waiver-metadata instead of silently passing every expiry", () => {
+      const root = healthyProject({
+        platformWaivers: [EXPIRED_WAIVER],
+        mappings: [],
+      });
+      const run = runGate(root, {
+        BDD_MODE: BOOTSTRAP,
+        BDD_TODAY: "not-a-date",
+      });
+      expect(codes(run)).toContain("waiver-metadata");
+    });
+
+    it("still reports the expiry when the date is usable", () => {
+      const root = healthyProject({
+        platformWaivers: [EXPIRED_WAIVER],
+        mappings: [],
+      });
+      const run = runGate(root, { BDD_MODE: BOOTSTRAP });
+      expect(codes(run)).toContain("waiver-expired");
+    });
+  });
+
+  describe("#4/#9 a partially copied scripts/ directory fails readably", () => {
+    // Vendors fifteen files and spawns a fresh Node, so it is the slowest case
+    // in the suite; the default per-test budget is not enough under load.
+    it("emits an envelope and exits nonzero instead of an ENOENT stack", () => {
+      const project = makeProject({
+        map: { ...HEALTHY_MAP, mappings: [] },
+        features: {
+          "home.feature": featureSource("Home", [
+            { id: HOME_ID, tags: [WEB, RATIFIED] },
+          ]),
+        },
+      });
+      const scripts = vendorGateWithoutSchemas(project);
+      const result = spawnSync(
+        process.execPath,
+        [path.join(scripts, "check-bdd-coverage.mjs"), "--json"],
+        {
+          encoding: "utf-8",
+          env: {
+            ...hermeticEnv(project),
+            BDD_COVERAGE_ROOT: project,
+            BDD_TODAY: TODAY,
+            BDD_MODE: ENFORCED,
+          },
+        }
+      );
+      // A named, operator-readable line — not a raw stack from an import the
+      // operator never made.
+      const stack = result.stderr
+        .split("\n")
+        .some(line => line.trimStart().startsWith("at "));
+      expect(stack).toBe(false);
+      expect(result.stderr).toContain(
+        "[bdd-coverage] invalid command envelope"
+      );
+      expect(result.stderr).toContain("lisa-command-envelope.v1.schema.json");
+      const envelope = JSON.parse(result.stdout.trim()) as {
+        status: string;
+        reason?: string;
+      };
+      expect(envelope.status).toBe("invalid");
+      expect(envelope.reason).toBeTruthy();
+      expect(result.status).toBe(1);
+    }, 30_000);
+  });
+
+  describe("#10 the array form of `type` is validated, not waved through", () => {
+    it("rejects a value matching none of the declared types", async () => {
+      const module = (await import(
+        path.join(REPO_ROOT, SHARED_DIR, "lisa-schema-validate.mjs")
+      )) as {
+        validateAgainstSchema: (
+          document: unknown,
+          schema: unknown
+        ) => { valid: boolean; errors: string[] };
+      };
+      const schema = {
+        type: "object",
+        properties: { a: { type: ["string", "null"] } },
+      };
+      expect(module.validateAgainstSchema({ a: 1 }, schema).valid).toBe(false);
+      expect(module.validateAgainstSchema({ a: null }, schema).valid).toBe(
+        true
+      );
+      expect(module.validateAgainstSchema({ a: "x" }, schema).valid).toBe(true);
+      expect(
+        module.validateAgainstSchema(1, { type: ["object", "string"] }).valid
+      ).toBe(false);
+    });
+  });
+
+  describe("#5 REFUTED — the state contract's conditionals ARE enforced", () => {
+    it("is read by check-state-classification, which enforces each one", () => {
+      const source = read(`${SHARED_DIR}/check-state-classification.mjs`);
+      expect(source).toContain("lisa-state-contract.v1.schema.json");
+      expect(source).toContain("validateAgainstSchema");
+      for (const requirement of [
+        "entity.ownership",
+        "entity.sweptBy",
+        "entity.rebuiltBy",
+        "entity.enforcedBy",
+        "contract.noop?.capabilityManifest",
+      ]) {
+        expect(source).toContain(requirement);
+      }
+    });
+  });
+
+  describe("the enforced defect set is unchanged", () => {
+    it("still refuses a malformed discovery block in enforced mode", () => {
+      const root = healthyProject({
+        testDiscovery: {
+          [PLAYWRIGHT]: PLAYWRIGHT_DISCOVERY,
+          unknownRunner: PLAYWRIGHT_DISCOVERY,
+        },
+      });
+      const run = runGate(root, { BDD_MODE: ENFORCED });
+      expect(codes(run)).toContain("discovery-invalid");
+    });
+  });
+});

--- a/tests/unit/scripts/bdd-gate-defects.test.ts
+++ b/tests/unit/scripts/bdd-gate-defects.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Source-shape regressions for the analyser classes reported against the
+ * vendored v2 BDD gate (CodySwannGT/lisa#2468, section B).
+ *
+ * These cases assert on the SOURCE because the finding IS the shape of the
+ * source. All seventeen bare `.sort()` calls behaved correctly — every one of
+ * them sorted a string array, where the default order is exactly right — so no
+ * behavioural test can distinguish before from after. What the class costs is
+ * the next array: the first numeric one sorts `[2, 10]` to `[10, 2]` and
+ * nothing notices. Pinning the shape is the only thing that stops that.
+ *
+ * @module tests/unit/scripts/bdd-gate-defects
+ */
+import { GATE_DIR, sourceCode } from "./bdd/sources";
+import { read } from "./bdd/support";
+
+/** Every vendored gate source the SonarCloud findings were raised against. */
+const GATE_SOURCES = [
+  `${GATE_DIR}/check-bdd-coverage.mjs`,
+  `${GATE_DIR}/bdd-matrix.mjs`,
+  `${GATE_DIR}/bdd/baseline.mjs`,
+  `${GATE_DIR}/bdd/contract.mjs`,
+  `${GATE_DIR}/bdd/discover.mjs`,
+  `${GATE_DIR}/bdd/envelope.mjs`,
+  `${GATE_DIR}/bdd/parse.mjs`,
+  `${GATE_DIR}/bdd/render.mjs`,
+  `${GATE_DIR}/bdd/report.mjs`,
+  `${GATE_DIR}/bdd/validate.mjs`,
+  `${GATE_DIR}/bdd/waivers.mjs`,
+];
+
+describe("bdd gate: analyser classes (lisa#2468 section B)", () => {
+  describe("S2871 — every sort declares its comparator", () => {
+    it.each(GATE_SOURCES)("%s has no bare .sort()", source => {
+      expect(sourceCode(source)).not.toContain(".sort()");
+    });
+
+    it("names one shared comparator rather than a per-file copy", () => {
+      expect(sourceCode(`${GATE_DIR}/bdd/contract.mjs`)).toContain(
+        "export const byCodeUnit"
+      );
+    });
+  });
+
+  describe("S4036 — git is never resolved off a bare PATH lookup", () => {
+    it("does not spawn the literal command name", () => {
+      expect(read(`${GATE_DIR}/bdd/baseline.mjs`)).not.toMatch(
+        /spawnSync\(\s*"git"/u
+      );
+    });
+
+    it("resolves an absolute path and verifies it is a real file", () => {
+      const source = sourceCode(`${GATE_DIR}/bdd/baseline.mjs`);
+      expect(source).toContain("path.isAbsolute(candidate)");
+      expect(source).toContain("fs.statSync(candidate).isFile()");
+    });
+  });
+
+  describe("S3403 — no comparison that can only ever have one answer", () => {
+    it("discover.mjs tests the regex groups by type, not against undefined", () => {
+      const source = sourceCode(`${GATE_DIR}/bdd/discover.mjs`);
+      expect(source).not.toContain("evidence === undefined");
+      expect(source).not.toContain("template !== undefined");
+      expect(source).toContain('typeof evidence !== "string"');
+      expect(source).toContain('typeof template === "string"');
+    });
+  });
+
+  describe("S3735 — the unused-parameter `void` is gone", () => {
+    it("enforcedDefects no longer takes a platforms parameter", () => {
+      expect(read(`${GATE_DIR}/check-bdd-coverage.mjs`)).not.toMatch(
+        /\bvoid\s+platforms\b/u
+      );
+    });
+  });
+});

--- a/tests/unit/scripts/bdd-gate-paths.test.ts
+++ b/tests/unit/scripts/bdd-gate-paths.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Regression tests for the reported findings about how the gate READS the
+ * repository (CodySwannGT/lisa#2468, section A: #6, #7, #8).
+ *
+ * Each case is a repository the gate previously mis-read: an unparsable base
+ * revision, a path prefix that matched half a directory name, and a feature
+ * file whose steps live in a `Background:`.
+ *
+ * @module tests/unit/scripts/bdd-gate-paths
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import {
+  BOOTSTRAP,
+  ENFORCED,
+  HEALTHY_MAP,
+  HOME_EVIDENCE,
+  HOME_ID,
+  HOME_SPEC,
+  PLAYWRIGHT,
+  PLAYWRIGHT_DISCOVERY,
+  RATIFIED,
+  WEB,
+  codes,
+  commitAll,
+  healthyProject,
+  runGate,
+  writeMap,
+} from "./bdd/support";
+
+/**
+ * A one-feature file whose Background carries some of the primary steps.
+ * @param steps - The scenario's own steps, after the Background's Given.
+ * @returns Gherkin source.
+ */
+function withBackground(steps: readonly string[]): string {
+  return [
+    "Feature: Background",
+    "",
+    "  Background:",
+    "    Given a signed-in visitor",
+    "",
+    `  @${HOME_ID} @${WEB} @${RATIFIED}`,
+    "  Scenario: acts",
+    ...steps.map(step => `    ${step}`),
+    "",
+  ].join("\n");
+}
+
+/**
+ * A project whose only feature file is the supplied Background fixture.
+ * @param steps - The scenario's own steps.
+ * @returns Project root.
+ */
+function backgroundProject(steps: readonly string[]): string {
+  const root = healthyProject(
+    {},
+    { features: { "background.feature": withBackground(steps) } }
+  );
+  fs.rmSync(path.join(root, "bdd", "features", "home.feature"));
+  return root;
+}
+
+describe("bdd gate: repository-reading findings (lisa#2468)", () => {
+  describe("#6 an unreadable base coverage map fails closed", () => {
+    it("reports a baseline defect rather than an empty comparison", () => {
+      const root = healthyProject();
+      fs.writeFileSync(
+        path.join(root, "bdd", "coverage-map.json"),
+        "{ this is not json"
+      );
+      const baseSha = commitAll(root);
+      writeMap(root, HEALTHY_MAP);
+      const run = runGate(root, { BDD_MODE: ENFORCED, BDD_BASE_SHA: baseSha });
+      expect(codes(run)).toContain("baseline");
+    });
+  });
+
+  describe("#7 path prefixes match whole segments", () => {
+    it("an ignore prefix of e2e/live does not swallow e2e/live-personas", () => {
+      const root = healthyProject(
+        {
+          testDiscovery: {
+            [PLAYWRIGHT]: { ...PLAYWRIGHT_DISCOVERY, ignore: ["e2e/live"] },
+          },
+        },
+        {
+          files: {
+            "e2e/live-personas/persona.spec.ts": `test("undeclared persona flow", async () => {});\n`,
+          },
+        }
+      );
+      const run = runGate(root, { BDD_MODE: BOOTSTRAP });
+      expect(codes(run)).toContain("spec-undisclosed");
+    });
+
+    it("still honours an ignore prefix that really does cover the file", () => {
+      const root = healthyProject(
+        {
+          testDiscovery: {
+            [PLAYWRIGHT]: { ...PLAYWRIGHT_DISCOVERY, ignore: ["e2e/live"] },
+          },
+        },
+        {
+          files: {
+            "e2e/live/persona.spec.ts": `test("ignored live flow", async () => {});\n`,
+          },
+        }
+      );
+      const run = runGate(root, { BDD_MODE: BOOTSTRAP });
+      expect(codes(run)).not.toContain("spec-undisclosed");
+    });
+
+    it("a discovery root of . covers every repo-relative exclusion", () => {
+      const root = healthyProject({
+        testDiscovery: {
+          [PLAYWRIGHT]: { ...PLAYWRIGHT_DISCOVERY, roots: ["."] },
+        },
+        mappings: [],
+        exclusions: [
+          {
+            file: HOME_SPEC,
+            evidence: HOME_EVIDENCE,
+            reason: "smoke check, aligned to no product behavior",
+          },
+        ],
+      });
+      const run = runGate(root, { BDD_MODE: BOOTSTRAP });
+      expect(codes(run)).not.toContain("exclusion-stale");
+    });
+
+    it("still reports an exclusion no configured root covers", () => {
+      const root = healthyProject({
+        mappings: [],
+        exclusions: [
+          {
+            file: "somewhere-else/other.spec.ts",
+            evidence: HOME_EVIDENCE,
+            reason: "not under any declared root",
+          },
+        ],
+      });
+      const run = runGate(root, { BDD_MODE: BOOTSTRAP });
+      expect(codes(run)).toContain("exclusion-stale");
+    });
+  });
+
+  describe("#8 Background steps count toward a scenario's primary steps", () => {
+    it("does not report a missing Given that Background supplies", () => {
+      const root = backgroundProject([
+        "When they act",
+        "Then something is true",
+      ]);
+      expect(codes(runGate(root, { BDD_MODE: BOOTSTRAP }))).not.toContain(
+        "scenario-steps"
+      );
+    });
+
+    it("still reports a step no Background and no scenario supplies", () => {
+      const root = backgroundProject(["When they act"]);
+      expect(codes(runGate(root, { BDD_MODE: BOOTSTRAP }))).toContain(
+        "scenario-steps"
+      );
+    });
+  });
+});

--- a/tests/unit/scripts/bdd/sources.ts
+++ b/tests/unit/scripts/bdd/sources.ts
@@ -1,0 +1,65 @@
+/**
+ * Helpers for the cases that assert on the gate's SOURCE and on how it behaves
+ * once vendored into an adopter's `scripts/` directory.
+ *
+ * Kept apart from `support.ts`, which is about laying down fixture projects.
+ *
+ * @module tests/unit/scripts/bdd/sources
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { REPO_ROOT, read } from "./support";
+
+/** Template directories the gate is vendored from. */
+export const GATE_DIR = "expo/copy-overwrite/scripts";
+export const SHARED_DIR = "all/copy-overwrite/scripts";
+
+/**
+ * A source file with its block comments stripped.
+ *
+ * A source-shape assertion must be about the CODE: prose that quotes the shape
+ * it forbids would otherwise fail the check, and prose that quotes the shape it
+ * requires would satisfy it without any code doing so.
+ * @param relativePath - Repo-relative path.
+ * @returns The file's code, comments removed.
+ */
+export function sourceCode(relativePath: string): string {
+  return read(relativePath).replace(/\/\*[\s\S]*?\*\//gu, "");
+}
+
+/**
+ * Copy the gate into an adopter-shaped `scripts/` directory, deliberately
+ * WITHOUT `scripts/schemas/` — what a half-finished copy leaves behind.
+ * @param project - Fixture project root.
+ * @returns The scripts directory.
+ */
+export function vendorGateWithoutSchemas(project: string): string {
+  // The real path, because the gate's own entry guard compares `process.argv[1]`
+  // against `import.meta.url`, and macOS `os.tmpdir()` is a symlink — passing
+  // the symlinked spelling makes Node's `main` block never run at all.
+  const scripts = path.join(fs.realpathSync(project), "scripts");
+  fs.mkdirSync(path.join(scripts, "bdd"), { recursive: true });
+  for (const name of fs.readdirSync(path.join(REPO_ROOT, GATE_DIR))) {
+    const from = path.join(REPO_ROOT, GATE_DIR, name);
+    if (fs.statSync(from).isFile()) {
+      fs.copyFileSync(from, path.join(scripts, name));
+    }
+  }
+  for (const name of fs.readdirSync(path.join(REPO_ROOT, GATE_DIR, "bdd"))) {
+    fs.copyFileSync(
+      path.join(REPO_ROOT, GATE_DIR, "bdd", name),
+      path.join(scripts, "bdd", name)
+    );
+  }
+  for (const name of [
+    "lisa-command-envelope.mjs",
+    "lisa-schema-validate.mjs",
+  ]) {
+    fs.copyFileSync(
+      path.join(REPO_ROOT, SHARED_DIR, name),
+      path.join(scripts, name)
+    );
+  }
+  return scripts;
+}


### PR DESCRIPTION
Fixes the defects reported in #2468 against the v2 BDD gate sources. `TunnlAI/frontend` vendored these files byte-identically, so SonarCloud analysed them as new code — every finding is Lisa's, and fixing it here fixes every adopter at once.

**9 of 10 correctness findings fixed, 1 refuted with evidence. All 21 analyser findings resolved.**

## Correctness findings (section A)

| # | Verdict | What it actually was |
|---|---|---|
| 1 | **Fixed** | The floor compared the DISPLAY percentage. 2000/2001 obligations is 99.95002%, which rounds to `100` and cleared a floor of 100. Summaries now carry `exact` alongside `percentage`; only `exact` is ever compared against a floor. |
| 2 | **Fixed** | `BDD_TODAY` was trusted unvalidated. Expiry is a lexical `<` against an ISO date, and every comparison with a non-date is false — so `BDD_TODAY=not-a-date` passed **every** expired waiver. Now a `waiver-metadata` defect, plus a `bootstrap-metadata` defect for the bootstrap time-box, which had the identical hole. |
| 3 | **Fixed** | `enforcedDefects` never read its `platforms` parameter and hid that behind a `void` (`S3735`). Parameter and call-site argument dropped. |
| 4 | **Fixed** | `buildEnvelope` could throw where nothing caught it — no envelope on stdout and a Node-supplied exit code. Now caught; the fields are emitted with `status: "invalid"`, so the run stays machine-readable, operator-readable and nonzero. |
| 5 | **REFUTED** | See below. |
| 6 | **Fixed** | An unparsable base `bdd/coverage-map.json` left `available: true` with an empty `before` set, silently disabling `coverage-regression` and `scenario-deleted`. Now fails closed with the reason named. |
| 7 | **Fixed** | Path prefixes were *character* prefixes: an ignore of `e2e/live` swallowed `e2e/live-personas/…` (hiding a whole directory of undeclared tests), and a discovery root of `.` matched nothing, so valid exclusions read as stale. Matching is now segment-wise. |
| 8 | **Fixed** | `Background:` was ignored, so conforming Gherkin (Given in the Background, When/Then per scenario) reported `scenario-steps` defects it did not have. Background steps now seed each scenario's primary steps. |
| 9 | **Fixed** | A module-scope `readFileSync` of the schema threw before any handler ran, so a partially-copied `scripts/` gave a raw ENOENT stack. Now a nullable read with a named error that fails validation closed. |
| 10 | **Fixed** | `typeof schema.type === "string"` skipped the array form `["string","null"]` — the keyword passed the allowlist and the value went unvalidated. Array form implemented; `validateNode` decomposed, which also clears `S3776` (complexity 39). |

### Why #5 is refuted

The finding claims nothing reads `lisa-state-contract.v1.schema.json` and that its conditional requirements are unenforceable. Both halves are wrong in practice:

- The schema **is** read — `all/copy-overwrite/scripts/check-state-classification.mjs:47-52` loads it and line 494 validates against it.
- Every conditional it documents **is** enforced imperatively in that same script: `fixture-owned` requires `ownership` (:239) and `sweptBy` (:244), `derived-rebuild` requires `rebuiltBy` (:250), `forbidden` requires `enforcedBy` (:253), and `declared-noop` requires reason/owner/capabilityManifest (:396-404, `noop-underspecified`).

Only the narrow observation is true — `validateAgainstSchema` implements no conditional keywords, by design and loudly documented. Adding `if`/`then` to the schema would make the validator *throw*, since an unimplemented keyword is an error. A regression test now pins the imperative enforcement so the refutation stays falsifiable.

## Analyser classes (section B)

- **`S2871` × 17** — every bare `.sort()` now uses the shared `byCodeUnit` comparator exported from `bdd/contract.mjs`. **All seventeen sorted string arrays**, where the default order is already correct, so ordering is preserved byte-for-byte. Deliberately **not** `localeCompare`: its result depends on the runner's ICU data and would reorder committed report artifacts. The risk the class carries is the next array — the first numeric one sorts `[2, 10]` to `[10, 2]` and nothing notices — so a source-level test pins the shape.
- **`S4036` × 2** — git is resolved to an **absolute, verified** path (fixed system locations, then each `PATH` entry resolved and confirmed to be a real file) rather than delegating the choice of binary to `PATH`.
- **`S3403` × 2** — `evidence === undefined` was genuinely dead: the regex alternation guarantees one group participates, so `??` always yields a string. What it *meant* to test is "did this call carry a usable title", which the length check performs. `template !== undefined` meant "did the title come from a template literal", now stated as `typeof template === "string"`.
- **`S3735`, `S3776`** — cleared as part of #3 and #10.

## The gate is not weakened

The enforced defect set is unchanged: `spec-undisclosed`, `coverage-regression`, `obligation-uncovered`, `floor-*` and stale-evidence credit removal all behave exactly as before. The two behaviour changes (#7, #8) make the gate **stricter or more accurate**, never more permissive — #7 restores discovery of tests an over-broad ignore prefix was hiding, and #8 stops false `scenario-steps` failures on valid Gherkin.

## Test evidence

- 3 new suites, 30 cases: `bdd-gate-defects` (analyser classes), `bdd-gate-correctness` (measurement/output findings), `bdd-gate-paths` (repository-reading findings). All 30 were RED against the pre-fix sources.
- `vitest run tests/unit/scripts/bdd-*.test.ts command-envelope state-classification` → **203 passed, 0 failed** across 17 files.
- `bun run lint`, `bun run typecheck`, `bun run knip:check`, `bun run check:upstream-evidence-manifest` all clean.

Work-Item: CodySwannGT/lisa#2468

🤖 Generated with Claude Code
