### PR TITLE
fix(parity): make the push gate read the artifacts it vouches for

### DIFF
--- a/.github/workflows/plugins-sync.yml
+++ b/.github/workflows/plugins-sync.yml
@@ -40,6 +40,15 @@ jobs:
           bun-version: '1.3.8'
       - name: Install dependencies
         run: bun install --frozen-lockfile
+      # #2548 committed literal `<<<<<<< HEAD` blocks into six generated parity
+      # SKILL.md files and the sync check below still passed, because it
+      # compares the generated copies against plugins/src and BOTH sides were
+      # broken identically. So the marker gate runs first, and here rather than
+      # only in .husky/pre-push.local: a cloud agent or a hookless clone pushes
+      # without ever running the local hook, and this job is a required context
+      # on every pull request.
+      - name: Check for leftover merge-conflict markers
+        run: bun run check:conflict-markers
       - name: Check plugin artifacts are in sync with plugins/src
         run: bun run check:plugins
       - name: Check rules eager/reference pairing

--- a/.husky/pre-push.local
+++ b/.husky/pre-push.local
@@ -1,3 +1,33 @@
+# Leftover merge-conflict marker gate (issue #2552).
+#
+# PR #2548 pushed six generated parity SKILL.md files containing literal
+# `<<<<<<< HEAD` blocks and passed every gate: the parity gate greps for the pin
+# VALUE (present inside the conflict block), the test suite parses frontmatter
+# and never the body, and `🧩 Plugin artifacts match source` compared two copies
+# that were broken identically. Nothing read the bytes. This does.
+#
+# Tracked files only, and only a COMPLETE `<<<<<<< / ======= / >>>>>>>` triple
+# counts, so an untracked scratch file or prose quoting one side of a conflict
+# cannot block a push.
+
+echo "🩹 Checking for leftover merge-conflict markers..."
+
+CONFLICT_MARKER_OUT="$(mktemp)"
+node scripts/check-conflict-markers.mjs >"$CONFLICT_MARKER_OUT" 2>&1
+CONFLICT_MARKER_EXIT=$?
+
+if [ "$CONFLICT_MARKER_EXIT" -ne 0 ]; then
+  echo "❌ Push blocked: leftover merge-conflict markers in tracked files:"
+  cat "$CONFLICT_MARKER_OUT"
+  echo ""
+  echo "Finish the merge/rebase before pushing. Never resolve this with"
+  echo "--no-verify: the markers are in the bytes that would ship."
+  rm -f "$CONFLICT_MARKER_OUT"
+  exit 1
+fi
+echo "✅ No leftover conflict markers"
+rm -f "$CONFLICT_MARKER_OUT"
+
 # Third-party plugin parity drift gate (issue #1955).
 #
 # Repo-local (this file is the .husky/pre-push extension slot, so it survives
@@ -78,3 +108,41 @@ else
   exit 1
 fi
 rm -f "$PARITY_DRIFT_ERR"
+
+# Routing-artifact validity gate (issue #2552).
+#
+# The block above reads skill FRONTMATTER only. `parity/plugin-routing/*.json`
+# is the other half of the same contract — and the pre-flight gate for
+# `implement-plugin-parity` — so until now it could sit red indefinitely while
+# every push reported green. Three consecutive safety-net refreshes moved the
+# `synced-from` stamp and left the artifact behind for exactly that reason.
+#
+# Gate semantics:
+#   - exit 1 (an artifact violates the contract) → BLOCK. Wrong on any machine.
+#   - exit 2 (usage/operational: the routing dir is gone, a filesystem error)
+#     → BLOCK. A gate that cannot run is not a gate that passed; treating that
+#     as a warning is how a gate becomes vacuous in the first place.
+#
+# "No plugin cache on this machine" is NOT exit 2 here. The validator reports
+# an unconfirmable version as `unverifiable` and still exits 0, so a fresh clone
+# or CI runner keeps every schema/routing/coverage gate and loses only the
+# version comparison it genuinely cannot make.
+
+echo "🧭 Validating plugin routing artifacts..."
+
+ROUTING_VALIDATE_OUT="$(mktemp)"
+node scripts/plugin-routing-validate.mjs >"$ROUTING_VALIDATE_OUT" 2>&1
+ROUTING_VALIDATE_EXIT=$?
+
+if [ "$ROUTING_VALIDATE_EXIT" -ne 0 ]; then
+  echo "❌ Push blocked: plugin routing artifacts failed validation:"
+  cat "$ROUTING_VALIDATE_OUT"
+  echo ""
+  echo "Fix now and include it in this push: bring each artifact's"
+  echo "upstreamVersion and routing block back in line with its skill pin."
+  echo "Details: node scripts/plugin-routing-validate.mjs"
+  rm -f "$ROUTING_VALIDATE_OUT"
+  exit 1
+fi
+echo "✅ $(tail -n 1 "$ROUTING_VALIDATE_OUT")"
+rm -f "$ROUTING_VALIDATE_OUT"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "refresh:upstream-public-commits": "node scripts/generate-upstream-evidence-manifest.mjs --refresh-public-commits",
     "check:rules-pairing": "bash scripts/check-rules-pairing.sh",
     "check:workflow-inputs": "node scripts/detect-stale-workflow-inputs.mjs --project . --project typescript/create-only --project rails/create-only --json",
+    "check:conflict-markers": "node scripts/check-conflict-markers.mjs",
     "check:duplicate-versions": "node scripts/check-duplicate-versions.mjs",
     "check:required-check-promotions": "node scripts/check-required-check-promotions.mjs",
     "verify:health-contract": "bun run build:dist && node scripts/verify-health-contract-built.mjs",

--- a/parity/plugin-routing/safety-net@cc-marketplace.md
+++ b/parity/plugin-routing/safety-net@cc-marketplace.md
@@ -158,3 +158,26 @@ Both artifacts are corrected here. Wiring the validator into the push gate or CI
 is what would actually close the loop; it is recorded as a follow-up rather than
 done inline, because the validator was red on arrival and enabling it as a gate
 would newly block every push — a gate-policy change that deserves its own review.
+
+### Follow-up closed — 2026-08-14, issue #2552
+
+That review happened and the wiring landed. `.husky/pre-push.local` now runs
+`plugin-routing-validate.mjs` alongside the drift detector, so a lagging artifact
+blocks the push that creates it. Re-running the sentry lag by hand (artifact back
+to `1.3.1` against the `1.3.2` cache) blocks with
+`upstreamVersion 1.3.1 != cache max 1.3.2` **while the drift gate on the same run
+still reports `✅ Plugin parity pins are current`** — which is precisely the
+half-blind reading that let the lag survive three refreshes.
+
+Enabling it did not newly block anyone. A machine with no plugin cache used to be
+a hard failure for every artifact (`no semver in the cache to confirm`); the
+validator now reports that as **unverifiable** and still exits 0, keeping the
+schema, routing, coverage, and anti-pattern gates. A cacheless clone therefore
+validates strictly more than before, not less.
+
+The same issue also closed the hole PR #2548 walked through: six generated parity
+`SKILL.md` files carrying literal `<<<<<<< HEAD` blocks passed everything,
+because the pin value sat *inside* the conflict block. `check-conflict-markers.mjs`
+reads the bytes of every tracked file, in the push gate and in the required
+`🧩 Plugin artifacts match source` job — the latter because a cloud agent never
+runs the local hook.

--- a/scripts/check-conflict-markers.mjs
+++ b/scripts/check-conflict-markers.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+/**
+ * Deterministic gate against leftover merge-conflict markers in tracked files
+ * (issue #2552).
+ *
+ * PR #2548 committed literal `<<<<<<< HEAD` conflict blocks into six generated
+ * parity `SKILL.md` files and passed every gate on the way in:
+ *
+ *   - the parity push gate greps for the pin *value*, which was present inside
+ *     the conflict block, so it read as current;
+ *   - the test suite parses skill frontmatter, never the body;
+ *   - `🧩 Plugin artifacts match source` compares the generated copies against
+ *     `plugins/src`, and both sides were broken the *same* way, so they matched.
+ *
+ * Nothing in the loop read the bytes. This script does, and only that.
+ *
+ * Determinism guarantees (so the unit test is reproducible and CI is stable):
+ *   - zero third-party dependencies (Node built-ins only),
+ *   - no network access,
+ *   - no `Date` / `Math.random`,
+ *   - the file list comes from `git ls-files`, so the gate sees exactly what a
+ *     push would carry — an untracked scratch file can never block a push.
+ *
+ * Detection deliberately requires the COMPLETE ordered marker triple
+ * (`<<<<<<<` … `=======` … `>>>>>>>`), which is what git actually writes.
+ * Content between the start and the separator is ignored, so the diff3 base
+ * marker (`|||||||`) is accepted. A lone `<<<<<<<` line is NOT reported:
+ * documentation that quotes one side of a conflict is legitimate content, and a
+ * gate that fires on files it should not read is its own outage.
+ *
+ * CLI:
+ *   node scripts/check-conflict-markers.mjs [--root <dir>] [--json]
+ *
+ * Exit codes (mirroring the sibling parity scripts):
+ *   0 — no tracked file carries a conflict block.
+ *   1 — ≥1 tracked file carries a conflict block.
+ *   2 — operational/usage error: unknown flag, a flag missing its value,
+ *       `--root` absent or not a git repository, or git being unavailable.
+ *
+ * @module scripts/check-conflict-markers
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+
+/** `<<<<<<<` alone, or followed by whitespace and a label (`<<<<<<< HEAD`). */
+const START_RE = /^<{7}(?:[ \t].*)?$/;
+
+/** The separator git writes between the two sides: exactly seven `=`. */
+const SEPARATOR_RE = /^={7}$/;
+
+/** `>>>>>>>` alone, or followed by whitespace and a label. */
+const END_RE = /^>{7}(?:[ \t].*)?$/;
+
+/** Files larger than this are skipped — no source file is this big. */
+const MAX_FILE_BYTES = 5 * 1024 * 1024;
+
+/** Leading bytes probed for a NUL, which marks the file as binary. */
+const BINARY_PROBE_BYTES = 8000;
+
+/** Max bytes of `git ls-files` output (7k+ tracked paths is ~0.3 MB today). */
+const MAX_GIT_OUTPUT_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Usage error — thrown by `parseArgs` / `listTrackedFiles` for an invalid
+ * invocation so `main` can distinguish it (exit 2) from a finding (exit 1).
+ */
+export class UsageError extends Error {}
+
+/**
+ * Find every complete conflict block in `content`.
+ *
+ * A block is a `<<<<<<<` line, then a `=======` line, then a `>>>>>>>` line, in
+ * that order. A second `<<<<<<<` abandons any partial block and starts a new
+ * one, matching how git nests nothing and always re-opens.
+ *
+ * @param {string} content - full text of a file.
+ * @returns {{ startLine: number, separatorLine: number, endLine: number }[]}
+ *   one entry per complete block, with 1-based line numbers.
+ */
+export function findConflictBlocks(content) {
+  const lines = String(content).split(/\r?\n/);
+  const blocks = [];
+  let startLine = -1;
+  let separatorLine = -1;
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    if (START_RE.test(line)) {
+      startLine = index + 1;
+      separatorLine = -1;
+      continue;
+    }
+    if (startLine === -1) {
+      continue;
+    }
+    if (SEPARATOR_RE.test(line)) {
+      if (separatorLine === -1) {
+        separatorLine = index + 1;
+      }
+      continue;
+    }
+    if (END_RE.test(line)) {
+      if (separatorLine !== -1) {
+        blocks.push({ endLine: index + 1, separatorLine, startLine });
+      }
+      startLine = -1;
+      separatorLine = -1;
+    }
+  }
+  return blocks;
+}
+
+/**
+ * True iff `buffer` looks binary (a NUL byte in its leading bytes) — the same
+ * heuristic git uses to decide a blob is not text.
+ *
+ * @param {Buffer} buffer - the file contents.
+ * @returns {boolean} whether the file should be skipped as binary.
+ */
+function isBinary(buffer) {
+  return (
+    buffer.indexOf(0, 0) !== -1 && buffer.indexOf(0, 0) < BINARY_PROBE_BYTES
+  );
+}
+
+/**
+ * List every tracked file in `root`, relative to it. Throws `UsageError` when
+ * git is unavailable or `root` is not a repository.
+ *
+ * @param {string} root - the repository root.
+ * @returns {string[]} tracked paths, relative to `root`.
+ */
+function listTrackedFiles(root) {
+  let stdout;
+  try {
+    stdout = execFileSync("git", ["-C", root, "ls-files", "-z"], {
+      encoding: "utf8",
+      maxBuffer: MAX_GIT_OUTPUT_BYTES,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch (error) {
+    throw new UsageError(
+      `could not list tracked files in ${root}: ${error.message}`
+    );
+  }
+  return stdout.split("\0").filter(entry => entry !== "");
+}
+
+/**
+ * Scan one tracked file. Missing (staged-deleted), oversized, and binary files
+ * are skipped rather than reported.
+ *
+ * @param {string} root - the repository root.
+ * @param {string} file - a tracked path relative to `root`.
+ * @returns {{ file: string, blocks: ReadonlyArray<Record<string, number>> } | null}
+ *   the finding, or `null` when the file is clean or skipped.
+ */
+function scanFile(root, file) {
+  const absolute = path.join(root, file);
+  let stat;
+  try {
+    stat = fs.statSync(absolute);
+  } catch {
+    return null;
+  }
+  if (!stat.isFile() || stat.size > MAX_FILE_BYTES) {
+    return null;
+  }
+  let buffer;
+  try {
+    buffer = fs.readFileSync(absolute);
+  } catch {
+    return null;
+  }
+  if (isBinary(buffer)) {
+    return null;
+  }
+  const blocks = findConflictBlocks(buffer.toString("utf8"));
+  return blocks.length === 0 ? null : { blocks, file };
+}
+
+/**
+ * Assemble the machine-readable report.
+ *
+ * @param {ReadonlyArray<{ file: string, blocks: ReadonlyArray<Record<string, number>> }>} results
+ *   the conflicted files, sorted by path.
+ * @param {{ root: string, scanned: number }} opts - resolved options + scan size.
+ * @returns {Record<string, unknown>} the report object.
+ */
+export function buildReport(results, opts) {
+  return {
+    results,
+    root: opts.root,
+    schemaVersion: 1,
+    summary: {
+      clean: opts.scanned - results.length,
+      conflicted: results.length,
+      scanned: opts.scanned,
+    },
+  };
+}
+
+/**
+ * Render the human-readable report.
+ *
+ * @param {{ results: ReadonlyArray<{ file: string, blocks: ReadonlyArray<Record<string, number>> }>, summary: { scanned: number, conflicted: number } }} report
+ *   the report object.
+ * @returns {string} the rendered report.
+ */
+function humanReport(report) {
+  if (report.summary.conflicted === 0) {
+    return `✓ no leftover conflict markers in ${report.summary.scanned} tracked files`;
+  }
+  const lines = report.results.flatMap(result => [
+    `✗ ${result.file}`,
+    ...result.blocks.map(
+      block =>
+        `    - conflict block opens at line ${block.startLine}, separator at line ${block.separatorLine}, closes at line ${block.endLine}`
+    ),
+  ]);
+  return [
+    ...lines,
+    "",
+    `${report.summary.conflicted} of ${report.summary.scanned} tracked files carry leftover conflict markers`,
+  ].join("\n");
+}
+
+/**
+ * Parse argv into resolved options. Throws `UsageError` on a bad invocation.
+ *
+ * @param {readonly string[]} argv - arguments (without node/script prefix).
+ * @returns {{ root: string, json: boolean }} options.
+ */
+export function parseArgs(argv) {
+  let root = null;
+  let json = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      json = true;
+    } else if (arg === "--root") {
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        throw new UsageError("--root requires a value");
+      }
+      root = next;
+      i += 1;
+    } else {
+      throw new UsageError(`unknown argument: ${arg}`);
+    }
+  }
+  return { json, root: path.resolve(root ?? REPO_ROOT) };
+}
+
+/**
+ * Run the gate. Returns the process exit code (does not call `exit`).
+ *
+ * @param {readonly string[]} argv - arguments (without node/script prefix).
+ * @param {{ stdout?: { write(s: string): void }, stderr?: { write(s: string): void } }} [io]
+ *   injectable streams (defaults to process streams).
+ * @returns {number} the exit code (0 clean, 1 markers found, 2 usage error).
+ */
+export function main(argv, io = {}) {
+  const out = io.stdout ?? process.stdout;
+  const err = io.stderr ?? process.stderr;
+  let opts;
+  let files;
+  try {
+    opts = parseArgs(argv);
+    if (!fs.existsSync(opts.root) || !fs.statSync(opts.root).isDirectory()) {
+      throw new UsageError(`--root is not a directory: ${opts.root}`);
+    }
+    files = listTrackedFiles(opts.root);
+  } catch (error) {
+    err.write(`error: ${error.message}\n`);
+    return 2;
+  }
+  let results;
+  try {
+    results = files
+      .map(file => scanFile(opts.root, file))
+      .filter(result => result !== null)
+      .sort((a, b) => a.file.localeCompare(b.file));
+  } catch (error) {
+    err.write(`error: failed to scan tracked files: ${error.message}\n`);
+    return 2;
+  }
+  const report = buildReport(results, {
+    root: opts.root,
+    scanned: files.length,
+  });
+  out.write(
+    (opts.json ? JSON.stringify(report, null, 2) : humanReport(report)) + "\n"
+  );
+  return results.length === 0 ? 0 : 1;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  // exitCode (not process.exit): when stdout is a pipe, writes are async and
+  // process.exit() truncates the report mid-flush.
+  process.exitCode = main(process.argv.slice(2));
+}

--- a/scripts/plugin-routing-validate.mjs
+++ b/scripts/plugin-routing-validate.mjs
@@ -158,6 +158,14 @@ export function cacheMaxVersion(cacheRoot, name, marketplace) {
  * contract): a semver value must equal the cache max; `"unknown"` is valid only
  * when the cache has no semver anywhere.
  *
+ * A semver `upstreamVersion` with NO semver in the cache is deliberately not an
+ * error. It means THIS machine cannot see the plugin (fresh clone, CI runner,
+ * plugin uninstalled) — not that the artifact is wrong. `isVersionUnverifiable`
+ * reports that state separately so the caller can warn instead of blocking,
+ * mirroring how the drift detector treats `not-installed` (issue #2552). Every
+ * other gate — schema, routing, coverage, anti-patterns — still runs, so a
+ * cacheless machine validates strictly more than it used to.
+ *
  * @param {unknown} upstreamVersion - the artifact's `upstreamVersion`.
  * @param {string | null} cacheMax - resolved max semver, or null.
  * @returns {string[]} validation error messages (empty when valid).
@@ -174,14 +182,25 @@ function validateVersion(upstreamVersion, cacheMax) {
     ];
   }
   if (cacheMax === null) {
-    return [
-      `upstreamVersion ${upstreamVersion} but no semver in the cache to confirm`,
-    ];
+    return [];
   }
   if (compareSemver(upstreamVersion, cacheMax) !== 0) {
     return [`upstreamVersion ${upstreamVersion} != cache max ${cacheMax}`];
   }
   return [];
+}
+
+/**
+ * True iff the artifact pins a semver `upstreamVersion` that this machine has
+ * no cached copy to confirm against. A cache-visibility fact, not a contract
+ * violation — reported so the push gate can warn without blocking.
+ *
+ * @param {unknown} upstreamVersion - the artifact's `upstreamVersion`.
+ * @param {string | null} cacheMax - resolved max semver, or null.
+ * @returns {boolean} whether the version claim is unverifiable here.
+ */
+export function isVersionUnverifiable(upstreamVersion, cacheMax) {
+  return cacheMax === null && isValidSemver(upstreamVersion);
 }
 
 /**
@@ -430,14 +449,20 @@ function truncate(text) {
  * @param {string} routingDir - the routing directory.
  * @param {string} file - the artifact filename (`*.json`).
  * @param {string} cacheRoot - the installed-plugin cache root.
- * @returns {{ file: string, errors: string[] }} the per-file result.
+ * @returns {{ file: string, errors: string[], unverifiable: boolean }}
+ *   the per-file result. `unverifiable` means the version claim could not be
+ *   confirmed on this machine; it never blocks.
  */
 function validateFile(routingDir, file, cacheRoot) {
   let artifact;
   try {
     artifact = JSON.parse(fs.readFileSync(path.join(routingDir, file), "utf8"));
   } catch (error) {
-    return { errors: [`invalid JSON: ${error.message}`], file };
+    return {
+      errors: [`invalid JSON: ${error.message}`],
+      file,
+      unverifiable: false,
+    };
   }
   const hasIds =
     artifact !== null &&
@@ -455,13 +480,21 @@ function validateFile(routingDir, file, cacheRoot) {
     filename: file,
     mdExists,
   });
-  return { errors, file };
+  const upstreamVersion =
+    artifact !== null && typeof artifact === "object"
+      ? artifact.upstreamVersion
+      : undefined;
+  return {
+    errors,
+    file,
+    unverifiable: isVersionUnverifiable(upstreamVersion, cacheMax),
+  };
 }
 
 /**
  * Assemble the machine-readable report.
  *
- * @param {ReadonlyArray<{ file: string, errors: string[] }>} results - per-file results.
+ * @param {ReadonlyArray<{ file: string, errors: string[], unverifiable?: boolean }>} results - per-file results.
  * @param {{ cacheRoot: string, routingDir: string }} opts - resolved options.
  * @returns {Record<string, unknown>} the report object.
  */
@@ -475,6 +508,7 @@ export function buildReport(results, opts) {
     summary: {
       invalid,
       scanned: results.length,
+      unverifiable: results.filter(r => r.unverifiable === true).length,
       valid: results.length - invalid,
     },
   };
@@ -483,20 +517,27 @@ export function buildReport(results, opts) {
 /**
  * Render the human-readable report.
  *
- * @param {{ results: ReadonlyArray<{ file: string, errors: string[] }>, summary: { scanned: number, valid: number, invalid: number } }} report - report object.
+ * @param {{ results: ReadonlyArray<{ file: string, errors: string[], unverifiable?: boolean }>, summary: { scanned: number, valid: number, invalid: number, unverifiable: number } }} report - report object.
  * @returns {string} the rendered report.
  */
 function humanReport(report) {
-  const lines = report.results.map(r =>
-    r.errors.length === 0
-      ? `✓ ${r.file}`
-      : `✗ ${r.file}\n${r.errors.map(e => `    - ${e}`).join("\n")}`
-  );
+  const lines = report.results.map(r => {
+    if (r.errors.length > 0) {
+      return `✗ ${r.file}\n${r.errors.map(e => `    - ${e}`).join("\n")}`;
+    }
+    return r.unverifiable === true
+      ? `⚠ ${r.file} (version unverifiable: plugin not in this machine's cache)`
+      : `✓ ${r.file}`;
+  });
   const s = report.summary;
+  const unverifiable =
+    s.unverifiable > 0
+      ? `, ${s.unverifiable} unverifiable on this machine`
+      : "";
   return [
     ...lines,
     "",
-    `${s.valid}/${s.scanned} routing artifacts valid, ${s.invalid} invalid`,
+    `${s.valid}/${s.scanned} routing artifacts valid, ${s.invalid} invalid${unverifiable}`,
   ].join("\n");
 }
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2070,6 +2070,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "9c49f8c7c453f8749c90def3e22d412c3345c533d24b30dc7745ffa052ad6fa1",
     "scripts/build-plugins.sh":
       "b98f0e4789ce903ebf704abaa649c6d4a4721ce0cf2b5caf4ccddeb04fc0d5e0",
+    "scripts/check-conflict-markers.mjs":
+      "e2b25dd56eb3742f074ae5b8ece13ef194518e70e5bac4c2f49e3b819d3f7dc4",
     "scripts/check-duplicate-versions.mjs":
       "84d97e94eb834522848ddce951bb54ae9da1e4be252e2c51fed0c01c4f4d6b72",
     "scripts/check-learnings-budget.ts":
@@ -2169,7 +2171,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/plugin-parity-drift.mjs":
       "34235c4c75c8735aaca96e3e0a52073ba1dee8bad54c85af01c3cf9912d0ea57",
     "scripts/plugin-routing-validate.mjs":
-      "eb38cf139eb04a27dd6493ff6f766945060d5bf73a35856bd3da4c8e4110e2ba",
+      "ddb2fcd950cbd66ca642e946aef33fd0bb2e7c4081ee96c19d4628a7d45694b8",
     "scripts/probes/wave3-verification.sh":
       "c341c3682f2401339a433a48efc8b8dd80c9c190f12ec6287139bebd1e47c049",
     "scripts/remote-agent-aws-setup.sh":
@@ -8063,6 +8065,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "rails/merge/.claude/settings.json": true,
     "scratchpad/decision-points.sh": true,
     "scripts/build-plugins.sh": true,
+    "scripts/check-conflict-markers.mjs": true,
     "scripts/check-duplicate-versions.mjs": true,
     "scripts/check-learnings-budget.ts": true,
     "scripts/check-plugins-sync.sh": true,
@@ -8832,6 +8835,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/hooks/inject-rules.test.ts": true,
     "tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts": true,
     "tests/unit/hooks/lint-on-edit.test.ts": true,
+    "tests/unit/hooks/parity-push-gate.test.ts": true,
     "tests/unit/hooks/parity-safety-net-guards.test.ts": true,
     "tests/unit/hooks/parity-safety-net-heredoc-body-quote-state.test.ts": true,
     "tests/unit/hooks/parity-safety-net-heredoc-continuation.test.ts": true,
@@ -8895,6 +8899,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/bdd/sources.ts": true,
     "tests/unit/scripts/bdd/support.ts": true,
     "tests/unit/scripts/build-cursor-hooks-json.test.ts": true,
+    "tests/unit/scripts/check-conflict-markers.test.ts": true,
     "tests/unit/scripts/check-duplicate-versions-helpers.ts": true,
     "tests/unit/scripts/check-duplicate-versions.test.ts": true,
     "tests/unit/scripts/check-duplicate-versions.units.test.ts": true,
@@ -8934,6 +8939,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/per-agent-hook-filter.test.ts": true,
     "tests/unit/scripts/plugin-parity-drift-helpers.ts": true,
     "tests/unit/scripts/plugin-parity-drift.test.ts": true,
+    "tests/unit/scripts/plugin-routing-validate-cache-visibility.test.ts": true,
     "tests/unit/scripts/plugin-routing-validate-helpers.ts": true,
     "tests/unit/scripts/plugin-routing-validate.test.ts": true,
     "tests/unit/scripts/plugin-sync-scripts.test.ts": true,

--- a/tests/unit/hooks/parity-push-gate.test.ts
+++ b/tests/unit/hooks/parity-push-gate.test.ts
@@ -1,0 +1,221 @@
+/**
+ * The parity push gate has to read what it claims to check (issue #2552).
+ *
+ * Two proven holes, both of which shipped:
+ *
+ *   1. `.husky/pre-push.local` ran only `plugin-parity-drift.mjs`, which reads
+ *      skill FRONTMATTER. `parity/plugin-routing/*.json` — the other half of the
+ *      same contract — was never read, so it sat invalid through three
+ *      consecutive safety-net refreshes while every push reported green.
+ *   2. PR #2548 pushed six generated parity `SKILL.md` files carrying literal
+ *      `<<<<<<< HEAD` blocks. The pin VALUE was inside the conflict block, so
+ *      the drift gate read it as current and passed.
+ *
+ * These tests run the real hook file end-to-end against a throwaway repository,
+ * because a hook asserted only by grepping its text is the same class of
+ * evidence that produced the defect: a claim nobody executed.
+ *
+ * @module tests/unit/hooks/parity-push-gate
+ */
+import { execFileSync } from "node:child_process";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanGitEnv } from "../../helpers/test-utils";
+
+const HOOK = path.resolve(".husky/pre-push.local");
+const GIT = "/usr/bin/git";
+const SH = "/bin/sh";
+const SCRIPTS_DIR = "scripts";
+const HOOK_RELATIVE = ".husky/pre-push.local";
+const ROUTING_DIR = "parity/plugin-routing";
+const ARTIFACT = "has-manifest@demo-marketplace.json";
+const FIXTURE_ROUTING = path.resolve("parity/fixtures/routing/valid");
+const SCRIPTS = [
+  "check-conflict-markers.mjs",
+  "plugin-parity-drift.mjs",
+  "plugin-routing-validate.mjs",
+] as const;
+
+const SKILL_PATH =
+  "plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md";
+
+/** Marker literals as quoted strings, so this file is not itself flagged. */
+const START = "<<<<<<< HEAD";
+const SEP = "=======";
+const END = ">>>>>>> b4b3aff42 (chore(parity): refresh the pin)";
+
+/** A clean parity skill, pinned exactly the way the real one is. */
+const CLEAN_SKILL = [
+  "---",
+  "name: lisa-parity-safety-net-rules",
+  "synced-from: safety-net@cc-marketplace@2.0.4",
+  "---",
+  "",
+  "> **2.0.4 review.** No rule surface changed upstream.",
+  "",
+].join("\n");
+
+/** The exact #2548 shape: both sides kept, pin value present inside the block. */
+const CONFLICTED_SKILL = [
+  "---",
+  "name: lisa-parity-safety-net-rules",
+  "synced-from: safety-net@cc-marketplace@2.0.4",
+  "---",
+  "",
+  "> **2.0.4 review.**",
+  START,
+  "> hash the sorted (path, content) manifest of every rule-bearing directory.",
+  SEP,
+  "> Upstream 2.0.3-2.0.4 changed three things.",
+  END,
+  "",
+].join("\n");
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+/**
+ * Build a throwaway repository carrying the real hook, the real gate scripts, a
+ * valid routing artifact, and one parity skill.
+ *
+ * @param skill - the SKILL.md body to commit.
+ * @returns The absolute repository root.
+ */
+function gateRepo(skill: string): string {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-2552-gate-"));
+  const env = cleanGitEnv(process.env);
+  const git = (...args: readonly string[]): void => {
+    execFileSync(GIT, [...args], { cwd: root, env, stdio: "ignore" });
+  };
+  roots.push(root);
+  for (const dir of [
+    ".husky",
+    SCRIPTS_DIR,
+    ROUTING_DIR,
+    ".claude/skills",
+    path.dirname(SKILL_PATH),
+  ]) {
+    mkdirSync(path.join(root, dir), { recursive: true });
+  }
+  copyFileSync(HOOK, path.join(root, HOOK_RELATIVE));
+  for (const script of SCRIPTS) {
+    copyFileSync(
+      path.resolve(SCRIPTS_DIR, script),
+      path.join(root, SCRIPTS_DIR, script)
+    );
+  }
+  // A real, schema-valid routing artifact + its paired .md companion.
+  for (const entry of [ARTIFACT, "has-manifest@demo-marketplace.md"]) {
+    copyFileSync(
+      path.join(FIXTURE_ROUTING, entry),
+      path.join(root, ROUTING_DIR, entry)
+    );
+  }
+  writeFileSync(path.join(root, ".claude/skills/.keep"), "", "utf8");
+  writeFileSync(path.join(root, SKILL_PATH), skill, "utf8");
+  git("init", "-q");
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "Test");
+  git("add", "-A");
+  git("commit", "-q", "-m", "seed");
+  return root;
+}
+
+/**
+ * Run the copied hook with `sh` and capture its exit code and output.
+ *
+ * @param root - the throwaway repository root.
+ * @returns The exit code and combined output.
+ */
+function runHook(root: string): { code: number; output: string } {
+  try {
+    const stdout = execFileSync(SH, [HOOK_RELATIVE], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...cleanGitEnv(process.env),
+        // Pin the cache to somewhere that cannot exist so the run is
+        // deterministic regardless of what the developer has installed.
+        CLAUDE_PLUGIN_CACHE: path.join(root, "no-such-plugin-cache"),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, output: stdout };
+  } catch (error) {
+    const e = error as { status?: number; stdout?: string; stderr?: string };
+    return {
+      code: typeof e.status === "number" ? e.status : -1,
+      output: `${e.stdout ?? ""}${e.stderr ?? ""}`,
+    };
+  }
+}
+
+describe("parity push gate", () => {
+  it("passes a clean tree with no plugin cache on the machine", () => {
+    const { code, output } = runHook(gateRepo(CLEAN_SKILL));
+    expect(code).toBe(0);
+    expect(output).toContain("No leftover conflict markers");
+    expect(output).toContain("routing artifacts valid");
+  });
+
+  it("blocks the push on a conflict marker in a parity skill (#2548)", () => {
+    const { code, output } = runHook(gateRepo(CONFLICTED_SKILL));
+    expect(code).toBe(1);
+    expect(output).toContain("leftover merge-conflict markers");
+    expect(output).toContain(SKILL_PATH);
+  });
+
+  it("blocks the push when a routing artifact violates the contract", () => {
+    const root = gateRepo(CLEAN_SKILL);
+    const artifact = path.join(root, ROUTING_DIR, ARTIFACT);
+    const parsed = JSON.parse(readFileSync(artifact, "utf8")) as {
+      routing: Record<string, { outcome: string }>;
+    };
+    parsed.routing.codex.outcome = "not-a-real-outcome";
+    writeFileSync(artifact, JSON.stringify(parsed, null, 2), "utf8");
+    const { code, output } = runHook(root);
+    expect(code).toBe(1);
+    expect(output).toContain("routing artifacts failed validation");
+    expect(output).toContain("outcome invalid");
+  });
+
+  it("blocks the push when the routing directory has gone missing", () => {
+    const root = gateRepo(CLEAN_SKILL);
+    rmSync(path.join(root, ROUTING_DIR), { force: true, recursive: true });
+    // A gate that cannot run has not passed. Warning here is how a gate
+    // becomes vacuous, which is the whole subject of #2552.
+    expect(runHook(root).code).toBe(1);
+  });
+});
+
+describe("parity push gate wiring", () => {
+  const source = readFileSync(HOOK, "utf8");
+
+  it.each(SCRIPTS)("invokes scripts/%s", script => {
+    expect(source).toContain(`node ${SCRIPTS_DIR}/${script}`);
+  });
+
+  it("runs the conflict-marker gate in CI too, not only in the local hook", () => {
+    // A cloud agent or a hookless clone never runs .husky/pre-push.local.
+    const workflow = readFileSync(
+      path.resolve(".github/workflows/plugins-sync.yml"),
+      "utf8"
+    );
+    expect(workflow).toContain("bun run check:conflict-markers");
+  });
+});

--- a/tests/unit/scripts/check-conflict-markers.test.ts
+++ b/tests/unit/scripts/check-conflict-markers.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Unit tests for scripts/check-conflict-markers.mjs (issue #2552).
+ *
+ * The headline case is PR #2548: six generated parity `SKILL.md` files were
+ * committed with literal `<<<<<<< HEAD` conflict blocks and passed every gate,
+ * because the parity gate greps for a pin *value* (which sat inside the
+ * conflict block), the test suite never parses skill markdown, and the
+ * generated-vs-source comparison passed since both sides were broken the same
+ * way. This script is the gate that reads the bytes.
+ *
+ * Detection deliberately requires the COMPLETE ordered marker triple. A lone
+ * `<<<<<<<` line is left alone because prose that documents a merge conflict is
+ * legitimate content — a gate that fires on files it should not read is its own
+ * outage. Marker literals below are built as quoted strings so this very test
+ * file is not flagged by the gate it tests.
+ *
+ * Per the Test Isolation house rule, expected values are HARDCODED.
+ *
+ * @module tests/unit/scripts/check-conflict-markers
+ */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { afterEach, describe, expect, it } from "vitest";
+import { findConflictBlocks } from "../../../scripts/check-conflict-markers.mjs";
+import { cleanGitEnv } from "../../helpers/test-utils";
+
+const SCRIPT = path.resolve("scripts/check-conflict-markers.mjs");
+const GIT = "/usr/bin/git";
+const ADD_ALL = ["add", "-A"] as const;
+
+const START = "<<<<<<< HEAD";
+const BASE = "||||||| merged common ancestor";
+const SEP = "=======";
+const END = ">>>>>>> feature-branch";
+
+/** The exact #2548 shape: a conflicted blockquote inside a parity SKILL.md. */
+const SKILL_WITH_MARKERS = [
+  "---",
+  "name: lisa-parity-safety-net-rules",
+  "synced-from: safety-net@cc-marketplace@2.0.4",
+  "---",
+  "",
+  "> **2.0.4 review.**",
+  START,
+  "> hash the sorted (path, content) manifest of every rule-bearing directory.",
+  SEP,
+  "> Upstream 2.0.3-2.0.4 changed three things.",
+  END,
+  "",
+].join("\n");
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+/**
+ * Create a temporary git repository with `files` written and committed.
+ *
+ * @param files - relative path to file contents.
+ * @returns The absolute repository root.
+ */
+function tempRepo(files: Readonly<Record<string, string>>): string {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-2552-"));
+  const env = cleanGitEnv(process.env);
+  const entries = Object.entries(files);
+  const git = (...args: readonly string[]): void => {
+    execFileSync(GIT, [...args], { cwd: root, env, stdio: "ignore" });
+  };
+  roots.push(root);
+  for (const [relative, content] of entries) {
+    const target = path.join(root, relative);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, content, "utf8");
+  }
+  git("init", "-q");
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "Test");
+  if (entries.length > 0) {
+    git(...ADD_ALL);
+    git("commit", "-q", "-m", "seed");
+  }
+  return root;
+}
+
+/**
+ * Run the CLI and capture its exit code plus combined output.
+ *
+ * @param args - CLI arguments after the script path.
+ * @returns The exit code and stdout text.
+ */
+function run(args: readonly string[]): { code: number; stdout: string } {
+  try {
+    const stdout = execFileSync(process.execPath, [SCRIPT, ...args], {
+      encoding: "utf8",
+    });
+    return { code: 0, stdout };
+  } catch (error) {
+    const e = error as { status?: number; stdout?: string };
+    return {
+      code: typeof e.status === "number" ? e.status : -1,
+      stdout: e.stdout ?? "",
+    };
+  }
+}
+
+describe("findConflictBlocks", () => {
+  it("finds a complete git conflict block and reports 1-based line numbers", () => {
+    const content = ["alpha", START, "ours", SEP, "theirs", END, "omega"].join(
+      "\n"
+    );
+    expect(findConflictBlocks(content)).toEqual([
+      { endLine: 6, separatorLine: 4, startLine: 2 },
+    ]);
+  });
+
+  it("accepts the diff3 base marker between the start and the separator", () => {
+    const content = [START, "ours", BASE, "base", SEP, "theirs", END].join(
+      "\n"
+    );
+    expect(findConflictBlocks(content)).toEqual([
+      { endLine: 7, separatorLine: 5, startLine: 1 },
+    ]);
+  });
+
+  it("finds every block in a file, not just the first", () => {
+    const block = [START, "ours", SEP, "theirs", END];
+    expect(
+      findConflictBlocks([...block, "between", ...block].join("\n"))
+    ).toHaveLength(2);
+  });
+
+  it("ignores a lone start marker with no separator or terminator", () => {
+    expect(
+      findConflictBlocks([START, "ours", "no end here"].join("\n"))
+    ).toEqual([]);
+  });
+
+  it("ignores a lone terminator with no opening marker", () => {
+    expect(findConflictBlocks(["text", SEP, END].join("\n"))).toEqual([]);
+  });
+
+  it("ignores a markdown setext heading underline of seven equals", () => {
+    expect(findConflictBlocks(["Heading", SEP, "body"].join("\n"))).toEqual([]);
+  });
+
+  it("ignores markers that are not at the start of a line", () => {
+    const content = [`  ${START}`, `  ${SEP}`, `  ${END}`].join("\n");
+    expect(findConflictBlocks(content)).toEqual([]);
+  });
+
+  it("ignores a run of more than seven angle brackets", () => {
+    const content = ["<<<<<<<<", "ours", SEP, "theirs", ">>>>>>>>"].join("\n");
+    expect(findConflictBlocks(content)).toEqual([]);
+  });
+
+  it("handles CRLF line endings", () => {
+    const content = [START, "ours", SEP, "theirs", END].join("\r\n");
+    expect(findConflictBlocks(content)).toHaveLength(1);
+  });
+
+  it("returns nothing for clean content", () => {
+    expect(findConflictBlocks("nothing to see here\n")).toEqual([]);
+  });
+});
+
+describe("check-conflict-markers CLI", () => {
+  it("exits 0 for a clean tracked tree", () => {
+    const root = tempRepo({ "README.md": "# clean\n" });
+    expect(run(["--root", root]).code).toBe(0);
+  });
+
+  it("catches the #2548 shape: markers inside a generated parity SKILL.md", () => {
+    const skill = "plugins/lisa/skills/lisa-parity-safety-net-rules/SKILL.md";
+    const root = tempRepo({ [skill]: SKILL_WITH_MARKERS });
+    const { code, stdout } = run(["--root", root]);
+    expect(code).toBe(1);
+    expect(stdout).toContain(skill);
+    expect(stdout).toContain("line 7");
+  });
+
+  it("reports every offending file in the machine-readable report", () => {
+    const root = tempRepo({
+      "a.md": [START, "x", SEP, "y", END].join("\n"),
+      "b.md": [START, "x", SEP, "y", END].join("\n"),
+      "clean.md": "fine\n",
+    });
+    const { code, stdout } = run(["--root", root, "--json"]);
+    expect(code).toBe(1);
+    const report = JSON.parse(stdout) as {
+      summary: { conflicted: number; scanned: number };
+      results: readonly { file: string }[];
+    };
+    expect(report.summary.conflicted).toBe(2);
+    expect(
+      report.results.map(r => r.file).sort((a, b) => a.localeCompare(b))
+    ).toEqual(["a.md", "b.md"]);
+  });
+
+  it("ignores untracked files so a scratch file cannot block a push", () => {
+    const root = tempRepo({ "README.md": "# clean\n" });
+    writeFileSync(
+      path.join(root, "scratch.md"),
+      [START, "x", SEP, "y", END].join("\n"),
+      "utf8"
+    );
+    expect(run(["--root", root]).code).toBe(0);
+  });
+
+  it("skips binary files instead of decoding them as text", () => {
+    const root = tempRepo({ "README.md": "# clean\n" });
+    writeFileSync(
+      path.join(root, "blob.bin"),
+      Buffer.from([0x00, 0x01, 0x00, 0x02])
+    );
+    const env = cleanGitEnv(process.env);
+    execFileSync(GIT, [...ADD_ALL], { cwd: root, env, stdio: "ignore" });
+    execFileSync(GIT, ["commit", "-q", "-m", "blob"], {
+      cwd: root,
+      env,
+      stdio: "ignore",
+    });
+    expect(run(["--root", root]).code).toBe(0);
+  });
+
+  it("exits 2 on an unknown flag", () => {
+    expect(run(["--bogus"]).code).toBe(2);
+  });
+
+  it("exits 2 when a flag is missing its value", () => {
+    expect(run(["--root"]).code).toBe(2);
+  });
+
+  it("exits 2 when --root is not a directory", () => {
+    expect(run(["--root", path.join(tmpdir(), "lisa-2552-absent")]).code).toBe(
+      2
+    );
+  });
+
+  it("exits 2 when --root is not a git repository", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "lisa-2552-nogit-"));
+    roots.push(root);
+    expect(run(["--root", root]).code).toBe(2);
+  });
+});
+
+describe("the Lisa repository itself is marker-free", () => {
+  it("exits 0 against the real tracked tree", () => {
+    expect(run([]).code).toBe(0);
+  });
+});

--- a/tests/unit/scripts/plugin-routing-validate-cache-visibility.test.ts
+++ b/tests/unit/scripts/plugin-routing-validate-cache-visibility.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Cache visibility is a fact about the machine, not about the artifact
+ * (issue #2552).
+ *
+ * The routing validator only became safe to use as a push gate once it stopped
+ * treating "this plugin is not in my cache" as a contract violation. It used to
+ * emit `upstreamVersion X but no semver in the cache to confirm` and exit 1, so
+ * wiring it into `.husky/pre-push.local` would have made the repository
+ * unpushable from any machine without a Claude plugin cache — a fresh clone, a
+ * CI runner, a cloud session. That is the outage a gate must not cause.
+ *
+ * The replacement reports the version claim as `unverifiable` and exits 0 while
+ * still running every other gate, so a cacheless machine now validates strictly
+ * more than it did before, not less.
+ *
+ * Per the Test Isolation house rule, expected values are HARDCODED.
+ *
+ * @module tests/unit/scripts/plugin-routing-validate-cache-visibility
+ */
+import { describe, expect, it } from "vitest";
+import {
+  isVersionUnverifiable,
+  validateArtifact,
+} from "../../../scripts/plugin-routing-validate.mjs";
+import {
+  ABSENT_DIR,
+  baseArtifact,
+  baseContext,
+  CACHE_FLAG,
+  ROUTING_DIR_FLAG,
+  runValidate,
+  summaryOf,
+  VALID_DIR,
+} from "./plugin-routing-validate-helpers";
+
+describe("routing validation with no plugin cache", () => {
+  it("exits 0 and counts the artifact as unverifiable rather than invalid", () => {
+    const { code, report } = runValidate([
+      ROUTING_DIR_FLAG,
+      VALID_DIR,
+      CACHE_FLAG,
+      ABSENT_DIR,
+      "--json",
+    ]);
+    expect(code).toBe(0);
+    expect(report.summary).toEqual(summaryOf(1, 1, 0, 1));
+  });
+
+  it("raises no error for a semver upstream the cache cannot confirm", () => {
+    expect(
+      validateArtifact(baseArtifact(), { ...baseContext(), cacheMax: null })
+    ).toEqual([]);
+  });
+
+  it("still keeps every non-version gate on a cacheless machine", () => {
+    const artifact = baseArtifact();
+    artifact.routing.codex.outcome = "frobnicate";
+    const errors = validateArtifact(artifact, {
+      ...baseContext(),
+      cacheMax: null,
+    });
+    expect(errors).toContain("routing.codex outcome invalid: frobnicate");
+  });
+});
+
+describe("isVersionUnverifiable", () => {
+  it("is true only for a semver pin with nothing cached to compare against", () => {
+    expect(isVersionUnverifiable("1.2.3", null)).toBe(true);
+  });
+
+  it("is false when the cache can confirm or contradict the pin", () => {
+    expect(isVersionUnverifiable("1.2.3", "1.2.3")).toBe(false);
+    expect(isVersionUnverifiable("1.2.3", "9.9.9")).toBe(false);
+  });
+
+  it('is false for "unknown", which the version contract handles directly', () => {
+    expect(isVersionUnverifiable("unknown", null)).toBe(false);
+  });
+});

--- a/tests/unit/scripts/plugin-routing-validate-helpers.ts
+++ b/tests/unit/scripts/plugin-routing-validate-helpers.ts
@@ -33,6 +33,7 @@ export const STAMP_ACTION = `scaffold Lisa-native skill stamped synced-from: ${P
 export interface FileResult {
   readonly file: string;
   readonly errors: readonly string[];
+  readonly unverifiable?: boolean;
 }
 
 /** The machine-readable routing-validation report. */
@@ -42,6 +43,7 @@ export interface RoutingReport {
     readonly scanned: number;
     readonly valid: number;
     readonly invalid: number;
+    readonly unverifiable: number;
   };
   readonly results: readonly FileResult[];
 }
@@ -70,12 +72,31 @@ export function runValidate(args: readonly string[]): {
       report: (stdout.trim() === ""
         ? {
             schemaVersion: 1,
-            summary: { scanned: 0, valid: 0, invalid: 0 },
+            summary: { scanned: 0, valid: 0, invalid: 0, unverifiable: 0 },
             results: [],
           }
         : JSON.parse(stdout)) as RoutingReport,
     };
   }
+}
+
+/**
+ * Build an expected report summary. Keeps the assertions to one line each so
+ * the test file stays inside its max-lines budget.
+ *
+ * @param scanned - artifacts scanned.
+ * @param valid - artifacts with no blocking errors.
+ * @param invalid - artifacts with ≥1 blocking error.
+ * @param unverifiable - artifacts whose version this machine cannot confirm.
+ * @returns The expected summary object.
+ */
+export function summaryOf(
+  scanned: number,
+  valid: number,
+  invalid: number,
+  unverifiable = 0
+): RoutingReport["summary"] {
+  return { invalid, scanned, unverifiable, valid };
 }
 
 /** The validation context shape consumed by validateArtifact. */

--- a/tests/unit/scripts/plugin-routing-validate.test.ts
+++ b/tests/unit/scripts/plugin-routing-validate.test.ts
@@ -29,6 +29,7 @@ import {
   PLUGIN_NAME,
   ROUTING_DIR_FLAG,
   runValidate,
+  summaryOf,
   VALID_DIR,
 } from "./plugin-routing-validate-helpers";
 
@@ -57,7 +58,7 @@ describe("plugin-routing-validate end-to-end", () => {
       "--json",
     ]);
     expect(code).toBe(0);
-    expect(report.summary).toEqual({ scanned: 1, valid: 1, invalid: 0 });
+    expect(report.summary).toEqual(summaryOf(1, 1, 0));
   });
 
   it("exits 1 and reports the bad outcome for an invalid artifact", () => {
@@ -69,7 +70,7 @@ describe("plugin-routing-validate end-to-end", () => {
       "--json",
     ]);
     expect(code).toBe(1);
-    expect(report.summary).toEqual({ scanned: 1, valid: 0, invalid: 1 });
+    expect(report.summary).toEqual(summaryOf(1, 0, 1));
     expect(has(report.results[0]?.errors ?? [], "outcome invalid")).toBe(true);
   });
 
@@ -87,7 +88,7 @@ describe("plugin-routing-validate end-to-end", () => {
     const { code, report } = runValidate(["--bogus"]);
     expect(code).toBe(2);
     expect(report.schemaVersion).toBe(1);
-    expect(report.summary).toEqual({ scanned: 0, valid: 0, invalid: 0 });
+    expect(report.summary).toEqual(summaryOf(0, 0, 0));
     expect(report.results).toEqual([]);
   });
 });
@@ -280,15 +281,6 @@ describe("validateArtifact version contract", () => {
           cacheMax: "9.9.9",
         }),
         "!= cache max"
-      )
-    ).toBe(true);
-  });
-
-  it("flags a semver upstream with no semver in the cache", () => {
-    expect(
-      has(
-        validateArtifact(baseArtifact(), { ...baseContext(), cacheMax: null }),
-        "no semver in the cache"
       )
     ).toBe(true);
   });


### PR DESCRIPTION
Closes the vacuous green in the parity push gate, and the hole PR #2548 walked through — the same defect from two directions.

## What was unenforced

`.husky/pre-push.local` ran `plugin-parity-drift.mjs` and nothing else. That script reads skill **frontmatter**. `parity/plugin-routing/*.json` — the other half of the same contract, and the pre-flight gate for `implement-plugin-parity` — was never read, so it could sit invalid indefinitely while every push reported green. It did, three consecutive safety-net refreshes in a row (#2402, #2546).

The gate also never read the **bytes** of the skills it vouched for. PR #2548 committed literal `<<<<<<< HEAD` blocks into six generated parity `SKILL.md` files and passed everything: the drift gate matched the pin *value*, which sat inside the conflict block; the suite parses frontmatter, never the body; and `🧩 Plugin artifacts match source` compared two copies that were broken identically.

## What this adds

**1. `scripts/check-conflict-markers.mjs`** — reads every tracked file and blocks on a complete `<<<<<<<` / `=======` / `>>>>>>>` triple. Wired into `.husky/pre-push.local` **and** into the required `🧩 Plugin artifacts match source` job, because a cloud agent or hookless clone never runs the local hook.

**2. `plugin-routing-validate.mjs` in the push gate.** Exit 1 blocks. Exit 2 (routing dir gone, filesystem error) also blocks — a gate that cannot run has not passed, which is the whole subject of this issue.

**3. The validator no longer fails on cache invisibility.** It used to emit `upstreamVersion X but no semver in the cache to confirm` and exit 1, so wiring it in as-is would have bricked pushes from every machine without a Claude plugin cache. It now reports that as `unverifiable`, exits 0, and keeps every other gate. A cacheless clone therefore validates strictly **more** than before, not less.

## Deviation from the issue's AC3

The issue proposed mapping the validator's **exit 2** to a warning, on the assumption that exit 2 is how "no plugin cache" surfaces. It is not — a cacheless machine produced exit **1**, one error per artifact. The behaviour AC3 asks for (no cache ⇒ warn, do not block) is delivered by the `unverifiable` classification instead, and exit 2 keeps blocking so a missing routing directory cannot silently disable the gate.

## Proxy vs property

Both halves assert the property, not a proxy for it: the marker gate reads file bytes rather than trusting a regenerated copy to match, and the routing gate reads the artifacts rather than the pin value that describes them.

## Verification

Measured, re-runnable, not asserted.

**The acceptance test — would it have caught #2548?** A conflict block planted into the real `plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md`:

| gate, same working tree | verdict |
| --- | --- |
| `plugin-parity-drift.mjs` (the gate as it shipped) | **exit 0** — `safety-net@cc-marketplace 2.0.4 / 2.0.4 / ok`, `0 of 5 synced skills drifted` |
| `.husky/pre-push.local` (this PR) | **exit 1** — `✗ plugins/src/base/skills/lisa-parity-safety-net-rules/SKILL.md`, conflict block opens at line 37 |

**The routing half**, reproducing the historical sentry lag (artifact back to `1.3.1` against a `1.3.2` cache) — the drift gate still says the pins are current on the very same run:

```
🧭 Checking third-party plugin parity drift...
✅ Plugin parity pins are current
🧭 Validating plugin routing artifacts...
❌ Push blocked: plugin routing artifacts failed validation:
✗ sentry@claude-plugins-official.json
    - upstreamVersion 1.3.1 != cache max 1.3.2
```

**No false positives.** `7340` tracked files scanned, `0` markers. Clean tree runs the full gate green in ~1s.

**AC3, no plugin cache:** `CLAUDE_PLUGIN_CACHE=/nonexistent node scripts/plugin-routing-validate.mjs` → exit **0**, `7/7 routing artifacts valid, 0 invalid, 5 unverifiable on this machine`.

**The tests bind.** Deleting the conflict-marker block from the hook kills 3 tests; deleting the routing-validator block kills 4. `tests/unit/hooks/parity-push-gate.test.ts` executes the real hook file against a throwaway repository rather than grepping its text — a hook asserted only by grepping is the same class of evidence that produced the defect.

## Not done here

Distributing the marker gate to host projects via the `.husky/pre-push` template. Real value, fleet-wide blast radius, and it deserves its own review.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2552
