### PR TITLE
fix(ratchet): let a promotion carry an exemption its upstream already approved

### DIFF
--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -135,6 +135,7 @@ jobs:
       - name: 📐 Compare thresholds against merge-base
         env:
           BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           if [ -z "$BASE_REF" ]; then
             echo "Not a pull request — nothing to ratchet against."
@@ -148,7 +149,17 @@ jobs:
             echo "Base ref origin/$BASE_REF is not available in this checkout — cannot evaluate the ratchet."
             exit 1
           fi
-          node scripts/check-threshold-ratchet.mjs --base "origin/$BASE_REF"
+          # The head branch NAME, so the ratchet can tell a promotion between
+          # deploy-chain branches from an ordinary PR (#2531). Passed only when
+          # the branch resolves in this checkout — a fork PR's head ref does
+          # not, and an unresolvable head must leave the gate strict, never
+          # relax it. Omitting the flag is the pre-#2531 behavior exactly.
+          if git rev-parse --verify "origin/$HEAD_REF" >/dev/null 2>&1; then
+            node scripts/check-threshold-ratchet.mjs \
+              --base "origin/$BASE_REF" --head "origin/$HEAD_REF"
+          else
+            node scripts/check-threshold-ratchet.mjs --base "origin/$BASE_REF"
+          fi
 
   # ---------------------------------------------------------------------------
   # Server-side backstop for work-item traceability (#1978, fleet rollout #2046)

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1893,6 +1893,7 @@ jobs:
       - name: 📐 Compare thresholds against merge-base
         env:
           BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           if [ -z "$BASE_REF" ]; then
             echo "Not a pull request — nothing to ratchet against."
@@ -1906,7 +1907,17 @@ jobs:
             echo "Base ref origin/$BASE_REF is not available in this checkout — cannot evaluate the ratchet."
             exit 1
           fi
-          node scripts/check-threshold-ratchet.mjs --base "origin/$BASE_REF"
+          # The head branch NAME, so the ratchet can tell a promotion between
+          # deploy-chain branches from an ordinary PR (#2531). Passed only when
+          # the branch resolves in this checkout — a fork PR's head ref does
+          # not, and an unresolvable head must leave the gate strict, never
+          # relax it. Omitting the flag is the pre-#2531 behavior exactly.
+          if git rev-parse --verify "origin/$HEAD_REF" >/dev/null 2>&1; then
+            node scripts/check-threshold-ratchet.mjs \
+              --base "origin/$BASE_REF" --head "origin/$HEAD_REF"
+          else
+            node scripts/check-threshold-ratchet.mjs --base "origin/$BASE_REF"
+          fi
 
   # ---------------------------------------------------------------------------
   # Server-side backstop for work-item traceability (#1978, fleet rollout #2046)

--- a/plugins/lisa-copilot/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa-copilot/hooks/threshold-ratchet.mjs
@@ -24,6 +24,13 @@
  * itself an exception in the same change that weakens a gate. `key: "*"`
  * allows every key in the file.
  *
+ * One exception, and only one: a PROMOTION between deploy-chain branches
+ * (`--base` + `--head`, both named in `deploy.branches`, head upstream of
+ * base, head fully containing base). There the allow list is read from the
+ * head, because the change under review is the baseline plus history that has
+ * already passed this same gate. See `isPromotion` for why that is the only
+ * discriminator that holds.
+ *
  * Extraction lives in threshold-ratchet-families.mjs; comparison rules in
  * threshold-ratchet-compare.mjs. Zero dependencies.
  */
@@ -132,6 +139,148 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
 }
 
 /**
+ * Strip a remote prefix so `origin/staging` and `staging` compare equal to a
+ * branch name declared in `.lisa.config.json`.
+ * @param {string} ref Git ref, possibly remote-qualified
+ * @returns {string} Bare branch name
+ */
+function bareBranch(ref) {
+  return ref.replace(/^refs\/heads\//u, "").replace(/^origin\//u, "");
+}
+
+/**
+ * The deploy chain, earliest environment first, from `deploy.branches`.
+ *
+ * Declaration order IS the chain order — that is already how Lisa reads it
+ * (dev → staging → production), and it is what makes "upstream of" decidable.
+ * @param {unknown} config Parsed `.lisa.config.json`
+ * @returns {string[]} Branch names in chain order
+ */
+function deployChain(config) {
+  const branches = config?.deploy?.branches;
+  if (!branches || typeof branches !== "object") return [];
+  return Object.values(branches).filter(b => typeof b === "string" && b !== "");
+}
+
+/**
+ * Whether this is a promotion of one deploy-chain branch into the next.
+ *
+ * A promotion carries approved history into a branch that is behind, so the
+ * exemptions it brings with it are not new — each one already faced this gate
+ * on the upstream branch. Reading the allow list from the baseline there
+ * reports every one of them as newly added, and the documented remedy is
+ * circular: recording them means adding `thresholdRatchet.allow` entries,
+ * which is itself the Tier 3 change being blocked. That deadlocked the whole
+ * promotion lane (#2531).
+ *
+ * The discriminator is branch IDENTITY, not ancestry. "The head contains the
+ * base" is true of any ordinary topic branch that is up to date with its base
+ * — and a repository with a strict up-to-date branch-protection rule REQUIRES
+ * that of every PR — so ancestry alone would hand self-approval to exactly the
+ * changes Tier 3 exists to stop. Being a deploy-chain branch cannot be
+ * arranged by a topic branch: those branches are protected, so everything on
+ * them arrived through a reviewed PR that passed this same ratchet.
+ *
+ * Ancestry is still required, as a second condition rather than the only one:
+ * a head that has diverged from its base is not "the baseline plus approved
+ * history", and the strict reading should stand.
+ *
+ * The chain is read from the BASELINE config, so a change cannot declare
+ * itself a promotion by adding `deploy.branches` entries in the same commit.
+ * @param {string} root Repo root
+ * @param {unknown} baselineConfig `.lisa.config.json` at the baseline
+ * @param {string | undefined} baseRef Ref being merged into
+ * @param {string | undefined} headRef Ref being merged from
+ * @returns {boolean} True when the allow list may be read from the head
+ */
+function isPromotion(root, baselineConfig, baseRef, headRef) {
+  if (!baseRef || !headRef) return false;
+  const chain = deployChain(baselineConfig);
+  const basePosition = chain.indexOf(bareBranch(baseRef));
+  const headPosition = chain.indexOf(bareBranch(headRef));
+  if (basePosition === -1 || headPosition === -1) return false;
+  if (headPosition >= basePosition) return false;
+  // Empty string on success, null when git exits non-zero or the ref is bogus.
+  if (git(["merge-base", "--is-ancestor", baseRef, headRef], root) !== null) {
+    return true;
+  }
+  // Both ARE deploy-chain branches, so this is a promotion that has diverged —
+  // typically a hotfix that landed on the base and was never synced down. The
+  // strict reading is correct here, but silence would leave an operator
+  // guessing why this promotion behaves differently from the last one.
+  process.stderr.write(
+    `threshold-ratchet: ${bareBranch(headRef)} does not contain ` +
+      `${bareBranch(baseRef)}, so this promotion is not the baseline plus ` +
+      `approved history and the allow list is read from the baseline. Sync ` +
+      `${bareBranch(baseRef)} down into ${bareBranch(headRef)} first.\n`
+  );
+  return false;
+}
+
+/**
+ * Resolve the allow list and say where it came from.
+ * @param {string} root Repo root
+ * @param {string} baselineRef Ref the comparison baselines against
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string | undefined} baseRef Base ref (base mode only)
+ * @param {string | undefined} headRef Head ref (base mode only)
+ * @returns {{ entries: object[], promotion: boolean, note: string | null }}
+ *   Entries, whether this is a promotion, and an audit line to print when the
+ *   entries came from anywhere but the baseline
+ */
+function resolveAllowList(root, baselineRef, mode, baseRef, headRef) {
+  const baselineConfig = parseJson(
+    git(["show", `${baselineRef}:.lisa.config.json`], root)
+  );
+  if (mode !== "base" || !isPromotion(root, baselineConfig, baseRef, headRef)) {
+    return {
+      entries: extractAllowEntries(baselineConfig),
+      promotion: false,
+      note: null,
+    };
+  }
+  return {
+    entries: extractAllowEntries(
+      parseJson(git(["show", "HEAD:.lisa.config.json"], root))
+    ),
+    promotion: true,
+    note:
+      `threshold-ratchet: promotion ${bareBranch(headRef)} → ` +
+      `${bareBranch(baseRef)}; both are deploy-chain branches declared at ` +
+      `${baselineRef} and the head fully contains the base, so the allow list ` +
+      `is read from the head. Exemptions below were approved upstream, not by ` +
+      `this change.`,
+  };
+}
+
+/**
+ * Split off the allow-entry additions a promotion is carrying forward.
+ *
+ * `applyAllowList` never drops an `allow-added` finding, from either side —
+ * an exception must not approve its own creation. That is right for an
+ * ordinary PR and wrong for a promotion, where the entry is not being created:
+ * it already exists on the upstream branch, where its creation faced this same
+ * unconditional block and needed a human to clear it. Without this the fix
+ * would be cosmetic — a promotion carrying an approved exemption also carries
+ * the `.lisa.config.json` diff that records it, so it would still be blocked
+ * by the finding for the record of its own approval.
+ *
+ * Only `allow-added` is carried. An actual threshold weakening in the same
+ * promotion still has to be covered by an allow entry.
+ * @param {Array<{ type: string }>} findings All findings from the change
+ * @param {boolean} promotion Whether the change is a recognised promotion
+ * @returns {{ carried: object[], rest: object[] }} Findings excused as already
+ *   approved upstream, and findings still subject to the allow list
+ */
+function partitionCarriedEntries(findings, promotion) {
+  if (!promotion) return { carried: [], rest: findings };
+  return {
+    carried: findings.filter(f => f.type === "allow-added"),
+    rest: findings.filter(f => f.type !== "allow-added"),
+  };
+}
+
+/**
  * Decide the exit code when the ratchet cannot determine what changed.
  *
  * `staged` and `base` are enforcement gates — pre-commit and CI. A gate that
@@ -161,9 +310,11 @@ function undeterminable(mode, reason) {
  * @param {"hook"|"staged"|"base"} mode Comparison mode
  * @param {string | undefined} [baseRef] Base ref (base mode only)
  * @param {string[] | undefined} [onlyFiles] Restrict to these paths (hook mode)
+ * @param {string | undefined} [headRef] Head ref (base mode only), used solely
+ *   to recognise a promotion between deploy-chain branches
  * @returns {number} Process exit code (2 for hook mode, 1 otherwise; 0 clean)
  */
-function run(mode, baseRef, onlyFiles) {
+function run(mode, baseRef, onlyFiles, headRef) {
   const root = git(["rev-parse", "--show-toplevel"])?.trim();
   if (!root) return undeterminable(mode, "not a git repository");
   const plan = resolvePlan(mode, root, baseRef, onlyFiles);
@@ -205,13 +356,21 @@ function run(mode, baseRef, onlyFiles) {
   );
   if (findings.length === 0) return 0;
 
-  const baselineConfig = parseJson(
-    git(["show", `${plan.baselineRef}:.lisa.config.json`], root)
+  const allow = resolveAllowList(
+    root,
+    plan.baselineRef,
+    mode,
+    baseRef,
+    headRef
   );
-  const { blocked, allowed } = applyAllowList(
-    findings,
-    extractAllowEntries(baselineConfig)
-  );
+  const split = partitionCarriedEntries(findings, allow.promotion);
+  const { blocked, allowed } = applyAllowList(split.rest, allow.entries);
+  if (allow.note) process.stdout.write(`${allow.note}\n`);
+  for (const finding of split.carried) {
+    process.stdout.write(
+      `threshold-ratchet: carried forward by this promotion, approved upstream — ${finding.message}\n`
+    );
+  }
   for (const finding of allowed) {
     process.stdout.write(
       `threshold-ratchet: allowed by .lisa.config.json exception — ${finding.message}\n`
@@ -257,11 +416,16 @@ function runHookMode() {
  */
 function main() {
   const args = process.argv.slice(2);
+  const headIndex = args.indexOf("--head");
+  const headRef = headIndex === -1 ? undefined : args[headIndex + 1];
   if (args[0] === "--staged") return run("staged");
-  if (args[0] === "--base") return run("base", args[1]);
+  // `--head` is optional and additive: a caller that omits it gets exactly the
+  // behavior that shipped before promotions were recognised, so an older
+  // workflow driving a newer script stays strict rather than silently relaxing.
+  if (args[0] === "--base") return run("base", args[1], undefined, headRef);
   if (args[0] === "--hook") return runHookMode();
   process.stderr.write(
-    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref>\n"
+    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref> [--head <ref>]\n"
   );
   return 0;
 }

--- a/plugins/lisa-cursor/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa-cursor/hooks/threshold-ratchet.mjs
@@ -24,6 +24,13 @@
  * itself an exception in the same change that weakens a gate. `key: "*"`
  * allows every key in the file.
  *
+ * One exception, and only one: a PROMOTION between deploy-chain branches
+ * (`--base` + `--head`, both named in `deploy.branches`, head upstream of
+ * base, head fully containing base). There the allow list is read from the
+ * head, because the change under review is the baseline plus history that has
+ * already passed this same gate. See `isPromotion` for why that is the only
+ * discriminator that holds.
+ *
  * Extraction lives in threshold-ratchet-families.mjs; comparison rules in
  * threshold-ratchet-compare.mjs. Zero dependencies.
  */
@@ -132,6 +139,148 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
 }
 
 /**
+ * Strip a remote prefix so `origin/staging` and `staging` compare equal to a
+ * branch name declared in `.lisa.config.json`.
+ * @param {string} ref Git ref, possibly remote-qualified
+ * @returns {string} Bare branch name
+ */
+function bareBranch(ref) {
+  return ref.replace(/^refs\/heads\//u, "").replace(/^origin\//u, "");
+}
+
+/**
+ * The deploy chain, earliest environment first, from `deploy.branches`.
+ *
+ * Declaration order IS the chain order — that is already how Lisa reads it
+ * (dev → staging → production), and it is what makes "upstream of" decidable.
+ * @param {unknown} config Parsed `.lisa.config.json`
+ * @returns {string[]} Branch names in chain order
+ */
+function deployChain(config) {
+  const branches = config?.deploy?.branches;
+  if (!branches || typeof branches !== "object") return [];
+  return Object.values(branches).filter(b => typeof b === "string" && b !== "");
+}
+
+/**
+ * Whether this is a promotion of one deploy-chain branch into the next.
+ *
+ * A promotion carries approved history into a branch that is behind, so the
+ * exemptions it brings with it are not new — each one already faced this gate
+ * on the upstream branch. Reading the allow list from the baseline there
+ * reports every one of them as newly added, and the documented remedy is
+ * circular: recording them means adding `thresholdRatchet.allow` entries,
+ * which is itself the Tier 3 change being blocked. That deadlocked the whole
+ * promotion lane (#2531).
+ *
+ * The discriminator is branch IDENTITY, not ancestry. "The head contains the
+ * base" is true of any ordinary topic branch that is up to date with its base
+ * — and a repository with a strict up-to-date branch-protection rule REQUIRES
+ * that of every PR — so ancestry alone would hand self-approval to exactly the
+ * changes Tier 3 exists to stop. Being a deploy-chain branch cannot be
+ * arranged by a topic branch: those branches are protected, so everything on
+ * them arrived through a reviewed PR that passed this same ratchet.
+ *
+ * Ancestry is still required, as a second condition rather than the only one:
+ * a head that has diverged from its base is not "the baseline plus approved
+ * history", and the strict reading should stand.
+ *
+ * The chain is read from the BASELINE config, so a change cannot declare
+ * itself a promotion by adding `deploy.branches` entries in the same commit.
+ * @param {string} root Repo root
+ * @param {unknown} baselineConfig `.lisa.config.json` at the baseline
+ * @param {string | undefined} baseRef Ref being merged into
+ * @param {string | undefined} headRef Ref being merged from
+ * @returns {boolean} True when the allow list may be read from the head
+ */
+function isPromotion(root, baselineConfig, baseRef, headRef) {
+  if (!baseRef || !headRef) return false;
+  const chain = deployChain(baselineConfig);
+  const basePosition = chain.indexOf(bareBranch(baseRef));
+  const headPosition = chain.indexOf(bareBranch(headRef));
+  if (basePosition === -1 || headPosition === -1) return false;
+  if (headPosition >= basePosition) return false;
+  // Empty string on success, null when git exits non-zero or the ref is bogus.
+  if (git(["merge-base", "--is-ancestor", baseRef, headRef], root) !== null) {
+    return true;
+  }
+  // Both ARE deploy-chain branches, so this is a promotion that has diverged —
+  // typically a hotfix that landed on the base and was never synced down. The
+  // strict reading is correct here, but silence would leave an operator
+  // guessing why this promotion behaves differently from the last one.
+  process.stderr.write(
+    `threshold-ratchet: ${bareBranch(headRef)} does not contain ` +
+      `${bareBranch(baseRef)}, so this promotion is not the baseline plus ` +
+      `approved history and the allow list is read from the baseline. Sync ` +
+      `${bareBranch(baseRef)} down into ${bareBranch(headRef)} first.\n`
+  );
+  return false;
+}
+
+/**
+ * Resolve the allow list and say where it came from.
+ * @param {string} root Repo root
+ * @param {string} baselineRef Ref the comparison baselines against
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string | undefined} baseRef Base ref (base mode only)
+ * @param {string | undefined} headRef Head ref (base mode only)
+ * @returns {{ entries: object[], promotion: boolean, note: string | null }}
+ *   Entries, whether this is a promotion, and an audit line to print when the
+ *   entries came from anywhere but the baseline
+ */
+function resolveAllowList(root, baselineRef, mode, baseRef, headRef) {
+  const baselineConfig = parseJson(
+    git(["show", `${baselineRef}:.lisa.config.json`], root)
+  );
+  if (mode !== "base" || !isPromotion(root, baselineConfig, baseRef, headRef)) {
+    return {
+      entries: extractAllowEntries(baselineConfig),
+      promotion: false,
+      note: null,
+    };
+  }
+  return {
+    entries: extractAllowEntries(
+      parseJson(git(["show", "HEAD:.lisa.config.json"], root))
+    ),
+    promotion: true,
+    note:
+      `threshold-ratchet: promotion ${bareBranch(headRef)} → ` +
+      `${bareBranch(baseRef)}; both are deploy-chain branches declared at ` +
+      `${baselineRef} and the head fully contains the base, so the allow list ` +
+      `is read from the head. Exemptions below were approved upstream, not by ` +
+      `this change.`,
+  };
+}
+
+/**
+ * Split off the allow-entry additions a promotion is carrying forward.
+ *
+ * `applyAllowList` never drops an `allow-added` finding, from either side —
+ * an exception must not approve its own creation. That is right for an
+ * ordinary PR and wrong for a promotion, where the entry is not being created:
+ * it already exists on the upstream branch, where its creation faced this same
+ * unconditional block and needed a human to clear it. Without this the fix
+ * would be cosmetic — a promotion carrying an approved exemption also carries
+ * the `.lisa.config.json` diff that records it, so it would still be blocked
+ * by the finding for the record of its own approval.
+ *
+ * Only `allow-added` is carried. An actual threshold weakening in the same
+ * promotion still has to be covered by an allow entry.
+ * @param {Array<{ type: string }>} findings All findings from the change
+ * @param {boolean} promotion Whether the change is a recognised promotion
+ * @returns {{ carried: object[], rest: object[] }} Findings excused as already
+ *   approved upstream, and findings still subject to the allow list
+ */
+function partitionCarriedEntries(findings, promotion) {
+  if (!promotion) return { carried: [], rest: findings };
+  return {
+    carried: findings.filter(f => f.type === "allow-added"),
+    rest: findings.filter(f => f.type !== "allow-added"),
+  };
+}
+
+/**
  * Decide the exit code when the ratchet cannot determine what changed.
  *
  * `staged` and `base` are enforcement gates — pre-commit and CI. A gate that
@@ -161,9 +310,11 @@ function undeterminable(mode, reason) {
  * @param {"hook"|"staged"|"base"} mode Comparison mode
  * @param {string | undefined} [baseRef] Base ref (base mode only)
  * @param {string[] | undefined} [onlyFiles] Restrict to these paths (hook mode)
+ * @param {string | undefined} [headRef] Head ref (base mode only), used solely
+ *   to recognise a promotion between deploy-chain branches
  * @returns {number} Process exit code (2 for hook mode, 1 otherwise; 0 clean)
  */
-function run(mode, baseRef, onlyFiles) {
+function run(mode, baseRef, onlyFiles, headRef) {
   const root = git(["rev-parse", "--show-toplevel"])?.trim();
   if (!root) return undeterminable(mode, "not a git repository");
   const plan = resolvePlan(mode, root, baseRef, onlyFiles);
@@ -205,13 +356,21 @@ function run(mode, baseRef, onlyFiles) {
   );
   if (findings.length === 0) return 0;
 
-  const baselineConfig = parseJson(
-    git(["show", `${plan.baselineRef}:.lisa.config.json`], root)
+  const allow = resolveAllowList(
+    root,
+    plan.baselineRef,
+    mode,
+    baseRef,
+    headRef
   );
-  const { blocked, allowed } = applyAllowList(
-    findings,
-    extractAllowEntries(baselineConfig)
-  );
+  const split = partitionCarriedEntries(findings, allow.promotion);
+  const { blocked, allowed } = applyAllowList(split.rest, allow.entries);
+  if (allow.note) process.stdout.write(`${allow.note}\n`);
+  for (const finding of split.carried) {
+    process.stdout.write(
+      `threshold-ratchet: carried forward by this promotion, approved upstream — ${finding.message}\n`
+    );
+  }
   for (const finding of allowed) {
     process.stdout.write(
       `threshold-ratchet: allowed by .lisa.config.json exception — ${finding.message}\n`
@@ -257,11 +416,16 @@ function runHookMode() {
  */
 function main() {
   const args = process.argv.slice(2);
+  const headIndex = args.indexOf("--head");
+  const headRef = headIndex === -1 ? undefined : args[headIndex + 1];
   if (args[0] === "--staged") return run("staged");
-  if (args[0] === "--base") return run("base", args[1]);
+  // `--head` is optional and additive: a caller that omits it gets exactly the
+  // behavior that shipped before promotions were recognised, so an older
+  // workflow driving a newer script stays strict rather than silently relaxing.
+  if (args[0] === "--base") return run("base", args[1], undefined, headRef);
   if (args[0] === "--hook") return runHookMode();
   process.stderr.write(
-    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref>\n"
+    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref> [--head <ref>]\n"
   );
   return 0;
 }

--- a/plugins/lisa/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa/hooks/threshold-ratchet.mjs
@@ -24,6 +24,13 @@
  * itself an exception in the same change that weakens a gate. `key: "*"`
  * allows every key in the file.
  *
+ * One exception, and only one: a PROMOTION between deploy-chain branches
+ * (`--base` + `--head`, both named in `deploy.branches`, head upstream of
+ * base, head fully containing base). There the allow list is read from the
+ * head, because the change under review is the baseline plus history that has
+ * already passed this same gate. See `isPromotion` for why that is the only
+ * discriminator that holds.
+ *
  * Extraction lives in threshold-ratchet-families.mjs; comparison rules in
  * threshold-ratchet-compare.mjs. Zero dependencies.
  */
@@ -132,6 +139,148 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
 }
 
 /**
+ * Strip a remote prefix so `origin/staging` and `staging` compare equal to a
+ * branch name declared in `.lisa.config.json`.
+ * @param {string} ref Git ref, possibly remote-qualified
+ * @returns {string} Bare branch name
+ */
+function bareBranch(ref) {
+  return ref.replace(/^refs\/heads\//u, "").replace(/^origin\//u, "");
+}
+
+/**
+ * The deploy chain, earliest environment first, from `deploy.branches`.
+ *
+ * Declaration order IS the chain order — that is already how Lisa reads it
+ * (dev → staging → production), and it is what makes "upstream of" decidable.
+ * @param {unknown} config Parsed `.lisa.config.json`
+ * @returns {string[]} Branch names in chain order
+ */
+function deployChain(config) {
+  const branches = config?.deploy?.branches;
+  if (!branches || typeof branches !== "object") return [];
+  return Object.values(branches).filter(b => typeof b === "string" && b !== "");
+}
+
+/**
+ * Whether this is a promotion of one deploy-chain branch into the next.
+ *
+ * A promotion carries approved history into a branch that is behind, so the
+ * exemptions it brings with it are not new — each one already faced this gate
+ * on the upstream branch. Reading the allow list from the baseline there
+ * reports every one of them as newly added, and the documented remedy is
+ * circular: recording them means adding `thresholdRatchet.allow` entries,
+ * which is itself the Tier 3 change being blocked. That deadlocked the whole
+ * promotion lane (#2531).
+ *
+ * The discriminator is branch IDENTITY, not ancestry. "The head contains the
+ * base" is true of any ordinary topic branch that is up to date with its base
+ * — and a repository with a strict up-to-date branch-protection rule REQUIRES
+ * that of every PR — so ancestry alone would hand self-approval to exactly the
+ * changes Tier 3 exists to stop. Being a deploy-chain branch cannot be
+ * arranged by a topic branch: those branches are protected, so everything on
+ * them arrived through a reviewed PR that passed this same ratchet.
+ *
+ * Ancestry is still required, as a second condition rather than the only one:
+ * a head that has diverged from its base is not "the baseline plus approved
+ * history", and the strict reading should stand.
+ *
+ * The chain is read from the BASELINE config, so a change cannot declare
+ * itself a promotion by adding `deploy.branches` entries in the same commit.
+ * @param {string} root Repo root
+ * @param {unknown} baselineConfig `.lisa.config.json` at the baseline
+ * @param {string | undefined} baseRef Ref being merged into
+ * @param {string | undefined} headRef Ref being merged from
+ * @returns {boolean} True when the allow list may be read from the head
+ */
+function isPromotion(root, baselineConfig, baseRef, headRef) {
+  if (!baseRef || !headRef) return false;
+  const chain = deployChain(baselineConfig);
+  const basePosition = chain.indexOf(bareBranch(baseRef));
+  const headPosition = chain.indexOf(bareBranch(headRef));
+  if (basePosition === -1 || headPosition === -1) return false;
+  if (headPosition >= basePosition) return false;
+  // Empty string on success, null when git exits non-zero or the ref is bogus.
+  if (git(["merge-base", "--is-ancestor", baseRef, headRef], root) !== null) {
+    return true;
+  }
+  // Both ARE deploy-chain branches, so this is a promotion that has diverged —
+  // typically a hotfix that landed on the base and was never synced down. The
+  // strict reading is correct here, but silence would leave an operator
+  // guessing why this promotion behaves differently from the last one.
+  process.stderr.write(
+    `threshold-ratchet: ${bareBranch(headRef)} does not contain ` +
+      `${bareBranch(baseRef)}, so this promotion is not the baseline plus ` +
+      `approved history and the allow list is read from the baseline. Sync ` +
+      `${bareBranch(baseRef)} down into ${bareBranch(headRef)} first.\n`
+  );
+  return false;
+}
+
+/**
+ * Resolve the allow list and say where it came from.
+ * @param {string} root Repo root
+ * @param {string} baselineRef Ref the comparison baselines against
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string | undefined} baseRef Base ref (base mode only)
+ * @param {string | undefined} headRef Head ref (base mode only)
+ * @returns {{ entries: object[], promotion: boolean, note: string | null }}
+ *   Entries, whether this is a promotion, and an audit line to print when the
+ *   entries came from anywhere but the baseline
+ */
+function resolveAllowList(root, baselineRef, mode, baseRef, headRef) {
+  const baselineConfig = parseJson(
+    git(["show", `${baselineRef}:.lisa.config.json`], root)
+  );
+  if (mode !== "base" || !isPromotion(root, baselineConfig, baseRef, headRef)) {
+    return {
+      entries: extractAllowEntries(baselineConfig),
+      promotion: false,
+      note: null,
+    };
+  }
+  return {
+    entries: extractAllowEntries(
+      parseJson(git(["show", "HEAD:.lisa.config.json"], root))
+    ),
+    promotion: true,
+    note:
+      `threshold-ratchet: promotion ${bareBranch(headRef)} → ` +
+      `${bareBranch(baseRef)}; both are deploy-chain branches declared at ` +
+      `${baselineRef} and the head fully contains the base, so the allow list ` +
+      `is read from the head. Exemptions below were approved upstream, not by ` +
+      `this change.`,
+  };
+}
+
+/**
+ * Split off the allow-entry additions a promotion is carrying forward.
+ *
+ * `applyAllowList` never drops an `allow-added` finding, from either side —
+ * an exception must not approve its own creation. That is right for an
+ * ordinary PR and wrong for a promotion, where the entry is not being created:
+ * it already exists on the upstream branch, where its creation faced this same
+ * unconditional block and needed a human to clear it. Without this the fix
+ * would be cosmetic — a promotion carrying an approved exemption also carries
+ * the `.lisa.config.json` diff that records it, so it would still be blocked
+ * by the finding for the record of its own approval.
+ *
+ * Only `allow-added` is carried. An actual threshold weakening in the same
+ * promotion still has to be covered by an allow entry.
+ * @param {Array<{ type: string }>} findings All findings from the change
+ * @param {boolean} promotion Whether the change is a recognised promotion
+ * @returns {{ carried: object[], rest: object[] }} Findings excused as already
+ *   approved upstream, and findings still subject to the allow list
+ */
+function partitionCarriedEntries(findings, promotion) {
+  if (!promotion) return { carried: [], rest: findings };
+  return {
+    carried: findings.filter(f => f.type === "allow-added"),
+    rest: findings.filter(f => f.type !== "allow-added"),
+  };
+}
+
+/**
  * Decide the exit code when the ratchet cannot determine what changed.
  *
  * `staged` and `base` are enforcement gates — pre-commit and CI. A gate that
@@ -161,9 +310,11 @@ function undeterminable(mode, reason) {
  * @param {"hook"|"staged"|"base"} mode Comparison mode
  * @param {string | undefined} [baseRef] Base ref (base mode only)
  * @param {string[] | undefined} [onlyFiles] Restrict to these paths (hook mode)
+ * @param {string | undefined} [headRef] Head ref (base mode only), used solely
+ *   to recognise a promotion between deploy-chain branches
  * @returns {number} Process exit code (2 for hook mode, 1 otherwise; 0 clean)
  */
-function run(mode, baseRef, onlyFiles) {
+function run(mode, baseRef, onlyFiles, headRef) {
   const root = git(["rev-parse", "--show-toplevel"])?.trim();
   if (!root) return undeterminable(mode, "not a git repository");
   const plan = resolvePlan(mode, root, baseRef, onlyFiles);
@@ -205,13 +356,21 @@ function run(mode, baseRef, onlyFiles) {
   );
   if (findings.length === 0) return 0;
 
-  const baselineConfig = parseJson(
-    git(["show", `${plan.baselineRef}:.lisa.config.json`], root)
+  const allow = resolveAllowList(
+    root,
+    plan.baselineRef,
+    mode,
+    baseRef,
+    headRef
   );
-  const { blocked, allowed } = applyAllowList(
-    findings,
-    extractAllowEntries(baselineConfig)
-  );
+  const split = partitionCarriedEntries(findings, allow.promotion);
+  const { blocked, allowed } = applyAllowList(split.rest, allow.entries);
+  if (allow.note) process.stdout.write(`${allow.note}\n`);
+  for (const finding of split.carried) {
+    process.stdout.write(
+      `threshold-ratchet: carried forward by this promotion, approved upstream — ${finding.message}\n`
+    );
+  }
   for (const finding of allowed) {
     process.stdout.write(
       `threshold-ratchet: allowed by .lisa.config.json exception — ${finding.message}\n`
@@ -257,11 +416,16 @@ function runHookMode() {
  */
 function main() {
   const args = process.argv.slice(2);
+  const headIndex = args.indexOf("--head");
+  const headRef = headIndex === -1 ? undefined : args[headIndex + 1];
   if (args[0] === "--staged") return run("staged");
-  if (args[0] === "--base") return run("base", args[1]);
+  // `--head` is optional and additive: a caller that omits it gets exactly the
+  // behavior that shipped before promotions were recognised, so an older
+  // workflow driving a newer script stays strict rather than silently relaxing.
+  if (args[0] === "--base") return run("base", args[1], undefined, headRef);
   if (args[0] === "--hook") return runHookMode();
   process.stderr.write(
-    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref>\n"
+    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref> [--head <ref>]\n"
   );
   return 0;
 }

--- a/plugins/src/base/hooks/threshold-ratchet.mjs
+++ b/plugins/src/base/hooks/threshold-ratchet.mjs
@@ -24,6 +24,13 @@
  * itself an exception in the same change that weakens a gate. `key: "*"`
  * allows every key in the file.
  *
+ * One exception, and only one: a PROMOTION between deploy-chain branches
+ * (`--base` + `--head`, both named in `deploy.branches`, head upstream of
+ * base, head fully containing base). There the allow list is read from the
+ * head, because the change under review is the baseline plus history that has
+ * already passed this same gate. See `isPromotion` for why that is the only
+ * discriminator that holds.
+ *
  * Extraction lives in threshold-ratchet-families.mjs; comparison rules in
  * threshold-ratchet-compare.mjs. Zero dependencies.
  */
@@ -132,6 +139,148 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
 }
 
 /**
+ * Strip a remote prefix so `origin/staging` and `staging` compare equal to a
+ * branch name declared in `.lisa.config.json`.
+ * @param {string} ref Git ref, possibly remote-qualified
+ * @returns {string} Bare branch name
+ */
+function bareBranch(ref) {
+  return ref.replace(/^refs\/heads\//u, "").replace(/^origin\//u, "");
+}
+
+/**
+ * The deploy chain, earliest environment first, from `deploy.branches`.
+ *
+ * Declaration order IS the chain order — that is already how Lisa reads it
+ * (dev → staging → production), and it is what makes "upstream of" decidable.
+ * @param {unknown} config Parsed `.lisa.config.json`
+ * @returns {string[]} Branch names in chain order
+ */
+function deployChain(config) {
+  const branches = config?.deploy?.branches;
+  if (!branches || typeof branches !== "object") return [];
+  return Object.values(branches).filter(b => typeof b === "string" && b !== "");
+}
+
+/**
+ * Whether this is a promotion of one deploy-chain branch into the next.
+ *
+ * A promotion carries approved history into a branch that is behind, so the
+ * exemptions it brings with it are not new — each one already faced this gate
+ * on the upstream branch. Reading the allow list from the baseline there
+ * reports every one of them as newly added, and the documented remedy is
+ * circular: recording them means adding `thresholdRatchet.allow` entries,
+ * which is itself the Tier 3 change being blocked. That deadlocked the whole
+ * promotion lane (#2531).
+ *
+ * The discriminator is branch IDENTITY, not ancestry. "The head contains the
+ * base" is true of any ordinary topic branch that is up to date with its base
+ * — and a repository with a strict up-to-date branch-protection rule REQUIRES
+ * that of every PR — so ancestry alone would hand self-approval to exactly the
+ * changes Tier 3 exists to stop. Being a deploy-chain branch cannot be
+ * arranged by a topic branch: those branches are protected, so everything on
+ * them arrived through a reviewed PR that passed this same ratchet.
+ *
+ * Ancestry is still required, as a second condition rather than the only one:
+ * a head that has diverged from its base is not "the baseline plus approved
+ * history", and the strict reading should stand.
+ *
+ * The chain is read from the BASELINE config, so a change cannot declare
+ * itself a promotion by adding `deploy.branches` entries in the same commit.
+ * @param {string} root Repo root
+ * @param {unknown} baselineConfig `.lisa.config.json` at the baseline
+ * @param {string | undefined} baseRef Ref being merged into
+ * @param {string | undefined} headRef Ref being merged from
+ * @returns {boolean} True when the allow list may be read from the head
+ */
+function isPromotion(root, baselineConfig, baseRef, headRef) {
+  if (!baseRef || !headRef) return false;
+  const chain = deployChain(baselineConfig);
+  const basePosition = chain.indexOf(bareBranch(baseRef));
+  const headPosition = chain.indexOf(bareBranch(headRef));
+  if (basePosition === -1 || headPosition === -1) return false;
+  if (headPosition >= basePosition) return false;
+  // Empty string on success, null when git exits non-zero or the ref is bogus.
+  if (git(["merge-base", "--is-ancestor", baseRef, headRef], root) !== null) {
+    return true;
+  }
+  // Both ARE deploy-chain branches, so this is a promotion that has diverged —
+  // typically a hotfix that landed on the base and was never synced down. The
+  // strict reading is correct here, but silence would leave an operator
+  // guessing why this promotion behaves differently from the last one.
+  process.stderr.write(
+    `threshold-ratchet: ${bareBranch(headRef)} does not contain ` +
+      `${bareBranch(baseRef)}, so this promotion is not the baseline plus ` +
+      `approved history and the allow list is read from the baseline. Sync ` +
+      `${bareBranch(baseRef)} down into ${bareBranch(headRef)} first.\n`
+  );
+  return false;
+}
+
+/**
+ * Resolve the allow list and say where it came from.
+ * @param {string} root Repo root
+ * @param {string} baselineRef Ref the comparison baselines against
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string | undefined} baseRef Base ref (base mode only)
+ * @param {string | undefined} headRef Head ref (base mode only)
+ * @returns {{ entries: object[], promotion: boolean, note: string | null }}
+ *   Entries, whether this is a promotion, and an audit line to print when the
+ *   entries came from anywhere but the baseline
+ */
+function resolveAllowList(root, baselineRef, mode, baseRef, headRef) {
+  const baselineConfig = parseJson(
+    git(["show", `${baselineRef}:.lisa.config.json`], root)
+  );
+  if (mode !== "base" || !isPromotion(root, baselineConfig, baseRef, headRef)) {
+    return {
+      entries: extractAllowEntries(baselineConfig),
+      promotion: false,
+      note: null,
+    };
+  }
+  return {
+    entries: extractAllowEntries(
+      parseJson(git(["show", "HEAD:.lisa.config.json"], root))
+    ),
+    promotion: true,
+    note:
+      `threshold-ratchet: promotion ${bareBranch(headRef)} → ` +
+      `${bareBranch(baseRef)}; both are deploy-chain branches declared at ` +
+      `${baselineRef} and the head fully contains the base, so the allow list ` +
+      `is read from the head. Exemptions below were approved upstream, not by ` +
+      `this change.`,
+  };
+}
+
+/**
+ * Split off the allow-entry additions a promotion is carrying forward.
+ *
+ * `applyAllowList` never drops an `allow-added` finding, from either side —
+ * an exception must not approve its own creation. That is right for an
+ * ordinary PR and wrong for a promotion, where the entry is not being created:
+ * it already exists on the upstream branch, where its creation faced this same
+ * unconditional block and needed a human to clear it. Without this the fix
+ * would be cosmetic — a promotion carrying an approved exemption also carries
+ * the `.lisa.config.json` diff that records it, so it would still be blocked
+ * by the finding for the record of its own approval.
+ *
+ * Only `allow-added` is carried. An actual threshold weakening in the same
+ * promotion still has to be covered by an allow entry.
+ * @param {Array<{ type: string }>} findings All findings from the change
+ * @param {boolean} promotion Whether the change is a recognised promotion
+ * @returns {{ carried: object[], rest: object[] }} Findings excused as already
+ *   approved upstream, and findings still subject to the allow list
+ */
+function partitionCarriedEntries(findings, promotion) {
+  if (!promotion) return { carried: [], rest: findings };
+  return {
+    carried: findings.filter(f => f.type === "allow-added"),
+    rest: findings.filter(f => f.type !== "allow-added"),
+  };
+}
+
+/**
  * Decide the exit code when the ratchet cannot determine what changed.
  *
  * `staged` and `base` are enforcement gates — pre-commit and CI. A gate that
@@ -161,9 +310,11 @@ function undeterminable(mode, reason) {
  * @param {"hook"|"staged"|"base"} mode Comparison mode
  * @param {string | undefined} [baseRef] Base ref (base mode only)
  * @param {string[] | undefined} [onlyFiles] Restrict to these paths (hook mode)
+ * @param {string | undefined} [headRef] Head ref (base mode only), used solely
+ *   to recognise a promotion between deploy-chain branches
  * @returns {number} Process exit code (2 for hook mode, 1 otherwise; 0 clean)
  */
-function run(mode, baseRef, onlyFiles) {
+function run(mode, baseRef, onlyFiles, headRef) {
   const root = git(["rev-parse", "--show-toplevel"])?.trim();
   if (!root) return undeterminable(mode, "not a git repository");
   const plan = resolvePlan(mode, root, baseRef, onlyFiles);
@@ -205,13 +356,21 @@ function run(mode, baseRef, onlyFiles) {
   );
   if (findings.length === 0) return 0;
 
-  const baselineConfig = parseJson(
-    git(["show", `${plan.baselineRef}:.lisa.config.json`], root)
+  const allow = resolveAllowList(
+    root,
+    plan.baselineRef,
+    mode,
+    baseRef,
+    headRef
   );
-  const { blocked, allowed } = applyAllowList(
-    findings,
-    extractAllowEntries(baselineConfig)
-  );
+  const split = partitionCarriedEntries(findings, allow.promotion);
+  const { blocked, allowed } = applyAllowList(split.rest, allow.entries);
+  if (allow.note) process.stdout.write(`${allow.note}\n`);
+  for (const finding of split.carried) {
+    process.stdout.write(
+      `threshold-ratchet: carried forward by this promotion, approved upstream — ${finding.message}\n`
+    );
+  }
   for (const finding of allowed) {
     process.stdout.write(
       `threshold-ratchet: allowed by .lisa.config.json exception — ${finding.message}\n`
@@ -257,11 +416,16 @@ function runHookMode() {
  */
 function main() {
   const args = process.argv.slice(2);
+  const headIndex = args.indexOf("--head");
+  const headRef = headIndex === -1 ? undefined : args[headIndex + 1];
   if (args[0] === "--staged") return run("staged");
-  if (args[0] === "--base") return run("base", args[1]);
+  // `--head` is optional and additive: a caller that omits it gets exactly the
+  // behavior that shipped before promotions were recognised, so an older
+  // workflow driving a newer script stays strict rather than silently relaxing.
+  if (args[0] === "--base") return run("base", args[1], undefined, headRef);
   if (args[0] === "--hook") return runHookMode();
   process.stderr.write(
-    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref>\n"
+    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref> [--head <ref>]\n"
   );
   return 0;
 }

--- a/rails/copy-overwrite/scripts/check-threshold-ratchet.mjs
+++ b/rails/copy-overwrite/scripts/check-threshold-ratchet.mjs
@@ -24,6 +24,13 @@
  * itself an exception in the same change that weakens a gate. `key: "*"`
  * allows every key in the file.
  *
+ * One exception, and only one: a PROMOTION between deploy-chain branches
+ * (`--base` + `--head`, both named in `deploy.branches`, head upstream of
+ * base, head fully containing base). There the allow list is read from the
+ * head, because the change under review is the baseline plus history that has
+ * already passed this same gate. See `isPromotion` for why that is the only
+ * discriminator that holds.
+ *
  * Extraction lives in threshold-ratchet-families.mjs; comparison rules in
  * threshold-ratchet-compare.mjs. Zero dependencies.
  */
@@ -132,6 +139,148 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
 }
 
 /**
+ * Strip a remote prefix so `origin/staging` and `staging` compare equal to a
+ * branch name declared in `.lisa.config.json`.
+ * @param {string} ref Git ref, possibly remote-qualified
+ * @returns {string} Bare branch name
+ */
+function bareBranch(ref) {
+  return ref.replace(/^refs\/heads\//u, "").replace(/^origin\//u, "");
+}
+
+/**
+ * The deploy chain, earliest environment first, from `deploy.branches`.
+ *
+ * Declaration order IS the chain order — that is already how Lisa reads it
+ * (dev → staging → production), and it is what makes "upstream of" decidable.
+ * @param {unknown} config Parsed `.lisa.config.json`
+ * @returns {string[]} Branch names in chain order
+ */
+function deployChain(config) {
+  const branches = config?.deploy?.branches;
+  if (!branches || typeof branches !== "object") return [];
+  return Object.values(branches).filter(b => typeof b === "string" && b !== "");
+}
+
+/**
+ * Whether this is a promotion of one deploy-chain branch into the next.
+ *
+ * A promotion carries approved history into a branch that is behind, so the
+ * exemptions it brings with it are not new — each one already faced this gate
+ * on the upstream branch. Reading the allow list from the baseline there
+ * reports every one of them as newly added, and the documented remedy is
+ * circular: recording them means adding `thresholdRatchet.allow` entries,
+ * which is itself the Tier 3 change being blocked. That deadlocked the whole
+ * promotion lane (#2531).
+ *
+ * The discriminator is branch IDENTITY, not ancestry. "The head contains the
+ * base" is true of any ordinary topic branch that is up to date with its base
+ * — and a repository with a strict up-to-date branch-protection rule REQUIRES
+ * that of every PR — so ancestry alone would hand self-approval to exactly the
+ * changes Tier 3 exists to stop. Being a deploy-chain branch cannot be
+ * arranged by a topic branch: those branches are protected, so everything on
+ * them arrived through a reviewed PR that passed this same ratchet.
+ *
+ * Ancestry is still required, as a second condition rather than the only one:
+ * a head that has diverged from its base is not "the baseline plus approved
+ * history", and the strict reading should stand.
+ *
+ * The chain is read from the BASELINE config, so a change cannot declare
+ * itself a promotion by adding `deploy.branches` entries in the same commit.
+ * @param {string} root Repo root
+ * @param {unknown} baselineConfig `.lisa.config.json` at the baseline
+ * @param {string | undefined} baseRef Ref being merged into
+ * @param {string | undefined} headRef Ref being merged from
+ * @returns {boolean} True when the allow list may be read from the head
+ */
+function isPromotion(root, baselineConfig, baseRef, headRef) {
+  if (!baseRef || !headRef) return false;
+  const chain = deployChain(baselineConfig);
+  const basePosition = chain.indexOf(bareBranch(baseRef));
+  const headPosition = chain.indexOf(bareBranch(headRef));
+  if (basePosition === -1 || headPosition === -1) return false;
+  if (headPosition >= basePosition) return false;
+  // Empty string on success, null when git exits non-zero or the ref is bogus.
+  if (git(["merge-base", "--is-ancestor", baseRef, headRef], root) !== null) {
+    return true;
+  }
+  // Both ARE deploy-chain branches, so this is a promotion that has diverged —
+  // typically a hotfix that landed on the base and was never synced down. The
+  // strict reading is correct here, but silence would leave an operator
+  // guessing why this promotion behaves differently from the last one.
+  process.stderr.write(
+    `threshold-ratchet: ${bareBranch(headRef)} does not contain ` +
+      `${bareBranch(baseRef)}, so this promotion is not the baseline plus ` +
+      `approved history and the allow list is read from the baseline. Sync ` +
+      `${bareBranch(baseRef)} down into ${bareBranch(headRef)} first.\n`
+  );
+  return false;
+}
+
+/**
+ * Resolve the allow list and say where it came from.
+ * @param {string} root Repo root
+ * @param {string} baselineRef Ref the comparison baselines against
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string | undefined} baseRef Base ref (base mode only)
+ * @param {string | undefined} headRef Head ref (base mode only)
+ * @returns {{ entries: object[], promotion: boolean, note: string | null }}
+ *   Entries, whether this is a promotion, and an audit line to print when the
+ *   entries came from anywhere but the baseline
+ */
+function resolveAllowList(root, baselineRef, mode, baseRef, headRef) {
+  const baselineConfig = parseJson(
+    git(["show", `${baselineRef}:.lisa.config.json`], root)
+  );
+  if (mode !== "base" || !isPromotion(root, baselineConfig, baseRef, headRef)) {
+    return {
+      entries: extractAllowEntries(baselineConfig),
+      promotion: false,
+      note: null,
+    };
+  }
+  return {
+    entries: extractAllowEntries(
+      parseJson(git(["show", "HEAD:.lisa.config.json"], root))
+    ),
+    promotion: true,
+    note:
+      `threshold-ratchet: promotion ${bareBranch(headRef)} → ` +
+      `${bareBranch(baseRef)}; both are deploy-chain branches declared at ` +
+      `${baselineRef} and the head fully contains the base, so the allow list ` +
+      `is read from the head. Exemptions below were approved upstream, not by ` +
+      `this change.`,
+  };
+}
+
+/**
+ * Split off the allow-entry additions a promotion is carrying forward.
+ *
+ * `applyAllowList` never drops an `allow-added` finding, from either side —
+ * an exception must not approve its own creation. That is right for an
+ * ordinary PR and wrong for a promotion, where the entry is not being created:
+ * it already exists on the upstream branch, where its creation faced this same
+ * unconditional block and needed a human to clear it. Without this the fix
+ * would be cosmetic — a promotion carrying an approved exemption also carries
+ * the `.lisa.config.json` diff that records it, so it would still be blocked
+ * by the finding for the record of its own approval.
+ *
+ * Only `allow-added` is carried. An actual threshold weakening in the same
+ * promotion still has to be covered by an allow entry.
+ * @param {Array<{ type: string }>} findings All findings from the change
+ * @param {boolean} promotion Whether the change is a recognised promotion
+ * @returns {{ carried: object[], rest: object[] }} Findings excused as already
+ *   approved upstream, and findings still subject to the allow list
+ */
+function partitionCarriedEntries(findings, promotion) {
+  if (!promotion) return { carried: [], rest: findings };
+  return {
+    carried: findings.filter(f => f.type === "allow-added"),
+    rest: findings.filter(f => f.type !== "allow-added"),
+  };
+}
+
+/**
  * Decide the exit code when the ratchet cannot determine what changed.
  *
  * `staged` and `base` are enforcement gates — pre-commit and CI. A gate that
@@ -161,9 +310,11 @@ function undeterminable(mode, reason) {
  * @param {"hook"|"staged"|"base"} mode Comparison mode
  * @param {string | undefined} [baseRef] Base ref (base mode only)
  * @param {string[] | undefined} [onlyFiles] Restrict to these paths (hook mode)
+ * @param {string | undefined} [headRef] Head ref (base mode only), used solely
+ *   to recognise a promotion between deploy-chain branches
  * @returns {number} Process exit code (2 for hook mode, 1 otherwise; 0 clean)
  */
-function run(mode, baseRef, onlyFiles) {
+function run(mode, baseRef, onlyFiles, headRef) {
   const root = git(["rev-parse", "--show-toplevel"])?.trim();
   if (!root) return undeterminable(mode, "not a git repository");
   const plan = resolvePlan(mode, root, baseRef, onlyFiles);
@@ -205,13 +356,21 @@ function run(mode, baseRef, onlyFiles) {
   );
   if (findings.length === 0) return 0;
 
-  const baselineConfig = parseJson(
-    git(["show", `${plan.baselineRef}:.lisa.config.json`], root)
+  const allow = resolveAllowList(
+    root,
+    plan.baselineRef,
+    mode,
+    baseRef,
+    headRef
   );
-  const { blocked, allowed } = applyAllowList(
-    findings,
-    extractAllowEntries(baselineConfig)
-  );
+  const split = partitionCarriedEntries(findings, allow.promotion);
+  const { blocked, allowed } = applyAllowList(split.rest, allow.entries);
+  if (allow.note) process.stdout.write(`${allow.note}\n`);
+  for (const finding of split.carried) {
+    process.stdout.write(
+      `threshold-ratchet: carried forward by this promotion, approved upstream — ${finding.message}\n`
+    );
+  }
   for (const finding of allowed) {
     process.stdout.write(
       `threshold-ratchet: allowed by .lisa.config.json exception — ${finding.message}\n`
@@ -257,11 +416,16 @@ function runHookMode() {
  */
 function main() {
   const args = process.argv.slice(2);
+  const headIndex = args.indexOf("--head");
+  const headRef = headIndex === -1 ? undefined : args[headIndex + 1];
   if (args[0] === "--staged") return run("staged");
-  if (args[0] === "--base") return run("base", args[1]);
+  // `--head` is optional and additive: a caller that omits it gets exactly the
+  // behavior that shipped before promotions were recognised, so an older
+  // workflow driving a newer script stays strict rather than silently relaxing.
+  if (args[0] === "--base") return run("base", args[1], undefined, headRef);
   if (args[0] === "--hook") return runHookMode();
   process.stderr.write(
-    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref>\n"
+    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref> [--head <ref>]\n"
   );
   return 0;
 }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -695,7 +695,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/threshold-ratchet-families.mjs":
       "8fa58cc7276add0b2edf1de92bdcc32d81d840811ef0614ddc724010b59a888c",
     "plugins/src/base/hooks/threshold-ratchet.mjs":
-      "e1e3f22b33267212b90f915f83821559d1a45cab5b16c7164b86bd6c7b53549b",
+      "1e46e6ca651e87e7814a4f486af5784ed2f7a8a48eadcaa7d3fef26e380929f9",
     "plugins/src/base/hooks/threshold-ratchet.sh":
       "b86f4d0b554e44fd119ad8a8920cd0ba6c9dbe779f7ee219d381cf0629453990",
     "plugins/src/base/hooks/ticket-sync-reminder.sh":
@@ -2009,7 +2009,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/copy-overwrite/lefthook.yml":
       "28bb382b9171a04fb92ebafc1f1522b8639f5edc4fcffcc6940e7fba3460fb4e",
     "rails/copy-overwrite/scripts/check-threshold-ratchet.mjs":
-      "e1e3f22b33267212b90f915f83821559d1a45cab5b16c7164b86bd6c7b53549b",
+      "1e46e6ca651e87e7814a4f486af5784ed2f7a8a48eadcaa7d3fef26e380929f9",
     "rails/copy-overwrite/scripts/lisa-clean-git-env.sh":
       "e7121a0ee9e1bf7c01cd2ab55f563dd6d9ab75990739bb6ddf571a513efa10e9",
     "rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs":
@@ -2267,7 +2267,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs":
       "48d3fa3043e144bcf52feb0e20db887d75c7ebda3b1fa708fe93f6554f6bec78",
     "typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs":
-      "e1e3f22b33267212b90f915f83821559d1a45cab5b16c7164b86bd6c7b53549b",
+      "1e46e6ca651e87e7814a4f486af5784ed2f7a8a48eadcaa7d3fef26e380929f9",
     "typescript/copy-overwrite/scripts/check-verification-coverage.mjs":
       "3c1d27d0668fc66a18cb014f2b607878f0a88c178a773fbe964b8e46b19e86d6",
     "typescript/copy-overwrite/scripts/lisa-mutation.mjs":
@@ -8933,6 +8933,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/skipped-required-checks.test.ts": true,
     "tests/unit/scripts/state-classification.test.ts": true,
     "tests/unit/scripts/threshold-ratchet-gates.test.ts": true,
+    "tests/unit/scripts/threshold-ratchet-promotion.test.ts": true,
     "tests/unit/scripts/threshold-ratchet-wiring.test.ts": true,
     "tests/unit/scripts/threshold-ratchet.test.ts": true,
     "tests/unit/scripts/upstream-evidence-manifest.test.ts": true,

--- a/tests/unit/scripts/threshold-ratchet-promotion.test.ts
+++ b/tests/unit/scripts/threshold-ratchet-promotion.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for the threshold ratchet's promotion path, part 4.
+ *
+ * The other three suites exercise the pure comparator. This one runs the
+ * entry script against real git repositories, because the property under test
+ * is about branch topology and cannot be expressed against a comparator that
+ * never sees a ref.
+ *
+ * The property: a promotion between deploy-chain branches may read its allow
+ * list from the change under review, and NOTHING else may. Every test here
+ * pairs a promotion with a byte-identical ordinary PR, because the two differ
+ * only in which branch the change sits on — if the ordinary case ever stops
+ * being blocked, the ratchet has been disabled rather than fixed (#2531).
+ */
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const HOOKS_REL = "plugins/src/base/hooks";
+const ENTRY = "threshold-ratchet.mjs";
+const RATCHET_MODULES = [
+  "threshold-ratchet-families.mjs",
+  "threshold-ratchet-compare.mjs",
+];
+const ESLINT_FILE = "eslint.thresholds.json";
+const LISA_CONFIG = ".lisa.config.json";
+const BASE_BRANCH = "staging";
+const CHAIN_HEAD = "dev";
+const TOPIC_BRANCH = "feature/raise-the-ceiling";
+const BLOCK_BANNER = "Quality gate weakened";
+/** The exemption a human approved upstream, as recorded on the head branch. */
+const APPROVED_ALLOW = {
+  file: ESLINT_FILE,
+  key: "*",
+  reason: "Approved by Cody Swann for PR #443",
+};
+
+/**
+ * Build the `.lisa.config.json` body: an ordered deploy chain plus whatever
+ * allow entries the branch has recorded.
+ * @param allow - Allow entries to record
+ * @param chain - Deploy chain, environment name to branch name
+ * @returns Serialized config
+ */
+function configText(
+  allow: readonly object[],
+  chain: Readonly<Record<string, string>> = {
+    dev: CHAIN_HEAD,
+    staging: BASE_BRANCH,
+    production: "main",
+  }
+): string {
+  return `${JSON.stringify(
+    { deploy: { branches: chain }, thresholdRatchet: { allow } },
+    undefined,
+    2
+  )}\n`;
+}
+
+/**
+ * Run git in a repository, throwing on failure so a broken fixture cannot
+ * masquerade as a passing test.
+ * @param cwd - Repository directory
+ * @param args - Git arguments
+ */
+function git(cwd: string, ...args: readonly string[]): void {
+  const result = spawnSync(
+    "/usr/bin/git",
+    ["-c", "user.email=t@t", "-c", "user.name=t", ...args],
+    { cwd, encoding: "utf-8" }
+  );
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")}: ${result.stderr}`);
+  }
+}
+
+/**
+ * Create a repository whose `staging` branch holds the baseline: an eslint
+ * ceiling of 10 warnings and no recorded exemptions.
+ * @returns Absolute path to the repository
+ */
+function baselineRepo(): string {
+  // realpath, because the script only runs main() when argv[1] resolves to its
+  // own module URL, and on macOS os.tmpdir() is a symlink — the two would
+  // never match and every test here would silently measure a no-op.
+  const dir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "lisa-ratchet-promo-"))
+  );
+  git(dir, "init", "-q", "-b", BASE_BRANCH);
+  for (const module of [ENTRY, ...RATCHET_MODULES]) {
+    fs.copyFileSync(
+      path.join(REPO_ROOT, HOOKS_REL, module),
+      path.join(dir, module)
+    );
+  }
+  fs.writeFileSync(path.join(dir, LISA_CONFIG), configText([]), "utf-8");
+  fs.writeFileSync(
+    path.join(dir, ESLINT_FILE),
+    `${JSON.stringify({ maxWarnings: 10 })}\n`,
+    "utf-8"
+  );
+  git(dir, "add", "-A");
+  git(dir, "commit", "-qm", "baseline on staging");
+  return dir;
+}
+
+/**
+ * Commit the weakening under review onto a new branch: the eslint ceiling
+ * rises to 25, and the allow entry approving that rise is recorded alongside
+ * it. Identical content whichever branch it lands on — the branch is the
+ * only variable these tests change.
+ * @param dir - Repository directory
+ * @param branch - Branch to create and commit on
+ * @param chain - Deploy chain to record in the config
+ */
+function commitWeakening(
+  dir: string,
+  branch: string,
+  chain?: Readonly<Record<string, string>>
+): void {
+  git(dir, "checkout", "-qb", branch);
+  fs.writeFileSync(
+    path.join(dir, ESLINT_FILE),
+    `${JSON.stringify({ maxWarnings: 25 })}\n`,
+    "utf-8"
+  );
+  fs.writeFileSync(
+    path.join(dir, LISA_CONFIG),
+    configText([APPROVED_ALLOW], chain),
+    "utf-8"
+  );
+  git(dir, "add", "-A");
+  git(dir, "commit", "-qm", "chore: raise the eslint ceiling");
+}
+
+/**
+ * Run the ratchet in `base` mode.
+ * @param dir - Repository directory
+ * @param headRef - Head ref to declare, or undefined to omit `--head`
+ * @returns Exit status and combined output
+ */
+function ratchet(
+  dir: string,
+  headRef?: string
+): { readonly status: number | null; readonly output: string } {
+  const result = spawnSync(
+    process.execPath,
+    [
+      path.join(dir, ENTRY),
+      "--base",
+      BASE_BRANCH,
+      ...(headRef === undefined ? [] : ["--head", headRef]),
+    ],
+    { cwd: dir, encoding: "utf-8" }
+  );
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+  };
+}
+
+describe("threshold-ratchet promotions", () => {
+  it("passes a promotion carrying an exemption approved upstream", () => {
+    const dir = baselineRepo();
+    commitWeakening(dir, CHAIN_HEAD);
+    const blockedBefore = ratchet(dir);
+    const afterFix = ratchet(dir, CHAIN_HEAD);
+    fs.rmSync(dir, { recursive: true, force: true });
+
+    // Omitting --head is the pre-#2531 behavior, and it is the deadlock: the
+    // allow list comes from staging, which is behind, so an exemption already
+    // approved on dev reads as newly added and the promotion cannot merge.
+    expect(blockedBefore.output).toContain(BLOCK_BANNER);
+    expect(blockedBefore.status).toBe(1);
+
+    expect(afterFix.status).toBe(0);
+    expect(afterFix.output).not.toContain(BLOCK_BANNER);
+    // Loud, not silent: a gate that relaxes has to say so and say why.
+    expect(afterFix.output).toContain(
+      `promotion ${CHAIN_HEAD} → ${BASE_BRANCH}`
+    );
+    expect(afterFix.output).toContain("carried forward by this promotion");
+  });
+
+  it("still blocks an ordinary PR that grants itself the same exemption", () => {
+    const dir = baselineRepo();
+    commitWeakening(dir, TOPIC_BRANCH);
+    // The head contains the base, which is what a strict up-to-date
+    // branch-protection rule REQUIRES of every PR. Ancestry alone would
+    // therefore have handed self-approval to essentially every change; being
+    // a deploy-chain branch is the condition that cannot be arranged.
+    const contains = spawnSync(
+      "/usr/bin/git",
+      ["merge-base", "--is-ancestor", BASE_BRANCH, TOPIC_BRANCH],
+      { cwd: dir, encoding: "utf-8" }
+    );
+    const result = ratchet(dir, TOPIC_BRANCH);
+    fs.rmSync(dir, { recursive: true, force: true });
+
+    expect(contains.status).toBe(0);
+    expect(result.output).toContain(BLOCK_BANNER);
+    expect(result.output).toContain("new threshold exception");
+    expect(result.status).toBe(1);
+  });
+
+  it("does not let a change declare itself a deploy-chain branch", () => {
+    const dir = baselineRepo();
+    commitWeakening(dir, TOPIC_BRANCH, {
+      sneaky: TOPIC_BRANCH,
+      staging: BASE_BRANCH,
+    });
+    const result = ratchet(dir, TOPIC_BRANCH);
+    fs.rmSync(dir, { recursive: true, force: true });
+
+    // The chain is read from the baseline for exactly this reason.
+    expect(result.output).toContain(BLOCK_BANNER);
+    expect(result.status).toBe(1);
+  });
+
+  it("keeps the strict reading when the head has diverged from the base", () => {
+    const dir = baselineRepo();
+    commitWeakening(dir, CHAIN_HEAD);
+    git(dir, "checkout", "-q", BASE_BRANCH);
+    fs.writeFileSync(path.join(dir, "HOTFIX.md"), "hotfix\n", "utf-8");
+    git(dir, "add", "-A");
+    git(dir, "commit", "-qm", "fix: hotfix landed straight on staging");
+    git(dir, "checkout", "-q", CHAIN_HEAD);
+    const result = ratchet(dir, CHAIN_HEAD);
+    fs.rmSync(dir, { recursive: true, force: true });
+
+    // A head that does not contain its base is not "the baseline plus
+    // approved history", whatever the branch is called.
+    expect(result.output).toContain(BLOCK_BANNER);
+    expect(result.output).toContain("Sync staging down into dev first");
+    expect(result.status).toBe(1);
+  });
+
+  it("does not treat a demotion as a promotion", () => {
+    const dir = baselineRepo();
+    commitWeakening(dir, CHAIN_HEAD);
+    // staging is downstream of dev, so naming it as the head is not a
+    // promotion however the refs relate.
+    const result = ratchet(dir, BASE_BRANCH);
+    fs.rmSync(dir, { recursive: true, force: true });
+
+    expect(result.output).toContain(BLOCK_BANNER);
+    expect(result.status).toBe(1);
+  });
+
+  it("blocks a weakening a promotion carries with no allow entry at all", () => {
+    const dir = baselineRepo();
+    git(dir, "checkout", "-qb", CHAIN_HEAD);
+    fs.writeFileSync(
+      path.join(dir, ESLINT_FILE),
+      `${JSON.stringify({ maxWarnings: 25 })}\n`,
+      "utf-8"
+    );
+    git(dir, "add", "-A");
+    git(dir, "commit", "-qm", "chore: raise the ceiling with no exemption");
+    const result = ratchet(dir, CHAIN_HEAD);
+    fs.rmSync(dir, { recursive: true, force: true });
+
+    // Being a promotion changes where the allow list is READ FROM. It does
+    // not excuse a weakening that nobody ever approved.
+    expect(result.output).toContain(BLOCK_BANNER);
+    expect(result.output).toContain("maxWarnings");
+    expect(result.status).toBe(1);
+  });
+});

--- a/typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs
+++ b/typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs
@@ -24,6 +24,13 @@
  * itself an exception in the same change that weakens a gate. `key: "*"`
  * allows every key in the file.
  *
+ * One exception, and only one: a PROMOTION between deploy-chain branches
+ * (`--base` + `--head`, both named in `deploy.branches`, head upstream of
+ * base, head fully containing base). There the allow list is read from the
+ * head, because the change under review is the baseline plus history that has
+ * already passed this same gate. See `isPromotion` for why that is the only
+ * discriminator that holds.
+ *
  * Extraction lives in threshold-ratchet-families.mjs; comparison rules in
  * threshold-ratchet-compare.mjs. Zero dependencies.
  */
@@ -132,6 +139,148 @@ function resolvePlan(mode, root, baseRef, onlyFiles) {
 }
 
 /**
+ * Strip a remote prefix so `origin/staging` and `staging` compare equal to a
+ * branch name declared in `.lisa.config.json`.
+ * @param {string} ref Git ref, possibly remote-qualified
+ * @returns {string} Bare branch name
+ */
+function bareBranch(ref) {
+  return ref.replace(/^refs\/heads\//u, "").replace(/^origin\//u, "");
+}
+
+/**
+ * The deploy chain, earliest environment first, from `deploy.branches`.
+ *
+ * Declaration order IS the chain order — that is already how Lisa reads it
+ * (dev → staging → production), and it is what makes "upstream of" decidable.
+ * @param {unknown} config Parsed `.lisa.config.json`
+ * @returns {string[]} Branch names in chain order
+ */
+function deployChain(config) {
+  const branches = config?.deploy?.branches;
+  if (!branches || typeof branches !== "object") return [];
+  return Object.values(branches).filter(b => typeof b === "string" && b !== "");
+}
+
+/**
+ * Whether this is a promotion of one deploy-chain branch into the next.
+ *
+ * A promotion carries approved history into a branch that is behind, so the
+ * exemptions it brings with it are not new — each one already faced this gate
+ * on the upstream branch. Reading the allow list from the baseline there
+ * reports every one of them as newly added, and the documented remedy is
+ * circular: recording them means adding `thresholdRatchet.allow` entries,
+ * which is itself the Tier 3 change being blocked. That deadlocked the whole
+ * promotion lane (#2531).
+ *
+ * The discriminator is branch IDENTITY, not ancestry. "The head contains the
+ * base" is true of any ordinary topic branch that is up to date with its base
+ * — and a repository with a strict up-to-date branch-protection rule REQUIRES
+ * that of every PR — so ancestry alone would hand self-approval to exactly the
+ * changes Tier 3 exists to stop. Being a deploy-chain branch cannot be
+ * arranged by a topic branch: those branches are protected, so everything on
+ * them arrived through a reviewed PR that passed this same ratchet.
+ *
+ * Ancestry is still required, as a second condition rather than the only one:
+ * a head that has diverged from its base is not "the baseline plus approved
+ * history", and the strict reading should stand.
+ *
+ * The chain is read from the BASELINE config, so a change cannot declare
+ * itself a promotion by adding `deploy.branches` entries in the same commit.
+ * @param {string} root Repo root
+ * @param {unknown} baselineConfig `.lisa.config.json` at the baseline
+ * @param {string | undefined} baseRef Ref being merged into
+ * @param {string | undefined} headRef Ref being merged from
+ * @returns {boolean} True when the allow list may be read from the head
+ */
+function isPromotion(root, baselineConfig, baseRef, headRef) {
+  if (!baseRef || !headRef) return false;
+  const chain = deployChain(baselineConfig);
+  const basePosition = chain.indexOf(bareBranch(baseRef));
+  const headPosition = chain.indexOf(bareBranch(headRef));
+  if (basePosition === -1 || headPosition === -1) return false;
+  if (headPosition >= basePosition) return false;
+  // Empty string on success, null when git exits non-zero or the ref is bogus.
+  if (git(["merge-base", "--is-ancestor", baseRef, headRef], root) !== null) {
+    return true;
+  }
+  // Both ARE deploy-chain branches, so this is a promotion that has diverged —
+  // typically a hotfix that landed on the base and was never synced down. The
+  // strict reading is correct here, but silence would leave an operator
+  // guessing why this promotion behaves differently from the last one.
+  process.stderr.write(
+    `threshold-ratchet: ${bareBranch(headRef)} does not contain ` +
+      `${bareBranch(baseRef)}, so this promotion is not the baseline plus ` +
+      `approved history and the allow list is read from the baseline. Sync ` +
+      `${bareBranch(baseRef)} down into ${bareBranch(headRef)} first.\n`
+  );
+  return false;
+}
+
+/**
+ * Resolve the allow list and say where it came from.
+ * @param {string} root Repo root
+ * @param {string} baselineRef Ref the comparison baselines against
+ * @param {"hook"|"staged"|"base"} mode Comparison mode
+ * @param {string | undefined} baseRef Base ref (base mode only)
+ * @param {string | undefined} headRef Head ref (base mode only)
+ * @returns {{ entries: object[], promotion: boolean, note: string | null }}
+ *   Entries, whether this is a promotion, and an audit line to print when the
+ *   entries came from anywhere but the baseline
+ */
+function resolveAllowList(root, baselineRef, mode, baseRef, headRef) {
+  const baselineConfig = parseJson(
+    git(["show", `${baselineRef}:.lisa.config.json`], root)
+  );
+  if (mode !== "base" || !isPromotion(root, baselineConfig, baseRef, headRef)) {
+    return {
+      entries: extractAllowEntries(baselineConfig),
+      promotion: false,
+      note: null,
+    };
+  }
+  return {
+    entries: extractAllowEntries(
+      parseJson(git(["show", "HEAD:.lisa.config.json"], root))
+    ),
+    promotion: true,
+    note:
+      `threshold-ratchet: promotion ${bareBranch(headRef)} → ` +
+      `${bareBranch(baseRef)}; both are deploy-chain branches declared at ` +
+      `${baselineRef} and the head fully contains the base, so the allow list ` +
+      `is read from the head. Exemptions below were approved upstream, not by ` +
+      `this change.`,
+  };
+}
+
+/**
+ * Split off the allow-entry additions a promotion is carrying forward.
+ *
+ * `applyAllowList` never drops an `allow-added` finding, from either side —
+ * an exception must not approve its own creation. That is right for an
+ * ordinary PR and wrong for a promotion, where the entry is not being created:
+ * it already exists on the upstream branch, where its creation faced this same
+ * unconditional block and needed a human to clear it. Without this the fix
+ * would be cosmetic — a promotion carrying an approved exemption also carries
+ * the `.lisa.config.json` diff that records it, so it would still be blocked
+ * by the finding for the record of its own approval.
+ *
+ * Only `allow-added` is carried. An actual threshold weakening in the same
+ * promotion still has to be covered by an allow entry.
+ * @param {Array<{ type: string }>} findings All findings from the change
+ * @param {boolean} promotion Whether the change is a recognised promotion
+ * @returns {{ carried: object[], rest: object[] }} Findings excused as already
+ *   approved upstream, and findings still subject to the allow list
+ */
+function partitionCarriedEntries(findings, promotion) {
+  if (!promotion) return { carried: [], rest: findings };
+  return {
+    carried: findings.filter(f => f.type === "allow-added"),
+    rest: findings.filter(f => f.type !== "allow-added"),
+  };
+}
+
+/**
  * Decide the exit code when the ratchet cannot determine what changed.
  *
  * `staged` and `base` are enforcement gates — pre-commit and CI. A gate that
@@ -161,9 +310,11 @@ function undeterminable(mode, reason) {
  * @param {"hook"|"staged"|"base"} mode Comparison mode
  * @param {string | undefined} [baseRef] Base ref (base mode only)
  * @param {string[] | undefined} [onlyFiles] Restrict to these paths (hook mode)
+ * @param {string | undefined} [headRef] Head ref (base mode only), used solely
+ *   to recognise a promotion between deploy-chain branches
  * @returns {number} Process exit code (2 for hook mode, 1 otherwise; 0 clean)
  */
-function run(mode, baseRef, onlyFiles) {
+function run(mode, baseRef, onlyFiles, headRef) {
   const root = git(["rev-parse", "--show-toplevel"])?.trim();
   if (!root) return undeterminable(mode, "not a git repository");
   const plan = resolvePlan(mode, root, baseRef, onlyFiles);
@@ -205,13 +356,21 @@ function run(mode, baseRef, onlyFiles) {
   );
   if (findings.length === 0) return 0;
 
-  const baselineConfig = parseJson(
-    git(["show", `${plan.baselineRef}:.lisa.config.json`], root)
+  const allow = resolveAllowList(
+    root,
+    plan.baselineRef,
+    mode,
+    baseRef,
+    headRef
   );
-  const { blocked, allowed } = applyAllowList(
-    findings,
-    extractAllowEntries(baselineConfig)
-  );
+  const split = partitionCarriedEntries(findings, allow.promotion);
+  const { blocked, allowed } = applyAllowList(split.rest, allow.entries);
+  if (allow.note) process.stdout.write(`${allow.note}\n`);
+  for (const finding of split.carried) {
+    process.stdout.write(
+      `threshold-ratchet: carried forward by this promotion, approved upstream — ${finding.message}\n`
+    );
+  }
   for (const finding of allowed) {
     process.stdout.write(
       `threshold-ratchet: allowed by .lisa.config.json exception — ${finding.message}\n`
@@ -257,11 +416,16 @@ function runHookMode() {
  */
 function main() {
   const args = process.argv.slice(2);
+  const headIndex = args.indexOf("--head");
+  const headRef = headIndex === -1 ? undefined : args[headIndex + 1];
   if (args[0] === "--staged") return run("staged");
-  if (args[0] === "--base") return run("base", args[1]);
+  // `--head` is optional and additive: a caller that omits it gets exactly the
+  // behavior that shipped before promotions were recognised, so an older
+  // workflow driving a newer script stays strict rather than silently relaxing.
+  if (args[0] === "--base") return run("base", args[1], undefined, headRef);
   if (args[0] === "--hook") return runHookMode();
   process.stderr.write(
-    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref>\n"
+    "usage: threshold-ratchet.mjs --hook | --staged | --base <ref> [--head <ref>]\n"
   );
   return 0;
 }

--- a/wiki/decisions/2026-08-12-ratchet-policy.md
+++ b/wiki/decisions/2026-08-12-ratchet-policy.md
@@ -25,6 +25,16 @@ This conflicts with shipped Lisa behavior. Lisa ships several ratchet families:
   merge-base), with lowering permitted only via a `thresholdRatchet.allow` entry
   merged from the baseline side.
 
+  *Amended 2026-08-13 (#2531):* "from the baseline side" deadlocked the promotion lane.
+  On a `dev` → `staging` promotion the baseline is the branch that is behind, so an
+  exemption already approved upstream reads as newly added — and the remedy (record it
+  in `thresholdRatchet.allow`) is itself the Tier 3 change being blocked. The allow list
+  is now read from the head for a promotion between branches named in `deploy.branches`,
+  where the head is upstream of the base and fully contains it. The discriminator is
+  branch identity, not ancestry: a strict up-to-date branch-protection rule makes "the
+  head contains the base" true of every ordinary PR, so ancestry alone would have
+  retired Tier 3 entirely.
+
 Brownfield onboarding depends on ratchets: a red project adopts incrementally instead
 of being blocked until fully remediated.
 


### PR DESCRIPTION
## Summary

Closes #2531.

The ratchet honors `thresholdRatchet.allow` only from the baseline side. That is right for an ordinary PR — nobody grants themselves an exception in the same change that needs it. On a promotion it deadlocks: the baseline is `staging`, which is behind, so an exemption approved on `dev` through the sanctioned path reads as newly added. And the documented remedy is circular, because recording it means adding allow entries, which is itself the Tier 3 change being blocked. `TunnlAI/frontend#527` needed a repository-role bypass to merge.

The allow list is now read from the head when **all** of these hold:

1. `--head` was supplied (new, optional flag);
2. both branches are named in `deploy.branches` — read from the **baseline** config;
3. the head is upstream of the base in that chain;
4. the head fully contains the base.

## Why not option 1 as written

The issue's option 1 was ancestry alone: read from the head when `git merge-base --is-ancestor base head`. **That would have retired Tier 3 entirely.** "The head contains the base" is true of any topic branch that is up to date with its base — and a strict up-to-date branch-protection rule *requires* that of every PR. The self-approval case the rule exists to stop would have passed.

The discriminator has to be **branch identity**, which a topic branch cannot arrange: deploy-chain branches are protected, so everything on them arrived through a reviewed PR that faced this same ratchet. Ancestry is kept as a second condition — a head that has diverged from its base is not "the baseline plus approved history" — and a promotion blocked for that reason now says so and names the sync-down that fixes it.

**Option 2 does not separate the two cases.** On a promotion *and* on an ordinary PR, the allow entry is introduced by a commit in `merge-base..HEAD`, reachable only from the head branch. There is no reachability query that tells them apart.

## `allow-added` is carried forward too

Without this the fix would be cosmetic. A promotion carrying an approved exemption also carries the `.lisa.config.json` diff that records it, and `applyAllowList` never drops an `allow-added` finding — so the promotion would still be blocked by the finding for the record of its own approval. Only `allow-added` is carried; a weakening nobody approved is still blocked.

## Safety properties

- `--head` is optional and additive, so an older workflow driving a newer script stays strict rather than silently relaxing.
- The chain is read from the baseline, so a change cannot declare itself a promotion.
- The relaxation is announced on stdout, naming both branches and the ref the chain came from.

## Bite controls

`tests/unit/scripts/threshold-ratchet-promotion.test.ts` runs the entry script against **real git repositories**. The promotion and the ordinary PR carry byte-identical content — the eslint ceiling rising 10 → 25 plus the allow entry approving it — and differ only in the branch the commit sits on.

| control | before | after |
|---|---|---|
| promotion `dev` → `staging` carrying an exemption approved upstream | **1 (blocked)** | **0 (allowed)** |
| ordinary PR granting itself the same exemption | 1 | **1** |
| PR declaring itself a deploy-chain branch in the same commit | 1 | **1** |
| deploy-chain head diverged from its base | 1 | **1** |
| demotion (`staging` named as head) | 1 | **1** |
| promotion carrying a weakening with no allow entry | 1 | **1** |

Control 3 (blocked → allowed), with the audit trail:

```
threshold-ratchet: promotion dev → staging; both are deploy-chain branches declared at
  1bb61be… and the head fully contains the base, so the allow list is read from the head.
  Exemptions below were approved upstream, not by this change.
threshold-ratchet: carried forward by this promotion, approved upstream —
  .lisa.config.json: new threshold exception for eslint.thresholds.json → *
threshold-ratchet: allowed by .lisa.config.json exception —
  eslint.thresholds.json: maxWarnings changed 10 → 25
exit=0
```

Control 4 — the one that matters — with its head confirmed to contain its base:

```
      git merge-base --is-ancestor staging HEAD -> TRUE
⛔ Quality gate weakened — blocked by the threshold ratchet.
  • .lisa.config.json: new threshold exception for eslint.thresholds.json → *
  • eslint.thresholds.json: maxWarnings changed 10 → 25
exit=1
```

Reverting the script fails exactly the two tests that measure the fix; the four guard controls hold in both directions, which is what proves the ratchet was not simply disabled.

## Verification

- `bunx vitest run tests/unit/scripts/threshold-ratchet` — 48 passed (4 files)
- `bun run lint`, `bun run typecheck`, `prettier --check` — clean
- Full pre-push suite — green

Work-Item: CodySwannGT/lisa#2531

🤖 Generated with Claude Code
