### PR TITLE
feat(ast-grep): ban fs-extra namespace members that do not exist under Node ESM

### DIFF
--- a/ast-grep/rules/no-missing-fs-extra-namespace-member-js.yml
+++ b/ast-grep/rules/no-missing-fs-extra-namespace-member-js.yml
@@ -1,0 +1,53 @@
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+#
+# JavaScript-language twin of `no-missing-fs-extra-namespace-member.yml`.
+#
+# ast-grep binds one parser per rule: `language: typescript` scans only
+# .ts/.mts/.cts, so .js/.mjs/.cjs would otherwise be an unguarded gap — and a
+# guard with a silent hole is the failure mode this rule exists to prevent.
+# Build scripts and tooling in TypeScript projects are routinely .mjs, and
+# fs-extra is exactly the kind of dependency they reach for.
+#
+# The `constraints` block MUST stay byte-identical to the TypeScript rule.
+# `tests/unit/config/ast-grep-template.test.ts` asserts both files carry the
+# same allow list AND that it still equals the set real Node reports, so these
+# two cannot drift apart or drift away from reality unnoticed.
+#
+# See the TypeScript rule for the full rationale on why this is an allow list
+# rather than a deny list, and why the set is stable across fs-extra 11.x.
+id: no-missing-fs-extra-namespace-member-js
+language: javascript
+severity: error
+message: |
+  `fs-extra` does not expose this member on its ESM namespace object.
+
+  `import * as fse from "fs-extra"` resolves to fs-extra's CommonJS entry, so
+  Node derives the namespace keys with cjs-module-lexer. Only fs-extra's own
+  directly-assigned functions survive that. Absent members include every JSON
+  helper (readJson, readJSON, writeJson, outputJson, and their Sync forms),
+  every node:fs passthrough (readFile, writeFile, readdir, stat, existsSync,
+  appendFile, ...), and copySync, moveSync, removeSync, pathExistsSync and
+  outputFileSync.
+
+  The call is `undefined` at run time and throws a TypeError, and unit tests
+  cannot see it — Vitest and Jest resolve the import through CJS interop and
+  hand back the default export's properties.
+
+  Fix by importing the concrete API instead:
+    - file I/O     -> `readFile` / `writeFile` from `node:fs/promises`
+    - JSON         -> read the file, then `JSON.parse` / `JSON.stringify`
+    - whole module -> `import fse from "fs-extra"`. The DEFAULT export does
+                      carry every member and is deliberately not flagged here.
+rule:
+  all:
+    - pattern: $NS.$MEMBER
+    - inside:
+        kind: program
+        stopBy: end
+        has:
+          pattern: import * as $NS from "fs-extra"
+constraints:
+  MEMBER:
+    not:
+      regex: ^(copy|createFile|createFileSync|createLink|createLinkSync|createSymlink|createSymlinkSync|default|emptyDir|emptyDirSync|emptydir|emptydirSync|ensureDir|ensureDirSync|ensureFile|ensureFileSync|ensureLink|ensureLinkSync|ensureSymlink|ensureSymlinkSync|exists|mkdirp|mkdirpSync|mkdirs|mkdirsSync|move|outputFile|pathExists|read|readv|remove|write|writev)$

--- a/ast-grep/rules/no-missing-fs-extra-namespace-member.yml
+++ b/ast-grep/rules/no-missing-fs-extra-namespace-member.yml
@@ -1,0 +1,64 @@
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+#
+# Bans `fs-extra` namespace members that do not exist under real Node ESM.
+#
+# The allow list below is an ALLOW list, not a deny list, and that is
+# deliberate. A deny list fails open: any absent member nobody thought to
+# enumerate passes silently, which is the exact rot this rule exists to
+# prevent. An allow list fails closed — an unrecognised member is flagged
+# loudly and a human decides.
+#
+# The list is the set of keys real Node reports for
+# `import * as fse from "fs-extra"`. It is byte-identical across fs-extra
+# 11.1.1, 11.3.3, 11.3.4 and 11.3.5, because the bare specifier always routes
+# through the package `exports` map to the CommonJS entry (`./lib/index.js`)
+# and Node derives the namespace keys with cjs-module-lexer from a re-export
+# shape that has not changed. `lib/esm.mjs` — which does export the JSON
+# helpers — is reachable only via the `fs-extra/esm` subpath, which is a
+# different import.
+#
+# Anti-rot: `tests/unit/core/fs-extra-namespace-callsites.test.ts` in the Lisa
+# monorepo derives this same set from real Node at run time, and
+# `tests/unit/config/ast-grep-template.test.ts` asserts the list below still
+# equals it. If fs-extra ever changes its namespace surface, that pairing goes
+# red centrally instead of this list silently drifting in every host project.
+id: no-missing-fs-extra-namespace-member
+language: typescript
+severity: error
+message: |
+  `fs-extra` does not expose this member on its ESM namespace object.
+
+  `import * as fse from "fs-extra"` resolves to fs-extra's CommonJS entry, so
+  Node derives the namespace keys with cjs-module-lexer. Only fs-extra's own
+  directly-assigned functions survive that. Absent members include every JSON
+  helper (readJson, readJSON, writeJson, outputJson, and their Sync forms),
+  every node:fs passthrough (readFile, writeFile, readdir, stat, existsSync,
+  appendFile, ...), and copySync, moveSync, removeSync, pathExistsSync and
+  outputFileSync.
+
+  The call is `undefined` at run time and throws a TypeError. Unit tests are
+  structurally blind to it: Vitest and Jest resolve the import through CJS
+  interop and hand back the default export's properties, so the call is a
+  function in every test and `undefined` in production. Lisa shipped this
+  defect three times in one release window (#2482, #2487) — once as a crash
+  that stranded seven merged PRs, twice inside error-swallowing `catch` blocks
+  where the TypeError replaced the error being handled.
+
+  Fix by importing the concrete API instead:
+    - file I/O     -> `readFile` / `writeFile` from `node:fs/promises`
+    - JSON         -> read the file, then `JSON.parse` / `JSON.stringify`
+    - whole module -> `import fse from "fs-extra"`. The DEFAULT export does
+                      carry every member and is deliberately not flagged here.
+rule:
+  all:
+    - pattern: $NS.$MEMBER
+    - inside:
+        kind: program
+        stopBy: end
+        has:
+          pattern: import * as $NS from "fs-extra"
+constraints:
+  MEMBER:
+    not:
+      regex: ^(copy|createFile|createFileSync|createLink|createLinkSync|createSymlink|createSymlinkSync|default|emptyDir|emptyDirSync|emptydir|emptydirSync|ensureDir|ensureDirSync|ensureFile|ensureFileSync|ensureLink|ensureLinkSync|ensureSymlink|ensureSymlinkSync|exists|mkdirp|mkdirpSync|mkdirs|mkdirsSync|move|outputFile|pathExists|read|readv|remove|write|writev)$

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2242,6 +2242,10 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "9cd675cbba11457ba70c9c4f853f3e5cf652fe98c508075946f02bf045710ca6",
     "typescript/copy-overwrite/ast-grep/rules/no-inline-component-in-view.yml":
       "a662cb959ad5d96e4dda09d6dce1d69318e7c13f3d01787658184fd6075c2781",
+    "typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member-js.yml":
+      "1e23c39fdb8a6295d1fa50dc80e92d7945b4bcfd4e78bd3fb8eb0606e02d2629",
+    "typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member.yml":
+      "c69c7ca0ab2f88f23ab6a740d7bf7d975aa0433ba5410aee184046d513aaf727",
     "typescript/copy-overwrite/ast-grep/utils/.gitkeep":
       "6792ca57f00ff5a84a4713a08308a8ab3144858b0b0d9f8251b8c26c48948fb7",
     "typescript/copy-overwrite/audit.ignore.config.json":
@@ -2540,6 +2544,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "ast-grep/rules/harper/require-statuscode-on-thrown-error.yml": true,
     "ast-grep/rules/no-inline-component-in-container.yml": true,
     "ast-grep/rules/no-inline-component-in-view.yml": true,
+    "ast-grep/rules/no-missing-fs-extra-namespace-member-js.yml": true,
+    "ast-grep/rules/no-missing-fs-extra-namespace-member.yml": true,
     "ast-grep/rules/phaser/no-canvas-renderer.yml": true,
     "ast-grep/rules/phaser/no-raw-webgl-context.yml": true,
     "ast-grep/rules/ruby/no-find-by-sql-without-params.yml": true,
@@ -9224,6 +9230,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "typescript/copy-overwrite/ast-grep/rules/.gitkeep": true,
     "typescript/copy-overwrite/ast-grep/rules/no-inline-component-in-container.yml": true,
     "typescript/copy-overwrite/ast-grep/rules/no-inline-component-in-view.yml": true,
+    "typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member-js.yml": true,
+    "typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member.yml": true,
     "typescript/copy-overwrite/ast-grep/utils/.gitkeep": true,
     "typescript/copy-overwrite/audit.ignore.config.json": true,
     "typescript/copy-overwrite/commitlint.config.cjs": true,

--- a/tests/unit/config/ast-grep-template.test.ts
+++ b/tests/unit/config/ast-grep-template.test.ts
@@ -20,12 +20,15 @@ function readText(relativePath: string): string {
   return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8");
 }
 
+/** Stack templates that ship an ast-grep payload. */
+type Stack = "typescript" | "rails" | "phaser";
+
 /**
  * Copy one stack's ast-grep template payload into a temporary project root.
  * @param stack - Stack template to copy
  * @returns Temporary project root
  */
-function copyTemplateAstGrep(stack: "typescript" | "rails" | "phaser"): string {
+function copyTemplateAstGrep(stack: Stack): string {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `lisa-${stack}-sg-`));
   fs.cpSync(
     path.join(REPO_ROOT, stack, "copy-overwrite", AST_GREP_RULES, ".."),
@@ -47,7 +50,7 @@ function copyTemplateAstGrep(stack: "typescript" | "rails" | "phaser"): string {
  * @param expectedRuleId - Rule id expected in ast-grep output
  */
 function scanExpectingDiagnostic(
-  stack: "typescript" | "rails" | "phaser",
+  stack: Stack,
   filePath: string,
   source: string,
   expectedRuleId: string
@@ -72,6 +75,117 @@ function scanExpectingDiagnostic(
   expect(status).toBe(1);
   expect(output).toContain(expectedRuleId);
 }
+
+/** One ast-grep diagnostic, narrowed to the fields these tests assert on. */
+type Diagnostic = {
+  readonly ruleId: string;
+  readonly text: string;
+};
+
+/**
+ * Scan a planted source file with one stack's rules and return the diagnostics
+ * attributable to a single rule.
+ *
+ * Returning the matches — rather than just an exit status — lets a test assert
+ * that a rule stayed silent on legitimate code while another asserts it fired
+ * on a violation. A rule that matches nothing at all passes a "no diagnostics"
+ * assertion just as convincingly as a correct one, so the two assertions are
+ * only meaningful as a pair.
+ * @param stack - Stack template under test
+ * @param filePath - Project-relative file to write and scan
+ * @param source - Source text to scan
+ * @param ruleId - Rule whose diagnostics should be returned
+ * @returns Diagnostics produced by that rule
+ */
+function scanForRule(
+  stack: Stack,
+  filePath: string,
+  source: string,
+  ruleId: string
+): readonly Diagnostic[] {
+  const tempDir = copyTemplateAstGrep(stack);
+  const absoluteFile = path.join(tempDir, filePath);
+  let output = "";
+
+  fs.mkdirSync(path.dirname(absoluteFile), { recursive: true });
+  fs.writeFileSync(absoluteFile, source, "utf-8");
+  ({ stdout: output } = spawnSync(
+    AST_GREP,
+    ["scan", "--json=compact", filePath],
+    {
+      cwd: tempDir,
+      encoding: "utf-8",
+    }
+  ));
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+  return (JSON.parse(output || "[]") as readonly Diagnostic[]).filter(
+    diagnostic => diagnostic.ruleId === ruleId
+  );
+}
+
+/**
+ * Rule files that must agree on which `fs-extra` members are reachable.
+ *
+ * Both the stack template copies that ship to host projects and the mirrored
+ * copies Lisa scans itself with. Including the mirrors pins them to the
+ * template as a side effect: a mirror edited out of step with its source stops
+ * matching real Node and fails here, rather than quietly protecting Lisa to a
+ * different standard than the fleet.
+ */
+const FS_EXTRA_RULES = [
+  "typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member.yml",
+  "typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member-js.yml",
+  "ast-grep/rules/no-missing-fs-extra-namespace-member.yml",
+  "ast-grep/rules/no-missing-fs-extra-namespace-member-js.yml",
+] as const;
+
+/** Rule id of the TypeScript-language `fs-extra` namespace rule. */
+const FS_EXTRA_RULE_ID = "no-missing-fs-extra-namespace-member";
+
+/**
+ * Read the `fs-extra` namespace keys as real Node resolves them.
+ *
+ * This is the anti-rot half of the control. The shipped ast-grep rules must
+ * hardcode their allow list — ast-grep cannot resolve a module — so something
+ * has to notice if `fs-extra` ever changes what its namespace exposes. Lisa
+ * declares `fs-extra` as a real dependency, so it can run that probe centrally
+ * on behalf of every host project, none of which declare `fs-extra` at all.
+ * @returns Every own key on the Node-resolved namespace object
+ */
+function fsExtraNamespaceMembers(): ReadonlySet<string> {
+  const script =
+    'import * as fse from "fs-extra"; process.stdout.write(JSON.stringify(Object.keys(fse)));';
+  return new Set(
+    JSON.parse(
+      spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+        cwd: REPO_ROOT,
+        encoding: "utf-8",
+      }).stdout
+    ) as readonly string[]
+  );
+}
+
+/**
+ * Extract the member allow list from a rule file's `MEMBER` constraint.
+ *
+ * Throws rather than returning an empty set when the pattern does not match:
+ * an extractor that quietly yields nothing would make the comparison below
+ * pass against a rule file it never actually read.
+ * @param relativePath - Rule file relative to the repository root
+ * @returns Members the rule treats as reachable
+ */
+function allowListFromRule(relativePath: string): ReadonlySet<string> {
+  const matched = /regex:\s*\^\((?<body>[^)]+)\)\$/u.exec(
+    readText(relativePath)
+  );
+  const body = matched?.groups?.["body"];
+  if (body === undefined || body.length === 0) {
+    throw new Error(`No MEMBER allow list found in ${relativePath}`);
+  }
+  return new Set(body.split("|"));
+}
+
 describe("ast-grep stack templates", () => {
   it("ships real TypeScript rules into downstream TypeScript-family projects", () => {
     expect(readText("typescript/copy-overwrite/sgconfig.yml")).toContain(
@@ -92,6 +206,75 @@ describe("ast-grep stack templates", () => {
       'const Foo = () => null;\nFoo.displayName = "Wrong";\n',
       "no-inline-component-in-view"
     );
+  });
+
+  it("flags fs-extra namespace members Node's ESM namespace does not expose", () => {
+    expect(fs.existsSync(path.join(REPO_ROOT, FS_EXTRA_RULES[0]))).toBe(true);
+
+    scanExpectingDiagnostic(
+      "typescript",
+      "src/tools/build.ts",
+      'import * as fse from "fs-extra";\n\nexport const load = async () => await fse.readJson("a.json");\n',
+      FS_EXTRA_RULE_ID
+    );
+  });
+
+  it("leaves real fs-extra members, and default imports, alone", () => {
+    // Proves the rule is actually loaded and firing in this harness. Without
+    // it, the silence asserted below would be indistinguishable from a rule
+    // that never ran.
+    const violations = scanForRule(
+      "typescript",
+      "src/tools/violation.ts",
+      'import * as fse from "fs-extra";\n\nexport const load = async () => await fse.readJson("a.json");\n',
+      FS_EXTRA_RULE_ID
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.text).toBe("fse.readJson");
+
+    // `pathExists` is genuinely on the namespace, and the DEFAULT export
+    // carries every member including `readJson` — flagging either would be a
+    // fleet-wide false positive at error severity.
+    const clean = scanForRule(
+      "typescript",
+      "src/tools/clean.ts",
+      [
+        'import * as fse from "fs-extra";',
+        'import fseDefault from "fs-extra";',
+        'import * as nodePath from "node:path";',
+        "",
+        "export const check = async () => {",
+        '  if (await fse.pathExists("a")) {',
+        '    await fse.ensureDir("b");',
+        '    await fse.copy("b", "c");',
+        '    await fse.remove("c");',
+        "  }",
+        '  await fseDefault.readJson("d.json");',
+        '  return nodePath.join("a", "b");',
+        "};",
+        "",
+      ].join("\n"),
+      FS_EXTRA_RULE_ID
+    );
+    expect(clean).toEqual([]);
+  });
+
+  it("keeps the hardcoded fs-extra allow list equal to what real Node exposes", () => {
+    const actual = fsExtraNamespaceMembers();
+
+    // Guards the probe itself: an empty set would satisfy every subset check
+    // below while proving nothing about fs-extra.
+    expect(actual.size).toBeGreaterThan(10);
+    expect(actual.has("pathExists")).toBe(true);
+    expect(actual.has("readJson")).toBe(false);
+
+    const byName = (left: string, right: string): number =>
+      left.localeCompare(right);
+    const expected = [...actual].sort(byName);
+
+    for (const rule of FS_EXTRA_RULES) {
+      expect([...allowListFromRule(rule)].sort(byName)).toEqual(expected);
+    }
   });
 
   it("ships Ruby security rules into downstream Rails projects", () => {

--- a/typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member-js.yml
+++ b/typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member-js.yml
@@ -1,0 +1,53 @@
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+#
+# JavaScript-language twin of `no-missing-fs-extra-namespace-member.yml`.
+#
+# ast-grep binds one parser per rule: `language: typescript` scans only
+# .ts/.mts/.cts, so .js/.mjs/.cjs would otherwise be an unguarded gap — and a
+# guard with a silent hole is the failure mode this rule exists to prevent.
+# Build scripts and tooling in TypeScript projects are routinely .mjs, and
+# fs-extra is exactly the kind of dependency they reach for.
+#
+# The `constraints` block MUST stay byte-identical to the TypeScript rule.
+# `tests/unit/config/ast-grep-template.test.ts` asserts both files carry the
+# same allow list AND that it still equals the set real Node reports, so these
+# two cannot drift apart or drift away from reality unnoticed.
+#
+# See the TypeScript rule for the full rationale on why this is an allow list
+# rather than a deny list, and why the set is stable across fs-extra 11.x.
+id: no-missing-fs-extra-namespace-member-js
+language: javascript
+severity: error
+message: |
+  `fs-extra` does not expose this member on its ESM namespace object.
+
+  `import * as fse from "fs-extra"` resolves to fs-extra's CommonJS entry, so
+  Node derives the namespace keys with cjs-module-lexer. Only fs-extra's own
+  directly-assigned functions survive that. Absent members include every JSON
+  helper (readJson, readJSON, writeJson, outputJson, and their Sync forms),
+  every node:fs passthrough (readFile, writeFile, readdir, stat, existsSync,
+  appendFile, ...), and copySync, moveSync, removeSync, pathExistsSync and
+  outputFileSync.
+
+  The call is `undefined` at run time and throws a TypeError, and unit tests
+  cannot see it — Vitest and Jest resolve the import through CJS interop and
+  hand back the default export's properties.
+
+  Fix by importing the concrete API instead:
+    - file I/O     -> `readFile` / `writeFile` from `node:fs/promises`
+    - JSON         -> read the file, then `JSON.parse` / `JSON.stringify`
+    - whole module -> `import fse from "fs-extra"`. The DEFAULT export does
+                      carry every member and is deliberately not flagged here.
+rule:
+  all:
+    - pattern: $NS.$MEMBER
+    - inside:
+        kind: program
+        stopBy: end
+        has:
+          pattern: import * as $NS from "fs-extra"
+constraints:
+  MEMBER:
+    not:
+      regex: ^(copy|createFile|createFileSync|createLink|createLinkSync|createSymlink|createSymlinkSync|default|emptyDir|emptyDirSync|emptydir|emptydirSync|ensureDir|ensureDirSync|ensureFile|ensureFileSync|ensureLink|ensureLinkSync|ensureSymlink|ensureSymlinkSync|exists|mkdirp|mkdirpSync|mkdirs|mkdirsSync|move|outputFile|pathExists|read|readv|remove|write|writev)$

--- a/typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member.yml
+++ b/typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member.yml
@@ -1,0 +1,64 @@
+# This file is managed by Lisa.
+# Do not edit directly — changes will be overwritten on the next `lisa` run.
+#
+# Bans `fs-extra` namespace members that do not exist under real Node ESM.
+#
+# The allow list below is an ALLOW list, not a deny list, and that is
+# deliberate. A deny list fails open: any absent member nobody thought to
+# enumerate passes silently, which is the exact rot this rule exists to
+# prevent. An allow list fails closed — an unrecognised member is flagged
+# loudly and a human decides.
+#
+# The list is the set of keys real Node reports for
+# `import * as fse from "fs-extra"`. It is byte-identical across fs-extra
+# 11.1.1, 11.3.3, 11.3.4 and 11.3.5, because the bare specifier always routes
+# through the package `exports` map to the CommonJS entry (`./lib/index.js`)
+# and Node derives the namespace keys with cjs-module-lexer from a re-export
+# shape that has not changed. `lib/esm.mjs` — which does export the JSON
+# helpers — is reachable only via the `fs-extra/esm` subpath, which is a
+# different import.
+#
+# Anti-rot: `tests/unit/core/fs-extra-namespace-callsites.test.ts` in the Lisa
+# monorepo derives this same set from real Node at run time, and
+# `tests/unit/config/ast-grep-template.test.ts` asserts the list below still
+# equals it. If fs-extra ever changes its namespace surface, that pairing goes
+# red centrally instead of this list silently drifting in every host project.
+id: no-missing-fs-extra-namespace-member
+language: typescript
+severity: error
+message: |
+  `fs-extra` does not expose this member on its ESM namespace object.
+
+  `import * as fse from "fs-extra"` resolves to fs-extra's CommonJS entry, so
+  Node derives the namespace keys with cjs-module-lexer. Only fs-extra's own
+  directly-assigned functions survive that. Absent members include every JSON
+  helper (readJson, readJSON, writeJson, outputJson, and their Sync forms),
+  every node:fs passthrough (readFile, writeFile, readdir, stat, existsSync,
+  appendFile, ...), and copySync, moveSync, removeSync, pathExistsSync and
+  outputFileSync.
+
+  The call is `undefined` at run time and throws a TypeError. Unit tests are
+  structurally blind to it: Vitest and Jest resolve the import through CJS
+  interop and hand back the default export's properties, so the call is a
+  function in every test and `undefined` in production. Lisa shipped this
+  defect three times in one release window (#2482, #2487) — once as a crash
+  that stranded seven merged PRs, twice inside error-swallowing `catch` blocks
+  where the TypeError replaced the error being handled.
+
+  Fix by importing the concrete API instead:
+    - file I/O     -> `readFile` / `writeFile` from `node:fs/promises`
+    - JSON         -> read the file, then `JSON.parse` / `JSON.stringify`
+    - whole module -> `import fse from "fs-extra"`. The DEFAULT export does
+                      carry every member and is deliberately not flagged here.
+rule:
+  all:
+    - pattern: $NS.$MEMBER
+    - inside:
+        kind: program
+        stopBy: end
+        has:
+          pattern: import * as $NS from "fs-extra"
+constraints:
+  MEMBER:
+    not:
+      regex: ^(copy|createFile|createFileSync|createLink|createLinkSync|createSymlink|createSymlinkSync|default|emptyDir|emptyDirSync|emptydir|emptydirSync|ensureDir|ensureDirSync|ensureFile|ensureFileSync|ensureLink|ensureLinkSync|ensureSymlink|ensureSymlinkSync|exists|mkdirp|mkdirpSync|mkdirs|mkdirsSync|move|outputFile|pathExists|read|readv|remove|write|writev)$


### PR DESCRIPTION
Ships the fleet-wide lint-time control for the `import * as fse from "fs-extra"` namespace defect class. Lisa hit this three times in one release window (#2482, #2487) — once as a crash that stranded seven merged PRs behind three failed Release runs, twice inside error-swallowing `catch` blocks where the resulting TypeError replaced the error being handled. #2500 gave Lisa a runtime-derived control over its own tree; host projects had none.

Resolves #2494 (closed by hand after merge — the `Closes` keyword does not fire in this repo).

## The verification that changed the deliverable

Mid-build this looked like fatal version drift. **Every published fs-extra tarball from 11.1.1 to 11.3.5 exposes 44 ESM named exports, including `readJson`, `writeJson`, `copySync` and `removeSync`** — all members this rule flags. An allow list derived from one version would have false-positived fleet-wide at error severity.

It is not drift. fs-extra's `exports` map routes the bare specifier to the **CommonJS** entry:

```json
{ ".": "./lib/index.js", "./esm": "./lib/esm.mjs" }
```

`lib/esm.mjs` — the file with those 44 exports — is reachable only via the separate `fs-extra/esm` subpath, which is a different import. So `import * as fse from "fs-extra"` gets its namespace from Node's **cjs-module-lexer** reading `lib/index.js`, and only fs-extra's directly-assigned functions survive that.

Verified by real `npm install` plus a Node probe at 11.1.1, 11.3.3, 11.3.4 and 11.3.5 — **byte-identical 33 keys at every version**, listed below. Lisa depends on `fs-extra@^11.0.0`, entirely inside the verified range, and the surveyed fleet hoists 11.3.4/11.3.5.

This matters for review: **anyone who re-derives the list by reading the tarball will reach the opposite conclusion and think this rule is broken.** The list must be derived by importing, not by reading `lib/esm.mjs`. It also upgrades the safety case from "a snapshot of one version, hopefully stable" to "invariant across every version the fleet hoists", for a structural reason rather than a lucky one.

## Deviation from the issue: the deny list was fail-open

The issue proposed hardcoding the **forbidden** members (`readFile|writeFile|readJson|...`). That fails open — any absent member nobody thought to enumerate passes silently, and the gap is invisible precisely because it looks green. That is the same failure mode as the fail-open classes in #2495 and the vacuous required check in #2497: a control that reports success without proving anything.

Inverted to an **allow list** of the 33 members that do exist. An unrecognised member fails closed and a human decides. This is not just an implementation of the issue — it fixes a fail-open in the issue's own proposal, and it is the more important half of the change.

## Design choices worth not "tightening" later

**Matches any namespace binding, not a hardcoded `fse`.** The rule unifies the namespace metavariable across the member access and the import statement:

```yaml
rule:
  all:
    - pattern: $NS.$MEMBER
    - inside:
        kind: program
        stopBy: end
        has:
          pattern: import * as $NS from "fs-extra"
```

So `import * as fsExtra from "fs-extra"` is caught, and an unrelated `import * as path from "node:path"` is not. `fse` is only Lisa's convention; hosts need not share it.

**Default imports are deliberately exempt.** `import fse from "fs-extra"` followed by `fse.readJson(...)` is *correct code* — the default export carries every member. Flagging it would have been a fleet-wide false positive at error severity. A future maintainer may read the exemption as an oversight; it is not.

**Comments are structurally immune.** Lisa's own `src/` contains two JSDoc blocks that literally contain the string `fse.readJson` while documenting this defect. AST matching never sees comment text, so no comment-stripping pass is needed — unlike the runtime check, which needs one.

**Two rules, not one.** ast-grep binds one parser per rule. `language: typescript` scans only `.ts/.mts/.cts` (verified); `.js/.mjs/.cjs` would otherwise be an unguarded hole in exactly the build-script files that reach for fs-extra. The `javascript` twin closes it, and a test pins the two allow lists together so they cannot drift apart.

## Anti-rot pairing, and why it is not in the template

The issue asked that a hardcoded list be paired with something that notices when fs-extra changes. That sentinel is `tests/unit/config/ast-grep-template.test.ts`, which derives the set from real Node and asserts all four rule files still match it — the two stack-template copies that ship to hosts, and the two Lisa scans itself with. Checking the mirrors pins them to the template as a side effect: a mirror edited out of step with its source stops matching real Node and fails here, instead of quietly protecting Lisa to a different standard than the fleet.

The sentinel lives **in this repo only**, not in the stack template. Two reasons:

- **Phantom dependency.** No host declares `fs-extra`; it is only hoisted transitively. A per-host probe importing it would break on any hoisting change.
- **Lisa's runtime check asserts `callSites.length > 0`** — right for a repo with 110 call sites, an immediate failure in the 14 host repos that have zero.

One live sentinel in the repo that actually depends on fs-extra beats fourteen copies of a probe that cannot run.

## Ratchet safety

Error severity, cleared by a read-only survey of 20 repos across `tunnlai`, `geminisportsai`, `propswap` and `gunnertech`: **zero violations — no repo imports `fs-extra` at all** (only `@types/fs-extra` as a devDep), and none is `"type": "module"`. A free ratchet that prevents the class before the first host adopts ESM, meeting the `wiki/decisions/2026-08-12-ratchet-policy.md` bar of a deterministic check with a known-zero violation surface.

Lisa's own tree is also clean: `ast-grep scan src scripts` reports **0 violations**, so the mirrored rules give Lisa lint-time protection alongside its runtime sentinel at no cost.

### Honest limit on what "error severity" buys today — #2506

I traced the chain from "rule fires" to "merge blocked" rather than assuming it, and **the last link is missing**: `🔎 AST Grep Scan` is **not a required status check** on `main`. The rule fires, the job reddens, and auto-merge proceeds anyway.

Everything upstream of that is sound — `sg_scan` has no `continue-on-error`, `ast-grep scan` exits 1 on `severity: error` (verified), and Lisa's `ci.yml` passes `skip_jobs: ''` — so the job goes red exactly as designed. Nothing consumes the result.

This is not specific to this rule; it makes **every** ast-grep rule in the repo advisory, including the existing `no-inline-component-*`, `harper/*`, `phaser/*` and `ruby/*` rules. Filed as **#2506**, not fixed here: changing branch protection is a human-gated governance change, and a build agent should not grant its own lint rule enforcement power as a side effect of shipping it.

The enforcement story is one thread across three tickets, so following it in order:

- **#2494** (this PR) — a proven detector, error severity, zero fleet violations.
- **#2506** — that detector is not a required context, so it cannot block a merge. One templated line in `typescript/github-rulesets/quality-checks.json`, fleet-wide on next apply.
- **#2509** — the policy those two imply: *a check may only become a required context if its budget has proven headroom.* Directly relevant here, since making `🔎 AST Grep Scan` required is exactly such a promotion, and the Rails caveat in #2506 (a context no job reports would block every Rails PR permanently) is the failure that policy exists to prevent.

So this PR should be read as delivering a **correct and proven detector** whose enforcement is one ruleset edit away — not as a gate that is live today. The zero-violation survey means nothing regresses in the meantime.

## Proof it fires, in both directions

Against a real violation rather than only its own fixture:

```
FLAGGED (15):
  fse.readJson   fse.readJSON    fse.writeJson      fse.outputJson
  fse.readFile   fse.writeFile   fse.readdir        fse.stat
  fse.existsSync fse.copySync    fse.moveSync       fse.removeSync
  fse.pathExistsSync   fse.outputFileSync   fse.appendFile
```

Not flagged in the same file: `fse.copy`, `fse.ensureDir`, `fse.ensureDirSync`, `fse.ensureFile`, `fse.emptyDir`, `fse.move`, `fse.outputFile`, `fse.pathExists`, `fse.remove`, `fse.mkdirp`, `fse.mkdirsSync`, `fse.createSymlink`, `fse.exists`; plus `path.join`, both `fseDefault.*` calls, and the JSDoc prose naming `fse.readJson`.

Note `copySync`, `moveSync`, `removeSync`, `pathExistsSync` and `outputFileSync` are flagged while `copy`, `move`, `remove` and `pathExists` are not — the Sync variants really are absent. Assuming "member present implies Sync variant present" would have produced four false negatives; deriving the list caught it.

## The 33 members

`copy`, `createFile`, `createFileSync`, `createLink`, `createLinkSync`, `createSymlink`, `createSymlinkSync`, `default`, `emptyDir`, `emptyDirSync`, `emptydir`, `emptydirSync`, `ensureDir`, `ensureDirSync`, `ensureFile`, `ensureFileSync`, `ensureLink`, `ensureLinkSync`, `ensureSymlink`, `ensureSymlinkSync`, `exists`, `mkdirp`, `mkdirpSync`, `mkdirs`, `mkdirsSync`, `move`, `outputFile`, `pathExists`, `read`, `readv`, `remove`, `write`, `writev`

## Tests

Three, in `tests/unit/config/ast-grep-template.test.ts`. Each is built so it cannot pass vacuously:

- the silence assertion is paired with a violation scanned through the **same harness**, because "no diagnostics" is otherwise indistinguishable from a rule that never loaded;
- the allow-list extractor **throws** rather than returning an empty set when its pattern does not match, since an empty set would satisfy the comparison while proving nothing;
- the Node probe asserts a non-trivial key count, plus `pathExists` present and `readJson` absent, before comparing.

## Deliberately not done here: no seventh rule-test — filed as #2505

`ast-grep/rule-tests/` holds six rule-test files and six snapshots, and **nothing in the repo or CI ever invokes `ast-grep test`**. They do not run.

The obvious move was to add a seventh alongside them, matching the visible convention. I did not, and this is a considered choice rather than an omission: a test file that never executes is the same false-green this PR exists to prevent — it reads as coverage to anyone skimming the tree while proving nothing. Adding one manufactures the appearance of coverage, which is worse than a visible gap. The coverage went into vitest, which does run.

Filed as #2505 rather than left as a note here, since a note in a merged PR is not a work item.

Work-Item: CodySwannGT/lisa#2494
