### PR TITLE
fix(maestro): stop leg_order escalating the caller's grant and failing on a flaky API

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -101,11 +101,18 @@
 # set". The job's own comment records the three alternatives and why each was
 # rejected. Consequences worth knowing:
 #
-#   • It needs the `actions: read` permission, and a called workflow cannot hold
-#     a permission its CALLER did not grant. A caller with only `contents: read`
-#     gets a named 403 from that job — not a silent revert to concurrency.
-#   • If that job fails or times out, Android still runs. The run goes red and
-#     the legs overlap for that night, which is exactly today's behavior.
+#   • Reading the jobs API needs `actions: read`, and that scope must arrive as
+#     the forwarded `LEG_ORDER_TOKEN` secret — NOT as a `permissions:` entry in
+#     this file. A called workflow requesting a scope its caller never granted
+#     is a `startup_failure` for the CALLER'S ENTIRE RUN, decided before the run
+#     starts, so no `if:` and no unset input can contain it. That is the #2046
+#     rule; this feature broke it once (#2566) and the job carries the full note.
+#   • NO degraded path fails this job. A missing token, a 403, a flaky API, a
+#     renamed iOS job — each warns loudly and lets Android start, which is the
+#     behaviour every run had before this feature existed. Failing instead would
+#     be worse than the contention: row 26 of the nightly gate turns any
+#     non-success job into a `fail` verdict for the whole suite, blocking the
+#     merge gate on a night when both legs were green.
 #   • Opting IN costs an idle ubuntu-latest runner for as long as the iOS suite
 #     takes, plus one held job slot. The default path does not pay it: with the
 #     input unset the job runs no steps and ends in seconds. Wall clock is the
@@ -409,6 +416,20 @@ on:
         required: false
       MAESTRO_SECRET_ENV:
         description: 'Newline-separated KEY=VALUE pairs of sensitive flow variables (e.g. test-account passwords), forwarded like maestro_env. GitHub masks each line in logs.'
+        required: false
+      LEG_ORDER_TOKEN:
+        description: >-
+          Token used ONLY by the leg-ordering job to read this run's own job
+          list, and only when serialize_platform_legs is true. Pass the calling
+          workflow's own secrets.GITHUB_TOKEN from a caller whose own
+          `permissions:` block includes `actions: read` — a forwarded secret
+          carries the
+          CALLER's scopes, which is what lets this workflow read the jobs API
+          without DECLARING a scope. Declaring one instead would be a
+          `startup_failure` for the entire run of every caller granting less
+          (#2046), which is why this is a secret and not a `permissions:` entry.
+          Absent or unscoped, the ordering job reports the gap and lets the
+          Android leg start — it never fails the run over it.
         required: false
 
 permissions:
@@ -774,11 +795,24 @@ jobs:
     needs: [preflight, build]
     if: ${{ !cancelled() && needs.preflight.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      # Reading this run's own job list. A caller whose token is narrower than
-      # this gets a named 403 from the step below rather than a silent pass.
-      actions: read
+    # DELIBERATELY no `permissions:` block, and this is not a style choice — it
+    # is the #2046 rule, which this job originally broke. A called workflow may
+    # only DOWNGRADE the caller's grant: requesting a scope the caller never
+    # held is a `startup_failure` for the ENTIRE run, not a skipped job, and it
+    # is decided BEFORE the run starts — so `if:` never runs, and having
+    # `serialize_platform_legs` unset does not save you. An `actions: read`
+    # declared here would therefore have broken every caller granting less,
+    # including on paths where this job does nothing. See the identical comment
+    # on `quality.yml`'s work_item_traceability job, and the regression test in
+    # tests/unit/hooks/work-item-wiring.test.ts; the counterpart guard for this
+    # workflow is in tests/integration/maestro-leg-order.test.ts.
+    #
+    # The scope this job actually needs travels as a SECRET instead
+    # (`LEG_ORDER_TOKEN`), because a secret carries the CALLER's token and its
+    # scopes without this workflow declaring anything. Opting in stays entirely
+    # self-service: no migration, no release sequencing, and no way for an
+    # adopter who never opted in to be affected.
+    #
     # Its own input rather than a sum of the two budgets it actually spans:
     # GitHub Actions expressions have NO arithmetic operators, so
     # `pre_suite_timeout_minutes + suite_timeout_minutes` is a syntax error, not
@@ -794,7 +828,13 @@ jobs:
         # for a job that will never exist.
         if: ${{ inputs.serialize_platform_legs && needs.preflight.outputs.run_ios == 'true' && needs.preflight.outputs.run_android == 'true' }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          # The CALLER's token, forwarded as a secret. `github.token` here would
+          # be this workflow's own token, capped by the `contents: read` above
+          # and therefore never able to read the jobs list — and widening that
+          # cap is the escalation the job comment forbids. Empty when the caller
+          # did not wire the secret, which the script reports and releases on
+          # rather than failing.
+          GH_TOKEN: ${{ secrets.LEG_ORDER_TOKEN }}
           API_URL: ${{ github.api_url }}
           REPOSITORY: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
@@ -812,31 +852,95 @@ jobs:
           # the whole pre-suite budget. The slack is added in the shell below
           # because GitHub Actions expressions have no arithmetic.
           PRE_SUITE_TIMEOUT_MINUTES: ${{ inputs.pre_suite_timeout_minutes }}
-          DISCOVERY_SLACK_MINUTES: '5'
+          # Must absorb pre_suite's RUNNER ACQUISITION as well as its budget —
+          # this job only learns the iOS leg exists once pre_suite concludes,
+          # and pre_suite cannot conclude before it gets a runner.
+          DISCOVERY_SLACK_MINUTES: '15'
           MAX_PAGES: '10'
+          # Consecutive transport failures tolerated before giving up. A 90
+          # minute iOS suite is ~270 requests at this poll interval, so treating
+          # a single 502 as fatal would make the ordering itself the flakiest
+          # thing in the run.
+          MAX_TRANSIENT: '5'
         run: |
-          set -euo pipefail
+          set -uo pipefail
           DISCOVERY_SECONDS=$(( (PRE_SUITE_TIMEOUT_MINUTES + DISCOVERY_SLACK_MINUTES) * 60 ))
           page_file="$(mktemp)"
           started=$SECONDS
-          discovered=false
+          transient=0
+
+          # EVERY degraded path lands here, and none of them fails the job.
+          #
+          # `leg_order` can only ever DELAY the Android leg. When it cannot tell
+          # what the iOS leg is doing it has two options and both are bad:
+          # release Android (the legs overlap for one night — exactly the
+          # behaviour of every run before this feature existed) or fail (which
+          # row 26 of the nightly gate turns into a `fail` verdict for the whole
+          # suite, blocking the merge gate on a night when both legs were green
+          # — see docs/nightly-e2e-gate.md). Releasing is strictly the smaller
+          # harm, so the annotation is the alarm and the run stays green.
+          #
+          # What this must NEVER do is claim the iOS leg finished. It says the
+          # ordering was skipped and why.
+          release() {
+            # Deliberately worded to share NO phrase with the success line
+            # above it. These two messages are the only way a reader — or the
+            # test suite — can tell "the legs were ordered" from "the ordering
+            # was abandoned", so a substring common to both would blur exactly
+            # the distinction that matters.
+            echo "::warning title=Leg order could not order the legs::$1 The Android leg is starting anyway, so the two platform legs may overlap for this run — which is the behaviour serialize_platform_legs was turned on to avoid. No claim is made about the iOS suite's state; the ordering was skipped."
+            exit 0
+          }
+
+          if [[ -z "${GH_TOKEN// }" ]]; then
+            release "No LEG_ORDER_TOKEN secret was passed, so this run's job list cannot be read. In the calling workflow, forward its own secrets.GITHUB_TOKEN as the LEG_ORDER_TOKEN secret, and add 'actions: read' to that workflow's own permissions block. It has to be a forwarded secret rather than a permission declared in the reusable workflow: a called workflow requesting a scope its caller never granted is a startup_failure for the entire run."
+          fi
+
           while true; do
             total=0
             pending=0
             page=1
+            sweep_ok=true
             while true; do
-              if ! curl -fsSL \
+              # Capture the status rather than relying on `-f`, so a permission
+              # problem (permanent, and fixable only by the caller) is told
+              # apart from a 502 (transient, and fixed by asking again).
+              status="$(curl -sSL \
                 -H "Authorization: Bearer $GH_TOKEN" \
                 -H "Accept: application/vnd.github+json" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 -o "$page_file" \
-                "$API_URL/repos/$REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs?per_page=100&page=$page"; then
-                echo "::error title=Leg order could not read this run's jobs::GET /repos/$REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs failed. The usual cause is token scope: serialize_platform_legs needs \`actions: read\`, and a called workflow cannot hold a permission the CALLER did not grant. Add \`actions: read\` to the calling workflow's permissions block."
-                exit 1
+                -w '%{http_code}' \
+                "$API_URL/repos/$REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs?per_page=100&page=$page")" || status="000"
+              case "$status" in
+                200) ;;
+                401|403|404)
+                  release "The jobs API answered HTTP $status, which is a token problem and will not fix itself by retrying. The LEG_ORDER_TOKEN secret must carry 'actions: read' — grant that scope in the CALLING workflow's own permissions block, and forward that workflow's secrets.GITHUB_TOKEN as LEG_ORDER_TOKEN."
+                  ;;
+                *)
+                  transient=$(( transient + 1 ))
+                  if [[ "$transient" -ge "$MAX_TRANSIENT" ]]; then
+                    release "The jobs API failed $transient times in a row (last: HTTP $status)."
+                  fi
+                  echo "Jobs API returned HTTP $status (transient $transient/$MAX_TRANSIENT); retrying."
+                  sweep_ok=false
+                  break
+                  ;;
+              esac
+              matched="$(jq --arg name "$IOS_JOB_NAME" '[.jobs[]? | select(.name | endswith($name))] | length' "$page_file" 2>/dev/null)" || matched=""
+              unfinished="$(jq --arg name "$IOS_JOB_NAME" '[.jobs[]? | select(.name | endswith($name)) | select(.status != "completed")] | length' "$page_file" 2>/dev/null)" || unfinished=""
+              returned="$(jq '.jobs? // [] | length' "$page_file" 2>/dev/null)" || returned=""
+              # A 200 carrying something that is not the expected JSON — an HTML
+              # error page, a truncated body — must not be read as "no jobs".
+              if [[ -z "$matched" || -z "$unfinished" || -z "$returned" ]]; then
+                transient=$(( transient + 1 ))
+                if [[ "$transient" -ge "$MAX_TRANSIENT" ]]; then
+                  release "The jobs API returned $transient unparseable bodies in a row."
+                fi
+                echo "Jobs API body was not the expected JSON (transient $transient/$MAX_TRANSIENT); retrying."
+                sweep_ok=false
+                break
               fi
-              matched="$(jq --arg name "$IOS_JOB_NAME" '[.jobs[] | select(.name | endswith($name))] | length' "$page_file")"
-              unfinished="$(jq --arg name "$IOS_JOB_NAME" '[.jobs[] | select(.name | endswith($name)) | select(.status != "completed")] | length' "$page_file")"
-              returned="$(jq '.jobs | length' "$page_file")"
               total=$(( total + matched ))
               pending=$(( pending + unfinished ))
               if [[ "$returned" -lt 100 ]]; then
@@ -844,37 +948,46 @@ jobs:
               fi
               page=$(( page + 1 ))
               if [[ "$page" -gt "$MAX_PAGES" ]]; then
-                echo "::error title=Leg order could not enumerate this run's jobs::More than $MAX_PAGES pages of jobs. Refusing to report the iOS leg finished on a job list this step could not read to the end."
-                exit 1
+                release "This run has more than $MAX_PAGES pages of jobs, so the job list could not be read to the end."
               fi
             done
+            if [[ "$sweep_ok" != "true" ]]; then
+              sleep "$POLL_SECONDS"
+              continue
+            fi
+            # A clean sweep resets the streak: MAX_TRANSIENT counts CONSECUTIVE
+            # failures, so a flaky hour does not accumulate into a false verdict.
+            transient=0
             # The absent case is NOT the done case. Zero matching jobs means
             # "iOS has not been created yet" or "the name constant is stale",
-            # and neither of those is "iOS finished". Reporting success here
-            # would be a guard that passes because it looked at nothing.
+            # and neither of those is "iOS finished". Reporting the leg complete
+            # here would be a guard that passes because it looked at nothing —
+            # so this path releases with a warning that says exactly that,
+            # rather than claiming a terminal iOS leg.
             if [[ "$total" -eq 0 ]]; then
               if [[ $(( SECONDS - started )) -ge "$DISCOVERY_SECONDS" ]]; then
-                echo "::error title=Leg order never found the iOS leg::No job in this run has a name ending in '$IOS_JOB_NAME' after ${DISCOVERY_SECONDS}s. Either the iOS job was renamed without updating IOS_JOB_NAME in this workflow, or it never entered the run. Not reporting the iOS leg complete on evidence that does not exist."
-                exit 1
+                release "No job in this run has a name ending in '$IOS_JOB_NAME' after ${DISCOVERY_SECONDS}s. Either the iOS job was renamed without updating IOS_JOB_NAME in this workflow, or it never entered the run."
               fi
               echo "iOS leg not in the job list yet; waiting ($(( SECONDS - started ))s elapsed)."
               sleep "$POLL_SECONDS"
               continue
             fi
-            discovered=true
             if [[ "$pending" -eq 0 ]]; then
               # Terminal is terminal. A FAILED iOS leg releases Android exactly
-              # like a passing one — the point of this gate is that the two legs
+              # like a passing one — the point of this job is that the two legs
               # never touch the persona at the same time, not that Android is
               # only worth running when iOS was green. Gating on conclusion
               # would let one flaky iOS flow silently halve the suite.
+              #
+              # This is the ONLY line that may claim the iOS leg finished, and
+              # it is reachable only with at least one matching job, all of
+              # them `completed`.
               echo "iOS leg finished ($total job(s), terminal). Releasing the Android leg."
-              break
+              exit 0
             fi
             echo "iOS leg still running ($pending of $total job(s) not completed); waiting."
             sleep "$POLL_SECONDS"
           done
-          echo "discovered=$discovered"
 
       - name: 🚦 Report the ordering decision
         env:

--- a/expo/create-only/.github/workflows/maestro-e2e.yml
+++ b/expo/create-only/.github/workflows/maestro-e2e.yml
@@ -71,11 +71,15 @@ on:
 
 permissions:
   contents: read
-  # Read-only, and only this run's own job list. It is what
-  # `serialize_platform_legs` below needs to know when the iOS leg has
-  # finished — a called workflow cannot hold a permission the caller did not
-  # grant, so dropping this line turns that input into a red job rather than a
-  # silent no-op. Harmless when the input is off.
+  # Read-only, and only this run's own job list. It is granted HERE, in the
+  # caller, because that is the only place it can safely be granted: a called
+  # workflow that DECLARES a scope its caller did not grant is a
+  # `startup_failure` for the whole run. So this line plus the forwarded
+  # LEG_ORDER_TOKEN secret below are what let `serialize_platform_legs` read
+  # when the iOS leg finished.
+  #
+  # Drop this line and nothing breaks — the ordering job reports the gap and
+  # lets the Android leg start. You lose the ordering, not the suite.
   actions: read
 
 # Keyed on the ENVIRONMENT this suite drives, not on the ref. Every run of this
@@ -126,10 +130,19 @@ jobs:
       # other's session, so the loser hits a sign-in screen mid-suite and fails
       # an assertion that has nothing wrong with it. This runs iOS first, then
       # Android. It is ordering, not gating: a FAILING iOS leg still releases
-      # Android, so turning it on never narrows what gets tested. Requires the
-      # `actions: read` permission above. Leave it off if your legs use
-      # per-platform accounts — the concurrency is free coverage in that case.
+      # Android, so turning it on never narrows what gets tested. Needs the
+      # `actions: read` permission above AND the LEG_ORDER_TOKEN secret below;
+      # without either it reports the gap and runs the legs concurrently rather
+      # than failing. Leave it off if your legs use per-platform accounts — the
+      # concurrency is free coverage in that case. The cost when on is the suite
+      # taking iOS PLUS Android instead of the slower of the two.
       # serialize_platform_legs: true
     secrets:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       MAESTRO_SECRET_ENV: ${{ secrets.MAESTRO_SECRET_ENV }}
+      # Only read when serialize_platform_legs is true. A forwarded secret
+      # carries THIS workflow's token and therefore THIS workflow's
+      # `actions: read` — which is why the scope can be granted above without
+      # the reusable workflow having to declare it and startup-fail every caller
+      # that grants less. Harmless to pass when the input is off.
+      LEG_ORDER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -209,7 +209,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/create-only/.github/workflows/deploy.yml":
       "27f5037db910501f8d76f828f91a605e3c4d321d1df362d317c440ab7abc9f14",
     "expo/create-only/.github/workflows/maestro-e2e.yml":
-      "889084395ca48e07d01725158bf8b091e5c19f1800d5f4beee777e2b95530246",
+      "cb7ae17a845f4a0cab21b8eb87291f2746610880c6a611731520ee1b925ecf85",
     "expo/create-only/.github/workflows/nightly-e2e-bypass-reaper.yml":
       "db78a1012a00cf4e8b023a67bb57566ae85cf790c3856f3e299636c766f0c242",
     "expo/create-only/.github/workflows/nightly-e2e-health.yml":

--- a/tests/integration/maestro-leg-order-wait.test.ts
+++ b/tests/integration/maestro-leg-order-wait.test.ts
@@ -10,16 +10,22 @@
  * would prove nothing about ordering; a poll loop that returned immediately
  * would satisfy it perfectly.
  *
- * Four things are proved by running it:
+ * The contract, in two halves that must not be confused:
  *
- *   • it does NOT return while the iOS job is still running (the ordering);
- *   • it DOES return on an iOS job that failed, was skipped, timed out, or was
- *     cancelled — ordering, never gating, so no flaky iOS flow can delete the
- *     Android suite from the night;
- *   • a poll that matches ZERO iOS jobs is an error, never a pass. That is the
- *     failure mode this job could most easily have had: a guard reporting
- *     success because it looked at nothing;
- *   • a refused API is a named error, not a silent revert to concurrency.
+ *   ORDERING — while the iOS job exists and is not `completed`, this must not
+ *   return. That is the whole feature.
+ *
+ *   DEGRADATION — when it cannot tell what the iOS job is doing, it exits 0 and
+ *   says the ordering was SKIPPED. It never exits non-zero, because row 26 of
+ *   the nightly gate turns any non-success job into a `fail` verdict for the
+ *   whole suite (docs/nightly-e2e-gate.md), which would block the merge gate on
+ *   a night when both legs were green. Releasing costs one night of overlap —
+ *   the behaviour every run had before this feature existed.
+ *
+ * The line between them is what these tests actually guard: exactly one message
+ * may claim the iOS leg finished, and it is reachable only after counting at
+ * least one matching job with `status == "completed"`. Every degraded path says
+ * the opposite, in words.
  */
 
 import * as fs from "fs-extra";
@@ -34,6 +40,7 @@ import {
   iosApiJob,
   runWaitStep,
   startFakeApi,
+  startFlakyApi,
   startRefusingApi,
 } from "./support/maestro-leg-order-harness";
 import type { SimulatedWorkflow } from "../helpers/workflow-job-graph";
@@ -48,11 +55,22 @@ const REUSABLE_YML = path.join(
 
 const LEG_ORDER = "leg_order";
 
-/**
- * The wait step shells out to jq, which every ubuntu-latest runner ships — so
- * this block always runs in CI and only ever skips on a dev machine without it.
- */
+/** The one message that asserts the iOS leg reached a terminal state. */
+const FINISHED = "iOS leg finished";
+/** Every degraded path says this instead, and never the above. */
+const SKIPPED = "the ordering was skipped";
+
 const hasJq = spawnSync("/bin/sh", ["-c", "command -v jq"]).status === 0;
+
+// jq ships on every ubuntu-latest runner, so this block always runs in CI. A
+// silent skip would delete every executable proof in this file and still report
+// green — the exact shape of vacuous pass this suite exists to prevent — so on
+// CI a missing jq is a failure, not a skip.
+if (!hasJq && process.env.CI) {
+  throw new Error(
+    "jq is required for the leg-order wait tests and is missing on this CI runner. Refusing to skip the only executable proof that the ordering holds."
+  );
+}
 
 describe.skipIf(!hasJq)("maestro-native-e2e leg ordering — the wait", () => {
   let workflow: SimulatedWorkflow;
@@ -63,7 +81,7 @@ describe.skipIf(!hasJq)("maestro-native-e2e leg ordering — the wait", () => {
     ) as SimulatedWorkflow;
   });
 
-  describe("bite control 1 — ordering holds", () => {
+  describe("ordering — it does not return early", () => {
     it("does not return while the iOS job is still running", async () => {
       // The API reports iOS queued, then in_progress twice, before completing.
       // Returning on any of the first three would release Android while iOS
@@ -77,14 +95,11 @@ describe.skipIf(!hasJq)("maestro-native-e2e leg ordering — the wait", () => {
       try {
         const result = await runWaitStep(workflow, LEG_ORDER, api);
         expect(result.status).toBe(0);
-        // Three "still running" lines then a release: it kept asking until the
-        // answer changed, in its own words rather than a counter this test
-        // invented. A loop that returned on the first poll would print none.
         const waited = result.stdout
           .split("\n")
           .filter(line => line.includes("still running"));
         expect(waited).toHaveLength(3);
-        expect(result.stdout).toContain("Releasing the Android leg");
+        expect(result.stdout).toContain(FINISHED);
       } finally {
         await api.close();
       }
@@ -96,54 +111,124 @@ describe.skipIf(!hasJq)("maestro-native-e2e leg ordering — the wait", () => {
       // whole budget on a suite that had already finished.
       const api = await startFakeApi([[iosApiJob("completed", "success")]]);
       try {
-        expect((await runWaitStep(workflow, LEG_ORDER, api)).status).toBe(0);
+        const result = await runWaitStep(workflow, LEG_ORDER, api);
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain(FINISHED);
       } finally {
         await api.close();
       }
     });
 
-    it("errors rather than passing when no iOS job is ever found", async () => {
-      // The absent case is NOT the done case. Zero matches means the job has
-      // not been created yet, or the name constant is stale — and neither of
-      // those is "iOS finished". The discovery window is collapsed to zero here
-      // so the bound is reached on the first poll instead of in five minutes.
-      const api = await startFakeApi([[ANDROID_API_JOB]]);
-      try {
-        const result = await runWaitStep(workflow, LEG_ORDER, api, {
-          PRE_SUITE_TIMEOUT_MINUTES: "0",
-          DISCOVERY_SLACK_MINUTES: "0",
-        });
-        expect(result.status).not.toBe(0);
-        expect(result.stdout + result.stderr).toContain(
-          "never found the iOS leg"
-        );
-      } finally {
-        await api.close();
-      }
-    });
-
-    it("fails loudly when the jobs API refuses it", async () => {
-      // The `actions: read` case. A 403 must not read as "iOS is done", and
-      // must not read as "carry on quietly" either — the caller has to find out
-      // its permissions block is short, and the error names the fix.
-      const api = await startRefusingApi(403);
+    it("rides out transient 5xx rather than treating one as a verdict", async () => {
+      // ~270 requests across a 90-minute iOS suite. Before this, a single 502
+      // released Android AND concluded the job `failure`, which row 26 turns
+      // into a blocked merge gate on a night both legs were green.
+      const api = await startFlakyApi(3, [
+        ANDROID_API_JOB,
+        iosApiJob("completed", "success"),
+      ]);
       try {
         const result = await runWaitStep(workflow, LEG_ORDER, api);
-        expect(result.status).not.toBe(0);
-        expect(result.stdout + result.stderr).toContain("actions: read");
+        expect(result.status).toBe(0);
+        // It waited for the real answer rather than releasing on the flake.
+        expect(result.stdout).toContain(FINISHED);
+        expect(result.stdout).not.toContain(SKIPPED);
+      } finally {
+        await api.close();
+      }
+    });
+
+    it("gives up after MAX_TRANSIENT consecutive failures, without failing", async () => {
+      const api = await startFlakyApi(50, [iosApiJob("completed", "success")]);
+      try {
+        const result = await runWaitStep(workflow, LEG_ORDER, api, {
+          MAX_TRANSIENT: "3",
+        });
+        expect(result.status).toBe(0);
+        expect(result.stdout + result.stderr).toContain(SKIPPED);
+        expect(result.stdout).not.toContain(FINISHED);
       } finally {
         await api.close();
       }
     });
   });
 
-  describe("bite control 3 — a failing iOS leg does not suppress Android", () => {
+  describe("degradation — it warns and releases, and never fails the job", () => {
+    it("releases when no LEG_ORDER_TOKEN was passed", async () => {
+      // The permission story lives in a forwarded secret, so an unwired caller
+      // is the common case rather than an exotic one. It must not fail: that
+      // would block the merge gate of every adopter who opted in before wiring
+      // the secret.
+      const api = await startFakeApi([[iosApiJob("in_progress", null)]]);
+      try {
+        const result = await runWaitStep(workflow, LEG_ORDER, api, {
+          GH_TOKEN: "",
+        });
+        expect(result.status).toBe(0);
+        expect(result.stdout + result.stderr).toContain("LEG_ORDER_TOKEN");
+        expect(result.stdout).not.toContain(FINISHED);
+      } finally {
+        await api.close();
+      }
+    });
+
+    it.each([401, 403, 404])(
+      "releases immediately on HTTP %i instead of retrying a token problem",
+      async status => {
+        // A scope problem does not fix itself, so burning MAX_TRANSIENT polls
+        // on it just delays the same outcome. The message must name the fix.
+        const api = await startRefusingApi(status);
+        try {
+          const result = await runWaitStep(workflow, LEG_ORDER, api);
+          expect(result.status).toBe(0);
+          expect(result.stdout + result.stderr).toContain("actions: read");
+          expect(result.stdout).not.toContain(FINISHED);
+        } finally {
+          await api.close();
+        }
+      }
+    );
+
+    it("releases, without claiming iOS finished, when no iOS job is found", async () => {
+      // The absent case is NOT the done case. Zero matches means the job has
+      // not been created yet, or the name constant is stale — neither of those
+      // is "iOS finished". This used to exit 1; it now exits 0 for the row-26
+      // reason, which makes the WORDING the entire guard: it must say the
+      // ordering was skipped, never that the leg completed.
+      const api = await startFakeApi([[ANDROID_API_JOB]]);
+      try {
+        const result = await runWaitStep(workflow, LEG_ORDER, api, {
+          PRE_SUITE_TIMEOUT_MINUTES: "0",
+          DISCOVERY_SLACK_MINUTES: "0",
+        });
+        expect(result.status).toBe(0);
+        expect(result.stdout + result.stderr).toContain(SKIPPED);
+        expect(result.stdout + result.stderr).toContain("IOS_JOB_NAME");
+        expect(result.stdout).not.toContain(FINISHED);
+      } finally {
+        await api.close();
+      }
+    });
+
+    it("treats a 200 carrying non-JSON as transient, not as an empty run", async () => {
+      // An HTML error page behind a 200 must not read as "no jobs in this run",
+      // which would burn the discovery window and skip the ordering.
+      const api = await startFlakyApi(2, [iosApiJob("completed", "success")]);
+      try {
+        const result = await runWaitStep(workflow, LEG_ORDER, api);
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain(FINISHED);
+      } finally {
+        await api.close();
+      }
+    });
+  });
+
+  describe("a failing iOS leg does not suppress Android", () => {
     it("releases Android on an iOS leg that FAILED", async () => {
       // Ordering, not gating. Waiting on a CONCLUSION instead of a terminal
       // STATUS would let one flaky iOS flow delete the whole Android suite from
-      // the night and report the narrower result under the same green check —
-      // trading a contention bug for a coverage bug, which is the worse of the
-      // two.
+      // the night and report the narrower result under the same green check.
       const api = await startFakeApi([
         [ANDROID_API_JOB, iosApiJob("in_progress", null)],
         [ANDROID_API_JOB, iosApiJob("completed", "failure")],
@@ -151,7 +236,7 @@ describe.skipIf(!hasJq)("maestro-native-e2e leg ordering — the wait", () => {
       try {
         const result = await runWaitStep(workflow, LEG_ORDER, api);
         expect(result.status).toBe(0);
-        expect(result.stdout).toContain("Releasing the Android leg");
+        expect(result.stdout).toContain(FINISHED);
       } finally {
         await api.close();
       }
@@ -164,7 +249,9 @@ describe.skipIf(!hasJq)("maestro-native-e2e leg ordering — the wait", () => {
           [ANDROID_API_JOB, iosApiJob("completed", conclusion)],
         ]);
         try {
-          expect((await runWaitStep(workflow, LEG_ORDER, api)).status).toBe(0);
+          const result = await runWaitStep(workflow, LEG_ORDER, api);
+          expect(result.status).toBe(0);
+          expect(result.stdout).toContain(FINISHED);
         } finally {
           await api.close();
         }

--- a/tests/integration/maestro-leg-order.test.ts
+++ b/tests/integration/maestro-leg-order.test.ts
@@ -121,14 +121,56 @@ describe("maestro-native-e2e leg ordering — job graph", () => {
 
     it("is reachable from the shipped caller template", () => {
       // The template is create-only, so this is the wiring NEW adopters get.
-      // `actions: read` is the half nobody would guess: a called workflow
-      // cannot hold a permission the caller did not grant, so without it the
-      // input produces a red job instead of an ordering.
+      // The scope is granted in the CALLER and travels as a forwarded secret —
+      // see the permissions guard below for why it cannot be declared in the
+      // reusable workflow.
       const permissions = caller.permissions as Record<string, string>;
+      const text = fs.readFileSync(CALLER_YML, "utf-8");
       expect(permissions.actions).toBe("read");
-      expect(fs.readFileSync(CALLER_YML, "utf-8")).toContain(
-        `# ${SERIALIZE}: true`
-      );
+      expect(text).toContain(`# ${SERIALIZE}: true`);
+      expect(text).toContain("LEG_ORDER_TOKEN:");
+    });
+
+    it("takes the ordering token as a secret, not a declared scope", () => {
+      const secrets = (
+        (raw.on as Record<string, Record<string, unknown>>).workflow_call as {
+          secrets: Record<string, Record<string, unknown>>;
+        }
+      ).secrets;
+      expect(secrets.LEG_ORDER_TOKEN).toBeDefined();
+      expect(secrets.LEG_ORDER_TOKEN.required).toBe(false);
+    });
+  });
+
+  describe("the #2046 rule — no job may escalate the caller's grant", () => {
+    it("declares no job-level permissions block anywhere in this workflow", () => {
+      // THE regression guard for #2566. A called workflow may only DOWNGRADE
+      // the caller's grant: requesting a scope the caller never held is a
+      // `startup_failure` for the ENTIRE run, decided BEFORE the run starts —
+      // so the job's `if:` never runs and an unset `serialize_platform_legs`
+      // does not save anyone. The first cut of this feature declared
+      // `actions: read` here and would have broken every caller granting less,
+      // on every path, including ones where the job does nothing.
+      //
+      // This mirrors tests/unit/hooks/work-item-wiring.test.ts, which pins the
+      // same property on quality.yml's work_item_traceability job. The scope
+      // this job needs arrives as the forwarded LEG_ORDER_TOKEN secret, which
+      // carries the CALLER's token and therefore declares nothing.
+      //
+      // Asserted over EVERY job, not just leg_order: the rule is a property of
+      // the file, and the next job added here is the one most likely to break
+      // it.
+      const declaring = Object.entries(workflow.jobs)
+        .filter(([, job]) => (job as { permissions?: unknown }).permissions)
+        .map(([name]) => name);
+      expect(declaring).toEqual([]);
+    });
+
+    it("keeps the workflow-level grant at contents: read", () => {
+      // The negative control for the assertion above. Moving the escalation up
+      // to the workflow level would satisfy a per-job check while causing the
+      // identical startup_failure, so the ceiling is pinned too.
+      expect(raw.permissions).toEqual({ contents: "read" });
     });
   });
 

--- a/tests/integration/support/maestro-leg-order-harness.ts
+++ b/tests/integration/support/maestro-leg-order-harness.ts
@@ -130,6 +130,36 @@ export const startRefusingApi = (status: number): Promise<FakeApi> =>
   );
 
 /**
+ * Starts a fake jobs API that fails `failures` times, then serves `jobs`.
+ *
+ * The failures are 5xx — the transport-flake shape the poll loop must ride out
+ * rather than treat as a verdict.
+ *
+ * @param failures How many leading requests answer 502.
+ * @param jobs The job list served from then on.
+ * @returns The base URL and a shutdown hook.
+ */
+export const startFlakyApi = (
+  failures: number,
+  jobs: ApiJob[]
+): Promise<FakeApi> => {
+  const script: ApiJob[][] = Array.from({ length: failures }, () => []);
+  const remaining = script[Symbol.iterator]();
+  return publish(
+    http.createServer((_request, response) => {
+      const step = remaining.next();
+      if (step.done !== true) {
+        response.writeHead(502, { "content-type": "text/html" });
+        response.end("<html>bad gateway</html>");
+        return;
+      }
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ total_count: jobs.length, jobs }));
+    })
+  );
+};
+
+/**
  * Runs the leg-ordering wait step's REAL shell against a fake jobs API.
  *
  * Deliberately asynchronous. The fake API lives in the test process, so a
@@ -171,6 +201,7 @@ export const runWaitStep = (
           PRE_SUITE_TIMEOUT_MINUTES: "1",
           DISCOVERY_SLACK_MINUTES: "1",
           MAX_PAGES: "10",
+          MAX_TRANSIENT: "5",
           ...overrides,
         },
       },


### PR DESCRIPTION
Closes #2566. Follow-up to #2563 (merged as `7c810deb5`, shipped in 3.13.2).

## Critical: the `permissions:` block startup-fails the whole run

The `leg_order` job I added in #2563 declared:

```yaml
permissions:
  contents: read
  actions: read
```

A called workflow may only **downgrade** the caller's grant. Requesting a scope the caller never held is a **`startup_failure` for the caller's ENTIRE run**, not a per-job 403 — and it is decided **before** the run starts, so the job's `if:` never runs and `serialize_platform_legs` being unset does not save anyone. **The "opt-in, default unchanged" property did not hold.** Every caller granting less would break, on every path, including ones where the job does nothing.

This repo had already learned this from **#2046** and encoded it as a rule with a regression test:

- `.github/workflows/quality.yml:1855-1863` — *"DELIBERATELY no `permissions:` block … requesting a scope the caller never held is a startup_failure for the ENTIRE run, not a skipped job. These workflows are consumed @main by repos whose ci.yml is create-only and can never self-heal."*
- `.github/workflows/quality-rails.yml:152-156` — the same rule, cross-referenced.
- `tests/unit/hooks/work-item-wiring.test.ts:285-294` — *"never escalates permissions above the caller's grant"*, asserting `job?.permissions` is `undefined`.

The precedent was two files from the one I was editing and I did not look. **Nothing in CI could have caught it**: actionlint does not resolve cross-repo callers, and the tests I wrote exercised a 403 path production can never reach.

**Exposure:** the two live adopters pin `@v3.5.2` and are not broken today — they would break on their next Lisa bump. The shipped caller template uses `@main`, so anything tracking main was exposed from 3.13.2 until this lands.

### Why a migration is not the fix

`maestro-native-e2e.yml` declares `permissions: contents: read` at the **workflow** level (`:142`), which caps every job regardless of the job-level block — the same shape as `quality.yml:236`. So even after a migration taught every caller to grant `actions: read`, the job still would not receive it unless the reusable workflow **also** declared the scope, which is the identical escalation one level up. A migration would have carried the fleet-breaking risk forward and added a release-sequencing problem on top, for repos whose caller is create-only and can never self-heal.

### What this does instead

The scope travels as an optional **`LEG_ORDER_TOKEN` secret**. A forwarded secret carries the **caller's** token and therefore the caller's scopes, so the reusable workflow declares nothing and **no caller can startup-fail**. A caller that opts in adds `actions: read` to its own `permissions:` and forwards its own `secrets.GITHUB_TOKEN`. No migration, no sequencing, and no way for an adopter who never opted in to be affected.

The regression guard asserts **no job in this workflow declares `permissions:`** — over every job, not just `leg_order`, since the next job added is the one most likely to break it — with the workflow-level ceiling pinned as its **negative control**, so the escalation cannot simply move up a level and still pass.

## High: one 502 was a verdict

`curl -fsSL` with no retry, polled every 20s, is ~270 requests across a 90-minute iOS suite. A single 502, timeout or reset exited 1 — which both **released Android immediately** (restoring the contention this feature exists to prevent) **and** concluded `leg_order` as `failure`, which per row 26 (`docs/nightly-e2e-gate.md:119`) makes the whole suite verdict `fail`: a blocked merge gate on a night when both legs were green.

Now the HTTP status is captured with `-w '%{http_code}'`; 401/403/404 are permanent and release at once; five consecutive 5xx/network/unparseable responses are tolerated first, and any clean sweep resets the streak. A 200 carrying an HTML error page counts as transient rather than reading as "no jobs in this run".

### Generalised: no degraded path fails this job

Row 26 makes that reasoning true of *every* degraded path, not just transient 5xx. A missing token, a 403, a renamed iOS job, an unreadable job list — each now warns loudly and lets Android start, which is the behaviour every run had before this feature existed. **Releasing costs one night of overlap; failing blocks the fleet's merge gate.**

The line that matters is preserved: exactly **one** message may claim the iOS leg reached a terminal state, and it is reachable only after counting at least one matching job with `status == "completed"`. The degraded messages deliberately share **no phrase** with it — that is what the tests assert on, and it is why the warning says "No claim is made about the iOS suite's state" rather than "this does not mean the iOS leg finished".

## Also

- Discovery slack 5 → **15 minutes**: it must absorb `pre_suite`'s runner **acquisition**, not only its 20-minute budget.
- The three comments that stated the wrong failure mode (`:104-106`, the job block, and the template's `permissions:` note).
- The dead `discovered` variable.
- `describe.skipIf(!hasJq)` now **throws under CI** rather than silently deleting every executable proof in the file.

## Evidence

| | Result |
|---|---|
| Against the merged `7c810deb5` | **11 failed**, 23 passed (34) |
| With this change | **34 passed** (34) |

The 11 include `declares no job-level permissions block anywhere in this workflow` — the guard for the critical defect.

Also green: `actionlint` and `shellcheck` on both workflows, `bun run lint`, `typecheck`, `sg:scan`, prettier, and the neighbouring suites (`maestro`, `nightly-e2e`, `work-item-wiring` — 203 tests), plus the full pre-push suite.

## One thing I found while writing this

My first draft of the error text embedded a literal `${{ secrets.GITHUB_TOKEN }}` inside the `run:` block as user guidance. GitHub interpolates `${{ }}` in `run:` **before** the shell sees it and a backslash does not escape it, so that would have substituted the real token into an echoed string rather than printing the instruction. Both messages now name the secret in prose instead.

🤖 Generated with Claude Code

Work-Item: CodySwannGT/lisa#2566
