### PR TITLE
fix(parity): catch both routing artifacts up to their skill pins

### DIFF
--- a/parity/FOLLOWUPS.md
+++ b/parity/FOLLOWUPS.md
@@ -76,9 +76,9 @@ maps to an upstream plugin publishing semver still carries its `synced-from` pin
 | ----------------------------------- | --------------------------------------------- |
 | `parity-code-simplifier`            | `code-simplifier@claude-plugins-official@1.0.0`     |
 | `parity-coderabbit`                 | `coderabbit@claude-plugins-official@1.1.1`          |
-| `parity-safety-net-rules`           | `safety-net@cc-marketplace@2.0.1`                   |
-| `parity-sentry-seer`                | `sentry@claude-plugins-official@1.3.1`              |
-| `parity-sentry-sdk-setup`           | `sentry@claude-plugins-official@1.3.1`              |
+| `parity-safety-net-rules`           | `safety-net@cc-marketplace@2.0.4`                   |
+| `parity-sentry-seer`                | `sentry@claude-plugins-official@1.3.2`              |
+| `parity-sentry-sdk-setup`           | `sentry@claude-plugins-official@1.3.2`              |
 | `parity-code-review`                | **no pin** — upstream has no semver → not drift-trackable (track manually) |
 | `parity-skill-creator`              | **no pin** — upstream has no semver → not drift-trackable (track manually) |
 

--- a/parity/plugin-routing/safety-net@cc-marketplace.json
+++ b/parity/plugin-routing/safety-net@cc-marketplace.json
@@ -3,8 +3,8 @@
   "plugin": "safety-net@cc-marketplace",
   "pluginName": "safety-net",
   "marketplace": "cc-marketplace",
-  "upstreamVersion": "2.0.1",
-  "analyzedAt": "2026-08-11",
+  "upstreamVersion": "2.0.4",
+  "analyzedAt": "2026-08-14",
   "status": "approved",
   "components": [
     {
@@ -26,8 +26,8 @@
     "codex": {
       "outcome": "reimplement",
       "actions": [
-        "keep the Lisa-native PreToolUse hook (plugins/src/base/hooks/parity-safety-net.sh, fanned out via the per-agent hook generators from #1054–1058) as the canonical Bash guard, stamped synced-from: safety-net@cc-marketplace@2.0.1",
-        "keep the consolidated lisa-parity-safety-net-rules skill as the Lisa-native equivalent of the upstream cc-safety-net rule-management skill, stamped synced-from: safety-net@cc-marketplace@2.0.1"
+        "keep the Lisa-native PreToolUse hook (plugins/src/base/hooks/parity-safety-net.sh, fanned out via the per-agent hook generators from #1054–1058) as the canonical Bash guard, stamped synced-from: safety-net@cc-marketplace@2.0.4",
+        "keep the consolidated lisa-parity-safety-net-rules skill as the Lisa-native equivalent of the upstream cc-safety-net rule-management skill, stamped synced-from: safety-net@cc-marketplace@2.0.4"
       ],
       "rationale": "A hook-bearing plugin has no MCP/LSP re-point. Upstream 2.0 does now publish a native Codex integration (`cc-safety-net install --codex`), which would ordinarily outrank reimplement in the preference order — but it is an npx/Node installer that writes per-agent config outside Lisa's distribution model, and #1960 already made the Lisa hook canonical on every agent precisely so one audited guard set ships identically everywhere without an npx dependency. Keeping reimplement preserves that decision; the vendor-integration option is flagged for owner review in the addendum rather than taken unilaterally."
     },
@@ -39,8 +39,8 @@
     "agy": {
       "outcome": "reimplement",
       "actions": [
-        "keep the Lisa-native PreToolUse hook (plugins/src/base/hooks/parity-safety-net.sh, fanned out via the per-agent hook generators from #1054–1058) as the canonical Bash guard, stamped synced-from: safety-net@cc-marketplace@2.0.1",
-        "keep the consolidated lisa-parity-safety-net-rules skill as the Lisa-native equivalent of the upstream cc-safety-net rule-management skill, stamped synced-from: safety-net@cc-marketplace@2.0.1"
+        "keep the Lisa-native PreToolUse hook (plugins/src/base/hooks/parity-safety-net.sh, fanned out via the per-agent hook generators from #1054–1058) as the canonical Bash guard, stamped synced-from: safety-net@cc-marketplace@2.0.4",
+        "keep the consolidated lisa-parity-safety-net-rules skill as the Lisa-native equivalent of the upstream cc-safety-net rule-management skill, stamped synced-from: safety-net@cc-marketplace@2.0.4"
       ],
       "rationale": "Curated third-party plugins are not in agy's fan-out, so agy receives nothing natively. Upstream 2.0 ships an Antigravity CLI installer, but the same npx-dependency and dual-engine objections as Codex apply; the Lisa hook stays canonical and the vendor option is flagged for owner review."
     },

--- a/parity/plugin-routing/safety-net@cc-marketplace.md
+++ b/parity/plugin-routing/safety-net@cc-marketplace.md
@@ -1,7 +1,7 @@
 # Parity routing review — `safety-net@cc-marketplace`
 
 - **Plugin:** `safety-net@cc-marketplace`
-- **Upstream version:** `2.0.1`
+- **Upstream version:** `2.0.4`
 - **Analyzed:** 2026-08-11 (re-review; previously 2026-07-22 at 1.0.6, originally 2026-05-30 at 0.9.0)
 - **Status:** `approved`
 
@@ -120,3 +120,41 @@ Deciding whether to suppress the Lisa hook/skill for Copilot specifically (so
 the vendor runner is the sole guard there) is the same owner-level call as the
 Codex/agy vendor-integration question above, and is left open pending that
 decision.
+
+## Addendum — 2026-08-14, catching this artifact up to the 2.0.4 pin
+
+The `synced-from` pin itself moved to `2.0.4` separately, in `a0ad92f7d`, on the
+strength of a surface comparison recorded in that commit message: a digest of the
+sorted (path, content) manifest of every rule-bearing directory in the plugin
+cache came out identical across 2.0.3 and 2.0.4 — `src/` 230 files at digest
+`7e346e205fbd1aa7` on both, `skills/` and `hooks/` byte-identical — leaving only
+`version` strings, per-integration manifests, rebuilt `dist/` output, and one
+statusline test-harness fix. **Nothing was absorbed, and nothing needs to be.**
+Combined with the 2.0.3 review (Kimi Code + Amp installer support, no
+rule-contract change), the whole 2.0.1 → 2.0.4 range leaves Lisa's
+reimplementation untouched.
+
+This addendum only brings **this artifact** up to that pin. It had been left at
+`2.0.1`.
+
+**The two guard-family gaps are unchanged** and still deferred: `secret.*` and
+`rm.git-metadata`, tracked in `parity/FOLLOWUPS.md` §5.
+
+### Process note — the artifact keeps lagging the skill pin
+
+This is the third consecutive safety-net refresh to move the `synced-from` stamp
+and leave the routing artifact behind. When this correction was written the skill
+read `2.0.4` while this artifact still read `2.0.1`, and the sentry artifact read
+`1.3.1` against a `1.3.2` skill pin.
+
+**The push gate structurally cannot catch it.** `.husky/pre-push.local` runs
+`plugin-parity-drift.mjs`, which reads only skill frontmatter. So
+`plugin-routing-validate.mjs` can sit red indefinitely while every push stays
+green, and the thing that finally trips over it is the next
+`implement-plugin-parity` run, for which the validator is the pre-flight gate.
+The lag is not an attention failure — nothing in the loop reports it.
+
+Both artifacts are corrected here. Wiring the validator into the push gate or CI
+is what would actually close the loop; it is recorded as a follow-up rather than
+done inline, because the validator was red on arrival and enabling it as a gate
+would newly block every push — a gate-policy change that deserves its own review.

--- a/parity/plugin-routing/sentry@claude-plugins-official.json
+++ b/parity/plugin-routing/sentry@claude-plugins-official.json
@@ -3,7 +3,7 @@
   "plugin": "sentry@claude-plugins-official",
   "pluginName": "sentry",
   "marketplace": "claude-plugins-official",
-  "upstreamVersion": "1.3.1",
+  "upstreamVersion": "1.3.2",
   "analyzedAt": "2026-07-22",
   "status": "approved",
   "components": [
@@ -12,7 +12,7 @@
       "id": "sentry",
       "path": ".claude-plugin/plugin.json",
       "classification": "mcp-server",
-      "notes": "HTTP MCP server (https://mcp.sentry.dev/mcp?utm_source=plugin). As of 1.2.0 declared inline in plugin.json mcpServers only \u2014 one logical MCP component."
+      "notes": "HTTP MCP server (https://mcp.sentry.dev/mcp?utm_source=plugin). As of 1.2.0 declared inline in plugin.json mcpServers only — one logical MCP component."
     },
     {
       "kind": "skill",
@@ -90,8 +90,8 @@
       "outcome": "re-point-mcp-lsp",
       "actions": [
         "emit the sentry HTTP MCP into Codex's .codex-plugin MCP pointer",
-        "reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.3.1 (or claude-only where a skill is Claude-specific)",
-        "reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.3.1"
+        "reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.3.2 (or claude-only where a skill is Claude-specific)",
+        "reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.3.2"
       ],
       "rationale": "The dominant component is the sentry HTTP MCP, re-pointed into Codex's .codex-plugin pointer; the consolidated workflow skills (incl. the folded-in seer/debug workflow) are reimplemented as Lisa skills so no component group is dropped."
     },
@@ -107,8 +107,8 @@
       "outcome": "re-point-mcp-lsp",
       "actions": [
         "emit the sentry HTTP MCP via agy's user-global mcp-installer (src/agy/mcp-installer.ts)",
-        "reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.3.1 (or claude-only where Claude-specific)",
-        "reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.3.1"
+        "reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.3.2 (or claude-only where Claude-specific)",
+        "reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.3.2"
       ],
       "rationale": "The dominant component is the sentry HTTP MCP, re-pointed via agy's mcp-installer; the consolidated workflow skills (incl. the folded-in seer/debug workflow) are reimplemented as Lisa skills (agy's fan-out does not carry curated third-party plugins)."
     },
@@ -116,8 +116,8 @@
       "outcome": "re-point-mcp-lsp",
       "actions": [
         "emit the sentry HTTP MCP as an inline mcpServers entry on Copilot's manifest",
-        "reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.3.1 (or enable Copilot's native equivalent where applicable)",
-        "reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.3.1"
+        "reimplement the 10 consolidated workflow skills as Lisa-native skills (Lisa consolidates further into lisa-parity-sentry-sdk-setup) stamped synced-from: sentry@claude-plugins-official@1.3.2 (or enable Copilot's native equivalent where applicable)",
+        "reimplement the sentry-debug-issue AI-debugging workflow (formerly the seer command) as a Lisa-native skill (lisa-parity-sentry-seer) stamped synced-from: sentry@claude-plugins-official@1.3.2"
       ],
       "rationale": "The dominant component is the sentry HTTP MCP, emitted inline on Copilot's manifest; the consolidated workflow skills (incl. the folded-in seer/debug workflow) are reimplemented as Lisa skills so no component group is dropped."
     }


### PR DESCRIPTION
Closes #2544

Work-Item: CodySwannGT/lisa#2544

## Scope changed mid-flight — read this first

This PR originally also bumped the `synced-from` pin `2.0.3 → 2.0.4`. **That half landed independently in `a0ad92f7d` while this was in review**, so it has been dropped and the branch rebased. What remains is only the part that is still missing from `main`: the two routing artifacts, which were left behind.

## What's still broken on main

| artifact | artifact says | skill pinned | cache |
| --- | --- | --- | --- |
| `safety-net@cc-marketplace.json` | **2.0.1** | 2.0.4 | 2.0.4 |
| `sentry@claude-plugins-official.json` | **1.3.1** | 1.3.2 | 1.3.2 |

`node scripts/plugin-routing-validate.mjs` on current `main` → **5/7 valid, 2 invalid**. With this PR → **7/7**.

## Why this keeps happening

This is the **third consecutive** safety-net refresh to move the `synced-from` stamp and leave the routing artifact behind. I fixed the identical lag on the sentry artifact in #2402; it recurred on both artifacts within days.

It is not an attention failure by any author — **nothing in the loop reports it**. `.husky/pre-push.local` runs `plugin-parity-drift.mjs`, which reads only skill frontmatter. So `plugin-routing-validate.mjs` can sit red indefinitely while every push stays green, and the thing that finally trips over it is the next `implement-plugin-parity` run, for which the validator is the pre-flight gate. `a0ad92f7d` is a clean demonstration: a careful, well-evidenced pin bump that the gate confirmed as green while leaving the validator red.

## On the 2.0.4 upstream review

Not re-litigated here — `a0ad92f7d` did it more rigorously than my original attempt, digesting the sorted (path, content) manifest of every rule-bearing directory (`src/` 230 files at digest `7e346e205fbd1aa7` on both 2.0.3 and 2.0.4; `skills/` and `hooks/` byte-identical). Its conclusion stands: nothing to absorb. The matrix addendum now cites that commit as the evidence rather than restating a weaker version of it.

The two deferred guard-family gaps (`secret.*`, `rm.git-metadata`) are unchanged and still tracked in `parity/FOLLOWUPS.md` §5.

## Also corrected

The pin table in `parity/FOLLOWUPS.md` (`safety-net` 2.0.1 → 2.0.4, both sentry rows 1.3.1 → 1.3.2).

Sentry's `1.3.1 → 1.3.2` delta is doc content inside existing skills (`ai-monitoring.md`, `tracing.md`), not a component change, so its component list stands and only the version and stamps move.

No skill, hook, or generated plugin artifact changes — the fan-out and the upstream evidence manifest are untouched.

## Verification

```
node scripts/plugin-routing-validate.mjs  → 7/7 valid, 0 invalid   (main: 5/7)
node scripts/plugin-parity-drift.mjs      → 0 of 5 drifted, exit 0
pre-push                                  → passed; "✅ Plugin parity pins are current"
```

## Recommended follow-up (deliberately not here)

Wire `plugin-routing-validate.mjs` into the push gate or CI so the artifact half cannot rot unnoticed a fourth time. Not done inline: the validator is red on `main` right now, so enabling it as a gate would newly block every push until this merges — a gate-policy change that deserves its own review rather than riding along on an unblock.

🤖 Generated with Claude Code
