### PR TITLE
feat(maestro): order the platform legs so one persona is not driven twice at once

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -65,6 +65,53 @@
 # displaced run tests nothing and stomps nothing, whereas two concurrent runs
 # corrupt each other's fixtures and produce reds nobody can attribute.
 #
+# ── ORDERING THE TWO PLATFORM LEGS (`serialize_platform_legs`) ───────────────
+#
+# The concurrency group above is the WRONG tool for one specific problem, and
+# reaching for it there costs a day. It excludes whole workflow CALLS from each
+# other — this suite versus the Playwright suite. Inside one call, `android` and
+# `ios` are sibling jobs with identical `needs` and no edge between them, so
+# they always ran at the same time and a shared group changes nothing about it.
+#
+# That matters when both legs sign in as the SAME test persona. Two sign-ins
+# against one account invalidate each other's session, and the loser is logged
+# out mid-suite: it then asserts on an authenticated screen and finds the
+# sign-in screen. The failure is indistinguishable from a product defect by
+# inspection, and it moves between flows from night to night.
+#
+# Measured, not theorized. On geminisportsai/frontend-v2 the Maestro suite on
+# `dev` was 1 success in 6 runs; run 31757559016 failed 2 of 38 Android flows on
+# `id: ^(?:SIGNIN.INPUT_PHONE|TAB_BAR.S…` while the iOS leg passed — a sign-in
+# screen where a tab bar was expected. On TunnlAI/frontend, flow failure rate
+# was 33% while the legs overlapped and 16% after one leg finished, across two
+# runs.
+#
+# `serialize_platform_legs: true` runs iOS to completion first, then Android.
+# It is OFF by default, because a project whose legs use per-platform accounts
+# gets its whole suite in the length of its slowest leg and should keep that.
+#
+# ORDERING, NOT GATING. A FAILING iOS leg still releases Android. Anything else
+# would let a single flaky iOS flow delete the Android suite from the night and
+# report the narrower result under the same green check — trading a contention
+# bug for a coverage bug, which is the worse of the two.
+#
+# The mechanism is a `leg_order` job that Android depends on and that polls this
+# run's own job list for the iOS job. It is indirect because `needs` cannot hold
+# an expression: there is no way to write "depend on `ios` only when an input is
+# set". The job's own comment records the three alternatives and why each was
+# rejected. Consequences worth knowing:
+#
+#   • It needs the `actions: read` permission, and a called workflow cannot hold
+#     a permission its CALLER did not grant. A caller with only `contents: read`
+#     gets a named 403 from that job — not a silent revert to concurrency.
+#   • If that job fails or times out, Android still runs. The run goes red and
+#     the legs overlap for that night, which is exactly today's behavior.
+#   • Opting IN costs an idle ubuntu-latest runner for as long as the iOS suite
+#     takes, plus one held job slot. The default path does not pay it: with the
+#     input unset the job runs no steps and ends in seconds. Wall clock is the
+#     larger bill either way — the suite now takes iOS PLUS Android rather than
+#     the slower of the two, which is the actual price of not sharing a persona.
+#
 # ── TWO SETUP SEAMS, AND WHICH ONE YOU WANT ──────────────────────────────────
 #
 # `pre_suite_command` — runs EXACTLY ONCE per workflow run, in its own job that
@@ -321,6 +368,41 @@ on:
         required: false
         default: ''
         type: string
+      serialize_platform_legs:
+        description: >-
+          Run the iOS leg to completion BEFORE the Android leg starts, instead of
+          running both at once. Set this when the two legs authenticate as the
+          SAME test persona: concurrently they mutate one server-side session,
+          and the loser gets logged out mid-suite and asserts against a sign-in
+          screen where an authenticated screen was expected. That failure looks
+          exactly like a product defect and is not one — see the "Ordering the
+          two platform legs" section in this file's header for the measurements.
+          `concurrency_group` does NOT do this: it serializes whole workflow
+          CALLS against each other (Maestro vs Playwright), not leg against leg
+          inside one call. Default false = both legs start together, prior
+          behavior preserved byte for byte. A failing iOS leg never suppresses
+          Android — ordering here is "after", never "only if it passed". The
+          cost of turning it on is the suite taking iOS PLUS Android instead of
+          the slower of the two, and one idle ubuntu-latest runner held for the
+          length of the iOS suite; leave it off if your legs use per-platform
+          accounts, because the concurrency is free coverage in that case.
+        required: false
+        default: false
+        type: boolean
+      serialize_timeout_minutes:
+        description: >-
+          Ceiling for the leg-ordering job, which only does anything when
+          serialize_platform_legs is on. That job waits through the pre-suite
+          job AND the whole iOS suite, so it must exceed
+          pre_suite_timeout_minutes + suite_timeout_minutes — and it cannot be
+          derived from them, because GitHub Actions expressions have no
+          arithmetic operators at all. Raise it in lockstep if you raise either
+          of those. Timing out here does not lose the Android leg: that job runs
+          on `!cancelled()`, so a blown budget degrades to today's concurrent
+          legs with a red job naming the cause.
+        required: false
+        default: 150
+        type: number
     secrets:
       EXPO_TOKEN:
         description: 'Expo token for EAS builds. When absent, the whole suite skips with a warning.'
@@ -662,9 +744,163 @@ jobs:
             echo "Pre-suite command exported: $(echo "$PAIRS" | tr ' ' '\n' | cut -d= -f1 | tr '\n' ' ')"
           fi
 
+  leg_order:
+    name: 🚦 Leg order (iOS → Android)
+    # The Android leg depends on THIS job, and this job is what waits for the
+    # iOS leg. The indirection is forced: `needs` cannot contain an expression,
+    # so `android` cannot conditionally depend on `ios`. The three alternatives
+    # were each worse:
+    #
+    #   • `needs: [ios]` on android outright — serializes EVERY adopter,
+    #     including the ones with per-platform personas who are paying nothing
+    #     for concurrency today.
+    #   • a second, duplicated android job wired `needs: [ios]`, picked by `if`
+    #     — 400 duplicated lines, and whichever copy is unused concludes
+    #     `skipped` on every run, which the nightly health gate's row 26 reads
+    #     as `incomplete_run` for every adopter (docs/nightly-e2e-gate.md §2.4).
+    #   • job-level `concurrency` shared between the two legs — that is mutual
+    #     exclusion with no ORDER, and the owner asked for iOS first.
+    #
+    # Runs beside `pre_suite`, not after it, so the default path pays nothing:
+    # with the input unset this job does no work and concludes while `pre_suite`
+    # is still running, and `android` was already waiting on `pre_suite` anyway.
+    # Its start time is therefore unchanged.
+    #
+    # DELIBERATELY NOT gated on `inputs.serialize_platform_legs`, for the same
+    # reason `pre_suite` is not gated on `pre_suite_command != ''`: a job that
+    # skips itself whenever the input is unset turns every green nightly into a
+    # blocked one for every adopter who does not use the seam. The JOB always
+    # runs in a wired run and the WORK is gated per-step below.
+    needs: [preflight, build]
+    if: ${{ !cancelled() && needs.preflight.outputs.should_run == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Reading this run's own job list. A caller whose token is narrower than
+      # this gets a named 403 from the step below rather than a silent pass.
+      actions: read
+    # Its own input rather than a sum of the two budgets it actually spans:
+    # GitHub Actions expressions have NO arithmetic operators, so
+    # `pre_suite_timeout_minutes + suite_timeout_minutes` is a syntax error, not
+    # a value. tests/integration/maestro-leg-order.test.ts pins the default here
+    # above the sum of those two defaults so the three cannot drift apart
+    # silently.
+    timeout-minutes: ${{ inputs.serialize_timeout_minutes }}
+    steps:
+      - name: 🚦 Wait for the iOS leg to finish
+        # Three conditions, all required. Serialization is opt-in; and there is
+        # nothing to order unless BOTH legs are actually in this run, so a
+        # platform-narrowed dispatch falls straight through instead of waiting
+        # for a job that will never exist.
+        if: ${{ inputs.serialize_platform_legs && needs.preflight.outputs.run_ios == 'true' && needs.preflight.outputs.run_android == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          # Matched as a SUFFIX of the API's job name: a reusable workflow's
+          # jobs are reported as `<caller job name> / <this job name>`, so an
+          # equality test would never match. Pinned against `jobs.ios.name` by
+          # tests/integration/maestro-leg-order.test.ts, because a renamed iOS
+          # job with a stale constant here is a gate that waits for nothing.
+          IOS_JOB_NAME: 🍎 Maestro iOS
+          POLL_SECONDS: '20'
+          # How long the iOS job may take to APPEAR in the job list. This job
+          # starts beside `pre_suite`, and iOS does not exist as a queued job
+          # until `pre_suite` concludes, so the discovery window has to cover
+          # the whole pre-suite budget. The slack is added in the shell below
+          # because GitHub Actions expressions have no arithmetic.
+          PRE_SUITE_TIMEOUT_MINUTES: ${{ inputs.pre_suite_timeout_minutes }}
+          DISCOVERY_SLACK_MINUTES: '5'
+          MAX_PAGES: '10'
+        run: |
+          set -euo pipefail
+          DISCOVERY_SECONDS=$(( (PRE_SUITE_TIMEOUT_MINUTES + DISCOVERY_SLACK_MINUTES) * 60 ))
+          page_file="$(mktemp)"
+          started=$SECONDS
+          discovered=false
+          while true; do
+            total=0
+            pending=0
+            page=1
+            while true; do
+              if ! curl -fsSL \
+                -H "Authorization: Bearer $GH_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                -o "$page_file" \
+                "$API_URL/repos/$REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs?per_page=100&page=$page"; then
+                echo "::error title=Leg order could not read this run's jobs::GET /repos/$REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs failed. The usual cause is token scope: serialize_platform_legs needs \`actions: read\`, and a called workflow cannot hold a permission the CALLER did not grant. Add \`actions: read\` to the calling workflow's permissions block."
+                exit 1
+              fi
+              matched="$(jq --arg name "$IOS_JOB_NAME" '[.jobs[] | select(.name | endswith($name))] | length' "$page_file")"
+              unfinished="$(jq --arg name "$IOS_JOB_NAME" '[.jobs[] | select(.name | endswith($name)) | select(.status != "completed")] | length' "$page_file")"
+              returned="$(jq '.jobs | length' "$page_file")"
+              total=$(( total + matched ))
+              pending=$(( pending + unfinished ))
+              if [[ "$returned" -lt 100 ]]; then
+                break
+              fi
+              page=$(( page + 1 ))
+              if [[ "$page" -gt "$MAX_PAGES" ]]; then
+                echo "::error title=Leg order could not enumerate this run's jobs::More than $MAX_PAGES pages of jobs. Refusing to report the iOS leg finished on a job list this step could not read to the end."
+                exit 1
+              fi
+            done
+            # The absent case is NOT the done case. Zero matching jobs means
+            # "iOS has not been created yet" or "the name constant is stale",
+            # and neither of those is "iOS finished". Reporting success here
+            # would be a guard that passes because it looked at nothing.
+            if [[ "$total" -eq 0 ]]; then
+              if [[ $(( SECONDS - started )) -ge "$DISCOVERY_SECONDS" ]]; then
+                echo "::error title=Leg order never found the iOS leg::No job in this run has a name ending in '$IOS_JOB_NAME' after ${DISCOVERY_SECONDS}s. Either the iOS job was renamed without updating IOS_JOB_NAME in this workflow, or it never entered the run. Not reporting the iOS leg complete on evidence that does not exist."
+                exit 1
+              fi
+              echo "iOS leg not in the job list yet; waiting ($(( SECONDS - started ))s elapsed)."
+              sleep "$POLL_SECONDS"
+              continue
+            fi
+            discovered=true
+            if [[ "$pending" -eq 0 ]]; then
+              # Terminal is terminal. A FAILED iOS leg releases Android exactly
+              # like a passing one — the point of this gate is that the two legs
+              # never touch the persona at the same time, not that Android is
+              # only worth running when iOS was green. Gating on conclusion
+              # would let one flaky iOS flow silently halve the suite.
+              echo "iOS leg finished ($total job(s), terminal). Releasing the Android leg."
+              break
+            fi
+            echo "iOS leg still running ($pending of $total job(s) not completed); waiting."
+            sleep "$POLL_SECONDS"
+          done
+          echo "discovered=$discovered"
+
+      - name: 🚦 Report the ordering decision
+        env:
+          SERIALIZE: ${{ inputs.serialize_platform_legs }}
+          RUN_IOS: ${{ needs.preflight.outputs.run_ios }}
+          RUN_ANDROID: ${{ needs.preflight.outputs.run_android }}
+        run: |
+          if [[ "$SERIALIZE" != "true" ]]; then
+            echo "serialize_platform_legs is off — both platform legs start together (default behavior)."
+          elif [[ "$RUN_IOS" != "true" || "$RUN_ANDROID" != "true" ]]; then
+            echo "Only one platform leg is in this run (ios=$RUN_IOS android=$RUN_ANDROID) — nothing to order."
+          else
+            echo "iOS leg complete; the Android leg is released."
+          fi
+
   android:
     name: 🤖 Maestro Android
-    needs: [preflight, build, pre_suite]
+    # `leg_order` is in `needs` purely for the EDGE — it is what makes GitHub
+    # hold this job until that one concludes, and `leg_order` is what waits for
+    # the iOS leg when serialization is on. It deliberately appears in no `if`
+    # clause below: the existing `!cancelled()` is what lets this job run when
+    # `leg_order` fails or times out, so a broken serializer degrades to today's
+    # concurrent behavior (loudly, with a red job) instead of dropping the
+    # entire Android suite. Contrast `pre_suite`, which IS result-gated, because
+    # established state is a precondition for testing and mere ordering is not.
+    needs: [preflight, build, pre_suite, leg_order]
     runs-on: ubuntu-latest
     # Caller-tunable, defaulting to 90 to match the iOS job: the 60 inherited
     # from frontend-v2's original workflow started timing out once its suite

--- a/expo/create-only/.github/workflows/maestro-e2e.yml
+++ b/expo/create-only/.github/workflows/maestro-e2e.yml
@@ -71,6 +71,12 @@ on:
 
 permissions:
   contents: read
+  # Read-only, and only this run's own job list. It is what
+  # `serialize_platform_legs` below needs to know when the iOS leg has
+  # finished — a called workflow cannot hold a permission the caller did not
+  # grant, so dropping this line turns that input into a red job rather than a
+  # silent no-op. Harmless when the input is off.
+  actions: read
 
 # Keyed on the ENVIRONMENT this suite drives, not on the ref. Every run of this
 # workflow targets the same backend no matter which branch dispatched it, so
@@ -114,6 +120,16 @@ jobs:
       # than any stagger, so the suite scheduled first can begin hours after the
       # one scheduled second.
       # concurrency_group: 'e2e-shared-test-user-dev'
+      #
+      # Uncomment when both platform legs sign in as the SAME test account. The
+      # legs run concurrently by default and each one's sign-in invalidates the
+      # other's session, so the loser hits a sign-in screen mid-suite and fails
+      # an assertion that has nothing wrong with it. This runs iOS first, then
+      # Android. It is ordering, not gating: a FAILING iOS leg still releases
+      # Android, so turning it on never narrows what gets tested. Requires the
+      # `actions: read` permission above. Leave it off if your legs use
+      # per-platform accounts — the concurrency is free coverage in that case.
+      # serialize_platform_legs: true
     secrets:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       MAESTRO_SECRET_ENV: ${{ secrets.MAESTRO_SECRET_ENV }}

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -209,7 +209,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/create-only/.github/workflows/deploy.yml":
       "27f5037db910501f8d76f828f91a605e3c4d321d1df362d317c440ab7abc9f14",
     "expo/create-only/.github/workflows/maestro-e2e.yml":
-      "805256e2922abb8d08c00e833adb4f0c521e62cc7259ee5c0524475d496914f1",
+      "889084395ca48e07d01725158bf8b091e5c19f1800d5f4beee777e2b95530246",
     "expo/create-only/.github/workflows/nightly-e2e-bypass-reaper.yml":
       "db78a1012a00cf4e8b023a67bb57566ae85cf790c3856f3e299636c766f0c242",
     "expo/create-only/.github/workflows/nightly-e2e-health.yml":
@@ -8563,6 +8563,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/integration/jest-expo-haste-pruning.test.ts": true,
     "tests/integration/lisa.test.ts": true,
     "tests/integration/maestro-caller-template.test.ts": true,
+    "tests/integration/maestro-leg-order-wait.test.ts": true,
+    "tests/integration/maestro-leg-order.test.ts": true,
     "tests/integration/maestro-native-concurrency.test.ts": true,
     "tests/integration/maestro-native-driver-retry.test.ts": true,
     "tests/integration/maestro-native-flake-classification.test.ts": true,
@@ -8584,6 +8586,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/integration/standards-proof-tamper.test.ts": true,
     "tests/integration/standards-proof-timeout.test.ts": true,
     "tests/integration/standards-proof-typescript.test.ts": true,
+    "tests/integration/support/maestro-leg-order-harness.ts": true,
     "tests/unit/agy/block-no-verify-agy.test.ts": true,
     "tests/unit/agy/mcp-collect.test.ts": true,
     "tests/unit/agy/mcp-installer.test.ts": true,

--- a/tests/integration/maestro-leg-order-wait.test.ts
+++ b/tests/integration/maestro-leg-order-wait.test.ts
@@ -1,0 +1,174 @@
+/**
+ * `serialize_platform_legs` — the executable half. The job graph is pinned in
+ * `maestro-leg-order.test.ts`; this file runs the `leg_order` job's REAL poll
+ * loop, taken verbatim out of the workflow YAML, against a fake Actions jobs
+ * API.
+ *
+ * `needs` cannot hold an expression, so no edge can say "depend on `ios` only
+ * when an input is set". The edge is therefore `android → leg_order`, and THIS
+ * is the code that decides how long that edge holds. Asserting the edge alone
+ * would prove nothing about ordering; a poll loop that returned immediately
+ * would satisfy it perfectly.
+ *
+ * Four things are proved by running it:
+ *
+ *   • it does NOT return while the iOS job is still running (the ordering);
+ *   • it DOES return on an iOS job that failed, was skipped, timed out, or was
+ *     cancelled — ordering, never gating, so no flaky iOS flow can delete the
+ *     Android suite from the night;
+ *   • a poll that matches ZERO iOS jobs is an error, never a pass. That is the
+ *     failure mode this job could most easily have had: a guard reporting
+ *     success because it looked at nothing;
+ *   • a refused API is a named error, not a silent revert to concurrency.
+ */
+
+import * as fs from "fs-extra";
+import yaml from "js-yaml";
+import { spawnSync } from "node:child_process";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  ANDROID_API_JOB,
+  iosApiJob,
+  runWaitStep,
+  startFakeApi,
+  startRefusingApi,
+} from "./support/maestro-leg-order-harness";
+import type { SimulatedWorkflow } from "../helpers/workflow-job-graph";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REUSABLE_YML = path.join(
+  path.resolve(__dirname, "..", ".."),
+  ".github",
+  "workflows",
+  "maestro-native-e2e.yml"
+);
+
+const LEG_ORDER = "leg_order";
+
+/**
+ * The wait step shells out to jq, which every ubuntu-latest runner ships — so
+ * this block always runs in CI and only ever skips on a dev machine without it.
+ */
+const hasJq = spawnSync("/bin/sh", ["-c", "command -v jq"]).status === 0;
+
+describe.skipIf(!hasJq)("maestro-native-e2e leg ordering — the wait", () => {
+  let workflow: SimulatedWorkflow;
+
+  beforeAll(async () => {
+    workflow = yaml.load(
+      await fs.readFile(REUSABLE_YML, "utf-8")
+    ) as SimulatedWorkflow;
+  });
+
+  describe("bite control 1 — ordering holds", () => {
+    it("does not return while the iOS job is still running", async () => {
+      // The API reports iOS queued, then in_progress twice, before completing.
+      // Returning on any of the first three would release Android while iOS
+      // still holds the persona — which is the bug, restated.
+      const api = await startFakeApi([
+        [ANDROID_API_JOB, iosApiJob("queued", null)],
+        [ANDROID_API_JOB, iosApiJob("in_progress", null)],
+        [ANDROID_API_JOB, iosApiJob("in_progress", null)],
+        [ANDROID_API_JOB, iosApiJob("completed", "success")],
+      ]);
+      try {
+        const result = await runWaitStep(workflow, LEG_ORDER, api);
+        expect(result.status).toBe(0);
+        // Three "still running" lines then a release: it kept asking until the
+        // answer changed, in its own words rather than a counter this test
+        // invented. A loop that returned on the first poll would print none.
+        const waited = result.stdout
+          .split("\n")
+          .filter(line => line.includes("still running"));
+        expect(waited).toHaveLength(3);
+        expect(result.stdout).toContain("Releasing the Android leg");
+      } finally {
+        await api.close();
+      }
+    });
+
+    it("matches the API's caller-prefixed job name", async () => {
+      // A reusable workflow's jobs are reported as `<caller job> / <job>`, so
+      // an equality match would never fire and this job would wait out its
+      // whole budget on a suite that had already finished.
+      const api = await startFakeApi([[iosApiJob("completed", "success")]]);
+      try {
+        expect((await runWaitStep(workflow, LEG_ORDER, api)).status).toBe(0);
+      } finally {
+        await api.close();
+      }
+    });
+
+    it("errors rather than passing when no iOS job is ever found", async () => {
+      // The absent case is NOT the done case. Zero matches means the job has
+      // not been created yet, or the name constant is stale — and neither of
+      // those is "iOS finished". The discovery window is collapsed to zero here
+      // so the bound is reached on the first poll instead of in five minutes.
+      const api = await startFakeApi([[ANDROID_API_JOB]]);
+      try {
+        const result = await runWaitStep(workflow, LEG_ORDER, api, {
+          PRE_SUITE_TIMEOUT_MINUTES: "0",
+          DISCOVERY_SLACK_MINUTES: "0",
+        });
+        expect(result.status).not.toBe(0);
+        expect(result.stdout + result.stderr).toContain(
+          "never found the iOS leg"
+        );
+      } finally {
+        await api.close();
+      }
+    });
+
+    it("fails loudly when the jobs API refuses it", async () => {
+      // The `actions: read` case. A 403 must not read as "iOS is done", and
+      // must not read as "carry on quietly" either — the caller has to find out
+      // its permissions block is short, and the error names the fix.
+      const api = await startRefusingApi(403);
+      try {
+        const result = await runWaitStep(workflow, LEG_ORDER, api);
+        expect(result.status).not.toBe(0);
+        expect(result.stdout + result.stderr).toContain("actions: read");
+      } finally {
+        await api.close();
+      }
+    });
+  });
+
+  describe("bite control 3 — a failing iOS leg does not suppress Android", () => {
+    it("releases Android on an iOS leg that FAILED", async () => {
+      // Ordering, not gating. Waiting on a CONCLUSION instead of a terminal
+      // STATUS would let one flaky iOS flow delete the whole Android suite from
+      // the night and report the narrower result under the same green check —
+      // trading a contention bug for a coverage bug, which is the worse of the
+      // two.
+      const api = await startFakeApi([
+        [ANDROID_API_JOB, iosApiJob("in_progress", null)],
+        [ANDROID_API_JOB, iosApiJob("completed", "failure")],
+      ]);
+      try {
+        const result = await runWaitStep(workflow, LEG_ORDER, api);
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain("Releasing the Android leg");
+      } finally {
+        await api.close();
+      }
+    });
+
+    it.each(["skipped", "timed_out", "cancelled", "neutral"])(
+      "releases Android on an iOS leg that concluded %s",
+      async conclusion => {
+        const api = await startFakeApi([
+          [ANDROID_API_JOB, iosApiJob("completed", conclusion)],
+        ]);
+        try {
+          expect((await runWaitStep(workflow, LEG_ORDER, api)).status).toBe(0);
+        } finally {
+          await api.close();
+        }
+      }
+    );
+  });
+});

--- a/tests/integration/maestro-leg-order.test.ts
+++ b/tests/integration/maestro-leg-order.test.ts
@@ -1,0 +1,291 @@
+/**
+ * `serialize_platform_legs` — the opt-in iOS-then-Android ordering, job-graph
+ * half. The poll loop that does the actual waiting is proved by executing it,
+ * in `maestro-leg-order-wait.test.ts`.
+ *
+ * The defect this closes: `android` and `ios` are sibling jobs with identical
+ * `needs` and no edge between them, so they always ran at once. When both legs
+ * sign in as the same test persona they invalidate each other's session and the
+ * loser asserts on an authenticated screen and finds the sign-in screen —
+ * measured at 1 success in 6 runs on geminisportsai/frontend-v2, and at 33%
+ * flow failure while the legs overlap vs 16% after one finishes on
+ * TunnlAI/frontend.
+ *
+ * `needs` cannot hold an expression, so there is no way to write "depend on
+ * `ios` only when an input is set". The ordering is therefore split: this file
+ * pins the unconditional `android → leg_order` edge and the guards around it,
+ * and the sibling file pins what `leg_order` does with that time.
+ *
+ * The properties here:
+ *
+ *   • the input is opt-in and defaults to today's behavior;
+ *   • Android gains no unconditional edge to iOS, and `leg_order` starts no
+ *     later than a job Android already waited on, so the default path cannot
+ *     lose wall clock;
+ *   • Android runs even when `leg_order` fails — with a failed `pre_suite` as
+ *     the negative control, so "runs anyway" is not mistaken for a blanket;
+ *   • single-platform runs neither deadlock nor skip.
+ */
+
+import * as fs from "fs-extra";
+import yaml from "js-yaml";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { needsOf, runPreflight } from "./support/maestro-leg-order-harness";
+import {
+  evaluateIf,
+  simulateRun,
+  type SimulatedWorkflow,
+} from "../helpers/workflow-job-graph";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const REUSABLE_YML = path.join(
+  REPO_ROOT,
+  ".github",
+  "workflows",
+  "maestro-native-e2e.yml"
+);
+const CALLER_YML = path.join(
+  REPO_ROOT,
+  "expo",
+  "create-only",
+  ".github",
+  "workflows",
+  "maestro-e2e.yml"
+);
+
+const LEG_ORDER = "leg_order";
+const ANDROID = "android";
+const IOS = "ios";
+const PRE_SUITE = "pre_suite";
+const PREFLIGHT = "preflight";
+const SERIALIZE = "serialize_platform_legs";
+
+describe("maestro-native-e2e leg ordering — job graph", () => {
+  let workflow: SimulatedWorkflow;
+  let raw: Record<string, unknown>;
+  let caller: Record<string, unknown>;
+
+  beforeAll(async () => {
+    raw = yaml.load(await fs.readFile(REUSABLE_YML, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    workflow = raw as unknown as SimulatedWorkflow;
+    caller = yaml.load(await fs.readFile(CALLER_YML, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+  });
+
+  /**
+   * The reusable workflow's `workflow_call` inputs block.
+   *
+   * @returns Every declared input, keyed by name.
+   */
+  const inputsOf = (): Record<string, Record<string, unknown>> =>
+    (
+      (raw.on as Record<string, Record<string, unknown>>).workflow_call as {
+        inputs: Record<string, Record<string, unknown>>;
+      }
+    ).inputs;
+
+  describe("the input", () => {
+    it("is opt-in: a boolean defaulting to false", () => {
+      // The concurrency_group precedent — an unset input must leave every
+      // existing consumer on exactly the behavior it has today.
+      const input = inputsOf()[SERIALIZE];
+      expect(input).toBeDefined();
+      expect(input.required).toBe(false);
+      expect(input.default).toBe(false);
+      expect(input.type).toBe("boolean");
+    });
+
+    it("budgets the ordering job above the two waits it spans", () => {
+      // GitHub Actions expressions have no arithmetic operators, so this
+      // ceiling cannot be derived from the two budgets it must cover and is an
+      // input instead. Unpinned, the three defaults drift apart and the job
+      // starts timing out on an iOS suite that is merely slow.
+      const declared = inputsOf();
+      const serializeTimeout = Number(
+        declared.serialize_timeout_minutes.default
+      );
+      const spanned =
+        Number(declared.pre_suite_timeout_minutes.default) +
+        Number(declared.suite_timeout_minutes.default);
+      expect(serializeTimeout).toBeGreaterThan(spanned);
+    });
+
+    it("is reachable from the shipped caller template", () => {
+      // The template is create-only, so this is the wiring NEW adopters get.
+      // `actions: read` is the half nobody would guess: a called workflow
+      // cannot hold a permission the caller did not grant, so without it the
+      // input produces a red job instead of an ordering.
+      const permissions = caller.permissions as Record<string, string>;
+      expect(permissions.actions).toBe("read");
+      expect(fs.readFileSync(CALLER_YML, "utf-8")).toContain(
+        `# ${SERIALIZE}: true`
+      );
+    });
+  });
+
+  describe("bite control 1 — ordering holds", () => {
+    it("puts leg_order on Android's needs, so GitHub holds Android for it", () => {
+      // The edge is unconditional; the CONDITION lives inside leg_order's own
+      // step, because `needs` cannot hold an expression.
+      expect(needsOf(workflow, ANDROID)).toContain(LEG_ORDER);
+    });
+
+    it("declares leg_order between build and android", () => {
+      // Keeps the graph topological in declaration order, which is what the
+      // simulator (and a human reading the file) walks.
+      const order = Object.keys(workflow.jobs);
+      expect(order.indexOf(LEG_ORDER)).toBeLessThan(order.indexOf(ANDROID));
+      expect(order.indexOf(LEG_ORDER)).toBeGreaterThan(order.indexOf("build"));
+    });
+
+    it("matches the iOS job by the name that job actually declares", () => {
+      // A renamed iOS job with a stale constant here is a job that waits for
+      // something that does not exist. The absent-case test in the sibling file
+      // turns that into an error rather than a pass; this pin is what stops it
+      // happening at all.
+      const step = (workflow.jobs[LEG_ORDER].steps ?? [])[0];
+      const pinned = (step.env as Record<string, string>).IOS_JOB_NAME;
+      expect(pinned).toBe(workflow.jobs[IOS].name);
+    });
+  });
+
+  describe("bite control 2 — default unchanged", () => {
+    it("does no waiting when the input is unset", () => {
+      // The wait step's own guard, evaluated against an otherwise fully wired
+      // run. False here means the step never executes, so leg_order concludes
+      // as fast as a runner can start it.
+      const step = (workflow.jobs[LEG_ORDER].steps ?? [])[0];
+      const wired = {
+        needs: {
+          preflight: { outputs: { run_ios: "true", run_android: "true" } },
+        },
+      };
+      expect(evaluateIf(step.if, { ...wired, inputs: {} })).toBe(false);
+      expect(
+        evaluateIf(step.if, { ...wired, inputs: { [SERIALIZE]: false } })
+      ).toBe(false);
+      // ...and true only when the caller opted in.
+      expect(
+        evaluateIf(step.if, { ...wired, inputs: { [SERIALIZE]: true } })
+      ).toBe(true);
+    });
+
+    it("never gives Android an unconditional edge to iOS", () => {
+      // The change that would have been easy and wrong: `needs: [ios]` on
+      // android serializes EVERY adopter, including the ones with per-platform
+      // personas who are paying nothing for concurrency today.
+      expect(needsOf(workflow, ANDROID)).not.toContain(IOS);
+      expect(needsOf(workflow, IOS)).not.toContain(ANDROID);
+    });
+
+    it("starts leg_order no later than a job Android already waited on", () => {
+      // This is why the default path pays nothing in wall clock. leg_order's
+      // dependencies are a subset of pre_suite's, so it becomes eligible at the
+      // same moment pre_suite does — and Android already could not start before
+      // pre_suite finished. Depending on pre_suite here would instead push a
+      // fresh runner acquisition onto Android's critical path on every run,
+      // opted in or not.
+      const legOrderNeeds = needsOf(workflow, LEG_ORDER);
+      const preSuiteNeeds = needsOf(workflow, PRE_SUITE);
+      expect(legOrderNeeds).not.toContain(PRE_SUITE);
+      expect(legOrderNeeds.every(job => preSuiteNeeds.includes(job))).toBe(
+        true
+      );
+      expect(needsOf(workflow, ANDROID)).toContain(PRE_SUITE);
+    });
+
+    it("runs leg_order rather than skipping it in a wired run", () => {
+      // Row 26 of the nightly gate reads any non-`success` job behind a
+      // `mode: "run"` suite as `incomplete_run`. A job gated on
+      // `inputs.serialize_platform_legs` at JOB level would therefore turn
+      // every green nightly into a blocked one for every adopter who does not
+      // use the seam — which is all of them on the day this lands.
+      const outputs = runPreflight(workflow, "all");
+      const run = simulateRun(workflow, {
+        seed: { name: PREFLIGHT, outputs },
+        inputs: { platform: "all" },
+      });
+      expect(run.jobs[LEG_ORDER].ran).toBe(true);
+      expect(run.jobs[LEG_ORDER].result).toBe("success");
+      expect(run.jobs[ANDROID].ran).toBe(true);
+      expect(run.jobs[IOS].ran).toBe(true);
+    });
+  });
+
+  describe("bite control 3 — a failing leg does not suppress Android", () => {
+    it("runs Android even when leg_order itself fails", () => {
+      // Android's guard deliberately carries NO result allowlist for
+      // leg_order — the existing `!cancelled()` is what lets a broken
+      // serializer degrade to today's concurrent legs instead of dropping the
+      // Android suite entirely.
+      const outputs = runPreflight(workflow, "all");
+      const run = simulateRun(workflow, {
+        seed: { name: PREFLIGHT, outputs },
+        inputs: { platform: "all", [SERIALIZE]: true },
+        forcedResults: { [LEG_ORDER]: "failure" },
+      });
+      expect(run.jobs[LEG_ORDER].result).toBe("failure");
+      expect(run.jobs[ANDROID].ran).toBe(true);
+    });
+
+    it("still fails Android closed on a failed pre_suite", () => {
+      // The negative control for the assertion above: `!cancelled()` is not a
+      // blanket "run anyway". A pre-suite failure means known state was never
+      // established, and that must still stop the leg. Without this, the test
+      // above would also pass on a guard that had stopped guarding.
+      const outputs = runPreflight(workflow, "all");
+      const run = simulateRun(workflow, {
+        seed: { name: PREFLIGHT, outputs },
+        inputs: { platform: "all", [SERIALIZE]: true },
+        forcedResults: { [PRE_SUITE]: "failure" },
+      });
+      expect(run.jobs[ANDROID].ran).toBe(false);
+    });
+  });
+
+  describe("bite control 4 — single-platform runs", () => {
+    it.each([
+      { platform: "android", android: true, ios: false },
+      { platform: "ios", android: false, ios: true },
+    ])(
+      "platform=$platform runs only its own leg, with leg_order green",
+      ({ platform, android, ios }) => {
+        const outputs = runPreflight(workflow, platform);
+        const run = simulateRun(workflow, {
+          seed: { name: PREFLIGHT, outputs },
+          inputs: { platform, [SERIALIZE]: true },
+        });
+        expect(run.jobs[ANDROID].ran).toBe(android);
+        expect(run.jobs[IOS].ran).toBe(ios);
+        // Never skipped — see the row 26 note above.
+        expect(run.jobs[LEG_ORDER].result).toBe("success");
+      }
+    );
+
+    it.each(["android", "ios"])(
+      "platform=%s waits for nothing, so it cannot deadlock",
+      platform => {
+        // With one leg absent there is no contention to order. Waiting anyway
+        // would block on a job that never enters the run and burn the whole
+        // discovery window before failing.
+        const step = (workflow.jobs[LEG_ORDER].steps ?? [])[0];
+        const outputs = runPreflight(workflow, platform);
+        expect(
+          evaluateIf(step.if, {
+            inputs: { [SERIALIZE]: true },
+            needs: { preflight: { outputs } },
+          })
+        ).toBe(false);
+      }
+    );
+  });
+});

--- a/tests/integration/support/maestro-leg-order-harness.ts
+++ b/tests/integration/support/maestro-leg-order-harness.ts
@@ -1,0 +1,244 @@
+/**
+ * Harness for the Maestro leg-ordering tests.
+ *
+ * Two things the assertions need, neither of which may be re-implemented: a
+ * fake GitHub jobs API that the workflow's own poll loop can be pointed at, and
+ * a runner that executes step scripts taken verbatim out of the YAML. Copying a
+ * poll loop or a platform fan-out into a test makes the test agree with itself
+ * rather than with the workflow.
+ *
+ * The scripted API hands out one response per request by walking an iterator
+ * and repeating the final entry — no request counter, because the property the
+ * tests actually assert ("it kept asking until the answer changed") is readable
+ * from the step's own stdout, which is better evidence than a number this file
+ * made up.
+ *
+ * @module tests/integration/support/maestro-leg-order-harness
+ */
+
+import * as fs from "fs-extra";
+import { execFile, execFileSync } from "node:child_process";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import type { SimulatedWorkflow } from "../../helpers/workflow-job-graph";
+
+/** `bash` by absolute path — never resolved through a writeable $PATH. */
+const BASH = "/bin/bash";
+
+/** One entry of the Actions jobs API, trimmed to what the step reads. */
+export interface ApiJob {
+  name: string;
+  status: string;
+  conclusion: string | null;
+}
+
+/** A fake jobs API. */
+export interface FakeApi {
+  url: string;
+  close: () => Promise<void>;
+}
+
+/** What running a step produced. */
+export interface StepRun {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * An iOS job entry in whichever lifecycle state a test needs.
+ *
+ * The name carries the caller prefix on purpose: a reusable workflow's jobs are
+ * reported by the API as `<caller job name> / <called job name>`, so a fixture
+ * without it would pass against an equality match that can never fire in
+ * production.
+ *
+ * @param status The API `status` field.
+ * @param conclusion The API `conclusion` field, null while not completed.
+ * @returns The job entry.
+ */
+export const iosApiJob = (
+  status: string,
+  conclusion: string | null
+): ApiJob => ({
+  name: "📱 Maestro Native E2E / 🍎 Maestro iOS",
+  status,
+  conclusion,
+});
+
+/** An Android job entry, which must never satisfy the iOS match. */
+export const ANDROID_API_JOB: ApiJob = {
+  name: "📱 Maestro Native E2E / 🤖 Maestro Android",
+  status: "in_progress",
+  conclusion: null,
+};
+
+/**
+ * Publishes a listening server as a fake API handle.
+ *
+ * @param server The server to listen with.
+ * @returns Its base URL and a shutdown hook.
+ */
+const publish = async (server: http.Server): Promise<FakeApi> => {
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>(resolve => {
+        server.close(() => resolve());
+      }),
+  };
+};
+
+/**
+ * Starts a fake GitHub jobs API serving a scripted sequence of job lists.
+ *
+ * @param script One job list per request; the final entry repeats forever.
+ * @returns The base URL and a shutdown hook.
+ */
+export const startFakeApi = (script: ApiJob[][]): Promise<FakeApi> => {
+  const remaining = script[Symbol.iterator]();
+  const nextJobs = (): ApiJob[] => {
+    const step = remaining.next();
+    return step.done === true ? script[script.length - 1] : step.value;
+  };
+  return publish(
+    http.createServer((_request, response) => {
+      const jobs = nextJobs();
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ total_count: jobs.length, jobs }));
+    })
+  );
+};
+
+/**
+ * Starts a fake jobs API that refuses every request with the given status.
+ *
+ * @param status The HTTP status to answer with.
+ * @returns The base URL and a shutdown hook.
+ */
+export const startRefusingApi = (status: number): Promise<FakeApi> =>
+  publish(
+    http.createServer((_request, response) => {
+      response.writeHead(status, { "content-type": "application/json" });
+      response.end(JSON.stringify({ message: "Resource not accessible" }));
+    })
+  );
+
+/**
+ * Runs the leg-ordering wait step's REAL shell against a fake jobs API.
+ *
+ * Deliberately asynchronous. The fake API lives in the test process, so a
+ * synchronous child would block the event loop the server needs to answer
+ * curl — the step would then hang forever against a server that is up.
+ *
+ * @param workflow The parsed workflow.
+ * @param job The job id holding the wait step.
+ * @param api The fake API to point it at.
+ * @param overrides Env overrides on top of the step's own declared values.
+ * @returns The exit status and captured output.
+ */
+export const runWaitStep = (
+  workflow: SimulatedWorkflow,
+  job: string,
+  api: FakeApi,
+  overrides: Record<string, string> = {}
+): Promise<StepRun> => {
+  const step = (workflow.jobs[job].steps ?? [])[0];
+  if (!step?.run) throw new Error(`${job} wait step not found`);
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "maestro-leg-order-"));
+  return new Promise<StepRun>(resolve => {
+    execFile(
+      BASH,
+      ["-c", step.run ?? ""],
+      {
+        cwd: scratch,
+        encoding: "utf-8",
+        env: {
+          PATH: process.env.PATH ?? "",
+          HOME: scratch,
+          GH_TOKEN: "fake-token",
+          API_URL: api.url,
+          REPOSITORY: "acme/app",
+          RUN_ID: "1",
+          RUN_ATTEMPT: "1",
+          IOS_JOB_NAME: String(workflow.jobs.ios.name),
+          POLL_SECONDS: "0.05",
+          PRE_SUITE_TIMEOUT_MINUTES: "1",
+          DISCOVERY_SLACK_MINUTES: "1",
+          MAX_PAGES: "10",
+          ...overrides,
+        },
+      },
+      (error, stdout, stderr) =>
+        resolve({
+          status: typeof error?.code === "number" ? error.code : error ? -1 : 0,
+          stdout,
+          stderr,
+        })
+    );
+  });
+};
+
+/**
+ * Runs the preflight step's real shell and returns the outputs it wrote.
+ *
+ * The platform fan-out is preflight's decision; re-deriving it here would let
+ * the simulation and the workflow disagree without any test noticing.
+ *
+ * @param workflow The parsed workflow.
+ * @param platform The `platform` input value.
+ * @returns The `$GITHUB_OUTPUT` key/value pairs the step wrote.
+ */
+export const runPreflight = (
+  workflow: SimulatedWorkflow,
+  platform: string
+): Record<string, string> => {
+  const step = (workflow.jobs.preflight.steps ?? []).find(
+    candidate => candidate.id === "check"
+  );
+  if (!step?.run) throw new Error("preflight check step not found");
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "maestro-preflight-"));
+  const flowsDir = path.join(scratch, "flows");
+  const outputFile = path.join(scratch, "github-output");
+  fs.mkdirpSync(flowsDir);
+  fs.writeFileSync(outputFile, "");
+  execFileSync(BASH, ["-e", "-c", step.run], {
+    cwd: scratch,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      EXPO_TOKEN: "token",
+      PLATFORM: platform,
+      FLOWS_DIR: flowsDir,
+      REQUIRE_PREREQUISITES: "false",
+      GITHUB_OUTPUT: outputFile,
+    },
+  });
+  return Object.fromEntries(
+    fs
+      .readFileSync(outputFile, "utf-8")
+      .split("\n")
+      .filter(line => line.includes("="))
+      .map(line => [
+        line.slice(0, line.indexOf("=")),
+        line.slice(line.indexOf("=") + 1),
+      ])
+  );
+};
+
+/**
+ * Normalizes a job's `needs` to a list.
+ *
+ * @param workflow The parsed workflow.
+ * @param job The job id.
+ * @returns The dependency job names.
+ */
+export const needsOf = (workflow: SimulatedWorkflow, job: string): string[] => {
+  const declared = workflow.jobs[job].needs;
+  return typeof declared === "string" ? [declared] : (declared ?? []);
+};


### PR DESCRIPTION
Closes #2540

## The defect

`android` and `ios` are sibling jobs with identical `needs: [preflight, build, pre_suite]` and no edge between them, so they always run **concurrently**. When both legs authenticate as the **same test persona**, the two sign-ins invalidate each other's session and the loser is logged out mid-suite — it then asserts on an authenticated screen and finds the sign-in screen. The failure is indistinguishable from a product defect by inspection and moves between flows from night to night.

**Measured, not theorized.** On `geminisportsai/frontend-v2`, Maestro on `dev` was **1 success in 6 runs**; run `31757559016` failed 2 of 38 Android flows on `id: ^(?:SIGNIN.INPUT_PHONE|TAB_BAR.S…` while the iOS leg passed. On `TunnlAI/frontend`, flow failure was **33% while the legs overlapped vs 16% after one leg finished**, across two runs.

`concurrency_group` (v3.9.0) does **not** address this. It excludes whole workflow *calls* from each other — this suite versus the Playwright suite — not leg against leg inside one call. `frontend-v2` already applies that group and still sees this.

## The change

A new `serialize_platform_legs` input (boolean, `default: false`) runs the iOS leg to completion before Android starts.

### Why it is not just `needs: [ios]`

**`needs` cannot hold an expression.** There is no way to write "depend on `ios` only when an input is set". Three alternatives were considered and each is worse:

| Alternative | Why not |
| --- | --- |
| `needs: [ios]` on `android` outright | Serializes **every** adopter, including those with per-platform personas who are paying nothing for concurrency today. |
| A duplicated `android` job wired `needs: [ios]`, selected by `if` | ~400 duplicated lines, and whichever copy is unused concludes `skipped` on every run — which row 26 of the nightly health gate reads as `incomplete_run` for every adopter (`docs/nightly-e2e-gate.md` §2.4). |
| Job-level `concurrency` shared by the two legs | Mutual exclusion with **no order**; whichever job acquires the group first wins, and the owner asked for iOS first. |

So the ordering is a small `leg_order` job that `android` depends on, and that polls this run's own job list for the iOS job. The `needs` edge is unconditional; the *condition* lives inside that job's step.

### How the failure-tolerance requirement is preserved

This is the part that mattered most, so it is stated explicitly:

**Android's `if:` is unchanged.** `leg_order` was added to `needs` and appears in **no** `if` clause. The existing `!cancelled()` is what lets Android run when `leg_order` fails, times out, or is otherwise unhappy — a broken serializer degrades to today's concurrent legs (loudly, with a red job) instead of dropping the entire Android suite. Contrast `pre_suite`, which **is** result-gated via an allowlist, because established state is a precondition for testing and mere ordering is not.

And inside the job, **the wait ends on a terminal `status`, never on a `conclusion`.** A FAILING iOS leg releases Android exactly like a passing one. Gating on conclusion would let one flaky iOS flow delete the Android suite from the night and report the narrower result under the same green check — trading a contention bug for a coverage bug, which is the worse of the two.

### Other design points

- **`leg_order` runs beside `pre_suite`, not after it** (`needs: [preflight, build]`). With the input unset it does nothing and concludes while `pre_suite` — a job Android already waited on — is still running, so **Android's start time does not move**. Depending on `pre_suite` would instead have pushed a fresh runner acquisition onto Android's critical path on every run, opted in or not.
- **It always runs rather than gating itself on the input at job level.** Same reason `pre_suite` is not gated on `pre_suite_command != ''`: a job that skips itself whenever the input is unset turns every green nightly into a blocked one for every adopter who does not use the seam.
- **Zero matching jobs is an ERROR, not a pass.** The iOS job may not exist yet, or the name constant may be stale — neither of those is "iOS finished". A guard that reports success because it looked at nothing is the failure mode this job could most easily have had.
- **`actions: read`** is required, and a called workflow cannot hold a permission its caller did not grant. The shipped caller template now declares it; a caller that does not gets a named 403 naming the fix, not a silent revert to concurrency.
- **`serialize_timeout_minutes`** is its own input rather than `pre_suite_timeout_minutes + suite_timeout_minutes`, because **GitHub Actions expressions have no arithmetic operators at all** — `actionlint` caught that during development. A test pins the default above the sum of the two defaults so the three cannot drift apart silently.

## Bite controls

All four, each proved rather than asserted. `tests/integration/maestro-leg-order.test.ts` walks the job graph; `tests/integration/maestro-leg-order-wait.test.ts` executes the `leg_order` step's **real shell, taken verbatim out of the YAML**, against a fake Actions jobs API.

**1. Ordering holds.** Two halves, because no single edge can express it. Job graph: `android`'s `needs` contains `leg_order`, and `leg_order` is declared between `build` and `android`. Executable: pointed at an API reporting iOS `queued`, `in_progress`, `in_progress`, `completed`, the step prints exactly **three** "still running" lines before releasing — in its own words, not a counter the test invented. A loop that returned on the first poll prints none.

**2. Default unchanged.** With the input unset the wait step's guard evaluates `false` (and `true` only when opted in); `android.needs` never contains `ios`; `leg_order`'s dependencies are a **subset** of `pre_suite`'s, which is the property that makes the default path free in wall clock; and a simulated default run has `leg_order` concluding `success` rather than `skipped`.

**3. A failing iOS leg does not suppress Android.** Executable: the step exits 0 on an iOS job that concluded `failure`, and on `skipped` / `timed_out` / `cancelled` / `neutral`. Graph: a simulated run with `leg_order` **forced to `failure`** still starts Android — with a run where `pre_suite` is forced to failure as the **negative control**, still correctly stopping Android, so "runs anyway" cannot be mistaken for a guard that stopped guarding.

**4. Single-platform runs.** `platform: android` and `platform: ios` each run only their own leg with `leg_order` green, and the wait step's guard is `false` in both cases — evaluated against outputs from the **real preflight shell**, so the fan-out is preflight's answer rather than the test's.

### Failing-then-passing

Same tests, both revisions:

| | Result |
| --- | --- |
| Against unmodified `maestro-native-e2e.yml` + caller | **23 failed**, 2 passed (25) |
| With this change | **25 passed** (25) |

The two that pass before and after are the negative controls — "no unconditional `android → ios` edge" and "a failed `pre_suite` still stops Android" — which hold on `main` too and are there to catch a regression in the opposite direction.

Also green: `actionlint` (clean on both workflows), `bun run lint`, `bun run typecheck`, `bun run sg:scan`, prettier, and the full pre-push suite (**11,556 tests**, 0 failures).

## Note for the reviewer: Playwright → Maestro ordering is NOT in this PR

The owner also wants Playwright to run before Maestro. That is a **separate change** and this one does not attempt it.

A shared `concurrency_group` prevents the two suites from **overlapping** but imposes no **order** — whichever run acquires the group first wins. Cron staggering does not decide it either: a run waits for a hosted runner before it starts, and those waits have been measured here at **2h24m** (run `31557572592`) and **6h55m** (run `31574372761`), either of which exceeds any practical stagger, so the suite scheduled first can begin hours after the one scheduled second.

Real chaining needs a mechanism that carries an ordering edge across workflow boundaries — a `workflow_run` trigger firing Maestro on Playwright's completion, or one orchestrating workflow that invokes both reusable workflows as ordered jobs. The `workflow_run` route brings its own constraints (it only fires on the default branch and does not inherit the triggering run's inputs); the orchestrator route means adopters install one caller instead of two. Both are more than a new input, and neither belongs bolted onto this change.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2540
