### PR TITLE
fix(ast-grep): scope the fs-extra rule to code Node runs directly

### DIFF
--- a/ast-grep/rules/no-missing-fs-extra-namespace-member-js.yml
+++ b/ast-grep/rules/no-missing-fs-extra-namespace-member-js.yml
@@ -39,6 +39,24 @@ message: |
     - JSON         -> read the file, then `JSON.parse` / `JSON.stringify`
     - whole module -> `import fse from "fs-extra"`. The DEFAULT export does
                       carry every member and is deliberately not flagged here.
+# Test trees are excluded on purpose — see the TypeScript rule for the full
+# rationale. In short: the defect class is "works under a bundler, `undefined`
+# under real Node", so it can only bite code Node executes directly, and the
+# runtime control in the Lisa monorepo already scopes itself to source trees
+# for exactly that reason. Keep this list in step with the TypeScript rule.
+ignores:
+  - '**/tests/**'
+  - '**/test/**'
+  - '**/__tests__/**'
+  - '**/__mocks__/**'
+  - '**/*.test.js'
+  - '**/*.test.mjs'
+  - '**/*.test.cjs'
+  - '**/*.test.jsx'
+  - '**/*.spec.js'
+  - '**/*.spec.mjs'
+  - '**/*.spec.cjs'
+  - '**/*.spec.jsx'
 rule:
   all:
     - pattern: $NS.$MEMBER

--- a/ast-grep/rules/no-missing-fs-extra-namespace-member.yml
+++ b/ast-grep/rules/no-missing-fs-extra-namespace-member.yml
@@ -50,6 +50,32 @@ message: |
     - JSON         -> read the file, then `JSON.parse` / `JSON.stringify`
     - whole module -> `import fse from "fs-extra"`. The DEFAULT export does
                       carry every member and is deliberately not flagged here.
+# Test trees are excluded on purpose, matching the scope the runtime control
+# already chose. The defect class is "works under a bundler, `undefined` under
+# real Node" — so it can only bite code that Node executes directly. Vitest and
+# Jest resolve `import * as fse from "fs-extra"` through CJS interop and hand
+# back the default export's properties, which is precisely why test files can
+# call `fse.writeJson` forever without ever being wrong.
+#
+# `tests/unit/core/fs-extra-namespace-callsites.test.ts` scopes itself to
+# ["src", "scripts"] for this reason — "trees whose code is executed by Node
+# directly, not through a bundler". This rule matches that scope rather than
+# inventing a second, wider one. Path globs are used instead of a src/scripts
+# allowlist because host project layouts vary (apps/, packages/, lib/) while
+# test directory conventions do not.
+ignores:
+  - '**/tests/**'
+  - '**/test/**'
+  - '**/__tests__/**'
+  - '**/__mocks__/**'
+  - '**/*.test.ts'
+  - '**/*.test.mts'
+  - '**/*.test.cts'
+  - '**/*.test.tsx'
+  - '**/*.spec.ts'
+  - '**/*.spec.mts'
+  - '**/*.spec.cts'
+  - '**/*.spec.tsx'
 rule:
   all:
     - pattern: $NS.$MEMBER

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2243,9 +2243,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/ast-grep/rules/no-inline-component-in-view.yml":
       "a662cb959ad5d96e4dda09d6dce1d69318e7c13f3d01787658184fd6075c2781",
     "typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member-js.yml":
-      "1e23c39fdb8a6295d1fa50dc80e92d7945b4bcfd4e78bd3fb8eb0606e02d2629",
+      "1664d70f1c5c37341e9ae29bfbe375d47b2e0df3cf2022c1933af209233109e9",
     "typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member.yml":
-      "c69c7ca0ab2f88f23ab6a740d7bf7d975aa0433ba5410aee184046d513aaf727",
+      "2601f136c89e2c70490a9a439f8a077157b09af525f6066fdae751001f8cc0ae",
     "typescript/copy-overwrite/ast-grep/utils/.gitkeep":
       "6792ca57f00ff5a84a4713a08308a8ab3144858b0b0d9f8251b8c26c48948fb7",
     "typescript/copy-overwrite/audit.ignore.config.json":

--- a/tests/unit/config/ast-grep-template.test.ts
+++ b/tests/unit/config/ast-grep-template.test.ts
@@ -144,6 +144,16 @@ const FS_EXTRA_RULES = [
 const FS_EXTRA_RULE_ID = "no-missing-fs-extra-namespace-member";
 
 /**
+ * A namespace call to a member `fs-extra` does not expose under real Node.
+ *
+ * Shared so the "fires here / stays silent there" pairs differ only by file
+ * path — if the source text varied between them, the comparison would prove
+ * nothing about scoping.
+ */
+const FS_EXTRA_VIOLATION =
+  'import * as fse from "fs-extra";\n\nexport const load = async () => await fse.readJson("a.json");\n';
+
+/**
  * Read the `fs-extra` namespace keys as real Node resolves them.
  *
  * This is the anti-rot half of the control. The shipped ast-grep rules must
@@ -214,7 +224,7 @@ describe("ast-grep stack templates", () => {
     scanExpectingDiagnostic(
       "typescript",
       "src/tools/build.ts",
-      'import * as fse from "fs-extra";\n\nexport const load = async () => await fse.readJson("a.json");\n',
+      FS_EXTRA_VIOLATION,
       FS_EXTRA_RULE_ID
     );
   });
@@ -226,7 +236,7 @@ describe("ast-grep stack templates", () => {
     const violations = scanForRule(
       "typescript",
       "src/tools/violation.ts",
-      'import * as fse from "fs-extra";\n\nexport const load = async () => await fse.readJson("a.json");\n',
+      FS_EXTRA_VIOLATION,
       FS_EXTRA_RULE_ID
     );
     expect(violations).toHaveLength(1);
@@ -257,6 +267,32 @@ describe("ast-grep stack templates", () => {
       FS_EXTRA_RULE_ID
     );
     expect(clean).toEqual([]);
+  });
+
+  it("scopes the fs-extra rule to code Node runs directly, not test trees", () => {
+    // Identical source, two locations. The rule is about "works under a
+    // bundler, undefined under real Node", so it can only bite code Node
+    // executes directly — Vitest and Jest hand back the default export's
+    // properties, which is why test files may call these members forever
+    // without being wrong. This mirrors the scope
+    // tests/unit/core/fs-extra-namespace-callsites.test.ts already chose.
+    const inSource = scanForRule(
+      "typescript",
+      "src/tools/loader.ts",
+      FS_EXTRA_VIOLATION,
+      FS_EXTRA_RULE_ID
+    );
+    const inTests = scanForRule(
+      "typescript",
+      "tests/unit/loader.test.ts",
+      FS_EXTRA_VIOLATION,
+      FS_EXTRA_RULE_ID
+    );
+
+    // Asserted as a pair: the source match is what proves the exclusion below
+    // narrows the rule rather than disabling it.
+    expect(inSource).toHaveLength(1);
+    expect(inTests).toEqual([]);
   });
 
   it("keeps the hardcoded fs-extra allow list equal to what real Node exposes", () => {

--- a/typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member-js.yml
+++ b/typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member-js.yml
@@ -39,6 +39,24 @@ message: |
     - JSON         -> read the file, then `JSON.parse` / `JSON.stringify`
     - whole module -> `import fse from "fs-extra"`. The DEFAULT export does
                       carry every member and is deliberately not flagged here.
+# Test trees are excluded on purpose — see the TypeScript rule for the full
+# rationale. In short: the defect class is "works under a bundler, `undefined`
+# under real Node", so it can only bite code Node executes directly, and the
+# runtime control in the Lisa monorepo already scopes itself to source trees
+# for exactly that reason. Keep this list in step with the TypeScript rule.
+ignores:
+  - '**/tests/**'
+  - '**/test/**'
+  - '**/__tests__/**'
+  - '**/__mocks__/**'
+  - '**/*.test.js'
+  - '**/*.test.mjs'
+  - '**/*.test.cjs'
+  - '**/*.test.jsx'
+  - '**/*.spec.js'
+  - '**/*.spec.mjs'
+  - '**/*.spec.cjs'
+  - '**/*.spec.jsx'
 rule:
   all:
     - pattern: $NS.$MEMBER

--- a/typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member.yml
+++ b/typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member.yml
@@ -50,6 +50,32 @@ message: |
     - JSON         -> read the file, then `JSON.parse` / `JSON.stringify`
     - whole module -> `import fse from "fs-extra"`. The DEFAULT export does
                       carry every member and is deliberately not flagged here.
+# Test trees are excluded on purpose, matching the scope the runtime control
+# already chose. The defect class is "works under a bundler, `undefined` under
+# real Node" — so it can only bite code that Node executes directly. Vitest and
+# Jest resolve `import * as fse from "fs-extra"` through CJS interop and hand
+# back the default export's properties, which is precisely why test files can
+# call `fse.writeJson` forever without ever being wrong.
+#
+# `tests/unit/core/fs-extra-namespace-callsites.test.ts` scopes itself to
+# ["src", "scripts"] for this reason — "trees whose code is executed by Node
+# directly, not through a bundler". This rule matches that scope rather than
+# inventing a second, wider one. Path globs are used instead of a src/scripts
+# allowlist because host project layouts vary (apps/, packages/, lib/) while
+# test directory conventions do not.
+ignores:
+  - '**/tests/**'
+  - '**/test/**'
+  - '**/__tests__/**'
+  - '**/__mocks__/**'
+  - '**/*.test.ts'
+  - '**/*.test.mts'
+  - '**/*.test.cts'
+  - '**/*.test.tsx'
+  - '**/*.spec.ts'
+  - '**/*.spec.mts'
+  - '**/*.spec.cts'
+  - '**/*.spec.tsx'
 rule:
   all:
     - pattern: $NS.$MEMBER


### PR DESCRIPTION
**`main` is currently red on `🔎 AST Grep Scan`. This fixes it.** Follow-up to #2512 (#2494).

Any PR opened against `main` right now shows that job red. It is not their change.

## What went wrong

I verified the new `fs-extra` rule locally with `ast-grep scan src scripts` and reported **0 violations**. CI runs bare `ast-grep scan`, which walks the **whole repository**, and found **1142** — every one in `tests/`, across 104 files that do `import * as fs from "fs-extra"`.

So the claim "0 violations" was true of a scan narrower than the one that gates. A clean scan of two directories, reported as a clean scan.

Then `🔎 AST Grep Scan` went red on #2512 and **#2512 merged anyway**, because that job is not a required status check — the finding filed as #2506, reproducing itself on the PR that introduced the detector, about forty minutes after it was written down.

## The 1142 are not defects

The class is *"works under a bundler, `undefined` under real Node"*, so it can only bite code Node executes directly. Vitest and Jest resolve `import * as fs from "fs-extra"` through CJS interop and hand back the default export's properties — which is exactly why those test files can call `fs.writeJson` indefinitely and never be wrong.

The runtime control this rule complements, `tests/unit/core/fs-extra-namespace-callsites.test.ts`, **already made this scope decision deliberately**, limiting itself to `["src", "scripts"]` — *"trees whose code is executed by Node directly, not through a bundler."* My static rule failed to match that existing scope and invented a wider one by omission.

## The fix

Test-path `ignores:` on all four rule files (two stack-template, two mirrored). Path globs rather than an `src`/`scripts` allowlist, because host layouts vary (`apps/`, `packages/`, `lib/`) while test directory conventions do not.

## Narrowing a rule to make a build pass deserves suspicion

So it is proved in three directions rather than asserted:

```
repo-wide scan (what CI runs)    ->  0 violations, exit 0
planted violation in src/        ->  1 match, fse.readJson
identical source under tests/    ->  0 matches
```

**The middle line is the one that matters** — it shows the exclusion *narrowed* the rule rather than disabling it. Without it, line 1 would be indistinguishable from having deleted the rule entirely.

A new test pins all three, scanning **byte-identical source at two different paths** so the pair differs only by location. The violation fixture is hoisted to a shared constant precisely so the two halves cannot drift apart and quietly stop comparing the same thing.

## Note for review

The general failure here is worth more than the specific bug: **the scope of a verification is part of its result.** "0 violations" is not a finding unless the scope matches the gate's. I ran a narrower instrument than CI and reported its silence as a pass — the same class of error this batch has spent the day cataloguing, committed while cataloguing it.

Work-Item: CodySwannGT/lisa#2494
