### PR TITLE
test(work-item): resolve the git-path state file and cover a linked worktree

### DIFF
--- a/tests/unit/scripts/lisa-work-item.test.ts
+++ b/tests/unit/scripts/lisa-work-item.test.ts
@@ -281,7 +281,12 @@ function wedgeRebase(fixture: Fixture, branch: string): void {
  * this binding exists to serve.
  */
 function stateFilePath(fixture: Fixture): string {
-  return path.join(
+  // `path.resolve`, not `path.join`. `--git-path` answers relatively in a main
+  // checkout (`.git/lisa/...`) but ABSOLUTELY in a linked worktree
+  // (`/repo/.git/worktrees/<name>/lisa/...`), and joining an absolute path onto
+  // the root concatenates instead of resolving — yielding a path that does not
+  // exist, in precisely the linked-worktree case this helper exists to serve.
+  return path.resolve(
     fixture.root,
     git(
       fixture.root,
@@ -416,6 +421,36 @@ function prRange(
 }
 
 describe("work-item binding and commit messages", () => {
+  it("binds inside a linked worktree, whose private state lives under .git/worktrees/", () => {
+    // The binding exists to serve worktree-based agents, but every other case
+    // here runs in a main checkout, where `.git/lisa/` and the worktree's
+    // private dir happen to be the same place. Only a linked worktree tells
+    // `git rev-parse --git-path` apart from a hardcoded `.git/lisa/` — and it
+    // answers with an ABSOLUTE path there, which is what the helper must
+    // resolve rather than join onto the worktree root.
+    const fixture = createFixture();
+    const linked: Fixture = {
+      ...fixture,
+      root: path.join(fixture.root, "linked"),
+    };
+    git(
+      fixture.root,
+      ["worktree", "add", "-q", "-b", "feature/linked", "linked", "main"],
+      fixture.env
+    );
+
+    expect(command(linked, ["bind", "acme/widgets#42"]).status).toBe(0);
+
+    const linkedState = stateFilePath(linked);
+    expect(linkedState).toContain(path.join(".git", "worktrees", "linked"));
+    expect(linkedState).not.toBe(stateFilePath(fixture));
+    expect(JSON.parse(readFileSync(linkedState, "utf8"))).toMatchObject({
+      branch: "feature/linked",
+      provider: "github",
+      ref: "acme/widgets#42",
+    });
+  });
+
   it("merges local config, writes worktree-private state atomically, and preserves the subject", () => {
     const fixture = createFixture(githubConfig("identity"));
     writeFileSync(


### PR DESCRIPTION
Follow-up to #2466 / #2469, which landed the `--git-path` resolution but combined it with `path.join`.

## The defect

`stateFilePath()` in `tests/unit/scripts/lisa-work-item.test.ts` resolves the work-item state file through `git rev-parse --git-path`, matching the CLI, and its comment says this exists so a **linked worktree** finds its private state dir.

But `--git-path` answers differently depending on where it runs:

| where | answer |
| --- | --- |
| main checkout | `.git/lisa/work-item.json` (relative) |
| linked worktree | `/repo/.git/worktrees/<name>/lisa/work-item.json` (**absolute**) |

`path.join(root, absolutePath)` concatenates rather than resolving, so the helper produced a path that cannot exist:

```
/tmp/lisa-work-item-X/linked/private/var/.../lisa-work-item-X/.git/worktrees/linked/lisa/work-item.json
```

It therefore broke in exactly the linked-worktree case its own comment describes. `path.resolve` returns an absolute answer unchanged and still anchors the relative one.

## Why it was invisible

Every case in that suite ran in a main checkout, where `.git/lisa/` and the worktree-private dir are the same place — so nothing distinguished a correct resolution from the hardcoded path it replaced. The suite passed either way.

This PR adds a case that binds inside a **real linked worktree**, which is what makes the fix provable. Reverting `path.resolve` to `path.join` fails it with the concatenated `ENOENT` above; the rest of the suite stays green, confirming the new case is the only thing that can see the difference.

## Verification

- `tests/unit/scripts/lisa-work-item.test.ts`: 39 passed (was 38), stable across four consecutive runs.
- Reverted-fix control: 1 failed / 38 skipped, ENOENT on the concatenated path.

Work-Item: CodySwannGT/lisa#2479
