### PR TITLE
fix(migrations): read and write through node:fs/promises, not the fs-extra namespace

### DIFF
--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8696,6 +8696,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/config/vitest-nestjs.test.ts": true,
     "tests/unit/config/vitest-typescript.test.ts": true,
     "tests/unit/core/bootstrap-environment.test.ts": true,
+    "tests/unit/core/fs-extra-namespace-members.test.ts": true,
     "tests/unit/core/host-rules-parity.test.ts": true,
     "tests/unit/core/host-rules-pointer.test.ts": true,
     "tests/unit/core/instruction-files-migration.test.ts": true,

--- a/src/migrations/ensure-oxlint-base-configs.ts
+++ b/src/migrations/ensure-oxlint-base-configs.ts
@@ -1,3 +1,4 @@
+import { readFile, writeFile } from "node:fs/promises";
 import * as path from "node:path";
 import * as fse from "fs-extra";
 import { readJsonOrNull } from "../utils/json-utils.js";
@@ -166,9 +167,10 @@ async function findStaleFiles(
 ): Promise<readonly string[]> {
   const checked = await Promise.all(
     [...files].map(async ([name, content]) => {
-      const existing = await fse
-        .readFile(path.join(projectDir, VENDOR_DIR, name), "utf-8")
-        .catch(() => null as string | null);
+      const existing = await readFile(
+        path.join(projectDir, VENDOR_DIR, name),
+        "utf-8"
+      ).catch(() => null as string | null);
       return { name, stale: existing !== content };
     })
   );
@@ -273,10 +275,7 @@ export class EnsureOxlintBaseConfigsMigration implements Migration {
     await fse.ensureDir(vendorDir);
     await Promise.all(
       plan.staleFiles.map(name =>
-        fse.writeFile(
-          path.join(vendorDir, name),
-          plan.files.get(name) as string
-        )
+        writeFile(path.join(vendorDir, name), plan.files.get(name) as string)
       )
     );
 
@@ -285,7 +284,7 @@ export class EnsureOxlintBaseConfigsMigration implements Migration {
       const oxlintrc = (await readJsonOrNull<OxlintConfigLike>(
         oxlintrcPath
       )) as OxlintConfigLike;
-      await fse.writeFile(
+      await writeFile(
         oxlintrcPath,
         `${JSON.stringify({ ...oxlintrc, extends: plan.nextExtends }, null, 2)}\n`
       );

--- a/tests/unit/core/fs-extra-namespace-members.test.ts
+++ b/tests/unit/core/fs-extra-namespace-members.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Guards the `import * as fse from "fs-extra"` namespace against members that
+ * only exist under a bundler's CJS interop (issue #2482).
+ *
+ * `fs-extra` is CommonJS. Its own additions (`ensureDir`, `pathExists`, …) are
+ * detected as named exports, but the `graceful-fs` passthroughs it re-exports
+ * off `module.exports` — `readFile`, `writeFile`, `readJson` — are NOT. Under
+ * real Node ESM those are `undefined` on the namespace object.
+ *
+ * Vitest resolves the same import through Vite's interop, which hands back the
+ * default export's properties, so `fse.readFile(...)` works in every unit test
+ * and throws `fse.readFile is not a function` in the shipped `dist/`. That gap
+ * let a broken migration pass CI and then fail `lisa apply` for every host
+ * project, taking the release pipeline with it.
+ *
+ * These assertions therefore probe the REAL Node ESM namespace in a child
+ * process rather than the one this test file would see.
+ * @module tests/unit/core/fs-extra-namespace-members
+ */
+import { execFileSync } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+/** Members `fs-extra` exposes as genuine ESM named exports. */
+const NAMESPACE_SAFE = ["copy", "ensureDir", "pathExists", "remove"] as const;
+
+/** Members reachable only via the default export, never off the namespace. */
+const NAMESPACE_UNSAFE = ["readFile", "writeFile", "readJson"] as const;
+
+/**
+ * Resolve `typeof` for each member on the real Node ESM namespace.
+ * @param members - fs-extra member names to probe.
+ * @returns Member name to its `typeof` as Node sees it.
+ */
+function typesUnderNodeEsm(members: readonly string[]): Record<string, string> {
+  const script = `
+    import * as fse from "fs-extra";
+    const out = {};
+    for (const name of ${JSON.stringify(members)}) out[name] = typeof fse[name];
+    process.stdout.write(JSON.stringify(out));
+  `;
+  return JSON.parse(
+    execFileSync(process.execPath, ["--input-type=module", "-e", script], {
+      encoding: "utf8",
+    })
+  ) as Record<string, string>;
+}
+
+describe("fs-extra ESM namespace members", () => {
+  it("exposes fs-extra's own helpers on the namespace", () => {
+    expect(typesUnderNodeEsm(NAMESPACE_SAFE)).toEqual({
+      copy: "function",
+      ensureDir: "function",
+      pathExists: "function",
+      remove: "function",
+    });
+  });
+
+  it("does NOT expose the graceful-fs passthroughs on the namespace", () => {
+    // Not a wish — a description. Calling any of these as `fse.<name>()` in
+    // src/ ships a TypeError that no unit test can see, so this test states the
+    // constraint explicitly and fails loudly if a future fs-extra changes it.
+    expect(typesUnderNodeEsm(NAMESPACE_UNSAFE)).toEqual({
+      readFile: "undefined",
+      writeFile: "undefined",
+      readJson: "undefined",
+    });
+  });
+
+  it("is not contradicted by the interop this very test file runs under", async () => {
+    // Proof the gap is real: the bundler-resolved namespace disagrees with the
+    // Node-resolved one above. This is why `fse.readFile` passed CI.
+    const bundled = (await import("fs-extra")) as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(typeof bundled["readFile"]).toBe("function");
+    expect(typesUnderNodeEsm(["readFile"])["readFile"]).toBe("undefined");
+  });
+});


### PR DESCRIPTION
**Unblocks the release pipeline.** `lisa apply` is currently broken on `main` for every host project, and the resulting red `ui-health` Playwright e2e already failed the Release run for `37342ba7` — so #2471, #2472 and #2473 merged to `main` but never reached a published tag.

## Symptom

```
[INFO] Running migrations...
[WARN] Rolling back changes...
[OK] Rollback complete
[ERROR] fse.readFile is not a function
```

Reproduced locally against a built `dist/` using the e2e's own fixture shape.

## Cause

`src/migrations/ensure-oxlint-base-configs.ts` (added by #2473) does `import * as fse from "fs-extra"` and then calls `fse.readFile` / `fse.writeFile`.

`fs-extra` is CommonJS. Node's ESM detects its own additions as named exports, but **not** the `graceful-fs` passthroughs it re-exports off `module.exports`:

| member | `typeof` on the ESM namespace |
| --- | --- |
| `ensureDir`, `pathExists`, `copy`, `remove` | `function` |
| `readFile`, `writeFile`, `readJson` | **`undefined`** |

Switched to `readFile` / `writeFile` from `node:fs/promises`, matching the sibling `ensure-learnings-gitattributes.ts`.

## Why CI could not catch it

`tests/unit/migrations/ensure-oxlint-base-configs.test.ts` exercises this exact code and passes. Vitest resolves `import * as fse` through Vite's CJS interop, which hands back the **default export's** properties — so `fse.readFile` is a function in every unit test and `undefined` in the shipped `dist/`. The unit suite is structurally blind to this.

The added guard (`tests/unit/core/fs-extra-namespace-members.test.ts`) therefore probes the **real Node ESM namespace in a child process**, and includes a case asserting that the bundler-resolved namespace disagrees with Node's — which is the gap itself, stated as a test.

## Verification

- Rebuilt `dist/`, re-ran the e2e's fixture shape: apply completes with **no error and no rollback** (was: rollback + `[ERROR]`).
- `tests/unit/core/fs-extra-namespace-members.test.ts` + `ensure-oxlint-base-configs.test.ts`: 14 passed.
- Full `test:cov`: 10906 passed (the manifest test needed the regenerated `upstream-evidence-manifest.ts`, included here).

## Related, deliberately NOT in this PR

Two more call sites hit the same undefined members but sit inside error-swallowing `try/catch`, so they fail silently instead of crashing — tracked on #2482:

- `src/core/lisa.ts:947` — plugin-sync marker never written, costing a redundant full sync every run.
- `src/core/lisa-plugin-selection.ts:31` — `readProjectConfig` **always returns `{}`**, so standalone `wiki` / `openclaw` selection by project config never takes effect.

Repairing those changes behavior, which does not belong in a hotfix that unblocks releases.

Work-Item: CodySwannGT/lisa#2482
