### PR TITLE
fix(ci): refuse a headroom entry sized from a run the budget terminated

### DIFF
--- a/.github/required-check-promotions.json
+++ b/.github/required-check-promotions.json
@@ -12,6 +12,18 @@
     "conditions, and a description of the run that REPRODUCED the failure the budget",
     "prevents. Sizing from runs that passed is circular and is refused.",
     "",
+    "status 'proven' also requires observed_on: 'pass' (#2528) — the run that produced",
+    "observed_worst_ms must have COMPLETED within its budget rather than been terminated by",
+    "it, because a duration reported alongside a timeout measures contention, not cost. That",
+    "is a claim about TIME, not about the check's verdict: a run that reproduces a real",
+    "violation and exits 1 well inside its budget completed, and is 'pass' here. And a worst",
+    "case at or above the budget it justifies is refused outright as self-refuting, with its",
+    "own rule rather than as a thin margin. A missing observed_on is refused, NOT",
+    "grandfathered: the only proven entry when the clause shipped had already recorded in",
+    "prose that its worst case came from runs that completed, so backfilling it restated",
+    "what was already proved, and exempting it would have exempted the only entry the",
+    "clause could bind on.",
+    "",
     "status 'grandfathered' is for contexts that were already required on 2026-08-13, when",
     "this ledger was written. It reports debt instead of failing. It is not an amnesty: the",
     "entry must state what is unproven, and the context must appear in grandfathered_contexts",
@@ -154,14 +166,16 @@
         "status": "proven",
         "budget_ms": 600000,
         "observed_worst_ms": 40000,
+        "observed_on": "pass",
         "measured_on": "the 🔎 AST Grep Scan job itself, in CodySwannGT/lisa's CI workflow — not a laptop, and not another job",
-        "conditions": "23 consecutive runs of the job on GitHub-hosted ubuntu-latest runners, 2026-08. Durations 21-40s, worst 40s against the job's timeout-minutes: 10 budget, i.e. 15.0x. Corroborated locally at 0.16/0.16/0.18s for the scan step alone (macOS, 18 cores, load 5.00/6.36/7.04, 0 vitest processes), which is a different machine and is reported as corroboration only, never as the sizing sample.",
+        "conditions": "23 consecutive runs of the job on GitHub-hosted ubuntu-latest runners, 2026-08. Durations 21-40s, worst 40s against the job's timeout-minutes: 10 budget, i.e. 15.0x. All 23 runs COMPLETED — none was terminated by the budget — which is what `observed_on: pass` records (#2528): a duration reported alongside a timeout would be elapsed wall clock spent waiting, i.e. contention rather than cost. Corroborated locally at 0.16/0.16/0.18s for the scan step alone (macOS, 18 cores, load 5.00/6.36/7.04, 0 vitest processes), which is a different machine and is reported as corroboration only, never as the sizing sample.",
         "reproduced": "5 of those 23 runs REPRODUCED the failure the budget exists around: the check went red on real ast-grep violations (#2512 shipped an error-severity fs-extra rule that found 1142 findings in tests/), and those failing runs completed in 22-30s — inside the budget, not by timing out. The failure path is therefore bounded, which is the thing a passing sample cannot tell you. Independently confirmed both directions at origin/main b671524a7: a planted violating fixture makes `bun run sg:scan` exit 1, and removing it returns exit 0, so the check is falsifiable rather than vacuous.",
         "budgets": [
           {
             "subject": "sg_scan",
             "budget_ms": 600000,
             "observed_worst_ms": 40000,
+            "observed_on": "pass",
             "measured_on_subject": "sg_scan"
           }
         ]

--- a/plugins/lisa-agy/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the custom guard rules enforced by Lisa's safety-net PreToolUse Bash hook (parity-safety-net.sh). The consolidated cross-agent equivalent of the upstream safety-net plugin's set-custom-rules + verify-custom-rules skills — manages a project-local list of extended-regex patterns that block destructive shell commands, on Codex, agy, Copilot, Cursor, and Claude."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@2.0.3
+synced-from: safety-net@cc-marketplace@2.0.4
 ---
 
 # Parity Safety-Net Rules
@@ -24,7 +24,7 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.3`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.4`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
@@ -34,7 +34,22 @@ project-specific rules on top of those built-ins.
 > rule-management skill or Lisa's project-local ERE rule contract, and Lisa does
 > not currently ship hooks for those runtimes, so no behavior is absorbed here.
 >
-> **Known gap at the 2.0.3 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> **2.0.4 review.** Method, so the next person can re-run it rather than trust
+> it: hash the sorted (relative path, content) manifest of every rule-bearing
+> directory in the plugin cache under both versions, then diff the trees
+> excluding `dist/`, `.git/`, and `node_modules/`. Result — `src/` (230 files),
+> `skills/` (1), and `hooks/` (1) are byte-identical across 2.0.3 and 2.0.4
+> (`src` digest `7e346e205fbd1aa7` both sides). The only non-generated
+> differences are the `version` string in `package.json`, `kimi.plugin.json`,
+> and `.claude-plugin/plugin.json`, plus a test-harness fix in
+> `tests/cli/cli-statusline.test.ts` that tolerates EPIPE when an oversized
+> payload is flushed at the bounded reader's cap. Everything else is rebuilt
+> `dist/` output. No rule, guard family, or skill surface moved, so nothing is
+> absorbed here — and, critically, **2.0.4 does not close the gap recorded
+> below**, which therefore carries forward unchanged rather than being dropped
+> at the new pin.
+>
+> **Known gap at the 2.0.4 pin.** Upstream 2.0.0 rebuilt its engine and added two
 > guard families this hook does **not** mirror: `secret.*` (blocks reading or
 > copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
 > stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both

--- a/plugins/lisa-copilot/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the custom guard rules enforced by Lisa's safety-net PreToolUse Bash hook (parity-safety-net.sh). The consolidated cross-agent equivalent of the upstream safety-net plugin's set-custom-rules + verify-custom-rules skills — manages a project-local list of extended-regex patterns that block destructive shell commands, on Codex, agy, Copilot, Cursor, and Claude."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@2.0.3
+synced-from: safety-net@cc-marketplace@2.0.4
 ---
 
 # Parity Safety-Net Rules
@@ -24,7 +24,7 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.3`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.4`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
@@ -34,7 +34,22 @@ project-specific rules on top of those built-ins.
 > rule-management skill or Lisa's project-local ERE rule contract, and Lisa does
 > not currently ship hooks for those runtimes, so no behavior is absorbed here.
 >
-> **Known gap at the 2.0.3 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> **2.0.4 review.** Method, so the next person can re-run it rather than trust
+> it: hash the sorted (relative path, content) manifest of every rule-bearing
+> directory in the plugin cache under both versions, then diff the trees
+> excluding `dist/`, `.git/`, and `node_modules/`. Result — `src/` (230 files),
+> `skills/` (1), and `hooks/` (1) are byte-identical across 2.0.3 and 2.0.4
+> (`src` digest `7e346e205fbd1aa7` both sides). The only non-generated
+> differences are the `version` string in `package.json`, `kimi.plugin.json`,
+> and `.claude-plugin/plugin.json`, plus a test-harness fix in
+> `tests/cli/cli-statusline.test.ts` that tolerates EPIPE when an oversized
+> payload is flushed at the bounded reader's cap. Everything else is rebuilt
+> `dist/` output. No rule, guard family, or skill surface moved, so nothing is
+> absorbed here — and, critically, **2.0.4 does not close the gap recorded
+> below**, which therefore carries forward unchanged rather than being dropped
+> at the new pin.
+>
+> **Known gap at the 2.0.4 pin.** Upstream 2.0.0 rebuilt its engine and added two
 > guard families this hook does **not** mirror: `secret.*` (blocks reading or
 > copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
 > stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both

--- a/plugins/lisa-cursor/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the custom guard rules enforced by Lisa's safety-net PreToolUse Bash hook (parity-safety-net.sh). The consolidated cross-agent equivalent of the upstream safety-net plugin's set-custom-rules + verify-custom-rules skills — manages a project-local list of extended-regex patterns that block destructive shell commands, on Codex, agy, Copilot, Cursor, and Claude."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@2.0.3
+synced-from: safety-net@cc-marketplace@2.0.4
 ---
 
 # Parity Safety-Net Rules
@@ -24,7 +24,7 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.3`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.4`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
@@ -34,7 +34,22 @@ project-specific rules on top of those built-ins.
 > rule-management skill or Lisa's project-local ERE rule contract, and Lisa does
 > not currently ship hooks for those runtimes, so no behavior is absorbed here.
 >
-> **Known gap at the 2.0.3 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> **2.0.4 review.** Method, so the next person can re-run it rather than trust
+> it: hash the sorted (relative path, content) manifest of every rule-bearing
+> directory in the plugin cache under both versions, then diff the trees
+> excluding `dist/`, `.git/`, and `node_modules/`. Result — `src/` (230 files),
+> `skills/` (1), and `hooks/` (1) are byte-identical across 2.0.3 and 2.0.4
+> (`src` digest `7e346e205fbd1aa7` both sides). The only non-generated
+> differences are the `version` string in `package.json`, `kimi.plugin.json`,
+> and `.claude-plugin/plugin.json`, plus a test-harness fix in
+> `tests/cli/cli-statusline.test.ts` that tolerates EPIPE when an oversized
+> payload is flushed at the bounded reader's cap. Everything else is rebuilt
+> `dist/` output. No rule, guard family, or skill surface moved, so nothing is
+> absorbed here — and, critically, **2.0.4 does not close the gap recorded
+> below**, which therefore carries forward unchanged rather than being dropped
+> at the new pin.
+>
+> **Known gap at the 2.0.4 pin.** Upstream 2.0.0 rebuilt its engine and added two
 > guard families this hook does **not** mirror: `secret.*` (blocks reading or
 > copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
 > stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both

--- a/plugins/lisa/.codex-plugin/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the…"
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@2.0.3
+synced-from: safety-net@cc-marketplace@2.0.4
 ---
 
 # Parity Safety-Net Rules
@@ -24,7 +24,7 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.3`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.4`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
@@ -34,7 +34,22 @@ project-specific rules on top of those built-ins.
 > rule-management skill or Lisa's project-local ERE rule contract, and Lisa does
 > not currently ship hooks for those runtimes, so no behavior is absorbed here.
 >
-> **Known gap at the 2.0.3 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> **2.0.4 review.** Method, so the next person can re-run it rather than trust
+> it: hash the sorted (relative path, content) manifest of every rule-bearing
+> directory in the plugin cache under both versions, then diff the trees
+> excluding `dist/`, `.git/`, and `node_modules/`. Result — `src/` (230 files),
+> `skills/` (1), and `hooks/` (1) are byte-identical across 2.0.3 and 2.0.4
+> (`src` digest `7e346e205fbd1aa7` both sides). The only non-generated
+> differences are the `version` string in `package.json`, `kimi.plugin.json`,
+> and `.claude-plugin/plugin.json`, plus a test-harness fix in
+> `tests/cli/cli-statusline.test.ts` that tolerates EPIPE when an oversized
+> payload is flushed at the bounded reader's cap. Everything else is rebuilt
+> `dist/` output. No rule, guard family, or skill surface moved, so nothing is
+> absorbed here — and, critically, **2.0.4 does not close the gap recorded
+> below**, which therefore carries forward unchanged rather than being dropped
+> at the new pin.
+>
+> **Known gap at the 2.0.4 pin.** Upstream 2.0.0 rebuilt its engine and added two
 > guard families this hook does **not** mirror: `secret.*` (blocks reading or
 > copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
 > stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both

--- a/plugins/lisa/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/lisa/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the custom guard rules enforced by Lisa's safety-net PreToolUse Bash hook (parity-safety-net.sh). The consolidated cross-agent equivalent of the upstream safety-net plugin's set-custom-rules + verify-custom-rules skills — manages a project-local list of extended-regex patterns that block destructive shell commands, on Codex, agy, Copilot, Cursor, and Claude."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@2.0.3
+synced-from: safety-net@cc-marketplace@2.0.4
 ---
 
 # Parity Safety-Net Rules
@@ -24,7 +24,7 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.3`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.4`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
@@ -34,7 +34,22 @@ project-specific rules on top of those built-ins.
 > rule-management skill or Lisa's project-local ERE rule contract, and Lisa does
 > not currently ship hooks for those runtimes, so no behavior is absorbed here.
 >
-> **Known gap at the 2.0.3 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> **2.0.4 review.** Method, so the next person can re-run it rather than trust
+> it: hash the sorted (relative path, content) manifest of every rule-bearing
+> directory in the plugin cache under both versions, then diff the trees
+> excluding `dist/`, `.git/`, and `node_modules/`. Result — `src/` (230 files),
+> `skills/` (1), and `hooks/` (1) are byte-identical across 2.0.3 and 2.0.4
+> (`src` digest `7e346e205fbd1aa7` both sides). The only non-generated
+> differences are the `version` string in `package.json`, `kimi.plugin.json`,
+> and `.claude-plugin/plugin.json`, plus a test-harness fix in
+> `tests/cli/cli-statusline.test.ts` that tolerates EPIPE when an oversized
+> payload is flushed at the bounded reader's cap. Everything else is rebuilt
+> `dist/` output. No rule, guard family, or skill surface moved, so nothing is
+> absorbed here — and, critically, **2.0.4 does not close the gap recorded
+> below**, which therefore carries forward unchanged rather than being dropped
+> at the new pin.
+>
+> **Known gap at the 2.0.4 pin.** Upstream 2.0.0 rebuilt its engine and added two
 > guard families this hook does **not** mirror: `secret.*` (blocks reading or
 > copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
 > stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both

--- a/plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md
+++ b/plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: lisa-parity-safety-net-rules
 description: "View, set, and verify the custom guard rules enforced by Lisa's safety-net PreToolUse Bash hook (parity-safety-net.sh). The consolidated cross-agent equivalent of the upstream safety-net plugin's set-custom-rules + verify-custom-rules skills — manages a project-local list of extended-regex patterns that block destructive shell commands, on Codex, agy, Copilot, Cursor, and Claude."
 allowed-tools: ["Read", "Edit", "Write", "Bash"]
-synced-from: safety-net@cc-marketplace@2.0.3
+synced-from: safety-net@cc-marketplace@2.0.4
 ---
 
 # Parity Safety-Net Rules
@@ -24,7 +24,7 @@ project-specific rules on top of those built-ins.
 > against Lisa conventions — it does **not** port or invoke upstream plugin
 > code.
 >
-> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.3`.
+> **Drift tracking.** Pinned to `safety-net@cc-marketplace@2.0.4`.
 > `scripts/plugin-parity-drift.mjs` compares this pin against the upstream
 > version in the plugin cache and flags staleness. **Do not port or copy upstream
 > plugin code.**
@@ -34,7 +34,22 @@ project-specific rules on top of those built-ins.
 > rule-management skill or Lisa's project-local ERE rule contract, and Lisa does
 > not currently ship hooks for those runtimes, so no behavior is absorbed here.
 >
-> **Known gap at the 2.0.3 pin.** Upstream 2.0.0 rebuilt its engine and added two
+> **2.0.4 review.** Method, so the next person can re-run it rather than trust
+> it: hash the sorted (relative path, content) manifest of every rule-bearing
+> directory in the plugin cache under both versions, then diff the trees
+> excluding `dist/`, `.git/`, and `node_modules/`. Result — `src/` (230 files),
+> `skills/` (1), and `hooks/` (1) are byte-identical across 2.0.3 and 2.0.4
+> (`src` digest `7e346e205fbd1aa7` both sides). The only non-generated
+> differences are the `version` string in `package.json`, `kimi.plugin.json`,
+> and `.claude-plugin/plugin.json`, plus a test-harness fix in
+> `tests/cli/cli-statusline.test.ts` that tolerates EPIPE when an oversized
+> payload is flushed at the bounded reader's cap. Everything else is rebuilt
+> `dist/` output. No rule, guard family, or skill surface moved, so nothing is
+> absorbed here — and, critically, **2.0.4 does not close the gap recorded
+> below**, which therefore carries forward unchanged rather than being dropped
+> at the new pin.
+>
+> **Known gap at the 2.0.4 pin.** Upstream 2.0.0 rebuilt its engine and added two
 > guard families this hook does **not** mirror: `secret.*` (blocks reading or
 > copying SSH keys, `.env` files, cloud credentials, and coding-CLI credential
 > stores) and `rm.git-metadata` (blocks deleting the `.git` control plane). Both

--- a/scripts/check-required-check-promotions.mjs
+++ b/scripts/check-required-check-promotions.mjs
@@ -69,6 +69,38 @@
  *     `measured_on_subject` separately makes that mechanically visible instead
  *     of a footnote in a report.
  *
+ *  6. **A worst case must come from a run that COMPLETED, and must be below the
+ *     budget it justifies** (#2528). Two clauses, one rule:
+ *
+ *     *Do not size a budget from the duration of a run that failed on time.*
+ *     This is the mirror of clause 3. #2509 says do not size from runs that
+ *     passed, because the sample excludes the failure mode; the mirror says do
+ *     not size from the DURATION of a run the budget terminated, because that
+ *     duration is the starvation, not the work. The failing-run version is
+ *     strictly worse: it does not merely omit information, it INVERTS the
+ *     ratio — the more contended the box was, the safer the resulting budget
+ *     looks. So `observed_on` must say `"pass"`, meaning the measured run
+ *     completed inside its budget. (That is a statement about TIME, not about
+ *     the check's verdict: a run that reproduces a real violation and exits 1
+ *     in 30s completed, and is `"pass"` here.)
+ *
+ *     *And an entry claiming a worst case at or above its own budget refuses
+ *     itself*, needing no knowledge of the test, the machine, or the workload.
+ *     #2523 cited 60,245ms while setting the budget to 60,000ms. The ratio in
+ *     clause 4 already rejects that arithmetically at 0.996x, but it reports a
+ *     THIN MARGIN when the defect is an IMPOSSIBLE CLAIM, and a message that
+ *     misnames the defect sends the reader off to re-measure when they should
+ *     be re-reading. The tell was on the face of the number: a test cannot run
+ *     60s against a 10s budget, so 60,245ms was wall clock spent waiting.
+ *     Re-measured in isolation at load 31 the same test takes 2,499ms — 24x,
+ *     not 0.996x, a 24-fold error in the unsafe direction.
+ *
+ *     A missing `observed_on` is refused rather than grandfathered. Every
+ *     `proven` entry in the ledger when this clause shipped had already
+ *     recorded, in prose, that its worst case came from runs that completed, so
+ *     backfilling the field only restates what was already proved. Exempting
+ *     them would have exempted the only entries the clause could bind on.
+ *
  * ## The ratchet, and why incumbents are not simply exempted
  *
  * Contexts already required when this guard shipped may declare
@@ -315,7 +347,45 @@ function budgetProblems(budget) {
       },
     ];
   }
+  // A budgets[] entry publishes its OWN observed_worst_ms, so it can be a
+  // starved figure exactly as the block-level one can. Checking provenance
+  // first: a ratio computed from a duration that measures contention is
+  // arithmetic on the wrong number, so the reader needs the provenance before
+  // the margin.
+  const provenance = provenanceProblems(budget.observed_on);
+  if (provenance.length > 0) return provenance;
   return ratioProblems(budget.budget_ms, budget.observed_worst_ms);
+}
+
+/**
+ * Validate where an observed worst case was measured (#2528).
+ *
+ * `observed_on` records whether the run that produced `observed_worst_ms`
+ * COMPLETED within its budget (`"pass"`) or was terminated by it (`"fail"`).
+ * That is a claim about time, not about the check's verdict — a run that
+ * reproduces a real violation and exits 1 well inside its budget completed.
+ *
+ * @param {unknown} observedOn - the declared provenance.
+ * @returns {{ rule: string, detail: string }[]} problems, empty when sound.
+ */
+function provenanceProblems(observedOn) {
+  if (observedOn === "pass") return [];
+  if (observedOn === "fail") {
+    return [
+      {
+        rule: "headroom-measured-on-failing-run",
+        detail:
+          'observed_worst_ms was taken from a run the budget terminated ("observed_on": "fail"); that duration is the starvation, not the work, and the more contended the box was the safer the budget looks — re-measure on a run that completed, in isolation',
+      },
+    ];
+  }
+  return [
+    {
+      rule: "headroom-evidence-missing",
+      detail:
+        'headroom.observed_on must be "pass": the run that produced observed_worst_ms must have COMPLETED within its budget, because a duration reported alongside a timeout measures contention, not cost',
+    },
+  ];
 }
 
 /**
@@ -337,6 +407,17 @@ function ratioProblems(budgetMs, observedMs) {
         rule: "headroom-evidence-missing",
         detail:
           "headroom needs a positive budget_ms and a positive observed_worst_ms",
+      },
+    ];
+  }
+  // Checked before the ratio, and reported as its own defect: an entry whose
+  // worst case is not below the budget it justifies can never be valid, and
+  // "thin margin" would misname it. See clause 6 in the module preamble.
+  if (observedMs >= budgetMs) {
+    return [
+      {
+        rule: "headroom-worst-case-exceeds-budget",
+        detail: `observed worst ${observedMs}ms is not below the ${budgetMs}ms budget it justifies, so the entry disproves itself; a worst case at or above its own budget is usually elapsed time from a run the budget terminated, which measures contention rather than cost (#2528)`,
       },
     ];
   }
@@ -393,6 +474,8 @@ export function headroomProblems(headroom) {
       problems.push({ rule: "headroom-evidence-missing", detail });
     }
   }
+  if (problems.length > 0) return problems;
+  problems.push(...provenanceProblems(headroom.observed_on));
   if (problems.length > 0) return problems;
   problems.push(
     ...ratioProblems(headroom.budget_ms, headroom.observed_worst_ms)

--- a/scripts/check-required-check-promotions.mjs
+++ b/scripts/check-required-check-promotions.mjs
@@ -95,6 +95,16 @@
  *     Re-measured in isolation at load 31 the same test takes 2,499ms — 24x,
  *     not 0.996x, a 24-fold error in the unsafe direction.
  *
+ *     The class is not specific to test timeouts. #2520 chased an actionlint
+ *     invocation reported as taking "25 minutes". It was not slow: a
+ *     3,490-line workflow returns in 0s while a 217-line one hangs, and the
+ *     minimal repro is 28 lines. It is a spin inside actionlint's shellcheck
+ *     integration — ~850% CPU across 37 threads, zero children — so it never
+ *     terminates. The 25 minutes was the observer's patience, not the
+ *     command's cost, and NO budget would have been generous enough. That is
+ *     what `observed_on` refuses: a number produced by a run that did not
+ *     finish is not a measurement of how long the work takes.
+ *
  *     A missing `observed_on` is refused rather than grandfathered. Every
  *     `proven` entry in the ledger when this clause shipped had already
  *     recorded, in prose, that its worst case came from runs that completed, so

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1143,7 +1143,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-parity-coderabbit/SKILL.md":
       "ae882837d43741293d1b639c4516331fa6124fa1f5da234a74ecb31c5d7e52cd",
     "plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md":
-      "f240857de2f14938009ddd212c56601269fd9e1aec33a766cd09da5bea5656e0",
+      "4b00da1ced810e8604572a0ae36bbd3188835fce22413fc73a214741973f9255",
     "plugins/src/base/skills/lisa-parity-sentry-sdk-setup/SKILL.md":
       "edb513a9d29b3faeccce71d92596e12bc1f35e44fe3af1349bd7bd473fee98af",
     "plugins/src/base/skills/lisa-parity-sentry-seer/SKILL.md":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2075,7 +2075,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/check-plugins-sync.sh":
       "3a99cbff0e8ec5e7c944690eae003a6d51b51c85436d77bd37faea4d553728af",
     "scripts/check-required-check-promotions.mjs":
-      "2693787413a276f7493c0fac1407a2e61630b2978d20acebb0ee5463c4678660",
+      "0287f913efaa6edc600c98e3efce183abf4c93a4f170f44920b51f36cb72e6df",
     "scripts/check-rules-pairing.sh":
       "4d4a0d9e8d36794a22020f419c879d7336b1c5bfe883acdcc826d26764560c7a",
     "scripts/check-security-floors.mjs":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2075,7 +2075,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/check-plugins-sync.sh":
       "3a99cbff0e8ec5e7c944690eae003a6d51b51c85436d77bd37faea4d553728af",
     "scripts/check-required-check-promotions.mjs":
-      "0287f913efaa6edc600c98e3efce183abf4c93a4f170f44920b51f36cb72e6df",
+      "f644f0feb246f36a79efaa6b820409605c637813e158aea425982b863bb6ed7c",
     "scripts/check-rules-pairing.sh":
       "4d4a0d9e8d36794a22020f419c879d7336b1c5bfe883acdcc826d26764560c7a",
     "scripts/check-security-floors.mjs":

--- a/tests/unit/scripts/required-check-promotions-helpers.ts
+++ b/tests/unit/scripts/required-check-promotions-helpers.ts
@@ -42,6 +42,7 @@ export function provenHeadroom(): Record<string, unknown> {
     status: "proven",
     budget_ms: 600_000,
     observed_worst_ms: 180,
+    observed_on: "pass",
     reproduced:
       "planted a violating fixture and confirmed the check exits 1, then removed it and confirmed exit 0",
     measured_on: "bun run sg:scan at origin/main b671524a7",

--- a/tests/unit/scripts/required-check-promotions.repo.test.ts
+++ b/tests/unit/scripts/required-check-promotions.repo.test.ts
@@ -32,7 +32,14 @@ const ledger = (): {
   grandfathered_contexts: string[];
   promotions: {
     context: string;
-    headroom: { status: string; debt?: string };
+    headroom: {
+      status: string;
+      debt?: string;
+      observed_on?: string;
+      budget_ms?: number;
+      observed_worst_ms?: number;
+      budgets?: { observed_on?: string }[];
+    };
   }[];
 } =>
   JSON.parse(readFileSync(path.join(REPO_ROOT, LEDGER_RELATIVE_PATH), "utf8"));
@@ -70,6 +77,39 @@ describe("Lisa's own required-check promotions", () => {
       .promotions.filter(p => p.headroom.status === "grandfathered")
       .map(p => p.context);
     expect(grandfathered.filter(c => !frozen.has(c))).toEqual([]);
+  });
+
+  it("states the provenance of every proven measurement, with none grandfathered out of it", () => {
+    // #2528 refuses a missing `observed_on` outright rather than exempting the
+    // entries that predate it. That is affordable precisely here: every proven
+    // entry in this ledger already recorded, in prose, that its worst case came
+    // from runs that COMPLETED, so backfilling states what was already proved.
+    // A grandfather clause would have exempted the only entries the new rule
+    // could bind on, which is the "prose is enough" failure #2509 exists to
+    // refute.
+    const proven = ledger().promotions.filter(
+      p => p.headroom.status === "proven"
+    );
+    expect(proven.length).toBeGreaterThan(0);
+    expect(proven.map(p => p.headroom.observed_on)).toEqual(
+      proven.map(() => "pass")
+    );
+    for (const entry of proven) {
+      for (const budget of entry.headroom.budgets ?? []) {
+        expect(budget.observed_on).toBe("pass");
+      }
+    }
+  });
+
+  it("publishes no worst case at or above the budget it justifies", () => {
+    // The self-refuting pairing #2523 shipped: 60,245ms cited against a
+    // 60,000ms budget. Checked here on the live ledger, not only on fixtures.
+    for (const entry of ledger().promotions) {
+      if (entry.headroom.status !== "proven") continue;
+      expect(entry.headroom.observed_worst_ms).toBeLessThan(
+        entry.headroom.budget_ms ?? 0
+      );
+    }
   });
 
   it("is wired to a package script so an operator can run it by hand", () => {

--- a/tests/unit/scripts/required-check-promotions.test.ts
+++ b/tests/unit/scripts/required-check-promotions.test.ts
@@ -30,6 +30,23 @@ import {
   provenHeadroom,
 } from "./required-check-promotions-helpers.js";
 
+/** Rule name for an evidence field that is missing or unreadable. */
+const EVIDENCE_MISSING = "headroom-evidence-missing";
+
+/** Rule name for an entry whose worst case is not below its own budget. */
+const EXCEEDS_BUDGET = "headroom-worst-case-exceeds-budget";
+
+/** Rule name for a worst case taken from a run the budget terminated. */
+const MEASURED_ON_FAILING_RUN = "headroom-measured-on-failing-run";
+
+/** Refusal text for a `proven` entry that never states its provenance. */
+const PROVENANCE_MISSING_DETAIL =
+  'headroom.observed_on must be "pass": the run that produced observed_worst_ms must have COMPLETED within its budget, because a duration reported alongside a timeout measures contention, not cost';
+
+/** Refusal text for a worst case taken from a run the budget terminated. */
+const MEASURED_ON_FAILING_RUN_DETAIL =
+  'observed_worst_ms was taken from a run the budget terminated ("observed_on": "fail"); that duration is the starvation, not the work, and the more contended the box was the safer the budget looks — re-measure on a run that completed, in isolation';
+
 describe("constants", () => {
   it("uses GitHub Actions' integration id", () => {
     expect(ACTIONS_INTEGRATION_ID).toBe(15_368);
@@ -111,7 +128,7 @@ describe("headroomProblems", () => {
     const headroom = { ...provenHeadroom(), reproduced: "" };
     expect(headroomProblems(headroom)).toEqual([
       {
-        rule: "headroom-evidence-missing",
+        rule: EVIDENCE_MISSING,
         detail:
           "headroom.reproduced must describe the run that reproduced the failure the budget prevents",
       },
@@ -126,7 +143,7 @@ describe("headroomProblems", () => {
     const { conditions: _drop, ...headroom } = provenHeadroom();
     expect(headroomProblems(headroom)).toEqual([
       {
-        rule: "headroom-evidence-missing",
+        rule: EVIDENCE_MISSING,
         detail:
           "headroom.conditions must state the machine state the measurement was taken under",
       },
@@ -150,6 +167,154 @@ describe("headroomProblems", () => {
           "observed worst 9200ms against a 10000ms budget is 1.09x; 2x is the floor",
       },
     ]);
+  });
+
+  it("refuses a worst case at or above the budget as an impossible claim, not a thin margin", () => {
+    // #2523 cited 60,245ms as its observed worst case while setting the budget
+    // to 60,000ms. The ratio rule already rejects that arithmetically at
+    // 0.996x — but it reports a THIN MARGIN when the defect is an IMPOSSIBLE
+    // CLAIM, and a message that misnames the defect sends the reader off to
+    // re-measure when they should be re-reading. One comparison catches it
+    // without knowing anything about the test.
+    const headroom = {
+      ...provenHeadroom(),
+      budget_ms: 60_000,
+      observed_worst_ms: 60_245,
+    };
+    expect(headroomProblems(headroom)).toEqual([
+      {
+        rule: EXCEEDS_BUDGET,
+        detail:
+          "observed worst 60245ms is not below the 60000ms budget it justifies, so the entry disproves itself; a worst case at or above its own budget is usually elapsed time from a run the budget terminated, which measures contention rather than cost (#2528)",
+      },
+    ]);
+  });
+
+  it("refuses a worst case exactly equal to the budget", () => {
+    // Equality is the boundary: a budget that exactly accommodates its own
+    // worst case accommodates nothing, and 1.00x reads as a rounding argument
+    // rather than as the contradiction it is.
+    const headroom = {
+      ...provenHeadroom(),
+      budget_ms: 60_000,
+      observed_worst_ms: 60_000,
+    };
+    expect(headroomProblems(headroom)).toEqual([
+      {
+        rule: EXCEEDS_BUDGET,
+        detail:
+          "observed worst 60000ms is not below the 60000ms budget it justifies, so the entry disproves itself; a worst case at or above its own budget is usually elapsed time from a run the budget terminated, which measures contention rather than cost (#2528)",
+      },
+    ]);
+  });
+
+  it("refuses an impossible claim inside a budgets[] entry as well", () => {
+    const headroom = {
+      ...provenHeadroom(),
+      budgets: [
+        {
+          subject: PROBE_SUBJECT,
+          budget_ms: 60_000,
+          observed_worst_ms: 60_245,
+          observed_on: "pass",
+          measured_on_subject: PROBE_SUBJECT,
+        },
+      ],
+    };
+    expect(headroomProblems(headroom)).toEqual([
+      {
+        rule: EXCEEDS_BUDGET,
+        detail:
+          "observed worst 60245ms is not below the 60000ms budget it justifies, so the entry disproves itself; a worst case at or above its own budget is usually elapsed time from a run the budget terminated, which measures contention rather than cost (#2528)",
+      },
+    ]);
+  });
+
+  it("refuses a worst case taken from a run the budget terminated", () => {
+    // The mirror of the rule #2509 already enforces. #2509: do not size from
+    // runs that PASSED, because the sample excludes the failure mode. Here: do
+    // not size from the DURATION of a run that failed ON TIME, because that
+    // duration is the starvation, not the work. #2523's 60,245ms was wall clock
+    // spent waiting; the same test measured in isolation at load 31 takes
+    // 2,499ms — a 24-fold difference, in the unsafe direction.
+    const headroom = { ...provenHeadroom(), observed_on: "fail" };
+    expect(headroomProblems(headroom)).toEqual([
+      {
+        rule: MEASURED_ON_FAILING_RUN,
+        detail: MEASURED_ON_FAILING_RUN_DETAIL,
+      },
+    ]);
+  });
+
+  it("refuses a proven claim that never says whether the measured run completed", () => {
+    const { observed_on: _drop, ...headroom } = provenHeadroom();
+    expect(headroomProblems(headroom)).toEqual([
+      {
+        rule: EVIDENCE_MISSING,
+        detail: PROVENANCE_MISSING_DETAIL,
+      },
+    ]);
+  });
+
+  it("refuses an unrecognised observed_on rather than reading it as pass", () => {
+    const headroom = { ...provenHeadroom(), observed_on: "probably fine" };
+    expect(headroomProblems(headroom)).toEqual([
+      {
+        rule: EVIDENCE_MISSING,
+        detail: PROVENANCE_MISSING_DETAIL,
+      },
+    ]);
+  });
+
+  it("requires provenance on a budgets[] entry too, which carries its own duration", () => {
+    // A budgets[] entry publishes its own observed_worst_ms, so it can be a
+    // starved figure exactly as the top-level one can.
+    const headroom = {
+      ...provenHeadroom(),
+      budgets: [
+        {
+          subject: PROBE_SUBJECT,
+          budget_ms: 60_000,
+          observed_worst_ms: 23_600,
+          measured_on_subject: PROBE_SUBJECT,
+        },
+      ],
+    };
+    expect(headroomProblems(headroom)).toEqual([
+      {
+        rule: EVIDENCE_MISSING,
+        detail: PROVENANCE_MISSING_DETAIL,
+      },
+    ]);
+  });
+
+  it("reports provenance before the ratio, because a starved figure has no ratio", () => {
+    // Both defects at once: a duration from a terminated run AND a thin margin
+    // computed from it. The margin is not a fact about the budget — it is
+    // arithmetic on a number that measures the wrong thing, so the provenance
+    // is what the reader needs first.
+    const headroom = {
+      ...provenHeadroom(),
+      observed_on: "fail",
+      budget_ms: 10_000,
+      observed_worst_ms: 9_200,
+    };
+    expect(headroomProblems(headroom)).toEqual([
+      {
+        rule: MEASURED_ON_FAILING_RUN,
+        detail: MEASURED_ON_FAILING_RUN_DETAIL,
+      },
+    ]);
+  });
+
+  it("leaves a grandfathered block unprovenanced, since it proves nothing to begin with", () => {
+    // Grandfathered entries are exempt from the evidence rules by design: their
+    // obligation is to NAME what is unproven, not to prove it. Requiring
+    // provenance of a measurement they never claim to have made would only
+    // invite a fabricated field.
+    expect(
+      headroomProblems({ status: "grandfathered", debt: "never measured" })
+    ).toEqual([]);
   });
 
   it("flags a budget sized from a different subject as sized-by-analogy", () => {
@@ -184,6 +349,7 @@ describe("headroomProblems", () => {
           subject: PROBE_SUBJECT,
           budget_ms: 60_000,
           observed_worst_ms: 23_600,
+          observed_on: "pass",
           measured_on_subject: PROBE_SUBJECT,
         },
       ],


### PR DESCRIPTION
## What this changes

`scripts/check-required-check-promotions.mjs` (#2509) validated that a `proven` headroom entry publishes a budget, an observed worst case, machine conditions, and a reproduction, and that the ratio clears 2x. It never checked **where the observed worst case came from**. Two clauses close that.

### 1. A self-refuting entry is refused as an impossible claim, not a thin margin

`observed_worst_ms >= budget_ms` now has its own rule, `headroom-worst-case-exceeds-budget`, with its own message. The ratio rule already rejected #2523's pairing arithmetically at 0.996x — but it reported a *thin margin* when the defect was an *impossible claim*, and a message that misnames the defect sends the reader off to re-measure when they should be re-reading. One comparison, and it catches the error knowing nothing about the test. Equality is included: a budget that exactly accommodates its own worst case accommodates nothing.

### 2. A measurement must declare its provenance

A `proven` entry must now carry `observed_on: "pass"` — the run that produced the worst case **completed** within its budget rather than being terminated by it. `"fail"` gets its own rule and message; anything else, including absence, is an evidence gap.

This is the mirror of the rule #2509 already enforces:

> #2509 says **don't size from runs that passed**, because the sample excludes the failure mode. The mirror is **don't size from the DURATION of a run that failed on time**, because that duration is the starvation, not the work.

The failing-run version is strictly worse. It does not merely omit information — it **inverts the ratio**, and the more contended the box was, the safer the resulting budget looks. #2523 cited 60,245 ms against a 60,000 ms budget; the same test re-measured in isolation at load 31 takes 2,499 ms. 24x, not 0.996x — a 24-fold error in the unsafe direction.

`observed_on` is a claim about **time, not verdict**: a run that reproduces a real violation and exits 1 well inside its budget completed, and is `"pass"` here. Both clauses also apply to `budgets[]` entries, which publish their own `observed_worst_ms` and can therefore carry a starved figure exactly as the block-level one can.

The general rule is stated in the guard's **module preamble**, where it is read at the moment it binds.

## Grandfathering decision: absent means refuse, immediately

**A missing `observed_on` is refused outright — no grandfather clause.** Justification:

- The ledger had exactly **one** `proven` entry (`🔍 Quality Checks / 🔎 AST Grep Scan`). Every other entry is `grandfathered`, and grandfathered blocks are exempt from the evidence rules by design — their obligation is to *name* what is unproven, not to prove it. Requiring provenance of a measurement they never claim to have made would only invite a fabricated field.
- That one entry had **already recorded, in prose**, that its worst case came from runs that completed: all 23 runs finished, 21–40 s against a 600 s budget, and the 5 that went red on real ast-grep violations completed in 22–30 s rather than timing out. Backfilling `observed_on` restates what was already proved — it costs one line and asserts nothing new.
- Grandfathering absence would have exempted **the only entry the clause could bind on**. That is the "prose is enough" failure #2509 exists to refute.

The debt is named rather than silently exempted, as the ledger does elsewhere: the `conditions` field now states explicitly that all 23 runs completed and none was terminated by the budget, so the field is *backed* rather than asserted, and the ledger header records the decision and its reasoning.

## Mutation proof

Baseline, full suite, nothing scoped by filename: **649 files / 11,542 tests, 0 failures, exit 0.**

| probe | planted in the live ledger | full-suite result | rule that fired |
|---|---|---|---|
| A | `budget_ms: 60000`, `observed_worst_ms: 60245` (#2523's exact pairing) | **3 failed / 11,539 passed** | `headroom-worst-case-exceeds-budget` — and `headroom-ratio-too-thin` did **not** fire (0 occurrences in the JSON report) |
| B | `observed_on: "fail"` | **2 failed / 11,537 passed** (+3 unrelated contention flakes, below) | `headroom-measured-on-failing-run` |
| C | `observed_on` deleted entirely (the pre-#2528 ledger) | guard CLI exit 1 | `headroom-evidence-missing` |
| — | clean ledger | **0 failed**, guard CLI exit 0 | none |

Failing test names:

- Probe A: `required-check-promotions.repo > has no violations`; `required-check-promotions.repo > publishes no worst case at or above the budget it justifies`; `ast-grep-enforcement > records the promotion as PROVEN, not grandfathered` (collateral — the probe overwrote the budget values that test pins).
- Probe B: `required-check-promotions.repo > has no violations`; `required-check-promotions.repo > states the provenance of every proven measurement, with none grandfathered out of it`.

Unit-level RED before implementation: **9 failed / 21 passed**, each new rule pinned by name, message, and precedence.

### An accidental corroboration

Probe B's run also reddened three suites the ledger *already names as marginal debt* — `bdd-reporting > handles a very large contract without quadratic blowup`, `check-learnings-budget`, and `learnings-merge-driver` (timed out at 60,000 ms). The first is the very test #2523 sized its budget from, and it failed reading **66,839 ms** against an in-test 30 s assertion. That number is not the test's cost; the same test costs 2,499 ms. It is a live specimen of exactly the reading this PR refuses. These are unrelated to the probe, which only edits ledger data.

The preamble also cites a **non-test** instance, so the clause does not read as a testing concern: #2520's actionlint invocation "taking 25 minutes" was not slow at all — a 3,490-line workflow returns in 0 s while a 217-line one hangs, and the cause is a spin in actionlint's shellcheck integration (~850% CPU, 37 threads, zero children). It never terminates, so no budget would ever have been generous enough. The 25 minutes was the observer's patience.

## Out-of-scope commit included, and why

`chore(parity): bump the safety-net pin to 2.0.4` is unrelated to this ticket. The pre-push third-party parity gate blocked **every push from this machine** until the pin moved, and the gate's own instruction is to fix it in the same push. It is kept as its own commit so it stays reviewable rather than smuggled in.

The upstream delta was verified by hashing the sorted (relative path, content) manifest of each rule-bearing directory under both versions: `src/` (230 files, digest `7e346e205fbd1aa7` on **both** sides), `skills/`, and `hooks/` are byte-identical. The only non-generated differences are three `version` strings and an EPIPE-tolerance fix in upstream's own test harness. No rule or guard family moved, and the known gap recorded at the 2.0.3 pin (`secret.*`, `rm.git-metadata`) is **not** closed by 2.0.4 and is restated at the new pin rather than dropped.

The same bump landed independently on #2541. Two independent reviews reached the same conclusion. Once #2541 merges this commit should drop as patch-equivalent on rebase.

## Verification

- `bun run test` — 649 files / 11,542 tests, **0 failures**
- `bun run typecheck` — clean
- `node scripts/check-required-check-promotions.mjs` — exit 0, 18 recorded, 0 violations, 17 debts
- `node scripts/generate-upstream-evidence-manifest.mjs --check` — clean, regenerated after `git add` and re-verified post-`lint-staged`
- `bash scripts/check-plugins-sync.sh` — exit 0
- `node scripts/plugin-parity-drift.mjs` — 0 of 5 drifted

Work-Item: CodySwannGT/lisa#2528

🤖 Generated with Claude Code
