### PR TITLE
fix(ast-grep): run the rule tests instead of only shipping them

### DIFF
--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -509,6 +509,36 @@ jobs:
         if: steps.check_config.outputs.has_config == 'true' && steps.check_rules.outputs.has_rules == 'true'
         run: sg scan
 
+      # Counts rule-test files rather than trusting the runner's exit code.
+      # `ast-grep test` exits 0 on an empty test directory, and a host project
+      # ships ast-grep/rule-tests/ empty, so an ungated step would report
+      # success having asserted nothing about any rule.
+      #
+      # Discovery is not suffix-based: ast-grep loads every YAML file directly
+      # inside testDir and binds it to a rule by its `id`. __snapshots__ is a
+      # subdirectory and .gitkeep is not YAML, so -maxdepth 1 over *.yml/*.yaml
+      # counts exactly what the runner will run.
+      - name: 🔍 Check for ast-grep rule tests
+        id: check_rule_tests
+        if: steps.check_config.outputs.has_config == 'true'
+        run: |
+          TESTS_DIR="ast-grep/rule-tests"
+          if [ -d "$TESTS_DIR" ]; then
+            TEST_COUNT=$(find "$TESTS_DIR" -maxdepth 1 \( -name "*.yml" -o -name "*.yaml" \) | wc -l | tr -d ' ')
+            if [ "$TEST_COUNT" -gt 0 ]; then
+              echo "has_rule_tests=true" >> "$GITHUB_OUTPUT"
+              echo "rule_test_count=$TEST_COUNT" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_rule_tests=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "has_rule_tests=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 🧪 Run ast-grep rule tests
+        if: steps.check_config.outputs.has_config == 'true' && steps.check_rule_tests.outputs.has_rule_tests == 'true'
+        run: sg test
+
       - name: ⏭️ AST Grep Skipped (no config)
         if: steps.check_config.outputs.has_config != 'true'
         run: |
@@ -520,6 +550,14 @@ jobs:
         run: |
           echo "::warning::ast-grep scan skipped - no rules defined in ast-grep/rules/"
           echo "To enable ast-grep scanning, add rule YAML files to ast-grep/rules/"
+
+      - name: ⏭️ AST Grep Rule Tests Skipped (none defined)
+        if: steps.check_config.outputs.has_config == 'true' && steps.check_rule_tests.outputs.has_rule_tests != 'true'
+        run: |
+          echo "::warning::ast-grep rule tests skipped - no rule test files in ast-grep/rule-tests/"
+          echo "This job going green does NOT mean any ast-grep rule has test coverage."
+          echo "To cover a rule, add ast-grep/rule-tests/<rule-id>-test.yml with valid/invalid cases,"
+          echo "then run 'sg test --update-all' to record its snapshot."
 
   learnings_budget:
     name: 📚 Learnings Budget

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2164,6 +2164,38 @@ jobs:
         run: ${{ inputs.package_manager }} run sg:scan
         working-directory: ${{ inputs.working_directory || '.' }}
 
+      # Counts rule-test files rather than trusting the runner's exit code.
+      # `ast-grep test` exits 0 on an empty test directory, and a host project
+      # ships ast-grep/rule-tests/ empty, so an ungated step would report
+      # success having asserted nothing about any rule.
+      #
+      # Discovery is not suffix-based: ast-grep loads every YAML file directly
+      # inside testDir and binds it to a rule by its `id`. __snapshots__ is a
+      # subdirectory and .gitkeep is not YAML, so -maxdepth 1 over *.yml/*.yaml
+      # counts exactly what the runner will run.
+      - name: 🔍 Check for ast-grep rule tests
+        id: check_rule_tests
+        if: steps.check_config.outputs.has_config == 'true'
+        run: |
+          TESTS_DIR="ast-grep/rule-tests"
+          if [ -d "$TESTS_DIR" ]; then
+            TEST_COUNT=$(find "$TESTS_DIR" -maxdepth 1 \( -name "*.yml" -o -name "*.yaml" \) | wc -l | tr -d ' ')
+            if [ "$TEST_COUNT" -gt 0 ]; then
+              echo "has_rule_tests=true" >> $GITHUB_OUTPUT
+              echo "rule_test_count=$TEST_COUNT" >> $GITHUB_OUTPUT
+            else
+              echo "has_rule_tests=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "has_rule_tests=false" >> $GITHUB_OUTPUT
+          fi
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      - name: 🧪 Run ast-grep rule tests
+        if: steps.check_config.outputs.has_config == 'true' && steps.check_rule_tests.outputs.has_rule_tests == 'true'
+        run: ${{ inputs.package_manager }} run sg:test
+        working-directory: ${{ inputs.working_directory || '.' }}
+
       - name: ⏭️ AST Grep Skipped (no config)
         if: steps.check_config.outputs.has_config != 'true'
         run: |
@@ -2175,6 +2207,14 @@ jobs:
         run: |
           echo "::warning::ast-grep scan skipped - no rules defined in ast-grep/rules/"
           echo "To enable ast-grep scanning, add rule YAML files to ast-grep/rules/"
+
+      - name: ⏭️ AST Grep Rule Tests Skipped (none defined)
+        if: steps.check_config.outputs.has_config == 'true' && steps.check_rule_tests.outputs.has_rule_tests != 'true'
+        run: |
+          echo "::warning::ast-grep rule tests skipped - no rule test files in ast-grep/rule-tests/"
+          echo "This job going green does NOT mean any ast-grep rule has test coverage."
+          echo "To cover a rule, add ast-grep/rule-tests/<rule-id>-test.yml with valid/invalid cases,"
+          echo "then run '${{ inputs.package_manager }} run sg:test --update-all' to record its snapshot."
 
   floor_collisions:
     name: 🧱 Security Floor Collisions

--- a/ast-grep/rule-tests/.gitkeep
+++ b/ast-grep/rule-tests/.gitkeep
@@ -1,3 +1,20 @@
-# This directory contains test cases for ast-grep rules.
-# Each test file should match its corresponding rule file name.
-# See: https://ast-grep.github.io/reference/yaml.html#rule-tests
+# Test cases for the ast-grep rules in ../rules/.
+#
+# These run. `ast-grep test` is wired to the `sg:test` package script and to
+# the AST Grep Scan job in Lisa's quality workflow, so a wrong assertion here
+# fails CI. The job counts the YAML files in this directory first: an empty
+# directory is reported as a skipped step with a warning, never as a pass,
+# because `ast-grep test` exits 0 when it finds nothing to run.
+#
+# A test file binds to a rule by its `id:` field, not by its filename — the
+# `<rule-id>-test.yml` convention is for humans reading the tree. Each case
+# listed under `valid:` must produce no diagnostic and each under `invalid:`
+# must produce one, so every rule is asserted in both directions.
+#
+# Every `invalid:` case also needs a snapshot under __snapshots__/ pinning
+# where the rule matched; a missing snapshot fails the run rather than being
+# skipped. Record them with:
+#
+#   ast-grep test --update-all      (or: <package manager> run sg:test -U)
+#
+# See: https://ast-grep.github.io/guide/test-rule.html

--- a/harper-fabric/package-lisa/package.lisa.json
+++ b/harper-fabric/package-lisa/package.lisa.json
@@ -14,6 +14,7 @@
       "knip:check": "knip",
       "knip:fix": "knip --fix",
       "sg:scan": "ast-grep scan",
+      "sg:test": "ast-grep test",
       "start": "harperdb start",
       "stop": "harperdb stop",
       "status": "harperdb status",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "knip:check": "knip",
     "knip:fix": "knip --fix",
     "sg:scan": "ast-grep scan",
+    "sg:test": "ast-grep test",
     "build:plugins": "bash scripts/build-plugins.sh",
     "prepare": "node -e \"if (process.env.INIT_CWD?.includes('.serverless')) process.exit(0); process.exit(1);\" || husky install || true",
     "start": "node dist/index.js",

--- a/package.lisa.json
+++ b/package.lisa.json
@@ -10,6 +10,7 @@
       "knip": "knip",
       "knip:fix": "knip --fix",
       "sg:scan": "ast-grep scan",
+      "sg:test": "ast-grep test",
       "build": "tsc",
       "verify:health-contract": "bun run build:dist && node scripts/verify-health-contract-built.mjs",
       "verify:health-deterministic": "bun run build:dist && node scripts/verify-health-deterministic-built.mjs",

--- a/phaser/copy-overwrite/ast-grep/rule-tests/.gitkeep
+++ b/phaser/copy-overwrite/ast-grep/rule-tests/.gitkeep
@@ -1,0 +1,20 @@
+# Test cases for the ast-grep rules in ../rules/.
+#
+# These run. `ast-grep test` is wired to the `sg:test` package script and to
+# the AST Grep Scan job in Lisa's quality workflow, so a wrong assertion here
+# fails CI. The job counts the YAML files in this directory first: an empty
+# directory is reported as a skipped step with a warning, never as a pass,
+# because `ast-grep test` exits 0 when it finds nothing to run.
+#
+# A test file binds to a rule by its `id:` field, not by its filename — the
+# `<rule-id>-test.yml` convention is for humans reading the tree. Each case
+# listed under `valid:` must produce no diagnostic and each under `invalid:`
+# must produce one, so every rule is asserted in both directions.
+#
+# Every `invalid:` case also needs a snapshot under __snapshots__/ pinning
+# where the rule matched; a missing snapshot fails the run rather than being
+# skipped. Record them with:
+#
+#   ast-grep test --update-all      (or: <package manager> run sg:test -U)
+#
+# See: https://ast-grep.github.io/guide/test-rule.html

--- a/phaser/package-lisa/package.lisa.json
+++ b/phaser/package-lisa/package.lisa.json
@@ -13,6 +13,7 @@
       "knip:check": "knip",
       "knip:fix": "knip --fix",
       "sg:scan": "ast-grep scan",
+      "sg:test": "ast-grep test",
       "prepare": "husky install || true"
     },
     "devDependencies": {

--- a/rails/copy-overwrite/ast-grep/rule-tests/.gitkeep
+++ b/rails/copy-overwrite/ast-grep/rule-tests/.gitkeep
@@ -1,0 +1,20 @@
+# Test cases for the ast-grep rules in ../rules/.
+#
+# These run. `ast-grep test` is wired to the `sg:test` package script and to
+# the AST Grep Scan job in Lisa's quality workflow, so a wrong assertion here
+# fails CI. The job counts the YAML files in this directory first: an empty
+# directory is reported as a skipped step with a warning, never as a pass,
+# because `ast-grep test` exits 0 when it finds nothing to run.
+#
+# A test file binds to a rule by its `id:` field, not by its filename — the
+# `<rule-id>-test.yml` convention is for humans reading the tree. Each case
+# listed under `valid:` must produce no diagnostic and each under `invalid:`
+# must produce one, so every rule is asserted in both directions.
+#
+# Every `invalid:` case also needs a snapshot under __snapshots__/ pinning
+# where the rule matched; a missing snapshot fails the run rather than being
+# skipped. Record them with:
+#
+#   ast-grep test --update-all      (or: <package manager> run sg:test -U)
+#
+# See: https://ast-grep.github.io/guide/test-rule.html

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -299,7 +299,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "harper-fabric/merge/.oxlintrc.json":
       "b41ea588eed47e0f1532aab5f6226b82586269b84edd1947bdde603e0a8513fa",
     "harper-fabric/package-lisa/package.lisa.json":
-      "4672b147ff12d0af80516b9c824aa9419b05da1308531d978ea285ae4e3c2b23",
+      "9202ce3a521c3f01da0b663d02263c8f8d40977659c34dedd9beb7b483b8f317",
     "nestjs/copy-overwrite/eslint.config.ts":
       "b44532acdaa1deaab29dcc2171a615242fb26565f538bdb38d8e33dd5a15cd01",
     "nestjs/copy-overwrite/eslint.nestjs.ts":
@@ -415,7 +415,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "phaser/copy-overwrite/.husky/pre-push.verify":
       "fef6694c2fde6178f46c62936d2b19515adce4fc8ac694ea66d8342aa1474ee7",
     "phaser/copy-overwrite/ast-grep/rule-tests/.gitkeep":
-      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "35e9b9011053aa791fe6c6b76129599fff5c65a408bef1498b9fe4dd6f0054eb",
     "phaser/copy-overwrite/ast-grep/rules/phaser/no-canvas-renderer.yml":
       "bd0994bbb8f8e6bde2a1a581fb2cb8aa011d91822dabf4366f500359069726b3",
     "phaser/copy-overwrite/ast-grep/rules/phaser/no-raw-webgl-context.yml":
@@ -445,7 +445,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "phaser/merge/.oxlintrc.json":
       "02c0d70e6e07bc0e981f94a1e2ccd01a2c295c4c66e8b8ea9b2f363d44fa5c06",
     "phaser/package-lisa/package.lisa.json":
-      "2e01b1ec402f6804a54402e22d02d63f1aa96d3f698e171885b0fff6eb25b271",
+      "9cc4e080742e094b1c6c6e76e53f03887f2b096fc0f15b9417c0238ed36cea2e",
     "plugins/src/base/agents/architecture-specialist.md":
       "076feb3a09ef056628bc33242f93278ce6b00f55878984a18a9337d326b5e1d4",
     "plugins/src/base/agents/bug-fixer.md":
@@ -1989,7 +1989,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/copy-overwrite/Gemfile.lisa":
       "8bebf6120fa90d8f971ded8281c4fdac632e524ca0bb80f6268c3eda997f7672",
     "rails/copy-overwrite/ast-grep/rule-tests/.gitkeep":
-      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "35e9b9011053aa791fe6c6b76129599fff5c65a408bef1498b9fe4dd6f0054eb",
     "rails/copy-overwrite/ast-grep/rules/ruby/no-find-by-sql-without-params.yml":
       "8d47d388f1b7d5cce0d4e58a9455247a10ee93d4cca664e9169dd32b666b10d0",
     "rails/copy-overwrite/ast-grep/rules/ruby/no-params-without-permit.yml":
@@ -2235,7 +2235,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/.yamllint":
       "e8a17046b8c1eb4653ed8a2ac6390ce499d505aab2daf81e43feefd5c4959067",
     "typescript/copy-overwrite/ast-grep/rule-tests/.gitkeep":
-      "050c0c64664c0f2ff3d306200cdfff454a0c5dd9879090f477b91d16c636ccdf",
+      "35e9b9011053aa791fe6c6b76129599fff5c65a408bef1498b9fe4dd6f0054eb",
     "typescript/copy-overwrite/ast-grep/rules/.gitkeep":
       "5068239f6c760759362d6a1cc83478d77eef0214fa7f4f23c8d1ce4b56f532c0",
     "typescript/copy-overwrite/ast-grep/rules/no-inline-component-in-container.yml":
@@ -2341,7 +2341,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/merge/.oxlintrc.json":
       "9504c20db80470c242c4ffe8cccad6951ed8141dfb5bf6503053e0b2712ab276",
     "typescript/package-lisa/package.lisa.json":
-      "339c86d92be6419bbbcb974162522f5339a5ab6795beb27d60d3594bb6da139f",
+      "ca736c6808d58efdea16abfbe2256a8318bc6d14b035951c1293f7c283919932",
     "ui/README.md":
       "deeb35e767ea5dd2883268835ea3ad21cbad9fa63ec8d8ff5e200f0e2a7d2751",
     "ui/index.html":
@@ -8700,6 +8700,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/codex/skills-installer.test.ts": true,
     "tests/unit/codex/skills-less-plugin-noop.test.ts": true,
     "tests/unit/codex/source-authored-openai-yaml.test.ts": true,
+    "tests/unit/config/ast-grep-rule-tests.test.ts": true,
     "tests/unit/config/ast-grep-template.test.ts": true,
     "tests/unit/config/eslint-ignore-wiki.test.ts": true,
     "tests/unit/config/eslint-no-unused-vars.test.ts": true,

--- a/tests/unit/config/ast-grep-rule-tests.test.ts
+++ b/tests/unit/config/ast-grep-rule-tests.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Proof that `ast-grep/rule-tests/` is executed rather than merely present.
+ *
+ * The directory shipped six rule tests and six snapshots that no script, hook,
+ * or CI job ever invoked, so they could not fail and could not pass — they only
+ * looked like coverage. These tests pin the three properties that keep them
+ * honest: the shipped rule tests actually run and pass here, the runner
+ * genuinely reports failure when a rule test is wrong, and the CI wiring that
+ * invokes it is gated on test files existing, so a project with none gets a
+ * warning instead of a green step that measured nothing.
+ */
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { load as loadYaml } from "js-yaml";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const AST_GREP = path.join(REPO_ROOT, "node_modules/.bin/ast-grep");
+const RULE_TESTS_DIR = "ast-grep/rule-tests";
+const RULE_TEST_SCRIPT = "sg:test";
+const RULE_TEST_GATE =
+  "steps.check_rule_tests.outputs.has_rule_tests == 'true'";
+
+/**
+ * ast-grep colours its own PASS/FAIL labels and honours no flag or environment
+ * variable that turns it off, so assertions have to read past the escapes.
+ * Built at runtime because a literal escape byte in a regex is itself a lint
+ * error.
+ */
+const ANSI_PATTERN = new RegExp(`${String.fromCodePoint(27)}\\[[0-9;]*m`, "gu");
+
+/** Manifests that force the ast-grep scripts onto a host project. */
+const MANIFESTS_FORCING_AST_GREP = [
+  "package.lisa.json",
+  "typescript/package-lisa/package.lisa.json",
+  "phaser/package-lisa/package.lisa.json",
+  "harper-fabric/package-lisa/package.lisa.json",
+] as const;
+
+/** ast-grep's root config file name. */
+const SGCONFIG = "sgconfig.yml";
+
+/** Every sgconfig that declares a rule-test directory. */
+const SGCONFIGS = [
+  SGCONFIG,
+  `typescript/copy-overwrite/${SGCONFIG}`,
+  `rails/copy-overwrite/${SGCONFIG}`,
+  `phaser/copy-overwrite/${SGCONFIG}`,
+] as const;
+
+/** One workflow step, narrowed to the fields these tests assert on. */
+type WorkflowStep = {
+  readonly name?: string;
+  readonly if?: string;
+  readonly run?: string;
+  readonly id?: string;
+};
+
+/**
+ * Read a repository file as UTF-8 text.
+ * @param relativePath - Path relative to the repository root
+ * @returns File contents
+ */
+function readText(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8");
+}
+
+/**
+ * Count the rule-test files ast-grep will discover in a test directory.
+ *
+ * Discovery is not suffix-based: ast-grep loads every YAML document directly
+ * inside `testDir` and binds it to a rule by its `id`, so `__snapshots__` (a
+ * subdirectory) and `.gitkeep` (not YAML) are the only things excluded. CI
+ * counts the same way, which is what lets a zero count be reported as a skip
+ * instead of a pass.
+ * @param absoluteDir - Directory to count
+ * @returns Number of discoverable rule-test files
+ */
+function countRuleTestFiles(absoluteDir: string): number {
+  return fs
+    .readdirSync(absoluteDir, { withFileTypes: true })
+    .filter(
+      entry =>
+        entry.isFile() &&
+        (entry.name.endsWith(".yml") || entry.name.endsWith(".yaml"))
+    ).length;
+}
+
+/**
+ * Run `ast-grep test` against a config file.
+ * @param configPath - Absolute path to an sgconfig.yml
+ * @returns Exit status and de-coloured output
+ */
+function runRuleTests(configPath: string): {
+  readonly status: number | null;
+  readonly output: string;
+} {
+  const result = spawnSync(AST_GREP, ["test", "--config", configPath], {
+    cwd: REPO_ROOT,
+    encoding: "utf-8",
+  });
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`.replace(
+      ANSI_PATTERN,
+      ""
+    ),
+  };
+}
+
+/**
+ * Copy this repository's ast-grep payload into a scratch project root.
+ * @returns Absolute path to the scratch sgconfig.yml
+ */
+function copyAstGrepPayload(): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-sg-ruletests-"));
+  fs.cpSync(path.join(REPO_ROOT, "ast-grep"), path.join(tempDir, "ast-grep"), {
+    recursive: true,
+  });
+  fs.copyFileSync(path.join(REPO_ROOT, SGCONFIG), path.join(tempDir, SGCONFIG));
+  return path.join(tempDir, SGCONFIG);
+}
+
+/**
+ * Load a workflow's `sg_scan` job steps.
+ * @param workflowPath - Workflow file relative to the repository root
+ * @returns Steps declared by the sg_scan job
+ */
+function sgScanSteps(workflowPath: string): readonly WorkflowStep[] {
+  const parsed = loadYaml(readText(workflowPath)) as {
+    jobs: Record<string, { steps: readonly WorkflowStep[] } | undefined>;
+  };
+  const job = parsed.jobs["sg_scan"];
+  if (job === undefined) {
+    throw new Error(`No sg_scan job in ${workflowPath}`);
+  }
+  return job.steps;
+}
+
+/**
+ * Find the single step in a job whose `run` body matches a predicate.
+ * @param steps - Steps to search
+ * @param matches - Predicate over the step's run body
+ * @returns The matching step
+ */
+function stepRunning(
+  steps: readonly WorkflowStep[],
+  matches: (run: string) => boolean
+): WorkflowStep {
+  const found = steps.filter(
+    step => typeof step.run === "string" && matches(step.run)
+  );
+  // Exactly one, so an ungated second copy added later cannot hide behind it.
+  expect(found).toHaveLength(1);
+  return found[0] as WorkflowStep;
+}
+
+/**
+ * Assert that a workflow's sg_scan job runs the rule tests behind a real gate.
+ * @param workflowPath - Workflow file relative to the repository root
+ * @param matches - Predicate identifying the rule-test invocation
+ */
+function expectGatedRuleTestStep(
+  workflowPath: string,
+  matches: (run: string) => boolean
+): void {
+  const steps = sgScanSteps(workflowPath);
+  const runStep = stepRunning(steps, matches);
+  const gate = steps.find(step => step.id === "check_rule_tests");
+
+  expect(gate?.run).toContain(RULE_TESTS_DIR);
+  expect(gate?.run).toContain("has_rule_tests");
+  // Without this condition the step goes green in every host project that
+  // ships the directory empty, which is a measurement of nothing.
+  expect(runStep.if).toContain(RULE_TEST_GATE);
+  expect(
+    steps.some(
+      step =>
+        typeof step.run === "string" &&
+        step.run.includes("::warning::") &&
+        step.run.includes("rule test")
+    )
+  ).toBe(true);
+}
+
+describe("ast-grep rule tests execute", () => {
+  it("passes every rule test shipped in this repository", () => {
+    const { status, output } = runRuleTests(path.join(REPO_ROOT, SGCONFIG));
+    const onDisk = countRuleTestFiles(path.join(REPO_ROOT, RULE_TESTS_DIR));
+
+    // Guards against a vacuous green: `ast-grep test` exits 0 on an empty test
+    // directory, so "0 failed" alone would be satisfied by running nothing.
+    expect(onDisk).toBeGreaterThan(0);
+    expect(output).toContain(`Running ${onDisk} tests`);
+    expect(output).toContain(`${onDisk} passed; 0 failed`);
+    expect(status).toBe(0);
+  });
+
+  it("reports a non-zero exit when a rule test asserts the wrong thing", () => {
+    const configPath = copyAstGrepPayload();
+    const tempDir = path.dirname(configPath);
+    // Inverted on purpose: the valid case is a real violation and the invalid
+    // case is clean code, so the runner must report both a Noisy and a Missing
+    // result. Asserting both directions is what proves the runner checks the
+    // rule rather than merely parsing the file.
+    fs.writeFileSync(
+      path.join(tempDir, RULE_TESTS_DIR, "phaser-no-canvas-renderer-test.yml"),
+      [
+        "id: phaser-no-canvas-renderer",
+        "valid:",
+        "  - 'const config = { type: Phaser.CANVAS };'",
+        "invalid:",
+        "  - 'const config = { type: Phaser.WEBGL };'",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const { status, output } = runRuleTests(configPath);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+
+    expect(output).toContain("Noisy");
+    expect(output).toContain("Missing");
+    expect(output).toContain("FAIL phaser-no-canvas-renderer");
+    expect(status).not.toBe(0);
+  });
+
+  it("exits zero on an empty test directory, which is why CI counts files", () => {
+    const configPath = copyAstGrepPayload();
+    const tempDir = path.dirname(configPath);
+    fs.rmSync(path.join(tempDir, RULE_TESTS_DIR), {
+      recursive: true,
+      force: true,
+    });
+    fs.mkdirSync(path.join(tempDir, RULE_TESTS_DIR));
+
+    const { status, output } = runRuleTests(configPath);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+
+    // A host project ships the rule-test directory empty. Left ungated, the CI
+    // step would go green here having proved nothing — the exact failure this
+    // suite exists to prevent.
+    expect(output).toContain("Running 0 tests");
+    expect(status).toBe(0);
+  });
+
+  it("keeps every sgconfig pointed at the directory CI counts", () => {
+    for (const sgconfig of SGCONFIGS) {
+      const parsed = loadYaml(readText(sgconfig)) as {
+        testConfigs?: readonly { testDir: string }[];
+      };
+      expect(parsed.testConfigs).toEqual([{ testDir: RULE_TESTS_DIR }]);
+    }
+  });
+});
+
+describe("ast-grep rule tests are wired to a runnable script", () => {
+  it("defines the rule-test script in this repository", () => {
+    const manifest = JSON.parse(readText("package.json")) as {
+      scripts: Record<string, string>;
+    };
+    expect(manifest.scripts[RULE_TEST_SCRIPT]).toBe("ast-grep test");
+  });
+
+  it("forces the rule-test script onto every stack that forces the scan script", () => {
+    for (const manifestPath of MANIFESTS_FORCING_AST_GREP) {
+      const scripts = (
+        JSON.parse(readText(manifestPath)) as {
+          force: { scripts: Record<string, string> };
+        }
+      ).force.scripts;
+
+      // Paired: a stack that scans but cannot test its rules is the state this
+      // ticket removed, so the two scripts must travel together.
+      expect(scripts["sg:scan"]).toBe("ast-grep scan");
+      expect(scripts[RULE_TEST_SCRIPT]).toBe("ast-grep test");
+    }
+  });
+});
+
+describe("ast-grep rule tests are wired into CI", () => {
+  it("runs the rule-test script in the TypeScript-family quality workflow", () => {
+    expectGatedRuleTestStep(".github/workflows/quality.yml", run =>
+      run.includes("run sg:test")
+    );
+  });
+
+  it("runs the rule tests in the Rails quality workflow", () => {
+    expectGatedRuleTestStep(
+      ".github/workflows/quality-rails.yml",
+      run => run.trim() === "sg test"
+    );
+  });
+});

--- a/tests/unit/config/ast-grep-rule-tests.test.ts
+++ b/tests/unit/config/ast-grep-rule-tests.test.ts
@@ -282,8 +282,11 @@ describe("ast-grep rule tests are wired to a runnable script", () => {
 
 describe("ast-grep rule tests are wired into CI", () => {
   it("runs the rule-test script in the TypeScript-family quality workflow", () => {
+    // `endsWith`, not `includes` — the skip notice mentions `sg:test` in its
+    // remediation text, and matching that would let the notice stand in for
+    // the invocation.
     expectGatedRuleTestStep(".github/workflows/quality.yml", run =>
-      run.includes("run sg:test")
+      run.trim().endsWith("run sg:test")
     );
   });
 

--- a/typescript/copy-overwrite/ast-grep/rule-tests/.gitkeep
+++ b/typescript/copy-overwrite/ast-grep/rule-tests/.gitkeep
@@ -1,3 +1,20 @@
-# This directory contains test cases for ast-grep rules.
-# Each test file should match its corresponding rule file name.
-# See: https://ast-grep.github.io/reference/yaml.html#rule-tests
+# Test cases for the ast-grep rules in ../rules/.
+#
+# These run. `ast-grep test` is wired to the `sg:test` package script and to
+# the AST Grep Scan job in Lisa's quality workflow, so a wrong assertion here
+# fails CI. The job counts the YAML files in this directory first: an empty
+# directory is reported as a skipped step with a warning, never as a pass,
+# because `ast-grep test` exits 0 when it finds nothing to run.
+#
+# A test file binds to a rule by its `id:` field, not by its filename — the
+# `<rule-id>-test.yml` convention is for humans reading the tree. Each case
+# listed under `valid:` must produce no diagnostic and each under `invalid:`
+# must produce one, so every rule is asserted in both directions.
+#
+# Every `invalid:` case also needs a snapshot under __snapshots__/ pinning
+# where the rule matched; a missing snapshot fails the run rather than being
+# skipped. Record them with:
+#
+#   ast-grep test --update-all      (or: <package manager> run sg:test -U)
+#
+# See: https://ast-grep.github.io/guide/test-rule.html

--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -16,6 +16,7 @@
       "knip:check": "knip",
       "knip:fix": "knip --fix",
       "sg:scan": "ast-grep scan",
+      "sg:test": "ast-grep test",
       "prepare": "node -e \"if (process.env.INIT_CWD?.includes('.serverless')) process.exit(0); process.exit(1);\" || husky install || true",
       "nightly:health": "node scripts/check-nightly-e2e-health.mjs",
       "check:skipped-required-checks": "node scripts/check-skipped-required-checks.mjs",

--- a/wiki/documentation/overview.md
+++ b/wiki/documentation/overview.md
@@ -1118,6 +1118,7 @@ Start small—one rule, one command, one hook—and expand as your team gains co
 | `bun run test:integration` | Run integration tests |
 | `bun run knip` | Dead code detection |
 | `bun run sg:scan` | ast-grep pattern scan |
+| `bun run sg:test` | Run the ast-grep rule tests in `ast-grep/rule-tests/` |
 | `bun run format` | Format with Prettier |
 
 ---


### PR DESCRIPTION
## What was wrong

`ast-grep/rule-tests/` held six rule tests and six snapshots that **nothing ever ran**. `package.json` defined `sg:scan` with no test counterpart, neither quality workflow invoked one, and `grep -rn "ast-grep test"` matched nothing in the repository. The files asserted `valid:`/`invalid:` cases for six rules and proved none of them — while reading as coverage to anyone skimming the tree, and teaching the next person who adds a rule to follow a convention that does nothing.

Same false-green class as the required check that reviewed nothing (#2497), the test-inert gate arms (#2492), and the existential assertions that always passed (#2501): a check that cannot run is indistinguishable from a check that ran and found nothing.

## Resolution: wired up, not deleted

The issue offered two honest options. Running the tests settled it.

**All six pass unmodified.** They were correct the whole time, just unreachable:

```
Running 6 tests
PASS phaser-no-raw-webgl-context                 ....
PASS harper-no-full-table-scan                   ........
PASS phaser-no-canvas-renderer                   ...
PASS harper-no-empty-conditions-with-sort        .....
PASS harper-require-statuscode-on-thrown-error   ......
PASS harper-no-early-return-in-search-loop       ....
test result: ok. 6 passed; 0 failed;
```

And the format proves things the vitest harness cannot:

- **A missing snapshot is a hard failure**, not a skip. The six recorded snapshots pin the exact character span each rule matched — `Phaser.CANVAS` at offset 23–36, not merely "something matched somewhere in the file". Verified by copying one rule and its test into a scratch project *without* the `__snapshots__` directory: `FAIL … No phaser-no-canvas-renderer baseline found`, exit 4. That same experiment is where the `id:`-not-filename binding below was measured — the copy was deliberately given a different filename and still ran.
- **Both directions are asserted natively.** A `valid:` case that matches reports `Noisy`; an `invalid:` case that does not match reports `Missing`. The trap that makes a "rule stays silent" assertion pass vacuously cannot be expressed here — the runner checks the negative direction as a first-class result.

Deleting twelve working files to keep ast-grep coverage only for the one pattern #2494 put in vitest would have been a net loss. Option 2 remains strictly better than the status quo, but option 1 is better than option 2.

## Changes

- **`sg:test` → `ast-grep test`** in this repository's `package.json`, and forced onto every stack template that already forces `sg:scan`: `typescript`, `phaser`, `harper-fabric` (plus Lisa's own `package.lisa.json`). Each already ships `@ast-grep/cli`, so the new script has exactly the same requirements as the scan script beside it.
- **A `🧪 Run ast-grep rule tests` step** in the `sg_scan` job of both `quality.yml` and `quality-rails.yml`. Added to the existing job rather than a new one on purpose: `🔎 AST Grep Scan` is already a required context, so this gates today instead of whenever someone remembers to add a new context to branch protection. The job's display name is unchanged, since renaming it would break the required-check contract fleet-wide.
- **The four `.gitkeep` notes** now describe how the runner actually binds a test to a rule. The old note said the filename must match the rule file; it does not — ast-grep binds by the `id:` field, and the `<rule-id>-test.yml` convention is purely for humans. Two of the four templates had no note at all.
- **`tests/unit/config/ast-grep-rule-tests.test.ts`** (8 tests), which also runs the rule tests under vitest, so they cannot go inert again even if the CI wiring is later removed.

## The part that matters most

`ast-grep test` **exits 0 when it finds nothing to run**, and every host project ships `ast-grep/rule-tests/` containing only a `.gitkeep`. An ungated step would therefore have gone green across the entire fleet having asserted nothing about any rule — reproducing this ticket's own bug somewhere new, at greater scale.

So the CI step is gated on *counting rule-test files*, not on the runner's exit code. A zero count is reported as a skipped step with a warning that says so out loud:

> `::warning::ast-grep rule tests skipped - no rule test files in ast-grep/rule-tests/`
> `This job going green does NOT mean any ast-grep rule has test coverage.`

Both counts were verified by running the exact shell from the workflow: **6** in this repository, **0** against a simulated host project carrying rules but an empty test directory.

## Fleet blast radius — checked, not assumed

`quality.yml` is consumed downstream at `@main`, so this starts running rule tests in host repos the moment it merges. The empty-directory case is the common one, but it is not the only one: **four host projects already have rule tests that have never executed either.**

| Project | Rule tests | Result |
|---|---|---|
| `geminisportsai/frontend-v2` | 4 | 4 passed, 0 failed |
| `geminisportsai/backend-v2` | 1 | 1 passed, 0 failed |
| `harperstarter` | 1 | 1 passed, 0 failed |
| `advisory-rankings` | 1 | 1 passed, 0 failed |

All seven pass, so nothing goes red on merge — and seven more previously-inert assertions start gating. Had any failed, that would have been a genuine finding to fix first rather than a reason to hold the wiring back.

## Verification

| Check | Result |
|---|---|
| `bun run sg:test` (the new script) | 6 passed, 0 failed, exit 0 |
| Negative control — inverted rule test | `Noisy` + `Missing` + `FAIL`, exit 4 |
| Empty test dir (host-project shape) | `Running 0 tests`, exit 0 — hence the file-count gate |
| CI counting shell, this repo / empty host | 6 / 0 |
| `ast-grep scan` — **no path argument**, whole repo | clean, exit 0 |
| `bun run test` (full suite) | 11473 passed; only the manifest test red pre-regen, green after |
| `bun run typecheck` / `bun run lint` / `prettier --check` | clean |
| `bun run build:upstream-evidence-manifest` | 6 template hashes + 1 new surface entry; stable on re-run |

## Known gap, deliberately not closed here

Six of sixteen rules have rule tests. The ten without (`ruby/*`, the two `fs-extra` rules, the two React component rules) stay uncovered by this PR — that gap is real but pre-existing, and the `fs-extra` pair already has working vitest coverage from #2494. What changes is that a rule test written for any of the other ten will now actually run.

Work-Item: CodySwannGT/lisa#2505

🤖 Generated with Claude Code
