### PR TITLE
fix(automations): stop erasing unknown run-record fields from the whole history

### DIFF
--- a/plugins/lisa-agy/scripts/automation-run-record.mjs
+++ b/plugins/lisa-agy/scripts/automation-run-record.mjs
@@ -41,6 +41,7 @@ export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
  *   readonly runId?: string
  *   readonly ts?: string | Date
  *   readonly maxEntries?: number
+ *   readonly extras?: Readonly<Record<string, unknown>>
  * }} RecordAutomationRunInput
  */
 
@@ -188,7 +189,26 @@ function buildAutomationRunRecord(input) {
     throw new Error("Automation run_id is required.");
   }
 
+  // Unknown keys are preserved rather than dropped. `recordAutomationRun`
+  // rewrites the WHOLE history file on every append, and stored records are
+  // re-validated through this function on read — so dropping an unrecognised
+  // key here does not merely omit it from the new row, it erases it from every
+  // row that already had it. The loss is invisible: the write succeeds, the
+  // file stays valid JSONL, and the reader returns records that look complete.
+  // Consumers get a false all-clear instead of an error (#2524).
+  //
+  // Validated fields are spread LAST so a corrupt or hostile stored row cannot
+  // override `outcome`, `run_id`, or any other checked value with an extra key
+  // of the same name.
+  const extras =
+    input.extras &&
+    typeof input.extras === "object" &&
+    !Array.isArray(input.extras)
+      ? input.extras
+      : {};
+
   return {
+    ...extras,
     ts,
     loop_id: loopId,
     outcome: input.outcome,
@@ -198,6 +218,17 @@ function buildAutomationRunRecord(input) {
     run_id: runId,
   };
 }
+
+/** Keys this module validates explicitly; everything else is passed through. */
+const KNOWN_RECORD_KEYS = new Set([
+  "ts",
+  "loop_id",
+  "outcome",
+  "summary",
+  "runbook",
+  "refs",
+  "run_id",
+]);
 
 /**
  * @param {unknown} value
@@ -215,6 +246,12 @@ function validateStoredRecord(value) {
     runbook: String(value.runbook ?? ""),
     refs: Array.isArray(value.refs) ? value.refs.map(ref => String(ref)) : [],
     runId: String(value.run_id ?? ""),
+    // Carry every unrecognised key forward. Without this, re-validating a
+    // stored record on read silently strips it, and the next append writes the
+    // stripped history back over the file (#2524).
+    extras: Object.fromEntries(
+      Object.entries(value).filter(([key]) => !KNOWN_RECORD_KEYS.has(key))
+    ),
   });
 }
 

--- a/plugins/lisa-copilot/scripts/automation-run-record.mjs
+++ b/plugins/lisa-copilot/scripts/automation-run-record.mjs
@@ -41,6 +41,7 @@ export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
  *   readonly runId?: string
  *   readonly ts?: string | Date
  *   readonly maxEntries?: number
+ *   readonly extras?: Readonly<Record<string, unknown>>
  * }} RecordAutomationRunInput
  */
 
@@ -188,7 +189,26 @@ function buildAutomationRunRecord(input) {
     throw new Error("Automation run_id is required.");
   }
 
+  // Unknown keys are preserved rather than dropped. `recordAutomationRun`
+  // rewrites the WHOLE history file on every append, and stored records are
+  // re-validated through this function on read — so dropping an unrecognised
+  // key here does not merely omit it from the new row, it erases it from every
+  // row that already had it. The loss is invisible: the write succeeds, the
+  // file stays valid JSONL, and the reader returns records that look complete.
+  // Consumers get a false all-clear instead of an error (#2524).
+  //
+  // Validated fields are spread LAST so a corrupt or hostile stored row cannot
+  // override `outcome`, `run_id`, or any other checked value with an extra key
+  // of the same name.
+  const extras =
+    input.extras &&
+    typeof input.extras === "object" &&
+    !Array.isArray(input.extras)
+      ? input.extras
+      : {};
+
   return {
+    ...extras,
     ts,
     loop_id: loopId,
     outcome: input.outcome,
@@ -198,6 +218,17 @@ function buildAutomationRunRecord(input) {
     run_id: runId,
   };
 }
+
+/** Keys this module validates explicitly; everything else is passed through. */
+const KNOWN_RECORD_KEYS = new Set([
+  "ts",
+  "loop_id",
+  "outcome",
+  "summary",
+  "runbook",
+  "refs",
+  "run_id",
+]);
 
 /**
  * @param {unknown} value
@@ -215,6 +246,12 @@ function validateStoredRecord(value) {
     runbook: String(value.runbook ?? ""),
     refs: Array.isArray(value.refs) ? value.refs.map(ref => String(ref)) : [],
     runId: String(value.run_id ?? ""),
+    // Carry every unrecognised key forward. Without this, re-validating a
+    // stored record on read silently strips it, and the next append writes the
+    // stripped history back over the file (#2524).
+    extras: Object.fromEntries(
+      Object.entries(value).filter(([key]) => !KNOWN_RECORD_KEYS.has(key))
+    ),
   });
 }
 

--- a/plugins/lisa-cursor/scripts/automation-run-record.mjs
+++ b/plugins/lisa-cursor/scripts/automation-run-record.mjs
@@ -41,6 +41,7 @@ export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
  *   readonly runId?: string
  *   readonly ts?: string | Date
  *   readonly maxEntries?: number
+ *   readonly extras?: Readonly<Record<string, unknown>>
  * }} RecordAutomationRunInput
  */
 
@@ -188,7 +189,26 @@ function buildAutomationRunRecord(input) {
     throw new Error("Automation run_id is required.");
   }
 
+  // Unknown keys are preserved rather than dropped. `recordAutomationRun`
+  // rewrites the WHOLE history file on every append, and stored records are
+  // re-validated through this function on read — so dropping an unrecognised
+  // key here does not merely omit it from the new row, it erases it from every
+  // row that already had it. The loss is invisible: the write succeeds, the
+  // file stays valid JSONL, and the reader returns records that look complete.
+  // Consumers get a false all-clear instead of an error (#2524).
+  //
+  // Validated fields are spread LAST so a corrupt or hostile stored row cannot
+  // override `outcome`, `run_id`, or any other checked value with an extra key
+  // of the same name.
+  const extras =
+    input.extras &&
+    typeof input.extras === "object" &&
+    !Array.isArray(input.extras)
+      ? input.extras
+      : {};
+
   return {
+    ...extras,
     ts,
     loop_id: loopId,
     outcome: input.outcome,
@@ -198,6 +218,17 @@ function buildAutomationRunRecord(input) {
     run_id: runId,
   };
 }
+
+/** Keys this module validates explicitly; everything else is passed through. */
+const KNOWN_RECORD_KEYS = new Set([
+  "ts",
+  "loop_id",
+  "outcome",
+  "summary",
+  "runbook",
+  "refs",
+  "run_id",
+]);
 
 /**
  * @param {unknown} value
@@ -215,6 +246,12 @@ function validateStoredRecord(value) {
     runbook: String(value.runbook ?? ""),
     refs: Array.isArray(value.refs) ? value.refs.map(ref => String(ref)) : [],
     runId: String(value.run_id ?? ""),
+    // Carry every unrecognised key forward. Without this, re-validating a
+    // stored record on read silently strips it, and the next append writes the
+    // stripped history back over the file (#2524).
+    extras: Object.fromEntries(
+      Object.entries(value).filter(([key]) => !KNOWN_RECORD_KEYS.has(key))
+    ),
   });
 }
 

--- a/plugins/lisa/scripts/automation-run-record.mjs
+++ b/plugins/lisa/scripts/automation-run-record.mjs
@@ -41,6 +41,7 @@ export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
  *   readonly runId?: string
  *   readonly ts?: string | Date
  *   readonly maxEntries?: number
+ *   readonly extras?: Readonly<Record<string, unknown>>
  * }} RecordAutomationRunInput
  */
 
@@ -188,7 +189,26 @@ function buildAutomationRunRecord(input) {
     throw new Error("Automation run_id is required.");
   }
 
+  // Unknown keys are preserved rather than dropped. `recordAutomationRun`
+  // rewrites the WHOLE history file on every append, and stored records are
+  // re-validated through this function on read — so dropping an unrecognised
+  // key here does not merely omit it from the new row, it erases it from every
+  // row that already had it. The loss is invisible: the write succeeds, the
+  // file stays valid JSONL, and the reader returns records that look complete.
+  // Consumers get a false all-clear instead of an error (#2524).
+  //
+  // Validated fields are spread LAST so a corrupt or hostile stored row cannot
+  // override `outcome`, `run_id`, or any other checked value with an extra key
+  // of the same name.
+  const extras =
+    input.extras &&
+    typeof input.extras === "object" &&
+    !Array.isArray(input.extras)
+      ? input.extras
+      : {};
+
   return {
+    ...extras,
     ts,
     loop_id: loopId,
     outcome: input.outcome,
@@ -198,6 +218,17 @@ function buildAutomationRunRecord(input) {
     run_id: runId,
   };
 }
+
+/** Keys this module validates explicitly; everything else is passed through. */
+const KNOWN_RECORD_KEYS = new Set([
+  "ts",
+  "loop_id",
+  "outcome",
+  "summary",
+  "runbook",
+  "refs",
+  "run_id",
+]);
 
 /**
  * @param {unknown} value
@@ -215,6 +246,12 @@ function validateStoredRecord(value) {
     runbook: String(value.runbook ?? ""),
     refs: Array.isArray(value.refs) ? value.refs.map(ref => String(ref)) : [],
     runId: String(value.run_id ?? ""),
+    // Carry every unrecognised key forward. Without this, re-validating a
+    // stored record on read silently strips it, and the next append writes the
+    // stripped history back over the file (#2524).
+    extras: Object.fromEntries(
+      Object.entries(value).filter(([key]) => !KNOWN_RECORD_KEYS.has(key))
+    ),
   });
 }
 

--- a/plugins/src/base/scripts/automation-run-record.mjs
+++ b/plugins/src/base/scripts/automation-run-record.mjs
@@ -41,6 +41,7 @@ export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
  *   readonly runId?: string
  *   readonly ts?: string | Date
  *   readonly maxEntries?: number
+ *   readonly extras?: Readonly<Record<string, unknown>>
  * }} RecordAutomationRunInput
  */
 
@@ -188,7 +189,26 @@ function buildAutomationRunRecord(input) {
     throw new Error("Automation run_id is required.");
   }
 
+  // Unknown keys are preserved rather than dropped. `recordAutomationRun`
+  // rewrites the WHOLE history file on every append, and stored records are
+  // re-validated through this function on read — so dropping an unrecognised
+  // key here does not merely omit it from the new row, it erases it from every
+  // row that already had it. The loss is invisible: the write succeeds, the
+  // file stays valid JSONL, and the reader returns records that look complete.
+  // Consumers get a false all-clear instead of an error (#2524).
+  //
+  // Validated fields are spread LAST so a corrupt or hostile stored row cannot
+  // override `outcome`, `run_id`, or any other checked value with an extra key
+  // of the same name.
+  const extras =
+    input.extras &&
+    typeof input.extras === "object" &&
+    !Array.isArray(input.extras)
+      ? input.extras
+      : {};
+
   return {
+    ...extras,
     ts,
     loop_id: loopId,
     outcome: input.outcome,
@@ -198,6 +218,17 @@ function buildAutomationRunRecord(input) {
     run_id: runId,
   };
 }
+
+/** Keys this module validates explicitly; everything else is passed through. */
+const KNOWN_RECORD_KEYS = new Set([
+  "ts",
+  "loop_id",
+  "outcome",
+  "summary",
+  "runbook",
+  "refs",
+  "run_id",
+]);
 
 /**
  * @param {unknown} value
@@ -215,6 +246,12 @@ function validateStoredRecord(value) {
     runbook: String(value.runbook ?? ""),
     refs: Array.isArray(value.refs) ? value.refs.map(ref => String(ref)) : [],
     runId: String(value.run_id ?? ""),
+    // Carry every unrecognised key forward. Without this, re-validating a
+    // stored record on read silently strips it, and the next append writes the
+    // stripped history back over the file (#2524).
+    extras: Object.fromEntries(
+      Object.entries(value).filter(([key]) => !KNOWN_RECORD_KEYS.has(key))
+    ),
   });
 }
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -903,7 +903,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/reference/work-item-definition-of-ready.md":
       "ebcfe89f5a33a8008c4a54c1c2f4a092952df3263adc8f537a4c0b6ad8dbe18d",
     "plugins/src/base/scripts/automation-run-record.mjs":
-      "89143e06975d8333b137fd2bdb5f12bcd703403752337f00c25d18fefba6a4c8",
+      "a499794a20f82a1e311ef4cb5188dd890f25b970e19e788d6945f2d5898dc9d2",
     "plugins/src/base/scripts/automation-status-claude-adapter.mjs":
       "b1054acf4a5cbbe5354bd62a22b96533bcbc69b6cb9245976ceb8af638a04494",
     "plugins/src/base/scripts/automation-status-codex-adapter.mjs":

--- a/tests/unit/strategies/automation-run-record.test.ts
+++ b/tests/unit/strategies/automation-run-record.test.ts
@@ -209,3 +209,105 @@ describe("automation run records (#1797)", () => {
     ).resolves.toMatchObject({ records: [], skippedCorruptLines: 0 });
   });
 });
+
+describe("unknown field preservation (#2524)", () => {
+  const stored = (runId: string, extra: Record<string, unknown>): string =>
+    JSON.stringify({
+      ts: BASE_TS,
+      loop_id: LOOP_ID,
+      outcome: NOTHING_NEEDED,
+      summary: "prior run",
+      runbook: RUNBOOK_PATH,
+      refs: [],
+      run_id: runId,
+      ...extra,
+    });
+
+  it("keeps an unknown field on the record it was written with", async () => {
+    const result = await recordAutomationRun({
+      projectRoot: root,
+      loopId: LOOP_ID,
+      outcome: NOTHING_NEEDED,
+      summary: "carries extras",
+      runbook: RUNBOOK_PATH,
+      runId: "run-1",
+      ts: BASE_TS,
+      extras: { standing_rulings: ["ruling-a", "ruling-b"] },
+    });
+
+    expect(result.record).toMatchObject({
+      run_id: "run-1",
+      standing_rulings: ["ruling-a", "ruling-b"],
+    });
+  });
+
+  // The severe case: `recordAutomationRun` rewrites the WHOLE file on append,
+  // so a dropped key is erased from rows that already had it — not merely
+  // omitted from the new one.
+  it("keeps unknown fields on PRIOR rows when a later append rewrites the file", async () => {
+    put(RECORDS_PATH, `${stored("run-1", { standing_rulings: ["kept"] })}\n`);
+
+    await recordAutomationRun({
+      projectRoot: root,
+      loopId: LOOP_ID,
+      outcome: NOTHING_NEEDED,
+      summary: "second run",
+      runbook: RUNBOOK_PATH,
+      runId: "run-2",
+      ts: BASE_TS,
+    });
+
+    const lines = readLines(RECORDS_PATH);
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0] ?? "{}")).toMatchObject({
+      run_id: "run-1",
+      standing_rulings: ["kept"],
+    });
+  });
+
+  it("survives a full write → read → append → read round trip", async () => {
+    await recordAutomationRun({
+      projectRoot: root,
+      loopId: LOOP_ID,
+      outcome: NOTHING_NEEDED,
+      summary: "first",
+      runbook: RUNBOOK_PATH,
+      runId: "run-1",
+      ts: BASE_TS,
+      extras: { standing_rulings: ["r1"] },
+    });
+    await recordAutomationRun({
+      projectRoot: root,
+      loopId: LOOP_ID,
+      outcome: NOTHING_NEEDED,
+      summary: "second",
+      runbook: RUNBOOK_PATH,
+      runId: "run-2",
+      ts: BASE_TS,
+    });
+
+    const { records } = await readAutomationRunRecords(
+      path.join(root, RECORDS_PATH)
+    );
+    expect(records[0]).toMatchObject({ standing_rulings: ["r1"] });
+  });
+
+  it("never lets an extra key override a validated field", async () => {
+    put(RECORDS_PATH, `${stored("run-1", { standing_rulings: ["kept"] })}\n`);
+
+    const result = await recordAutomationRun({
+      projectRoot: root,
+      loopId: LOOP_ID,
+      outcome: NOTHING_NEEDED,
+      summary: "hostile extras",
+      runbook: RUNBOOK_PATH,
+      runId: "run-2",
+      ts: BASE_TS,
+      extras: { outcome: "forged", run_id: "forged", standing_rulings: ["ok"] },
+    });
+
+    expect(result.record.outcome).toBe(NOTHING_NEEDED);
+    expect(result.record.run_id).toBe("run-2");
+    expect(result.record).toMatchObject({ standing_rulings: ["ok"] });
+  });
+});


### PR DESCRIPTION
## Problem

`plugins/src/base/scripts/automation-run-record.mjs` silently discards every field
outside a fixed seven-key shape — and it does so **retroactively across the entire
history file on every append**, not just to the record being written.

Reported downstream as TUN-596 (`standing_rulings` stripped on every append) and
upstream-scoped to `@codyswann/lisa`. Verified here; the blast radius is larger than
reported.

## Mechanism

`buildAutomationRunRecord` (line 161) returns a literal with exactly seven keys:

```js
return { ts, loop_id, outcome, summary, runbook, refs, run_id };
```

`validateStoredRecord` (line 206) rebuilds **stored** records by passing them back
through that same function, so any key it does not name is dropped on read.

`recordAutomationRun` then rewrites the whole file:

```js
const readResult = await readAutomationRunRecords(filePath);   // strips extras from ALL prior records
const nextRecords = [...readResult.records, record].slice(-maxEntries);
await writeJsonlAtomically(filePath, nextRecords);             // writes the stripped history back
```

So a single append rewrites every historical record in its stripped form. Fields are not
merely absent from new rows — **they are erased from rows that already had them.**

## Why it is worse than a missing field

The loss is invisible at every point a human or agent would look:

- the write succeeds and reports `appended: true`
- the file stays valid JSONL, so no parse error surfaces
- the reader returns records that look complete
- consumers therefore get a **false all-clear** rather than an error

TUN-595 reports the reader surfacing 52 of 92 rulings and **zero from the last two
days** — consistent with this: recent appends progressively strip the history they
rewrite. A downstream session worked around it by reading the JSON directly; every cycle
going through the reader is getting an answer that is wrong in the safe-looking
direction.

This is the same defect class as CodySwannGT/lisa#2497 (a required check reporting
`SUCCESS` while reviewing nothing): a component that reports success having silently
done less than it claims.

## Fix

Preserve unknown keys through both the build and the read path, with validated fields
taking precedence over any same-named extra so a corrupt row cannot override
`outcome`/`run_id`. Round-trip must be lossless: a record written with extra fields,
read back, and rewritten by a later append must retain them.

## Test coverage required

- an extra field survives a write → read → append → read cycle
- an extra field on a **pre-existing** row survives an append that rewrites the file
- an extra key named `outcome`/`run_id`/etc. cannot override the validated value
- the seven known fields still validate and still throw on invalid `outcome`

## Related

- TUN-595 — reader surfaces 52 of 92 rulings, 0 from the last two days (downstream symptom)
- TUN-596 — `standing_rulings` stripped on append (downstream report)
- #2497 — a required check that satisfied while proving nothing (same class)



Work-Item: CodySwannGT/lisa#2524
