### PR TITLE
fix(ci): invoke ast-grep directly so the rule-test step is self-sufficient

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2189,33 +2189,35 @@ jobs:
           else
             echo "has_rule_tests=false" >> $GITHUB_OUTPUT
           fi
-          # The tests existing does not mean the RUNNER exists. `sg:test` ships
-          # via package.lisa.json, which only reaches a host project on its next
-          # `lisa apply` — but this workflow is consumed at @main, so the step
-          # arrives immediately and the script does not. Gating on the test files
-          # alone turned every repo that already had rule tests red the moment
-          # #2525 merged (`error: Script not found "sg:test"`). See #2532.
-          if node -e "process.exit(require('./package.json').scripts?.['sg:test']?0:1)" 2>/dev/null; then
-            echo "has_test_script=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_test_script=false" >> $GITHUB_OUTPUT
-          fi
         working-directory: ${{ inputs.working_directory || '.' }}
 
+      # Invokes the ast-grep binary directly, never a `sg:test` package.json
+      # script. Everything that TRIGGERS this step — sgconfig.yml and the
+      # rule-test files — is shipped by Lisa, but a script alias lives in the
+      # host project's package.json, which Lisa only rewrites on `lisa apply`.
+      # Trigger and target travel by different routes at different speeds, so
+      # they can never be guaranteed to agree: this workflow is consumed at
+      # @main, so #2525's step reached every consumer immediately while the
+      # script did not, and each one went red on `Script not found "sg:test"`
+      # (#2532). Gating on the script existing (the first patch) traded that
+      # for a step that reports success having run nothing, which is the worse
+      # failure. The binary has no such split — it is present in any project
+      # whose sg:scan already works, and npx fetches it when it is not — so the
+      # step is self-sufficient and the whole failure class is gone (#2530).
+      #
+      # `sg:test` stays in package.lisa.json as a local developer alias. CI no
+      # longer depends on it.
       - name: 🧪 Run ast-grep rule tests
-        if: steps.check_config.outputs.has_config == 'true' && steps.check_rule_tests.outputs.has_rule_tests == 'true' && steps.check_rule_tests.outputs.has_test_script == 'true'
-        run: ${{ inputs.package_manager }} run sg:test
-        working-directory: ${{ inputs.working_directory || '.' }}
-
-      # Warn loudly rather than failing: a missing `sg:test` is a not-yet-applied
-      # Lisa version, not a defect in this project's code, and failing the shared
-      # gate for it takes CI down fleet-wide. The wording states plainly that the
-      # rule tests did NOT run, so this cannot become the silent false-green that
-      # #2525 set out to prevent.
-      - name: ⚠️ ast-grep rule tests present but not runnable
-        if: steps.check_config.outputs.has_config == 'true' && steps.check_rule_tests.outputs.has_rule_tests == 'true' && steps.check_rule_tests.outputs.has_test_script != 'true'
+        if: steps.check_config.outputs.has_config == 'true' && steps.check_rule_tests.outputs.has_rule_tests == 'true'
         run: |
-          echo "::warning::${{ steps.check_rule_tests.outputs.rule_test_count }} ast-grep rule test file(s) exist but were NOT RUN: package.json has no 'sg:test' script. This job going green does NOT mean any ast-grep rule has test coverage. Run 'lisa apply' to add the script (Lisa #2532)."
+          # The project's own pinned CLI first, so CI runs the same version as
+          # `sg:scan` and the developer's machine. npx only when it has none.
+          if [ -x "node_modules/.bin/ast-grep" ]; then
+            exec node_modules/.bin/ast-grep test
+          fi
+          echo "::notice::@ast-grep/cli is not a dependency of this project; running the Lisa-pinned CLI via npx."
+          exec npx --yes --package "@ast-grep/cli@0.40.4" ast-grep test
+        working-directory: ${{ inputs.working_directory || '.' }}
 
       - name: ⏭️ AST Grep Skipped (no config)
         if: steps.check_config.outputs.has_config != 'true'
@@ -2235,7 +2237,7 @@ jobs:
           echo "::warning::ast-grep rule tests skipped - no rule test files in ast-grep/rule-tests/"
           echo "This job going green does NOT mean any ast-grep rule has test coverage."
           echo "To cover a rule, add ast-grep/rule-tests/<rule-id>-test.yml with valid/invalid cases,"
-          echo "then run '${{ inputs.package_manager }} run sg:test --update-all' to record its snapshot."
+          echo "then run 'ast-grep test --update-all' to record its snapshot."
 
   floor_collisions:
     name: 🧱 Security Floor Collisions

--- a/ast-grep/rule-tests/.gitkeep
+++ b/ast-grep/rule-tests/.gitkeep
@@ -1,8 +1,8 @@
 # Test cases for the ast-grep rules in ../rules/.
 #
-# These run. `ast-grep test` is wired to the `sg:test` package script and to
-# the AST Grep Scan job in Lisa's quality workflow, so a wrong assertion here
-# fails CI. The job counts the YAML files in this directory first: an empty
+# These run. The AST Grep Scan job in Lisa's quality workflow invokes the
+# `ast-grep` binary directly, so a wrong assertion here fails CI whether or not
+# this project has run `lisa apply` since the step shipped. The job counts the YAML files in this directory first: an empty
 # directory is reported as a skipped step with a warning, never as a pass,
 # because `ast-grep test` exits 0 when it finds nothing to run.
 #

--- a/phaser/copy-overwrite/ast-grep/rule-tests/.gitkeep
+++ b/phaser/copy-overwrite/ast-grep/rule-tests/.gitkeep
@@ -1,8 +1,8 @@
 # Test cases for the ast-grep rules in ../rules/.
 #
-# These run. `ast-grep test` is wired to the `sg:test` package script and to
-# the AST Grep Scan job in Lisa's quality workflow, so a wrong assertion here
-# fails CI. The job counts the YAML files in this directory first: an empty
+# These run. The AST Grep Scan job in Lisa's quality workflow invokes the
+# `ast-grep` binary directly, so a wrong assertion here fails CI whether or not
+# this project has run `lisa apply` since the step shipped. The job counts the YAML files in this directory first: an empty
 # directory is reported as a skipped step with a warning, never as a pass,
 # because `ast-grep test` exits 0 when it finds nothing to run.
 #

--- a/rails/copy-overwrite/ast-grep/rule-tests/.gitkeep
+++ b/rails/copy-overwrite/ast-grep/rule-tests/.gitkeep
@@ -1,8 +1,8 @@
 # Test cases for the ast-grep rules in ../rules/.
 #
-# These run. `ast-grep test` is wired to the `sg:test` package script and to
-# the AST Grep Scan job in Lisa's quality workflow, so a wrong assertion here
-# fails CI. The job counts the YAML files in this directory first: an empty
+# These run. The AST Grep Scan job in Lisa's quality workflow invokes the
+# `ast-grep` binary directly, so a wrong assertion here fails CI whether or not
+# this project has run `lisa apply` since the step shipped. The job counts the YAML files in this directory first: an empty
 # directory is reported as a skipped step with a warning, never as a pass,
 # because `ast-grep test` exits 0 when it finds nothing to run.
 #

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -415,7 +415,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "phaser/copy-overwrite/.husky/pre-push.verify":
       "fef6694c2fde6178f46c62936d2b19515adce4fc8ac694ea66d8342aa1474ee7",
     "phaser/copy-overwrite/ast-grep/rule-tests/.gitkeep":
-      "35e9b9011053aa791fe6c6b76129599fff5c65a408bef1498b9fe4dd6f0054eb",
+      "bbbdb778ba76fa0bf120a9d49325e726adafc6a833e8d56a87c449a33a818cbd",
     "phaser/copy-overwrite/ast-grep/rules/phaser/no-canvas-renderer.yml":
       "bd0994bbb8f8e6bde2a1a581fb2cb8aa011d91822dabf4366f500359069726b3",
     "phaser/copy-overwrite/ast-grep/rules/phaser/no-raw-webgl-context.yml":
@@ -1989,7 +1989,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/copy-overwrite/Gemfile.lisa":
       "8bebf6120fa90d8f971ded8281c4fdac632e524ca0bb80f6268c3eda997f7672",
     "rails/copy-overwrite/ast-grep/rule-tests/.gitkeep":
-      "35e9b9011053aa791fe6c6b76129599fff5c65a408bef1498b9fe4dd6f0054eb",
+      "bbbdb778ba76fa0bf120a9d49325e726adafc6a833e8d56a87c449a33a818cbd",
     "rails/copy-overwrite/ast-grep/rules/ruby/no-find-by-sql-without-params.yml":
       "8d47d388f1b7d5cce0d4e58a9455247a10ee93d4cca664e9169dd32b666b10d0",
     "rails/copy-overwrite/ast-grep/rules/ruby/no-params-without-permit.yml":
@@ -2237,7 +2237,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/.yamllint":
       "e8a17046b8c1eb4653ed8a2ac6390ce499d505aab2daf81e43feefd5c4959067",
     "typescript/copy-overwrite/ast-grep/rule-tests/.gitkeep":
-      "35e9b9011053aa791fe6c6b76129599fff5c65a408bef1498b9fe4dd6f0054eb",
+      "bbbdb778ba76fa0bf120a9d49325e726adafc6a833e8d56a87c449a33a818cbd",
     "typescript/copy-overwrite/ast-grep/rules/.gitkeep":
       "5068239f6c760759362d6a1cc83478d77eef0214fa7f4f23c8d1ce4b56f532c0",
     "typescript/copy-overwrite/ast-grep/rules/no-inline-component-in-container.yml":

--- a/tests/unit/config/ast-grep-rule-tests.test.ts
+++ b/tests/unit/config/ast-grep-rule-tests.test.ts
@@ -8,6 +8,13 @@
  * genuinely reports failure when a rule test is wrong, and the CI wiring that
  * invokes it is gated on test files existing, so a project with none gets a
  * warning instead of a green step that measured nothing.
+ *
+ * A fourth property was added after the CI step took the fleet down: it must
+ * be self-sufficient. Gating it on a `sg:test` script the host project has to
+ * supply produced first a hard failure in every unpinned consumer and then,
+ * once that was patched, a step that reported success having run nothing. The
+ * last describe block executes the shipped step body against real project
+ * trees so both of those regressions are caught here rather than in CI.
  */
 import { describe, expect, it } from "vitest";
 import { spawnSync } from "node:child_process";
@@ -17,9 +24,21 @@ import * as path from "node:path";
 import { load as loadYaml } from "js-yaml";
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
-const AST_GREP = path.join(REPO_ROOT, "node_modules/.bin/ast-grep");
+/** Where a package manager puts executables, in this repo and in a consumer. */
+const LOCAL_BIN_DIR = "node_modules/.bin";
+const AST_GREP = path.join(REPO_ROOT, LOCAL_BIN_DIR, "ast-grep");
+/** The TypeScript-family reusable workflow these tests assert on. */
+const TS_QUALITY_WORKFLOW = ".github/workflows/quality.yml";
 const RULE_TESTS_DIR = "ast-grep/rule-tests";
 const RULE_TEST_SCRIPT = "sg:test";
+const SCAN_BIN = "ast-grep scan";
+const RULE_TEST_BIN = "ast-grep test";
+/**
+ * The rule-test invocation, distinguished from the skip notice's remediation
+ * text, which also names `ast-grep test`. Matching loosely would let the
+ * notice stand in for the invocation.
+ */
+const RULE_TEST_INVOCATION = `${LOCAL_BIN_DIR}/${RULE_TEST_BIN}`;
 const RULE_TEST_GATE =
   "steps.check_rule_tests.outputs.has_rule_tests == 'true'";
 
@@ -38,6 +57,12 @@ const MANIFESTS_FORCING_AST_GREP = [
   "phaser/package-lisa/package.lisa.json",
   "harper-fabric/package-lisa/package.lisa.json",
 ] as const;
+
+/**
+ * Absolute, so the interpreter is not resolved through a writeable PATH.
+ * GitHub-hosted runners and every developer machine ship bash here.
+ */
+const BASH = "/bin/bash";
 
 /** ast-grep's root config file name. */
 const SGCONFIG = "sgconfig.yml";
@@ -108,6 +133,81 @@ function runRuleTests(configPath: string): {
       ""
     ),
   };
+}
+
+/**
+ * Build a scratch project shaped like a real consumer that has NOT yet run
+ * `lisa apply`: ast-grep config and rule tests present, `sg:test` absent from
+ * package.json, and `@ast-grep/cli` installed as a dependency.
+ *
+ * This is the shape that broke the fleet — `geminisportsai/backend-v2` had
+ * exactly this — so it is the shape the CI step has to survive.
+ * @returns Absolute path to the scratch project root
+ */
+function consumerWithoutRuleTestScript(): string {
+  const projectDir = path.dirname(copyAstGrepPayload());
+  const binDir = path.join(projectDir, LOCAL_BIN_DIR);
+  const manifest = `${JSON.stringify(
+    { name: "consumer", version: "1.0.0", scripts: { "sg:scan": SCAN_BIN } },
+    undefined,
+    2
+  )}\n`;
+  fs.writeFileSync(path.join(projectDir, "package.json"), manifest, "utf-8");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.symlinkSync(AST_GREP, path.join(binDir, "ast-grep"));
+  return projectDir;
+}
+
+/**
+ * Run the workflow's rule-test step body verbatim in a project directory.
+ *
+ * Executes the shell the runner would execute, not a paraphrase of it, so the
+ * assertions below measure the shipped step rather than a description of it.
+ * @param workflowPath - Workflow file relative to the repository root
+ * @param projectDir - Directory to run the step body in
+ * @returns Exit status and de-coloured output
+ */
+function runRuleTestStep(
+  workflowPath: string,
+  projectDir: string
+): { readonly status: number | null; readonly output: string } {
+  const step = sgScanSteps(workflowPath).find(candidate =>
+    (candidate.name ?? "").includes("Run ast-grep rule tests")
+  );
+  if (step?.run === undefined) {
+    throw new Error(`No rule-test step in ${workflowPath}`);
+  }
+  const result = spawnSync(BASH, ["-c", step.run], {
+    cwd: projectDir,
+    encoding: "utf-8",
+  });
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`.replace(
+      ANSI_PATTERN,
+      ""
+    ),
+  };
+}
+
+/**
+ * Overwrite a rule test with assertions that are inverted, so the rule tests
+ * genuinely fail rather than merely being absent.
+ * @param projectDir - Scratch project root
+ */
+function breakOneRuleTest(projectDir: string): void {
+  fs.writeFileSync(
+    path.join(projectDir, RULE_TESTS_DIR, "phaser-no-canvas-renderer-test.yml"),
+    [
+      "id: phaser-no-canvas-renderer",
+      "valid:",
+      "  - 'const config = { type: Phaser.CANVAS };'",
+      "invalid:",
+      "  - 'const config = { type: Phaser.WEBGL };'",
+      "",
+    ].join("\n"),
+    "utf-8"
+  );
 }
 
 /**
@@ -261,7 +361,7 @@ describe("ast-grep rule tests are wired to a runnable script", () => {
     const manifest = JSON.parse(readText("package.json")) as {
       scripts: Record<string, string>;
     };
-    expect(manifest.scripts[RULE_TEST_SCRIPT]).toBe("ast-grep test");
+    expect(manifest.scripts[RULE_TEST_SCRIPT]).toBe(RULE_TEST_BIN);
   });
 
   it("forces the rule-test script onto every stack that forces the scan script", () => {
@@ -274,19 +374,16 @@ describe("ast-grep rule tests are wired to a runnable script", () => {
 
       // Paired: a stack that scans but cannot test its rules is the state this
       // ticket removed, so the two scripts must travel together.
-      expect(scripts["sg:scan"]).toBe("ast-grep scan");
-      expect(scripts[RULE_TEST_SCRIPT]).toBe("ast-grep test");
+      expect(scripts["sg:scan"]).toBe(SCAN_BIN);
+      expect(scripts[RULE_TEST_SCRIPT]).toBe(RULE_TEST_BIN);
     }
   });
 });
 
 describe("ast-grep rule tests are wired into CI", () => {
-  it("runs the rule-test script in the TypeScript-family quality workflow", () => {
-    // `endsWith`, not `includes` — the skip notice mentions `sg:test` in its
-    // remediation text, and matching that would let the notice stand in for
-    // the invocation.
-    expectGatedRuleTestStep(".github/workflows/quality.yml", run =>
-      run.trim().endsWith("run sg:test")
+  it("runs the rule tests in the TypeScript-family quality workflow", () => {
+    expectGatedRuleTestStep(TS_QUALITY_WORKFLOW, run =>
+      run.includes(RULE_TEST_INVOCATION)
     );
   });
 
@@ -295,5 +392,71 @@ describe("ast-grep rule tests are wired into CI", () => {
       ".github/workflows/quality-rails.yml",
       run => run.trim() === "sg test"
     );
+  });
+
+  it("invokes the ast-grep binary, never a host-project package script", () => {
+    const steps = sgScanSteps(TS_QUALITY_WORKFLOW);
+    const runStep = stepRunning(steps, run =>
+      run.includes(RULE_TEST_INVOCATION)
+    );
+
+    // The whole failure class in #2530: everything that TRIGGERS this step is
+    // shipped by Lisa, while a `package.json` script alias only arrives on the
+    // host project's next `lisa apply`. The workflow is consumed at @main, so
+    // the two travel at different speeds and cannot be kept in agreement.
+    // Depending on the binary instead removes the split entirely.
+    expect(runStep.run).not.toContain(RULE_TEST_SCRIPT);
+    expect(runStep.run).toContain(RULE_TEST_INVOCATION);
+    // Pinned, so a consumer with no local CLI still runs a known version.
+    expect(runStep.run).toContain("@ast-grep/cli@");
+  });
+
+  it("does not gate the rule tests on anything a host project must supply", () => {
+    const steps = sgScanSteps(TS_QUALITY_WORKFLOW);
+    const runStep = stepRunning(steps, run =>
+      run.includes(RULE_TEST_INVOCATION)
+    );
+
+    // The first patch for the fleet outage gated the step on `sg:test`
+    // existing, which stopped the red but replaced it with a step that
+    // reported success having run nothing — strictly worse than the bug. The
+    // gate must be the rule-test FILES and nothing else.
+    expect(runStep.if).toContain(RULE_TEST_GATE);
+    expect(runStep.if).not.toContain("has_test_script");
+    expect(
+      steps.some(step => (step.run ?? "").includes("has_test_script"))
+    ).toBe(false);
+  });
+});
+
+/**
+ * Executes the shipped step against real project trees. Asserting on the YAML
+ * proves what the step SAYS; these prove what it DOES.
+ */
+describe("the CI rule-test step bites", () => {
+  it("passes in a consumer that has rule tests but no sg:test script", () => {
+    const projectDir = consumerWithoutRuleTestScript();
+    const onDisk = countRuleTestFiles(path.join(projectDir, RULE_TESTS_DIR));
+    const { status, output } = runRuleTestStep(TS_QUALITY_WORKFLOW, projectDir);
+    fs.rmSync(projectDir, { recursive: true, force: true });
+
+    // Was `error: Script not found "sg:test"` — the fleet outage in #2530.
+    expect(output).not.toContain("Script not found");
+    // Green because the tests ran and passed, not because nothing ran.
+    expect(output).toContain(`Running ${onDisk} tests`);
+    expect(output).toContain(`${onDisk} passed; 0 failed`);
+    expect(status).toBe(0);
+  });
+
+  it("still fails that same consumer when a rule test is genuinely wrong", () => {
+    const projectDir = consumerWithoutRuleTestScript();
+    breakOneRuleTest(projectDir);
+    const { status, output } = runRuleTestStep(TS_QUALITY_WORKFLOW, projectDir);
+    fs.rmSync(projectDir, { recursive: true, force: true });
+
+    // The control that matters: removing the script dependency must not have
+    // made the step unable to report failure.
+    expect(output).toContain("FAIL phaser-no-canvas-renderer");
+    expect(status).not.toBe(0);
   });
 });

--- a/tests/unit/config/ast-grep-rule-tests.test.ts
+++ b/tests/unit/config/ast-grep-rule-tests.test.ts
@@ -39,6 +39,8 @@ const RULE_TEST_BIN = "ast-grep test";
  * notice stand in for the invocation.
  */
 const RULE_TEST_INVOCATION = `${LOCAL_BIN_DIR}/${RULE_TEST_BIN}`;
+/** The CLI the step falls back to when the project has not installed one. */
+const PINNED_CLI = "@ast-grep/cli@0.40.4";
 const RULE_TEST_GATE =
   "steps.check_rule_tests.outputs.has_rule_tests == 'true'";
 
@@ -407,8 +409,10 @@ describe("ast-grep rule tests are wired into CI", () => {
     // Depending on the binary instead removes the split entirely.
     expect(runStep.run).not.toContain(RULE_TEST_SCRIPT);
     expect(runStep.run).toContain(RULE_TEST_INVOCATION);
-    // Pinned, so a consumer with no local CLI still runs a known version.
-    expect(runStep.run).toContain("@ast-grep/cli@");
+    // The exact pin, not merely the package name: a fallback that floats is
+    // a different guarantee from one that runs a known version, and the
+    // difference has to be visible here rather than in a consumer's CI.
+    expect(runStep.run).toContain(PINNED_CLI);
   });
 
   it("does not gate the rule tests on anything a host project must supply", () => {

--- a/typescript/copy-overwrite/ast-grep/rule-tests/.gitkeep
+++ b/typescript/copy-overwrite/ast-grep/rule-tests/.gitkeep
@@ -1,8 +1,8 @@
 # Test cases for the ast-grep rules in ../rules/.
 #
-# These run. `ast-grep test` is wired to the `sg:test` package script and to
-# the AST Grep Scan job in Lisa's quality workflow, so a wrong assertion here
-# fails CI. The job counts the YAML files in this directory first: an empty
+# These run. The AST Grep Scan job in Lisa's quality workflow invokes the
+# `ast-grep` binary directly, so a wrong assertion here fails CI whether or not
+# this project has run `lisa apply` since the step shipped. The job counts the YAML files in this directory first: an empty
 # directory is reported as a skipped step with a warning, never as a pass,
 # because `ast-grep test` exits 0 when it finds nothing to run.
 #


### PR DESCRIPTION
## Summary

Closes #2530.

The `🧪 Run ast-grep rule tests` step is now self-sufficient: it invokes the `ast-grep` binary instead of a `sg:test` script the host project has to supply.

Everything that **triggers** the step — `sgconfig.yml` and the files in `ast-grep/rule-tests/` — is shipped by Lisa. The thing it **invoked** was a `package.json` script, which Lisa only rewrites on the project's next `lisa apply`. Trigger and target travel by different routes at different speeds, so they can never be guaranteed to agree. `quality.yml` is consumed at `@main`, so when #2525 added the step it reached every consumer immediately and the script did not — `geminisportsai/backend-v2` went red fifteen minutes later on `error: Script not found "sg:test"`.

#2533 stopped the bleeding by gating the step on the script existing. That traded a hard failure for a step that reports success having run nothing, which is the worse of the two — a guard whose green means only that it declined to look. Invoking the binary removes the split rather than choosing which side of it to fail on.

`quality-rails.yml` already worked this way (`npm i -g @ast-grep/cli` then `sg test`), which is why it never broke.

## Changes

- `quality.yml`: the rule-test step runs `node_modules/.bin/ast-grep test` when the project has the CLI installed, else `npx --yes --package @ast-grep/cli@0.40.4 ast-grep test`. Both branches verified by hand.
- `has_test_script` and the "present but not runnable" warning step are removed. The gate is back to the rule-test files alone.
- `sg:test` stays in `package.lisa.json` as a local developer alias — CI no longer depends on it.
- The rule-test `.gitkeep` notes no longer promise CI runs via the script (and the evidence manifest is regenerated for the three pinned copies).

## Bite controls

`tests/unit/config/ast-grep-rule-tests.test.ts` now **executes the shipped step body** against real project trees rather than only asserting on the YAML. Fixtures are built to match `geminisportsai/backend-v2`'s shape: ast-grep config + rule tests present, `sg:test` absent, `@ast-grep/cli` installed.

**Control 1 — red → green.** A consumer with rule tests and no `sg:test`:

```
BEFORE (#2525, the reported break):
  $ bun run sg:test
  error: Script not found "sg:test"
  exit=1

BEFORE (#2533, on main today):
  has_test_script=false  =>  step gated OFF, job GREEN having run 0 rule tests

AFTER:
  Running 1 tests
  PASS no-console-log  ..
  test result: ok. 1 passed; 0 failed;
  exit=0
```

**Control 2 — must stay red.** The same consumer with one rule test inverted (the `valid:` case is a real violation, the `invalid:` case is clean):

```
AFTER:
  [Noisy]   Expect no-console-log to report no issue, but some issues found in: console.log(1);
  [Missing] Expect rule no-console-log to report issues, but none found in: logger.info(1);
  FAIL no-console-log  NM
  Error: test failed. 0 passed; 1 failed;
  exit=4
```

The step is not vacuous — it still bites.

**Control 3 — the tests themselves bite.** Reverting `quality.yml` to `main` fails 5 of the 12 tests in the file:

```
× runs the rule tests in the TypeScript-family quality workflow
× invokes the ast-grep binary, never a host-project package script
× does not gate the rule tests on anything a host project must supply
× passes in a consumer that has rule tests but no sg:test script
× still fails that same consumer when a rule test is genuinely wrong
  Tests  5 failed | 7 passed (12)
```

## Verification

- `bunx vitest run tests/unit/config/ast-grep-rule-tests.test.ts` — 12 passed
- `bun run lint`, `bun run typecheck`, `prettier --check` — clean
- Full pre-push suite — **11525 passed**, 0 failed

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2530
