### PR TITLE
feat(ci): refuse a required status context whose headroom nobody proved

### DIFF
--- a/.github/required-check-promotions.json
+++ b/.github/required-check-promotions.json
@@ -1,0 +1,253 @@
+{
+  "schema_version": 1,
+  "//": [
+    "Promotion ledger for required status contexts — CodySwannGT/lisa#2509.",
+    "A check may only become a required status context if its budget has proven headroom.",
+    "Enforced by scripts/check-required-check-promotions.mjs, which runs inside",
+    "tests/unit/scripts/required-check-promotions.repo.test.ts and therefore inside the",
+    "already-required '🔍 Quality Checks / 🧪 Run Unit Tests' context. Read that script's",
+    "module preamble before editing this file: it explains what counts as proof and why.",
+    "",
+    "status 'proven' requires budget_ms, observed_worst_ms, a >=2x margin, the machine",
+    "conditions, and a description of the run that REPRODUCED the failure the budget",
+    "prevents. Sizing from runs that passed is circular and is refused.",
+    "",
+    "status 'grandfathered' is for contexts that were already required on 2026-08-13, when",
+    "this ledger was written. It reports debt instead of failing. It is not an amnesty: the",
+    "entry must state what is unproven, and the context must appear in grandfathered_contexts",
+    "below. That list is FROZEN — a new promotion cannot join it, it must prove headroom."
+  ],
+  "grandfathered_frozen_on": "2026-08-13",
+  "grandfathered_contexts": [
+    "CodeRabbit",
+    "GitGuardian Security Checks",
+    "Quality Checks / Code Quality",
+    "Quality Checks / Lint",
+    "Quality Checks / Security",
+    "Quality Checks / 🔗 Work-Item Traceability",
+    "🌙 Nightly E2E Health / 🌙 Gate",
+    "🔍 Quality Checks / 🏗️ Build",
+    "🔍 Quality Checks / 📐 Check Formatting",
+    "🔍 Quality Checks / 🔍 Type Check",
+    "🔍 Quality Checks / 🔒 Security Scan",
+    "🔍 Quality Checks / 🔗 Work-Item Traceability",
+    "🔍 Quality Checks / 🧪 Run Integration Tests",
+    "🔍 Quality Checks / 🧪 Run Unit Tests",
+    "🔍 Quality Checks / 🧹 Lint",
+    "🔍 Quality Checks / 🧾 BDD Behavior Contract",
+    "🧩 Plugin artifacts match source"
+  ],
+  "promotions": [
+    {
+      "context": "🔍 Quality Checks / 🧹 Lint",
+      "integration_id": 15368,
+      "declared_in": ["typescript/github-rulesets/quality-checks.json"],
+      "caller_workflow": ".github/workflows/ci.yml",
+      "caller_job": "quality",
+      "called_workflow": ".github/workflows/quality.yml",
+      "job_id": "lint",
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "Required before #2509. No wall-clock budget on this job's path has ever been measured against a reproduced failure; the job budget is inherited from the workflow, not derived from a measurement."
+      }
+    },
+    {
+      "context": "🔍 Quality Checks / 🔍 Type Check",
+      "integration_id": 15368,
+      "declared_in": ["typescript/github-rulesets/quality-checks.json"],
+      "caller_workflow": ".github/workflows/ci.yml",
+      "caller_job": "quality",
+      "called_workflow": ".github/workflows/quality.yml",
+      "job_id": "typecheck",
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "Required before #2509. Budget never measured against a reproduced failure. `tsc` is an external process with unbounded latency under contention — the exact mechanism #2490 documents — so this is a real gap, not a formality."
+      }
+    },
+    {
+      "context": "🔍 Quality Checks / 🏗️ Build",
+      "integration_id": 15368,
+      "declared_in": ["typescript/github-rulesets/quality-checks.json"],
+      "caller_workflow": ".github/workflows/ci.yml",
+      "caller_job": "quality",
+      "called_workflow": ".github/workflows/quality.yml",
+      "job_id": "build",
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "Required before #2509. Budget never measured against a reproduced failure."
+      }
+    },
+    {
+      "context": "🔍 Quality Checks / 📐 Check Formatting",
+      "integration_id": 15368,
+      "declared_in": ["typescript/github-rulesets/quality-checks.json"],
+      "caller_workflow": ".github/workflows/ci.yml",
+      "caller_job": "quality",
+      "called_workflow": ".github/workflows/quality.yml",
+      "job_id": "format",
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "Required before #2509. Budget never measured against a reproduced failure."
+      }
+    },
+    {
+      "context": "🔍 Quality Checks / 🔒 Security Scan",
+      "integration_id": 15368,
+      "declared_in": ["typescript/github-rulesets/quality-checks.json"],
+      "caller_workflow": ".github/workflows/ci.yml",
+      "caller_job": "quality",
+      "called_workflow": ".github/workflows/quality.yml",
+      "job_id": "npm_security_scan",
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "Required before #2509. Budget never measured against a reproduced failure. This job also depends on an external advisory service, so its worst case is not bounded by this repository at all."
+      }
+    },
+    {
+      "context": "🔍 Quality Checks / 🧪 Run Unit Tests",
+      "integration_id": 15368,
+      "declared_in": ["typescript/github-rulesets/quality-checks.json"],
+      "caller_workflow": ".github/workflows/ci.yml",
+      "caller_job": "quality",
+      "called_workflow": ".github/workflows/quality.yml",
+      "job_id": "test_unit",
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "THE outstanding debt this ledger exists to record. Three known-marginal budgets ride inside this required context. (1) sonar-secrets' 60s budget was sized BY ANALOGY in #2490 — its 16-way paired probe ran against plugin-sync-scripts, not against sonar-secrets — and has never been re-measured against a reproduced sonar-secrets timeout; the suite failed 3 of 5 pre-push attempts across loads from 5 to ~300 vitest workers, including one run with only FIVE workers and 11,275 of 11,276 tests passing, so the honest claim is a budget that loses at any load, just less often when the box is quiet. (2) learnings-writer failed at 10,259ms against a 10,000ms budget — 2.6% over — then passed 5/5 on immediate re-run under unchanged conditions. (3) check-learnings-budget's `npm pack` takes 23.6s quiet and 45.8s loaded. #2509 scope item 3 names sonar-secrets as the first to re-measure. (4) A SIXTH suite, observed while writing this ledger on 2026-08-13: tests/unit/scripts/lisa-github-rulesets.test.ts timed out at 10,000ms on two of six cases, with a DIFFERENT pair failing on each of two consecutive runs, at load 27.01 on 18 cores with 57 sibling vitest processes live. It spawns `git init` and `bash` synchronously per case and is not wired to the io-latency budget helper — confirming #2490's warning that the five-suite roster is not a closed set. Deliberately NOT widened here: a timeout gives a lower bound, never an observed worst case, so nothing measured so far can size a budget for it. Widening it by analogy is the exact error this ledger refuses. (5) #2523 raised the whole suite's budget from 10s to 60s in Lisa's create-only vitest.config.local.ts, correctly scoped away from the fleet default so no downstream project inherits a looser budget it has no evidence for. That fix is genuinely measurement-backed — thirteen failing runs, a ruled-out table covering load, parallelism, disk, memory, spawn latency and fsync, and an empirical check that the override applies. It is NOT recorded as proven headroom, for one reason that this ledger's own ratio rule makes visible: #2523 cites an observed worst of 60,245ms and sets the budget to 60,000ms, which is 0.996x — below its own measured worst case, and far below the 2x floor. If that figure is a file-level elapsed time rather than a single test's duration then the ratio is unknown rather than inverted, but either way it is not proven, and the same near-miss shape as learnings-writer's 10,259ms against 10,000ms. Re-measure the per-test worst case before treating the unit-test path as having headroom."
+      }
+    },
+    {
+      "context": "🔍 Quality Checks / 🧪 Run Integration Tests",
+      "integration_id": 15368,
+      "declared_in": ["typescript/github-rulesets/quality-checks.json"],
+      "caller_workflow": ".github/workflows/ci.yml",
+      "caller_job": "quality",
+      "called_workflow": ".github/workflows/quality.yml",
+      "job_id": "test_integration",
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "Required before #2509. Budget never measured against a reproduced failure. #2490 states explicitly that the five suites wired to the io-latency budget are NOT a closed set — a nine-run sample elsewhere caught three more — so absence from that roster is not evidence of headroom here."
+      }
+    },
+    {
+      "context": "🔍 Quality Checks / 🔗 Work-Item Traceability",
+      "integration_id": 15368,
+      "declared_in": ["typescript/github-rulesets/quality-checks.json"],
+      "caller_workflow": ".github/workflows/ci.yml",
+      "caller_job": "quality",
+      "called_workflow": ".github/workflows/quality.yml",
+      "job_id": "work_item_traceability",
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "Required before #2509. Budget never measured against a reproduced failure. The job calls the tracker API, so its worst case depends on a third party rather than on this repository."
+      }
+    },
+    {
+      "context": "🔍 Quality Checks / 🧾 BDD Behavior Contract",
+      "integration_id": 15368,
+      "declared_in": ["expo/github-rulesets/bdd-coverage.json"],
+      "caller_workflow": "expo/create-only/.github/workflows/ci.yml",
+      "caller_job": "quality",
+      "called_workflow": ".github/workflows/quality.yml",
+      "job_id": "bdd_coverage",
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "Required before #2509, on Expo projects only. Budget never measured against a reproduced failure, and never measured on a real Expo project from this repository."
+      }
+    },
+    {
+      "context": "🌙 Nightly E2E Health / 🌙 Gate",
+      "integration_id": 15368,
+      "declared_in": ["expo/github-rulesets/nightly-e2e-health.json"],
+      "caller_workflow": "expo/create-only/.github/workflows/nightly-e2e-health.yml",
+      "caller_job": "health",
+      "called_workflow": ".github/workflows/nightly-e2e-health.yml",
+      "job_id": "gate",
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "Required before #2509, on Expo projects only. The gate is fail-closed by design (#2416), which makes an unproven budget MORE consequential rather than less: a timeout reads as a failed health check and blocks merge. Never measured against a reproduced failure."
+      }
+    },
+    {
+      "context": "🧩 Plugin artifacts match source",
+      "integration_id": 15368,
+      "declared_in": [".lisa.config.json"],
+      "caller_workflow": ".github/workflows/plugins-sync.yml",
+      "caller_job": "plugins-sync",
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "Promoted in #2510, hours before this ledger was written, so it is an incumbent by a narrow margin. #2510 reports the job as deterministic, offline, and ~25s, and removed the `paths:` filter that would have deadlocked it (measured on PR #2496) — but ~25s is a sample of runs that PASSED, which is precisely the circular sizing #2509 refuses. Re-measure against a reproduced failure before treating this entry as proven."
+      }
+    },
+    {
+      "context": "Quality Checks / Lint",
+      "integration_id": 15368,
+      "declared_in": ["rails/github-rulesets/quality-checks.json"],
+      "caller_workflow": "rails/create-only/.github/workflows/ci.yml",
+      "caller_job": "quality",
+      "called_workflow": ".github/workflows/quality-rails.yml",
+      "job_id": "lint",
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "Required before #2509, on Rails projects only. No budget on any Rails path has ever been measured from this repository."
+      }
+    },
+    {
+      "context": "Quality Checks / Code Quality",
+      "integration_id": 15368,
+      "declared_in": ["rails/github-rulesets/quality-checks.json"],
+      "caller_workflow": "rails/create-only/.github/workflows/ci.yml",
+      "caller_job": "quality",
+      "called_workflow": ".github/workflows/quality-rails.yml",
+      "job_id": "code-quality",
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "Required before #2509, on Rails projects only. No budget on any Rails path has ever been measured from this repository."
+      }
+    },
+    {
+      "context": "Quality Checks / Security",
+      "integration_id": 15368,
+      "declared_in": ["rails/github-rulesets/quality-checks.json"],
+      "caller_workflow": "rails/create-only/.github/workflows/ci.yml",
+      "caller_job": "quality",
+      "called_workflow": ".github/workflows/quality-rails.yml",
+      "job_id": "security",
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "Required before #2509, on Rails projects only. No budget on any Rails path has ever been measured from this repository."
+      }
+    },
+    {
+      "context": "Quality Checks / 🔗 Work-Item Traceability",
+      "integration_id": 15368,
+      "declared_in": ["rails/github-rulesets/quality-checks.json"],
+      "caller_workflow": "rails/create-only/.github/workflows/ci.yml",
+      "caller_job": "quality",
+      "called_workflow": ".github/workflows/quality-rails.yml",
+      "job_id": "work_item_traceability",
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "Required before #2509, on Rails projects only. Budget never measured against a reproduced failure. Note the mixed naming in this template — three non-emoji contexts and this emoji one — which is not a mistake: quality-rails.yml genuinely names its newer jobs with emoji and its older jobs without. Verify the job name, never the convention."
+      }
+    },
+    {
+      "context": "CodeRabbit",
+      "integration_id": 347564,
+      "declared_in": ["all/github-rulesets/base.json"],
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "Required before #2509. Not a GitHub Actions check, so there is no job budget to size — but it carries a worse debt of the same family: CodeRabbit reports `success — \"Review rate limited\"`, a green that proves nothing was reviewed. A hollow green satisfies a required context exactly as a real one does. Tracked by the `--pr` arm of check-skipped-required-checks, which reports and does not block."
+      }
+    },
+    {
+      "context": "GitGuardian Security Checks",
+      "integration_id": 46505,
+      "declared_in": ["all/github-rulesets/base.json"],
+      "headroom": {
+        "status": "grandfathered",
+        "debt": "Required before #2509. Not a GitHub Actions check, so there is no job budget to size; its worst case belongs to a third party and is not measurable from this repository."
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "check:rules-pairing": "bash scripts/check-rules-pairing.sh",
     "check:workflow-inputs": "node scripts/detect-stale-workflow-inputs.mjs --project . --project typescript/create-only --project rails/create-only --json",
     "check:duplicate-versions": "node scripts/check-duplicate-versions.mjs",
+    "check:required-check-promotions": "node scripts/check-required-check-promotions.mjs",
     "verify:health-contract": "bun run build:dist && node scripts/verify-health-contract-built.mjs",
     "verify:health-deterministic": "bun run build:dist && node scripts/verify-health-deterministic-built.mjs",
     "verify:learner-frontmatter-built": "bun run build:dist && node scripts/verify-learner-frontmatter-built.mjs",

--- a/scripts/check-required-check-promotions.mjs
+++ b/scripts/check-required-check-promotions.mjs
@@ -1,0 +1,683 @@
+#!/usr/bin/env node
+/**
+ * check-required-check-promotions — refuse a required status context whose
+ * safety nobody proved (CodySwannGT/lisa#2509).
+ *
+ * ## The rule
+ *
+ * **A check may only become a required status context if its budget has proven
+ * headroom.** "Proven" means measured against a run that actually REPRODUCED
+ * the failure the budget exists to prevent — not inferred from runs that
+ * passed. Sizing a budget from passing samples is circular: the sample already
+ * excludes the failure mode.
+ *
+ * ## Why this is a control and not a paragraph
+ *
+ * Promoting a check to required changes the cost of every marginal time budget
+ * on its path from "an agent re-runs" to "nothing merges." Nothing connected
+ * those two decisions: promotion happens in `<type>/github-rulesets/*.json` and
+ * in `.lisa.config.json`, while budgets live independently in the suites. A
+ * check can be promoted carrying a budget that loses occasionally at any load,
+ * and the first symptom is a permanently flaky merge gate, org-wide.
+ *
+ * It ships as a control rather than a rule document because that is what the
+ * measurement supports. In this repository, over one session, executable
+ * controls were obeyed 50 of 50 times and prose rules roughly 0 of 13 —
+ * including by the agents who had just written them. `.claude/rules` also
+ * explicitly excludes "prose restating a lint rule, hook, or CI gate."
+ *
+ * ## What it enforces, and which measured failure each clause came from
+ *
+ * Every declared required context must have an entry in
+ * `.github/required-check-promotions.json`. A context with no entry FAILS —
+ * that is the precondition itself. For each entry:
+ *
+ *  1. **The job must exist and be named exactly right.**
+ *     `rails/github-rulesets/quality-checks.json` names four contexts, three
+ *     non-emoji (`Quality Checks / Lint`) and one emoji
+ *     (`Quality Checks / 🔗 Work-Item Traceability`). Adding a context to that
+ *     file by symmetry with the TypeScript template produces a context no job
+ *     ever reports, which blocks every pull request in the repository forever.
+ *     So the ledger names the workflow and job id, and this guard reads the
+ *     YAML and compares the `name:` against the context.
+ *
+ *  2. **The reporting workflow may not be `paths:`-filtered.** Measured on PR
+ *     #2496: a filtered workflow does not run, so its context never reports and
+ *     GitHub shows "Expected — waiting for status to be reported" forever. Not
+ *     "runs and passes" — never reports at all.
+ *
+ *  3. **The headroom must be evidenced.** A `proven` entry must publish the
+ *     budget, the observed worst case, the machine conditions it was measured
+ *     under, and a description of the run that reproduced the failure. A
+ *     figure without its conditions is not a measurement:
+ *     `check-learnings-budget` was reported at 45.8s "in isolation" while ~56
+ *     sibling vitest processes were live, and that retracted number nearly
+ *     shipped as a permanent comment.
+ *
+ *  4. **The margin must be at least {@link MIN_HEADROOM_RATIO}x.**
+ *     `learnings-writer` failed at 10,259ms against a 10,000ms budget — 2.6%
+ *     over — then passed 5/5 on immediate re-run under UNCHANGED conditions.
+ *     If the box did not change and the result did, the budget is not measuring
+ *     the box; it is measuring nothing, because it has no headroom.
+ *     `plugin-sync-scripts` consumed 92% of its budget (1.09x) and failed 15 of
+ *     16 concurrent runs; at 60s (~2.5x) it failed 0 of 16. The floor therefore
+ *     sits inside (1.09, 2.54], and 2 is the conservative choice in that range.
+ *
+ *  5. **A budget may not be sized from a different subject.** #2490 raised five
+ *     budgets and sized `sonar-secrets`' 60s BY ANALOGY — its 16-way paired
+ *     probe ran against `plugin-sync-scripts`. Declaring `subject` and
+ *     `measured_on_subject` separately makes that mechanically visible instead
+ *     of a footnote in a report.
+ *
+ * ## The ratchet, and why incumbents are not simply exempted
+ *
+ * Contexts already required when this guard shipped may declare
+ * `"status": "grandfathered"`, which turns their problems into reported DEBT
+ * (exit 0) rather than violations. That is not an amnesty: the entry must state
+ * in `debt` exactly what is unproven, and the context must appear in the
+ * ledger's frozen `grandfathered_contexts` list. That list was fixed when the
+ * ledger was written, so a NEW promotion cannot buy its way in by claiming to
+ * be old. Reddening `main` to punish yesterday's promotions would only get the
+ * guard deleted; recording what each incumbent has not proven is the part that
+ * keeps working.
+ *
+ * ## Where it runs
+ *
+ * `tests/unit/scripts/required-check-promotions.repo.test.ts` calls
+ * {@link evaluate} against this repository, so it executes inside
+ * `🔍 Quality Checks / 🧪 Run Unit Tests` — itself a required context. An
+ * operator can also run `npm run check:required-check-promotions`.
+ *
+ * Usage:
+ *   node scripts/check-required-check-promotions.mjs [rootDir] [--json]
+ *
+ * @module scripts/check-required-check-promotions
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+
+/** Integration id GitHub Actions reports status checks under. */
+export const ACTIONS_INTEGRATION_ID = 15_368;
+
+/** Ledger location, relative to the repository root. */
+export const LEDGER_RELATIVE_PATH = ".github/required-check-promotions.json";
+
+/**
+ * Smallest acceptable budget-to-observed-worst-case ratio.
+ *
+ * Derived, not chosen: 1.09x failed 15/16 and ~2.54x failed 0/16 on the only
+ * budget in this repository ever proven under load, so the floor lies in
+ * (1.09, 2.54]. See the module preamble.
+ */
+export const MIN_HEADROOM_RATIO = 2;
+
+/** Directory names never scanned for ruleset templates. */
+const SKIPPED_DIRECTORIES = new Set([
+  "node_modules",
+  "dist",
+  "coverage",
+  ".git",
+]);
+
+/** Separator GitHub puts between a caller job name and a called job name. */
+const CONTEXT_SEPARATOR = " / ";
+
+/** Raised for operator error (bad arguments, unreadable ledger). */
+export class UsageError extends Error {}
+
+/**
+ * Split a status context into the caller job name and the called job name.
+ *
+ * A reusable-workflow job reports as `<caller job name> / <called job name>`;
+ * a job in the calling workflow reports under its own name alone. Splitting on
+ * the FIRST separator only, because a called job name may itself contain one.
+ *
+ * @param {string} context - the status check context.
+ * @returns {{ callerName: string, calledName: string | null }} the two halves.
+ */
+export function splitContext(context) {
+  const index = context.indexOf(CONTEXT_SEPARATOR);
+  if (index === -1) return { callerName: context, calledName: null };
+  return {
+    callerName: context.slice(0, index),
+    calledName: context.slice(index + CONTEXT_SEPARATOR.length),
+  };
+}
+
+/**
+ * Read the required contexts declared by one ruleset template.
+ *
+ * @param {string} absolute - absolute path to the template JSON.
+ * @param {string} relative - path reported as the source.
+ * @returns {{ context: string, integrationId: number, source: string }[]} declarations.
+ */
+function contextsFromTemplate(absolute, relative) {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(absolute, "utf8"));
+  } catch {
+    return [];
+  }
+  const found = [];
+  for (const rule of parsed?.rules ?? []) {
+    if (rule?.type !== "required_status_checks") continue;
+    for (const check of rule?.parameters?.required_status_checks ?? []) {
+      if (typeof check?.context !== "string") continue;
+      found.push({
+        context: check.context,
+        integrationId:
+          typeof check.integration_id === "number"
+            ? check.integration_id
+            : ACTIONS_INTEGRATION_ID,
+        source: relative,
+      });
+    }
+  }
+  return found;
+}
+
+/**
+ * Read the per-repository `addRequiredChecks` opt-in.
+ *
+ * This surface is NOT templated and exists precisely because a Lisa-only
+ * context must never ship in a shared template — host projects would inherit a
+ * context they never report (the #2476 defect). A guard blind to it would clear
+ * every context added this way.
+ *
+ * @param {string} root - absolute repository root.
+ * @returns {{ context: string, integrationId: number, source: string }[]} declarations.
+ */
+function contextsFromConfig(root) {
+  const absolute = path.join(root, ".lisa.config.json");
+  if (!fs.existsSync(absolute)) return [];
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(absolute, "utf8"));
+  } catch {
+    return [];
+  }
+  const added = parsed?.github?.rulesets?.addRequiredChecks ?? {};
+  const found = [];
+  for (const entries of Object.values(added)) {
+    for (const entry of Array.isArray(entries) ? entries : []) {
+      if (typeof entry?.context !== "string") continue;
+      found.push({
+        context: entry.context,
+        integrationId:
+          typeof entry.integration_id === "number"
+            ? entry.integration_id
+            : ACTIONS_INTEGRATION_ID,
+        source: ".lisa.config.json",
+      });
+    }
+  }
+  return found;
+}
+
+/**
+ * Collect every required context this repository declares, from both surfaces.
+ *
+ * @param {string} root - absolute repository root.
+ * @returns {{ context: string, integrationId: number, source: string }[]}
+ *   declarations, sorted by context then source.
+ */
+export function collectDeclaredContexts(root) {
+  const found = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory() || SKIPPED_DIRECTORIES.has(entry.name)) continue;
+    const rulesetDir = path.join(root, entry.name, "github-rulesets");
+    if (!fs.existsSync(rulesetDir)) continue;
+    for (const file of fs.readdirSync(rulesetDir).sort()) {
+      if (!file.endsWith(".json")) continue;
+      found.push(
+        ...contextsFromTemplate(
+          path.join(rulesetDir, file),
+          `${entry.name}/github-rulesets/${file}`
+        )
+      );
+    }
+  }
+  found.push(...contextsFromConfig(root));
+  return found.sort(
+    (a, b) =>
+      a.context.localeCompare(b.context) || a.source.localeCompare(b.source)
+  );
+}
+
+/**
+ * Parse a workflow into the two facts a required context depends on: which
+ * jobs it declares, and whether it actually runs on every pull request.
+ *
+ * @param {string} absolute - absolute path to the workflow YAML.
+ * @returns {{ jobs: Map<string, string>, onPullRequest: boolean, pathFilterKeys: string[] } | null}
+ *   the parsed facts, or null when the file is absent or unparseable.
+ */
+export function readWorkflow(absolute) {
+  if (!fs.existsSync(absolute)) return null;
+  let doc;
+  try {
+    doc = yaml.load(fs.readFileSync(absolute, "utf8"));
+  } catch {
+    return null;
+  }
+  if (typeof doc !== "object" || doc === null) return null;
+  // `on:` is a YAML 1.1 boolean. js-yaml's default schema keeps it a string,
+  // but a schema change upstream would silently move the key to `true` and a
+  // guard reading only one spelling would then report "no pull_request
+  // trigger" for every workflow in the fleet.
+  const triggers = doc.on ?? doc[true] ?? {};
+  const pullRequest =
+    typeof triggers === "object" && triggers !== null
+      ? triggers.pull_request
+      : undefined;
+  const onPullRequest =
+    (typeof triggers === "object" &&
+      triggers !== null &&
+      "pull_request" in triggers) ||
+    triggers === "pull_request" ||
+    (Array.isArray(triggers) && triggers.includes("pull_request"));
+  const pathFilterKeys =
+    typeof pullRequest === "object" && pullRequest !== null
+      ? ["paths", "paths-ignore"].filter(key => key in pullRequest)
+      : [];
+  const jobs = new Map();
+  for (const [id, job] of Object.entries(doc.jobs ?? {})) {
+    jobs.set(id, typeof job?.name === "string" ? job.name : id);
+  }
+  return { jobs, onPullRequest, pathFilterKeys };
+}
+
+/**
+ * Validate one declared budget inside a headroom block.
+ *
+ * @param {object} budget - a `headroom.budgets[]` entry.
+ * @returns {{ rule: string, detail: string }[]} problems, empty when sound.
+ */
+function budgetProblems(budget) {
+  const subject = budget?.subject;
+  const measuredOn = budget?.measured_on_subject;
+  if (typeof subject !== "string" || typeof measuredOn !== "string") {
+    return [
+      {
+        rule: "headroom-evidence-missing",
+        detail:
+          "every headroom.budgets[] entry needs a subject and a measured_on_subject",
+      },
+    ];
+  }
+  if (subject !== measuredOn) {
+    return [
+      {
+        rule: "budget-sized-by-analogy",
+        detail: `budget for '${subject}' was measured on '${measuredOn}'; a budget must be measured on the subject that consumes it`,
+      },
+    ];
+  }
+  return ratioProblems(budget.budget_ms, budget.observed_worst_ms);
+}
+
+/**
+ * Compare an observed worst case against its budget.
+ *
+ * @param {unknown} budgetMs - the declared wall-clock budget.
+ * @param {unknown} observedMs - the worst case actually observed.
+ * @returns {{ rule: string, detail: string }[]} problems, empty when sound.
+ */
+function ratioProblems(budgetMs, observedMs) {
+  if (
+    typeof budgetMs !== "number" ||
+    typeof observedMs !== "number" ||
+    budgetMs <= 0 ||
+    observedMs <= 0
+  ) {
+    return [
+      {
+        rule: "headroom-evidence-missing",
+        detail:
+          "headroom needs a positive budget_ms and a positive observed_worst_ms",
+      },
+    ];
+  }
+  const ratio = budgetMs / observedMs;
+  if (ratio < MIN_HEADROOM_RATIO) {
+    return [
+      {
+        rule: "headroom-ratio-too-thin",
+        detail: `observed worst ${observedMs}ms against a ${budgetMs}ms budget is ${ratio.toFixed(2)}x; ${MIN_HEADROOM_RATIO}x is the floor`,
+      },
+    ];
+  }
+  return [];
+}
+
+/**
+ * Validate a headroom block.
+ *
+ * A `grandfathered` block is shape-checked by the caller instead, because its
+ * obligation is to NAME what is unproven rather than to prove it.
+ *
+ * @param {object} headroom - the `headroom` object from a ledger entry.
+ * @returns {{ rule: string, detail: string }[]} problems, empty when sound.
+ */
+export function headroomProblems(headroom) {
+  const status = headroom?.status;
+  if (status !== "proven" && status !== "grandfathered") {
+    return [
+      {
+        rule: "unknown-headroom-status",
+        detail: `headroom.status must be 'proven' or 'grandfathered', got '${String(status)}'`,
+      },
+    ];
+  }
+  if (status === "grandfathered") return [];
+  const problems = [];
+  const prose = [
+    [
+      "reproduced",
+      "headroom.reproduced must describe the run that reproduced the failure the budget prevents",
+    ],
+    [
+      "measured_on",
+      "headroom.measured_on must name what was measured, so the next person can re-measure it",
+    ],
+    [
+      "conditions",
+      "headroom.conditions must state the machine state the measurement was taken under",
+    ],
+  ];
+  for (const [field, detail] of prose) {
+    const value = headroom[field];
+    if (typeof value !== "string" || value.trim() === "") {
+      problems.push({ rule: "headroom-evidence-missing", detail });
+    }
+  }
+  if (problems.length > 0) return problems;
+  problems.push(
+    ...ratioProblems(headroom.budget_ms, headroom.observed_worst_ms)
+  );
+  if (problems.length > 0) return problems;
+  for (const budget of headroom.budgets ?? []) {
+    problems.push(...budgetProblems(budget));
+  }
+  return problems;
+}
+
+/**
+ * Verify that the workflow wiring a ledger entry declares actually reports the
+ * context it claims to.
+ *
+ * @param {object} entry - the ledger entry.
+ * @param {string} root - absolute repository root.
+ * @returns {{ rule: string, detail: string }[]} problems, empty when sound.
+ */
+export function wiringProblems(entry, root) {
+  const { callerName, calledName } = splitContext(entry.context);
+  if (typeof entry.caller_workflow !== "string") {
+    return [
+      {
+        rule: "caller-workflow-missing",
+        detail:
+          "an Actions-reported context must declare caller_workflow and caller_job",
+      },
+    ];
+  }
+  const caller = readWorkflow(path.join(root, entry.caller_workflow));
+  if (caller === null) {
+    return [
+      {
+        rule: "caller-workflow-missing",
+        detail: `caller_workflow '${entry.caller_workflow}' is absent or unparseable`,
+      },
+    ];
+  }
+  const problems = [];
+  if (!caller.onPullRequest) {
+    problems.push({
+      rule: "pull-request-trigger-missing",
+      detail: `'${entry.caller_workflow}' does not run on pull_request, so this context never reports on a pull request`,
+    });
+  }
+  if (caller.pathFilterKeys.length > 0) {
+    problems.push({
+      rule: "path-filtered-workflow",
+      detail: `'${entry.caller_workflow}' filters pull_request by ${caller.pathFilterKeys.join("/")}; a filtered workflow does not run, so a required context on it waits forever (#2496)`,
+    });
+  }
+  problems.push(
+    ...jobNameProblems(caller, entry.caller_job, callerName, "caller")
+  );
+  if (calledName !== null) {
+    problems.push(...calledJobProblems(entry, root, calledName));
+  }
+  return problems;
+}
+
+/**
+ * Compare a workflow job's display name against the half of the context it is
+ * supposed to report as.
+ *
+ * @param {{ jobs: Map<string, string> }} workflow - parsed workflow.
+ * @param {unknown} jobId - the job id the ledger declares.
+ * @param {string} expected - the context half the job must render as.
+ * @param {"caller" | "called"} side - which half, for the rule name.
+ * @returns {{ rule: string, detail: string }[]} problems, empty when sound.
+ */
+function jobNameProblems(workflow, jobId, expected, side) {
+  if (typeof jobId !== "string" || !workflow.jobs.has(jobId)) {
+    return [
+      {
+        rule: `${side}-job-missing`,
+        detail: `no job '${String(jobId)}' in the ${side} workflow; a context no job reports blocks every pull request forever`,
+      },
+    ];
+  }
+  const actual = workflow.jobs.get(jobId);
+  if (actual !== expected) {
+    return [
+      {
+        rule: `${side}-job-name-mismatch`,
+        detail: `job '${jobId}' is named '${actual}' but the context expects '${expected}'`,
+      },
+    ];
+  }
+  return [];
+}
+
+/**
+ * Verify the reusable workflow half of a `caller / called` context.
+ *
+ * @param {object} entry - the ledger entry.
+ * @param {string} root - absolute repository root.
+ * @param {string} calledName - the expected called-job display name.
+ * @returns {{ rule: string, detail: string }[]} problems, empty when sound.
+ */
+function calledJobProblems(entry, root, calledName) {
+  if (typeof entry.called_workflow !== "string") {
+    return [
+      {
+        rule: "called-workflow-missing",
+        detail: `context '${entry.context}' names a reusable-workflow job, so the entry must declare called_workflow and job_id`,
+      },
+    ];
+  }
+  const called = readWorkflow(path.join(root, entry.called_workflow));
+  if (called === null) {
+    return [
+      {
+        rule: "called-workflow-missing",
+        detail: `called_workflow '${entry.called_workflow}' is absent or unparseable`,
+      },
+    ];
+  }
+  return jobNameProblems(called, entry.job_id, calledName, "called");
+}
+
+/**
+ * Read the promotion ledger.
+ *
+ * @param {string} root - absolute repository root.
+ * @returns {object | null} the parsed ledger, or null when absent/unparseable.
+ */
+export function loadLedger(root) {
+  const absolute = path.join(root, LEDGER_RELATIVE_PATH);
+  if (!fs.existsSync(absolute)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(absolute, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check one matched ledger entry and file its problems as violations or debt.
+ *
+ * @param {object} args - entry, declaration, root, frozen set, and sinks.
+ * @returns {void}
+ */
+function evaluateEntry({ entry, integrationId, root, frozen, out }) {
+  const grandfathered = entry.headroom?.status === "grandfathered";
+  const file = (rule, detail) =>
+    (grandfathered ? out.debts : out.violations).push({
+      context: entry.context,
+      rule,
+      detail,
+    });
+  if (grandfathered) {
+    if (!frozen.has(entry.context)) {
+      out.violations.push({
+        context: entry.context,
+        rule: "grandfather-not-frozen",
+        detail:
+          "only contexts already required when the ledger was written may be grandfathered; a new promotion must prove its headroom",
+      });
+      return;
+    }
+    const debt = entry.headroom?.debt;
+    if (typeof debt !== "string" || debt.trim() === "") {
+      out.violations.push({
+        context: entry.context,
+        rule: "grandfather-missing-debt",
+        detail:
+          "a grandfathered entry must say in `debt` exactly what about its headroom is unproven",
+      });
+      return;
+    }
+    out.debts.push({
+      context: entry.context,
+      rule: "grandfathered-headroom",
+      detail: debt,
+    });
+  }
+  if (integrationId === ACTIONS_INTEGRATION_ID) {
+    for (const p of wiringProblems(entry, root)) file(p.rule, p.detail);
+  }
+  for (const p of headroomProblems(entry.headroom)) file(p.rule, p.detail);
+}
+
+/**
+ * Evaluate every required context this repository declares against the ledger.
+ *
+ * @param {string} root - absolute repository root.
+ * @returns {{ violations: {context: string|null, rule: string, detail: string}[],
+ *   debts: {context: string|null, rule: string, detail: string}[], covered: number }}
+ *   the report. A non-empty `violations` is a failed promotion precondition.
+ */
+export function evaluate(root) {
+  const out = { violations: [], debts: [], covered: 0 };
+  const ledger = loadLedger(root);
+  if (ledger === null) {
+    out.violations.push({
+      context: null,
+      rule: "ledger-missing",
+      detail: `${LEDGER_RELATIVE_PATH} is absent or unparseable; refusing to report that promotions are sound when nothing was read`,
+    });
+    return out;
+  }
+  const frozen = new Set(ledger.grandfathered_contexts ?? []);
+  const declared = new Map();
+  for (const d of collectDeclaredContexts(root)) {
+    if (!declared.has(d.context)) declared.set(d.context, d.integrationId);
+  }
+  const seen = new Set();
+  for (const entry of ledger.promotions ?? []) {
+    if (seen.has(entry.context)) {
+      out.violations.push({
+        context: entry.context,
+        rule: "duplicate-promotion-entry",
+        detail: "the ledger records this context more than once",
+      });
+      continue;
+    }
+    seen.add(entry.context);
+    if (!declared.has(entry.context)) {
+      out.violations.push({
+        context: entry.context,
+        rule: "orphan-promotion-entry",
+        detail:
+          "the ledger promotes a context no ruleset template or config declares; delete the entry or restore the declaration",
+      });
+      continue;
+    }
+    out.covered += 1;
+    evaluateEntry({
+      entry,
+      integrationId: declared.get(entry.context),
+      root,
+      frozen,
+      out,
+    });
+  }
+  for (const context of declared.keys()) {
+    if (seen.has(context)) continue;
+    out.violations.push({
+      context,
+      rule: "missing-promotion-entry",
+      detail: `'${context}' is required but has no entry in ${LEDGER_RELATIVE_PATH}; a promotion must record what proves it safe`,
+    });
+  }
+  return out;
+}
+
+/**
+ * Render a human-readable report.
+ *
+ * @param {ReturnType<typeof evaluate>} result - the evaluation.
+ * @returns {string} the report text.
+ */
+export function formatReport(result) {
+  const lines = [
+    `Required-check promotions: ${result.covered} recorded, ${result.violations.length} violation(s), ${result.debts.length} outstanding debt(s).`,
+  ];
+  for (const v of result.violations) {
+    lines.push(`  ✖ [${v.rule}] ${v.context ?? "(ledger)"}: ${v.detail}`);
+  }
+  for (const d of result.debts) {
+    lines.push(`  • [${d.rule}] ${d.context ?? "(ledger)"}: ${d.detail}`);
+  }
+  if (result.violations.length === 0) {
+    lines.push(
+      "No unproven promotion. Debt lines are recorded, not enforced — see #2509."
+    );
+  }
+  return lines.join("\n");
+}
+
+/**
+ * CLI entry point.
+ *
+ * @returns {void}
+ */
+function main() {
+  const args = process.argv.slice(2);
+  const json = args.includes("--json");
+  const root = path.resolve(args.find(a => !a.startsWith("--")) ?? ".");
+  const result = evaluate(root);
+  console.log(json ? JSON.stringify(result, null, 2) : formatReport(result));
+  if (result.violations.length > 0) process.exitCode = 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2074,6 +2074,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "007430c2d6938efcc79ccbfd5717ebe2c7cf66b4de9a21a3e67b8db7f3600349",
     "scripts/check-plugins-sync.sh":
       "3a99cbff0e8ec5e7c944690eae003a6d51b51c85436d77bd37faea4d553728af",
+    "scripts/check-required-check-promotions.mjs":
+      "2693787413a276f7493c0fac1407a2e61630b2978d20acebb0ee5463c4678660",
     "scripts/check-rules-pairing.sh":
       "4d4a0d9e8d36794a22020f419c879d7336b1c5bfe883acdcc826d26764560c7a",
     "scripts/check-security-floors.mjs":
@@ -2429,6 +2431,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     ".github/GITHUB_ACTIONS.md": true,
     ".github/dependabot.yml": true,
     ".github/pull_request_template.md": true,
+    ".github/required-check-promotions.json": true,
     ".github/workflows/auto-update-pr-branches-dispatch.yml": true,
     ".github/workflows/auto-update-pr-branches.yml": true,
     ".github/workflows/build.yml": true,
@@ -8057,6 +8060,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "scripts/check-duplicate-versions.mjs": true,
     "scripts/check-learnings-budget.ts": true,
     "scripts/check-plugins-sync.sh": true,
+    "scripts/check-required-check-promotions.mjs": true,
     "scripts/check-rules-pairing.sh": true,
     "scripts/check-security-floors.mjs": true,
     "scripts/check-state-classification.mjs": true,
@@ -8915,6 +8919,10 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/plugin-routing-validate.test.ts": true,
     "tests/unit/scripts/plugin-sync-scripts.test.ts": true,
     "tests/unit/scripts/plugin-sync-workflow.test.ts": true,
+    "tests/unit/scripts/required-check-promotions-helpers.ts": true,
+    "tests/unit/scripts/required-check-promotions.repo.test.ts": true,
+    "tests/unit/scripts/required-check-promotions.test.ts": true,
+    "tests/unit/scripts/required-check-promotions.wiring.test.ts": true,
     "tests/unit/scripts/security-floors.test.ts": true,
     "tests/unit/scripts/setup-jira-cli-config.test.ts": true,
     "tests/unit/scripts/skipped-required-checks-wiring.test.ts": true,

--- a/tests/unit/scripts/required-check-promotions-helpers.ts
+++ b/tests/unit/scripts/required-check-promotions-helpers.ts
@@ -1,0 +1,206 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * Builders for synthetic repository roots used by the
+ * `check-required-check-promotions` unit tests.
+ *
+ * The guard reads four surfaces off disk — ruleset templates, the promotion
+ * ledger, `.lisa.config.json`, and workflow YAML. Driving it through real files
+ * rather than injected objects is deliberate: every defect this guard exists to
+ * catch (#2509) was a mismatch BETWEEN two of those files, so a test that stubs
+ * the reads would prove the join logic while assuming away the join.
+ */
+
+/** Numeric integration id GitHub Actions reports status checks under. */
+export const ACTIONS_ID = 15_368;
+
+/** The context #2506 promotes; the worked example throughout these tests. */
+export const AST_GREP_CONTEXT = "🔍 Quality Checks / 🔎 AST Grep Scan";
+
+/** A context reported by a job in the calling workflow, with no `/` half. */
+export const BARE_CONTEXT = "🧩 Plugin artifacts match source";
+
+/** The suite #2490 ran its 16-way probe against. */
+export const PROBE_SUBJECT = "plugin-sync-scripts";
+
+/** Calling workflow path used by the wired fixtures. */
+export const CI_WORKFLOW = ".github/workflows/ci.yml";
+
+/** Reusable workflow path used by the wired fixtures. */
+export const QUALITY_WORKFLOW = ".github/workflows/quality.yml";
+
+/**
+ * A headroom block that satisfies every evidence rule, for tests that need a
+ * valid baseline to mutate one field of.
+ *
+ * @returns {object} a fresh `proven` headroom block.
+ */
+export function provenHeadroom(): Record<string, unknown> {
+  return {
+    status: "proven",
+    budget_ms: 600_000,
+    observed_worst_ms: 180,
+    reproduced:
+      "planted a violating fixture and confirmed the check exits 1, then removed it and confirmed exit 0",
+    measured_on: "bun run sg:scan at origin/main b671524a7",
+    conditions: "load 5.00/6.36/7.04 on 18 cores, 0 vitest processes",
+  };
+}
+
+/** Shape of a synthetic workflow: its triggers and its jobId → name map. */
+type WorkflowSpec = {
+  readonly name?: string;
+  readonly pullRequest?: boolean;
+  readonly paths?: readonly string[];
+  readonly jobs: Readonly<Record<string, string>>;
+};
+
+/**
+ * Render the `on:` block for a synthetic workflow.
+ *
+ * @param spec - trigger shape.
+ * @returns YAML lines.
+ */
+function triggerLines(spec: WorkflowSpec): readonly string[] {
+  if (spec.pullRequest === false) {
+    return ["  schedule:", "    - cron: '0 6 * * *'"];
+  }
+  const filter = spec.paths
+    ? ["    paths:", ...spec.paths.map(p => `      - '${p}'`)]
+    : [];
+  return ["  pull_request:", ...filter];
+}
+
+/**
+ * Serialize a minimal but structurally real GitHub Actions workflow.
+ *
+ * @param spec - trigger shape and a jobId → display-name map.
+ * @returns YAML text.
+ */
+export function workflowYaml(spec: WorkflowSpec): string {
+  const lines = [
+    `name: ${spec.name ?? "CI"}`,
+    "",
+    "on:",
+    ...triggerLines(spec),
+    "",
+    "jobs:",
+    ...Object.entries(spec.jobs).flatMap(([id, jobName]) => [
+      `  ${id}:`,
+      `    name: ${jobName}`,
+      "    runs-on: ubuntu-latest",
+    ]),
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+/** Which of the guard's four input surfaces a synthetic root should carry. */
+type RootSpec = {
+  /** context → integration id, written into a typescript ruleset template. */
+  readonly required?: Readonly<Record<string, number>>;
+  /** ledger object; omit to write no ledger at all. */
+  readonly ledger?: unknown;
+  /** workflow relative path → YAML text. */
+  readonly workflows?: Readonly<Record<string, string>>;
+  /** `.lisa.config.json` contents; omit to write none. */
+  readonly lisaConfig?: unknown;
+};
+
+/**
+ * Materialize a throwaway repository root on disk.
+ *
+ * @param spec - which of the four surfaces to write, and with what contents.
+ * @returns absolute path to the created root.
+ */
+export function makeRoot(spec: RootSpec): string {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-promotions-"));
+  if (spec.required) {
+    const dir = path.join(root, "typescript", "github-rulesets");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, "quality-checks.json"),
+      `${JSON.stringify(
+        {
+          name: "quality checks",
+          target: "branch",
+          enforcement: "active",
+          rules: [
+            {
+              type: "required_status_checks",
+              parameters: {
+                required_status_checks: Object.entries(spec.required).map(
+                  ([context, integration_id]) => ({ context, integration_id })
+                ),
+              },
+            },
+          ],
+        },
+        null,
+        2
+      )}\n`
+    );
+  }
+  mkdirSync(path.join(root, ".github"), { recursive: true });
+  if (spec.ledger !== undefined) {
+    writeFileSync(
+      path.join(root, ".github", "required-check-promotions.json"),
+      `${JSON.stringify(spec.ledger, null, 2)}\n`
+    );
+  }
+  for (const [relative, body] of Object.entries(spec.workflows ?? {})) {
+    const absolute = path.join(root, relative);
+    mkdirSync(path.dirname(absolute), { recursive: true });
+    writeFileSync(absolute, body);
+  }
+  if (spec.lisaConfig !== undefined) {
+    writeFileSync(
+      path.join(root, ".lisa.config.json"),
+      `${JSON.stringify(spec.lisaConfig, null, 2)}\n`
+    );
+  }
+  return root;
+}
+
+/**
+ * Build the standard single-context fixture: one required context reported by
+ * a reusable-workflow job, plus both workflows wired correctly.
+ *
+ * @param overrides - ledger entry fields to replace or add.
+ * @param frozen - contexts to list in `grandfathered_contexts`.
+ * @returns absolute path to the created root.
+ */
+export function makeWiredRoot(
+  overrides: Record<string, unknown> = {},
+  frozen: readonly string[] = []
+): string {
+  const context = AST_GREP_CONTEXT;
+  return makeRoot({
+    required: { [context]: ACTIONS_ID },
+    workflows: {
+      [CI_WORKFLOW]: workflowYaml({
+        jobs: { quality: "🔍 Quality Checks" },
+      }),
+      [QUALITY_WORKFLOW]: workflowYaml({
+        jobs: { sg_scan: "🔎 AST Grep Scan" },
+      }),
+    },
+    ledger: {
+      schema_version: 1,
+      grandfathered_contexts: frozen,
+      promotions: [
+        {
+          context,
+          integration_id: ACTIONS_ID,
+          caller_workflow: CI_WORKFLOW,
+          caller_job: "quality",
+          called_workflow: QUALITY_WORKFLOW,
+          job_id: "sg_scan",
+          headroom: provenHeadroom(),
+          ...overrides,
+        },
+      ],
+    },
+  });
+}

--- a/tests/unit/scripts/required-check-promotions.repo.test.ts
+++ b/tests/unit/scripts/required-check-promotions.repo.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The guard applied to THIS repository (issue #2509).
+ *
+ * The unit suite proves the rules fire on synthetic roots. This one proves they
+ * are actually binding on Lisa's own governance surface — which is the only
+ * thing that makes it an executable control rather than a well-tested library
+ * nobody points at anything.
+ *
+ * It runs inside `🧪 Run Unit Tests`, which is already a required context, so a
+ * promotion that skips the ledger cannot merge.
+ *
+ * @module tests/unit/scripts/required-check-promotions.repo
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  collectDeclaredContexts,
+  evaluate,
+  LEDGER_RELATIVE_PATH,
+} from "../../../scripts/check-required-check-promotions.mjs";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  ".."
+);
+
+const ledger = (): {
+  grandfathered_contexts: string[];
+  promotions: {
+    context: string;
+    headroom: { status: string; debt?: string };
+  }[];
+} =>
+  JSON.parse(readFileSync(path.join(REPO_ROOT, LEDGER_RELATIVE_PATH), "utf8"));
+
+describe("Lisa's own required-check promotions", () => {
+  it("has no violations", () => {
+    const result = evaluate(REPO_ROOT);
+    expect(result.violations).toEqual([]);
+  });
+
+  it("covers every context Lisa declares required, in a template or in config", () => {
+    const declared = new Set(
+      collectDeclaredContexts(REPO_ROOT).map(d => d.context)
+    );
+    const recorded = new Set(ledger().promotions.map(p => p.context));
+    expect([...declared].filter(c => !recorded.has(c))).toEqual([]);
+    expect([...recorded].filter(c => !declared.has(c))).toEqual([]);
+  });
+
+  it("records the sonar-secrets analogy debt against the unit-test context", () => {
+    // #2509 scope item 3: sonar-secrets is the one shipped budget known to be
+    // sized by analogy — its 16-way probe ran against plugin-sync-scripts. It
+    // rides inside `🧪 Run Unit Tests`, which is already required, so the debt
+    // is real today and belongs on the record rather than in a comment.
+    const entry = ledger().promotions.find(
+      p => p.context === "🔍 Quality Checks / 🧪 Run Unit Tests"
+    );
+    expect(entry?.headroom.status).toBe("grandfathered");
+    expect(entry?.headroom.debt).toContain("sonar-secrets");
+  });
+
+  it("freezes incumbency: nothing may be grandfathered that is not already listed", () => {
+    const frozen = new Set(ledger().grandfathered_contexts);
+    const grandfathered = ledger()
+      .promotions.filter(p => p.headroom.status === "grandfathered")
+      .map(p => p.context);
+    expect(grandfathered.filter(c => !frozen.has(c))).toEqual([]);
+  });
+
+  it("is wired to a package script so an operator can run it by hand", () => {
+    const pkg = JSON.parse(
+      readFileSync(path.join(REPO_ROOT, "package.json"), "utf8")
+    );
+    expect(pkg.scripts["check:required-check-promotions"]).toBe(
+      "node scripts/check-required-check-promotions.mjs"
+    );
+  });
+});

--- a/tests/unit/scripts/required-check-promotions.test.ts
+++ b/tests/unit/scripts/required-check-promotions.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for the evidence rules of
+ * scripts/check-required-check-promotions.mjs (issue #2509).
+ *
+ * The rule under test: **a check may only become a required status context if
+ * its budget has proven headroom.** This file pins what counts as proof —
+ * reproduce, then measure, then compare the ratio. The wiring half of the rule
+ * (a context no job reports, a context on a path-filtered workflow) lives in
+ * `required-check-promotions.wiring.test.ts`.
+ *
+ * Every expected value is hardcoded per the Test Isolation house rule; nothing
+ * here computes an expectation by calling the function under test.
+ *
+ * @module tests/unit/scripts/required-check-promotions
+ */
+import { describe, expect, it } from "vitest";
+import {
+  ACTIONS_INTEGRATION_ID,
+  collectDeclaredContexts,
+  headroomProblems,
+  MIN_HEADROOM_RATIO,
+  splitContext,
+} from "../../../scripts/check-required-check-promotions.mjs";
+import {
+  ACTIONS_ID,
+  AST_GREP_CONTEXT,
+  BARE_CONTEXT,
+  makeRoot,
+  PROBE_SUBJECT,
+  provenHeadroom,
+} from "./required-check-promotions-helpers.js";
+
+describe("constants", () => {
+  it("uses GitHub Actions' integration id", () => {
+    expect(ACTIONS_INTEGRATION_ID).toBe(15_368);
+  });
+
+  it("requires at least a 2x margin between observed worst case and budget", () => {
+    expect(MIN_HEADROOM_RATIO).toBe(2);
+  });
+});
+
+describe("splitContext", () => {
+  it("splits a reusable-workflow context into caller and called job names", () => {
+    expect(splitContext(AST_GREP_CONTEXT)).toEqual({
+      callerName: "🔍 Quality Checks",
+      calledName: "🔎 AST Grep Scan",
+    });
+  });
+
+  it("treats a bare context as a job in the calling workflow", () => {
+    expect(splitContext(BARE_CONTEXT)).toEqual({
+      callerName: BARE_CONTEXT,
+      calledName: null,
+    });
+  });
+
+  it("splits on the first separator only, so a job name may contain a slash", () => {
+    expect(splitContext("A / B / C")).toEqual({
+      callerName: "A",
+      calledName: "B / C",
+    });
+  });
+});
+
+describe("collectDeclaredContexts", () => {
+  it("reads contexts out of every ruleset template", () => {
+    const root = makeRoot({
+      required: { "🔍 Quality Checks / 🧹 Lint": ACTIONS_ID },
+    });
+    expect(collectDeclaredContexts(root)).toEqual([
+      {
+        context: "🔍 Quality Checks / 🧹 Lint",
+        integrationId: 15_368,
+        source: "typescript/github-rulesets/quality-checks.json",
+      },
+    ]);
+  });
+
+  it("also reads the per-repo addRequiredChecks opt-in, which is not templated", () => {
+    // The #2476 defect: a Lisa-only context lives in `.lisa.config.json`, never
+    // in a shared template, because host projects would inherit a context they
+    // never report. A guard blind to that surface would clear it silently.
+    const root = makeRoot({
+      lisaConfig: {
+        github: {
+          rulesets: {
+            addRequiredChecks: {
+              "quality checks": [{ context: BARE_CONTEXT }],
+            },
+          },
+        },
+      },
+    });
+    expect(collectDeclaredContexts(root)).toEqual([
+      {
+        context: BARE_CONTEXT,
+        integrationId: 15_368,
+        source: ".lisa.config.json",
+      },
+    ]);
+  });
+});
+
+describe("headroomProblems", () => {
+  it("accepts a fully evidenced proven block", () => {
+    expect(headroomProblems(provenHeadroom())).toEqual([]);
+  });
+
+  it("refuses a proven claim with no reproduction", () => {
+    const headroom = { ...provenHeadroom(), reproduced: "" };
+    expect(headroomProblems(headroom)).toEqual([
+      {
+        rule: "headroom-evidence-missing",
+        detail:
+          "headroom.reproduced must describe the run that reproduced the failure the budget prevents",
+      },
+    ]);
+  });
+
+  it("refuses a proven claim with no machine conditions", () => {
+    // A figure without its conditions is not a measurement: #2490 reported
+    // check-learnings-budget at 45.8s "in isolation" while ~56 sibling vitest
+    // processes were live, and that retracted number nearly shipped as a
+    // permanent comment.
+    const { conditions: _drop, ...headroom } = provenHeadroom();
+    expect(headroomProblems(headroom)).toEqual([
+      {
+        rule: "headroom-evidence-missing",
+        detail:
+          "headroom.conditions must state the machine state the measurement was taken under",
+      },
+    ]);
+  });
+
+  it("refuses a margin thinner than 2x, which is what no headroom looks like", () => {
+    // learnings-writer failed at 10,259ms against 10,000ms — 2.6% over — then
+    // passed 5/5 unchanged. plugin-sync-scripts consumed 92% of its budget and
+    // failed 15 of 16. The only budget in this repo proven under load left
+    // ~2.5x. So the floor sits inside (1.09, 2.54].
+    const headroom = {
+      ...provenHeadroom(),
+      budget_ms: 10_000,
+      observed_worst_ms: 9_200,
+    };
+    expect(headroomProblems(headroom)).toEqual([
+      {
+        rule: "headroom-ratio-too-thin",
+        detail:
+          "observed worst 9200ms against a 10000ms budget is 1.09x; 2x is the floor",
+      },
+    ]);
+  });
+
+  it("flags a budget sized from a different subject as sized-by-analogy", () => {
+    // #2490 sized sonar-secrets' 60s budget from a 16-way probe run against
+    // plugin-sync-scripts. Sizing from a sample that excludes the failure mode
+    // is circular, and it is mechanically visible right here.
+    const headroom = {
+      ...provenHeadroom(),
+      budgets: [
+        {
+          subject: "sonar-secrets",
+          budget_ms: 60_000,
+          observed_worst_ms: 10_000,
+          measured_on_subject: PROBE_SUBJECT,
+        },
+      ],
+    };
+    expect(headroomProblems(headroom)).toEqual([
+      {
+        rule: "budget-sized-by-analogy",
+        detail:
+          "budget for 'sonar-secrets' was measured on 'plugin-sync-scripts'; a budget must be measured on the subject that consumes it",
+      },
+    ]);
+  });
+
+  it("accepts a budget measured on its own subject", () => {
+    const headroom = {
+      ...provenHeadroom(),
+      budgets: [
+        {
+          subject: PROBE_SUBJECT,
+          budget_ms: 60_000,
+          observed_worst_ms: 23_600,
+          measured_on_subject: PROBE_SUBJECT,
+        },
+      ],
+    };
+    expect(headroomProblems(headroom)).toEqual([]);
+  });
+
+  it("refuses an unknown status rather than treating it as proven", () => {
+    expect(headroomProblems({ status: "probably fine" })).toEqual([
+      {
+        rule: "unknown-headroom-status",
+        detail:
+          "headroom.status must be 'proven' or 'grandfathered', got 'probably fine'",
+      },
+    ]);
+  });
+});

--- a/tests/unit/scripts/required-check-promotions.wiring.test.ts
+++ b/tests/unit/scripts/required-check-promotions.wiring.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Unit tests for the wiring and ratchet rules of
+ * scripts/check-required-check-promotions.mjs (issue #2509).
+ *
+ * Split from `required-check-promotions.test.ts`, which owns the evidence
+ * rules. This file pins the three ways a promotion goes wrong that were
+ * MEASURED rather than reasoned about: a context no job reports, a context on a
+ * `paths:`-filtered workflow, and a promotion nobody recorded at all.
+ *
+ * @module tests/unit/scripts/required-check-promotions.wiring
+ */
+import { describe, expect, it } from "vitest";
+import { evaluate } from "../../../scripts/check-required-check-promotions.mjs";
+import {
+  ACTIONS_ID,
+  AST_GREP_CONTEXT,
+  BARE_CONTEXT,
+  CI_WORKFLOW,
+  makeRoot,
+  makeWiredRoot,
+  provenHeadroom,
+  QUALITY_WORKFLOW,
+  workflowYaml,
+} from "./required-check-promotions-helpers.js";
+
+const LINT_CONTEXT = "🔍 Quality Checks / 🧹 Lint";
+const NIGHTLY_WORKFLOW = ".github/workflows/nightly.yml";
+const NIGHTLY_CONTEXT = "🌙 Nightly E2E Health / 🌙 Gate";
+
+const rules = (result: { violations: readonly { rule: string }[] }): string[] =>
+  result.violations.map(v => v.rule);
+const debtRules = (result: { debts: readonly { rule: string }[] }): string[] =>
+  result.debts.map(d => d.rule);
+
+/**
+ * Build a root carrying one required context and one ledger entry for it.
+ *
+ * @param context - the required context.
+ * @param entry - the ledger entry body, minus its context.
+ * @param options - extra surfaces to write.
+ * @param options.workflows - workflow relative path → YAML text.
+ * @param options.frozen - contexts listed in `grandfathered_contexts`.
+ * @returns absolute path to the created root.
+ */
+function rootWith(
+  context: string,
+  entry: Record<string, unknown>,
+  options: {
+    workflows?: Record<string, string>;
+    frozen?: readonly string[];
+  } = {}
+): string {
+  return makeRoot({
+    required: { [context]: ACTIONS_ID },
+    workflows: options.workflows,
+    ledger: {
+      schema_version: 1,
+      grandfathered_contexts: options.frozen ?? [],
+      promotions: [{ context, integration_id: ACTIONS_ID, ...entry }],
+    },
+  });
+}
+
+describe("evaluate — the promotion precondition", () => {
+  it("passes a correctly wired, fully proven promotion", () => {
+    const result = evaluate(makeWiredRoot());
+    expect(result.violations).toEqual([]);
+    expect(result.debts).toEqual([]);
+    expect(result.covered).toBe(1);
+  });
+
+  it("refuses a required context with no ledger entry", () => {
+    // This is the precondition itself: you cannot add a context without
+    // recording what proves it safe.
+    const root = makeRoot({
+      required: { [AST_GREP_CONTEXT]: ACTIONS_ID },
+      ledger: { schema_version: 1, grandfathered_contexts: [], promotions: [] },
+    });
+    expect(rules(evaluate(root))).toEqual(["missing-promotion-entry"]);
+  });
+
+  it("refuses a ledger entry for a context nothing declares", () => {
+    const root = makeRoot({
+      ledger: {
+        schema_version: 1,
+        grandfathered_contexts: [],
+        promotions: [
+          {
+            context: "🔍 Quality Checks / 👻 Ghost",
+            integration_id: ACTIONS_ID,
+            headroom: provenHeadroom(),
+          },
+        ],
+      },
+    });
+    expect(rules(evaluate(root))).toEqual(["orphan-promotion-entry"]);
+  });
+
+  it("refuses a context whose caller job name does not match the workflow", () => {
+    // Measured failure mode 1. rails/github-rulesets/quality-checks.json mixes
+    // emoji and non-emoji job names in one file. A context added by symmetry
+    // with the TypeScript template names a job that never reports, and every
+    // pull request in that repository then waits forever.
+    const root = rootWith(
+      AST_GREP_CONTEXT,
+      {
+        caller_workflow: CI_WORKFLOW,
+        caller_job: "quality",
+        called_workflow: QUALITY_WORKFLOW,
+        job_id: "sg_scan",
+        headroom: provenHeadroom(),
+      },
+      {
+        workflows: {
+          [CI_WORKFLOW]: workflowYaml({ jobs: { quality: "Quality Checks" } }),
+          [QUALITY_WORKFLOW]: workflowYaml({
+            jobs: { sg_scan: "🔎 AST Grep Scan" },
+          }),
+        },
+      }
+    );
+    expect(rules(evaluate(root))).toEqual(["caller-job-name-mismatch"]);
+  });
+
+  it("refuses a context whose called job is absent from the reusable workflow", () => {
+    expect(rules(evaluate(makeWiredRoot({ job_id: "lint" })))).toEqual([
+      "called-job-missing",
+    ]);
+  });
+
+  it("refuses a context reported by a path-filtered workflow", () => {
+    // Measured failure mode 2, on PR #2496: a filtered workflow does not run,
+    // so the context never reports and the pull request waits forever. Not
+    // "runs and passes" — never reports at all.
+    const root = rootWith(
+      BARE_CONTEXT,
+      {
+        caller_workflow: ".github/workflows/plugins-sync.yml",
+        caller_job: "sync",
+        headroom: provenHeadroom(),
+      },
+      {
+        workflows: {
+          ".github/workflows/plugins-sync.yml": workflowYaml({
+            paths: ["plugins/**"],
+            jobs: { sync: BARE_CONTEXT },
+          }),
+        },
+      }
+    );
+    expect(rules(evaluate(root))).toEqual(["path-filtered-workflow"]);
+  });
+
+  it("refuses a context whose workflow never runs on pull_request", () => {
+    const root = rootWith(
+      NIGHTLY_CONTEXT,
+      {
+        caller_workflow: NIGHTLY_WORKFLOW,
+        caller_job: "health",
+        called_workflow: QUALITY_WORKFLOW,
+        job_id: "gate",
+        headroom: provenHeadroom(),
+      },
+      {
+        workflows: {
+          [NIGHTLY_WORKFLOW]: workflowYaml({
+            pullRequest: false,
+            jobs: { health: "🌙 Nightly E2E Health" },
+          }),
+          [QUALITY_WORKFLOW]: workflowYaml({ jobs: { gate: "🌙 Gate" } }),
+        },
+      }
+    );
+    expect(rules(evaluate(root))).toEqual(["pull-request-trigger-missing"]);
+  });
+
+  it("does not demand a workflow for a check GitHub Actions does not report", () => {
+    // CodeRabbit and GitGuardian are Apps. There is no job to name, so the
+    // wiring rules cannot apply — but the headroom rule still does.
+    const root = makeRoot({
+      required: { CodeRabbit: 347_564 },
+      ledger: {
+        schema_version: 1,
+        grandfathered_contexts: [],
+        promotions: [
+          {
+            context: "CodeRabbit",
+            integration_id: 347_564,
+            headroom: provenHeadroom(),
+          },
+        ],
+      },
+    });
+    expect(evaluate(root).violations).toEqual([]);
+  });
+});
+
+describe("evaluate — the grandfather ratchet", () => {
+  it("reports an incumbent's unproven budget as debt without failing the build", () => {
+    // Incumbents are recorded with their debt named, not silently exempted.
+    // Reddening main to punish yesterday's promotions gets the guard deleted.
+    const root = makeWiredRoot(
+      {
+        headroom: {
+          status: "grandfathered",
+          debt: "sonar-secrets' 60s budget was sized by analogy from a plugin-sync-scripts probe (#2490); never re-measured against a reproduced sonar-secrets timeout",
+        },
+      },
+      [AST_GREP_CONTEXT]
+    );
+    const result = evaluate(root);
+    expect(result.violations).toEqual([]);
+    expect(debtRules(result)).toEqual(["grandfathered-headroom"]);
+  });
+
+  it("refuses to grandfather a context that is not in the frozen list", () => {
+    // The ratchet. Incumbency was fixed when the ledger was written; a new
+    // promotion cannot buy its way in by claiming to be old.
+    const root = makeWiredRoot({
+      headroom: { status: "grandfathered", debt: "not measured" },
+    });
+    expect(rules(evaluate(root))).toEqual(["grandfather-not-frozen"]);
+  });
+
+  it("refuses a grandfathered entry that does not say what is unproven", () => {
+    const root = rootWith(
+      AST_GREP_CONTEXT,
+      { headroom: { status: "grandfathered" } },
+      { frozen: [AST_GREP_CONTEXT] }
+    );
+    expect(rules(evaluate(root))).toEqual(["grandfather-missing-debt"]);
+  });
+
+  it("downgrades a grandfathered entry's wiring problems to debt, not violations", () => {
+    const root = rootWith(
+      NIGHTLY_CONTEXT,
+      {
+        caller_workflow: NIGHTLY_WORKFLOW,
+        caller_job: "health",
+        called_workflow: QUALITY_WORKFLOW,
+        job_id: "gate",
+        headroom: {
+          status: "grandfathered",
+          debt: "scheduled workflow, never measured",
+        },
+      },
+      {
+        workflows: {
+          [NIGHTLY_WORKFLOW]: workflowYaml({
+            pullRequest: false,
+            jobs: { health: "🌙 Nightly E2E Health" },
+          }),
+          [QUALITY_WORKFLOW]: workflowYaml({ jobs: { gate: "🌙 Gate" } }),
+        },
+        frozen: [NIGHTLY_CONTEXT],
+      }
+    );
+    const result = evaluate(root);
+    expect(result.violations).toEqual([]);
+    expect(debtRules(result)).toContain("pull-request-trigger-missing");
+  });
+});
+
+describe("evaluate — refusing to answer", () => {
+  it("refuses rather than passing when the ledger is absent", () => {
+    // A guard that silently passes on a missing declaration is worse than no
+    // guard: it teaches people the surface is covered.
+    const root = makeRoot({ required: { [LINT_CONTEXT]: ACTIONS_ID } });
+    expect(rules(evaluate(root))).toEqual(["ledger-missing"]);
+  });
+
+  it("refuses when the ledger names the same context twice", () => {
+    const entry = {
+      context: LINT_CONTEXT,
+      integration_id: ACTIONS_ID,
+      caller_workflow: CI_WORKFLOW,
+      caller_job: "quality",
+      called_workflow: QUALITY_WORKFLOW,
+      job_id: "lint",
+      headroom: provenHeadroom(),
+    };
+    const root = makeRoot({
+      required: { [LINT_CONTEXT]: ACTIONS_ID },
+      workflows: {
+        [CI_WORKFLOW]: workflowYaml({ jobs: { quality: "🔍 Quality Checks" } }),
+        [QUALITY_WORKFLOW]: workflowYaml({ jobs: { lint: "🧹 Lint" } }),
+      },
+      ledger: {
+        schema_version: 1,
+        grandfathered_contexts: [],
+        promotions: [entry, entry],
+      },
+    });
+    expect(rules(evaluate(root))).toContain("duplicate-promotion-entry");
+  });
+});


### PR DESCRIPTION
Ships the #2509 rule — **a check may only become a required status context if its budget has proven headroom** — as an executable control rather than a rule document.

## Why a control and not a paragraph

`.claude/rules/PROJECT_RULES.md` already excludes "prose restating a lint rule, hook, or CI gate — enforce it in the tool instead." And the measurement in this repository today was stark: **executable controls held 50/50, prose rules ran roughly 0/13**, including violations by the agents who had just authored them. So the policy statement lives where it binds — as the module preamble of a guard that fails the build — and not in a file that would be read by nobody at the moment it mattered.

The prose is not lost. `scripts/check-required-check-promotions.mjs` opens with the full argument: what counts as proof, which measured failure produced each clause, and why incumbents are recorded rather than exempted.

## What it enforces

Every required context Lisa declares — in `<type>/github-rulesets/*.json` **and** in `.lisa.config.json`'s `addRequiredChecks` (the #2476 surface a template-only guard would miss) — must have an entry in `.github/required-check-promotions.json`. **A context with no entry fails the build. That is the precondition itself.**

For each entry, the guard reads the actual workflow YAML and checks:

| Clause | The measured failure it comes from |
|---|---|
| the job exists and its `name:` matches the context | `rails/github-rulesets/quality-checks.json` mixes emoji and non-emoji names. A context added by symmetry names a job nothing reports and blocks **every** Rails PR forever. |
| the reporting workflow has no `paths:` filter | PR #2496: a filtered workflow does not run, so the context never reports at all — "Expected — waiting for status to be reported", forever. |
| budget, observed worst case, machine conditions, and a **reproduced** failure are all published | #2490 reported `check-learnings-budget` at 45.8s "in isolation" while ~56 sibling vitest processes were live. A figure without its conditions is not a measurement. |
| the margin is at least **2x** | Derived, not chosen. `learnings-writer` failed at 10,259ms against 10,000ms — 2.6% over — then passed 5/5 on immediate re-run under *unchanged* conditions. `plugin-sync-scripts` consumed 92% of its budget (1.09x) and failed 15 of 16; at ~2.54x it failed 0 of 16. The floor lies in (1.09, 2.54]. |
| `subject` and `measured_on_subject` must match | #2490 sized `sonar-secrets`' 60s budget **by analogy** — its 16-way probe ran against `plugin-sync-scripts`. Declaring both fields separately makes that mechanically visible instead of a footnote. |

## The ratchet — incumbents are recorded, not exempted

The 17 contexts already required on 2026-08-13 are `grandfathered`: their problems report as **debt** (exit 0) rather than violations. That is not an amnesty. Each entry must state in `debt` exactly what is unproven, and the context must appear in the frozen `grandfathered_contexts` list — **a new promotion cannot join it.** Reddening `main` to punish yesterday's promotions gets a guard deleted; naming what each incumbent has not proven is the part that keeps working.

The headline debt is `🧪 Run Unit Tests`, which carries `sonar-secrets`' analogy-sized budget. That is #2509 scope item 3, now on the record rather than in a report.

## A sixth marginal suite, found while writing this

`tests/unit/scripts/lisa-github-rulesets.test.ts` timed out at 10,000ms on two of six cases, with a **different pair failing on each of two consecutive runs**, at load 27.01 on 18 cores. It spawns `git init` and `bash` synchronously per case and is not wired to the io-latency helper — confirming #2490's warning that the five-suite roster is not closed.

**Deliberately not widened here.** A timeout is a *lower bound*, never an observed worst case, so nothing measured so far can size a budget for it. Widening it by analogy is the exact error this ledger refuses — so it is recorded as debt instead.

## Verification

- **Falsifiability, both directions.** A planted unrecorded promotion (`🐢 Slow Lint Rules` added to the TypeScript template) makes the guard exit **1** naming the missing entry; the clean tree exits **0**. The template was restored byte-for-byte.
- 33 tests across three suites: the evidence rules, the wiring rules, and the ratchet, plus the guard applied to this repository.
- It runs inside `🔍 Quality Checks / 🧪 Run Unit Tests` — **already a required context** — so a promotion that skips the ledger cannot merge. No new job, no new required context, no fleet impact.
- `bun run lint`, `bun run typecheck`, `bun run format` clean. Manifest regenerated after `git add`.

## Scope

Lisa-only, on purpose. The ledger governs *Lisa's templates*, which is where fleet promotions are authored — so it covers the fleet's promotion decisions at their source without shipping a file every host project would have to write before its next update went green.

## Not done here

**No branch protection was edited.** A build agent granting itself lint-rule enforcement power is exactly what stays human-gated. A separate operator run of `scripts/lisa-github-rulesets.sh` is required for any promotion to take effect.

## About red pre-push runs on this branch

Four pre-push attempts failed with 128, 100, 69, and 65 failures — **~90% of them explicit `Test timed out in 10000ms`, and zero logic failures in any run.** None was in the four suites this PR adds; the eight files here are read by none of the failing suites. Causes identified in order: a runaway `actionlint` pinning 7.6 of 18 cores for 25 minutes (unrelated to this work, now dead, see #2520), then two concurrent `vitest run --coverage` runs over ~11,500 tests. That is this PR's own subject matter reproducing itself under the gate it is trying to protect.

Work-Item: CodySwannGT/lisa#2509

🤖 Generated with Claude Code
