### PR TITLE
test(design-source): prove every fail-closed arm reaches the verdict

### DIFF
--- a/plugins/lisa-agy/scripts/design-source-gate.mjs
+++ b/plugins/lisa-agy/scripts/design-source-gate.mjs
@@ -294,8 +294,17 @@ export function classifyDesignSource(file, config) {
   return { ...base, status: "undeclared" };
 }
 
-/** Per-file statuses that fail the gate. */
-const VIOLATION_STATUSES = new Set([
+/**
+ * Per-file statuses that fail the gate.
+ *
+ * Exported so the suite can pin the set itself, not just its members' behavior.
+ * Classifying a file `unreadable` is not a guard; *failing the change* because
+ * of it is. Issue #2492 measured the difference: with only classification
+ * asserted, deleting `conflicting` or `unreadable` from this list flipped the
+ * verdict to PASS with the whole suite still green. The pinning test now fails
+ * on any edit to this set — a removal and an addition alike.
+ */
+export const VIOLATION_STATUSES = new Set([
   "undeclared",
   "malformed",
   "conflicting",

--- a/plugins/lisa-copilot/scripts/design-source-gate.mjs
+++ b/plugins/lisa-copilot/scripts/design-source-gate.mjs
@@ -294,8 +294,17 @@ export function classifyDesignSource(file, config) {
   return { ...base, status: "undeclared" };
 }
 
-/** Per-file statuses that fail the gate. */
-const VIOLATION_STATUSES = new Set([
+/**
+ * Per-file statuses that fail the gate.
+ *
+ * Exported so the suite can pin the set itself, not just its members' behavior.
+ * Classifying a file `unreadable` is not a guard; *failing the change* because
+ * of it is. Issue #2492 measured the difference: with only classification
+ * asserted, deleting `conflicting` or `unreadable` from this list flipped the
+ * verdict to PASS with the whole suite still green. The pinning test now fails
+ * on any edit to this set — a removal and an addition alike.
+ */
+export const VIOLATION_STATUSES = new Set([
   "undeclared",
   "malformed",
   "conflicting",

--- a/plugins/lisa-cursor/scripts/design-source-gate.mjs
+++ b/plugins/lisa-cursor/scripts/design-source-gate.mjs
@@ -294,8 +294,17 @@ export function classifyDesignSource(file, config) {
   return { ...base, status: "undeclared" };
 }
 
-/** Per-file statuses that fail the gate. */
-const VIOLATION_STATUSES = new Set([
+/**
+ * Per-file statuses that fail the gate.
+ *
+ * Exported so the suite can pin the set itself, not just its members' behavior.
+ * Classifying a file `unreadable` is not a guard; *failing the change* because
+ * of it is. Issue #2492 measured the difference: with only classification
+ * asserted, deleting `conflicting` or `unreadable` from this list flipped the
+ * verdict to PASS with the whole suite still green. The pinning test now fails
+ * on any edit to this set — a removal and an addition alike.
+ */
+export const VIOLATION_STATUSES = new Set([
   "undeclared",
   "malformed",
   "conflicting",

--- a/plugins/lisa/scripts/design-source-gate.mjs
+++ b/plugins/lisa/scripts/design-source-gate.mjs
@@ -294,8 +294,17 @@ export function classifyDesignSource(file, config) {
   return { ...base, status: "undeclared" };
 }
 
-/** Per-file statuses that fail the gate. */
-const VIOLATION_STATUSES = new Set([
+/**
+ * Per-file statuses that fail the gate.
+ *
+ * Exported so the suite can pin the set itself, not just its members' behavior.
+ * Classifying a file `unreadable` is not a guard; *failing the change* because
+ * of it is. Issue #2492 measured the difference: with only classification
+ * asserted, deleting `conflicting` or `unreadable` from this list flipped the
+ * verdict to PASS with the whole suite still green. The pinning test now fails
+ * on any edit to this set — a removal and an addition alike.
+ */
+export const VIOLATION_STATUSES = new Set([
   "undeclared",
   "malformed",
   "conflicting",

--- a/plugins/src/base/scripts/design-source-gate.mjs
+++ b/plugins/src/base/scripts/design-source-gate.mjs
@@ -294,8 +294,17 @@ export function classifyDesignSource(file, config) {
   return { ...base, status: "undeclared" };
 }
 
-/** Per-file statuses that fail the gate. */
-const VIOLATION_STATUSES = new Set([
+/**
+ * Per-file statuses that fail the gate.
+ *
+ * Exported so the suite can pin the set itself, not just its members' behavior.
+ * Classifying a file `unreadable` is not a guard; *failing the change* because
+ * of it is. Issue #2492 measured the difference: with only classification
+ * asserted, deleting `conflicting` or `unreadable` from this list flipped the
+ * verdict to PASS with the whole suite still green. The pinning test now fails
+ * on any edit to this set — a removal and an addition alike.
+ */
+export const VIOLATION_STATUSES = new Set([
   "undeclared",
   "malformed",
   "conflicting",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -919,7 +919,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/scripts/cross-pollinate.mjs":
       "e9a536389d2581370f6c470b8a070aaae96660646efc528a7ff7fb25d324a903",
     "plugins/src/base/scripts/design-source-gate.mjs":
-      "2c8121404ac6dd71f74a3080561aa6daecb4f719fdd1360622511d35186bc13f",
+      "4db12844df14cc5dbcbdb96df9273cdce08057bc839493649fa65fccf559953b",
     "plugins/src/base/scripts/doctor-report.mjs":
       "f183e62848ac539da56a525fe2105fc6251a49e555a01dd1bba10d9227b1a6bf",
     "plugins/src/base/scripts/install-remote-agent-aws.mjs":

--- a/tests/unit/strategies/design-source-gate-fixtures.ts
+++ b/tests/unit/strategies/design-source-gate-fixtures.ts
@@ -61,3 +61,43 @@ export const annotated = (relPath: string, annotation: string): ChangedFile =>
  */
 export const unannotated = (relPath: string): ChangedFile =>
   changed(relPath, "export const Component = () => null;\n");
+
+/**
+ * Every per-file status that must fail the whole change, paired with a changed
+ * file that provably produces it.
+ *
+ * Stated here as an independent, hardcoded list rather than derived from the
+ * gate's own `VIOLATION_STATUSES`. A table driven by the set under test is
+ * self-matching: deleting a member deletes its own case and stays green, which
+ * is precisely the inertness issue #2492 found. Driving the table from this
+ * list instead — and pinning the gate's set against these keys — makes a
+ * removal fail its own case and an addition fail the pin.
+ */
+export const VIOLATION_VERDICT_CASES: readonly (readonly [
+  string,
+  ChangedFile,
+])[] = [
+  ["undeclared", unannotated("src/components/Undeclared.tsx")],
+  [
+    "malformed",
+    annotated(
+      "src/components/Malformed.tsx",
+      "// DESIGN-SOURCE: see the Slack mock"
+    ),
+  ],
+  [
+    "conflicting",
+    annotated(
+      "src/components/Conflicting.tsx",
+      `// DESIGN-SOURCE: ${FIGMA_URL}\n// ${MARKER}`
+    ),
+  ],
+  [
+    "unreadable",
+    {
+      path: "src/components/Unreadable.tsx",
+      changeType: "modified",
+      content: null,
+    },
+  ],
+];

--- a/tests/unit/strategies/design-source-gate-verdict.test.ts
+++ b/tests/unit/strategies/design-source-gate-verdict.test.ts
@@ -10,12 +10,17 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { evaluateDesignSource } from "../../../plugins/src/base/scripts/design-source-gate.mjs";
+import {
+  VIOLATION_STATUSES,
+  classifyDesignSource,
+  evaluateDesignSource,
+} from "../../../plugins/src/base/scripts/design-source-gate.mjs";
 
 import {
   FIGMA_URL,
   MARKER,
   PATHS,
+  VIOLATION_VERDICT_CASES,
   annotated,
   changed,
   unannotated,
@@ -138,4 +143,35 @@ describe("design-source gate — change verdict", () => {
     expect(result.verdict).toBe("PASS");
     expect(result.syncBackPreferred).toEqual([]);
   });
+});
+
+describe("design-source gate — every failing status reaches the verdict", () => {
+  // Issue #2492: classifying a file `conflicting` or `unreadable` was asserted,
+  // but nothing asserted the label *caused* a FAIL. Deleting either word from
+  // VIOLATION_STATUSES flipped the gate to PASS with all 38 tests green. These
+  // two tests close the class rather than the two instances.
+  it("pins the failing-status set so no member can be added or removed untested", () => {
+    const byName = (left: string, right: string): number =>
+      left.localeCompare(right);
+
+    expect([...VIOLATION_STATUSES].toSorted(byName)).toEqual(
+      VIOLATION_VERDICT_CASES.map(([status]) => status).toSorted(byName)
+    );
+  });
+
+  it.each(VIOLATION_VERDICT_CASES)(
+    "FAILs the whole change on a lone %s file",
+    (status, file) => {
+      // Guard the fixture first: if it stopped producing this status, the
+      // verdict assertion below would prove nothing about this arm.
+      expect(classifyDesignSource(file).status).toBe(status);
+
+      const result = evaluateDesignSource({ files: [file] });
+
+      expect(result.verdict).toBe("FAIL");
+      expect(result.violations.map(v => v.path)).toEqual([file.path]);
+      expect(result.reasons).toContain(`${status}:${file.path}`);
+      expect(result.summary.violations).toBe(1);
+    }
+  );
 });

--- a/tests/unit/strategies/design-source-gate.test.ts
+++ b/tests/unit/strategies/design-source-gate.test.ts
@@ -9,6 +9,13 @@
  * UI surface declare its design source, and by failing closed when it cannot
  * prove one either way. The verdict-level assertions live in the sibling
  * `design-source-gate-verdict` suite.
+ *
+ * Every test here is named for the classification it asserts, never for the
+ * consequence that classification carries. Issue #2492 found six named the
+ * other way — "fails closed when the changed file cannot be read" while
+ * asserting only `status: "unreadable"` — so a reader auditing test names
+ * concluded the fail-closed behavior was covered when nothing checked it.
+ * A name that promises a verdict belongs in the sibling suite, which asserts one.
  * @module tests/unit/strategies/design-source-gate
  */
 import { describe, expect, it } from "vitest";
@@ -79,7 +86,7 @@ describe("design-source gate — per-file classification", () => {
     });
   });
 
-  it("accepts the designated marker as an explicit, recorded exception", () => {
+  it("classifies the designated marker as an explicit, recorded exception", () => {
     expect(
       classifyDesignSource(annotated(PATHS.debugPanel, `// ${MARKER}`))
     ).toMatchObject({ uiSurface: true, status: "marked-exception" });
@@ -97,14 +104,14 @@ describe("design-source gate — per-file classification", () => {
     expect(svelte.reason).toBe("internal-only debug affordance");
   });
 
-  it("fails a UI file that declares nothing at all", () => {
+  it("classifies a UI file that declares nothing at all as undeclared", () => {
     expect(classifyDesignSource(unannotated(PATHS.invented))).toMatchObject({
       uiSurface: true,
       status: "undeclared",
     });
   });
 
-  it("fails closed on an annotation whose value is neither form", () => {
+  it("classifies an annotation whose value is neither form as malformed", () => {
     expect(
       classifyDesignSource(
         annotated(
@@ -115,7 +122,7 @@ describe("design-source gate — per-file classification", () => {
     ).toMatchObject({ status: "malformed" });
   });
 
-  it("fails closed on a non-Figma URL rather than accepting any link", () => {
+  it("classifies a non-Figma URL as malformed rather than accepting any link", () => {
     expect(
       classifyDesignSource(
         annotated(
@@ -126,7 +133,7 @@ describe("design-source gate — per-file classification", () => {
     ).toMatchObject({ status: "malformed" });
   });
 
-  it("fails closed when a file both cites Figma and denies having a source", () => {
+  it("classifies a file that both cites Figma and denies a source as conflicting", () => {
     expect(
       classifyDesignSource(
         annotated(
@@ -137,7 +144,7 @@ describe("design-source gate — per-file classification", () => {
     ).toMatchObject({ status: "conflicting" });
   });
 
-  it("fails closed when the changed file cannot be read", () => {
+  it("classifies a changed file that cannot be read as unreadable", () => {
     expect(
       classifyDesignSource({
         path: "src/components/Gone.tsx",


### PR DESCRIPTION
## What

Closes the classification-vs-consequence gap in the `design-source-of-truth` gate: two of its four fail-closed arms could be deleted with the whole suite still green.

**The gate's behavior is unchanged.** It still fails closed on `undeclared`, `malformed`, `conflicting`, and `unreadable`, plus both unresolved-diff cases (#2441). This PR only makes that behavior provable.

## Re-measurement first

#2492 carried a caveat: its cardinality numbers came from a filename-scoped probe, and that method has a known false-negative mode in this repo — on #2495 it reported 0 for a live security fix that actually had 4 covering tests, because the suite had split at the 300-line lint ceiling.

So every status was re-measured by removing it from `VIOLATION_STATUSES` and running the **whole** vitest suite:

| status | tests failed (whole suite) |
|---|---|
| `undeclared` | 2 |
| `malformed` | 1 |
| `conflicting` | **0** |
| `unreadable` | **0** |

**The original claim holds.** The false-negative mode did not apply: this suite had already split into `design-source-gate.test.ts` + `design-source-gate-verdict.test.ts` at authoring time, and both match a `design-source-gate` filename filter, so the original probe did see both files. The 38-test baseline in the issue is exactly the two files combined (28 + 10).

Two probe artifacts were excluded from attribution, both methodology noise rather than coverage: `upstream-evidence-manifest` fails in *every* mutated run because the mutation edits a tracked public source without regenerating the manifest, and a handful of unrelated tests flaked under concurrent cross-worktree load.

## The defect that stands regardless

`design-source-gate.test.ts:140` was **named** *"fails closed when the changed file cannot be read"* while asserting only `toMatchObject({ status: "unreadable" })`. The name promises the property the assertion never checks, so a reader auditing test names concludes the behavior is covered.

Auditing the other tests for the same shape found **six** — the one the issue named plus five more:

| line | name | asserted |
|---|---|---|
| 82 | "accepts the designated marker as an explicit, recorded exception" | `status: "marked-exception"` |
| 100 | "fails a UI file that declares nothing at all" | `status: "undeclared"` |
| 107 | "fails closed on an annotation whose value is neither form" | `status: "malformed"` |
| 118 | "fails closed on a non-Figma URL rather than accepting any link" | `status: "malformed"` |
| 129 | "fails closed when a file both cites Figma and denies having a source" | `status: "conflicting"` |
| 140 | "fails closed when the changed file cannot be read" | `status: "unreadable"` |

Three more are borderline, where the verb is the codebase's own name for the result bucket (`seals`, `ignores` ×2); those were left alone. All 10 tests in the verdict suite already assert `result.verdict` and were clean.

## The fix

**1. A table-driven guard over the failing statuses** — the structural fix, which makes the class impossible rather than patching two instances. Each status must independently produce `verdict: FAIL`.

The subtle part: the table is driven by `VIOLATION_VERDICT_CASES`, a hardcoded list in the fixtures module, **not** by iterating `VIOLATION_STATUSES`. A table driven by the set under test is self-matching — deleting a member deletes its own case and stays green, reproducing the exact inertness this issue is about. Instead:

- each hardcoded case asserts the verdict → **removing** a status fails that case;
- one pinning test asserts set equality both ways → **adding** a status with no verdict case fails the pin.

Each case also guards its fixture (`classifyDesignSource(file).status === status`) so a fixture that drifts to a different status can't leave the arm silently unproven.

**2. Six test names corrected** to state the classification they assert. Assertions are unchanged and nothing is removed — the verdict property those names promised is now genuinely covered, by the table above, in the sibling suite that asserts verdicts. The classification suite's module docstring now records the naming discipline.

**3. `VIOLATION_STATUSES` exported** so the suite can pin the set itself, not just its members' behavior.

## Verification

Post-fix mutation, whole suite — every status now has non-zero cardinality:

| status | before | after |
|---|---|---|
| `undeclared` | 2 | **4** |
| `malformed` | 1 | **3** |
| `conflicting` | 0 | **2** |
| `unreadable` | 0 | **2** |

Suite grew 38 → 43 tests, all green. Parity fanout applied to all agent variants (`lisa`, `lisa-cursor`, `lisa-copilot`, `lisa-agy`) via `build:plugins`; all five copies hash-identical.

Work-Item: CodySwannGT/lisa#2492
