### PR TITLE
fix(ci): make work-item traceability fail when it cannot verify, and repair block-less callers

### DIFF
--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -235,23 +235,35 @@ jobs:
             exit 0
           fi
           tracker="$(node -p 'require("./.lisa.config.json").tracker' 2>/dev/null | tr '[:upper:]' '[:lower:]')"
+          # Token-scope readiness — see the quality.yml counterpart. Checked
+          # first because every arm of this gate goes through the GitHub API,
+          # and it FAILS rather than exits 0: a check that cannot verify must
+          # not report success (#2476, #2497). The repair is always in the
+          # CALLER's ci.yml, which is the only place the grant can come from.
+          scope_gap() {
+            echo "::error::Work-Item Traceability could verify NOTHING: the calling workflow does not grant '$1'. Add contents/issues/pull-requests read to the quality job's permissions in this repo's .github/workflows/ci.yml, or run 'lisa apply' to have Lisa add the block for you."
+            exit 1
+          }
+          pr_probe="repos/${GITHUB_REPOSITORY}/pulls?per_page=1"
+          if [ -n "${LISA_PR_NUMBER:-}" ]; then
+            pr_probe="repos/${GITHUB_REPOSITORY}/pulls/${LISA_PR_NUMBER}"
+          fi
+          if ! gh api "$pr_probe" >/dev/null 2>&1; then
+            scope_gap "pull-requests: read"
+          fi
+          if [ "$tracker" = "github" ] && \
+             ! gh api "repos/${GITHUB_REPOSITORY}/issues?per_page=1" >/dev/null 2>&1; then
+            scope_gap "issues: read"
+          fi
+          # Tracker-credential readiness stays warn-and-skip: mapping a secret
+          # is a different axis from granting a token scope, and #2476 scoped
+          # only the scope gap. A KNOWN remaining fail-open.
           if [ "$tracker" = "jira" ] && { [ -z "${JIRA_API_TOKEN:-}" ] || [ -z "${JIRA_LOGIN:-}" ]; }; then
             echo "::warning::tracker is jira but JIRA_API_TOKEN/JIRA_LOGIN are not mapped to this workflow — work-item traceability cannot verify the tracker backlink and is NOT enforced. Map both secrets in the caller's ci.yml to enable it."
             exit 0
           fi
           if [ "$tracker" = "linear" ] && [ -z "${LINEAR_API_KEY:-}" ]; then
             echo "::warning::tracker is linear but LINEAR_API_KEY is not mapped to this workflow — work-item traceability cannot verify the tracker backlink and is NOT enforced. Map the secret in the caller's ci.yml to enable it."
-            exit 0
-          fi
-          # Token-scope readiness (github tracker): the inherited caller token
-          # may lack issues:read, in which case the validator cannot read the
-          # tracker issue at all. That is a caller-configuration gap, not a
-          # traceability failure, so name it and skip rather than blocking a PR
-          # nobody can unblock. Repos whose ci.yml grants issues:read enforce
-          # for real.
-          if [ "$tracker" = "github" ] && \
-             ! gh api "repos/${GITHUB_REPOSITORY}/issues?per_page=1" >/dev/null 2>&1; then
-            echo "::warning::The caller workflow does not grant issues:read, so the tracker issue cannot be read and work-item traceability is NOT enforced. Add 'issues: read' to the quality job's permissions in this repo's .github/workflows/ci.yml to enable it."
             exit 0
           fi
           node scripts/lisa-work-item.mjs validate-pr

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1950,11 +1950,18 @@ jobs:
     # (`gh pr view`) and issues:read (`gh issue view`), but a called workflow
     # may only DOWNGRADE the caller's grant: requesting a scope the caller never
     # held is a startup_failure for the ENTIRE run, not a skipped job. These
-    # workflows are consumed @main by repos whose ci.yml is create-only and can
-    # never self-heal, so an escalation here would break every one of them —
-    # including on push paths where this job does not even run. Inheriting the
-    # caller's token instead keeps the blast radius inside this job, and the
-    # readiness probe below turns a missing scope into a report, not a red X.
+    # workflows are consumed @main by repos whose ci.yml is create-only, so an
+    # escalation here would break every one of them — including on push paths
+    # where this job does not even run. Inheriting the caller's token instead
+    # keeps the blast radius inside this job.
+    #
+    # Measured, not assumed (#2476): on a private consumer whose caller job
+    # granted contents/issues/pull-requests read, this job's `gh` calls
+    # succeeded and the real validation ran; on a private consumer whose caller
+    # job had NO permissions block, they failed. So the caller's grant is the
+    # only lever, and the readiness probe below FAILS when it is missing — it
+    # used to exit 0 with a warning, which reported success for a gate that had
+    # verified nothing.
 
     steps:
       - name: 📥 Checkout repository
@@ -2039,23 +2046,49 @@ jobs:
           # traceability failure would be a false red, so name the missing
           # secret and skip. `tracker: github` needs only github.token.
           tracker="$(node -p 'require("./.lisa.config.json").tracker' 2>/dev/null | tr '[:upper:]' '[:lower:]')"
+          # Token-scope readiness — checked FIRST, because every arm of this
+          # gate goes through the GitHub API and none of them can run without
+          # it. A reusable workflow may only DOWNGRADE the caller's grant, so a
+          # scope the caller never held cannot be recovered here; the repair is
+          # always the same three lines in the CALLER's ci.yml.
+          #
+          # This used to `exit 0` with a warning, which made the check report
+          # success while verifying nothing — measured on a private consumer
+          # whose gate was green with no trailer, no body line, and no backlink.
+          # A gate that cannot verify must not report success (#2476, #2497), so
+          # it now fails and names the exact scope and the exact edit.
+          scope_gap() {
+            echo "::error::Work-Item Traceability could verify NOTHING: the calling workflow does not grant '$1'. Add contents/issues/pull-requests read to the quality job's permissions in this repo's .github/workflows/ci.yml, or run 'lisa apply' to have Lisa add the block for you."
+            exit 1
+          }
+          pr_probe="repos/${GITHUB_REPOSITORY}/pulls?per_page=1"
+          if [ -n "${LISA_PR_NUMBER:-}" ]; then
+            pr_probe="repos/${GITHUB_REPOSITORY}/pulls/${LISA_PR_NUMBER}"
+          fi
+          # Needed on EVERY tracker: the PR body carries the Work-Item line and
+          # `gh pr view` is how the validator reads it.
+          if ! gh api "$pr_probe" >/dev/null 2>&1; then
+            scope_gap "pull-requests: read"
+          fi
+          # Needed only for `tracker: github`, whose backlink check reads the
+          # tracker issue. jira/linear read their own APIs with their own
+          # credentials, handled below.
+          if [ "$tracker" = "github" ] && \
+             ! gh api "repos/${GITHUB_REPOSITORY}/issues?per_page=1" >/dev/null 2>&1; then
+            scope_gap "issues: read"
+          fi
+          # Credential readiness for the non-GitHub trackers. These remain
+          # warn-and-skip rather than fail: mapping a secret is a different axis
+          # from granting a token scope, with a different blast radius, and
+          # #2476 scoped only the scope gap. It is a KNOWN remaining fail-open —
+          # a jira/linear repo with unmapped credentials still reports success
+          # while checking nothing.
           if [ "$tracker" = "jira" ] && { [ -z "${JIRA_API_TOKEN:-}" ] || [ -z "${JIRA_LOGIN:-}" ]; }; then
             echo "::warning::tracker is jira but JIRA_API_TOKEN/JIRA_LOGIN are not mapped to this workflow — work-item traceability cannot verify the tracker backlink and is NOT enforced. Map both secrets in the caller's ci.yml to enable it."
             exit 0
           fi
           if [ "$tracker" = "linear" ] && [ -z "${LINEAR_API_KEY:-}" ]; then
             echo "::warning::tracker is linear but LINEAR_API_KEY is not mapped to this workflow — work-item traceability cannot verify the tracker backlink and is NOT enforced. Map the secret in the caller's ci.yml to enable it."
-            exit 0
-          fi
-          # Token-scope readiness (github tracker): the inherited caller token
-          # may lack issues:read, in which case the validator cannot read the
-          # tracker issue at all. That is a caller-configuration gap, not a
-          # traceability failure, so name it and skip rather than blocking a PR
-          # nobody can unblock. Repos whose ci.yml grants issues:read enforce
-          # for real.
-          if [ "$tracker" = "github" ] && \
-             ! gh api "repos/${GITHUB_REPOSITORY}/issues?per_page=1" >/dev/null 2>&1; then
-            echo "::warning::The caller workflow does not grant issues:read, so the tracker issue cannot be read and work-item traceability is NOT enforced. Add 'issues: read' to the quality job's permissions in this repo's .github/workflows/ci.yml to enable it."
             exit 0
           fi
           node scripts/lisa-work-item.mjs validate-pr

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8734,6 +8734,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/config/vitest-cdk.test.ts": true,
     "tests/unit/config/vitest-nestjs.test.ts": true,
     "tests/unit/config/vitest-typescript.test.ts": true,
+    "tests/unit/config/work-item-traceability-scope-gate.test.ts": true,
     "tests/unit/config/worktree-exclusion-anchoring.test.ts": true,
     "tests/unit/core/bootstrap-environment.test.ts": true,
     "tests/unit/core/fs-extra-namespace-callsites.test.ts": true,

--- a/src/migrations/ensure-quality-caller-scopes.ts
+++ b/src/migrations/ensure-quality-caller-scopes.ts
@@ -20,8 +20,42 @@ const CALLER_USES =
 /** A job key inside `jobs:` — two-space indent, no value on the line. */
 const JOB_KEY = /^ {2}\S[^:]*:\s*$/u;
 
-/** Scopes the work_item_traceability job needs from the caller's token. */
-const REQUIRED_SCOPES: readonly string[] = ["issues", "pull-requests"];
+/** Distinguishes the rails reusable workflow from the standard one. */
+const RAILS_CALLER = /quality-rails\.yml@/u;
+
+/** One `scope: level` pair the caller must grant. */
+type Scope = readonly [name: string, level: string];
+
+/**
+ * Scopes the caller must grant, per reusable workflow.
+ *
+ * `contents: read` is the floor both workflows declare. `issues: read` and
+ * `pull-requests: read` are what work_item_traceability's `gh issue view` and
+ * `gh pr view` need, and a reusable workflow may only DOWNGRADE the caller's
+ * grant — so if the caller does not hold them, that job can never enforce
+ * anything.
+ *
+ * quality-rails.yml additionally declares `checks: write` and
+ * `pull-requests: write` at the workflow level. A called workflow that requests
+ * more than the caller granted is a startup_failure for the ENTIRE run (#2049),
+ * so a rails caller must be granted at least those levels — writing
+ * `pull-requests: read` there would take the whole workflow down.
+ */
+const SCOPES_BY_WORKFLOW: Readonly<
+  Record<"rails" | "standard", readonly Scope[]>
+> = {
+  standard: [
+    ["contents", "read"],
+    ["issues", "read"],
+    ["pull-requests", "read"],
+  ],
+  rails: [
+    ["contents", "read"],
+    ["checks", "write"],
+    ["issues", "read"],
+    ["pull-requests", "write"],
+  ],
+};
 
 /** Tracker credentials, by the `tracker` value that actually needs them. */
 const TRACKER_SECRETS: Readonly<Record<string, readonly string[]>> = {
@@ -51,7 +85,7 @@ interface Block {
  */
 function findCallerJob(
   lines: readonly string[]
-): { start: number; end: number } | null {
+): { start: number; end: number; usesAt: number } | null {
   const usesAt = lines.findIndex(line => CALLER_USES.test(line));
   if (usesAt < 0) return null;
 
@@ -63,6 +97,7 @@ function findCallerJob(
   return {
     start: start < 0 ? 0 : start,
     end: after < 0 ? lines.length : after,
+    usesAt,
   };
 }
 
@@ -131,11 +166,20 @@ async function readTracker(projectDir: string): Promise<string | null> {
 interface Plan {
   readonly text: string | null;
   readonly lines: readonly string[];
-  readonly job: { start: number; end: number } | null;
+  readonly job: { start: number; end: number; usesAt: number } | null;
   readonly permissions: Block | null;
-  readonly missingScopes: readonly string[];
+  readonly missingScopes: readonly Scope[];
   readonly secrets: Block | null;
   readonly missingSecrets: readonly string[];
+}
+
+/**
+ * Render the scope lines of a caller `permissions:` block.
+ * @param scopes - Scope/level pairs to render
+ * @returns Indented YAML lines
+ */
+function scopeLines(scopes: readonly Scope[]): readonly string[] {
+  return scopes.map(([name, level]) => `      ${name}: ${level}`);
 }
 
 /**
@@ -148,11 +192,24 @@ interface Plan {
  * backstop runs but reports not-enforceable forever. This migration closes that
  * gap in place.
  *
- * Deliberately conservative, because it edits a file the host owns:
+ * A caller with NO `permissions:` block is the BROKEN shape, not the safe one.
+ * It was previously skipped on the premise that the repo default is "typically
+ * permissive"; measurement disproved that (#2476). On two private consumers a
+ * block-less caller job received `contents: read` + `metadata: read`, so
+ * `gh pr view` and `gh issue view` both failed and the gate could never pass —
+ * while a sibling repo whose caller granted the two read scopes ran the real
+ * validation. Those repos can never self-heal through the copy strategies
+ * either, because `.github/workflows/ci.yml` is create-only. So this migration
+ * now writes the block when it is absent.
  *
- * - Patches an EXISTING `permissions:` block only. A caller with no block
- *   inherits the repo default (typically permissive, so already sufficient);
- *   inventing a block there would RESTRICT scopes the called jobs may rely on.
+ * Still deliberately conservative, because it edits a file the host owns:
+ *
+ * - Grants read-only scopes for `quality.yml`, whose 32 jobs were audited to
+ *   need no write scope (#1769), so an invented block cannot cost a job access
+ *   it uses today. `quality-rails.yml` declares `checks: write` and
+ *   `pull-requests: write` at the workflow level, and a caller granting less
+ *   than the called workflow declares is a startup_failure for the whole run
+ *   (#2049) — so a rails caller is granted those levels, never `read`.
  * - Never downgrades: a scope already granted at `write` is left alone.
  * - Never rewrites `secrets: inherit` into an explicit map — that is the host's
  *   choice and converting it changes what the called workflow receives.
@@ -187,6 +244,10 @@ export class EnsureQualityCallerScopesMigration implements Migration {
     const job = findCallerJob(lines);
     if (!job) return { ...empty, text, lines };
 
+    const required =
+      SCOPES_BY_WORKFLOW[
+        RAILS_CALLER.test(lines[job.usesAt] as string) ? "rails" : "standard"
+      ];
     const permissions = findBlock(lines, "permissions", job);
     const granted = new Set(
       permissions
@@ -196,9 +257,9 @@ export class EnsureQualityCallerScopesMigration implements Migration {
             .filter((key): key is string => Boolean(key))
         : []
     );
-    const missingScopes = permissions
-      ? REQUIRED_SCOPES.filter(scope => !granted.has(scope))
-      : [];
+    // With no block at all NOTHING is granted, so the whole set is missing —
+    // that is the case this migration exists to repair.
+    const missingScopes = required.filter(([name]) => !granted.has(name));
 
     const tracker = await readTracker(ctx.projectDir);
     const wanted = (tracker ? TRACKER_SECRETS[tracker] : undefined) ?? [];
@@ -253,12 +314,26 @@ export class EnsureQualityCallerScopesMigration implements Migration {
     // Apply insertions bottom-up so each earlier index stays valid against the
     // array the previous step produced.
     const insertions = [
-      plan.permissions && plan.missingScopes.length > 0
-        ? {
-            at: plan.permissions.end,
-            text: plan.missingScopes.map(scope => `      ${scope}: read`),
-          }
-        : null,
+      plan.missingScopes.length === 0
+        ? null
+        : plan.permissions
+          ? {
+              at: plan.permissions.end,
+              text: scopeLines(plan.missingScopes),
+            }
+          : {
+              // No block: write a whole one immediately above `uses:`, which is
+              // the one key a caller job always has.
+              at: (plan.job as { usesAt: number }).usesAt,
+              text: [
+                "    # A reusable workflow may only DOWNGRADE the caller's grant, so the",
+                "    # work-item traceability job can enforce nothing the caller does not",
+                "    # hold. With no block here the job received contents+metadata read",
+                "    # only, and its `gh pr view` / `gh issue view` calls failed (#2476).",
+                "    permissions:",
+                ...scopeLines(plan.missingScopes),
+              ],
+            },
       plan.secrets && plan.missingSecrets.length > 0
         ? {
             at: plan.secrets.end,
@@ -284,7 +359,9 @@ export class EnsureQualityCallerScopesMigration implements Migration {
 
     const parts = [
       plan.missingScopes.length > 0
-        ? `permissions (${plan.missingScopes.join(", ")})`
+        ? `permissions (${plan.missingScopes
+            .map(([name, level]) => `${name}: ${level}`)
+            .join(", ")})`
         : null,
       plan.missingSecrets.length > 0
         ? `tracker secrets (${plan.missingSecrets.join(", ")})`

--- a/tests/unit/config/work-item-traceability-scope-gate.test.ts
+++ b/tests/unit/config/work-item-traceability-scope-gate.test.ts
@@ -1,0 +1,214 @@
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { load } from "js-yaml";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+/**
+ * The Work-Item Traceability gate runs as inline bash inside the reusable
+ * `quality.yml`, deliberately NOT as a checked-in script: host projects carry a
+ * create-only `ci.yml` and a copy-overwrite `scripts/lisa-work-item.mjs` that
+ * updates only on `lisa apply`, so a gate that depended on a fresh host script
+ * would not reach the `@main` fleet at all.
+ *
+ * That makes the step's `run:` body the actual unit under test. These tests
+ * extract it from the workflow and execute it against stub `gh` binaries, which
+ * is the only way to exercise the branch that matters: what the gate does when
+ * the caller's token cannot read the PR. An assertion that only covered the
+ * happy path could not tell a working guard from a deleted one.
+ */
+
+const WORKFLOWS = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  ".github",
+  "workflows"
+);
+
+/** Both reusable workflows ship the same gate and must not drift apart. */
+const WORKFLOW_FILES = ["quality.yml", "quality-rails.yml"] as const;
+
+/**
+ * Absolute interpreter path — resolving `bash` through PATH would pick up the
+ * per-test stub directory these fixtures prepend.
+ */
+const BASH = "/bin/bash";
+
+/** Shape of the parsed workflow, narrowed to what these tests read. */
+interface Workflow {
+  readonly jobs: Record<
+    string,
+    { readonly steps?: readonly { name?: string; run?: string }[] }
+  >;
+}
+
+/**
+ * Extract the traceability validation step's shell body.
+ * @param file - Workflow file name under `.github/workflows`
+ * @returns The step's `run:` script
+ */
+function validationScript(file: string): string {
+  const parsed = load(
+    readFileSync(path.join(WORKFLOWS, file), "utf8")
+  ) as Workflow;
+  const steps = parsed.jobs["work_item_traceability"]?.steps ?? [];
+  const step = steps.find(candidate =>
+    (candidate.name ?? "").includes("Validate Work-Item")
+  );
+  if (!step?.run) throw new Error(`validation step not found in ${file}`);
+  return step.run;
+}
+
+/** What a fixture run reports back. */
+interface StepOutcome {
+  readonly status: number | null;
+  readonly output: string;
+}
+
+/**
+ * Collapse a spawn result into status plus combined output.
+ * @param result - The spawn result
+ * @returns Exit status and merged stdout/stderr
+ */
+function toResult(result: SpawnSyncReturns<string>): StepOutcome {
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+  };
+}
+
+/** Per-test scratch state. */
+interface Resources {
+  dir: string;
+}
+
+const resources: Resources = { dir: "" };
+
+beforeEach(async () => {
+  resources.dir = await mkdtemp(path.join(tmpdir(), "lisa-wit-scope-"));
+});
+
+afterEach(async () => {
+  await rm(resources.dir, { recursive: true, force: true });
+});
+
+/**
+ * Build a fake host project plus stub binaries, then run the extracted step.
+ * @param options - Fixture knobs
+ * @param options.workflow - Workflow file the step is extracted from
+ * @param options.ghExitCode - Exit status the stub `gh` reports for every call
+ * @param options.tracker - Value written to `.lisa.config.json`
+ * @param options.env - Extra environment for the step
+ * @returns The step's exit status and combined output
+ */
+function runStep(options: {
+  workflow: string;
+  ghExitCode: number;
+  tracker: string;
+  env?: Record<string, string>;
+}): StepOutcome {
+  const project = path.join(resources.dir, "project");
+  const bin = path.join(resources.dir, "bin");
+  const gh = path.join(bin, "gh");
+  const script = path.join(resources.dir, "step.sh");
+  const env = {
+    ...process.env,
+    PATH: `${bin}:${process.env["PATH"] ?? ""}`,
+    GITHUB_REPOSITORY: "acme/widget",
+    LISA_PR_NUMBER: "42",
+    LISA_PR_BASE_SHA: "aaaa",
+    LISA_PR_HEAD_SHA: "bbbb",
+    JIRA_API_TOKEN: "",
+    JIRA_LOGIN: "",
+    LINEAR_API_KEY: "",
+    ...options.env,
+  };
+
+  mkdirSync(path.join(project, "scripts"), { recursive: true });
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(
+    path.join(project, ".lisa.config.json"),
+    JSON.stringify({ tracker: options.tracker })
+  );
+  // Stands in for the host's checked-in validator. Reaching it at all means
+  // every readiness precondition passed.
+  writeFileSync(
+    path.join(project, "scripts", "lisa-work-item.mjs"),
+    'console.log("STUB_VALIDATOR_RAN");\n'
+  );
+  writeFileSync(gh, `#!/bin/sh\nexit ${options.ghExitCode}\n`);
+  chmodSync(gh, 0o755);
+  writeFileSync(script, validationScript(options.workflow));
+
+  // `bash -e` mirrors the GitHub Actions default shell, so a bare failing
+  // command aborts the step exactly as it would on a runner.
+  return toResult(
+    spawnSync(BASH, ["-e", script], { cwd: project, encoding: "utf8", env })
+  );
+}
+
+describe.each(WORKFLOW_FILES)(
+  "%s work_item_traceability token-scope readiness",
+  workflow => {
+    it("fails, naming the scope and the fix, when the PR cannot be read", () => {
+      const result = runStep({ workflow, ghExitCode: 1, tracker: "github" });
+
+      expect(result.status).not.toBe(0);
+      expect(result.output).toContain("pull-requests: read");
+      expect(result.output).toContain(".github/workflows/ci.yml");
+      // The gate must not have gone on to claim it verified anything.
+      expect(result.output).not.toContain("STUB_VALIDATOR_RAN");
+    });
+
+    it("never reports success on a missing scope, whatever the tracker", () => {
+      for (const tracker of ["github", "jira", "linear"]) {
+        const result = runStep({
+          workflow,
+          ghExitCode: 1,
+          tracker,
+          // Credentials present, so the tracker-credential arms cannot mask
+          // the scope gap by exiting early.
+          env: {
+            JIRA_API_TOKEN: "t",
+            JIRA_LOGIN: "u",
+            LINEAR_API_KEY: "k",
+          },
+        });
+
+        expect(result.status, `tracker ${tracker}`).not.toBe(0);
+        expect(result.output, `tracker ${tracker}`).toContain(
+          "does not grant 'pull-requests: read'"
+        );
+      }
+    });
+
+    it("proceeds to the real validator once the scopes are present", () => {
+      const result = runStep({ workflow, ghExitCode: 0, tracker: "github" });
+
+      expect(result.output).toContain("STUB_VALIDATOR_RAN");
+      expect(result.status).toBe(0);
+    });
+
+    it("skips cleanly when the host has no validator at all", () => {
+      // A project not yet on the work-item template must stay green: there is
+      // nothing to verify, which is different from being unable to verify.
+      const project = path.join(resources.dir, "bare");
+      mkdirSync(project, { recursive: true });
+      const script = path.join(resources.dir, "bare-step.sh");
+      writeFileSync(script, validationScript(workflow));
+
+      const result = spawnSync(BASH, ["-e", script], {
+        cwd: project,
+        encoding: "utf8",
+        env: { ...process.env, GITHUB_REPOSITORY: "acme/widget" },
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("skipping");
+    });
+  }
+);

--- a/tests/unit/hooks/work-item-wiring.test.ts
+++ b/tests/unit/hooks/work-item-wiring.test.ts
@@ -293,12 +293,17 @@ describe("work-item Git enforcement wiring", () => {
       expect(job?.permissions).toBeUndefined();
     });
 
-    it("reports rather than blocks when the inherited token cannot read the tracker", () => {
+    it("blocks rather than reports when the inherited token cannot read the PR", () => {
       const validate = steps.find(step => step.run?.includes(VALIDATE_PR));
-      // Without issues:read the validator cannot read the issue at all. That
-      // is a caller-configuration gap, not a traceability failure — blocking
-      // there would wedge every PR in a repo nobody can unwedge.
-      expect(validate?.run).toContain("issues:read");
+      // This used to warn and `exit 0`, which reported SUCCESS for a gate that
+      // had verified nothing — measured green on a private consumer whose PR
+      // carried no trailer, no body line and no backlink (#2476). A check that
+      // cannot verify must not claim it did, so the readiness probe now fails
+      // and names the exact scope and the exact caller-side edit.
+      expect(validate?.run).toContain("pull-requests: read");
+      expect(validate?.run).toContain("issues: read");
+      expect(validate?.run).toContain("scope_gap");
+      expect(validate?.run).toContain(".github/workflows/ci.yml");
     });
 
     it("stays skippable so a repo can adopt tracked work on its own schedule", () => {

--- a/tests/unit/migrations/ensure-quality-caller-scopes.test.ts
+++ b/tests/unit/migrations/ensure-quality-caller-scopes.test.ts
@@ -145,17 +145,73 @@ describe("EnsureQualityCallerScopesMigration", () => {
     expect(updated.match(/issues: read/gu)).toHaveLength(1);
   });
 
-  it("leaves a caller with no permissions block alone", async () => {
-    // No block means the job inherits the repo default, which is typically
-    // permissive enough already. Inventing a block would RESTRICT scopes the
-    // called jobs may rely on.
+  it("invents a permissions block when the caller has none", async () => {
+    // The no-block case is the BROKEN one, not the safe one (#2476). A caller
+    // job with no `permissions:` gets the repo default, which on every modern
+    // repo is `contents: read` + `metadata: read` — measured on two private
+    // consumers, where `gh pr view` and `gh issue view` both failed.
     await writeCi(`jobs:
   quality:
+    name: Quality Checks
     uses: CodySwannGT/lisa/.github/workflows/quality.yml@main
     secrets: inherit
 `);
 
-    expect(await migration.applies(createContext())).toBe(false);
+    expect(await migration.applies(createContext())).toBe(true);
+    await migration.apply(createContext());
+    const { load } = await import("js-yaml");
+    const parsed = load(await readCi()) as {
+      jobs: Record<string, { permissions?: Record<string, string> }>;
+    };
+
+    expect(parsed.jobs["quality"]?.permissions).toEqual({
+      contents: "read",
+      issues: "read",
+      "pull-requests": "read",
+    });
+  });
+
+  it("invents the rails caller's block with the write scopes that workflow declares", async () => {
+    // quality-rails.yml declares `checks: write` + `pull-requests: write` at
+    // the workflow level. A caller granting less than the called workflow
+    // declares is a startup_failure for the whole run, so a read-only block
+    // here would be worse than no block at all.
+    await writeCi(`jobs:
+  quality:
+    uses: CodySwannGT/lisa/.github/workflows/quality-rails.yml@main
+`);
+
+    await migration.apply(createContext());
+    const { load } = await import("js-yaml");
+    const parsed = load(await readCi()) as {
+      jobs: Record<string, { permissions?: Record<string, string> }>;
+    };
+
+    expect(parsed.jobs["quality"]?.permissions).toEqual({
+      contents: "read",
+      checks: "write",
+      issues: "read",
+      "pull-requests": "write",
+    });
+  });
+
+  it("grants a rails caller pull-requests at write, never read", async () => {
+    // Same startup_failure trap reached from the other side: patching an
+    // existing block must not insert `pull-requests: read` below the
+    // `pull-requests: write` that quality-rails.yml declares.
+    await writeCi(`jobs:
+  quality:
+    permissions:
+      contents: read
+    uses: CodySwannGT/lisa/.github/workflows/quality-rails.yml@main
+`);
+
+    await migration.apply(createContext());
+    const updated = await readCi();
+
+    expect(updated).toContain("      pull-requests: write");
+    expect(updated).not.toContain("      pull-requests: read");
+    expect(updated).toContain("      checks: write");
   });
 
   it("never rewrites secrets: inherit into an explicit map", async () => {


### PR DESCRIPTION
Closes defect 1 of #2476. **Defect 2 (the aspirational `required-checks.json` seed) was already fixed by #2483** — merge `aeafb83`, published in `v3.5.0`. Nothing here touches it.

Work-Item: CodySwannGT/lisa#2476

## What was actually wrong

The reported symptom was "the gate can never pass". Measurement found the worse half of it: **the gate reported SUCCESS while verifying nothing.**

Evidence, from three real consumers rather than from reasoning:

| Repo | Visibility | Caller `permissions:` | Observed |
|---|---|---|---|
| `CodySwannGT/lisa` | public | grants the reads | `WORK_ITEM_TRACKING_OK … PR body, and tracker backlink` — real validation |
| `geminisportsai/ask-gemini` | private | grants the reads (hand-added) | probe cleared, validator ran, **red on a genuine missing trailer** |
| `TunnlAI/frontend` | private | **none** | job **green** having checked nothing |

That third row is the defect class from #2497: a check that cannot verify must not report success. The `TunnlAI/frontend` run exits 0 at a readiness arm and reports a passing context regardless of what the PR contains.

Row 2 also settles the design question empirically: **a caller-side `permissions:` block does flow through to the called job**, despite `quality.yml`'s workflow-level `contents: read` floor. So the caller grant is the working lever, and no escalation in the reusable workflow is needed — or permitted.

## Option chosen: 3 (both), with arm 1 already shipped

**Option 1 (caller template)** was already done for all five stacks — `typescript`, `expo`, `nestjs`, `cdk`, `rails` create-only `ci.yml` all grant the scopes on `main`. New repos are fine. What was missing is everything else:

**1a. Existing repos could never self-heal.** `ensure-quality-caller-scopes` deliberately skipped a caller job with **no** `permissions:` block, on the stated premise that the repo default is "typically permissive, so already sufficient". Both private measurements above disprove that — a block-less caller job gets contents+metadata read only. And `.github/workflows/ci.yml` is create-only, so the copy strategies can never repair it. The migration now **writes the block when it is absent**.

**1b. That same migration could have caused an outage.** It patched an existing block by inserting `pull-requests: read` — including for `quality-rails.yml` callers. `quality-rails.yml` declares `checks: write` + `pull-requests: write` at the workflow level, and a caller granting *less* than the called workflow declares is itself a `startup_failure`. Rails callers now get the write levels.

**Option 2 (degrade legibly)** — the readiness probe now runs **first**, covers `pull-requests: read` on every tracker and `issues: read` on `tracker: github`, and **fails** with one operator-readable line naming the exact scope and the exact edit:

```
Work-Item Traceability could verify NOTHING: the calling workflow does not grant
'pull-requests: read'. Add contents/issues/pull-requests read to the quality job's
permissions in this repo's .github/workflows/ci.yml, or run 'lisa apply' to have
Lisa add the block for you.
```

Previously it probed only `issues: read`, only for `tracker: github`, and `exit 0`'d.

**The reusable workflows still declare NO `permissions:` block.** Requesting a scope the caller never held is a `startup_failure` for the entire run — zero jobs, no contexts, every consuming PR blocked (#2049). The grant can only come from the caller; this PR makes the caller side reachable and the gate honest, and touches nothing else.

## Which consumers are fixed, and when

"Fixed upstream" is not "fixed in the fleet":

- **`@main` consumers** get the honest gate on merge. A private repo whose caller has no `permissions:` block flips from a **false green to a named red** — deliberately, and repairable in one `lisa apply` run now that the migration writes the block. Public repos are unaffected (public PR/issue reads succeed on any token), and repos that already grant the scopes are unaffected.
- **Pinned consumers** (e.g. `TunnlAI/frontend` on `@v3.5.2`) get nothing until they bump the pin. Their caller-side half is done (TUN-608 / PR #544, merge `cd826235`); the sequence for them is bump the pin **and** `lisa apply`. **TUN-609 is the ticket to close behind this PR.**
- **New repos** were already correct via the create-only templates.

## Verification

- **Failure path proved, not assumed.** The step's `run:` body is extracted from the YAML and executed under `bash -e` against a stub `gh`. Failing `gh` ⇒ non-zero exit, the scope named, and the validator demonstrably never reached; passing `gh` ⇒ validator runs, exit 0. Both reusable workflows are covered by the same parameterized suite so they cannot drift.
- **Mutation-proved.** Reverting the guard to `exit 0` in `quality.yml` and running the **whole** suite failed exactly two tests, both naming the behaviour and both scoped to the mutated file: `quality.yml … > fails, naming the scope and the fix, when the PR cannot be read` and `quality.yml … > never reports success on a missing scope, whatever the tracker`. `quality-rails.yml`'s copies stayed green, confirming the tests bind to the file they name. Reverted.
- **Parsed, not grepped.** Both workflows were parsed with a YAML parser and their job graphs checked for dangling `needs` edges — `quality.yml` 36 jobs, `quality-rails.yml` 13 jobs, zero dangling. (`actionlint` was **not** used: it spins forever on this repo's workflows, and `timeout` does not exist on this machine.) A workflow that fails to parse yields `jobs=0` at startup and reports no contexts at all — a different failure from a check going red, and the one that matters here.
- **Full suite**: 651 files / all green. Typecheck and lint clean. Manifest regenerated after `git add` and after `lint-staged` reformatting, amended in the same commit, verified with `--check`.

## Known remaining fail-open (out of scope, labelled in-file)

Tracker-credential readiness (`jira`/`linear` secrets unmapped) still warns and exits 0, so such a repo still reports success while checking nothing. That is a secrets-mapping axis with a different blast radius; #2476 scoped the token-scope gap. It is now called out in a code comment at both sites rather than left implicit.

🤖 Generated with Claude Code
