### PR TITLE
fix(ci): refuse to answer from an untranscribed required-checks snapshot

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1853,8 +1853,18 @@ jobs:
   # without the script (non-TypeScript stacks, anything not yet re-applied) or
   # without the declaration reports a notice and passes. What it will not do is
   # read nothing and call that a clean bill of health — it says which piece is
-  # missing. Seeded-but-unreviewed repositories are handled a level down, by the
-  # seed's `"enforcement": "warn"`.
+  # missing.
+  #
+  # A SEEDED repository is the dangerous case, and it is handled inside the
+  # guard (#2476). `required_contexts` is a CACHE of a live ruleset fetch, and
+  # Lisa's seed ships it EMPTY and unstamped because Lisa cannot know what your
+  # ruleset requires — an earlier seed shipped a guess that was measured wrong
+  # in this fleet, claiming one context was required that no ruleset required
+  # and omitting six that were. Until `ruleset.baseline_fetched_at` is stamped,
+  # the guard prints NOT CHECKED and suppresses every rule that reads the
+  # cache. It never prints a ✅ it cannot support. Refusal is exit 1 except
+  # under the seed's `"enforcement": "warn"`, which keeps a fresh install loud
+  # rather than red.
   skipped_required_checks:
     name: 🔒 Skipped Required Checks
     runs-on: ubuntu-latest

--- a/expo/create-only/.github/required-checks.json
+++ b/expo/create-only/.github/required-checks.json
@@ -1,11 +1,13 @@
 {
   "_readme": [
     "See typescript/create-only/.github/required-checks.json in Lisa for the full rationale. In short: GitHub counts a SKIPPED required status check as SATISFIED, so a `skip_jobs` token that silences a required context makes the merge gate decorative.",
-    "This expo seed declares the three tokens the shipped ci.yml skips. Every one of them is currently NOT ruleset-required, so nothing here is a false green — but the declaration exists so that the day one of them BECOMES required, the guard says so instead of the gate quietly going hollow.",
-    "Transcribe `required_contexts` byte for byte from your ruleset and keep it current with `--remote`.",
-    "The nightly-gate context is listed because Lisa ships expo/github-rulesets/nightly-e2e-health.json requiring it on dev. No skip_jobs token silences it today, so nothing is a false green — it is here so that the day one does, the guard says so instead of staying quiet.",
-    "Lisa's quality.yml runs the offline arm of this guard on every pull request. This seed ships `\"enforcement\": \"warn\"` because Lisa cannot know which contexts YOUR ruleset requires: findings are reported in the job summary and the build still passes, EXCEPT a proven false green (`skipped_required_check`), which blocks in every mode. Review the findings, then DELETE the `enforcement` key so the guard can block.",
-    "`skip_jobs` is matched as an exact comma-delimited token and GitHub Actions expression syntax has no string-replace, so write the list with no spaces: `skip_jobs: 'a,b'`, never `skip_jobs: 'a, b'`. A spaced token matches nothing and the job runs — this guard reports that as `whitespace_in_skip_token`."
+    "This seed declares the three tokens the shipped ci.yml skips, so that the day one of them is required the guard can say so instead of the gate quietly going hollow. The `ruleset_required: false` on each is a DEFAULT, not a measurement — it is only meaningful once you have transcribed `required_contexts` from your own ruleset, which is what stamping `baseline_fetched_at` asserts.",
+    "⚠️ `required_contexts` SHIPS EMPTY AND UNSTAMPED ON PURPOSE. Lisa cannot know what YOUR ruleset requires, and an earlier version of this seed shipped a guess that was measured WRONG (#2476): it claimed `🔗 Work-Item Traceability` was required when no ruleset required it, and omitted six contexts that were. Until `ruleset.baseline_fetched_at` carries the date you transcribed the real list, the guard reports NOT CHECKED rather than answering from fiction.",
+    "To arm it: gh api repos/OWNER/NAME/rulesets --jq '.[] | \"\\\\(.id) \\\\(.name)\"' to find the ids, then gh api repos/OWNER/NAME/rulesets/ID --jq '.rules[] | select(.type==\"required_status_checks\") | .parameters.required_status_checks[].context' for the contexts. Paste them into `required_contexts` BYTE FOR BYTE, fill in `ruleset.repo` / `ruleset.ids`, and set `baseline_fetched_at` to today.",
+    "A transcription expires after 90 days, because a ruleset can be edited with no signal in this repository. The shipped `.github/workflows/required-checks-drift.yml` runs `--remote` weekly to catch that; `--remote` reads the ruleset live and so answers even when the cache is untrusted.",
+    "Lisa's quality.yml runs the offline arm on every pull request. This seed ships `\"enforcement\": \"warn\"`, which downgrades findings AND the NOT-CHECKED refusal to reports so a fresh install does not go red on arrival. Delete the key once you have transcribed the list — then it blocks.",
+    "`skip_jobs` is matched as an exact comma-delimited token and GitHub Actions expression syntax has no string-replace, so write the list with no spaces: `skip_jobs: 'a,b'`, never `skip_jobs: 'a, b'`. A spaced token matches nothing and the job runs — reported as `whitespace_in_skip_token`.",
+    "`_example_required_contexts` below is a STARTING POINT FOR TYPING, never read by the guard. Verify every line against your own ruleset before promoting any of it."
   ],
   "enforcement": "warn",
   "ruleset": {
@@ -17,7 +19,8 @@
     ".github/workflows/ci.yml"
   ],
   "exemption_ticket_pattern": "^[A-Z][A-Z0-9]+-\\d+$",
-  "required_contexts": [
+  "required_contexts": [],
+  "_example_required_contexts": [
     "🔍 Quality Checks / 🧹 Lint",
     "🔍 Quality Checks / 🔍 Type Check",
     "🔍 Quality Checks / 🏗️ Build",

--- a/nestjs/create-only/.github/required-checks.json
+++ b/nestjs/create-only/.github/required-checks.json
@@ -1,10 +1,13 @@
 {
   "_readme": [
     "See typescript/create-only/.github/required-checks.json in Lisa for the full rationale. In short: GitHub counts a SKIPPED required status check as SATISFIED, so a `skip_jobs` token that silences a required context makes the merge gate decorative.",
-    "This nestjs seed declares the three tokens the shipped ci.yml skips. Every one of them is currently NOT ruleset-required, so nothing here is a false green — but the declaration exists so that the day one of them BECOMES required, the guard says so instead of the gate quietly going hollow.",
-    "Transcribe `required_contexts` byte for byte from your ruleset and keep it current with `--remote`.",
-    "Lisa's quality.yml runs the offline arm of this guard on every pull request. This seed ships `\"enforcement\": \"warn\"` because Lisa cannot know which contexts YOUR ruleset requires: findings are reported in the job summary and the build still passes, EXCEPT a proven false green (`skipped_required_check`), which blocks in every mode. Review the findings, then DELETE the `enforcement` key so the guard can block.",
-    "`skip_jobs` is matched as an exact comma-delimited token and GitHub Actions expression syntax has no string-replace, so write the list with no spaces: `skip_jobs: 'a,b'`, never `skip_jobs: 'a, b'`. A spaced token matches nothing and the job runs — this guard reports that as `whitespace_in_skip_token`."
+    "This seed declares the three tokens the shipped ci.yml skips, so that the day one of them is required the guard can say so instead of the gate quietly going hollow. The `ruleset_required: false` on each is a DEFAULT, not a measurement — it is only meaningful once you have transcribed `required_contexts` from your own ruleset, which is what stamping `baseline_fetched_at` asserts.",
+    "⚠️ `required_contexts` SHIPS EMPTY AND UNSTAMPED ON PURPOSE. Lisa cannot know what YOUR ruleset requires, and an earlier version of this seed shipped a guess that was measured WRONG (#2476): it claimed `🔗 Work-Item Traceability` was required when no ruleset required it, and omitted six contexts that were. Until `ruleset.baseline_fetched_at` carries the date you transcribed the real list, the guard reports NOT CHECKED rather than answering from fiction.",
+    "To arm it: gh api repos/OWNER/NAME/rulesets --jq '.[] | \"\\\\(.id) \\\\(.name)\"' to find the ids, then gh api repos/OWNER/NAME/rulesets/ID --jq '.rules[] | select(.type==\"required_status_checks\") | .parameters.required_status_checks[].context' for the contexts. Paste them into `required_contexts` BYTE FOR BYTE, fill in `ruleset.repo` / `ruleset.ids`, and set `baseline_fetched_at` to today.",
+    "A transcription expires after 90 days, because a ruleset can be edited with no signal in this repository. The shipped `.github/workflows/required-checks-drift.yml` runs `--remote` weekly to catch that; `--remote` reads the ruleset live and so answers even when the cache is untrusted.",
+    "Lisa's quality.yml runs the offline arm on every pull request. This seed ships `\"enforcement\": \"warn\"`, which downgrades findings AND the NOT-CHECKED refusal to reports so a fresh install does not go red on arrival. Delete the key once you have transcribed the list — then it blocks.",
+    "`skip_jobs` is matched as an exact comma-delimited token and GitHub Actions expression syntax has no string-replace, so write the list with no spaces: `skip_jobs: 'a,b'`, never `skip_jobs: 'a, b'`. A spaced token matches nothing and the job runs — reported as `whitespace_in_skip_token`.",
+    "`_example_required_contexts` below is a STARTING POINT FOR TYPING, never read by the guard. Verify every line against your own ruleset before promoting any of it."
   ],
   "enforcement": "warn",
   "ruleset": {
@@ -16,7 +19,8 @@
     ".github/workflows/ci.yml"
   ],
   "exemption_ticket_pattern": "^[A-Z][A-Z0-9]+-\\d+$",
-  "required_contexts": [
+  "required_contexts": [],
+  "_example_required_contexts": [
     "🔍 Quality Checks / 🧹 Lint",
     "🔍 Quality Checks / 🔍 Type Check",
     "🔍 Quality Checks / 🏗️ Build",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -199,7 +199,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/copy-overwrite/tsconfig.json":
       "c92e2c2c109e8794ee351f634361ef46297f5a0cd606aaf5c19911da836df307",
     "expo/create-only/.github/required-checks.json":
-      "d69d4b9cf275f5e07a090f5763f80bb946435c33627dfe21d261650cfe88851a",
+      "68194b5e096c8d49579e06aed5e41df71c43c4dc46bbbcb390b4a27cd1e78c7f",
     "expo/create-only/.github/workflows/ci.yml":
       "bf75c9d3b4f4a2cb24c2214d9fc27a9cb2247a6694b0cf02c40032b4d3e87cd9",
     "expo/create-only/.github/workflows/deploy.yml":
@@ -363,7 +363,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "nestjs/create-only/.github/k6/thresholds/strict.json":
       "e121ec72de4596b95c013a8c71f03653bcdf057cf7f8d1fec6f0e13c1381867f",
     "nestjs/create-only/.github/required-checks.json":
-      "6bbbe6976ec39c516608f69b02a431187d948d63b0b28ab7ad32a052e87ea171",
+      "7d9af483f6150e2f7281f008dd08b56590721f3c86f6b1a3b7548f7838a0137f",
     "nestjs/create-only/.github/workflows/ci.yml":
       "0985668e6d0478f1993bed8ccd398601d8e73376afd8775e1269ae129418152e",
     "nestjs/create-only/.github/workflows/deploy.yml":
@@ -2253,7 +2253,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/scripts/check-nightly-e2e-health.mjs":
       "c9dd6f6816b35d4d8f684892878d4181b9cb5266a7f2e2814970aa49dc04a001",
     "typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs":
-      "e4a9d255c74a7ddeac3db5fdf47b5c5f8110f49f63576983d7e4ffe23e4a631b",
+      "0a8b14790f38e00e5abfc665d3e3d2c29e0a139a2a22c4a65e0c08547b42fb7f",
     "typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs":
       "e1e3f22b33267212b90f915f83821559d1a45cab5b16c7164b86bd6c7b53549b",
     "typescript/copy-overwrite/scripts/check-verification-coverage.mjs":
@@ -2275,7 +2275,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/vitest.config.ts":
       "da92f06cc3ce68462c6f2f3d95adb1b1464591ce383a24e3334dc986e0c1e0fb",
     "typescript/create-only/.github/required-checks.json":
-      "86718597f15cd23527ba32e6490ba2269457a78e18abb257f97bde5076d3dc7d",
+      "49063a033604c8e98f7782e4352d67dea77ac9b949189f166e43044f0af7e4f4",
     "typescript/create-only/.github/workflows/auto-update-pr-branches-dispatch.yml":
       "347f8a3830efdc3ad701fae0858994f4e45df8100844e91948b017b98115a28c",
     "typescript/create-only/.github/workflows/auto-update-pr-branches.yml":
@@ -2299,7 +2299,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/create-only/.github/workflows/claude.yml":
       "fd230bf19769a12b1b3afeeeb1d5f51c44338db974c26ff05dc381f0e1ba2382",
     "typescript/create-only/.github/workflows/required-checks-drift.yml":
-      "ec0d93396043b3d9fe0263a3ffbdc4721b1890020886bd97a09afe779c703adf",
+      "e3eed885502d389e3b9ac3d083b340f5a52e469aceec592a947c56ec5b17cf5c",
     "typescript/create-only/.gitleaksignore":
       "6927d376648675331801c798a4390b652a22a3e5d350cd26f36d42c10af02d67",
     "typescript/create-only/audit.ignore.local.json":

--- a/tests/unit/scripts/skipped-required-checks-wiring.test.ts
+++ b/tests/unit/scripts/skipped-required-checks-wiring.test.ts
@@ -11,12 +11,19 @@
  *    repo must be able to report findings without going red on the day Lisa
  *    installs the job. A gate that reddens a repository on arrival gets
  *    deleted, not fixed.
+ *  - snapshot trust (#2476) — `required_contexts` is a CACHE of a live ruleset
+ *    fetch, and an unstamped cache is not an answer. The seed Lisa shipped was
+ *    measured wrong: it claimed a context was required that no ruleset
+ *    required, and omitted six that were. A guard reading that would clear a
+ *    genuinely-skipped required check and flag a non-required one — worse than
+ *    a guard nobody runs, because it teaches people to trust it.
  *  - `whitespace_in_skip_token` (#2427) — GitHub Actions expression syntax has
  *    no string-replace, so `skip_jobs: 'test, test:e2e'` cannot be normalized
  *    in the workflow. It fails CLOSED (the job runs), so nothing unverified
  *    ships — but the skip silently did not happen, and until the guard ran in
  *    CI nothing anywhere could say so.
  */
+import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -39,6 +46,16 @@ interface Violation {
 /** What the guard exports, as this suite consumes it. */
 interface GuardModule {
   readonly VIOLATIONS: Record<string, string>;
+  readonly SNAPSHOT_MAX_AGE_DAYS: number;
+  snapshotTrust(
+    declaration: Record<string, unknown>,
+    now?: number
+  ): { trusted: boolean; reason: string };
+  evaluateSkippedRequiredChecks(
+    declaration: Record<string, unknown>,
+    skipped: readonly string[],
+    options?: { trustRequiredContexts?: boolean }
+  ): { violations: Violation[]; checked: number };
   readSkipJobs(
     contents: string,
     sourcePath: string,
@@ -52,8 +69,11 @@ interface GuardModule {
   runGuard(argv: readonly string[]): {
     violations: Violation[];
     enforcement: string;
+    trust: { trusted: boolean; reason: string };
   };
 }
+
+const DAY_MS = 86_400_000;
 
 /**
  * Creates a throwaway repository with a `.github/workflows` directory.
@@ -64,6 +84,31 @@ interface GuardModule {
 function emptyRepo(prefix: string): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   fs.mkdirSync(path.join(root, ".github", "workflows"), { recursive: true });
+  return root;
+}
+
+/**
+ * Builds a repo whose declaration has never been transcribed.
+ *
+ * @param enforcement - Optional `enforcement` value to write
+ * @returns The repository root
+ */
+function untranscribedRepo(enforcement?: string): string {
+  const root = emptyRepo("skipreq-untranscribed-");
+  fs.writeFileSync(
+    path.join(root, CI_WORKFLOW.replace(/\//gu, path.sep)),
+    "      skip_jobs: ''"
+  );
+  fs.writeFileSync(
+    path.join(root, ".github", "required-checks.json"),
+    JSON.stringify({
+      ...(enforcement === undefined ? {} : { enforcement }),
+      ruleset: { repo: "", ids: [], baseline_fetched_at: "" },
+      required_contexts: [],
+      workflows: [CI_WORKFLOW],
+      skip_job_declarations: {},
+    })
+  );
   return root;
 }
 
@@ -147,6 +192,130 @@ describe("check-skipped-required-checks, as a shipped CI job", () => {
     });
   });
 
+  describe("an untranscribed `required_contexts` is NOT AN ANSWER (#2476)", () => {
+    const REQUIRED_RULES = ["skipped_required_check"];
+
+    it("refuses an EMPTY `baseline_fetched_at` — the state Lisa's seeds ship in", () => {
+      const trust = mod.snapshotTrust({ ruleset: { baseline_fetched_at: "" } });
+      expect(trust.trusted).toBe(false);
+      // The reason has to name the measured failure, or the next person
+      // "fixes" the refusal by deleting the check.
+      expect(trust.reason).toContain("measured WRONG");
+    });
+
+    it("refuses a MISSING ruleset block, and a stamp it cannot parse", () => {
+      expect(mod.snapshotTrust({}).trusted).toBe(false);
+      expect(
+        mod.snapshotTrust({ ruleset: { baseline_fetched_at: "last tuesday" } })
+          .trusted
+      ).toBe(false);
+    });
+
+    it("trusts a fresh stamp and EXPIRES an old one", () => {
+      const now = Date.parse("2026-08-13T00:00:00Z");
+      const at = (days: number): Record<string, unknown> => ({
+        ruleset: {
+          baseline_fetched_at: new Date(now - days * DAY_MS).toISOString(),
+        },
+      });
+      expect(mod.snapshotTrust(at(1), now).trusted).toBe(true);
+      expect(
+        mod.snapshotTrust(at(mod.SNAPSHOT_MAX_AGE_DAYS - 1), now).trusted
+      ).toBe(true);
+      expect(
+        mod.snapshotTrust(at(mod.SNAPSHOT_MAX_AGE_DAYS + 1), now).trusted
+      ).toBe(false);
+    });
+
+    it("SUPPRESSES every rule that reads `required_contexts` when untrusted", () => {
+      // The false-green rule would otherwise fire off a fabricated list — the
+      // exact "confident wrong answer" #2476 measured.
+      const declaration = {
+        required_contexts: [REQUIRED],
+        workflows: [CI_WORKFLOW],
+        skip_job_declarations: {
+          "test:e2e": {
+            suppressed_contexts: [REQUIRED],
+            ruleset_required: true,
+          },
+        },
+      };
+      expect(
+        mod
+          .evaluateSkippedRequiredChecks(declaration, ["test:e2e"])
+          .violations.map(violation => violation.kind)
+      ).toEqual(REQUIRED_RULES);
+      expect(
+        mod.evaluateSkippedRequiredChecks(declaration, ["test:e2e"], {
+          trustRequiredContexts: false,
+        }).violations
+      ).toEqual([]);
+    });
+
+    it("KEEPS the rules that do not read it — an undeclared token is still undeclared", () => {
+      const violations = mod.evaluateSkippedRequiredChecks(
+        {
+          required_contexts: [REQUIRED],
+          workflows: [CI_WORKFLOW],
+          skip_job_declarations: {},
+        },
+        ["surprise"],
+        { trustRequiredContexts: false }
+      ).violations;
+      expect(violations.map(violation => violation.kind)).toEqual([
+        mod.VIOLATIONS.undeclared,
+      ]);
+    });
+
+    it("reports the refusal through runGuard rather than a clean verdict", () => {
+      const result = mod.runGuard([untranscribedRepo()]);
+      expect(result.trust.trusted).toBe(false);
+      expect(result.violations).toEqual([]);
+    });
+
+    it("the CLI prints NOT CHECKED, never a ✅, and exits non-zero", () => {
+      const run = spawnSync(
+        process.execPath,
+        [path.join(REPO_ROOT, SCRIPT_REL), untranscribedRepo()],
+        { encoding: "utf8" }
+      );
+      expect(run.stdout).toContain("NOT CHECKED");
+      expect(run.stdout).not.toContain("✅");
+      expect(run.status).toBe(1);
+    });
+
+    it("`enforcement: warn` keeps the refusal loud but exits 0", () => {
+      // A fresh install must not redden a whole fleet on arrival — that is how
+      // a gate gets deleted instead of transcribed. It still never says ✅.
+      const run = spawnSync(
+        process.execPath,
+        [path.join(REPO_ROOT, SCRIPT_REL), untranscribedRepo("warn")],
+        { encoding: "utf8" }
+      );
+      expect(run.stdout).toContain("NOT CHECKED");
+      expect(run.stdout).not.toContain("✅");
+      expect(run.status).toBe(0);
+    });
+  });
+
+  describe("the shipped seeds ship UNTRANSCRIBED (#2476)", () => {
+    it.each([
+      "expo/create-only",
+      "nestjs/create-only",
+      "typescript/create-only",
+    ])("%s ships no guessed required_contexts and no stamp", seedDir => {
+      const seed = JSON.parse(
+        fs.readFileSync(
+          path.join(REPO_ROOT, seedDir, ".github/required-checks.json"),
+          "utf-8"
+        )
+      ) as Record<string, never>;
+      expect(seed.required_contexts).toEqual([]);
+      expect(seed.ruleset.baseline_fetched_at).toBe("");
+      expect(mod.snapshotTrust(seed).trusted).toBe(false);
+    });
+  });
+
   describe("`enforcement`, the adoption ramp (#2426)", () => {
     /**
      * Writes a declaration carrying one `enforcement` value.
@@ -164,6 +333,7 @@ describe("check-skipped-required-checks, as a shipped CI job", () => {
         path.join(root, ".github", "required-checks.json"),
         JSON.stringify({
           ...(enforcement === undefined ? {} : { enforcement }),
+          ruleset: { baseline_fetched_at: new Date().toISOString() },
           required_contexts: [REQUIRED],
           workflows: [CI_WORKFLOW],
           skip_job_declarations: {},

--- a/typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs
+++ b/typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs
@@ -33,6 +33,31 @@
  * own declaration stating that a token it really skips silences a context its
  * ruleset really requires — blocks in every mode.
  *
+ * ## `required_contexts` is a CACHE, and an unstamped cache is NOT AN ANSWER
+ *
+ * The single worst thing this guard can do is render a confident verdict from a
+ * list nobody ever compared against a real ruleset. Measured (#2476): the seed
+ * Lisa shipped claimed `🔗 Work-Item Traceability` was required — no ruleset
+ * required it — and OMITTED SIX contexts that genuinely were. A guard reading
+ * that would clear a genuinely-skipped required check and flag a non-required
+ * one. That is worse than a guard nobody runs, because it teaches people to
+ * trust it.
+ *
+ * So `required_contexts` is treated as a cache of a live fetch, not as
+ * testimony. It is trusted only while `ruleset.baseline_fetched_at` carries a
+ * parseable timestamp no older than SNAPSHOT_MAX_AGE_DAYS. Untranscribed or
+ * expired, the guard REFUSES to answer: every rule that depends on
+ * `required_contexts` is skipped, no ✅ is printed, and the report says NOT
+ * CHECKED and why. The rules that do NOT read `required_contexts` — an
+ * undeclared token, a token written with whitespace — still run, because they
+ * are true regardless of what the ruleset requires.
+ *
+ * Refusal is exit 1, so an explicit `npm run check:skipped-required-checks`
+ * cannot be mistaken for a pass. Under `"enforcement": "warn"` — which is what
+ * Lisa's seeds ship, and only its seeds — refusal is loud and exit 0, because
+ * reddening every repository in a fleet the day an untranscribed seed arrives
+ * is how a gate gets deleted rather than transcribed.
+ *
  * ## Why this exists
  *
  * **GitHub counts a `skipped` required status check as SATISFIED.** A job named
@@ -90,6 +115,18 @@ import { pathToFileURL } from "node:url";
 
 /** Repo-relative path of the per-repo declaration file. */
 export const DECLARATION_PATH = ".github/required-checks.json";
+
+/**
+ * How long a transcribed `required_contexts` snapshot stays trustworthy.
+ *
+ * A SOURCE CONSTANT, not an input: a ceiling somebody can widen from a config
+ * file fails open on exactly the runs nobody tests. Rulesets are edited in an
+ * admin console with no signal in the repository, so an old transcription is
+ * not evidence — it is a memory of evidence. Ninety days is long enough that
+ * the weekly `--remote` run refreshes it many times over, and short enough that
+ * an abandoned repository stops being told its skips are fine.
+ */
+export const SNAPSHOT_MAX_AGE_DAYS = 90;
 
 /**
  * Matches a `skip_jobs:` key and captures everything after the colon.
@@ -418,6 +455,58 @@ export function collectSkipJobTokens(rootDir, workflows) {
 }
 
 /**
+ * Decides whether `required_contexts` may be believed at all.
+ *
+ * The stamp is `ruleset.baseline_fetched_at`, and it means one specific thing:
+ * somebody read this list off a live ruleset on that date. An empty stamp is
+ * the state Lisa's seeds ship in, and the seeds are a GUESS — a guess that was
+ * measured wrong (#2476). No stamp, no answer.
+ *
+ * @param {object} declaration - The per-repo declaration
+ * @param {number} [now] - Current epoch milliseconds, injectable for tests
+ * @returns {{trusted: boolean, reason: string}} Whether to believe the snapshot, and why not
+ */
+export function snapshotTrust(declaration, now = Date.now()) {
+  const stamp = declaration.ruleset?.baseline_fetched_at;
+  if (typeof stamp !== "string" || stamp.trim() === "") {
+    return {
+      trusted: false,
+      reason: `\`ruleset.baseline_fetched_at\` is empty, so \`required_contexts\` has never been transcribed from a live ruleset. Lisa's seed ships a GUESS, and the guess was measured WRONG in this fleet: it claimed "🔍 Quality Checks / 🔗 Work-Item Traceability" was required when no ruleset required it, and omitted six contexts that were. Transcribe the real list, stamp the date, and this guard starts answering.`,
+    };
+  }
+  const fetchedAt = Date.parse(stamp);
+  if (Number.isNaN(fetchedAt)) {
+    return {
+      trusted: false,
+      reason: `\`ruleset.baseline_fetched_at\` is ${JSON.stringify(stamp)}, which is not a date this can read. Use an ISO-8601 timestamp, e.g. "2026-08-13".`,
+    };
+  }
+  const ageDays = (now - fetchedAt) / 86_400_000;
+  if (ageDays > SNAPSHOT_MAX_AGE_DAYS) {
+    return {
+      trusted: false,
+      reason: `\`required_contexts\` was last transcribed ${Math.floor(ageDays)} days ago, past the ${SNAPSHOT_MAX_AGE_DAYS}-day ceiling. Rulesets are edited in an admin console with no signal in this repository, so a stale transcription is a memory of evidence rather than evidence.`,
+    };
+  }
+  return { trusted: true, reason: "" };
+}
+
+/**
+ * The transcription instructions, printed wherever the snapshot is refused.
+ *
+ * @param {object} declaration - The per-repo declaration
+ * @returns {string} A copy-pasteable recipe
+ */
+export function transcriptionRecipe(declaration) {
+  const repo = declaration.ruleset?.repo || "OWNER/NAME";
+  return [
+    `  gh api repos/${repo}/rulesets --jq '.[] | "\\(.id) \\(.name)"'`,
+    `  gh api repos/${repo}/rulesets/RULESET_ID --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'`,
+    `Paste the output into \`required_contexts\` byte for byte, record the ids in \`ruleset.ids\`, and set \`ruleset.baseline_fetched_at\` to today.`,
+  ].join("\n");
+}
+
+/**
  * The whole verdict, as a pure function of the two snapshots and what the
  * workflows actually declare.
  *
@@ -438,11 +527,25 @@ export function collectSkipJobTokens(rootDir, workflows) {
  *  5. An exemption for a token nobody skips any more is ORPHANED. Deleting it is
  *     one line, and leaving it teaches readers the exemption list is fiction.
  *
+ * Rules 2, 3 and 4 all read `required_contexts`, so all three are SUPPRESSED
+ * when `trustRequiredContexts` is false. Rules 1 and 5 do not read it and keep
+ * running: whether a token was reviewed, and whether an exemption still refers
+ * to a real skip, are true regardless of what any ruleset requires. Suppressing
+ * a rule is not the same as passing it — the caller reports NOT CHECKED.
+ *
  * @param {object} declaration - The per-repo declaration
  * @param {ReadonlyArray<string>} skipped - Tokens the workflows actually skip
+ * @param {{trustRequiredContexts?: boolean}} [options] - Set
+ *   `trustRequiredContexts: false` to suppress every rule that reads the
+ *   `required_contexts` snapshot
  * @returns {{violations: object[], checked: number}} Violations and how many tokens were examined
  */
-export function evaluateSkippedRequiredChecks(declaration, skipped) {
+export function evaluateSkippedRequiredChecks(
+  declaration,
+  skipped,
+  options = {}
+) {
+  const trustRequired = options.trustRequiredContexts !== false;
   const required = new Set(declaration.required_contexts);
   const declarations = declaration.skip_job_declarations ?? {};
   const ticketPattern = new RegExp(
@@ -460,6 +563,7 @@ export function evaluateSkippedRequiredChecks(declaration, skipped) {
       });
       continue;
     }
+    if (!trustRequired) continue;
     const suppressed = entry.suppressed_contexts ?? [];
     const hits = suppressed.filter(context => required.has(context));
 
@@ -576,22 +680,38 @@ export function compareRulesetBaseline(snapshot, live) {
 /**
  * Runs the guard.
  *
+ * `--remote` reads the ruleset live, so it does not need the cache to be
+ * trustworthy — it is the thing that MAKES it trustworthy. Under `--remote` the
+ * required-context rules therefore run regardless of the stamp, and any
+ * disagreement surfaces as `ruleset_snapshot_drift` rather than as a verdict
+ * about skips.
+ *
  * @param {ReadonlyArray<string>} argv - CLI arguments
- * @returns {{violations: object[], checked: number, tokens: string[], enforcement: string}} The result
+ * @returns {{violations: object[], checked: number, tokens: string[], enforcement: string, trust: {trusted: boolean, reason: string}, recipe: string}} The result
  */
 export function runGuard(argv) {
   const positional = argv.filter(arg => !arg.startsWith("--"));
   const rootDir = positional[0] ?? process.cwd();
   const declaration = loadDeclaration(rootDir);
   const collected = collectSkipJobTokens(rootDir, declaration.workflows);
-  const result = evaluateSkippedRequiredChecks(declaration, collected.tokens);
+  const remote = argv.includes("--remote");
+  const live = remote
+    ? fetchLiveRequiredContexts(declaration.ruleset)
+    : undefined;
+  const trust = remote
+    ? { trusted: true, reason: "" }
+    : snapshotTrust(declaration);
+  const result = evaluateSkippedRequiredChecks(
+    live === undefined
+      ? declaration
+      : { ...declaration, required_contexts: live },
+    collected.tokens,
+    { trustRequiredContexts: trust.trusted }
+  );
   const violations = [...collected.violations, ...result.violations];
-  if (argv.includes("--remote")) {
+  if (live !== undefined) {
     violations.push(
-      ...compareRulesetBaseline(
-        declaration.required_contexts,
-        fetchLiveRequiredContexts(declaration.ruleset)
-      )
+      ...compareRulesetBaseline(declaration.required_contexts, live)
     );
   }
   return {
@@ -599,6 +719,8 @@ export function runGuard(argv) {
     checked: result.checked,
     tokens: collected.tokens,
     enforcement: declaration.enforcement ?? "error",
+    trust,
+    recipe: transcriptionRecipe(declaration),
   };
 }
 
@@ -609,7 +731,7 @@ export function runGuard(argv) {
  * @returns {void}
  */
 function main(argv) {
-  /** @type {{violations: object[], checked: number, tokens: string[], enforcement: string}} */
+  /** @type {{violations: object[], checked: number, tokens: string[], enforcement: string, trust: {trusted: boolean, reason: string}, recipe: string}} */
   let result;
   try {
     result = runGuard(argv);
@@ -631,7 +753,15 @@ function main(argv) {
 
   if (argv.includes("--json")) {
     process.stdout.write(
-      `${JSON.stringify({ ok: result.violations.length === 0, ...result }, null, 2)}\n`
+      `${JSON.stringify(
+        {
+          ok: result.violations.length === 0 && result.trust.trusted,
+          answered: result.trust.trusted,
+          ...result,
+        },
+        null,
+        2
+      )}\n`
     );
     return;
   }
@@ -647,10 +777,39 @@ function main(argv) {
     !warnOnly || ALWAYS_BLOCKING.includes(violation.kind);
   const blocking = result.violations.filter(blocks);
   const lines = ["## 🔒 Skipped required checks", ""];
-  if (result.violations.length === 0) {
+
+  // The refusal comes FIRST and replaces the verdict. Printing "✅ none
+  // silences a required check" from a snapshot nobody transcribed is the one
+  // outcome that is worse than never running: it is a confident wrong answer,
+  // and it teaches people to trust it (#2476).
+  if (!result.trust.trusted) {
     lines.push(
-      `✅ ${result.checked} \`skip_jobs\` token(s) examined; none silences a ruleset-required status check.`
+      `⛔ **NOT CHECKED** — this guard cannot say whether any skip silences a required status check, and will not pretend to.`,
+      "",
+      result.trust.reason,
+      "",
+      "```",
+      result.recipe,
+      "```",
+      "",
+      `Meanwhile \`--remote\` answers WITHOUT the cache, because it reads the ruleset live: \`npm run check:skipped-required-checks:remote\`.`,
+      ""
     );
+    process.stderr.write(
+      `::${warnOnly ? "warning" : "error"} title=Skipped-required checks NOT CHECKED::${result.trust.reason.split("\n")[0]}\n`
+    );
+  }
+
+  if (result.violations.length === 0) {
+    if (result.trust.trusted) {
+      lines.push(
+        `✅ ${result.checked} \`skip_jobs\` token(s) examined; none silences a ruleset-required status check.`
+      );
+    } else {
+      lines.push(
+        `The rules that do NOT read \`required_contexts\` were still applied to ${result.checked} token(s) and found nothing.`
+      );
+    }
   } else {
     lines.push(
       `${blocking.length > 0 ? "❌" : "⚠️"} ${result.violations.length} violation(s) across ${result.checked} \`skip_jobs\` token(s):`,
@@ -676,7 +835,13 @@ function main(argv) {
       appendFileSync(process.env.GITHUB_STEP_SUMMARY, report);
     });
   }
-  if (blocking.length > 0) process.exitCode = 1;
+  // Refusal is a failure, not a pass: an explicit run must never be mistaken
+  // for a clean bill of health. `warn` — which only Lisa's untranscribed seeds
+  // ship — downgrades it, because reddening a whole fleet the day a seed
+  // arrives is how a gate gets deleted instead of transcribed.
+  if (blocking.length > 0 || (!result.trust.trusted && !warnOnly)) {
+    process.exitCode = 1;
+  }
 }
 
 if (

--- a/typescript/create-only/.github/required-checks.json
+++ b/typescript/create-only/.github/required-checks.json
@@ -3,11 +3,13 @@
     "Two REVIEWED SNAPSHOTS that scripts/check-skipped-required-checks.mjs makes police each other.",
     "Neither is derivable from this repository: `required_contexts` lives in a GitHub ruleset that humans edit in an admin console, and the skip_jobs token -> job name map lives in Lisa's quality.yml, which is not vendored here.",
     "Why it matters: GitHub counts a SKIPPED required status check as SATISFIED. A job named in `skip_jobs` still reports green against its required context having run zero steps, so the merge gate can never be red and therefore can never block anything.",
-    "Transcribe `required_contexts` BYTE FOR BYTE from the ruleset, emoji and the ' / ' separator included. The guard compares with exact string equality on purpose: a repo routinely carries confusable pairs (an external app's required `SonarCloud Code Analysis` beside a skippable, not-required `SonarCloud SAST`; `Run Tests` beside `Run Unit Tests`), and a fuzzy match would raise a false alarm whose obvious fix is to delete the guard.",
-    "Run `node scripts/check-skipped-required-checks.mjs --remote` periodically: two snapshots in one repo can only catch each other drifting from the CODE, never from a ruleset edited in the console.",
-    "Fill in `ruleset.repo` / `ruleset.ids` before --remote can work. Find the ids with: gh api repos/OWNER/NAME/rulesets --jq '.[] | \"\\(.id) \\(.name)\"'. Once they are filled in, the shipped `.github/workflows/required-checks-drift.yml` runs --remote weekly; until then it reports UNCONFIGURED and passes.",
-    "Lisa's quality.yml runs the offline arm of this guard on every pull request. This seed ships `\"enforcement\": \"warn\"` because Lisa cannot know which contexts YOUR ruleset requires: findings are reported in the job summary and the build still passes, EXCEPT a proven false green (`skipped_required_check`), which blocks in every mode. Review the findings, then DELETE the `enforcement` key so the guard can block.",
-    "`skip_jobs` is matched as an exact comma-delimited token and GitHub Actions expression syntax has no string-replace, so write the list with no spaces: `skip_jobs: 'a,b'`, never `skip_jobs: 'a, b'`. A spaced token matches nothing and the job runs — this guard reports that as `whitespace_in_skip_token`."
+    "⚠️ `required_contexts` SHIPS EMPTY AND UNSTAMPED ON PURPOSE. Lisa cannot know what YOUR ruleset requires, and an earlier version of this seed shipped a guess that was measured WRONG (#2476): it claimed `🔗 Work-Item Traceability` was required when no ruleset required it, and omitted six contexts that were. Until `ruleset.baseline_fetched_at` carries the date you transcribed the real list, the guard reports NOT CHECKED rather than answering from fiction.",
+    "To arm it: gh api repos/OWNER/NAME/rulesets --jq '.[] | \"\\(.id) \\(.name)\"' to find the ids, then gh api repos/OWNER/NAME/rulesets/ID --jq '.rules[] | select(.type==\"required_status_checks\") | .parameters.required_status_checks[].context' for the contexts. Paste them into `required_contexts` BYTE FOR BYTE (emoji and the ' / ' separator included), fill in `ruleset.repo` / `ruleset.ids`, and set `baseline_fetched_at` to today.",
+    "The guard compares with exact string equality on purpose: a repo routinely carries confusable pairs (an external app's required `SonarCloud Code Analysis` beside a skippable, not-required `SonarCloud SAST`; `Run Tests` beside `Run Unit Tests`), and a fuzzy match would raise a false alarm whose obvious fix is to delete the guard.",
+    "A transcription expires after 90 days, because a ruleset can be edited with no signal in this repository. The shipped `.github/workflows/required-checks-drift.yml` runs `--remote` weekly to catch that; `--remote` reads the ruleset live and so answers even when the cache is untrusted.",
+    "Lisa's quality.yml runs the offline arm on every pull request. This seed ships `\"enforcement\": \"warn\"`, which downgrades findings AND the NOT-CHECKED refusal to reports so a fresh install does not go red on arrival. Delete the key once you have transcribed the list — then it blocks.",
+    "`skip_jobs` is matched as an exact comma-delimited token and GitHub Actions expression syntax has no string-replace, so write the list with no spaces: `skip_jobs: 'a,b'`, never `skip_jobs: 'a, b'`. A spaced token matches nothing and the job runs — reported as `whitespace_in_skip_token`.",
+    "`_example_required_contexts` below is a STARTING POINT FOR TYPING, never read by the guard. Verify every line against your own ruleset before promoting any of it."
   ],
   "enforcement": "warn",
   "ruleset": {
@@ -17,15 +19,15 @@
   },
   "workflows": [".github/workflows/ci.yml"],
   "exemption_ticket_pattern": "^[A-Z][A-Z0-9]+-\\d+$",
-  "required_contexts": [
+  "required_contexts": [],
+  "_example_required_contexts": [
     "🔍 Quality Checks / 🧹 Lint",
     "🔍 Quality Checks / 🔍 Type Check",
     "🔍 Quality Checks / 🏗️ Build",
     "🔍 Quality Checks / 📐 Check Formatting",
     "🔍 Quality Checks / 🔒 Security Scan",
     "🔍 Quality Checks / 🧪 Run Unit Tests",
-    "🔍 Quality Checks / 🧪 Run Integration Tests",
-    "🔍 Quality Checks / 🔗 Work-Item Traceability"
+    "🔍 Quality Checks / 🧪 Run Integration Tests"
   ],
   "skip_job_declarations": {}
 }

--- a/typescript/create-only/.github/workflows/required-checks-drift.yml
+++ b/typescript/create-only/.github/workflows/required-checks-drift.yml
@@ -15,6 +15,13 @@
 # reintroduces the false-green class the guard exists to refuse. This workflow
 # never runs on `pull_request`, so it cannot wedge a merge.
 #
+# `--remote` is also the arm that STRUCTURALLY CANNOT LIE (#2476). It evaluates
+# the skip rules against the contexts it just read from the live ruleset, not
+# against the committed cache, so it answers correctly even in a repository
+# whose `required_contexts` has never been transcribed — which is exactly the
+# state the offline arm refuses to answer in. Arming this workflow is therefore
+# the fastest way to get a real answer.
+#
 # Reading a repository ruleset needs a token with administration:read. The
 # default GITHUB_TOKEN generally does not have it, so provide a PAT as the
 # repository secret RULESET_READ_TOKEN. Without it this job goes red rather


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2476

Follow-up to #2472, which merged on auto-merge before the #2476 finding landed. This is part 2 of that issue; the `work_item_traceability` caller-permissions half is untouched here.

## The problem #2472 shipped

#2472 wired `check-skipped-required-checks.mjs` into `quality.yml`. #2476 then measured, at `geminisportsai/ask-gemini`, that the seed that guard reads is **aspirational, not transcribed**: it claimed `🔗 Work-Item Traceability` was required when no ruleset requires it, and **omitted six contexts that genuinely are**.

So as merged, the guard validates against a fiction — it would **clear a genuinely-skipped required check** and **flag a non-required one** — and print a green tick while doing it. Measured on an untranscribed repo:

```
# as merged (#2472)
✅ 0 `skip_jobs` token(s) examined; none silences a ruleset-required status check.
exit=0

# with this PR
⛔ **NOT CHECKED** — this guard cannot say whether any skip silences a required status check, and will not pretend to.
exit=1
```

A confident wrong answer is worse than a guard nobody runs, because it teaches people to trust it.

## The fix: `required_contexts` is a cache, not testimony

Trusted only while `ruleset.baseline_fetched_at` carries a parseable date no older than the **90-day `SNAPSHOT_MAX_AGE_DAYS` source constant** (a ceiling in an input fails open on exactly the runs nobody tests). Untranscribed or expired:

| | |
|---|---|
| Rules that **read** `required_contexts` | **suppressed** — `skipped_required_check` and both coherence rules |
| Rules that do not | **still run** — an undeclared token and a whitespace token are true regardless of any ruleset |
| Verdict | **no ✅, ever.** Leads with `⛔ NOT CHECKED`, the reason, and a copy-pasteable `gh api` transcription recipe |
| Exit | **1** — an explicit run cannot be mistaken for a pass |

Suppressing a rule is not passing it: the report says which question went unanswered and why.

### The one deliberate softening, flagged for review

Refusal is exit 1 **except** under `"enforcement": "warn"` — which is what, and only what, Lisa's untranscribed seeds ship. It stays loud (annotation + summary, never a ✅) but exits 0.

Reason: without it, the next `lisa apply` turns every repository in the fleet red for a snapshot Lisa itself shipped unstamped, and a gate that reddens a repo on arrival gets deleted rather than transcribed. **If you want refusal to be red everywhere from day one, it is one constant** — say so and I will flip it.

## Seeds now ship honest

`required_contexts: []`, no stamp, and the former guesses moved to `_example_required_contexts` — a key **the guard never reads** and the readme labels a starting point for typing, not a claim. A test pins all three seeds (`typescript`, `expo`, `nestjs`) as untranscribed so no future edit can quietly re-introduce a guess.

## Offline vs remote, reconsidered as asked

`--remote` is **strengthened, not merely retained**: it now evaluates the skip rules against the contexts it *just read from the live ruleset*, not against the committed cache. It therefore **structurally cannot have this problem**, and answers correctly even where the offline arm refuses — which makes arming the weekly `required-checks-drift.yml` the fastest route to a real verdict, and that is now said in the workflow header and the seed readme.

The offline arm still owns the pull-request path, and the reason is unchanged and is the same failure class: it needs no network and no `gh` auth, whereas a gate that did would flake, and a flaky gate gets skipped — and GitHub counts a skipped required check as satisfied. Offline is now honestly scoped as *a cache with an expiry, refreshed by the scheduled remote arm*, rather than as an independent source of truth.

## Tests

`tests/unit/scripts/skipped-required-checks-wiring.test.ts` — empty stamp, missing `ruleset` block, unparseable stamp, the 90-day boundary in both directions, rule suppression vs retention, and two end-to-end CLI runs asserting `NOT CHECKED`, the **absence of ✅**, and exit 1 / exit 0-under-warn. Plus the seeds-ship-untranscribed pin.

Evidence: 59 script/workflow suites, 870 tests, typecheck and eslint clean. Pre-existing/environmental only: `check-learnings-budget` (needs the Bun runner) and manifest staleness before regeneration.

## ⚠️ Workflow permissions

**None added or changed.**

🤖 Generated with Claude Code

