### PR TITLE
feat(ci): detect a required check that satisfies while doing no work

### DIFF
--- a/expo/create-only/.github/required-checks.json
+++ b/expo/create-only/.github/required-checks.json
@@ -7,7 +7,12 @@
     "A transcription expires after 90 days, because a ruleset can be edited with no signal in this repository. The shipped `.github/workflows/required-checks-drift.yml` runs `--remote` weekly to catch that; `--remote` reads the ruleset live and so answers even when the cache is untrusted.",
     "Lisa's quality.yml runs the offline arm on every pull request. This seed ships `\"enforcement\": \"warn\"`, which downgrades findings AND the NOT-CHECKED refusal to reports so a fresh install does not go red on arrival. Delete the key once you have transcribed the list — then it blocks.",
     "`skip_jobs` is matched as an exact comma-delimited token and GitHub Actions expression syntax has no string-replace, so write the list with no spaces: `skip_jobs: 'a,b'`, never `skip_jobs: 'a, b'`. A spaced token matches nothing and the job runs — reported as `whitespace_in_skip_token`.",
-    "`_example_required_contexts` below is a STARTING POINT FOR TYPING, never read by the guard. Verify every line against your own ruleset before promoting any of it."
+    "`_example_required_contexts` below is a STARTING POINT FOR TYPING, never read by the guard. Verify every line against your own ruleset before promoting any of it.",
+    "THE FAMILY: required-and-red is loud; required-and-vacuous is not; advisory-and-stale is invisible. All three are one gate reporting satisfied without proving anything. `required_contexts` + `skip_job_declarations` above cover the SKIPPED variant; `evidence_bearing_checks` below covers the VACUOUS one.",
+    "VACUOUS, measured (CodySwannGT/lisa#2497): a required `CodeRabbit` context posted `success` with the description `Review rate limited`, having reviewed nothing, on two security-relevant PRs that then merged and shipped. `gh pr checks` prints `pass` for that exactly as it does for a real review — only the DESCRIPTION tells them apart.",
+    "Run it per PR: `npm run check:vacuous-required-checks -- --pr=1234` (or `node scripts/check-skipped-required-checks.mjs --pr=1234`). It reads `gh pr checks --json name,state,bucket,description`, which is the only route that carries the description for a legacy commit status like CodeRabbit's.",
+    "`evidence_bearing_checks` names the checks whose GREEN is supposed to mean something reviewed the code. Use `{}` to accept the shipped description vocabulary, or add `proof` / `no_work` arrays to extend it — extensions ADD to the defaults, they do not replace them. Undeclared checks are never examined, because most CI jobs ship an empty description and flagging them all would bury the one finding that matters.",
+    "This arm REPORTS AND NEVER BLOCKS, in every enforcement mode. A review bot can go hollow because an org-wide SPENDING CAP was hit, and a gate that reddens every PR on a billing state is worse than the one it criticises. What it changes is what you may CLAIM: a PR carrying a `vacuous_required_check` finding has not been shown to be reviewed, so do not record it as reviewed."
   ],
   "enforcement": "warn",
   "ruleset": {
@@ -54,5 +59,8 @@
       "ruleset_required": false,
       "reason": "DAST needs a deployed target and is run against staging, not on every PR. Not a required context."
     }
+  },
+  "evidence_bearing_checks": {
+    "CodeRabbit": {}
   }
 }

--- a/nestjs/create-only/.github/required-checks.json
+++ b/nestjs/create-only/.github/required-checks.json
@@ -7,7 +7,12 @@
     "A transcription expires after 90 days, because a ruleset can be edited with no signal in this repository. The shipped `.github/workflows/required-checks-drift.yml` runs `--remote` weekly to catch that; `--remote` reads the ruleset live and so answers even when the cache is untrusted.",
     "Lisa's quality.yml runs the offline arm on every pull request. This seed ships `\"enforcement\": \"warn\"`, which downgrades findings AND the NOT-CHECKED refusal to reports so a fresh install does not go red on arrival. Delete the key once you have transcribed the list — then it blocks.",
     "`skip_jobs` is matched as an exact comma-delimited token and GitHub Actions expression syntax has no string-replace, so write the list with no spaces: `skip_jobs: 'a,b'`, never `skip_jobs: 'a, b'`. A spaced token matches nothing and the job runs — reported as `whitespace_in_skip_token`.",
-    "`_example_required_contexts` below is a STARTING POINT FOR TYPING, never read by the guard. Verify every line against your own ruleset before promoting any of it."
+    "`_example_required_contexts` below is a STARTING POINT FOR TYPING, never read by the guard. Verify every line against your own ruleset before promoting any of it.",
+    "THE FAMILY: required-and-red is loud; required-and-vacuous is not; advisory-and-stale is invisible. All three are one gate reporting satisfied without proving anything. `required_contexts` + `skip_job_declarations` above cover the SKIPPED variant; `evidence_bearing_checks` below covers the VACUOUS one.",
+    "VACUOUS, measured (CodySwannGT/lisa#2497): a required `CodeRabbit` context posted `success` with the description `Review rate limited`, having reviewed nothing, on two security-relevant PRs that then merged and shipped. `gh pr checks` prints `pass` for that exactly as it does for a real review — only the DESCRIPTION tells them apart.",
+    "Run it per PR: `npm run check:vacuous-required-checks -- --pr=1234` (or `node scripts/check-skipped-required-checks.mjs --pr=1234`). It reads `gh pr checks --json name,state,bucket,description`, which is the only route that carries the description for a legacy commit status like CodeRabbit's.",
+    "`evidence_bearing_checks` names the checks whose GREEN is supposed to mean something reviewed the code. Use `{}` to accept the shipped description vocabulary, or add `proof` / `no_work` arrays to extend it — extensions ADD to the defaults, they do not replace them. Undeclared checks are never examined, because most CI jobs ship an empty description and flagging them all would bury the one finding that matters.",
+    "This arm REPORTS AND NEVER BLOCKS, in every enforcement mode. A review bot can go hollow because an org-wide SPENDING CAP was hit, and a gate that reddens every PR on a billing state is worse than the one it criticises. What it changes is what you may CLAIM: a PR carrying a `vacuous_required_check` finding has not been shown to be reviewed, so do not record it as reviewed."
   ],
   "enforcement": "warn",
   "ruleset": {
@@ -53,5 +58,8 @@
       "ruleset_required": false,
       "reason": "The shipped ci.yml runs ZAP as its own `zap` job against a deployed target after quality passes, not inside the quality callee. Not a required context."
     }
+  },
+  "evidence_bearing_checks": {
+    "CodeRabbit": {}
   }
 }

--- a/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -291,7 +291,22 @@ Delegate to the `pull-request-review` skill with the PR number. It owns the whol
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. If that skill needs to push a commit, leave
+thread-resolution gate clears.
+
+**A green review check is not proof a review happened.** That skill's Step 1b
+returns a `reviewed` / `NOT REVIEWED` verdict — record it, and repeat it in this
+skill's final report. Measured (CodySwannGT/lisa#2497): `CodeRabbit` was a
+*required* context and posted `success — "Review rate limited"` on #2483 and
+#2484, so branch protection recorded a satisfied review gate for two
+security-relevant PRs nothing had read; both merged and shipped in `v3.5.1`.
+
+`NOT REVIEWED` is **not a blocker** — do not hold the merge on it, do not treat
+it as a failing check, and do not try to force the bot to re-run. A hollow
+review check is usually an org-wide vendor spending cap, which is a billing
+matter no amount of driving will clear, and whether such a check belongs in the
+required set at all is an open owner decision. It is a **reporting** obligation:
+the PR merged unreviewed, and the report has to say so instead of implying a
+review it did not get. If that skill needs to push a commit, leave
 auto-merge armed (section 1); when it returns, re-read `headRefOid` and reset
 `verify_commit` to the returned/pushed head, then continue. Do not re-implement review handling here
 — it is the single source of truth for review-thread handling.
@@ -452,3 +467,16 @@ At every terminal state, release the babysitter lease
 (`gh pr edit <pr> --remove-label "lisa:babysitter-on-duty"`) so the CI
 auto-fix workflow can take over as fixer of last resort if the branch goes
 red later with nobody driving it.
+
+**Every terminal report carries the step-(d) review verdict**, including a
+successful `MERGED`. "Merged, all checks green" is exactly the sentence that hid
+#2483 and #2484: both were green, both were merged, and neither had been read by
+anything. Green means *no gate objected*; it does not mean *something looked*.
+So state the verdict alongside the outcome:
+
+- `MERGED — reviewed (CodeRabbit "Review approved")`
+- `MERGED — NOT REVIEWED: CodeRabbit posted success but "Review rate limited"`
+
+This is reporting, never a terminal state of its own. `NOT REVIEWED` does not
+turn a merged PR into a blocked one, and it must never be used to withhold a
+merge — it changes what the record says, not what the loop does.

--- a/plugins/lisa-agy/skills/lisa-pull-request-review/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-pull-request-review/SKILL.md
@@ -37,8 +37,49 @@ gh api graphql -f query='
   -F owner=<owner> -F repo=<repo> -F pr=<pr>
 ```
 
-Keep only threads where `isResolved == false`. If there are none, report success
-and exit (nothing to do).
+Keep only threads where `isResolved == false`.
+
+**If there are none, you have not yet learned anything — run Step 1b before
+concluding.** Zero unresolved threads has two completely different causes, and
+this query cannot tell them apart: *a reviewer looked and found nothing*, or
+*nothing ever looked*. Reporting the first when it was the second is the defect
+in CodySwannGT/lisa#2497.
+
+## Step 1b: Did any review actually happen? (required before reporting)
+
+A required review check can post `success` having reviewed nothing. Measured on
+PRs #2483 and #2484: `CodeRabbit` reported `success — "Review rate limited"`,
+zero reviews, and both merged on that green carrying security-relevant changes.
+
+```bash
+gh pr checks <pr> --json name,state,bucket,description \
+  --jq '.[] | select(.name | test("(?i)coderabbit|review")) | "\(.name)\t\(.state)\t\(.description)"'
+```
+
+**The state column reads `SUCCESS` whether the review was real or hollow — only
+the description distinguishes them.** `Review approved` / `Review completed` is
+a real review; `Review rate limited`, `Review queued`, or a missing context is
+not. Never read `gh pr view --json statusCheckRollup` for this: CodeRabbit posts
+a legacy commit status, which that route returns *without* the description.
+
+Where the project ships Lisa's guard, prefer its machine-readable form, which
+also says whether the check is ruleset-required (so whether branch protection
+recorded a satisfied review gate for a review that did not happen):
+
+```bash
+node scripts/check-skipped-required-checks.mjs --pr=<pr> --json
+```
+
+It reports and never fails — a hollow check is often a vendor spending cap, not
+a repository defect, and it is not this skill's call to block on one.
+
+Carry the finding into your Step 4 report. **Do not write "no unresolved review
+threads" on its own** — it is true of an unreviewed PR too. Say which you
+observed:
+
+- `reviewed — CodeRabbit "Review approved", 0 unresolved threads`
+- `NOT REVIEWED — CodeRabbit success but "Review rate limited" (vacuous); 0 threads means nobody looked`
+- `NOT REVIEWED — no review check reported on this PR at all`
 
 ## Step 2: Triage and act on each unresolved thread
 
@@ -74,6 +115,13 @@ Push any commits made (`git push`), then report a per-thread summary
 judgment. This skill resolves **threads**; it does not dismiss review-decision
 gates (`CHANGES_REQUESTED`) or merge the PR — the caller (`drive-pr-to-merge`)
 owns those.
+
+**Open the report with the Step 1b verdict, before the thread counts.** A thread
+summary describes what was done about review findings; it says nothing about
+whether a review produced any. State `reviewed` or `NOT REVIEWED (<why>)` first,
+then the counts. A caller that records "reviews addressed" in evidence must
+carry that verdict through verbatim — a PR whose only review check was vacuous
+has not been reviewed, no matter how clean its thread list is.
 
 ## Composition
 

--- a/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -291,7 +291,22 @@ Delegate to the `pull-request-review` skill with the PR number. It owns the whol
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. If that skill needs to push a commit, leave
+thread-resolution gate clears.
+
+**A green review check is not proof a review happened.** That skill's Step 1b
+returns a `reviewed` / `NOT REVIEWED` verdict — record it, and repeat it in this
+skill's final report. Measured (CodySwannGT/lisa#2497): `CodeRabbit` was a
+*required* context and posted `success — "Review rate limited"` on #2483 and
+#2484, so branch protection recorded a satisfied review gate for two
+security-relevant PRs nothing had read; both merged and shipped in `v3.5.1`.
+
+`NOT REVIEWED` is **not a blocker** — do not hold the merge on it, do not treat
+it as a failing check, and do not try to force the bot to re-run. A hollow
+review check is usually an org-wide vendor spending cap, which is a billing
+matter no amount of driving will clear, and whether such a check belongs in the
+required set at all is an open owner decision. It is a **reporting** obligation:
+the PR merged unreviewed, and the report has to say so instead of implying a
+review it did not get. If that skill needs to push a commit, leave
 auto-merge armed (section 1); when it returns, re-read `headRefOid` and reset
 `verify_commit` to the returned/pushed head, then continue. Do not re-implement review handling here
 — it is the single source of truth for review-thread handling.
@@ -452,3 +467,16 @@ At every terminal state, release the babysitter lease
 (`gh pr edit <pr> --remove-label "lisa:babysitter-on-duty"`) so the CI
 auto-fix workflow can take over as fixer of last resort if the branch goes
 red later with nobody driving it.
+
+**Every terminal report carries the step-(d) review verdict**, including a
+successful `MERGED`. "Merged, all checks green" is exactly the sentence that hid
+#2483 and #2484: both were green, both were merged, and neither had been read by
+anything. Green means *no gate objected*; it does not mean *something looked*.
+So state the verdict alongside the outcome:
+
+- `MERGED — reviewed (CodeRabbit "Review approved")`
+- `MERGED — NOT REVIEWED: CodeRabbit posted success but "Review rate limited"`
+
+This is reporting, never a terminal state of its own. `NOT REVIEWED` does not
+turn a merged PR into a blocked one, and it must never be used to withhold a
+merge — it changes what the record says, not what the loop does.

--- a/plugins/lisa-copilot/skills/lisa-pull-request-review/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-pull-request-review/SKILL.md
@@ -37,8 +37,49 @@ gh api graphql -f query='
   -F owner=<owner> -F repo=<repo> -F pr=<pr>
 ```
 
-Keep only threads where `isResolved == false`. If there are none, report success
-and exit (nothing to do).
+Keep only threads where `isResolved == false`.
+
+**If there are none, you have not yet learned anything — run Step 1b before
+concluding.** Zero unresolved threads has two completely different causes, and
+this query cannot tell them apart: *a reviewer looked and found nothing*, or
+*nothing ever looked*. Reporting the first when it was the second is the defect
+in CodySwannGT/lisa#2497.
+
+## Step 1b: Did any review actually happen? (required before reporting)
+
+A required review check can post `success` having reviewed nothing. Measured on
+PRs #2483 and #2484: `CodeRabbit` reported `success — "Review rate limited"`,
+zero reviews, and both merged on that green carrying security-relevant changes.
+
+```bash
+gh pr checks <pr> --json name,state,bucket,description \
+  --jq '.[] | select(.name | test("(?i)coderabbit|review")) | "\(.name)\t\(.state)\t\(.description)"'
+```
+
+**The state column reads `SUCCESS` whether the review was real or hollow — only
+the description distinguishes them.** `Review approved` / `Review completed` is
+a real review; `Review rate limited`, `Review queued`, or a missing context is
+not. Never read `gh pr view --json statusCheckRollup` for this: CodeRabbit posts
+a legacy commit status, which that route returns *without* the description.
+
+Where the project ships Lisa's guard, prefer its machine-readable form, which
+also says whether the check is ruleset-required (so whether branch protection
+recorded a satisfied review gate for a review that did not happen):
+
+```bash
+node scripts/check-skipped-required-checks.mjs --pr=<pr> --json
+```
+
+It reports and never fails — a hollow check is often a vendor spending cap, not
+a repository defect, and it is not this skill's call to block on one.
+
+Carry the finding into your Step 4 report. **Do not write "no unresolved review
+threads" on its own** — it is true of an unreviewed PR too. Say which you
+observed:
+
+- `reviewed — CodeRabbit "Review approved", 0 unresolved threads`
+- `NOT REVIEWED — CodeRabbit success but "Review rate limited" (vacuous); 0 threads means nobody looked`
+- `NOT REVIEWED — no review check reported on this PR at all`
 
 ## Step 2: Triage and act on each unresolved thread
 
@@ -74,6 +115,13 @@ Push any commits made (`git push`), then report a per-thread summary
 judgment. This skill resolves **threads**; it does not dismiss review-decision
 gates (`CHANGES_REQUESTED`) or merge the PR — the caller (`drive-pr-to-merge`)
 owns those.
+
+**Open the report with the Step 1b verdict, before the thread counts.** A thread
+summary describes what was done about review findings; it says nothing about
+whether a review produced any. State `reviewed` or `NOT REVIEWED (<why>)` first,
+then the counts. A caller that records "reviews addressed" in evidence must
+carry that verdict through verbatim — a PR whose only review check was vacuous
+has not been reviewed, no matter how clean its thread list is.
 
 ## Composition
 

--- a/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -291,7 +291,22 @@ Delegate to the `pull-request-review` skill with the PR number. It owns the whol
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. If that skill needs to push a commit, leave
+thread-resolution gate clears.
+
+**A green review check is not proof a review happened.** That skill's Step 1b
+returns a `reviewed` / `NOT REVIEWED` verdict — record it, and repeat it in this
+skill's final report. Measured (CodySwannGT/lisa#2497): `CodeRabbit` was a
+*required* context and posted `success — "Review rate limited"` on #2483 and
+#2484, so branch protection recorded a satisfied review gate for two
+security-relevant PRs nothing had read; both merged and shipped in `v3.5.1`.
+
+`NOT REVIEWED` is **not a blocker** — do not hold the merge on it, do not treat
+it as a failing check, and do not try to force the bot to re-run. A hollow
+review check is usually an org-wide vendor spending cap, which is a billing
+matter no amount of driving will clear, and whether such a check belongs in the
+required set at all is an open owner decision. It is a **reporting** obligation:
+the PR merged unreviewed, and the report has to say so instead of implying a
+review it did not get. If that skill needs to push a commit, leave
 auto-merge armed (section 1); when it returns, re-read `headRefOid` and reset
 `verify_commit` to the returned/pushed head, then continue. Do not re-implement review handling here
 — it is the single source of truth for review-thread handling.
@@ -452,3 +467,16 @@ At every terminal state, release the babysitter lease
 (`gh pr edit <pr> --remove-label "lisa:babysitter-on-duty"`) so the CI
 auto-fix workflow can take over as fixer of last resort if the branch goes
 red later with nobody driving it.
+
+**Every terminal report carries the step-(d) review verdict**, including a
+successful `MERGED`. "Merged, all checks green" is exactly the sentence that hid
+#2483 and #2484: both were green, both were merged, and neither had been read by
+anything. Green means *no gate objected*; it does not mean *something looked*.
+So state the verdict alongside the outcome:
+
+- `MERGED — reviewed (CodeRabbit "Review approved")`
+- `MERGED — NOT REVIEWED: CodeRabbit posted success but "Review rate limited"`
+
+This is reporting, never a terminal state of its own. `NOT REVIEWED` does not
+turn a merged PR into a blocked one, and it must never be used to withhold a
+merge — it changes what the record says, not what the loop does.

--- a/plugins/lisa-cursor/skills/lisa-pull-request-review/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-pull-request-review/SKILL.md
@@ -37,8 +37,49 @@ gh api graphql -f query='
   -F owner=<owner> -F repo=<repo> -F pr=<pr>
 ```
 
-Keep only threads where `isResolved == false`. If there are none, report success
-and exit (nothing to do).
+Keep only threads where `isResolved == false`.
+
+**If there are none, you have not yet learned anything — run Step 1b before
+concluding.** Zero unresolved threads has two completely different causes, and
+this query cannot tell them apart: *a reviewer looked and found nothing*, or
+*nothing ever looked*. Reporting the first when it was the second is the defect
+in CodySwannGT/lisa#2497.
+
+## Step 1b: Did any review actually happen? (required before reporting)
+
+A required review check can post `success` having reviewed nothing. Measured on
+PRs #2483 and #2484: `CodeRabbit` reported `success — "Review rate limited"`,
+zero reviews, and both merged on that green carrying security-relevant changes.
+
+```bash
+gh pr checks <pr> --json name,state,bucket,description \
+  --jq '.[] | select(.name | test("(?i)coderabbit|review")) | "\(.name)\t\(.state)\t\(.description)"'
+```
+
+**The state column reads `SUCCESS` whether the review was real or hollow — only
+the description distinguishes them.** `Review approved` / `Review completed` is
+a real review; `Review rate limited`, `Review queued`, or a missing context is
+not. Never read `gh pr view --json statusCheckRollup` for this: CodeRabbit posts
+a legacy commit status, which that route returns *without* the description.
+
+Where the project ships Lisa's guard, prefer its machine-readable form, which
+also says whether the check is ruleset-required (so whether branch protection
+recorded a satisfied review gate for a review that did not happen):
+
+```bash
+node scripts/check-skipped-required-checks.mjs --pr=<pr> --json
+```
+
+It reports and never fails — a hollow check is often a vendor spending cap, not
+a repository defect, and it is not this skill's call to block on one.
+
+Carry the finding into your Step 4 report. **Do not write "no unresolved review
+threads" on its own** — it is true of an unreviewed PR too. Say which you
+observed:
+
+- `reviewed — CodeRabbit "Review approved", 0 unresolved threads`
+- `NOT REVIEWED — CodeRabbit success but "Review rate limited" (vacuous); 0 threads means nobody looked`
+- `NOT REVIEWED — no review check reported on this PR at all`
 
 ## Step 2: Triage and act on each unresolved thread
 
@@ -74,6 +115,13 @@ Push any commits made (`git push`), then report a per-thread summary
 judgment. This skill resolves **threads**; it does not dismiss review-decision
 gates (`CHANGES_REQUESTED`) or merge the PR — the caller (`drive-pr-to-merge`)
 owns those.
+
+**Open the report with the Step 1b verdict, before the thread counts.** A thread
+summary describes what was done about review findings; it says nothing about
+whether a review produced any. State `reviewed` or `NOT REVIEWED (<why>)` first,
+then the counts. A caller that records "reviews addressed" in evidence must
+carry that verdict through verbatim — a PR whose only review check was vacuous
+has not been reviewed, no matter how clean its thread list is.
 
 ## Composition
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -291,7 +291,22 @@ Delegate to the `pull-request-review` skill with the PR number. It owns the whol
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. If that skill needs to push a commit, leave
+thread-resolution gate clears.
+
+**A green review check is not proof a review happened.** That skill's Step 1b
+returns a `reviewed` / `NOT REVIEWED` verdict — record it, and repeat it in this
+skill's final report. Measured (CodySwannGT/lisa#2497): `CodeRabbit` was a
+*required* context and posted `success — "Review rate limited"` on #2483 and
+#2484, so branch protection recorded a satisfied review gate for two
+security-relevant PRs nothing had read; both merged and shipped in `v3.5.1`.
+
+`NOT REVIEWED` is **not a blocker** — do not hold the merge on it, do not treat
+it as a failing check, and do not try to force the bot to re-run. A hollow
+review check is usually an org-wide vendor spending cap, which is a billing
+matter no amount of driving will clear, and whether such a check belongs in the
+required set at all is an open owner decision. It is a **reporting** obligation:
+the PR merged unreviewed, and the report has to say so instead of implying a
+review it did not get. If that skill needs to push a commit, leave
 auto-merge armed (section 1); when it returns, re-read `headRefOid` and reset
 `verify_commit` to the returned/pushed head, then continue. Do not re-implement review handling here
 — it is the single source of truth for review-thread handling.
@@ -452,3 +467,16 @@ At every terminal state, release the babysitter lease
 (`gh pr edit <pr> --remove-label "lisa:babysitter-on-duty"`) so the CI
 auto-fix workflow can take over as fixer of last resort if the branch goes
 red later with nobody driving it.
+
+**Every terminal report carries the step-(d) review verdict**, including a
+successful `MERGED`. "Merged, all checks green" is exactly the sentence that hid
+#2483 and #2484: both were green, both were merged, and neither had been read by
+anything. Green means *no gate objected*; it does not mean *something looked*.
+So state the verdict alongside the outcome:
+
+- `MERGED — reviewed (CodeRabbit "Review approved")`
+- `MERGED — NOT REVIEWED: CodeRabbit posted success but "Review rate limited"`
+
+This is reporting, never a terminal state of its own. `NOT REVIEWED` does not
+turn a merged PR into a blocked one, and it must never be used to withhold a
+merge — it changes what the record says, not what the loop does.

--- a/plugins/lisa/.codex-plugin/skills/lisa-pull-request-review/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-pull-request-review/SKILL.md
@@ -37,8 +37,49 @@ gh api graphql -f query='
   -F owner=<owner> -F repo=<repo> -F pr=<pr>
 ```
 
-Keep only threads where `isResolved == false`. If there are none, report success
-and exit (nothing to do).
+Keep only threads where `isResolved == false`.
+
+**If there are none, you have not yet learned anything — run Step 1b before
+concluding.** Zero unresolved threads has two completely different causes, and
+this query cannot tell them apart: *a reviewer looked and found nothing*, or
+*nothing ever looked*. Reporting the first when it was the second is the defect
+in CodySwannGT/lisa#2497.
+
+## Step 1b: Did any review actually happen? (required before reporting)
+
+A required review check can post `success` having reviewed nothing. Measured on
+PRs #2483 and #2484: `CodeRabbit` reported `success — "Review rate limited"`,
+zero reviews, and both merged on that green carrying security-relevant changes.
+
+```bash
+gh pr checks <pr> --json name,state,bucket,description \
+  --jq '.[] | select(.name | test("(?i)coderabbit|review")) | "\(.name)\t\(.state)\t\(.description)"'
+```
+
+**The state column reads `SUCCESS` whether the review was real or hollow — only
+the description distinguishes them.** `Review approved` / `Review completed` is
+a real review; `Review rate limited`, `Review queued`, or a missing context is
+not. Never read `gh pr view --json statusCheckRollup` for this: CodeRabbit posts
+a legacy commit status, which that route returns *without* the description.
+
+Where the project ships Lisa's guard, prefer its machine-readable form, which
+also says whether the check is ruleset-required (so whether branch protection
+recorded a satisfied review gate for a review that did not happen):
+
+```bash
+node scripts/check-skipped-required-checks.mjs --pr=<pr> --json
+```
+
+It reports and never fails — a hollow check is often a vendor spending cap, not
+a repository defect, and it is not this skill's call to block on one.
+
+Carry the finding into your Step 4 report. **Do not write "no unresolved review
+threads" on its own** — it is true of an unreviewed PR too. Say which you
+observed:
+
+- `reviewed — CodeRabbit "Review approved", 0 unresolved threads`
+- `NOT REVIEWED — CodeRabbit success but "Review rate limited" (vacuous); 0 threads means nobody looked`
+- `NOT REVIEWED — no review check reported on this PR at all`
 
 ## Step 2: Triage and act on each unresolved thread
 
@@ -74,6 +115,13 @@ Push any commits made (`git push`), then report a per-thread summary
 judgment. This skill resolves **threads**; it does not dismiss review-decision
 gates (`CHANGES_REQUESTED`) or merge the PR — the caller (`drive-pr-to-merge`)
 owns those.
+
+**Open the report with the Step 1b verdict, before the thread counts.** A thread
+summary describes what was done about review findings; it says nothing about
+whether a review produced any. State `reviewed` or `NOT REVIEWED (<why>)` first,
+then the counts. A caller that records "reviews addressed" in evidence must
+carry that verdict through verbatim — a PR whose only review check was vacuous
+has not been reviewed, no matter how clean its thread list is.
 
 ## Composition
 

--- a/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/lisa/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -291,7 +291,22 @@ Delegate to the `pull-request-review` skill with the PR number. It owns the whol
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. If that skill needs to push a commit, leave
+thread-resolution gate clears.
+
+**A green review check is not proof a review happened.** That skill's Step 1b
+returns a `reviewed` / `NOT REVIEWED` verdict — record it, and repeat it in this
+skill's final report. Measured (CodySwannGT/lisa#2497): `CodeRabbit` was a
+*required* context and posted `success — "Review rate limited"` on #2483 and
+#2484, so branch protection recorded a satisfied review gate for two
+security-relevant PRs nothing had read; both merged and shipped in `v3.5.1`.
+
+`NOT REVIEWED` is **not a blocker** — do not hold the merge on it, do not treat
+it as a failing check, and do not try to force the bot to re-run. A hollow
+review check is usually an org-wide vendor spending cap, which is a billing
+matter no amount of driving will clear, and whether such a check belongs in the
+required set at all is an open owner decision. It is a **reporting** obligation:
+the PR merged unreviewed, and the report has to say so instead of implying a
+review it did not get. If that skill needs to push a commit, leave
 auto-merge armed (section 1); when it returns, re-read `headRefOid` and reset
 `verify_commit` to the returned/pushed head, then continue. Do not re-implement review handling here
 — it is the single source of truth for review-thread handling.
@@ -452,3 +467,16 @@ At every terminal state, release the babysitter lease
 (`gh pr edit <pr> --remove-label "lisa:babysitter-on-duty"`) so the CI
 auto-fix workflow can take over as fixer of last resort if the branch goes
 red later with nobody driving it.
+
+**Every terminal report carries the step-(d) review verdict**, including a
+successful `MERGED`. "Merged, all checks green" is exactly the sentence that hid
+#2483 and #2484: both were green, both were merged, and neither had been read by
+anything. Green means *no gate objected*; it does not mean *something looked*.
+So state the verdict alongside the outcome:
+
+- `MERGED — reviewed (CodeRabbit "Review approved")`
+- `MERGED — NOT REVIEWED: CodeRabbit posted success but "Review rate limited"`
+
+This is reporting, never a terminal state of its own. `NOT REVIEWED` does not
+turn a merged PR into a blocked one, and it must never be used to withhold a
+merge — it changes what the record says, not what the loop does.

--- a/plugins/lisa/skills/lisa-pull-request-review/SKILL.md
+++ b/plugins/lisa/skills/lisa-pull-request-review/SKILL.md
@@ -37,8 +37,49 @@ gh api graphql -f query='
   -F owner=<owner> -F repo=<repo> -F pr=<pr>
 ```
 
-Keep only threads where `isResolved == false`. If there are none, report success
-and exit (nothing to do).
+Keep only threads where `isResolved == false`.
+
+**If there are none, you have not yet learned anything — run Step 1b before
+concluding.** Zero unresolved threads has two completely different causes, and
+this query cannot tell them apart: *a reviewer looked and found nothing*, or
+*nothing ever looked*. Reporting the first when it was the second is the defect
+in CodySwannGT/lisa#2497.
+
+## Step 1b: Did any review actually happen? (required before reporting)
+
+A required review check can post `success` having reviewed nothing. Measured on
+PRs #2483 and #2484: `CodeRabbit` reported `success — "Review rate limited"`,
+zero reviews, and both merged on that green carrying security-relevant changes.
+
+```bash
+gh pr checks <pr> --json name,state,bucket,description \
+  --jq '.[] | select(.name | test("(?i)coderabbit|review")) | "\(.name)\t\(.state)\t\(.description)"'
+```
+
+**The state column reads `SUCCESS` whether the review was real or hollow — only
+the description distinguishes them.** `Review approved` / `Review completed` is
+a real review; `Review rate limited`, `Review queued`, or a missing context is
+not. Never read `gh pr view --json statusCheckRollup` for this: CodeRabbit posts
+a legacy commit status, which that route returns *without* the description.
+
+Where the project ships Lisa's guard, prefer its machine-readable form, which
+also says whether the check is ruleset-required (so whether branch protection
+recorded a satisfied review gate for a review that did not happen):
+
+```bash
+node scripts/check-skipped-required-checks.mjs --pr=<pr> --json
+```
+
+It reports and never fails — a hollow check is often a vendor spending cap, not
+a repository defect, and it is not this skill's call to block on one.
+
+Carry the finding into your Step 4 report. **Do not write "no unresolved review
+threads" on its own** — it is true of an unreviewed PR too. Say which you
+observed:
+
+- `reviewed — CodeRabbit "Review approved", 0 unresolved threads`
+- `NOT REVIEWED — CodeRabbit success but "Review rate limited" (vacuous); 0 threads means nobody looked`
+- `NOT REVIEWED — no review check reported on this PR at all`
 
 ## Step 2: Triage and act on each unresolved thread
 
@@ -74,6 +115,13 @@ Push any commits made (`git push`), then report a per-thread summary
 judgment. This skill resolves **threads**; it does not dismiss review-decision
 gates (`CHANGES_REQUESTED`) or merge the PR — the caller (`drive-pr-to-merge`)
 owns those.
+
+**Open the report with the Step 1b verdict, before the thread counts.** A thread
+summary describes what was done about review findings; it says nothing about
+whether a review produced any. State `reviewed` or `NOT REVIEWED (<why>)` first,
+then the counts. A caller that records "reviews addressed" in evidence must
+carry that verdict through verbatim — a PR whose only review check was vacuous
+has not been reviewed, no matter how clean its thread list is.
 
 ## Composition
 

--- a/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
+++ b/plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md
@@ -291,7 +291,22 @@ Delegate to the `pull-request-review` skill with the PR number. It owns the whol
 comment cycle: fetch every unresolved human + bot thread (with resolution state via
 GraphQL), implement valid feedback (commit + push), reply to invalid feedback, and
 resolve every thread via `resolveReviewThread` so the branch-protection
-thread-resolution gate clears. If that skill needs to push a commit, leave
+thread-resolution gate clears.
+
+**A green review check is not proof a review happened.** That skill's Step 1b
+returns a `reviewed` / `NOT REVIEWED` verdict — record it, and repeat it in this
+skill's final report. Measured (CodySwannGT/lisa#2497): `CodeRabbit` was a
+*required* context and posted `success — "Review rate limited"` on #2483 and
+#2484, so branch protection recorded a satisfied review gate for two
+security-relevant PRs nothing had read; both merged and shipped in `v3.5.1`.
+
+`NOT REVIEWED` is **not a blocker** — do not hold the merge on it, do not treat
+it as a failing check, and do not try to force the bot to re-run. A hollow
+review check is usually an org-wide vendor spending cap, which is a billing
+matter no amount of driving will clear, and whether such a check belongs in the
+required set at all is an open owner decision. It is a **reporting** obligation:
+the PR merged unreviewed, and the report has to say so instead of implying a
+review it did not get. If that skill needs to push a commit, leave
 auto-merge armed (section 1); when it returns, re-read `headRefOid` and reset
 `verify_commit` to the returned/pushed head, then continue. Do not re-implement review handling here
 — it is the single source of truth for review-thread handling.
@@ -452,3 +467,16 @@ At every terminal state, release the babysitter lease
 (`gh pr edit <pr> --remove-label "lisa:babysitter-on-duty"`) so the CI
 auto-fix workflow can take over as fixer of last resort if the branch goes
 red later with nobody driving it.
+
+**Every terminal report carries the step-(d) review verdict**, including a
+successful `MERGED`. "Merged, all checks green" is exactly the sentence that hid
+#2483 and #2484: both were green, both were merged, and neither had been read by
+anything. Green means *no gate objected*; it does not mean *something looked*.
+So state the verdict alongside the outcome:
+
+- `MERGED — reviewed (CodeRabbit "Review approved")`
+- `MERGED — NOT REVIEWED: CodeRabbit posted success but "Review rate limited"`
+
+This is reporting, never a terminal state of its own. `NOT REVIEWED` does not
+turn a merged PR into a blocked one, and it must never be used to withhold a
+merge — it changes what the record says, not what the loop does.

--- a/plugins/src/base/skills/lisa-pull-request-review/SKILL.md
+++ b/plugins/src/base/skills/lisa-pull-request-review/SKILL.md
@@ -37,8 +37,49 @@ gh api graphql -f query='
   -F owner=<owner> -F repo=<repo> -F pr=<pr>
 ```
 
-Keep only threads where `isResolved == false`. If there are none, report success
-and exit (nothing to do).
+Keep only threads where `isResolved == false`.
+
+**If there are none, you have not yet learned anything — run Step 1b before
+concluding.** Zero unresolved threads has two completely different causes, and
+this query cannot tell them apart: *a reviewer looked and found nothing*, or
+*nothing ever looked*. Reporting the first when it was the second is the defect
+in CodySwannGT/lisa#2497.
+
+## Step 1b: Did any review actually happen? (required before reporting)
+
+A required review check can post `success` having reviewed nothing. Measured on
+PRs #2483 and #2484: `CodeRabbit` reported `success — "Review rate limited"`,
+zero reviews, and both merged on that green carrying security-relevant changes.
+
+```bash
+gh pr checks <pr> --json name,state,bucket,description \
+  --jq '.[] | select(.name | test("(?i)coderabbit|review")) | "\(.name)\t\(.state)\t\(.description)"'
+```
+
+**The state column reads `SUCCESS` whether the review was real or hollow — only
+the description distinguishes them.** `Review approved` / `Review completed` is
+a real review; `Review rate limited`, `Review queued`, or a missing context is
+not. Never read `gh pr view --json statusCheckRollup` for this: CodeRabbit posts
+a legacy commit status, which that route returns *without* the description.
+
+Where the project ships Lisa's guard, prefer its machine-readable form, which
+also says whether the check is ruleset-required (so whether branch protection
+recorded a satisfied review gate for a review that did not happen):
+
+```bash
+node scripts/check-skipped-required-checks.mjs --pr=<pr> --json
+```
+
+It reports and never fails — a hollow check is often a vendor spending cap, not
+a repository defect, and it is not this skill's call to block on one.
+
+Carry the finding into your Step 4 report. **Do not write "no unresolved review
+threads" on its own** — it is true of an unreviewed PR too. Say which you
+observed:
+
+- `reviewed — CodeRabbit "Review approved", 0 unresolved threads`
+- `NOT REVIEWED — CodeRabbit success but "Review rate limited" (vacuous); 0 threads means nobody looked`
+- `NOT REVIEWED — no review check reported on this PR at all`
 
 ## Step 2: Triage and act on each unresolved thread
 
@@ -74,6 +115,13 @@ Push any commits made (`git push`), then report a per-thread summary
 judgment. This skill resolves **threads**; it does not dismiss review-decision
 gates (`CHANGES_REQUESTED`) or merge the PR — the caller (`drive-pr-to-merge`)
 owns those.
+
+**Open the report with the Step 1b verdict, before the thread counts.** A thread
+summary describes what was done about review findings; it says nothing about
+whether a review produced any. State `reviewed` or `NOT REVIEWED (<why>)` first,
+then the counts. A caller that records "reviews addressed" in evidence must
+carry that verdict through verbatim — a PR whose only review check was vacuous
+has not been reviewed, no matter how clean its thread list is.
 
 ## Composition
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -201,7 +201,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/copy-overwrite/tsconfig.json":
       "c92e2c2c109e8794ee351f634361ef46297f5a0cd606aaf5c19911da836df307",
     "expo/create-only/.github/required-checks.json":
-      "68194b5e096c8d49579e06aed5e41df71c43c4dc46bbbcb390b4a27cd1e78c7f",
+      "9f23b0477f93c3193ab22251dd03251038cfe45c5a2603cb49fdf97cae799442",
     "expo/create-only/.github/workflows/ci.yml":
       "bf75c9d3b4f4a2cb24c2214d9fc27a9cb2247a6694b0cf02c40032b4d3e87cd9",
     "expo/create-only/.github/workflows/deploy.yml":
@@ -365,7 +365,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "nestjs/create-only/.github/k6/thresholds/strict.json":
       "e121ec72de4596b95c013a8c71f03653bcdf057cf7f8d1fec6f0e13c1381867f",
     "nestjs/create-only/.github/required-checks.json":
-      "7d9af483f6150e2f7281f008dd08b56590721f3c86f6b1a3b7548f7838a0137f",
+      "6d40f9e3e89e1a7f533f6a995e1b9e5cc2fa089693b0cfbd8e8f883ae200589a",
     "nestjs/create-only/.github/workflows/ci.yml":
       "0985668e6d0478f1993bed8ccd398601d8e73376afd8775e1269ae129418152e",
     "nestjs/create-only/.github/workflows/deploy.yml":
@@ -985,7 +985,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
       "ed46df59bfd1097acad4a5ad960811ffb37b318c94e36e5f78ea3b96c2d76136",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
-      "66a89df3976ddb17af5c31415eeb6192c4c9e0ebba7ab3ee38b4fa6ebadb4955",
+      "3919c6161900916090ee315df322938efc5b53bdfabf78efe8683432cf8ae488",
     "plugins/src/base/skills/lisa-epic-triage/SKILL.md":
       "d02760411249bddbd396f283191fe3e82bb7b95bf9393a19a7025dc5a57c3ab7",
     "plugins/src/base/skills/lisa-evaluation-suite/SKILL.md":
@@ -1183,7 +1183,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-project-ideation/examples/unavailable-data-rejection.md":
       "362835db13cb8f73179754bce427d0f7caef7738a575aa5b936a0383b7f81078",
     "plugins/src/base/skills/lisa-pull-request-review/SKILL.md":
-      "f53f2674888609686cb86204e19863de1494b3975f4ec255711d65165403395d",
+      "10bb42cba995cdd6b945efd6ef3d48578860b9d09c94aefd17c298b53aed5053",
     "plugins/src/base/skills/lisa-qa-checklist/SKILL.md":
       "da1de96ada92d18f5f6b57e2751b95d5da28a6505debdb7ccd823b95bdd1405b",
     "plugins/src/base/skills/lisa-qa-clear/SKILL.md":
@@ -2259,7 +2259,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/scripts/check-nightly-e2e-health.mjs":
       "c9dd6f6816b35d4d8f684892878d4181b9cb5266a7f2e2814970aa49dc04a001",
     "typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs":
-      "0a8b14790f38e00e5abfc665d3e3d2c29e0a139a2a22c4a65e0c08547b42fb7f",
+      "8eaac3ea96d92b55c418877c1fe338a7c0b3a8f48ef3593258f54a633f761c85",
     "typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs":
       "e1e3f22b33267212b90f915f83821559d1a45cab5b16c7164b86bd6c7b53549b",
     "typescript/copy-overwrite/scripts/check-verification-coverage.mjs":
@@ -2281,7 +2281,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/vitest.config.ts":
       "da92f06cc3ce68462c6f2f3d95adb1b1464591ce383a24e3334dc986e0c1e0fb",
     "typescript/create-only/.github/required-checks.json":
-      "49063a033604c8e98f7782e4352d67dea77ac9b949189f166e43044f0af7e4f4",
+      "0ec5fbf2fe2dcb366db0d0002357b881053143223a09a25e1dc488a87b142eb2",
     "typescript/create-only/.github/workflows/auto-update-pr-branches-dispatch.yml":
       "347f8a3830efdc3ad701fae0858994f4e45df8100844e91948b017b98115a28c",
     "typescript/create-only/.github/workflows/auto-update-pr-branches.yml":
@@ -2337,7 +2337,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/merge/.oxlintrc.json":
       "9504c20db80470c242c4ffe8cccad6951ed8141dfb5bf6503053e0b2712ab276",
     "typescript/package-lisa/package.lisa.json":
-      "7f121eec2d022cad7e3cf960806fefe7f30ef626cc89f951d322b40f5a9bd5ca",
+      "339c86d92be6419bbbcb974162522f5339a5ab6795beb27d60d3594bb6da139f",
     "ui/README.md":
       "deeb35e767ea5dd2883268835ea3ad21cbad9fa63ec8d8ff5e200f0e2a7d2751",
     "ui/index.html":
@@ -8916,6 +8916,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/threshold-ratchet-wiring.test.ts": true,
     "tests/unit/scripts/threshold-ratchet.test.ts": true,
     "tests/unit/scripts/upstream-evidence-manifest.test.ts": true,
+    "tests/unit/scripts/vacuous-required-checks.test.ts": true,
     "tests/unit/scripts/verification-coverage.test.ts": true,
     "tests/unit/scripts/work-item-github-failure-diagnosis.test.ts": true,
     "tests/unit/scripts/work-item-tracker-unreachable.test.ts": true,

--- a/tests/unit/scripts/vacuous-required-checks.test.ts
+++ b/tests/unit/scripts/vacuous-required-checks.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Tests for the VACUOUS-required-check arm of the skipped-required-check guard.
+ *
+ * The defect it reports (CodySwannGT/lisa#2497, measured): a required status
+ * check posted `success` while performing zero reviews.
+ *
+ * ```
+ * PR #2483  reviews: 0   status: success — "Review rate limited"
+ * PR #2484  reviews: 0   status: success — "Review rate limited"
+ * ```
+ *
+ * Both merged on that green, both carried security-relevant changes, both are
+ * in published tag `v3.5.1`. Branch protection recorded "reviewed" for work
+ * nothing reviewed. **The status column says `pass` either way — only the
+ * DESCRIPTION distinguishes a real review from a hollow one.**
+ *
+ * Every case below is written against the byte-exact strings GitHub really
+ * returned for those PRs, read through `gh pr checks --json`.
+ */
+import { pathToFileURL } from "node:url";
+import * as path from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SCRIPT_REL =
+  "typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs";
+
+/** One violation, as this suite consumes it. */
+interface Violation {
+  readonly kind: string;
+  readonly token: string | null;
+  readonly message: string;
+}
+
+/** One check as `gh pr checks --json name,state,bucket,description` returns it. */
+interface CheckRow {
+  readonly name: string;
+  readonly state: string;
+  readonly bucket?: string;
+  readonly description?: string;
+}
+
+/** The guard's vacuity exports. */
+interface GuardModule {
+  readonly VIOLATIONS: Record<string, string>;
+  readonly NEVER_BLOCKING: readonly string[];
+  readonly REVIEW_DESCRIPTION_DEFAULTS: {
+    readonly proof: readonly string[];
+    readonly no_work: readonly string[];
+  };
+  classifyCheckDescription(
+    description: string | undefined,
+    vocabulary?: Record<string, readonly string[]>
+  ): string;
+  evaluateVacuousChecks(
+    declaration: Record<string, unknown>,
+    checks: readonly CheckRow[],
+    options?: { trustRequiredContexts?: boolean }
+  ): { violations: Violation[]; checked: number };
+}
+
+/** The measured CodeRabbit context name. */
+const CODERABBIT = "CodeRabbit";
+
+/** The measured hollow description — `success` while reviewing nothing. */
+const RATE_LIMITED = "Review rate limited";
+
+/**
+ * Builds a declaration that treats CodeRabbit as evidence-bearing.
+ *
+ * @param overrides - Keys merged over the base declaration
+ * @returns A declaration object
+ */
+function declarationWith(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    required_contexts: [CODERABBIT],
+    workflows: [".github/workflows/ci.yml"],
+    skip_job_declarations: {},
+    evidence_bearing_checks: { [CODERABBIT]: {} },
+    ...overrides,
+  };
+}
+
+describe("vacuous required checks", () => {
+  let mod: GuardModule;
+
+  beforeAll(async () => {
+    mod = (await import(
+      pathToFileURL(path.join(REPO_ROOT, SCRIPT_REL)).href
+    )) as unknown as GuardModule;
+  });
+
+  describe("classifying a description", () => {
+    it("reads the two measured CodeRabbit strings on opposite sides", () => {
+      // The whole point of #2497: `pass` either way, description differs.
+      expect(mod.classifyCheckDescription(RATE_LIMITED)).toBe("no-work");
+      expect(mod.classifyCheckDescription("Review approved")).toBe("proved");
+    });
+
+    it("treats an unrecognised description as UNPROVEN, never as proof", () => {
+      // Fail-safe: a vocabulary nobody enumerated must not read as a pass.
+      expect(mod.classifyCheckDescription("Somebody rephrased this")).toBe(
+        "unproven"
+      );
+      expect(mod.classifyCheckDescription("")).toBe("unproven");
+      expect(mod.classifyCheckDescription(undefined)).toBe("unproven");
+    });
+
+    it("matches proof STRICTLY and no-work LOOSELY", () => {
+      // Strict where a match grants credit; loose where a match denies it.
+      // A suffixed proof string is no longer the phrase that was reviewed...
+      expect(mod.classifyCheckDescription("Review approved with caveats")).toBe(
+        "unproven"
+      );
+      // ...but a suffixed no-work string still means no work was done.
+      expect(
+        mod.classifyCheckDescription("Review rate limited (retry in 12m)")
+      ).toBe("no-work");
+    });
+
+    it("ignores case and surrounding whitespace on both sides", () => {
+      expect(mod.classifyCheckDescription("  REVIEW APPROVED  ")).toBe(
+        "proved"
+      );
+      expect(mod.classifyCheckDescription("REVIEW RATE LIMITED")).toBe(
+        "no-work"
+      );
+    });
+
+    it("lets a repository extend the vocabulary without losing the defaults", () => {
+      const vocabulary = { proof: ["Deep scan finished"] };
+      expect(
+        mod.classifyCheckDescription("Deep scan finished", vocabulary)
+      ).toBe("proved");
+      // The shipped no-work list still applies to the same check.
+      expect(mod.classifyCheckDescription(RATE_LIMITED, vocabulary)).toBe(
+        "no-work"
+      );
+    });
+
+    it("ships a vocabulary whose two lists never overlap", () => {
+      // An overlapping phrase would make the verdict depend on evaluation
+      // order, which is how a guard silently starts granting credit.
+      const proof = mod.REVIEW_DESCRIPTION_DEFAULTS.proof.map(value =>
+        value.toLowerCase()
+      );
+      for (const phrase of mod.REVIEW_DESCRIPTION_DEFAULTS.no_work) {
+        expect(proof).not.toContain(phrase.toLowerCase());
+      }
+    });
+  });
+
+  describe("evaluating one PR's checks", () => {
+    it("reports the measured #2483 shape — SUCCESS that reviewed nothing", () => {
+      const result = mod.evaluateVacuousChecks(declarationWith(), [
+        {
+          name: CODERABBIT,
+          state: "SUCCESS",
+          bucket: "pass",
+          description: RATE_LIMITED,
+        },
+      ]);
+      expect(result.violations.map(violation => violation.kind)).toEqual([
+        mod.VIOLATIONS.vacuous,
+      ]);
+      expect(result.checked).toBe(1);
+    });
+
+    it("says branch protection recorded it when the check is ruleset-required", () => {
+      const [violation] = mod.evaluateVacuousChecks(declarationWith(), [
+        {
+          name: CODERABBIT,
+          state: "SUCCESS",
+          description: RATE_LIMITED,
+        },
+      ]).violations;
+      expect(violation.message).toMatch(/branch protection/i);
+    });
+
+    it("still reports a vacuous check that is NOT ruleset-required", () => {
+      // advisory-and-stale is the invisible end of the family, not a non-issue.
+      const result = mod.evaluateVacuousChecks(
+        declarationWith({ required_contexts: [] }),
+        [
+          {
+            name: CODERABBIT,
+            state: "SUCCESS",
+            description: RATE_LIMITED,
+          },
+        ]
+      );
+      expect(result.violations).toHaveLength(1);
+      expect(result.violations[0].message).not.toMatch(/branch protection/i);
+    });
+
+    it("does not claim required-ness it cannot prove when the snapshot is untrusted", () => {
+      const [violation] = mod.evaluateVacuousChecks(
+        declarationWith(),
+        [
+          {
+            name: CODERABBIT,
+            state: "SUCCESS",
+            description: RATE_LIMITED,
+          },
+        ],
+        { trustRequiredContexts: false }
+      ).violations;
+      expect(violation.kind).toBe(mod.VIOLATIONS.vacuous);
+      expect(violation.message).not.toMatch(/branch protection/i);
+      expect(violation.message).toMatch(/not transcribed|cannot say/i);
+    });
+
+    it("passes a check that proved it did work", () => {
+      const result = mod.evaluateVacuousChecks(declarationWith(), [
+        { name: CODERABBIT, state: "SUCCESS", description: "Review approved" },
+      ]);
+      expect(result.violations).toEqual([]);
+    });
+
+    it("reports an unrecognised green description as UNPROVEN", () => {
+      const result = mod.evaluateVacuousChecks(declarationWith(), [
+        { name: CODERABBIT, state: "SUCCESS", description: "Reviewed, maybe" },
+      ]);
+      expect(result.violations.map(violation => violation.kind)).toEqual([
+        mod.VIOLATIONS.unproven,
+      ]);
+    });
+
+    it("reports a declared evidence check that never reported at all", () => {
+      // Measured on #2493/#2491/#2488: CodeRabbit posted no context whatsoever.
+      const result = mod.evaluateVacuousChecks(declarationWith(), [
+        { name: "🔍 Quality Checks / 🧹 Lint", state: "SUCCESS" },
+      ]);
+      expect(result.violations.map(violation => violation.kind)).toEqual([
+        mod.VIOLATIONS.unproven,
+      ]);
+      expect(result.violations[0].message).toMatch(/did not report/i);
+    });
+
+    it("stays silent about a check that is genuinely RED", () => {
+      // required-and-red is the loud case; it needs no help from this arm.
+      const result = mod.evaluateVacuousChecks(declarationWith(), [
+        {
+          name: CODERABBIT,
+          state: "FAILURE",
+          description: "Changes requested",
+        },
+      ]);
+      expect(result.violations).toEqual([]);
+    });
+
+    it("reports a check still PENDING rather than calling it proof", () => {
+      const result = mod.evaluateVacuousChecks(declarationWith(), [
+        { name: CODERABBIT, state: "PENDING", description: "Review queued" },
+      ]);
+      expect(result.violations.map(violation => violation.kind)).toEqual([
+        mod.VIOLATIONS.unproven,
+      ]);
+    });
+
+    it("ignores every check the repository has not declared evidence-bearing", () => {
+      // Most CI jobs ship an empty description; flagging them all would be
+      // noise, and the obvious fix for a noisy guard is to delete it.
+      const result = mod.evaluateVacuousChecks(
+        declarationWith({ evidence_bearing_checks: {} }),
+        [
+          { name: "🔍 Quality Checks / 🧹 Lint", state: "SUCCESS" },
+          {
+            name: CODERABBIT,
+            state: "SUCCESS",
+            description: RATE_LIMITED,
+          },
+        ]
+      );
+      expect(result.violations).toEqual([]);
+      expect(result.checked).toBe(0);
+    });
+
+    it("matches the check NAME with exact string equality", () => {
+      // The sibling rules compare contexts byte for byte for the same reason:
+      // repos carry confusable pairs, and a fuzzy match raises a false alarm.
+      const result = mod.evaluateVacuousChecks(declarationWith(), [
+        {
+          name: "CodeRabbit (legacy)",
+          state: "SUCCESS",
+          description: RATE_LIMITED,
+        },
+      ]);
+      expect(result.violations.map(violation => violation.kind)).toEqual([
+        mod.VIOLATIONS.unproven,
+      ]);
+      expect(result.violations[0].message).toMatch(/did not report/i);
+    });
+
+    it("answers nothing at all when no check is declared evidence-bearing", () => {
+      const result = mod.evaluateVacuousChecks(
+        { required_contexts: [], workflows: [], skip_job_declarations: {} },
+        [
+          {
+            name: CODERABBIT,
+            state: "SUCCESS",
+            description: RATE_LIMITED,
+          },
+        ]
+      );
+      expect(result.violations).toEqual([]);
+    });
+  });
+
+  describe("this arm REPORTS and never blocks", () => {
+    it("lists both vacuity kinds as never-blocking", () => {
+      // Gating is downstream of an open owner decision, and a new blocking
+      // check that fires on a vendor's BILLING state would be exactly wrong.
+      expect(mod.NEVER_BLOCKING).toContain(mod.VIOLATIONS.vacuous);
+      expect(mod.NEVER_BLOCKING).toContain(mod.VIOLATIONS.unproven);
+    });
+
+    it("never lets a kind be both always-blocking and never-blocking", () => {
+      for (const kind of mod.NEVER_BLOCKING) {
+        expect(mod.VIOLATIONS.suppressesRequired).not.toBe(kind);
+        expect(mod.VIOLATIONS.remoteDrift).not.toBe(kind);
+      }
+    });
+  });
+});

--- a/typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs
+++ b/typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * check-skipped-required-checks — refuse a `skip_jobs` token that silences a
- * ruleset-required status check.
+ * check-skipped-required-checks — refuse a required status check that satisfies
+ * without proving anything.
  *
  * Shipped by Lisa (copy-overwrite). Generalized from tunnl's TUN-402 guard: the
  * logic is Lisa's and gets updated fleet-wide, the two REVIEWED SNAPSHOTS it
@@ -10,6 +10,23 @@
  *
  * Usage:
  *   node scripts/check-skipped-required-checks.mjs [rootDir] [--remote] [--json]
+ *   node scripts/check-skipped-required-checks.mjs --pr=1234 [--repo=OWNER/NAME]
+ *
+ * ## The family this guard covers
+ *
+ * **Required-and-red is loud; required-and-vacuous is not; advisory-and-stale is
+ * invisible.** All three are the same defect wearing different clothes — a gate
+ * that reports satisfied without having proven anything — and the useful
+ * question is never "did the check pass" but "did the check do anything".
+ *
+ * Two of the three live here:
+ *
+ *  - **Skipped** (`--remote` / offline arm, below): GitHub counts a `skipped`
+ *    required check as SATISFIED, so a `skip_jobs` token makes the gate
+ *    decorative. Static, offline, BLOCKING.
+ *  - **Vacuous** (`--pr` arm): the check really ran and really reported
+ *    `success`, having done no work — measured on CodeRabbit posting
+ *    `success — "Review rate limited"`. Live, per-PR, REPORTING ONLY.
  *
  * ## Where this runs
  *
@@ -96,6 +113,57 @@
  * network and `gh` auth on every run would flake, and a flaky guard gets
  * skipped — which reintroduces exactly the false-green class this file refuses.
  *
+ * ## `--pr` — the VACUOUS arm, and why it only ever reports
+ *
+ * Measured (CodySwannGT/lisa#2497): `CodeRabbit` was in this repository's
+ * required set, and on PRs #2483 and #2484 it posted `success` with the
+ * description `Review rate limited` having performed ZERO reviews. Both merged
+ * on that green, both carried security-relevant changes, both shipped in tag
+ * `v3.5.1`. Branch protection recorded "reviewed" for work nothing reviewed.
+ *
+ * The failure is silent by construction, and this is the whole point:
+ *
+ * ```
+ * gh pr checks <PR> | grep -i coderabbit
+ * CodeRabbit    pass    0    Review rate limited     <- hollow
+ * CodeRabbit    pass    1    Review completed        <- real
+ * ```
+ *
+ * **The status column says `pass` either way. Only the description
+ * distinguishes them.** So anything gating on such a check must read the
+ * description, and `--pr` is the machine-readable form of that one-line triage.
+ *
+ * This arm NEVER blocks — `NEVER_BLOCKING`, enforced regardless of the
+ * declaration's `enforcement` mode. Two independent reasons, both load-bearing:
+ *
+ *  1. A review bot's availability can depend on an org-wide SPENDING CAP. A
+ *     blocking check that fires on a billing state makes merges hostage to
+ *     accounting, which is a worse gate than the one it replaces.
+ *  2. Whether a review bot belongs in the required set at all is a governance
+ *     decision an owner has to make. Shipping the gate before the decision
+ *     would pre-empt it. Detection is what is uncontroversial; act on it.
+ *
+ * ## Proof is matched STRICTLY, no-work LOOSELY
+ *
+ * The two description lists are deliberately asymmetric, because their errors
+ * are not symmetric:
+ *
+ *  - A `proof` phrase must match the whole description (case-insensitive,
+ *    trimmed). Matching here GRANTS CREDIT, and a loose match that grants
+ *    credit is exactly the false green this file exists to refuse.
+ *  - A `no_work` phrase matches as a substring. Matching here DENIES credit,
+ *    so breadth is safe — and it survives a vendor appending detail
+ *    (`Review rate limited (retry in 12m)`).
+ *
+ * Anything matching neither is `unproven` — reported, never silently passed. A
+ * vocabulary nobody enumerated must not read as a pass.
+ *
+ * Unlike `required_contexts`, this vocabulary is NOT repo-specific: `Review
+ * rate limited` is the vendor's own product string, identical in every
+ * repository. That is why shipping it as a default is safe where shipping a
+ * guessed ruleset was not (#2476) — and why a wrong guess here costs one line
+ * of report rather than a red build.
+ *
  * ## Exact string equality, everywhere
  *
  * Every comparison here is `===`. Repos routinely carry confusable pairs — an
@@ -170,6 +238,55 @@ export const VIOLATIONS = Object.freeze({
   badExemption: "exemption_without_valid_ticket",
   remoteDrift: "ruleset_snapshot_drift",
   whitespace: "whitespace_in_skip_token",
+  vacuous: "vacuous_required_check",
+  unproven: "unproven_required_check",
+});
+
+/**
+ * The shipped description vocabulary for review-bot style checks.
+ *
+ * `proof` is matched STRICTLY (whole description, case-insensitive, trimmed)
+ * because a match grants credit. `no_work` is matched LOOSELY (substring)
+ * because a match denies it. See the header for why that asymmetry is the safe
+ * direction.
+ *
+ * Every string here was read off a real check on a real PR in this fleet, not
+ * invented: `Review rate limited` (#2483, #2484, #2495), `Review approved`
+ * (#2350). A repository may extend either list per check without losing these.
+ */
+export const REVIEW_DESCRIPTION_DEFAULTS = Object.freeze({
+  proof: Object.freeze([
+    "review approved",
+    "review completed",
+    "changes requested",
+    "comments posted",
+  ]),
+  no_work: Object.freeze([
+    "rate limited",
+    "review queued",
+    "review skipped",
+    "skipped",
+    "queued",
+    "waiting",
+    "in progress",
+    "no review",
+    "disabled",
+    "quota",
+    "billing",
+  ]),
+});
+
+/**
+ * Verdicts `classifyCheckDescription` returns.
+ *
+ * `unproven` is the FALLBACK on purpose: the absence of a recognised phrase is
+ * the absence of evidence, and this file's whole thesis is that those are not
+ * the same as a pass.
+ */
+export const DESCRIPTION_VERDICTS = Object.freeze({
+  proved: "proved",
+  noWork: "no-work",
+  unproven: "unproven",
 });
 
 /** Enforcement modes a declaration may select. */
@@ -194,6 +311,50 @@ const ALWAYS_BLOCKING = Object.freeze([
   VIOLATIONS.suppressesRequired,
   VIOLATIONS.remoteDrift,
 ]);
+
+/**
+ * Violation kinds that NEVER fail the build, in any enforcement mode.
+ *
+ * The vacuity arm reports and stops there. A required check can go hollow
+ * because a vendor hit an org-wide SPENDING CAP, and a gate that reddens every
+ * PR the moment a bill goes unpaid is a worse gate than the one it is
+ * criticising. Whether such a check belongs in the required set at all is a
+ * governance decision an owner makes in an admin console, not one this script
+ * may pre-empt by turning its own finding into a blocker.
+ *
+ * Detection is the uncontroversial half, and it is the half that was missing:
+ * nothing anywhere could previously tell "the check reported success" apart
+ * from "the check did anything".
+ *
+ * This list is checked BEFORE `ALWAYS_BLOCKING` and before the enforcement
+ * mode, so deleting the `enforcement` key cannot silently arm it.
+ */
+export const NEVER_BLOCKING = Object.freeze([
+  VIOLATIONS.vacuous,
+  VIOLATIONS.unproven,
+]);
+
+/**
+ * Reads `--name=value` or `--name value` out of argv.
+ *
+ * Returns `undefined` for an absent flag and for `--name` with no value, so a
+ * typo cannot be read as an empty PR number and silently examine nothing.
+ *
+ * @param {ReadonlyArray<string>} argv - CLI arguments
+ * @param {string} name - The flag, including its leading dashes
+ * @returns {string|undefined} The value, or undefined
+ */
+export function readFlagValue(argv, name) {
+  const inline = argv.find(arg => arg.startsWith(`${name}=`));
+  if (inline !== undefined) {
+    const value = inline.slice(name.length + 1).trim();
+    return value === "" ? undefined : value;
+  }
+  const at = argv.indexOf(name);
+  if (at === -1) return undefined;
+  const next = argv[at + 1];
+  return next === undefined || next.startsWith("--") ? undefined : next;
+}
 
 /**
  * True when a line is a whole-line YAML comment.
@@ -401,6 +562,30 @@ export function loadDeclaration(rootDir) {
       throw new Error(
         `check-skipped-required-checks: \`${token}.suppressed_contexts\` must contain only context strings — they are compared byte for byte against \`required_contexts\`.`
       );
+    }
+  }
+
+  // Same reasoning for the vacuity declarations: a non-object entry would read
+  // as "declared" and then yield an empty vocabulary, quietly examining the
+  // check against defaults the author thought they had overridden.
+  for (const [name, entry] of Object.entries(
+    declaration.evidence_bearing_checks ?? {}
+  )) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      throw new Error(
+        `check-skipped-required-checks: the declaration for \`${name}\` in \`evidence_bearing_checks\` must be an object — use \`{}\` to accept the shipped description vocabulary.`
+      );
+    }
+    for (const list of ["proof", "no_work"]) {
+      if (entry[list] === undefined) continue;
+      if (
+        !Array.isArray(entry[list]) ||
+        entry[list].some(phrase => typeof phrase !== "string")
+      ) {
+        throw new Error(
+          `check-skipped-required-checks: \`evidence_bearing_checks.${name}.${list}\` must be an array of description strings.`
+        );
+      }
     }
   }
   return declaration;
@@ -617,6 +802,184 @@ export function evaluateSkippedRequiredChecks(
 }
 
 /**
+ * Decides whether a check's description proves the check did any work.
+ *
+ * @param {string|undefined} description - The check's description, verbatim
+ * @param {{proof?: ReadonlyArray<string>, no_work?: ReadonlyArray<string>}} [vocabulary] -
+ *   Per-check additions. Merged WITH the shipped defaults rather than replacing
+ *   them, so a repository naming one extra proof phrase does not silently lose
+ *   the no-work list that catches the measured defect.
+ * @returns {string} One of `DESCRIPTION_VERDICTS`
+ */
+export function classifyCheckDescription(description, vocabulary = {}) {
+  const text = (description ?? "").trim().toLowerCase();
+  if (text === "") return DESCRIPTION_VERDICTS.unproven;
+
+  // No-work is tested FIRST. The lists are asserted non-overlapping in the
+  // suite, so order cannot change a verdict today — testing the denying rule
+  // first means a future overlap fails safe (denied) rather than granting
+  // credit, which is the direction that matters.
+  const noWork = [
+    ...REVIEW_DESCRIPTION_DEFAULTS.no_work,
+    ...(vocabulary.no_work ?? []),
+  ];
+  if (noWork.some(phrase => text.includes(phrase.trim().toLowerCase()))) {
+    return DESCRIPTION_VERDICTS.noWork;
+  }
+
+  const proof = [
+    ...REVIEW_DESCRIPTION_DEFAULTS.proof,
+    ...(vocabulary.proof ?? []),
+  ];
+  if (proof.some(phrase => text === phrase.trim().toLowerCase())) {
+    return DESCRIPTION_VERDICTS.proved;
+  }
+  return DESCRIPTION_VERDICTS.unproven;
+}
+
+/**
+ * Reports every declared evidence-bearing check that satisfied without proving
+ * it did work.
+ *
+ * A check is examined only when the repository named it in
+ * `evidence_bearing_checks` — matched by EXACT name, like every other
+ * comparison in this file. Most CI jobs ship an empty description, so
+ * flagging them all would bury the one finding that matters, and the obvious
+ * fix for a noisy guard is to delete it.
+ *
+ * Four outcomes per declared check:
+ *
+ *  - Green + a `proof` description → nothing. This is the case the whole
+ *    machine exists to reach.
+ *  - Green + a `no_work` description → `vacuous_required_check`. The measured
+ *    #2483/#2484 defect.
+ *  - Green + anything else → `unproven_required_check`. Not an accusation: a
+ *    statement that this run produced no evidence either way.
+ *  - Absent entirely → `unproven_required_check`. Measured on #2493/#2491/
+ *    #2488, where the bot posted no context at all; "no unresolved review
+ *    threads" there means nobody looked, not that nothing was wrong.
+ *
+ * A RED check is deliberately ignored. Required-and-red is the loud case and
+ * needs no help from here; reporting it too would make this arm indistinguish-
+ * able from ordinary CI noise.
+ *
+ * `required_contexts` changes only the WORDING — whether branch protection
+ * actually recorded this hollow green as a satisfied gate. When that snapshot
+ * is untrusted the finding still stands; the guard just declines to claim
+ * required-ness it has not transcribed.
+ *
+ * @param {object} declaration - The per-repo declaration
+ * @param {ReadonlyArray<{name: string, state: string, bucket?: string, description?: string}>} checks -
+ *   Checks as `gh pr checks --json name,state,bucket,description` returns them
+ * @param {{trustRequiredContexts?: boolean}} [options] - Set
+ *   `trustRequiredContexts: false` to stop asserting whether a check is required
+ * @returns {{violations: object[], checked: number}} Violations and how many declared checks were examined
+ */
+export function evaluateVacuousChecks(declaration, checks, options = {}) {
+  const declared = declaration.evidence_bearing_checks ?? {};
+  const trustRequired = options.trustRequiredContexts !== false;
+  const required = new Set(declaration.required_contexts ?? []);
+  const violations = [];
+  let checked = 0;
+
+  for (const [name, entry] of Object.entries(declared)) {
+    checked += 1;
+    const vocabulary = typeof entry === "object" && entry !== null ? entry : {};
+    const found = checks.find(check => check.name === name);
+
+    if (found === undefined) {
+      violations.push({
+        kind: VIOLATIONS.unproven,
+        token: name,
+        message: `\`${name}\` is declared evidence-bearing but did not report on this pull request at all. A report of "no unresolved review threads" from this PR means NOBODY LOOKED, not that nothing was wrong — say which one you observed. (If the context was renamed, fix \`evidence_bearing_checks\`; names are compared byte for byte.)`,
+      });
+      continue;
+    }
+
+    const state = String(found.state ?? "").toUpperCase();
+    if (state === "FAILURE" || state === "ERROR") continue;
+
+    const verdict = classifyCheckDescription(found.description, vocabulary);
+    if (verdict === DESCRIPTION_VERDICTS.proved && state === "SUCCESS") {
+      continue;
+    }
+
+    const requiredNote = !trustRequired
+      ? " Whether it is ruleset-required is NOT KNOWN here — `required_contexts` has not been transcribed, so this cannot say what the merge gate recorded."
+      : required.has(name)
+        ? " This context IS ruleset-required, so branch protection recorded a satisfied review gate for a review that did not happen."
+        : " This context is not in `required_contexts`, so no merge gate was falsified — but nothing reviewed this either.";
+
+    violations.push(
+      verdict === DESCRIPTION_VERDICTS.noWork && state === "SUCCESS"
+        ? {
+            kind: VIOLATIONS.vacuous,
+            token: name,
+            contexts: [name],
+            message: `\`${name}\` reported ${state} with the description ${JSON.stringify(found.description ?? "")}, which says it DID NO WORK.${requiredNote} \`gh pr checks\` prints \`pass\` for this exactly as it does for a real review — the description is the only thing that tells them apart. Treat this PR as UNREVIEWED.`,
+          }
+        : {
+            kind: VIOLATIONS.unproven,
+            token: name,
+            message: `\`${name}\` reported ${state} with the description ${JSON.stringify(found.description ?? "")}, which proves neither that it reviewed anything nor that it did not.${requiredNote} Read the check itself before treating this PR as reviewed, or add the phrase to \`evidence_bearing_checks.${name}.proof\` once you have confirmed what it means.`,
+          }
+    );
+  }
+
+  return { violations, checked };
+}
+
+/**
+ * Reads one pull request's checks, descriptions included.
+ *
+ * `--json` is what makes this usable: the plain `gh pr checks` table is the
+ * human triage, and the description column is the load-bearing one, but only
+ * the JSON form survives being parsed. Both CheckRuns and legacy commit
+ * StatusContexts come back through this single call — CodeRabbit posts the
+ * latter, which `gh pr view --json statusCheckRollup` returns WITHOUT a
+ * description, so that route cannot see the defect at all.
+ *
+ * A non-zero exit is expected and ignored: `gh pr checks` exits 8 while checks
+ * are pending and 1 when any check failed, and both are perfectly readable
+ * states for this arm. Only unparseable output is an error.
+ *
+ * @param {string|number} pr - Pull request number or URL
+ * @param {string} [repo] - `OWNER/NAME`; defaults to the current repository
+ * @returns {Array<{name: string, state: string, bucket?: string, description?: string}>} The checks
+ * @throws {Error} When `gh` is unavailable or its output cannot be parsed
+ */
+export function fetchPullRequestChecks(pr, repo) {
+  const args = [
+    "pr",
+    "checks",
+    String(pr),
+    "--json",
+    "name,state,bucket,description",
+  ];
+  if (repo) args.push("--repo", repo);
+  let raw;
+  try {
+    raw = execFileSync("gh", args, { encoding: "utf8" });
+  } catch (error) {
+    raw = typeof error?.stdout === "string" ? error.stdout : "";
+    if (raw.trim() === "") {
+      throw new Error(
+        `check-skipped-required-checks: could not read checks for PR ${pr}${repo ? ` in ${repo}` : ""} — ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) throw new TypeError("not an array");
+    return parsed;
+  } catch (error) {
+    throw new Error(
+      `check-skipped-required-checks: \`gh pr checks --json\` returned output this cannot parse (${error instanceof Error ? error.message : String(error)}). Refusing to report "nothing vacuous" from output nobody read.`
+    );
+  }
+}
+
+/**
  * Fetches the live required contexts for every declared ruleset.
  *
  * @param {object} ruleset - `{ repo, ids }` from the declaration
@@ -693,6 +1056,7 @@ export function runGuard(argv) {
   const positional = argv.filter(arg => !arg.startsWith("--"));
   const rootDir = positional[0] ?? process.cwd();
   const declaration = loadDeclaration(rootDir);
+  const pr = readFlagValue(argv, "--pr");
   const collected = collectSkipJobTokens(rootDir, declaration.workflows);
   const remote = argv.includes("--remote");
   const live = remote
@@ -714,6 +1078,21 @@ export function runGuard(argv) {
       ...compareRulesetBaseline(declaration.required_contexts, live)
     );
   }
+
+  // The vacuity arm is layered ON TOP of the offline run rather than replacing
+  // it: it is a third variant of one family, so it belongs in one report. Its
+  // findings are `NEVER_BLOCKING`, so adding them cannot change the exit code
+  // the offline arm would have produced on its own.
+  const vacuity =
+    pr === undefined
+      ? undefined
+      : evaluateVacuousChecks(
+          declaration,
+          fetchPullRequestChecks(pr, readFlagValue(argv, "--repo")),
+          { trustRequiredContexts: trust.trusted }
+        );
+  if (vacuity !== undefined) violations.push(...vacuity.violations);
+
   return {
     violations,
     checked: result.checked,
@@ -721,6 +1100,8 @@ export function runGuard(argv) {
     enforcement: declaration.enforcement ?? "error",
     trust,
     recipe: transcriptionRecipe(declaration),
+    pr,
+    evidenceChecked: vacuity?.checked ?? 0,
   };
 }
 
@@ -774,9 +1155,10 @@ function main(argv) {
    * @returns {boolean} True when it blocks
    */
   const blocks = violation =>
-    !warnOnly || ALWAYS_BLOCKING.includes(violation.kind);
+    !NEVER_BLOCKING.includes(violation.kind) &&
+    (!warnOnly || ALWAYS_BLOCKING.includes(violation.kind));
   const blocking = result.violations.filter(blocks);
-  const lines = ["## 🔒 Skipped required checks", ""];
+  const lines = ["## 🔒 Required checks that prove nothing", ""];
 
   // The refusal comes FIRST and replaces the verdict. Printing "✅ none
   // silences a required check" from a snapshot nobody transcribed is the one
@@ -803,7 +1185,12 @@ function main(argv) {
   if (result.violations.length === 0) {
     if (result.trust.trusted) {
       lines.push(
-        `✅ ${result.checked} \`skip_jobs\` token(s) examined; none silences a ruleset-required status check.`
+        `✅ ${result.checked} \`skip_jobs\` token(s) examined; none silences a ruleset-required status check.`,
+        ...(result.pr === undefined
+          ? []
+          : [
+              `✅ ${result.evidenceChecked} evidence-bearing check(s) examined on PR #${result.pr}; each proved it did work.`,
+            ])
       );
     } else {
       lines.push(
@@ -825,6 +1212,16 @@ function main(argv) {
       lines.push(
         "",
         `This declaration sets \`"enforcement": "warn"\`, so everything above except a proven false green (\`${VIOLATIONS.suppressesRequired}\`) is reported without failing the build. Review each finding, fix or declare it, then delete the \`enforcement\` key so this guard can block.`
+      );
+    }
+    if (
+      result.violations.some(violation =>
+        NEVER_BLOCKING.includes(violation.kind)
+      )
+    ) {
+      lines.push(
+        "",
+        `\`${VIOLATIONS.vacuous}\` and \`${VIOLATIONS.unproven}\` are REPORT-ONLY in every enforcement mode — they never fail a build. A required check can go hollow because a vendor hit an org-wide spending cap, and reddening every PR on a billing state would be a worse gate than the one being criticised. What they change is what you may CLAIM: a PR carrying either finding has not been shown to be reviewed, so do not record it as reviewed.`
       );
     }
   }

--- a/typescript/create-only/.github/required-checks.json
+++ b/typescript/create-only/.github/required-checks.json
@@ -9,7 +9,12 @@
     "A transcription expires after 90 days, because a ruleset can be edited with no signal in this repository. The shipped `.github/workflows/required-checks-drift.yml` runs `--remote` weekly to catch that; `--remote` reads the ruleset live and so answers even when the cache is untrusted.",
     "Lisa's quality.yml runs the offline arm on every pull request. This seed ships `\"enforcement\": \"warn\"`, which downgrades findings AND the NOT-CHECKED refusal to reports so a fresh install does not go red on arrival. Delete the key once you have transcribed the list — then it blocks.",
     "`skip_jobs` is matched as an exact comma-delimited token and GitHub Actions expression syntax has no string-replace, so write the list with no spaces: `skip_jobs: 'a,b'`, never `skip_jobs: 'a, b'`. A spaced token matches nothing and the job runs — reported as `whitespace_in_skip_token`.",
-    "`_example_required_contexts` below is a STARTING POINT FOR TYPING, never read by the guard. Verify every line against your own ruleset before promoting any of it."
+    "`_example_required_contexts` below is a STARTING POINT FOR TYPING, never read by the guard. Verify every line against your own ruleset before promoting any of it.",
+    "THE FAMILY: required-and-red is loud; required-and-vacuous is not; advisory-and-stale is invisible. All three are one gate reporting satisfied without proving anything. `required_contexts` + `skip_job_declarations` above cover the SKIPPED variant; `evidence_bearing_checks` below covers the VACUOUS one.",
+    "VACUOUS, measured (CodySwannGT/lisa#2497): a required `CodeRabbit` context posted `success` with the description `Review rate limited`, having reviewed nothing, on two security-relevant PRs that then merged and shipped. `gh pr checks` prints `pass` for that exactly as it does for a real review — only the DESCRIPTION tells them apart.",
+    "Run it per PR: `npm run check:vacuous-required-checks -- --pr=1234` (or `node scripts/check-skipped-required-checks.mjs --pr=1234`). It reads `gh pr checks --json name,state,bucket,description`, which is the only route that carries the description for a legacy commit status like CodeRabbit's.",
+    "`evidence_bearing_checks` names the checks whose GREEN is supposed to mean something reviewed the code. Use `{}` to accept the shipped description vocabulary, or add `proof` / `no_work` arrays to extend it — extensions ADD to the defaults, they do not replace them. Undeclared checks are never examined, because most CI jobs ship an empty description and flagging them all would bury the one finding that matters.",
+    "This arm REPORTS AND NEVER BLOCKS, in every enforcement mode. A review bot can go hollow because an org-wide SPENDING CAP was hit, and a gate that reddens every PR on a billing state is worse than the one it criticises. What it changes is what you may CLAIM: a PR carrying a `vacuous_required_check` finding has not been shown to be reviewed, so do not record it as reviewed."
   ],
   "enforcement": "warn",
   "ruleset": {
@@ -17,7 +22,9 @@
     "ids": [],
     "baseline_fetched_at": ""
   },
-  "workflows": [".github/workflows/ci.yml"],
+  "workflows": [
+    ".github/workflows/ci.yml"
+  ],
   "exemption_ticket_pattern": "^[A-Z][A-Z0-9]+-\\d+$",
   "required_contexts": [],
   "_example_required_contexts": [
@@ -29,5 +36,8 @@
     "🔍 Quality Checks / 🧪 Run Unit Tests",
     "🔍 Quality Checks / 🧪 Run Integration Tests"
   ],
-  "skip_job_declarations": {}
+  "skip_job_declarations": {},
+  "evidence_bearing_checks": {
+    "CodeRabbit": {}
+  }
 }

--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -19,7 +19,8 @@
       "prepare": "node -e \"if (process.env.INIT_CWD?.includes('.serverless')) process.exit(0); process.exit(1);\" || husky install || true",
       "nightly:health": "node scripts/check-nightly-e2e-health.mjs",
       "check:skipped-required-checks": "node scripts/check-skipped-required-checks.mjs",
-      "check:skipped-required-checks:remote": "node scripts/check-skipped-required-checks.mjs --remote"
+      "check:skipped-required-checks:remote": "node scripts/check-skipped-required-checks.mjs --remote",
+      "check:vacuous-required-checks": "node scripts/check-skipped-required-checks.mjs"
     },
     "devDependencies": {
       "eslint-plugin-oxlint": "^1.62.0",


### PR DESCRIPTION
Ships the **detection half** of #2497. The governance half — whether a review bot belongs in the required set when its availability depends on a spending cap — stays open for the owner. **No ruleset, required context, or branch protection is touched by this PR.**

## The measured problem

```
required contexts on main  ->  CodeRabbit IS in the required list

PR #2483  reviews: 0   status: success — "Review rate limited"
PR #2484  reviews: 0   status: success — "Review rate limited"
```

Both merged on that green, both carried security-relevant changes, both are in published tag `v3.5.1`. Branch protection recorded "reviewed" for work nothing reviewed.

The failure is silent by construction:

```
gh pr checks <PR> | grep -i coderabbit
CodeRabbit    pass    0    Review rate limited     <- hollow
CodeRabbit    pass    1    Review completed        <- real
```

**The status column says `pass` either way. Only the description distinguishes them.**

## The class, not the instance

This is not one flaky bot. **Success and did-nothing were the same observable**, and that shape showed up four independent times in this one session:

| Instance | What reported OK | What had actually happened |
|---|---|---|
| #2497 (this) | required review check `success` | zero reviews |
| #2492 | fail-closed gate arms green | no test could fail them |
| #2485 | checks green | not required, so could never block |
| tooling | `pgrep -fc vitest` printed nothing | BSD `pgrep` has no `-c`; it errored to stderr and read as `0` |

That last one is the cleanest miniature of the whole bug: *a check that cannot run was indistinguishable from a check that ran and found nothing.* It cost a sibling agent a wasted run. (The working form is `ps aux | grep -c '[v]itest'`.)

The family, stated once: **required-and-red is loud; required-and-vacuous is not; advisory-and-stale is invisible.** The useful question is never "did the check pass" but **"did the check do anything"**.

## Relationship to #2485 (same file, complementary changes)

Both PRs touch `check-skipped-required-checks.mjs`, and a reviewer seeing that will reasonably suspect duplicated effort. They are opposite ends of one family, from the same audit:

- **#2485** removes a confusable *advisory* check that could never block (`🧪 Run Tests` deleted outright rather than renamed), and rewrites the confusable-pairs paragraph in the module header.
- **This PR** adds detection for a *required* check that passes without proving anything, and inserts the family narrative immediately above that paragraph.

The two edits auto-merge cleanly — verified with `git merge-tree`, both narratives intact, `node --check` passing. One caveat for anyone else rebasing across #2485: `src/core/upstream-evidence-manifest.ts` **does** conflict, and it must not be resolved as a union. It is generated, so take either side, then re-run `bun run build:upstream-evidence-manifest` after `git add`.

## What this ships

**Extended `check-skipped-required-checks.mjs` rather than adding a parallel script.** It already owns "a required check that satisfies without proving anything" — for the case where CI *skips* the context — and this is a third variant of the same family, so it belongs in one guard and one report. It also already had a live `gh`-shelling arm (`--remote`), so the network dependency is precedent, not a new liability; the enforced offline path is unchanged.

- **`--pr=<n>`** reads `gh pr checks --json name,state,bucket,description` and classifies every declared evidence-bearing check as `proved` / `no-work` / `unproven`. That JSON route is the *only* one that carries the description for a legacy commit status like CodeRabbit's — `gh pr view --json statusCheckRollup` omits it entirely and cannot see the defect at all.
- **Proof matches strictly, no-work matches loosely.** A `proof` phrase must equal the whole description; a `no_work` phrase matches as a substring. Matching proof *grants credit*, so a loose match there would be the exact false green this guard exists to refuse; matching no-work *denies* credit, so breadth is safe and it survives `Review rate limited (retry in 12m)`. Anything unrecognised is `unproven` — reported, never silently a pass.
- **`evidence_bearing_checks`** in the seed declares which checks' greenness is supposed to mean something reviewed the code. Undeclared checks are never examined: most CI jobs ship an empty description, and flagging them all would bury the one finding that matters.

### It reports; it does not block

`vacuous_required_check` and `unproven_required_check` are in a new `NEVER_BLOCKING` set, checked *before* the enforcement mode so deleting the `enforcement` key cannot silently arm them. Two reasons:

1. A review bot goes hollow because of an org-wide **spending cap**. A gate that reddens every PR on a billing state is worse than the one it criticises.
2. Whether such a check belongs in the required set is the owner's open decision. Shipping the gate first would pre-empt it.

What it changes is what a report may **claim** — not what any loop does.

### Where a reader actually meets it

The standalone command was the easy part; the real hole was in the evidence path. `lisa-pull-request-review` previously said: *"If there are none, report success and exit (nothing to do)."* Zero unresolved threads has two causes that query cannot separate — *a reviewer looked and found nothing*, or *nothing ever looked*.

- **`lisa-pull-request-review`** gains a required Step 1b before it may report, and must open its report with `reviewed` / `NOT REVIEWED (<why>)` rather than a bare thread count.
- **`lisa-drive-pr-to-merge`** carries that verdict into every terminal state, **including a successful `MERGED`** — "merged, all checks green" is precisely the sentence that hid #2483 and #2484. It is explicitly *not* a blocker there: it never withholds a merge.

Both fan out to all five agent surfaces (claude, codex, cursor, agy, copilot).

## The instruments had the same bug, four times

Building this surfaced four cases of the *exact defect being fixed* — an instrument reporting a value that does not mean what its readers take it to mean. They are worth listing as a set, because the pattern is the finding:

| # | Instrument | Reports | Actually means |
|---|---|---|---|
| 1 | `gh pr checks <n> 2>/dev/null` | empty → "check absent" | the *error* was discarded; `n` was an issue, not a PR |
| 2 | `ps aux \| grep -c vitest` | "64 workers" | ~2x inflated — counts zsh and `npm exec` wrappers |
| 3 | `gh pr view --json statusCheckRollup` | `SUCCESS`, nothing wrong | `description` field omitted entirely; the defect is invisible |
| 4 | `cmd \| tee log \| tail` | exit 0 → "tests passed" | a pipeline returns the **last** command's status |

**#1 was mine**, and I retracted it publicly on the issue rather than quietly correcting it: I claimed several PRs showed no review context at all, when in fact those numbers were issues and my `2>/dev/null` had swallowed `Could not resolve to a PullRequest`. The corrected roster is 40 of 45 merged PRs hollow, **zero** absent. An error read as a zero — committed while investigating a bug about exactly that.

**#4 deserves a correction of its own.** It is usually blamed on `tail`, but measured:

```
node -e "process.exit(3)" | tee log | tail -1   ->  exit 0
node -e "process.exit(3)" | tee log             ->  exit 0     <- tee alone, still 0
set -o pipefail; ... | tee log                  ->  exit 3     <- the actual fix
```

So `| tee log` — recommended as the *remedy* for losing output to truncation — silently hid failures on its own, before anyone appended `tail`. The fix is `set -o pipefail` (or reading `${PIPESTATUS[0]}`), not choosing between `tee` and `tail`.

This is the same shape as the bug this PR fixes: `success` and did-nothing were one observable. It does not spare the people auditing instruments, which is the argument for making the distinction *machine-readable* rather than trusting a reader to notice.

## Verification

Empirical, against the live PRs:

| PR | Description | Verdict | Exit |
|---|---|---|---|
| #2483 | `Review rate limited` | `vacuous_required_check` | 0 |
| #2350 | `Review approved` | clean | 0 |

Exit `0` in the second column is the point, and it was re-confirmed with the `enforcement` key **deleted** (strict mode) to prove the never-blocking guarantee is not an artifact of the seeds' `warn`.

- 20 new unit tests, written against the byte-exact strings GitHub really returned; 45 pass across both guard suites with no regression to the existing 25.
- `enforcement: warn` preserved in all three seeds — deliberately, since Lisa cannot know a host's ruleset.
- Manifest regenerated after `git add`.

## The check is not decorative — it is unavailable. That distinction is the whole decision.

#2507, merged today, is the control case the 40 hollow PRs lacked. CodeRabbit gave it a **real review**: `Review in progress`, then an actual finding — a boundary-coverage gap where flipping `<=` to `<` left the suite green. That review **blocked the merge** (`CHANGES_REQUESTED` plus one unresolved thread, with every check green and auto-merge already enabled) and produced a real fix.

So today's evidence contains both states from the same required context:

| | Outcome |
|---|---|
| #2507 | real review → found a defect → **blocked a merge** |
| 40 of the last 45 | `success` → reviewed nothing → **merged** |

That matters more than the 89% alone. A gate that *never* works is decorative and the answer is to remove it. A gate that works when reachable and self-satisfies when it is not has an **availability** failure — and the fix space is completely different: fund the cap, monitor it as infrastructure, or make unavailability fail closed instead of open. The measurement says which of those two situations this is, and it is the second.

This is also why the detector reports rather than blocks. The check is worth having; what is not worth having is `success` meaning two different things.

## What remains for the owner

#2497 stays **open**. Undecided, and deliberately untouched here:

1. Whether `CodeRabbit` should be a required context at all given the spending-cap dependency.
2. If it stays required, monitoring that cap as infrastructure.
3. Whether this detector should ever become blocking — which is downstream of (1).

Work-Item: CodySwannGT/lisa#2497

🤖 Generated with Claude Code
