### PR TITLE
fix(tests): give Lisa's own suite a liveness budget it can actually meet

### DIFF
--- a/vitest.config.local.ts
+++ b/vitest.config.local.ts
@@ -11,6 +11,27 @@ import * as path from "node:path";
 const config: ViteUserConfig = {
   test: {
     include: ["tests/**/*.test.ts"],
+    // Lisa's own suite (~11.5k tests) is unlike a downstream project's: a large
+    // sub-population spawns real subprocesses (git, bash, npm pack, tsc, oxlint)
+    // or performs fsync-paired filesystem work in temp repositories. Against the
+    // fleet default of 10s (src/configs/vitest/typescript.ts) those tests sit
+    // close enough to the budget that WHICH ones lose is a dice roll per run —
+    // 13 consecutive pre-push attempts failed with 10 to 161 timeouts, zero
+    // assertion failures, and never in the pushing author's own suites (#2522).
+    //
+    // Ruled out by measurement before changing this, not by reasoning: sibling
+    // load (fails at load 4.5 with zero siblings), parallelism (--maxWorkers=4
+    // was WORSE, 124 vs 54), disk (682GB free), memory (52% free), subprocess
+    // spawn (2.0/5.5/19.8ms for echo/git/node) and fsync (0.25ms/write).
+    //
+    // This is a LIVENESS bound, not a performance assertion: a hung test still
+    // fails, just later. Tests that genuinely assert performance pass their own
+    // per-test timeout, which overrides this and is deliberately left alone.
+    // Scoped to Lisa's create-only local config on purpose — downstream projects
+    // do not carry these suites and must not inherit a looser budget they have
+    // no evidence for (#2509).
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
     coverage: {
       include: ["src/**/*.ts"],
       exclude: ["src/index.ts"],


### PR DESCRIPTION
## The gate could not be passed

Lisa's pre-push `test:cov` gate failed **13 consecutive times across three agents**:
`127, 128, 85, 65, 128, 100, 69, 65, 161, 54, 17, 10, 37` failures. Every one was
`Test timed out in 10000ms` or `Hook timed out in 10000ms`. **Zero assertion failures.
Never in the pushing author's own suites.** The count was random rather than converging,
so it was a dice roll — not a regression anyone had introduced.

**With this change: `Test Files 642 passed (642)`, `Tests 11466 passed (11466)`, first
clean run in fourteen attempts.** This PR's own push is the proof — the pre-push hook
runs the working tree's config, so the commit that raises the budget is the one that had
to pass the gate.

## Ruled out first, by measurement rather than reasoning

| Suspected | Measured |
|---|---|
| Sibling load / contention | fails at load 4.5 with **zero** concurrent runs |
| Over-parallelization | `--maxWorkers=4` was **worse** — 124 failures vs 54 |
| Disk pressure | 682 GB free |
| Memory pressure | 52% free |
| Subprocess spawn latency | 2.0 ms `/bin/echo`, 5.5 ms `git`, 19.8 ms `node` |
| Filesystem latency | **0.25 ms/fsync** over 20 open+write+fsync+close cycles |
| Hung processes | 142 stuck `lisa-self-postinstall` trees cleared; failures continued |

## Cause

The fleet default `testTimeout: 10000` (`src/configs/vitest/typescript.ts:70`) meets a
suite only Lisa has: ~11,474 tests, a large sub-population of which spawns real
subprocesses (`git`, `bash`, `npm pack`, `tsc`, `oxlint`) or does fsync-paired
filesystem work in temp repositories. Observed individual durations on a quiet box
reached **60,245 ms**. A 10 s budget cannot accommodate that population, so which tests
lose varies per run.

This is the largest instance in the repository of #2509's thesis: **a budget with no
proven headroom, guarding every push.** #2490 raised five such budgets; a nine-run
measurement later found **33 files outside that roster**; these runs hit 45. It was never
a closed set, and enumerating it one suite at a time was never going to converge.

## Why this is not weakening a gate

For this population the timeout is a **liveness bound, not a performance assertion** — a
hung test still fails, just 60 s later instead of 10 s. The tests that genuinely assert
performance (e.g. `handles a very large contract without quadratic blowup`) pass their
own explicit per-test timeout, which overrides the global and is deliberately untouched.

**Scoped to Lisa's create-only `vitest.config.local.ts`, not the fleet factory default.**
Downstream projects do not carry Lisa's repo-tooling suites and must not inherit a looser
budget they have no evidence for — which is #2509's rule applied to this change itself.

## Verification

The config merge was verified empirically rather than by reading `mergeVitestConfigs`:
a deliberate 12-second test **passes** under the new budget and would fail under 10 s.
Then removed.

Full gate green: typecheck, security audit, slow lint, knip, `test:cov` 11466/11466,
integration 298/298, plugin parity pins current.

## Unblocks

`fix/2505-run-ast-grep-rule-tests`, `feat/2509-required-check-headroom`,
`fix/2506-require-ast-grep-scan`, and #2516's abort-path fix — all committed and locally
green, none pushable until now.

`--no-verify` was never used and is not an option.

Work-Item: CodySwannGT/lisa#2522

🤖 Generated with Claude Code
