### PR TITLE
fix(ci): do not run sg:test before the script exists in the host project

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2189,12 +2189,33 @@ jobs:
           else
             echo "has_rule_tests=false" >> $GITHUB_OUTPUT
           fi
+          # The tests existing does not mean the RUNNER exists. `sg:test` ships
+          # via package.lisa.json, which only reaches a host project on its next
+          # `lisa apply` — but this workflow is consumed at @main, so the step
+          # arrives immediately and the script does not. Gating on the test files
+          # alone turned every repo that already had rule tests red the moment
+          # #2525 merged (`error: Script not found "sg:test"`). See #2532.
+          if node -e "process.exit(require('./package.json').scripts?.['sg:test']?0:1)" 2>/dev/null; then
+            echo "has_test_script=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_test_script=false" >> $GITHUB_OUTPUT
+          fi
         working-directory: ${{ inputs.working_directory || '.' }}
 
       - name: 🧪 Run ast-grep rule tests
-        if: steps.check_config.outputs.has_config == 'true' && steps.check_rule_tests.outputs.has_rule_tests == 'true'
+        if: steps.check_config.outputs.has_config == 'true' && steps.check_rule_tests.outputs.has_rule_tests == 'true' && steps.check_rule_tests.outputs.has_test_script == 'true'
         run: ${{ inputs.package_manager }} run sg:test
         working-directory: ${{ inputs.working_directory || '.' }}
+
+      # Warn loudly rather than failing: a missing `sg:test` is a not-yet-applied
+      # Lisa version, not a defect in this project's code, and failing the shared
+      # gate for it takes CI down fleet-wide. The wording states plainly that the
+      # rule tests did NOT run, so this cannot become the silent false-green that
+      # #2525 set out to prevent.
+      - name: ⚠️ ast-grep rule tests present but not runnable
+        if: steps.check_config.outputs.has_config == 'true' && steps.check_rule_tests.outputs.has_rule_tests == 'true' && steps.check_rule_tests.outputs.has_test_script != 'true'
+        run: |
+          echo "::warning::${{ steps.check_rule_tests.outputs.rule_test_count }} ast-grep rule test file(s) exist but were NOT RUN: package.json has no 'sg:test' script. This job going green does NOT mean any ast-grep rule has test coverage. Run 'lisa apply' to add the script (Lisa #2532)."
 
       - name: ⏭️ AST Grep Skipped (no config)
         if: steps.check_config.outputs.has_config != 'true'


### PR DESCRIPTION
## Fleet CI is failing on `Script not found "sg:test"`

`🔎 AST Grep Scan` fails on every downstream repository that has ast-grep rule tests but
has not yet run `lisa apply` since #2525:

```
error: Script not found "sg:test"
##[error]Process completed with exit code 1.
```

Observed on `geminisportsai/backend-v2` (PR #2990). By the earlier fleet survey the same
condition holds for `geminisportsai/frontend-v2` (4 rule tests), `harperstarter` (1) and
`advisory-rankings` (1).

## Cause

#2525 added this step to the reusable `quality.yml`:

```yaml
- name: 🧪 Run ast-grep rule tests
  if: steps.check_config.outputs.has_config == 'true' && steps.check_rule_tests.outputs.has_rule_tests == 'true'
  run: ${{ inputs.package_manager }} run sg:test
```

`has_rule_tests` counts **files** in `ast-grep/rule-tests/`. It does not check that the
`sg:test` **script** exists. `sg:test` was added to `package.lisa.json` in the same PR, so
a host project only gets it after its next `lisa apply` — but `quality.yml` is consumed at
`@main`, so the workflow change reaches every repository *immediately*, while the script
does not.

Any repo that already had rule tests therefore went red the moment #2525 merged. `sg:scan`
does not have this problem because it shipped in an earlier Lisa and is already applied
everywhere.

## Why the guard did not catch it

#2525's guard was designed against exactly the right failure — `ast-grep test` exits 0 on
an empty directory, so counting files rather than trusting the exit code was correct. It
just guarded the wrong half: it verified the tests exist, not that the runner does.

## Fix

Gate the step on the script existing as well, and when rule tests are present but `sg:test`
is not yet applied, **warn loudly and continue** rather than failing. A missing script is a
not-yet-applied Lisa version, not a defect in the project's code, and failing the shared
gate for it takes down CI fleet-wide.

The warning must state plainly that the rule tests did **not** run, so this cannot become
the silent false-green #2525 set out to prevent.

## Related

- #2505 / #2525 — added the step
- #2506 — a red ast-grep scan cannot block a merge (separate issue, still open)



Work-Item: CodySwannGT/lisa#2532
