### PR TITLE
fix(state): regenerate the stale Lisa-owned hash ledger

### DIFF
--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -18,7 +18,11 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   "scripts/lisa-command-envelope.mjs": Object.freeze([
     "2011331056b1c86bd181649713a395dbfd2768f9fcd7e37b521d6ad2a9318ea9",
     "4f76bb7d466eb153a4e1414d06f12856a1242de2cfa4cb4b1b942cf29d8b7f37",
+    "6b198f088cd3cd862d4357fbb069b1ad5d3afeb7be594f2bf1ff603b092a8354",
     "e06cb11f1418fe94564cea527a22b039f53b7ab10c1cd182264a31e52bba9fa8",
+  ]),
+  "scripts/lisa-destructive-guard.mjs": Object.freeze([
+    "4fb431a3c58f443e303d613934d023d9e95ddae5c42710bb7009f7c080c82a64",
   ]),
   "scripts/lisa-enforcement-fallback.sh": Object.freeze([
     "1bec5f3c284b3febdc471487ee6a23ffb72bd4e7b293f9e26b0188f32318c722",


### PR DESCRIPTION
## main is red

The `Release and Deploy` run for merge `bd132b8cf` fails the ledger gate:

```
FAIL tests/unit/scripts/lisa-owned-hash-ledger.test.ts
  > is regenerated whenever a Lisa-owned template changes
  Lisa-owned hash ledger is out of date.
  Run `bun run build:lisa-owned-hash-ledger` and commit the result.
```

## No author got this wrong

Three PRs, each green on its own branch:

| PR | commit | what it did |
|---|---|---|
| #2470 | `8e274babd` | **added** the ledger and the gate that reads it |
| #2545 | `a40d58b24` | changed the header of `all/copy-overwrite/scripts/lisa-command-envelope.mjs`, a Lisa-owned template, so its hash moved |
| #2491 | `5142b180b` | **added** `all/copy-overwrite/scripts/lisa-destructive-guard.mjs`, a Lisa-owned template with no ledger entry at all |

#2470 created the obligation after the other two branches were cut, and a generated artifact keyed to template content cannot be validated from inside either branch. Regenerating moves exactly four lines and nothing else — one new hash for `lisa-command-envelope.mjs`, one new entry for `lisa-destructive-guard.mjs`.

## The part that outlasts this fix

The ledger is now a **second** regeneration obligation beside `build:upstream-evidence-manifest`. The manifest one is in everyone's checklist; the ledger one is days old and in nobody's. Two PRs touching *different* Lisa-owned templates can each be green and still land a red `main`. #2557 records two follow-ups: a same-commit check with the shape the manifest already has, and documenting the pair together.

Also worth knowing: local `bun run test` covers **650 files / 11,551 tests**; CI's unit job covers **656 / 11,658**. The local command does not reproduce CI's set, which is why this passed locally for three separate authors.

## Verification

`656/656` files, `11,658/11,658` tests green with the regenerated ledger. Pre-push integration 298/298, `✅ Plugin parity pins are current`.

Work-Item: CodySwannGT/lisa#2557