### PR TITLE
fix(build): stamp the ownership header as the build generates copy-overwrite assets

### DIFF
--- a/all/copy-overwrite/scripts/lisa-destructive-guard.mjs
+++ b/all/copy-overwrite/scripts/lisa-destructive-guard.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+// This file is managed by Lisa and IS replaced on each `lisa` run.
+// Do not edit directly — durable changes belong upstream in Lisa.
+
 /**
  * lisa-destructive-guard — the executable arm of `production-fails-closed`.
  *

--- a/all/copy-overwrite/scripts/lisa-enforcement-fallback.sh
+++ b/all/copy-overwrite/scripts/lisa-enforcement-fallback.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 #
 # Run Lisa's Bash enforcement guards when the plugin that normally provides them
 # is not installed.

--- a/all/copy-overwrite/scripts/lisa-hooks/block-direct-issue-create.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/block-direct-issue-create.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 # PreToolUse hook for Bash: refuse a direct tracker-creation command that
 # declares no readiness.
 #

--- a/all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 # PreToolUse hook: refuse agent writes to the session-instruction files.
 #
 # `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` are the files

--- a/all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 # PreToolUse hook for Bash: blocks commands that bypass git's verification hooks.
 # Bypassing pre-commit/pre-push hooks (which exist for a reason) is blocked in
 # all of its forms; the fix is to address the underlying issue, not silence the

--- a/all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 # PreToolUse hook for Bash: blocks structural JSON parsing with text tools.
 # Text tools (grep/sed/cut/awk) break on valid JSON — multiline values, escaped
 # quotes, reordered keys, nested objects — producing silently wrong output

--- a/all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 # PreToolUse hook for Bash: a safety net that blocks destructive shell commands
 # before they run. Lisa-native reimplementation of the upstream
 # `safety-net@cc-marketplace` plugin's PreToolUse Bash-guard (parity work,

--- a/all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 #
 # Shared wrapper around `sonar hook <event>` for every agent surface.
 #

--- a/expo/copy-overwrite/.easignore.extra
+++ b/expo/copy-overwrite/.easignore.extra
@@ -1,2 +1,5 @@
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 # Ignoring large assets not needed for build
 public/images/

--- a/rails/copy-overwrite/.rubocop.yml
+++ b/rails/copy-overwrite/.rubocop.yml
@@ -1,3 +1,6 @@
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 inherit_from:
   - .rubocop_todo.yml
   - rubocop.thresholds.yml

--- a/rails/copy-overwrite/ast-grep/rules/ruby/no-find-by-sql-without-params.yml
+++ b/rails/copy-overwrite/ast-grep/rules/ruby/no-find-by-sql-without-params.yml
@@ -1,3 +1,6 @@
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 id: no-find-by-sql-without-params
 language: ruby
 severity: error

--- a/rails/copy-overwrite/ast-grep/rules/ruby/no-params-without-permit.yml
+++ b/rails/copy-overwrite/ast-grep/rules/ruby/no-params-without-permit.yml
@@ -1,3 +1,6 @@
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 id: no-params-without-permit
 language: ruby
 severity: warning

--- a/rails/copy-overwrite/ast-grep/rules/ruby/no-raw-sql-in-where.yml
+++ b/rails/copy-overwrite/ast-grep/rules/ruby/no-raw-sql-in-where.yml
@@ -1,3 +1,6 @@
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 id: no-raw-sql-in-where
 language: ruby
 severity: error

--- a/rails/copy-overwrite/ast-grep/rules/ruby/no-skip-before-action-without-scope.yml
+++ b/rails/copy-overwrite/ast-grep/rules/ruby/no-skip-before-action-without-scope.yml
@@ -1,3 +1,6 @@
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 id: no-skip-before-action-without-scope
 language: ruby
 severity: warning

--- a/rails/copy-overwrite/ast-grep/rules/ruby/no-unsafe-send.yml
+++ b/rails/copy-overwrite/ast-grep/rules/ruby/no-unsafe-send.yml
@@ -1,3 +1,6 @@
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 id: no-unsafe-send
 language: ruby
 severity: error

--- a/rails/copy-overwrite/ast-grep/rules/ruby/no-update-columns.yml
+++ b/rails/copy-overwrite/ast-grep/rules/ruby/no-update-columns.yml
@@ -1,3 +1,6 @@
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 id: no-update-columns
 language: ruby
 severity: warning

--- a/rails/copy-overwrite/config/initializers/version.rb
+++ b/rails/copy-overwrite/config/initializers/version.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
 
 # Reads application version from the VERSION file at project root.
 # The VERSION file is managed by standard-version and bumped during releases.

--- a/rails/copy-overwrite/lefthook.yml
+++ b/rails/copy-overwrite/lefthook.yml
@@ -1,3 +1,6 @@
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 pre-commit:
   parallel: true
   commands:

--- a/rails/copy-overwrite/scripts/check-threshold-ratchet.mjs
+++ b/rails/copy-overwrite/scripts/check-threshold-ratchet.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+// This file is managed by Lisa and IS replaced on each `lisa` run.
+// Do not edit directly — durable changes belong upstream in Lisa.
+
 /**
  * Threshold ratchet gate — quality thresholds may tighten, never weaken.
  *

--- a/rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs
+++ b/rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs
@@ -1,3 +1,6 @@
+// This file is managed by Lisa and IS replaced on each `lisa` run.
+// Do not edit directly — durable changes belong upstream in Lisa.
+
 /**
  * Threshold ratchet — comparison rules and reporting.
  *

--- a/rails/copy-overwrite/scripts/threshold-ratchet-families.mjs
+++ b/rails/copy-overwrite/scripts/threshold-ratchet-families.mjs
@@ -1,3 +1,6 @@
+// This file is managed by Lisa and IS replaced on each `lisa` run.
+// Do not edit directly — durable changes belong upstream in Lisa.
+
 /**
  * Threshold ratchet — watched file families and value extractors.
  *

--- a/scripts/build-plugins.sh
+++ b/scripts/build-plugins.sh
@@ -12,6 +12,20 @@ SRC_DIR="$PLUGINS_DIR/src"
 # Read version from package.json so plugins stay in sync with Lisa releases
 VERSION=$(node -e "console.log(require('$ROOT_DIR/package.json').version)")
 
+# Materialize a Lisa-owned source file into a copy-overwrite/ template tree.
+#
+# Never a plain `cp`. These destinations are `copy-overwrite` assets, and a
+# `copy-overwrite` asset that reads as editable silently loses downstream
+# hardening on the next sync — already observed on block-no-verify.sh. They are
+# also the only assets that cannot carry a hand-typed ownership header, because
+# this script would erase it on the next build (#2547). So the header is stamped
+# here, as the file is generated: the authored source stays honest about being
+# editable, the shipped copy states that it is replaced, and the two cannot
+# disagree because one produces the other.
+materialize() {
+  node "$ROOT_DIR/scripts/materialize-copy-overwrite.mjs" "$1" "$2"
+}
+
 inject_version() {
   local manifest="$1"
   if [ -f "$manifest" ]; then
@@ -82,11 +96,12 @@ if [ -f "$SRC_DIR/base/hooks/threshold-ratchet.mjs" ]; then
     mkdir -p "$ratchet_scripts_dir"
     # The entry point takes the template check-* naming; its relative imports
     # (threshold-ratchet-*.mjs) keep their canonical names in both trees.
-    cp "$SRC_DIR/base/hooks/threshold-ratchet.mjs" \
+    materialize "$SRC_DIR/base/hooks/threshold-ratchet.mjs" \
       "$ratchet_scripts_dir/check-threshold-ratchet.mjs"
-    cp "$SRC_DIR/base/hooks/threshold-ratchet-families.mjs" \
-      "$SRC_DIR/base/hooks/threshold-ratchet-compare.mjs" \
-      "$ratchet_scripts_dir/"
+    for ratchet_module in threshold-ratchet-families threshold-ratchet-compare; do
+      materialize "$SRC_DIR/base/hooks/$ratchet_module.mjs" \
+        "$ratchet_scripts_dir/$ratchet_module.mjs"
+    done
   done
 fi
 
@@ -108,7 +123,7 @@ fi
 for guard in block-no-verify parity-safety-net block-shell-json-parsing \
   block-instruction-file-edits block-direct-issue-create; do
   if [ -f "$SRC_DIR/base/hooks/$guard.sh" ]; then
-    cp "$SRC_DIR/base/hooks/$guard.sh" "$HOST_GUARD_DIR/$guard.sh"
+    materialize "$SRC_DIR/base/hooks/$guard.sh" "$HOST_GUARD_DIR/$guard.sh"
     chmod +x "$HOST_GUARD_DIR/$guard.sh"
   fi
 done
@@ -122,7 +137,8 @@ done
 # guards are, not because it is dispatched the same way.
 if [ -f "$SRC_DIR/base/hooks/sonar-secrets.sh" ]; then
   mkdir -p "$HOST_GUARD_DIR"
-  cp "$SRC_DIR/base/hooks/sonar-secrets.sh" "$HOST_GUARD_DIR/sonar-secrets.sh"
+  materialize "$SRC_DIR/base/hooks/sonar-secrets.sh" \
+    "$HOST_GUARD_DIR/sonar-secrets.sh"
   chmod +x "$HOST_GUARD_DIR/sonar-secrets.sh"
 fi
 
@@ -132,7 +148,7 @@ fi
 # and an unconditional copy fails the whole build there.
 if [ -f "$ROOT_DIR/scripts/lisa-enforcement-fallback.sh" ]; then
   mkdir -p "$ROOT_DIR/all/copy-overwrite/scripts"
-  cp "$ROOT_DIR/scripts/lisa-enforcement-fallback.sh" \
+  materialize "$ROOT_DIR/scripts/lisa-enforcement-fallback.sh" \
     "$ROOT_DIR/all/copy-overwrite/scripts/lisa-enforcement-fallback.sh"
   chmod +x "$ROOT_DIR/all/copy-overwrite/scripts/lisa-enforcement-fallback.sh"
 fi

--- a/scripts/materialize-copy-overwrite.mjs
+++ b/scripts/materialize-copy-overwrite.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * Copy a Lisa-owned file into a `copy-overwrite/` template tree, stamping the
+ * ownership header on the way in.
+ *
+ * Thirteen `copy-overwrite` assets are not authored where they ship. The build
+ * materializes them from `plugins/src/base/hooks/` (the five PreToolUse guards,
+ * the Sonar wrapper, the three threshold-ratchet modules into two stack lanes)
+ * and from `scripts/lisa-enforcement-fallback.sh` (the dispatcher). A header
+ * typed into the shipped copy is erased by the next `bun run build`, which is
+ * why those thirteen were the only files #2545 could not correct.
+ *
+ * The header cannot move upstream to the source either. `plugins/src/base/hooks/
+ * block-no-verify.sh` is precisely the file maintainers edit, so telling it that
+ * it will be overwritten would be a fresh instance of the false statement #2538
+ * exists to remove. So the header becomes a property of the *generation step*:
+ * the source stays honest, the shipped copy states its real contract, and the
+ * two can never disagree because one produces the other.
+ *
+ * This matters most on exactly these files. A `copy-overwrite` asset that reads
+ * as editable silently loses downstream hardening — a consumer repo hardened its
+ * `block-no-verify.sh` and the next sync reverted it, noticed only because two
+ * of its own tests started failing.
+ * @module scripts/materialize-copy-overwrite
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * The `copy-overwrite` ownership contract, verbatim from the header #2545
+ * established. Duplicated nowhere: `tests/unit/templates/
+ * template-ownership-header.test.ts` asserts the same two sentences over every
+ * template in the lane, and this generator writes them into the thirteen that
+ * cannot hold a hand-typed copy.
+ */
+export const OWNERSHIP_HEADER = [
+  "This file is managed by Lisa and IS replaced on each `lisa` run.",
+  "Do not edit directly — durable changes belong upstream in Lisa.",
+];
+
+/**
+ * Line comment syntax per extension, for the formats this generator emits.
+ *
+ * Deliberately a closed map rather than a default. A file type that is not
+ * listed makes `materialize` throw, so wiring a new generated asset through
+ * here is a decision someone has to make — the alternative is a silent
+ * pass-through that reintroduces the headerless copy this module exists to end.
+ */
+const COMMENT_PREFIX = new Map([
+  [".sh", "#"],
+  [".bash", "#"],
+  [".mjs", "//"],
+  [".cjs", "//"],
+  [".js", "//"],
+]);
+
+/**
+ * The comment prefix a generated file's format uses.
+ * @param {string} filePath - Path whose extension selects the syntax.
+ * @returns {string | undefined} Prefix, or undefined when unsupported.
+ */
+export const commentPrefixFor = filePath =>
+  COMMENT_PREFIX.get(path.extname(filePath));
+
+/**
+ * The header block as it appears in a file of the given comment syntax.
+ * @param {string} prefix - Line comment prefix, e.g. `#` or `//`.
+ * @returns {string[]} The header lines, ready to splice in.
+ */
+const headerLines = prefix => OWNERSHIP_HEADER.map(line => `${prefix} ${line}`);
+
+/**
+ * Whether contents already state the ownership contract.
+ * @param {string} contents - File contents.
+ * @returns {boolean} True when every header sentence is present.
+ */
+export const hasOwnershipHeader = contents =>
+  OWNERSHIP_HEADER.every(line => contents.includes(line));
+
+/**
+ * Contents with the ownership header stamped in.
+ *
+ * Placement is not cosmetic: a `#!` line that stops being line 1 stops being a
+ * shebang, so the header lands *below* it when one is present. Idempotent, so
+ * re-running the build over an already-stamped tree is a no-op rather than a
+ * pile of headers.
+ * @param {string} contents - Source file contents.
+ * @param {string} filePath - Destination path, for its extension.
+ * @returns {string} Contents carrying the header.
+ * @throws {Error} When the destination's format has no known comment syntax.
+ */
+export const withOwnershipHeader = (contents, filePath) => {
+  const prefix = commentPrefixFor(filePath);
+  if (prefix === undefined) {
+    throw new Error(
+      `No comment syntax known for ${path.basename(filePath)} — a generated ` +
+        `copy-overwrite asset must be able to state its ownership contract.`
+    );
+  }
+  if (hasOwnershipHeader(contents)) return contents;
+
+  const lines = contents.split("\n");
+  const insertAt = lines[0]?.startsWith("#!") ? 1 : 0;
+  return [
+    ...lines.slice(0, insertAt),
+    ...headerLines(prefix),
+    "",
+    ...lines.slice(insertAt),
+  ].join("\n");
+};
+
+/**
+ * Contents with the ownership header removed, leaving the authored source.
+ *
+ * The byte-equality tests that pin a shipped copy to its reviewed original run
+ * through here, so "generated file minus its stamp" has exactly one definition
+ * and cannot drift from what the stamp step actually writes.
+ * @param {string} contents - Generated file contents.
+ * @param {string} filePath - Path, for its comment syntax.
+ * @returns {string} Contents without the header block.
+ */
+export const withoutOwnershipHeader = (contents, filePath) => {
+  const prefix = commentPrefixFor(filePath);
+  if (prefix === undefined) return contents;
+
+  const block = headerLines(prefix);
+  const lines = contents.split("\n");
+  const at = lines.findIndex(
+    (line, index) => line === block[0] && lines[index + 1] === block[1]
+  );
+  if (at === -1) return contents;
+
+  // The blank separator belongs to the stamp, not to the source, so it comes
+  // out with it — otherwise round-tripping would grow a line each build.
+  const end =
+    lines[at + block.length] === "" ? at + block.length + 1 : at + block.length;
+  return [...lines.slice(0, at), ...lines.slice(end)].join("\n");
+};
+
+/**
+ * Read a source file and write it to a destination carrying the header.
+ * @param {string} source - Authored file to materialize.
+ * @param {string} destination - Path inside a `copy-overwrite/` tree.
+ * @returns {void}
+ */
+export const materialize = (source, destination) => {
+  writeFileSync(
+    destination,
+    withOwnershipHeader(readFileSync(source, "utf8"), destination)
+  );
+};
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const [source, destination] = process.argv.slice(2);
+  if (!source || !destination) {
+    console.error(
+      "usage: materialize-copy-overwrite.mjs <source> <destination>"
+    );
+    process.exit(1);
+  }
+  materialize(source, destination);
+}

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -118,6 +118,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   "scripts/check-threshold-ratchet.mjs": Object.freeze([
     "04f660131bf50864239eb09cbf4d9555e53921254f6ab45ff2b85c173e160901",
     "1e46e6ca651e87e7814a4f486af5784ed2f7a8a48eadcaa7d3fef26e380929f9",
+    "46b7c2213112306af9702c910a9bcf485ea0b46154e46f0afe8fb8b5b0ba6c08",
     "49dee610439f4f21aecb0420a0cc72f5d3595a36f2489970053096190b9909c4",
     "6da00221189ed0f8a2938f15e02bcc2633d44f5f05489979fbb94202bc45a6d4",
     "e1e3f22b33267212b90f915f83821559d1a45cab5b16c7164b86bd6c7b53549b",
@@ -147,10 +148,12 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   ]),
   "scripts/lisa-destructive-guard.mjs": Object.freeze([
     "4fb431a3c58f443e303d613934d023d9e95ddae5c42710bb7009f7c080c82a64",
+    "66ade2c9cc0554c4934ed94a44563fd9d648b37cacfa9a5d31f17ac4f181e5a3",
   ]),
   "scripts/lisa-enforcement-fallback.sh": Object.freeze([
     "1bec5f3c284b3febdc471487ee6a23ffb72bd4e7b293f9e26b0188f32318c722",
     "3049c2f1051c7c02dd60b62355964651e1565ebe6bdcb5e37634cd686cf1deb1",
+    "68e1b78d5d4471fadbe2eb575ae46221838217290123a9910d76dba0f1c34131",
     "8dc942ac4edc2017d6b8277296c8f80542e7c024eef1bb65de609979d0ca9a0e",
     "9cab71562d01421d57c6719318a4d03a6249a45c1aea434db3ff26e3065eeb66",
     "d7d88e44763694bed5eae998cd3663922c957e49f9f9621d9201f0417a4128ad",
@@ -166,8 +169,10 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "60a4f94ec671b2372f7492680ab327d97aff686588ce85791f54e0fbd098b0ca",
     "73e94b73830d8961026947d99bf4ac5f959b5bca025203b913d8a6363cbe2b9f",
     "847dfca48823a495fc3de47dfdb4b26e49d6808c6570c46d024a99793df1d370",
+    "8d1f04ef5c5da9db9190e22b37a435e118e39d6e7deafc5402b4593c8e9db2b2",
   ]),
   "scripts/lisa-hooks/block-instruction-file-edits.sh": Object.freeze([
+    "3e709e1ec8a5843c00684bc477ad32ddab2c5fdb11f71d5aeec0c49609eaf025",
     "6f52076e3488821d638b6dd45b5faca527d92b181cc12e6e5033859e0786c8a7",
     "850cfc23852eb752114ae1e938a1c7bcf34bc50c85d3aaca0c02311cc8c0ef70",
     "8996e0bcbf1db085a5d99734e797c91f5025997bd967bc374efff8348dac14c2",
@@ -182,6 +187,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "3b93a0affab6413e3c14a6f43de5acb586286ed1819ece0a66b30429b4d00490",
     "3ff7255f395a9552366faaac34d383f4c95fecfb39882cd1d57854356422fe61",
     "7790a560850c9d38709dbaccdaa10733e632c1bd4d975cbec7e3cc5a8650b36a",
+    "83a8b8108654086afb6a6f23a8f09f9f041eb2cd4094c5531fa7ab1f75e873dc",
     "a6ed91576efebb6ba40cfa4e9d8a3e8566314909210ae8d5860be62a3feb4cff",
     "aa95a84f9f9224914947a09b858535aa8bd052199ff64cb53768cf78fb69b687",
     "b9f299cb9d3ad75b71296376ae2c40eb207a3b2706dafdaa41fc586050a53aad",
@@ -190,6 +196,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   ]),
   "scripts/lisa-hooks/block-shell-json-parsing.sh": Object.freeze([
     "1934a15e154fda3c2a40979a5cd6225661b14fe7bc77328a69ce499bea85dba7",
+    "234cb82cc9033bd04940a553d4ddc95b078e585e41777d6529d887676edc40b1",
     "3b5f074f3ab5708030af507eea962389f3b067c5dbdc76580bd9e44d3ac6c603",
     "90601e31603c440d8f19d213d63bfef8d18596c60f88cb6e28c93d12453c5c0c",
   ]),
@@ -199,6 +206,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "1162ffd16cef3b23282d2f5207abcb88429462a74a9df1035f0df4968f6dd456",
     "14fc5e292aebf83dd24fec12fb32e2beb509a9324f127a24a64d5c5d4d05c576",
     "1bf3512bb94923a6cb25b1e7a619a3fc8e1336bffa16f499b459aaee3eaed66d",
+    "1d4fbe135f1bb4e861d286a6512ed201d4522250dfe3f9eba6584bc5ff166a95",
     "388cf8847581d96a1ff8ea98290a33a5f96d67cdd502ea807a0b8d88efe90e19",
     "64546813f168fb446f39e34bc674fd3af85b15bd5e7f4f6bf4503463e701a7b9",
     "772202ddd42d626625ff719666afbbe83445d8bae1bc7c0fb5ffdcb402be83f8",
@@ -213,6 +221,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "fa8f4a6517eacd9266feb7afd62398cdf2075d4824cac24b45bb64ad0cd18c86",
   ]),
   "scripts/lisa-hooks/sonar-secrets.sh": Object.freeze([
+    "18e63683064305dab1200456896cbb9384ab35ee6bc51d3789ffbba46d1b1081",
     "7a408788975a6351d53e14aa32bb9a5d161f33df9dfea59ba32784ae33a62e67",
     "945453fb275a58aa7185e150e6b05e5810739750928ab5bd6edfbf87d1c8aa0d",
     "bf4132e49ba18e2f7e941520c299c15aeeacfd220e489f3d2eb8397f2048157b",
@@ -259,11 +268,13 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "67b5769dde341d06799c7a49c1fbcd46d92df1268177cc575e704e5a8a2d3096",
     "8bc4b379d7057b2fecf9cb35820c39efad0a65df7df49073786f996cc2a74810",
     "90affbeaed0d65c032dccfc0bd4a4b26eda291f6b61aa8b12599f41842452e0a",
+    "cf99167b05d210afad01fb41fc4aed548c66ee0e9a7c4decb8afa1f180eb5640",
   ]),
   "scripts/threshold-ratchet-families.mjs": Object.freeze([
     "8fa58cc7276add0b2edf1de92bdcc32d81d840811ef0614ddc724010b59a888c",
     "93190f926689725418c1ec9eae15c55910b128cff6e3cb10185e466c7b90cc4f",
     "db14245ed89b483912af287bdee917a7a921dc21bb29b49be37fc799c05c413f",
+    "f50e35d11295a836bd5b6d818aed6daea68ff70bdffbbdf9f67b09984a2628da",
     "fee19c88c89eed5a2949dea42c4a4c794f04aabf0e36c71cdda70ffaaf2b17c9",
   ]),
 });

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -11,23 +11,23 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-command-envelope.mjs":
       "6b198f088cd3cd862d4357fbb069b1ad5d3afeb7be594f2bf1ff603b092a8354",
     "all/copy-overwrite/scripts/lisa-destructive-guard.mjs":
-      "4fb431a3c58f443e303d613934d023d9e95ddae5c42710bb7009f7c080c82a64",
+      "66ade2c9cc0554c4934ed94a44563fd9d648b37cacfa9a5d31f17ac4f181e5a3",
     "all/copy-overwrite/scripts/lisa-enforcement-fallback.sh":
-      "3049c2f1051c7c02dd60b62355964651e1565ebe6bdcb5e37634cd686cf1deb1",
+      "68e1b78d5d4471fadbe2eb575ae46221838217290123a9910d76dba0f1c34131",
     "all/copy-overwrite/scripts/lisa-floor-collisions.mjs":
       "2d11968f6852ab745cba939de03c6d6cb5f413975d2cfc8fc447bdd0b218e91a",
     "all/copy-overwrite/scripts/lisa-hooks/block-direct-issue-create.sh":
-      "22184f1dd1b96e818741bd4ae659446299535d7ce594817155edebac4172a7ba",
+      "8d1f04ef5c5da9db9190e22b37a435e118e39d6e7deafc5402b4593c8e9db2b2",
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
-      "d47314b66d6ce85f77d6e058f861eede4462b2b0a33d54e82ff1c931167ec3f7",
+      "3e709e1ec8a5843c00684bc477ad32ddab2c5fdb11f71d5aeec0c49609eaf025",
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh":
-      "3ff7255f395a9552366faaac34d383f4c95fecfb39882cd1d57854356422fe61",
+      "83a8b8108654086afb6a6f23a8f09f9f041eb2cd4094c5531fa7ab1f75e873dc",
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh":
-      "90601e31603c440d8f19d213d63bfef8d18596c60f88cb6e28c93d12453c5c0c",
+      "234cb82cc9033bd04940a553d4ddc95b078e585e41777d6529d887676edc40b1",
     "all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh":
-      "d9ea58150aa27e7f0aa9a4ef155ed446d30bdfc932d01c64e2b8ca211aa0de7b",
+      "1d4fbe135f1bb4e861d286a6512ed201d4522250dfe3f9eba6584bc5ff166a95",
     "all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh":
-      "bf4132e49ba18e2f7e941520c299c15aeeacfd220e489f3d2eb8397f2048157b",
+      "18e63683064305dab1200456896cbb9384ab35ee6bc51d3789ffbba46d1b1081",
     "all/copy-overwrite/scripts/lisa-schema-validate.mjs":
       "2ace82daacdebbbb00a7eceb09fbe82cabec04330a083ca10417b2ee4e0a63eb",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
@@ -153,7 +153,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "eslint-plugin-ui-standards/rules/no-direct-rn-imports.js":
       "e25d0c26e865ea72c4914a7c3f10ff92bd084efd04f8665c896b1d9eed923299",
     "expo/copy-overwrite/.easignore.extra":
-      "bb3cefcd1623ac81e4c04d565b2de9a0a7bb7fcd7b2878e860147eb0846a66b9",
+      "1d30dac09405c41e23f6212553abacea478d7759b69c18edac0c0053f00e0d37",
     "expo/copy-overwrite/eslint.config.ts":
       "889ff793099bb65f969c2ccdf1690c8748f20e489999c1a80ae160dfb19f0531",
     "expo/copy-overwrite/eslint.expo.ts":
@@ -1985,7 +1985,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/copy-contents/scripts/lisa-mutation.sh":
       "ed4ab6e8b612adb14f6ae0b160cf044e06fd3d5f6089eb4681a7c6c02a0f2abe",
     "rails/copy-overwrite/.rubocop.yml":
-      "5da977f7ac17634ae6658edd273a4ab0f1b7641e9958d23147e493593964186a",
+      "641857d3540f8b5a4524e3815ce4e1162ab4010b0d8663b1edb2abdad41dbf09",
     "rails/copy-overwrite/.versionrc":
       "b6c4c0258819fa186a91d96cdeac7a017f36cfe1d2c59ccb69cff75c1a8598e0",
     "rails/copy-overwrite/Gemfile.lisa":
@@ -1993,31 +1993,31 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/copy-overwrite/ast-grep/rule-tests/.gitkeep":
       "bbbdb778ba76fa0bf120a9d49325e726adafc6a833e8d56a87c449a33a818cbd",
     "rails/copy-overwrite/ast-grep/rules/ruby/no-find-by-sql-without-params.yml":
-      "8d47d388f1b7d5cce0d4e58a9455247a10ee93d4cca664e9169dd32b666b10d0",
+      "313278315d8c8b0c0b0d905d78d56640c29fa5e367fc020a16d1868f7e44be83",
     "rails/copy-overwrite/ast-grep/rules/ruby/no-params-without-permit.yml":
-      "8d2d8e1316a1412028fcdf57e9163cc23efd17e2893cb206da8fdcd3e66e7065",
+      "87b1a9cabe0752a5b97c247cb9e0abfc737c2cde15ef3fee27a8e258d10db868",
     "rails/copy-overwrite/ast-grep/rules/ruby/no-raw-sql-in-where.yml":
-      "e68126e681324dadae4748150a504a6eb8d26239514ab276d48f8f8232f4a948",
+      "5a60062a92ceede29dd091523c9e30def305075a229ebaf94cb611d8c2bb5f84",
     "rails/copy-overwrite/ast-grep/rules/ruby/no-skip-before-action-without-scope.yml":
-      "f0b5164c4bcd4f811268fd2d729e795ffa0f136df1753e1ab6a2fca2ec963840",
+      "da03a58620aff4cb3b191e7ec78566438bf5cdd2366a5a3be667774d5f7e2bbe",
     "rails/copy-overwrite/ast-grep/rules/ruby/no-unsafe-send.yml":
-      "b66774133fa7fe7cc62645e4f790e4e32bbfe718a6fc6bf38f3267d751a8f9cd",
+      "eb3eb2d96462f28d6815cf0261af2ed2b18e7258ec88a3338f8ae17c5741d583",
     "rails/copy-overwrite/ast-grep/rules/ruby/no-update-columns.yml":
-      "29a68b4994bccb9605fa13efc20c50102d38dfd2dcd96a3bbf9eb01d67efd2da",
+      "5036436ebb4baa703987f3a818d0e33411daa07656611c334fb110316f98cd99",
     "rails/copy-overwrite/ast-grep/utils/.gitkeep":
       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "rails/copy-overwrite/config/initializers/version.rb":
-      "fa664a84f407877b5ddbd3709a2352b30e4dc6fbce538a8503bad6c52448dc86",
+      "703bdfcceb031f38d19ddebe7ae3d432051f0d444ab7467b406ddd8e451ec9c7",
     "rails/copy-overwrite/lefthook.yml":
-      "28bb382b9171a04fb92ebafc1f1522b8639f5edc4fcffcc6940e7fba3460fb4e",
+      "3ae82d0a6ad86708d8ceaa1f9a3bbe12ef64e8fa12a0248bed5e3180bb431c68",
     "rails/copy-overwrite/scripts/check-threshold-ratchet.mjs":
-      "1e46e6ca651e87e7814a4f486af5784ed2f7a8a48eadcaa7d3fef26e380929f9",
+      "46b7c2213112306af9702c910a9bcf485ea0b46154e46f0afe8fb8b5b0ba6c08",
     "rails/copy-overwrite/scripts/lisa-clean-git-env.sh":
       "d15af6f13eedbca41046070972380e69fc0af8f7d903aac12b8644389b9a0c91",
     "rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs":
-      "90affbeaed0d65c032dccfc0bd4a4b26eda291f6b61aa8b12599f41842452e0a",
+      "cf99167b05d210afad01fb41fc4aed548c66ee0e9a7c4decb8afa1f180eb5640",
     "rails/copy-overwrite/scripts/threshold-ratchet-families.mjs":
-      "8fa58cc7276add0b2edf1de92bdcc32d81d840811ef0614ddc724010b59a888c",
+      "f50e35d11295a836bd5b6d818aed6daea68ff70bdffbbdf9f67b09984a2628da",
     "rails/copy-overwrite/sgconfig.yml":
       "ff5b62de42eb969a851fdc53ee6932a32ffe010b567ed2c62460ed454ad2a24f",
     "rails/create-only/.github/workflows/ci.yml":
@@ -2069,7 +2069,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/merge/.claude/settings.json":
       "9c49f8c7c453f8749c90def3e22d412c3345c533d24b30dc7745ffa052ad6fa1",
     "scripts/build-plugins.sh":
-      "b98f0e4789ce903ebf704abaa649c6d4a4721ce0cf2b5caf4ccddeb04fc0d5e0",
+      "2ae01e074226393086369b8e7db807baa14ae61fe4f8aa89b149be0835d7e664",
     "scripts/check-conflict-markers.mjs":
       "e2b25dd56eb3742f074ae5b8ece13ef194518e70e5bac4c2f49e3b819d3f7dc4",
     "scripts/check-duplicate-versions.mjs":
@@ -2166,6 +2166,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "c811f9e10dbcb38499a9791c1ae9051460b347051d04a1d2046925bab9a53c96",
     "scripts/lisa-work-item.mjs":
       "51081847e980f314a764c2e50a7a121b1ced9ef4b980f33898057de4c7b852e6",
+    "scripts/materialize-copy-overwrite.mjs":
+      "3f8dea8027087b83d0f985dc070a529b5e62755643d946684d780b86c498a411",
     "scripts/migrate-deploy-order.sh":
       "77d909b4cbbfc05169a79168d7868600ea7f56f846feefb7d5121618c54800c3",
     "scripts/plugin-parity-drift.mjs":
@@ -2227,7 +2229,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/.claude/hooks/worktree-create.sh":
       "8dbddc0297ca574d150b3e669550320bd2df6e592c083317626f53a91f36d349",
     "typescript/copy-overwrite/.github/GITHUB_ACTIONS.md":
-      "eb70191370c5481c8e1ec30bc1c19dac4611f678219c46012f5a32e49989af90",
+      "c6ea804e74b62ee11ec881909fb0d6fe7088e44e9af3d832fad91a7aa5df0d8b",
     "typescript/copy-overwrite/.github/dependabot.yml":
       "73330408894b35567b068dd12dcb2edd0b01235fd63547938c62ca0dbc0485e2",
     "typescript/copy-overwrite/.lintstagedrc.json":
@@ -2247,9 +2249,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/ast-grep/rules/.gitkeep":
       "5068239f6c760759362d6a1cc83478d77eef0214fa7f4f23c8d1ce4b56f532c0",
     "typescript/copy-overwrite/ast-grep/rules/no-inline-component-in-container.yml":
-      "9cd675cbba11457ba70c9c4f853f3e5cf652fe98c508075946f02bf045710ca6",
+      "cb3c9ba6ee7849f767f9c95423f271447254564dc97122a3c871c8d76c9f688b",
     "typescript/copy-overwrite/ast-grep/rules/no-inline-component-in-view.yml":
-      "a662cb959ad5d96e4dda09d6dce1d69318e7c13f3d01787658184fd6075c2781",
+      "6ecf2527ded51d3ede76f80bb7f376e557bcf596523b5ca03e2afd2962a45d37",
     "typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member-js.yml":
       "a1c25176b326e26070870d65dcd6e4651880f4121563fc0082022e7f525e5e1b",
     "typescript/copy-overwrite/ast-grep/rules/no-missing-fs-extra-namespace-member.yml":
@@ -2273,7 +2275,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs":
       "1bcd3f065465731df4eb02b93b73a0162d287e365ed1a396138d97d71d403b31",
     "typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs":
-      "1e46e6ca651e87e7814a4f486af5784ed2f7a8a48eadcaa7d3fef26e380929f9",
+      "46b7c2213112306af9702c910a9bcf485ea0b46154e46f0afe8fb8b5b0ba6c08",
     "typescript/copy-overwrite/scripts/check-verification-coverage.mjs":
       "3c037e2f0d2c7ae48d3b8c798522847910daef671a787393997fc71107cc7ead",
     "typescript/copy-overwrite/scripts/lisa-mutation.mjs":
@@ -2281,9 +2283,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/scripts/nightly-e2e-suites.schema.json":
       "a6041930ca4536f3a76e4f54976ff846ab575f5f07a2356722eedcb06795e684",
     "typescript/copy-overwrite/scripts/threshold-ratchet-compare.mjs":
-      "90affbeaed0d65c032dccfc0bd4a4b26eda291f6b61aa8b12599f41842452e0a",
+      "cf99167b05d210afad01fb41fc4aed548c66ee0e9a7c4decb8afa1f180eb5640",
     "typescript/copy-overwrite/scripts/threshold-ratchet-families.mjs":
-      "8fa58cc7276add0b2edf1de92bdcc32d81d840811ef0614ddc724010b59a888c",
+      "f50e35d11295a836bd5b6d818aed6daea68ff70bdffbbdf9f67b09984a2628da",
     "typescript/copy-overwrite/sgconfig.yml":
       "ff5b62de42eb969a851fdc53ee6932a32ffe010b567ed2c62460ed454ad2a24f",
     "typescript/copy-overwrite/tsconfig.eslint.json":
@@ -8113,6 +8115,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "scripts/lisa-remote-env/setup.sh": true,
     "scripts/lisa-update-local.sh": true,
     "scripts/lisa-work-item.mjs": true,
+    "scripts/materialize-copy-overwrite.mjs": true,
     "scripts/migrate-deploy-order.sh": true,
     "scripts/plugin-parity-drift.mjs": true,
     "scripts/plugin-routing-validate.mjs": true,

--- a/tests/unit/hooks/host-enforcement-fallback.test.ts
+++ b/tests/unit/hooks/host-enforcement-fallback.test.ts
@@ -30,6 +30,11 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import {
+  hasOwnershipHeader,
+  withoutOwnershipHeader,
+} from "../../../scripts/materialize-copy-overwrite.mjs";
+
 /** Absolute, so the interpreter is never resolved through a writeable PATH. */
 const BASH = "/bin/bash";
 
@@ -81,6 +86,32 @@ const GUARDS = [
   "block-direct-issue-create",
 ] as const;
 
+/**
+ * Everything the build materializes into `all/copy-overwrite/scripts/`.
+ *
+ * `sonar-secrets.sh` ships beside the guards but is not dispatched like one, so
+ * it stays out of `GUARDS` above — and had no byte-equality pin at all until
+ * the ownership stamp gave every generated copy a reason to be enumerated in
+ * one place. The dispatcher is here for the same reason: these seven plus the
+ * six ratchet copies are the thirteen assets #2547 is about, and a fourteenth
+ * added to the build without appearing here is the failure this list exists to
+ * make loud.
+ */
+const MATERIALIZED: readonly { shipped: string; source: string }[] = [
+  ...GUARDS.map(guard => ({
+    shipped: path.join(SHIPPED_HOOKS, `${guard}.sh`),
+    source: path.join(PLUGIN_HOOKS, `${guard}.sh`),
+  })),
+  {
+    shipped: path.join(SHIPPED_HOOKS, "sonar-secrets.sh"),
+    source: path.join(PLUGIN_HOOKS, "sonar-secrets.sh"),
+  },
+  {
+    shipped: SHIPPED_FALLBACK,
+    source: path.join(REPO_ROOT, SCRIPTS, FALLBACK_NAME),
+  },
+];
+
 const temporaries: string[] = [];
 
 afterEach(() => {
@@ -90,20 +121,47 @@ afterEach(() => {
 });
 
 describe("the guards a host project receives", () => {
-  it.each(GUARDS)("%s is byte-identical to the reviewed original", guard => {
-    // Copies rot. The remote-env scripts sat 74 lines behind their asset until
-    // exactly this assertion was added, so the shipped guard gets the same
-    // treatment as the ratchet: synced by the build, pinned by a test.
-    expect(readFileSync(path.join(SHIPPED_HOOKS, `${guard}.sh`), "utf8")).toBe(
-      readFileSync(path.join(PLUGIN_HOOKS, `${guard}.sh`), "utf8")
-    );
-  });
+  it.each(MATERIALIZED)(
+    "$shipped is byte-identical to the reviewed original",
+    ({ shipped, source }) => {
+      // Copies rot. The remote-env scripts sat 74 lines behind their asset until
+      // exactly this assertion was added, so the shipped guard gets the same
+      // treatment as the ratchet: synced by the build, pinned by a test.
+      //
+      // Compared with the ownership stamp stripped, using the generator's own
+      // stripper (#2547) — re-implementing the removal here would let the test
+      // keep passing against a stamp the build no longer writes.
+      expect(
+        withoutOwnershipHeader(readFileSync(shipped, "utf8"), shipped),
+        shipped
+      ).toBe(readFileSync(source, "utf8"));
+    }
+  );
 
-  it("ships the dispatcher unchanged too", () => {
-    expect(readFileSync(SHIPPED_FALLBACK, "utf8")).toBe(
-      readFileSync(path.join(REPO_ROOT, SCRIPTS, FALLBACK_NAME), "utf8")
-    );
-  });
+  it.each(MATERIALIZED)(
+    "$shipped states that it is replaced",
+    ({ shipped }) => {
+      // The direction the stripping above cannot see. A shipped guard that reads
+      // as editable is the expensive failure: a consumer repo hardened its
+      // block-no-verify.sh, the next sync reverted it, and the loss surfaced only
+      // because two of that repo's own tests started failing.
+      expect(hasOwnershipHeader(readFileSync(shipped, "utf8")), shipped).toBe(
+        true
+      );
+    }
+  );
+
+  it.each(MATERIALIZED)(
+    "$source, which maintainers edit, is not told it will be overwritten",
+    ({ source }) => {
+      // The other half of the contract. Moving the header upstream would have
+      // been the easy fix and a fresh instance of #2538's defect — these source
+      // files are durable, and a warning on them deters correct edits.
+      expect(hasOwnershipHeader(readFileSync(source, "utf8")), source).toBe(
+        false
+      );
+    }
+  );
 });
 
 /**

--- a/tests/unit/hooks/sonar-secrets.test.ts
+++ b/tests/unit/hooks/sonar-secrets.test.ts
@@ -28,6 +28,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 import { useIoLatencyBudget } from "../../helpers/io-latency-budget.js";
+import { withoutOwnershipHeader } from "../../../scripts/materialize-copy-overwrite.mjs";
 
 // Spawns `/bin/bash` against the real generated shim. Failed 4 of 12 full-suite
 // runs measured at load ~115 with 38 agent worktrees present, without being
@@ -190,7 +191,14 @@ describe("the shipped wrapper", () => {
   it("is byte-identical to the reviewed original", () => {
     // Copies rot. The guards beside it get the same assertion for the same
     // reason: synced by the build, pinned by a test.
-    expect(readFileSync(SHIPPED, "utf8")).toBe(readFileSync(SOURCE, "utf8"));
+    //
+    // Minus the ownership header, which the build stamps on as it materializes
+    // the copy (#2547) — the shipped file is a copy-overwrite asset and has to
+    // say so, while the source here is the file maintainers edit and must not.
+    // Stripped with the generator's own function so the two cannot disagree.
+    expect(withoutOwnershipHeader(readFileSync(SHIPPED, "utf8"), SHIPPED)).toBe(
+      readFileSync(SOURCE, "utf8")
+    );
   });
 });
 

--- a/tests/unit/scripts/threshold-ratchet-wiring.test.ts
+++ b/tests/unit/scripts/threshold-ratchet-wiring.test.ts
@@ -10,6 +10,11 @@ import { describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import {
+  hasOwnershipHeader,
+  withoutOwnershipHeader,
+} from "../../../scripts/materialize-copy-overwrite.mjs";
+
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const HOOKS_REL = "plugins/src/base/hooks";
 const RATCHET_MODULES = [
@@ -33,16 +38,44 @@ function read(relativePath: string): string {
 
 describe("threshold-ratchet wiring", () => {
   it("template copies are byte-identical to the canonical modules", () => {
+    // Compared with the ownership header stripped, because the build stamps one
+    // on as it materializes each copy (#2547). The stripper is the generator's
+    // own, so "the copy minus its stamp" has exactly one definition — a test
+    // that re-implemented the removal could pass against a stamp the build no
+    // longer writes.
     for (const dir of TEMPLATE_SCRIPT_DIRS) {
-      expect(
-        read(`${dir}/${ENTRY_TEMPLATE_NAME}`),
-        `${dir}/${ENTRY_TEMPLATE_NAME}`
-      ).toBe(read(`${HOOKS_REL}/threshold-ratchet.mjs`));
+      const entry = `${dir}/${ENTRY_TEMPLATE_NAME}`;
+      expect(withoutOwnershipHeader(read(entry), entry), entry).toBe(
+        read(`${HOOKS_REL}/threshold-ratchet.mjs`)
+      );
       for (const module of RATCHET_MODULES) {
-        expect(read(`${dir}/${module}`), `${dir}/${module}`).toBe(
+        const copy = `${dir}/${module}`;
+        expect(withoutOwnershipHeader(read(copy), copy), copy).toBe(
           read(`${HOOKS_REL}/${module}`)
         );
       }
+    }
+  });
+
+  it("stamps the ownership header on every ratchet copy, and on no canonical module", () => {
+    // The stripping above would keep passing if the stamp silently stopped
+    // being written, so the stamp gets its own assertion — in both directions.
+    // The canonical modules under plugins/src are the files maintainers edit;
+    // telling them they will be overwritten is the false statement #2538 exists
+    // to remove, so the header must appear on the copy and nowhere else.
+    for (const dir of TEMPLATE_SCRIPT_DIRS) {
+      for (const name of [ENTRY_TEMPLATE_NAME, ...RATCHET_MODULES]) {
+        expect(
+          hasOwnershipHeader(read(`${dir}/${name}`)),
+          `${dir}/${name}`
+        ).toBe(true);
+      }
+    }
+    for (const module of [...RATCHET_MODULES, "threshold-ratchet.mjs"]) {
+      expect(
+        hasOwnershipHeader(read(`${HOOKS_REL}/${module}`)),
+        `${HOOKS_REL}/${module}`
+      ).toBe(false);
     }
   });
 

--- a/tests/unit/templates/template-ownership-header.test.ts
+++ b/tests/unit/templates/template-ownership-header.test.ts
@@ -51,6 +51,30 @@ const HEADERS = {
 const COMMENTABLE = /\.(ya?ml|[cm]?js|tsx?|sh|rb)$/u;
 
 /**
+ * The only `copy-overwrite` file formats allowed to say nothing, each with the
+ * reason it cannot.
+ *
+ * Enumerated, and asserted to be exhaustive, because a category boundary that
+ * nobody has to write down is how #2549 happened: `COMMENTABLE` above quietly
+ * excused every file it did not match, so a create-only workflow with no header
+ * at all was invisible to the guard meant to govern it. Here the whole lane is
+ * the population and this map is the whole exception list — a template in a
+ * format that is not written down below fails, and someone has to decide
+ * whether it gets a header or an entry.
+ *
+ * Note what is NOT here. `.prettierignore`, `.yamllint`, `.gitleaksignore.local`,
+ * `Gemfile.lisa`, `pre-push.verify`, `.easignore.extra` and a `.md` all take a
+ * comment and all carry the header, so none of them needs an excuse.
+ */
+const NO_COMMENT_SYNTAX: Record<string, string> = {
+  ".json": "JSON has no comment syntax at all",
+  ".versionrc": "a JSON body under a dotfile name",
+  ".nvmrc": "a bare version string — nvm reads the whole file as the version",
+  ".gitkeep": "must stay empty; content defeats the placeholder",
+  ".keep": "must stay empty; content defeats the placeholder",
+};
+
+/**
  * Line-1 constructs that stop working if the header lands above them, so
  * finding one on line 2 means the header displaced it.
  */
@@ -207,13 +231,122 @@ describe("template ownership headers state their real contract (#2538)", () => {
     expect(silent).toEqual([]);
   });
 
+  it("leaves no commentable copy-overwrite template silent about who owns it (#2547)", async () => {
+    // The #2549 assertion above, pointed at the other lane — and this is the
+    // lane where silence costs the most. A create-only file that says nothing
+    // is read as maybe-Lisa's and left alone; a copy-overwrite file that says
+    // nothing is read as editable and edited, and the next sync deletes the
+    // edit without telling anyone. That already happened to a consumer repo's
+    // hardened `block-no-verify.sh`.
+    const silent: string[] = [];
+    let audited = 0;
+    for (const lane of LANES) {
+      for (const file of await templateFiles(lane, "copy-overwrite")) {
+        if (!COMMENTABLE.test(file)) continue;
+        audited += 1;
+        const contents = await readFile(file, "utf8");
+        if (!HEADERS["copy-overwrite"].every(line => contents.includes(line))) {
+          silent.push(path.relative(process.cwd(), file));
+        }
+      }
+    }
+
+    expect(audited).toBeGreaterThan(50);
+    expect(silent).toEqual([]);
+  });
+
+  it("exempts only copy-overwrite formats that cannot hold a comment (#2547)", async () => {
+    // The population here is the WHOLE lane, not the commentable slice, because
+    // `COMMENTABLE` is itself an exemption and an exemption nobody writes down
+    // is the #2549 defect in a different costume. Every file either states its
+    // contract or its format appears in `NO_COMMENT_SYNTAX` with a reason.
+    const unexplained: string[] = [];
+    const exemptionsUsed = new Set<string>();
+    let audited = 0;
+
+    for (const lane of LANES) {
+      for (const file of await templateFiles(lane, "copy-overwrite")) {
+        audited += 1;
+        const contents = await readFile(file, "utf8");
+        if (HEADERS["copy-overwrite"].every(line => contents.includes(line))) {
+          continue;
+        }
+        // `.nvmrc` and `.gitkeep` are dotfiles, and `extname` reports no
+        // extension for those — falling back to the whole name is what lets
+        // them be named in the exemption list rather than slipping past it.
+        const extension = path.extname(file) || path.basename(file);
+        if (extension in NO_COMMENT_SYNTAX) {
+          exemptionsUsed.add(extension);
+          continue;
+        }
+        unexplained.push(path.relative(process.cwd(), file));
+      }
+    }
+
+    expect(audited).toBeGreaterThan(100);
+    expect(unexplained).toEqual([]);
+    // A written-down excuse for a format the lane no longer ships is a hole
+    // waiting for a file to fall into it, so the list has to stay used.
+    const byName = (a: string, b: string): number => a.localeCompare(b);
+    expect([...exemptionsUsed].sort(byName)).toEqual(
+      Object.keys(NO_COMMENT_SYNTAX).sort(byName)
+    );
+  });
+
+  it("cannot generate a copy-overwrite asset without stamping the header (#2547)", async () => {
+    // Thirteen copy-overwrite assets are not authored where they ship: the
+    // build materializes them from `plugins/src/base/hooks/` and from
+    // `scripts/lisa-enforcement-fallback.sh`. A header typed into those copies
+    // is erased on the next `bun run build`, which is why #2545 could correct
+    // 86 files and not these.
+    //
+    // The fix stamps the header during generation, so the assertion that keeps
+    // it true is about the GENERATOR, not about today's thirteen files. A
+    // fourteenth asset added with a bare `cp` into a copy-overwrite tree would
+    // pass every file-list check above by simply not being in the list — this
+    // one fails on the `cp` itself.
+    const build = await readFile(
+      path.join(process.cwd(), "scripts", "build-plugins.sh"),
+      "utf8"
+    );
+
+    // Matched on the `cp` itself rather than on a `copy-overwrite` substring in
+    // the destination: two of the four sync sites write through a shell
+    // variable (`$HOST_GUARD_DIR`, `$ratchet_scripts_dir`), so a path-shaped
+    // filter reads them as harmless. Measured — the first version of this
+    // assertion did exactly that and sat green while a reverted call site was
+    // shipping headerless guards.
+    //
+    // So the rule is an allowlist of one: the plugin tree copy, which lands in
+    // `plugins/` and is not a template. Any other `cp` has to be justified here
+    // before it can ship.
+    const PLUGIN_TREE_COPY = 'cp -r "$src/." "$out/"';
+    const copies = build
+      .split("\n")
+      .map(line => line.trim())
+      .filter(line => !line.startsWith("#"))
+      .filter(line => /(^|\s)cp\s/u.test(line));
+
+    expect(copies).toEqual([PLUGIN_TREE_COPY]);
+    // And the stamping helper is actually reached, so deleting the sync
+    // altogether would not read as a pass.
+    expect(build).toContain("materialize-copy-overwrite.mjs");
+  });
+
   it("keeps the header below a shebang and a Ruby magic comment", async () => {
     // Placement is not cosmetic. A `#!` line that stops being line 1 stops
     // being a shebang, and `# frozen_string_literal: true` silently stops
     // applying if anything but a shebang precedes it — so a careless header
     // insert is a behavior change wearing a comment's clothes.
+    // Both lanes. The generated copy-overwrite hooks are shebang scripts the
+    // build now writes a header into (#2547), so this is exactly where a
+    // placement bug would be introduced by machine rather than by hand.
     const files = (
-      await Promise.all(LANES.map(lane => templateFiles(lane, "create-only")))
+      await Promise.all(
+        STRATEGIES.flatMap(strategy =>
+          LANES.map(lane => templateFiles(lane, strategy))
+        )
+      )
     )
       .flat()
       .filter(file => COMMENTABLE.test(file));

--- a/typescript/copy-overwrite/.github/GITHUB_ACTIONS.md
+++ b/typescript/copy-overwrite/.github/GITHUB_ACTIONS.md
@@ -1,3 +1,6 @@
+<!-- This file is managed by Lisa and IS replaced on each `lisa` run. -->
+<!-- Do not edit directly — durable changes belong upstream in Lisa. -->
+
 # GitHub Actions Configuration
 
 This directory contains the CI/CD workflows and automation for the project. This document explains how to configure and use the GitHub Actions workflows.

--- a/typescript/copy-overwrite/ast-grep/rules/no-inline-component-in-container.yml
+++ b/typescript/copy-overwrite/ast-grep/rules/no-inline-component-in-container.yml
@@ -1,3 +1,6 @@
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 id: no-inline-component-in-container
 language: tsx
 severity: error

--- a/typescript/copy-overwrite/ast-grep/rules/no-inline-component-in-view.yml
+++ b/typescript/copy-overwrite/ast-grep/rules/no-inline-component-in-view.yml
@@ -1,3 +1,6 @@
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
 id: no-inline-component-in-view
 language: tsx
 severity: error

--- a/typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs
+++ b/typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+// This file is managed by Lisa and IS replaced on each `lisa` run.
+// Do not edit directly — durable changes belong upstream in Lisa.
+
 /**
  * Threshold ratchet gate — quality thresholds may tighten, never weaken.
  *

--- a/typescript/copy-overwrite/scripts/threshold-ratchet-compare.mjs
+++ b/typescript/copy-overwrite/scripts/threshold-ratchet-compare.mjs
@@ -1,3 +1,6 @@
+// This file is managed by Lisa and IS replaced on each `lisa` run.
+// Do not edit directly — durable changes belong upstream in Lisa.
+
 /**
  * Threshold ratchet — comparison rules and reporting.
  *

--- a/typescript/copy-overwrite/scripts/threshold-ratchet-families.mjs
+++ b/typescript/copy-overwrite/scripts/threshold-ratchet-families.mjs
@@ -1,3 +1,6 @@
+// This file is managed by Lisa and IS replaced on each `lisa` run.
+// Do not edit directly — durable changes belong upstream in Lisa.
+
 /**
  * Threshold ratchet — watched file families and value extractors.
  *


### PR DESCRIPTION
## What

Makes the ownership header a property of the **generation step**, so the thirteen `copy-overwrite` assets that structurally could not carry one now do — and extends the #2545 guard to assert over the whole lane with its exceptions written down.

Closes #2547

## Which of the thirteen got headers, and how

All thirteen, via their generator. **Zero documented exclusions in the covered set** — every one is a `.sh` or `.mjs` file that takes a comment fine.

| Generated destination | Materialized from | Count |
| --- | --- | --- |
| `all/copy-overwrite/scripts/lisa-hooks/*.sh` | `plugins/src/base/hooks/` (5 PreToolUse guards + `sonar-secrets.sh`) | 6 |
| `all/copy-overwrite/scripts/lisa-enforcement-fallback.sh` | `scripts/lisa-enforcement-fallback.sh` | 1 |
| `{typescript,rails}/copy-overwrite/scripts/{check-threshold-ratchet,threshold-ratchet-families,threshold-ratchet-compare}.mjs` | `plugins/src/base/hooks/threshold-ratchet*.mjs` | 6 |

`scripts/materialize-copy-overwrite.mjs` stamps the header as each file is written — below any shebang, idempotently — and `scripts/build-plugins.sh` calls it at all four sync sites in place of `cp`.

**Why not upstream.** Putting the header on `plugins/src/base/hooks/block-no-verify.sh` would be a fresh instance of #2538's defect: that is precisely the file maintainers edit, and a false overwrite warning is what deterred a correct downstream fix for an hour. So the source stays honest, the shipped copy states its real contract, and the two cannot disagree because one produces the other. Both directions are now asserted — header present on every shipped copy, **absent** from every source.

## The population, not the file list

The #2549 lesson is that selecting a population on "already has a header" excuses the file that has none. Three assertions now cover the whole lane:

1. **No commentable `copy-overwrite` template is silent** — the #2549 assertion pointed at the other lane, with the same `audited > 50` vacuity guard.
2. **Across the ENTIRE lane**, a file either states its contract or its format appears in `NO_COMMENT_SYNTAX` with a written reason. The exemption list is `.json`, `.versionrc` (a JSON body), `.nvmrc` (a bare version string), `.gitkeep`/`.keep` (must stay empty) — and **every entry must match a real file**, so a stale excuse cannot sit waiting for something to fall into it.
3. **`build-plugins.sh` may contain exactly one `cp`** — the plugin tree copy, which lands in `plugins/` and is not a template. Any other copy has to be justified before it ships.

That third one earned its shape by failing. The first version filtered on a `copy-overwrite` substring in the destination, and two of the four sync sites write through a shell variable (`$HOST_GUARD_DIR`, `$ratchet_scripts_dir`) — so when the probe reverted one of them to a bare `cp`, the guard stayed green while headerless guards shipped. It is now an allowlist of one line.

## Fourteen more files, for an ordinary reason

Fourteen hand-authored `copy-overwrite` templates were silent because nothing selected them: `lisa-destructive-guard.mjs`, `.rubocop.yml`, `lefthook.yml`, `config/initializers/version.rb`, eight `ast-grep` rule files, `.easignore.extra`, and `.github/GITHUB_ACTIONS.md`. They get the header so the lane can be asserted whole rather than in the slice that happens to pass. Note that none of them is on the exemption list — `.easignore.extra` and the `.md` both take a comment, and "nobody could think what to do with it" is exactly how the #2549 blind spot happened.

## Proved it bites — both directions

| Probe | Result |
| --- | --- |
| **File-level.** Header stripped from `all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh` | **4 failed** — `…states that it is replaced`, `leaves no commentable copy-overwrite template silent about who owns it (#2547)`, `exempts only copy-overwrite formats that cannot hold a comment (#2547)`, plus the evidence manifest. The file is named in 3 of them. |
| **Population-level.** A *new* `probe-2547.sh` added to the lane with no header — in no file list anywhere | **2 failed** — `leaves no commentable copy-overwrite template silent about who owns it (#2547)` and `exempts only copy-overwrite formats that cannot hold a comment (#2547)`, both naming `probe-2547.sh`. This is the one that proves the population is right rather than the file list. |
| **Generator-level.** One `materialize` call reverted to a bare `cp` | **1 failed** — `cannot generate a copy-overwrite asset without stamping the header (#2547)`, printing the offending line. (Caught a real hole in the first version of that assertion; see above.) |
| Clean tree | **663 files / 11,743 tests pass** |

## Verification

| Check | Result |
| --- | --- |
| Full suite, unscoped, post-rebase | 663 files / 11,743 tests pass (baseline before the change: 656 / 11,658) |
| `bun run build` | clean — working tree unchanged afterwards, the invariant #2545 used |
| `bun run build:plugins` run twice | idempotent — no second-pass diff, so the stamp does not stack |
| `bun run lint` (oxlint + eslint) | clean |
| `tsc --noEmit` | clean |
| `check:rules-pairing` | clean |
| `bash -n` on `build-plugins.sh` + the shipped dispatcher | clean |
| `node --check scripts/materialize-copy-overwrite.mjs` | clean |
| `scripts/check-conflict-markers.mjs` | ✓ no leftover markers in 7350 tracked files |
| Plugin parity drift / routing artifacts | 0 drifted, 7/7 valid |

`src/core/upstream-evidence-manifest.ts` and `src/core/lisa-owned-hash-ledger.ts` are regenerated because both hash tracked files. The rebase onto `origin/main` conflicted in the manifest; it was resolved by taking `origin/main`'s generated file and regenerating from scratch, then confirmed stable (a second regeneration produces no diff).

## Out of scope

The same exemption census for `create-only`'s non-commentable templates — 20 files including machine-managed ledgers under `.lisa/` (`PROJECT_LEARNINGS.md`, `ACCOUNTABILITY.md`) where a header would interfere with the reader. That lane is governed by #2549's assertion at the commentable boundary; extending it is a separate decision, named here rather than skipped quietly.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2547
