### PR TITLE
test(tracker): quantify the decidability contract universally, not existentially

### DIFF
--- a/plugins/lisa-copilot/rules/reference/derived-branch-plan.md
+++ b/plugins/lisa-copilot/rules/reference/derived-branch-plan.md
@@ -85,9 +85,25 @@ Stated plainly, because the session that produced this contract exists to make e
 
 This is **not** an executable control. `ready-role-filing`'s sibling guard is a hook that exits 2 and physically refuses a tool call; nothing here refuses anything. What enforces this contract is a validator agent reading `SKILL.md` and choosing to apply it — the same rung of the ladder that failed to bind 13 filings out of 13.
 
-What the regression suite adds is narrower than enforcement and worth naming precisely: it pins the **wording** across all six generated skill roots, so the contract cannot be silently deleted, softened, or lost in a regeneration. It cannot catch a validator that documents the rule and then ignores it at runtime.
+The regression suite has two halves. **Why they bind differently is `falsifiable-checks`' subject, not this rule's** — read the quantifier guidance there. What belongs here is the measurement, because this contract happens to be where it was taken.
 
-That is the ceiling for now rather than a shortcut, because `SKILL.md` *is* the validators' execution substrate — there is no compiled artifact underneath to attach a hook to. The honest summary is: absence-as-`false` was undecidable and is now *decidable*, which is a real improvement and a strictly weaker claim than *enforced*. Treat a gate verdict resting on this contract as evidence, not proof, until a deterministic checker exists to read the declaration off a live item.
+- `runtime-behavior-change-decidability.test.ts` asserts the wording is *present* across all six generated skill roots. It pins the contract against silent deletion or a lossy regeneration, and proves nothing about any particular copy.
+- `runtime-behavior-change-consistency.test.ts` asserts no copy says the *wrong* thing, over every occurrence in the corpus: every declaration marker uses the em-dash discriminator, every absence-derivation site resolves to *underivable* within its own sentence, and no phrasing maps an absent section to `false` or hands authority back to the caller.
+
+This document states its rule **twice** — once in gate S8, once in the execution step — which is what made the gap observable. `lisa-linear-validate-issue` once spelled the discriminator with an ASCII hyphen in its execution step while its own S8 used the em-dash, and 192 assertions stayed green through that mutation twice running. The fix pinned the execution step and left S8's copy bare. Mutating each site separately, whole suite, before and after the second half landed:
+
+| mutated site | before | after |
+|---|---|---|
+| execution step reads an absent section as `false` | 18 | 36 |
+| **gate S8's prose reads an absent section as `false`** | **0** | **18** |
+| writers stop rendering the section | 36 | 54 |
+| a caller's assertion beats the stored declaration | 18 | 36 |
+
+Zero out of 11,270 — same file, same rule, same commit, one site pinned and its twin bare.
+
+(The wrong spelling is deliberately not written out above. This section sits inside the corpus the consistency suite scans, and the first draft of it quoted the defect as an illustration and failed its own check.)
+
+**The executable half of this contract is nothing.** Both suites read markdown. `SKILL.md` *is* the validators' execution substrate — there is no compiled artifact underneath to attach a hook to, so there is no function to call and no return value to assert. What they prove is that the instruction the agent reads is internally consistent; what neither can prove is that the agent then obeys it. Absence-as-`false` was undecidable, is now *decidable* and *non-contradictory*, and both of those are strictly weaker than *enforced*. Treat a gate verdict resting on this contract as evidence, not proof, until a deterministic checker exists to read the declaration off a live item.
 
 This costs nothing in derivation difficulty. A single-environment project — Lisa itself is one, `deploy.branches: { production: main }` — recomputes every applicable item to the same branch. The gate was never hard to satisfy; it was impossible to *audit*, and those are different problems with different fixes. Weakening S19 would have fixed neither.
 

--- a/plugins/lisa-cursor/rules/derived-branch-plan-reference.mdc
+++ b/plugins/lisa-cursor/rules/derived-branch-plan-reference.mdc
@@ -90,9 +90,25 @@ Stated plainly, because the session that produced this contract exists to make e
 
 This is **not** an executable control. `ready-role-filing`'s sibling guard is a hook that exits 2 and physically refuses a tool call; nothing here refuses anything. What enforces this contract is a validator agent reading `SKILL.md` and choosing to apply it — the same rung of the ladder that failed to bind 13 filings out of 13.
 
-What the regression suite adds is narrower than enforcement and worth naming precisely: it pins the **wording** across all six generated skill roots, so the contract cannot be silently deleted, softened, or lost in a regeneration. It cannot catch a validator that documents the rule and then ignores it at runtime.
+The regression suite has two halves. **Why they bind differently is `falsifiable-checks`' subject, not this rule's** — read the quantifier guidance there. What belongs here is the measurement, because this contract happens to be where it was taken.
 
-That is the ceiling for now rather than a shortcut, because `SKILL.md` *is* the validators' execution substrate — there is no compiled artifact underneath to attach a hook to. The honest summary is: absence-as-`false` was undecidable and is now *decidable*, which is a real improvement and a strictly weaker claim than *enforced*. Treat a gate verdict resting on this contract as evidence, not proof, until a deterministic checker exists to read the declaration off a live item.
+- `runtime-behavior-change-decidability.test.ts` asserts the wording is *present* across all six generated skill roots. It pins the contract against silent deletion or a lossy regeneration, and proves nothing about any particular copy.
+- `runtime-behavior-change-consistency.test.ts` asserts no copy says the *wrong* thing, over every occurrence in the corpus: every declaration marker uses the em-dash discriminator, every absence-derivation site resolves to *underivable* within its own sentence, and no phrasing maps an absent section to `false` or hands authority back to the caller.
+
+This document states its rule **twice** — once in gate S8, once in the execution step — which is what made the gap observable. `lisa-linear-validate-issue` once spelled the discriminator with an ASCII hyphen in its execution step while its own S8 used the em-dash, and 192 assertions stayed green through that mutation twice running. The fix pinned the execution step and left S8's copy bare. Mutating each site separately, whole suite, before and after the second half landed:
+
+| mutated site | before | after |
+|---|---|---|
+| execution step reads an absent section as `false` | 18 | 36 |
+| **gate S8's prose reads an absent section as `false`** | **0** | **18** |
+| writers stop rendering the section | 36 | 54 |
+| a caller's assertion beats the stored declaration | 18 | 36 |
+
+Zero out of 11,270 — same file, same rule, same commit, one site pinned and its twin bare.
+
+(The wrong spelling is deliberately not written out above. This section sits inside the corpus the consistency suite scans, and the first draft of it quoted the defect as an illustration and failed its own check.)
+
+**The executable half of this contract is nothing.** Both suites read markdown. `SKILL.md` *is* the validators' execution substrate — there is no compiled artifact underneath to attach a hook to, so there is no function to call and no return value to assert. What they prove is that the instruction the agent reads is internally consistent; what neither can prove is that the agent then obeys it. Absence-as-`false` was undecidable, is now *decidable* and *non-contradictory*, and both of those are strictly weaker than *enforced*. Treat a gate verdict resting on this contract as evidence, not proof, until a deterministic checker exists to read the declaration off a live item.
 
 This costs nothing in derivation difficulty. A single-environment project — Lisa itself is one, `deploy.branches: { production: main }` — recomputes every applicable item to the same branch. The gate was never hard to satisfy; it was impossible to *audit*, and those are different problems with different fixes. Weakening S19 would have fixed neither.
 

--- a/plugins/lisa/rules/reference/derived-branch-plan.md
+++ b/plugins/lisa/rules/reference/derived-branch-plan.md
@@ -85,9 +85,25 @@ Stated plainly, because the session that produced this contract exists to make e
 
 This is **not** an executable control. `ready-role-filing`'s sibling guard is a hook that exits 2 and physically refuses a tool call; nothing here refuses anything. What enforces this contract is a validator agent reading `SKILL.md` and choosing to apply it — the same rung of the ladder that failed to bind 13 filings out of 13.
 
-What the regression suite adds is narrower than enforcement and worth naming precisely: it pins the **wording** across all six generated skill roots, so the contract cannot be silently deleted, softened, or lost in a regeneration. It cannot catch a validator that documents the rule and then ignores it at runtime.
+The regression suite has two halves. **Why they bind differently is `falsifiable-checks`' subject, not this rule's** — read the quantifier guidance there. What belongs here is the measurement, because this contract happens to be where it was taken.
 
-That is the ceiling for now rather than a shortcut, because `SKILL.md` *is* the validators' execution substrate — there is no compiled artifact underneath to attach a hook to. The honest summary is: absence-as-`false` was undecidable and is now *decidable*, which is a real improvement and a strictly weaker claim than *enforced*. Treat a gate verdict resting on this contract as evidence, not proof, until a deterministic checker exists to read the declaration off a live item.
+- `runtime-behavior-change-decidability.test.ts` asserts the wording is *present* across all six generated skill roots. It pins the contract against silent deletion or a lossy regeneration, and proves nothing about any particular copy.
+- `runtime-behavior-change-consistency.test.ts` asserts no copy says the *wrong* thing, over every occurrence in the corpus: every declaration marker uses the em-dash discriminator, every absence-derivation site resolves to *underivable* within its own sentence, and no phrasing maps an absent section to `false` or hands authority back to the caller.
+
+This document states its rule **twice** — once in gate S8, once in the execution step — which is what made the gap observable. `lisa-linear-validate-issue` once spelled the discriminator with an ASCII hyphen in its execution step while its own S8 used the em-dash, and 192 assertions stayed green through that mutation twice running. The fix pinned the execution step and left S8's copy bare. Mutating each site separately, whole suite, before and after the second half landed:
+
+| mutated site | before | after |
+|---|---|---|
+| execution step reads an absent section as `false` | 18 | 36 |
+| **gate S8's prose reads an absent section as `false`** | **0** | **18** |
+| writers stop rendering the section | 36 | 54 |
+| a caller's assertion beats the stored declaration | 18 | 36 |
+
+Zero out of 11,270 — same file, same rule, same commit, one site pinned and its twin bare.
+
+(The wrong spelling is deliberately not written out above. This section sits inside the corpus the consistency suite scans, and the first draft of it quoted the defect as an illustration and failed its own check.)
+
+**The executable half of this contract is nothing.** Both suites read markdown. `SKILL.md` *is* the validators' execution substrate — there is no compiled artifact underneath to attach a hook to, so there is no function to call and no return value to assert. What they prove is that the instruction the agent reads is internally consistent; what neither can prove is that the agent then obeys it. Absence-as-`false` was undecidable, is now *decidable* and *non-contradictory*, and both of those are strictly weaker than *enforced*. Treat a gate verdict resting on this contract as evidence, not proof, until a deterministic checker exists to read the declaration off a live item.
 
 This costs nothing in derivation difficulty. A single-environment project — Lisa itself is one, `deploy.branches: { production: main }` — recomputes every applicable item to the same branch. The gate was never hard to satisfy; it was impossible to *audit*, and those are different problems with different fixes. Weakening S19 would have fixed neither.
 

--- a/plugins/src/base/rules/reference/derived-branch-plan.md
+++ b/plugins/src/base/rules/reference/derived-branch-plan.md
@@ -85,9 +85,25 @@ Stated plainly, because the session that produced this contract exists to make e
 
 This is **not** an executable control. `ready-role-filing`'s sibling guard is a hook that exits 2 and physically refuses a tool call; nothing here refuses anything. What enforces this contract is a validator agent reading `SKILL.md` and choosing to apply it — the same rung of the ladder that failed to bind 13 filings out of 13.
 
-What the regression suite adds is narrower than enforcement and worth naming precisely: it pins the **wording** across all six generated skill roots, so the contract cannot be silently deleted, softened, or lost in a regeneration. It cannot catch a validator that documents the rule and then ignores it at runtime.
+The regression suite has two halves. **Why they bind differently is `falsifiable-checks`' subject, not this rule's** — read the quantifier guidance there. What belongs here is the measurement, because this contract happens to be where it was taken.
 
-That is the ceiling for now rather than a shortcut, because `SKILL.md` *is* the validators' execution substrate — there is no compiled artifact underneath to attach a hook to. The honest summary is: absence-as-`false` was undecidable and is now *decidable*, which is a real improvement and a strictly weaker claim than *enforced*. Treat a gate verdict resting on this contract as evidence, not proof, until a deterministic checker exists to read the declaration off a live item.
+- `runtime-behavior-change-decidability.test.ts` asserts the wording is *present* across all six generated skill roots. It pins the contract against silent deletion or a lossy regeneration, and proves nothing about any particular copy.
+- `runtime-behavior-change-consistency.test.ts` asserts no copy says the *wrong* thing, over every occurrence in the corpus: every declaration marker uses the em-dash discriminator, every absence-derivation site resolves to *underivable* within its own sentence, and no phrasing maps an absent section to `false` or hands authority back to the caller.
+
+This document states its rule **twice** — once in gate S8, once in the execution step — which is what made the gap observable. `lisa-linear-validate-issue` once spelled the discriminator with an ASCII hyphen in its execution step while its own S8 used the em-dash, and 192 assertions stayed green through that mutation twice running. The fix pinned the execution step and left S8's copy bare. Mutating each site separately, whole suite, before and after the second half landed:
+
+| mutated site | before | after |
+|---|---|---|
+| execution step reads an absent section as `false` | 18 | 36 |
+| **gate S8's prose reads an absent section as `false`** | **0** | **18** |
+| writers stop rendering the section | 36 | 54 |
+| a caller's assertion beats the stored declaration | 18 | 36 |
+
+Zero out of 11,270 — same file, same rule, same commit, one site pinned and its twin bare.
+
+(The wrong spelling is deliberately not written out above. This section sits inside the corpus the consistency suite scans, and the first draft of it quoted the defect as an illustration and failed its own check.)
+
+**The executable half of this contract is nothing.** Both suites read markdown. `SKILL.md` *is* the validators' execution substrate — there is no compiled artifact underneath to attach a hook to, so there is no function to call and no return value to assert. What they prove is that the instruction the agent reads is internally consistent; what neither can prove is that the agent then obeys it. Absence-as-`false` was undecidable, is now *decidable* and *non-contradictory*, and both of those are strictly weaker than *enforced*. Treat a gate verdict resting on this contract as evidence, not proof, until a deterministic checker exists to read the declaration off a live item.
 
 This costs nothing in derivation difficulty. A single-environment project — Lisa itself is one, `deploy.branches: { production: main }` — recomputes every applicable item to the same branch. The gate was never hard to satisfy; it was impossible to *audit*, and those are different problems with different fixes. Weakening S19 would have fixed neither.
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -829,7 +829,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/reference/dependency-trust-classes.md":
       "82216b80d4807e0ad302d04924032cc6a7a95b26f72ea853e378572a5c31821c",
     "plugins/src/base/rules/reference/derived-branch-plan.md":
-      "325245c8a40042f35bd83fabc3d6752724fbb2789d6fddade0e5191442846127",
+      "728ef5366d8d2645cce47e4544a7c175d7a7ba8bd6f7768ddb21e4415d53f4ad",
     "plugins/src/base/rules/reference/design-source-of-truth.md":
       "38f477cb0703627ac5daf561a9a1c42bd41be6d20113aba22f30d5e47d573dcf",
     "plugins/src/base/rules/reference/do-it-now.md":
@@ -9129,7 +9129,9 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/repo-scope-claim.test.ts": true,
     "tests/unit/strategies/reset-seed-coverage-rule.test.ts": true,
     "tests/unit/strategies/rework-triage-skill.test.ts": true,
+    "tests/unit/strategies/runtime-behavior-change-consistency.test.ts": true,
     "tests/unit/strategies/runtime-behavior-change-decidability.test.ts": true,
+    "tests/unit/strategies/runtime-behavior-change-sources.ts": true,
     "tests/unit/strategies/security-two-bucket-contract.test.ts": true,
     "tests/unit/strategies/session-operating-pack.test.ts": true,
     "tests/unit/strategies/setup-automations-readiness-warning.test.ts": true,

--- a/tests/unit/strategies/runtime-behavior-change-consistency.test.ts
+++ b/tests/unit/strategies/runtime-behavior-change-consistency.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Internal-consistency coverage for the `runtime_behavior_change` contract —
+ * the falsifiable half of the decidability suite.
+ *
+ * Read this together with `runtime-behavior-change-decidability.test.ts`. The
+ * two files divide one contract along the axis that actually broke:
+ *
+ * - **Decidability (sibling file)** asserts the contract wording is *present*.
+ *   That pins it against silent deletion or a lossy regeneration. Every
+ *   assertion there is existential — "some copy says the right thing".
+ * - **Consistency (this file)** asserts no copy says the *wrong* thing. Every
+ *   assertion here is universal — quantified over every occurrence in the
+ *   corpus, so a second copy cannot contradict the first.
+ *
+ * The distinction is not academic. The defect that produced this file shipped
+ * twice. `lisa-linear-validate-issue` spelled the discriminator `` `None -` ``
+ * in its execution step while its own gate S8 spelled it `` `None —` ``, and a
+ * suite of 192 existential assertions stayed green through the mutation both
+ * times: `toContain` is satisfied by any one correct occurrence, and so is a
+ * regex for the correct sentence, because these files state the grammar twice.
+ * The correct S8 copy vouched for the broken execution step.
+ *
+ * A validator whose execution step disagrees with its own documented gate
+ * reads a correctly-exempt item as *underivable* — or, far worse in the other
+ * direction, reads an absent section as `false`, which is exactly the silent
+ * assumption that made S8, S11, S14, and S19 unauditable on a live item.
+ *
+ * **What this can and cannot prove.** `SKILL.md` *is* the validators'
+ * execution substrate — `runtime_behavior_change` has no compiled artifact
+ * underneath, so there is no function to call and no return value to assert.
+ * These are still assertions over prose. What changed is the quantifier, and
+ * that is the half that binds: a universal negative over the whole corpus
+ * cannot be satisfied by a correct copy elsewhere in the file. Deletion is the
+ * sibling file's job; contradiction is this one's. Neither catches an agent
+ * that reads a correct instruction and disobeys it.
+ * @module tests/unit/strategies/runtime-behavior-change-consistency
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  CONTRACT_SKILLS,
+  RULE_ROOTS,
+  SKILL_ROOTS,
+  VALIDATORS,
+  readRule,
+  readSkill,
+} from "./runtime-behavior-change-sources.js";
+
+/** Every `` `None …` `` code span, tolerating a markdown line wrap inside it. */
+const MARKER_SPAN = /`None[^`]*`/gs;
+
+/** Every place the prose points at a missing declaration. */
+const ABSENCE_SITE = /\babsent\b\W{0,4}\bsection\b/gi;
+
+/**
+ * Phrasings that read a missing declaration as `false`.
+ *
+ * Stated as a universal negative on purpose. The positive form — "the file
+ * says underivable somewhere" — is what let the marker mutation through twice.
+ */
+const ABSENCE_AS_FALSE: readonly RegExp[] = [
+  /\babsent\b\W{0,4}\bsection\b[^.\n]{0,30}?(?:\b(?:means|is|reads as)\b|→|=)\s*\*{0,2}`?false`?/i,
+  /\babsence\b[^.\n]{0,30}?(?:\b(?:means|is|reads as)\b|→|=)\s*\*{0,2}`?false`?/i,
+  /\bno section\b[^.\n]{0,30}?(?:\b(?:means|is|reads as)\b|→|=)\s*\*{0,2}`?false`?/i,
+  /\|[^|\n]*\babsent\b[^|\n]*\|\s*\*{0,2}`?false`?\*{0,2}\s*\|/i,
+];
+
+/** Phrasings that hand authority back to the caller's assertion. */
+const CALLER_BEATS_STORED: readonly RegExp[] = [
+  /\bcallers?(?:'s|')?\b[^.\n]{0,60}?\b(?:is taken as given|takes precedence|is authoritative|is trusted|is believed)\b/i,
+  /\basserted\b[^.\n]{0,40}?\bbeats\b[^.\n]{0,40}?\bpersisted\b/i,
+];
+
+/**
+ * How many times each skill must state the absence rule.
+ *
+ * Two for a validator is load-bearing, not incidental: the gate prose and the
+ * execution step each carry a copy, and that duplication is the structure the
+ * marker bug hid in. Requiring both means neither can be quietly dropped, and
+ * the per-site check below means neither can quietly disagree.
+ */
+const ABSENCE_SITE_MINIMUM: Readonly<Record<string, number>> = {
+  "lisa-github-validate-issue": 2,
+  "lisa-jira-validate-ticket": 2,
+  "lisa-linear-validate-issue": 2,
+  "lisa-github-write-issue": 1,
+  "lisa-jira-write-ticket": 1,
+  "lisa-linear-write-issue": 1,
+  "lisa-implement": 1,
+};
+
+/** Characters of context a derivation site gets to resolve to a verdict. */
+const SITE_WINDOW = 90;
+
+/**
+ * Collapse markdown line wrapping so a span split across lines compares
+ * against the same literal as one written on a single line.
+ * @param value - Raw matched text.
+ * @returns The text with runs of whitespace collapsed to one space.
+ */
+const unwrap = (value: string): string => value.replace(/\s+/gu, " ");
+
+/**
+ * Every marker span in a document, unwrapped.
+ * @param content - The document body.
+ * @returns The normalized spans, in source order.
+ */
+const markerSpans = (content: string): readonly string[] =>
+  [...content.matchAll(MARKER_SPAN)].map(match => unwrap(match[0]));
+
+/**
+ * Every absence-derivation site in a document, with its trailing context.
+ * @param content - The document body.
+ * @returns One window per site, in source order.
+ */
+const absenceWindows = (content: string): readonly string[] =>
+  [...content.matchAll(ABSENCE_SITE)].map(match =>
+    content.slice(match.index, match.index + SITE_WINDOW)
+  );
+
+describe("every declaration marker uses the em-dash discriminator", () => {
+  describe.each(SKILL_ROOTS)("%s", root => {
+    it.each(CONTRACT_SKILLS)("%s spells every marker `None —`", slug => {
+      const spans = markerSpans(readSkill(root, slug));
+
+      // Non-vacuity. A universal check over an empty corpus passes trivially,
+      // which is the one way this assertion could rot into a no-op.
+      expect(spans.length).toBeGreaterThan(0);
+
+      for (const span of spans) expect(span).toMatch(/^`None —/u);
+    });
+  });
+});
+
+describe("every rule copy uses the em-dash discriminator", () => {
+  describe.each(RULE_ROOTS)("%s", root => {
+    it.each(["eager", "reference"] as const)("%s tier", tier => {
+      const spans = markerSpans(readRule(root, tier));
+
+      expect(spans.length).toBeGreaterThan(0);
+
+      for (const span of spans) expect(span).toMatch(/^`None —/u);
+    });
+  });
+});
+
+describe("no copy reads an absent declaration as false", () => {
+  describe.each(SKILL_ROOTS)("%s", root => {
+    it.each(CONTRACT_SKILLS)("%s states the rule the same way twice", slug => {
+      const content = readSkill(root, slug);
+      const windows = absenceWindows(content);
+
+      expect(windows.length).toBeGreaterThanOrEqual(
+        ABSENCE_SITE_MINIMUM[slug] ?? 1
+      );
+
+      // Each site must resolve to a verdict on its own. A correct copy
+      // elsewhere in the file is not allowed to vouch for a broken one.
+      for (const window of windows) expect(window).toMatch(/underivable/iu);
+
+      for (const pattern of ABSENCE_AS_FALSE) {
+        expect(content).not.toMatch(pattern);
+      }
+    });
+  });
+});
+
+describe("no rule copy reads an absent declaration as false", () => {
+  describe.each(RULE_ROOTS)("%s", root => {
+    it.each(["eager", "reference"] as const)("%s tier", tier => {
+      const content = readRule(root, tier);
+
+      expect(content).toMatch(/underivable/iu);
+
+      for (const pattern of ABSENCE_AS_FALSE) {
+        expect(content).not.toMatch(pattern);
+      }
+    });
+  });
+});
+
+describe("no copy hands authority back to the caller", () => {
+  describe.each(SKILL_ROOTS)("%s", root => {
+    it.each(VALIDATORS)("%s keeps the stored declaration on top", slug => {
+      const content = readSkill(root, slug);
+
+      for (const pattern of CALLER_BEATS_STORED) {
+        expect(content).not.toMatch(pattern);
+      }
+    });
+  });
+
+  describe.each(RULE_ROOTS)("%s", root => {
+    it("the reference tier keeps the stored declaration on top", () => {
+      const content = readRule(root, "reference");
+
+      for (const pattern of CALLER_BEATS_STORED) {
+        expect(content).not.toMatch(pattern);
+      }
+    });
+  });
+});

--- a/tests/unit/strategies/runtime-behavior-change-decidability.test.ts
+++ b/tests/unit/strategies/runtime-behavior-change-decidability.test.ts
@@ -28,79 +28,33 @@
  *
  * Every assertion runs against all six generated skill roots, because the
  * generated artifacts are what agents actually load.
+ *
+ * **Scope, and where the other half lives.** Every assertion in this file is
+ * existential — "some copy of the contract says the right thing" — which pins
+ * the wording against silent deletion and nothing more. That is not enough on
+ * its own: these documents state the grammar twice, in gate S8 and again in
+ * the execution step, so a correct copy can vouch for a broken one. The
+ * universal half — "no copy says the wrong thing" — lives in
+ * `runtime-behavior-change-consistency.test.ts`, and the shared corpus both
+ * files read lives in `runtime-behavior-change-sources.ts`. The three-way
+ * split is the 300-line lint ceiling, not a scope boundary; a coverage probe
+ * that scores by filename must read all three.
  * @module tests/unit/strategies/runtime-behavior-change-decidability
  */
-import { readFileSync } from "node:fs";
-import path from "node:path";
-
 import { describe, expect, it } from "vitest";
 
-const SKILL_ROOTS = [
-  "plugins/src/base/skills",
-  "plugins/lisa/skills",
-  "plugins/lisa/.codex-plugin/skills",
-  "plugins/lisa-cursor/skills",
-  "plugins/lisa-agy/skills",
-  "plugins/lisa-copilot/skills",
-] as const;
-
-const RULE_ROOTS = [
-  "plugins/src/base/rules",
-  "plugins/lisa/rules",
-  "plugins/lisa-cursor/rules",
-  "plugins/lisa-copilot/rules",
-] as const;
-
-const SLUG = "derived-branch-plan";
-const FLAG = "runtime_behavior_change";
-const SECTION = "Target Backend Environment";
-/** The machine discriminator. Its exact spelling is the contract. */
-const EXEMPT_PREFIX = "None —";
-
-const WRITERS = [
-  "lisa-github-write-issue",
-  "lisa-jira-write-ticket",
-  "lisa-linear-write-issue",
-] as const;
-
-const VALIDATORS = [
-  "lisa-github-validate-issue",
-  "lisa-jira-validate-ticket",
-  "lisa-linear-validate-issue",
-] as const;
-
-/**
- * Read one skill's SKILL.md from a generated or source root.
- * @param root - The skills root.
- * @param slug - The skill directory name.
- * @returns The file contents.
- */
-const readSkill = (root: string, slug: string): string =>
-  readFileSync(path.resolve(root, slug, "SKILL.md"), "utf-8");
-
-/**
- * Read a rule body, tolerating Cursor's flat `.mdc` layout.
- * @param root - The rules root.
- * @param tier - Either "eager" or "reference".
- * @returns The rule contents.
- */
-const readRule = (root: string, tier: "eager" | "reference"): string => {
-  const nested = path.resolve(root, tier, `${SLUG}.md`);
-  const flat = path.resolve(
-    root,
-    tier === "eager" ? `${SLUG}.mdc` : `${SLUG}-reference.mdc`
-  );
-  try {
-    return readFileSync(nested, "utf-8");
-  } catch (error) {
-    // Fall back only when the nested rule is ABSENT. Catching everything meant
-    // a permissions or encoding failure on the nested path was reported
-    // against the flat one, sending a maintainer to a file that was never the
-    // problem.
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-    return readFileSync(flat, "utf-8");
-  }
-};
+import {
+  EXEMPT_PREFIX,
+  FLAG,
+  RULE_ROOTS,
+  SECTION,
+  SKILL_ROOTS,
+  SLUG,
+  VALIDATORS,
+  WRITERS,
+  readRule,
+  readSkill,
+} from "./runtime-behavior-change-sources.js";
 
 describe("the rule persists the behavioral flag instead of asserting it", () => {
   describe.each(RULE_ROOTS)("%s", root => {

--- a/tests/unit/strategies/runtime-behavior-change-sources.ts
+++ b/tests/unit/strategies/runtime-behavior-change-sources.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared corpus for the two `runtime_behavior_change` contract suites.
+ *
+ * `runtime-behavior-change-decidability.test.ts` asserts the contract wording
+ * is **present**; `runtime-behavior-change-consistency.test.ts` asserts no copy
+ * of it **contradicts** another. They read the same roots, so the roots live
+ * here rather than in two hand-maintained lists — two drifting copies of one
+ * rule is the precise defect these suites exist to catch, and repeating it in
+ * the harness would be self-parody.
+ *
+ * The split into two files is the 300-line lint ceiling, not a scope boundary.
+ * A coverage probe that scores by filename must read both or it will
+ * under-report, which is a known false-negative mode in this repo.
+ * @module tests/unit/strategies/runtime-behavior-change-sources
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/** Every generated skill root an agent may actually load. */
+export const SKILL_ROOTS = [
+  "plugins/src/base/skills",
+  "plugins/lisa/skills",
+  "plugins/lisa/.codex-plugin/skills",
+  "plugins/lisa-cursor/skills",
+  "plugins/lisa-agy/skills",
+  "plugins/lisa-copilot/skills",
+] as const;
+
+/** Every generated rule root. Cursor keeps a flat `.mdc` layout. */
+export const RULE_ROOTS = [
+  "plugins/src/base/rules",
+  "plugins/lisa/rules",
+  "plugins/lisa-cursor/rules",
+  "plugins/lisa-copilot/rules",
+] as const;
+
+export const SLUG = "derived-branch-plan";
+export const FLAG = "runtime_behavior_change";
+export const SECTION = "Target Backend Environment";
+
+/** The machine discriminator. Its exact spelling is the contract. */
+export const EXEMPT_PREFIX = "None —";
+
+/** The three skills that persist the declaration onto a work item. */
+export const WRITERS = [
+  "lisa-github-write-issue",
+  "lisa-jira-write-ticket",
+  "lisa-linear-write-issue",
+] as const;
+
+/** The three skills that derive the flag back off a live work item. */
+export const VALIDATORS = [
+  "lisa-github-validate-issue",
+  "lisa-jira-validate-ticket",
+  "lisa-linear-validate-issue",
+] as const;
+
+/** Every skill carrying a copy of the declaration grammar. */
+export const CONTRACT_SKILLS = [
+  ...WRITERS,
+  ...VALIDATORS,
+  "lisa-implement",
+] as const;
+
+/**
+ * Read one skill's SKILL.md from a generated or source root.
+ * @param root - The skills root.
+ * @param slug - The skill directory name.
+ * @returns The file contents.
+ */
+export const readSkill = (root: string, slug: string): string =>
+  readFileSync(path.resolve(root, slug, "SKILL.md"), "utf-8");
+
+/**
+ * Read a rule body, tolerating Cursor's flat `.mdc` layout.
+ * @param root - The rules root.
+ * @param tier - Either "eager" or "reference".
+ * @returns The rule contents.
+ */
+export const readRule = (root: string, tier: "eager" | "reference"): string => {
+  const nested = path.resolve(root, tier, `${SLUG}.md`);
+  const flat = path.resolve(
+    root,
+    tier === "eager" ? `${SLUG}.mdc` : `${SLUG}-reference.mdc`
+  );
+  try {
+    return readFileSync(nested, "utf-8");
+  } catch (error) {
+    // Fall back only when the nested rule is ABSENT. Catching everything meant
+    // a permissions or encoding failure on the nested path was reported
+    // against the flat one, sending a maintainer to a file that was never the
+    // problem.
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    return readFileSync(flat, "utf-8");
+  }
+};


### PR DESCRIPTION
Follow-up to #2495 and #2502. The issue asked whether the decidability suite could catch the marker mismatch it was written for. #2502 already fixed that specific case, so this PR asked the harder question the issue was really pointing at — can the suite catch a **behavioral** regression, not a wording one — and found a second hole of exactly the same shape.

## The measurement

`runtime_behavior_change` has no executable implementation. Outside the tests themselves it appears in zero `.ts` / `.mjs` / `.sh` files: the validators are `SKILL.md` prose executed by an agent. So "neuter the behavior" means mutating the substrate. Four mutations, applied to `plugins/src/base` and fanned out through `build:plugins`:

| behavioral mutation | before | after |
|---|---|---|
| execution step reads an absent section as `false` | 18 | 36 |
| **gate S8's prose reads an absent section as `false`** | **0** | **18** |
| writers stop rendering the section (the pre-#2495 hole) | 36 | 54 |
| a caller's assertion beats the stored declaration | 18 | 36 |

Baseline before any mutation: **11270 passed, 636 files, 0 failed** — whole suite, via `bun run test`, never a single file.

The second row is the finding. Reverting gate S8's own copy of the rule from

> an **absent section means underivable** — never `false`

to *"an absent section means `false`"* failed **zero tests out of 11270**. The validator's documented gate then contradicts its own execution step, on the one property the contract exists to guarantee, and nothing notices.

## Why it was zero — the two-copies trap

These validator documents state the declaration grammar **twice**: once in gate S8's prose, once in the execution step. That duplication is the whole story.

#2502 correctly inverted the assertion — assert the *wrong* spelling is absent, not the right one present — but pinned it to **one** of the two copies. `expect(content).toMatch(/absent section → \*\*underivable\*\*/)` matches the execution step and, because of where the bold markers fall, never matched S8's copy at all. So the fix hardened the site that had broken and left its twin bare. Same trap, mirror image, one commit later.

That is *why* an existential assertion always passed: "some copy says the right thing" is satisfied by whichever copy is still correct, no matter which one you broke. It was true of all 192 assertions, and it is a single property rather than a list of regex mistakes.

**The general form of that lesson is not restated here.** It belongs to the `falsifiable-checks` rule, which #2489 is extending with exactly this refinement — assert no copy is wrong rather than that some copy is right, and enumerate the property rather than the known-bad instance. Restating a general lesson in two places is the same duplication defect this PR just measured, so this work cites that rule and supplies the case study.

## What changed

A second suite, quantified **universally** instead:

- `tests/unit/strategies/runtime-behavior-change-consistency.test.ts` — no copy says the *wrong* thing, over every occurrence in the corpus. Every declaration marker uses the em-dash discriminator; every absence-derivation site resolves to *underivable* within its own sentence; no phrasing anywhere maps an absent section to `false` or hands authority back to the caller. A correct copy elsewhere cannot satisfy a universal negative — which is precisely why it catches what the existential half slept through.
- `tests/unit/strategies/runtime-behavior-change-sources.ts` — the shared corpus. Both suites read the roots from here rather than each keeping a list, because two drifting copies of one rule is the exact defect these suites exist to catch and repeating it in the harness would be self-parody. It also removes the duplicated `readRule` helper.
- `runtime-behavior-change-decidability.test.ts` keeps every existing assertion. Its preamble now states that its half is existential and names where the other half lives. Nothing was weakened; S8/S11/S14/S19 are untouched and absence still derives as **underivable**, never `false`.

Two generalizations worth calling out, both instances of `falsifiable-checks`' "enumerate the property, not the known-bad instance":

- #2502's `not.toContain("`None -`")` caught exactly one wrong spelling. The replacement asserts every declaration marker *starts with* the em-dash form, so an en-dash, a missing dash, or a double hyphen fails too — and it now covers the rules and `lisa-implement`, not just the three validators.
- The absence check is per-site, not per-file. Each derivation site must resolve to a verdict on its own evidence, so no copy can vouch for another.

It caught its own author immediately: writing this contract into the rule, I quoted the wrong marker literally as an illustration, and the new test failed on the rule file. The prose now says so out loud rather than quietly working around it.

## Being honest about the ceiling

`SKILL.md` *is* the validators' execution substrate — there is no compiled artifact underneath, no function to call, no return value to assert. **I could not assert that a validator handed a stored issue returns `underivable`, because no such callable validator exists.** Both halves of this suite read markdown.

What changed is the quantifier, not the substrate, and the rule now says which half is which. `derived-branch-plan`'s "How strongly this binds" section — which #2495 already wrote honestly — is updated to name the two halves separately, record that the mirrored hole failed 0 of 11270 until this landed, and repeat that neither half is an executable control:

> What these suites now prove is that the instruction the agent reads is internally consistent; what no test here can prove is that the agent then obeys it.

So, stated without softening: **the executable half of this contract is nothing. The decidability suite is pinned prose, the consistency suite is pinned prose, and neither can prove an agent obeys what it reads.** This is not "improved coverage" — it is a strictly weaker claim than enforcement, and the rule says so in those terms.

The claim ladder is now absence-as-`false` was *undecidable* → is *decidable* (#2495) → is *non-contradictory* (this PR), all three strictly weaker than *enforced*. A gate verdict resting on this contract remains evidence, not proof.

Reviewers: please treat that paragraph as load-bearing. A rule that overstates its own enforcement is the exact defect this batch is about, and the first draft of this very section overstated it.

## Contention corrupts this measurement — it does not merely slow it

This is not a footnote about machine load. It is a claim about when the number above can be trusted, and reviewers should weigh it as one.

**Cardinality can only be measured by running the whole suite.** The cheap substitute is scoping the run to the file whose name matches the fix — and that variant has a known false-negative mode in this repo: it once reported **0 on a live security fix that had 4 covering tests**, because the suite had split at the 300-line lint ceiling and the covering tests were in the sibling file. This contract has now split exactly that way, into three files. That is why the module preambles in all three cross-reference each other and state in terms that the split is a lint ceiling, **not** a scope boundary — a future probe that scores by filename will otherwise under-report this very contract.

The consequence is the part worth review attention: under contention the whole-suite run is the expensive option, so budget pressure does not just delay a cardinality measurement, **it pushes the measurer toward the variant that returns the wrong answer.** Headroom is therefore a *correctness* input for this class of work, not a throughput preference. Filed as supporting evidence for #2490, and this is the reasoning #2509 rests on — *a check may only become a required context if its budget has proven headroom* — because a required check measured under starvation is a check whose green nobody can interpret.

One qualification in the other direction, so nobody over-corrects: **a cardinality of zero is robust to contention.** Load can only *add* failures, never remove them, so a mutation that fails nothing under load fails nothing on an idle box. The 0-of-11,270 result stands independently of what else was running; only the *after* numbers needed a clean box. That generalizes beyond this PR — any zero measured under load remains valid — so its home is `falsifiable-checks` rather than here, and it is offered to #2489 on the same reasoning that moved the quantifier lesson there.

## Verification

- Whole suite green on the rebased branch: **11410 passed, 639 files, 0 failed**, exit 0. Plus typecheck, lint, `check-plugins-sync.sh`, and `check:upstream-evidence-manifest`.
- Rebased onto `5f834b490`. The rebase was textually clean, and the manifest was **regenerated and diffed anyway** — `git diff --stat` empty, so no silently-kept hash. A clean rebase is not evidence the manifest is right; #2497 hit exactly that (clean rebase, one committed hash matching no file on disk).
- Mutation-verified in both directions on all four behavioral mutations, table above; every mutation applied to `plugins/src/base` and regenerated so all six skill roots and four rule roots were measured as an agent would load them.
- Parity fanout regenerated: base, `lisa`, `lisa-cursor`, `lisa-copilot` rule roots all carry the updated contract.

Work-Item: CodySwannGT/lisa#2501

🤖 Generated with Claude Code
