### PR TITLE
fix(maestro-e2e): never let the pre-suite job conclude `skipped`

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -81,8 +81,13 @@
 # state, so a suite that runs after it failed is a suite running against
 # unknown state — its greens prove nothing and its reds are unattributable.
 # The platform legs allowlist the pre-suite job results they will start after
-# (`success` and `skipped` — skipped is "no command was configured"); every
-# other result, including any GitHub adds later, keeps them from starting.
+# (`success` and `skipped`); every other result, including any GitHub adds
+# later, keeps them from starting.
+#
+# Note that the pre-suite JOB runs in every wired run whether or not a command
+# was supplied — an unset `pre_suite_command` skips the job's STEPS, not the
+# job. That is not a stylistic choice: see the job's own comment and the health
+# gate paragraph below.
 #
 # Graceful degradation: when EXPO_TOKEN is not provisioned or the flows
 # directory does not exist, every job skips with a warning instead of
@@ -104,6 +109,13 @@
 # `docs/nightly-e2e-gate.md`. Renaming or removing the per-platform test jobs
 # below is fine; making one of them conclude something other than `success`
 # while the run stays green is what the gate is watching for.
+#
+# That rule binds EVERY job here, not only the platform ones, and it is why the
+# pre-suite job below runs unconditionally in a wired run instead of skipping
+# itself when no `pre_suite_command` is supplied. A job that skips whenever an
+# optional input is unset would report `incomplete_run` — a blocked merge gate —
+# on every adopter that does not use the seam. Before adding a job to this
+# workflow, ask what it concludes in a run where the caller passed nothing.
 
 name: 📱 Maestro Native E2E
 
@@ -431,7 +443,18 @@ jobs:
     # marks the whole job failed. Without this, an Android build failure would
     # skip the pre-suite job and the surviving iOS leg would then run against
     # state nobody established. Same rationale as the platform jobs below.
-    if: ${{ !cancelled() && needs.preflight.outputs.should_run == 'true' && inputs.pre_suite_command != '' }}
+    #
+    # DELIBERATELY NOT gated on `inputs.pre_suite_command != ''`, even though
+    # that reads like the obvious guard. The nightly health gate's completeness
+    # rule (row 26) treats ANY job in a `mode: "run"` suite that concludes
+    # something other than `success` as `incomplete_run` — that is what stops a
+    # platform-narrowed dispatch from clearing a merge gate for an arm that
+    # never ran. A pre-suite job that SKIPS itself whenever the input is unset
+    # would therefore turn every green nightly into a blocked one for every
+    # adopter who does not use this seam — which is all of them on the day this
+    # lands. So the JOB always runs in a wired run and the WORK is gated
+    # per-step below; an unused seam costs a few seconds and concludes green.
+    if: ${{ !cancelled() && needs.preflight.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.pre_suite_timeout_minutes }}
     outputs:
@@ -439,16 +462,27 @@ jobs:
       # output is the only channel that reaches the platform legs.
       maestro_env: ${{ steps.capture.outputs.maestro_env }}
     steps:
+      - name: 🈳 No pre-suite command configured
+        # The visible half of the always-run decision above: a reader opening a
+        # green job with every step skipped should not have to work out whether
+        # something silently failed to fire.
+        if: ${{ inputs.pre_suite_command == '' }}
+        run: |
+          echo "No pre_suite_command was supplied; nothing to establish before the suites."
+          echo "See this workflow's header for which work belongs in this seam."
+
       - name: 📥 Checkout repository
+        if: ${{ inputs.pre_suite_command != '' }}
         uses: actions/checkout@v6
 
       - name: 🥟 Setup Bun
-        if: ${{ inputs.pre_suite_install_dependencies && inputs.package_manager == 'bun' }}
+        if: ${{ inputs.pre_suite_command != '' && inputs.pre_suite_install_dependencies && inputs.package_manager == 'bun' }}
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
       - name: 🔧 Setup Node.js
+        if: ${{ inputs.pre_suite_command != '' }}
         uses: actions/setup-node@v6
         with:
           package-manager-cache: false
@@ -458,7 +492,7 @@ jobs:
         # Opt-in: the platform legs install nothing, so the default keeps this
         # job's toolchain identical to theirs. A command that needs
         # node_modules asks for it rather than every adopter paying an install.
-        if: ${{ inputs.pre_suite_install_dependencies }}
+        if: ${{ inputs.pre_suite_command != '' && inputs.pre_suite_install_dependencies }}
         env:
           PACKAGE_MANAGER: ${{ inputs.package_manager }}
         run: |
@@ -477,6 +511,7 @@ jobs:
         # moved between the two seams without rewiring what it can read. E2E_*
         # names (not MAESTRO_*) keep the multiline inputs out of any MAESTRO_*
         # scan.
+        if: ${{ inputs.pre_suite_command != '' }}
         env:
           E2E_ENV_INPUT: ${{ inputs.maestro_env }}
           E2E_SECRET_ENV_INPUT: ${{ secrets.MAESTRO_SECRET_ENV }}
@@ -490,6 +525,7 @@ jobs:
         # The cross-job counterpart to $GITHUB_ENV. Created empty so the command
         # can append unconditionally, and named in $GITHUB_ENV so the command
         # reads it the same way it would read $GITHUB_ENV.
+        if: ${{ inputs.pre_suite_command != '' }}
         run: |
           EXPORT_FILE="$RUNNER_TEMP/maestro-pre-suite-env"
           : > "$EXPORT_FILE"
@@ -501,10 +537,12 @@ jobs:
         # the whole contract: the command's purpose is establishing known state,
         # so "it failed but test anyway" produces a suite whose greens prove
         # nothing and whose reds are unattributable.
+        if: ${{ inputs.pre_suite_command != '' }}
         run: ${{ inputs.pre_suite_command }}
 
       - name: 📦 Capture pre-suite exports
         id: capture
+        if: ${{ inputs.pre_suite_command != '' }}
         shell: bash
         run: |
           # ALLOWLIST, not denylist, and both lists are SOURCE CONSTANTS —
@@ -573,12 +611,14 @@ jobs:
     # failed, the download-artifact step fails fast with a clear error.
     #
     # The pre-suite clause is an ALLOWLIST of results this job will start
-    # after, not a denylist of ones it won't: `success` (the command ran) and
-    # `skipped` (no command configured — the default for every adopter who
-    # never sets one). `failure`, `cancelled`, and anything GitHub adds later
-    # all fall through to "do not start". `!cancelled()` deliberately does NOT
-    # cover this — it is what lets a job run despite a failed dependency, which
-    # is right for a build artifact and wrong for established state.
+    # after, not a denylist of ones it won't: `success` (the job ran — with or
+    # without a command) and `skipped` (the preflight said this project is not
+    # wired, in which case run_android is false anyway; kept so the allowlist
+    # stays correct if that guard ever changes). `failure`, `cancelled`, and
+    # anything GitHub adds later all fall through to "do not start".
+    # `!cancelled()` deliberately does NOT cover this — it is what lets a job
+    # run despite a failed dependency, which is right for a build artifact and
+    # wrong for established state.
     if: ${{ !cancelled() && needs.preflight.outputs.run_android == 'true' && contains(fromJSON('["success", "skipped"]'), needs.pre_suite.result) }}
     steps:
       - name: 📥 Checkout repository

--- a/tests/integration/maestro-pre-suite-seam.test.ts
+++ b/tests/integration/maestro-pre-suite-seam.test.ts
@@ -176,6 +176,8 @@ describe("maestro-native-e2e pre-suite seam", () => {
   });
 
   it("does not run it at all when preflight says the project is unwired", () => {
+    // An unwired project skips every job in the workflow, this one included —
+    // there is nothing to establish state for.
     const result = run("all", { [PRE_SUITE_INPUT]: A_RESET }, {}, "");
     expect(result.jobs[PRE_SUITE].ran).toBe(false);
     expect(result.commandExecutions[PRE_SUITE_INPUT] ?? 0).toBe(0);
@@ -274,11 +276,29 @@ describe("maestro-native-e2e pre-suite seam", () => {
 
   it("changes nothing for an adopter who never sets pre_suite_command", () => {
     const result = run("all", { [SETUP_INPUT]: A_READ });
-    expect(result.jobs[PRE_SUITE].ran).toBe(false);
-    expect(result.jobs[PRE_SUITE].result).toBe("skipped");
-    // `skipped` is on the legs' allowlist, so both still run, twice over.
+    // The JOB runs (see the row-26 test below); its WORK does not.
+    expect(result.commandExecutions[PRE_SUITE_INPUT] ?? 0).toBe(0);
     expect(result.jobs[ANDROID].ran).toBe(true);
     expect(result.jobs[IOS].ran).toBe(true);
     expect(result.commandExecutions[SETUP_INPUT]).toBe(2);
+  });
+
+  it("row 26: no job skips itself in a wired run just because an input is unset", () => {
+    // The nightly health gate's completeness rule treats ANY job behind a
+    // `mode: "run"` suite that concludes something other than `success` as
+    // `incomplete_run` — a BLOCKED merge gate. So a job that skips whenever an
+    // optional input is unset would redden every adopter who does not use that
+    // input. The obvious spelling of the pre-suite guard
+    // (`&& inputs.pre_suite_command != ''` on the JOB) does exactly that, which
+    // is why the work is gated per-step instead.
+    //
+    // A caller passing NOTHING optional is the case that must stay clean.
+    const result = run("all");
+    for (const [name, outcome] of Object.entries(result.jobs)) {
+      expect(`${name}:${outcome.ran}`).toBe(`${name}:true`);
+    }
+    expect(String(workflow.jobs[PRE_SUITE].if)).not.toContain(
+      `inputs.${PRE_SUITE_INPUT} != ''`
+    );
   });
 });


### PR DESCRIPTION
Closes #2493 · follow-up to #2478

## What I got wrong in #2478

I gated the new `pre_suite` job on `inputs.pre_suite_command != ''`. That reads
like the obvious guard and it is wrong, because of how the nightly health gate
reads a run.

`typescript/copy-overwrite/scripts/check-nightly-e2e-health.mjs`, for a suite
declared `match.mode: "run"`:

```js
const shortfall = jobs.find(job => job.conclusion !== GREEN_CONCLUSION);
if (jobs.length === 0 || shortfall) { /* … reason: incomplete_run */ }
```

Row 26 is right and load-bearing — it is what stops a `platform: android`
dispatch from clearing a merge gate for an iOS arm that never ran. But it cannot
tell "an arm was skipped" apart from "an optional seam was not configured". A job
that skips itself whenever an optional input is unset therefore reports
`incomplete_run` on **every green nightly**, for every adopter who does not use
the seam — which is all four callers today. A merge gate that blocks on a healthy
suite is strictly worse than the race #2478 fixed.

## Blast radius (measured)

Not yet live. All four callers still run older gate scripts without the
completeness check — `tunnlai/frontend`'s copy of `check-nightly-e2e-health.mjs`
contains neither `mode === "run"` nor `incomplete_run`. But all four consume this
reusable at `@main`, so they already have the skipping job; this closes the hole
before any of them picks up the current gate script.

## The fix

Run the **job** unconditionally in a wired run; gate the **work** per-step. An
unused seam does no checkout, no install, runs no command, says so in its log, and
concludes `success` in a few seconds.

Everything else is unchanged. The fail-closed contract in particular: a command
that fails still fails the job, and `failure` is still off the platform legs'
result allowlist.

`skipped` stays on that allowlist, but its meaning changed and the comment now
says so — it is the unwired-project case (preflight `should_run == false`), where
`run_android` / `run_ios` are false anyway. It is kept so the allowlist remains
correct if that guard ever changes.

## Regression test

The job-graph simulation now runs the case that matters — a caller passing
**nothing optional** — and asserts every job starts:

```ts
const result = run("all");
for (const [name, outcome] of Object.entries(result.jobs)) {
  expect(`${name}:${outcome.ran}`).toBe(`${name}:true`);
}
expect(String(workflow.jobs.pre_suite.if)).not.toContain("inputs.pre_suite_command != ''");
```

The second assertion names the exact spelling that caused this, so the mistake
cannot be reintroduced by someone who finds the guard "obviously missing". The
workflow header also now carries the general rule: *before adding a job here, ask
what it concludes in a run where the caller passed nothing.*

## Testing

- 80 tests pass across the seam, exports, maestro-native and nightly-gate contract
  suites, including the new row-26 case.
- Every prior guarantee still asserted: exactly-once (1 / 1 / 1 across
  `all` / `android` / `ios`), fail-closed (no leg starts on a failed pre-suite),
  and `setup_command` unchanged at 2 executions with both platforms.
- `prettier --check` and `eslint --quiet` clean on the changed files.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2493
